### PR TITLE
Screen-share auto-relock (best-effort, crash-safe)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,14 +66,18 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # ── macOS biometric (Touch ID) + screen-share detection (Stage E) ──
 # These objc2 crates are already in the dependency graph transitively (via tauri/tao);
-# we pin the same 0.6/0.3 family. LocalAuthentication = Touch ID KEK gate; AppKit = NSScreen
-# isCaptured screen-share watcher. macOS-only — gated under cfg(target_os = "macos").
+# we pin the same 0.6/0.3 family. LocalAuthentication = Touch ID KEK gate.
+# Screen-share auto-relock uses the PURE CoreGraphics C window-list API (no ObjC msg_send / no
+# NSException risk): objc2-core-graphics CGWindow + objc2-core-foundation CFArray/CFDictionary/
+# CFString for reading window owner + title. macOS-only — gated under cfg(target_os = "macos").
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 block2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSString", "NSError"] }
 objc2-app-kit = { version = "0.3", features = ["NSScreen"] }
 objc2-local-authentication = { version = "0.3", features = ["LAContext", "LAError", "block2"] }
+objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGWindow"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFDictionary", "CFString"] }
 
 [features]
 # default keeps Metal on for whisper; nothing else conditional in P0

--- a/src-tauri/src/screenshare.rs
+++ b/src-tauri/src/screenshare.rs
@@ -1,24 +1,44 @@
 //! Screen-share / screen-capture watcher → auto-relock (Stage E).
 //!
-//! When the screen STARTS being captured or shared (a screen recording, a Zoom/Meet "share
-//! screen", a QuickTime capture, etc.) any session-unlocked sealed folders are a privacy leak —
-//! their plaintext markdown is live in the DB and on screen. This watcher detects the rising edge
-//! (not-captured → captured) of `NSScreen.isCaptured` and calls `relock_all_inner`, which clears
-//! the session unlock set and zeroizes the cached KEK, plus emits a Tauri event so the UI can
-//! toast.
+//! When the screen STARTS being shared in a video call (a Zoom/Meet/Teams "share screen") any
+//! session-unlocked sealed folders are a privacy leak — their plaintext markdown is live in the DB
+//! and on screen. This watcher detects the rising edge (not-sharing → sharing) and calls
+//! `relock_all_inner`, which clears the session unlock set and zeroizes the cached KEK, plus emits
+//! a Tauri event so the UI can toast.
 //!
-//! IMPLEMENTATION: a ~1.5s `tokio::interval` poll of `NSScreen.isCaptured` across all screens on a
-//! background task. The model wants "fire on START", which the rising-edge detection over the poll
-//! gives us (we only act on false→true, never re-fire while it stays captured). We deliberately do
-//! NOT use the deprecated `CGDisplayIsCaptured()` — it is semantically wrong (exclusive-render,
-//! not screen-share) and deprecated.
+//! DETECTION IS A BEST-EFFORT HEURISTIC (the user explicitly accepted false positives — a relock is
+//! cheap and non-destructive). There is NO public macOS API that reliably reports "a conferencing
+//! app is sharing the screen": `CGDisplayIsCaptured` only fires on *exclusive* display capture and
+//! never trips on Zoom/Meet/Teams; `NSScreen.isCaptured` does not exist on macOS (it is a UIScreen /
+//! iOS selector — sending it was the prior boot-abort root cause). So instead we look for the
+//! tell-tale UI a conferencing app floats ONLY while a share is active: the "you're sharing your
+//! screen" / "stop sharing" control bars and share toolbars. We enumerate on-screen windows with
+//! the pure CoreGraphics C function `CGWindowListCopyWindowInfo` and match each window's owner +
+//! title against a maintainable heuristic table (see the consts below). Biasing on the *sharing
+//! control window* (not merely the app running, nor merely being in a call) keeps false positives
+//! to the share-active window.
 //!
-//! HONEST DENT (documented): full-screen / whole-display share flips `isCaptured`; a single-window
-//! WebRTC share (e.g. Meet sharing one Chrome tab) may NOT flip whole-screen `isCaptured`. Relock
-//! is best-effort hiding — it cannot recall what is already on screen.
+//! IMPLEMENTATION: a ~1.5s poll on a dedicated OS thread, marshaled to the main thread, with
+//! rising-edge detection (we act only on false→true, never re-fire while sharing stays on).
 //!
