### PR TITLE
v0.3.1 — graceful init (never hard-crash on keychain/DB failure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.3.0"
+version = "0.3.1"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -20,6 +20,12 @@ pub enum AppError {
     Locked(String),
     #[error("secrets error: {0}")]
     Secrets(String),
+    /// macOS Keychain access was denied or the secure store was unreachable at runtime (the user
+    /// clicked "Deny" on the keychain prompt, or the keychain is locked). Distinct from
+    /// [`AppError::Secrets`] so startup can branch on the "couldn't reach the keychain" case and
+    /// show a specific, non-technical message instead of crashing.
+    #[error("keychain access denied: {0}")]
+    KeychainDenied(String),
     #[error("config error: {0}")]
     Config(String),
     #[error("provider unavailable: {0}")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,8 +33,6 @@ pub fn run() {
         )
         .init();
 
-    let state = AppState::init().expect("failed to initialize app state");
-
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(
@@ -47,7 +45,6 @@ pub fn run() {
                 })
                 .build(),
         )
-        .manage(state)
         .invoke_handler(tauri::generate_handler![
             commands::start_recording,
             commands::stop_recording,
@@ -110,6 +107,22 @@ pub fn run() {
             commands::remove_lock,
         ])
         .setup(|app| {
+            // Open the encrypted library FIRST. If it fails (keychain access denied, or the DB
+            // key doesn't match / the file is corrupt) we must NOT panic/abort — that is the
+            // v0.3.0 hard-crash. Instead show a friendly dialog and exit cleanly, leaving the DB
+            // and its backups untouched on disk.
+            let state = match AppState::init() {
+                Ok(s) => s,
+                Err(e) => {
+                    show_fatal_init_dialog(app.handle().clone(), &e);
+                    // Return Ok so the event loop spins: the dialog runs on a worker thread and
+                    // dispatches to the main run loop, then calls std::process::exit(1). We do NOT
+                    // run the rest of setup (windows/tray/MCP) without a valid AppState.
+                    return Ok(());
+                }
+            };
+            app.manage(state);
+
             create_bar_window(app.handle())?;
             if let Err(e) = app.global_shortcut().register(SUMMON_SHORTCUT) {
                 tracing::warn!(target: "shortcut", error = %e, "could not register global shortcut");
@@ -148,6 +161,63 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Startup-failure handler: AppState::init() returned Err. Show a clear, non-technical native
+/// dialog explaining that the encrypted library couldn't be opened, then exit cleanly with code 1
+/// — NEVER a Rust panic/abort (the v0.3.0 hard-crash). The two failure modes are distinguished in
+/// both the message and the log:
+///   (a) [`AppError::KeychainDenied`] — macOS refused keychain access (user clicked "Deny", or the
+///       keychain is locked).
+///   (b) anything else (storage / migration) — the DB couldn't be opened: the key doesn't match
+///       the data (e.g. restored from another Mac) or the file is damaged.
+/// This NEVER touches the database or its backups — it is a read-only, fail-safe exit path.
+fn show_fatal_init_dialog(handle: tauri::AppHandle, err: &crate::error::AppError) {
+    use crate::error::AppError;
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    const TITLE: &str = "Murmur can't open your library";
+
+    let (body, log_reason) = match err {
+        AppError::KeychainDenied(_) => (
+            "macOS didn't grant access to your keychain, so Murmur couldn't unlock its encrypted \
+             database.\n\nYour notes are safe and have not been changed. Please reopen Murmur and \
+             choose \"Always Allow\" when macOS asks for keychain access. If this keeps happening, \
+             contact support.",
+            "keychain access denied or unavailable",
+        ),
+        _ => (
+            "Murmur couldn't unlock its encrypted database. This can happen if the database key \
+             doesn't match the data on this Mac (for example after restoring from a backup or \
+             another computer) or if the file is damaged.\n\nYour notes have NOT been changed or \
+             deleted. Please reopen Murmur, and if this keeps happening, contact support.",
+            "database could not be opened (key mismatch / corruption)",
+        ),
+    };
+
+    // Technical detail goes to the log only (Display carries no PII / no secret material).
+    tracing::error!(target: "state", error = %err, reason = log_reason, "startup aborted: AppState::init failed");
+
+    // Hide the config-created main window so its webview can't flash a broken state behind the
+    // dialog (its commands would have no managed AppState).
+    if let Some(main) = handle.get_webview_window("main") {
+        let _ = main.hide();
+    }
+
+    // blocking_show() MUST run off the main thread — it dispatches the native dialog to the main
+    // run loop and blocks the caller, so calling it on the main thread would deadlock. Spawn a
+    // worker that shows the modal, then exits cleanly (code 1) once the user clicks OK.
+    let body = body.to_string();
+    std::thread::spawn(move || {
+        handle
+            .dialog()
+            .message(body)
+            .title(TITLE)
+            .kind(MessageDialogKind::Error)
+            .buttons(MessageDialogButtons::Ok)
+            .blocking_show();
+        std::process::exit(1);
+    });
 }
 
 /// Create the always-on-top, frameless, transparent floating recorder bar (hidden until

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -99,15 +99,30 @@ fn hex_to_key32(hex: &str) -> Option<[u8; 32]> {
 /// Build a keyring entry for `(SERVICE, account)`. `account` is the provider key name,
 /// e.g. "anthropic_api_key".
 fn entry(account: &str) -> Result<Entry> {
-    Entry::new(SERVICE, account)
-        .map_err(|e| AppError::Secrets(format!("failed to open keychain entry: {e}")))
+    Entry::new(SERVICE, account).map_err(|e| classify("open keychain entry", e))
+}
+
+/// Map a keyring error to a typed [`AppError`]. Runtime access failures — the user clicked
+/// "Deny" on the macOS keychain prompt, or the keychain is locked/unreachable — become
+/// [`AppError::KeychainDenied`] so startup can show a specific, recoverable message and exit
+/// cleanly instead of crashing. Everything else (malformed item, length, ambiguity) stays a
+/// generic [`AppError::Secrets`]. `NoEntry` is handled by callers (it means "not set", not error).
+/// The message carries only the platform error text — never the secret value — so it is safe to
+/// log under the no-PII rule.
+fn classify(ctx: impl std::fmt::Display, e: KeyringError) -> AppError {
+    match e {
+        KeyringError::PlatformFailure(_) | KeyringError::NoStorageAccess(_) => {
+            AppError::KeychainDenied(format!("{ctx}: {e}"))
+        }
+        other => AppError::Secrets(format!("{ctx}: {other}")),
+    }
 }
 
 /// Store/replace a secret in the macOS Keychain.
 pub fn set_secret(account: &str, secret: &str) -> Result<()> {
     entry(account)?
         .set_password(secret)
-        .map_err(|e| AppError::Secrets(format!("failed to set secret: {e}")))
+        .map_err(|e| classify("set secret", e))
 }
 
 /// Read a secret from the Keychain. `Ok(None)` if no entry exists (not an error).
@@ -115,7 +130,7 @@ pub fn get_secret(account: &str) -> Result<Option<String>> {
     match entry(account)?.get_password() {
         Ok(secret) => Ok(Some(secret)),
         Err(KeyringError::NoEntry) => Ok(None),
-        Err(e) => Err(AppError::Secrets(format!("failed to get secret: {e}"))),
+        Err(e) => Err(classify("get secret", e)),
     }
 }
 
@@ -124,7 +139,7 @@ pub fn delete_secret(account: &str) -> Result<()> {
     match entry(account)?.delete_credential() {
         Ok(()) => Ok(()),
         Err(KeyringError::NoEntry) => Ok(()),
-        Err(e) => Err(AppError::Secrets(format!("failed to delete secret: {e}"))),
+        Err(e) => Err(classify("delete secret", e)),
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -35,16 +35,33 @@ pub struct AppState {
 
 impl AppState {
     /// Open DB at the app-data dir, run migrations, load config. Called once in `lib::run`.
+    ///
+    /// Returns `Err` (never panics) on any failure so the caller can show a graceful dialog and
+    /// exit cleanly: a [`AppError::KeychainDenied`] when macOS refused keychain access, or a
+    /// storage/migration error when the database itself could not be opened (key mismatch /
+    /// corruption). On EVERY failure path the on-disk database and its `.pre-encrypt.bak` backup
+    /// are left byte-for-byte intact — opening with a wrong key fails read-only (proven by
+    /// `init_with_wrong_key_errors_and_preserves_db`), and migration only swaps after a verified
+    /// encrypted copy exists (see `storage::migration`).
     pub fn init() -> Result<Self> {
         let db_path = Self::db_path()?;
-        // SQLCipher at-rest: fetch (or create) the DEK once, migrate any existing PLAINTEXT DB to
-        // encrypted (safe: original untouched until a verified atomic swap), then open keyed.
+        // SQLCipher at-rest: fetch (or create) the DEK once (Keychain). A denial surfaces as a
+        // typed AppError::KeychainDenied here — propagated, not unwrapped.
         let dek = crate::secrets::get_or_create_db_dek()?;
-        if crate::storage::migration::needs_encryption(&db_path)? {
+        Self::init_at(&db_path, &dek)
+    }
+
+    /// Core of [`AppState::init`] with the DB path + DEK injected, so it can be unit-tested
+    /// against a temp database without touching the real Keychain or app-data dir. Migrates any
+    /// existing PLAINTEXT DB to encrypted (safe: the original is untouched until a verified atomic
+    /// swap), then opens the keyed connection. A wrong/garbage key makes `Db::open_with_key` fail
+    /// before any write, so the file is left unchanged.
+    fn init_at(db_path: &std::path::Path, dek: &str) -> Result<Self> {
+        if crate::storage::migration::needs_encryption(db_path)? {
             tracing::info!(target: "state", "plaintext DB detected — encrypting at rest");
-            crate::storage::migration::encrypt_in_place(&db_path, &dek)?;
+            crate::storage::migration::encrypt_in_place(db_path, dek)?;
         }
-        let db = Db::open_with_key(&db_path, &dek)?;
+        let db = Db::open_with_key(db_path, dek)?;
         let config = AppConfig::load(&db)?;
 
         tracing::info!(target: "state", "app state initialized");
@@ -69,5 +86,80 @@ impl AppState {
         std::fs::create_dir_all(&dir)
             .map_err(|e| AppError::Storage(format!("create app-data dir: {e}")))?;
         Ok(dir.join(DB_FILE))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    const GOOD_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const WRONG_KEY: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+    fn tmp_path(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-state-{tag}-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    /// Build a real SQLCipher-encrypted DB (keyed with `GOOD_KEY`) by seeding a plaintext DB and
+    /// running the production encrypt-in-place path.
+    fn seed_encrypted_db(path: &std::path::Path) {
+        let c = Connection::open(path).unwrap();
+        c.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE meetings(id TEXT PRIMARY KEY, started_at TEXT, title TEXT);
+             CREATE TABLE segments(meeting_id TEXT, idx INTEGER, text TEXT);
+             CREATE TABLE notes(meeting_id TEXT, markdown TEXT);
+             INSERT INTO meetings VALUES('m1','2026-07-01','Sync'),('m2','2026-07-02','Review');
+             PRAGMA user_version=7;",
+        )
+        .unwrap();
+        drop(c);
+        crate::storage::migration::encrypt_in_place(path, GOOD_KEY).unwrap();
+        // Fold any sidecar WAL/SHM into the main file so the byte-equality check below is stable.
+        assert!(path.exists());
+    }
+
+    /// A wrong/garbage DEK must make `init_at` return `Err` (NOT panic) AND leave the on-disk
+    /// database byte-for-byte unchanged — init fails read-only and never destroys data.
+    #[test]
+    fn init_with_wrong_key_errors_and_preserves_db() {
+        let p = tmp_path("wrongkey-init");
+        seed_encrypted_db(&p);
+
+        let before = std::fs::read(&p).unwrap();
+
+        let res = AppState::init_at(&p, WRONG_KEY);
+        assert!(
+            res.is_err(),
+            "wrong key must return Err, never panic or yield an empty/garbage DB"
+        );
+
+        let after = std::fs::read(&p).unwrap();
+        assert_eq!(
+            before, after,
+            "a failed open must leave the database file byte-for-byte intact"
+        );
+
+        // Proof the data survived: the CORRECT key still decrypts the untouched file.
+        let conn = Connection::open(&p).unwrap();
+        conn.pragma_update(None, "key", format!("x'{GOOD_KEY}'"))
+            .unwrap();
+        let n: i64 = conn
+            .query_row("SELECT count(*) FROM meetings", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 2, "rows intact after the failed wrong-key open");
+
+        let _ = std::fs::remove_file(&p);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Removes the AppState::init().expect() abort. On keychain-denied or DB-key-mismatch the app shows a clear dialog ('Murmur can't open your library', notes are safe) and exits cleanly — no panic/abort, DB never touched. 128 tests; regression: wrong key → Err, DB byte-identical.