### PR TITLE
Phase 0/1 + transcription engine + full per-folder lock

### DIFF
--- a/docs/PHASE0-PLAN.md
+++ b/docs/PHASE0-PLAN.md
@@ -1,907 +1,203 @@
-# MeetNotes — Phase 0 Implementation Blueprint (Walking Skeleton)
+<!-- Phase 0 implementation plan, code-grounded, generated 2026-06-26. -->
 
-> Status: **Plan — implementation-ready.** Date: 2026-06-24.
-> Authoritative source: [`DESIGN.md`](./DESIGN.md) §10 "Faza 0". This document pins the
-> exact file tree, dependency versions, module API surface, Tauri command signatures,
-> and build order so that independent agents can implement modules in parallel **without
-> interface drift**. No code is written here — only the contract.
+# Murmur Phase 0 — Unified Implementation Plan
+### SQLCipher at-rest + per-folder biometric lock + rich folder UI
 
-## 0. Phase 0 scope (locked)
+Crate `murmur` / lib `meetnotes_lib` at `/Users/jakubgawronski/Projects/meetnotes`. **In scope:** F2 Layer 1 (SQLCipher), F2 Layer 2 (per-folder content key behind biometric), F1 (folder UI + lock lifecycle), MCP exposure filter + token, screen-share auto-relock. **Explicitly OUT:** in-app graph, cloud/sync/sharing, enrichment, hosted MCP, CRDTs.
 
-End-to-end proof: **mic-only capture → local Whisper transcription → pluggable
-`SummarizerProvider` → Obsidian `.md` export**, with a minimal Tauri UI and minimal
-SQLite persistence.
-
-In scope:
-- Mic-only capture via `cpal` → 16 kHz mono WAV (written with `hound`; **no ffmpeg
-  dependency in Phase 0** — see §1 note).
-- Local Whisper transcription via `whisper-rs` (Metal), batch mode (after Stop).
-- `SummarizerProvider` trait + **all three v1 providers**: `ClaudeCodeProvider`
-  (**default**), `AnthropicProvider`, `OllamaProvider`.
-- Obsidian export: atomic `.tmp`→`rename` write into a user-chosen vault folder.
-- Minimal Tauri UI: Record/Stop button, live status, last-note Markdown preview,
-  Settings (vault path + provider selection + Anthropic key entry).
-- Minimal SQLite persistence: `meetings`, `segments`, `notes`, `settings` (the full
-  DESIGN §5.4 schema — implemented now, only partly surfaced in UI).
-- API key in macOS Keychain via `keyring`.
-
-Explicitly **deferred** (NOT Phase 0): ScreenCaptureKit / system audio, speaker
-diarization, live transcription, Library list UI, template editor, Whisper model picker
-UI (model path is a setting, downloaded manually for now), `obsidian://` URI, signing/
-notarization, vault auto-detection from `obsidian.json` (manual folder pick only in P0).
+**The single hardest truth (from all three analyses, and the spec §5.2):** the migration is the only destructive operation and biometric must release a real key from a `.biometryCurrentSet`-ACL'd Keychain entry, not flip a boolean. Everything below is ordered so the destructive step is proven on a throwaway copy before it touches real data, and so the boolean-theater trap is closed by design.
 
 ---
 
-## 1. Toolchain probe (recorded 2026-06-24 on this machine)
+## 1. BUILD ORDER
 
-| Tool | Status | Version found | Implication for later agents |
-|---|---|---|---|
-| `node` | ✅ present | v24.16.0 | Frontend build OK. |
-| `npm` | ✅ present | 11.13.0 | Frontend deps install OK. |
-| `cargo` | ❌ **MISSING** | — | **Cannot compile-check Rust** until installed. |
-| `rustc` | ❌ **MISSING** | — | Same. |
-| Tauri CLI | ❌ MISSING | — | Install via `cargo install tauri-cli` or `npm i -D @tauri-apps/cli`. |
-| `cmake` | ❌ **MISSING** | — | **Required by `whisper-rs-sys`** (builds whisper.cpp). Blocker for transcribe module compile. |
-| `ffmpeg` | ✅ present | 8.1.1 | Not needed in P0 (we use `hound`); available for P2 mixing. |
-| `clang` | ✅ present | Apple clang 21.0.0 | Satisfies C/C++ compiler for whisper.cpp build. |
-| `pkg-config` | ❌ MISSING | — | May be needed by some `-sys` crates; install via Homebrew if a build fails. |
-| Xcode CLT | ✅ present | `/Library/Developer/CommandLineTools` | Provides Metal toolchain + SDK headers. |
-| OS | macOS 26.5 (Darwin 25.5.0), arm64 (Apple Silicon) | — | Metal acceleration available; target `aarch64-apple-darwin`. |
+Legend: **S/M/L** effort · **[INLINE]** = orchestrator edits a shared Rust file serially (conflict-prone, see §2) · **[WORKFLOW]** = delegable to a parallel workflow (new file or isolated FE surface).
 
-### Prerequisite-install commands (run BEFORE any Rust compile-check)
-```bash
-# Rust toolchain (rustup) — installs cargo + rustc
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source "$HOME/.cargo/env"
-rustup target add aarch64-apple-darwin
+### Stage A — SQLCipher foundation (must land first; nothing else is safe until the DB is encrypted-and-migrated)
 
-# Build deps for whisper.cpp (cmake) + pkg-config, via Homebrew
-brew install cmake pkg-config
+**A1. Flip the rusqlite feature + verify the universal build. — M — [INLINE]**
+- `Cargo.toml:41`: `features = ["bundled"]` → primary `["bundled-sqlcipher-vendored-openssl"]`, documented fallback `["bundled-sqlcipher"]` (SecurityFramework/CommonCrypto, no OpenSSL in the graph → sidesteps the cross-compile trigger).
+- **HARD GATE before this is accepted (DB+CRYPTO analysis §1):** green `tauri build --target universal-apple-darwin` on the actual release runner AND a launch test on both arm64 and x86_64 (or `arch -x86_64`). Compile success is NOT enough — the `libssl.3.dylib` code-sign/load failure only shows at runtime ([Tauri #9684]). If it fails, fall back to `bundled-sqlcipher` and confirm SecurityFramework is selected. `tauri.conf.json:31` is `"targets":"all"` — the release path is the universal lipo, so this gate is mandatory, not optional.
+- Mitigation preference order: (1) build each arch natively + manual `lipo`; (2) fall back to `bundled-sqlcipher`; (3) cross-compile with `PKG_CONFIG_SYSROOT_DIR` (least recommended).
 
-# Tauri CLI (project-local)
-npm install -D @tauri-apps/cli@^2
-```
-**Gate for compile-checking agents:** until `cargo`, `rustc`, and `cmake` are present,
-Rust modules can be authored against the signatures in §5 but **cannot be `cargo
-check`-ed**. Frontend (§4) can be built/typechecked immediately (node+npm present).
+**A2. DEK lifecycle in the Keychain. — S — [INLINE]** (`secrets/keychain.rs`)
+- Add `pub const ACCOUNT_DB_DEK: &str = "murmur_db_dek";` and `get_or_create_db_dek() -> Result<String>` returning a **64-char hex string** (32 random bytes via `getrandom`), reusing the existing `get_secret`/`set_secret` plumbing verbatim. Hex form → SQLCipher consumes it as a raw key blob with **no KDF**.
+- DEK uses plain `keyring` (released at launch, file-theft protection) — **no biometric prompt at launch**. This is deliberately distinct from the KEK (Stage E).
+- New dep: `getrandom` (needs approval — tiny, standard, cryptographic RNG).
 
-> **Why no `ffmpeg` crate dependency in Phase 0:** DESIGN §5.1 specifies ffmpeg mixing
-> for *mic + system* audio. Phase 0 is **mic-only mono**, so we capture directly at the
-> device sample rate via `cpal`, resample to 16 kHz mono in-process, and write WAV with
-> `hound`. This removes a heavy native/bundling dependency from the skeleton. ffmpeg
-> returns in Phase 2 when two tracks must be mixed. `ffmpeg` binary is present on this
-> machine regardless.
+**A3. Key the connection at open. — S — [INLINE]** (`db.rs:56`)
+- Split `Db::open(path)` → fetches DEK, calls new `Db::open_with_key(path, dek_hex)`. The `PRAGMA key = x'<hex>'` must be the **FIRST** statement on the connection, before the existing `PRAGMA foreign_keys/journal_mode` batch at `db.rs:60`. Use `conn.pragma_update(None, "key", format!("x'{dek_hex}'"))` — never string-interpolated `execute_batch`, never log the key or formatted PRAGMA.
+- The first read in `migrate()` (`db.rs:73`) validates the key (wrong key → `SQLITE_NOTADB`). WAL stays (encrypted page-by-page).
+- `open_with_key` is the seam the MCP server reuses (§MCP gotcha) and the migration verify-step reuses.
 
----
+**A4. Safe migration module. — M — [WORKFLOW]** (new `src-tauri/src/storage/migration.rs`)
+- `is_plaintext_sqlite(path)`: read first 16 bytes; plaintext starts with magic `"SQLite format 3\0"`, SQLCipher's first 16 bytes are random salt → magic absent. Non-existent/<16 bytes ⇒ new install ⇒ no migration. This makes detection **idempotent**.
+- `encrypt_in_place(db_path, dek_hex)`: the full sequence — checkpoint+collapse WAL → `VACUUM INTO` plaintext backup (`.pre-encrypt.bak`) → `ATTACH ... KEY x'<hex>'` + `SELECT sqlcipher_export('encrypted')` + `DETACH` → set `user_version` on target (export does NOT copy it) → **fresh-reopen the encrypted target with the DEK** and verify (`cipher_integrity_check`, exact per-table row counts vs source, sample-decrypt of newest meeting `(id,title)`) → atomic `rename` into place → retain backup.
+- **Never `PRAGMA rekey`** (cannot encrypt a plaintext DB; export is mandatory). The original is never mutated until the atomic `rename`; every `?` before it leaves the plaintext DB bit-for-bit intact.
+- This is a new file → delegable, but its **call-site wiring in `state.rs` is [INLINE]** (A5).
 
-## 2. Repository file tree (exact, under `/Users/jakubgawronski/Projects/meetnotes`)
+**A5. Wire migration into AppState::init. — S — [INLINE]** (`state.rs:32`)
+- Before `Db::open`: fetch DEK once; `if migration::needs_encryption(&db_path)? { migration::encrypt_in_place(&db_path, &dek)?; }`; then `Db::open_with_key(&db_path, &dek)`. The rest of the app only ever sees an encrypted DB.
+- Add `error.rs` variant `Migration` (and `Auth`/`Locked` now, used later).
 
-```
-meetnotes/
-├─ docs/
-│  ├─ DESIGN.md
-│  └─ PHASE0-PLAN.md                      # this file
-├─ .gitignore
-├─ package.json                           # frontend + tauri CLI scripts
-├─ package-lock.json
-├─ tsconfig.json
-├─ tsconfig.app.json
-├─ tsconfig.spec.json
-├─ angular.json                           # Angular workspace (single app "meetnotes")
-├─ index.html                             # Tauri/Angular entry (devServer + dist root)
-├─ src/                                   # ── FRONTEND (Angular 18, standalone) ──
-│  ├─ main.ts
-│  ├─ styles.css
-│  ├─ app/
-│  │  ├─ app.config.ts                    # provideZonelessChangeDetection, router, http
-│  │  ├─ app.routes.ts                    # /record (default), /settings
-│  │  ├─ app.component.ts                 # shell: nav + <router-outlet>
-│  │  ├─ core/
-│  │  │  ├─ ipc.service.ts                # thin wrapper over @tauri-apps/api invoke/listen
-│  │  │  ├─ models.ts                     # TS mirrors of Rust DTOs (§6)
-│  │  │  └─ recorder.store.ts             # signal-based state: status, lastNote, error
-│  │  └─ features/
-│  │     ├─ record/
-│  │     │  └─ record.component.ts        # Record/Stop, status line, last-note preview
-│  │     └─ settings/
-│  │        └─ settings.component.ts      # vault path, provider, anthropic key, model path
-│  └─ assets/
-└─ src-tauri/                             # ── RUST CORE ──
-   ├─ Cargo.toml                          # §3
-   ├─ Cargo.lock
-   ├─ build.rs                            # tauri_build::build()
-   ├─ tauri.conf.json                     # window, bundle id, devUrl, frontendDist
-   ├─ capabilities/
-   │  └─ default.json                     # core permissions (no fs/shell exposed to webview)
-   ├─ icons/                              # placeholder app icons
-   └─ src/
-      ├─ main.rs                          # tauri::Builder, manage(AppState), command registry
-      ├─ lib.rs                           # `pub mod` re-exports; `run()` entrypoint
-      ├─ error.rs                         # AppError (thiserror) + Result alias; serde for IPC
-      ├─ state.rs                         # AppState (Mutex-guarded handles), AppConfig
-      ├─ commands.rs                      # ALL #[tauri::command] fns (§7)
-      ├─ events.rs                        # event name constants + payload structs
-      ├─ audio/
-      │  ├─ mod.rs                        # pub use recorder::*, wav::*
-      │  ├─ recorder.rs                   # Recorder (cpal capture → samples buffer)
-      │  └─ wav.rs                        # write 16kHz mono WAV via hound + resample
-      ├─ transcribe/
-      │  ├─ mod.rs                        # pub use whisper::*, types::*
-      │  ├─ types.rs                      # Segment, Transcript
-      │  └─ whisper.rs                    # Transcriber (whisper-rs, Metal)
-      ├─ summarize/
-      │  ├─ mod.rs                        # trait + factory + re-exports
-      │  ├─ provider.rs                   # SummarizerProvider trait, request/availability types
-      │  ├─ claude_code.rs               # ClaudeCodeProvider (spawn `claude -p`)
-      │  ├─ anthropic.rs                  # AnthropicProvider (reqwest → api.anthropic.com)
-      │  ├─ ollama.rs                      # OllamaProvider (reqwest → localhost:11434)
-      │  └─ template.rs                   # default note prompt template
-      ├─ export/
-      │  ├─ mod.rs                        # pub use obsidian::*
-      │  └─ obsidian.rs                   # atomic .md write into vault
-      ├─ storage/
-      │  ├─ mod.rs                        # pub use db::*, models::*
-      │  ├─ db.rs                         # Db (rusqlite Connection wrapper) + migrations
-      │  └─ models.rs                     # Meeting, NoteRecord row structs + status enum
-      ├─ secrets/
-      │  ├─ mod.rs                        # pub use keychain::*
-      │  └─ keychain.rs                   # get/set/delete api key via keyring
-      ├─ settings/
-      │  ├─ mod.rs                        # pub use config::*
-      │  └─ config.rs                     # AppConfig load/save (settings table)
-      └─ pipeline.rs                      # orchestrates capture→transcribe→summarize→export
-```
+**A6. MCP keying fix (the gotcha — must ride with A3/A5). — S — [INLINE]** (`lib.rs:104-108`, `mcp.rs:120`)
+- `mcp.rs` re-derives the path and calls `Db::open(db_path)` on its own thread with **no key** → silently breaks the existing local Claude connection the moment encryption lands. Because `Db::open` now fetches the DEK internally, `mcp.rs:120 Db::open` keeps working **once `Db::open` is the keyed path** — verify the MCP thread can fetch from Keychain off the main thread. This is one of the three "must not break."
+
+> **Stage A gate (MIGRATION SAFETY GATE §3 must fully pass here).** No later stage starts until the migration round-trips on a throwaway copy of real data.
+
+### Stage B — Lock data model + crypto primitives (additive; unblocks C/D/E)
+
+**B1. AES-256-GCM wrap/unwrap primitives. — S — [WORKFLOW]** (new `src-tauri/src/crypto.rs`)
+- `aes_gcm_encrypt/decrypt`, KEK-wrap/unwrap of per-folder content keys. Cell format `nonce(12) || ciphertext || tag(16)` as BLOB. New dep `aes-gcm` (RustCrypto, needs approval) + optional `zeroize`. Deliberately NOT OpenSSL-via-rusqlite — keep app-layer crypto in an auditable Rust crate.
+
+**B2. Folder + lock schema (guarded migration). — M — [INLINE]** (`db.rs::migrate`, `db.rs:73`)
+- Append to the `CREATE TABLE IF NOT EXISTS` batch: `folders` table (`id, path UNIQUE, parent_id, locked INTEGER DEFAULT 0, wrapped_key BLOB, key_nonce BLOB, created_at`) + `idx_folders_parent`.
+- Guarded `ALTER`s (check `pragma_table_info` first, since `migrate()` is idempotent and `ALTER ADD COLUMN` errors if the column exists): `notes.folder_id`, `notes.content_blob` (AES-GCM markdown when sealed; NULL when open). The two analyses differ on whether to also tag `meetings` — reconciled: **govern exposure at the note level** (`notes.folder_id`), because the note is the only artifact exported to the vault and exposed via MCP. Segments/audio are already local-only and never exported.
+- This is the single most conflict-prone edit — one orchestrator pass.
+
+**B3. Folder models + session state. — S — split.**
+- `storage/models.rs`: add `Folder`, `FolderNode { folder, note_count, unlocked, children }`. **[WORKFLOW]**
+- `state.rs:16`: add `unlocked_folders: Arc<Mutex<HashSet<String>>>` (Arc so MCP thread shares it) and `master_kek: Mutex<Option<[u8;32]>>`; init at `state.rs:39`. **[INLINE]**
+
+### Stage C — Lock lifecycle commands (the exposure state machine)
+
+**C1. Db helpers. — M — [INLINE]** (`db.rs`)
+- `insert_folder`, `list_folders`, `count_notes_per_folder`, `set_note_folder`, `folder_for_path`, `set_folder_locked`, content-blob encrypt/decrypt, plus the exposure-aware reads `search_visible`, `list_meetings_visible`, `get_note_if_visible` (for §D). Reuses `crypto.rs`.
+
+**C2. 8 commands + `relock_all_inner`. — M — [INLINE]** (`commands.rs` + register in `lib.rs:48-95`)
+- `list_folders`, `create_folder`, `move_note`, `lock_folder` (no biometric — locking is always safe: generate CK, wrap under KEK, encrypt governed notes' markdown→`content_blob`, blank plaintext, delete `.md` from vault, clear `exported_path`), `unlock_folder` (async — biometric → KEK → unwrap CK → add to `unlocked_folders` for the session; **does NOT re-export**), `relock_folder`, `relock_all` (+ `pub(crate) relock_all_inner` for the screen-share watcher to call without a command boundary), `remove_lock` (permanent: decrypt back to plaintext, re-export `.md`, drop `locked_folders`/clear flags → back to default OPEN).
+- **Lock model the commands enforce** (the AGREED LOCK MODEL): default OPEN; lock is explicit per-folder; session-unlock decrypts for in-app + MCP this session without re-export; permanent remove-lock re-exports; auto-relock on screen-share start clears the session set + zeroizes KEK.
+- **Atomicity rule (F1 risk + DB+CRYPTO §4.4):** lock = DB transaction for column writes, delete the vault `.md` only AFTER commit; treat a leftover `.md` as reconcile-on-next-launch. `move_note` must not commit `exported_path`/`folder_id` before bytes are durable (cross-FS copy-fallback).
+- **Pipeline (`pipeline.rs::resolve_subfolder`, ~`:276`):** Phase 0 simplest — new meetings always land OPEN; sealing is an explicit user action afterward (matches "lock is explicit"). Do not auto-seal at export time in P0.
+
+### Stage D — MCP exposure filter + bearer token
+
+**D1. Thread the unlock set into MCP + 3-state filter. — M — [INLINE]** (`mcp.rs:17/23/61/111`, `lib.rs:104`)
+- `spawn/run/handle_rpc/handle_tool_call` gain `unlocked: Arc<Mutex<HashSet<String>>>` (clone of `AppState.unlocked_folders`); update call site at `lib.rs:104-108`.
+- Swap `mcp.rs:127/147/167` to `_visible` query variants with a `LEFT JOIN folders f ON f.id = n.folder_id WHERE (f.locked IS NULL OR f.locked=0 OR f.id IN (<unlocked>))`.
+- **Decryption-free MCP design (LOCK+MCP analysis §3a):** on `unlock_folder`, decrypt the governed notes' `content_blob` into the plaintext `markdown` column **for the session duration**; re-blank on relock. Then MCP reads plaintext `markdown` exactly as today and only consults the `f.locked / IN (unlocked)` predicate — the KEK never reaches the MCP thread (smaller attack surface).
+
+**D2. Optional bearer token (backward-compatible). — S — [INLINE]** (`mcp.rs:41`)
+- Mint a random token on first launch → Keychain (`murmur_mcp_token`) → write into the managed MCP config so it "just works." Enforce `Authorization: Bearer <token>` only on `tools/call` (`mcp.rs:77`); leave `initialize`/`tools/list`/`ping` open for discovery. Bind stays `127.0.0.1` (`mcp.rs:24`, unchanged). Gate behind `K_MCP_REQUIRE_TOKEN`. This closes the "a local process reads sealed notes during a session" hole without breaking the existing un-authenticated client mid-upgrade.
+
+### Stage E — Biometric KEK release + screen-share auto-relock (the cryptographically-real lock)
+
+**E1. Biometric KEK release. — M — [WORKFLOW]** (new `src-tauri/src/biometric.rs`)
+- Use **`tauri-plugin-biometry` (Choochmeque fork)**, NOT the official `tauri-plugin-biometric` (Android/iOS only — no macOS Touch ID). The fork's `macos.rs` is real `objc2-local-authentication` + `objc2-security`, sets `kSecUseDataProtectionKeychain = true` (the flag that makes `kSecAttrAccessControl` honored), carries the prompt via `kSecUseAuthenticationContext`.
+- Store the **master KEK** (32 random bytes) via the plugin's `set_data` behind the biometric ACL once at first lock setup. `unlock_folder` → `get_data(reason)` triggers Touch ID → returns KEK → unwrap the folder's `wrapped_key`.
+- **Correction to the spec wording (decision needed):** the fork uses `SecAccessControlCreateFlags::UserPresence`; for locked notes prefer **`BiometryCurrentSet`** (auto-invalidates the entry when the enrolled fingerprint set changes) — a one-line change in the vendored plugin. Recommend `BiometryCurrentSet`; optionally `| DevicePasscode` for a passcode escape hatch. **This is the boolean-theater closer** (spec §5.2, §F2 risk #1): the KEK bytes are physically inaccessible without a passing Touch ID. Requires real code-signing (`entitlements.plist` present); ad-hoc signing may work in dev, production needs Developer ID.
+- Register `.plugin(tauri_plugin_biometry::init())` at `lib.rs:35` — **[INLINE]**. New dep `tauri-plugin-biometry` (needs approval).
+
+**E2. Screen-share watcher → auto-relock. — M — [WORKFLOW]** (new `src-tauri/src/screenshare.rs`, spawned from `lib.rs::setup` ~`:96` — **[INLINE]** spawn line)
+- **Verdict: feasible and event-driven on macOS 12+.** Primary: observe `NSScreen.isCaptured` via an `NSNotificationCenter` observer (the public, App-Store-safe signal that posts on capture-state change; objc2 stack the biometry plugin already pulls in). On `false→true`, call `relock_all_inner` (clear `unlocked_folders` + zeroize `master_kek`) and emit `EVENT_STATUS`/a new `murmur://screen-share-started` so the UI toasts.
+- Fallback: 1–2s `tokio::interval` polling `NSScreen.isCaptured` on the rising edge (the model says "on start, not a timer" — a 1s poll achieves the same user-visible behavior and is the pragmatic P0 fallback). **Do NOT use `CGDisplayIsCaptured()`** (deprecated + semantically wrong — exclusive-render, not screen-share).
+- **Honest dent (state in UI):** full-screen/display share is caught; single-window WebRTC share (Meet-in-a-Chrome-tab) may not flip whole-screen `isCaptured` — same blind spot as the existing `detect_meeting_app`. Relock is best-effort hiding; it does not recall what's already on screen.
+
+**E3. Config flags. — S — [INLINE]** (`settings/config.rs:63+`)
+- `K_DB_ENCRYPTED`, `K_LOCK_ENABLED`, `K_MCP_REQUIRE_TOKEN`, `K_RELOCK_ON_SCREENSHARE` — add to the key-constant block + `load`/`save`.
+
+### Stage F — Rich folder UI (Angular; depends only on the IPC contract, can start in parallel against stubs)
+
+All Standalone + OnPush + `inject()` + signals/`computed`/`output()`/`input()`; no `@Input/@Output/EventEmitter`, no `*ngIf/*ngFor`, no `markForCheck`, no `subscribe()` for streams, no `setTimeout` in components (`afterNextRender` for focus), timeouts only in services with `DestroyRef.onDestroy`. Zero new npm packages. Inline SVG icons (no `lucide-angular`).
+
+**F1. IPC + models contract. — S — [WORKFLOW]** (`core/models.ts`, `core/ipc.service.ts`)
+- Types: `FolderNode { id, name, parentId, noteCount, noteCountRecursive, locked, children }`, `UnlockResult`, extend `Meeting` with `folderId`. Methods mirror the command surface (snake_case invoke, camelCase args): `listFolders`, `createFolder`, `moveNote`, `listMeetingsByFolder`, `setFolderLocked`, `unlockFolderSession`, `relockSessionFolders`, `onScreenShareStarted`; const `EVENT_SCREEN_SHARE_STARTED = "murmur://screen-share-started"`. **Compiles against backend stubs → unblocks all FE work.**
+
+**F2. ToastService + slot in AppComponent. — S — [WORKFLOW]** (new `services/toast.service.ts`) — tracked-timeout queue with `DestroyRef.onDestroy`.
+
+**F3. FoldersService signal store. — S — [WORKFLOW]** — `tree`, `loading`, `sessionUnlocked: signal<ReadonlySet<string>>`, `unlockedCount = computed`, `exposureOf(f) → 'open'|'locked'|'session'`; ops `load/create/moveNote/setLocked/sessionUnlock/relockAllSession`. Plain signal service (this app uses signal services, not NgRx).
+
+**F4. LockBadgeComponent. — S — [WORKFLOW]** — pure input-driven 3-state (`open`/`locked`/`session`) badge, tokens only, `aria-label` per state, `rise`/`--ease-spring` motion respecting `prefers-reduced-motion`.
+
+**F5. FolderRow + FolderTree. — M — [WORKFLOW]** — recursive tree via child-component recursion (not `*ngFor`); inline create (`afterNextRender` focus); `output<string|null>()` selection; per-folder `.count` chip.
+
+**F6. MoveToMenuComponent. — S — [WORKFLOW]** — popover folder picker (DnD-lite; **decision: ship Move menu for v1, not drag-and-drop** — same IPC, keyboard-accessible, upgradeable later). **Lock-state guard confirm is load-bearing:** moving INTO a locked folder warns "encrypts + removes Markdown from vault"; moving OUT warns "re-exports plaintext."
+
+**F7. LibraryComponent two-pane refactor. — M — [WORKFLOW]** — folder tree left + existing list right; `activeFolderId` signal; `folderMeetings`/`folderLoading` mirroring the existing `tagMeetings` machinery (latest-wins stale guard); `displayedMeetings` 3-way computed (search > folder > tag > all) — **no existing branch removed**. Locked rows render `app-lock-badge` + masked title until session-unlock.
+
+**F8. DetailComponent Move action + read-only badge. — S — [WORKFLOW]**
+
+**F9. ScreenShareService + wire into AppComponent. — S — [WORKFLOW]** — listens `onScreenShareStarted` → `relockAllSession()` → toast; init in `AppComponent` main-window only (guard `if (isBar()) return;`).
+
+**F10. "N unlocked this session" pill + Settings honest-boundary copy. — S — [WORKFLOW]** — pill is `computed` over the service (zero polling); Settings privacy-card gets the copy-only "locked notes are pulled from the vault; open notes remain plaintext `.md`" paragraph (the spec's honest vault boundary).
 
 ---
 
-## 3. `src-tauri/Cargo.toml` — pinned dependency list
+## 2. CONFLICT MAP
 
-```toml
-[package]
-name = "meetnotes"
-version = "0.0.0"
-description = "MeetNotes — local meeting capture, transcription, and AI notes for Obsidian"
-edition = "2021"
-rust-version = "1.77"
+**Shared Rust files → serial [INLINE] by orchestrator (never two workflows editing the same file):**
 
-[lib]
-name = "meetnotes_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+| File | Edited in stages | Why serial |
+|---|---|---|
+| `Cargo.toml` | A1, B1, E1 | feature flip + 3 new deps; one consolidated dep-approval pass |
+| `storage/db.rs` | A3 (`open`/`open_with_key`), B2 (schema+guarded ALTER), C1 (helpers) | one file, three stages — **most conflict-prone**, fully serial |
+| `state.rs` | A5 (migration wire), B3 (session fields) | `AppState` struct + `init` |
+| `lib.rs` | A6 (MCP keying), C2 (+8 handlers at `:48`), D1 (pass unlocked set at `:104`), E1 (`.plugin` at `:35`), E2 (spawn watcher at `:96`) | five distinct line-regions; do as one pass per stage |
+| `mcp.rs` | A6/D1 (thread unlocked set, `_visible` swaps), D2 (token at `:41`) | server file |
+| `settings/config.rs` | E3 (flags) | key block + load/save |
+| `error.rs` | A5 (`Migration`, `Auth`, `Locked`) | one small pass |
+| `commands.rs` | C2 (8 commands) | large file (47KB) — one stage owns it |
 
-[build-dependencies]
-tauri-build = { version = "2.2", features = [] }
+**New modules / isolated surfaces → parallel [WORKFLOW] (no shared-file contention):**
+- `storage/migration.rs` (A4), `crypto.rs` (B1), `biometric.rs` (E1), `screenshare.rs` (E2) — new files; only their **call-site wiring** in `state.rs`/`lib.rs` is INLINE.
+- All of Stage F (Angular) — entirely separate from Rust; can start as soon as the F1 IPC contract is fixed, against backend stubs. New FE files (`folder-tree`, `folder-row`, `lock-badge`, `move-to-menu`, `folders.service`, `toast.service`, `screen-share.service`) are independent; only `library.component.ts`, `detail.component.ts`, `app.component.ts`, `ipc.service.ts`, `models.ts` are shared-FE and should be serialized among FE tasks.
 
-[dependencies]
-# ── Tauri shell ──
-tauri = { version = "2.11", features = ["macos-private-api"] }
-tauri-plugin-dialog = "2.2"          # native folder/file picker for vault path + model file
-
-# ── Audio capture + WAV ──
-cpal = "0.16"                        # cross-platform mic capture (CoreAudio on macOS)
-hound = "3.5"                        # WAV reader/writer (16-bit PCM)
-rubato = "0.16"                      # sample-rate conversion → 16 kHz mono for Whisper
-
-# ── Transcription ──
-whisper-rs = { version = "0.16", features = ["metal"] }   # whisper.cpp bindings, Metal accel
-                                                          # (pulls whisper-rs-sys; needs cmake+clang)
-
-# ── HTTP (Anthropic + Ollama providers) ──
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-
-# ── Async runtime ──
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "io-util", "time", "sync"] }
-async-trait = "0.1"                  # for the SummarizerProvider trait
-
-# ── Storage ──
-rusqlite = { version = "0.32", features = ["bundled"] }   # bundled SQLite — no system dep
-
-# ── Serde ──
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-
-# ── Errors ──
-anyhow = "1"                         # internal error plumbing in modules
-thiserror = "1"                      # typed AppError surfaced over IPC
-
-# ── Secrets ──
-keyring = { version = "3", features = ["apple-native"] }  # macOS Keychain (stay on v3, NOT v4)
-
-# ── Misc ──
-chrono = { version = "0.4", features = ["clock", "serde"] }   # timestamps / filename dates
-dirs = "5"                           # locate default vault / app-data dirs
-uuid = { version = "1", features = ["v4"] }                   # meeting ids
-tracing = "0.1"                      # structured logging (NO PII — ids only)
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-[features]
-# default keeps Metal on for whisper; nothing else conditional in P0
-default = []
-```
-
-**Crate-choice rationale (load-bearing):**
-- `rusqlite` over `sqlx`: Phase 0 is synchronous, single-process, embedded; `bundled`
-  feature compiles SQLite in (no system lib, no `cmake` for SQLite, no async runtime
-  coupling). DESIGN allows "rusqlite or sqlx" — we pin **rusqlite**.
-- `hound` + `rubato` instead of ffmpeg: pure-Rust WAV + resample; avoids bundling ffmpeg
-  for a mic-only mono skeleton (see §1 note).
-- `keyring` **v3** (not v4): v4 split into `keyring-core` + separate store crates with a
-  different API; v3 with `apple-native` is the stable, documented macOS path.
-- `reqwest` with `rustls-tls` (not native-tls): avoids OpenSSL system dependency.
-- `tokio` `process` feature: required to spawn `claude -p` for `ClaudeCodeProvider`.
+**Parallelization summary:** Stage A is a hard serial prefix (foundation). Once A lands, B1/crypto + F1-F10 frontend can run in parallel. C/D/E share `db.rs`/`lib.rs`/`mcp.rs` and must serialize among themselves but can overlap the frontend.
 
 ---
 
-## 4. Frontend stack decision
+## 3. MIGRATION SAFETY GATE (ordered checklist — run before the flag ships to any real DB)
 
-**Chosen: Angular 18 (standalone components, zoneless change detection) + Vite-style
-Angular CLI dev server, talking to the core via `@tauri-apps/api`.**
+Run top-to-bottom; do not advance on a failure. This gate IS the Stage-A exit criterion.
 
-Justification (brief):
-- The team knows **TypeScript/Angular** (explicit constraint) — zero ramp-up, and the
-  house Angular conventions (signals-first, standalone, `inject()`, `@if`/`@for`) carry
-  over directly. Phase 0 has 2 screens; Angular's overhead is negligible at this size and
-  pays off as the UI grows (Library/Detail/Onboarding in later phases).
-- Tauri is frontend-agnostic; it serves a static `dist/` and exposes `invoke`/`listen`.
-  Angular CLI's dev server (HMR) is used as Tauri `devUrl` in dev, and `ng build` output
-  (`dist/meetnotes/browser`) is the `frontendDist` for the bundle. No SSR.
-- **Zoneless** (`provideZonelessChangeDetection`) keeps it light and signal-driven, which
-  matches the event/`listen`-based status updates from the Rust core cleanly via signals.
+1. **Rust round-trip unit tests green** (file-backed `tempfile`, not in-memory, since `sqlcipher_export`+`rename` are file ops; extend `db.rs` tests ~`:862`):
+   - `encrypt_migration_round_trips` — plaintext DB with known fixtures (3 meetings, segments, 2 notes, tags, timeline) → `encrypt_in_place` → assert no longer plaintext, `.pre-encrypt.bak` exists and IS plaintext, reopen with DEK and every row count + known `(id,title)` + known segment text read back **byte-identical**.
+   - `wrong_key_fails_closed` — different key errors (no silent empty DB).
+   - `migration_is_idempotent` — second run is a no-op, data intact.
+   - `migration_rollback_on_verify_failure` — forced verify failure leaves the original plaintext DB **untouched**, no partial replacement.
+   - `fresh_install_no_migration` — non-existent path ⇒ `Db::open` creates a fresh encrypted DB.
+   - `brand_data_survives_lock_unlock` (Layer 2) — lock folder → column opaque to raw read → session-key decrypt → plaintext returns; wrong CK fails.
+2. **Throwaway real-shaped harness** (cargo example / ignored test): COPY the developer's actual `~/Library/Application Support/MeetNotes/meetnotes.sqlite` to a throwaway temp path (NEVER the original) → run the full `AppState::init` migration path against the copy with a throwaway DEK → diff row counts + a sample of every table copy-vs-encrypted. **Must pass on real-world data shape/volume before the flag ships.**
+3. **Manual E2E on a disposable profile:** point the built app at a throwaway app-data dir seeded with a plaintext DB → confirm first-launch migrates → app reads all meetings → `.pre-encrypt.bak` present → **MCP server still works** (the keying gotcha: `mcp.rs:120 Db::open` succeeds because `Db::open` now fetches the DEK) → second cold launch skips migration (idempotent).
+4. **Universal-build runtime gate (A1):** green `tauri build --target universal-apple-darwin` + launch on both arm64 and x86_64.
+5. **Backup retention:** `.pre-encrypt.bak` retained for one launch cycle; documented disaster-recovery path (a user reporting lost data has the plaintext snapshot on disk).
 
-### `package.json` (frontend + Tauri CLI) — pinned npm deps
-```jsonc
-{
-  "name": "meetnotes",
-  "version": "0.0.0",
-  "scripts": {
-    "start": "ng serve --port 1420",          // Tauri devUrl
-    "build": "ng build",                       // → dist/meetnotes/browser
-    "tauri": "tauri",
-    "dev": "tauri dev",
-    "bundle": "tauri build"
-  },
-  "dependencies": {
-    "@angular/animations": "^18.2.0",
-    "@angular/common": "^18.2.0",
-    "@angular/compiler": "^18.2.0",
-    "@angular/core": "^18.2.0",
-    "@angular/forms": "^18.2.0",
-    "@angular/platform-browser": "^18.2.0",
-    "@angular/platform-browser-dynamic": "^18.2.0",
-    "@angular/router": "^18.2.0",
-    "rxjs": "^7.8.0",
-    "tslib": "^2.6.0",
-    "zone.js": "^0.15.0",                      // present but zoneless CD used; kept for CLI compat
-    "@tauri-apps/api": "^2.0.0",
-    "@tauri-apps/plugin-dialog": "^2.0.0"
-  },
-  "devDependencies": {
-    "@angular/cli": "^18.2.0",
-    "@angular/compiler-cli": "^18.2.0",
-    "@angular-devkit/build-angular": "^18.2.0",
-    "@tauri-apps/cli": "^2.0.0",
-    "typescript": "~5.5.0"
-  }
-}
-```
-> Angular 18 (not 21) is pinned for Phase 0 because it is the proven-stable combination
-> with Tauri 2's static-serve model and the team's existing tooling; upgrading is a
-> mechanical later step. Conventions (signals, standalone, `@if`/`@for`) are identical.
-
-`tauri.conf.json` key fields:
-- `build.devUrl = "http://localhost:1420"`, `build.beforeDevCommand = "npm run start"`
-- `build.frontendDist = "../dist/meetnotes/browser"`, `build.beforeBuildCommand = "npm run build"`
-- `app.windows[0] = { title: "MeetNotes", width: 900, height: 680 }`
-- `identifier = "com.meetnotes.app"`
+Invariant proven by this gate: **the original `db_path` is never mutated until a fully-verified encrypted copy exists; the only mutating moment is the atomic APFS `rename`.**
 
 ---
 
-## 5. Rust module public API (EXACT signatures — the interface contract)
-
-> These signatures are **binding**. Each module is implementable in isolation against
-> them. Cross-module calls use only what is listed here. Internal helpers are free.
-> `Result<T>` below means `crate::error::Result<T>` unless qualified.
-
-### 5.1 `error.rs`
-```rust
-use serde::Serialize;
-
-#[derive(Debug, thiserror::Error)]
-pub enum AppError {
-    #[error("audio capture error: {0}")]
-    Audio(String),
-    #[error("transcription error: {0}")]
-    Transcribe(String),
-    #[error("summarizer error: {0}")]
-    Summarize(String),
-    #[error("export error: {0}")]
-    Export(String),
-    #[error("storage error: {0}")]
-    Storage(String),
-    #[error("secrets error: {0}")]
-    Secrets(String),
-    #[error("config error: {0}")]
-    Config(String),
-    #[error("provider unavailable: {0}")]
-    Unavailable(String),
-    #[error("invalid argument: {0}")]
-    InvalidArg(String),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
-pub type Result<T> = std::result::Result<T, AppError>;
-
-// IPC: AppError serializes to a string message so Tauri commands can return it.
-impl Serialize for AppError {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error>;
-}
-```
-
-### 5.2 `state.rs`
-```rust
-use std::sync::Mutex;
-use crate::audio::Recorder;
-use crate::storage::Db;
-use crate::settings::AppConfig;
-
-pub struct AppState {
-    pub recorder: Mutex<Option<Recorder>>,   // Some while recording
-    pub db: Db,                               // Db is internally Send+Sync (Mutex<Connection>)
-    pub config: Mutex<AppConfig>,             // in-memory cache of settings table
-    pub current_meeting: Mutex<Option<uuid::Uuid>>,
-}
-
-impl AppState {
-    /// Open DB at app-data dir, run migrations, load config. Called once in main.rs.
-    pub fn init() -> crate::error::Result<Self>;
-}
-```
-
-### 5.3 `events.rs`
-```rust
-use serde::Serialize;
-
-pub const EVENT_STATUS: &str = "meetnotes://status";
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StatusPayload {
-    pub stage: String,        // "idle" | "recording" | "transcribing" | "summarizing" | "exporting" | "done" | "error"
-    pub message: String,      // human-readable, NO PII
-    pub meeting_id: Option<String>,
-}
-```
-
-### 5.4 `audio/recorder.rs`
-```rust
-use crate::error::Result;
-
-/// Owns the cpal input stream and accumulates mono f32 samples at the device rate.
-pub struct Recorder {
-    // private: stream handle, shared sample buffer, source_sample_rate
-}
-
-impl Recorder {
-    /// Open default input device, start capturing. Non-blocking; capture runs on cpal thread.
-    pub fn start() -> Result<Self>;
-
-    /// Stop the stream, return (mono_samples_at_source_rate, source_sample_rate_hz).
-    pub fn stop(self) -> Result<(Vec<f32>, u32)>;
-
-    /// Current peak level 0.0..=1.0 for the UI meter (best-effort, lock-free read).
-    pub fn level(&self) -> f32;
-}
-```
-
-### 5.5 `audio/wav.rs`
-```rust
-use std::path::Path;
-use crate::error::Result;
-
-pub const TARGET_RATE_HZ: u32 = 16_000;
-
-/// Resample mono f32 @ src_rate to 16 kHz mono and write 16-bit PCM WAV to `path`.
-pub fn write_wav_16k_mono(path: &Path, samples: &[f32], src_rate: u32) -> Result<()>;
-
-/// Resample mono f32 @ src_rate to 16 kHz mono f32 (in-memory, for Whisper input).
-pub fn resample_to_16k(samples: &[f32], src_rate: u32) -> Result<Vec<f32>>;
-```
-
-### 5.6 `transcribe/types.rs`
-```rust
-use serde::{Serialize, Deserialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Segment {
-    pub idx: i64,
-    pub start_s: f64,
-    pub end_s: f64,
-    pub text: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Transcript {
-    pub full_text: String,
-    pub segments: Vec<Segment>,
-    pub language: Option<String>,
-}
-```
-
-### 5.7 `transcribe/whisper.rs`
-```rust
-use std::path::Path;
-use crate::error::Result;
-use crate::transcribe::types::Transcript;
-
-/// Wraps a loaded whisper.cpp model (Metal). Construct once; reuse per transcription.
-pub struct Transcriber {
-    // private: WhisperContext
-}
-
-impl Transcriber {
-    /// Load a GGUF model from `model_path`. Errors if file missing or load fails.
-    pub fn load(model_path: &Path) -> Result<Self>;
-
-    /// Transcribe 16 kHz mono f32 samples. `lang` = Some("en") or None for auto.
-    pub fn transcribe(&self, samples_16k_mono: &[f32], lang: Option<&str>) -> Result<Transcript>;
-}
-```
-
-### 5.8 `summarize/provider.rs`
-```rust
-use async_trait::async_trait;
-use serde::{Serialize, Deserialize};
-use crate::error::Result;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MeetingMeta {
-    pub date_iso: String,          // "2026-06-24"
-    pub title_hint: Option<String>,
-    pub duration_s: i64,
-    pub language: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct SummarizeRequest {
-    pub transcript: String,
-    pub meta: MeetingMeta,
-    pub template: String,          // note-format prompt (summarize/template.rs)
-    pub vault_titles: Vec<String>, // existing note titles → [[link]] targets
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum Availability {
-    Available,
-    Unavailable { reason: String },
-}
-
-#[async_trait]
-pub trait SummarizerProvider: Send + Sync {
-    /// Stable id: "claude_code" | "anthropic" | "ollama".
-    fn id(&self) -> &str;
-
-    /// Cheap, non-failing readiness probe (key set? ollama up? claude in PATH?).
-    async fn availability(&self) -> Availability;
-
-    /// Produce finished Obsidian-ready Markdown from the request.
-    async fn summarize(&self, req: &SummarizeRequest) -> Result<String>;
-}
-```
-
-### 5.9 `summarize/mod.rs` (factory)
-```rust
-use std::sync::Arc;
-use crate::summarize::provider::SummarizerProvider;
-use crate::settings::AppConfig;
-
-pub mod provider;
-pub mod claude_code;
-pub mod anthropic;
-pub mod ollama;
-pub mod template;
-
-pub use provider::{SummarizerProvider as _, MeetingMeta, SummarizeRequest, Availability};
-
-/// Default provider id when settings unset.
-pub const DEFAULT_PROVIDER_ID: &str = "claude_code";
-
-/// Build a provider by id, wiring config + secrets. Unknown id → AppError::InvalidArg.
-pub fn make_provider(id: &str, config: &AppConfig) -> crate::error::Result<Arc<dyn SummarizerProvider>>;
-
-/// All three provider instances (for availability fan-out in Settings UI).
-pub fn all_providers(config: &AppConfig) -> Vec<Arc<dyn SummarizerProvider>>;
-```
-
-### 5.10 `summarize/claude_code.rs`
-```rust
-use crate::summarize::provider::*;
-
-pub struct ClaudeCodeProvider {
-    // private: binary path (default "claude"), system prompt
-}
-
-impl ClaudeCodeProvider {
-    pub fn new() -> Self;
-    pub fn with_binary(path: String) -> Self;
-}
-
-#[async_trait::async_trait]
-impl SummarizerProvider for ClaudeCodeProvider {
-    fn id(&self) -> &str;                                   // "claude_code"
-    async fn availability(&self) -> Availability;          // `which claude` reachable?
-    async fn summarize(&self, req: &SummarizeRequest) -> crate::error::Result<String>;
-    // spawns: claude -p --system-prompt <tpl> --disallowedTools <all> ; stdin = transcript;
-    // validates stdout starts with "---" (front-matter) else AppError::Summarize.
-}
-```
-
-### 5.11 `summarize/anthropic.rs`
-```rust
-use crate::summarize::provider::*;
-
-pub struct AnthropicProvider {
-    // private: reqwest::Client, model id, api_key (loaded from Keychain at construction)
-}
-
-impl AnthropicProvider {
-    /// `api_key` already resolved from Keychain by the factory. model defaults to
-    /// "claude-opus-4-8" if config value empty.
-    pub fn new(api_key: Option<String>, model: String) -> Self;
-}
-
-#[async_trait::async_trait]
-impl SummarizerProvider for AnthropicProvider {
-    fn id(&self) -> &str;                                   // "anthropic"
-    async fn availability(&self) -> Availability;          // key present? (no network call)
-    async fn summarize(&self, req: &SummarizeRequest) -> crate::error::Result<String>;
-    // POST https://api.anthropic.com/v1/messages, headers x-api-key + anthropic-version
-    // "2023-06-01"; system=template, user=transcript+meta; returns content[0].text.
-}
-```
-
-### 5.12 `summarize/ollama.rs`
-```rust
-use crate::summarize::provider::*;
-
-pub struct OllamaProvider {
-    // private: reqwest::Client, base_url (default http://localhost:11434), model
-}
-
-impl OllamaProvider {
-    pub fn new(base_url: String, model: String) -> Self;   // model e.g. "llama3.1"
-}
-
-#[async_trait::async_trait]
-impl SummarizerProvider for OllamaProvider {
-    fn id(&self) -> &str;                                   // "ollama"
-    async fn availability(&self) -> Availability;          // GET {base}/api/tags reachable?
-    async fn summarize(&self, req: &SummarizeRequest) -> crate::error::Result<String>;
-    // POST {base}/api/generate { model, prompt:(template+transcript), stream:false }
-}
-```
-
-### 5.13 `summarize/template.rs`
-```rust
-use crate::summarize::provider::SummarizeRequest;
-
-/// The canonical Obsidian note-format prompt (front-matter + sections), shared by all providers.
-pub fn default_template() -> String;
-
-/// Render the full prompt text a provider sends (template + meta + vault titles + transcript).
-pub fn render_prompt(req: &SummarizeRequest) -> String;
-```
-
-### 5.14 `export/obsidian.rs`
-```rust
-use std::path::{Path, PathBuf};
-use crate::error::Result;
-
-/// Atomically write `markdown` into `vault_dir` (optionally `subfolder`) as a uniquely
-/// named .md file derived from `title` + `date_iso`. Writes to a dotfile `.tmp` then
-/// renames. On name collision appends " (N)". Returns the final path written.
-pub fn write_note(
-    vault_dir: &Path,
-    subfolder: Option<&str>,
-    title: &str,
-    date_iso: &str,
-    markdown: &str,
-) -> Result<PathBuf>;
-
-/// List existing note titles (file stems of *.md) in the vault for [[link]] suggestions.
-pub fn list_vault_titles(vault_dir: &Path) -> Result<Vec<String>>;
-```
-
-### 5.15 `storage/models.rs`
-```rust
-use serde::{Serialize, Deserialize};
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum MeetingStatus { Draft, Recording, Transcribed, Summarized, Exported, Error }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Meeting {
-    pub id: String,                 // uuid
-    pub started_at: String,         // ISO 8601
-    pub ended_at: Option<String>,
-    pub title: Option<String>,
-    pub duration_s: i64,
-    pub audio_path: Option<String>,
-    pub status: MeetingStatus,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NoteRecord {
-    pub meeting_id: String,
-    pub provider_id: String,
-    pub markdown: String,
-    pub created_at: String,
-    pub exported_path: Option<String>,
-}
-```
-
-### 5.16 `storage/db.rs`
-```rust
-use std::path::Path;
-use crate::error::Result;
-use crate::storage::models::{Meeting, MeetingStatus, NoteRecord};
-use crate::transcribe::types::Segment;
-
-/// Thread-safe SQLite wrapper (internal Mutex<rusqlite::Connection>).
-pub struct Db { /* private */ }
-
-impl Db {
-    pub fn open(path: &Path) -> Result<Self>;     // opens + runs migrations
-    pub fn migrate(&self) -> Result<()>;          // idempotent CREATE TABLE IF NOT EXISTS
-
-    pub fn insert_meeting(&self, m: &Meeting) -> Result<()>;
-    pub fn update_meeting_status(&self, id: &str, status: MeetingStatus) -> Result<()>;
-    pub fn finalize_meeting(&self, id: &str, ended_at: &str, duration_s: i64, audio_path: &str) -> Result<()>;
-    pub fn set_meeting_title(&self, id: &str, title: &str) -> Result<()>;
-    pub fn get_meeting(&self, id: &str) -> Result<Option<Meeting>>;
-    pub fn latest_meeting(&self) -> Result<Option<Meeting>>;
-
-    pub fn insert_segments(&self, meeting_id: &str, segments: &[Segment]) -> Result<()>;
-
-    pub fn upsert_note(&self, note: &NoteRecord) -> Result<()>;
-    pub fn get_note(&self, meeting_id: &str, provider_id: &str) -> Result<Option<NoteRecord>>;
-    pub fn latest_note(&self) -> Result<Option<NoteRecord>>;
-    pub fn set_note_exported_path(&self, meeting_id: &str, provider_id: &str, path: &str) -> Result<()>;
-
-    // settings k/v table
-    pub fn get_setting(&self, key: &str) -> Result<Option<String>>;
-    pub fn set_setting(&self, key: &str, value: &str) -> Result<()>;
-    pub fn all_settings(&self) -> Result<Vec<(String, String)>>;
-}
-```
-SQL migrations (created by `migrate()`):
-```sql
-CREATE TABLE IF NOT EXISTS meetings (
-  id TEXT PRIMARY KEY, started_at TEXT NOT NULL, ended_at TEXT,
-  title TEXT, duration_s INTEGER NOT NULL DEFAULT 0,
-  audio_path TEXT, status TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS segments (
-  meeting_id TEXT NOT NULL, idx INTEGER NOT NULL,
-  start_s REAL NOT NULL, end_s REAL NOT NULL, text TEXT NOT NULL,
-  PRIMARY KEY (meeting_id, idx),
-  FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE);
-CREATE TABLE IF NOT EXISTS notes (
-  meeting_id TEXT NOT NULL, provider_id TEXT NOT NULL,
-  markdown TEXT NOT NULL, created_at TEXT NOT NULL, exported_path TEXT,
-  PRIMARY KEY (meeting_id, provider_id),
-  FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE);
-CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-```
-
-### 5.17 `secrets/keychain.rs`
-```rust
-use crate::error::Result;
-
-pub const SERVICE: &str = "com.meetnotes.app";
-
-/// account is the provider key name, e.g. "anthropic_api_key".
-pub fn set_secret(account: &str, secret: &str) -> Result<()>;
-pub fn get_secret(account: &str) -> Result<Option<String>>;   // None if not found
-pub fn delete_secret(account: &str) -> Result<()>;             // Ok if already absent
-```
-
-### 5.18 `settings/config.rs`
-```rust
-use serde::{Serialize, Deserialize};
-use crate::error::Result;
-use crate::storage::Db;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AppConfig {
-    pub provider_id: String,           // default "claude_code"
-    pub vault_path: Option<String>,
-    pub vault_subfolder: Option<String>,
-    pub whisper_model_path: Option<String>,
-    pub language: Option<String>,      // "en" | None=auto
-    pub anthropic_model: String,       // default "claude-opus-4-8"
-    pub ollama_base_url: String,       // default "http://localhost:11434"
-    pub ollama_model: String,          // default "llama3.1"
-    pub claude_binary: String,         // default "claude"
-}
-
-impl Default for AppConfig {
-    fn default() -> Self; // fills the defaults above
-}
-
-impl AppConfig {
-    /// Read all known keys from the settings table, falling back to Default.
-    pub fn load(db: &Db) -> Result<Self>;
-    /// Persist every field into the settings table (NOT the api key — that's Keychain).
-    pub fn save(&self, db: &Db) -> Result<()>;
-}
-```
-
-### 5.19 `pipeline.rs` (orchestration)
-```rust
-use std::path::PathBuf;
-use tauri::AppHandle;
-use crate::error::Result;
-use crate::state::AppState;
-
-/// Full post-Stop pipeline: write WAV → transcribe → persist segments → summarize with
-/// configured provider → persist note → export .md → update meeting status. Emits
-/// StatusPayload on EVENT_STATUS at each stage. Returns the exported note path + markdown.
-pub struct PipelineResult { pub note_markdown: String, pub exported_path: PathBuf, pub meeting_id: String }
-
-pub async fn run_after_stop(
-    app: &AppHandle,
-    state: &AppState,
-    meeting_id: &str,
-    samples: Vec<f32>,
-    src_rate: u32,
-    duration_s: i64,
-) -> Result<PipelineResult>;
-```
-
-### 5.20 `lib.rs` / `main.rs`
-```rust
-// lib.rs
-pub mod error; pub mod state; pub mod events; pub mod commands; pub mod pipeline;
-pub mod audio; pub mod transcribe; pub mod summarize; pub mod export;
-pub mod storage; pub mod secrets; pub mod settings;
-pub fn run();   // builds tauri::Builder, manages AppState, registers commands, runs app
-
-// main.rs
-fn main() { meetnotes_lib::run(); }
-```
+## 4. COMMIT SEQUENCE (with gates)
+
+Branch off `main` (never target main). One logical commit per item; CI gate = `NX_DAEMON=false cargo build` + `cargo test` for Rust, lint/test/build for FE; runtime gate where noted.
+
+1. `feat(crypto): SQLCipher feature flip + keyed Db::open + DEK in Keychain` (A1–A3) — **gate: universal-build runtime test (§3.4) + `db.rs` tests.**
+2. `feat(crypto): safe plaintext→encrypted migration + verify + atomic swap` (A4–A5, error variants) — **gate: full MIGRATION SAFETY GATE §3.1–§3.3. This is the destructive-step commit — most scrutiny.**
+3. `fix(mcp): key the MCP DB handle so local Claude survives encryption` (A6) — **gate: manual MCP E2E §3.3.**
+4. `feat(crypto): AES-GCM content primitives + folder/lock schema` (B1–B3) — **gate: `crypto.rs` + schema-idempotency tests.**
+5. `feat(folders): lock lifecycle commands + Db helpers` (C1–C2) — **gate: `brand_data_survives_lock_unlock` + lock/unlock atomicity tests.**
+6. `feat(mcp): exposure-aware visibility filter + optional bearer token` (D1–D2) — **gate: 3-state filter test (sealed hidden / open visible / session-unlocked visible) + token-backward-compat check.**
+7. `feat(security): biometric KEK release (.biometryCurrentSet)` (E1, config flags) — **gate: code-signed build + real Touch ID prompt releases key (NOT a boolean); biometric-change invalidation.**
+8. `feat(security): screen-share auto-relock watcher` (E2) — **gate: live screen-share start → session keys zeroized → MCP + in-app revert to opaque.**
+9. `feat(ui): folder IPC contract + ToastService + FoldersService` (F1–F3).
+10. `feat(ui): LockBadge + FolderTree/FolderRow + MoveToMenu` (F4–F6).
+11. `feat(ui): Library two-pane + Detail move + ScreenShare auto-relock + Settings copy` (F7–F10) — **gate: lint/test/build green; manual walkthrough lock→Touch-ID-unlock→screen-share-relock.**
 
 ---
 
-## 6. Frontend DTO mirrors (`src/app/core/models.ts`)
+## 5. OPEN RISKS + THE 3 THINGS THAT MUST NOT BREAK
 
-TypeScript interfaces mirroring the `camelCase`-serialized Rust types so the UI compiles
-against the same contract:
-```ts
-export type Stage = 'idle'|'recording'|'transcribing'|'summarizing'|'exporting'|'done'|'error';
-export interface StatusPayload { stage: Stage; message: string; meetingId: string|null; }
-export type Availability = { Available: true } | { Unavailable: { reason: string } };
-export interface ProviderStatus { id: string; available: boolean; reason?: string; }
-export interface AppConfigDto {
-  providerId: string; vaultPath: string|null; vaultSubfolder: string|null;
-  whisperModelPath: string|null; language: string|null; anthropicModel: string;
-  ollamaBaseUrl: string; ollamaModel: string; claudeBinary: string;
-}
-export interface NoteDto { meetingId: string; providerId: string; markdown: string; exportedPath: string|null; }
-export interface StartResult { meetingId: string; }
-export interface StopResult { meetingId: string; markdown: string; exportedPath: string; }
-```
+**MUST NOT BREAK (spec §5.2 + all three analyses):**
+1. **Do not corrupt the real DB.** The migration is the only destructive op. Safety rests entirely on: never mutate the original, `VACUUM INTO` backup, fresh-reopen verify (counts + sample decrypt), atomic `rename`. **Prove on a throwaway copy of real data (§3.2) before the flag ships.** A botched mid-swap loses all meeting history.
+2. **Biometric must gate real key release, not a boolean.** The KEK must come from a Keychain entry created with `.biometryCurrentSet` (Security.framework ACL via the biometry plugin's data-protection store). A boolean `if authenticated {}` is theater — a locked folder gives zero extra protection once the SQLCipher DB is open. Requires real code-signing.
+3. **MCP token must not break the existing local Claude connection.** Two sub-risks: (a) the keying gotcha — `mcp.rs Db::open` must fetch the DEK or the existing client breaks silently the instant encryption lands (fixed by routing through keyed `Db::open`, A6); (b) the new bearer token is enforced only on `tools/call`, auto-provisioned into the managed config, leaving discovery open — so the upgrade "just works" without manual reconfiguration.
 
----
+**Other open risks (ranked):**
+- **Universal-build OpenSSL cross-compile** (A1) — the single most common Tauri universal-build breaker; runtime `libssl` load failure is invisible at compile time. Mitigation: native-per-arch + manual lipo, or fall back to `bundled-sqlcipher`.
+- **Locked content drops out of full-text search** (`db.rs:252` `LIKE` over now-opaque blobs). **Decision: accept it for P0** (locked = not searchable until unlocked) — simplest and most honest; state it in the lock UI. Do NOT build a plaintext search index (re-leaks).
+- **Session key cache is plaintext in process memory** while unlocked — unavoidable for an in-app-viewable lock; mitigate with `zeroize` + screen-share relock; document.
+- **Lock/vault atomicity** — a crash between encrypt-column and delete-`.md` leaves a plaintext `.md` the DB thinks is gone; DB transaction + delete-after-commit + reconcile-on-launch.
+- **Single-window screen-share blind spot** — Meet-in-a-Chrome-tab may not flip whole-screen `isCaptured`; document the honest dent.
 
-## 7. Tauri command functions (`commands.rs`) — exact signatures
+**Decisions needing user sign-off:** (1) primary `bundled-sqlcipher-vendored-openssl` vs fallback `bundled-sqlcipher`; (2) `BiometryCurrentSet` (hard-fail on re-enrollment) vs `UserPresence`+passcode; (3) Move menu vs native DnD in P0 (plan ships Move menu); (4) 4 new Rust deps need approval per the no-new-deps stance — `getrandom`, `aes-gcm`, `zeroize`(optional), `tauri-plugin-biometry`.
 
-All are `#[tauri::command]`, registered in `main.rs` `invoke_handler`. State injected via
-`tauri::State<'_, AppState>` and `AppHandle`. Errors return `AppError` (serialized to a
-string message; frontend `invoke` rejects).
-
-```rust
-/// Begin mic capture. Inserts a Meeting(Draft→Recording), stores Recorder in state,
-/// sets current_meeting. Returns the new meeting id. Errors if already recording.
-#[tauri::command]
-async fn start_recording(app: AppHandle, state: State<'_, AppState>) -> Result<StartResult, AppError>;
-
-/// Stop capture, then run the full pipeline (pipeline::run_after_stop). Returns the
-/// exported note path + markdown. Emits status events throughout. Errors if not recording.
-#[tauri::command]
-async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> Result<StopResult, AppError>;
-
-/// Current mic peak level 0.0..=1.0 for the meter (0.0 when idle). Cheap, polled by UI.
-#[tauri::command]
-fn recording_level(state: State<'_, AppState>) -> Result<f32, AppError>;
-
-/// The most recent note (markdown + export path) for the last-note preview pane.
-#[tauri::command]
-fn get_last_note(state: State<'_, AppState>) -> Result<Option<NoteDto>, AppError>;
-
-/// Read current config (settings table), without secrets.
-#[tauri::command]
-fn get_config(state: State<'_, AppState>) -> Result<AppConfigDto, AppError>;
-
-/// Persist config to settings table + refresh in-memory cache. Does NOT touch Keychain.
-#[tauri::command]
-fn save_config(state: State<'_, AppState>, config: AppConfigDto) -> Result<(), AppError>;
-
-/// Store/replace the Anthropic API key in Keychain (account "anthropic_api_key").
-#[tauri::command]
-fn set_anthropic_key(key: String) -> Result<(), AppError>;
-
-/// Whether an Anthropic key is currently stored (UI shows "set"/"not set"; never the value).
-#[tauri::command]
-fn has_anthropic_key() -> Result<bool, AppError>;
-
-/// availability() fan-out across all three providers for the Settings UI.
-#[tauri::command]
-async fn provider_statuses(state: State<'_, AppState>) -> Result<Vec<ProviderStatus>, AppError>;
-
-/// Re-run summarize+export for an existing meeting with the configured provider (Detail
-/// "re-summarize"/"re-export" seed — minimal use in P0, wired but UI optional).
-#[tauri::command]
-async fn resummarize(app: AppHandle, state: State<'_, AppState>, meeting_id: String) -> Result<StopResult, AppError>;
-```
-
-Frontend `IpcService` exposes one method per command plus `onStatus(cb)` wrapping
-`listen<StatusPayload>(EVENT_STATUS, cb)`.
-
----
-
-## 8. Build sequence (dependency-ordered; each step independently checkable)
-
-> Steps 0–1 are prerequisites. Rust steps (3+) require `cargo`+`cmake` present (§1).
-> Modules within a step have no inter-dependencies and can be authored in parallel.
-
-0. **Toolchain**: install rustup/cargo, `cmake`, `pkg-config`, Tauri CLI (§1 commands).
-   Verify `cargo --version`, `cmake --version`.
-1. **Scaffold**: `npm create tauri-app` equivalent — create Angular workspace (`src/`) +
-   `src-tauri/` skeleton; commit `Cargo.toml` (§3) and `package.json` (§4).
-   Checkpoint: `npm run build` (frontend) succeeds; `cargo check` on an empty `lib.rs`.
-2. **Foundations (parallel, no deps)**: `error.rs`, `events.rs`, `storage/models.rs`,
-   `transcribe/types.rs`, `summarize/provider.rs` (trait + DTOs), `summarize/template.rs`.
-   Checkpoint: `cargo check` — types compile in isolation.
-3. **Storage + secrets + settings (parallel; depend on step 2)**: `storage/db.rs`
-   (migrations + CRUD), `secrets/keychain.rs`, `settings/config.rs`.
-   Checkpoint: a `cargo test` for `Db::open`+`migrate`+round-trip a setting.
-4. **Audio (depends on error.rs)**: `audio/recorder.rs` (cpal), `audio/wav.rs`
-   (hound+rubato). Checkpoint: unit test resamples a sine to 16 kHz; manual mic capture
-   writes a playable WAV.
-5. **Transcribe (depends on types + a GGUF model on disk)**: `transcribe/whisper.rs`.
-   Checkpoint: transcribe a known 16 kHz WAV → non-empty `Transcript`. **Needs cmake.**
-6. **Providers (parallel; depend on provider.rs + secrets + settings)**:
-   `claude_code.rs`, `anthropic.rs`, `ollama.rs`, then `summarize/mod.rs` factory.
-   Checkpoint: `availability()` returns the right verdict for each in dev env;
-   `ClaudeCodeProvider::summarize` produces front-matter markdown from a sample transcript.
-7. **Export (depends on error.rs)**: `export/obsidian.rs` atomic write + title listing.
-   Checkpoint: writes `.md` atomically into a temp vault; collision → ` (1)` suffix.
-8. **Orchestration**: `state.rs` (AppState::init), `pipeline.rs` (wires 3–7),
-   `commands.rs` (§7), `lib.rs`/`main.rs` registration + `tauri.conf.json`.
-   Checkpoint: `cargo check` whole crate; `tauri dev` launches the window.
-9. **Frontend wiring**: `models.ts`, `ipc.service.ts`, `recorder.store.ts`,
-   `record.component.ts`, `settings.component.ts`, routes/config.
-   Checkpoint: `npm run build` + `tauri dev` — UI invokes commands, status updates render.
-10. **E2E walking-skeleton verification (manual)**: launch app → set vault path + Whisper
-    model path → pick `claude_code` → Record → speak → Stop → observe status stages →
-    `.md` appears in vault → preview pane shows markdown → row in `meetings`/`notes`.
-    Repeat once each with `ollama` and `anthropic` selected.
-
-**Definition of Done (Phase 0):** step 10 passes for the default `ClaudeCode` provider
-end-to-end on this machine, with all three providers compiling and selectable, lint/build
-green, and a note file present in the vault.
-
----
-
-## 9. Open risks carried into Phase 0
-- `whisper-rs-sys` build **requires `cmake`** (currently missing) — install before step 5.
-- GGUF model is **manually placed** in P0 (path is a setting); auto-download is Phase 3.
-- `ClaudeCodeProvider` depends on `claude` being in PATH; `availability()` must degrade
-  gracefully and the UI must surface "not available" without crashing the pipeline.
-- Mic permission prompt (macOS `NSMicrophoneUsageDescription`) must be in `Info.plist`
-  via `tauri.conf.json` bundle config — without it `cpal` capture fails silently.
+Files grounding this plan: `/Users/jakubgawronski/Projects/meetnotes/docs/ARCHITECTURE-LOCAL-CLOUD.md`, `src-tauri/Cargo.toml:41`, `src-tauri/tauri.conf.json:31`, `src-tauri/src/storage/db.rs:56,73`, `src-tauri/src/state.rs:32`, `src-tauri/src/lib.rs:35,48,96,104`, `src-tauri/src/mcp.rs:17,24,41,77,120`, `src-tauri/src/secrets/keychain.rs:5`.

--- a/docs/PHASE1-PLAN.md
+++ b/docs/PHASE1-PLAN.md
@@ -1,0 +1,85 @@
+<!-- Phase 1 in-app graph plan, code-grounded, 2026-06-26 -->
+
+# Murmur Phase 1 — In-App Self-Assembling Graph: Decision-Ready Plan
+
+Verified against live code (`db.rs:87/249/460/828/944/1085/1145/1183`, `commands.rs:730/1348/1704`, `lib.rs:51/84/120`, `pipeline.rs:182/264`, `state.rs:31`). All references confirmed.
+
+## 1. Chosen visualization approach + why
+
+**Hybrid, two-layer: structured People/Projects directory (spine) + a bounded single-entity inline-SVG "neighborhood" view (decoration).**
+
+- **REJECT full force-directed graph for v1.** A hand-rolled TS physics sim in a zoneless app fights change detection, burns battery on a desktop recorder, degrades past a few hundred nodes, is screen-reader-invisible, and grows unboundedly with every meeting — the classic "demo-pretty, field-janky" prod risk. No npm graph lib is allowed anyway.
+- **Directory is the prod-ready, complete feature on its own:** grouped sortable entity cards with visible mention counts, expandable backlinks reusing the existing `sources.component` chip → `/meeting/:id` deep-link. Keyboard-native, scales to thousands via client slice/`limit()`, zero layout math.
+- **Neighborhood SVG is additive and bounded:** selected entity at center, top-K≈12 co-occurring satellites on a circle, edge width ∝ shared-meeting count. Positions computed **once via `cos/sin` in a `computed()`** — never simulated, no `requestAnimationFrame`/`setInterval`. Reuses the `murmurWave` brand glyph in the hub, `--accent-gradient` for people vs violet `#9d7bff` for projects (existing tokens). If it ever feels heavy, drop the SVG with zero functional loss.
+
+This is the prod-ready call because the feature is correct and complete using only the directory; the SVG decorates a sound data model rather than being load-bearing.
+
+## 2. Build order (numbered; file:symbol; size; inline vs workflow)
+
+Strictly serial dependency chain 1→4 (each step's output is the next's input); 5–6 fan out.
+
+| # | Step | file:symbol | Size | Execution |
+|---|------|-------------|------|-----------|
+| 1 | **Schema** — append `entities` + `entity_mentions` `CREATE TABLE/INDEX IF NOT EXISTS` to the idempotent batch; add `EntityKind` enum (`as_str`/`FromStr` mirroring `MeetingStatus` at `db.rs:16-45`) + `EntityWithCount`/`GraphEdges` structs | `storage/db.rs::migrate` (~`:147`, alongside `idx_folders_parent`), `storage/models.rs` | **S** | **Serialize-inline** (foundation; everything blocks on it) |
+| 2 | **DB helpers** — `upsert_entity` (case-insensitive dedup via `name_ci`, keep first-seen casing, `INSERT OR IGNORE` + re-read for race), `add_mention` (idempotent PK), `list_entities_visible`, `entity_mentions_visible`, `graph_edges_visible` — **all reuse `visibility_clause("n", unlocked)` (`:1183`)** over `entity_mentions → meetings → notes n LEFT JOIN folders f`, replicating the `EXISTS(visible note) OR NOT EXISTS(any note)` predicate of `list_meetings_visible` (`:1085`)/`meeting_is_visible` (`:1145`) verbatim | new section `storage/db.rs` (~`:1080`, before visibility block) | **M** | **Serialize-inline** (correctness-critical; the anti-leak guarantee lives here) |
+| 3 | **Dual-sink + pipeline hook** — extract `build_and_persist_entities` free fn (Sink A: always DB upsert+mention; Sink B: vault stub mirror **only if vault configured AND meeting's folder `locked=false`** via `folder_by_id().locked` disk-truth, NOT session-unlock); rewrite `link_meeting_entities` to thin wrapper (drop the hard "no vault" error); add best-effort call in pipeline after export | `commands.rs::link_meeting_entities` (`:730`) + new `build_and_persist_entities`; `pipeline.rs::summarize_and_export` (just before `Ok(PipelineResult)` at `:266`) | **M** | **Serialize-inline** (touches shared `commands.rs` + `pipeline.rs`; sequencing matters) |
+| 4 | **`get_graph` + `get_entity_detail` commands** — snapshot live `unlocked` set (same as `list_folders` at `commands.rs:1353`), call step-2 helpers, build `GraphData`/`EntityDetail` camelCase payloads; register both in `generate_handler!` | `commands.rs` (new commands + `GraphNode/Edge/Data` types); `lib.rs` `generate_handler!` (`:51`, beside `:84`) | **M** | **Serialize-inline** (shared `lib.rs` registration; depends on 2) |
+| 5 | **IPC contract** — add `GraphEntity`/`GraphData`/`EntityNeighbor`/`EntityDetail` interfaces (reuse existing `VaultSource` for backlink chips); add `getGraph()`/`getEntityDetail(id)` methods | `src/app/core/models.ts`, `src/app/core/ipc.service.ts` | **S** | **Delegate-to-workflow** (frontend lane; starts once step-4 payload shape is frozen) |
+| 6 | **Graph UI** — lazy `/graph` route + one nav link after Analytics; 4 standalone/OnPush/signals components: `graph.component` (container: `loading`/`isEmpty`/`kindFilter`/`sort`/`query`/`selectedId` signals, `computed` view-model), `entity-card` (`input()`/`output()`), `entity-detail` (side panel, `sources.component` chips), `entity-neighborhood` (trig-laid-out inline SVG). Re-fetch `getGraph()` on `FoldersService` lock-state change; one `.banner is-accent` disclosure when locked folders exist | `src/app/app.routes.ts`, `app.component.ts`, new `src/app/features/graph/{graph,entity-card,entity-detail,entity-neighborhood}.component.ts` | **L** | **Delegate-to-workflow** (frontend lane; depends on 5) |
+
+## 3. Conflict map
+
+**Shared Rust files (edited in steps 1–4, all serial — never parallelize across these):**
+- `storage/db.rs` — **3 separate edit zones, no overlap:** migrate batch (~`:147`), helpers (~`:1080`), nothing in the visibility fn itself (read-only reuse). Append-only; low risk.
+- `commands.rs` — `link_meeting_entities` (`:730`) rewritten **in place**; new fns + types appended; `lib.rs` import unchanged. Conflict only if another agent touches `:730` concurrently — none planned.
+- `lib.rs` — single 2-line addition to `generate_handler!` array (`:84` neighborhood). Trivial, but it's the one file every Tauri-command PR touches → land step 4 before any other command work.
+- `pipeline.rs` — single insertion before `Ok(PipelineResult)` (`:266`); shared by both `run_inner` and `resummarize_existing` (`:300`) → re-summarize refreshes the graph for free, `add_mention` idempotency prevents double-count.
+
+**New modules (zero conflict):** `models.rs` additions are append-only; optional `summarize/graph_sink.rs` if `build_and_persist_entities` is split out. `summarize/graph.rs` and `export/entity_stub.rs` are **reused unchanged** (graph extraction is Sink A's source; entity_stub is Sink B).
+
+**Angular (steps 5–6, isolated lane):** all-new `features/graph/` dir; only append-edits to `models.ts`/`ipc.service.ts`/`app.routes.ts`/`app.component.ts` (one nav link). No collision with Rust lane — can run in parallel **after** the step-4 payload contract is frozen.
+
+**Ordering rule:** 1→2→3→4 strictly serial on the Rust side (shared files + data dependency). 5 starts when 4's serialized shape is fixed; 6 follows 5. Do not parallelize Rust steps.
+
+## 4. Lock-awareness invariants (sealed meetings never leak)
+
+1. **Visibility is computed at READ time, never persisted.** Every graph read snapshots the live `state.unlocked_folders` (`state.rs:31`) at command entry and pushes it through `visibility_clause`. No cache to invalidate.
+2. **Mentions are written once while content was readable, and survive sealing.** Sealing blanks `notes.markdown` (`seal_note:944`) but never touches `entities`/`entity_mentions`. The rows persist; they merely become *invisible* at read. **Never re-extract a sealed meeting** — on-demand extraction reads `markdown=''` and yields nothing, so it can't corrupt or rebuild a sealed graph.
+3. **The graph join reaches the predicate through the meeting's notes:** `entity_mentions → meetings → notes n LEFT JOIN folders f`, asserting `EXISTS(visible note) OR NOT EXISTS(any note)` — byte-identical to `list_meetings_visible`. The graph can never disagree with Library/MCP about what's visible.
+4. **`HAVING mention_count > 0` makes single-sealed entities vanish.** An entity mentioned *only* in sealed-not-unlocked meetings contributes zero visible mentions → drops out of nodes, edges, and counts entirely. Its name lived only in encrypted markdown, so it never reaches the renderer.
+5. **`relock_all` (`commands.rs:1704`, fired on screen-share start) clears the set** → the next `get_graph` instantly drops every sealed contribution. FE re-fetches on the shared `FoldersService` signal change — live drop-out, no stale view.
+6. **`mentionCount` is ALWAYS the visible count** — the backend never leaks a higher "true" count. The FE makes no security decision; it renders what the backend returns, plus one honest `.banner` disclosure when locked folders exist.
+7. **Sink B uses folder `locked` (disk truth), not session `unlocked`.** Even a session-unlocked folder must NOT re-emit `.md` stubs (they were removed on seal, stay out until permanent remove-lock). Reads use `unlocked`; the vault-write gate uses `locked`. This is the one place the two differ and must not be conflated.
+
+## 5. Test plan
+
+**Rust (`#[cfg(test)]` in `db.rs`, mirroring `migrate_is_idempotent` at `:1381`; in-memory SQLCipher Db):**
+- **Entity dedup:** `upsert_entity("Anna Kowalska", Person)` then `upsert_entity("anna kowalska", Person)` → same id, **first-seen casing kept** ("Anna Kowalska"). Different `kind` with same name → two distinct rows (the `(name_ci, kind)` unique index). Concurrent-insert race path returns the winner's id.
+- **Mention idempotency:** `add_mention` twice → one row (PK), `list_entities_visible` count = 1.
+- **Visibility filter — the core anti-leak test:** seed entity E mentioned in meeting M whose note is in folder F. With F open OR `unlocked={F}` → E present with count 1; with F locked and `unlocked={}` → E **absent** (count 0, filtered by `HAVING`). Entity mentioned in BOTH an open meeting and a sealed one → present with count = **1** (visible only), never 2.
+- **Co-occurrence visibility:** two entities sharing one sealed meeting → no edge when sealed; edge with `weight=1` when unlocked. Pair-dedup (`a.entity_id < b.entity_id`) yields exactly one edge per pair.
+- **Cascade:** `delete_meeting` prunes mentions (existing `ON DELETE CASCADE`); entity with zero remaining mentions disappears from `list_entities_visible`.
+- **Dual-sink skip:** `build_and_persist_entities` for a meeting in a `locked=true` folder → DB rows written, **zero vault `.md` files** created (assert against a temp vault dir). Open folder → both DB rows AND vault stubs. No vault configured → DB rows only, no error.
+
+**Frontend (existing test harness):**
+- `get_graph` empty → `isEmpty` state renders `.empty-state`; non-empty → grouped People/Projects with correct counts.
+- `kindFilter`/`sort`/`query` `computed` view-model derivations.
+- Neighborhood `computed` lays out exactly K satellites at correct trig coordinates; satellite click re-selects.
+- Lock-state change on `FoldersService` triggers `getGraph()` re-fetch (sealed entity drops live).
+
+**System / manual:** capture a meeting → entity appears in graph → move it to a folder → seal+relock → entity disappears → session-unlock → reappears; confirm vault has stubs for the open-folder meeting only.
+
+## 6. The 2–3 things that must be right + risks
+
+**MUST be right:**
+1. **The visibility join is byte-identical to `list_meetings_visible` (`db.rs:1085`).** If the graph's predicate drifts from the canonical one, a sealed meeting's entity leaks — defeating Phase 0's entire lock model. Mitigation: copy the `EXISTS/NOT EXISTS` clause verbatim, and the visibility test (§5) is the gate. This is the single highest-stakes line of code.
+2. **Sink B gates on folder `locked` (disk), not session `unlocked`.** Conflating them re-writes encrypted-content `.md` stubs back to the vault on a session-unlock — a plaintext leak to disk. The seal-timing subtlety (extraction needs plaintext, only available while open/unlocked; rows persist through seal; never re-extract sealed) must be implemented exactly as specified.
+3. **Best-effort graph build never fails the note.** The `pipeline.rs:266` hook must `warn!`-and-continue on error. A graph-extraction LLM failure blocking note export would be a severe regression to the core product.
+
+**RISKS:**
+- **`name_ci` Unicode folding:** populate via `name.to_lowercase()` (full Unicode), NOT the existing ASCII-only `eq_ignore_ascii_case` in `graph.rs::clean` — otherwise accented names ("Zoë") dedup inconsistently. Superset of current behavior, no regression; optionally align `clean` too.
+- **Graph growth / first-paint cost:** mitigated by the cheap aggregate `get_graph` (O(entities)) + lazy `get_entity_detail` (heavy join paid only on selection) + client `limit()` slice + server-capped top-K neighbors. No global layout, so no perf cliff.
+- **Re-summarize double-counting:** `add_mention` idempotency (`INSERT OR IGNORE` on PK) makes the `resummarize_existing` path safe — verified by the idempotency test.
+- **Orphan entities** (lost all mentions via cascade): harmless — filtered by `HAVING count > 0`; optional GC later, not v1.
+
+**No new npm packages** (hand-rolled SVG only) and **no new Rust crates** (`uuid`/`chrono`/`rusqlite`/`serde` all already in use) — consistent with Murmur's self-contained positioning. Obsidian vault stubs remain the OPTIONAL Sink B mirror; the encrypted DB tables are the source of truth.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2000,6 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -2144,6 +2145,7 @@ dependencies = [
  "chrono",
  "cpal",
  "dirs 5.0.1",
+ "getrandom 0.2.17",
  "hound",
  "keyring",
  "regex",
@@ -2524,6 +2526,28 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -626,6 +672,15 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "darling"
@@ -1261,6 +1316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2214,7 @@ dependencies = [
 name = "murmur"
 version = "0.2.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "chrono",
@@ -2528,6 +2603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-src"
 version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2792,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2916,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2926,7 +3019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4647,6 +4749,16 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2217,12 +2217,17 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "async-trait",
+ "block2",
  "chrono",
  "cpal",
  "dirs 5.0.1",
  "getrandom 0.2.17",
  "hound",
  "keyring",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-local-authentication",
  "regex",
  "reqwest 0.12.28",
  "rubato",
@@ -2381,9 +2386,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2440,6 +2453,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2501,6 +2515,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2567,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-local-authentication"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48e0b8b339e0d9d2ed4416b7f93f9d4daadff7d4dd797f89867cde11aeac607"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2588,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ thiserror = "1"
 # ── Secrets ──
 keyring = { version = "3", features = ["apple-native"] }
 getrandom = "0.2"
+aes-gcm = "0.10"
 
 # ── Misc ──
 chrono = { version = "0.4", features = ["clock", "serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs
 async-trait = "0.1"
 
 # ── Storage ──
-rusqlite = { version = "0.32", features = ["bundled"] }
+# bundled-sqlcipher-vendored-openssl: whole-DB at-rest encryption, no system OpenSSL dependency
+# (universal-capable). Fallback if the universal build breaks: "bundled-sqlcipher".
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
 
 # ── Serde ──
 serde = { version = "1", features = ["derive"] }
@@ -50,6 +52,7 @@ thiserror = "1"
 
 # ── Secrets ──
 keyring = { version = "3", features = ["apple-native"] }
+getrandom = "0.2"
 
 # ── Misc ──
 chrono = { version = "0.4", features = ["clock", "serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,17 @@ tiny_http = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# ── macOS biometric (Touch ID) + screen-share detection (Stage E) ──
+# These objc2 crates are already in the dependency graph transitively (via tauri/tao);
+# we pin the same 0.6/0.3 family. LocalAuthentication = Touch ID KEK gate; AppKit = NSScreen
+# isCaptured screen-share watcher. macOS-only — gated under cfg(target_os = "macos").
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+block2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError"] }
+objc2-app-kit = { version = "0.3", features = ["NSScreen"] }
+objc2-local-authentication = { version = "0.3", features = ["LAContext", "LAError", "block2"] }
+
 [features]
 # default keeps Metal on for whisper; nothing else conditional in P0
 default = []

--- a/src-tauri/src/audio/listener.rs
+++ b/src-tauri/src/audio/listener.rs
@@ -87,6 +87,10 @@ impl VoiceListener {
                     Ok(s) => s,
                     Err(_) => continue,
                 };
+                // VOICE TRIGGER uses the Fast (greedy/best_of:1) profile via `transcribe` —
+                // NOT the batch beam-search path. We only need a wake-phrase match on a short
+                // ~2s window many times over; low latency matters far more than transcript
+                // quality here, so beam search would be wasted CPU. Keep it greedy.
                 if let Ok(t) = transcriber.transcribe(&s16, language.as_deref()) {
                     if is_wake_phrase(&t.full_text) {
                         tracing::info!(target: "voice", "wake phrase detected");

--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -1,0 +1,308 @@
+//! Wall-clock merge of two independently-captured transcript streams into ONE attributed,
+//! time-ordered segment list (Phase B "Me vs Others").
+//!
+//! ## Why this exists (the critical correctness detail)
+//!
+//! The mic (cpal) and the system audio (ScreenCaptureKit sidecar) are captured on SEPARATE
+//! streams with INDEPENDENT clocks. Each is transcribed on its OWN timeline, so a segment's
+//! `start_s`/`end_s` are RELATIVE to that stream's first sample (t=0 at its capture start).
+//! You CANNOT merge them by sample count: the two clocks drift relative to each other
+//! (seconds per hour), so "system sample N" and "mic sample N" do not refer to the same wall
+//! moment. Concatenating or zipping by index would scramble who-said-what-when.
+//!
+//! The fix: anchor each stream to the HOST wall-clock instant at which it started capturing
+//! (`Recorder::started_at`, and the system stream's spawn instant). The offset between the two
+//! anchors converts every segment's stream-relative time into a shared ABSOLUTE timeline; we
+//! then merge-sort by absolute start. The earlier-starting stream is the timeline origin
+//! (absolute t=0), and the later stream's segments are shifted forward by its start delay.
+//!
+//! ## Attribution (cheap 2-way diarization)
+//!
+//! Each segment is labelled purely by WHICH stream produced it: mic → `"me"`, system → others.
+//! HONEST DENTS:
+//! - This is NOT per-remote-person diarization. Every remote participant collapses into the
+//!   single `"others"` label — we attribute by capture stream, not by voice fingerprint.
+//! - ECHO: if the user runs the call on SPEAKERS (not headphones), the mic re-captures the
+//!   remote audio, so some "others" speech also lands in the mic stream and gets mislabelled
+//!   "me". Recommend headphones (surface this in the UI later).
+//! - If ScreenCaptureKit permission is denied / system capture is off, there is no system
+//!   stream at all and the caller falls back to mic-only (everything "me").
+
+use std::time::Instant;
+
+use crate::transcribe::types::Segment;
+
+/// The "me" stream label (local microphone).
+pub const SPEAKER_ME: &str = "me";
+/// The "others" stream label (captured system audio — all remote participants collapsed).
+pub const SPEAKER_OTHERS: &str = "others";
+
+/// One transcribed stream plus the host instant at which its capture started.
+pub struct StreamInput {
+    /// Stream-relative segments (start/end in seconds from THIS stream's first sample).
+    pub segments: Vec<Segment>,
+    /// Host wall-clock instant when this stream started capturing.
+    pub started_at: Instant,
+    /// Attribution label applied to every segment from this stream (`"me"` / `"others"`).
+    pub speaker: &'static str,
+}
+
+/// Merge the mic + system streams into one absolute-timeline, speaker-attributed segment list.
+///
+/// Steps:
+/// 1. Pick the EARLIER `started_at` as the absolute timeline origin (t=0).
+/// 2. For each stream, shift its segment times forward by `started_at - origin` (its capture
+///    delay relative to the origin) → absolute start/end.
+/// 3. Tag every segment with its stream's speaker label.
+/// 4. Drop empty/whitespace-only segments (a muted-mic span yields silence → Whisper yields
+///    nothing → nothing to merge; this also prunes any stray blank Whisper output).
+/// 5. Merge-sort by absolute start (ties broken by absolute end, then speaker for determinism).
+/// 6. Re-index `idx` 0..N over the merged order.
+///
+/// Times never go negative: the origin is the earliest start, so every shift is `>= 0`.
+pub fn merge_streams(streams: Vec<StreamInput>) -> Vec<Segment> {
+    let Some(origin) = streams.iter().map(|s| s.started_at).min() else {
+        return Vec::new();
+    };
+
+    let mut merged: Vec<Segment> = Vec::new();
+    for stream in &streams {
+        // Capture delay of this stream relative to the timeline origin, in seconds (>= 0).
+        let offset_s = stream
+            .started_at
+            .saturating_duration_since(origin)
+            .as_secs_f64();
+        for seg in &stream.segments {
+            // DROP fully-silent/empty segments (e.g. a muted mic span).
+            if seg.text.trim().is_empty() {
+                continue;
+            }
+            merged.push(Segment {
+                idx: 0, // re-assigned after the sort
+                start_s: seg.start_s + offset_s,
+                end_s: seg.end_s + offset_s,
+                text: seg.text.clone(),
+                speaker: Some(stream.speaker.to_string()),
+            });
+        }
+    }
+
+    // Stable merge order by absolute start; deterministic tie-breaks so overlapping mic/system
+    // segments (both parties talking at once) sort reproducibly rather than corrupting order.
+    merged.sort_by(|a, b| {
+        a.start_s
+            .partial_cmp(&b.start_s)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(
+                a.end_s
+                    .partial_cmp(&b.end_s)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then_with(|| a.speaker.cmp(&b.speaker))
+    });
+
+    for (i, seg) in merged.iter_mut().enumerate() {
+        seg.idx = i as i64;
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn seg(idx: i64, start_s: f64, end_s: f64, text: &str) -> Segment {
+        Segment {
+            idx,
+            start_s,
+            end_s,
+            text: text.into(),
+            speaker: None,
+        }
+    }
+
+    /// The core correctness test: two streams with DIFFERENT host start offsets must interleave
+    /// by ABSOLUTE wall-clock time, not by stream-relative time, and carry the right labels.
+    ///
+    /// Scenario: system audio starts 5.0 s AFTER the mic.
+    ///   mic    (origin):  "hello" @ 0..2 (abs 0..2),  "bye"  @ 10..11 (abs 10..11)
+    ///   system (+5.0 s):  "hi"    @ 0..1 (abs 5..6),   "ok"   @ 4..5  (abs 9..10)
+    /// Expected absolute order: hello(0) < hi(5) < ok(9) < bye(10).
+    #[test]
+    fn merges_by_absolute_wall_clock_not_relative() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            segments: vec![seg(0, 0.0, 2.0, "hello"), seg(1, 10.0, 11.0, "bye")],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        let system = StreamInput {
+            segments: vec![seg(0, 0.0, 1.0, "hi"), seg(1, 4.0, 5.0, "ok")],
+            started_at: origin + Duration::from_secs(5),
+            speaker: SPEAKER_OTHERS,
+        };
+
+        let out = merge_streams(vec![mic, system]);
+
+        let order: Vec<(&str, Option<&str>)> = out
+            .iter()
+            .map(|s| (s.text.as_str(), s.speaker.as_deref()))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("hello", Some("me")),
+                ("hi", Some("others")),
+                ("ok", Some("others")),
+                ("bye", Some("me")),
+            ]
+        );
+
+        // Absolute times: the +5 s system stream is shifted forward.
+        assert_eq!(out[0].start_s, 0.0); // hello
+        assert_eq!(out[1].start_s, 5.0); // hi  (0 + 5)
+        assert_eq!(out[2].start_s, 9.0); // ok  (4 + 5)
+        assert_eq!(out[3].start_s, 10.0); // bye
+
+        // idx is re-indexed over the merged order.
+        assert_eq!(out.iter().map(|s| s.idx).collect::<Vec<_>>(), vec![0, 1, 2, 3]);
+    }
+
+    /// When the SYSTEM stream starts FIRST, it becomes the origin and the mic is shifted forward.
+    #[test]
+    fn earlier_stream_becomes_origin_either_direction() {
+        let base = Instant::now();
+        let system = StreamInput {
+            segments: vec![seg(0, 0.0, 1.0, "remote-first")],
+            started_at: base, // earlier
+            speaker: SPEAKER_OTHERS,
+        };
+        let mic = StreamInput {
+            segments: vec![seg(0, 0.0, 1.0, "me-later")],
+            started_at: base + Duration::from_secs(3), // +3 s
+            speaker: SPEAKER_ME,
+        };
+
+        // Order of args must not matter — pass mic first to prove offset is by start time.
+        let out = merge_streams(vec![mic, system]);
+        assert_eq!(out[0].text, "remote-first");
+        assert_eq!(out[0].start_s, 0.0);
+        assert_eq!(out[0].speaker.as_deref(), Some("others"));
+        assert_eq!(out[1].text, "me-later");
+        assert_eq!(out[1].start_s, 3.0); // shifted by the +3 s mic delay
+        assert_eq!(out[1].speaker.as_deref(), Some("me"));
+    }
+
+    /// Overlapping speech (both talk at once) keeps BOTH segments and a deterministic order —
+    /// no segment is dropped or its label corrupted.
+    #[test]
+    fn overlapping_segments_are_not_corrupted() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            segments: vec![seg(0, 2.0, 4.0, "me-overlap")],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        let system = StreamInput {
+            segments: vec![seg(0, 2.0, 5.0, "others-overlap")],
+            started_at: origin, // same start → same absolute t
+            speaker: SPEAKER_OTHERS,
+        };
+        let out = merge_streams(vec![mic, system]);
+        assert_eq!(out.len(), 2, "both overlapping segments survive");
+        // Equal start; tie broken by end (4.0 < 5.0) → mic ("me-overlap") first.
+        assert_eq!(out[0].text, "me-overlap");
+        assert_eq!(out[0].speaker.as_deref(), Some("me"));
+        assert_eq!(out[1].text, "others-overlap");
+        assert_eq!(out[1].speaker.as_deref(), Some("others"));
+    }
+
+    /// Empty / whitespace-only segments (e.g. a muted-mic silent span) are dropped.
+    #[test]
+    fn drops_empty_and_blank_segments() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            segments: vec![
+                seg(0, 0.0, 1.0, "kept"),
+                seg(1, 1.0, 2.0, ""),     // empty (muted span → no speech)
+                seg(2, 2.0, 3.0, "   "), // whitespace-only
+            ],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        let out = merge_streams(vec![mic]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].text, "kept");
+        assert_eq!(out[0].idx, 0);
+    }
+
+    /// A single stream (mic-only fallback when system capture is off/denied) passes through
+    /// labelled "me", re-indexed, with no time shift.
+    #[test]
+    fn single_stream_passthrough_is_mic_only_me() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            segments: vec![seg(7, 0.0, 1.0, "a"), seg(9, 1.0, 2.0, "b")],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        let out = merge_streams(vec![mic]);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|s| s.speaker.as_deref() == Some("me")));
+        assert_eq!(out.iter().map(|s| s.idx).collect::<Vec<_>>(), vec![0, 1]);
+        assert_eq!(out[0].start_s, 0.0);
+    }
+
+    /// No streams → empty merge (no panic on the `min()` of an empty iterator).
+    #[test]
+    fn no_streams_yields_empty() {
+        assert!(merge_streams(Vec::new()).is_empty());
+    }
+
+    /// REGRESSION (mute × wall-clock alignment — the load-bearing Phase-B invariant).
+    ///
+    /// A muted-mic span writes SILENCE that keeps the mic buffer full-length (see
+    /// `recorder::accumulate_frames`), so Whisper yields NOTHING for those seconds and the
+    /// FIRST post-unmute "me" segment keeps its true stream-relative start (~the mute
+    /// duration). This test proves that the merge then places that post-unmute "me" segment
+    /// at the correct ABSOLUTE position relative to the "others" speech that happened DURING
+    /// the mute — i.e. the timeline did not collapse forward (which is exactly what dropping
+    /// muted frames instead of writing silence would have caused).
+    ///
+    /// Scenario (both streams start together, mic muted 0..30 s):
+    ///   mic    (origin):  [silence 0..30 → no segment], "back now" @ 30..31 (abs 30..31)
+    ///   system (origin):  "remote talks while you're muted" @ 5..8 (abs 5..8)
+    /// Expected absolute order: others(5) BEFORE me(30) — the mute did NOT pull "me" forward.
+    #[test]
+    fn muted_mic_span_keeps_post_unmute_segment_in_absolute_order() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            // The 0..30 s muted span produced silence → Whisper emitted nothing for it; the
+            // only mic segment is the real speech AFTER unmute, still at its true t≈30 s.
+            segments: vec![seg(0, 30.0, 31.0, "back now")],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        let system = StreamInput {
+            segments: vec![seg(0, 5.0, 8.0, "remote talks while you're muted")],
+            started_at: origin,
+            speaker: SPEAKER_OTHERS,
+        };
+
+        let out = merge_streams(vec![mic, system]);
+
+        assert_eq!(out.len(), 2, "no audio/content lost across the mute boundary");
+        // "others" (spoken during the mute) MUST precede the post-unmute "me" segment.
+        assert_eq!(out[0].speaker.as_deref(), Some("others"));
+        assert_eq!(out[0].start_s, 5.0, "others speech stays at its true wall-clock time");
+        assert_eq!(out[1].speaker.as_deref(), Some("me"));
+        assert_eq!(
+            out[1].start_s, 30.0,
+            "post-unmute mic segment is NOT pulled forward — the muted-silence span \
+             preserved the mic stream's wall-clock timeline"
+        );
+        // Re-indexed over the merged order.
+        assert_eq!(out.iter().map(|s| s.idx).collect::<Vec<_>>(), vec![0, 1]);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,9 +1,11 @@
 pub mod listener;
+pub mod merge;
 pub mod mixer;
 pub mod recorder;
 pub mod system;
 pub mod wav;
 
+pub use merge::*;
 pub use mixer::*;
 pub use recorder::*;
 pub use wav::*;

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -17,6 +17,13 @@ use crate::error::{AppError, Result};
 struct Shared {
     samples: Mutex<Vec<f32>>,
     peak: AtomicU32,
+    /// Live mic-mute flag, toggled mid-recording via `set_mic_muted`. When `true`, the cpal
+    /// data callback writes SILENCE (zeros) for the muted frames into `samples` — it does NOT
+    /// drop them. Keeping full-length silence preserves the mic stream's wall-clock timeline so
+    /// later segments stay aligned (dropping samples would shift everything after the mute and
+    /// corrupt the wall-clock merge). Privacy is preserved: no real mic audio is captured while
+    /// muted.
+    muted: AtomicBool,
 }
 
 impl Shared {
@@ -24,6 +31,7 @@ impl Shared {
         Self {
             samples: Mutex::new(Vec::new()),
             peak: AtomicU32::new(0),
+            muted: AtomicBool::new(false),
         }
     }
 
@@ -33,6 +41,14 @@ impl Shared {
 
     fn load_peak(&self) -> f32 {
         f32::from_bits(self.peak.load(Ordering::Relaxed))
+    }
+
+    fn set_muted(&self, muted: bool) {
+        self.muted.store(muted, Ordering::Relaxed);
+    }
+
+    fn is_muted(&self) -> bool {
+        self.muted.load(Ordering::Relaxed)
     }
 }
 
@@ -62,6 +78,12 @@ struct StartInfo {
 pub struct Recorder {
     shared: Arc<Shared>,
     source_sample_rate: u32,
+    /// Host wall-clock instant captured the moment cpal capture started, used to anchor this
+    /// stream's sample-relative segment timestamps onto an absolute timeline in the wall-clock
+    /// merge (see `audio::merge`). The mic (cpal) and system (ScreenCaptureKit) streams run on
+    /// INDEPENDENT clocks, so sample-count alignment drifts seconds/hour — anchoring each stream
+    /// to its own host start is what keeps "me" and "others" segments correctly interleaved.
+    started_at: std::time::Instant,
     stop_tx: Sender<()>,
     thread: Option<JoinHandle<()>>,
 }
@@ -99,6 +121,10 @@ impl Recorder {
         Ok(Self {
             shared,
             source_sample_rate: info.source_sample_rate,
+            // Anchor right after the stream reports ready (i.e. capture is live). The few-ms gap
+            // between the device actually opening and this line is negligible against the
+            // seconds/hour cross-clock drift this anchoring exists to defeat.
+            started_at: std::time::Instant::now(),
             stop_tx,
             thread: Some(thread),
         })
@@ -137,6 +163,23 @@ impl Recorder {
     /// The device's native capture sample rate (Hz).
     pub fn source_sample_rate(&self) -> u32 {
         self.source_sample_rate
+    }
+
+    /// Host wall-clock instant when this stream's capture started (for the wall-clock merge).
+    pub fn started_at(&self) -> std::time::Instant {
+        self.started_at
+    }
+
+    /// Live-toggle the mic mute mid-recording (no stream teardown). While muted the cpal data
+    /// callback writes SILENCE into the buffer instead of the captured mic frames — the stream
+    /// stays full-length so the timeline never shifts. Lock-free; safe to call from a command.
+    pub fn set_muted(&self, muted: bool) {
+        self.shared.set_muted(muted);
+    }
+
+    /// Read the current mute flag (lock-free).
+    pub fn is_muted(&self) -> bool {
+        self.shared.is_muted()
     }
 
     /// Clone up to the last `max_samples` captured mono samples WITHOUT draining — used by
@@ -252,25 +295,7 @@ where
 
     let err_shared = shared.clone();
     let data_cb = move |data: &[T], _: &cpal::InputCallbackInfo| {
-        // Downmix interleaved frames to mono by averaging channels.
-        let mut mono = Vec::with_capacity(data.len() / channels + 1);
-        let mut peak = 0.0f32;
-        for frame in data.chunks(channels) {
-            let mut acc = 0.0f32;
-            for s in frame {
-                acc += f32::from_sample(*s);
-            }
-            let v = acc / channels as f32;
-            let mag = v.abs();
-            if mag > peak {
-                peak = mag;
-            }
-            mono.push(v);
-        }
-        shared.store_peak(peak.clamp(0.0, 1.0));
-        if let Ok(mut buf) = shared.samples.lock() {
-            buf.extend_from_slice(&mono);
-        }
+        accumulate_frames(&shared, data, channels);
     };
 
     let err_cb = move |err| {
@@ -282,4 +307,102 @@ where
     device
         .build_input_stream(config, data_cb, err_cb, None)
         .map_err(|e| AppError::Audio(format!("failed to build input stream: {e}")))
+}
+
+/// Process one cpal capture buffer: downmix interleaved `data` to mono and append it to
+/// `shared.samples`, tracking the peak meter — UNLESS muted, in which case append the SAME
+/// number of SILENT (zero) frames and force the meter to 0.0.
+///
+/// Pulled out of the closure so the mute/silence behaviour is unit-testable without a device.
+/// CRITICAL: the muted branch appends `frame_count` zeros (NOT zero samples) so the mic stream
+/// stays exactly as long as it would have been live — that full-length silence is what keeps the
+/// stream's wall-clock timeline intact for the merge.
+fn accumulate_frames<T>(shared: &Arc<Shared>, data: &[T], channels: usize)
+where
+    T: Sample,
+    f32: cpal::FromSample<T>,
+{
+    let channels = channels.max(1);
+    let frame_count = data.len() / channels;
+
+    if shared.is_muted() {
+        shared.store_peak(0.0);
+        if let Ok(mut buf) = shared.samples.lock() {
+            let new_len = buf.len() + frame_count;
+            buf.resize(new_len, 0.0);
+        }
+        return;
+    }
+
+    let mut mono = Vec::with_capacity(frame_count + 1);
+    let mut peak = 0.0f32;
+    for frame in data.chunks(channels) {
+        let mut acc = 0.0f32;
+        for s in frame {
+            acc += f32::from_sample(*s);
+        }
+        let v = acc / channels as f32;
+        let mag = v.abs();
+        if mag > peak {
+            peak = mag;
+        }
+        mono.push(v);
+    }
+    shared.store_peak(peak.clamp(0.0, 1.0));
+    if let Ok(mut buf) = shared.samples.lock() {
+        buf.extend_from_slice(&mono);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A live (un-muted) buffer is downmixed to mono and appended; the meter tracks the peak.
+    #[test]
+    fn unmuted_appends_downmixed_audio() {
+        let shared = Arc::new(Shared::new());
+        // 2 mono frames at 1 channel.
+        accumulate_frames(&shared, &[0.5f32, -0.25f32], 1);
+        let buf = shared.samples.lock().unwrap();
+        assert_eq!(&*buf, &[0.5f32, -0.25f32]);
+        assert!((shared.load_peak() - 0.5).abs() < 1e-6);
+    }
+
+    /// MUTE: the buffer grows by the right number of SILENT frames (length preserved, content
+    /// zeroed) and the meter is forced to 0 — the privacy + timeline-alignment guarantee.
+    #[test]
+    fn muted_writes_silence_but_keeps_length() {
+        let shared = Arc::new(Shared::new());
+        // Seed one real frame, then mute and feed a loud 3-frame stereo buffer (6 samples).
+        accumulate_frames(&shared, &[1.0f32], 1);
+        shared.set_muted(true);
+        assert!(shared.is_muted());
+        accumulate_frames(&shared, &[0.9f32, 0.9, -0.9, -0.9, 0.8, 0.8], 2);
+
+        let buf = shared.samples.lock().unwrap();
+        // 1 live frame + 3 muted frames (6 samples / 2 channels) = 4 samples, no dropped frames.
+        assert_eq!(buf.len(), 4, "muted span must keep the stream full-length");
+        assert_eq!(&buf[1..], &[0.0f32, 0.0, 0.0], "muted frames must be silence");
+        assert_eq!(shared.load_peak(), 0.0, "meter reads 0 while muted");
+    }
+
+    /// The mute flag flips both ways and is observed by the helper.
+    #[test]
+    fn mute_flag_flips() {
+        let shared = Arc::new(Shared::new());
+        assert!(!shared.is_muted(), "starts unmuted");
+        shared.set_muted(true);
+        assert!(shared.is_muted());
+        shared.set_muted(false);
+        assert!(!shared.is_muted());
+
+        // Un-muting resumes capturing real audio.
+        shared.set_muted(true);
+        accumulate_frames(&shared, &[0.5f32], 1);
+        shared.set_muted(false);
+        accumulate_frames(&shared, &[0.5f32], 1);
+        let buf = shared.samples.lock().unwrap();
+        assert_eq!(&*buf, &[0.0f32, 0.5f32], "silence then real audio after unmute");
+    }
 }

--- a/src-tauri/src/audio/system.rs
+++ b/src-tauri/src/audio/system.rs
@@ -27,6 +27,11 @@ pub fn is_available() -> bool {
 pub struct SystemAudioRecorder {
     child: Child,
     wav_path: PathBuf,
+    /// Host wall-clock instant when the sidecar was spawned (capture start). The mic (cpal) and
+    /// this ScreenCaptureKit stream run on INDEPENDENT clocks, so the wall-clock merge anchors
+    /// each stream's segments to its own host start instead of aligning by sample count (which
+    /// drifts seconds/hour). See `audio::merge`.
+    started_at: std::time::Instant,
 }
 
 impl SystemAudioRecorder {
@@ -42,7 +47,16 @@ impl SystemAudioRecorder {
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| AppError::Audio(format!("failed to spawn system-audio sidecar: {e}")))?;
-        Ok(Self { child, wav_path })
+        Ok(Self {
+            child,
+            wav_path,
+            started_at: std::time::Instant::now(),
+        })
+    }
+
+    /// Host wall-clock instant when this system-audio stream started capturing (for the merge).
+    pub fn started_at(&self) -> std::time::Instant {
+        self.started_at
     }
 
     /// SIGTERM the sidecar so it finalizes the WAV, wait for it, and return the WAV path

--- a/src-tauri/src/biometric.rs
+++ b/src-tauri/src/biometric.rs
@@ -1,0 +1,188 @@
+//! macOS Touch ID / device-owner authentication gate (Stage E).
+//!
+//! Releases the per-folder unlock path only after a passing biometric (or, as a fallback, a
+//! passcode) prompt via Apple's `LocalAuthentication` framework. This is the "teeth" that turn a
+//! locked folder from a boolean into a real authentication gate at unlock time.
+//!
+//! GRACEFUL DEGRADATION (deliberate): if LocalAuthentication is unavailable — no Touch ID
+//! hardware, a headless/CI box, a policy that can't be evaluated — we return `Ok(true)` and log
+//! it rather than locking the user out. We NEVER panic across the FFI boundary. The
+//! cryptographically-real key protection lives in the Keychain ACL (the KEK release path); this
+//! module is the interactive presence check layered on top.
+//!
+//! THREADING: the LocalAuthentication evaluation is callback-based and may block on user
+//! interaction, so the whole thing runs inside `tokio::task::spawn_blocking` and bridges the
+//! Objective-C reply block back through a `std::sync::mpsc` channel — it never blocks the async
+//! runtime's worker threads.
+
+use crate::error::{AppError, Result};
+
+/// Authenticate the device owner (Touch ID, falling back to the device passcode) before a
+/// security-sensitive action. `reason` is shown verbatim in the system prompt (e.g.
+/// "Unlock this folder").
+///
+/// Returns:
+/// - `Ok(true)`  — authenticated, OR biometrics/LA is unavailable (graceful degradation).
+/// - `Ok(false)` — the user was prompted and FAILED/cancelled the prompt.
+/// - `Err(_)`    — an unexpected internal failure (e.g. the blocking task was cancelled).
+///
+/// Never panics; FFI errors degrade to `Ok(true)` with a warning log.
+pub async fn authenticate(reason: &str) -> Result<bool> {
+    let reason = reason.to_string();
+    tokio::task::spawn_blocking(move || authenticate_blocking(&reason))
+        .await
+        .map_err(|e| AppError::Auth(format!("biometric task join failed: {e}")))?
+}
+
+/// macOS implementation: real LocalAuthentication via objc2.
+/// Decide WHICH policy to evaluate, or `None` to degrade-to-allow when nothing is evaluable.
+///
+/// Prefer biometrics; fall back to device-owner auth (which also accepts the device passcode) so a
+/// Mac without Touch ID hardware can still gate on the login password. If NEITHER policy can be
+/// evaluated (no hardware + no passcode, an unsigned/sandboxed test binary, or a CI box),
+/// returns `None` — the caller then allows the unlock rather than locking the user out.
+///
+/// Side-effect-free: `canEvaluatePolicy` does NOT show a prompt (only `evaluatePolicy` does), so
+/// this is safe to call from tests without popping a real Touch ID dialog.
+#[cfg(target_os = "macos")]
+fn resolve_policy(
+    context: &objc2_local_authentication::LAContext,
+) -> Option<objc2_local_authentication::LAPolicy> {
+    use objc2_local_authentication::LAPolicy;
+
+    // canEvaluatePolicy returns Ok(()) when evaluable, Err(NSError) otherwise.
+    let bio_ok = unsafe {
+        context
+            .canEvaluatePolicy_error(LAPolicy::DeviceOwnerAuthenticationWithBiometrics)
+            .is_ok()
+    };
+    if bio_ok {
+        return Some(LAPolicy::DeviceOwnerAuthenticationWithBiometrics);
+    }
+    let owner_ok = unsafe {
+        context
+            .canEvaluatePolicy_error(LAPolicy::DeviceOwnerAuthentication)
+            .is_ok()
+    };
+    if owner_ok {
+        // No biometrics, but a passcode is set → prompt for the passcode.
+        return Some(LAPolicy::DeviceOwnerAuthentication);
+    }
+    // Nothing to evaluate (no Touch ID, no passcode, CI/headless/unsigned). Don't lock out.
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn authenticate_blocking(reason: &str) -> Result<bool> {
+    use std::sync::mpsc;
+
+    use block2::RcBlock;
+    use objc2_foundation::{NSError, NSString};
+    use objc2_local_authentication::LAContext;
+
+    // SAFETY: standard LAContext construction; no special invariants beyond a valid ObjC runtime,
+    // which is always present in a macOS app/test process.
+    let context = unsafe { LAContext::new() };
+
+    let policy = match resolve_policy(&context) {
+        Some(p) => p,
+        None => {
+            tracing::warn!(
+                target: "biometric",
+                "LocalAuthentication unavailable (no biometrics or passcode policy evaluable) — allowing unlock without a prompt"
+            );
+            return Ok(true);
+        }
+    };
+
+    // Bridge the async ObjC reply block → a sync channel we wait on within this blocking thread.
+    let (tx, rx) = mpsc::channel::<std::result::Result<bool, String>>();
+    let ns_reason = NSString::from_str(reason);
+
+    let reply = RcBlock::new(move |success: objc2::runtime::Bool, error: *mut NSError| {
+        let result = if success.as_bool() {
+            Ok(true)
+        } else if error.is_null() {
+            // No error but not successful → treat as a denied prompt.
+            Ok(false)
+        } else {
+            // SAFETY: LocalAuthentication hands us a valid autoreleased NSError on failure; we only
+            // read its localizedDescription and never retain it past this closure.
+            let desc = unsafe { (*error).localizedDescription() };
+            Err(desc.to_string())
+        };
+        // The receiver is alive for the duration of evaluatePolicy; ignore a closed channel.
+        let _ = tx.send(result);
+    });
+
+    // SAFETY: `reason` is a valid NSString and `reply` is a sendable block (RcBlock). The reply is
+    // invoked exactly once by the framework on completion.
+    unsafe {
+        context.evaluatePolicy_localizedReason_reply(policy, &ns_reason, &reply);
+    }
+
+    // Block this (blocking-pool) thread until the framework calls back. A 60s ceiling guards
+    // against a wedged prompt; on timeout we DENY (fail-closed) since the user was actively asked.
+    match rx.recv_timeout(std::time::Duration::from_secs(60)) {
+        Ok(Ok(true)) => Ok(true),
+        Ok(Ok(false)) => {
+            tracing::info!(target: "biometric", "biometric prompt denied or cancelled by user");
+            Ok(false)
+        }
+        Ok(Err(desc)) => {
+            tracing::info!(target: "biometric", error = %desc, "biometric evaluation failed");
+            Ok(false)
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!(target: "biometric", "biometric prompt timed out — denying");
+            Ok(false)
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            // The reply block was dropped without firing — treat as an unavailable LA stack and
+            // degrade to allow rather than wedging the unlock flow.
+            tracing::warn!(
+                target: "biometric",
+                "biometric reply channel disconnected without a result — allowing unlock"
+            );
+            Ok(true)
+        }
+    }
+}
+
+/// Non-macOS fallback: there is no Touch ID, so the gate is a no-op (graceful degradation). This
+/// crate ships macOS-only, but keeping the cfg makes `cargo build`/`test` on other hosts work.
+#[cfg(not(target_os = "macos"))]
+fn authenticate_blocking(_reason: &str) -> Result<bool> {
+    tracing::warn!(
+        target: "biometric",
+        "biometric authentication not supported on this platform — allowing unlock"
+    );
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// macOS: `resolve_policy` is side-effect-free (`canEvaluatePolicy` never prompts). Calling it
+    /// must not panic across the objc2 FFI and must return a clean `Option<LAPolicy>` — which is
+    /// the degradation decision (`None` ⇒ allow, `Some` ⇒ would prompt). We do NOT assert a
+    /// specific variant because it is environment-dependent (signed-and-Touch-ID vs.
+    /// unsigned/CI), and asserting one would be a fabricated, environment-shaped pass. This proves
+    /// the FFI boundary + the graceful-degradation branch are sound WITHOUT firing a real prompt.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_policy_does_not_panic_or_prompt() {
+        use objc2_local_authentication::LAContext;
+        let context = unsafe { LAContext::new() };
+        // The point is that this returns at all (no panic, no UI). Both arms are valid outcomes.
+        let _decision = resolve_policy(&context);
+    }
+
+    /// Non-macOS: the gate degrades to allow without any FFI.
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn authenticate_degrades_to_allow_off_platform() {
+        assert!(authenticate("test").await.unwrap());
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -93,6 +93,10 @@ pub struct MeetingDetailDto {
     pub meeting: Meeting,
     pub note: Option<NoteDto>,
     pub segments: Vec<Segment>,
+    /// Phase 0.5 — `true` when the meeting's folder is sealed AND not session-unlocked. The FE
+    /// renders a locked state (Touch-ID-to-unlock) instead of content; `note`/`segments` are
+    /// empty in that case (the content is encrypted at rest, decrypted only on session-unlock).
+    pub locked: bool,
 }
 
 // ── Commands (PHASE0-PLAN §7) ──
@@ -468,6 +472,14 @@ pub fn export_audio(
     meeting_id: String,
     dest_path: String,
 ) -> Result<(), AppError> {
+    // Phase 0.5 READ-GATE: refuse to export the audio of a sealed-and-not-unlocked meeting. Its
+    // WAV is AES-GCM-encrypted at rest (audio_path → <file>.enc) and there is no plaintext on disk
+    // to copy until the folder is session-unlocked; fail closed with a Locked error.
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to export the audio".into(),
+        ));
+    }
     let meeting = state
         .db
         .get_meeting(&meeting_id)?
@@ -1368,6 +1380,12 @@ pub async fn get_timeline(
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<MeetingTimeline, AppError> {
+    // Phase 0.5 READ-GATE: a sealed-and-not-unlocked meeting returns an EMPTY timeline (its
+    // `timelines.data` is blanked at rest while sealed, but mask explicitly + skip regeneration so
+    // we never re-derive a timeline from now-blank segments).
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Ok(MeetingTimeline::default());
+    }
     if let Some(json) = state.db.get_timeline_data(&meeting_id)? {
         if let Ok(t) = serde_json::from_str::<MeetingTimeline>(&json) {
             return Ok(t);
@@ -1408,6 +1426,24 @@ pub fn get_meeting_detail(
     let Some(meeting) = state.db.get_meeting(&meeting_id)? else {
         return Ok(None);
     };
+
+    // Phase 0.5 READ-GATE: a meeting in a locked-and-NOT-session-unlocked folder returns a MASKED
+    // DTO — `locked: true`, no note, no segments. The plaintext columns are blanked at rest while
+    // sealed (and the audio is encrypted), but we mask explicitly so the FE never shows the empty
+    // shell as if it were real content, and so the title can be masked too.
+    //
+    // `audio_path` is NULLED here too: the FE feeds it straight into `convertFileSrc` (the Tauri
+    // `asset:` protocol, scoped to the audio dir) which serves the file to the webview WITHOUT
+    // touching the `export_audio` command — i.e. the only audio read path that does NOT pass
+    // through `meeting_is_unlocked`. While sealed the on-disk file is the AES-GCM `.enc` (so even a
+    // leaked path serves ciphertext), but we must not depend on that single invariant: nulling the
+    // path here means the gate covers the asset protocol regardless of the on-disk seal state, so a
+    // plaintext WAV that briefly survives in the scoped dir (e.g. recorded into an already-sealed
+    // folder, or a crash window) can never be served to a locked meeting's view.
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Ok(Some(masked_detail(meeting)));
+    }
+
     let note = state
         .db
         .get_latest_note_for_meeting(&meeting_id)?
@@ -1422,7 +1458,28 @@ pub fn get_meeting_detail(
         meeting,
         note,
         segments,
+        locked: false,
     }))
+}
+
+/// Build the MASKED detail DTO for a sealed-and-not-session-unlocked meeting. Pure (no DB / state)
+/// so the read-gate's masking contract is unit-testable. EVERY content channel is closed:
+/// - `title` → "🔒 Locked" (the real title lives in `meetings.title`, plaintext-at-rest);
+/// - `audio_path` → `None` so the FE has nothing to hand `convertFileSrc` (the `asset:` protocol
+///   serve path that bypasses the `export_audio` command + `meeting_is_unlocked` gate);
+/// - `note` / `segments` → empty;
+/// - `locked` → true so the FE renders the unlock affordance, not an empty shell.
+fn masked_detail(meeting: Meeting) -> MeetingDetailDto {
+    MeetingDetailDto {
+        meeting: Meeting {
+            title: Some("🔒 Locked".to_string()),
+            audio_path: None,
+            ..meeting
+        },
+        note: None,
+        segments: Vec::new(),
+        locked: true,
+    }
 }
 
 /// Whether a usable Whisper model is present for the chosen size + language (or the
@@ -1716,6 +1773,11 @@ pub fn lock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), 
         state.db.seal_note(meeting_id, provider_id, blob)?;
     }
 
+    // Phase 0.5 — seal the TRANSCRIPT + TIMELINE (defense-in-depth in the OPEN db) and the AUDIO
+    // WAV at rest, all under the SAME folder CK. Verify-before-destroy inside (no transcript /
+    // audio loss). Done after the note seal so a partial-seal crash still leaves recoverable blobs.
+    seal_folder_extras(state.inner(), &folder_id, &ck)?;
+
     // AFTER the column writes, delete the vault `.md` files (a leftover .md is reconcilable;
     // lost content is not — so this is last).
     for p in exported_paths {
@@ -1781,6 +1843,10 @@ pub async fn unlock_folder(
             .restore_note_markdown(&n.meeting_id, &n.provider_id, &markdown)?;
     }
 
+    // Phase 0.5 — decrypt the TRANSCRIPT + TIMELINE back into their plaintext columns and
+    // materialize a playable WAV (decrypt .enc → file) for the session, under the SAME CK.
+    unseal_folder_extras(state.inner(), &folder_id, &ck)?;
+
     // Cache the KEK for the session (zeroized on relock-all) + add to the unlock set.
     {
         let mut g = state
@@ -1830,8 +1896,11 @@ pub fn relock_folder(state: State<'_, AppState>, folder_id: String) -> Result<()
         g.remove(&folder_id);
     }
     let mut one = std::collections::HashSet::new();
-    one.insert(folder_id);
+    one.insert(folder_id.clone());
     state.db.blank_sealed_notes_in_folders(&one)?;
+    // Phase 0.5 — re-blank the transcript + timeline plaintext and drop the decrypted session WAV
+    // (the .enc + the *_blob columns stay; the folder is still locked=1 on disk).
+    reblank_folder_extras(state.inner(), &folder_id)?;
     Ok(())
 }
 
@@ -1866,6 +1935,11 @@ pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
     let locked: std::collections::HashSet<String> =
         state.db.locked_folder_ids()?.into_iter().collect();
     state.db.blank_sealed_notes_in_folders(&locked)?;
+    // Phase 0.5 — re-blank the transcript + timeline + drop the decrypted session WAVs for every
+    // locked folder too (the .enc + *_blob columns stay).
+    for fid in &locked {
+        reblank_folder_extras(state, fid)?;
+    }
     Ok(())
 }
 
@@ -1956,6 +2030,10 @@ pub fn remove_lock(state: State<'_, AppState>, folder_id: String) -> Result<(), 
         }
     }
 
+    // Phase 0.5 — permanently restore the TRANSCRIPT + TIMELINE plaintext (clear *_blob columns)
+    // and the AUDIO WAV (decrypt .enc → file, drop .enc) under the SAME CK. Never lose audio.
+    unseal_folder_extras_permanent(state.inner(), &folder_id, &ck)?;
+
     // Flip the folder back to OPEN + drop it from the session set.
     state.db.set_folder_locked(&folder_id, false, None)?;
     {
@@ -1966,6 +2044,225 @@ pub fn remove_lock(state: State<'_, AppState>, folder_id: String) -> Result<(), 
         g.remove(&folder_id);
     }
     Ok(())
+}
+
+/// SESSION-unlock the folder OWNING a meeting (so the FE can unlock straight from the locked
+/// Detail view). Resolves the meeting's folder, then delegates to the existing biometric
+/// `unlock_folder` path (Touch ID → KEK → unwrap CK → decrypt note + transcript + timeline + audio
+/// for the session). A meeting at the vault root or in an open folder is already unlocked → no-op
+/// (returns `None`); a sealed folder returns the refreshed `FolderNode`.
+#[tauri::command]
+pub async fn unlock_meeting(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Option<FolderNode>, AppError> {
+    let Some(folder_id) = state.db.folder_for_meeting(&meeting_id)? else {
+        return Ok(None); // vault root — nothing to unlock.
+    };
+    let folder = state
+        .db
+        .folder_by_id(&folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    if !folder.locked {
+        return Ok(None); // open folder — already visible.
+    }
+    // Reuse the SAME biometric unlock path (do not fork the lifecycle).
+    unlock_folder(state, folder_id).await.map(Some)
+}
+
+// ── Phase 0.5 full per-folder lock: transcript + timeline + audio seal helpers ──
+//
+// The note markdown was already sealed (encrypt→content_blob, blank plaintext). These helpers
+// extend the SAME lifecycle to a folder's TRANSCRIPT (segments.text), TIMELINE (timelines.data),
+// and the AUDIO WAV (a file at meetings.audio_path, NOT in the SQLCipher DB → plaintext on disk).
+// All key off the folder content key (CK) the caller has already unwrapped.
+
+/// Suffix marking an audio file as AES-GCM-encrypted-at-rest (sealed folder). The presence of
+/// this suffix on `meetings.audio_path` is the on-disk "audio is sealed" signal.
+const ENC_SUFFIX: &str = ".enc";
+
+/// SEAL every governed meeting's transcript + timeline under `ck`, then the audio WAV. Mirrors
+/// `lock_folder`'s note seal: each blob is verified-decryptable BEFORE the plaintext is blanked /
+/// the plaintext WAV is removed — content (transcript / audio) is never lost.
+fn seal_folder_extras(state: &AppState, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    let meeting_ids = state.db.meeting_ids_in_folder(folder_id)?;
+    for mid in &meeting_ids {
+        // Transcript: encrypt each segment's plaintext text, verify, then seal (blank text).
+        let segs = state.db.raw_segments(mid)?;
+        let mut sealed_segs: Vec<(i64, Vec<u8>)> = Vec::new();
+        for s in &segs {
+            // Skip rows already sealed (text_blob present, text blank) — idempotent.
+            if s.text_blob.is_some() && s.text.is_empty() {
+                continue;
+            }
+            let blob = crate::crypto::encrypt(ck, s.text.as_bytes())?;
+            if crate::crypto::decrypt(ck, &blob)? != s.text.as_bytes() {
+                return Err(AppError::Storage(
+                    "transcript seal verification failed (segment blob mismatch)".into(),
+                ));
+            }
+            sealed_segs.push((s.idx, blob));
+        }
+        for (idx, blob) in &sealed_segs {
+            state.db.seal_segment(mid, *idx, blob)?;
+        }
+
+        // Timeline: encrypt the cached JSON (if any), verify, then seal (blank data).
+        if let Some(tl) = state.db.raw_timeline(mid)? {
+            if !(tl.data_blob.is_some() && tl.data.is_empty()) {
+                let blob = crate::crypto::encrypt(ck, tl.data.as_bytes())?;
+                if crate::crypto::decrypt(ck, &blob)? != tl.data.as_bytes() {
+                    return Err(AppError::Storage(
+                        "timeline seal verification failed (blob mismatch)".into(),
+                    ));
+                }
+                state.db.seal_timeline(mid, &blob)?;
+            }
+        }
+
+        // Audio: encrypt the plaintext WAV → <file>.enc (verify-before-destroy inside
+        // encrypt_file), then remove the plaintext and re-point audio_path at the .enc.
+        if let Some(path) = state.db.get_meeting(mid)?.and_then(|m| m.audio_path) {
+            if !path.ends_with(ENC_SUFFIX) && std::path::Path::new(&path).exists() {
+                let enc_path = format!("{path}{ENC_SUFFIX}");
+                crate::crypto::encrypt_file(ck, std::path::Path::new(&path), std::path::Path::new(&enc_path))?;
+                // Only NOW (a verified .enc exists) is the plaintext safe to remove.
+                let _ = std::fs::remove_file(&path);
+                state.db.set_meeting_audio_path(mid, Some(&enc_path))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// SESSION-unlock: decrypt every governed meeting's transcript + timeline back into the plaintext
+/// columns and materialize a playable WAV (decrypt <file>.enc → <file>) re-pointing audio_path at
+/// it. Keeps the `.enc` + the `*_blob` columns (folder is still locked on disk).
+fn unseal_folder_extras(state: &AppState, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    let meeting_ids = state.db.meeting_ids_in_folder(folder_id)?;
+    for mid in &meeting_ids {
+        for s in state.db.raw_segments(mid)? {
+            let Some(blob) = &s.text_blob else { continue };
+            let pt = crate::crypto::decrypt(ck, blob)?;
+            let text = String::from_utf8(pt)
+                .map_err(|_| AppError::Storage("decrypted segment is not valid UTF-8".into()))?;
+            state.db.restore_segment_text(mid, s.idx, &text)?;
+        }
+        if let Some(tl) = state.db.raw_timeline(mid)? {
+            if let Some(blob) = &tl.data_blob {
+                let pt = crate::crypto::decrypt(ck, blob)?;
+                let data = String::from_utf8(pt)
+                    .map_err(|_| AppError::Storage("decrypted timeline is not valid UTF-8".into()))?;
+                state.db.restore_timeline_data(mid, &data)?;
+            }
+        }
+        if let Some(enc_path) = state.db.get_meeting(mid)?.and_then(|m| m.audio_path) {
+            if enc_path.ends_with(ENC_SUFFIX) {
+                let plain = enc_path.trim_end_matches(ENC_SUFFIX).to_string();
+                crate::crypto::decrypt_file(ck, std::path::Path::new(&enc_path), std::path::Path::new(&plain))?;
+                state.db.set_meeting_audio_path(mid, Some(&plain))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// RE-BLANK (relock): re-blank the plaintext transcript + timeline of every governed meeting and
+/// remove the decrypted session WAV, re-pointing audio_path back at the `.enc`. The `*_blob`
+/// columns + the `.enc` stay (the folder is still `locked=1`). Idempotent.
+fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppError> {
+    for mid in state.db.meeting_ids_in_folder(folder_id)? {
+        for s in state.db.raw_segments(&mid)? {
+            if s.text_blob.is_some() && !s.text.is_empty() {
+                state.db.restore_segment_text(&mid, s.idx, "")?;
+            }
+        }
+        if let Some(tl) = state.db.raw_timeline(&mid)? {
+            if tl.data_blob.is_some() && !tl.data.is_empty() {
+                state.db.restore_timeline_data(&mid, "")?;
+            }
+        }
+        if let Some(path) = state.db.get_meeting(&mid)?.and_then(|m| m.audio_path) {
+            if !path.ends_with(ENC_SUFFIX) {
+                let enc_path = format!("{path}{ENC_SUFFIX}");
+                if std::path::Path::new(&enc_path).exists() {
+                    // The .enc is the durable copy; drop the decrypted session WAV + re-point.
+                    let _ = std::fs::remove_file(&path);
+                    state.db.set_meeting_audio_path(&mid, Some(&enc_path))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// PERMANENT remove-lock: decrypt every governed meeting's transcript + timeline back to plaintext,
+/// clear the `*_blob` columns, and permanently restore the plaintext WAV (decrypt .enc → file,
+/// remove the .enc). NEVER lose audio — the plaintext is written + the file decrypts before the
+/// `.enc` is removed.
+fn unseal_folder_extras_permanent(
+    state: &AppState,
+    folder_id: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    for mid in state.db.meeting_ids_in_folder(folder_id)? {
+        // Transcript: restore each segment from its blob (or keep the in-memory text if the folder
+        // was session-unlocked and the blob is absent), then clear all blobs for the meeting.
+        for s in state.db.raw_segments(&mid)? {
+            if let Some(blob) = &s.text_blob {
+                let pt = crate::crypto::decrypt(ck, blob)?;
+                let text = String::from_utf8(pt)
+                    .map_err(|_| AppError::Storage("decrypted segment is not valid UTF-8".into()))?;
+                state.db.restore_segment_text(&mid, s.idx, &text)?;
+            }
+        }
+        state.db.clear_segment_blobs(&mid)?;
+
+        if let Some(tl) = state.db.raw_timeline(&mid)? {
+            if let Some(blob) = &tl.data_blob {
+                let pt = crate::crypto::decrypt(ck, blob)?;
+                let data = String::from_utf8(pt)
+                    .map_err(|_| AppError::Storage("decrypted timeline is not valid UTF-8".into()))?;
+                state.db.restore_timeline_data(&mid, &data)?;
+            }
+        }
+        state.db.clear_timeline_blob(&mid)?;
+
+        // Audio: permanently restore the plaintext WAV from the .enc, then drop the .enc.
+        if let Some(enc_path) = state.db.get_meeting(&mid)?.and_then(|m| m.audio_path) {
+            if enc_path.ends_with(ENC_SUFFIX) {
+                let plain = enc_path.trim_end_matches(ENC_SUFFIX).to_string();
+                crate::crypto::decrypt_file(ck, std::path::Path::new(&enc_path), std::path::Path::new(&plain))?;
+                // Verified plaintext exists → safe to remove the .enc.
+                let _ = std::fs::remove_file(&enc_path);
+                state.db.set_meeting_audio_path(&mid, Some(&plain))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// READ-GATE predicate (the user's actual complaint): a meeting is unlocked iff its folder is open
+/// (NULL / not locked) OR its folder id is in the current session unlock set. Used by
+/// `get_meeting_detail` / `get_segments` / `get_timeline` / `export_audio` to refuse a sealed-and-
+/// not-session-unlocked meeting's content even though the SQLCipher DB is open.
+fn meeting_is_unlocked(state: &AppState, meeting_id: &str) -> Result<bool, AppError> {
+    let folder_id = match state.db.folder_for_meeting(meeting_id)? {
+        Some(f) => f,
+        None => return Ok(true), // no folder / vault root → always open.
+    };
+    let folder = match state.db.folder_by_id(&folder_id)? {
+        Some(f) => f,
+        None => return Ok(true),
+    };
+    if !folder.locked {
+        return Ok(true); // open folder.
+    }
+    let unlocked = state
+        .unlocked_folders
+        .lock()
+        .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+    Ok(unlocked.contains(&folder_id))
 }
 
 /// The configured vault path (non-empty), or `None`.
@@ -2020,5 +2317,62 @@ pub fn stop_voice_listener(app: &AppHandle) {
     let state = app.state::<AppState>();
     if let Some(mut l) = state.voice_listener.lock().ok().and_then(|mut g| g.take()) {
         l.stop();
+    }
+}
+
+#[cfg(test)]
+mod lock_read_gate_tests {
+    use super::*;
+
+    fn meeting_with_audio(audio_path: Option<&str>) -> Meeting {
+        Meeting {
+            id: "m1".to_string(),
+            started_at: "2026-06-27T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Quarterly board strategy".to_string()),
+            duration_s: 1800,
+            audio_path: audio_path.map(|s| s.to_string()),
+            status: MeetingStatus::Summarized,
+            folder_id: Some("secret-folder".to_string()),
+        }
+    }
+
+    /// REGRESSION (audio asset-protocol leak): `get_meeting_detail`'s masked DTO for a sealed-and-
+    /// not-session-unlocked meeting MUST null `audio_path`. The FE feeds `audio_path` straight into
+    /// `convertFileSrc` (the Tauri `asset:` protocol, scoped to the audio dir) which serves the
+    /// file to the webview WITHOUT going through the `export_audio` command or `meeting_is_unlocked`
+    /// — the one audio read path outside the command gate. Before the fix the masked DTO kept
+    /// `audio_path` via `..meeting`; if a PLAINTEXT WAV lived in the scoped dir (e.g. a recording
+    /// auto-filed / moved into an already-sealed folder, where the pipeline writes
+    /// `<audio>/{id}.wav` with no seal-awareness, or a crash window before re-seal) the locked
+    /// view would serve raw audio. Nulling the path closes the bypass regardless of on-disk state.
+    #[test]
+    fn masked_detail_nulls_audio_path_so_asset_protocol_cannot_serve_a_locked_recording() {
+        // The dangerous case: a PLAINTEXT WAV still on disk in the scoped audio dir.
+        let plaintext_wav = "/Users/x/Library/Application Support/MeetNotes/audio/m1.wav";
+        let masked = masked_detail(meeting_with_audio(Some(plaintext_wav)));
+
+        // The single load-bearing assertion: no path for `convertFileSrc` to serve.
+        assert_eq!(
+            masked.meeting.audio_path, None,
+            "masked detail must NULL audio_path — the FE asset-protocol serve path bypasses the command gate"
+        );
+        // And the rest of the mask: title hidden, no note, no segments, locked flag set.
+        assert_eq!(masked.meeting.title.as_deref(), Some("🔒 Locked"));
+        assert!(masked.note.is_none(), "no note while locked");
+        assert!(masked.segments.is_empty(), "no segments while locked");
+        assert!(masked.locked, "locked flag set so the FE renders the unlock affordance");
+        // Non-content metadata is preserved so the FE can offer "unlock this folder".
+        assert_eq!(masked.meeting.id, "m1");
+        assert_eq!(masked.meeting.folder_id.as_deref(), Some("secret-folder"));
+    }
+
+    /// Even with NO audio (already `.enc`-renamed or never recorded), the masked DTO is `None` —
+    /// the mask is unconditional, not dependent on the on-disk seal state.
+    #[test]
+    fn masked_detail_nulls_audio_path_even_when_already_absent() {
+        let masked = masked_detail(meeting_with_audio(None));
+        assert_eq!(masked.meeting.audio_path, None);
+        assert!(masked.locked);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -73,6 +73,17 @@ pub struct AppConfigDto {
     pub note_language: String,
     #[serde(default)]
     pub mcp_require_token: bool,
+    /// Stage E: default true (matches AppConfig::default) when the FE omits it on an older payload.
+    #[serde(default = "default_true")]
+    pub lock_require_biometric: bool,
+    /// Stage E: default true (matches AppConfig::default) when the FE omits it on an older payload.
+    #[serde(default = "default_true")]
+    pub relock_on_screenshare: bool,
+}
+
+/// serde default for the Stage E security flags (which default ON in `AppConfig`).
+fn default_true() -> bool {
+    true
 }
 
 /// A meeting + its latest note + transcript segments (Library Detail view).
@@ -1064,6 +1075,8 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         auto_organize: c.auto_organize,
         note_language: c.note_language.clone(),
         mcp_require_token: c.mcp_require_token,
+        lock_require_biometric: c.lock_require_biometric,
+        relock_on_screenshare: c.relock_on_screenshare,
     }
 }
 
@@ -1100,6 +1113,8 @@ fn dto_to_config(d: AppConfigDto) -> AppConfig {
             d.note_language
         },
         mcp_require_token: d.mcp_require_token,
+        lock_require_biometric: d.lock_require_biometric,
+        relock_on_screenshare: d.relock_on_screenshare,
     }
 }
 
@@ -1573,10 +1588,25 @@ pub fn lock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), 
 /// the plaintext markdown column for the session, and add the folder id to the session unlock set.
 /// Does NOT re-export to the vault. Returns the refreshed folder node.
 #[tauri::command]
-pub fn unlock_folder(
+pub async fn unlock_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<FolderNode, AppError> {
+    // Biometric gate (Stage E teeth): require a passing Touch ID / device-owner auth before we
+    // release the KEK and decrypt any sealed note. Gated by K_LOCK_REQUIRE_BIOMETRIC (default on)
+    // so it can be disabled. On hardware/policy unavailability the gate degrades to allow (see
+    // biometric::authenticate), so this never locks out a Mac without Touch ID.
+    let require_biometric = {
+        let cfg = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Storage("config mutex poisoned".into()))?;
+        cfg.lock_require_biometric
+    };
+    if require_biometric && !crate::biometric::authenticate("Unlock this folder").await? {
+        return Err(AppError::Auth("biometric authentication failed".into()));
+    }
+
     let folder = state
         .db
         .folder_by_id(&folder_id)?

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@ use crate::settings::AppConfig;
 use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarEvent, ChatTurn,
-    DigestResult, Meeting, MeetingStatus, MeetingTimeline, NoteRecord, PinResult, RecipeRecord,
-    SearchHit, TopicThread,
+    DigestResult, Folder, FolderNode, Meeting, MeetingStatus, MeetingTimeline, NoteRecord,
+    PinResult, RecipeRecord, SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -71,6 +71,8 @@ pub struct AppConfigDto {
     pub note_style: String,
     pub auto_organize: bool,
     pub note_language: String,
+    #[serde(default)]
+    pub mcp_require_token: bool,
 }
 
 /// A meeting + its latest note + transcript segments (Library Detail view).
@@ -1061,6 +1063,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         note_style: c.note_style.clone(),
         auto_organize: c.auto_organize,
         note_language: c.note_language.clone(),
+        mcp_require_token: c.mcp_require_token,
     }
 }
 
@@ -1096,6 +1099,7 @@ fn dto_to_config(d: AppConfigDto) -> AppConfig {
         } else {
             d.note_language
         },
+        mcp_require_token: d.mcp_require_token,
     }
 }
 
@@ -1312,6 +1316,496 @@ pub async fn download_model(state: State<'_, AppState>) -> Result<String, AppErr
 #[tauri::command]
 pub fn toggle_bar(app: AppHandle) {
     crate::toggle_bar(&app);
+}
+
+// ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──
+//
+// Lock model: default OPEN (note exported to vault + visible in MCP). Lock is explicit per
+// folder. Sealing encrypts each note's markdown into `content_blob` under a per-folder content
+// key (CK), blanks the markdown column, removes the `.md` from the vault, and stores the
+// KEK-wrapped CK in `folders.wrapped_key`. Session-unlock decrypts back into the markdown column
+// for the session (no re-export). relock re-blanks. remove_lock is permanent (re-exports).
+
+/// Build the folder tree (roots → children) from the flat folder list + per-folder note counts +
+/// the current session unlock set.
+#[tauri::command]
+pub fn list_folders(state: State<'_, AppState>) -> Result<Vec<FolderNode>, AppError> {
+    let folders = state.db.list_folders()?;
+    let counts = state.db.count_notes_per_folder()?;
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    Ok(build_folder_tree(&folders, &counts, &unlocked))
+}
+
+/// Assemble `FolderNode` roots (parent_id == None) and recurse children. Sealed-but-session-
+/// unlocked folders carry `unlocked = true`.
+fn build_folder_tree(
+    folders: &[Folder],
+    counts: &std::collections::HashMap<String, usize>,
+    unlocked: &std::collections::HashSet<String>,
+) -> Vec<FolderNode> {
+    fn node(
+        f: &Folder,
+        folders: &[Folder],
+        counts: &std::collections::HashMap<String, usize>,
+        unlocked: &std::collections::HashSet<String>,
+    ) -> FolderNode {
+        let children = folders
+            .iter()
+            .filter(|c| c.parent_id.as_deref() == Some(f.id.as_str()))
+            .map(|c| node(c, folders, counts, unlocked))
+            .collect();
+        FolderNode {
+            id: f.id.clone(),
+            name: f.name.clone(),
+            parent_id: f.parent_id.clone(),
+            note_count: counts.get(&f.id).copied().unwrap_or(0),
+            locked: f.locked,
+            unlocked: f.locked && unlocked.contains(&f.id),
+            children,
+        }
+    }
+    folders
+        .iter()
+        .filter(|f| f.parent_id.is_none())
+        .map(|f| node(f, folders, counts, unlocked))
+        .collect()
+}
+
+/// Create a folder under an optional parent. The vault-relative path is derived from the parent
+/// path + the sanitized folder name; the matching vault subdirectory is created on disk.
+#[tauri::command]
+pub fn create_folder(
+    state: State<'_, AppState>,
+    name: String,
+    parent_id: Option<String>,
+) -> Result<Folder, AppError> {
+    let clean = crate::summarize::organize::sanitize_folder(&name)
+        .ok_or_else(|| AppError::InvalidArg("folder name is empty or invalid".into()))?;
+
+    // Resolve the parent's vault-relative path (if any) and compose the child path.
+    let parent_path = match parent_id.as_deref() {
+        Some(pid) => {
+            let parent = state
+                .db
+                .folder_by_id(pid)?
+                .ok_or_else(|| AppError::InvalidArg(format!("no parent folder {pid}")))?;
+            Some(parent.path)
+        }
+        None => None,
+    };
+    let rel_path = match &parent_path {
+        Some(p) if !p.is_empty() => format!("{p}/{clean}"),
+        _ => clean.clone(),
+    };
+
+    // Create the vault subdirectory (best-effort but surfaced): only when a vault is configured.
+    if let Some(vault) = vault_path(&state) {
+        let dir = std::path::Path::new(&vault).join(&rel_path);
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| AppError::Export(format!("create folder dir failed: {e}")))?;
+    }
+
+    let folder = Folder {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: clean,
+        path: rel_path,
+        parent_id,
+        locked: false,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    state.db.insert_folder(&folder)?;
+    Ok(folder)
+}
+
+/// Move a note into a folder (or to the root with `folder_id = None`). If the note has an
+/// exported `.md` and NEITHER the source nor the target folder is locked, the file is moved on
+/// disk (copy-then-remove, best-effort, never loses bytes). Moving into/out of a locked folder
+/// does not touch the vault here (sealing/unsealing owns that lifecycle).
+#[tauri::command]
+pub fn move_note(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    folder_id: Option<String>,
+) -> Result<(), AppError> {
+    // Resolve current + target folder lock state.
+    let note = state.db.get_latest_note_for_meeting(&meeting_id)?;
+    let target_locked = match folder_id.as_deref() {
+        Some(fid) => {
+            state
+                .db
+                .folder_by_id(fid)?
+                .ok_or_else(|| AppError::InvalidArg(format!("no folder {fid}")))?
+                .locked
+        }
+        None => false,
+    };
+    // The source folder's lock state: derive from the note's exported_path being present
+    // (sealed notes have exported_path = NULL). If exported_path is None we treat the source as
+    // "no movable file" and skip the FS move entirely.
+    let exported = note.as_ref().and_then(|n| n.exported_path.clone());
+
+    // Reassign in the DB first (the source-of-truth association).
+    state.db.set_note_folder(&meeting_id, folder_id.as_deref())?;
+
+    // Best-effort FS move only when a plaintext .md exists and the target is open.
+    if let (Some(src_path), false) = (exported, target_locked) {
+        if let Some(vault) = vault_path(&state) {
+            let target_rel = match folder_id.as_deref() {
+                Some(fid) => state.db.folder_by_id(fid)?.map(|f| f.path),
+                None => None,
+            };
+            move_note_file(&state, &meeting_id, &src_path, &vault, target_rel.as_deref())?;
+        }
+    }
+    Ok(())
+}
+
+/// Move the exported `.md` to the target folder's vault subdir, preserving content. Re-points
+/// the note's `exported_path`. Copy-then-remove so a failure never loses bytes.
+fn move_note_file(
+    state: &State<'_, AppState>,
+    meeting_id: &str,
+    src_path: &str,
+    vault: &str,
+    target_rel: Option<&str>,
+) -> Result<(), AppError> {
+    let src = std::path::Path::new(src_path);
+    let bytes = match std::fs::read_to_string(src) {
+        Ok(b) => b,
+        // Source file already gone → nothing to move; leave DB association as set.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(AppError::Export(format!("read note for move failed: {e}"))),
+    };
+    let file_name = src
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| AppError::Export("note path has no filename".into()))?;
+    let dest_dir = match target_rel.filter(|p| !p.is_empty()) {
+        Some(rel) => std::path::Path::new(vault).join(rel),
+        None => std::path::Path::new(vault).to_path_buf(),
+    };
+    let dest = dest_dir.join(file_name);
+    if dest == src {
+        return Ok(());
+    }
+    std::fs::create_dir_all(&dest_dir)
+        .map_err(|e| AppError::Export(format!("create move dir failed: {e}")))?;
+    // Write the destination atomically, THEN remove the source (never lose bytes).
+    crate::export::overwrite_note(&dest, &bytes)?;
+    let _ = std::fs::remove_file(src);
+    // Re-point the exported path for every provider row of this meeting.
+    if let Some(existing) = state.db.get_latest_note_for_meeting(meeting_id)? {
+        state.db.set_note_exported_path(
+            meeting_id,
+            &existing.provider_id,
+            &dest.to_string_lossy(),
+        )?;
+    }
+    Ok(())
+}
+
+/// SEAL a folder: generate a content key, KEK-wrap it, encrypt every governed note's markdown
+/// into `content_blob`, then (after a DB commit) blank the markdown + delete the vault `.md`.
+/// Atomicity: each note's blob is verified decryptable BEFORE we blank/delete; a crash after the
+/// DB write but before the `.md` delete leaves a stale plaintext `.md` (reconcilable) — never
+/// lost content.
+#[tauri::command]
+pub fn lock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
+    let folder = state
+        .db
+        .folder_by_id(&folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    if folder.locked {
+        return Ok(()); // already sealed — idempotent.
+    }
+
+    let kek = crate::secrets::get_or_create_master_kek()?;
+    let ck = crate::crypto::random_key()?;
+    let wrapped = crate::crypto::encrypt(&kek, &ck)?;
+
+    // Gather the notes to seal. A meeting may have MULTIPLE provider rows (e.g. re-summarized
+    // with ollama then anthropic) each with DISTINCT markdown — seal EVERY (meeting, provider)
+    // row into its OWN blob. Collapsing to one blob per meeting would destroy every provider's
+    // content but the first (the PRIME-DIRECTIVE content-loss bug this guards against).
+    let notes = state.db.notes_in_folder(&folder_id)?;
+    let mut sealed_rows: Vec<(String, String, Vec<u8>)> = Vec::new();
+    for n in &notes {
+        // Encrypt this row's markdown and VERIFY it reads back before we touch the plaintext.
+        let blob = crate::crypto::encrypt(&ck, n.markdown.as_bytes())?;
+        let check = crate::crypto::decrypt(&ck, &blob)?;
+        if check != n.markdown.as_bytes() {
+            return Err(AppError::Storage(
+                "seal verification failed (decrypted blob mismatch)".into(),
+            ));
+        }
+        sealed_rows.push((n.meeting_id.clone(), n.provider_id.clone(), blob));
+    }
+
+    // Capture every governed note's .md path BEFORE any seal_note nulls exported_path.
+    let exported_paths: Vec<String> = notes.iter().filter_map(|n| n.exported_path.clone()).collect();
+
+    // Persist: mark the folder locked (+ wrapped key) and write every sealed blob per provider
+    // row (markdown blanked, exported_path cleared). Each write is guarded by the verification
+    // above, so a crash mid-loop leaves already-sealed rows recoverable and not-yet-sealed rows
+    // with intact plaintext — never lost content.
+    state
+        .db
+        .set_folder_locked(&folder_id, true, Some(&wrapped))?;
+    for (meeting_id, provider_id, blob) in &sealed_rows {
+        state.db.seal_note(meeting_id, provider_id, blob)?;
+    }
+
+    // AFTER the column writes, delete the vault `.md` files (a leftover .md is reconcilable;
+    // lost content is not — so this is last).
+    for p in exported_paths {
+        let _ = std::fs::remove_file(&p);
+    }
+    Ok(())
+}
+
+/// SESSION-unlock a sealed folder: KEK → unwrap CK → decrypt each note's `content_blob` back into
+/// the plaintext markdown column for the session, and add the folder id to the session unlock set.
+/// Does NOT re-export to the vault. Returns the refreshed folder node.
+#[tauri::command]
+pub fn unlock_folder(
+    state: State<'_, AppState>,
+    folder_id: String,
+) -> Result<FolderNode, AppError> {
+    let folder = state
+        .db
+        .folder_by_id(&folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    if !folder.locked {
+        return Err(AppError::InvalidArg("folder is not locked".into()));
+    }
+    let wrapped = state
+        .db
+        .folder_wrapped_key(&folder_id)?
+        .ok_or_else(|| AppError::Storage("locked folder has no wrapped key".into()))?;
+
+    let kek = crate::secrets::get_or_create_master_kek()?;
+    let ck_bytes = crate::crypto::decrypt(&kek, &wrapped)?;
+    let ck: [u8; 32] = ck_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| AppError::Storage("unwrapped content key has wrong length".into()))?;
+
+    // Decrypt EACH sealed provider row's own blob back into its own markdown column for the
+    // session (no dedup by meeting — every provider's distinct content is restored independently).
+    let notes = state.db.notes_in_folder(&folder_id)?;
+    for n in &notes {
+        let Some(blob) = &n.content_blob else {
+            continue; // open note (shouldn't happen in a sealed folder) — skip.
+        };
+        let pt = crate::crypto::decrypt(&ck, blob)?;
+        let markdown = String::from_utf8(pt)
+            .map_err(|_| AppError::Storage("decrypted note is not valid UTF-8".into()))?;
+        state
+            .db
+            .restore_note_markdown(&n.meeting_id, &n.provider_id, &markdown)?;
+    }
+
+    // Cache the KEK for the session (zeroized on relock-all) + add to the unlock set.
+    {
+        let mut g = state
+            .master_kek
+            .lock()
+            .map_err(|_| AppError::Storage("master-kek mutex poisoned".into()))?;
+        *g = Some(kek);
+    }
+    {
+        let mut g = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+        g.insert(folder_id.clone());
+    }
+
+    // Return the refreshed node.
+    let counts = state.db.count_notes_per_folder()?;
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    Ok(FolderNode {
+        id: folder.id.clone(),
+        name: folder.name.clone(),
+        parent_id: folder.parent_id.clone(),
+        note_count: counts.get(&folder.id).copied().unwrap_or(0),
+        locked: true,
+        unlocked: unlocked.contains(&folder.id),
+        children: Vec::new(),
+    })
+}
+
+/// Re-seal a session-unlocked folder for the rest of this session: re-blank the plaintext
+/// markdown of its sealed notes and drop the folder from the unlock set. The `content_blob`
+/// stays — the folder is still `locked=1` on disk.
+#[tauri::command]
+pub fn relock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
+    {
+        let mut g = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+        g.remove(&folder_id);
+    }
+    let mut one = std::collections::HashSet::new();
+    one.insert(folder_id);
+    state.db.blank_sealed_notes_in_folders(&one)?;
+    Ok(())
+}
+
+/// Relock ALL session-unlocked folders + zeroize the cached KEK (called on screen-share start in
+/// Stage E, and exposed as a command). Re-blanks the plaintext markdown of every sealed note.
+#[tauri::command]
+pub fn relock_all(state: State<'_, AppState>) -> Result<(), AppError> {
+    relock_all_inner(&state)
+}
+
+/// Inner relock-all usable without a command boundary (Stage E screen-share watcher).
+pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
+    // Clear the session set.
+    {
+        let mut g = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+        g.clear();
+    }
+    // Zeroize the cached KEK copy.
+    {
+        let mut g = state
+            .master_kek
+            .lock()
+            .map_err(|_| AppError::Storage("master-kek mutex poisoned".into()))?;
+        if let Some(mut k) = g.take() {
+            k.iter_mut().for_each(|b| *b = 0);
+        }
+    }
+    // Re-blank every sealed note across all locked folders.
+    let locked: std::collections::HashSet<String> =
+        state.db.locked_folder_ids()?.into_iter().collect();
+    state.db.blank_sealed_notes_in_folders(&locked)?;
+    Ok(())
+}
+
+/// PERMANENTLY remove a folder's lock: KEK → unwrap CK → decrypt each note back to plaintext
+/// markdown, clear `content_blob`, set `locked=0` + `wrapped_key=NULL`, and re-export each note's
+/// `.md` to the vault. The folder returns to the default OPEN state.
+#[tauri::command]
+pub fn remove_lock(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
+    let folder = state
+        .db
+        .folder_by_id(&folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    if !folder.locked {
+        return Ok(()); // already open — idempotent.
+    }
+    let wrapped = state
+        .db
+        .folder_wrapped_key(&folder_id)?
+        .ok_or_else(|| AppError::Storage("locked folder has no wrapped key".into()))?;
+    let kek = crate::secrets::get_or_create_master_kek()?;
+    let ck_bytes = crate::crypto::decrypt(&kek, &wrapped)?;
+    let ck: [u8; 32] = ck_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| AppError::Storage("unwrapped content key has wrong length".into()))?;
+
+    let vault = vault_path(&state);
+    let notes = state.db.notes_in_folder(&folder_id)?;
+
+    // Step 1: restore EVERY provider row's plaintext from ITS OWN blob (or keep the in-memory
+    // markdown if the folder is session-unlocked and the blob is absent). This must happen for
+    // every row BEFORE any blob is cleared — otherwise a sibling provider's content is lost.
+    for n in &notes {
+        let markdown = if let Some(blob) = &n.content_blob {
+            let pt = crate::crypto::decrypt(&ck, blob)?;
+            String::from_utf8(pt)
+                .map_err(|_| AppError::Storage("decrypted note is not valid UTF-8".into()))?
+        } else {
+            n.markdown.clone()
+        };
+        state
+            .db
+            .restore_note_markdown(&n.meeting_id, &n.provider_id, &markdown)?;
+    }
+
+    // Step 2: per meeting, clear the blobs (all rows now hold plaintext) and re-export ONE `.md`
+    // (the latest provider's note — matching how the rest of the app treats "the note" for a
+    // meeting). All provider rows for that meeting share the re-exported path.
+    let mut seen = std::collections::HashSet::new();
+    for n in &notes {
+        if !seen.insert(n.meeting_id.clone()) {
+            continue;
+        }
+        state.db.clear_note_content_blob(&n.meeting_id)?;
+
+        let Some(vault) = vault.as_deref() else {
+            continue;
+        };
+        let latest = match state.db.get_latest_note_for_meeting(&n.meeting_id)? {
+            Some(l) => l,
+            None => continue,
+        };
+        let meeting = state.db.get_meeting(&n.meeting_id)?;
+        let (title, date) = match meeting {
+            Some(m) => (
+                m.title.clone().unwrap_or_else(|| "Untitled".into()),
+                m.started_at.clone(),
+            ),
+            None => ("Untitled".to_string(), chrono::Utc::now().to_rfc3339()),
+        };
+        let sub = if folder.path.is_empty() {
+            None
+        } else {
+            Some(folder.path.as_str())
+        };
+        if let Ok(path) = crate::export::write_note(
+            std::path::Path::new(vault),
+            sub,
+            &title,
+            &date,
+            &latest.markdown,
+        ) {
+            state.db.set_note_exported_path(
+                &n.meeting_id,
+                &latest.provider_id,
+                &path.to_string_lossy(),
+            )?;
+        }
+    }
+
+    // Flip the folder back to OPEN + drop it from the session set.
+    state.db.set_folder_locked(&folder_id, false, None)?;
+    {
+        let mut g = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+        g.remove(&folder_id);
+    }
+    Ok(())
+}
+
+/// The configured vault path (non-empty), or `None`.
+fn vault_path(state: &State<'_, AppState>) -> Option<String> {
+    state
+        .config
+        .lock()
+        .ok()
+        .and_then(|c| c.vault_path.clone())
+        .filter(|p| !p.is_empty())
 }
 
 /// (Re)start the voice-trigger listener if enabled — model present and not recording —

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@ use crate::settings::AppConfig;
 use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarEvent, ChatTurn,
-    DigestResult, Folder, FolderNode, Meeting, MeetingStatus, MeetingTimeline, NoteRecord,
-    PinResult, RecipeRecord, SearchHit, TopicThread,
+    DigestResult, EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
+    MeetingTimeline, NoteRecord, PinResult, RecipeRecord, SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -724,8 +724,82 @@ pub fn pin_moment(
     })
 }
 
-/// Resolve the people + projects in a meeting note and write/append [[Person]] / [[Project]]
-/// stub notes in the vault with a backlink to this meeting — the graph self-assembles.
+/// Extract the people + projects from a meeting note and persist them through the dual-sink:
+///
+/// - **Sink A (always):** upsert each entity into the encrypted DB (`upsert_entity`, case-
+///   insensitive dedup) and record a mention (`add_mention`, idempotent). The DB is the
+///   source of truth for the in-app graph and works with NO vault configured.
+/// - **Sink B (gated):** mirror each entity as a `[[ ]]` vault stub via `ensure_entity_backlink`
+///   ONLY when a vault is configured AND the meeting's folder is NOT locked (`folder_by_id`
+///   disk-truth — NOT session unlock). A session-unlocked folder must NOT re-emit `.md` stubs
+///   (they were removed on seal and stay out until a permanent remove-lock), so the write gate
+///   uses `locked` while every READ uses `unlocked`. A meeting at the vault root (no folder)
+///   has no lock and gets its stubs.
+///
+/// Returns the extracted `GraphPayload`. The caller decides whether extraction failures are fatal
+/// (the `link_meeting_entities` command surfaces them; the pipeline hook swallows them).
+pub async fn build_and_persist_entities(
+    state: &AppState,
+    meeting_id: &str,
+    title: &str,
+    markdown: &str,
+) -> Result<crate::summarize::graph::GraphPayload, AppError> {
+    let config = {
+        state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone()
+    };
+    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let payload =
+        crate::summarize::graph::extract_entities(provider.as_ref(), title, markdown).await?;
+
+    // Sink A — ALWAYS persist to the encrypted DB (the graph's source of truth).
+    for p in &payload.people {
+        let id = state.db.upsert_entity(p, crate::storage::models::EntityKind::Person)?;
+        state.db.add_mention(&id, meeting_id)?;
+    }
+    for pr in &payload.projects {
+        let id = state
+            .db
+            .upsert_entity(pr, crate::storage::models::EntityKind::Project)?;
+        state.db.add_mention(&id, meeting_id)?;
+    }
+
+    // Sink B — vault [[ ]] stubs, ONLY when a vault is configured AND the meeting's folder is
+    // NOT sealed on disk. Disk-truth `locked` (not session `unlocked`): a session-unlock must
+    // never re-write encrypted-content stubs back to plaintext on disk.
+    let vault = config.vault_path.clone().filter(|p| !p.is_empty());
+    if let Some(vault) = vault {
+        let folder_locked = match state.db.get_meeting(meeting_id)?.and_then(|m| m.folder_id) {
+            Some(folder_id) => state
+                .db
+                .folder_by_id(&folder_id)?
+                .map(|f| f.locked)
+                .unwrap_or(false),
+            None => false, // vault root → never locked
+        };
+        if !folder_locked {
+            let vault_path = std::path::Path::new(&vault);
+            for p in &payload.people {
+                crate::export::entity_stub::ensure_entity_backlink(vault_path, "People", p, title)?;
+            }
+            for pr in &payload.projects {
+                crate::export::entity_stub::ensure_entity_backlink(
+                    vault_path, "Projects", pr, title,
+                )?;
+            }
+        }
+    }
+
+    Ok(payload)
+}
+
+/// Resolve the people + projects in a meeting note → persist them to the encrypted DB graph
+/// (always) and mirror them as `[[Person]]` / `[[Project]]` vault stubs (only when a vault is
+/// configured + the meeting's folder is unsealed). The graph self-assembles. The DB sink works
+/// even with no vault set — hence no hard "set a vault folder" error anymore.
 #[tauri::command]
 pub async fn link_meeting_entities(
     state: State<'_, AppState>,
@@ -739,30 +813,48 @@ pub async fn link_meeting_entities(
         .db
         .get_latest_note_for_meeting(&meeting_id)?
         .ok_or_else(|| AppError::InvalidArg("this meeting has no note yet".into()))?;
-    let config = {
+    let title = meeting.title.clone().unwrap_or_else(|| "Meeting".to_string());
+    build_and_persist_entities(&state, &meeting_id, &title, &note.markdown).await
+}
+
+/// Max co-occurring neighbors returned with an entity's detail (the neighborhood satellites).
+const ENTITY_NEIGHBOR_LIMIT: i64 = 12;
+
+/// The self-assembling graph: all VISIBLE entity nodes (with their visible mention counts) + all
+/// VISIBLE co-occurrence edges. Snapshots the live session `unlocked` set (same as `list_folders`)
+/// and pushes it through the visibility predicate, so sealed-and-not-unlocked meetings contribute
+/// nothing — the graph can never disagree with Library/MCP about what's visible.
+#[tauri::command]
+pub fn get_graph(state: State<'_, AppState>) -> Result<GraphData, AppError> {
+    let unlocked = {
         state
-            .config
+            .unlocked_folders
             .lock()
-            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
             .clone()
     };
-    let vault = config
-        .vault_path
-        .clone()
-        .filter(|p| !p.is_empty())
-        .ok_or_else(|| AppError::InvalidArg("set a vault folder in Settings first".into()))?;
-    let title = meeting.title.clone().unwrap_or_else(|| "Meeting".to_string());
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
-    let payload =
-        crate::summarize::graph::extract_entities(provider.as_ref(), &title, &note.markdown).await?;
-    let vault_path = std::path::Path::new(&vault);
-    for p in &payload.people {
-        crate::export::entity_stub::ensure_entity_backlink(vault_path, "People", p, &title)?;
-    }
-    for pr in &payload.projects {
-        crate::export::entity_stub::ensure_entity_backlink(vault_path, "Projects", pr, &title)?;
-    }
-    Ok(payload)
+    state.db.build_graph(&unlocked)
+}
+
+/// Detail for one entity: the entity, its VISIBLE backlinked meetings (as `VaultSource` chips),
+/// and its top co-occurring neighbors. Snapshots the live `unlocked` set like `get_graph`.
+/// Errors with `InvalidArg` if the entity id is unknown.
+#[tauri::command]
+pub fn get_entity_detail(
+    state: State<'_, AppState>,
+    entity_id: String,
+) -> Result<EntityDetail, AppError> {
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    state
+        .db
+        .build_entity_detail(&entity_id, &unlocked, ENTITY_NEIGHBOR_LIMIT)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no entity with id {entity_id}")))
 }
 
 /// Ask-My-Vault: answer a question across ALL past meetings' notes (grounded, with sources).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -129,6 +129,7 @@ pub async fn start_recording(
         duration_s: 0,
         audio_path: None,
         status: MeetingStatus::Recording,
+        folder_id: None,
     })?;
 
     // Free the mic from the voice listener (if any) before opening it for the recording.
@@ -1465,8 +1466,10 @@ pub fn move_note(
     // "no movable file" and skip the FS move entirely.
     let exported = note.as_ref().and_then(|n| n.exported_path.clone());
 
-    // Reassign in the DB first (the source-of-truth association).
-    state.db.set_note_folder(&meeting_id, folder_id.as_deref())?;
+    // Reassign in the DB first (the source-of-truth association). Targets EVERY provider row of
+    // the meeting (WHERE meeting_id = ?1) so the meeting's folder is consistent across providers
+    // and the seal/unlock lifecycle (which iterates provider rows) stays coherent.
+    state.db.set_meeting_folder(&meeting_id, folder_id.as_deref())?;
 
     // Best-effort FS move only when a plaintext .md exists and the target is open.
     if let (Some(src_path), false) = (exported, target_locked) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -231,18 +231,26 @@ pub async fn stop_recording(
     };
     let meeting_id = meeting_uuid.to_string();
 
+    // Capture the mic stream's host start instant BEFORE consuming the recorder — it anchors the
+    // mic ("me") segments onto the absolute timeline in the wall-clock merge (pipeline.rs).
+    let mic_started_at = recorder.started_at();
     let (samples, src_rate) = recorder.stop()?;
 
-    // Stop the system-audio sidecar (if any) and collect its WAV for mixing.
-    let system_wav = {
+    // Stop the system-audio sidecar (if any) and collect its WAV + host start instant. The
+    // sidecar's start instant anchors the system ("others") segments; the two streams run on
+    // INDEPENDENT clocks, so we merge by wall-clock, not sample count (see audio::merge).
+    let (system_wav, system_started_at) = {
         let rec = state
             .system_recorder
             .lock()
             .ok()
             .and_then(|mut slot| slot.take());
         match rec {
-            Some(r) => r.stop().unwrap_or(None),
-            None => None,
+            Some(r) => {
+                let started = r.started_at();
+                (r.stop().unwrap_or(None), Some(started))
+            }
+            None => (None, None),
         }
     };
 
@@ -250,7 +258,15 @@ pub async fn stop_recording(
     let duration_s = compute_duration_s(&state, &meeting_id, samples.len(), src_rate);
 
     let result = pipeline::run_after_stop(
-        &app, &state, &meeting_id, samples, src_rate, duration_s, system_wav,
+        &app,
+        &state,
+        &meeting_id,
+        samples,
+        src_rate,
+        duration_s,
+        system_wav,
+        mic_started_at,
+        system_started_at,
     )
     .await?;
 
@@ -295,6 +311,32 @@ pub fn recording_level(state: State<'_, AppState>) -> Result<f32, AppError> {
         .lock()
         .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
     Ok(recorder.as_ref().map(|r| r.level()).unwrap_or(0.0))
+}
+
+/// Live-toggle the microphone mute mid-recording (no stream teardown). While muted, the cpal
+/// capture callback writes SILENCE into the mic buffer for those frames — the stream stays
+/// full-length so its wall-clock timeline (and thus "me"/"others" alignment) is preserved, and
+/// no real mic audio is captured (privacy). No-op if not recording.
+#[tauri::command]
+pub fn set_mic_muted(state: State<'_, AppState>, muted: bool) -> Result<(), AppError> {
+    let recorder = state
+        .recorder
+        .lock()
+        .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+    if let Some(r) = recorder.as_ref() {
+        r.set_muted(muted);
+    }
+    Ok(())
+}
+
+/// Whether the mic is currently muted on the live recorder (false when not recording).
+#[tauri::command]
+pub fn is_mic_muted(state: State<'_, AppState>) -> Result<bool, AppError> {
+    let recorder = state
+        .recorder
+        .lock()
+        .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+    Ok(recorder.as_ref().map(|r| r.is_muted()).unwrap_or(false))
 }
 
 /// The most recent note (markdown + export path) for the last-note preview pane.
@@ -1188,7 +1230,10 @@ fn dto_to_config(d: AppConfigDto) -> AppConfig {
         claude_binary: d.claude_binary,
         capture_system_audio: d.capture_system_audio,
         model_size: if d.model_size.trim().is_empty() {
-            "small".to_string()
+            // Mirror AppConfig::default().model_size — an empty/blank choice from the FE must
+            // fall back to the multilingual large-v3 default (best Polish quality), NOT a
+            // smaller model that would silently downgrade transcription.
+            AppConfig::default().model_size
         } else {
             d.model_size
         },

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -46,6 +46,40 @@ pub fn random_key() -> Result<[u8; 32]> {
     Ok(k)
 }
 
+/// Encrypt the file at `src` under `key` into `dest` (the `nonce(12) || ciphertext+tag` blob),
+/// then VERIFY the ciphertext decrypts back byte-identical to the source BEFORE returning. This
+/// mirrors `seal_note`'s verify-before-destroy: the caller removes the plaintext only after a
+/// successful return, so a corrupt write can never lose audio. The plaintext WAV (separate file
+/// at `meetings.audio_path`, NOT in the SQLCipher DB) is encrypted at rest for locked folders.
+pub fn encrypt_file(key: &[u8; 32], src: &std::path::Path, dest: &std::path::Path) -> Result<()> {
+    let plaintext = std::fs::read(src)
+        .map_err(|e| AppError::Storage(format!("read audio for encrypt: {e}")))?;
+    let blob = encrypt(key, &plaintext)?;
+    // Verify the blob decrypts back byte-identical BEFORE we ever write it (and before the caller
+    // destroys the plaintext). A tampered/short blob fails closed here.
+    let check = decrypt(key, &blob)?;
+    if check != plaintext {
+        return Err(AppError::Storage(
+            "audio seal verification failed (decrypted blob mismatch)".into(),
+        ));
+    }
+    std::fs::write(dest, &blob)
+        .map_err(|e| AppError::Storage(format!("write encrypted audio: {e}")))?;
+    Ok(())
+}
+
+/// Decrypt the encrypted-WAV file at `src` (a `nonce(12) || ciphertext+tag` blob) under `key`
+/// into the plaintext WAV at `dest`. Used to materialize a playable WAV for the session on
+/// unlock, and to permanently restore the plaintext on remove-lock.
+pub fn decrypt_file(key: &[u8; 32], src: &std::path::Path, dest: &std::path::Path) -> Result<()> {
+    let blob = std::fs::read(src)
+        .map_err(|e| AppError::Storage(format!("read encrypted audio: {e}")))?;
+    let plaintext = decrypt(key, &blob)?;
+    std::fs::write(dest, &plaintext)
+        .map_err(|e| AppError::Storage(format!("write decrypted audio: {e}")))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +105,61 @@ mod tests {
         let ck = random_key().unwrap();
         let wrapped = encrypt(&kek, &ck).unwrap();
         assert_eq!(decrypt(&kek, &wrapped).unwrap(), ck);
+    }
+
+    fn temp_path(label: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "meetnotes-crypto-test-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    #[test]
+    fn audio_encrypt_decrypt_round_trips_byte_identical() {
+        // Synthesize a small "WAV" payload (bytes are opaque to the crypto layer — a real WAV
+        // header would be identical content). Encrypt → .enc, remove plaintext, decrypt → assert
+        // byte-identical, and assert the ciphertext does NOT contain the plaintext.
+        let key = random_key().unwrap();
+        let wav = temp_path("audio.wav");
+        let enc = temp_path("audio.wav.enc");
+        let restored = temp_path("audio-restored.wav");
+        let payload: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&wav, &payload).unwrap();
+
+        // ENCRYPT (verify-before-destroy happens inside) → then simulate the lock removing the
+        // plaintext WAV.
+        encrypt_file(&key, &wav, &enc).unwrap();
+        let blob = std::fs::read(&enc).unwrap();
+        assert!(
+            !contains(&blob, &payload),
+            "ciphertext must not leak the plaintext audio"
+        );
+        std::fs::remove_file(&wav).unwrap();
+        assert!(!wav.exists(), "plaintext WAV removed while sealed");
+
+        // DECRYPT for the session → byte-identical.
+        decrypt_file(&key, &enc, &restored).unwrap();
+        assert_eq!(std::fs::read(&restored).unwrap(), payload, "audio round-trips byte-identical");
+
+        // Wrong key fails closed.
+        assert!(decrypt_file(&random_key().unwrap(), &enc, &restored).is_err());
+
+        let _ = std::fs::remove_file(&enc);
+        let _ = std::fs::remove_file(&restored);
+    }
+
+    /// Naive subslice search for the leak assertion.
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        if needle.is_empty() || needle.len() > haystack.len() {
+            return false;
+        }
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 }

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -1,0 +1,75 @@
+//! Application-layer AES-256-GCM for the per-folder lock (Layer 2, distinct from the whole-DB
+//! SQLCipher layer). A locked folder's note markdown is encrypted under a per-folder content key
+//! (CK); each CK is wrapped under a master KEK that is released only by biometric. Cell format:
+//! `nonce(12) || ciphertext || tag(16)`, stored as a BLOB.
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+
+use crate::error::{AppError, Result};
+
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+
+/// Encrypt `plaintext` under a 32-byte key → `nonce(12) || ciphertext+tag`.
+pub fn encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>> {
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    getrandom::getrandom(&mut nonce_bytes)
+        .map_err(|e| AppError::Storage(format!("nonce RNG: {e}")))?;
+    let ct = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext)
+        .map_err(|e| AppError::Storage(format!("AES-GCM encrypt: {e}")))?;
+    let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypt a `nonce(12) || ciphertext+tag` blob under a 32-byte key. A wrong key or tampered
+/// ciphertext fails closed (`AppError::Locked`).
+pub fn decrypt(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>> {
+    if blob.len() < NONCE_LEN + TAG_LEN {
+        return Err(AppError::Storage("ciphertext too short".into()));
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let (nonce_bytes, ct) = blob.split_at(NONCE_LEN);
+    cipher
+        .decrypt(Nonce::from_slice(nonce_bytes), ct)
+        .map_err(|_| AppError::Locked("decryption failed (wrong key or tampered data)".into()))
+}
+
+/// A random 32-byte key (folder content key or master KEK).
+pub fn random_key() -> Result<[u8; 32]> {
+    let mut k = [0u8; 32];
+    getrandom::getrandom(&mut k).map_err(|e| AppError::Storage(format!("key RNG: {e}")))?;
+    Ok(k)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_and_hides_plaintext() {
+        let k = random_key().unwrap();
+        let pt = "locked note markdown 🔒".as_bytes();
+        let blob = encrypt(&k, pt).unwrap();
+        assert_ne!(&blob[NONCE_LEN..], pt, "ciphertext must differ from plaintext");
+        assert_eq!(decrypt(&k, &blob).unwrap(), pt);
+    }
+
+    #[test]
+    fn wrong_key_fails_closed() {
+        let blob = encrypt(&random_key().unwrap(), b"secret").unwrap();
+        assert!(decrypt(&random_key().unwrap(), &blob).is_err());
+    }
+
+    #[test]
+    fn kek_wraps_and_unwraps_a_content_key() {
+        let kek = random_key().unwrap();
+        let ck = random_key().unwrap();
+        let wrapped = encrypt(&kek, &ck).unwrap();
+        assert_eq!(decrypt(&kek, &wrapped).unwrap(), ck);
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -12,6 +12,12 @@ pub enum AppError {
     Export(String),
     #[error("storage error: {0}")]
     Storage(String),
+    #[error("migration error: {0}")]
+    Migration(String),
+    #[error("authentication error: {0}")]
+    Auth(String),
+    #[error("locked: {0}")]
+    Locked(String),
     #[error("secrets error: {0}")]
     Secrets(String),
     #[error("config error: {0}")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,8 @@ pub fn run() {
             commands::add_reminder,
             commands::pin_moment,
             commands::link_meeting_entities,
+            commands::get_graph,
+            commands::get_entity_detail,
             commands::ask_vault,
             commands::generate_digest,
             commands::topic_threads,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,14 @@ pub fn run() {
             commands::model_present,
             commands::download_model,
             commands::toggle_bar,
+            commands::list_folders,
+            commands::create_folder,
+            commands::move_note,
+            commands::lock_folder,
+            commands::unlock_folder,
+            commands::relock_folder,
+            commands::relock_all,
+            commands::remove_lock,
         ])
         .setup(|app| {
             create_bar_window(app.handle())?;
@@ -102,10 +110,18 @@ pub fn run() {
             commands::restart_voice_listener(app.handle().clone());
             setup_tray(app.handle())?;
             // Localhost MCP server (read-only meeting tools for Claude Desktop/Code; no egress).
+            // Share the session unlock set so sealed-and-not-unlocked notes stay invisible.
             if let Some(db_path) =
                 dirs::data_dir().map(|b| b.join("MeetNotes").join("meetnotes.sqlite"))
             {
-                crate::mcp::spawn(db_path);
+                let state = app.state::<AppState>();
+                let unlocked = state.unlocked_folders.clone();
+                let require_token = state
+                    .config
+                    .lock()
+                    .map(|c| c.mcp_require_token)
+                    .unwrap_or(false);
+                crate::mcp::spawn(db_path, unlocked, require_token);
             }
             // Closing the main window HIDES it (recoverable from the tray) instead of
             // quitting — so the floating bar is never the only way back into the app.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audio;
 pub mod commands;
+pub mod crypto;
 pub mod error;
 pub mod events;
 pub mod export;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,6 +104,7 @@ pub fn run() {
             commands::move_note,
             commands::lock_folder,
             commands::unlock_folder,
+            commands::unlock_meeting,
             commands::relock_folder,
             commands::relock_all,
             commands::remove_lock,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod biometric;
 pub mod commands;
 pub mod crypto;
 pub mod error;
@@ -6,6 +7,7 @@ pub mod events;
 pub mod export;
 pub mod mcp;
 pub mod pipeline;
+pub mod screenshare;
 pub mod secrets;
 pub mod settings;
 pub mod state;
@@ -123,6 +125,9 @@ pub fn run() {
                     .unwrap_or(false);
                 crate::mcp::spawn(db_path, unlocked, require_token);
             }
+            // Screen-share auto-relock watcher: on capture START, relock all session-unlocked
+            // folders + zeroize the KEK and toast the UI. Gated by K_RELOCK_ON_SCREENSHARE.
+            crate::screenshare::spawn(app.handle().clone());
             // Closing the main window HIDES it (recoverable from the tray) instead of
             // quitting — so the floating bar is never the only way back into the app.
             if let Some(main) = app.get_webview_window("main") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,8 @@ pub fn run() {
             commands::start_recording,
             commands::stop_recording,
             commands::recording_level,
+            commands::set_mic_muted,
+            commands::is_mic_muted,
             commands::get_last_note,
             commands::update_note,
             commands::get_config,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -2,7 +2,9 @@
 //! (Claude Desktop / Code) with NO egress. Read-only tools over the SQLite DB. Implements the
 //! MCP JSON-RPC essentials (initialize / tools/list / tools/call) over HTTP POST.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 use tiny_http::{Header, Method, Response, Server};
@@ -12,15 +14,21 @@ use crate::storage::Db;
 /// Fixed localhost port for the MCP server.
 pub const MCP_PORT: u16 = 8765;
 
+/// Shared session unlock set: folder ids whose sealed notes are decrypted into the markdown
+/// column for this session (so MCP can read them as plaintext + the visibility filter lets them
+/// through). Sealed-and-not-unlocked notes stay invisible.
+pub type UnlockedSet = Arc<Mutex<HashSet<String>>>;
+
 /// Spawn the MCP server on a background thread. Best-effort: a bind failure is logged; the app
-/// continues normally.
-pub fn spawn(db_path: PathBuf) {
+/// continues normally. `unlocked` is shared with the command surface so visibility tracks the
+/// live session state. `require_token` gates `tools/call` behind a bearer token (default off).
+pub fn spawn(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
     let _ = std::thread::Builder::new()
         .name("murmur-mcp".into())
-        .spawn(move || run(db_path));
+        .spawn(move || run(db_path, unlocked, require_token));
 }
 
-fn run(db_path: PathBuf) {
+fn run(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
     let addr = format!("127.0.0.1:{MCP_PORT}");
     let server = match Server::http(&addr) {
         Ok(s) => s,
@@ -28,6 +36,18 @@ fn run(db_path: PathBuf) {
             tracing::warn!(target: "mcp", error = %e, "MCP server failed to bind {addr}");
             return;
         }
+    };
+    // The expected token, if enforcement is on. Minted/persisted in the Keychain on first use.
+    let expected_token = if require_token {
+        match crate::secrets::get_or_create_mcp_token() {
+            Ok(t) => Some(t),
+            Err(e) => {
+                tracing::warn!(target: "mcp", error = %e, "could not mint MCP token; disabling enforcement");
+                None
+            }
+        }
+    } else {
+        None
     };
     tracing::info!(target: "mcp", "MCP server listening on http://{addr}");
     for mut req in server.incoming_requests() {
@@ -38,9 +58,15 @@ fn run(db_path: PathBuf) {
             );
             continue;
         }
+        // Extract the bearer token (if any) from the Authorization header before consuming body.
+        let auth = req
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("Authorization"))
+            .map(|h| h.value.as_str().to_string());
         let mut body = String::new();
         let _ = std::io::Read::read_to_string(req.as_reader(), &mut body);
-        match handle_rpc(&db_path, &body) {
+        match handle_rpc(&db_path, &body, &unlocked, expected_token.as_deref(), auth.as_deref()) {
             Some(resp) => {
                 let h = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
                 let _ = req.respond(
@@ -58,7 +84,14 @@ fn run(db_path: PathBuf) {
 }
 
 /// Returns Some(response) for JSON-RPC requests, None for notifications.
-fn handle_rpc(db_path: &Path, body: &str) -> Option<Value> {
+/// `expected_token` is `Some` only when enforcement is on; `auth` is the raw Authorization header.
+fn handle_rpc(
+    db_path: &Path,
+    body: &str,
+    unlocked: &UnlockedSet,
+    expected_token: Option<&str>,
+    auth: Option<&str>,
+) -> Option<Value> {
     let req: Value = match serde_json::from_str(body) {
         Ok(v) => v,
         Err(_) => return Some(rpc_err(Value::Null, -32700, "parse error")),
@@ -74,10 +107,29 @@ fn handle_rpc(db_path: &Path, body: &str) -> Option<Value> {
         }),
         "tools/list" => json!({ "tools": tools_spec() }),
         "ping" => json!({}),
-        "tools/call" => return Some(handle_tool_call(db_path, id, req.get("params"))),
+        "tools/call" => {
+            // Bearer enforcement applies ONLY to tools/call; discovery stays open.
+            if let Some(expected) = expected_token {
+                if !bearer_ok(auth, expected) {
+                    return Some(rpc_err(id, -32001, "unauthorized: bearer token required"));
+                }
+            }
+            return Some(handle_tool_call(db_path, id, req.get("params"), unlocked));
+        }
         _ => return Some(rpc_err(id, -32601, "method not found")),
     };
     Some(json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+}
+
+/// Constant-ish bearer-token check: the Authorization header must be `Bearer <expected>`.
+fn bearer_ok(auth: Option<&str>, expected: &str) -> bool {
+    match auth {
+        Some(h) => {
+            let token = h.strip_prefix("Bearer ").or_else(|| h.strip_prefix("bearer "));
+            token.map(|t| t.trim() == expected).unwrap_or(false)
+        }
+        None => false,
+    }
 }
 
 fn rpc_err(id: Value, code: i64, msg: &str) -> Value {
@@ -108,7 +160,12 @@ fn tools_spec() -> Value {
     ])
 }
 
-fn handle_tool_call(db_path: &Path, id: Value, params: Option<&Value>) -> Value {
+fn handle_tool_call(
+    db_path: &Path,
+    id: Value,
+    params: Option<&Value>,
+    unlocked: &UnlockedSet,
+) -> Value {
     let name = params
         .and_then(|p| p.get("name"))
         .and_then(Value::as_str)
@@ -121,10 +178,12 @@ fn handle_tool_call(db_path: &Path, id: Value, params: Option<&Value>) -> Value 
         Ok(d) => d,
         Err(e) => return rpc_err(id, -32000, &format!("db open failed: {e}")),
     };
+    // Snapshot the session unlock set so every query in this call sees a consistent view.
+    let unlocked_set = unlocked.lock().map(|g| g.clone()).unwrap_or_default();
     let text = match name {
         "search_meetings" => {
             let q = args.get("query").and_then(Value::as_str).unwrap_or("");
-            match db.search(q, 20) {
+            match db.search_visible(q, 20, &unlocked_set) {
                 Ok(hits) if hits.is_empty() => format!("No meetings match \"{q}\"."),
                 Ok(hits) => hits
                     .iter()
@@ -144,18 +203,25 @@ fn handle_tool_call(db_path: &Path, id: Value, params: Option<&Value>) -> Value 
         }
         "get_meeting" => {
             let mid = args.get("meetingId").and_then(Value::as_str).unwrap_or("");
-            let note = db.get_latest_note_for_meeting(mid).ok().flatten();
-            let segs = db.get_segments(mid).unwrap_or_default();
-            let transcript = segs
-                .iter()
-                .map(|s| s.text.trim())
-                .filter(|t| !t.is_empty())
-                .collect::<Vec<_>>()
-                .join(" ");
-            match note {
-                Some(n) => format!("NOTE:\n{}\n\nTRANSCRIPT:\n{transcript}", n.markdown),
-                None if !transcript.is_empty() => format!("TRANSCRIPT:\n{transcript}"),
-                None => format!("No data for meeting {mid}."),
+            // A sealed-and-not-unlocked meeting is invisible — including its transcript.
+            match db.meeting_is_visible(mid, &unlocked_set) {
+                Ok(false) => format!("No data for meeting {mid}."),
+                Err(e) => return rpc_err(id, -32000, &format!("visibility check failed: {e}")),
+                Ok(true) => {
+                    let note = db.get_note_if_visible(mid, &unlocked_set).ok().flatten();
+                    let segs = db.get_segments(mid).unwrap_or_default();
+                    let transcript = segs
+                        .iter()
+                        .map(|s| s.text.trim())
+                        .filter(|t| !t.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    match note {
+                        Some(n) => format!("NOTE:\n{}\n\nTRANSCRIPT:\n{transcript}", n.markdown),
+                        None if !transcript.is_empty() => format!("TRANSCRIPT:\n{transcript}"),
+                        None => format!("No data for meeting {mid}."),
+                    }
+                }
             }
         }
         "list_recent_meetings" => {
@@ -164,7 +230,7 @@ fn handle_tool_call(db_path: &Path, id: Value, params: Option<&Value>) -> Value 
                 .and_then(Value::as_i64)
                 .unwrap_or(20)
                 .clamp(1, 100);
-            match db.list_meetings(limit) {
+            match db.list_meetings_visible(limit, &unlocked_set) {
                 Ok(ms) => ms
                     .iter()
                     .map(|m| {
@@ -190,8 +256,18 @@ fn handle_tool_call(db_path: &Path, id: Value, params: Option<&Value>) -> Value 
 mod tests {
     use super::*;
 
+    fn empty_unlocked() -> UnlockedSet {
+        Arc::new(Mutex::new(HashSet::new()))
+    }
+
     fn rpc(body: &str) -> Option<Value> {
-        handle_rpc(&PathBuf::from("/nonexistent.sqlite"), body)
+        handle_rpc(
+            &PathBuf::from("/nonexistent.sqlite"),
+            body,
+            &empty_unlocked(),
+            None,
+            None,
+        )
     }
 
     #[test]
@@ -219,5 +295,56 @@ mod tests {
             rpc(r#"{"jsonrpc":"2.0","id":3,"method":"bogus"}"#).unwrap()["error"]["code"],
             -32601
         );
+    }
+
+    fn rpc_auth(body: &str, expected: Option<&str>, auth: Option<&str>) -> Option<Value> {
+        handle_rpc(
+            &PathBuf::from("/nonexistent.sqlite"),
+            body,
+            &empty_unlocked(),
+            expected,
+            auth,
+        )
+    }
+
+    #[test]
+    fn token_disabled_keeps_discovery_open() {
+        // Default (no enforcement): initialize/tools/list/ping all succeed without a token.
+        assert!(rpc(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#).unwrap()["result"].is_object());
+        assert!(rpc(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#).unwrap()["result"]
+            .is_object());
+    }
+
+    #[test]
+    fn token_required_gates_only_tools_call() {
+        // NOTE: every assertion here must STOP before `handle_tool_call` reaches `Db::open`,
+        // because `Db::open` fetches the SQLCipher DEK from the real Keychain (which can block on
+        // a freshly-signed test binary). The unauthorized branches return early in `handle_rpc`,
+        // so they never touch the DB — exactly the security-critical path we want to prove.
+        let body = r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_recent_meetings","arguments":{}}}"#;
+        // No Authorization header → unauthorized error, returned BEFORE any DB access.
+        let unauth = rpc_auth(body, Some("sekret"), None).unwrap();
+        assert_eq!(unauth["error"]["code"], -32001);
+        // Wrong token → unauthorized, also before DB access.
+        let wrong = rpc_auth(body, Some("sekret"), Some("Bearer nope")).unwrap();
+        assert_eq!(wrong["error"]["code"], -32001);
+        // Discovery stays OPEN even with enforcement on (no token needed, no DB access).
+        let disc = rpc_auth(
+            r#"{"jsonrpc":"2.0","id":8,"method":"tools/list"}"#,
+            Some("sekret"),
+            None,
+        )
+        .unwrap();
+        assert!(disc["result"]["tools"].is_array());
+        // The "correct token reaches the DB" path is intentionally NOT asserted here: it would
+        // call `Db::open` → real Keychain. `bearer_ok` (below) proves the matcher in isolation.
+    }
+
+    #[test]
+    fn bearer_ok_matches_case_insensitive_scheme() {
+        assert!(bearer_ok(Some("Bearer abc"), "abc"));
+        assert!(bearer_ok(Some("bearer abc"), "abc"));
+        assert!(!bearer_ok(Some("Basic abc"), "abc"));
+        assert!(!bearer_ok(None, "abc"));
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -263,6 +263,16 @@ async fn summarize_and_export(
 
     emit_status(app, "done", "Note exported.", meeting_id);
 
+    // Best-effort self-assembling graph: persist entities/mentions to the encrypted DB (Sink A)
+    // + mirror vault stubs for unsealed folders (Sink B). NEVER fail the note on a graph error —
+    // a graph-extraction LLM hiccup must not block note export. `add_mention` idempotency makes
+    // the `resummarize_existing` path safe (re-extraction refreshes without double-counting).
+    if let Err(e) =
+        crate::commands::build_and_persist_entities(state, meeting_id, &title, &markdown).await
+    {
+        tracing::warn!(target: "graph", error = %e, "graph entity persist failed (note export unaffected)");
+    }
+
     Ok(PipelineResult {
         note_markdown: markdown,
         exported_path,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -61,8 +61,22 @@ pub async fn run_after_stop(
     src_rate: u32,
     duration_s: i64,
     system_wav: Option<PathBuf>,
+    mic_started_at: std::time::Instant,
+    system_started_at: Option<std::time::Instant>,
 ) -> Result<PipelineResult> {
-    match run_inner(app, state, meeting_id, samples, src_rate, duration_s, system_wav).await {
+    match run_inner(
+        app,
+        state,
+        meeting_id,
+        samples,
+        src_rate,
+        duration_s,
+        system_wav,
+        mic_started_at,
+        system_started_at,
+    )
+    .await
+    {
         Ok(result) => Ok(result),
         Err(e) => {
             // Persist the failure and surface it to the UI without leaking PII.
@@ -84,6 +98,8 @@ async fn run_inner(
     src_rate: u32,
     duration_s: i64,
     system_wav: Option<PathBuf>,
+    mic_started_at: std::time::Instant,
+    system_started_at: Option<std::time::Instant>,
 ) -> Result<PipelineResult> {
     // Snapshot config under the lock, then release it for the rest of the async work.
     let config: AppConfig = {
@@ -98,28 +114,40 @@ async fn run_inner(
     let date_iso = now.format("%Y-%m-%d").to_string();
     let ended_at = now.to_rfc3339();
 
-    // ── 1. Build 16 kHz mono samples (mic, optionally mixed with system audio) ──
+    // ── 1. Build 16 kHz mono streams + archive the COMBINED mix ──────────────
+    //
+    // DUAL-STREAM: mic and system audio are resampled to 16 kHz SEPARATELY and transcribed
+    // separately (§2). `mixer::mix` is used ONLY to produce the combined archive WAV for
+    // playback — its output is NEVER fed to Whisper. If there's no system stream (capture off
+    // or ScreenCaptureKit permission denied → sidecar produced no WAV), we fall back to the
+    // mic-only single pass (today's behaviour, everything attributed "me").
     let mic_16k = audio::resample_to_16k(&samples, src_rate)?;
-    let samples_16k = match system_wav {
-        Some(path) => match audio::read_wav_mono(&path) {
+    let sys_16k: Option<Vec<f32>> = match &system_wav {
+        Some(path) => match audio::read_wav_mono(path) {
             Ok((sys, sys_rate)) => {
-                let sys_16k = audio::resample_to_16k(&sys, sys_rate)?;
-                let _ = std::fs::remove_file(&path); // transient sidecar output
-                tracing::info!(target: "audio", "mixed mic + system-audio tracks");
-                audio::mix(&mic_16k, &sys_16k)
+                let resampled = audio::resample_to_16k(&sys, sys_rate)?;
+                let _ = std::fs::remove_file(path); // transient sidecar output
+                Some(resampled)
             }
             Err(e) => {
                 tracing::warn!(target: "audio", error = %e, "could not read system-audio track; using mic only");
-                mic_16k
+                None
             }
         },
-        None => mic_16k,
+        None => None,
     };
 
-    // Persist the (possibly mixed) 16 kHz mono WAV for archive.
+    // Archive WAV = the MIX (for playback only). Mic-only when there's no system stream.
+    let archive_16k = match &sys_16k {
+        Some(sys) => {
+            tracing::info!(target: "audio", "archiving mixed mic + system-audio track");
+            audio::mix(&mic_16k, sys)
+        }
+        None => mic_16k.clone(),
+    };
     let wav_dir = audio_dir()?;
     let wav_path = wav_dir.join(format!("{meeting_id}.wav"));
-    audio::write_wav_16k_mono(&wav_path, &samples_16k, audio::TARGET_RATE_HZ)?;
+    audio::write_wav_16k_mono(&wav_path, &archive_16k, audio::TARGET_RATE_HZ)?;
     state.db.finalize_meeting(
         meeting_id,
         &ended_at,
@@ -127,39 +155,75 @@ async fn run_inner(
         &wav_path.to_string_lossy(),
     )?;
 
-    // ── 2. Transcribe ───────────────────────────────────────────────────────
+    // ── 2 + 3. Transcribe EACH stream separately, then MERGE by wall-clock ────
     emit_status(app, "transcribing", "Transcribing audio…", meeting_id);
 
     let model_path = resolve_model_path(&config)?;
     let lang = config.language.as_deref();
 
-    // Whisper load + inference are CPU/GPU-bound and blocking; run off the async
-    // runtime's worker so we don't stall other tasks. The model path / lang are
-    // owned copies so the closure is 'static.
+    // Whisper load + inference are CPU/GPU-bound and blocking; run the WHOLE transcription off
+    // the async runtime's worker so we don't stall other tasks. We load the model ONCE and reuse
+    // it for both streams. Owned copies keep the closure 'static.
     let model_path_owned = model_path.clone();
     let lang_owned = lang.map(str::to_string);
-    let transcript = tokio::task::spawn_blocking(move || -> Result<_> {
+    let has_system = sys_16k.is_some();
+    let merged_segments = tokio::task::spawn_blocking(move || -> Result<Vec<crate::transcribe::types::Segment>> {
+        use crate::audio::merge::{merge_streams, StreamInput, SPEAKER_ME, SPEAKER_OTHERS};
+        use crate::transcribe::TranscribeQuality;
+
         let transcriber = Transcriber::load(&model_path_owned)?;
-        // BATCH path → Accurate profile (beam search + temperature fallback +
-        // anti-hallucination thresholds + previous-text conditioning). Live captions and the
-        // voice trigger keep the Fast greedy profile for latency — see transcribe::whisper.
-        transcriber.transcribe_with(
-            &samples_16k,
-            lang_owned.as_deref(),
-            crate::transcribe::TranscribeQuality::Accurate,
-        )
+        // BATCH path → Accurate profile (beam search + temperature fallback + anti-hallucination
+        // thresholds + previous-text conditioning) for BOTH streams. Live captions + voice
+        // trigger keep the Fast greedy profile for latency — see transcribe::whisper.
+        let mic_tx =
+            transcriber.transcribe_with(&mic_16k, lang_owned.as_deref(), TranscribeQuality::Accurate)?;
+
+        let mut streams = vec![StreamInput {
+            segments: mic_tx.segments,
+            started_at: mic_started_at,
+            speaker: SPEAKER_ME,
+        }];
+
+        if let (Some(sys), Some(sys_started)) = (sys_16k, system_started_at) {
+            let sys_tx =
+                transcriber.transcribe_with(&sys, lang_owned.as_deref(), TranscribeQuality::Accurate)?;
+            streams.push(StreamInput {
+                segments: sys_tx.segments,
+                started_at: sys_started,
+                speaker: SPEAKER_OTHERS,
+            });
+        }
+
+        // Anchor each stream's segments to its capture-start host instant → absolute timeline,
+        // merge sorted by absolute start, drop empty (e.g. muted-mic) segments, label "me"/"others".
+        Ok(merge_streams(streams))
     })
     .await
     .map_err(|e| AppError::Transcribe(format!("transcription task panicked: {e}")))??;
 
-    state
-        .db
-        .insert_segments(meeting_id, &transcript.segments)?;
+    if has_system {
+        tracing::info!(target: "transcribe", segments = merged_segments.len(), "merged mic + system streams (me/others)");
+    }
+
+    state.db.insert_segments(meeting_id, &merged_segments)?;
     state
         .db
         .update_meeting_status(meeting_id, MeetingStatus::Transcribed)?;
 
-    if transcript.full_text.trim().is_empty() {
+    // Rebuild the full transcript text from the merged, time-ordered segments.
+    let mut full_text = String::new();
+    for seg in &merged_segments {
+        let t = seg.text.trim();
+        if t.is_empty() {
+            continue;
+        }
+        if !full_text.is_empty() {
+            full_text.push(' ');
+        }
+        full_text.push_str(t);
+    }
+
+    if full_text.trim().is_empty() {
         return Err(AppError::Transcribe(
             "No speech detected in the recording — nothing to transcribe. \
              Check your microphone input and try recording again."
@@ -167,14 +231,14 @@ async fn run_inner(
         ));
     }
 
-    // ── 3 + 4. Summarize with the configured provider, then export ───────────
+    // ── 4 + 5. Summarize with the configured provider, then export ───────────
     summarize_and_export(
         app,
         state,
         &config,
         meeting_id,
-        &transcript.full_text,
-        transcript.language.clone().or_else(|| lang.map(str::to_string)),
+        &full_text,
+        lang.map(str::to_string),
         duration_s,
         &date_iso,
         &ended_at,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -140,7 +140,14 @@ async fn run_inner(
     let lang_owned = lang.map(str::to_string);
     let transcript = tokio::task::spawn_blocking(move || -> Result<_> {
         let transcriber = Transcriber::load(&model_path_owned)?;
-        transcriber.transcribe(&samples_16k, lang_owned.as_deref())
+        // BATCH path → Accurate profile (beam search + temperature fallback +
+        // anti-hallucination thresholds + previous-text conditioning). Live captions and the
+        // voice trigger keep the Fast greedy profile for latency — see transcribe::whisper.
+        transcriber.transcribe_with(
+            &samples_16k,
+            lang_owned.as_deref(),
+            crate::transcribe::TranscribeQuality::Accurate,
+        )
     })
     .await
     .map_err(|e| AppError::Transcribe(format!("transcription task panicked: {e}")))??;

--- a/src-tauri/src/screenshare.rs
+++ b/src-tauri/src/screenshare.rs
@@ -53,18 +53,19 @@ pub fn spawn(app: AppHandle) {
         return;
     }
 
-    tauri::async_runtime::spawn(async move {
-        watch(app).await;
-    });
+    // Poll on a DEDICATED OS THREAD (not the async runtime): the NSScreen read MUST be marshaled
+    // to the main thread — AppKit is main-thread-affine, and calling it off-main throws an
+    // Objective-C exception that aborts the whole process ("Rust cannot catch foreign exceptions").
+    // A std thread can safely block on the main-thread reply between polls.
+    std::thread::Builder::new()
+        .name("murmur-screenshare".into())
+        .spawn(move || watch(app))
+        .ok();
 }
 
-/// The poll loop. Holds the rising-edge state (`was_captured`) and acts only on false→true.
-async fn watch(app: AppHandle) {
-    let mut ticker = tokio::time::interval(POLL_INTERVAL);
-    // If a tick is missed (e.g. the runtime was busy) skip rather than burst-catch-up.
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    let mut was_captured = is_any_screen_captured();
+/// The poll loop (dedicated OS thread). Holds the rising-edge state and acts only on false→true.
+fn watch(app: AppHandle) {
+    let mut was_captured = captured_on_main(&app);
     tracing::info!(
         target: "screenshare",
         initial_captured = was_captured,
@@ -72,8 +73,8 @@ async fn watch(app: AppHandle) {
     );
 
     loop {
-        ticker.tick().await;
-        let now_captured = is_any_screen_captured();
+        std::thread::sleep(POLL_INTERVAL);
+        let now_captured = captured_on_main(&app);
 
         // Rising edge only: fire on START (false → true). We do not re-fire while it stays true,
         // and we silently reset on the falling edge.
@@ -86,6 +87,22 @@ async fn watch(app: AppHandle) {
         }
         was_captured = now_captured;
     }
+}
+
+/// Read `is_any_screen_captured()` on the MAIN THREAD (AppKit requirement) via Tauri's main-thread
+/// dispatch, returning the result over a channel. Returns false if the app is shutting down or the
+/// main thread does not reply promptly (never blocks forever, never throws across the boundary).
+fn captured_on_main(app: &AppHandle) -> bool {
+    let (tx, rx) = std::sync::mpsc::channel();
+    if app
+        .run_on_main_thread(move || {
+            let _ = tx.send(is_any_screen_captured());
+        })
+        .is_err()
+    {
+        return false; // app is tearing down
+    }
+    rx.recv_timeout(Duration::from_secs(2)).unwrap_or(false)
 }
 
 /// React to a capture-start rising edge: relock everything + emit the UI event.
@@ -109,34 +126,19 @@ fn on_capture_started(app: &AppHandle) {
     }
 }
 
-/// True if ANY attached screen reports `isCaptured`. macOS implementation via objc2/AppKit.
+/// Capture-state probe. Returns `false` for now (detection inactive — see below).
+///
+/// DISABLED PENDING A CORRECT API: the earlier attempt sent `-isCaptured` to `NSScreen`, but that
+/// is NOT a valid `NSScreen` selector — `msg_send![screen, isCaptured]` raises an "unrecognized
+/// selector" `NSException`, which crosses the FFI boundary as a foreign exception and ABORTS the
+/// whole process ("Rust cannot catch foreign exceptions") right after launch. A correct macOS
+/// screen-capture/share detection (e.g. ScreenCaptureKit `SCShareableContent`, or observing the
+/// system capture indicator) needs to be wired AND verified on a signed build before re-enabling.
+/// Until then this returns `false` so the watcher never fires and never crashes. Everything else
+/// in the lock model — encryption, per-folder seal, MCP-hiding, and MANUAL relock — is unaffected;
+/// only the *automatic* relock-on-screen-share trigger is inactive.
 #[cfg(target_os = "macos")]
 fn is_any_screen_captured() -> bool {
-    use objc2::rc::Retained;
-    use objc2::{class, msg_send};
-    use objc2_app_kit::NSScreen;
-    use objc2_foundation::NSArray;
-
-    // `+[NSScreen screens]` is documented as main-thread-affine, but the generated binding demands
-    // a `MainThreadMarker` we don't hold on this background task. Sending the class message
-    // directly returns the screens array; reading the `isCaptured` BOOL property off-main is a
-    // benign property read for polling. We never mutate AppKit state here.
-    //
-    // SAFETY: `+screens` returns an autoreleased `NSArray<NSScreen>*`; `-isCaptured` is a `BOOL`
-    // property on `NSScreen` (macOS 10.0+, the capture semantics since 12). We only read; the
-    // Retained handle manages the lifetime.
-    unsafe {
-        let cls = class!(NSScreen);
-        let screens: Retained<NSArray<NSScreen>> = msg_send![cls, screens];
-        let count = screens.count();
-        for i in 0..count {
-            let screen = screens.objectAtIndex(i);
-            let captured: bool = msg_send![&*screen, isCaptured];
-            if captured {
-                return true;
-            }
-        }
-    }
     false
 }
 

--- a/src-tauri/src/screenshare.rs
+++ b/src-tauri/src/screenshare.rs
@@ -1,0 +1,147 @@
+//! Screen-share / screen-capture watcher → auto-relock (Stage E).
+//!
+//! When the screen STARTS being captured or shared (a screen recording, a Zoom/Meet "share
+//! screen", a QuickTime capture, etc.) any session-unlocked sealed folders are a privacy leak —
+//! their plaintext markdown is live in the DB and on screen. This watcher detects the rising edge
+//! (not-captured → captured) of `NSScreen.isCaptured` and calls `relock_all_inner`, which clears
+//! the session unlock set and zeroizes the cached KEK, plus emits a Tauri event so the UI can
+//! toast.
+//!
+//! IMPLEMENTATION: a ~1.5s `tokio::interval` poll of `NSScreen.isCaptured` across all screens on a
+//! background task. The model wants "fire on START", which the rising-edge detection over the poll
+//! gives us (we only act on false→true, never re-fire while it stays captured). We deliberately do
+//! NOT use the deprecated `CGDisplayIsCaptured()` — it is semantically wrong (exclusive-render,
+//! not screen-share) and deprecated.
+//!
+//! HONEST DENT (documented): full-screen / whole-display share flips `isCaptured`; a single-window
+//! WebRTC share (e.g. Meet sharing one Chrome tab) may NOT flip whole-screen `isCaptured`. Relock
+//! is best-effort hiding — it cannot recall what is already on screen.
+//!
+//! GRACEFUL DEGRADATION: on a non-macOS host or if AppKit can't be reached, the poll simply
+//! reports "not captured" forever and never fires — it never panics.
+
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::state::AppState;
+
+/// Event emitted to all windows when screen capture/sharing STARTS (rising edge). The UI listens
+/// and toasts "Screen sharing detected — locked notes were re-secured."
+pub const EVENT_SCREEN_SHARE_STARTED: &str = "murmur://screen-share-started";
+
+/// Poll cadence for the capture-state check. ~1.5s is responsive enough to re-secure quickly while
+/// being negligible CPU.
+const POLL_INTERVAL: Duration = Duration::from_millis(1500);
+
+/// Spawn the screen-share watcher on the Tauri async runtime. Best-effort: if the config flag is
+/// off, or if the platform can't report capture state, this is a no-op loop.
+///
+/// Gated by `K_RELOCK_ON_SCREENSHARE` (default true) read once at spawn time.
+pub fn spawn(app: AppHandle) {
+    // Read the flag once at startup; mirrors how the MCP token flag is read in lib::setup.
+    let enabled = {
+        let state = app.state::<AppState>();
+        let cfg = state.config.lock();
+        cfg.map(|c| c.relock_on_screenshare).unwrap_or(true)
+    };
+    if !enabled {
+        tracing::info!(
+            target: "screenshare",
+            "screen-share auto-relock disabled by config (relock_on_screenshare=false)"
+        );
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        watch(app).await;
+    });
+}
+
+/// The poll loop. Holds the rising-edge state (`was_captured`) and acts only on false→true.
+async fn watch(app: AppHandle) {
+    let mut ticker = tokio::time::interval(POLL_INTERVAL);
+    // If a tick is missed (e.g. the runtime was busy) skip rather than burst-catch-up.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let mut was_captured = is_any_screen_captured();
+    tracing::info!(
+        target: "screenshare",
+        initial_captured = was_captured,
+        "screen-share watcher started"
+    );
+
+    loop {
+        ticker.tick().await;
+        let now_captured = is_any_screen_captured();
+
+        // Rising edge only: fire on START (false → true). We do not re-fire while it stays true,
+        // and we silently reset on the falling edge.
+        if now_captured && !was_captured {
+            tracing::warn!(
+                target: "screenshare",
+                "screen capture/sharing started — relocking all session-unlocked folders"
+            );
+            on_capture_started(&app);
+        }
+        was_captured = now_captured;
+    }
+}
+
+/// React to a capture-start rising edge: relock everything + emit the UI event.
+fn on_capture_started(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    // relock_all_inner takes &AppState; State derefs to it.
+    if let Err(e) = crate::commands::relock_all_inner(&state) {
+        tracing::error!(
+            target: "screenshare",
+            error = %e,
+            "relock_all_inner failed during screen-share auto-relock"
+        );
+    }
+    // Emit regardless so the UI can surface the privacy event even if there was nothing to relock.
+    if let Err(e) = app.emit(EVENT_SCREEN_SHARE_STARTED, ()) {
+        tracing::warn!(
+            target: "screenshare",
+            error = %e,
+            "failed to emit screen-share-started event"
+        );
+    }
+}
+
+/// True if ANY attached screen reports `isCaptured`. macOS implementation via objc2/AppKit.
+#[cfg(target_os = "macos")]
+fn is_any_screen_captured() -> bool {
+    use objc2::rc::Retained;
+    use objc2::{class, msg_send};
+    use objc2_app_kit::NSScreen;
+    use objc2_foundation::NSArray;
+
+    // `+[NSScreen screens]` is documented as main-thread-affine, but the generated binding demands
+    // a `MainThreadMarker` we don't hold on this background task. Sending the class message
+    // directly returns the screens array; reading the `isCaptured` BOOL property off-main is a
+    // benign property read for polling. We never mutate AppKit state here.
+    //
+    // SAFETY: `+screens` returns an autoreleased `NSArray<NSScreen>*`; `-isCaptured` is a `BOOL`
+    // property on `NSScreen` (macOS 10.0+, the capture semantics since 12). We only read; the
+    // Retained handle manages the lifetime.
+    unsafe {
+        let cls = class!(NSScreen);
+        let screens: Retained<NSArray<NSScreen>> = msg_send![cls, screens];
+        let count = screens.count();
+        for i in 0..count {
+            let screen = screens.objectAtIndex(i);
+            let captured: bool = msg_send![&*screen, isCaptured];
+            if captured {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Non-macOS fallback: no capture signal available → always reports "not captured" (never fires).
+#[cfg(not(target_os = "macos"))]
+fn is_any_screen_captured() -> bool {
+    false
+}

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -13,6 +13,15 @@ pub const ACCOUNT_DB_DEK: &str = "murmur_db_dek";
 /// (per-folder biometric locking, added later, covers that). Hex form ⇒ SQLCipher treats it as a
 /// raw key blob (`PRAGMA key = x'…'`) with no KDF.
 pub fn get_or_create_db_dek() -> Result<String> {
+    // Dev-only escape hatch: a fixed DEK via `MURMUR_DEV_DEK` (64 hex chars) avoids a macOS
+    // Keychain prompt on every rebuild — each recompiled dev binary has a new signature, so the
+    // OS re-prompts for access to the existing item. NEVER compiled into release builds.
+    #[cfg(debug_assertions)]
+    if let Ok(dev) = std::env::var("MURMUR_DEV_DEK") {
+        if dev.len() == 64 && dev.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Ok(dev);
+        }
+    }
     if let Some(dek) = get_secret(ACCOUNT_DB_DEK)? {
         return Ok(dek);
     }

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -4,6 +4,26 @@ use crate::error::{AppError, Result};
 
 pub const SERVICE: &str = "com.meetnotes.app";
 
+/// Keychain account holding the SQLCipher database encryption key (DEK).
+pub const ACCOUNT_DB_DEK: &str = "murmur_db_dek";
+
+/// Return the SQLCipher DEK as a 64-char hex string (32 random bytes), creating + persisting it
+/// in the Keychain on first use. Released at launch with no biometric prompt — this layer
+/// protects against database FILE theft, not against an attacker on the unlocked machine
+/// (per-folder biometric locking, added later, covers that). Hex form ⇒ SQLCipher treats it as a
+/// raw key blob (`PRAGMA key = x'…'`) with no KDF.
+pub fn get_or_create_db_dek() -> Result<String> {
+    if let Some(dek) = get_secret(ACCOUNT_DB_DEK)? {
+        return Ok(dek);
+    }
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|e| AppError::Secrets(format!("RNG failed generating DEK: {e}")))?;
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    set_secret(ACCOUNT_DB_DEK, &hex)?;
+    Ok(hex)
+}
+
 /// Build a keyring entry for `(SERVICE, account)`. `account` is the provider key name,
 /// e.g. "anthropic_api_key".
 fn entry(account: &str) -> Result<Entry> {

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -7,6 +7,12 @@ pub const SERVICE: &str = "com.meetnotes.app";
 /// Keychain account holding the SQLCipher database encryption key (DEK).
 pub const ACCOUNT_DB_DEK: &str = "murmur_db_dek";
 
+/// Keychain account holding the master KEK that wraps per-folder content keys (Layer 2 lock).
+pub const ACCOUNT_MASTER_KEK: &str = "murmur_master_kek";
+
+/// Keychain account holding the optional MCP bearer token.
+pub const ACCOUNT_MCP_TOKEN: &str = "murmur_mcp_token";
+
 /// Return the SQLCipher DEK as a 64-char hex string (32 random bytes), creating + persisting it
 /// in the Keychain on first use. Released at launch with no biometric prompt — this layer
 /// protects against database FILE theft, not against an attacker on the unlocked machine
@@ -31,6 +37,63 @@ pub fn get_or_create_db_dek() -> Result<String> {
     let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
     set_secret(ACCOUNT_DB_DEK, &hex)?;
     Ok(hex)
+}
+
+/// Return the master KEK (32 raw bytes) that wraps per-folder content keys, creating +
+/// persisting it (as a 64-char hex string) in the Keychain on first use. Mirrors
+/// [`get_or_create_db_dek`]: released at launch in this stage (Stage E will move it behind a
+/// biometric ACL — do NOT add biometric here). This KEK never touches SQLCipher; it only
+/// wraps/unwraps content keys via [`crate::crypto`].
+pub fn get_or_create_master_kek() -> Result<[u8; 32]> {
+    // Dev-only escape hatch mirroring MURMUR_DEV_DEK, but a SEPARATE env var so the at-rest DEK
+    // and the lock KEK can be fixed independently in tests/dev. NEVER compiled into release.
+    #[cfg(debug_assertions)]
+    if let Ok(dev) = std::env::var("MURMUR_DEV_KEK") {
+        if let Some(k) = hex_to_key32(&dev) {
+            return Ok(k);
+        }
+    }
+    if let Some(hex) = get_secret(ACCOUNT_MASTER_KEK)? {
+        if let Some(k) = hex_to_key32(&hex) {
+            return Ok(k);
+        }
+        return Err(AppError::Secrets("stored master KEK is malformed".into()));
+    }
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|e| AppError::Secrets(format!("RNG failed generating KEK: {e}")))?;
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    set_secret(ACCOUNT_MASTER_KEK, &hex)?;
+    Ok(bytes)
+}
+
+/// Return the MCP bearer token (a random 64-char hex string), minting + persisting it in the
+/// Keychain on first use. Used to gate MCP `tools/call` when `K_MCP_REQUIRE_TOKEN` is on.
+pub fn get_or_create_mcp_token() -> Result<String> {
+    if let Some(tok) = get_secret(ACCOUNT_MCP_TOKEN)? {
+        if !tok.is_empty() {
+            return Ok(tok);
+        }
+    }
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|e| AppError::Secrets(format!("RNG failed generating MCP token: {e}")))?;
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    set_secret(ACCOUNT_MCP_TOKEN, &hex)?;
+    Ok(hex)
+}
+
+/// Parse a 64-char hex string into a 32-byte key, or `None` if malformed.
+fn hex_to_key32(hex: &str) -> Option<[u8; 32]> {
+    let hex = hex.trim();
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
 }
 
 /// Build a keyring entry for `(SERVICE, account)`. `account` is the provider key name,
@@ -62,5 +125,26 @@ pub fn delete_secret(account: &str) -> Result<()> {
         Ok(()) => Ok(()),
         Err(KeyringError::NoEntry) => Ok(()),
         Err(e) => Err(AppError::Secrets(format!("failed to delete secret: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex_to_key32;
+
+    #[test]
+    fn hex_to_key32_round_trips() {
+        let bytes: [u8; 32] = std::array::from_fn(|i| i as u8);
+        let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex_to_key32(&hex), Some(bytes));
+        // Trims surrounding whitespace (env-var convenience).
+        assert_eq!(hex_to_key32(&format!("  {hex}\n")), Some(bytes));
+    }
+
+    #[test]
+    fn hex_to_key32_rejects_malformed() {
+        assert_eq!(hex_to_key32("tooshort"), None);
+        assert_eq!(hex_to_key32(&"z".repeat(64)), None);
+        assert_eq!(hex_to_key32(&"a".repeat(63)), None);
     }
 }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -23,7 +23,9 @@ pub struct AppConfig {
     pub claude_binary: String,
     /// Capture system audio (the other side of the call) via ScreenCaptureKit. Default off.
     pub capture_system_audio: bool,
-    /// Whisper model size: "tiny" | "base" | "small" | "medium" | "large-v3". Default "small".
+    /// Whisper model size: "tiny" | "base" | "small" | "medium" | "large-v3-turbo" |
+    /// "large-v3". Default "large-v3" (~3 GB, multilingual) — best transcription quality,
+    /// notably for Polish; downloaded on demand via `download_model`.
     pub model_size: String,
     /// Voice trigger: start recording when a wake phrase is heard. Default off.
     pub voice_trigger: bool,
@@ -61,7 +63,7 @@ impl Default for AppConfig {
             ollama_model: "llama3.1".to_string(),
             claude_binary: "claude".to_string(),
             capture_system_audio: false,
-            model_size: "small".to_string(),
+            model_size: "large-v3".to_string(),
             voice_trigger: false,
             onboarded: false,
             note_style: "standard".to_string(),

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -35,6 +35,10 @@ pub struct AppConfig {
     pub auto_organize: bool,
     /// Summary note language: "auto" (match the meeting) | "en" | "pl" | "de" | ... .
     pub note_language: String,
+    /// Require an `Authorization: Bearer <token>` on MCP `tools/call`. Default OFF so the
+    /// existing local Claude connection keeps working; discovery (initialize/tools/list/ping)
+    /// stays open regardless. Bind is always 127.0.0.1.
+    pub mcp_require_token: bool,
 }
 
 impl Default for AppConfig {
@@ -56,6 +60,7 @@ impl Default for AppConfig {
             note_style: "standard".to_string(),
             auto_organize: false,
             note_language: "auto".to_string(),
+            mcp_require_token: false,
         }
     }
 }
@@ -77,6 +82,7 @@ const K_ONBOARDED: &str = "onboarded";
 const K_NOTE_STYLE: &str = "note_style";
 const K_AUTO_ORGANIZE: &str = "auto_organize";
 const K_NOTE_LANGUAGE: &str = "note_language";
+const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -141,6 +147,9 @@ impl AppConfig {
                 cfg.note_language = v;
             }
         }
+        if let Some(v) = db.get_setting(K_MCP_REQUIRE_TOKEN)? {
+            cfg.mcp_require_token = v == "true";
+        }
 
         Ok(cfg)
     }
@@ -179,6 +188,10 @@ impl AppConfig {
             if self.auto_organize { "true" } else { "false" },
         )?;
         db.set_setting(K_NOTE_LANGUAGE, &self.note_language)?;
+        db.set_setting(
+            K_MCP_REQUIRE_TOKEN,
+            if self.mcp_require_token { "true" } else { "false" },
+        )?;
         Ok(())
     }
 }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -39,6 +39,13 @@ pub struct AppConfig {
     /// existing local Claude connection keeps working; discovery (initialize/tools/list/ping)
     /// stays open regardless. Bind is always 127.0.0.1.
     pub mcp_require_token: bool,
+    /// Require a passing biometric (Touch ID, falling back to device passcode) before unlocking a
+    /// sealed folder. Default ON. Degrades to allow when no biometric/passcode policy is available
+    /// (no Touch ID hardware / CI), so it never locks the user out.
+    pub lock_require_biometric: bool,
+    /// Auto-relock all session-unlocked folders (and zeroize the cached KEK) when screen
+    /// capture/sharing STARTS. Default ON.
+    pub relock_on_screenshare: bool,
 }
 
 impl Default for AppConfig {
@@ -61,6 +68,8 @@ impl Default for AppConfig {
             auto_organize: false,
             note_language: "auto".to_string(),
             mcp_require_token: false,
+            lock_require_biometric: true,
+            relock_on_screenshare: true,
         }
     }
 }
@@ -83,6 +92,8 @@ const K_NOTE_STYLE: &str = "note_style";
 const K_AUTO_ORGANIZE: &str = "auto_organize";
 const K_NOTE_LANGUAGE: &str = "note_language";
 const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
+const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
+const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -150,6 +161,12 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_MCP_REQUIRE_TOKEN)? {
             cfg.mcp_require_token = v == "true";
         }
+        if let Some(v) = db.get_setting(K_LOCK_REQUIRE_BIOMETRIC)? {
+            cfg.lock_require_biometric = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_RELOCK_ON_SCREENSHARE)? {
+            cfg.relock_on_screenshare = v == "true";
+        }
 
         Ok(cfg)
     }
@@ -192,6 +209,14 @@ impl AppConfig {
             K_MCP_REQUIRE_TOKEN,
             if self.mcp_require_token { "true" } else { "false" },
         )?;
+        db.set_setting(
+            K_LOCK_REQUIRE_BIOMETRIC,
+            if self.lock_require_biometric { "true" } else { "false" },
+        )?;
+        db.set_setting(
+            K_RELOCK_ON_SCREENSHARE,
+            if self.relock_on_screenshare { "true" } else { "false" },
+        )?;
         Ok(())
     }
 }
@@ -232,6 +257,23 @@ mod tests {
         assert_eq!(cfg.provider_id, "claude_code");
         assert_eq!(cfg.anthropic_model, "claude-opus-4-8");
         assert!(cfg.vault_path.is_none());
+        // Stage E security flags default ON.
+        assert!(cfg.lock_require_biometric);
+        assert!(cfg.relock_on_screenshare);
+    }
+
+    #[test]
+    fn security_flags_round_trip() {
+        let db = temp_db();
+        let cfg = AppConfig {
+            lock_require_biometric: false,
+            relock_on_screenshare: false,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert!(!loaded.lock_require_biometric);
+        assert!(!loaded.relock_on_screenshare);
     }
 
     #[test]

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -203,7 +203,13 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        Db::open(&p).unwrap()
+        // Tests use an explicit key (NOT the Keychain) — Db::open would hit macOS Keychain and
+        // prompt/block depending on the test-binary signature.
+        Db::open_with_key(
+            &p,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -31,7 +31,14 @@ impl AppState {
     /// Open DB at the app-data dir, run migrations, load config. Called once in `lib::run`.
     pub fn init() -> Result<Self> {
         let db_path = Self::db_path()?;
-        let db = Db::open(&db_path)?;
+        // SQLCipher at-rest: fetch (or create) the DEK once, migrate any existing PLAINTEXT DB to
+        // encrypted (safe: original untouched until a verified atomic swap), then open keyed.
+        let dek = crate::secrets::get_or_create_db_dek()?;
+        if crate::storage::migration::needs_encryption(&db_path)? {
+            tracing::info!(target: "state", "plaintext DB detected — encrypting at rest");
+            crate::storage::migration::encrypt_in_place(&db_path, &dek)?;
+        }
+        let db = Db::open_with_key(&db_path, &dek)?;
         let config = AppConfig::load(&db)?;
 
         tracing::info!(target: "state", "app state initialized");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::audio::listener::VoiceListener;
 use crate::audio::system::SystemAudioRecorder;
@@ -26,8 +26,9 @@ pub struct AppState {
     pub config: Mutex<AppConfig>,
     pub current_meeting: Mutex<Option<uuid::Uuid>>,
     /// Folder ids unlocked in the current session: sealed folders decrypted for in-app view +
-    /// MCP until relock (cleared on screen-share start or app exit).
-    pub unlocked_folders: Mutex<std::collections::HashSet<String>>,
+    /// MCP until relock (cleared on screen-share start or app exit). Arc so the MCP server
+    /// thread shares the SAME set as the command surface.
+    pub unlocked_folders: Arc<Mutex<std::collections::HashSet<String>>>,
     /// Master KEK released by biometric; None until first unlock, zeroized on relock.
     pub master_kek: Mutex<Option<[u8; 32]>>,
 }
@@ -55,7 +56,7 @@ impl AppState {
             db,
             config: Mutex::new(config),
             current_meeting: Mutex::new(None),
-            unlocked_folders: Mutex::new(std::collections::HashSet::new()),
+            unlocked_folders: Arc::new(Mutex::new(std::collections::HashSet::new())),
             master_kek: Mutex::new(None),
         })
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -25,6 +25,11 @@ pub struct AppState {
     /// In-memory cache of the settings table.
     pub config: Mutex<AppConfig>,
     pub current_meeting: Mutex<Option<uuid::Uuid>>,
+    /// Folder ids unlocked in the current session: sealed folders decrypted for in-app view +
+    /// MCP until relock (cleared on screen-share start or app exit).
+    pub unlocked_folders: Mutex<std::collections::HashSet<String>>,
+    /// Master KEK released by biometric; None until first unlock, zeroized on relock.
+    pub master_kek: Mutex<Option<[u8; 32]>>,
 }
 
 impl AppState {
@@ -50,6 +55,8 @@ impl AppState {
             db,
             config: Mutex::new(config),
             current_meeting: Mutex::new(None),
+            unlocked_folders: Mutex::new(std::collections::HashSet::new()),
+            master_kek: Mutex::new(None),
         })
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -131,9 +131,47 @@ impl Db {
                title TEXT NOT NULL,
                prompt TEXT NOT NULL,
                created_at TEXT NOT NULL
-             );",
+             );
+             CREATE TABLE IF NOT EXISTS folders (
+               id TEXT PRIMARY KEY,
+               name TEXT NOT NULL,
+               path TEXT NOT NULL UNIQUE,
+               parent_id TEXT,
+               locked INTEGER NOT NULL DEFAULT 0,
+               wrapped_key BLOB,
+               created_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_folders_parent ON folders(parent_id);",
         )
         .map_err(map_err)?;
+        // Guarded ALTERs — notes gain a folder association + a sealed-content blob (AES-GCM
+        // markdown when the folder is locked; NULL when open). migrate() re-runs each launch and
+        // `ALTER ADD COLUMN` errors if the column already exists, so check pragma_table_info first.
+        Self::add_column_if_missing(&conn, "notes", "folder_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "notes", "content_blob", "BLOB")?;
+        Ok(())
+    }
+
+    /// Add `column` to `table` if it is not already present (idempotent migration guard).
+    fn add_column_if_missing(
+        conn: &Connection,
+        table: &str,
+        column: &str,
+        decl: &str,
+    ) -> Result<()> {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .map_err(map_err)?;
+        let exists = stmt
+            .query_map([], |r| r.get::<_, String>(1))
+            .map_err(map_err)?
+            .filter_map(|r| r.ok())
+            .any(|c| c == column);
+        drop(stmt);
+        if !exists {
+            conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {decl};"))
+                .map_err(map_err)?;
+        }
         Ok(())
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -256,7 +256,10 @@ impl Db {
     pub fn get_meeting(&self, id: &str) -> Result<Option<Meeting>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT id, started_at, ended_at, title, duration_s, audio_path, status
+            "SELECT id, started_at, ended_at, title, duration_s, audio_path, status,
+                    (SELECT n.folder_id FROM notes n
+                      WHERE n.meeting_id = meetings.id AND n.folder_id IS NOT NULL LIMIT 1)
+                      AS folder_id
                FROM meetings WHERE id = ?1",
             rusqlite::params![id],
             row_to_meeting,
@@ -269,7 +272,10 @@ impl Db {
     pub fn latest_meeting(&self) -> Result<Option<Meeting>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT id, started_at, ended_at, title, duration_s, audio_path, status
+            "SELECT id, started_at, ended_at, title, duration_s, audio_path, status,
+                    (SELECT n.folder_id FROM notes n
+                      WHERE n.meeting_id = meetings.id AND n.folder_id IS NOT NULL LIMIT 1)
+                      AS folder_id
                FROM meetings ORDER BY started_at DESC, id DESC LIMIT 1",
             [],
             row_to_meeting,
@@ -284,7 +290,10 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT id, started_at, ended_at, title, duration_s, audio_path, status
+                "SELECT id, started_at, ended_at, title, duration_s, audio_path, status,
+                        (SELECT n.folder_id FROM notes n
+                          WHERE n.meeting_id = meetings.id AND n.folder_id IS NOT NULL LIMIT 1)
+                          AS folder_id
                    FROM meetings ORDER BY started_at DESC, id DESC LIMIT ?1",
             )
             .map_err(map_err)?;
@@ -311,7 +320,10 @@ impl Db {
         let mut stmt = conn
             .prepare(
                 "SELECT DISTINCT m.id, m.started_at, m.ended_at, m.title, m.duration_s, \
-                        m.audio_path, m.status
+                        m.audio_path, m.status, \
+                        (SELECT nf.folder_id FROM notes nf \
+                          WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1) \
+                          AS folder_id
                    FROM meetings m
                    LEFT JOIN segments s ON s.meeting_id = m.id
                    LEFT JOIN notes n ON n.meeting_id = m.id
@@ -562,7 +574,10 @@ impl Db {
         let mut stmt = conn
             .prepare(
                 "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, \
-                        m.status
+                        m.status, \
+                        (SELECT nf.folder_id FROM notes nf \
+                          WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1) \
+                          AS folder_id
                    FROM meetings m
                    JOIN meeting_tags t ON t.meeting_id = m.id
                   WHERE t.tag = ?1
@@ -873,9 +888,11 @@ impl Db {
         Ok(out)
     }
 
-    /// Assign (or clear) a note's folder. Targets every provider row for the meeting so the
-    /// note moves as a unit.
-    pub fn set_note_folder(&self, meeting_id: &str, folder_id: Option<&str>) -> Result<()> {
+    /// Assign (or clear) a MEETING's folder. A meeting's folder = its note's folder, so this
+    /// updates `folder_id` on EVERY provider row of the meeting (`WHERE meeting_id = ?1`) — the
+    /// note moves as a unit and the seal/unlock lifecycle (which iterates provider rows) stays
+    /// coherent (no row left in a stale folder). `None` clears the folder (move to vault root).
+    pub fn set_meeting_folder(&self, meeting_id: &str, folder_id: Option<&str>) -> Result<()> {
         let conn = self.lock();
         conn.execute(
             "UPDATE notes SET folder_id = ?2 WHERE meeting_id = ?1",
@@ -883,6 +900,11 @@ impl Db {
         )
         .map_err(map_err)?;
         Ok(())
+    }
+
+    /// Back-compat alias for [`Db::set_meeting_folder`] — a note's folder is the meeting's folder.
+    pub fn set_note_folder(&self, meeting_id: &str, folder_id: Option<&str>) -> Result<()> {
+        self.set_meeting_folder(meeting_id, folder_id)
     }
 
     /// Notes assigned to a folder (the rows needed to seal/unseal): the meeting, provider,
@@ -1023,7 +1045,10 @@ impl Db {
         let visible = visibility_clause("n", unlocked);
         let sql = format!(
             "SELECT DISTINCT m.id, m.started_at, m.ended_at, m.title, m.duration_s, \
-                    m.audio_path, m.status
+                    m.audio_path, m.status, \
+                    (SELECT nf.folder_id FROM notes nf \
+                      WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1) \
+                      AS folder_id
                FROM meetings m
                LEFT JOIN segments s ON s.meeting_id = m.id
                LEFT JOIN notes n ON n.meeting_id = m.id
@@ -1069,7 +1094,10 @@ impl Db {
         // sibling visible note exists. Simpler + correct: keep the meeting if it has zero notes
         // OR at least one visible note.
         let sql = format!(
-            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status
+            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
+                    (SELECT nf.folder_id FROM notes nf
+                      WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1)
+                      AS folder_id
                FROM meetings m
               WHERE NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
                  OR EXISTS (
@@ -1180,6 +1208,9 @@ fn row_to_meeting(row: &Row<'_>) -> rusqlite::Result<Result<Meeting>> {
     let duration_s: i64 = row.get(4)?;
     let audio_path: Option<String> = row.get(5)?;
     let status_str: String = row.get(6)?;
+    // Trailing column: the meeting's folder, derived from its note rows (NULL = vault root).
+    // Every SELECT feeding this mapper appends a `folder_id` column in this position.
+    let folder_id: Option<String> = row.get(7)?;
 
     Ok(MeetingStatus::from_str(&status_str).map(|status| Meeting {
         id,
@@ -1189,6 +1220,7 @@ fn row_to_meeting(row: &Row<'_>) -> rusqlite::Result<Result<Meeting>> {
         duration_s,
         audio_path,
         status,
+        folder_id,
     }))
 }
 
@@ -1341,6 +1373,7 @@ mod tests {
             duration_s: 0,
             audio_path: None,
             status: MeetingStatus::Draft,
+            folder_id: None,
         }
     }
 
@@ -1488,6 +1521,117 @@ mod tests {
             ]
         );
     }
+
+    use crate::storage::models::Folder;
+
+    fn seed_folder(db: &Db, id: &str, name: &str) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
+    fn note_for(db: &Db, meeting_id: &str, provider_id: &str, markdown: &str) {
+        db.upsert_note(&NoteRecord {
+            meeting_id: meeting_id.to_string(),
+            provider_id: provider_id.to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-26T09:05:00Z".to_string(),
+            exported_path: Some(format!("/vault/{meeting_id}-{provider_id}.md")),
+        })
+        .unwrap();
+    }
+
+    fn folder_id_of<'a>(meetings: &'a [Meeting], id: &str) -> &'a Option<String> {
+        &meetings
+            .iter()
+            .find(|m| m.id == id)
+            .expect("meeting present")
+            .folder_id
+    }
+
+    #[test]
+    fn meeting_folder_id_surfaces_in_list_and_search() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Secret");
+        // Meeting WITH a note moved into a folder.
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "# planning the budget review");
+        db.set_meeting_folder("m1", Some("f1")).unwrap();
+
+        // Meeting with a note but NO folder (root) → folder_id None.
+        db.insert_meeting(&sample_meeting("m2", "2026-06-24T11:00:00Z"))
+            .unwrap();
+        note_for(&db, "m2", "claude_code", "# budget at the root level");
+
+        // Meeting with NO note at all → folder_id None (no note rows to derive from).
+        db.insert_meeting(&sample_meeting("m3", "2026-06-24T12:00:00Z"))
+            .unwrap();
+
+        // list_meetings carries the derived folder_id.
+        let listed = db.list_meetings(50).unwrap();
+        assert_eq!(folder_id_of(&listed, "m1").as_deref(), Some("f1"));
+        assert_eq!(*folder_id_of(&listed, "m2"), None);
+        assert_eq!(*folder_id_of(&listed, "m3"), None);
+
+        // get_meeting carries it too.
+        assert_eq!(
+            db.get_meeting("m1").unwrap().unwrap().folder_id.as_deref(),
+            Some("f1")
+        );
+        assert_eq!(db.get_meeting("m2").unwrap().unwrap().folder_id, None);
+        assert_eq!(db.get_meeting("m3").unwrap().unwrap().folder_id, None);
+
+        // search hits carry the derived folder_id on the embedded meeting.
+        let hits = db.search("budget", 50).unwrap();
+        let h1 = hits.iter().find(|h| h.meeting.id == "m1").expect("m1 hit");
+        let h2 = hits.iter().find(|h| h.meeting.id == "m2").expect("m2 hit");
+        assert_eq!(h1.meeting.folder_id.as_deref(), Some("f1"));
+        assert_eq!(h2.meeting.folder_id, None);
+    }
+
+    #[test]
+    fn multi_provider_meeting_reports_one_consistent_folder_id() {
+        // A meeting re-summarized with TWO providers has two note rows. set_meeting_folder
+        // updates BOTH (WHERE meeting_id), so the correlated subselect returns a single,
+        // consistent folder regardless of which row it picks.
+        let db = mem_db();
+        seed_folder(&db, "f1", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "# claude budget note");
+        note_for(&db, "m1", "ollama", "# ollama budget note");
+        db.set_meeting_folder("m1", Some("f1")).unwrap();
+
+        // Both provider rows carry the same folder.
+        let folders: Vec<Option<String>> = {
+            let conn = db.lock();
+            let mut stmt = conn
+                .prepare("SELECT folder_id FROM notes WHERE meeting_id = 'm1' ORDER BY provider_id")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |r| r.get::<_, Option<String>>(0))
+                .unwrap();
+            rows.map(|r| r.unwrap()).collect()
+        };
+        assert_eq!(folders, vec![Some("f1".to_string()), Some("f1".to_string())]);
+
+        // list_meetings reports a single consistent folder_id (LIMIT 1 subselect, no dup rows).
+        let listed = db.list_meetings(50).unwrap();
+        let m1_rows: Vec<&Meeting> = listed.iter().filter(|m| m.id == "m1").collect();
+        assert_eq!(m1_rows.len(), 1, "one meeting row despite two provider notes");
+        assert_eq!(m1_rows[0].folder_id.as_deref(), Some("f1"));
+
+        // Clearing the folder (move to root) clears it for every provider row.
+        db.set_meeting_folder("m1", None).unwrap();
+        assert_eq!(db.get_meeting("m1").unwrap().unwrap().folder_id, None);
+    }
 }
 
 #[cfg(test)]
@@ -1544,6 +1688,7 @@ mod lock_tests {
             duration_s: 60,
             audio_path: None,
             status: MeetingStatus::Summarized,
+            folder_id: None,
         })
         .unwrap();
         db.upsert_note(&NoteRecord {

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8,8 +8,9 @@ use crate::error::{AppError, Result};
 use std::collections::HashSet;
 
 use crate::storage::models::{
-    Analytics, DayCount, Folder, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
-    StatusCount,
+    Analytics, DayCount, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData, GraphEdge,
+    GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
+    StatusCount, VaultSource,
 };
 use crate::transcribe::types::Segment;
 
@@ -40,6 +41,29 @@ impl FromStr for MeetingStatus {
             "EXPORTED" => Ok(MeetingStatus::Exported),
             "ERROR" => Ok(MeetingStatus::Error),
             other => Err(AppError::Storage(format!("unknown meeting status: {other}"))),
+        }
+    }
+}
+
+impl EntityKind {
+    /// Stable lowercase string used as the on-disk `entities.kind` column value.
+    /// Kept in sync with the serde `rename_all = "camelCase"` on the enum.
+    fn as_str(&self) -> &'static str {
+        match self {
+            EntityKind::Person => "person",
+            EntityKind::Project => "project",
+        }
+    }
+}
+
+impl FromStr for EntityKind {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "person" => Ok(EntityKind::Person),
+            "project" => Ok(EntityKind::Project),
+            other => Err(AppError::Storage(format!("unknown entity kind: {other}"))),
         }
     }
 }
@@ -144,7 +168,26 @@ impl Db {
                wrapped_key BLOB,
                created_at TEXT NOT NULL
              );
-             CREATE INDEX IF NOT EXISTS idx_folders_parent ON folders(parent_id);",
+             CREATE INDEX IF NOT EXISTS idx_folders_parent ON folders(parent_id);
+             CREATE TABLE IF NOT EXISTS entities (
+               id TEXT PRIMARY KEY,
+               name TEXT NOT NULL,
+               name_ci TEXT NOT NULL,
+               kind TEXT NOT NULL,
+               created_at TEXT NOT NULL,
+               UNIQUE (name_ci, kind)
+             );
+             CREATE TABLE IF NOT EXISTS entity_mentions (
+               entity_id TEXT NOT NULL,
+               meeting_id TEXT NOT NULL,
+               created_at TEXT NOT NULL,
+               PRIMARY KEY (entity_id, meeting_id),
+               FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_entity_mentions_meeting ON entity_mentions(meeting_id);
+             CREATE INDEX IF NOT EXISTS idx_entity_mentions_entity ON entity_mentions(entity_id);
+             CREATE INDEX IF NOT EXISTS idx_entities_kind ON entities(kind);",
         )
         .map_err(map_err)?;
         // Guarded ALTERs — notes gain a folder association + a sealed-content blob (AES-GCM
@@ -1164,6 +1207,375 @@ impl Db {
             .map_err(map_err)?;
         Ok(!has_notes || has_visible)
     }
+
+    // ── self-assembling graph (entities + mentions) ───────────────────────────
+    //
+    // Sink A of the dual-sink: the encrypted DB is the source of truth for the in-app
+    // graph. EVERY read below pushes the same `unlocked` set through `visibility_clause`
+    // over `entity_mentions → meetings → notes n LEFT JOIN folders f`, replicating the
+    // `EXISTS(visible note) OR NOT EXISTS(any note)` predicate of `list_meetings_visible`
+    // verbatim — so a sealed-and-not-unlocked meeting contributes ZERO to nodes, edges,
+    // and counts. The rows persist through sealing; they merely become invisible at read.
+
+    /// Upsert an entity by `(name_ci, kind)`, case-insensitively de-duplicated. Keeps the
+    /// FIRST-SEEN casing in `name` (a later "anna kowalska" does NOT overwrite "Anna Kowalska").
+    /// `name_ci` uses full-Unicode `to_lowercase()` (NOT ASCII-only folding) so accented names
+    /// dedup consistently. Returns the (new or existing) entity id. Race-safe: `INSERT OR IGNORE`
+    /// then re-read, so a concurrent insert resolves to the single winning row.
+    pub fn upsert_entity(&self, name: &str, kind: EntityKind) -> Result<String> {
+        let conn = self.lock();
+        let name = name.trim();
+        let name_ci = name.to_lowercase();
+        let kind_str = kind.as_str();
+        let id = uuid::Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        // INSERT OR IGNORE: if `(name_ci, kind)` already exists the insert is a no-op (the
+        // existing first-seen casing + id are kept). Either way we re-read the canonical id.
+        conn.execute(
+            "INSERT OR IGNORE INTO entities (id, name, name_ci, kind, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![id, name, name_ci, kind_str, created_at],
+        )
+        .map_err(map_err)?;
+        let resolved: String = conn
+            .query_row(
+                "SELECT id FROM entities WHERE name_ci = ?1 AND kind = ?2",
+                rusqlite::params![name_ci, kind_str],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(resolved)
+    }
+
+    /// Record that `entity_id` was mentioned in `meeting_id`. Idempotent via the PK
+    /// `(entity_id, meeting_id)` — re-summarize / re-extract never double-counts.
+    pub fn add_mention(&self, entity_id: &str, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT OR IGNORE INTO entity_mentions (entity_id, meeting_id, created_at)
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![entity_id, meeting_id, created_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// All entities that have ≥1 VISIBLE mention, with that visible mention count. An entity
+    /// mentioned ONLY in sealed-and-not-unlocked meetings has count 0 → dropped by `HAVING`,
+    /// so its name (which lived only in encrypted markdown) never reaches the renderer.
+    pub fn list_entities_visible(&self, unlocked: &HashSet<String>) -> Result<Vec<GraphNode>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT e.id, e.name, e.kind, COUNT(em.meeting_id) AS cnt
+               FROM entities e
+               JOIN entity_mentions em ON em.entity_id = e.id
+               JOIN meetings m ON m.id = em.meeting_id
+              WHERE (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              GROUP BY e.id, e.name, e.kind
+             HAVING cnt > 0
+              ORDER BY cnt DESC, e.name COLLATE NOCASE ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                let id: String = r.get(0)?;
+                let name: String = r.get(1)?;
+                let kind_str: String = r.get(2)?;
+                let mention_count: i64 = r.get(3)?;
+                Ok((id, name, kind_str, mention_count))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (id, name, kind_str, mention_count) = r.map_err(map_err)?;
+            out.push(GraphNode {
+                id,
+                name,
+                kind: EntityKind::from_str(&kind_str)?,
+                mention_count,
+            });
+        }
+        Ok(out)
+    }
+
+    /// The VISIBLE meetings mentioning `entity_id`, newest first, as `VaultSource` chips
+    /// (the same shape the FE uses for backlink chips). Sealed-not-unlocked meetings excluded.
+    pub fn entity_mentions_visible(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<VaultSource>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT m.id, m.title, m.started_at
+               FROM entity_mentions em
+               JOIN meetings m ON m.id = em.meeting_id
+              WHERE em.entity_id = ?1
+                AND (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              ORDER BY m.started_at DESC, m.id DESC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![entity_id], |r| {
+                let meeting_id: String = r.get(0)?;
+                let title: Option<String> = r.get(1)?;
+                let started_at: String = r.get(2)?;
+                Ok(VaultSource {
+                    meeting_id,
+                    title: title.unwrap_or_default(),
+                    started_at,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Entity↔entity co-occurrence edges: two entities sharing the SAME visible meeting, weighted
+    /// by the number of shared visible meetings. Pair-deduped via `a.entity_id < b.entity_id`
+    /// → exactly one undirected edge per pair, `source < target`. Both endpoints' meetings are
+    /// gated by the visibility predicate, so a co-occurrence in a sealed meeting yields no edge.
+    pub fn graph_edges_visible(&self, unlocked: &HashSet<String>) -> Result<Vec<GraphEdge>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT a.entity_id, b.entity_id, COUNT(*) AS weight
+               FROM entity_mentions a
+               JOIN entity_mentions b
+                 ON a.meeting_id = b.meeting_id AND a.entity_id < b.entity_id
+               JOIN meetings m ON m.id = a.meeting_id
+              WHERE (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              GROUP BY a.entity_id, b.entity_id
+              ORDER BY weight DESC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(GraphEdge {
+                    source: r.get(0)?,
+                    target: r.get(1)?,
+                    weight: r.get(2)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Whether `entity_id` has ≥1 VISIBLE mention right now — i.e. at least one mention lands in a
+    /// meeting that is visible under the SAME predicate as `list_meetings_visible` / the other
+    /// graph reads (`EXISTS(visible note) OR NOT EXISTS(any note)`). An entity mentioned ONLY in
+    /// sealed-and-not-unlocked meetings returns `false`, so its name (which lived only in encrypted
+    /// markdown) can never leak through `get_entity` / `build_entity_detail`. This is the gate the
+    /// detail path was missing: `get_entity` itself reads the raw `entities` row with no visibility
+    /// predicate, so callers that expose an entity to the FE MUST go through this check first.
+    pub fn entity_is_visible(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT EXISTS (
+                      SELECT 1
+                        FROM entity_mentions em
+                        JOIN meetings m ON m.id = em.meeting_id
+                       WHERE em.entity_id = ?1
+                         AND (
+                               NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                            OR EXISTS (
+                                 SELECT 1 FROM notes n
+                                  LEFT JOIN folders f ON f.id = n.folder_id
+                                  WHERE n.meeting_id = m.id AND {visible}
+                               )
+                             )
+                    )"
+        );
+        let visible: bool = conn
+            .query_row(&sql, rusqlite::params![entity_id], |r| {
+                Ok(r.get::<_, i64>(0)? != 0)
+            })
+            .map_err(map_err)?;
+        Ok(visible)
+    }
+
+    /// One entity row by id (`None` if absent), with its first-seen casing. NOTE: this reads the
+    /// raw `entities` row WITHOUT a visibility predicate — it must NOT be exposed to the FE for an
+    /// arbitrary id without first gating on [`entity_is_visible`] (see `build_entity_detail`).
+    pub fn get_entity(&self, entity_id: &str) -> Result<Option<GraphEntity>> {
+        let conn = self.lock();
+        let row = conn
+            .query_row(
+                "SELECT id, name, kind, created_at FROM entities WHERE id = ?1",
+                rusqlite::params![entity_id],
+                |r| {
+                    let id: String = r.get(0)?;
+                    let name: String = r.get(1)?;
+                    let kind_str: String = r.get(2)?;
+                    let created_at: String = r.get(3)?;
+                    Ok((id, name, kind_str, created_at))
+                },
+            )
+            .optional()
+            .map_err(map_err)?;
+        match row {
+            Some((id, name, kind_str, created_at)) => Ok(Some(GraphEntity {
+                id,
+                name,
+                kind: EntityKind::from_str(&kind_str)?,
+                created_at,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// The top-`limit` entities co-occurring with `entity_id` (the neighborhood satellites),
+    /// ranked by shared VISIBLE meeting count. Both the anchor's and the neighbor's mention must
+    /// land in a visible meeting, so sealed co-occurrences never surface a neighbor.
+    pub fn entity_neighbors_visible(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+        limit: i64,
+    ) -> Result<Vec<EntityNeighbor>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT e.id, e.name, e.kind, COUNT(*) AS shared
+               FROM entity_mentions a
+               JOIN entity_mentions b ON a.meeting_id = b.meeting_id AND b.entity_id != a.entity_id
+               JOIN entities e ON e.id = b.entity_id
+               JOIN meetings m ON m.id = a.meeting_id
+              WHERE a.entity_id = ?1
+                AND (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              GROUP BY e.id, e.name, e.kind
+              ORDER BY shared DESC, e.name COLLATE NOCASE ASC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![entity_id, limit], |r| {
+                let id: String = r.get(0)?;
+                let name: String = r.get(1)?;
+                let kind_str: String = r.get(2)?;
+                let shared_meetings: i64 = r.get(3)?;
+                Ok((id, name, kind_str, shared_meetings))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (id, name, kind_str, shared_meetings) = r.map_err(map_err)?;
+            out.push(EntityNeighbor {
+                id,
+                name,
+                kind: EntityKind::from_str(&kind_str)?,
+                shared_meetings,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Whether ANY folder is sealed-and-not-unlocked right now (i.e. a locked folder whose id is
+    /// NOT in the session `unlocked` set). Drives the FE's one honest "some entities hidden"
+    /// disclosure banner — it never leaks how many or which.
+    pub fn has_hidden_folders(&self, unlocked: &HashSet<String>) -> Result<bool> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT id FROM folders WHERE locked = 1")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        for r in rows {
+            let id = r.map_err(map_err)?;
+            if !unlocked.contains(&id) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Build the full graph payload (`get_graph`): all visible nodes + all visible edges +
+    /// the hidden-folder disclosure flag, snapshotting the passed-in session `unlocked` set.
+    pub fn build_graph(&self, unlocked: &HashSet<String>) -> Result<GraphData> {
+        let nodes = self.list_entities_visible(unlocked)?;
+        let edges = self.graph_edges_visible(unlocked)?;
+        let has_hidden = self.has_hidden_folders(unlocked)?;
+        Ok(GraphData {
+            nodes,
+            edges,
+            has_hidden,
+        })
+    }
+
+    /// Build the detail payload for one entity (`get_entity_detail`): the entity, its visible
+    /// backlinked meetings, and its top co-occurring neighbors. `None` if the entity is unknown
+    /// OR has ZERO visible mentions (mentioned only in sealed-not-unlocked meetings). The
+    /// visibility gate is mandatory here: `get_entity` reads the raw `entities` row with NO
+    /// predicate, so without this check a caller holding a stale entity id (cached from a prior
+    /// open-folder `get_graph`, before the folder was sealed/auto-relocked) could read back the
+    /// entity's `name` — which lived only in the sealed meeting's encrypted markdown. Routing
+    /// through `entity_is_visible` keeps the detail path consistent with every other graph read.
+    pub fn build_entity_detail(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+        neighbor_limit: i64,
+    ) -> Result<Option<EntityDetail>> {
+        // Anti-leak gate FIRST: a sealed-only entity is indistinguishable from an unknown id.
+        if !self.entity_is_visible(entity_id, unlocked)? {
+            return Ok(None);
+        }
+        let entity = match self.get_entity(entity_id)? {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+        let meetings = self.entity_mentions_visible(entity_id, unlocked)?;
+        let neighbors = self.entity_neighbors_visible(entity_id, unlocked, neighbor_limit)?;
+        Ok(Some(EntityDetail {
+            entity,
+            meetings,
+            neighbors,
+        }))
+    }
 }
 
 /// One note row needed to seal/unseal a folder.
@@ -1954,5 +2366,403 @@ mod lock_tests {
             return false;
         }
         haystack.windows(needle.len()).any(|w| w == needle)
+    }
+}
+
+#[cfg(test)]
+mod graph_tests {
+    //! File-backed (tempfile via `open_with_key` + a FIXED test key) tests for the in-app
+    //! self-assembling graph (entities + mentions). These NEVER touch the real Keychain — both
+    //! the SQLCipher DEK and the per-folder lock KEK are explicit literals. They exercise the
+    //! Sink-A DB helpers + the visibility predicate (the single highest-stakes anti-leak line),
+    //! and the Sink-B `locked`-gate (disk-truth, not session-unlock) for the vault stub mirror.
+
+    use super::*;
+    use crate::storage::models::{EntityKind, Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn temp_db_path(label: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "meetnotes-graph-test-{}-{}-{}.sqlite",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    fn file_db(label: &str) -> Db {
+        Db::open_with_key(&temp_db_path(label), TEST_DEK).unwrap()
+    }
+
+    /// A scratch vault directory for Sink-B `.md` stub assertions (unique per test).
+    fn temp_vault(label: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "meetnotes-graph-vault-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn seed_folder(db: &Db, id: &str, name: &str) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
+    /// Seed a meeting + one note row, optionally filed into `folder_id`.
+    fn seed_note(db: &Db, meeting_id: &str, markdown: &str, folder_id: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: meeting_id.to_string(),
+            started_at: format!("2026-06-26T09:00:00Z+{meeting_id}"),
+            ended_at: None,
+            title: Some(format!("title-{meeting_id}")),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: meeting_id.to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-26T09:05:00Z".to_string(),
+            exported_path: Some(format!("/vault/{meeting_id}.md")),
+        })
+        .unwrap();
+        db.set_note_folder(meeting_id, folder_id).unwrap();
+    }
+
+    /// Mirror of `lock_folder`: encrypt each note into a content blob, blank markdown, seal.
+    fn seal_folder(db: &Db, folder_id: &str, kek: &[u8; 32]) {
+        let ck = crate::crypto::random_key().unwrap();
+        let wrapped = crate::crypto::encrypt(kek, &ck).unwrap();
+        let notes = db.notes_in_folder(folder_id).unwrap();
+        let mut blobs = Vec::new();
+        for n in &notes {
+            let blob = crate::crypto::encrypt(&ck, n.markdown.as_bytes()).unwrap();
+            blobs.push((n.meeting_id.clone(), n.provider_id.clone(), blob));
+        }
+        db.set_folder_locked(folder_id, true, Some(&wrapped)).unwrap();
+        for (mid, pid, blob) in &blobs {
+            db.seal_note(mid, pid, blob).unwrap();
+        }
+    }
+
+    fn unlocked_set(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn entity_dedup() {
+        // Same name, different casing, same kind → ONE entity (case-insensitive on name_ci),
+        // FIRST-SEEN casing kept. Mentions across distinct meetings accumulate; a repeat mention
+        // is idempotent (PK). A same-name DIFFERENT kind is a distinct row.
+        let db = file_db("dedup");
+        seed_note(&db, "m1", "# note", None);
+        seed_note(&db, "m2", "# note", None);
+
+        let id1 = db.upsert_entity("Anna Kowalska", EntityKind::Person).unwrap();
+        let id2 = db.upsert_entity("anna kowalska", EntityKind::Person).unwrap();
+        assert_eq!(id1, id2, "case-insensitive dedup → same entity id");
+
+        // First-seen casing is preserved (the lowercase re-insert must NOT overwrite it).
+        let ent = db.get_entity(&id1).unwrap().unwrap();
+        assert_eq!(ent.name, "Anna Kowalska", "first-seen casing kept");
+
+        // Same name, DIFFERENT kind → a distinct entity row (the (name_ci, kind) unique index).
+        let proj = db.upsert_entity("Anna Kowalska", EntityKind::Project).unwrap();
+        assert_ne!(proj, id1, "same name + different kind = distinct entity");
+
+        // Mentions accumulate across meetings; a duplicate mention is idempotent.
+        db.add_mention(&id1, "m1").unwrap();
+        db.add_mention(&id1, "m1").unwrap(); // idempotent — no double count
+        db.add_mention(&id1, "m2").unwrap();
+
+        let empty = HashSet::new();
+        let nodes = db.list_entities_visible(&empty).unwrap();
+        let anna = nodes
+            .iter()
+            .find(|n| n.id == id1)
+            .expect("Anna present in visible nodes");
+        assert_eq!(anna.mention_count, 2, "two distinct meetings, idempotent repeat");
+        assert_eq!(anna.name, "Anna Kowalska");
+    }
+
+    #[test]
+    fn graph_visibility_filter() {
+        // The core anti-leak test. An entity mentioned ONLY in a SEALED folder's meeting is ABSENT
+        // from get_graph/list_entities_visible while the folder is locked + not in the unlocked
+        // set; it reappears when the folder id IS in the unlocked set. An entity also mentioned in
+        // an OPEN meeting keeps only its VISIBLE count (never the true count).
+        let db = file_db("visibility");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "secret", "Secret");
+        seed_note(&db, "open1", "# open", None); // root → always visible
+        seed_note(&db, "sealed1", "# sealed", Some("secret"));
+
+        // "Secret Person" mentioned ONLY in the sealed meeting.
+        let secret_p = db.upsert_entity("Secret Person", EntityKind::Person).unwrap();
+        db.add_mention(&secret_p, "sealed1").unwrap();
+        // "Shared Project" mentioned in BOTH the open and the sealed meeting.
+        let shared = db.upsert_entity("Shared Project", EntityKind::Project).unwrap();
+        db.add_mention(&shared, "open1").unwrap();
+        db.add_mention(&shared, "sealed1").unwrap();
+
+        let empty: HashSet<String> = HashSet::new();
+
+        // BEFORE sealing: both entities present; Shared has count 2.
+        let before = db.list_entities_visible(&empty).unwrap();
+        assert!(before.iter().any(|n| n.id == secret_p));
+        assert_eq!(
+            before.iter().find(|n| n.id == shared).unwrap().mention_count,
+            2
+        );
+        // An edge exists between the two (they co-occur in sealed1) — pre-seal.
+        let (lo, hi) = if secret_p < shared {
+            (secret_p.clone(), shared.clone())
+        } else {
+            (shared.clone(), secret_p.clone())
+        };
+        assert!(
+            db.graph_edges_visible(&empty)
+                .unwrap()
+                .iter()
+                .any(|e| e.source == lo && e.target == hi),
+            "co-occurring entities have an edge before sealing"
+        );
+
+        // SEAL the folder, session NOT unlocked.
+        seal_folder(&db, "secret", &kek);
+        let nodes = db.list_entities_visible(&empty).unwrap();
+        assert!(
+            !nodes.iter().any(|n| n.id == secret_p),
+            "entity only in a sealed-not-unlocked meeting must be ABSENT"
+        );
+        // Shared survives but with VISIBLE count 1 (only the open meeting), never the true 2.
+        let shared_node = nodes
+            .iter()
+            .find(|n| n.id == shared)
+            .expect("shared entity still visible via its open meeting");
+        assert_eq!(
+            shared_node.mention_count, 1,
+            "visible count only — sealed mention drops out, never leaks count 2"
+        );
+        // No edge when the only co-occurrence is sealed.
+        assert!(
+            db.graph_edges_visible(&empty).unwrap().is_empty(),
+            "co-occurrence in a sealed meeting yields no edge"
+        );
+        // build_graph reflects the same + flags hidden folders.
+        let graph = db.build_graph(&empty).unwrap();
+        assert!(graph.has_hidden, "a sealed-not-unlocked folder sets has_hidden");
+        assert!(!graph.nodes.iter().any(|n| n.id == secret_p));
+        // entity_mentions_visible: the secret entity has zero visible backlinks while sealed.
+        assert!(db.entity_mentions_visible(&secret_p, &empty).unwrap().is_empty());
+
+        // SESSION-UNLOCK the folder id → the sealed contribution reappears.
+        let unlocked = unlocked_set(&["secret"]);
+        let nodes_u = db.list_entities_visible(&unlocked).unwrap();
+        assert!(
+            nodes_u.iter().any(|n| n.id == secret_p),
+            "entity reappears once its folder id is in the unlocked set"
+        );
+        assert_eq!(
+            nodes_u.iter().find(|n| n.id == shared).unwrap().mention_count,
+            2,
+            "both mentions visible again when unlocked"
+        );
+        // Edge with weight 1 returns (one shared visible meeting).
+        let edges_u = db.graph_edges_visible(&unlocked).unwrap();
+        assert_eq!(edges_u.len(), 1, "exactly one deduped edge per pair");
+        assert_eq!(edges_u[0].weight, 1);
+        // build_graph no longer flags hidden (the only locked folder is now unlocked).
+        assert!(!db.build_graph(&unlocked).unwrap().has_hidden);
+        // The secret entity's visible backlinks return when unlocked.
+        assert_eq!(
+            db.entity_mentions_visible(&secret_p, &unlocked).unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn dual_sink_skips_vault_when_locked() {
+        // Sink B gates on the meeting's folder `locked` flag (DISK truth, NOT session-unlock):
+        // a meeting in a locked folder → DB rows still written (Sink A), but ZERO vault `.md`
+        // stubs. An OPEN folder → both DB rows AND vault stubs. This mirrors the gate in
+        // `commands::build_and_persist_entities` without invoking the LLM provider.
+        let db = file_db("dualsink");
+        let kek = crate::crypto::random_key().unwrap();
+        let vault = temp_vault("dualsink");
+
+        seed_folder(&db, "locked_f", "Locked");
+        seed_folder(&db, "open_f", "Open");
+        seed_note(&db, "m_locked", "# locked note", Some("locked_f"));
+        seed_note(&db, "m_open", "# open note", Some("open_f"));
+        seal_folder(&db, "locked_f", &kek); // locked_f now locked=true on disk
+
+        // The dual-sink gate, replicated: Sink A always; Sink B only when folder NOT locked.
+        let sink = |meeting_id: &str, person: &str| {
+            // Sink A — always persist to the DB.
+            let id = db.upsert_entity(person, EntityKind::Person).unwrap();
+            db.add_mention(&id, meeting_id).unwrap();
+            // Sink B — vault stub only if the meeting's folder is unsealed on disk.
+            let folder_locked = match db.get_meeting(meeting_id).unwrap().and_then(|m| m.folder_id) {
+                Some(fid) => db.folder_by_id(&fid).unwrap().map(|f| f.locked).unwrap_or(false),
+                None => false,
+            };
+            if !folder_locked {
+                crate::export::entity_stub::ensure_entity_backlink(
+                    &vault, "People", person, &format!("title-{meeting_id}"),
+                )
+                .unwrap();
+            }
+        };
+
+        sink("m_locked", "Locked Person");
+        sink("m_open", "Open Person");
+
+        // Sink A: BOTH entities are in the DB regardless of lock state.
+        // (Read with the locked folder session-unlocked so both meetings are visible for the
+        //  assertion — Sink A wrote rows for both either way.)
+        let unlocked = unlocked_set(&["locked_f"]);
+        let nodes = db.list_entities_visible(&unlocked).unwrap();
+        assert!(
+            nodes.iter().any(|n| n.name == "Locked Person"),
+            "Sink A: DB row written even for a locked-folder meeting"
+        );
+        assert!(nodes.iter().any(|n| n.name == "Open Person"));
+
+        // Sink B: the OPEN folder's entity has a vault stub; the LOCKED folder's does NOT.
+        let open_stub = vault.join("People").join("Open Person.md");
+        let locked_stub = vault.join("People").join("Locked Person.md");
+        assert!(open_stub.exists(), "open folder → vault stub written");
+        assert!(
+            !locked_stub.exists(),
+            "locked folder → NO vault stub (no plaintext leak to disk)"
+        );
+    }
+
+    #[test]
+    fn no_vault_configured_db_sink_still_works() {
+        // Sink A must work with NO vault: no error, DB rows written, no stubs (no vault dir).
+        let db = file_db("novault");
+        seed_note(&db, "m1", "# note", None);
+        let id = db.upsert_entity("Some Person", EntityKind::Person).unwrap();
+        db.add_mention(&id, "m1").unwrap();
+        let nodes = db.list_entities_visible(&HashSet::new()).unwrap();
+        assert!(nodes.iter().any(|n| n.id == id));
+    }
+
+    #[test]
+    fn cascade_prunes_mentions_and_entity_drops_out() {
+        // delete_meeting cascades to entity_mentions (FK ON DELETE CASCADE); an entity with zero
+        // remaining mentions disappears from list_entities_visible (HAVING count > 0).
+        let db = file_db("cascade");
+        seed_note(&db, "m1", "# note", None);
+        let id = db.upsert_entity("Solo Person", EntityKind::Person).unwrap();
+        db.add_mention(&id, "m1").unwrap();
+        assert!(db
+            .list_entities_visible(&HashSet::new())
+            .unwrap()
+            .iter()
+            .any(|n| n.id == id));
+
+        db.delete_meeting("m1").unwrap();
+        assert!(
+            !db.list_entities_visible(&HashSet::new())
+                .unwrap()
+                .iter()
+                .any(|n| n.id == id),
+            "entity with no remaining mentions drops out"
+        );
+        // The entity row itself remains (orphan), but contributes nothing — harmless.
+        assert!(db.get_entity(&id).unwrap().is_some());
+    }
+
+    #[test]
+    fn entity_detail_neighbors_and_backlinks() {
+        // build_entity_detail returns the entity, its visible backlinked meetings, and its top
+        // co-occurring neighbors ranked by shared visible meetings.
+        let db = file_db("detail");
+        seed_note(&db, "m1", "# note", None);
+        seed_note(&db, "m2", "# note", None);
+        let anna = db.upsert_entity("Anna", EntityKind::Person).unwrap();
+        let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+        let bob = db.upsert_entity("Bob", EntityKind::Person).unwrap();
+        // Anna+Atlas co-occur in m1 AND m2 (weight 2); Anna+Bob only in m1 (weight 1).
+        for (e, m) in [(&anna, "m1"), (&anna, "m2"), (&atlas, "m1"), (&atlas, "m2"), (&bob, "m1")] {
+            db.add_mention(e, m).unwrap();
+        }
+        let detail = db
+            .build_entity_detail(&anna, &HashSet::new(), 12)
+            .unwrap()
+            .unwrap();
+        assert_eq!(detail.entity.name, "Anna");
+        assert_eq!(detail.meetings.len(), 2, "Anna backlinks m1 + m2");
+        assert_eq!(detail.neighbors.first().unwrap().id, atlas, "Atlas is the top neighbor (shared 2)");
+        assert_eq!(detail.neighbors.first().unwrap().shared_meetings, 2);
+        assert!(detail.neighbors.iter().any(|n| n.id == bob));
+        // Unknown id → None.
+        assert!(db.build_entity_detail("nope", &HashSet::new(), 12).unwrap().is_none());
+    }
+
+    #[test]
+    fn entity_detail_hidden_when_only_sealed() {
+        // PRIME-DIRECTIVE anti-leak: an entity mentioned ONLY in a sealed-not-unlocked meeting
+        // must NEVER surface via get_entity_detail. The leak this guards: the FE held the entity
+        // id from a PRIOR open-folder get_graph; the folder is then sealed (or auto-relocked on
+        // screen-share); a subsequent get_entity_detail(id) must NOT return the entity — its
+        // `name` lived only in the sealed meeting's encrypted markdown. The detail returns None
+        // while sealed, and reappears only once the folder id is in the session `unlocked` set.
+        let db = file_db("detail-sealed");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "secret", "Secret");
+        seed_note(&db, "sealed1", "# sealed", Some("secret"));
+
+        let secret_p = db.upsert_entity("Secret Person", EntityKind::Person).unwrap();
+        db.add_mention(&secret_p, "sealed1").unwrap();
+
+        let empty: HashSet<String> = HashSet::new();
+
+        // While OPEN: detail is available (sanity — proves the test wires a real, resolvable id).
+        let open_detail = db.build_entity_detail(&secret_p, &empty, 12).unwrap();
+        assert!(open_detail.is_some(), "open folder → detail resolves");
+
+        // SEAL, session NOT unlocked.
+        seal_folder(&db, "secret", &kek);
+        assert!(
+            db.build_entity_detail(&secret_p, &empty, 12).unwrap().is_none(),
+            "entity only in a sealed-not-unlocked meeting must NOT surface via get_entity_detail \
+             (its name lived only in the sealed meeting) — must be None, not an empty-backlink shell"
+        );
+
+        // SESSION-UNLOCK the folder id → the entity (and its visible backlinks) reappear.
+        let unlocked = unlocked_set(&["secret"]);
+        let detail = db
+            .build_entity_detail(&secret_p, &unlocked, 12)
+            .unwrap()
+            .expect("entity detail reappears once its folder id is in the unlocked set");
+        assert_eq!(detail.entity.name, "Secret Person");
+        assert_eq!(detail.meetings.len(), 1, "the (now visible) sealed meeting backlinks");
     }
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -52,9 +52,20 @@ pub struct Db {
 }
 
 impl Db {
-    /// Opens + runs migrations.
+    /// Opens the encrypted DB (fetching the SQLCipher key from the Keychain) + runs migrations.
+    /// This is the path used by the MCP server thread too — it transparently keys the handle.
     pub fn open(path: &Path) -> Result<Self> {
+        let dek = crate::secrets::get_or_create_db_dek()?;
+        Self::open_with_key(path, &dek)
+    }
+
+    /// Opens an (SQLCipher-encrypted) DB with an explicit raw-hex key. The `PRAGMA key` MUST be
+    /// the first statement on the connection, before any other PRAGMA or query.
+    pub fn open_with_key(path: &Path, dek_hex: &str) -> Result<Self> {
         let conn = Connection::open(path).map_err(map_err)?;
+        // SQLCipher: key the connection FIRST (raw 32-byte key as a hex blob ⇒ no KDF).
+        conn.pragma_update(None, "key", format!("x'{dek_hex}'"))
+            .map_err(map_err)?;
         // Enforce FK cascades (segments/notes → meetings) and use WAL for
         // concurrent reads while a write is in progress.
         conn.execute_batch(

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -195,6 +195,10 @@ impl Db {
         // `ALTER ADD COLUMN` errors if the column already exists, so check pragma_table_info first.
         Self::add_column_if_missing(&conn, "notes", "folder_id", "TEXT")?;
         Self::add_column_if_missing(&conn, "notes", "content_blob", "BLOB")?;
+        // Phase B: 2-way stream attribution ("me"/"others"). Guarded ALTER (same idempotent
+        // pattern) — NULL for legacy rows transcribed before dual-stream, which read back as
+        // `speaker: None` (unattributed). NOT per-remote-person diarization; see types::Segment.
+        Self::add_column_if_missing(&conn, "segments", "speaker", "TEXT")?;
         Ok(())
     }
 
@@ -406,8 +410,8 @@ impl Db {
             let mut stmt = tx
                 .prepare(
                     "INSERT OR REPLACE INTO segments
-                       (meeting_id, idx, start_s, end_s, text)
-                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                       (meeting_id, idx, start_s, end_s, text, speaker)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 )
                 .map_err(map_err)?;
             for seg in segments {
@@ -417,6 +421,7 @@ impl Db {
                     seg.start_s,
                     seg.end_s,
                     seg.text,
+                    seg.speaker,
                 ])
                 .map_err(map_err)?;
             }
@@ -430,7 +435,7 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT idx, start_s, end_s, text
+                "SELECT idx, start_s, end_s, text, speaker
                    FROM segments WHERE meeting_id = ?1 ORDER BY idx",
             )
             .map_err(map_err)?;
@@ -441,6 +446,8 @@ impl Db {
                     start_s: row.get(1)?,
                     end_s: row.get(2)?,
                     text: row.get(3)?,
+                    // NULL (legacy / unattributed rows) → None.
+                    speaker: row.get(4)?,
                 })
             })
             .map_err(map_err)?;
@@ -1849,12 +1856,14 @@ mod tests {
                 start_s: 0.0,
                 end_s: 1.5,
                 text: "hello".into(),
+                speaker: Some("me".into()),
             },
             Segment {
                 idx: 1,
                 start_s: 1.5,
                 end_s: 3.0,
                 text: "world".into(),
+                speaker: None,
             },
         ];
         db.insert_segments("m1", &segs).unwrap();
@@ -1871,6 +1880,11 @@ mod tests {
             .unwrap();
         assert_eq!(count, 2);
         drop(conn);
+
+        // Speaker attribution round-trips: "me" persists, None reads back as None.
+        let read = db.get_segments("m1").unwrap();
+        assert_eq!(read[0].speaker.as_deref(), Some("me"));
+        assert_eq!(read[1].speaker, None);
 
         // deleting the meeting cascades to its segments
         db.lock()

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5,8 +5,11 @@ use std::sync::Mutex;
 use rusqlite::{Connection, OptionalExtension, Row};
 
 use crate::error::{AppError, Result};
+use std::collections::HashSet;
+
 use crate::storage::models::{
-    Analytics, DayCount, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit, StatusCount,
+    Analytics, DayCount, Folder, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
+    StatusCount,
 };
 use crate::transcribe::types::Segment;
 
@@ -768,6 +771,399 @@ impl Db {
             per_day,
         })
     }
+
+    // ── folders ──────────────────────────────────────────────────────────────
+
+    /// Insert a folder row. `path` is the vault-relative folder path (UNIQUE).
+    pub fn insert_folder(&self, f: &Folder) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO folders (id, name, path, parent_id, locked, wrapped_key, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6)",
+            rusqlite::params![
+                f.id,
+                f.name,
+                f.path,
+                f.parent_id,
+                f.locked as i64,
+                f.created_at,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// All folders (creation order). The tree is assembled by the caller.
+    pub fn list_folders(&self) -> Result<Vec<Folder>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, name, path, parent_id, locked, created_at
+                   FROM folders ORDER BY created_at, name",
+            )
+            .map_err(map_err)?;
+        let rows = stmt.query_map([], row_to_folder).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    pub fn folder_by_id(&self, id: &str) -> Result<Option<Folder>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id, name, path, parent_id, locked, created_at FROM folders WHERE id = ?1",
+            rusqlite::params![id],
+            row_to_folder,
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Set a folder's `locked` flag + its KEK-wrapped content key (`Some` when sealing,
+    /// `None` to clear on permanent remove-lock).
+    pub fn set_folder_locked(
+        &self,
+        id: &str,
+        locked: bool,
+        wrapped_key: Option<&[u8]>,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE folders SET locked = ?2, wrapped_key = ?3 WHERE id = ?1",
+            rusqlite::params![id, locked as i64, wrapped_key],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The KEK-wrapped content key for a sealed folder (`None` if the column is NULL).
+    pub fn folder_wrapped_key(&self, id: &str) -> Result<Option<Vec<u8>>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT wrapped_key FROM folders WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get::<_, Option<Vec<u8>>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// Count of notes assigned to each folder id (only folders with ≥1 note appear).
+    pub fn count_notes_per_folder(&self) -> Result<std::collections::HashMap<String, usize>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT folder_id, COUNT(*) FROM notes
+                  WHERE folder_id IS NOT NULL GROUP BY folder_id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)? as usize))
+            })
+            .map_err(map_err)?;
+        let mut out = std::collections::HashMap::new();
+        for r in rows {
+            let (id, n) = r.map_err(map_err)?;
+            out.insert(id, n);
+        }
+        Ok(out)
+    }
+
+    /// Assign (or clear) a note's folder. Targets every provider row for the meeting so the
+    /// note moves as a unit.
+    pub fn set_note_folder(&self, meeting_id: &str, folder_id: Option<&str>) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE notes SET folder_id = ?2 WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id, folder_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Notes assigned to a folder (the rows needed to seal/unseal): the meeting, provider,
+    /// current markdown, exported path, and any existing sealed blob.
+    pub fn notes_in_folder(&self, folder_id: &str) -> Result<Vec<SealableNote>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT meeting_id, provider_id, markdown, exported_path, content_blob
+                   FROM notes WHERE folder_id = ?1",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![folder_id], |r| {
+                Ok(SealableNote {
+                    meeting_id: r.get(0)?,
+                    provider_id: r.get(1)?,
+                    markdown: r.get(2)?,
+                    exported_path: r.get(3)?,
+                    content_blob: r.get(4)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Seal ONE provider row of a note: store its AES-GCM `content_blob`, blank that row's
+    /// plaintext `markdown`, and clear its `exported_path` (the `.md` leaves the vault).
+    /// Targets `(meeting_id, provider_id)` so distinct per-provider markdown each gets its own
+    /// blob — a meeting re-summarized with multiple providers never collapses to one blob (which
+    /// would destroy every provider's content but the first). The whole meeting is sealed by
+    /// calling this once per provider row.
+    pub fn seal_note(&self, meeting_id: &str, provider_id: &str, content_blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE notes SET content_blob = ?3, markdown = '', exported_path = NULL
+             WHERE meeting_id = ?1 AND provider_id = ?2",
+            rusqlite::params![meeting_id, provider_id, content_blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Restore ONE provider row's plaintext `markdown` (session-unlock or permanent remove-lock).
+    /// Does NOT touch `content_blob` (the caller decides whether to clear it). Per-provider so a
+    /// sibling provider's distinct markdown is never overwritten.
+    pub fn restore_note_markdown(
+        &self,
+        meeting_id: &str,
+        provider_id: &str,
+        markdown: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE notes SET markdown = ?3 WHERE meeting_id = ?1 AND provider_id = ?2",
+            rusqlite::params![meeting_id, provider_id, markdown],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Clear a note's sealed `content_blob` for every provider row of the meeting (permanent
+    /// remove-lock, after each row's plaintext is back). Safe to target the whole meeting here:
+    /// the plaintext has already been restored per-row, and we want NO blob left anywhere.
+    pub fn clear_note_content_blob(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE notes SET content_blob = NULL WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Re-blank the plaintext `markdown` of every note in `folder_ids` that still has a sealed
+    /// `content_blob` (relock / relock-all). Idempotent; leaves the blob intact.
+    pub fn blank_sealed_notes_in_folders(&self, folder_ids: &HashSet<String>) -> Result<()> {
+        if folder_ids.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "UPDATE notes SET markdown = ''
+                      WHERE folder_id = ?1 AND content_blob IS NOT NULL",
+                )
+                .map_err(map_err)?;
+            for id in folder_ids {
+                stmt.execute(rusqlite::params![id]).map_err(map_err)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Folder ids that are sealed (`locked=1`) — used to re-blank every sealed note on relock-all.
+    pub fn locked_folder_ids(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT id FROM folders WHERE locked = 1")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    // ── exposure-aware reads (MCP visibility filter, Stage D) ──────────────────
+    //
+    // A note is visible iff its folder is NULL or open (`locked=0`) OR its folder id is in the
+    // session `unlocked` set. Since session-unlock decrypts `content_blob` back into the
+    // `markdown` column, these reads see plaintext exactly like the in-app reads — they only add
+    // the folder predicate. Sealed-and-not-session-unlocked notes are invisible.
+
+    /// Search visible meetings only (MCP `search_meetings`).
+    pub fn search_visible(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<SearchHit>> {
+        let q = query.trim();
+        if q.is_empty() {
+            return Ok(Vec::new());
+        }
+        let like = format!("%{}%", escape_like(q));
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT DISTINCT m.id, m.started_at, m.ended_at, m.title, m.duration_s, \
+                    m.audio_path, m.status
+               FROM meetings m
+               LEFT JOIN segments s ON s.meeting_id = m.id
+               LEFT JOIN notes n ON n.meeting_id = m.id
+               LEFT JOIN folders f ON f.id = n.folder_id
+              WHERE (m.title LIKE ?1 ESCAPE '\\'
+                  OR s.text LIKE ?1 ESCAPE '\\'
+                  OR n.markdown LIKE ?1 ESCAPE '\\')
+                AND {visible}
+              ORDER BY m.started_at DESC, m.id DESC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![like, limit], row_to_meeting)
+            .map_err(map_err)?;
+        let mut meetings = Vec::new();
+        for r in rows {
+            meetings.push(r.map_err(map_err)??);
+        }
+        let mut hits = Vec::with_capacity(meetings.len());
+        for m in meetings {
+            let (snippet, matched_in) = search_snippet(&conn, &m, q, &like)?;
+            hits.push(SearchHit {
+                meeting: m,
+                snippet,
+                matched_in,
+            });
+        }
+        Ok(hits)
+    }
+
+    /// Recent visible meetings only (MCP `list_recent_meetings`). A meeting is visible if it has
+    /// no note, or any of its notes is visible (open/unlocked folder).
+    pub fn list_meetings_visible(
+        &self,
+        limit: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<Meeting>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        // A meeting is hidden only when EVERY note it has is sealed-and-not-unlocked. Expressed
+        // as: no note row exists that is currently sealed-and-hidden for this meeting, unless a
+        // sibling visible note exists. Simpler + correct: keep the meeting if it has zero notes
+        // OR at least one visible note.
+        let sql = format!(
+            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status
+               FROM meetings m
+              WHERE NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                 OR EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = m.id AND {visible}
+                    )
+              ORDER BY m.started_at DESC, m.id DESC
+              LIMIT ?1"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![limit], row_to_meeting)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)??);
+        }
+        Ok(out)
+    }
+
+    /// The latest visible note for a meeting (MCP `get_meeting`); `None` if the meeting's note
+    /// is sealed-and-not-session-unlocked.
+    pub fn get_note_if_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<NoteRecord>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT n.meeting_id, n.provider_id, n.markdown, n.created_at, n.exported_path
+               FROM notes n
+               LEFT JOIN folders f ON f.id = n.folder_id
+              WHERE n.meeting_id = ?1 AND {visible}
+              ORDER BY n.created_at DESC LIMIT 1"
+        );
+        conn.query_row(&sql, rusqlite::params![meeting_id], row_to_note)
+            .optional()
+            .map_err(map_err)
+    }
+
+    /// Whether a meeting is visible at all (any note visible, or no notes) — gates the transcript
+    /// in MCP `get_meeting` so a sealed meeting's transcript is not leaked either.
+    pub fn meeting_is_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = ?1) AS has_notes,
+                    EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = ?1 AND {visible}
+                    ) AS has_visible"
+        );
+        let (has_notes, has_visible): (bool, bool) = conn
+            .query_row(&sql, rusqlite::params![meeting_id], |r| {
+                Ok((r.get::<_, i64>(0)? != 0, r.get::<_, i64>(1)? != 0))
+            })
+            .map_err(map_err)?;
+        Ok(!has_notes || has_visible)
+    }
+}
+
+/// One note row needed to seal/unseal a folder.
+#[derive(Debug, Clone)]
+pub struct SealableNote {
+    pub meeting_id: String,
+    pub provider_id: String,
+    pub markdown: String,
+    pub exported_path: Option<String>,
+    pub content_blob: Option<Vec<u8>>,
+}
+
+/// Build the SQL predicate (no params) that selects notes whose folder is open or
+/// session-unlocked. `alias` is the notes-table alias (`n`); a sibling `folders f` join is
+/// assumed for the alias. The unlocked ids are inlined as quoted literals — safe because they
+/// are app-generated UUIDs, but we still escape single quotes defensively.
+fn visibility_clause(_alias: &str, unlocked: &HashSet<String>) -> String {
+    let mut clause = String::from("(f.locked IS NULL OR f.locked = 0");
+    if !unlocked.is_empty() {
+        let ids = unlocked
+            .iter()
+            .map(|id| format!("'{}'", id.replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        clause.push_str(&format!(" OR f.id IN ({ids})"));
+    }
+    clause.push(')');
+    clause
 }
 
 // ── row mappers ──────────────────────────────────────────────────────────────
@@ -905,6 +1301,18 @@ fn row_to_note(row: &Row<'_>) -> rusqlite::Result<NoteRecord> {
         markdown: row.get(2)?,
         created_at: row.get(3)?,
         exported_path: row.get(4)?,
+    })
+}
+
+/// Maps `(id, name, path, parent_id, locked, created_at)` → `Folder`.
+fn row_to_folder(row: &Row<'_>) -> rusqlite::Result<Folder> {
+    Ok(Folder {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        path: row.get(2)?,
+        parent_id: row.get(3)?,
+        locked: row.get::<_, i64>(4)? != 0,
+        created_at: row.get(5)?,
     })
 }
 
@@ -1079,5 +1487,327 @@ mod tests {
                 ("vault_path".to_string(), "/vault2".to_string()),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod lock_tests {
+    //! File-backed (tempfile via `open_with_key` + a FIXED test key) tests for the per-folder
+    //! seal/unseal lifecycle. These NEVER touch the real Keychain — both the SQLCipher DEK and
+    //! the lock KEK are explicit literals here. They reproduce the exact seal/unseal/remove
+    //! sequence the Stage-C commands run (db helpers + `crate::crypto`), so a regression in the
+    //! lifecycle fails here even though the command wrappers need a Tauri `State`.
+
+    use super::*;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+
+    /// Fixed SQLCipher key for file-backed test DBs (NOT the Keychain DEK).
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn temp_db_path(label: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "meetnotes-lock-test-{}-{}-{}.sqlite",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    fn file_db(label: &str) -> Db {
+        Db::open_with_key(&temp_db_path(label), TEST_DEK).unwrap()
+    }
+
+    fn seed_folder(db: &Db, id: &str, name: &str) -> Folder {
+        let f = Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        };
+        db.insert_folder(&f).unwrap();
+        f
+    }
+
+    fn seed_note(db: &Db, meeting_id: &str, markdown: &str, folder_id: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: meeting_id.to_string(),
+            started_at: "2026-06-26T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some(format!("title-{meeting_id}")),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: meeting_id.to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-26T09:05:00Z".to_string(),
+            exported_path: Some(format!("/vault/{meeting_id}.md")),
+        })
+        .unwrap();
+        db.set_note_folder(meeting_id, folder_id).unwrap();
+    }
+
+    /// Add a second provider row (distinct markdown) to an existing meeting — models the
+    /// re-summarize-with-another-provider state (e.g. `ollama` then `anthropic`).
+    fn add_provider_note(db: &Db, meeting_id: &str, provider_id: &str, markdown: &str) {
+        db.upsert_note(&NoteRecord {
+            meeting_id: meeting_id.to_string(),
+            provider_id: provider_id.to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-26T09:06:00Z".to_string(),
+            exported_path: Some(format!("/vault/{meeting_id}-{provider_id}.md")),
+        })
+        .unwrap();
+        // Keep the new row in the same folder as its siblings.
+        let folder_id = db
+            .lock()
+            .query_row(
+                "SELECT folder_id FROM notes WHERE meeting_id = ?1 AND folder_id IS NOT NULL LIMIT 1",
+                rusqlite::params![meeting_id],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .unwrap()
+            .flatten();
+        db.set_note_folder(meeting_id, folder_id.as_deref()).unwrap();
+    }
+
+    /// Mirror of `lock_folder`: generate CK, KEK-wrap, encrypt+verify each note (PER provider
+    /// row), seal. One blob per (meeting, provider) — distinct provider markdown must not collide.
+    fn seal_folder(db: &Db, folder_id: &str, kek: &[u8; 32]) {
+        let ck = crate::crypto::random_key().unwrap();
+        let wrapped = crate::crypto::encrypt(kek, &ck).unwrap();
+        let notes = db.notes_in_folder(folder_id).unwrap();
+        let mut blobs = Vec::new();
+        for n in &notes {
+            let blob = crate::crypto::encrypt(&ck, n.markdown.as_bytes()).unwrap();
+            // Verify decryptable BEFORE blanking (the command's atomicity rule).
+            assert_eq!(crate::crypto::decrypt(&ck, &blob).unwrap(), n.markdown.as_bytes());
+            blobs.push((n.meeting_id.clone(), n.provider_id.clone(), blob));
+        }
+        db.set_folder_locked(folder_id, true, Some(&wrapped)).unwrap();
+        for (mid, pid, blob) in &blobs {
+            db.seal_note(mid, pid, blob).unwrap();
+        }
+    }
+
+    /// Mirror of `unlock_folder`: KEK→unwrap CK→decrypt each blob back into ITS OWN row.
+    fn session_unlock(db: &Db, folder_id: &str, kek: &[u8; 32]) {
+        let wrapped = db.folder_wrapped_key(folder_id).unwrap().unwrap();
+        let ck_bytes = crate::crypto::decrypt(kek, &wrapped).unwrap();
+        let ck: [u8; 32] = ck_bytes.as_slice().try_into().unwrap();
+        let notes = db.notes_in_folder(folder_id).unwrap();
+        for n in &notes {
+            let blob = n.content_blob.as_ref().unwrap();
+            let pt = crate::crypto::decrypt(&ck, blob).unwrap();
+            db.restore_note_markdown(&n.meeting_id, &n.provider_id, &String::from_utf8(pt).unwrap())
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn lock_unlock_round_trips_byte_identical() {
+        let db = file_db("roundtrip");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        let md_a = "# Strategy\n\nbudget: 1_000_000 EUR\n- hire 3\n";
+        let md_b = "## 1:1 with Sarah\n\nshe wants a raise — zażółć gęślą jaźń 🔒\n";
+        seed_note(&db, "m1", md_a, Some("f1"));
+        seed_note(&db, "m2", md_b, Some("f1"));
+
+        // SEAL.
+        seal_folder(&db, "f1", &kek);
+
+        // After sealing: markdown column blank, content_blob present, exported_path NULL.
+        let sealed = db.notes_in_folder("f1").unwrap();
+        assert_eq!(sealed.len(), 2);
+        for n in &sealed {
+            assert_eq!(n.markdown, "", "markdown column must be blanked");
+            assert!(n.content_blob.is_some(), "content_blob must be present");
+            assert!(n.exported_path.is_none(), "exported_path must be cleared");
+        }
+        // The raw blob must NOT contain the plaintext (not recoverable without the CK).
+        for (n, expected) in sealed.iter().zip([md_a, md_b]) {
+            let blob = n.content_blob.as_ref().unwrap();
+            assert!(
+                !contains_subslice(blob, expected.as_bytes()),
+                "ciphertext must not leak plaintext"
+            );
+        }
+        // Folder is locked + carries a wrapped key.
+        assert!(db.folder_by_id("f1").unwrap().unwrap().locked);
+        assert!(db.folder_wrapped_key("f1").unwrap().is_some());
+
+        // SESSION-UNLOCK → markdown byte-identical.
+        session_unlock(&db, "f1", &kek);
+        let unlocked = db.notes_in_folder("f1").unwrap();
+        let by_id: std::collections::HashMap<_, _> =
+            unlocked.iter().map(|n| (n.meeting_id.as_str(), n)).collect();
+        assert_eq!(by_id["m1"].markdown, md_a, "m1 markdown must round-trip byte-identical");
+        assert_eq!(by_id["m2"].markdown, md_b, "m2 markdown must round-trip byte-identical");
+        // content_blob still present (folder is still locked on disk during a session unlock).
+        assert!(by_id["m1"].content_blob.is_some());
+    }
+
+    #[test]
+    fn multi_provider_seal_unlock_preserves_each_providers_markdown() {
+        // REGRESSION: a meeting with TWO provider notes (re-summarized with a second provider)
+        // must NOT collapse to a single shared blob on seal. Each (meeting, provider) row carries
+        // its OWN distinct markdown; sealing then unlocking must round-trip BOTH byte-identical.
+        // (Pre-fix: seal dedup'd by meeting → only the first provider's markdown was encrypted,
+        //  then blanked + restored to all rows, destroying the second provider's content.)
+        let db = file_db("multi-provider");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        let md_claude = "# Claude note\n\nstructured summary with action items\n";
+        let md_ollama = "# Ollama note\n\nDIFFERENT local-model summary — must survive 🔒\n";
+        seed_note(&db, "m1", md_claude, Some("f1")); // provider = claude_code
+        add_provider_note(&db, "m1", "ollama", md_ollama);
+
+        // Sanity: two distinct provider rows before sealing.
+        let before = db.notes_in_folder("f1").unwrap();
+        assert_eq!(before.len(), 2, "two provider rows expected");
+
+        seal_folder(&db, "f1", &kek);
+
+        // Each provider row sealed independently: markdown blanked, its own blob present.
+        let sealed = db.notes_in_folder("f1").unwrap();
+        assert_eq!(sealed.len(), 2);
+        for n in &sealed {
+            assert_eq!(n.markdown, "", "markdown blanked");
+            assert!(n.content_blob.is_some(), "each provider row keeps its own blob");
+        }
+        // The two blobs must differ (distinct plaintext → distinct ciphertext).
+        let blob_claude = sealed.iter().find(|n| n.provider_id == "claude_code").unwrap();
+        let blob_ollama = sealed.iter().find(|n| n.provider_id == "ollama").unwrap();
+        assert_ne!(
+            blob_claude.content_blob, blob_ollama.content_blob,
+            "distinct provider markdown must NOT share one blob (content-loss guard)"
+        );
+
+        // Unlock → BOTH providers' markdown returns byte-identical.
+        session_unlock(&db, "f1", &kek);
+        let unlocked = db.notes_in_folder("f1").unwrap();
+        let by_provider: std::collections::HashMap<_, _> =
+            unlocked.iter().map(|n| (n.provider_id.as_str(), n)).collect();
+        assert_eq!(
+            by_provider["claude_code"].markdown, md_claude,
+            "claude_code markdown must round-trip"
+        );
+        assert_eq!(
+            by_provider["ollama"].markdown, md_ollama,
+            "ollama markdown must round-trip (NOT overwritten by the sibling provider)"
+        );
+    }
+
+    #[test]
+    fn mcp_visibility_filter() {
+        let db = file_db("visibility");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "secret", "Secret");
+        seed_note(&db, "open1", "# open note about apples", None); // root, always visible
+        seed_note(&db, "sealed1", "# secret note about bananas", Some("secret"));
+
+        let empty: HashSet<String> = HashSet::new();
+
+        // Before sealing both are visible.
+        assert!(db
+            .list_meetings_visible(50, &empty)
+            .unwrap()
+            .iter()
+            .any(|m| m.id == "sealed1"));
+
+        // SEAL → the sealed note is invisible to MCP, the open one stays visible.
+        seal_folder(&db, "secret", &kek);
+        let visible_ids: HashSet<String> = db
+            .list_meetings_visible(50, &empty)
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert!(visible_ids.contains("open1"), "open note stays visible");
+        assert!(!visible_ids.contains("sealed1"), "sealed note is hidden");
+
+        // search_visible: a query that ONLY matches the sealed note's content returns nothing
+        // (its markdown is blanked + folder hidden), while the open note is found.
+        assert!(db.search_visible("bananas", 20, &empty).unwrap().is_empty());
+        assert!(!db.search_visible("apples", 20, &empty).unwrap().is_empty());
+
+        // get_meeting visibility gate.
+        assert!(!db.meeting_is_visible("sealed1", &empty).unwrap());
+        assert!(db.get_note_if_visible("sealed1", &empty).unwrap().is_none());
+        assert!(db.meeting_is_visible("open1", &empty).unwrap());
+
+        // SESSION-UNLOCK → the sealed note becomes visible again.
+        session_unlock(&db, "secret", &kek);
+        let mut unlocked = HashSet::new();
+        unlocked.insert("secret".to_string());
+        assert!(db.meeting_is_visible("sealed1", &unlocked).unwrap());
+        assert!(db.get_note_if_visible("sealed1", &unlocked).unwrap().is_some());
+        assert!(!db.search_visible("bananas", 20, &unlocked).unwrap().is_empty());
+        let visible_after: HashSet<String> = db
+            .list_meetings_visible(50, &unlocked)
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert!(visible_after.contains("sealed1"));
+    }
+
+    #[test]
+    fn remove_lock_re_plaintexts() {
+        let db = file_db("remove");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        let md = "# permanent\n\nback to plaintext\n";
+        seed_note(&db, "m1", md, Some("f1"));
+        seal_folder(&db, "f1", &kek);
+
+        // Sanity: sealed.
+        assert!(db.folder_by_id("f1").unwrap().unwrap().locked);
+        assert_eq!(db.notes_in_folder("f1").unwrap()[0].markdown, "");
+
+        // Mirror of remove_lock: KEK→unwrap CK→decrypt→restore plaintext→clear blob→unlock folder.
+        let wrapped = db.folder_wrapped_key("f1").unwrap().unwrap();
+        let ck_bytes = crate::crypto::decrypt(&kek, &wrapped).unwrap();
+        let ck: [u8; 32] = ck_bytes.as_slice().try_into().unwrap();
+        for n in db.notes_in_folder("f1").unwrap() {
+            let pt = crate::crypto::decrypt(&ck, n.content_blob.as_ref().unwrap()).unwrap();
+            let markdown = String::from_utf8(pt).unwrap();
+            db.restore_note_markdown(&n.meeting_id, &n.provider_id, &markdown)
+                .unwrap();
+            db.clear_note_content_blob(&n.meeting_id).unwrap();
+        }
+        db.set_folder_locked("f1", false, None).unwrap();
+
+        // Now: plaintext back, blob NULL, locked=0, wrapped_key NULL.
+        let after = db.notes_in_folder("f1").unwrap();
+        assert_eq!(after[0].markdown, md, "markdown restored byte-identical");
+        assert!(after[0].content_blob.is_none(), "content_blob cleared");
+        assert!(!db.folder_by_id("f1").unwrap().unwrap().locked);
+        assert!(db.folder_wrapped_key("f1").unwrap().is_none());
+
+        // Visible to MCP again with an empty session set.
+        assert!(db
+            .meeting_is_visible("m1", &HashSet::new())
+            .unwrap());
+    }
+
+    /// Naive subslice search for the leak assertion.
+    fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+        if needle.is_empty() || needle.len() > haystack.len() {
+            return false;
+        }
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -199,6 +199,12 @@ impl Db {
         // pattern) — NULL for legacy rows transcribed before dual-stream, which read back as
         // `speaker: None` (unattributed). NOT per-remote-person diarization; see types::Segment.
         Self::add_column_if_missing(&conn, "segments", "speaker", "TEXT")?;
+        // Phase 0.5 — full per-folder lock (defense-in-depth beyond SQLCipher-at-rest):
+        // sealed-folder transcripts + timelines carry an AES-GCM blob under the folder CK while
+        // sealed; the plaintext `text`/`data` column is blanked. Reversed on session-unlock.
+        // Guarded ALTER (idempotent); NULL for every row in an open folder.
+        Self::add_column_if_missing(&conn, "segments", "text_blob", "BLOB")?;
+        Self::add_column_if_missing(&conn, "timelines", "data_blob", "BLOB")?;
         Ok(())
     }
 
@@ -1072,6 +1078,174 @@ impl Db {
         Ok(out)
     }
 
+    // ── transcript + timeline sealing (Phase 0.5 full per-folder lock) ─────────
+    //
+    // Segments + timelines live IN the SQLCipher DB (encrypted at rest already), but were NOT
+    // gated in-app: a meeting in a locked-and-not-unlocked folder still returned its transcript +
+    // timeline. These helpers add the SAME defense-in-depth the note markdown already has — an
+    // AES-GCM blob under the folder CK in an OPEN db, with the plaintext column blanked while
+    // sealed, reversed on session-unlock / re-blanked on relock / permanently restored on
+    // remove-lock. All keyed off the meeting set of a folder (a meeting's folder = its notes'
+    // folder, derived from `notes.folder_id`).
+
+    /// Distinct meeting ids whose notes live in `folder_id` (the meetings governed by the
+    /// folder's lock). Used to seal/unseal each meeting's transcript + timeline.
+    pub fn meeting_ids_in_folder(&self, folder_id: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT meeting_id FROM notes WHERE folder_id = ?1")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![folder_id], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// The owning folder id for a meeting (its notes' `folder_id`), or `None` at the vault root.
+    /// Drives the read-gate predicate `meeting_is_unlocked`.
+    pub fn folder_for_meeting(&self, meeting_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT folder_id FROM notes
+              WHERE meeting_id = ?1 AND folder_id IS NOT NULL LIMIT 1",
+            rusqlite::params![meeting_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// The RAW segment rows of a meeting (idx, plaintext text, sealed `text_blob`), regardless of
+    /// seal state — for the seal/unseal lifecycle (NOT a user-facing read; that is `get_segments`).
+    pub fn raw_segments(&self, meeting_id: &str) -> Result<Vec<RawSegment>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT idx, text, text_blob FROM segments
+                   WHERE meeting_id = ?1 ORDER BY idx",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                Ok(RawSegment {
+                    idx: r.get(0)?,
+                    text: r.get(1)?,
+                    text_blob: r.get(2)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Seal ONE segment row: store its AES-GCM `text_blob` and blank the plaintext `text`.
+    /// Verified-before-blank by the caller (mirrors `seal_note`).
+    pub fn seal_segment(&self, meeting_id: &str, idx: i64, text_blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE segments SET text_blob = ?3, text = '' WHERE meeting_id = ?1 AND idx = ?2",
+            rusqlite::params![meeting_id, idx, text_blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Restore ONE segment row's plaintext `text` (session-unlock / remove-lock). Leaves
+    /// `text_blob` intact (the caller clears it only on permanent remove-lock).
+    pub fn restore_segment_text(&self, meeting_id: &str, idx: i64, text: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE segments SET text = ?3 WHERE meeting_id = ?1 AND idx = ?2",
+            rusqlite::params![meeting_id, idx, text],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Clear the sealed `text_blob` for every segment of a meeting (permanent remove-lock, after
+    /// the plaintext is restored).
+    pub fn clear_segment_blobs(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE segments SET text_blob = NULL WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The RAW timeline row of a meeting (plaintext `data`, sealed `data_blob`), regardless of
+    /// seal state — for the seal/unseal lifecycle. `None` if the meeting has no timeline cached.
+    pub fn raw_timeline(&self, meeting_id: &str) -> Result<Option<RawTimeline>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT data, data_blob FROM timelines WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+            |r| {
+                Ok(RawTimeline {
+                    data: r.get(0)?,
+                    data_blob: r.get(1)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Seal a meeting's timeline: store its AES-GCM `data_blob`, blank the plaintext `data`.
+    pub fn seal_timeline(&self, meeting_id: &str, data_blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE timelines SET data_blob = ?2, data = '' WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id, data_blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Restore a meeting's timeline plaintext `data` (session-unlock / remove-lock). Leaves
+    /// `data_blob` intact (cleared only on permanent remove-lock).
+    pub fn restore_timeline_data(&self, meeting_id: &str, data: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE timelines SET data = ?2 WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id, data],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Clear the sealed `data_blob` for a meeting's timeline (permanent remove-lock).
+    pub fn clear_timeline_blob(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE timelines SET data_blob = NULL WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Set (or clear) a meeting's `audio_path` — used by the audio-at-rest encryption lifecycle
+    /// to re-point at the decrypted-for-session copy and back to the plaintext WAV on remove-lock.
+    pub fn set_meeting_audio_path(&self, meeting_id: &str, audio_path: Option<&str>) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE meetings SET audio_path = ?2 WHERE id = ?1",
+            rusqlite::params![meeting_id, audio_path],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     // ── exposure-aware reads (MCP visibility filter, Stage D) ──────────────────
     //
     // A note is visible iff its folder is NULL or open (`locked=0`) OR its folder id is in the
@@ -1593,6 +1767,23 @@ pub struct SealableNote {
     pub markdown: String,
     pub exported_path: Option<String>,
     pub content_blob: Option<Vec<u8>>,
+}
+
+/// One transcript segment row in either seal state (Phase 0.5 lock lifecycle). When the folder is
+/// open `text_blob` is NULL and `text` is plaintext; when sealed-and-not-unlocked `text` is blank
+/// and `text_blob` holds the AES-GCM ciphertext.
+#[derive(Debug, Clone)]
+pub struct RawSegment {
+    pub idx: i64,
+    pub text: String,
+    pub text_blob: Option<Vec<u8>>,
+}
+
+/// A meeting's cached timeline JSON in either seal state (Phase 0.5 lock lifecycle).
+#[derive(Debug, Clone)]
+pub struct RawTimeline {
+    pub data: String,
+    pub data_blob: Option<Vec<u8>>,
 }
 
 /// Build the SQL predicate (no params) that selects notes whose folder is open or
@@ -2372,6 +2563,298 @@ mod lock_tests {
         assert!(db
             .meeting_is_visible("m1", &HashSet::new())
             .unwrap());
+    }
+
+    // ── Phase 0.5 full-lock helpers (transcript + timeline + audio) ──────────────
+
+    use crate::transcribe::types::Segment;
+
+    /// Seed transcript segments + a cached timeline JSON for a meeting (open state).
+    fn seed_transcript_and_timeline(db: &Db, meeting_id: &str, texts: &[&str], timeline_json: &str) {
+        let segs: Vec<Segment> = texts
+            .iter()
+            .enumerate()
+            .map(|(i, t)| Segment {
+                idx: i as i64,
+                start_s: i as f64,
+                end_s: (i + 1) as f64,
+                text: t.to_string(),
+                speaker: if i % 2 == 0 { Some("me".into()) } else { Some("others".into()) },
+            })
+            .collect();
+        db.insert_segments(meeting_id, &segs).unwrap();
+        db.set_timeline_data(meeting_id, timeline_json).unwrap();
+    }
+
+    /// Mirror of `seal_folder_extras`: seal every governed meeting's transcript + timeline under CK
+    /// (verify-before-blank), and the audio file at `audio_path` → `<file>.enc` (then "remove" the
+    /// plaintext + re-point audio_path), exactly like the command.
+    fn seal_extras(db: &Db, folder_id: &str, ck: &[u8; 32]) {
+        for mid in db.meeting_ids_in_folder(folder_id).unwrap() {
+            // transcript
+            let segs = db.raw_segments(&mid).unwrap();
+            for s in &segs {
+                if s.text_blob.is_some() && s.text.is_empty() {
+                    continue;
+                }
+                let blob = crate::crypto::encrypt(ck, s.text.as_bytes()).unwrap();
+                assert_eq!(crate::crypto::decrypt(ck, &blob).unwrap(), s.text.as_bytes());
+                db.seal_segment(&mid, s.idx, &blob).unwrap();
+            }
+            // timeline
+            if let Some(tl) = db.raw_timeline(&mid).unwrap() {
+                if !(tl.data_blob.is_some() && tl.data.is_empty()) {
+                    let blob = crate::crypto::encrypt(ck, tl.data.as_bytes()).unwrap();
+                    db.seal_timeline(&mid, &blob).unwrap();
+                }
+            }
+            // audio
+            if let Some(path) = db.get_meeting(&mid).unwrap().and_then(|m| m.audio_path) {
+                if !path.ends_with(".enc") && std::path::Path::new(&path).exists() {
+                    let enc = format!("{path}.enc");
+                    crate::crypto::encrypt_file(
+                        ck,
+                        std::path::Path::new(&path),
+                        std::path::Path::new(&enc),
+                    )
+                    .unwrap();
+                    std::fs::remove_file(&path).unwrap();
+                    db.set_meeting_audio_path(&mid, Some(&enc)).unwrap();
+                }
+            }
+        }
+    }
+
+    /// Mirror of `unseal_folder_extras`: decrypt transcript + timeline back into plaintext columns
+    /// and materialize a playable WAV for the session.
+    fn unseal_extras(db: &Db, folder_id: &str, ck: &[u8; 32]) {
+        for mid in db.meeting_ids_in_folder(folder_id).unwrap() {
+            for s in db.raw_segments(&mid).unwrap() {
+                if let Some(blob) = &s.text_blob {
+                    let text = String::from_utf8(crate::crypto::decrypt(ck, blob).unwrap()).unwrap();
+                    db.restore_segment_text(&mid, s.idx, &text).unwrap();
+                }
+            }
+            if let Some(tl) = db.raw_timeline(&mid).unwrap() {
+                if let Some(blob) = &tl.data_blob {
+                    let data = String::from_utf8(crate::crypto::decrypt(ck, blob).unwrap()).unwrap();
+                    db.restore_timeline_data(&mid, &data).unwrap();
+                }
+            }
+            if let Some(enc) = db.get_meeting(&mid).unwrap().and_then(|m| m.audio_path) {
+                if enc.ends_with(".enc") {
+                    let plain = enc.trim_end_matches(".enc").to_string();
+                    crate::crypto::decrypt_file(
+                        ck,
+                        std::path::Path::new(&enc),
+                        std::path::Path::new(&plain),
+                    )
+                    .unwrap();
+                    db.set_meeting_audio_path(&mid, Some(&plain)).unwrap();
+                }
+            }
+        }
+    }
+
+    /// The READ-GATE predicate (`meeting_is_unlocked`): folder open/NULL OR folder id in the
+    /// session set. The gated commands return masked/empty content when this is false.
+    fn meeting_unlocked(db: &Db, meeting_id: &str, unlocked: &HashSet<String>) -> bool {
+        match db.folder_for_meeting(meeting_id).unwrap() {
+            None => true,
+            Some(fid) => match db.folder_by_id(&fid).unwrap() {
+                None => true,
+                Some(f) => !f.locked || unlocked.contains(&fid),
+            },
+        }
+    }
+
+    #[test]
+    fn seal_transcript_timeline_round_trips_byte_identical() {
+        let db = file_db("extras-roundtrip");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        seed_note(&db, "m1", "# note", Some("f1"));
+        let texts = ["zażółć gęślą jaźń 🔒", "second segment with budget 1_000_000 EUR", ""];
+        let timeline = r#"{"turns":[{"speaker":"me","topic":"secret topic","start_s":0.0,"end_s":1.0}]}"#;
+        seed_transcript_and_timeline(&db, "m1", &texts, timeline);
+        let ck = crate::crypto::random_key().unwrap();
+        // Wrap CK so the folder carries a real wrapped_key (parity with the command).
+        let wrapped = crate::crypto::encrypt(&kek, &ck).unwrap();
+        db.set_folder_locked("f1", true, Some(&wrapped)).unwrap();
+
+        // SEAL transcript + timeline.
+        seal_extras(&db, "f1", &ck);
+
+        // At rest while sealed: plaintext blanked, blobs present, ciphertext does NOT leak.
+        let sealed = db.raw_segments("m1").unwrap();
+        assert_eq!(sealed.len(), 3);
+        for (s, expected) in sealed.iter().zip(texts) {
+            assert_eq!(s.text, "", "segment text blanked while sealed");
+            assert!(s.text_blob.is_some(), "segment text_blob present");
+            if !expected.is_empty() {
+                assert!(
+                    !contains_subslice(s.text_blob.as_ref().unwrap(), expected.as_bytes()),
+                    "segment ciphertext must not leak plaintext"
+                );
+            }
+        }
+        let raw_tl = db.raw_timeline("m1").unwrap().unwrap();
+        assert_eq!(raw_tl.data, "", "timeline data blanked while sealed");
+        assert!(raw_tl.data_blob.is_some());
+        assert!(
+            !contains_subslice(raw_tl.data_blob.as_ref().unwrap(), timeline.as_bytes()),
+            "timeline ciphertext must not leak plaintext"
+        );
+        // The user-facing reads see blank while sealed.
+        assert!(db.get_segments("m1").unwrap().iter().all(|s| s.text.is_empty()));
+        assert_eq!(db.get_timeline_data("m1").unwrap().as_deref(), Some(""));
+
+        // UNLOCK → byte-identical round-trip of EVERY segment + the timeline.
+        unseal_extras(&db, "f1", &ck);
+        let restored = db.get_segments("m1").unwrap();
+        let restored_texts: Vec<&str> = restored.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(restored_texts, texts, "transcript round-trips byte-identical");
+        assert_eq!(
+            db.get_timeline_data("m1").unwrap().as_deref(),
+            Some(timeline),
+            "timeline round-trips byte-identical"
+        );
+        // speaker attribution survives (it is not sealed — only text is).
+        assert_eq!(restored[0].speaker.as_deref(), Some("me"));
+        assert_eq!(restored[1].speaker.as_deref(), Some("others"));
+    }
+
+    #[test]
+    fn audio_encrypt_decrypt_round_trips_byte_identical() {
+        // Encrypt a temp WAV under the CK, assert the plaintext is removed while sealed, decrypt,
+        // assert byte-identical (mirrors the audio-at-rest seal lifecycle through the DB helpers).
+        let db = file_db("extras-audio");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        seed_note(&db, "m1", "# note", Some("f1"));
+
+        // A temp "WAV" file (opaque bytes — the crypto layer is content-agnostic).
+        let wav = temp_db_path("audio").with_extension("wav");
+        let payload: Vec<u8> = (0..8192u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&wav, &payload).unwrap();
+        db.set_meeting_audio_path("m1", Some(&wav.to_string_lossy())).unwrap();
+
+        let ck = crate::crypto::random_key().unwrap();
+        let wrapped = crate::crypto::encrypt(&kek, &ck).unwrap();
+        db.set_folder_locked("f1", true, Some(&wrapped)).unwrap();
+
+        // SEAL → .enc written, plaintext removed, audio_path re-pointed at the .enc.
+        seal_extras(&db, "f1", &ck);
+        assert!(!wav.exists(), "plaintext WAV removed while sealed");
+        let enc_path = db.get_meeting("m1").unwrap().unwrap().audio_path.unwrap();
+        assert!(enc_path.ends_with(".enc"), "audio_path points at the encrypted file");
+        assert!(std::path::Path::new(&enc_path).exists(), ".enc exists");
+        let blob = std::fs::read(&enc_path).unwrap();
+        assert!(
+            !contains_subslice(&blob, &payload),
+            "encrypted audio must not leak plaintext"
+        );
+
+        // UNLOCK → plaintext WAV materialized again, byte-identical.
+        unseal_extras(&db, "f1", &ck);
+        let plain_path = db.get_meeting("m1").unwrap().unwrap().audio_path.unwrap();
+        assert!(!plain_path.ends_with(".enc"), "audio_path re-points at the plaintext WAV");
+        assert_eq!(
+            std::fs::read(&plain_path).unwrap(),
+            payload,
+            "audio round-trips byte-identical"
+        );
+
+        let _ = std::fs::remove_file(&enc_path);
+        let _ = std::fs::remove_file(&plain_path);
+    }
+
+    #[test]
+    fn locked_meeting_detail_is_masked() {
+        // get_meeting_detail / get_segments / get_timeline return MASKED/EMPTY + the gate says
+        // "locked" when the folder is sealed-and-not-unlocked; full content after the folder id is
+        // added to the session unlock set.
+        let db = file_db("masked-read");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        seed_note(&db, "m1", "# secret note", Some("f1"));
+        seed_transcript_and_timeline(&db, "m1", &["secret words"], r#"{"turns":[]}"#);
+        let ck = crate::crypto::random_key().unwrap();
+        let wrapped = crate::crypto::encrypt(&kek, &ck).unwrap();
+        db.set_folder_locked("f1", true, Some(&wrapped)).unwrap();
+        seal_folder(&db, "f1", &kek); // seals the note (markdown)
+        // Re-seal extras under the folder's own CK (unwrap the wrapped we just set is the SAME CK
+        // the note seal used? No — seal_folder mints its OWN CK). Use the folder's wrapped CK.
+        let folder_wrapped = db.folder_wrapped_key("f1").unwrap().unwrap();
+        let folder_ck: [u8; 32] = crate::crypto::decrypt(&kek, &folder_wrapped)
+            .unwrap()
+            .as_slice()
+            .try_into()
+            .unwrap();
+        seal_extras(&db, "f1", &folder_ck);
+
+        let empty: HashSet<String> = HashSet::new();
+
+        // SEALED-not-unlocked → masked: gate says locked, plaintext columns blank.
+        assert!(!meeting_unlocked(&db, "m1", &empty), "gate: meeting is locked");
+        assert!(
+            db.get_segments("m1").unwrap().iter().all(|s| s.text.is_empty()),
+            "transcript empty while locked"
+        );
+        assert_eq!(db.get_timeline_data("m1").unwrap().as_deref(), Some(""));
+        assert!(
+            db.get_latest_note_for_meeting("m1").unwrap().unwrap().markdown.is_empty(),
+            "note markdown blank while locked"
+        );
+
+        // SESSION-UNLOCK (add folder id to the set + decrypt back) → full content.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f1".to_string());
+        session_unlock(&db, "f1", &kek); // note markdown
+        unseal_extras(&db, "f1", &folder_ck); // transcript + timeline
+        assert!(meeting_unlocked(&db, "m1", &unlocked), "gate: meeting unlocked");
+        assert_eq!(db.get_segments("m1").unwrap()[0].text, "secret words");
+        assert_eq!(db.get_timeline_data("m1").unwrap().as_deref(), Some(r#"{"turns":[]}"#));
+        assert_eq!(
+            db.get_latest_note_for_meeting("m1").unwrap().unwrap().markdown,
+            "# secret note"
+        );
+    }
+
+    #[test]
+    fn export_audio_refused_when_locked() {
+        // The export_audio gate: refuse (Locked) while sealed-not-unlocked; allowed once the
+        // folder id is in the session set. Mirrors the `meeting_is_unlocked` early-return.
+        let db = file_db("export-audio-gate");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "f1", "Secret");
+        seed_note(&db, "m1", "# note", Some("f1"));
+        let wav = temp_db_path("export-audio").with_extension("wav");
+        std::fs::write(&wav, b"RIFF....WAVEfmt fake-pcm").unwrap();
+        db.set_meeting_audio_path("m1", Some(&wav.to_string_lossy())).unwrap();
+        let ck = crate::crypto::random_key().unwrap();
+        let wrapped = crate::crypto::encrypt(&kek, &ck).unwrap();
+        db.set_folder_locked("f1", true, Some(&wrapped)).unwrap();
+        seal_extras(&db, "f1", &ck);
+
+        let empty: HashSet<String> = HashSet::new();
+        // LOCKED → export refused (the command early-returns AppError::Locked when the gate is
+        // false). There is also no plaintext WAV on disk to copy.
+        assert!(!meeting_unlocked(&db, "m1", &empty), "export refused while locked");
+        let enc = db.get_meeting("m1").unwrap().unwrap().audio_path.unwrap();
+        assert!(enc.ends_with(".enc"));
+        assert!(!std::path::Path::new(enc.trim_end_matches(".enc")).exists());
+
+        // UNLOCKED → allowed.
+        unseal_extras(&db, "f1", &ck);
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f1".to_string());
+        assert!(meeting_unlocked(&db, "m1", &unlocked), "export allowed once unlocked");
+        let plain = db.get_meeting("m1").unwrap().unwrap().audio_path.unwrap();
+        assert!(std::path::Path::new(&plain).exists(), "plaintext WAV available for export");
+
+        let _ = std::fs::remove_file(&enc);
+        let _ = std::fs::remove_file(&plain);
     }
 
     /// Naive subslice search for the leak assertion.

--- a/src-tauri/src/storage/migration.rs
+++ b/src-tauri/src/storage/migration.rs
@@ -1,0 +1,219 @@
+//! One-time, safety-first migration of an existing PLAINTEXT SQLite database to a SQLCipher
+//! encrypted one. The original file is never mutated until a fully-verified encrypted copy
+//! exists; the only mutating moment is the final atomic rename. A plaintext `.pre-encrypt.bak`
+//! snapshot is retained as a disaster-recovery path.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+
+use crate::error::{AppError, Result};
+
+fn mig_err(ctx: &str, e: impl std::fmt::Display) -> AppError {
+    AppError::Migration(format!("{ctx}: {e}"))
+}
+
+/// Should `path` be encrypted-in-place? True only if it exists AND is still a plaintext SQLite
+/// file. A non-existent path (fresh install) or an already-encrypted file ⇒ false. Idempotent.
+pub fn needs_encryption(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    is_plaintext_sqlite(path)
+}
+
+/// A plaintext SQLite file begins with the 16-byte magic "SQLite format 3\0". A SQLCipher file
+/// begins with random salt, so the magic is absent. <16 bytes ⇒ not a populated plaintext DB.
+fn is_plaintext_sqlite(path: &Path) -> Result<bool> {
+    let mut f = std::fs::File::open(path).map_err(|e| mig_err("open for sniff", e))?;
+    let mut buf = [0u8; 16];
+    let n = f.read(&mut buf).map_err(|e| mig_err("read header", e))?;
+    Ok(n == 16 && &buf == b"SQLite format 3\0")
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".pre-encrypt.bak");
+    PathBuf::from(s)
+}
+
+fn tmp_target(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".encrypting");
+    PathBuf::from(s)
+}
+
+/// Encrypt the plaintext DB at `path` in place: checkpoint WAL → plaintext backup → export into a
+/// fresh SQLCipher DB → verify (integrity + per-table row counts) → atomic swap. On any error
+/// before the swap, the original is left bit-for-bit intact and the temp target is removed.
+pub fn encrypt_in_place(path: &Path, dek_hex: &str) -> Result<()> {
+    let backup = backup_path(path);
+    let tmp = tmp_target(path);
+    let _ = std::fs::remove_file(&tmp);
+    let _ = std::fs::remove_file(&backup);
+
+    // 1–3: from the plaintext source — checkpoint WAL, snapshot backup, export to encrypted temp.
+    {
+        let src = Connection::open(path).map_err(|e| mig_err("open source", e))?;
+        let _ = src.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);"); // best-effort fold WAL
+        src.execute("VACUUM INTO ?1", [backup.to_string_lossy().as_ref()])
+            .map_err(|e| mig_err("backup VACUUM INTO", e))?;
+        src.execute(
+            "ATTACH DATABASE ?1 AS enc KEY ?2",
+            rusqlite::params![tmp.to_string_lossy().as_ref(), format!("x'{dek_hex}'")],
+        )
+        .map_err(|e| mig_err("attach encrypted target", e))?;
+        src.query_row("SELECT sqlcipher_export('enc')", [], |_| Ok(()))
+            .map_err(|e| mig_err("sqlcipher_export", e))?;
+        // sqlcipher_export does NOT copy user_version — carry it across.
+        let uv: i64 = src
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap_or(0);
+        let _ = src.execute_batch(&format!("PRAGMA enc.user_version = {uv};"));
+        src.execute_batch("DETACH DATABASE enc;")
+            .map_err(|e| mig_err("detach", e))?;
+    }
+
+    // 4: verify the encrypted target independently (any failure ⇒ bail, original untouched).
+    if let Err(e) = verify_encrypted(path, &tmp, dek_hex) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    // 5: atomic swap, then drop the stale plaintext WAL/SHM sidecars.
+    std::fs::rename(&tmp, path).map_err(|e| mig_err("atomic rename", e))?;
+    for suffix in ["-wal", "-shm"] {
+        let mut s = path.as_os_str().to_os_string();
+        s.push(suffix);
+        let _ = std::fs::remove_file(PathBuf::from(s));
+    }
+    tracing::info!(target: "migration", "database encrypted; plaintext backup at {}", backup.display());
+    Ok(())
+}
+
+fn table_count(conn: &Connection, table: &str) -> i64 {
+    conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |r| r.get(0))
+        .unwrap_or(-1)
+}
+
+/// Independently open the encrypted target with the key and prove it is a sound, complete copy:
+/// SQLCipher integrity check passes AND every core table's row count matches the source.
+fn verify_encrypted(source: &Path, encrypted: &Path, dek_hex: &str) -> Result<()> {
+    let src = Connection::open(source).map_err(|e| mig_err("verify open source", e))?;
+    let enc = Connection::open(encrypted).map_err(|e| mig_err("verify open encrypted", e))?;
+    enc.pragma_update(None, "key", format!("x'{dek_hex}'"))
+        .map_err(|e| mig_err("verify key", e))?;
+
+    // Integrity: any returned row signals a problem.
+    {
+        let mut stmt = enc
+            .prepare("PRAGMA cipher_integrity_check")
+            .map_err(|e| mig_err("integrity prepare", e))?;
+        let mut rows = stmt.query([]).map_err(|e| mig_err("integrity query", e))?;
+        if rows.next().map_err(|e| mig_err("integrity next", e))?.is_some() {
+            return Err(AppError::Migration(
+                "cipher_integrity_check reported problems".into(),
+            ));
+        }
+    }
+
+    // Row counts must match exactly for every core table.
+    for t in ["meetings", "segments", "notes"] {
+        let s = table_count(&src, t);
+        let e = table_count(&enc, t);
+        if s < 0 || s != e {
+            return Err(AppError::Migration(format!(
+                "row-count mismatch in {t}: source={s} encrypted={e}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-mig-{tag}-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    const KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// Build a realistic plaintext DB with fixtures across the core tables.
+    fn seed_plaintext(path: &Path) {
+        let c = Connection::open(path).unwrap();
+        c.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE meetings(id TEXT PRIMARY KEY, started_at TEXT, title TEXT);
+             CREATE TABLE segments(meeting_id TEXT, idx INTEGER, text TEXT);
+             CREATE TABLE notes(meeting_id TEXT, markdown TEXT);
+             INSERT INTO meetings VALUES('m1','2026-07-01','Sync'),('m2','2026-07-02','Review');
+             INSERT INTO segments VALUES('m1',0,'hello world'),('m1',1,'second line');
+             INSERT INTO notes VALUES('m1','# Note one'),('m2','# Note two');
+             PRAGMA user_version=7;",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn fresh_install_needs_no_migration() {
+        let p = tmp_path("fresh");
+        assert!(!needs_encryption(&p).unwrap()); // non-existent
+    }
+
+    #[test]
+    fn round_trips_and_is_idempotent() {
+        let p = tmp_path("roundtrip");
+        seed_plaintext(&p);
+        assert!(needs_encryption(&p).unwrap(), "plaintext should need encryption");
+
+        encrypt_in_place(&p, KEY).unwrap();
+
+        // No longer plaintext; backup exists and IS plaintext.
+        assert!(!is_plaintext_sqlite(&p).unwrap(), "should be encrypted now");
+        assert!(!needs_encryption(&p).unwrap(), "idempotent: encrypted file → no re-migration");
+        assert!(is_plaintext_sqlite(&backup_path(&p)).unwrap(), "backup is plaintext snapshot");
+
+        // Reopen encrypted, verify byte-identical reads + carried user_version.
+        let enc = Connection::open(&p).unwrap();
+        enc.pragma_update(None, "key", format!("x'{KEY}'")).unwrap();
+        let mc: i64 = enc.query_row("SELECT count(*) FROM meetings", [], |r| r.get(0)).unwrap();
+        assert_eq!(mc, 2);
+        let title: String = enc
+            .query_row("SELECT title FROM meetings WHERE id='m2'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "Review");
+        let seg: String = enc
+            .query_row("SELECT text FROM segments WHERE meeting_id='m1' AND idx=1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(seg, "second line");
+        let uv: i64 = enc.query_row("PRAGMA user_version", [], |r| r.get(0)).unwrap();
+        assert_eq!(uv, 7, "user_version carried across export");
+    }
+
+    #[test]
+    fn wrong_key_fails_closed() {
+        let p = tmp_path("wrongkey");
+        seed_plaintext(&p);
+        encrypt_in_place(&p, KEY).unwrap();
+
+        let bad = Connection::open(&p).unwrap();
+        bad.pragma_update(None, "key", "x'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'")
+            .unwrap();
+        let res: rusqlite::Result<i64> =
+            bad.query_row("SELECT count(*) FROM meetings", [], |r| r.get(0));
+        assert!(res.is_err(), "wrong key must fail, never return an empty/garbage DB");
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod migration;
 pub mod models;
 
 pub use db::*;

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -25,6 +25,33 @@ pub struct Meeting {
     pub status: MeetingStatus,
 }
 
+/// A vault folder Murmur tracks for organization + per-folder locking.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Folder {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub parent_id: Option<String>,
+    pub locked: bool,
+    pub created_at: String,
+}
+
+/// A folder node for the tree UI: note count + current session lock state + children.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderNode {
+    pub id: String,
+    pub name: String,
+    pub parent_id: Option<String>,
+    pub note_count: usize,
+    /// Folder is sealed (encrypted) on disk.
+    pub locked: bool,
+    /// Sealed AND unlocked in the current session (decrypted for view + MCP until relock).
+    pub unlocked: bool,
+    pub children: Vec<FolderNode>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoteRecord {

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -23,6 +23,9 @@ pub struct Meeting {
     pub duration_s: i64,
     pub audio_path: Option<String>,
     pub status: MeetingStatus,
+    /// Owning folder id (from the meeting's note rows), or `None` when at the vault root.
+    /// Derived from `notes.folder_id` — a meeting's folder = its note's folder.
+    pub folder_id: Option<String>,
 }
 
 /// A vault folder Murmur tracks for organization + per-folder locking.

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -11,6 +11,81 @@ pub enum MeetingStatus {
     Error,
 }
 
+/// The two entity kinds the self-assembling graph resolves from meeting notes.
+/// Stored as a stable lowercase string in `entities.kind` (mirrors `MeetingStatus`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum EntityKind {
+    Person,
+    Project,
+}
+
+/// A graph entity row (a person or project) — internal/DB-shaped, with its
+/// first-seen casing preserved in `name`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEntity {
+    pub id: String,
+    pub name: String,
+    pub kind: EntityKind,
+    pub created_at: String,
+}
+
+/// A graph node = an entity plus its VISIBLE mention count (sealed-and-not-unlocked
+/// meetings contribute zero). The directory + neighborhood views render these.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphNode {
+    pub id: String,
+    pub name: String,
+    pub kind: EntityKind,
+    /// VISIBLE mention count — never the true count; sealed meetings drop out.
+    pub mention_count: i64,
+}
+
+/// An undirected co-occurrence edge between two entities sharing ≥1 VISIBLE meeting.
+/// `source`/`target` are entity ids with `source < target` (dedup), `weight` = shared count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdge {
+    pub source: String,
+    pub target: String,
+    pub weight: i64,
+}
+
+/// The full graph payload returned by `get_graph`: every visible node + every visible edge.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphData {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    /// True when ≥1 folder is sealed-and-not-unlocked → some entities/mentions may be hidden.
+    /// The FE renders one honest disclosure banner; the count itself is never leaked.
+    pub has_hidden: bool,
+}
+
+/// A co-occurring neighbor of a selected entity (the neighborhood satellites), with the
+/// number of VISIBLE meetings the two share.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityNeighbor {
+    pub id: String,
+    pub name: String,
+    pub kind: EntityKind,
+    pub shared_meetings: i64,
+}
+
+/// The detail payload for one entity: the entity, its visible backlinked meetings
+/// (reusing the `VaultSource` chip shape), and its top co-occurring neighbors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityDetail {
+    pub entity: GraphEntity,
+    /// Visible meetings mentioning this entity (sealed-not-unlocked meetings excluded).
+    pub meetings: Vec<VaultSource>,
+    pub neighbors: Vec<EntityNeighbor>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Meeting {

--- a/src-tauri/src/summarize/organize.rs
+++ b/src-tauri/src/summarize/organize.rs
@@ -31,9 +31,10 @@ pub async fn classify_subfolder(
     sanitize_folder(&reply)
 }
 
-/// Reduce a model reply to a single safe folder name (first non-empty line, reserved
-/// path/link chars stripped). Returns `None` for empty/oversized results.
-fn sanitize_folder(reply: &str) -> Option<String> {
+/// Reduce a model reply (or user input) to a single safe folder name (first non-empty line,
+/// reserved path/link chars stripped). Returns `None` for empty/oversized results. Reused by the
+/// folder commands to sanitize user-supplied folder names into vault-safe path segments.
+pub fn sanitize_folder(reply: &str) -> Option<String> {
     let first = reply.lines().find(|l| !l.trim().is_empty())?.trim();
     let cleaned: String = first
         .chars()

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -79,6 +79,10 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             }
         };
 
+        // LIVE captions use the Fast (greedy/best_of:1) profile via `transcribe` — NOT the
+        // batch beam-search path. Captions tick every few seconds on overlapping windows, so
+        // latency must dominate; beam search + temperature fallback would burn CPU per tick.
+        // The authoritative high-quality transcript is produced once at Stop (pipeline.rs).
         match transcriber.transcribe(&samples_16k, lang.as_deref()) {
             Ok(t) => {
                 let text = t

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -18,12 +18,20 @@ pub const MODELS_SUBDIR: &str = "models";
 
 /// Map a chosen size + language to a whisper.cpp GGML model filename.
 ///
+/// Supported sizes (all served by the ggerganov/whisper.cpp HF mirror):
+/// `tiny`, `base`, `small`, `medium`, `large-v3-turbo`, `large-v3`.
+///
 /// English-only (`.en`) builds exist for tiny/base/small/medium — smaller + faster — and
 /// are used ONLY when the user explicitly selects English. Any other language (incl.
-/// Polish) or auto-detect needs the multilingual build. `large-v3` is multilingual-only.
+/// Polish) or auto-detect needs the multilingual build. `large-v3` and `large-v3-turbo`
+/// are multilingual-only (no `.en` variant), so Polish always resolves the full
+/// multilingual `ggml-large-v3.bin`.
+///
+/// An empty size falls back to the app default (`large-v3`), matching
+/// `AppConfig::default().model_size`.
 pub fn model_filename(size: &str, language: &str) -> String {
     let size = match size.trim() {
-        "" => "small",
+        "" => "large-v3",
         s => s,
     };
     let en_only = language == "en" && matches!(size, "tiny" | "base" | "small" | "medium");
@@ -144,4 +152,58 @@ async fn download_model(url: &str, dest: &Path) -> Result<()> {
         "whisper model ready"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn english_resolves_en_only_build_for_small_sizes() {
+        assert_eq!(model_filename("tiny", "en"), "ggml-tiny.en.bin");
+        assert_eq!(model_filename("base", "en"), "ggml-base.en.bin");
+        assert_eq!(model_filename("small", "en"), "ggml-small.en.bin");
+        assert_eq!(model_filename("medium", "en"), "ggml-medium.en.bin");
+    }
+
+    #[test]
+    fn large_v3_is_multilingual_only_even_for_english() {
+        // large-v3 / large-v3-turbo have no `.en` build — never append `.en`.
+        assert_eq!(model_filename("large-v3", "en"), "ggml-large-v3.bin");
+        assert_eq!(
+            model_filename("large-v3-turbo", "en"),
+            "ggml-large-v3-turbo.bin"
+        );
+    }
+
+    #[test]
+    fn polish_always_resolves_multilingual_build() {
+        // The global "Polish" option (language = "pl") must NEVER get an `.en` model.
+        assert_eq!(model_filename("large-v3", "pl"), "ggml-large-v3.bin");
+        assert_eq!(model_filename("medium", "pl"), "ggml-medium.bin");
+        assert_eq!(model_filename("small", "pl"), "ggml-small.bin");
+        assert_eq!(model_filename("tiny", "pl"), "ggml-tiny.bin");
+    }
+
+    #[test]
+    fn autodetect_resolves_multilingual_build() {
+        // Empty language (auto-detect) → multilingual for every size.
+        assert_eq!(model_filename("medium", ""), "ggml-medium.bin");
+        assert_eq!(model_filename("large-v3", ""), "ggml-large-v3.bin");
+    }
+
+    #[test]
+    fn empty_size_falls_back_to_large_v3_default() {
+        // Mirrors AppConfig::default().model_size.
+        assert_eq!(model_filename("", ""), "ggml-large-v3.bin");
+        assert_eq!(model_filename("   ", "pl"), "ggml-large-v3.bin");
+    }
+
+    #[test]
+    fn url_points_at_whispercpp_hf_mirror() {
+        assert_eq!(
+            model_url("ggml-large-v3.bin"),
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
+        );
+    }
 }

--- a/src-tauri/src/transcribe/types.rs
+++ b/src-tauri/src/transcribe/types.rs
@@ -7,6 +7,14 @@ pub struct Segment {
     pub start_s: f64,
     pub end_s: f64,
     pub text: String,
+    /// Cheap 2-way stream-attribution: `Some("me")` for the local mic stream,
+    /// `Some("others")` for the captured system-audio stream, `None` when the producing
+    /// stream is unknown (e.g. a legacy row, or the live/voice-trigger paths which do not
+    /// attribute). HONEST DENT: this is NOT per-remote-person diarization — every remote
+    /// participant collapses into the single "others" label, because attribution is decided
+    /// purely by WHICH capture stream produced the segment, not by voice fingerprinting.
+    #[serde(default)]
+    pub speaker: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -169,6 +169,10 @@ impl Transcriber {
                 start_s: t0 as f64 / CENTISECONDS_PER_SECOND,
                 end_s: t1 as f64 / CENTISECONDS_PER_SECOND,
                 text: trimmed.to_string(),
+                // The transcriber is stream-agnostic: speaker attribution ("me"/"others") is
+                // assigned by the wall-clock merge in `audio::merge` from which stream produced
+                // these segments, not here. Live/voice-trigger callers leave it as `None`.
+                speaker: None,
             });
         }
 

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -10,6 +10,56 @@ use crate::transcribe::types::{Segment, Transcript};
 /// Whisper emits segment timestamps in centiseconds (1/100 s). Divide to get seconds.
 const CENTISECONDS_PER_SECOND: f64 = 100.0;
 
+/// Decoding profile — selects the latency/quality trade-off for a transcription run.
+///
+/// The two paths genuinely want different decoders, so we parameterise the ONE
+/// `transcribe` implementation with this enum instead of duplicating the body:
+///
+/// - [`TranscribeQuality::Accurate`] — the BATCH path (`pipeline.rs`, run once after Stop).
+///   Beam search + temperature fallback + anti-hallucination thresholds + previous-text
+///   conditioning. Slower, but maximises wording/inflection quality — critical for
+///   Polish, which is heavily inflected and where greedy decoding hallucinates more.
+///
+/// - [`TranscribeQuality::Fast`] — the LIVE path (`live.rs` captions) and the
+///   VOICE-TRIGGER path (`audio/listener.rs`). Greedy, single-best, no fallback ladder:
+///   lowest latency so a caption/wake-word tick stays snappy. These run on short
+///   overlapping windows many times per recording, so beam search there would burn CPU
+///   for output the user barely reads — quality is not the goal on those paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscribeQuality {
+    /// Low-latency greedy decoding for live captions + voice-trigger windows.
+    Fast,
+    /// High-quality batch decoding for the authoritative post-Stop transcript.
+    Accurate,
+}
+
+// ── Accurate (batch) decoding constants — see `build_params`. ──
+//
+// whisper.cpp's defaults already encode the canonical OpenAI-Whisper anti-hallucination
+// values; we set them EXPLICITLY so the batch profile is self-documenting and immune to a
+// future upstream default change.
+
+/// Beam width for the batch path. 5 = OpenAI Whisper's reference beam size.
+const BATCH_BEAM_SIZE: i32 = 5;
+/// `patience` is unimplemented in whisper.cpp (v1.7.x); -1.0 keeps its documented default.
+const BATCH_BEAM_PATIENCE: f32 = -1.0;
+/// Start of the temperature-fallback ladder (greedy/deterministic first pass).
+const BATCH_TEMPERATURE: f32 = 0.0;
+/// Ladder step: 0.0 → 0.2 → … → 1.0 (6 rungs). Whisper falls back up the ladder only when
+/// a decode trips the entropy/logprob gates below.
+const BATCH_TEMPERATURE_INC: f32 = 0.2;
+/// Entropy (a.k.a. gzip-compression-ratio) gate. whisper.cpp uses token entropy as its
+/// analog of OpenAI's `compression_ratio_threshold`; 2.4 is the reference value. Above it,
+/// the segment is treated as repetitive/hallucinated and the next temperature rung is tried.
+const BATCH_ENTROPY_THOLD: f32 = 2.4;
+/// Average-logprob gate; below -1.0 the decode is "low confidence" → temperature fallback.
+const BATCH_LOGPROB_THOLD: f32 = -1.0;
+/// No-speech probability gate; above 0.6 a segment is treated as silence (not hallucinated).
+const BATCH_NO_SPEECH_THOLD: f32 = 0.6;
+/// Max tokens of PRIOR text fed back as the decoder prompt (coreference / grammar carry-over).
+/// whisper.cpp's own default; set explicitly to document that previous-text conditioning is ON.
+const BATCH_N_MAX_TEXT_CTX: i32 = 16384;
+
 /// Wraps a loaded whisper.cpp model (Metal). Construct once; reuse per transcription.
 ///
 /// `WhisperContext` is `Send + Sync`, so a single `Transcriber` can live in shared state
@@ -43,9 +93,25 @@ impl Transcriber {
         Ok(Self { ctx })
     }
 
-    /// Transcribe 16 kHz mono f32 samples. `lang = Some("en")` forces a language;
-    /// `None` lets whisper auto-detect.
+    /// Transcribe 16 kHz mono f32 samples at the [`TranscribeQuality::Fast`] profile.
+    ///
+    /// `lang = Some("en")`/`Some("pl")` forces a language; `None` lets whisper auto-detect.
+    /// This is the low-latency greedy path used by live captions + the voice trigger. The
+    /// batch pipeline calls [`Transcriber::transcribe_with`] with
+    /// [`TranscribeQuality::Accurate`] instead.
     pub fn transcribe(&self, samples_16k_mono: &[f32], lang: Option<&str>) -> Result<Transcript> {
+        self.transcribe_with(samples_16k_mono, lang, TranscribeQuality::Fast)
+    }
+
+    /// Transcribe 16 kHz mono f32 samples at an explicit [`TranscribeQuality`] profile.
+    ///
+    /// `lang = Some("en")` forces a language; `None` lets whisper auto-detect.
+    pub fn transcribe_with(
+        &self,
+        samples_16k_mono: &[f32],
+        lang: Option<&str>,
+        quality: TranscribeQuality,
+    ) -> Result<Transcript> {
         if samples_16k_mono.is_empty() {
             return Ok(Transcript {
                 full_text: String::new(),
@@ -59,9 +125,10 @@ impl Transcriber {
             .create_state()
             .map_err(|e| AppError::Transcribe(format!("create whisper state: {e}")))?;
 
-        // Greedy sampling is the fast, deterministic default for batch transcription.
-        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        // `None` => auto-detect language; `Some("en")` => force it.
+        let mut params = build_params(quality);
+        // `None` => auto-detect language; `Some("en")`/`Some("pl")` => force it. Forcing
+        // "pl" (the global Polish option) skips language detection and biases the decoder's
+        // token priors toward Polish — the single biggest win for Polish quality.
         params.set_language(lang);
         // Silence whisper.cpp's own stdout chatter — we surface progress via events.
         params.set_print_special(false);
@@ -125,6 +192,48 @@ impl Transcriber {
     }
 }
 
+/// Build the decoder [`FullParams`] for a given [`TranscribeQuality`] profile.
+///
+/// Only the sampling strategy + decoding-hygiene knobs differ here; the caller still sets
+/// `language` and silences the print flags. Keeping this in ONE place is why batch vs live
+/// can diverge without duplicating the `transcribe` body.
+fn build_params<'a>(quality: TranscribeQuality) -> FullParams<'a, 'a> {
+    match quality {
+        // LIVE captions + VOICE TRIGGER: keep greedy / best_of:1. These run on short,
+        // overlapping windows every couple of seconds, so latency dominates — beam search +
+        // a 6-rung temperature ladder would multiply the per-tick cost for output the user
+        // only glances at. Quality is the batch path's job, NOT the live path's. Do NOT add
+        // beam search here.
+        TranscribeQuality::Fast => FullParams::new(SamplingStrategy::Greedy { best_of: 1 }),
+
+        // BATCH (post-Stop authoritative transcript): the anti-hallucination + inflection
+        // levers. Beam search explores multiple hypotheses (better wording/grammar — matters
+        // for heavily-inflected Polish); the temperature ladder + entropy/logprob/no-speech
+        // gates let whisper retry a segment at a higher temperature when a decode looks
+        // repetitive or low-confidence (the classic anti-hallucination loop); previous-text
+        // conditioning carries grammar/coreference across segment boundaries.
+        TranscribeQuality::Accurate => {
+            let mut params = FullParams::new(SamplingStrategy::BeamSearch {
+                beam_size: BATCH_BEAM_SIZE,
+                patience: BATCH_BEAM_PATIENCE,
+            });
+            // Temperature-fallback ladder: 0.0 → +0.2 → … → 1.0.
+            params.set_temperature(BATCH_TEMPERATURE);
+            params.set_temperature_inc(BATCH_TEMPERATURE_INC);
+            // Anti-hallucination gates that trigger the next ladder rung.
+            params.set_entropy_thold(BATCH_ENTROPY_THOLD);
+            params.set_logprob_thold(BATCH_LOGPROB_THOLD);
+            params.set_no_speech_thold(BATCH_NO_SPEECH_THOLD);
+            // Previous-text conditioning ON: feed prior decoded text back as the prompt.
+            // whisper.cpp's flag is `no_context` (inverted) and defaults to TRUE (conditioning
+            // OFF), so we MUST flip it to false to keep coreference/grammar carry-over.
+            params.set_no_context(false);
+            params.set_n_max_text_ctx(BATCH_N_MAX_TEXT_CTX);
+            params
+        }
+    }
+}
+
 /// Read a 16 kHz WAV file into mono f32 samples in `[-1.0, 1.0]`.
 ///
 /// Supports 16-bit integer PCM (what `audio/wav.rs` writes) and 32-bit float WAVs.
@@ -172,4 +281,37 @@ fn read_wav_16k_mono(wav_path: &Path) -> Result<Vec<f32>> {
         .map(|frame| frame.iter().sum::<f32>() / channels as f32)
         .collect();
     Ok(mono)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_profiles_are_distinct_and_copy() {
+        // `Copy` lets call sites pass the profile by value without ceremony.
+        let q = TranscribeQuality::Accurate;
+        let _also = q;
+        assert_ne!(TranscribeQuality::Fast, TranscribeQuality::Accurate);
+    }
+
+    #[test]
+    fn build_params_constructs_both_profiles() {
+        // `whisper_full_default_params` is a pure C struct-filler — no model/context needed —
+        // so this exercises the batch setter chain (beam search + thresholds + no_context)
+        // and the live greedy path without GPU work. A panic/UB here would fail the test.
+        let _fast = build_params(TranscribeQuality::Fast);
+        let _accurate = build_params(TranscribeQuality::Accurate);
+    }
+
+    #[test]
+    fn batch_constants_match_whispercpp_reference_values() {
+        // Guards against an accidental drift away from the OpenAI-Whisper reference hygiene.
+        assert_eq!(BATCH_BEAM_SIZE, 5);
+        assert_eq!(BATCH_TEMPERATURE, 0.0);
+        assert_eq!(BATCH_TEMPERATURE_INC, 0.2);
+        assert_eq!(BATCH_ENTROPY_THOLD, 2.4);
+        assert_eq!(BATCH_LOGPROB_THOLD, -1.0);
+        assert_eq!(BATCH_NO_SPEECH_THOLD, 0.6);
+    }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,6 +15,9 @@ import {
 } from "@angular/router";
 import { filter, map } from "rxjs";
 import { IpcService } from "./core/ipc.service";
+import { FoldersService } from "./services/folders.service";
+import { ScreenShareService } from "./services/screen-share.service";
+import { ToastService } from "./services/toast.service";
 
 @Component({
   selector: "app-root",
@@ -78,6 +81,53 @@ import { IpcService } from "./core/ipc.service";
             </span>
             <span class="brand-word">murmur</span>
           </a>
+
+          <!-- Subtle session-privacy indicator: how many locked folders are
+               currently unlocked (plaintext-exposed) for this session. Reads
+               straight off the folders signal store; absent at zero. -->
+          @if (unlockedCount() > 0) {
+            <span
+              class="unlocked-pill"
+              role="status"
+              [attr.aria-label]="
+                unlockedCount() +
+                ' locked folder' +
+                (unlockedCount() === 1 ? '' : 's') +
+                ' unlocked this session'
+              "
+              [attr.title]="
+                'These folders are decrypted into plaintext until you re-lock or a screen share starts.'
+              "
+            >
+              <svg
+                class="unlocked-glyph"
+                viewBox="0 0 16 16"
+                width="12"
+                height="12"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+              <span class="unlocked-count">{{ unlockedCount() }}</span>
+              <span class="unlocked-label">unlocked</span>
+            </span>
+          }
+
           <nav class="app-nav">
             <a routerLink="/record" routerLinkActive="active">Record</a>
             <a routerLink="/library" routerLinkActive="active">Meetings</a>
@@ -91,6 +141,38 @@ import { IpcService } from "./core/ipc.service";
     <main class="app-main" [class.bare]="isBar()">
       <router-outlet></router-outlet>
     </main>
+
+    <!-- Toast viewport (MAIN window only): renders the app-wide queue from
+         ToastService — move-to-folder outcomes, screen-share re-lock notices. -->
+    @if (!isBar() && toasts().length > 0) {
+      <div class="toast-viewport" aria-live="polite" aria-atomic="false">
+        @for (t of toasts(); track t.id) {
+          <div class="toast" [class]="'is-' + t.kind" role="status">
+            <span class="toast-msg">{{ t.message }}</span>
+            <button
+              type="button"
+              class="toast-close"
+              aria-label="Dismiss notification"
+              (click)="dismissToast(t.id)"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="13"
+                height="13"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+        }
+      </div>
+    }
   `,
   styles: [
     `
@@ -231,6 +313,36 @@ import { IpcService } from "./core/ipc.service";
         background: var(--accent-soft);
       }
 
+      /* --- Session-privacy pill (N folders unlocked this session) --------- */
+      .unlocked-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        height: 26px;
+        padding: 0 var(--space-3) 0 var(--space-2);
+        border: 1px solid transparent;
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        line-height: 1;
+        white-space: nowrap;
+        animation: rise 240ms var(--transition) both;
+      }
+      .unlocked-glyph {
+        display: block;
+        flex: none;
+      }
+      .unlocked-count {
+        font-variant-numeric: tabular-nums;
+      }
+      .unlocked-label {
+        color: var(--accent-hover);
+        opacity: 0.85;
+      }
+
       .app-main {
         max-width: var(--content-max);
         margin: 0 auto;
@@ -243,12 +355,83 @@ import { IpcService } from "./core/ipc.service";
         padding: 0;
         min-height: 100vh;
       }
+
+      /* --- Toast viewport (bottom-right, frosted; stacks oldest → newest) --- */
+      .toast-viewport {
+        position: fixed;
+        right: var(--space-5);
+        bottom: var(--space-5);
+        z-index: 60;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        max-width: min(360px, calc(100vw - var(--space-6)));
+        pointer-events: none;
+      }
+      .toast {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-3);
+        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
+        border: 1px solid var(--glass-border);
+        border-left-width: 3px;
+        border-radius: var(--radius-md);
+        background: var(--surface-overlay);
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        line-height: 1.45;
+        box-shadow: var(--shadow-md), var(--glass-highlight);
+        pointer-events: auto;
+        animation: rise 220ms var(--ease-spring) both;
+      }
+      .toast.is-info {
+        border-left-color: var(--accent);
+      }
+      .toast.is-success {
+        border-left-color: var(--success);
+      }
+      .toast.is-danger {
+        border-left-color: var(--danger);
+      }
+      .toast-msg {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .toast-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        width: 24px;
+        height: 24px;
+        margin-top: -2px;
+        padding: 0;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
+      }
+      .toast-close:hover {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+      }
+      .toast-close:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
     `,
   ],
 })
 export class AppComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+  private readonly screenShare = inject(ScreenShareService);
+  private readonly toast = inject(ToastService);
 
   /** True in the floating-bar window (route /bar) — the app chrome is hidden there. */
   readonly isBar = toSignal(
@@ -259,18 +442,40 @@ export class AppComponent implements OnInit {
     { initialValue: location.pathname.startsWith("/bar") },
   );
 
+  /** How many locked folders are unlocked (plaintext-exposed) this session. */
+  readonly unlockedCount = this.folders.unlockedCount;
+
+  /** The app-wide toast queue, rendered in the main-window viewport. */
+  readonly toasts = this.toast.toasts;
+
   /** Make the bar window's document transparent (no aurora/grain behind the pill). */
   private readonly _bodyClass = effect(() => {
     document.body.classList.toggle("bar-shell", this.isBar());
   });
 
+  /** Dismiss a toast by id (also cancels its auto-dismiss timer in the service). */
+  dismissToast(id: number): void {
+    this.toast.dismiss(id);
+  }
+
   /**
    * First-run gate (MAIN window only). On startup, if the user hasn't completed
    * onboarding, send them to the wizard. The floating-bar window is never gated —
    * it just mirrors recording state and must stay chromeless.
+   *
+   * The main window also arms the screen-share privacy guard and primes the
+   * folder tree (so the "N unlocked" pill + locked-meeting masking have state).
+   * The bar window does neither — it stays chromeless and side-effect-free.
    */
   async ngOnInit(): Promise<void> {
     if (this.isBar()) return;
+
+    // Arm the screen-share guard + prime the folder store (main window only).
+    // Best-effort and non-blocking: a folders/listen failure must not trap the
+    // user on a blank app, so each is fire-and-forget with its own catch.
+    void this.screenShare.init();
+    void this.folders.load();
+
     try {
       const cfg = await this.ipc.getConfig();
       if (!cfg.onboarded) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -132,6 +132,7 @@ import { ToastService } from "./services/toast.service";
             <a routerLink="/record" routerLinkActive="active">Record</a>
             <a routerLink="/library" routerLinkActive="active">Meetings</a>
             <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
+            <a routerLink="/graph" routerLinkActive="active">Graph</a>
             <a routerLink="/ask" routerLinkActive="active">Ask</a>
             <a routerLink="/settings" routerLinkActive="active">Settings</a>
           </nav>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,11 @@ export const routes: Routes = [
       import("./features/ask/ask.component").then((m) => m.AskComponent),
   },
   {
+    path: "graph",
+    loadComponent: () =>
+      import("./features/graph/graph.component").then((m) => m.GraphComponent),
+  },
+  {
     path: "bar",
     loadComponent: () =>
       import("./features/bar/bar.component").then(

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -53,6 +53,20 @@ export class IpcService {
     return invoke<number>("recording_level");
   }
 
+  /**
+   * Mute / unmute the local microphone on the LIVE recorder. Muting silences
+   * only the mic — captured system audio ("others") keeps recording. No-op when
+   * not recording.
+   */
+  setMicMuted(muted: boolean): Promise<void> {
+    return invoke<void>("set_mic_muted", { muted });
+  }
+
+  /** Whether the live recorder's mic is currently muted (false when not recording). */
+  isMicMuted(): Promise<boolean> {
+    return invoke<boolean>("is_mic_muted");
+  }
+
   getLastNote(): Promise<NoteDto | null> {
     return invoke<NoteDto | null>("get_last_note");
   }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -11,8 +11,10 @@ import type {
   CalendarEvent,
   ChatTurn,
   DigestResult,
+  EntityDetail,
   Folder,
   FolderNode,
+  GraphData,
   GraphPayload,
   Meeting,
   MeetingDetail,
@@ -164,6 +166,20 @@ export class IpcService {
   /** Build the self-assembling graph: write [[Person]]/[[Project]] stub notes + backlinks. */
   linkMeetingEntities(meetingId: string): Promise<GraphPayload> {
     return invoke<GraphPayload>("link_meeting_entities", { meetingId });
+  }
+
+  /**
+   * The self-assembling graph: all VISIBLE entity nodes (with visible mention counts) + all
+   * VISIBLE co-occurrence edges + a `hasHidden` flag. Sealed-not-unlocked meetings contribute
+   * nothing; re-fetch on a FoldersService lock-state change to drop sealed entities live.
+   */
+  getGraph(): Promise<GraphData> {
+    return invoke<GraphData>("get_graph");
+  }
+
+  /** Detail for one entity: the entity + its visible backlinked meetings + top neighbors. */
+  getEntityDetail(entityId: string): Promise<EntityDetail> {
+    return invoke<EntityDetail>("get_entity_detail", { entityId });
   }
 
   /** Ask-My-Vault: grounded Q&A across ALL meetings, with source meetings. */

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -270,6 +270,17 @@ export class IpcService {
     return invoke<MeetingDetail | null>("get_meeting_detail", { meetingId });
   }
 
+  /**
+   * Resolve this meeting's owning folder and run the biometric unlock_folder
+   * path (Touch ID). Returns the updated `FolderNode` for the folder, or null
+   * when the meeting is at the vault root / in an open folder. After a success,
+   * re-fetch `getMeetingDetail` to get the full unmasked content. Rejects when
+   * the biometric prompt is denied / cancelled.
+   */
+  unlockMeeting(meetingId: string): Promise<FolderNode | null> {
+    return invoke<FolderNode | null>("unlock_meeting", { meetingId });
+  }
+
   /** AI-derived speaker + topic timeline for a meeting (generated + cached on first call). */
   getTimeline(meetingId: string): Promise<MeetingTimeline> {
     return invoke<MeetingTimeline>("get_timeline", { meetingId });

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -11,6 +11,8 @@ import type {
   CalendarEvent,
   ChatTurn,
   DigestResult,
+  Folder,
+  FolderNode,
   GraphPayload,
   Meeting,
   MeetingDetail,
@@ -269,6 +271,48 @@ export class IpcService {
   /** Show/hide the floating always-on-top recorder bar window. */
   toggleBar(): Promise<void> {
     return invoke<void>("toggle_bar");
+  }
+
+  // ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──
+
+  /** The folder tree (roots → children) with per-folder note counts + session lock state. */
+  listFolders(): Promise<FolderNode[]> {
+    return invoke<FolderNode[]>("list_folders");
+  }
+
+  /** Create a folder under an optional parent; creates the matching vault subdirectory. */
+  createFolder(name: string, parentId: string | null): Promise<Folder> {
+    return invoke<Folder>("create_folder", { name, parentId });
+  }
+
+  /** Move a note into a folder (or to the vault root with `folderId = null`). */
+  moveNote(meetingId: string, folderId: string | null): Promise<void> {
+    return invoke<void>("move_note", { meetingId, folderId });
+  }
+
+  /** Seal a folder: encrypt its notes into content blobs, blank markdown, remove vault .md. */
+  lockFolder(folderId: string): Promise<void> {
+    return invoke<void>("lock_folder", { folderId });
+  }
+
+  /** Session-unlock a sealed folder (decrypt into markdown for this session; no re-export). */
+  unlockFolder(folderId: string): Promise<FolderNode> {
+    return invoke<FolderNode>("unlock_folder", { folderId });
+  }
+
+  /** Re-seal a single session-unlocked folder (re-blank markdown; folder stays locked on disk). */
+  relockFolder(folderId: string): Promise<void> {
+    return invoke<void>("relock_folder", { folderId });
+  }
+
+  /** Re-seal ALL session-unlocked folders + zeroize the cached KEK (e.g. on screen-share). */
+  relockAll(): Promise<void> {
+    return invoke<void>("relock_all");
+  }
+
+  /** Permanently remove a folder's lock: decrypt to plaintext + re-export to the vault. */
+  removeLock(folderId: string): Promise<void> {
+    return invoke<void>("remove_lock", { folderId });
   }
 
   onStatus(cb: (payload: StatusPayload) => void): Promise<UnlistenFn> {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -210,6 +210,61 @@ export interface VaultSource {
   startedAt: string;
 }
 
+/** The two entity kinds the self-assembling graph resolves (Rust `EntityKind`, camelCase). */
+export type EntityKind = "person" | "project";
+
+/** A graph entity row (person or project), first-seen casing preserved in `name`. */
+export interface GraphEntity {
+  id: string;
+  name: string;
+  kind: EntityKind;
+  createdAt: string;
+}
+
+/** A graph node = an entity + its VISIBLE mention count (sealed meetings contribute zero). */
+export interface GraphNode {
+  id: string;
+  name: string;
+  kind: EntityKind;
+  /** VISIBLE mention count — never the true count; sealed-not-unlocked meetings drop out. */
+  mentionCount: number;
+}
+
+/**
+ * An undirected co-occurrence edge between two entities sharing ≥1 VISIBLE meeting.
+ * `source` < `target` (deduped); `weight` = number of shared visible meetings.
+ */
+export interface GraphEdge {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+/** The full graph payload from `getGraph()`: visible nodes + visible edges + a hidden flag. */
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  /** True when ≥1 folder is sealed-and-not-unlocked → render one honest disclosure banner. */
+  hasHidden: boolean;
+}
+
+/** A co-occurring neighbor of a selected entity (a neighborhood satellite). */
+export interface EntityNeighbor {
+  id: string;
+  name: string;
+  kind: EntityKind;
+  /** Number of VISIBLE meetings the two entities share. */
+  sharedMeetings: number;
+}
+
+/** Detail for one entity: the entity, its visible backlinked meetings, top neighbors. */
+export interface EntityDetail {
+  entity: GraphEntity;
+  /** Visible meetings mentioning this entity (reuses the `VaultSource` backlink chip shape). */
+  meetings: VaultSource[];
+  neighbors: EntityNeighbor[];
+}
+
 export interface AskVaultResult {
   answer: string;
   sources: VaultSource[];

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -125,6 +125,14 @@ export interface MeetingDetail {
   meeting: Meeting;
   note: NoteDto | null;
   segments: Segment[];
+  /**
+   * True when this meeting lives in a sealed-and-NOT-session-unlocked folder.
+   * The backend MASKS the payload in that case (title "🔒 Locked", note null,
+   * segments [], audioPath null) — the FE renders a lock gate instead of the
+   * note/transcript/audio/timeline. Re-fetch after `unlockMeeting` to get the
+   * full unmasked content (`locked` then absent/false).
+   */
+  locked?: boolean;
 }
 
 export interface StatusCount {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -112,6 +112,13 @@ export interface Segment {
   startS: number;
   endS: number;
   text: string;
+  /**
+   * Who produced this segment: `"me"` (the local mic / recorder), `"others"`
+   * (captured system audio), or `null` for legacy / mic-only recordings made
+   * before speaker attribution existed. A bare `string` is tolerated so a future
+   * backend can carry richer labels without a model break.
+   */
+  speaker?: "me" | "others" | string | null;
 }
 
 export interface MeetingDetail {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -77,6 +77,34 @@ export interface Meeting {
   durationS: number;
   audioPath: string | null;
   status: MeetingStatus;
+  /** Owning folder id, or null when at the vault root. */
+  folderId?: string | null;
+}
+
+/** A folder row as returned by createFolder (mirrors the Rust `Folder` DTO). */
+export interface Folder {
+  id: string;
+  name: string;
+  /** Vault-relative folder path. */
+  path: string;
+  parentId: string | null;
+  locked: boolean;
+  createdAt: string;
+}
+
+/**
+ * A folder node for the tree UI. `locked` = sealed (encrypted) on disk; `unlocked` = sealed AND
+ * decrypted for this session (visible in-app + MCP until relock). An open folder is
+ * `locked=false, unlocked=false`.
+ */
+export interface FolderNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  noteCount: number;
+  locked: boolean;
+  unlocked: boolean;
+  children: FolderNode[];
 }
 
 export interface Segment {

--- a/src/app/features/bar/bar.component.ts
+++ b/src/app/features/bar/bar.component.ts
@@ -7,6 +7,7 @@ import {
 } from "@angular/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { RecorderStore } from "../../core/recorder.store";
+import { MicMuteToggleComponent } from "../record/mic-mute-toggle.component";
 
 /**
  * The floating, always-on-top "OS bar" (a second Tauri window summoned with ⌘⇧R).
@@ -19,6 +20,7 @@ import { RecorderStore } from "../../core/recorder.store";
   selector: "app-floating-bar",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MicMuteToggleComponent],
   host: { "(document:keydown.escape)": "hide()" },
   template: `
     <div
@@ -47,6 +49,9 @@ import { RecorderStore } from "../../core/recorder.store";
             }
           </div>
         }
+        <!-- Mic-mute: icon-only in the slim pill. Silences only the mic;
+             system audio keeps recording. Never starts/stops anything. -->
+        <app-mic-mute-toggle [compact]="true" />
         <button
           type="button"
           class="circle stop"

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -20,6 +20,7 @@ import type {
   GraphPayload,
   MeetingDetail,
   MeetingTimeline,
+  Segment,
 } from "../../core/models";
 import {
   FoldersService,
@@ -682,6 +683,14 @@ interface ParsedNote {
                       (click)="seekTo(s.startS)"
                     >
                       <span class="seg-time">{{ fmt(s.startS) }}</span>
+                      @if (speakerChip(s.speaker); as chip) {
+                        <span
+                          class="seg-speaker"
+                          [style.background]="chip.bg"
+                          [style.color]="chip.fg"
+                          >{{ chip.label }}</span
+                        >
+                      }
                       <span class="seg-text">{{ s.text }}</span>
                     </button>
                   </li>
@@ -765,10 +774,6 @@ interface ParsedNote {
         gap: var(--space-2);
         color: var(--text-muted);
         font-size: 0.8125rem;
-      }
-      .meta-item,
-      .meta-sep {
-        color: var(--text-muted);
       }
 
       /* --- Tag editor (chips + inline add) --- */
@@ -984,7 +989,6 @@ interface ParsedNote {
         flex: none;
       }
       .audio-off-text {
-        color: var(--text-muted);
         font-size: 0.875rem;
       }
 
@@ -1169,10 +1173,6 @@ interface ParsedNote {
       }
       .section:hover {
         border-color: var(--border-strong);
-      }
-      .section-head {
-        margin: 0 0 var(--space-3);
-        color: var(--text-primary);
       }
 
       .prose p {
@@ -1372,11 +1372,9 @@ interface ParsedNote {
       }
       .editor-hint,
       .graph-caption {
+        margin: 0;
         color: var(--text-muted);
         font-size: 0.8125rem;
-      }
-      .graph-caption {
-        margin: 0;
       }
 
       /* Transient "Saved" confirmation */
@@ -1478,6 +1476,17 @@ interface ParsedNote {
         font-size: 0.8125rem;
         font-variant-numeric: tabular-nums;
         padding-top: 0.1em;
+      }
+
+      /* Speaker chip: an optional Me/Others tag between the time + text
+         (colours bound inline). Legacy/null segments render unlabeled. */
+      .seg-speaker {
+        flex: none;
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-pill);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        line-height: 1.5;
       }
 
       /* --- Empty / loading wells (.count/.state-card/.empty* are global) --- */
@@ -2551,6 +2560,37 @@ export class DetailComponent implements OnInit {
   /** Strip surrounding quotes/whitespace from a YAML scalar. */
   private cleanScalar(s: string): string {
     return s.trim().replace(/^["']/, "").replace(/["']$/, "").trim();
+  }
+
+  /**
+   * Map a transcript segment's `speaker` to a small presentational chip:
+   * "Me" (the local mic, accent) vs "Others" (captured system audio, neutral/
+   * violet). Returns null for legacy / mic-only segments (`null` / unknown) so
+   * they render unlabeled exactly as before. This is independent of the AI
+   * timeline's manual speaker-rename — that feature relabels timeline lanes, not
+   * these per-segment Me/Others tags.
+   */
+  speakerChip(
+    speaker: Segment["speaker"],
+  ): { label: string; bg: string; fg: string } | null {
+    switch (speaker) {
+      case "me":
+        // Local mic — the calm accent.
+        return {
+          label: "Me",
+          bg: "var(--accent-soft)",
+          fg: "var(--accent-hover)",
+        };
+      case "others":
+        // Captured system audio — a neutral violet, distinct from "Me".
+        return {
+          label: "Others",
+          bg: "rgba(157, 123, 255, 0.16)",
+          fg: "#b9a4ff",
+        };
+      default:
+        return null;
+    }
   }
 
   /** Seconds → m:ss for timestamps + player times. */

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -26,6 +26,7 @@ import {
   FoldersService,
   type FolderExposure,
 } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
 import { LockBadgeComponent } from "../folders/lock-badge.component";
 import { MoveToMenuComponent } from "../folders/move-to-menu.component";
 import { MeetingActionsComponent } from "./meeting-actions.component";
@@ -148,561 +149,635 @@ interface ParsedNote {
               }
             </div>
 
-            <!-- TAG EDITOR: chips + inline add (persists via setMeetingTags) -->
-            <div class="tag-editor">
-              @for (t of tags(); track t) {
-                <span class="pill tag-chip">
-                  {{ t }}
-                  <button
-                    type="button"
-                    class="tag-x"
-                    [attr.aria-label]="'Remove tag ' + t"
-                    [disabled]="tagsBusy()"
-                    (click)="removeTag(t)"
-                  >
-                    ×
-                  </button>
-                </span>
+            <!-- TAG EDITOR: chips + inline add (persists via setMeetingTags).
+                 Hidden while locked — there is nothing to tag on a masked note. -->
+            @if (!locked()) {
+              <div class="tag-editor">
+                @for (t of tags(); track t) {
+                  <span class="pill tag-chip">
+                    {{ t }}
+                    <button
+                      type="button"
+                      class="tag-x"
+                      [attr.aria-label]="'Remove tag ' + t"
+                      [disabled]="tagsBusy()"
+                      (click)="removeTag(t)"
+                    >
+                      ×
+                    </button>
+                  </span>
+                }
+                <input
+                  type="text"
+                  class="tag-input"
+                  placeholder="+ Add tag"
+                  aria-label="Add tag"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  [value]="tagDraft()"
+                  [disabled]="tagsBusy()"
+                  (input)="onTagInput($event)"
+                  (keydown.enter)="addTag()"
+                />
+              </div>
+              @if (tagsError(); as err) {
+                <span class="tag-error" role="alert">{{ err }}</span>
               }
-              <input
-                type="text"
-                class="tag-input"
-                placeholder="+ Add tag"
-                aria-label="Add tag"
-                autocapitalize="off"
-                autocomplete="off"
-                [value]="tagDraft()"
-                [disabled]="tagsBusy()"
-                (input)="onTagInput($event)"
-                (keydown.enter)="addTag()"
-              />
-            </div>
-            @if (tagsError(); as err) {
-              <span class="tag-error" role="alert">{{ err }}</span>
             }
           </div>
 
-          <div class="actions">
-            <button
-              type="button"
-              class="btn btn-primary"
-              (click)="resummarize(d.meeting.id)"
-              [disabled]="busy() || renaming()"
-            >
-              Re-summarize
-            </button>
-            @if (!renaming()) {
+          @if (!locked()) {
+            <div class="actions">
               <button
                 type="button"
-                class="btn btn-ghost"
-                (click)="startRename()"
-                [disabled]="busy()"
+                class="btn btn-primary"
+                (click)="resummarize(d.meeting.id)"
+                [disabled]="busy() || renaming()"
               >
-                Rename
+                Re-summarize
               </button>
-              <button
-                type="button"
-                class="btn btn-danger"
-                (click)="askDelete()"
-                [disabled]="busy()"
-              >
-                Delete
-              </button>
-
-              <!-- MOVE TO FOLDER: opens the folder picker popover. The picker
-                   itself owns the load-bearing encrypt/decrypt confirm. Layout
-                   is inline (no component-stylesheet rule) so it stays anchored
-                   to its trigger without growing the per-component style budget. -->
-              <div style="position: relative; display: inline-flex">
+              @if (!renaming()) {
                 <button
                   type="button"
                   class="btn btn-ghost"
-                  [attr.aria-expanded]="moveOpen()"
-                  aria-haspopup="menu"
-                  (click)="toggleMove()"
+                  (click)="startRename()"
                   [disabled]="busy()"
                 >
-                  Move to folder
+                  Rename
                 </button>
-                @if (moveOpen()) {
-                  <div
-                    style="position: absolute; top: calc(100% + 8px); left: 0; z-index: 30"
-                  >
-                    <app-move-to-menu
-                      [meetingId]="d.meeting.id"
-                      [currentFolderId]="d.meeting.folderId ?? null"
-                      (moved)="onMoved($event)"
-                      (close)="closeMove()"
-                    />
-                  </div>
-                }
-              </div>
-            }
+                <button
+                  type="button"
+                  class="btn btn-danger"
+                  (click)="askDelete()"
+                  [disabled]="busy()"
+                >
+                  Delete
+                </button>
 
-            <!-- EXPORT menu: copy / save note / save audio / print-to-PDF.
+                <!-- MOVE TO FOLDER: opens the folder picker popover. The picker
+                   itself owns the load-bearing encrypt/decrypt confirm. Layout
+                   is inline (no component-stylesheet rule) so it stays anchored
+                   to its trigger without growing the per-component style budget. -->
+                <div style="position: relative; display: inline-flex">
+                  <button
+                    type="button"
+                    class="btn btn-ghost"
+                    [attr.aria-expanded]="moveOpen()"
+                    aria-haspopup="menu"
+                    (click)="toggleMove()"
+                    [disabled]="busy()"
+                  >
+                    Move to folder
+                  </button>
+                  @if (moveOpen()) {
+                    <div
+                      style="position: absolute; top: calc(100% + 8px); left: 0; z-index: 30"
+                    >
+                      <app-move-to-menu
+                        [meetingId]="d.meeting.id"
+                        [currentFolderId]="d.meeting.folderId ?? null"
+                        (moved)="onMoved($event)"
+                        (close)="closeMove()"
+                      />
+                    </div>
+                  }
+                </div>
+              }
+
+              <!-- EXPORT menu: copy / save note / save audio / print-to-PDF.
                  Gated on a parsed note existing; disabled while editing it. -->
-            @if (note() && !renaming()) {
-              <div class="export" role="group" aria-label="Export">
-                <button
-                  type="button"
-                  class="btn btn-ghost export-btn"
-                  (click)="copyMarkdown()"
-                  [disabled]="editing() || busy()"
-                >
-                  {{ exportMsg() === "md-copied" ? "Copied" : "Copy Markdown" }}
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-ghost export-btn"
-                  (click)="saveMarkdown(d.meeting.id, d.meeting.title)"
-                  [disabled]="editing() || exporting()"
-                >
-                  {{ exportMsg() === "md-saved" ? "Saved" : "Save Markdown…" }}
-                </button>
-                @if (audioSrc()) {
+              @if (note() && !renaming()) {
+                <div class="export" role="group" aria-label="Export">
                   <button
                     type="button"
                     class="btn btn-ghost export-btn"
-                    (click)="saveAudio(d.meeting.id, d.meeting.title)"
+                    (click)="copyMarkdown()"
+                    [disabled]="editing() || busy()"
+                  >
+                    {{
+                      exportMsg() === "md-copied" ? "Copied" : "Copy Markdown"
+                    }}
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost export-btn"
+                    (click)="saveMarkdown(d.meeting.id, d.meeting.title)"
                     [disabled]="editing() || exporting()"
                   >
                     {{
-                      exportMsg() === "audio-saved" ? "Saved" : "Save audio…"
+                      exportMsg() === "md-saved" ? "Saved" : "Save Markdown…"
                     }}
                   </button>
-                }
-                <button
-                  type="button"
-                  class="btn btn-ghost export-btn"
-                  (click)="saveAsPdf()"
-                  [disabled]="editing()"
-                >
-                  Save as PDF
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-ghost export-btn"
-                  (click)="exportCanvas(d.meeting.id)"
-                  [disabled]="editing() || exportingCanvas()"
-                >
-                  {{ exportingCanvas() ? "Exporting…" : "Export Canvas" }}
-                </button>
-              </div>
-            }
-            @if (canvasMsg(); as path) {
-              <div class="saved-toast canvas-toast" role="status">
-                <span class="saved-toast-check" aria-hidden="true"></span>
-                Canvas saved · {{ path }}
-              </div>
-            }
-            @if (canvasError(); as err) {
-              <span class="msg msg-error" role="alert">{{ err }}</span>
-            }
-
-            <!-- CONNECT TO GRAPH: resolve people + projects into vault stubs.
-                 Gated on a parsed note existing; disabled while editing it. -->
-            @if (note() && !renaming()) {
-              <div class="graph-connect" role="group" aria-label="Graph">
-                <button
-                  type="button"
-                  class="btn btn-ghost export-btn"
-                  (click)="linkGraph()"
-                  [disabled]="editing() || linking()"
-                >
-                  {{ linking() ? "Linking…" : "Link people &amp; projects" }}
-                </button>
-              </div>
-            }
-
-            @if (exportError(); as err) {
-              <span class="msg msg-error" role="alert">{{ err }}</span>
-            }
-            @if (msg()) {
-              <span class="msg">{{ msg() }}</span>
-            }
-          </div>
-        </header>
-
-        <!-- Graph link result: resolved people + projects as chips + caption. -->
-        @if (graphError(); as err) {
-          <div class="card graph-card graph-card--error" role="alert">
-            {{ err }}
-          </div>
-        }
-        @if (graph(); as g) {
-          <div class="card graph-card" role="status">
-            @if (g.people.length || g.projects.length) {
-              <div class="graph-groups">
-                @if (g.people.length) {
-                  <div class="graph-group">
-                    <span class="graph-group-label">People</span>
-                    <div class="graph-pills">
-                      @for (p of g.people; track p) {
-                        <span class="pill tag">{{ p }}</span>
-                      }
-                    </div>
-                  </div>
-                }
-                @if (g.projects.length) {
-                  <div class="graph-group">
-                    <span class="graph-group-label">Projects</span>
-                    <div class="graph-pills">
-                      @for (pr of g.projects; track pr) {
-                        <span class="pill tag graph-pill--project">{{
-                          pr
-                        }}</span>
-                      }
-                    </div>
-                  </div>
-                }
-              </div>
-              <p class="graph-caption">
-                Added to your Obsidian vault graph (People/ &amp; Projects/)
-              </p>
-            } @else {
-              <p class="graph-caption">No people or projects to link yet.</p>
-            }
-          </div>
-        }
-
-        <!-- In-app delete confirmation (signal-driven; no window.confirm) ----- -->
-        @if (confirmingDelete()) {
-          <div
-            class="card confirm"
-            role="alertdialog"
-            aria-label="Delete meeting"
-          >
-            <div class="confirm-text">
-              <p class="confirm-title">Delete this meeting?</p>
-              <p class="confirm-copy">
-                This permanently removes the recording, transcript, summary and
-                the note in your vault. This can’t be undone.
-              </p>
-              @if (deleteError(); as err) {
-                <p class="confirm-error" role="alert">{{ err }}</p>
-              }
-            </div>
-            <div class="confirm-actions">
-              <button
-                type="button"
-                class="btn btn-ghost"
-                (click)="cancelDelete()"
-                [disabled]="deleting()"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                class="btn btn-danger"
-                (click)="confirmDelete(d.meeting.id)"
-                [disabled]="deleting()"
-              >
-                {{ deleting() ? "Deleting…" : "Delete" }}
-              </button>
-            </div>
-          </div>
-        }
-
-        <!-- 1) AUDIO PLAYER ------------------------------------------------ -->
-        @if (audioSrc(); as src) {
-          <div class="card player" [style.animation-delay.ms]="40">
-            <audio
-              #player
-              [src]="src"
-              preload="metadata"
-              (loadedmetadata)="onLoaded()"
-              (timeupdate)="onTimeUpdate()"
-              (play)="playing.set(true)"
-              (pause)="playing.set(false)"
-              (ended)="onEnded()"
-            ></audio>
-
-            <button
-              type="button"
-              class="play"
-              (click)="togglePlay()"
-              [attr.aria-label]="playing() ? 'Pause' : 'Play'"
-              [class.is-playing]="playing()"
-            >
-              @if (playing()) {
-                <span class="icon-pause" aria-hidden="true"></span>
-              } @else {
-                <span class="icon-play" aria-hidden="true"></span>
-              }
-            </button>
-
-            <div class="player-body">
-              <div
-                class="track"
-                role="slider"
-                tabindex="0"
-                aria-label="Seek"
-                [attr.aria-valuemin]="0"
-                [attr.aria-valuemax]="Math.round(duration())"
-                [attr.aria-valuenow]="Math.round(currentTime())"
-                (click)="seekFromEvent($event)"
-                (keydown)="onTrackKey($event)"
-              >
-                <div class="track-fill" [style.width.%]="progressPct()">
-                  <span class="track-knob"></span>
-                </div>
-              </div>
-              <div class="times">
-                <span class="time">{{ fmt(currentTime()) }}</span>
-                <span class="time time-total">{{ fmt(duration()) }}</span>
-              </div>
-            </div>
-          </div>
-        } @else {
-          <div class="card player player--empty">
-            <span class="audio-off" aria-hidden="true"></span>
-            <span class="audio-off-text">Audio not available</span>
-          </div>
-        }
-
-        <!-- 1b) INTERACTIVE TIMELINE (speakers + topics, shared playhead) -- -->
-        <app-meeting-timeline
-          [timeline]="timeline()"
-          [total]="timelineTotal()"
-          [currentTime]="currentTime()"
-          [loading]="timelineLoading()"
-          [error]="timelineError()"
-          [hasAudio]="!!audioSrc()"
-          (seek)="seekTo($event)"
-          (retry)="loadTimeline()"
-          (pin)="onPin($event)"
-          (renameSpeaker)="onRenameSpeaker($event)"
-        />
-
-        <!-- Pin confirmation / error (driven by the timeline's (pin) output). -->
-        @if (pinMsg(); as m) {
-          <div class="saved-toast pin-toast" role="status">
-            <span class="pin-toast-dot" aria-hidden="true"></span>
-            {{ m }}
-          </div>
-        }
-        @if (pinError(); as err) {
-          <div class="saved-toast pin-toast pin-toast--error" role="alert">
-            {{ err }}
-          </div>
-        }
-
-        <!-- 2) RICH ANALYSIS ---------------------------------------------- -->
-        <section class="block print-keep">
-          <div class="block-head">
-            <h3>Analysis</h3>
-            @if (!editing() && note()?.tags?.length) {
-              <div class="tags">
-                @for (t of note()!.tags; track t) {
-                  <span class="pill tag">{{ t }}</span>
-                }
-              </div>
-            }
-            @if (note() && !editing()) {
-              <button
-                type="button"
-                class="btn btn-ghost edit-btn"
-                (click)="startEdit()"
-              >
-                Edit
-              </button>
-            }
-          </div>
-
-          @if (note(); as n) {
-            @if (editing()) {
-              <!-- In-app note editor (raw markdown → re-written to the vault) -->
-              <article class="card editor">
-                <textarea
-                  class="editor-area"
-                  spellcheck="false"
-                  autocapitalize="off"
-                  autocomplete="off"
-                  aria-label="Note markdown"
-                  [value]="draft()"
-                  [disabled]="saving()"
-                  (input)="onDraftInput($event)"
-                ></textarea>
-
-                @if (saveError(); as err) {
-                  <p class="editor-error" role="alert">{{ err }}</p>
-                }
-
-                <div class="editor-foot">
-                  <span class="editor-hint"
-                    >Markdown · saved to your vault</span
-                  >
-                  <div class="editor-actions">
+                  @if (audioSrc()) {
                     <button
                       type="button"
-                      class="btn btn-ghost"
-                      (click)="cancelEdit()"
-                      [disabled]="saving()"
+                      class="btn btn-ghost export-btn"
+                      (click)="saveAudio(d.meeting.id, d.meeting.title)"
+                      [disabled]="editing() || exporting()"
                     >
-                      Cancel
+                      {{
+                        exportMsg() === "audio-saved" ? "Saved" : "Save audio…"
+                      }}
                     </button>
-                    <button
-                      type="button"
-                      class="btn btn-primary"
-                      (click)="saveNote()"
-                      [disabled]="saving()"
-                    >
-                      {{ saving() ? "Saving…" : "Save" }}
-                    </button>
-                  </div>
-                </div>
-              </article>
-            } @else {
-              @if (n.participants.length) {
-                <div class="card meta-card" [style.animation-delay.ms]="80">
-                  <span class="meta-card-label">Participants</span>
-                  <div class="people">
-                    @for (p of n.participants; track p) {
-                      <span class="person">{{ p }}</span>
-                    }
-                  </div>
-                </div>
-              }
-
-              @if (n.sections.length) {
-                @for (sec of n.sections; track sec.heading; let i = $index) {
-                  <article
-                    class="card section"
-                    [style.animation-delay.ms]="120 + i * 60"
-                  >
-                    <h4 class="section-head">{{ sec.heading }}</h4>
-
-                    @switch (sec.kind) {
-                      @case ("actions") {
-                        <ul class="checklist">
-                          @for (a of sec.actions; track $index) {
-                            <li class="check" [class.is-done]="a.done">
-                              <span
-                                class="check-box"
-                                [class.is-done]="a.done"
-                                aria-hidden="true"
-                              ></span>
-                              <span class="check-text">{{ a.text }}</span>
-                            </li>
-                          }
-                        </ul>
-                      }
-                      @case ("bullets") {
-                        <ul class="bullets">
-                          @for (b of sec.bullets; track $index) {
-                            <li class="bullet">{{ b }}</li>
-                          }
-                        </ul>
-                      }
-                      @default {
-                        <div class="prose">
-                          @for (para of sec.paragraphs; track $index) {
-                            <p>{{ para }}</p>
-                          }
-                        </div>
-                      }
-                    }
-                  </article>
-                }
-              } @else if (n.raw) {
-                <article class="card section" [style.animation-delay.ms]="120">
-                  <pre class="note-body">{{ n.raw }}</pre>
-                </article>
-              }
-
-              @if (justSaved()) {
-                <div class="saved-toast" role="status">
-                  <span class="saved-toast-check" aria-hidden="true"></span>
-                  Saved
-                </div>
-              }
-
-              @if (d.note?.exportedPath; as path) {
-                <div class="card saved" [style.animation-delay.ms]="160">
-                  <span class="saved-icon" aria-hidden="true"></span>
-                  <div class="saved-body">
-                    <span class="saved-label">Saved to vault</span>
-                    <span class="saved-path">{{ path }}</span>
-                  </div>
+                  }
                   <button
                     type="button"
-                    class="btn btn-ghost copy-btn"
-                    (click)="copy(path)"
+                    class="btn btn-ghost export-btn"
+                    (click)="saveAsPdf()"
+                    [disabled]="editing()"
                   >
-                    {{ copied() ? "Copied" : "Copy path" }}
+                    Save as PDF
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost export-btn"
+                    (click)="exportCanvas(d.meeting.id)"
+                    [disabled]="editing() || exportingCanvas()"
+                  >
+                    {{ exportingCanvas() ? "Exporting…" : "Export Canvas" }}
                   </button>
                 </div>
               }
-            }
-          } @else {
-            <div class="card empty-card empty-state">
-              <span class="empty-mark" aria-hidden="true"></span>
-              <p class="empty-title">No analysis yet</p>
-              <p class="empty">
-                Re-summarize this meeting to generate a structured note.
-              </p>
+              @if (canvasMsg(); as path) {
+                <div class="saved-toast canvas-toast" role="status">
+                  <span class="saved-toast-check" aria-hidden="true"></span>
+                  Canvas saved · {{ path }}
+                </div>
+              }
+              @if (canvasError(); as err) {
+                <span class="msg msg-error" role="alert">{{ err }}</span>
+              }
+
+              <!-- CONNECT TO GRAPH: resolve people + projects into vault stubs.
+                 Gated on a parsed note existing; disabled while editing it. -->
+              @if (note() && !renaming()) {
+                <div class="graph-connect" role="group" aria-label="Graph">
+                  <button
+                    type="button"
+                    class="btn btn-ghost export-btn"
+                    (click)="linkGraph()"
+                    [disabled]="editing() || linking()"
+                  >
+                    {{ linking() ? "Linking…" : "Link people &amp; projects" }}
+                  </button>
+                </div>
+              }
+
+              @if (exportError(); as err) {
+                <span class="msg msg-error" role="alert">{{ err }}</span>
+              }
+              @if (msg()) {
+                <span class="msg">{{ msg() }}</span>
+              }
             </div>
           }
-        </section>
+        </header>
 
-        <!-- 2·5) ACTION ITEMS (Reminders + Obsidian Tasks; hidden when none) - -->
-        <app-meeting-actions [meetingId]="d.meeting.id" />
-
-        <!-- 2a) RECIPES / GENERATE (grounded one-tap generations over text) - -->
-        <section class="block">
-          <div class="block-head">
-            <h3>Recipes</h3>
+        <!-- ============================================================= -->
+        <!-- PHASE 0.5 LOCK GATE — shown when the backend masked this       -->
+        <!-- meeting (sealed, not-session-unlocked folder). Replaces the    -->
+        <!-- note/transcript/audio/timeline/actions with a single frosted   -->
+        <!-- card + a biometric Unlock action. The masked "🔒 Locked" title -->
+        <!-- bar above still shows; the back-to-Meetings nav stays.         -->
+        <!-- ============================================================= -->
+        @if (locked()) {
+          <div
+            class="card empty-state"
+            role="group"
+            aria-labelledby="lock-gate-title"
+            style="animation: rise 420ms var(--transition) both"
+          >
+            <span
+              aria-hidden="true"
+              style="display: inline-flex; align-items: center; justify-content: center; width: 64px; height: 64px; margin-bottom: var(--space-2); border-radius: var(--radius-pill); background: var(--accent-soft); color: var(--accent-hover)"
+            >
+              <svg viewBox="0 0 24 24" width="28" height="28" fill="none">
+                <rect
+                  x="4.5"
+                  y="10.5"
+                  width="15"
+                  height="10.5"
+                  rx="2.4"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                />
+                <path
+                  d="M7.75 10.5V7.75a4.25 4.25 0 0 1 8.5 0V10.5"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                />
+                <circle cx="12" cy="15.4" r="1.6" fill="currentColor" />
+              </svg>
+            </span>
+            <p id="lock-gate-title" class="empty-title">
+              This meeting is locked
+            </p>
+            <p class="empty" style="max-width: 42ch">
+              It lives in a locked folder. Unlock to view the note, transcript
+              and audio.
+            </p>
+            <button
+              #unlockButton
+              type="button"
+              class="btn btn-primary"
+              style="margin-top: var(--space-2)"
+              (click)="unlock()"
+              [disabled]="unlocking()"
+            >
+              {{ unlocking() ? "Unlocking…" : "🔒 Unlock (Touch ID)" }}
+            </button>
           </div>
-          <app-meeting-recipes [meetingId]="d.meeting.id" />
-        </section>
+        }
 
-        <!-- 2b) CHAT WITH THIS MEETING (grounded Q&A over the transcript) -- -->
-        <section class="block">
-          <app-meeting-chat [meetingId]="d.meeting.id" />
-        </section>
+        @if (!locked()) {
+          <!-- Graph link result: resolved people + projects as chips + caption. -->
+          @if (graphError(); as err) {
+            <div class="card graph-card graph-card--error" role="alert">
+              {{ err }}
+            </div>
+          }
+          @if (graph(); as g) {
+            <div class="card graph-card" role="status">
+              @if (g.people.length || g.projects.length) {
+                <div class="graph-groups">
+                  @if (g.people.length) {
+                    <div class="graph-group">
+                      <span class="graph-group-label">People</span>
+                      <div class="graph-pills">
+                        @for (p of g.people; track p) {
+                          <span class="pill tag">{{ p }}</span>
+                        }
+                      </div>
+                    </div>
+                  }
+                  @if (g.projects.length) {
+                    <div class="graph-group">
+                      <span class="graph-group-label">Projects</span>
+                      <div class="graph-pills">
+                        @for (pr of g.projects; track pr) {
+                          <span class="pill tag graph-pill--project">{{
+                            pr
+                          }}</span>
+                        }
+                      </div>
+                    </div>
+                  }
+                </div>
+                <p class="graph-caption">
+                  Added to your Obsidian vault graph (People/ &amp; Projects/)
+                </p>
+              } @else {
+                <p class="graph-caption">No people or projects to link yet.</p>
+              }
+            </div>
+          }
 
-        <!-- 3) CLICK-TO-SEEK TRANSCRIPT ----------------------------------- -->
-        <section class="block">
-          <div class="block-head">
-            <h3>Transcript</h3>
-            @if (d.segments.length) {
-              <span class="count">{{ d.segments.length }}</span>
-            }
-          </div>
+          <!-- In-app delete confirmation (signal-driven; no window.confirm) ----- -->
+          @if (confirmingDelete()) {
+            <div
+              class="card confirm"
+              role="alertdialog"
+              aria-label="Delete meeting"
+            >
+              <div class="confirm-text">
+                <p class="confirm-title">Delete this meeting?</p>
+                <p class="confirm-copy">
+                  This permanently removes the recording, transcript, summary
+                  and the note in your vault. This can’t be undone.
+                </p>
+                @if (deleteError(); as err) {
+                  <p class="confirm-error" role="alert">{{ err }}</p>
+                }
+              </div>
+              <div class="confirm-actions">
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  (click)="cancelDelete()"
+                  [disabled]="deleting()"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-danger"
+                  (click)="confirmDelete(d.meeting.id)"
+                  [disabled]="deleting()"
+                >
+                  {{ deleting() ? "Deleting…" : "Delete" }}
+                </button>
+              </div>
+            </div>
+          }
 
-          @if (d.segments.length) {
-            <div class="card transcript-card" [style.animation-delay.ms]="200">
-              <ul class="segs">
-                @for (s of d.segments; track s.idx) {
-                  <li>
+          <!-- 1) AUDIO PLAYER ------------------------------------------------ -->
+          @if (audioSrc(); as src) {
+            <div class="card player" [style.animation-delay.ms]="40">
+              <audio
+                #player
+                [src]="src"
+                preload="metadata"
+                (loadedmetadata)="onLoaded()"
+                (timeupdate)="onTimeUpdate()"
+                (play)="playing.set(true)"
+                (pause)="playing.set(false)"
+                (ended)="onEnded()"
+              ></audio>
+
+              <button
+                type="button"
+                class="play"
+                (click)="togglePlay()"
+                [attr.aria-label]="playing() ? 'Pause' : 'Play'"
+                [class.is-playing]="playing()"
+              >
+                @if (playing()) {
+                  <span class="icon-pause" aria-hidden="true"></span>
+                } @else {
+                  <span class="icon-play" aria-hidden="true"></span>
+                }
+              </button>
+
+              <div class="player-body">
+                <div
+                  class="track"
+                  role="slider"
+                  tabindex="0"
+                  aria-label="Seek"
+                  [attr.aria-valuemin]="0"
+                  [attr.aria-valuemax]="Math.round(duration())"
+                  [attr.aria-valuenow]="Math.round(currentTime())"
+                  (click)="seekFromEvent($event)"
+                  (keydown)="onTrackKey($event)"
+                >
+                  <div class="track-fill" [style.width.%]="progressPct()">
+                    <span class="track-knob"></span>
+                  </div>
+                </div>
+                <div class="times">
+                  <span class="time">{{ fmt(currentTime()) }}</span>
+                  <span class="time time-total">{{ fmt(duration()) }}</span>
+                </div>
+              </div>
+            </div>
+          } @else {
+            <div class="card player player--empty">
+              <span class="audio-off" aria-hidden="true"></span>
+              <span class="audio-off-text">Audio not available</span>
+            </div>
+          }
+
+          <!-- 1b) INTERACTIVE TIMELINE (speakers + topics, shared playhead) -- -->
+          <app-meeting-timeline
+            [timeline]="timeline()"
+            [total]="timelineTotal()"
+            [currentTime]="currentTime()"
+            [loading]="timelineLoading()"
+            [error]="timelineError()"
+            [hasAudio]="!!audioSrc()"
+            (seek)="seekTo($event)"
+            (retry)="loadTimeline()"
+            (pin)="onPin($event)"
+            (renameSpeaker)="onRenameSpeaker($event)"
+          />
+
+          <!-- Pin confirmation / error (driven by the timeline's (pin) output). -->
+          @if (pinMsg(); as m) {
+            <div class="saved-toast pin-toast" role="status">
+              <span class="pin-toast-dot" aria-hidden="true"></span>
+              {{ m }}
+            </div>
+          }
+          @if (pinError(); as err) {
+            <div class="saved-toast pin-toast pin-toast--error" role="alert">
+              {{ err }}
+            </div>
+          }
+
+          <!-- 2) RICH ANALYSIS ---------------------------------------------- -->
+          <section class="block print-keep">
+            <div class="block-head">
+              <h3>Analysis</h3>
+              @if (!editing() && note()?.tags?.length) {
+                <div class="tags">
+                  @for (t of note()!.tags; track t) {
+                    <span class="pill tag">{{ t }}</span>
+                  }
+                </div>
+              }
+              @if (note() && !editing()) {
+                <button
+                  type="button"
+                  class="btn btn-ghost edit-btn"
+                  (click)="startEdit()"
+                >
+                  Edit
+                </button>
+              }
+            </div>
+
+            @if (note(); as n) {
+              @if (editing()) {
+                <!-- In-app note editor (raw markdown → re-written to the vault) -->
+                <article class="card editor">
+                  <textarea
+                    class="editor-area"
+                    spellcheck="false"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    aria-label="Note markdown"
+                    [value]="draft()"
+                    [disabled]="saving()"
+                    (input)="onDraftInput($event)"
+                  ></textarea>
+
+                  @if (saveError(); as err) {
+                    <p class="editor-error" role="alert">{{ err }}</p>
+                  }
+
+                  <div class="editor-foot">
+                    <span class="editor-hint"
+                      >Markdown · saved to your vault</span
+                    >
+                    <div class="editor-actions">
+                      <button
+                        type="button"
+                        class="btn btn-ghost"
+                        (click)="cancelEdit()"
+                        [disabled]="saving()"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-primary"
+                        (click)="saveNote()"
+                        [disabled]="saving()"
+                      >
+                        {{ saving() ? "Saving…" : "Save" }}
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              } @else {
+                @if (n.participants.length) {
+                  <div class="card meta-card" [style.animation-delay.ms]="80">
+                    <span class="meta-card-label">Participants</span>
+                    <div class="people">
+                      @for (p of n.participants; track p) {
+                        <span class="person">{{ p }}</span>
+                      }
+                    </div>
+                  </div>
+                }
+
+                @if (n.sections.length) {
+                  @for (sec of n.sections; track sec.heading; let i = $index) {
+                    <article
+                      class="card section"
+                      [style.animation-delay.ms]="120 + i * 60"
+                    >
+                      <h4 class="section-head">{{ sec.heading }}</h4>
+
+                      @switch (sec.kind) {
+                        @case ("actions") {
+                          <ul class="checklist">
+                            @for (a of sec.actions; track $index) {
+                              <li class="check" [class.is-done]="a.done">
+                                <span
+                                  class="check-box"
+                                  [class.is-done]="a.done"
+                                  aria-hidden="true"
+                                ></span>
+                                <span class="check-text">{{ a.text }}</span>
+                              </li>
+                            }
+                          </ul>
+                        }
+                        @case ("bullets") {
+                          <ul class="bullets">
+                            @for (b of sec.bullets; track $index) {
+                              <li class="bullet">{{ b }}</li>
+                            }
+                          </ul>
+                        }
+                        @default {
+                          <div class="prose">
+                            @for (para of sec.paragraphs; track $index) {
+                              <p>{{ para }}</p>
+                            }
+                          </div>
+                        }
+                      }
+                    </article>
+                  }
+                } @else if (n.raw) {
+                  <article
+                    class="card section"
+                    [style.animation-delay.ms]="120"
+                  >
+                    <pre class="note-body">{{ n.raw }}</pre>
+                  </article>
+                }
+
+                @if (justSaved()) {
+                  <div class="saved-toast" role="status">
+                    <span class="saved-toast-check" aria-hidden="true"></span>
+                    Saved
+                  </div>
+                }
+
+                @if (d.note?.exportedPath; as path) {
+                  <div class="card saved" [style.animation-delay.ms]="160">
+                    <span class="saved-icon" aria-hidden="true"></span>
+                    <div class="saved-body">
+                      <span class="saved-label">Saved to vault</span>
+                      <span class="saved-path">{{ path }}</span>
+                    </div>
                     <button
                       type="button"
-                      class="seg"
-                      [class.is-active]="isActiveSegment(s.startS, s.endS)"
-                      [disabled]="!audioSrc()"
-                      (click)="seekTo(s.startS)"
+                      class="btn btn-ghost copy-btn"
+                      (click)="copy(path)"
                     >
-                      <span class="seg-time">{{ fmt(s.startS) }}</span>
-                      @if (speakerChip(s.speaker); as chip) {
-                        <span
-                          class="seg-speaker"
-                          [style.background]="chip.bg"
-                          [style.color]="chip.fg"
-                          >{{ chip.label }}</span
-                        >
-                      }
-                      <span class="seg-text">{{ s.text }}</span>
+                      {{ copied() ? "Copied" : "Copy path" }}
                     </button>
-                  </li>
+                  </div>
                 }
-              </ul>
+              }
+            } @else {
+              <div class="card empty-card empty-state">
+                <span class="empty-mark" aria-hidden="true"></span>
+                <p class="empty-title">No analysis yet</p>
+                <p class="empty">
+                  Re-summarize this meeting to generate a structured note.
+                </p>
+              </div>
+            }
+          </section>
+
+          <!-- 2·5) ACTION ITEMS (Reminders + Obsidian Tasks; hidden when none) - -->
+          <app-meeting-actions [meetingId]="d.meeting.id" />
+
+          <!-- 2a) RECIPES / GENERATE (grounded one-tap generations over text) - -->
+          <section class="block">
+            <div class="block-head">
+              <h3>Recipes</h3>
             </div>
-          } @else {
-            <div class="card empty-card">
-              <p class="empty">No transcript.</p>
+            <app-meeting-recipes [meetingId]="d.meeting.id" />
+          </section>
+
+          <!-- 2b) CHAT WITH THIS MEETING (grounded Q&A over the transcript) -- -->
+          <section class="block">
+            <app-meeting-chat [meetingId]="d.meeting.id" />
+          </section>
+
+          <!-- 3) CLICK-TO-SEEK TRANSCRIPT ----------------------------------- -->
+          <section class="block">
+            <div class="block-head">
+              <h3>Transcript</h3>
+              @if (d.segments.length) {
+                <span class="count">{{ d.segments.length }}</span>
+              }
             </div>
-          }
-        </section>
+
+            @if (d.segments.length) {
+              <div
+                class="card transcript-card"
+                [style.animation-delay.ms]="200"
+              >
+                <ul class="segs">
+                  @for (s of d.segments; track s.idx) {
+                    <li>
+                      <button
+                        type="button"
+                        class="seg"
+                        [class.is-active]="isActiveSegment(s.startS, s.endS)"
+                        [disabled]="!audioSrc()"
+                        (click)="seekTo(s.startS)"
+                      >
+                        <span class="seg-time">{{ fmt(s.startS) }}</span>
+                        @if (speakerChip(s.speaker); as chip) {
+                          <span
+                            class="seg-speaker"
+                            [style.background]="chip.bg"
+                            [style.color]="chip.fg"
+                            >{{ chip.label }}</span
+                          >
+                        }
+                        <span class="seg-text">{{ s.text }}</span>
+                      </button>
+                    </li>
+                  }
+                </ul>
+              </div>
+            } @else {
+              <div class="card empty-card">
+                <p class="empty">No transcript.</p>
+              </div>
+            }
+          </section>
+        }
       } @else if (loading()) {
         <div class="card state-card">
           <p class="empty">Loading…</p>
@@ -1550,6 +1625,7 @@ export class DetailComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
 
   /** Exposed so the template can format aria values. */
   protected readonly Math = Math;
@@ -1558,6 +1634,19 @@ export class DetailComponent implements OnInit {
   readonly loading = signal(true);
   readonly busy = signal(false);
   readonly msg = signal("");
+
+  // --- Phase 0.5 lock gate -------------------------------------------------
+  /**
+   * True while the backend has MASKED this meeting (it lives in a sealed,
+   * not-session-unlocked folder). The template renders the lock gate instead
+   * of the note/transcript/audio/timeline/actions. Mirrors `detail()?.locked`.
+   */
+  readonly locked = computed(() => this.detail()?.locked === true);
+  /** True while an `unlockMeeting` biometric call is in flight (pending state). */
+  readonly unlocking = signal(false);
+  /** Focusable unlock button — focused after the gate renders (afterNextRender). */
+  private readonly unlockButton =
+    viewChild<ElementRef<HTMLButtonElement>>("unlockButton");
 
   // --- Move-to-folder popover ---------------------------------------------
   /** True while the folder-picker popover is open. */
@@ -1735,6 +1824,14 @@ export class DetailComponent implements OnInit {
     } finally {
       this.loading.set(false);
     }
+    // Locked (masked) meetings render the lock gate only — skip priming the
+    // timeline/tags (they're empty/masked) and focus the Unlock button instead.
+    if (this.locked()) {
+      afterNextRender(() => this.unlockButton()?.nativeElement.focus(), {
+        injector: this.injector,
+      });
+      return;
+    }
     // Kick the timeline off after the detail load; never blocks the page and
     // tolerates the first-call LLM latency (backend caches the result).
     if (this.detail()) {
@@ -1791,6 +1888,51 @@ export class DetailComponent implements OnInit {
       }
     }
     return null;
+  }
+
+  // --- Phase 0.5 lock gate -------------------------------------------------
+
+  /**
+   * Unlock this meeting's owning folder via the biometric (Touch ID) path, then
+   * RE-FETCH the now-unmasked detail and replace the `detail` signal in place so
+   * the note/transcript/audio/timeline render. The IPC returning null (root /
+   * already-open folder) is still treated as success — we re-fetch regardless.
+   * On failure (biometric denied / cancelled / error) we surface a toast and
+   * stay gated. Uses await (no subscribe-for-state); the button shows a pending
+   * state while in flight. Once unmasked, the timeline + tags are primed too.
+   */
+  async unlock(): Promise<void> {
+    const id = this.detail()?.meeting.id;
+    if (!id || this.unlocking()) {
+      return;
+    }
+    this.unlocking.set(true);
+    try {
+      // Run the biometric unlock_folder path for the meeting's folder.
+      await this.ipc.unlockMeeting(id);
+      // Re-fetch the now-unmasked detail and swap it in place. A null detail
+      // (deleted out from under us) keeps the not-found state honest.
+      const fresh = await this.ipc.getMeetingDetail(id);
+      this.detail.set(fresh);
+      if (fresh && !fresh.locked) {
+        // Refresh the folder tree so the header lock badge reflects the unlock,
+        // then prime the timeline + tags the masked load skipped. Non-blocking.
+        void this.folders.load();
+        void this.loadTimeline();
+        try {
+          this.tags.set(await this.ipc.getMeetingTags(id));
+        } catch {
+          this.tags.set([]);
+        }
+      }
+    } catch {
+      // Biometric denied / cancelled, or the unlock errored — stay gated.
+      this.toast.danger(
+        "Couldn’t unlock — authentication failed or cancelled.",
+      );
+    } finally {
+      this.unlocking.set(false);
+    }
   }
 
   /** Fetch (or re-fetch, via Retry) the AI-derived speaker + topic timeline. */

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -16,10 +16,17 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import type {
+  FolderNode,
   GraphPayload,
   MeetingDetail,
   MeetingTimeline,
 } from "../../core/models";
+import {
+  FoldersService,
+  type FolderExposure,
+} from "../../services/folders.service";
+import { LockBadgeComponent } from "../folders/lock-badge.component";
+import { MoveToMenuComponent } from "../folders/move-to-menu.component";
 import { MeetingActionsComponent } from "./meeting-actions.component";
 import { MeetingChatComponent } from "./meeting-chat.component";
 import { MeetingRecipesComponent } from "./meeting-recipes.component";
@@ -63,6 +70,8 @@ interface ParsedNote {
     MeetingActionsComponent,
     MeetingChatComponent,
     MeetingRecipesComponent,
+    LockBadgeComponent,
+    MoveToMenuComponent,
   ],
   template: `
     <section class="detail">
@@ -124,6 +133,18 @@ interface ParsedNote {
               <span class="meta-item">{{
                 formatDuration(d.meeting.durationS)
               }}</span>
+              <!-- Read-only folder + lock badge (where this note lives). -->
+              @if (folderBadge(); as fb) {
+                <span class="meta-sep" aria-hidden="true">·</span>
+                <span
+                  class="meta-item"
+                  style="display: inline-flex; align-items: center; gap: 4px"
+                  [attr.title]="fb.name"
+                >
+                  <app-lock-badge [exposure]="fb.exposure" />
+                  {{ fb.name }}
+                </span>
+              }
             </div>
 
             <!-- TAG EDITOR: chips + inline add (persists via setMeetingTags) -->
@@ -186,6 +207,35 @@ interface ParsedNote {
               >
                 Delete
               </button>
+
+              <!-- MOVE TO FOLDER: opens the folder picker popover. The picker
+                   itself owns the load-bearing encrypt/decrypt confirm. Layout
+                   is inline (no component-stylesheet rule) so it stays anchored
+                   to its trigger without growing the per-component style budget. -->
+              <div style="position: relative; display: inline-flex">
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  [attr.aria-expanded]="moveOpen()"
+                  aria-haspopup="menu"
+                  (click)="toggleMove()"
+                  [disabled]="busy()"
+                >
+                  Move to folder
+                </button>
+                @if (moveOpen()) {
+                  <div
+                    style="position: absolute; top: calc(100% + 8px); left: 0; z-index: 30"
+                  >
+                    <app-move-to-menu
+                      [meetingId]="d.meeting.id"
+                      [currentFolderId]="d.meeting.folderId ?? null"
+                      (moved)="onMoved($event)"
+                      (close)="closeMove()"
+                    />
+                  </div>
+                }
+              </div>
             }
 
             <!-- EXPORT menu: copy / save note / save audio / print-to-PDF.
@@ -781,6 +831,7 @@ interface ParsedNote {
         font-size: 0.8125rem;
       }
 
+      /* Read-only folder + lock badge in the meta row. */
       .actions {
         display: flex;
         flex-wrap: wrap;
@@ -1489,6 +1540,7 @@ export class DetailComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly folders = inject(FoldersService);
 
   /** Exposed so the template can format aria values. */
   protected readonly Math = Math;
@@ -1497,6 +1549,30 @@ export class DetailComponent implements OnInit {
   readonly loading = signal(true);
   readonly busy = signal(false);
   readonly msg = signal("");
+
+  // --- Move-to-folder popover ---------------------------------------------
+  /** True while the folder-picker popover is open. */
+  readonly moveOpen = signal(false);
+
+  /**
+   * Read-only folder badge for the header: the owning folder's name + exposure
+   * (open / locked / session), or null when the note is at the vault root or the
+   * folder isn't (yet) in the loaded tree. Reactive to both the meeting's
+   * `folderId` and the folders store, so a move/lock updates it live.
+   */
+  readonly folderBadge = computed<{
+    name: string;
+    exposure: FolderExposure;
+  } | null>(() => {
+    const fid = this.detail()?.meeting.folderId ?? null;
+    if (fid === null) {
+      return null;
+    }
+    const node = this.findFolder(this.folders.tree(), fid);
+    return node
+      ? { name: node.name, exposure: this.folders.exposureOf(node) }
+      : null;
+  });
 
   // --- Inline title rename state ------------------------------------------
   /** True while the header title is swapped for an inline text input. */
@@ -1654,6 +1730,10 @@ export class DetailComponent implements OnInit {
     // tolerates the first-call LLM latency (backend caches the result).
     if (this.detail()) {
       void this.loadTimeline();
+      // Prime the folder tree so the read-only folder/lock badge + the move
+      // picker have state on a direct navigation (idempotent; the root component
+      // also loads it). Non-blocking — a failure just hides the badge.
+      void this.folders.load();
       // Load the meeting's tags (best-effort; failure leaves the chips empty).
       try {
         this.tags.set(await this.ipc.getMeetingTags(id));
@@ -1661,6 +1741,47 @@ export class DetailComponent implements OnInit {
         this.tags.set([]);
       }
     }
+  }
+
+  // --- Move to folder ------------------------------------------------------
+
+  /** Open/close the folder-picker popover (closed while the detail is busy). */
+  toggleMove(): void {
+    if (this.busy()) {
+      return;
+    }
+    this.moveOpen.update((v) => !v);
+  }
+
+  /** Dismiss the folder-picker popover. */
+  closeMove(): void {
+    this.moveOpen.set(false);
+  }
+
+  /**
+   * Apply a completed move locally: patch the in-memory meeting's `folderId` so
+   * the header badge updates immediately (the picker already moved it via the
+   * service + reloaded the tree). Then close the popover.
+   */
+  onMoved(folderId: string | null): void {
+    this.detail.update((d) =>
+      d ? { ...d, meeting: { ...d.meeting, folderId } } : d,
+    );
+    this.closeMove();
+  }
+
+  /** Depth-first search for a folder node by id across the forest. */
+  private findFolder(nodes: FolderNode[], id: string): FolderNode | null {
+    for (const n of nodes) {
+      if (n.id === id) {
+        return n;
+      }
+      const hit = this.findFolder(n.children, id);
+      if (hit) {
+        return hit;
+      }
+    }
+    return null;
   }
 
   /** Fetch (or re-fetch, via Retry) the AI-derived speaker + topic timeline. */

--- a/src/app/features/folders/folder-drop.directive.ts
+++ b/src/app/features/folders/folder-drop.directive.ts
@@ -1,0 +1,106 @@
+import {
+  Directive,
+  ElementRef,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { NoteDragService } from "./note-drag.service";
+
+/**
+ * Makes its host a DROP TARGET for a meeting being dragged from the Library list
+ * (the enhancement path; the row's folder-chip popover is the guaranteed path).
+ *
+ * Responsibilities, all DOM-event plumbing kept OUT of the components:
+ *  - `dragover` → `preventDefault()` so the webview actually allows a drop
+ *    (WKWebView, like every browser, treats an un-prevented dragover as "no
+ *    drop allowed" and never fires `drop`).
+ *  - tracks an `over` signal while a note hovers, exposed via the `isDropTarget`
+ *    host class for the frosted highlight; only lights up for OUR payload.
+ *  - on `drop`, reads the dragged meeting id off the `DataTransfer` and emits
+ *    `dropNote` so the host screen runs the `moveNote` move.
+ *
+ * It does NOT perform the move itself or touch the folder store — single job.
+ */
+@Directive({
+  selector: "[appFolderDrop]",
+  standalone: true,
+  host: {
+    "[class.is-drop-target]": "over()",
+    "[class.is-drop-armed]": "armed()",
+    "(dragenter)": "onDragEnter($event)",
+    "(dragover)": "onDragOver($event)",
+    "(dragleave)": "onDragLeave($event)",
+    "(drop)": "onDrop($event)",
+  },
+})
+export class FolderDropDirective {
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly drag = inject(NoteDragService);
+
+  /**
+   * The folder id this target files INTO (null = vault root / "All notes").
+   * A drop emits `dropNote` with the dragged meeting id; the host pairs it with
+   * THIS target id to call `moveNote(meetingId, dropFolderId)`.
+   */
+  readonly dropFolderId = input<string | null>(null);
+
+  /** Emits the dragged meeting id when a note is dropped onto this target. */
+  readonly dropNote = output<string>();
+
+  /** True while a valid note is hovering directly over this target. */
+  private readonly _over = signal(false);
+  readonly over = this._over.asReadonly();
+
+  /**
+   * True whenever ANY note drag is in flight — used to gently arm every target
+   * (subtle dashed outline) so the user can see where notes can go the instant
+   * they pick a row up, not only once they hover a specific folder.
+   */
+  readonly armed = computed(() => this.drag.draggingId() !== null);
+
+  onDragEnter(event: DragEvent): void {
+    if (this.drag.draggingId() === null) {
+      return; // not our drag — ignore (e.g. a file dragged in from Finder)
+    }
+    event.preventDefault();
+    this._over.set(true);
+  }
+
+  onDragOver(event: DragEvent): void {
+    if (this.drag.draggingId() === null) {
+      return;
+    }
+    // MUST preventDefault or the webview never fires `drop`.
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "move";
+    }
+    this._over.set(true);
+  }
+
+  onDragLeave(event: DragEvent): void {
+    // Only clear when the pointer actually left the host subtree (dragleave
+    // also fires when crossing into a child element).
+    const related = event.relatedTarget as Node | null;
+    if (related && this.host.nativeElement.contains(related)) {
+      return;
+    }
+    this._over.set(false);
+  }
+
+  onDrop(event: DragEvent): void {
+    this._over.set(false);
+    const id =
+      event.dataTransfer?.getData(NoteDragService.MIME) ||
+      this.drag.draggingId();
+    this.drag.end();
+    if (!id) {
+      return;
+    }
+    event.preventDefault();
+    this.dropNote.emit(id);
+  }
+}

--- a/src/app/features/folders/folder-row.component.ts
+++ b/src/app/features/folders/folder-row.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  forwardRef,
   inject,
   input,
   output,
@@ -33,11 +34,17 @@ import { LockBadgeComponent } from "./lock-badge.component";
   selector: "app-folder-row",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [LockBadgeComponent, FolderTreeComponent],
+  // `folder-row` ↔ `folder-tree` are mutually recursive standalone components
+  // (a row renders its children through another tree). Their ES modules form a
+  // cycle, so a direct reference here is `undefined` at metadata-evaluation time
+  // — Angular would then hit `getComponentDef(undefined)` (reading 'ɵcmp') the
+  // first time a row instantiates a child tree. `forwardRef` defers the lookup
+  // until the def exists, breaking the cycle. (See folder-tree for the mirror.)
+  imports: [LockBadgeComponent, forwardRef(() => FolderTreeComponent)],
   template: `
     <div class="row-line" [style.--depth]="depth()">
       <!-- Disclosure caret (only when the folder has children) -->
-      @if (node().children.length) {
+      @if (childCount()) {
         <button
           type="button"
           class="caret"
@@ -204,9 +211,9 @@ import { LockBadgeComponent } from "./lock-badge.component";
     }
 
     <!-- Children: child-component recursion (NOT a nested @for of rows). -->
-    @if (expanded() && node().children.length) {
+    @if (expanded() && childCount()) {
       <app-folder-tree
-        [nodes]="node().children"
+        [nodes]="children()"
         [selectedId]="selectedId()"
         [depth]="depth() + 1"
         (select)="select.emit($event)"
@@ -397,6 +404,15 @@ export class FolderRowComponent {
   readonly exposure = computed<FolderExposure>(() =>
     this.folders.exposureOf(this.node()),
   );
+
+  /**
+   * This folder's children — always an array, even if the backend node omits
+   * the field. Keeps the disclosure caret + child recursion from ever reading
+   * `.length` off `undefined` (which would throw and blank the tree).
+   */
+  readonly children = computed<FolderNode[]>(() => this.node().children ?? []);
+  /** Number of children (drives the caret + recursion guards). */
+  readonly childCount = computed(() => this.children().length);
 
   toggleExpanded(): void {
     this.expanded.update((v) => !v);

--- a/src/app/features/folders/folder-row.component.ts
+++ b/src/app/features/folders/folder-row.component.ts
@@ -1,0 +1,436 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import {
+  FoldersService,
+  type FolderExposure,
+} from "../../services/folders.service";
+import type { FolderNode } from "../../core/models";
+import { FolderTreeComponent } from "./folder-tree.component";
+import { LockBadgeComponent } from "./lock-badge.component";
+
+/**
+ * One folder row in the tree: disclosure caret · name · note-count chip · inline
+ * {@link LockBadgeComponent} · a hover lock/unlock affordance. Selecting the row
+ * emits `select` (the folder id) so the parent screen can filter the meeting
+ * list; the row itself owns no selection state.
+ *
+ * Recursion is by CHILD COMPONENT — a row renders its children through a nested
+ * {@link FolderTreeComponent}, never a `@for`-of-rows inside a row. Each level's
+ * `depth` only drives the indent.
+ *
+ * Lock affordances delegate straight to {@link FoldersService}; the service
+ * reloads the tree, so this row re-renders with fresh flags (no local toggling
+ * of the backend-owned `locked` / `unlocked`).
+ */
+@Component({
+  selector: "app-folder-row",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LockBadgeComponent, FolderTreeComponent],
+  template: `
+    <div class="row-line" [style.--depth]="depth()">
+      <!-- Disclosure caret (only when the folder has children) -->
+      @if (node().children.length) {
+        <button
+          type="button"
+          class="caret"
+          [class.is-open]="expanded()"
+          [attr.aria-expanded]="expanded()"
+          [attr.aria-label]="
+            (expanded() ? 'Collapse ' : 'Expand ') + node().name
+          "
+          (click)="toggleExpanded()"
+        >
+          <svg viewBox="0 0 12 12" width="11" height="11" aria-hidden="true">
+            <path
+              d="M4.5 2.5 8 6l-3.5 3.5"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              fill="none"
+            />
+          </svg>
+        </button>
+      } @else {
+        <span class="caret caret--leaf" aria-hidden="true"></span>
+      }
+
+      <!-- The selectable folder button: name + lock badge + count chip -->
+      <button
+        type="button"
+        class="folder"
+        [class.is-selected]="selectedId() === node().id"
+        [attr.aria-pressed]="selectedId() === node().id"
+        (click)="select.emit(node().id)"
+      >
+        <span class="folder-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+            <path
+              d="M1.75 4.25c0-.7.55-1.25 1.25-1.25h2.8c.4 0 .77.18 1 .5l.6.75h4.6c.7 0 1.25.55 1.25 1.25v5.5c0 .7-.55 1.25-1.25 1.25H3c-.7 0-1.25-.55-1.25-1.25z"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        <span class="folder-name">{{ node().name }}</span>
+        <app-lock-badge [exposure]="exposure()" />
+        @if (node().noteCount > 0) {
+          <span class="count folder-count">{{ node().noteCount }}</span>
+        }
+      </button>
+
+      <!-- Lock / unlock affordance (revealed on hover/focus of the row) -->
+      <div class="row-actions">
+        @switch (exposure()) {
+          @case ("open") {
+            <button
+              type="button"
+              class="act-btn"
+              [disabled]="busy()"
+              [attr.aria-label]="'Lock ' + node().name"
+              title="Encrypt this folder"
+              (click)="onLock()"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          }
+          @case ("locked") {
+            <button
+              type="button"
+              class="act-btn"
+              [disabled]="busy()"
+              [attr.aria-label]="'Unlock ' + node().name + ' for this session'"
+              title="Unlock for this session"
+              (click)="onUnlock()"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          }
+          @case ("session") {
+            <button
+              type="button"
+              class="act-btn is-session"
+              [disabled]="busy()"
+              [attr.aria-label]="'Re-lock ' + node().name"
+              title="Re-seal now"
+              (click)="onRelock()"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          }
+        }
+      </div>
+    </div>
+
+    @if (lockError()) {
+      <p class="row-error" role="alert" [style.--depth]="depth()">
+        {{ lockError() }}
+      </p>
+    }
+
+    <!-- Children: child-component recursion (NOT a nested @for of rows). -->
+    @if (expanded() && node().children.length) {
+      <app-folder-tree
+        [nodes]="node().children"
+        [selectedId]="selectedId()"
+        [depth]="depth() + 1"
+        (select)="select.emit($event)"
+      />
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .row-line {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding-left: calc(var(--depth, 0) * var(--space-4));
+        border-radius: var(--radius-md);
+        transition: background var(--transition);
+      }
+      .row-line:hover {
+        background: var(--surface-hover);
+      }
+
+      .caret {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition:
+          transform var(--transition),
+          color var(--transition),
+          background var(--transition);
+      }
+      .caret:hover {
+        color: var(--text-primary);
+        background: var(--surface-input);
+      }
+      .caret.is-open {
+        transform: rotate(90deg);
+      }
+      .caret:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .caret--leaf {
+        cursor: default;
+      }
+
+      .folder {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: var(--space-2) var(--space-2);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font-family: inherit;
+        font-size: 0.9rem;
+        font-weight: 550;
+        letter-spacing: -0.01em;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition),
+          border-color var(--transition);
+      }
+      .folder:hover {
+        color: var(--text-primary);
+      }
+      .folder:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .folder.is-selected {
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+      }
+      .folder-icon {
+        display: inline-flex;
+        flex: none;
+        color: var(--text-muted);
+      }
+      .folder.is-selected .folder-icon {
+        color: var(--accent-hover);
+      }
+      .folder-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .folder-count {
+        margin-left: auto;
+        min-width: 22px;
+        height: 20px;
+      }
+
+      .row-actions {
+        display: inline-flex;
+        align-items: center;
+        flex: none;
+        opacity: 0;
+        transition: opacity var(--transition);
+      }
+      .row-line:hover .row-actions,
+      .row-line:focus-within .row-actions {
+        opacity: 1;
+      }
+      .act-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition),
+          border-color var(--transition),
+          transform var(--transition-fast);
+      }
+      .act-btn:hover {
+        color: var(--text-primary);
+        border-color: var(--border-strong);
+      }
+      .act-btn.is-session {
+        color: var(--accent-hover);
+      }
+      .act-btn:active {
+        transform: scale(0.92);
+      }
+      .act-btn:focus-visible {
+        outline: none;
+        opacity: 1;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .act-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      .row-error {
+        margin: var(--space-1) 0 var(--space-2);
+        padding-left: calc(var(--depth, 0) * var(--space-4) + var(--space-5));
+        color: var(--danger);
+        font-size: 0.78rem;
+      }
+    `,
+  ],
+})
+export class FolderRowComponent {
+  private readonly folders = inject(FoldersService);
+
+  /** This row's folder node. */
+  readonly node = input.required<FolderNode>();
+  /** The currently-selected folder id (null = vault root) — drives the highlight. */
+  readonly selectedId = input<string | null>(null);
+  /** Indent depth (0 at the roots). */
+  readonly depth = input<number>(0);
+
+  /** Emits the folder id when this row (or a descendant) is chosen. */
+  readonly select = output<string | null>();
+
+  /** Whether this row's children subtree is shown. Roots start expanded. */
+  readonly expanded = signal(true);
+  /** True while a lock op for THIS row is in flight (guards the affordance). */
+  readonly busy = signal(false);
+  /** Per-row lock error (cleared on the next attempt). */
+  readonly lockError = signal<string | null>(null);
+
+  /** This folder's privacy exposure, derived from its lock flags. */
+  readonly exposure = computed<FolderExposure>(() =>
+    this.folders.exposureOf(this.node()),
+  );
+
+  toggleExpanded(): void {
+    this.expanded.update((v) => !v);
+  }
+
+  /** Seal this folder (delegates to the service; tree reload re-renders the row). */
+  async onLock(): Promise<void> {
+    await this.run(() => this.folders.lock(this.node().id));
+  }
+
+  /** Session-unlock this folder. */
+  async onUnlock(): Promise<void> {
+    await this.run(() => this.folders.unlock(this.node().id));
+  }
+
+  /** Re-seal this session-unlocked folder. */
+  async onRelock(): Promise<void> {
+    await this.run(() => this.folders.relock(this.node().id));
+  }
+
+  /** Shared lock-op runner: guard, await, surface a per-row error on failure. */
+  private async run(op: () => Promise<void>): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    this.busy.set(true);
+    this.lockError.set(null);
+    try {
+      await op();
+    } catch {
+      // Leave the message visible until the next op (no component timer).
+      this.lockError.set("Couldn’t change this folder’s lock. Try again.");
+    } finally {
+      this.busy.set(false);
+    }
+  }
+}

--- a/src/app/features/folders/folder-row.component.ts
+++ b/src/app/features/folders/folder-row.component.ts
@@ -14,13 +14,25 @@ import {
 } from "../../services/folders.service";
 import type { FolderNode } from "../../core/models";
 import { FolderTreeComponent } from "./folder-tree.component";
-import { LockBadgeComponent } from "./lock-badge.component";
+import { FolderDropDirective } from "./folder-drop.directive";
 
 /**
- * One folder row in the tree: disclosure caret · name · note-count chip · inline
- * {@link LockBadgeComponent} · a hover lock/unlock affordance. Selecting the row
- * emits `select` (the folder id) so the parent screen can filter the meeting
- * list; the row itself owns no selection state.
+ * One folder row in the tree: disclosure caret · folder glyph · name · note-count
+ * chip · ONE unambiguous lock control. Selecting the row emits `select` (the
+ * folder id) so the parent screen can filter the meeting list; the row itself
+ * owns no selection state.
+ *
+ * SINGLE lock control (was a confusing double padlock — a passive badge AND a
+ * toggle). Now exactly one `lock-toggle` button per row carries BOTH the state
+ * and the action:
+ *   - open    → a faint open-padlock, revealed on hover; click = "Encrypt".
+ *   - locked  → a solid closed padlock, ALWAYS visible; click = "Unlock for
+ *               this session".
+ *   - session → an accent open-padlock, ALWAYS visible; click = "Re-seal now".
+ * State is read straight from the lock control, so there is no second glyph.
+ *
+ * The row is also a DROP TARGET (`appFolderDrop`): a meeting dragged from the
+ * list can be dropped here to file it into this folder.
  *
  * Recursion is by CHILD COMPONENT — a row renders its children through a nested
  * {@link FolderTreeComponent}, never a `@for`-of-rows inside a row. Each level's
@@ -40,9 +52,17 @@ import { LockBadgeComponent } from "./lock-badge.component";
   // — Angular would then hit `getComponentDef(undefined)` (reading 'ɵcmp') the
   // first time a row instantiates a child tree. `forwardRef` defers the lookup
   // until the def exists, breaking the cycle. (See folder-tree for the mirror.)
-  imports: [LockBadgeComponent, forwardRef(() => FolderTreeComponent)],
+  imports: [FolderDropDirective, forwardRef(() => FolderTreeComponent)],
   template: `
-    <div class="row-line" [style.--depth]="depth()">
+    <div
+      class="row-line"
+      [class.is-exposure-locked]="exposure() === 'locked'"
+      [class.is-exposure-session]="exposure() === 'session'"
+      [style.--depth]="depth()"
+      appFolderDrop
+      [dropFolderId]="node().id"
+      (dropNote)="dropNote.emit({ meetingId: $event, folderId: node().id })"
+    >
       <!-- Disclosure caret (only when the folder has children) -->
       @if (childCount()) {
         <button
@@ -70,7 +90,8 @@ import { LockBadgeComponent } from "./lock-badge.component";
         <span class="caret caret--leaf" aria-hidden="true"></span>
       }
 
-      <!-- The selectable folder button: name + lock badge + count chip -->
+      <!-- The selectable folder button: glyph + name + count chip.
+           NO lock badge here — the single lock control (below) owns lock state. -->
       <button
         type="button"
         class="folder"
@@ -89,58 +110,26 @@ import { LockBadgeComponent } from "./lock-badge.component";
           </svg>
         </span>
         <span class="folder-name">{{ node().name }}</span>
-        <app-lock-badge [exposure]="exposure()" />
         @if (node().noteCount > 0) {
           <span class="count folder-count">{{ node().noteCount }}</span>
         }
       </button>
 
-      <!-- Lock / unlock affordance (revealed on hover/focus of the row) -->
+      <!-- ONE lock control. It is the state AND the action: a single padlock per
+           row. Always visible while locked/session (so the privacy state always
+           reads); revealed on hover for an open folder (the "encrypt" action). -->
       <div class="row-actions">
         @switch (exposure()) {
           @case ("open") {
             <button
               type="button"
-              class="act-btn"
+              class="lock-toggle"
               [disabled]="busy()"
               [attr.aria-label]="'Lock ' + node().name"
               title="Encrypt this folder"
               (click)="onLock()"
             >
-              <svg
-                viewBox="0 0 16 16"
-                width="14"
-                height="14"
-                fill="none"
-                aria-hidden="true"
-              >
-                <rect
-                  x="3.5"
-                  y="7"
-                  width="9"
-                  height="6"
-                  rx="1.4"
-                  stroke="currentColor"
-                  stroke-width="1.3"
-                />
-                <path
-                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
-                  stroke="currentColor"
-                  stroke-width="1.3"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          }
-          @case ("locked") {
-            <button
-              type="button"
-              class="act-btn"
-              [disabled]="busy()"
-              [attr.aria-label]="'Unlock ' + node().name + ' for this session'"
-              title="Unlock for this session"
-              (click)="onUnlock()"
-            >
+              <!-- open padlock (shackle up & off the body) -->
               <svg
                 viewBox="0 0 16 16"
                 width="14"
@@ -166,15 +155,53 @@ import { LockBadgeComponent } from "./lock-badge.component";
               </svg>
             </button>
           }
+          @case ("locked") {
+            <button
+              type="button"
+              class="lock-toggle is-locked"
+              [disabled]="busy()"
+              [attr.aria-label]="'Unlock ' + node().name + ' for this session'"
+              title="Locked — click to unlock for this session"
+              (click)="onUnlock()"
+            >
+              <!-- closed padlock, filled body -->
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  fill="currentColor"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+                <circle cx="8" cy="10" r="1" fill="var(--surface-base)" />
+              </svg>
+            </button>
+          }
           @case ("session") {
             <button
               type="button"
-              class="act-btn is-session"
+              class="lock-toggle is-session"
               [disabled]="busy()"
               [attr.aria-label]="'Re-lock ' + node().name"
-              title="Re-seal now"
+              title="Unlocked this session — click to re-seal now"
               (click)="onRelock()"
             >
+              <!-- open padlock, accent — plaintext exposed this session -->
               <svg
                 viewBox="0 0 16 16"
                 width="14"
@@ -189,14 +216,15 @@ import { LockBadgeComponent } from "./lock-badge.component";
                   height="6"
                   rx="1.4"
                   stroke="currentColor"
-                  stroke-width="1.3"
+                  stroke-width="1.4"
                 />
                 <path
-                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65"
                   stroke="currentColor"
-                  stroke-width="1.3"
+                  stroke-width="1.4"
                   stroke-linecap="round"
                 />
+                <circle cx="8" cy="10" r="1.05" fill="currentColor" />
               </svg>
             </button>
           }
@@ -217,6 +245,7 @@ import { LockBadgeComponent } from "./lock-badge.component";
         [selectedId]="selectedId()"
         [depth]="depth() + 1"
         (select)="select.emit($event)"
+        (dropNote)="dropNote.emit($event)"
       />
     }
   `,
@@ -230,11 +259,33 @@ import { LockBadgeComponent } from "./lock-badge.component";
         align-items: center;
         gap: var(--space-1);
         padding-left: calc(var(--depth, 0) * var(--space-4));
+        border: 1px solid transparent;
         border-radius: var(--radius-md);
-        transition: background var(--transition);
+        transition:
+          background var(--transition),
+          border-color var(--transition),
+          box-shadow var(--transition);
       }
       .row-line:hover {
         background: var(--surface-hover);
+      }
+
+      /* --- Drop target (a note dragged from the list) --------------------- */
+      /* Armed: every folder shows a faint dashed hint the instant a drag starts. */
+      .row-line.is-drop-armed {
+        border-color: var(--border-strong);
+        border-style: dashed;
+      }
+      /* Active: the folder under the pointer lights up with the accent. */
+      .row-line.is-drop-target {
+        border-style: solid;
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .row-line.is-drop-target .folder,
+      .row-line.is-drop-target .folder-icon {
+        color: var(--accent-hover);
       }
 
       .caret {
@@ -322,18 +373,14 @@ import { LockBadgeComponent } from "./lock-badge.component";
         height: 20px;
       }
 
+      /* --- ONE lock control: state + action in a single button ----------- */
       .row-actions {
         display: inline-flex;
         align-items: center;
         flex: none;
-        opacity: 0;
-        transition: opacity var(--transition);
+        margin-right: 2px;
       }
-      .row-line:hover .row-actions,
-      .row-line:focus-within .row-actions {
-        opacity: 1;
-      }
-      .act-btn {
+      .lock-toggle {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -342,33 +389,72 @@ import { LockBadgeComponent } from "./lock-badge.component";
         padding: 0;
         border: 1px solid transparent;
         border-radius: var(--radius-sm);
-        background: var(--surface-input);
-        color: var(--text-secondary);
+        background: transparent;
+        color: var(--text-muted);
         cursor: pointer;
+        /* OPEN folders: the lock action is quiet until the row is hovered. */
+        opacity: 0;
         transition:
           color var(--transition),
           background var(--transition),
           border-color var(--transition),
+          opacity var(--transition),
           transform var(--transition-fast);
       }
-      .act-btn:hover {
+      .row-line:hover .lock-toggle,
+      .row-line:focus-within .lock-toggle {
+        opacity: 1;
+      }
+      /* LOCKED / SESSION: always visible — the control IS the state badge. */
+      .lock-toggle.is-locked,
+      .lock-toggle.is-session {
+        opacity: 1;
+        background: var(--surface-input);
+      }
+      .lock-toggle.is-locked {
+        color: var(--text-secondary);
+      }
+      .lock-toggle.is-session {
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+        /* a gentle one-shot pop when a folder unseals for the session */
+        animation: lock-pop 220ms var(--ease-spring) both;
+      }
+      .lock-toggle:hover:not(:disabled) {
         color: var(--text-primary);
+        background: var(--surface-hover);
         border-color: var(--border-strong);
       }
-      .act-btn.is-session {
+      .lock-toggle.is-session:hover:not(:disabled) {
         color: var(--accent-hover);
+        border-color: var(--accent);
       }
-      .act-btn:active {
+      .lock-toggle:active:not(:disabled) {
         transform: scale(0.92);
       }
-      .act-btn:focus-visible {
+      .lock-toggle:focus-visible {
         outline: none;
         opacity: 1;
         box-shadow: 0 0 0 3px var(--accent-ring);
       }
-      .act-btn:disabled {
+      .lock-toggle:disabled {
         opacity: 0.4;
         cursor: not-allowed;
+      }
+      @keyframes lock-pop {
+        from {
+          transform: scale(0.55);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .lock-toggle.is-session {
+          animation: none;
+        }
       }
 
       .row-error {
@@ -392,6 +478,9 @@ export class FolderRowComponent {
 
   /** Emits the folder id when this row (or a descendant) is chosen. */
   readonly select = output<string | null>();
+
+  /** Emits when a dragged meeting is dropped onto this row (or a descendant). */
+  readonly dropNote = output<{ meetingId: string; folderId: string | null }>();
 
   /** Whether this row's children subtree is shown. Roots start expanded. */
   readonly expanded = signal(true);

--- a/src/app/features/folders/folder-tree.component.ts
+++ b/src/app/features/folders/folder-tree.component.ts
@@ -5,6 +5,7 @@ import {
   Injector,
   afterNextRender,
   computed,
+  forwardRef,
   inject,
   input,
   output,
@@ -12,6 +13,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { FoldersService } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
 import type { FolderNode } from "../../core/models";
 import { FolderRowComponent } from "./folder-row.component";
 
@@ -33,7 +35,14 @@ import { FolderRowComponent } from "./folder-row.component";
   selector: "app-folder-tree",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FolderRowComponent],
+  // `folder-tree` ↔ `folder-row` are mutually recursive standalone components,
+  // so their ES modules form an import cycle. Referencing `FolderRowComponent`
+  // directly here is `undefined` at metadata-evaluation time and Angular then
+  // throws `getComponentDef(undefined)` (reading 'ɵcmp') the moment the `@for`
+  // below instantiates an `app-folder-row` — exactly the "view breaks after
+  // adding the first folder" bug. `forwardRef` defers the lookup, breaking the
+  // cycle. (See folder-row for the mirror.)
+  imports: [forwardRef(() => FolderRowComponent)],
   template: `
     <div class="tree" [class.is-root]="isRoot()">
       @if (isRoot()) {
@@ -75,7 +84,25 @@ import { FolderRowComponent } from "./folder-row.component";
       @if (isRoot()) {
         <!-- Inline "New folder" create (afterNextRender focus; not setTimeout) -->
         @if (creating()) {
-          <form class="new-folder" (submit)="confirmCreate($event)">
+          <form
+            class="new-folder"
+            [class.is-saving]="saving()"
+            (submit)="confirmCreate($event)"
+          >
+            <span class="new-folder-icon" aria-hidden="true">
+              @if (saving()) {
+                <span class="new-folder-spinner"></span>
+              } @else {
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="none">
+                  <path
+                    d="M1.75 4.25c0-.7.55-1.25 1.25-1.25h2.8c.4 0 .77.18 1 .5l.6.75h4.6c.7 0 1.25.55 1.25 1.25v5.5c0 .7-.55 1.25-1.25 1.25H3c-.7 0-1.25-.55-1.25-1.25z"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              }
+            </span>
             <input
               #nameInput
               type="text"
@@ -98,16 +125,29 @@ import { FolderRowComponent } from "./folder-row.component";
             </button>
             <button
               type="button"
-              class="btn btn-ghost"
+              class="new-folder-cancel"
+              aria-label="Cancel new folder"
               [disabled]="saving()"
               (click)="cancelCreate()"
             >
-              Cancel
+              <svg
+                viewBox="0 0 16 16"
+                width="13"
+                height="13"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+              </svg>
             </button>
           </form>
-          @if (createError()) {
-            <p class="tree-error" role="alert">{{ createError() }}</p>
-          }
+          <p class="new-folder-hint" aria-hidden="true">
+            Enter to create · Esc to cancel
+          </p>
         } @else {
           <button
             type="button"
@@ -221,36 +261,128 @@ import { FolderRowComponent } from "./folder-row.component";
         box-shadow: 0 0 0 3px var(--accent-ring);
       }
 
+      /* The inline create reads as one frosted field: an icon, the name input,
+         a primary "Add" and a quiet ✕ cancel — it slides in under the list. */
       .new-folder {
         display: flex;
         align-items: center;
         gap: var(--space-2);
         margin-top: var(--space-2);
+        padding: var(--space-1) var(--space-2);
+        border: 1px solid var(--accent);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        box-shadow: 0 0 0 3px var(--accent-ring);
+        animation: rise 200ms var(--ease-spring, var(--transition)) both;
+        transition:
+          border-color var(--transition),
+          box-shadow var(--transition),
+          opacity var(--transition);
+      }
+      .new-folder.is-saving {
+        opacity: 0.75;
+        border-color: var(--border-strong);
+        box-shadow: none;
+      }
+      .new-folder-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        width: 20px;
+        height: 20px;
+        color: var(--accent-hover);
+      }
+      .new-folder-spinner {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 2px solid var(--border-strong);
+        border-top-color: var(--accent-hover);
+        animation: nf-spin 700ms linear infinite;
+      }
+      @keyframes nf-spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
       .new-folder-input {
         flex: 1 1 auto;
         min-width: 0;
-        height: 36px;
+        height: 32px;
+        padding: 0 var(--space-1);
+        border: none;
+        background: transparent;
+        color: var(--text-primary);
+        font-family: inherit;
+        font-size: 0.9rem;
+        letter-spacing: -0.01em;
+      }
+      .new-folder-input:hover,
+      .new-folder-input:focus {
+        border: none;
+        background: transparent;
+        box-shadow: none;
+        outline: none;
+      }
+      .new-folder-input::placeholder {
+        color: var(--text-muted);
       }
       .new-folder-add {
-        height: 36px;
+        height: 28px;
         flex: none;
+        padding: 0 var(--space-3);
+        font-size: 0.8rem;
       }
-      .new-folder .btn-ghost {
-        height: 36px;
+      .new-folder-cancel {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         flex: none;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
       }
-
-      .tree-error {
-        margin: var(--space-1) 0 0;
-        color: var(--danger);
-        font-size: 0.78rem;
+      .new-folder-cancel:hover:not(:disabled) {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+      }
+      .new-folder-cancel:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .new-folder-cancel:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .new-folder-hint {
+        margin: var(--space-1) 0 0 var(--space-2);
+        color: var(--text-muted);
+        font-size: 0.72rem;
+        letter-spacing: 0.01em;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .new-folder {
+          animation: none;
+        }
+        .new-folder-spinner {
+          animation-duration: 1400ms;
+        }
       }
     `,
   ],
 })
 export class FolderTreeComponent {
   private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
   private readonly injector = inject(Injector);
 
   /** Nodes to render at this level. */
@@ -273,8 +405,6 @@ export class FolderTreeComponent {
   readonly draftName = signal("");
   /** True while the create IPC is in flight. */
   readonly saving = signal(false);
-  /** Create error (cleared when re-opening / re-submitting). */
-  readonly createError = signal<string | null>(null);
 
   /** The name field — focused after it renders (afterNextRender; no setTimeout). */
   private readonly nameInput =
@@ -282,7 +412,6 @@ export class FolderTreeComponent {
 
   /** Open the inline create field and move focus into it once it has rendered. */
   openCreate(): void {
-    this.createError.set(null);
     this.draftName.set("");
     this.creating.set(true);
     afterNextRender(() => this.nameInput()?.nativeElement.focus(), {
@@ -297,7 +426,6 @@ export class FolderTreeComponent {
     }
     this.creating.set(false);
     this.draftName.set("");
-    this.createError.set(null);
   }
 
   onNameInput(event: Event): void {
@@ -306,8 +434,10 @@ export class FolderTreeComponent {
 
   /**
    * Submit the new folder at the vault root. Awaits the service (which reloads
-   * the tree), then closes the field. On failure keeps the field open with an
-   * inline error so the user can retry.
+   * the tree), then closes the field and SELECTS the freshly-created folder so
+   * it's highlighted and its (empty) note list is shown — a clear success
+   * signal. On failure we keep the field open (so the typed name isn't lost)
+   * and surface a single danger toast; no inline error noise.
    */
   async confirmCreate(event: Event): Promise<void> {
     event.preventDefault();
@@ -316,13 +446,15 @@ export class FolderTreeComponent {
       return;
     }
     this.saving.set(true);
-    this.createError.set(null);
     try {
-      await this.folders.create(name, null);
+      const folder = await this.folders.create(name, null);
       this.creating.set(false);
       this.draftName.set("");
+      // Surface the new folder: select + highlight it (its row now exists in the
+      // reloaded tree). The parent screen filters the meeting list to it.
+      this.select.emit(folder.id);
     } catch {
-      this.createError.set("Couldn’t create that folder. Try another name.");
+      this.toast.danger("Couldn’t create that folder. Try another name.");
     } finally {
       this.saving.set(false);
     }

--- a/src/app/features/folders/folder-tree.component.ts
+++ b/src/app/features/folders/folder-tree.component.ts
@@ -1,0 +1,330 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { FoldersService } from "../../services/folders.service";
+import type { FolderNode } from "../../core/models";
+import { FolderRowComponent } from "./folder-row.component";
+
+/**
+ * The recursive folder tree. Renders `nodes` as {@link FolderRowComponent}s; the
+ * recursion is by child component — a row renders its children through ANOTHER
+ * `app-folder-tree`, never a nested `@for` of rows. This component is reused at
+ * every depth (the row passes `depth + 1`).
+ *
+ * At the ROOT (depth 0) it also owns:
+ *  - a "Vault root" pseudo-row so notes can be selected/moved to no folder, and
+ *  - an inline "New folder" create affordance (text field + confirm). Focus is
+ *    moved into the field with `afterNextRender` (no `setTimeout`); creation
+ *    delegates to {@link FoldersService.create}, which reloads the tree.
+ *
+ * Selection bubbles up via the `select` output (folder id, or null for root).
+ */
+@Component({
+  selector: "app-folder-tree",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FolderRowComponent],
+  template: `
+    <div class="tree" [class.is-root]="isRoot()">
+      @if (isRoot()) {
+        <!-- "Vault root" — selecting it filters to notes outside any folder. -->
+        <button
+          type="button"
+          class="root-row"
+          [class.is-selected]="selectedId() === null"
+          [attr.aria-pressed]="selectedId() === null"
+          (click)="select.emit(null)"
+        >
+          <span class="root-icon" aria-hidden="true">
+            <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+              <path
+                d="M2 13V5.5C2 4.7 2.7 4 3.5 4h3l1.5 1.7H12.5c.8 0 1.5.7 1.5 1.5V13"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="root-name">All notes</span>
+        </button>
+      }
+
+      @for (node of nodes(); track node.id) {
+        <app-folder-row
+          [node]="node"
+          [selectedId]="selectedId()"
+          [depth]="depth()"
+          (select)="select.emit($event)"
+        />
+      } @empty {
+        @if (isRoot()) {
+          <p class="tree-empty">No folders yet.</p>
+        }
+      }
+
+      @if (isRoot()) {
+        <!-- Inline "New folder" create (afterNextRender focus; not setTimeout) -->
+        @if (creating()) {
+          <form class="new-folder" (submit)="confirmCreate($event)">
+            <input
+              #nameInput
+              type="text"
+              class="new-folder-input"
+              placeholder="Folder name…"
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="New folder name"
+              [value]="draftName()"
+              [disabled]="saving()"
+              (input)="onNameInput($event)"
+              (keydown.escape)="cancelCreate()"
+            />
+            <button
+              type="submit"
+              class="btn btn-primary new-folder-add"
+              [disabled]="saving() || !draftName().trim()"
+            >
+              {{ saving() ? "Adding…" : "Add" }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost"
+              [disabled]="saving()"
+              (click)="cancelCreate()"
+            >
+              Cancel
+            </button>
+          </form>
+          @if (createError()) {
+            <p class="tree-error" role="alert">{{ createError() }}</p>
+          }
+        } @else {
+          <button
+            type="button"
+            class="new-folder-trigger"
+            (click)="openCreate()"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M8 3.5v9M3.5 8h9"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+            New folder
+          </button>
+        }
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .tree {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .root-row {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font-family: inherit;
+        font-size: 0.9rem;
+        font-weight: 550;
+        letter-spacing: -0.01em;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
+      }
+      .root-row:hover {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+      }
+      .root-row:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .root-row.is-selected {
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+      }
+      .root-icon {
+        display: inline-flex;
+        color: var(--text-muted);
+      }
+      .root-row.is-selected .root-icon {
+        color: var(--accent-hover);
+      }
+
+      .tree-empty {
+        margin: var(--space-1) 0 0 var(--space-3);
+        color: var(--text-muted);
+        font-size: 0.8125rem;
+      }
+
+      /* --- Inline create --- */
+      .new-folder-trigger {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        align-self: flex-start;
+        margin-top: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        border: 1px dashed var(--border-strong);
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font-family: inherit;
+        font-size: 0.85rem;
+        font-weight: 550;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          border-color var(--transition),
+          background var(--transition);
+      }
+      .new-folder-trigger:hover {
+        color: var(--text-primary);
+        border-color: var(--accent);
+        background: var(--accent-soft);
+      }
+      .new-folder-trigger:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+
+      .new-folder {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin-top: var(--space-2);
+      }
+      .new-folder-input {
+        flex: 1 1 auto;
+        min-width: 0;
+        height: 36px;
+      }
+      .new-folder-add {
+        height: 36px;
+        flex: none;
+      }
+      .new-folder .btn-ghost {
+        height: 36px;
+        flex: none;
+      }
+
+      .tree-error {
+        margin: var(--space-1) 0 0;
+        color: var(--danger);
+        font-size: 0.78rem;
+      }
+    `,
+  ],
+})
+export class FolderTreeComponent {
+  private readonly folders = inject(FoldersService);
+  private readonly injector = inject(Injector);
+
+  /** Nodes to render at this level. */
+  readonly nodes = input.required<FolderNode[]>();
+  /** Currently-selected folder id (null = vault root). */
+  readonly selectedId = input<string | null>(null);
+  /** Indent depth (0 at the roots; the inline create only shows at the root). */
+  readonly depth = input<number>(0);
+
+  /** Bubbles the chosen folder id (or null for the vault root) to the screen. */
+  readonly select = output<string | null>();
+
+  /** Whether THIS level is the tree root (owns "All notes" + create UI). */
+  readonly isRoot = computed(() => this.depth() === 0);
+
+  // --- Inline "new folder" create -----------------------------------------
+  /** True when the create field is open. */
+  readonly creating = signal(false);
+  /** Draft folder name bound to the field. */
+  readonly draftName = signal("");
+  /** True while the create IPC is in flight. */
+  readonly saving = signal(false);
+  /** Create error (cleared when re-opening / re-submitting). */
+  readonly createError = signal<string | null>(null);
+
+  /** The name field — focused after it renders (afterNextRender; no setTimeout). */
+  private readonly nameInput =
+    viewChild<ElementRef<HTMLInputElement>>("nameInput");
+
+  /** Open the inline create field and move focus into it once it has rendered. */
+  openCreate(): void {
+    this.createError.set(null);
+    this.draftName.set("");
+    this.creating.set(true);
+    afterNextRender(() => this.nameInput()?.nativeElement.focus(), {
+      injector: this.injector,
+    });
+  }
+
+  /** Close the create field without creating (ignored mid-save). */
+  cancelCreate(): void {
+    if (this.saving()) {
+      return;
+    }
+    this.creating.set(false);
+    this.draftName.set("");
+    this.createError.set(null);
+  }
+
+  onNameInput(event: Event): void {
+    this.draftName.set((event.target as HTMLInputElement).value);
+  }
+
+  /**
+   * Submit the new folder at the vault root. Awaits the service (which reloads
+   * the tree), then closes the field. On failure keeps the field open with an
+   * inline error so the user can retry.
+   */
+  async confirmCreate(event: Event): Promise<void> {
+    event.preventDefault();
+    const name = this.draftName().trim();
+    if (!name || this.saving()) {
+      return;
+    }
+    this.saving.set(true);
+    this.createError.set(null);
+    try {
+      await this.folders.create(name, null);
+      this.creating.set(false);
+      this.draftName.set("");
+    } catch {
+      this.createError.set("Couldn’t create that folder. Try another name.");
+    } finally {
+      this.saving.set(false);
+    }
+  }
+}

--- a/src/app/features/folders/folder-tree.component.ts
+++ b/src/app/features/folders/folder-tree.component.ts
@@ -192,10 +192,13 @@ import { FolderDropDirective } from "./folder-drop.directive";
       }
 
       .root-row {
-        display: inline-flex;
+        display: flex;
+        width: 100%;
+        min-width: 0;
         align-items: center;
         gap: var(--space-2);
         padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+        line-height: 1.3;
         border: 1px solid transparent;
         border-radius: var(--radius-md);
         background: transparent;
@@ -244,7 +247,15 @@ import { FolderDropDirective } from "./folder-drop.directive";
       }
       .root-icon {
         display: inline-flex;
+        flex: 0 0 auto;
         color: var(--text-muted);
+      }
+      .root-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .root-row.is-selected .root-icon {
         color: var(--accent-hover);

--- a/src/app/features/folders/folder-tree.component.ts
+++ b/src/app/features/folders/folder-tree.component.ts
@@ -16,6 +16,7 @@ import { FoldersService } from "../../services/folders.service";
 import { ToastService } from "../../services/toast.service";
 import type { FolderNode } from "../../core/models";
 import { FolderRowComponent } from "./folder-row.component";
+import { FolderDropDirective } from "./folder-drop.directive";
 
 /**
  * The recursive folder tree. Renders `nodes` as {@link FolderRowComponent}s; the
@@ -42,16 +43,20 @@ import { FolderRowComponent } from "./folder-row.component";
   // below instantiates an `app-folder-row` — exactly the "view breaks after
   // adding the first folder" bug. `forwardRef` defers the lookup, breaking the
   // cycle. (See folder-row for the mirror.)
-  imports: [forwardRef(() => FolderRowComponent)],
+  imports: [FolderDropDirective, forwardRef(() => FolderRowComponent)],
   template: `
     <div class="tree" [class.is-root]="isRoot()">
       @if (isRoot()) {
-        <!-- "Vault root" — selecting it filters to notes outside any folder. -->
+        <!-- "Vault root" — selecting it filters to notes outside any folder,
+             and it's a DROP TARGET so a note can be dragged out to the root. -->
         <button
           type="button"
           class="root-row"
           [class.is-selected]="selectedId() === null"
           [attr.aria-pressed]="selectedId() === null"
+          appFolderDrop
+          [dropFolderId]="null"
+          (dropNote)="dropNote.emit({ meetingId: $event, folderId: null })"
           (click)="select.emit(null)"
         >
           <span class="root-icon" aria-hidden="true">
@@ -74,6 +79,7 @@ import { FolderRowComponent } from "./folder-row.component";
           [selectedId]="selectedId()"
           [depth]="depth()"
           (select)="select.emit($event)"
+          (dropNote)="dropNote.emit($event)"
         />
       } @empty {
         @if (isRoot()) {
@@ -215,6 +221,26 @@ import { FolderRowComponent } from "./folder-row.component";
       .root-row.is-selected {
         color: var(--accent-hover);
         background: var(--accent-soft);
+      }
+      /* Drop target — armed (faint) while any note drags; lit under the pointer. */
+      .root-row {
+        border: 1px solid transparent;
+        transition:
+          color var(--transition),
+          background var(--transition),
+          border-color var(--transition),
+          box-shadow var(--transition);
+      }
+      .root-row.is-drop-armed {
+        border-color: var(--border-strong);
+        border-style: dashed;
+      }
+      .root-row.is-drop-target {
+        border-style: solid;
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        box-shadow: 0 0 0 3px var(--accent-ring);
       }
       .root-icon {
         display: inline-flex;
@@ -394,6 +420,9 @@ export class FolderTreeComponent {
 
   /** Bubbles the chosen folder id (or null for the vault root) to the screen. */
   readonly select = output<string | null>();
+
+  /** Bubbles a note dropped onto a folder (or the root) up to the screen. */
+  readonly dropNote = output<{ meetingId: string; folderId: string | null }>();
 
   /** Whether THIS level is the tree root (owns "All notes" + create UI). */
   readonly isRoot = computed(() => this.depth() === 0);

--- a/src/app/features/folders/lock-badge.component.ts
+++ b/src/app/features/folders/lock-badge.component.ts
@@ -1,0 +1,171 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
+import type { FolderExposure } from "../../services/folders.service";
+
+/**
+ * A pure, presentational 3-state privacy badge for a folder:
+ *  - `"open"`    — no glyph (the absence of a lock is itself the signal); a hair-
+ *                  line neutral dot keeps the slot from collapsing the row.
+ *  - `"locked"`  — a closed padlock (🔒): sealed + not visible this session.
+ *  - `"session"` — an open padlock (🔓), accent-tinted: sealed on disk but
+ *                  session-unlocked (plaintext visible until relock).
+ *
+ * Input-driven ONLY — no service, no state. The parent passes `exposure`; this
+ * component just paints it (inline SVG, tokens, an `aria-label` per state). It
+ * never sizes its own row; it sits inline at a fixed 16px box.
+ */
+@Component({
+  selector: "app-lock-badge",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "lock-badge",
+    "[class.is-open]": "exposure() === 'open'",
+    "[class.is-locked]": "exposure() === 'locked'",
+    "[class.is-session]": "exposure() === 'session'",
+    role: "img",
+    "[attr.aria-label]": "label()",
+    "[attr.title]": "label()",
+  },
+  template: `
+    @switch (exposure()) {
+      @case ("locked") {
+        <!-- Closed padlock: sealed, not visible this session. -->
+        <svg
+          viewBox="0 0 16 16"
+          width="13"
+          height="13"
+          fill="none"
+          aria-hidden="true"
+        >
+          <rect
+            x="3.25"
+            y="7"
+            width="9.5"
+            height="6.5"
+            rx="1.6"
+            stroke="currentColor"
+            stroke-width="1.4"
+          />
+          <path
+            d="M5.25 7V5.25a2.75 2.75 0 0 1 5.5 0V7"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+          />
+          <circle cx="8" cy="10.1" r="1.05" fill="currentColor" />
+        </svg>
+      }
+      @case ("session") {
+        <!-- Open padlock: session-unlocked (plaintext visible until relock). -->
+        <svg
+          viewBox="0 0 16 16"
+          width="13"
+          height="13"
+          fill="none"
+          aria-hidden="true"
+        >
+          <rect
+            x="3.25"
+            y="7"
+            width="9.5"
+            height="6.5"
+            rx="1.6"
+            stroke="currentColor"
+            stroke-width="1.4"
+          />
+          <path
+            d="M5.25 7V5.25a2.75 2.75 0 0 1 5.4-0.7"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+          />
+          <circle cx="8" cy="10.1" r="1.05" fill="currentColor" />
+        </svg>
+      }
+      @default {
+        <!-- Open folder: no lock; a faint dot holds the slot. -->
+        <span class="open-dot" aria-hidden="true"></span>
+      }
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        flex: none;
+        border-radius: var(--radius-pill);
+        transition:
+          color var(--transition),
+          background var(--transition),
+          transform var(--transition-fast);
+      }
+      :host svg {
+        display: block;
+      }
+      :host.is-open {
+        color: var(--text-muted);
+      }
+      :host.is-locked {
+        color: var(--text-secondary);
+      }
+      :host.is-session {
+        color: var(--accent-hover);
+      }
+      .open-dot {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: currentColor;
+        opacity: 0.45;
+      }
+      /* A gentle one-shot pop when a folder seals/unseals, never a loop. */
+      :host.is-session,
+      :host.is-locked {
+        animation: lock-pop 220ms var(--ease-spring) both;
+      }
+      @keyframes lock-pop {
+        from {
+          transform: scale(0.6);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        :host,
+        :host.is-session,
+        :host.is-locked {
+          animation: none;
+          transition: none;
+        }
+      }
+    `,
+  ],
+})
+export class LockBadgeComponent {
+  /** The folder's privacy exposure (open / locked / session). */
+  readonly exposure = input.required<FolderExposure>();
+
+  /** Screen-reader + tooltip label, derived from the exposure state. */
+  readonly label = computed(() => {
+    switch (this.exposure()) {
+      case "locked":
+        return "Locked — sealed and hidden";
+      case "session":
+        return "Unlocked for this session";
+      default:
+        return "Open folder";
+    }
+  });
+}

--- a/src/app/features/folders/move-to-menu.component.ts
+++ b/src/app/features/folders/move-to-menu.component.ts
@@ -306,7 +306,8 @@ export class MoveToMenuComponent {
     const walk = (nodes: FolderNode[], depth: number): void => {
       for (const node of nodes) {
         out.push({ node, depth });
-        if (node.children.length) {
+        // Defensive: tolerate a node without a `children` array.
+        if (node.children?.length) {
           walk(node.children, depth + 1);
         }
       }

--- a/src/app/features/folders/move-to-menu.component.ts
+++ b/src/app/features/folders/move-to-menu.component.ts
@@ -1,0 +1,409 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { FoldersService } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
+import type { FolderNode } from "../../core/models";
+import { LockBadgeComponent } from "./lock-badge.component";
+
+/** A flattened, indented folder option for the picker list. */
+interface FolderOption {
+  node: FolderNode;
+  depth: number;
+}
+
+/**
+ * "Move to…" popover — a folder picker (NOT drag-and-drop). The host renders the
+ * trigger; this popover lists every folder (plus "All notes" / vault root) and,
+ * on pick, moves `meetingId` via {@link FoldersService.moveNote}.
+ *
+ * Load-bearing confirm: a move that crosses an encryption boundary is destructive
+ * to the on-disk plaintext, so it MUST be confirmed first:
+ *  - INTO a locked folder  → "encrypts + removes the Markdown from your vault".
+ *  - OUT OF a locked folder → "re-exports the plaintext Markdown to your vault".
+ * A move between two open folders (or open↔root) needs no confirm and applies
+ * immediately. The confirm copy names the exact consequence — never a bare
+ * "Are you sure?".
+ */
+@Component({
+  selector: "app-move-to-menu",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LockBadgeComponent],
+  template: `
+    <div class="menu card" role="menu" aria-label="Move note to folder">
+      <header class="menu-head">
+        <h4 class="menu-title">Move to…</h4>
+        <button
+          type="button"
+          class="menu-close"
+          aria-label="Close move menu"
+          (click)="close.emit()"
+        >
+          <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+
+      @if (pending(); as target) {
+        <!-- Load-bearing confirm for a cross-encryption-boundary move -->
+        <div class="confirm" role="alertdialog" aria-modal="true">
+          <p class="confirm-title">{{ confirmTitle() }}</p>
+          <p class="confirm-body">{{ confirmBody() }}</p>
+          @if (moveError()) {
+            <p class="confirm-error" role="alert">{{ moveError() }}</p>
+          }
+          <div class="confirm-actions">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              [disabled]="moving()"
+              (click)="cancelConfirm()"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              [disabled]="moving()"
+              (click)="applyMove(target.id)"
+            >
+              {{ moving() ? "Moving…" : confirmCta() }}
+            </button>
+          </div>
+        </div>
+      } @else {
+        <ul class="opts">
+          <!-- Vault root -->
+          <li>
+            <button
+              type="button"
+              class="opt"
+              role="menuitem"
+              [class.is-current]="currentFolderId() === null"
+              [disabled]="moving() || currentFolderId() === null"
+              (click)="pick(null)"
+            >
+              <span class="opt-name">All notes (vault root)</span>
+              @if (currentFolderId() === null) {
+                <span class="opt-here">Here</span>
+              }
+            </button>
+          </li>
+
+          @for (opt of options(); track opt.node.id) {
+            <li>
+              <button
+                type="button"
+                class="opt"
+                role="menuitem"
+                [style.--depth]="opt.depth"
+                [class.is-current]="currentFolderId() === opt.node.id"
+                [disabled]="moving() || currentFolderId() === opt.node.id"
+                (click)="pick(opt.node.id)"
+              >
+                <span class="opt-name">{{ opt.node.name }}</span>
+                <app-lock-badge [exposure]="folders.exposureOf(opt.node)" />
+                @if (currentFolderId() === opt.node.id) {
+                  <span class="opt-here">Here</span>
+                }
+              </button>
+            </li>
+          } @empty {
+            <li><p class="opts-empty">No folders to move into.</p></li>
+          }
+        </ul>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .menu {
+        padding: var(--space-3);
+        min-width: 260px;
+        max-width: 320px;
+      }
+      .menu-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+        margin-bottom: var(--space-2);
+      }
+      .menu-title {
+        margin: 0;
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+      .menu-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        padding: 0;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        color: var(--text-muted);
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
+      }
+      .menu-close:hover {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+      }
+      .menu-close:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+
+      .opts {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        max-height: 280px;
+        overflow-y: auto;
+      }
+      .opt {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+        padding: var(--space-2) var(--space-2);
+        padding-left: calc(var(--space-2) + var(--depth, 0) * var(--space-4));
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font-family: inherit;
+        font-size: 0.875rem;
+        font-weight: 550;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
+      }
+      .opt:hover:not(:disabled) {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+      }
+      .opt:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .opt:disabled {
+        cursor: default;
+      }
+      .opt.is-current {
+        color: var(--text-muted);
+      }
+      .opt-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .opt-here {
+        flex: none;
+        padding: 0 var(--space-2);
+        border-radius: var(--radius-pill);
+        background: var(--surface-input);
+        color: var(--text-muted);
+        font-size: 0.7rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+      .opts-empty {
+        margin: var(--space-2);
+        color: var(--text-muted);
+        font-size: 0.8125rem;
+      }
+
+      /* --- Load-bearing confirm (names the exact destructive consequence) --- */
+      .confirm {
+        padding: var(--space-3);
+        border: 1px solid var(--warning);
+        border-radius: var(--radius-md);
+        background: var(--warning-soft);
+      }
+      .confirm-title {
+        margin: 0 0 var(--space-1);
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+      .confirm-body {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.5;
+      }
+      .confirm-error {
+        margin: var(--space-2) 0 0;
+        color: var(--danger);
+        font-size: 0.8rem;
+      }
+      .confirm-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--space-2);
+        margin-top: var(--space-4);
+      }
+    `,
+  ],
+})
+export class MoveToMenuComponent {
+  readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+
+  /** The note being moved. */
+  readonly meetingId = input.required<string>();
+  /** The note's current owning folder id (null = vault root) — drives "Here". */
+  readonly currentFolderId = input<string | null>(null);
+
+  /** Fired after a successful move, with the new folder id (null = root). */
+  readonly moved = output<string | null>();
+  /** Fired when the menu should be dismissed. */
+  readonly close = output<void>();
+
+  /** True while a move IPC is in flight. */
+  readonly moving = signal(false);
+  /** Non-null when the last move failed (kept until cancel / retry). */
+  readonly moveError = signal<string | null>(null);
+  /**
+   * The pending target awaiting a load-bearing confirm. Holds the target node
+   * (or null for the vault root, modelled as a sentinel id). Null = no confirm
+   * open and the option list is shown.
+   */
+  readonly pending = signal<{
+    id: string | null;
+    node: FolderNode | null;
+  } | null>(null);
+
+  /** Flattened, depth-indented folder options (depth-first). */
+  readonly options = computed<FolderOption[]>(() => {
+    const out: FolderOption[] = [];
+    const walk = (nodes: FolderNode[], depth: number): void => {
+      for (const node of nodes) {
+        out.push({ node, depth });
+        if (node.children.length) {
+          walk(node.children, depth + 1);
+        }
+      }
+    };
+    walk(this.folders.tree(), 0);
+    return out;
+  });
+
+  /** Find a node by id across the whole forest (for confirm copy / exposure). */
+  private nodeById(id: string | null): FolderNode | null {
+    if (id === null) {
+      return null;
+    }
+    return this.options().find((o) => o.node.id === id)?.node ?? null;
+  }
+
+  /** Whether the note currently lives in a sealed (locked) folder. */
+  private readonly sourceLocked = computed(() => {
+    const src = this.nodeById(this.currentFolderId());
+    return src?.locked ?? false;
+  });
+
+  /**
+   * Pick a target. If the move crosses an encryption boundary (into OR out of a
+   * locked folder) we open the load-bearing confirm; otherwise apply at once.
+   */
+  pick(targetId: string | null): void {
+    if (targetId === this.currentFolderId()) {
+      return; // already here
+    }
+    const targetNode = this.nodeById(targetId);
+    const intoLocked = targetNode?.locked ?? false;
+    const outOfLocked = this.sourceLocked();
+
+    if (intoLocked || outOfLocked) {
+      this.moveError.set(null);
+      this.pending.set({ id: targetId, node: targetNode });
+      return;
+    }
+    void this.applyMove(targetId);
+  }
+
+  /** Whether the pending move is INTO a locked folder (vs out of one). */
+  private readonly pendingIntoLocked = computed(
+    () => this.pending()?.node?.locked ?? false,
+  );
+
+  /** Confirm headline — names which boundary is being crossed. */
+  readonly confirmTitle = computed(() =>
+    this.pendingIntoLocked()
+      ? "Move into a locked folder?"
+      : "Move out of a locked folder?",
+  );
+
+  /** Confirm body — spells out the exact, irreversible-on-disk consequence. */
+  readonly confirmBody = computed(() => {
+    const name = this.pending()?.node?.name ?? "the vault root";
+    return this.pendingIntoLocked()
+      ? `This encrypts the note into “${name}” and removes its plaintext Markdown from your vault. It’ll only be readable while the folder is unlocked.`
+      : `This decrypts the note and re-exports its plaintext Markdown back into your vault at “${name}”.`;
+  });
+
+  /** Confirm primary-button label. */
+  readonly confirmCta = computed(() =>
+    this.pendingIntoLocked() ? "Encrypt & move" : "Re-export & move",
+  );
+
+  /** Dismiss the confirm and return to the option list. */
+  cancelConfirm(): void {
+    if (this.moving()) {
+      return;
+    }
+    this.pending.set(null);
+    this.moveError.set(null);
+  }
+
+  /**
+   * Perform the move. Awaits {@link FoldersService.moveNote} (which reloads the
+   * tree), toasts the outcome, emits `moved`, and closes. On failure the inline
+   * error is shown; the confirm/list stays open for a retry.
+   */
+  async applyMove(targetId: string | null): Promise<void> {
+    if (this.moving()) {
+      return;
+    }
+    this.moving.set(true);
+    this.moveError.set(null);
+    try {
+      await this.folders.moveNote(this.meetingId(), targetId);
+      const targetName = this.nodeById(targetId)?.name ?? "All notes";
+      this.toast.success(`Moved to ${targetName}`);
+      this.moved.emit(targetId);
+      this.close.emit();
+    } catch {
+      this.moveError.set("Couldn’t move this note. Please try again.");
+    } finally {
+      this.moving.set(false);
+    }
+  }
+}

--- a/src/app/features/folders/move-to-menu.component.ts
+++ b/src/app/features/folders/move-to-menu.component.ts
@@ -137,6 +137,14 @@ interface FolderOption {
         padding: var(--space-3);
         min-width: 260px;
         max-width: 320px;
+        /* Floating popover OVER the meeting list → must be OPAQUE. The global .card is a
+           frosted/translucent surface, which bled the list through (broken-looking modal). */
+        background: var(--surface-overlay);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-lg);
+        -webkit-backdrop-filter: none;
+        backdrop-filter: none;
       }
       .menu-head {
         display: flex;
@@ -245,7 +253,9 @@ interface FolderOption {
         padding: var(--space-3);
         border: 1px solid var(--warning);
         border-radius: var(--radius-md);
-        background: var(--warning-soft);
+        /* Opaque so nothing behind shows through; the warning border + halo carry the caution. */
+        background: var(--surface-overlay);
+        box-shadow: 0 0 0 4px var(--warning-soft);
       }
       .confirm-title {
         margin: 0 0 var(--space-1);

--- a/src/app/features/folders/note-drag.service.ts
+++ b/src/app/features/folders/note-drag.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, signal } from "@angular/core";
+
+/**
+ * Tiny coordinator for note → folder drag-and-drop within the Library.
+ *
+ * HTML5 drag-and-drop already carries the payload in the `DataTransfer`, but the
+ * webview (WKWebView) does NOT expose `getData()` during `dragover` — only on
+ * `drop`. The drop-target highlight needs to know "is a note being dragged right
+ * now?" DURING the drag, so we mirror the dragged meeting id into a signal here.
+ * Folders read {@link draggingId} to light up as valid targets; rows read it to
+ * dim the source. The signal is the single source of truth for the live drag.
+ *
+ * This is intentionally NOT the move itself — the actual `moveNote` IPC is fired
+ * by whoever owns the data (the Library), reading the id off the `DataTransfer`
+ * on `drop`. This service is purely the cross-component "a drag is in flight"
+ * readiness signal, mirroring the lock/exposure split used elsewhere.
+ */
+@Injectable({ providedIn: "root" })
+export class NoteDragService {
+  /** MIME-ish key the Library writes the dragged meeting id under. */
+  static readonly MIME = "application/x-murmur-note";
+
+  private readonly _draggingId = signal<string | null>(null);
+
+  /** The meeting id currently being dragged, or null when no drag is in flight. */
+  readonly draggingId = this._draggingId.asReadonly();
+
+  /** Mark a drag as started (called from the row's `dragstart`). */
+  begin(meetingId: string): void {
+    this._draggingId.set(meetingId);
+  }
+
+  /** Clear the drag (called on `dragend` / after a `drop`). */
+  end(): void {
+    this._draggingId.set(null);
+  }
+}

--- a/src/app/features/graph/entity-card.component.ts
+++ b/src/app/features/graph/entity-card.component.ts
@@ -1,0 +1,137 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from "@angular/core";
+import type { GraphNode } from "../../core/models";
+
+/**
+ * A single directory row in the graph's People/Projects list: a kind dot (cool
+ * accent for people, violet for projects), the entity name, and a tabular-nums
+ * mention-count chip. Selecting it emits the entity id so the container can open
+ * the detail panel. Purely presentational — no IPC, no state beyond inputs.
+ */
+@Component({
+  selector: "app-entity-card",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <button
+      type="button"
+      class="ec"
+      [class.is-project]="isProject()"
+      [class.is-selected]="selected()"
+      [attr.aria-pressed]="selected()"
+      [attr.aria-label]="
+        entity().name + ' — ' + kindLabel() + ', ' + countLabel()
+      "
+      (click)="select.emit(entity().id)"
+    >
+      <span class="ec-dot" aria-hidden="true"></span>
+      <span class="ec-name">{{ entity().name }}</span>
+      <span class="ec-kind" aria-hidden="true">{{ kindLabel() }}</span>
+      <span class="count ec-count" [attr.title]="countLabel()">
+        {{ entity().mentionCount }}
+      </span>
+    </button>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .ec {
+        display: grid;
+        grid-template-columns: auto 1fr auto auto;
+        align-items: center;
+        gap: var(--space-3);
+        width: 100%;
+        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--surface-raised);
+        color: var(--text-primary);
+        font-family: inherit;
+        font-size: 0.9375rem;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          border-color var(--transition),
+          transform var(--transition-fast),
+          box-shadow var(--transition);
+      }
+      .ec:hover {
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+        transform: translateY(-1px);
+      }
+      .ec:active {
+        transform: translateY(0);
+      }
+      .ec:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .ec.is-selected {
+        border-color: transparent;
+        background: var(--accent-soft);
+        box-shadow:
+          inset 0 0 0 1px var(--accent-ring),
+          var(--glass-highlight);
+      }
+      .ec-dot {
+        flex: none;
+        width: 9px;
+        height: 9px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      .ec.is-project .ec-dot {
+        background: #9d7bff;
+        box-shadow: 0 0 0 3px rgba(157, 123, 255, 0.18);
+      }
+      .ec-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 550;
+        letter-spacing: -0.01em;
+      }
+      .ec-kind {
+        flex: none;
+        color: var(--text-muted);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .ec-count {
+        flex: none;
+      }
+    `,
+  ],
+})
+export class EntityCardComponent {
+  /** The directory row to render (entity + its visible mention count). */
+  readonly entity = input.required<GraphNode>();
+  /** Whether this row is the currently-open entity in the detail panel. */
+  readonly selected = input(false);
+  /** Emits the entity id when the row is chosen. */
+  readonly select = output<string>();
+
+  protected readonly isProject = computed(
+    () => this.entity().kind === "project",
+  );
+  protected readonly kindLabel = computed(() =>
+    this.isProject() ? "Project" : "Person",
+  );
+  protected readonly countLabel = computed(() => {
+    const n = this.entity().mentionCount;
+    return n === 1 ? "1 mention" : `${n} mentions`;
+  });
+}

--- a/src/app/features/graph/entity-detail.component.ts
+++ b/src/app/features/graph/entity-detail.component.ts
@@ -1,0 +1,343 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { EntityDetail, EntityNeighbor } from "../../core/models";
+import { SourcesComponent } from "../../shared/sources.component";
+import { EntityNeighborhoodComponent } from "./entity-neighborhood.component";
+
+/**
+ * The right-hand detail panel for one selected entity. Loads its
+ * {@link EntityDetail} via IPC (re-loading whenever the `entityId` input
+ * changes), then renders: a header (name + kind chip), the bounded
+ * neighborhood SVG, the backlinked meetings as reusable `app-sources` chips
+ * (→ /meeting/:id), and a neighbors list where each row re-selects that entity.
+ *
+ * Loading/error/empty are all handled honestly. The IPC call is a one-shot
+ * awaited promise (not a data stream), so it's loaded imperatively inside an
+ * effect that tracks the input signal — no `subscribe`, no markForCheck.
+ */
+@Component({
+  selector: "app-entity-detail",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SourcesComponent, EntityNeighborhoodComponent],
+  template: `
+    <aside class="ed card" aria-label="Entity detail">
+      <button
+        type="button"
+        class="ed-close btn btn-ghost"
+        aria-label="Close detail"
+        (click)="close.emit()"
+      >
+        <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+          <path
+            d="M4 4l8 8M12 4l-8 8"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+
+      @if (loading()) {
+        <div class="ed-state">
+          <p class="empty">Loading…</p>
+        </div>
+      } @else if (error()) {
+        <div class="ed-state">
+          <p class="empty-title">Couldn’t load this entity</p>
+          <p class="empty">{{ error() }}</p>
+        </div>
+      } @else if (detail()) {
+        @if (detail(); as d) {
+          <header class="ed-head">
+            <span
+              class="ed-kind-dot"
+              [class.is-project]="d.entity.kind === 'project'"
+              aria-hidden="true"
+            ></span>
+            <div class="ed-head-text">
+              <h3 class="ed-name">{{ d.entity.name }}</h3>
+              <span class="ed-kind">
+                {{ d.entity.kind === "project" ? "Project" : "Person" }}
+                · {{ meetingCountLabel() }}
+              </span>
+            </div>
+          </header>
+
+          <!-- Bounded neighborhood decoration (computed once, no simulation). -->
+          <app-entity-neighborhood
+            class="ed-neighborhood"
+            [neighbors]="d.neighbors"
+            [centerName]="d.entity.name"
+            (select)="select.emit($event)"
+          />
+
+          <!-- Backlinked meetings → reuse the shared sources chip component. -->
+          <section class="ed-section">
+            <h4 class="ed-section-title">Mentioned in</h4>
+            @if (d.meetings.length) {
+              <app-sources [sources]="d.meetings" [limit]="6" />
+            } @else {
+              <p class="empty ed-section-empty">
+                No visible meetings mention this entity right now.
+              </p>
+            }
+          </section>
+
+          <!-- Neighbors: click to pivot the detail panel to that entity. -->
+          @if (d.neighbors.length) {
+            <section class="ed-section">
+              <h4 class="ed-section-title">Connected entities</h4>
+              <ul class="ed-neighbors">
+                @for (nb of d.neighbors; track nb.id) {
+                  <li>
+                    <button
+                      type="button"
+                      class="ed-neighbor"
+                      [class.is-project]="nb.kind === 'project'"
+                      (click)="select.emit(nb.id)"
+                    >
+                      <span class="ed-neighbor-dot" aria-hidden="true"></span>
+                      <span class="ed-neighbor-name">{{ nb.name }}</span>
+                      <span
+                        class="count ed-neighbor-count"
+                        [attr.title]="sharedLabel(nb)"
+                      >
+                        {{ nb.sharedMeetings }}
+                      </span>
+                    </button>
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+        }
+      }
+    </aside>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .ed {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+        padding: var(--space-5);
+        animation: rise 360ms var(--transition) both;
+      }
+      .ed-close {
+        position: absolute;
+        top: var(--space-3);
+        right: var(--space-3);
+        width: 32px;
+        height: 32px;
+        padding: 0;
+      }
+      .ed-state {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        padding: var(--space-6) var(--space-2);
+        text-align: center;
+      }
+
+      /* --- Header --- */
+      .ed-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding-right: var(--space-6);
+      }
+      .ed-kind-dot {
+        flex: none;
+        width: 12px;
+        height: 12px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+      .ed-kind-dot.is-project {
+        background: #9d7bff;
+        box-shadow: 0 0 0 4px rgba(157, 123, 255, 0.18);
+      }
+      .ed-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .ed-name {
+        margin: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .ed-kind {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .ed-neighborhood {
+        display: block;
+      }
+
+      /* --- Sections --- */
+      .ed-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .ed-section-title {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .ed-section-empty {
+        margin: 0;
+        font-size: 0.875rem;
+      }
+
+      /* --- Neighbors list --- */
+      .ed-neighbors {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .ed-neighbor {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: var(--space-3);
+        width: 100%;
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font-family: inherit;
+        font-size: 0.875rem;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          border-color var(--transition);
+      }
+      .ed-neighbor:hover {
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+      }
+      .ed-neighbor:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .ed-neighbor-dot {
+        flex: none;
+        width: 7px;
+        height: 7px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+      }
+      .ed-neighbor.is-project .ed-neighbor-dot {
+        background: #9d7bff;
+      }
+      .ed-neighbor-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 550;
+      }
+      .ed-neighbor-count {
+        flex: none;
+        min-width: 22px;
+        height: 22px;
+      }
+    `,
+  ],
+})
+export class EntityDetailComponent {
+  private readonly ipc = inject(IpcService);
+
+  /** The entity to show detail for; changing it re-loads the panel. */
+  readonly entityId = input.required<string>();
+  /** Emits when the user picks a neighbor — the container re-selects it. */
+  readonly select = output<string>();
+  /** Emits when the user dismisses the panel. */
+  readonly close = output<void>();
+
+  readonly detail = signal<EntityDetail | null>(null);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  protected readonly meetingCountLabel = computed(() => {
+    const n = this.detail()?.meetings.length ?? 0;
+    return n === 1 ? "1 meeting" : `${n} meetings`;
+  });
+
+  /**
+   * Re-load the detail whenever `entityId` changes. The IPC call is a one-shot
+   * promise, so we await it inside an effect that tracks the input signal — a
+   * stale-result guard drops responses that resolve after the id moved on
+   * (fast neighbor-to-neighbor pivots), so the panel never shows mismatched data.
+   */
+  private readonly _load = effect(
+    () => {
+      const id = this.entityId();
+      this.loading.set(true);
+      this.error.set(null);
+      void this.fetch(id);
+    },
+    // Sets loading/error synchronously inside the tracked effect, so writes
+    // must be permitted here.
+    { allowSignalWrites: true },
+  );
+
+  private async fetch(id: string): Promise<void> {
+    try {
+      const result = await this.ipc.getEntityDetail(id);
+      // Guard against an out-of-order resolution (the selection moved on).
+      if (this.entityId() !== id) {
+        return;
+      }
+      this.detail.set(result);
+    } catch (e) {
+      if (this.entityId() !== id) {
+        return;
+      }
+      this.detail.set(null);
+      this.error.set(String(e));
+    } finally {
+      if (this.entityId() === id) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  protected sharedLabel(nb: EntityNeighbor): string {
+    return nb.sharedMeetings === 1
+      ? "1 shared meeting"
+      : `${nb.sharedMeetings} shared meetings`;
+  }
+}

--- a/src/app/features/graph/entity-neighborhood.component.ts
+++ b/src/app/features/graph/entity-neighborhood.component.ts
@@ -1,0 +1,398 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from "@angular/core";
+import type { EntityKind, EntityNeighbor } from "../../core/models";
+
+/** A neighbor resolved to its fixed position on the neighborhood ring. */
+interface Satellite {
+  id: string;
+  name: string;
+  kind: EntityKind;
+  sharedMeetings: number;
+  /** Centre coordinates of the satellite node, in SVG user units. */
+  cx: number;
+  cy: number;
+  /** Label anchor — flips side so text never overruns the viewBox edge. */
+  labelX: number;
+  textAnchor: "start" | "end" | "middle";
+  /** Edge stroke width ∝ shared-meeting count (clamped). */
+  strokeWidth: number;
+}
+
+/** Square SVG canvas (user units); the hub sits dead-centre. */
+const SIZE = 320;
+const CENTER = SIZE / 2;
+/** Ring radius for the satellites — leaves room for labels at the rim. */
+const RADIUS = 104;
+/** Hard cap on rendered satellites (bounded decoration, never a full graph). */
+const MAX_SATELLITES = 12;
+const SAT_R = 5.5;
+
+/**
+ * A bounded, single-entity "neighborhood" — pure decoration over the directory.
+ *
+ * The selected entity sits at the centre (reusing the brand wave glyph), and up
+ * to {@link MAX_SATELLITES} co-occurring neighbors are laid out ONCE on a circle
+ * via cos/sin inside a `computed()`. There is NO force simulation, NO
+ * requestAnimationFrame/setInterval — positions are a pure function of the
+ * neighbor list, recomputed only when that input changes. Edge thickness scales
+ * with shared-meeting count. Clicking a satellite emits its id so the container
+ * can re-select that entity. Degrades gracefully to a lone hub at zero neighbors
+ * and honours `prefers-reduced-motion` (entrance only; nothing ever loops).
+ */
+@Component({
+  selector: "app-entity-neighborhood",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <figure class="nb">
+      <svg
+        class="nb-svg"
+        [attr.viewBox]="'0 0 ' + size + ' ' + size"
+        role="img"
+        [attr.aria-label]="ariaLabel()"
+      >
+        <defs>
+          <linearGradient id="nbWave" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#6e76ff" />
+            <stop offset="1" stop-color="#9d7bff" />
+          </linearGradient>
+          <radialGradient id="nbHubGlow" cx="50%" cy="50%" r="50%">
+            <stop offset="0" stop-color="rgba(110,118,255,0.35)" />
+            <stop offset="1" stop-color="rgba(110,118,255,0)" />
+          </radialGradient>
+        </defs>
+
+        <!-- Edges first, under the nodes. -->
+        <g class="nb-edges" aria-hidden="true">
+          @for (s of satellites(); track s.id) {
+            <line
+              class="nb-edge"
+              [attr.x1]="center"
+              [attr.y1]="center"
+              [attr.x2]="s.cx"
+              [attr.y2]="s.cy"
+              [attr.stroke-width]="s.strokeWidth"
+              [style.--i]="$index"
+            />
+          }
+        </g>
+
+        <!-- Soft hub glow + the centred brand wave. -->
+        <circle
+          [attr.cx]="center"
+          [attr.cy]="center"
+          r="46"
+          fill="url(#nbHubGlow)"
+          aria-hidden="true"
+        />
+        <g
+          class="nb-hub"
+          [attr.transform]="
+            'translate(' + (center - 14) + ',' + (center - 14) + ')'
+          "
+          aria-hidden="true"
+        >
+          <rect
+            class="nb-bar b1"
+            x="4.4"
+            y="10"
+            width="2.4"
+            height="8"
+            rx="1.2"
+          />
+          <rect
+            class="nb-bar b2"
+            x="8.4"
+            y="7"
+            width="2.4"
+            height="14"
+            rx="1.2"
+          />
+          <rect
+            class="nb-bar b3"
+            x="12.4"
+            y="4"
+            width="2.4"
+            height="20"
+            rx="1.2"
+          />
+          <rect
+            class="nb-bar b4"
+            x="16.4"
+            y="7"
+            width="2.4"
+            height="14"
+            rx="1.2"
+          />
+          <rect
+            class="nb-bar b5"
+            x="20.4"
+            y="10"
+            width="2.4"
+            height="8"
+            rx="1.2"
+          />
+        </g>
+
+        <!-- Satellites: each a clickable group (node + label). -->
+        <g class="nb-sats">
+          @for (s of satellites(); track s.id) {
+            <g
+              class="nb-sat"
+              [class.is-project]="s.kind === 'project'"
+              role="button"
+              tabindex="0"
+              [attr.aria-label]="satLabel(s)"
+              [style.--i]="$index"
+              (click)="select.emit(s.id)"
+              (keydown.enter)="select.emit(s.id)"
+              (keydown.space)="onSpace($event, s.id)"
+            >
+              <circle
+                class="nb-sat-hit"
+                [attr.cx]="s.cx"
+                [attr.cy]="s.cy"
+                r="16"
+              />
+              <circle
+                class="nb-sat-dot"
+                [attr.cx]="s.cx"
+                [attr.cy]="s.cy"
+                [attr.r]="satR"
+              />
+              <text
+                class="nb-sat-label"
+                [attr.x]="s.labelX"
+                [attr.y]="s.cy + 4"
+                [attr.text-anchor]="s.textAnchor"
+              >
+                {{ s.name }}
+              </text>
+            </g>
+          }
+        </g>
+      </svg>
+
+      @if (satellites().length === 0) {
+        <figcaption class="nb-empty">
+          No connections yet — this entity stands alone in your visible graph.
+        </figcaption>
+      } @else {
+        <figcaption class="nb-cap">
+          Edge thickness reflects how many meetings they share.
+        </figcaption>
+      }
+    </figure>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .nb {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .nb-svg {
+        display: block;
+        width: 100%;
+        max-width: 340px;
+        height: auto;
+        overflow: visible;
+      }
+
+      /* Hub brand wave. */
+      .nb-bar {
+        fill: url(#nbWave);
+      }
+
+      /* Edges grow in from the hub on entrance only — never loop. */
+      .nb-edge {
+        stroke: var(--border-strong);
+        opacity: 0;
+        stroke-linecap: round;
+        animation: nb-edge-in 360ms var(--transition) both;
+        animation-delay: calc(var(--i, 0) * 40ms + 80ms);
+        transition: stroke var(--transition);
+      }
+
+      .nb-sat {
+        cursor: pointer;
+        animation: nb-sat-in 360ms var(--ease-spring) both;
+        animation-delay: calc(var(--i, 0) * 40ms + 120ms);
+      }
+      .nb-sat-hit {
+        fill: transparent;
+      }
+      .nb-sat-dot {
+        fill: var(--accent);
+        stroke: var(--surface-base);
+        stroke-width: 2;
+        transition:
+          r var(--transition-fast),
+          fill var(--transition);
+      }
+      .nb-sat.is-project .nb-sat-dot {
+        fill: #9d7bff;
+      }
+      .nb-sat-label {
+        fill: var(--text-secondary);
+        font-family: var(--font-sans);
+        font-size: 11px;
+        font-weight: 550;
+        pointer-events: none;
+        transition: fill var(--transition);
+      }
+      .nb-sat:hover .nb-sat-dot,
+      .nb-sat:focus-visible .nb-sat-dot {
+        r: 7.5;
+      }
+      .nb-sat:hover .nb-sat-label,
+      .nb-sat:focus-visible .nb-sat-label {
+        fill: var(--text-primary);
+      }
+      .nb-sat:focus-visible {
+        outline: none;
+      }
+      .nb-sat:focus-visible .nb-sat-dot {
+        stroke: var(--accent-hover);
+        stroke-width: 2.5;
+      }
+
+      .nb-cap,
+      .nb-empty {
+        margin: 0;
+        max-width: 32ch;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        line-height: 1.45;
+      }
+
+      @keyframes nb-edge-in {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 0.7;
+        }
+      }
+      @keyframes nb-sat-in {
+        from {
+          opacity: 0;
+          transform: scale(0.6);
+          transform-origin: center;
+        }
+        to {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .nb-edge,
+        .nb-sat {
+          animation: none;
+          opacity: 1;
+        }
+        .nb-edge {
+          opacity: 0.7;
+        }
+      }
+    `,
+  ],
+})
+export class EntityNeighborhoodComponent {
+  /** The co-occurring neighbors to lay out (top-K is capped internally). */
+  readonly neighbors = input<EntityNeighbor[]>([]);
+  /** Display name of the centred entity (for the SVG aria-label). */
+  readonly centerName = input<string>("");
+  /** Emits a neighbor's id when its satellite is activated. */
+  readonly select = output<string>();
+
+  protected readonly size = SIZE;
+  protected readonly center = CENTER;
+  protected readonly satR = SAT_R;
+
+  /**
+   * Lay out up to {@link MAX_SATELLITES} neighbors on a circle, ONCE, via
+   * cos/sin. Pure derivation of the input — no simulation, no animation frame.
+   * Neighbors arrive sorted by the backend; we take the strongest top-K and
+   * scale edge width to the shared-meeting count within this set.
+   */
+  protected readonly satellites = computed<Satellite[]>(() => {
+    const all = this.neighbors();
+    const top = all.slice(0, MAX_SATELLITES);
+    const n = top.length;
+    if (n === 0) {
+      return [];
+    }
+
+    const maxShared = Math.max(1, ...top.map((s) => s.sharedMeetings));
+    // Start at the top (12 o'clock) and step evenly clockwise.
+    const step = (2 * Math.PI) / n;
+    const start = -Math.PI / 2;
+
+    return top.map((s, i) => {
+      const angle = start + i * step;
+      const cx = CENTER + RADIUS * Math.cos(angle);
+      const cy = CENTER + RADIUS * Math.sin(angle);
+      const cos = Math.cos(angle);
+      // Place the label outboard of the node, flipping side around the rim.
+      const onRight = cos > 0.2;
+      const onLeft = cos < -0.2;
+      const labelX = onRight ? cx + SAT_R + 6 : onLeft ? cx - SAT_R - 6 : cx;
+      const textAnchor: Satellite["textAnchor"] = onRight
+        ? "start"
+        : onLeft
+          ? "end"
+          : "middle";
+      // Map shared count → 1.2…5 px stroke; +0 baseline keeps thin edges visible.
+      const strokeWidth = 1.2 + (s.sharedMeetings / maxShared) * 3.8;
+
+      return {
+        id: s.id,
+        name: s.name,
+        kind: s.kind,
+        sharedMeetings: s.sharedMeetings,
+        cx,
+        cy,
+        labelX,
+        textAnchor,
+        strokeWidth: Math.round(strokeWidth * 100) / 100,
+      };
+    });
+  });
+
+  protected readonly ariaLabel = computed(() => {
+    const name = this.centerName() || "This entity";
+    const k = this.satellites().length;
+    if (k === 0) {
+      return `${name} has no connected entities in the visible graph.`;
+    }
+    return `${name} and its ${k} most-connected ${
+      k === 1 ? "entity" : "entities"
+    }.`;
+  });
+
+  protected satLabel(s: Satellite): string {
+    const shared =
+      s.sharedMeetings === 1
+        ? "1 shared meeting"
+        : `${s.sharedMeetings} shared meetings`;
+    return `${s.name} — ${shared}. Open this entity.`;
+  }
+
+  /** Space activates the satellite without scrolling the page. */
+  protected onSpace(event: Event, id: string): void {
+    event.preventDefault();
+    this.select.emit(id);
+  }
+}

--- a/src/app/features/graph/graph.component.ts
+++ b/src/app/features/graph/graph.component.ts
@@ -1,0 +1,558 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { GraphData, GraphNode } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+import { EntityCardComponent } from "./entity-card.component";
+import { EntityDetailComponent } from "./entity-detail.component";
+
+type KindFilter = "all" | "person" | "project";
+type SortKey = "mentions" | "name";
+
+/** A directory section (People or Projects) with its filtered/sorted rows. */
+interface DirectorySection {
+  kind: "person" | "project";
+  label: string;
+  entities: GraphNode[];
+}
+
+/**
+ * The /graph page — the self-assembling People/Projects graph.
+ *
+ * A structured directory is the load-bearing spine: every VISIBLE entity as a
+ * sortable, searchable, filterable card with its visible mention count. A
+ * single-entity neighborhood SVG (in the detail panel) is additive decoration.
+ *
+ * Lock-awareness: the backend returns ONLY visible entities + a `hasHidden`
+ * flag; we render exactly that, plus one honest disclosure banner. We re-fetch
+ * `getGraph()` whenever {@link FoldersService}'s tree signal changes (a session
+ * unlock/relock or screen-share re-lock shifts visibility), so sealed entities
+ * drop out — or reappear — live, with no stale view and no client-side security
+ * decision.
+ */
+@Component({
+  selector: "app-graph",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [EntityCardComponent, EntityDetailComponent],
+  template: `
+    <section class="graph">
+      <header class="g-head">
+        <div class="g-head-text">
+          <h2 class="g-title">Graph</h2>
+          <p class="g-intro">
+            The people and projects across your meetings — your graph builds
+            itself as you record.
+          </p>
+        </div>
+        @if (!loading() && total() > 0) {
+          <span class="count g-total" [attr.title]="total() + ' entities'">
+            {{ total() }}
+          </span>
+        }
+      </header>
+
+      @if (loading()) {
+        <div class="card state-card">
+          <p class="empty">Loading…</p>
+        </div>
+      } @else if (error()) {
+        <div class="card empty-state">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">Couldn’t load your graph</p>
+          <p class="empty">{{ error() }}</p>
+        </div>
+      } @else if (total() === 0) {
+        <div class="card empty-state">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">
+            Your graph builds itself as you record meetings
+          </p>
+          <p class="empty">
+            As Murmur recognises the people and projects you talk about, they’ll
+            appear here — connected by the meetings they share.
+          </p>
+        </div>
+      } @else {
+        <!-- One honest disclosure: sealed folders are withheld from the graph. -->
+        @if (hasHidden()) {
+          <div class="banner is-accent g-banner" role="status">
+            <span class="g-banner-glyph" aria-hidden="true"></span>
+            <span>
+              Some entities are hidden — unlock a folder to include them.
+            </span>
+          </div>
+        }
+
+        <div class="g-layout" [class.has-detail]="selectedId() !== null">
+          <!-- Directory (spine) -->
+          <div class="g-directory">
+            <div class="g-controls">
+              <div class="g-search">
+                <svg
+                  class="g-search-icon"
+                  viewBox="0 0 16 16"
+                  width="15"
+                  height="15"
+                  aria-hidden="true"
+                >
+                  <circle
+                    cx="7"
+                    cy="7"
+                    r="4.5"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    fill="none"
+                  />
+                  <path
+                    d="M10.5 10.5L14 14"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                  />
+                </svg>
+                <input
+                  type="search"
+                  class="g-search-input"
+                  placeholder="Search people and projects…"
+                  aria-label="Search entities"
+                  [value]="query()"
+                  (input)="onQuery($event)"
+                />
+              </div>
+
+              <div class="g-filter" role="group" aria-label="Filter by kind">
+                @for (f of kindFilters; track f.key) {
+                  <button
+                    type="button"
+                    class="g-seg"
+                    [class.is-active]="kindFilter() === f.key"
+                    [attr.aria-pressed]="kindFilter() === f.key"
+                    (click)="kindFilter.set(f.key)"
+                  >
+                    {{ f.label }}
+                  </button>
+                }
+              </div>
+
+              <label class="g-sort">
+                <span class="g-sort-label">Sort</span>
+                <select
+                  class="g-sort-select"
+                  aria-label="Sort entities"
+                  [value]="sort()"
+                  (change)="onSort($event)"
+                >
+                  <option value="mentions">Most mentioned</option>
+                  <option value="name">Name</option>
+                </select>
+              </label>
+            </div>
+
+            @if (visibleTotal() === 0) {
+              <div class="card g-no-results">
+                <p class="empty-title">No matches</p>
+                <p class="empty">
+                  Nothing matches your search and filters. Try clearing them.
+                </p>
+              </div>
+            } @else {
+              @for (section of sections(); track section.kind) {
+                @if (section.entities.length) {
+                  <div class="g-section">
+                    <div class="g-section-head">
+                      <span
+                        class="g-section-dot"
+                        [class.is-project]="section.kind === 'project'"
+                        aria-hidden="true"
+                      ></span>
+                      <h3 class="g-section-title">{{ section.label }}</h3>
+                      <span class="count g-section-count">
+                        {{ section.entities.length }}
+                      </span>
+                    </div>
+                    <div class="g-cards" role="list">
+                      @for (e of section.entities; track e.id) {
+                        <app-entity-card
+                          role="listitem"
+                          [style.--i]="$index"
+                          class="g-card"
+                          [entity]="e"
+                          [selected]="selectedId() === e.id"
+                          (select)="onSelect($event)"
+                        />
+                      }
+                    </div>
+                  </div>
+                }
+              }
+            }
+          </div>
+
+          <!-- Detail panel (sticky on wide viewports) -->
+          @if (selectedId(); as id) {
+            <app-entity-detail
+              class="g-detail"
+              [entityId]="id"
+              (select)="onSelect($event)"
+              (close)="clearSelection()"
+            />
+          }
+        </div>
+      }
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .graph {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+      }
+
+      /* --- Head --- */
+      .g-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+      .g-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .g-title {
+        margin: 0;
+      }
+      .g-intro {
+        margin: 0;
+        max-width: 60ch;
+        color: var(--text-secondary);
+        font-size: 0.9375rem;
+      }
+      .g-total {
+        flex: none;
+        margin-top: 6px;
+      }
+
+      .g-banner {
+        align-items: center;
+        animation: rise 320ms var(--transition) both;
+      }
+      .g-banner-glyph {
+        flex: none;
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-hover);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+
+      /* --- Two-pane layout --- */
+      .g-layout {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--space-5);
+        align-items: start;
+      }
+      .g-layout.has-detail {
+        grid-template-columns: minmax(0, 1.5fr) minmax(300px, 1fr);
+      }
+      .g-detail {
+        position: sticky;
+        top: 84px;
+      }
+
+      /* --- Controls --- */
+      .g-directory {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+        min-width: 0;
+      }
+      .g-controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--space-3);
+      }
+      .g-search {
+        position: relative;
+        flex: 1 1 220px;
+        min-width: 0;
+      }
+      .g-search-icon {
+        position: absolute;
+        left: var(--space-3);
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-muted);
+        pointer-events: none;
+      }
+      .g-search-input {
+        padding-left: var(--space-6);
+      }
+      .g-filter {
+        display: inline-flex;
+        padding: 3px;
+        gap: 2px;
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-pill);
+        background: var(--surface-input);
+      }
+      .g-seg {
+        padding: 0 var(--space-3);
+        height: 30px;
+        border: none;
+        border-radius: var(--radius-pill);
+        background: transparent;
+        color: var(--text-secondary);
+        font-family: inherit;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          color var(--transition);
+      }
+      .g-seg:hover {
+        color: var(--text-primary);
+      }
+      .g-seg:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .g-seg.is-active {
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+      }
+      .g-sort {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .g-sort-label {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .g-sort-select {
+        width: auto;
+        height: 36px;
+      }
+
+      /* --- Sections + cards --- */
+      .g-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .g-section-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .g-section-dot {
+        flex: none;
+        width: 9px;
+        height: 9px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      .g-section-dot.is-project {
+        background: #9d7bff;
+        box-shadow: 0 0 0 3px rgba(157, 123, 255, 0.18);
+      }
+      .g-section-title {
+        margin: 0;
+        font-size: 1rem;
+      }
+      .g-section-count {
+        margin-left: auto;
+      }
+      .g-cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: var(--space-3);
+      }
+      .g-card {
+        display: block;
+        animation: rise 320ms var(--transition) both;
+        animation-delay: calc(min(var(--i, 0), 12) * 24ms);
+      }
+      .g-no-results {
+        padding: var(--space-6);
+        text-align: center;
+      }
+      .g-no-results .empty-title {
+        margin: 0 0 var(--space-1);
+      }
+      .g-no-results .empty {
+        margin: 0;
+      }
+
+      /* --- Responsive: collapse to one column, detach the sticky panel. --- */
+      @media (max-width: 760px) {
+        .g-layout.has-detail {
+          grid-template-columns: 1fr;
+        }
+        .g-detail {
+          position: static;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .g-card,
+        .g-banner {
+          animation: none;
+        }
+      }
+    `,
+  ],
+})
+export class GraphComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+
+  readonly graphData = signal<GraphData | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  readonly kindFilter = signal<KindFilter>("all");
+  readonly sort = signal<SortKey>("mentions");
+  readonly query = signal("");
+  readonly selectedId = signal<string | null>(null);
+
+  protected readonly kindFilters: readonly {
+    key: KindFilter;
+    label: string;
+  }[] = [
+    { key: "all", label: "All" },
+    { key: "person", label: "People" },
+    { key: "project", label: "Projects" },
+  ];
+
+  /** Total VISIBLE entities returned by the backend (before any local filter). */
+  protected readonly total = computed(
+    () => this.graphData()?.nodes.length ?? 0,
+  );
+  /** Whether the backend withheld ≥1 sealed entity → show the disclosure. */
+  protected readonly hasHidden = computed(
+    () => this.graphData()?.hasHidden ?? false,
+  );
+
+  /** The filtered + searched + sorted nodes (the view-model for the directory). */
+  protected readonly visibleEntities = computed<GraphNode[]>(() => {
+    const nodes = this.graphData()?.nodes ?? [];
+    const kind = this.kindFilter();
+    const q = this.query().trim().toLowerCase();
+    const sort = this.sort();
+
+    const filtered = nodes.filter((n) => {
+      if (kind !== "all" && n.kind !== kind) {
+        return false;
+      }
+      if (q && !n.name.toLowerCase().includes(q)) {
+        return false;
+      }
+      return true;
+    });
+
+    return [...filtered].sort((a, b) => {
+      if (sort === "name") {
+        return a.name.localeCompare(b.name);
+      }
+      // Most-mentioned first, name as a stable tiebreak.
+      return b.mentionCount - a.mentionCount || a.name.localeCompare(b.name);
+    });
+  });
+
+  protected readonly visibleTotal = computed(
+    () => this.visibleEntities().length,
+  );
+
+  /** Group the view-model into People / Projects sections (in display order). */
+  protected readonly sections = computed<DirectorySection[]>(() => {
+    const all = this.visibleEntities();
+    return [
+      {
+        kind: "person" as const,
+        label: "People",
+        entities: all.filter((e) => e.kind === "person"),
+      },
+      {
+        kind: "project" as const,
+        label: "Projects",
+        entities: all.filter((e) => e.kind === "project"),
+      },
+    ];
+  });
+
+  /**
+   * Load the graph, and re-load it whenever the folder lock-state changes.
+   * Reading the folders `tree` signal registers this effect as its dependent,
+   * so its initial value drives the first fetch (no separate `ngOnInit`), and a
+   * later session unlock/relock — or a screen-share-triggered relock-all —
+   * re-runs the fetch so sealed entities drop out, or reappear, live. The
+   * backend is the sole authority on visibility; we just re-ask and re-render.
+   */
+  private readonly _refetchOnLock = effect(
+    () => {
+      // Establish the dependency; the value itself isn't needed here.
+      this.folders.tree();
+      void this.fetchGraph();
+    },
+    // fetchGraph() writes the loading/error/data signals (synchronously before
+    // its first await), so this tracked effect must be allowed to write.
+    { allowSignalWrites: true },
+  );
+
+  private async fetchGraph(): Promise<void> {
+    this.error.set(null);
+    try {
+      const data = await this.ipc.getGraph();
+      this.graphData.set(data);
+      // If the selected entity is no longer visible (e.g. its folder re-sealed),
+      // close the detail panel so we never point at a vanished node.
+      const sel = this.selectedId();
+      if (sel && !data.nodes.some((n) => n.id === sel)) {
+        this.selectedId.set(null);
+      }
+    } catch (e) {
+      this.graphData.set(null);
+      this.error.set(String(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  onQuery(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
+
+  onSort(event: Event): void {
+    this.sort.set((event.target as HTMLSelectElement).value as SortKey);
+  }
+
+  /** Open (or toggle closed) the detail panel for an entity. */
+  onSelect(id: string): void {
+    this.selectedId.update((cur) => (cur === id ? null : id));
+  }
+
+  clearSelection(): void {
+    this.selectedId.set(null);
+  }
+}

--- a/src/app/features/library/library.component.ts
+++ b/src/app/features/library/library.component.ts
@@ -23,6 +23,9 @@ import {
 } from "../../services/folders.service";
 import { FolderTreeComponent } from "../folders/folder-tree.component";
 import { LockBadgeComponent } from "../folders/lock-badge.component";
+import { MoveToMenuComponent } from "../folders/move-to-menu.component";
+import { NoteDragService } from "../folders/note-drag.service";
+import { ToastService } from "../../services/toast.service";
 
 /** Debounce window for search-as-you-type — quick enough to feel instant. */
 const SEARCH_DEBOUNCE_MS = 180;
@@ -37,12 +40,56 @@ interface SnippetPart {
   selector: "app-library",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, FolderTreeComponent, LockBadgeComponent],
+  imports: [
+    RouterLink,
+    FolderTreeComponent,
+    LockBadgeComponent,
+    MoveToMenuComponent,
+  ],
   template: `
     <section class="library">
       <!-- ============ LEFT PANE — folder tree (lock-aware) ============ -->
       <aside class="folders-pane card" aria-label="Folders">
-        <h3 class="folders-title">Folders</h3>
+        <div class="folders-head">
+          <h3 class="folders-title">Folders</h3>
+          @if (unlockedCount() > 0) {
+            <button
+              type="button"
+              class="relock-pill"
+              [disabled]="relockingAll()"
+              [attr.aria-label]="
+                'Re-seal all ' + unlockedCount() + ' unlocked folders now'
+              "
+              title="Re-seal every unlocked folder now"
+              (click)="relockAll()"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="12"
+                height="12"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                  stroke-linecap="round"
+                />
+              </svg>
+              Lock all
+            </button>
+          }
+        </div>
         @if (foldersLoading()) {
           <p class="folders-state empty">Loading folders…</p>
         } @else {
@@ -50,6 +97,7 @@ interface SnippetPart {
             [nodes]="folderTree()"
             [selectedId]="activeFolderId()"
             (select)="selectFolder($event)"
+            (dropNote)="onDropNote($event)"
           />
         }
       </aside>
@@ -222,19 +270,90 @@ interface SnippetPart {
             </div>
           } @else if (displayedMeetings().length === 0) {
             <div class="card empty-state">
-              <span class="empty-mark" aria-hidden="true"></span>
               @if (activeFolderId() !== null) {
-                <p class="empty-title">No notes in this folder</p>
+                <!-- ACTIONABLE empty folder: on-brand "drop here" illustration
+                     plus the two concrete ways to file a note. -->
+                <span class="empty-illo" aria-hidden="true">
+                  <svg viewBox="0 0 64 64" width="64" height="64" fill="none">
+                    <defs>
+                      <linearGradient
+                        id="emptyFolderGrad"
+                        x1="8"
+                        y1="14"
+                        x2="56"
+                        y2="52"
+                        gradientUnits="userSpaceOnUse"
+                      >
+                        <stop stop-color="#6e76ff" />
+                        <stop offset="1" stop-color="#9d7bff" />
+                      </linearGradient>
+                    </defs>
+                    <!-- open folder, dashed mouth inviting a drop -->
+                    <path
+                      d="M9 22c0-2.2 1.8-4 4-4h9.5c1.3 0 2.5.6 3.3 1.7l1.6 2.3H51c2.2 0 4 1.8 4 4v20c0 2.2-1.8 4-4 4H13c-2.2 0-4-1.8-4-4z"
+                      stroke="url(#emptyFolderGrad)"
+                      stroke-width="2.2"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M14 31h36"
+                      stroke="url(#emptyFolderGrad)"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-dasharray="3 4"
+                      opacity="0.7"
+                    />
+                    <!-- a note card dropping in, with the soundwave mark -->
+                    <g opacity="0.95">
+                      <rect
+                        x="24"
+                        y="9"
+                        width="16"
+                        height="20"
+                        rx="3"
+                        fill="var(--surface-overlay)"
+                        stroke="url(#emptyFolderGrad)"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M28 19v0M31 16.5v5M34 14v10M37 17.5v3"
+                        stroke="url(#emptyFolderGrad)"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                      />
+                    </g>
+                  </svg>
+                </span>
+                <p class="empty-title">Nothing filed here yet</p>
                 <p class="empty">
-                  Move a meeting here from its detail view, or pick another
-                  folder.
+                  Drag a meeting onto this folder, or use the
+                  <span class="empty-chip-hint">
+                    <svg
+                      viewBox="0 0 16 16"
+                      width="11"
+                      height="11"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M1.75 4.25c0-.7.55-1.25 1.25-1.25h2.8c.4 0 .77.18 1 .5l.6.75h4.6c.7 0 1.25.55 1.25 1.25v5.5c0 .7-.55 1.25-1.25 1.25H3c-.7 0-1.25-.55-1.25-1.25z"
+                        stroke="currentColor"
+                        stroke-width="1.3"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    folder button</span
+                  >
+                  on any meeting to move it in.
                 </p>
               } @else if (activeTag() === null) {
+                <span class="empty-mark" aria-hidden="true"></span>
                 <p class="empty-title">No meetings yet</p>
                 <p class="empty">
                   Record one from the Record tab to see it here.
                 </p>
               } @else {
+                <span class="empty-mark" aria-hidden="true"></span>
                 <p class="empty-title">
                   No meetings tagged “{{ activeTag() }}”
                 </p>
@@ -247,17 +366,36 @@ interface SnippetPart {
                 <li
                   class="row-item"
                   [class.is-confirming]="pendingDeleteId() === m.id"
+                  [class.is-dragging]="draggingId() === m.id"
+                  [class.is-menu-open]="movePopoverId() === m.id"
                 >
                   <a
                     class="row"
                     [routerLink]="['/meeting', m.id]"
                     [style.animation-delay.ms]="i * 45"
+                    draggable="true"
+                    (dragstart)="onRowDragStart($event, m)"
+                    (dragend)="onRowDragEnd()"
                   >
+                    <!-- Drag grip: signals the row is draggable; not a button so
+                         it never steals the row's navigation click. -->
+                    <span
+                      class="grip"
+                      aria-hidden="true"
+                      title="Drag to a folder"
+                    >
+                      <svg viewBox="0 0 16 16" width="14" height="14">
+                        <circle cx="6" cy="4" r="1.05" fill="currentColor" />
+                        <circle cx="10" cy="4" r="1.05" fill="currentColor" />
+                        <circle cx="6" cy="8" r="1.05" fill="currentColor" />
+                        <circle cx="10" cy="8" r="1.05" fill="currentColor" />
+                        <circle cx="6" cy="12" r="1.05" fill="currentColor" />
+                        <circle cx="10" cy="12" r="1.05" fill="currentColor" />
+                      </svg>
+                    </span>
+
                     <span class="row-main">
                       <span class="title-row">
-                        @if (folderExposureOf(m); as exp) {
-                          <app-lock-badge [exposure]="exp" />
-                        }
                         @if (isMasked(m)) {
                           <span class="title title--masked" aria-hidden="true"
                             >•••••••••••••</span
@@ -282,6 +420,58 @@ interface SnippetPart {
                       </span>
                     </span>
                     <span class="row-aside">
+                      <!-- FOLDER CHIP — the primary "choose which goes where"
+                           affordance. Shows the current folder (or "+ Add to
+                           folder" at root). A button (stop/prevent) so the row's
+                           link never fires; opens the Move-to popover below. -->
+                      <button
+                        type="button"
+                        class="folder-chip"
+                        [class.is-filed]="folderNameOf(m) !== null"
+                        [attr.aria-expanded]="movePopoverId() === m.id"
+                        aria-haspopup="menu"
+                        [attr.aria-label]="
+                          folderNameOf(m)
+                            ? 'In folder ' +
+                              folderNameOf(m) +
+                              ' — move to another folder'
+                            : 'Add this meeting to a folder'
+                        "
+                        (click)="
+                          $event.preventDefault();
+                          $event.stopPropagation();
+                          toggleMovePopover(m.id)
+                        "
+                      >
+                        @if (folderExposureOf(m); as exp) {
+                          <app-lock-badge [exposure]="exp" />
+                        } @else {
+                          <svg
+                            class="folder-chip-icon"
+                            viewBox="0 0 16 16"
+                            width="13"
+                            height="13"
+                            fill="none"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M1.75 4.25c0-.7.55-1.25 1.25-1.25h2.8c.4 0 .77.18 1 .5l.6.75h4.6c.7 0 1.25.55 1.25 1.25v5.5c0 .7-.55 1.25-1.25 1.25H3c-.7 0-1.25-.55-1.25-1.25z"
+                              stroke="currentColor"
+                              stroke-width="1.3"
+                              stroke-linejoin="round"
+                            />
+                          </svg>
+                        }
+                        <span class="folder-chip-label">{{
+                          folderNameOf(m) ?? "Add to folder"
+                        }}</span>
+                        @if (folderNameOf(m) === null) {
+                          <span class="folder-chip-plus" aria-hidden="true"
+                            >+</span
+                          >
+                        }
+                      </button>
+
                       <span class="pill" [class]="statusPillClass(m.status)">
                         <span class="pill-dot"></span>
                         {{ statusLabel(m.status) }}
@@ -289,6 +479,20 @@ interface SnippetPart {
                       <span class="chevron" aria-hidden="true">›</span>
                     </span>
                   </a>
+
+                  <!-- "Move to…" popover, anchored to the row's right edge. The
+                       picker owns the cross-encryption-boundary confirm + IPC; we
+                       just reconcile the local list on its moved event. -->
+                  @if (movePopoverId() === m.id) {
+                    <div class="move-anchor">
+                      <app-move-to-menu
+                        [meetingId]="m.id"
+                        [currentFolderId]="m.folderId ?? null"
+                        (moved)="onMoved(m.id, $event)"
+                        (close)="closeMovePopover()"
+                      />
+                    </div>
+                  }
 
                   <!-- Subtle delete affordance — a separate button (never the
                      row's link). stop/prevent so a click can't navigate. -->
@@ -397,14 +601,56 @@ interface SnippetPart {
         top: 0;
         padding: var(--space-3);
       }
+      .folders-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        margin-bottom: var(--space-2);
+        min-height: 24px;
+      }
       .folders-title {
-        margin: 0 0 var(--space-2);
+        margin: 0;
         padding: 0 var(--space-2);
         color: var(--text-muted);
         font-size: 0.75rem;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.04em;
+      }
+      /* "Lock all" — quiet accent pill, only present when a folder is exposed. */
+      .relock-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        height: 24px;
+        padding: 0 var(--space-2);
+        border: 1px solid transparent;
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-family: inherit;
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+        transition:
+          filter var(--transition),
+          transform var(--transition-fast);
+      }
+      .relock-pill:hover:not(:disabled) {
+        filter: brightness(1.12);
+      }
+      .relock-pill:active:not(:disabled) {
+        transform: scale(0.95);
+      }
+      .relock-pill:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .relock-pill:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
       }
       .folders-state {
         margin: var(--space-2);
@@ -425,6 +671,149 @@ interface SnippetPart {
         align-items: center;
         gap: var(--space-2);
         min-width: 0;
+      }
+
+      /* --- Drag grip (signals a row is draggable; reveals on row hover) ----- */
+      .grip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        width: 18px;
+        margin-left: calc(var(--space-2) * -1);
+        color: var(--text-muted);
+        cursor: grab;
+        opacity: 0;
+        transition:
+          opacity var(--transition),
+          color var(--transition);
+      }
+      .row:hover .grip,
+      .row:focus-visible .grip {
+        opacity: 0.65;
+      }
+      .row:hover .grip:hover {
+        opacity: 1;
+        color: var(--text-secondary);
+      }
+      .row[draggable="true"]:active .grip {
+        cursor: grabbing;
+      }
+
+      /* --- Folder chip — the primary filing affordance on every row -------- */
+      .folder-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        max-width: 168px;
+        height: 26px;
+        padding: 0 var(--space-2);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-pill);
+        background: var(--surface-input);
+        color: var(--text-muted);
+        font-family: inherit;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: -0.005em;
+        line-height: 1;
+        white-space: nowrap;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition),
+          border-color var(--transition),
+          transform var(--transition-fast);
+      }
+      .folder-chip:hover {
+        color: var(--text-primary);
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+      }
+      .folder-chip:active {
+        transform: scale(0.96);
+      }
+      .folder-chip:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      /* A note that IS filed reads in the accent voice — its folder is "real". */
+      .folder-chip.is-filed {
+        background: var(--accent-soft);
+        border-color: transparent;
+        color: var(--accent-hover);
+      }
+      .folder-chip.is-filed:hover {
+        background: var(--accent-soft);
+        filter: brightness(1.12);
+      }
+      .row-item.is-menu-open .folder-chip {
+        background: var(--accent-soft);
+        border-color: var(--accent);
+        color: var(--accent-hover);
+      }
+      .folder-chip-icon {
+        flex: none;
+      }
+      .folder-chip-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .folder-chip-plus {
+        font-size: 0.95rem;
+        line-height: 0;
+        margin-left: 1px;
+        opacity: 0.8;
+      }
+
+      /* --- "Move to…" popover anchor (right edge of the row) --------------- */
+      .move-anchor {
+        position: absolute;
+        top: calc(100% - var(--space-2));
+        right: var(--space-3);
+        z-index: 40;
+        animation: rise 160ms var(--transition) both;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .move-anchor {
+          animation: none;
+        }
+      }
+
+      /* --- Drag source: dim the row being dragged for a tidy affordance ---- */
+      .row-item.is-dragging {
+        opacity: 0.45;
+      }
+      .row-item.is-dragging .row {
+        background: var(--surface-hover);
+      }
+
+      /* --- Actionable empty-folder illustration --------------------------- */
+      .empty-illo {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: var(--space-3);
+        filter: drop-shadow(0 8px 24px rgba(110, 118, 255, 0.25));
+        animation: rise 420ms var(--transition) both;
+      }
+      .empty-chip-hint {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        padding: 1px var(--space-2);
+        margin: 0 2px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-weight: 600;
+        white-space: nowrap;
+        vertical-align: baseline;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .empty-illo {
+          animation: none;
+        }
       }
       .title--masked {
         color: var(--text-muted);
@@ -847,6 +1236,14 @@ export class LibraryComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly folders = inject(FoldersService);
+  private readonly drag = inject(NoteDragService);
+  private readonly toast = inject(ToastService);
+
+  /** The meeting id whose "Move to…" folder-chip popover is open (null = none). */
+  readonly movePopoverId = signal<string | null>(null);
+
+  /** The meeting id currently being dragged (mirrors the shared drag signal). */
+  readonly draggingId = this.drag.draggingId;
 
   /** The search box element — focused after a clear. */
   private readonly searchInput =
@@ -861,6 +1258,10 @@ export class LibraryComponent implements OnInit {
   readonly folderTree = this.folders.tree;
   /** True while the folder tree is loading (drives the left-pane state). */
   readonly foldersLoading = this.folders.loading;
+  /** How many sealed folders are session-unlocked right now (drives "Lock all"). */
+  readonly unlockedCount = this.folders.unlockedCount;
+  /** True while a "Lock all" op is in flight. */
+  readonly relockingAll = signal(false);
   /**
    * Selected folder id (null = no folder filter — show the tag/all list).
    * Mutually exclusive with the tag filter: selecting one clears the other.
@@ -1076,6 +1477,118 @@ export class LibraryComponent implements OnInit {
       this.tagLoading.set(false);
     }
     this.activeFolderId.set(folderId);
+  }
+
+  // --- Filing: the per-row folder chip + "Move to…" popover ----------------
+
+  /**
+   * The display name of a meeting's current folder, or null when it's at the
+   * vault root. Drives the folder chip's label ("Marketing" vs "+ Add to folder").
+   */
+  folderNameOf(m: Meeting): string | null {
+    const fid = m.folderId ?? null;
+    if (fid === null) {
+      return null;
+    }
+    return this.folderById().get(fid)?.name ?? null;
+  }
+
+  /** Open / close / toggle the row's folder picker popover (one open at a time). */
+  toggleMovePopover(id: string): void {
+    this.movePopoverId.update((cur) => (cur === id ? null : id));
+  }
+  closeMovePopover(): void {
+    this.movePopoverId.set(null);
+  }
+
+  /** Re-seal every session-unlocked folder at once (privacy "panic" affordance). */
+  async relockAll(): Promise<void> {
+    if (this.relockingAll()) {
+      return;
+    }
+    this.relockingAll.set(true);
+    try {
+      await this.folders.relockAll();
+      this.toast.success("All folders re-sealed");
+    } catch {
+      this.toast.danger("Couldn’t re-seal folders. Please try again.");
+    } finally {
+      this.relockingAll.set(false);
+    }
+  }
+
+  /**
+   * Apply a move (from the row chip popover OR a drag-drop) into `folderId` (null
+   * = vault root). The FoldersService reloads the tree (so counts refresh), and
+   * we patch the LIBRARY-LOCAL `meetings` signal's `folderId` so the derived
+   * `folderMeetings` recomputes at once — the moved note leaves the current
+   * folder view without a manual reload. `tagMeetings` is patched in lockstep so
+   * a tag view stays coherent if one is active.
+   */
+  private async applyMove(
+    meetingId: string,
+    folderId: string | null,
+  ): Promise<void> {
+    const patch = (list: Meeting[]): Meeting[] =>
+      list.map((m) => (m.id === meetingId ? { ...m, folderId } : m));
+    this.meetings.update(patch);
+    this.tagMeetings.update(patch);
+  }
+
+  /**
+   * The popover's `moved` output already ran the IPC move via FoldersService;
+   * here we only reconcile the local list + close the popover.
+   */
+  onMoved(meetingId: string, folderId: string | null): void {
+    void this.applyMove(meetingId, folderId);
+    this.closeMovePopover();
+  }
+
+  // --- Filing: drag a row onto a folder (the enhancement path) -------------
+
+  /** Begin a row drag: stash the meeting id on the transfer + the shared signal. */
+  onRowDragStart(event: DragEvent, m: Meeting): void {
+    // A locked-and-not-unlocked note is masked; dragging it is still fine (the
+    // move runs through the same load-bearing confirm at the destination), so we
+    // allow it. The transfer carries the id under our private MIME type.
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData(NoteDragService.MIME, m.id);
+    }
+    this.drag.begin(m.id);
+  }
+
+  /** End a row drag (fires whether or not it landed on a target). */
+  onRowDragEnd(): void {
+    this.drag.end();
+  }
+
+  /**
+   * A note was dropped onto a folder (or "All notes"). Run the move through the
+   * FoldersService (which owns the cross-encryption-boundary semantics + tree
+   * reload), then reconcile the local list. A no-op when it's already there.
+   */
+  async onDropNote(payload: {
+    meetingId: string;
+    folderId: string | null;
+  }): Promise<void> {
+    const { meetingId, folderId } = payload;
+    const current =
+      this.meetings().find((m) => m.id === meetingId)?.folderId ?? null;
+    if (current === folderId) {
+      return; // already filed here — nothing to do.
+    }
+    try {
+      await this.folders.moveNote(meetingId, folderId);
+      await this.applyMove(meetingId, folderId);
+      const name =
+        folderId === null
+          ? "All notes"
+          : (this.folderById().get(folderId)?.name ?? "folder");
+      this.toast.success(`Moved to ${name}`);
+    } catch {
+      this.toast.danger("Couldn’t move this note. Please try again.");
+    }
   }
 
   // --- Lock-aware row rendering -------------------------------------------

--- a/src/app/features/library/library.component.ts
+++ b/src/app/features/library/library.component.ts
@@ -11,7 +11,18 @@ import {
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { IpcService } from "../../core/ipc.service";
-import type { Meeting, MeetingStatus, SearchHit } from "../../core/models";
+import type {
+  FolderNode,
+  Meeting,
+  MeetingStatus,
+  SearchHit,
+} from "../../core/models";
+import {
+  FoldersService,
+  type FolderExposure,
+} from "../../services/folders.service";
+import { FolderTreeComponent } from "../folders/folder-tree.component";
+import { LockBadgeComponent } from "../folders/lock-badge.component";
 
 /** Debounce window for search-as-you-type — quick enough to feel instant. */
 const SEARCH_DEBOUNCE_MS = 180;
@@ -26,297 +37,411 @@ interface SnippetPart {
   selector: "app-library",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, FolderTreeComponent, LockBadgeComponent],
   template: `
     <section class="library">
-      <!-- Frosted search field, pinned to the top of the screen -->
-      <div class="search" [class.is-active]="searching()">
-        <span class="search-icon" aria-hidden="true">
-          <svg viewBox="0 0 20 20" width="18" height="18" fill="none">
-            <circle
-              cx="8.5"
-              cy="8.5"
-              r="5.5"
-              stroke="currentColor"
-              stroke-width="1.7"
-            />
-            <path
-              d="m13 13 4 4"
-              stroke="currentColor"
-              stroke-width="1.7"
-              stroke-linecap="round"
-            />
-          </svg>
-        </span>
-        <input
-          #searchInput
-          type="search"
-          class="search-input"
-          placeholder="Search meetings, transcripts & notes…"
-          autocapitalize="off"
-          autocomplete="off"
-          spellcheck="false"
-          aria-label="Search meetings"
-          [value]="query()"
-          (input)="onQueryInput($event)"
-          (keydown.escape)="clear()"
-        />
-        @if (query()) {
-          <button
-            type="button"
-            class="search-clear"
-            aria-label="Clear search"
-            (click)="clear()"
-          >
-            <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <!-- ============ LEFT PANE — folder tree (lock-aware) ============ -->
+      <aside class="folders-pane card" aria-label="Folders">
+        <h3 class="folders-title">Folders</h3>
+        @if (foldersLoading()) {
+          <p class="folders-state empty">Loading folders…</p>
+        } @else {
+          <app-folder-tree
+            [nodes]="folderTree()"
+            [selectedId]="activeFolderId()"
+            (select)="selectFolder($event)"
+          />
+        }
+      </aside>
+
+      <!-- ============ RIGHT PANE — search, filters, meeting list ============ -->
+      <div class="meetings-pane">
+        <!-- Frosted search field, pinned to the top of the screen -->
+        <div class="search" [class.is-active]="searching()">
+          <span class="search-icon" aria-hidden="true">
+            <svg viewBox="0 0 20 20" width="18" height="18" fill="none">
+              <circle
+                cx="8.5"
+                cy="8.5"
+                r="5.5"
+                stroke="currentColor"
+                stroke-width="1.7"
+              />
               <path
-                d="M4 4l8 8M12 4l-8 8"
+                d="m13 13 4 4"
                 stroke="currentColor"
                 stroke-width="1.7"
                 stroke-linecap="round"
               />
             </svg>
-          </button>
-        }
-      </div>
-
-      <!-- Tag filter chips (hidden during an active search; absent if no tags) -->
-      @if (!hasQuery() && tags().length > 0) {
-        <div class="tagbar" role="group" aria-label="Filter meetings by tag">
-          <button
-            type="button"
-            class="chip"
-            [class.is-active]="activeTag() === null"
-            [attr.aria-pressed]="activeTag() === null"
-            (click)="selectTag(null)"
-          >
-            All
-          </button>
-          @for (tag of tags(); track tag) {
+          </span>
+          <input
+            #searchInput
+            type="search"
+            class="search-input"
+            placeholder="Search meetings, transcripts & notes…"
+            autocapitalize="off"
+            autocomplete="off"
+            spellcheck="false"
+            aria-label="Search meetings"
+            [value]="query()"
+            (input)="onQueryInput($event)"
+            (keydown.escape)="clear()"
+          />
+          @if (query()) {
             <button
               type="button"
-              class="chip"
-              [class.is-active]="activeTag() === tag"
-              [attr.aria-pressed]="activeTag() === tag"
-              (click)="selectTag(tag)"
+              class="search-clear"
+              aria-label="Clear search"
+              (click)="clear()"
             >
-              {{ tag }}
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                />
+              </svg>
             </button>
           }
         </div>
-      }
 
-      @if (hasQuery()) {
-        <!-- ===================== SEARCH RESULTS ===================== -->
-        <header class="library-head">
-          <h2>Search</h2>
-          @if (!searching() && results().length > 0) {
-            <span class="count">{{ results().length }}</span>
-          }
-        </header>
-
-        @if (searching()) {
-          <div class="card state-card">
-            <p class="empty searching">
-              <span class="spinner" aria-hidden="true"></span>
-              Searching…
-            </p>
-          </div>
-        } @else if (results().length === 0) {
-          <div class="card empty-state">
-            <span class="empty-mark" aria-hidden="true"></span>
-            <p class="empty-title">No matches for “{{ query().trim() }}”</p>
-            <p class="empty">Try a different word or a shorter phrase.</p>
-          </div>
-        } @else {
-          <ul class="list card">
-            @for (hit of results(); track hit.meeting.id; let i = $index) {
-              <li>
-                <a
-                  class="row"
-                  [routerLink]="['/meeting', hit.meeting.id]"
-                  [style.animation-delay.ms]="i * 35"
-                >
-                  <span class="row-main">
-                    <span class="title">{{
-                      hit.meeting.title || "(untitled)"
-                    }}</span>
-                    <span class="meta">
-                      <span
-                        class="badge"
-                        [class]="matchBadgeClass(hit.matchedIn)"
-                        >{{ matchLabel(hit.matchedIn) }}</span
-                      >
-                      <span class="date">{{
-                        formatDate(hit.meeting.startedAt)
-                      }}</span>
-                    </span>
-                    @if (hit.snippet) {
-                      <span class="snippet">
-                        @for (part of snippetParts(hit.snippet); track $index) {
-                          @if (part.hit) {
-                            <mark class="snippet-hit">{{ part.text }}</mark>
-                          } @else {
-                            {{ part.text }}
-                          }
-                        }
-                      </span>
-                    }
-                  </span>
-                  <span class="chevron" aria-hidden="true">›</span>
-                </a>
-              </li>
-            }
-          </ul>
-        }
-      } @else {
-        <!-- ===================== MEETINGS LIST (no query) ===================== -->
-        <header class="library-head">
-          <h2>{{ activeTag() === null ? "Meetings" : activeTag() }}</h2>
-          @if (!listLoading() && displayedMeetings().length > 0) {
-            <span class="count">{{ displayedMeetings().length }}</span>
-          }
-        </header>
-
-        @if (listLoading()) {
-          <div class="card state-card">
-            <p class="empty">Loading…</p>
-          </div>
-        } @else if (displayedMeetings().length === 0) {
-          <div class="card empty-state">
-            <span class="empty-mark" aria-hidden="true"></span>
-            @if (activeTag() === null) {
-              <p class="empty-title">No meetings yet</p>
-              <p class="empty">
-                Record one from the Record tab to see it here.
-              </p>
-            } @else {
-              <p class="empty-title">No meetings tagged “{{ activeTag() }}”</p>
-              <p class="empty">Pick another tag, or choose All.</p>
-            }
-          </div>
-        } @else {
-          <ul class="list card">
-            @for (m of displayedMeetings(); track m.id; let i = $index) {
-              <li
-                class="row-item"
-                [class.is-confirming]="pendingDeleteId() === m.id"
+        <!-- Tag filter chips (hidden during an active search; absent if no tags) -->
+        @if (!hasQuery() && tags().length > 0) {
+          <div class="tagbar" role="group" aria-label="Filter meetings by tag">
+            <button
+              type="button"
+              class="chip"
+              [class.is-active]="activeTag() === null"
+              [attr.aria-pressed]="activeTag() === null"
+              (click)="selectTag(null)"
+            >
+              All
+            </button>
+            @for (tag of tags(); track tag) {
+              <button
+                type="button"
+                class="chip"
+                [class.is-active]="activeTag() === tag"
+                [attr.aria-pressed]="activeTag() === tag"
+                (click)="selectTag(tag)"
               >
-                <a
-                  class="row"
-                  [routerLink]="['/meeting', m.id]"
-                  [style.animation-delay.ms]="i * 45"
-                >
-                  <span class="row-main">
-                    <span class="title">{{ m.title || "(untitled)" }}</span>
-                    <span class="meta">
-                      <span class="date">{{ formatDate(m.startedAt) }}</span>
-                      @if (m.durationS > 0) {
-                        <span class="dot" aria-hidden="true">·</span>
-                        <span class="duration">{{
-                          formatDuration(m.durationS)
+                {{ tag }}
+              </button>
+            }
+          </div>
+        }
+
+        @if (hasQuery()) {
+          <!-- ===================== SEARCH RESULTS ===================== -->
+          <header class="library-head">
+            <h2>Search</h2>
+            @if (!searching() && results().length > 0) {
+              <span class="count">{{ results().length }}</span>
+            }
+          </header>
+
+          @if (searching()) {
+            <div class="card state-card">
+              <p class="empty searching">
+                <span class="spinner" aria-hidden="true"></span>
+                Searching…
+              </p>
+            </div>
+          } @else if (results().length === 0) {
+            <div class="card empty-state">
+              <span class="empty-mark" aria-hidden="true"></span>
+              <p class="empty-title">No matches for “{{ query().trim() }}”</p>
+              <p class="empty">Try a different word or a shorter phrase.</p>
+            </div>
+          } @else {
+            <ul class="list card">
+              @for (hit of results(); track hit.meeting.id; let i = $index) {
+                <li>
+                  <a
+                    class="row"
+                    [routerLink]="['/meeting', hit.meeting.id]"
+                    [style.animation-delay.ms]="i * 35"
+                  >
+                    <span class="row-main">
+                      <span class="title">{{
+                        hit.meeting.title || "(untitled)"
+                      }}</span>
+                      <span class="meta">
+                        <span
+                          class="badge"
+                          [class]="matchBadgeClass(hit.matchedIn)"
+                          >{{ matchLabel(hit.matchedIn) }}</span
+                        >
+                        <span class="date">{{
+                          formatDate(hit.meeting.startedAt)
                         }}</span>
+                      </span>
+                      @if (hit.snippet) {
+                        <span class="snippet">
+                          @for (
+                            part of snippetParts(hit.snippet);
+                            track $index
+                          ) {
+                            @if (part.hit) {
+                              <mark class="snippet-hit">{{ part.text }}</mark>
+                            } @else {
+                              {{ part.text }}
+                            }
+                          }
+                        </span>
                       }
                     </span>
-                  </span>
-                  <span class="row-aside">
-                    <span class="pill" [class]="statusPillClass(m.status)">
-                      <span class="pill-dot"></span>
-                      {{ statusLabel(m.status) }}
-                    </span>
                     <span class="chevron" aria-hidden="true">›</span>
-                  </span>
-                </a>
+                  </a>
+                </li>
+              }
+            </ul>
+          }
+        } @else {
+          <!-- ===================== MEETINGS LIST (no query) ===================== -->
+          <header class="library-head">
+            <h2>{{ listHeading() }}</h2>
+            @if (activeFolderExposure(); as exp) {
+              <app-lock-badge [exposure]="exp" />
+            }
+            @if (!listLoading() && displayedMeetings().length > 0) {
+              <span class="count">{{ displayedMeetings().length }}</span>
+            }
+          </header>
 
-                <!-- Subtle delete affordance — a separate button (never the
-                     row's link). stop/prevent so a click can't navigate. -->
-                <button
-                  type="button"
-                  class="row-delete"
-                  [attr.aria-label]="
-                    'Delete meeting: ' + (m.title || '(untitled)')
-                  "
-                  (click)="
-                    $event.preventDefault();
-                    $event.stopPropagation();
-                    askDelete(m.id)
-                  "
+          @if (listLoading()) {
+            <div class="card state-card">
+              <p class="empty">Loading…</p>
+            </div>
+          } @else if (displayedMeetings().length === 0) {
+            <div class="card empty-state">
+              <span class="empty-mark" aria-hidden="true"></span>
+              @if (activeFolderId() !== null) {
+                <p class="empty-title">No notes in this folder</p>
+                <p class="empty">
+                  Move a meeting here from its detail view, or pick another
+                  folder.
+                </p>
+              } @else if (activeTag() === null) {
+                <p class="empty-title">No meetings yet</p>
+                <p class="empty">
+                  Record one from the Record tab to see it here.
+                </p>
+              } @else {
+                <p class="empty-title">
+                  No meetings tagged “{{ activeTag() }}”
+                </p>
+                <p class="empty">Pick another tag, or choose All.</p>
+              }
+            </div>
+          } @else {
+            <ul class="list card">
+              @for (m of displayedMeetings(); track m.id; let i = $index) {
+                <li
+                  class="row-item"
+                  [class.is-confirming]="pendingDeleteId() === m.id"
                 >
-                  <svg
-                    viewBox="0 0 16 16"
-                    width="15"
-                    height="15"
-                    aria-hidden="true"
+                  <a
+                    class="row"
+                    [routerLink]="['/meeting', m.id]"
+                    [style.animation-delay.ms]="i * 45"
                   >
-                    <path
-                      d="M3 4.5h10M6.5 4.5V3.5a1 1 0 0 1 1-1h1a1 1 0 0 1 1 1v1M5.5 4.5l.4 8a1 1 0 0 0 1 .95h2.2a1 1 0 0 0 1-.95l.4-8"
-                      stroke="currentColor"
-                      stroke-width="1.3"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      fill="none"
-                    />
-                  </svg>
-                </button>
+                    <span class="row-main">
+                      <span class="title-row">
+                        @if (folderExposureOf(m); as exp) {
+                          <app-lock-badge [exposure]="exp" />
+                        }
+                        @if (isMasked(m)) {
+                          <span class="title title--masked" aria-hidden="true"
+                            >•••••••••••••</span
+                          >
+                          <span class="sr-only"
+                            >Locked note — title hidden</span
+                          >
+                        } @else {
+                          <span class="title">{{
+                            m.title || "(untitled)"
+                          }}</span>
+                        }
+                      </span>
+                      <span class="meta">
+                        <span class="date">{{ formatDate(m.startedAt) }}</span>
+                        @if (m.durationS > 0) {
+                          <span class="dot" aria-hidden="true">·</span>
+                          <span class="duration">{{
+                            formatDuration(m.durationS)
+                          }}</span>
+                        }
+                      </span>
+                    </span>
+                    <span class="row-aside">
+                      <span class="pill" [class]="statusPillClass(m.status)">
+                        <span class="pill-dot"></span>
+                        {{ statusLabel(m.status) }}
+                      </span>
+                      <span class="chevron" aria-hidden="true">›</span>
+                    </span>
+                  </a>
 
-                @if (pendingDeleteId() === m.id) {
-                  <!-- In-app confirm (signal-driven; NOT window.confirm) -->
-                  <div
-                    class="confirm"
-                    role="alertdialog"
-                    aria-modal="true"
+                  <!-- Subtle delete affordance — a separate button (never the
+                     row's link). stop/prevent so a click can't navigate. -->
+                  <button
+                    type="button"
+                    class="row-delete"
                     [attr.aria-label]="
                       'Delete meeting: ' + (m.title || '(untitled)')
                     "
+                    (click)="
+                      $event.preventDefault();
+                      $event.stopPropagation();
+                      askDelete(m.id)
+                    "
                   >
-                    <p class="confirm-title">Delete this meeting?</p>
-                    <p class="confirm-body">
-                      This permanently removes the recording, transcript,
-                      summary and vault note. It can’t be undone.
-                    </p>
-                    @if (deleteError()) {
-                      <p class="confirm-error" role="alert">
-                        {{ deleteError() }}
+                    <svg
+                      viewBox="0 0 16 16"
+                      width="15"
+                      height="15"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M3 4.5h10M6.5 4.5V3.5a1 1 0 0 1 1-1h1a1 1 0 0 1 1 1v1M5.5 4.5l.4 8a1 1 0 0 0 1 .95h2.2a1 1 0 0 0 1-.95l.4-8"
+                        stroke="currentColor"
+                        stroke-width="1.3"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        fill="none"
+                      />
+                    </svg>
+                  </button>
+
+                  @if (pendingDeleteId() === m.id) {
+                    <!-- In-app confirm (signal-driven; NOT window.confirm) -->
+                    <div
+                      class="confirm"
+                      role="alertdialog"
+                      aria-modal="true"
+                      [attr.aria-label]="
+                        'Delete meeting: ' + (m.title || '(untitled)')
+                      "
+                    >
+                      <p class="confirm-title">Delete this meeting?</p>
+                      <p class="confirm-body">
+                        This permanently removes the recording, transcript,
+                        summary and vault note. It can’t be undone.
                       </p>
-                    }
-                    <div class="confirm-actions">
-                      <button
-                        type="button"
-                        class="btn btn-ghost"
-                        [disabled]="deleting()"
-                        (click)="cancelDelete()"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        type="button"
-                        class="btn btn-danger"
-                        [disabled]="deleting()"
-                        (click)="confirmDelete(m.id)"
-                      >
-                        @if (deleting()) {
-                          <span class="spinner" aria-hidden="true"></span>
-                          Deleting…
-                        } @else {
-                          Delete
-                        }
-                      </button>
+                      @if (deleteError()) {
+                        <p class="confirm-error" role="alert">
+                          {{ deleteError() }}
+                        </p>
+                      }
+                      <div class="confirm-actions">
+                        <button
+                          type="button"
+                          class="btn btn-ghost"
+                          [disabled]="deleting()"
+                          (click)="cancelDelete()"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          class="btn btn-danger"
+                          [disabled]="deleting()"
+                          (click)="confirmDelete(m.id)"
+                        >
+                          @if (deleting()) {
+                            <span class="spinner" aria-hidden="true"></span>
+                            Deleting…
+                          } @else {
+                            Delete
+                          }
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                }
-              </li>
-            }
-          </ul>
+                  }
+                </li>
+              }
+            </ul>
+          }
         }
-      }
+      </div>
+      <!-- /.meetings-pane -->
     </section>
   `,
   styles: [
     `
+      /* Two-pane: folder tree (left) + meeting list (right). Collapses to a
+         single column on narrow widths so the list never gets squeezed. */
       .library {
+        display: grid;
+        grid-template-columns: minmax(200px, 248px) minmax(0, 1fr);
+        align-items: start;
+        gap: var(--space-5);
+      }
+      @media (max-width: 720px) {
+        .library {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      /* --- Left pane: folder tree (lock-aware) --- */
+      .folders-pane {
+        position: sticky;
+        top: 0;
+        padding: var(--space-3);
+      }
+      .folders-title {
+        margin: 0 0 var(--space-2);
+        padding: 0 var(--space-2);
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .folders-state {
+        margin: var(--space-2);
+        font-size: 0.8125rem;
+      }
+
+      /* --- Right pane: stacks search, filters and the list --- */
+      .meetings-pane {
         display: flex;
         flex-direction: column;
         gap: var(--space-5);
+        min-width: 0;
+      }
+
+      /* Masked title for a locked-folder note (hidden until session-unlock). */
+      .title-row {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        min-width: 0;
+      }
+      .title--masked {
+        color: var(--text-muted);
+        letter-spacing: 0.12em;
+        user-select: none;
+      }
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
       }
 
       /* --- Frosted search field (pinned, sticky to the scroll top) --- */
@@ -721,6 +846,7 @@ interface SnippetPart {
 export class LibraryComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly folders = inject(FoldersService);
 
   /** The search box element — focused after a clear. */
   private readonly searchInput =
@@ -729,6 +855,49 @@ export class LibraryComponent implements OnInit {
   // --- No-query meetings list (unchanged behaviour) -----------------------
   readonly meetings = signal<Meeting[]>([]);
   readonly loading = signal(true);
+
+  // --- Folder filter (left pane) ------------------------------------------
+  /** The lock-aware folder forest from the signal store. */
+  readonly folderTree = this.folders.tree;
+  /** True while the folder tree is loading (drives the left-pane state). */
+  readonly foldersLoading = this.folders.loading;
+  /**
+   * Selected folder id (null = no folder filter — show the tag/all list).
+   * Mutually exclusive with the tag filter: selecting one clears the other.
+   */
+  readonly activeFolderId = signal<string | null>(null);
+
+  /**
+   * Every folder node keyed by id (flattened) — for O(1) exposure/mask lookups
+   * keyed off a meeting's `folderId`. Recomputes whenever the tree reloads.
+   */
+  private readonly folderById = computed(() => {
+    const map = new Map<string, FolderNode>();
+    const walk = (nodes: FolderNode[]): void => {
+      for (const n of nodes) {
+        map.set(n.id, n);
+        if (n.children.length) {
+          walk(n.children);
+        }
+      }
+    };
+    walk(this.folderTree());
+    return map;
+  });
+
+  /**
+   * Meetings in the active folder. Derived from the already-loaded `meetings`
+   * list via the committed `Meeting.folderId` contract field (no extra IPC —
+   * the backend exposes no folder-scoped list command). When the field is
+   * absent (older backend) this is simply empty until notes carry a folderId.
+   */
+  readonly folderMeetings = computed(() => {
+    const fid = this.activeFolderId();
+    if (fid === null) {
+      return [];
+    }
+    return this.meetings().filter((m) => m.folderId === fid);
+  });
 
   // --- Tag filter ----------------------------------------------------------
   /** All distinct tags across meetings; empty → no filter bar is rendered. */
@@ -740,14 +909,49 @@ export class LibraryComponent implements OnInit {
   /** True while a tag's meetings are being fetched. */
   readonly tagLoading = signal(false);
 
-  /** The list to render when not searching: full list, or the tag-filtered one. */
-  readonly displayedMeetings = computed(() =>
-    this.activeTag() === null ? this.meetings() : this.tagMeetings(),
-  );
+  /**
+   * The list to render when not searching, in strict precedence (search is
+   * handled separately via `hasQuery()`):
+   *   folder selected → folder-filtered;
+   *   else tag selected → tag-filtered;
+   *   else → the full list.
+   * No existing branch is removed — the folder branch sits ABOVE the tag/all
+   * branches the screen already had.
+   */
+  readonly displayedMeetings = computed(() => {
+    if (this.activeFolderId() !== null) {
+      return this.folderMeetings();
+    }
+    return this.activeTag() === null ? this.meetings() : this.tagMeetings();
+  });
   /** Loading state for the visible no-query list (initial load or a tag fetch). */
-  readonly listLoading = computed(() =>
-    this.activeTag() === null ? this.loading() : this.tagLoading(),
-  );
+  readonly listLoading = computed(() => {
+    if (this.activeFolderId() !== null) {
+      // Folder filtering is client-side over `meetings`, so it shares the
+      // initial-load flag (and the tree's own loading shows in the left pane).
+      return this.loading();
+    }
+    return this.activeTag() === null ? this.loading() : this.tagLoading();
+  });
+
+  /** Heading for the no-query list: folder name → tag → "Meetings". */
+  readonly listHeading = computed(() => {
+    const fid = this.activeFolderId();
+    if (fid !== null) {
+      return this.folderById().get(fid)?.name ?? "Folder";
+    }
+    return this.activeTag() ?? "Meetings";
+  });
+
+  /** Exposure of the active folder (for the header lock badge); null when none. */
+  readonly activeFolderExposure = computed<FolderExposure | null>(() => {
+    const fid = this.activeFolderId();
+    if (fid === null) {
+      return null;
+    }
+    const node = this.folderById().get(fid);
+    return node ? this.folders.exposureOf(node) : null;
+  });
 
   // --- Delete affordance (in-app, signal-driven confirm) ------------------
   /** Id of the meeting whose inline confirm panel is open (null = none). */
@@ -814,6 +1018,11 @@ export class LibraryComponent implements OnInit {
     // Switching the view dismisses any open delete confirm to avoid a dangling
     // panel pointing at a row that may not be in the new list.
     this.cancelDelete();
+    // Tag + folder filters are mutually exclusive: picking a tag clears any
+    // active folder selection so the two never compose into an empty surprise.
+    if (tag !== null) {
+      this.activeFolderId.set(null);
+    }
     this.activeTag.set(tag);
 
     if (tag === null) {
@@ -838,6 +1047,57 @@ export class LibraryComponent implements OnInit {
         this.tagLoading.set(false);
       }
     }
+  }
+
+  // --- Folder filtering (left pane) ---------------------------------------
+
+  /**
+   * Select a folder (or `null` for "All notes" / the vault root). Mirrors the
+   * tag-filter machinery: it dismisses any open delete confirm, clears the
+   * mutually-exclusive tag filter, and (for a non-null folder) leaves the search
+   * alone — the right pane re-derives `folderMeetings` reactively. A null target
+   * (the tree's "All notes" row) returns to the full list. There is no async
+   * fetch (folder filtering is client-side over `meetings`), so no latest-wins
+   * race exists; the same idempotent-guard shape is kept for consistency.
+   */
+  selectFolder(folderId: string | null): void {
+    if (this.activeFolderId() === folderId) {
+      return;
+    }
+    this.cancelDelete();
+    // Folder + tag filters are mutually exclusive — picking a folder clears the
+    // tag selection (and its fetched list) so they never compose.
+    if (folderId !== null) {
+      this.activeTag.set(null);
+      this.tagMeetings.set([]);
+      this.tagLoading.set(false);
+    }
+    this.activeFolderId.set(folderId);
+  }
+
+  // --- Lock-aware row rendering -------------------------------------------
+
+  /**
+   * The exposure of the folder a meeting lives in (open / locked / session), or
+   * null when the note is at the vault root / its folder isn't known. Drives the
+   * inline lock badge on a meeting row.
+   */
+  folderExposureOf(m: Meeting): FolderExposure | null {
+    const fid = m.folderId ?? null;
+    if (fid === null) {
+      return null;
+    }
+    const node = this.folderById().get(fid);
+    return node ? this.folders.exposureOf(node) : null;
+  }
+
+  /**
+   * Whether a meeting's title must be masked: it lives in a folder that is
+   * sealed and NOT session-unlocked (`exposure === 'locked'`). A session-
+   * unlocked folder ('session') shows its titles normally.
+   */
+  isMasked(m: Meeting): boolean {
+    return this.folderExposureOf(m) === "locked";
   }
 
   // --- Search-as-you-type --------------------------------------------------
@@ -867,11 +1127,14 @@ export class LibraryComponent implements OnInit {
       return;
     }
 
-    // Search takes precedence over the tag filter: reset to the full list so
-    // that clearing the search returns to "All" (the chip bar is hidden while
-    // searching). Per-row delete still works against `meetings` underneath.
+    // Search takes precedence over BOTH the tag and folder filters: reset to
+    // the full list so clearing the search returns to "All" (the chip bar is
+    // hidden while searching). Per-row delete still works against `meetings`.
     if (this.activeTag() !== null) {
       void this.selectTag(null);
+    }
+    if (this.activeFolderId() !== null) {
+      this.activeFolderId.set(null);
     }
 
     this.searching.set(true);

--- a/src/app/features/library/library.component.ts
+++ b/src/app/features/library/library.component.ts
@@ -876,7 +876,10 @@ export class LibraryComponent implements OnInit {
     const walk = (nodes: FolderNode[]): void => {
       for (const n of nodes) {
         map.set(n.id, n);
-        if (n.children.length) {
+        // Defensive: a node from an older/odd backend may omit `children`.
+        // Never let a missing array throw here — that would take the whole
+        // Library view (both panes) down, not just the folder tree.
+        if (n.children?.length) {
           walk(n.children);
         }
       }

--- a/src/app/features/record/mic-mute-toggle.component.ts
+++ b/src/app/features/record/mic-mute-toggle.component.ts
@@ -1,0 +1,242 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+
+/**
+ * MIC-MUTE toggle — shown ONLY while recording (the host decides when to render
+ * it). A single clear button flips the LOCAL microphone between on and off;
+ * muting silences only the mic — captured system audio ("others") keeps
+ * recording, which the hint makes explicit.
+ *
+ * Presentational + self-owning: it reads the live mute state from the backend
+ * on mount (`isMicMuted`) and flips OPTIMISTICALLY on click (`setMicMuted`),
+ * rolling back if the IPC call rejects. It never starts/stops a recording, so
+ * it can sit beside the Stop / Start controls without interfering with them.
+ *
+ * Lives in its own file (own inline-style budget) and is reused by BOTH the
+ * Record screen and the floating bar — the `compact` input slims it for the
+ * pill. Inline SVG glyphs (no icon dependency); tokens only.
+ */
+@Component({
+  selector: "app-mic-mute-toggle",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <button
+      type="button"
+      class="mic"
+      [class.is-muted]="muted()"
+      [class.is-compact]="compact()"
+      [disabled]="busy()"
+      [attr.aria-pressed]="muted()"
+      [attr.aria-label]="muted() ? 'Unmute microphone' : 'Mute microphone'"
+      [title]="muted() ? 'Unmute microphone' : 'Mute microphone'"
+      (click)="toggle()"
+    >
+      @if (muted()) {
+        <!-- Mic-off: mic body + a diagonal slash. -->
+        <svg
+          class="mic-ico"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M9 9V5a3 3 0 0 1 5.12-2.12M15 9.34V10a3 3 0 0 1-3 3"
+            stroke="currentColor"
+            stroke-width="1.9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M17 11a5 5 0 0 1-.54 2.27M5 11a7 7 0 0 0 7 7m0 0v3m0-3a6.97 6.97 0 0 0 1.6-.18"
+            stroke="currentColor"
+            stroke-width="1.9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M3 3l18 18"
+            stroke="currentColor"
+            stroke-width="1.9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      } @else {
+        <!-- Mic-on: classic capsule mic + stand. -->
+        <svg
+          class="mic-ico"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <rect
+            x="9"
+            y="2"
+            width="6"
+            height="12"
+            rx="3"
+            stroke="currentColor"
+            stroke-width="1.9"
+          />
+          <path
+            d="M5 11a7 7 0 0 0 14 0M12 18v3"
+            stroke="currentColor"
+            stroke-width="1.9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      }
+      @if (!compact()) {
+        <span class="mic-label">{{ muted() ? "Muted" : "Mute" }}</span>
+      }
+    </button>
+    @if (muted() && !compact()) {
+      <span class="mic-hint" role="status">
+        Mic muted — still capturing others
+      </span>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+
+      /* The toggle — neutral when live, unmistakable accent/live when muted. */
+      .mic {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        height: 40px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-pill);
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.875rem;
+        font-weight: 550;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          border-color var(--transition),
+          color var(--transition),
+          box-shadow var(--transition),
+          transform var(--transition-fast);
+      }
+      .mic:hover:not(:disabled) {
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+        color: var(--text-primary);
+      }
+      .mic:active:not(:disabled) {
+        transform: translateY(1px);
+      }
+      .mic:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .mic:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      /* Muted — loud, alive: warm "live" fill so it reads at a glance. */
+      .mic.is-muted {
+        background: var(--live-soft);
+        border-color: transparent;
+        color: var(--live-hover);
+      }
+      .mic.is-muted:hover:not(:disabled) {
+        background: var(--live-soft);
+        color: var(--live-hover);
+        filter: brightness(1.08);
+      }
+      .mic.is-muted:focus-visible {
+        box-shadow: 0 0 0 3px rgba(255, 122, 92, 0.6);
+      }
+
+      /* Compact (floating bar): icon-only circle, sized to the slim pill. */
+      .mic.is-compact {
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+        padding: 0;
+        border-radius: 50%;
+      }
+
+      .mic-ico {
+        width: 18px;
+        height: 18px;
+        flex: none;
+      }
+      .mic-label {
+        line-height: 1;
+      }
+
+      .mic-hint {
+        color: var(--live-hover);
+        font-size: 0.8125rem;
+        font-weight: 500;
+        line-height: 1.3;
+        white-space: nowrap;
+      }
+    `,
+  ],
+})
+export class MicMuteToggleComponent implements OnInit {
+  private readonly ipc = inject(IpcService);
+
+  /** Slim, icon-only variant for the floating bar (hides the label + hint). */
+  readonly compact = input<boolean>(false);
+
+  /** Whether the mic is currently muted (init from the backend; flips optimistically). */
+  readonly muted = signal(false);
+  /** True while a setMicMuted IPC call is in flight (debounces double-clicks). */
+  readonly busy = signal(false);
+
+  async ngOnInit(): Promise<void> {
+    // Seed from the live recorder so the icon reflects reality on mount.
+    // Best-effort: a failure (or "not recording" → false) leaves it un-muted.
+    try {
+      this.muted.set(await this.ipc.isMicMuted());
+    } catch {
+      this.muted.set(false);
+    }
+  }
+
+  /**
+   * Optimistically flip the mic state, then persist via `setMicMuted`. On an
+   * IPC failure we roll the icon back so it never lies about the real state.
+   * Never touches start/stop — only the mic mute flag.
+   */
+  async toggle(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    const next = !this.muted();
+    this.muted.set(next);
+    this.busy.set(true);
+    try {
+      await this.ipc.setMicMuted(next);
+    } catch {
+      this.muted.set(!next);
+    } finally {
+      this.busy.set(false);
+    }
+  }
+}

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -6,18 +6,20 @@ import {
   computed,
   inject,
   signal,
+  viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { RecorderStore } from "../../core/recorder.store";
 import { IpcService } from "../../core/ipc.service";
 import type { Analytics, AppConfigDto } from "../../core/models";
 import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
+import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
 
 @Component({
   selector: "app-record",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, PreMeetingBriefComponent],
+  imports: [RouterLink, PreMeetingBriefComponent, MicMuteToggleComponent],
   host: { "(document:keydown)": "onKey($event)" },
   template: `
     <section class="record">
@@ -101,6 +103,11 @@ import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
                 <span class="wbar" [style.--i]="b"></span>
               }
             </div>
+            <!-- Mic-mute: silences only the local mic; system audio keeps
+                 recording. Sits beside Stop but never starts/stops anything.
+                 Compact (icon-only) so the pill stays uncrowded; the descriptive
+                 "still capturing others" copy rides the stage hint below. -->
+            <app-mic-mute-toggle [compact]="true" #micToggle />
             <button
               type="button"
               class="stop-btn"
@@ -875,6 +882,9 @@ export class RecordComponent implements OnInit {
   /** Bars in the live waveform (driven by the real mic level signal). */
   readonly bars = Array.from({ length: 28 }, (_, i) => i);
 
+  /** The in-pill mic-mute toggle — its `muted()` signal drives the stage hint. */
+  private readonly micToggle = viewChild(MicMuteToggleComponent);
+
   /** Latest partial transcript, trimmed — drives the ephemeral caption line. */
   readonly liveCaption = computed(() => this.store.liveCaption().trim());
 
@@ -950,8 +960,13 @@ export class RecordComponent implements OnInit {
 
   /** Context line beneath the bar. */
   readonly hint = computed(() => {
-    if (this.store.isRecording())
+    if (this.store.isRecording()) {
+      // When the mic is muted the recording continues from system audio only —
+      // make that unmistakable in the prominent hint line beneath the pill.
+      if (this.micToggle()?.muted())
+        return "Mic muted — still capturing others. Press ⌘R or Stop when done.";
       return "Recording — press ⌘R or Stop when done.";
+    }
     if (this.isProcessing()) return "Transcribing on-device, then summarizing…";
     if (this.vaultMissing()) return "Set a vault folder in Settings to start.";
     if (this.modelPresent() === false) return "Download the model to start.";

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -538,7 +538,16 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
           </p>
         </div>
 
-        <!-- (2) Local MCP server -->
+        <!-- (2) Locked folders (honest encryption boundary) -->
+        <div class="privacy-section">
+          <span class="privacy-section-label text-muted">Locked folders</span>
+          <p class="text-secondary privacy-note">
+            Locked folders are encrypted and pulled out of your Obsidian vault;
+            open notes remain plaintext .md files Obsidian can read.
+          </p>
+        </div>
+
+        <!-- (3) Local MCP server -->
         <div class="privacy-section">
           <span class="privacy-section-label text-muted">Local MCP server</span>
           <p class="text-secondary privacy-note">

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -26,13 +26,14 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
         </div>
       }
 
-      <!-- Transcription model: language + quality + auto-download -->
+      <!-- Transcription model: language + quality + on-demand download -->
       <div class="card model-card">
         <div class="model-copy">
           <h3>Transcription model</h3>
           <p class="text-secondary model-sub">
-            Runs on-device. Pick your language and quality — the matching
-            Whisper model downloads automatically.
+            Runs entirely on-device. Pick your language and quality — the
+            matching Whisper model is fetched once and reused for every
+            recording.
           </p>
         </div>
 
@@ -41,8 +42,8 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
             <span class="field-label">Language</span>
             <select formControlName="language" (change)="onModelChoiceChange()">
               <option value="">Auto-detect</option>
-              <option value="en">English</option>
               <option value="pl">Polski</option>
+              <option value="en">English</option>
               <option value="de">Deutsch</option>
               <option value="es">Español</option>
               <option value="fr">Français</option>
@@ -51,6 +52,10 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
               <option value="uk">Українська</option>
               <option value="nl">Nederlands</option>
             </select>
+            <span class="field-help text-muted">
+              Force the transcription language. Polish recommended if you record
+              mostly in Polish (auto-detect can misfire on short clips).
+            </span>
           </label>
 
           <label class="field">
@@ -61,10 +66,19 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
             >
               <option value="tiny">Tiny — fastest (~75 MB)</option>
               <option value="base">Base (~150 MB)</option>
-              <option value="small">Small — recommended (~470 MB)</option>
-              <option value="medium">Medium — accurate (~1.5 GB)</option>
-              <option value="large-v3">Large — best (~3 GB)</option>
+              <option value="small">Small (~470 MB)</option>
+              <option value="medium">Medium (~1.5 GB)</option>
+              <option value="large-v3-turbo">
+                Large v3 Turbo — fast &amp; accurate (~1.6 GB)
+              </option>
+              <option value="large-v3">
+                Large v3 — best accuracy, recommended (~3 GB)
+              </option>
             </select>
+            <span class="field-help text-muted">
+              Large v3 is the most accurate and the default — it’s a one-time ~3
+              GB download. Turbo is nearly as good and much smaller.
+            </span>
           </label>
         </div>
 
@@ -72,7 +86,10 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
           @if (modelPresent() === true) {
             <span class="pill is-success">
               <span class="pill-dot"></span>
-              Model ready
+              Downloaded ✓
+            </span>
+            <span class="text-muted model-note">
+              Stored on this Mac — used for every recording.
             </span>
           } @else if (modelPresent() === false) {
             <button
@@ -82,11 +99,19 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
               [disabled]="downloadingModel()"
             >
               @if (downloadingModel()) {
+                <span class="spin-ring" aria-hidden="true"></span>
                 Downloading…
               } @else {
-                Download model ({{ downloadHint() }})
+                Download ({{ downloadHint() }})
               }
             </button>
+            <span class="text-muted model-note">
+              @if (downloadingModel()) {
+                Fetching the model — large models can take a few minutes.
+              } @else {
+                {{ downloadHint() }}, one time, on-device.
+              }
+            </span>
           } @else {
             <span class="pill">
               <span class="pill-dot"></span>
@@ -694,6 +719,34 @@ import type { AppConfigDto, ProviderStatus } from "../../core/models";
       .model-status-row {
         display: flex;
         align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        min-height: 40px;
+      }
+      .model-note {
+        font-size: 0.85rem;
+      }
+      /* Inline spinner on the Download button (matches the onboarding wizard). */
+      .spin-ring {
+        width: 15px;
+        height: 15px;
+        border-radius: 50%;
+        border: 2px solid rgba(255, 255, 255, 0.35);
+        border-top-color: var(--text-on-accent);
+        animation: spin 0.8s linear infinite;
+        margin-right: var(--space-2);
+        vertical-align: -2px;
+        display: inline-block;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .spin-ring {
+          animation: none;
+        }
       }
 
       /* --- Notes card (summary style + auto-organize) --- */
@@ -1107,7 +1160,7 @@ export class SettingsComponent implements OnInit {
     ollamaModel: "llama3.1",
     claudeBinary: "claude",
     captureSystemAudio: false,
-    modelSize: "small",
+    modelSize: "large-v3",
     voiceTrigger: false,
     noteStyle: "standard",
     autoOrganize: false,
@@ -1154,7 +1207,7 @@ export class SettingsComponent implements OnInit {
   readonly modelDownloadError = signal<string | null>(null);
 
   /** Approx download size for the selected quality (shown on the Download button). */
-  readonly downloadHint = signal("~470 MB");
+  readonly downloadHint = signal("~3 GB");
 
   /** Preserved from the loaded config (not a form field) so saving never un-onboards. */
   private loadedOnboarded = true;
@@ -1174,7 +1227,7 @@ export class SettingsComponent implements OnInit {
         ollamaModel: cfg.ollamaModel,
         claudeBinary: cfg.claudeBinary,
         captureSystemAudio: cfg.captureSystemAudio ?? false,
-        modelSize: cfg.modelSize ?? "small",
+        modelSize: cfg.modelSize ?? "large-v3",
         voiceTrigger: cfg.voiceTrigger ?? false,
         noteStyle: cfg.noteStyle ?? "standard",
         autoOrganize: cfg.autoOrganize ?? false,
@@ -1258,6 +1311,7 @@ export class SettingsComponent implements OnInit {
       base: "~150 MB",
       small: "~470 MB",
       medium: "~1.5 GB",
+      "large-v3-turbo": "~1.6 GB",
       "large-v3": "~3 GB",
     };
     this.downloadHint.set(hints[this.form.getRawValue().modelSize] ?? "");

--- a/src/app/services/folders.service.ts
+++ b/src/app/services/folders.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, computed, inject, signal } from "@angular/core";
 import { IpcService } from "../core/ipc.service";
-import type { FolderNode } from "../core/models";
+import type { Folder, FolderNode } from "../core/models";
 
 /**
  * A folder's privacy exposure, derived from its lock flags:
@@ -75,13 +75,15 @@ export class FoldersService {
   /**
    * Create a folder under `parentId` (null = vault root). The IPC returns the new
    * `Folder` row (no counts/children), so we reload the tree to fold it in with
-   * the rest of the forest rather than splice a partial node.
+   * the rest of the forest rather than splice a partial node. The created
+   * `Folder` is returned so the caller can select/highlight it once it appears.
    */
-  async create(name: string, parentId: string | null = null): Promise<void> {
+  async create(name: string, parentId: string | null = null): Promise<Folder> {
     this._error.set(null);
     try {
-      await this.ipc.createFolder(name, parentId);
+      const folder = await this.ipc.createFolder(name, parentId);
       await this.load();
+      return folder;
     } catch (e) {
       this._error.set(String(e));
       throw e;
@@ -166,7 +168,8 @@ export class FoldersService {
     const walk = (list: FolderNode[]): void => {
       for (const node of list) {
         out.push(node);
-        if (node.children.length) {
+        // Defensive: tolerate a node that omits `children` (older backend).
+        if (node.children?.length) {
           walk(node.children);
         }
       }

--- a/src/app/services/folders.service.ts
+++ b/src/app/services/folders.service.ts
@@ -1,0 +1,177 @@
+import { Injectable, computed, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type { FolderNode } from "../core/models";
+
+/**
+ * A folder's privacy exposure, derived from its lock flags:
+ *  - `"open"`    — not sealed; markdown lives in the vault as plaintext.
+ *  - `"locked"`  — sealed (encrypted) on disk; markdown blanked, not visible.
+ *  - `"session"` — sealed on disk BUT session-unlocked (decrypted into markdown
+ *                  for this session only; re-seals on relock / screen-share).
+ */
+export type FolderExposure = "open" | "locked" | "session";
+
+/**
+ * Signal store for the folder tree + the per-folder lock lifecycle (Stage C).
+ *
+ * The backend is the source of truth for lock state: every mutating op resolves,
+ * then we `load()` the fresh tree so `locked` / `unlocked` always mirror disk +
+ * session reality (we never optimistically toggle a flag the backend owns). A
+ * session-"unlocked" folder is simply a `FolderNode` with `locked && unlocked`.
+ */
+@Injectable({ providedIn: "root" })
+export class FoldersService {
+  private readonly ipc = inject(IpcService);
+
+  private readonly _tree = signal<FolderNode[]>([]);
+  private readonly _loading = signal(false);
+  private readonly _error = signal<string | null>(null);
+
+  /** The folder forest (roots → children), as last returned by the backend. */
+  readonly tree = this._tree.asReadonly();
+  /** True while the tree is being (re)loaded from the backend. */
+  readonly loading = this._loading.asReadonly();
+  /** Non-null when the last op failed (cleared at the start of the next op). */
+  readonly error = this._error.asReadonly();
+
+  /** Flattened view of every node in the forest, for counts/lookups. */
+  private readonly allNodes = computed(() => this.flatten(this._tree()));
+
+  /**
+   * How many sealed folders are session-unlocked right now (`locked && unlocked`)
+   * — the count of folders currently exposing plaintext to this session, e.g.
+   * for a "Lock all" affordance or a privacy indicator.
+   */
+  readonly unlockedCount = computed(
+    () => this.allNodes().filter((n) => n.locked && n.unlocked).length,
+  );
+
+  /** Whether the forest has any sealed folders at all. */
+  readonly hasLockedFolders = computed(() =>
+    this.allNodes().some((n) => n.locked),
+  );
+
+  /** Derive a folder's three-state privacy exposure from its lock flags. */
+  exposureOf(node: FolderNode): FolderExposure {
+    if (!node.locked) {
+      return "open";
+    }
+    return node.unlocked ? "session" : "locked";
+  }
+
+  /** (Re)load the folder tree from the backend. Safe to call repeatedly. */
+  async load(): Promise<void> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      this._tree.set(await this.ipc.listFolders());
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Create a folder under `parentId` (null = vault root). The IPC returns the new
+   * `Folder` row (no counts/children), so we reload the tree to fold it in with
+   * the rest of the forest rather than splice a partial node.
+   */
+  async create(name: string, parentId: string | null = null): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.createFolder(name, parentId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Move a note into `folderId` (null = vault root); refreshes per-folder counts. */
+  async moveNote(meetingId: string, folderId: string | null): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.moveNote(meetingId, folderId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Seal a folder (encrypt its notes, blank markdown, remove the vault .md). */
+  async lock(folderId: string): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.lockFolder(folderId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Session-unlock a sealed folder (decrypt into markdown for this session). */
+  async unlock(folderId: string): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.unlockFolder(folderId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Re-seal a single session-unlocked folder (stays locked on disk). */
+  async relock(folderId: string): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.relockFolder(folderId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Re-seal ALL session-unlocked folders + zeroize the cached key. */
+  async relockAll(): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.relockAll();
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Permanently remove a folder's lock (decrypt + re-export plaintext to vault). */
+  async removeLock(folderId: string): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.removeLock(folderId);
+      await this.load();
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Depth-first flatten of the forest into a single node list. */
+  private flatten(nodes: FolderNode[]): FolderNode[] {
+    const out: FolderNode[] = [];
+    const walk = (list: FolderNode[]): void => {
+      for (const node of list) {
+        out.push(node);
+        if (node.children.length) {
+          walk(node.children);
+        }
+      }
+    };
+    walk(nodes);
+    return out;
+  }
+}

--- a/src/app/services/screen-share.service.ts
+++ b/src/app/services/screen-share.service.ts
@@ -1,0 +1,65 @@
+import { DestroyRef, Injectable, inject } from "@angular/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { FoldersService } from "./folders.service";
+import { ToastService } from "./toast.service";
+
+/** Backend event fired the instant a screen share begins (privacy panic signal). */
+export const EVENT_SCREEN_SHARE_STARTED = "murmur://screen-share-started";
+
+/**
+ * Privacy guard: when the OS begins a screen share, the backend has ALREADY
+ * re-sealed every session-unlocked folder (zeroizing the cached key). This
+ * service reacts on the front end — it reloads the folder tree so the UI drops
+ * back to the locked state the disk now reflects, and surfaces a calm toast so
+ * the user understands why their private folders just re-locked.
+ *
+ * Init-once: `init()` is idempotent (a second call is a no-op while a listener
+ * is live). The Tauri unlisten handle is torn down via `DestroyRef.onDestroy`.
+ */
+@Injectable({ providedIn: "root" })
+export class ScreenShareService {
+  private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Live event-listener handle (null when not yet initialised / torn down). */
+  private unlisten: UnlistenFn | null = null;
+  /** Guards against overlapping init() calls before the listen() resolves. */
+  private initializing = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.unlisten?.();
+      this.unlisten = null;
+    });
+  }
+
+  /**
+   * Begin listening for the screen-share signal. Call once at app start (e.g.
+   * from the root component). Re-entrant-safe: a second call while a listener is
+   * live (or being registered) does nothing.
+   */
+  async init(): Promise<void> {
+    if (this.unlisten || this.initializing) {
+      return;
+    }
+    this.initializing = true;
+    try {
+      this.unlisten = await listen(EVENT_SCREEN_SHARE_STARTED, () => {
+        void this.onScreenShareStarted();
+      });
+    } finally {
+      this.initializing = false;
+    }
+  }
+
+  /**
+   * React to a screen share starting: the backend already relocked, so we just
+   * resync the tree from disk and tell the user. The toast is informational; the
+   * security action happened in the backend before this event fired.
+   */
+  private async onScreenShareStarted(): Promise<void> {
+    await this.folders.load();
+    this.toast.info("Locked your private folders — screen sharing started");
+  }
+}

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,0 +1,103 @@
+import {
+  DestroyRef,
+  Injectable,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+
+/** A single live toast. `kind` tints the strip; `id` keys the @for + dismissal. */
+export interface Toast {
+  id: number;
+  message: string;
+  kind: "info" | "success" | "danger";
+}
+
+/** How long a toast lingers before it auto-dismisses (ms). */
+const DEFAULT_TTL_MS = 4200;
+
+/**
+ * App-wide toast queue, signal-based. Components read {@link toasts} (a readonly
+ * signal) and render them; anything can `push(...)` a transient message.
+ *
+ * Timer lifecycle is owned here, not in components: each toast schedules ONE
+ * tracked `setTimeout`, all of which are cleared in `DestroyRef.onDestroy`
+ * (sanctioned service-timer pattern — never a bare component setTimeout). The
+ * service is `providedIn: "root"`, so its DestroyRef is the root injector's and
+ * the timers live for the app's lifetime, but the cleanup keeps it leak-clean
+ * and HMR-safe.
+ */
+@Injectable({ providedIn: "root" })
+export class ToastService {
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _toasts = signal<Toast[]>([]);
+  /** The live toast queue, oldest first. */
+  readonly toasts = this._toasts.asReadonly();
+  /** True when at least one toast is showing (drives the host viewport). */
+  readonly hasToasts = computed(() => this._toasts().length > 0);
+
+  /** Monotonic id source so re-used messages still get a unique key. */
+  private nextId = 1;
+  /** Active auto-dismiss timers, keyed by toast id, so we can clear them. */
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+  constructor() {
+    // Clear every pending auto-dismiss timer on teardown — no orphaned timers.
+    this.destroyRef.onDestroy(() => {
+      for (const handle of this.timers.values()) {
+        clearTimeout(handle);
+      }
+      this.timers.clear();
+    });
+  }
+
+  /** Push a toast; returns its id. Auto-dismisses after `ttlMs` (0 = sticky). */
+  push(
+    message: string,
+    kind: Toast["kind"] = "info",
+    ttlMs: number = DEFAULT_TTL_MS,
+  ): number {
+    const id = this.nextId++;
+    this._toasts.update((list) => [...list, { id, message, kind }]);
+    if (ttlMs > 0) {
+      const handle = setTimeout(() => this.dismiss(id), ttlMs);
+      this.timers.set(id, handle);
+    }
+    return id;
+  }
+
+  /** Convenience: a neutral info toast. */
+  info(message: string, ttlMs?: number): number {
+    return this.push(message, "info", ttlMs);
+  }
+
+  /** Convenience: a success-tinted toast. */
+  success(message: string, ttlMs?: number): number {
+    return this.push(message, "success", ttlMs);
+  }
+
+  /** Convenience: a danger-tinted toast (sticks a little longer by default). */
+  danger(message: string, ttlMs = 6000): number {
+    return this.push(message, "danger", ttlMs);
+  }
+
+  /** Remove a toast by id (also cancels its pending auto-dismiss timer). */
+  dismiss(id: number): void {
+    const handle = this.timers.get(id);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      this.timers.delete(id);
+    }
+    this._toasts.update((list) => list.filter((t) => t.id !== id));
+  }
+
+  /** Clear every toast at once (and all their timers). */
+  clear(): void {
+    for (const handle of this.timers.values()) {
+      clearTimeout(handle);
+    }
+    this.timers.clear();
+    this._toasts.set([]);
+  }
+}


### PR DESCRIPTION
Merges all feature work into murmur.

**Phase 0 — encryption + lock:** SQLCipher whole-DB at-rest encryption + safe live migration; per-folder lock (seal/unlock/relock/remove, AES-GCM content-key under master KEK); MCP exposure filter + token; biometric Touch ID gate.

**Phase 1 — graph + filing:** in-app self-assembling graph (entities/mentions, lock-aware) + graph UI; direct meeting→folder filing (row chip + Move menu + drag-and-drop).

**Transcription engine:** large-v3 default + global Polish language + decoding hygiene (beam/temperature/thresholds, batch); dual-stream capture + live mic-mute + Me/Others attribution (wall-clock merge).

**Full per-folder lock (0.5):** gate detail/segments/timeline/audio for locked-not-unlocked meetings + seal transcript+timeline + encrypt audio WAV at rest; detail-view unlock gate (Touch ID).

123 Rust lib tests green; ng build + lint green. Honest dents: screen-share auto-relock inactive (needs ScreenCaptureKit, not NSScreen.isCaptured); biometric Touch ID + lock need a signed build to verify live; Me/Others is 2-way (not per-remote-person).