-//! GRACEFUL DEGRADATION: on a non-macOS host or if AppKit can't be reached, the poll simply
-//! reports "not captured" forever and never fires — it never panics.
+//! HONEST LIMITS (documented): this only sees what apps expose. (a) Apps that do NOT name their
+//! share-control window — Zoom in particular often exposes no `kCGWindowName` for its share toolbar
+//! — are MISSED by the title match. (b) A single-window/tab WebRTC share with no floating control
+//! bar can be missed. (c) macOS bias toward false positives means a browser tab merely *titled*
+//! "screen sharing" can trip it (accepted). The manual "Lock all" button in the UI remains the
+//! authoritative backstop for everything the heuristic misses.
+//!
+//! CRASH-SAFETY: every probe call is a plain CoreGraphics / CoreFoundation **C function**
+//! (`CGWindowListCopyWindowInfo`, `CFArrayGetCount`, `CFArrayGetValueAtIndex`,
+//! `CFDictionaryGetValue`, `CFGetTypeID`, CFString reads). NONE is an Objective-C `msg_send` /
+//! selector dispatch, so there is NO "unrecognized selector" `NSException` that could cross the FFI
+//! boundary and abort the process ("Rust cannot catch foreign exceptions") — which is exactly what
+//! the prior `msg_send![screen, isCaptured]` attempt did. We deliberately do NOT call NSWorkspace
+//! (which would require a guarded `respondsToSelector:` dance); the window list already names the
+//! owning app, so app-set corroboration is free and exception-free.
+//!
+//! GRACEFUL DEGRADATION: on a non-macOS host, or if the window list cannot be obtained, the poll
+//! simply reports "not sharing" and never fires — it never panics.
 
 use std::time::Duration;
 
@@ -26,16 +46,65 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use crate::state::AppState;
 
-/// Event emitted to all windows when screen capture/sharing STARTS (rising edge). The UI listens
-/// and toasts "Screen sharing detected — locked notes were re-secured."
+/// Event emitted to all windows when screen sharing STARTS (rising edge). The UI listens and toasts
+/// "Screen sharing detected — locked notes were re-secured."
 pub const EVENT_SCREEN_SHARE_STARTED: &str = "murmur://screen-share-started";
 
-/// Poll cadence for the capture-state check. ~1.5s is responsive enough to re-secure quickly while
+/// Poll cadence for the share-state check. ~1.5s is responsive enough to re-secure quickly while
 /// being negligible CPU.
 const POLL_INTERVAL: Duration = Duration::from_millis(1500);
 
