### PR TITLE
v0.4.0 — complete integrated state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.3.2"
+version = "0.4.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -69,7 +69,7 @@ pub fn get_or_create_db_dek() -> Result<String> {
 /// a Mac without Touch ID is never locked out; accessibility
 /// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`). Reading that item makes macOS present the Touch
 /// ID sheet directly — with the supplied `reason` string — and return the key on success. THAT
-/// single sheet IS the unlock auth: the caller must NOT also call [`crate::biometric::authenticate`]
+/// single sheet IS the unlock auth: the caller must NOT also run a separate biometric prompt
 /// (doing so would double-prompt). `reason` is shown verbatim on the sheet (e.g. "Unlock this
 /// folder").
 ///
@@ -86,7 +86,7 @@ pub fn get_or_create_master_kek() -> Result<[u8; 32]> {
 
 /// As [`get_or_create_master_kek`], but the `reason` string is shown verbatim on the Touch ID /
 /// passcode sheet that the biometric-gated keychain read presents (e.g. "Unlock this folder").
-/// THAT sheet is the unlock auth — do NOT also call [`crate::biometric::authenticate`].
+/// THAT sheet is the unlock auth — do NOT also run a separate biometric prompt.
 pub fn get_or_create_master_kek_with_reason(reason: &str) -> Result<[u8; 32]> {
     // Dev-only escape hatch mirroring MURMUR_DEV_DEK, but a SEPARATE env var so the at-rest DEK
     // and the lock KEK can be fixed independently in tests/dev. Returns FIRST so dev needs no Touch

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump to 0.4.0 (complete audio+security state) + 2 dead doc-link fixes.