### PR TITLE
v0.3.2 version-manifest bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Bring tauri.conf.json + package.json to 0.3.2 (Cargo.toml already bumped in #20) so the build produces a 0.3.2 bundle.