-/// Spawn the screen-share watcher on the Tauri async runtime. Best-effort: if the config flag is
-/// off, or if the platform can't report capture state, this is a no-op loop.
+// ── Heuristic tables (BEST-EFFORT — expect to tweak these as apps change) ─────────────────────────
+//
+// These are maintained by hand and WILL drift as conferencing apps rename processes or restyle
+// their share UI. They are matched case-insensitively as substrings. Keep them specific to the
+// *active-share* surface so we fire on sharing, not on the app merely running or being in a call.
+
+/// Window-OWNER names (`kCGWindowOwnerName`) of apps that can screen-share. Matching the owner is
+/// only the *first* gate — we additionally require a sharing-indicator title (see
+/// `APP_SHARING_INDICATORS`) so that merely running the app does not trip a relock. HEURISTIC.
+const CONFERENCING_OWNERS: &[&str] = &[
+    "zoom.us",       // Zoom
+    "zoom",          // Zoom (older / localized helper process names)
+    "microsoft teams", // Teams classic + "Microsoft Teams (work or school)"
+    "google chrome", // Meet / generic WebRTC share runs inside Chrome
+    "chromium",
+    "google chrome canary",
+    "safari",        // Meet / WebRTC share inside Safari
+    "microsoft edge",
+    "firefox",
+    "webex",         // Cisco Webex Meetings ("Webex", "Meeting Center")
+    "cisco webex",
+    "slack",         // Slack huddles
+    "discord",
+    "whereby",
+    "around",
+];
+
+/// STRONG, owner-AGNOSTIC active-share phrases. A window titled with one of these is almost
+/// certainly a live share-control bar (Teams: "You're sharing your screen"; Chrome/Meet: "X is
+/// sharing your screen"). We fire on these regardless of the reported owner — important because on
+/// macOS 26 (Tahoe) `CGWindowListCopyWindowInfo` mis-attributes some status-bar items to "Control
+/// Center" (FB18327911), which would otherwise hide the real owner. HEURISTIC.
+const STRONG_SHARING_PHRASES: &[&str] = &[
+    "sharing your screen", // covers "you are/you're/X is sharing your screen"
+    "stop sharing",        // the Stop-Sharing control common to share bars
+];
+
+/// WEAKER active-share hints that only count when the window is owned by a known conferencing app
+/// (`CONFERENCING_OWNERS`). HEURISTIC.
+const APP_SHARING_INDICATORS: &[&str] = &[
+    "you are sharing",
+    "you're sharing",
+    "screen sharing",
+    "screen share",
+    "share toolbar",  // Zoom share/annotation toolbar
+    "as_toolbar",     // Zoom internal share/annotation toolbar window name
+    "sharing indicator",
+];
+
+/// Spawn the screen-share watcher on a dedicated OS thread. Best-effort: if the config flag is off,
+/// or if the platform can't report share state, this is a no-op loop.
 ///
 /// Gated by `K_RELOCK_ON_SCREENSHARE` (default true) read once at spawn time.
 pub fn spawn(app: AppHandle) {
@@ -53,10 +122,10 @@ pub fn spawn(app: AppHandle) {
         return;
     }
 
-    // Poll on a DEDICATED OS THREAD (not the async runtime): the NSScreen read MUST be marshaled
-    // to the main thread — AppKit is main-thread-affine, and calling it off-main throws an
-    // Objective-C exception that aborts the whole process ("Rust cannot catch foreign exceptions").
-    // A std thread can safely block on the main-thread reply between polls.
+    // Poll on a DEDICATED OS THREAD (not the async runtime): we marshal the actual probe to the main
+    // thread (see `captured_on_main`) and block on its reply between polls, which a std thread can do
+    // safely. The probe itself is pure CoreGraphics C — main-thread-safe and exception-free — but we
+    // keep the marshaling for consistency with the rest of the macOS bridge.
     std::thread::Builder::new()
         .name("murmur-screenshare".into())
         .spawn(move || watch(app))
@@ -68,7 +137,7 @@ fn watch(app: AppHandle) {
     let mut was_captured = captured_on_main(&app);
     tracing::info!(
         target: "screenshare",
-        initial_captured = was_captured,
+        initial_sharing = was_captured,
         "screen-share watcher started"
     );
 
@@ -76,12 +145,12 @@ fn watch(app: AppHandle) {
         std::thread::sleep(POLL_INTERVAL);
         let now_captured = captured_on_main(&app);
 
-        // Rising edge only: fire on START (false → true). We do not re-fire while it stays true,
-        // and we silently reset on the falling edge.
+        // Rising edge only: fire on START (false → true). We do not re-fire while it stays true, and
+        // we silently reset on the falling edge.
         if now_captured && !was_captured {
             tracing::warn!(
                 target: "screenshare",
-                "screen capture/sharing started — relocking all session-unlocked folders"
+                "screen sharing started — relocking all session-unlocked folders"
             );
             on_capture_started(&app);
         }
@@ -89,9 +158,9 @@ fn watch(app: AppHandle) {
     }
 }
 
-/// Read `is_any_screen_captured()` on the MAIN THREAD (AppKit requirement) via Tauri's main-thread
-/// dispatch, returning the result over a channel. Returns false if the app is shutting down or the
-/// main thread does not reply promptly (never blocks forever, never throws across the boundary).
+/// Run `is_any_screen_captured()` on the MAIN THREAD via Tauri's main-thread dispatch, returning the
+/// result over a channel. Returns false if the app is shutting down or the main thread does not
+/// reply promptly (never blocks forever, never throws across the boundary).
 fn captured_on_main(app: &AppHandle) -> bool {
     let (tx, rx) = std::sync::mpsc::channel();
     if app
@@ -105,7 +174,7 @@ fn captured_on_main(app: &AppHandle) -> bool {
     rx.recv_timeout(Duration::from_secs(2)).unwrap_or(false)
 }
 
-/// React to a capture-start rising edge: relock everything + emit the UI event.
+/// React to a share-start rising edge: relock everything + emit the UI event.
 fn on_capture_started(app: &AppHandle) {
     let state = app.state::<AppState>();
     // relock_all_inner takes &AppState; State derefs to it.
@@ -126,24 +195,177 @@ fn on_capture_started(app: &AppHandle) {
     }
 }
 
-/// Capture-state probe. Returns `false` for now (detection inactive — see below).
+/// Pure heuristic decision: does an on-screen window (owner + title) look like a LIVE screen-share
+/// control surface? Factored out of the FFI walk so it is unit-testable without any window server.
 ///
-/// DISABLED PENDING A CORRECT API: the earlier attempt sent `-isCaptured` to `NSScreen`, but that
-/// is NOT a valid `NSScreen` selector — `msg_send![screen, isCaptured]` raises an "unrecognized
-/// selector" `NSException`, which crosses the FFI boundary as a foreign exception and ABORTS the
-/// whole process ("Rust cannot catch foreign exceptions") right after launch. A correct macOS
-/// screen-capture/share detection (e.g. ScreenCaptureKit `SCShareableContent`, or observing the
-/// system capture indicator) needs to be wired AND verified on a signed build before re-enabling.
-/// Until then this returns `false` so the watcher never fires and never crashes. Everything else
-/// in the lock model — encryption, per-folder seal, MCP-hiding, and MANUAL relock — is unaffected;
-/// only the *automatic* relock-on-screen-share trigger is inactive.
+/// Logic: fire if the title carries a STRONG owner-agnostic share phrase, OR if the owner is a known
+/// conferencing app AND the title carries a weaker app-share hint. Bias is toward active sharing —
+/// an app merely running (no share-control window) or an in-call-but-not-sharing state does not
+/// match.
 #[cfg(target_os = "macos")]
+fn is_active_share_window(owner: Option<&str>, title: Option<&str>) -> bool {
+    let title_lc = title.map(|t| t.to_ascii_lowercase());
+    if let Some(t) = title_lc.as_deref() {
+        if STRONG_SHARING_PHRASES.iter().any(|p| t.contains(p)) {
+            return true;
+        }
+    }
+
+    let owner_is_conferencing = owner
+        .map(|o| {
+            let o = o.to_ascii_lowercase();
+            CONFERENCING_OWNERS.iter().any(|c| o.contains(c))
+        })
+        .unwrap_or(false);
+    if owner_is_conferencing {
+        if let Some(t) = title_lc.as_deref() {
+            if APP_SHARING_INDICATORS.iter().any(|p| t.contains(p)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Read a string value (`kCGWindow*` key) out of a window-info dictionary. Crash-safe: every step is
+/// a CoreFoundation C function and a type-checked downcast — a missing key or a non-string value
+/// degrades to `None` rather than panicking.
+#[cfg(target_os = "macos")]
+fn dict_string(
+    dict: &objc2_core_foundation::CFDictionary,
+    key: &objc2_core_foundation::CFString,
+) -> Option<String> {
+    use core::ffi::c_void;
+
+    use objc2_core_foundation::{CFString, CFType};
+
+    let key_ptr = (key as *const CFString).cast::<c_void>();
+    // SAFETY: `key` is a valid CFString constant; `value` returns a borrowed (non-owned) pointer or
+    // null. We never retain it past this function.
+    let raw = unsafe { dict.value(key_ptr) };
+    if raw.is_null() {
+        return None;
+    }
+    // SAFETY: a non-null CF value; treat it as the root CFType, then type-check before reading.
+    let cf = unsafe { &*raw.cast::<CFType>() };
+    cf.downcast_ref::<CFString>().map(|s| s.to_string())
+}
+
+/// Share-state probe (macOS). Returns `true` when a live screen-share control surface is on screen.
+///
+/// Enumerates on-screen, non-desktop windows via the pure CoreGraphics C function
+/// `CGWindowListCopyWindowInfo` and matches each window's owner + title against the heuristic tables
+/// above. No Objective-C selector dispatch is involved, so it cannot raise a foreign `NSException`.
+/// Returns `false` when nothing is sharing (the sane default) or when the window list is
+/// unavailable.
+#[cfg(target_os = "macos")]
+fn is_any_screen_captured() -> bool {
+    use objc2_core_foundation::{CFDictionary, CFType};
+    use objc2_core_graphics::{
+        kCGNullWindowID, kCGWindowName, kCGWindowOwnerName, CGWindowListCopyWindowInfo,
+        CGWindowListOption,
+    };
+
+    // On-screen windows only, excluding desktop chrome (wallpaper, Dock, icons). This is the share
+    // *control bar* surface we want, and keeps the list small.
+    let option =
+        CGWindowListOption::OptionOnScreenOnly | CGWindowListOption::ExcludeDesktopElements;
+    let windows = match CGWindowListCopyWindowInfo(option, kCGNullWindowID) {
+        Some(list) => list,
+        // No window list (e.g. headless, or pre-Sonoma without Screen Recording permission). Treat
+        // as "not sharing" — best-effort, never throws.
+        None => return false,
+    };
+
+    let count = windows.count();
+    for idx in 0..count {
+        // SAFETY: idx in [0, count); the array holds borrowed window-info CFDictionary refs.
+        let raw = unsafe { windows.value_at_index(idx) };
+        if raw.is_null() {
+            continue;
+        }
+        // SAFETY: non-null CF value from the window list; type-check before treating as a dictionary.
+        let cf = unsafe { &*raw.cast::<CFType>() };
+        let Some(dict) = cf.downcast_ref::<CFDictionary>() else {
+            continue;
+        };
+
+        // SAFETY (statics): `kCGWindowOwnerName` / `kCGWindowName` are valid CoreGraphics CFString
+        // constants linked from the framework.
+        let owner = dict_string(dict, unsafe { kCGWindowOwnerName });
+        let title = dict_string(dict, unsafe { kCGWindowName });
+
+        if is_active_share_window(owner.as_deref(), title.as_deref()) {
+            tracing::info!(
+                target: "screenshare",
+                owner = owner.as_deref().unwrap_or("<unknown>"),
+                window = title.as_deref().unwrap_or("<unnamed>"),
+                "active screen-share indicator window detected (heuristic) — will relock"
+            );
+            return true;
+        }
+    }
+    false
+}
+
+/// Non-macOS fallback: no share signal available → always reports "not sharing" (never fires).
+#[cfg(not(target_os = "macos"))]
 fn is_any_screen_captured() -> bool {
     false
 }
 
-/// Non-macOS fallback: no capture signal available → always reports "not captured" (never fires).
-#[cfg(not(target_os = "macos"))]
-fn is_any_screen_captured() -> bool {
-    false
+#[cfg(test)]
+#[cfg(target_os = "macos")]
+mod tests {
+    use super::*;
+
+    /// The pure heuristic must fire on a real share-control title regardless of owner (Teams /
+    /// Chrome-Meet style), so a macOS-26 "Control Center" owner mis-attribution still trips it.
+    #[test]
+    fn strong_phrase_fires_owner_agnostic() {
+        assert!(is_active_share_window(
+            Some("Control Center"),
+            Some("Alex is sharing your screen")
+        ));
+        assert!(is_active_share_window(
+            Some("Microsoft Teams"),
+            Some("You're sharing your screen")
+        ));
+        assert!(is_active_share_window(None, Some("Stop Sharing")));
+    }
+
+    /// A known conferencing owner PLUS a weaker share hint fires; the same owner with a plain
+    /// in-call / app-running title does NOT (bias toward active sharing, not mere running).
+    #[test]
+    fn conferencing_owner_needs_a_share_hint() {
+        assert!(is_active_share_window(
+            Some("zoom.us"),
+            Some("Zoom - screen sharing")
+        ));
+        // In a Zoom meeting but NOT sharing → must not fire.
+        assert!(!is_active_share_window(Some("zoom.us"), Some("Zoom Meeting")));
+        // Zoom merely running with its main window → must not fire.
+        assert!(!is_active_share_window(Some("zoom.us"), Some("Zoom")));
+    }
+
+    /// Non-conferencing windows never fire, and a weak hint only counts for a conferencing owner.
+    #[test]
+    fn non_conferencing_or_no_signal_is_false() {
+        assert!(!is_active_share_window(Some("Finder"), Some("Desktop")));
+        assert!(!is_active_share_window(None, None));
+        // Weak hint, but a non-conferencing owner → not enough on its own.
+        assert!(!is_active_share_window(
+            Some("Preview"),
+            Some("screen sharing diagram.png")
+        ));
+    }
+
+    /// The real FFI probe must return a bool WITHOUT panicking across the CoreGraphics boundary.
+    /// We do not assert a specific value: in a normal test/CI environment nothing is sharing (so
+    /// `false` is expected), but asserting that would be environment-shaped — the load-bearing
+    /// guarantee is "no foreign-exception abort, returns cleanly".
+    #[test]
+    fn probe_does_not_panic_across_ffi() {
+        let _ = is_any_screen_captured();
+    }
 }


### PR DESCRIPTION
Re-enables screen-share auto-relock as a best-effort, crash-safe heuristic (no public macOS API detects modern screen-share). Enumerates on-screen windows via CGWindowListCopyWindowInfo (pure C — zero msg_send → the prior NSScreen.isCaptured abort root-cause is eliminated) and fires on an active share-control window; rising-edge → relock_all. Manual 'Lock all' remains the authoritative backstop. 127 Rust tests; boot-no-abort proven. Honest limit: Zoom's share toolbar often has no window title → owner alone doesn't fire (manual backstop covers it); firing on a real share needs manual verification on a signed build.