### PR TITLE
feat(local): prod-inert seams for on-device models — NameRedactor + flywheel + LocalReasoner (Phase 3a)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod events;
 pub mod export;
 pub mod mcp;
 pub mod pipeline;
+pub mod reason;
 pub mod screenshare;
 pub mod secrets;
 pub mod settings;

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -1,0 +1,203 @@
+//! Local on-device reasoning seam (Phase 3a — PROD-INERT).
+//!
+//! [`LocalReasoner`] is the trait the heavy local reasoner (mistral.rs with grammar-constrained
+//! decoding, Phase 3b) will implement. This increment ships ONLY the seam plus a deterministic
+//! [`StubReasoner`] and a robust JSON extractor — NO ML crate, NO model download. The real impl is
+//! a one-line swap at the construction site; nothing here is wired into a production path yet
+//! (`graph.rs`/`timeline.rs` keep their existing brittle parse until a later increment).
+//!
+//! The [`LocalReasoner::structured`] method is the load-bearing seam: it is where reliable
+//! tool-call / NER-classification JSON comes from. A real impl constrains decoding to the schema;
+//! the stub fakes it but still routes its output through [`extract_first_json`] so the
+//! recover-JSON-from-noisy-text path is exercised and testable.
+
+use serde_json::Value;
+
+use crate::error::{AppError, Result};
+
+/// A local (on-device, no-egress) reasoning model. Synchronous: the real impl runs a local model
+/// to completion on a worker thread; the stub is pure. All methods are deterministic for a given
+/// input in the stub.
+pub trait LocalReasoner: Send + Sync {
+    /// Stable id of the backing model ("stub" until the real model lands).
+    fn id(&self) -> &str;
+
+    /// Free-form reasoning: run `system` + `user` and return the model's text.
+    fn reason(&self, system: &str, user: &str) -> Result<String>;
+
+    /// Structured reasoning: run `system` + `user` and return a JSON value. `json_schema` is the
+    /// shape the output must conform to — a real impl constrains decoding to it; the stub ignores
+    /// the constraint but still returns valid JSON recovered via [`extract_first_json`].
+    fn structured(&self, system: &str, user: &str, json_schema: &Value) -> Result<Value>;
+}
+
+/// Extract the first BALANCED top-level JSON object `{...}` from `text`.
+///
+/// Honors braces that appear inside JSON string literals (and `\"` escapes), so it is robust where
+/// the `find('{')..=rfind('}')` slice in `graph.rs`/`timeline.rs` mis-cuts — e.g. when prose after
+/// the object contains a stray `}`, when the model emits two objects, or when a string value itself
+/// contains braces. Returns the matched substring, or `None` if no balanced object is present.
+///
+/// Byte-scanning is UTF-8-safe: the structural bytes `{` `}` `"` `\` are all ASCII, and UTF-8
+/// continuation bytes (>= 0x80) never collide with them, so multibyte content between the braces is
+/// passed through untouched and the returned slice always lands on char boundaries.
+pub fn extract_first_json(text: &str) -> Option<&str> {
+    let bytes = text.as_bytes();
+    let start = text.find('{')?;
+    let mut depth: usize = 0;
+    let mut in_str = false;
+    let mut escaped = false;
+    let mut i = start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+        } else {
+            match c {
+                b'"' => in_str = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    // `start` is at a '{', so depth is >= 1 here; the saturating guard is defensive.
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return Some(&text[start..=i]);
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Recover the first balanced JSON object from a (possibly noisy / fenced) reply and deserialize
+/// it into `T`. The robust counterpart to the brittle slice in `graph.rs`/`timeline.rs`.
+pub fn parse_first_json<T: serde::de::DeserializeOwned>(text: &str) -> Result<T> {
+    let json = extract_first_json(text)
+        .ok_or_else(|| AppError::Summarize("reasoner: no JSON object in reply".to_string()))?;
+    serde_json::from_str(json)
+        .map_err(|e| AppError::Summarize(format!("reasoner: invalid JSON ({e})")))
+}
+
+/// Deterministic, dependency-free stand-in for the real local reasoner (Phase 3b). Produces stable
+/// output for a given input so the seam + the JSON-recovery path can be unit-tested without a model.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StubReasoner;
+
+impl LocalReasoner for StubReasoner {
+    fn id(&self) -> &str {
+        "stub"
+    }
+
+    fn reason(&self, system: &str, user: &str) -> Result<String> {
+        // Deterministic echo-shape: stable for a given (system, user) so tests can assert equality.
+        Ok(format!(
+            "[stub-reason] system={} chars user={} chars",
+            system.chars().count(),
+            user.chars().count()
+        ))
+    }
+
+    fn structured(&self, _system: &str, user: &str, _json_schema: &Value) -> Result<Value> {
+        // Build a deterministic object, then SIMULATE a real model emitting it wrapped in prose +
+        // code fences, and recover it through the robust extractor — exercising the exact
+        // noisy-reply → JSON path the grammar-constrained model output will take in Phase 3b.
+        let obj = serde_json::json!({
+            "stub": true,
+            "echo": user,
+            "chars": user.chars().count(),
+        });
+        let noisy = format!("Sure, here is the JSON:\n```json\n{obj}\n```\nHope that helps!");
+        parse_first_json(&noisy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_object_from_surrounding_prose() {
+        let got = extract_first_json("blah blah {\"a\":1} trailing").unwrap();
+        assert_eq!(got, "{\"a\":1}");
+    }
+
+    #[test]
+    fn handles_braces_inside_strings() {
+        // A naive rfind('}') would over-slice here; the string-aware scanner stops at the real end.
+        let got = extract_first_json("noise {\"text\":\"a } b { c\"} more } junk").unwrap();
+        assert_eq!(got, "{\"text\":\"a } b { c\"}");
+    }
+
+    #[test]
+    fn handles_nested_objects() {
+        let got = extract_first_json("x {\"o\":{\"i\":2}} y").unwrap();
+        assert_eq!(got, "{\"o\":{\"i\":2}}");
+    }
+
+    #[test]
+    fn returns_first_of_two_objects() {
+        let got = extract_first_json("{\"first\":1} {\"second\":2}").unwrap();
+        assert_eq!(got, "{\"first\":1}");
+    }
+
+    #[test]
+    fn respects_escaped_quote_inside_string() {
+        let got = extract_first_json("{\"q\":\"he said \\\"hi}\\\"\"}").unwrap();
+        assert_eq!(got, "{\"q\":\"he said \\\"hi}\\\"\"}");
+    }
+
+    #[test]
+    fn none_when_no_json() {
+        assert!(extract_first_json("no json here").is_none());
+        assert!(extract_first_json("unbalanced {\"a\":1").is_none());
+    }
+
+    #[test]
+    fn parse_first_json_deserializes() {
+        #[derive(serde::Deserialize)]
+        struct P {
+            a: i32,
+        }
+        let p: P = parse_first_json("prefix {\"a\":7} suffix").unwrap();
+        assert_eq!(p.a, 7);
+        assert!(parse_first_json::<P>("no json").is_err());
+    }
+
+    #[test]
+    fn stub_reason_is_deterministic() {
+        let r = StubReasoner;
+        assert_eq!(r.id(), "stub");
+        let a = r.reason("sys", "hello").unwrap();
+        let b = r.reason("sys", "hello").unwrap();
+        assert_eq!(a, b);
+        // Different input → different output (the length fields move).
+        assert_ne!(r.reason("sys", "hello").unwrap(), r.reason("sys", "hi").unwrap());
+    }
+
+    #[test]
+    fn stub_structured_returns_valid_json_via_extractor() {
+        let r = StubReasoner;
+        let schema = serde_json::json!({ "type": "object" });
+        let v = r.structured("sys", "find Atlas", &schema).unwrap();
+        assert_eq!(v["stub"], serde_json::json!(true));
+        assert_eq!(v["echo"], serde_json::json!("find Atlas"));
+        assert_eq!(v["chars"], serde_json::json!("find Atlas".chars().count()));
+    }
+
+    #[test]
+    fn stub_structured_survives_braces_in_user_text() {
+        // The echoed user text contains braces; the extractor must still recover the whole object.
+        let r = StubReasoner;
+        let schema = serde_json::json!({});
+        let v = r.structured("sys", "json like {a:1} please", &schema).unwrap();
+        assert_eq!(v["echo"], serde_json::json!("json like {a:1} please"));
+    }
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8,9 +8,9 @@ use crate::error::{AppError, Result};
 use std::collections::HashSet;
 
 use crate::storage::models::{
-    Analytics, DayCount, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData, GraphEdge,
-    GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
-    StatusCount, VaultSource,
+    Analytics, CorrectionRecord, DayCount, EntityDetail, EntityKind, EntityNeighbor, Folder,
+    GraphData, GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord,
+    SearchHit, StatusCount, VaultSource,
 };
 use crate::embed::Embedder;
 use crate::transcribe::types::Segment;
@@ -255,7 +255,19 @@ impl Db {
              );
              CREATE INDEX IF NOT EXISTS idx_entity_mentions_meeting ON entity_mentions(meeting_id);
              CREATE INDEX IF NOT EXISTS idx_entity_mentions_entity ON entity_mentions(entity_id);
-             CREATE INDEX IF NOT EXISTS idx_entities_kind ON entities(kind);",
+             CREATE INDEX IF NOT EXISTS idx_entities_kind ON entities(kind);
+             CREATE TABLE IF NOT EXISTS correction_log (
+               id INTEGER PRIMARY KEY,
+               kind TEXT NOT NULL,
+               input TEXT NOT NULL,
+               model_output TEXT NOT NULL,
+               final_output TEXT,
+               accepted INTEGER NOT NULL DEFAULT 0,
+               owner_id TEXT NOT NULL DEFAULT 'local',
+               created_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_correction_log_kind_created
+               ON correction_log(kind, created_at);",
         )
         .map_err(map_err)?;
         // Guarded ALTERs — notes gain a folder association + a sealed-content blob (AES-GCM
@@ -473,6 +485,65 @@ impl Db {
         let conn = self.lock();
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
             .map_err(map_err)
+    }
+
+    // ── correction-log flywheel ──────────────────────────────────────────────
+
+    /// Append one model-output→correction example to the local `correction_log` (the dataset
+    /// substrate for later on-device LoRA fine-tuning). Returns the new row id (the passed `rec.id`
+    /// is ignored — SQLite assigns the autoincrement key). Entirely local + SQLCipher-encrypted;
+    /// nothing here egresses.
+    pub fn log_correction(&self, rec: &CorrectionRecord) -> Result<i64> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO correction_log
+               (kind, input, model_output, final_output, accepted, owner_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                rec.kind,
+                rec.input,
+                rec.model_output,
+                rec.final_output,
+                rec.accepted as i64,
+                rec.owner_id,
+                rec.created_at,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Read back the most-recent `limit` correction examples of `kind`, newest first.
+    pub fn list_corrections(&self, kind: &str, limit: i64) -> Result<Vec<CorrectionRecord>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, input, model_output, final_output, accepted, owner_id, created_at
+                   FROM correction_log
+                  WHERE kind = ?1
+                  ORDER BY created_at DESC, id DESC
+                  LIMIT ?2",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![kind, limit], |row| {
+                Ok(CorrectionRecord {
+                    id: row.get(0)?,
+                    kind: row.get(1)?,
+                    input: row.get(2)?,
+                    model_output: row.get(3)?,
+                    final_output: row.get(4)?,
+                    accepted: row.get::<_, i64>(5)? != 0,
+                    owner_id: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
     }
 
     // ── meetings ────────────────────────────────────────────────────────────
@@ -2976,6 +3047,58 @@ mod tests {
         let db = mem_db();
         db.migrate().unwrap();
         db.migrate().unwrap();
+    }
+
+    #[test]
+    fn correction_log_round_trips_and_filters_by_kind() {
+        use crate::storage::models::CorrectionRecord;
+        let db = mem_db();
+        let rec = |kind: &str, input: &str, model_output: &str, fin: Option<&str>, accepted: bool, at: &str| {
+            CorrectionRecord {
+                id: 0,
+                kind: kind.to_string(),
+                input: input.to_string(),
+                model_output: model_output.to_string(),
+                final_output: fin.map(str::to_string),
+                accepted,
+                owner_id: "local".to_string(),
+                created_at: at.to_string(),
+            }
+        };
+        // Insert two NER examples (one accepted-as-is, one edited) and one of another kind.
+        let id1 = db
+            .log_correction(&rec("ner", "in-1", "out-1", None, true, "2026-06-28T10:00:00Z"))
+            .unwrap();
+        let id2 = db
+            .log_correction(&rec(
+                "ner",
+                "in-2",
+                "out-2",
+                Some("fixed-2"),
+                false,
+                "2026-06-28T10:01:00Z",
+            ))
+            .unwrap();
+        db.log_correction(&rec("timeline", "in-3", "out-3", None, true, "2026-06-28T10:02:00Z"))
+            .unwrap();
+        assert!(id2 > id1);
+
+        // Only the matching kind comes back, newest first.
+        let ner = db.list_corrections("ner", 10).unwrap();
+        assert_eq!(ner.len(), 2);
+        assert_eq!(ner[0].id, id2);
+        assert_eq!(ner[0].input, "in-2");
+        assert_eq!(ner[0].final_output.as_deref(), Some("fixed-2"));
+        assert!(!ner[0].accepted);
+        assert_eq!(ner[1].id, id1);
+        assert!(ner[1].accepted);
+        assert_eq!(ner[1].final_output, None);
+        assert_eq!(ner[1].owner_id, "local");
+
+        // Limit is honoured.
+        assert_eq!(db.list_corrections("ner", 1).unwrap().len(), 1);
+        // A kind with no rows yields empty (not an error).
+        assert!(db.list_corrections("does-not-exist", 10).unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -241,6 +241,29 @@ pub struct RecipeRecord {
     pub created_at: String,
 }
 
+/// One row of the local correction-log "flywheel" (`correction_log`): a single
+/// model-output→human-correction example captured for later on-device fine-tuning (LoRA). Local +
+/// SQLCipher-encrypted like the rest of the DB; never egresses. `final_output` is `None` until the
+/// user edits the model output; `accepted` records whether the model output was kept as-is.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectionRecord {
+    pub id: i64,
+    /// Task discriminator, e.g. "ner" | "timeline" | "summary" — groups examples per model head.
+    pub kind: String,
+    /// The model's input (prompt / source text).
+    pub input: String,
+    /// What the model produced.
+    pub model_output: String,
+    /// The human-corrected output, if the user edited it (else `None`).
+    pub final_output: Option<String>,
+    /// True iff the model output was accepted unchanged.
+    pub accepted: bool,
+    /// Owner scope; "local" for the single-user on-device dataset.
+    pub owner_id: String,
+    pub created_at: String,
+}
+
 /// One parsed action-item checklist line from a note's "## Action items" section.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -44,6 +44,50 @@ pub fn restore(text: &str, map: &HashMap<String, String>) -> String {
     s
 }
 
+/// Seam for on-device personal-NAME redaction (Phase 3a).
+///
+/// The regex scrubbers above catch emails / cards / phones with high confidence, but personal
+/// NAMES need on-device NER (GLiNER, Phase 3b) — see the honest-scope note at the top of this
+/// file. This trait IS that seam: an implementation scrubs names → stable placeholder tokens and
+/// returns the token↔name pairs so the provider's reply can be de-tokenized, exactly mirroring the
+/// email/card/phone round-trip (`redact` / `restore`).
+///
+/// The DEFAULT impl wired into [`RedactingProvider::new`] is [`NoopNameRedactor`] — names pass
+/// through UNCHANGED, so production egress is byte-identical to before this seam existed (no risk
+/// of a heuristic garbling prompts). A real `GlinerNameRedactor` is a drop-in replacement at the
+/// `RedactingProvider::with_name_redactor` call site (Phase 3b).
+///
+/// Contract: an implementation SHOULD assign a STABLE token per distinct name, so the same name
+/// redacted across the `system` and `user` prompts of one `complete` call restores consistently.
+pub trait NameRedactor: Send + Sync {
+    /// Scrub personal names out of `text`. Returns `(scrubbed_text, token→name pairs)`, where each
+    /// token is a placeholder to be restored verbatim in the provider's reply.
+    fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>);
+}
+
+/// Default name redactor: a NO-OP. Returns the text unchanged and an empty map, so names egress
+/// exactly as they do today. This keeps the firewall's name behaviour identical until a real NER
+/// model (Phase 3b) is swapped in — zero regression, zero chance of a bad heuristic mangling a
+/// prompt.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopNameRedactor;
+
+impl NameRedactor for NoopNameRedactor {
+    fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>) {
+        (text.to_string(), Vec::new())
+    }
+}
+
+/// Restore name placeholders produced by a [`NameRedactor`] back to the original names. Disjoint
+/// from [`restore`] (the regex token namespace) so the two layers compose without collision.
+fn restore_names(text: &str, pairs: &[(String, String)]) -> String {
+    let mut s = text.to_string();
+    for (tok, name) in pairs {
+        s = s.replace(tok, name);
+    }
+    s
+}
+
 fn redact_into(
     text: &str,
     map: &mut HashMap<String, String>,
@@ -77,13 +121,34 @@ fn apply(
 }
 
 /// Provider decorator: redacts PII from inputs, restores it in outputs.
+///
+/// Two layers, both restored in the reply: the always-on regex scrubbers (emails/cards/phones,
+/// via [`redact`]/[`restore`]) and the [`NameRedactor`] seam. The name layer defaults to
+/// [`NoopNameRedactor`] (`new`), so production egress is byte-identical until a real NER model is
+/// installed via [`with_name_redactor`](RedactingProvider::with_name_redactor).
 pub struct RedactingProvider {
     inner: Arc<dyn SummarizerProvider>,
+    names: Arc<dyn NameRedactor>,
 }
 
 impl RedactingProvider {
+    /// Wrap `inner` with the regex firewall and the DEFAULT (no-op) name redactor. Name egress is
+    /// unchanged — this is the production constructor.
     pub fn new(inner: Arc<dyn SummarizerProvider>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            names: Arc::new(NoopNameRedactor),
+        }
+    }
+
+    /// Wrap `inner` with the regex firewall and an EXPLICIT name redactor (Phase 3b drop-in /
+    /// tests). The name layer scrubs before egress and restores in the reply, alongside the regex
+    /// layer.
+    pub fn with_name_redactor(
+        inner: Arc<dyn SummarizerProvider>,
+        names: Arc<dyn NameRedactor>,
+    ) -> Self {
+        Self { inner, names }
     }
 }
 
@@ -99,9 +164,13 @@ impl SummarizerProvider for RedactingProvider {
 
     async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
         let (red, map) = redact(&req.transcript);
+        // Name layer (default no-op → `red` unchanged, `name_pairs` empty → byte-identical egress).
+        let (red, name_pairs) = self.names.redact_names(&red);
         let mut r = req.clone();
         r.transcript = red;
         let out = self.inner.summarize(&r).await?;
+        // Restore both layers in the reply (disjoint token namespaces; order-independent).
+        let out = restore_names(&out, &name_pairs);
         Ok(restore(&out, &map))
     }
 
@@ -111,7 +180,13 @@ impl SummarizerProvider for RedactingProvider {
         let mut rev = HashMap::new();
         let rsys = redact_into(system, &mut map, &mut rev);
         let ruser = redact_into(user, &mut map, &mut rev);
+        // Name layer on each prompt (default no-op → unchanged). A stable-token NameRedactor maps
+        // the same name to the same token across both prompts, so the merged pairs restore cleanly.
+        let (rsys, mut name_pairs) = self.names.redact_names(&rsys);
+        let (ruser, more) = self.names.redact_names(&ruser);
+        name_pairs.extend(more);
         let out = self.inner.complete(&rsys, &ruser).await?;
+        let out = restore_names(&out, &name_pairs);
         Ok(restore(&out, &map))
     }
 }
@@ -138,5 +213,176 @@ mod tests {
         let (red, map) = redact("We decided to ship on Friday.");
         assert_eq!(red, "We decided to ship on Friday.");
         assert!(map.is_empty());
+    }
+
+    // ── name-redaction seam ──────────────────────────────────────────────────
+
+    /// Deterministic, test-only NER stand-in: scrubs a FIXED known set of names → stable tokens.
+    /// Stable per name (token derived from the name's index) so the same name maps to the same
+    /// token across the `system` and `user` prompts, matching the trait contract.
+    struct FixtureNameRedactor;
+
+    impl NameRedactor for FixtureNameRedactor {
+        fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>) {
+            let mut out = text.to_string();
+            let mut pairs = Vec::new();
+            for (i, name) in ["Anna Kowalska", "Bob Smith"].iter().enumerate() {
+                if out.contains(name) {
+                    let tok = format!("\u{27ea}NAME_{}\u{27eb}", i + 1);
+                    out = out.replace(name, &tok);
+                    pairs.push((tok, (*name).to_string()));
+                }
+            }
+            (out, pairs)
+        }
+    }
+
+    /// Inner provider that ECHOES the text it received, so a test can assert (a) the scrubbed text
+    /// is what actually reached the provider and (b) the reply is de-tokenized on the way back.
+    struct EchoProvider;
+
+    #[async_trait]
+    impl SummarizerProvider for EchoProvider {
+        fn id(&self) -> &str {
+            "echo"
+        }
+        async fn availability(&self) -> Availability {
+            Availability::Available
+        }
+        async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+            Ok(req.transcript.clone())
+        }
+        async fn complete(&self, system: &str, user: &str) -> Result<String> {
+            Ok(format!("{system}\n---\n{user}"))
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    fn sample_req(transcript: &str) -> SummarizeRequest {
+        use crate::summarize::provider::MeetingMeta;
+        SummarizeRequest {
+            transcript: transcript.to_string(),
+            meta: MeetingMeta {
+                date_iso: "2026-06-28".to_string(),
+                title_hint: None,
+                duration_s: 60,
+                language: None,
+            },
+            template: String::new(),
+            vault_titles: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn noop_name_redactor_is_identity() {
+        // The no-regression proof: the default name redactor leaves text byte-identical and yields
+        // an empty map, so nothing about name egress changes.
+        let (out, pairs) = NoopNameRedactor.redact_names("Anna Kowalska met Bob Smith on Friday.");
+        assert_eq!(out, "Anna Kowalska met Bob Smith on Friday.");
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn default_provider_egress_is_byte_identical_for_names() {
+        // Through the PRODUCTION constructor (default no-op name layer), a transcript with names
+        // and NO regex-PII reaches the inner provider verbatim — proving prod egress is unchanged.
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+
+        struct CaptureProvider(std::sync::Arc<std::sync::Mutex<String>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureProvider {
+            fn id(&self) -> &str {
+                "capture"
+            }
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                *self.0.lock().unwrap() = req.transcript.clone();
+                Ok("done".to_string())
+            }
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+
+        let prov = RedactingProvider::new(Arc::new(CaptureProvider(captured.clone())));
+        let transcript = "Anna Kowalska met Bob Smith on Friday to plan Atlas.";
+        block_on(prov.summarize(&sample_req(transcript))).unwrap();
+        // What egressed to the inner provider is byte-identical to the original (names intact).
+        assert_eq!(*captured.lock().unwrap(), transcript);
+    }
+
+    #[test]
+    fn name_seam_round_trips_through_provider() {
+        // With a real NameRedactor installed: names are scrubbed BEFORE the provider call and
+        // restored in the reply. The EchoProvider returns exactly what it received, so the echoed
+        // reply proves both halves of the round-trip.
+        let prov = RedactingProvider::with_name_redactor(
+            Arc::new(EchoProvider),
+            Arc::new(FixtureNameRedactor),
+        );
+        let transcript = "Anna Kowalska briefed Bob Smith.";
+        let out = block_on(prov.summarize(&sample_req(transcript))).unwrap();
+        // Reply is de-tokenized back to the real names...
+        assert_eq!(out, transcript);
+        assert!(!out.contains("NAME_"));
+    }
+
+    #[test]
+    fn name_seam_scrubs_before_egress() {
+        // Prove the SCRUB half independently: capture what the inner provider actually receives.
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+
+        struct CaptureProvider(std::sync::Arc<std::sync::Mutex<String>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureProvider {
+            fn id(&self) -> &str {
+                "capture"
+            }
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                *self.0.lock().unwrap() = req.transcript.clone();
+                Ok(req.transcript.clone())
+            }
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+
+        let prov = RedactingProvider::with_name_redactor(
+            Arc::new(CaptureProvider(captured.clone())),
+            Arc::new(FixtureNameRedactor),
+        );
+        let out = block_on(prov.summarize(&sample_req("Anna Kowalska briefed Bob Smith."))).unwrap();
+        let sent = captured.lock().unwrap().clone();
+        // The provider saw TOKENS, not names — no name leaked off-device.
+        assert!(!sent.contains("Anna Kowalska"));
+        assert!(!sent.contains("Bob Smith"));
+        assert!(sent.contains("\u{27ea}NAME_1\u{27eb}"));
+        // ...but the caller still gets the real names back.
+        assert!(out.contains("Anna Kowalska") && out.contains("Bob Smith"));
+    }
+
+    #[test]
+    fn name_seam_consistent_across_complete_prompts() {
+        // The same name in both `system` and `user` restores consistently (stable-token contract).
+        let prov = RedactingProvider::with_name_redactor(
+            Arc::new(EchoProvider),
+            Arc::new(FixtureNameRedactor),
+        );
+        let out = block_on(prov.complete("You assist Anna Kowalska.", "Anna Kowalska asks: status?"))
+            .unwrap();
+        assert!(!out.contains("NAME_"));
+        assert_eq!(out.matches("Anna Kowalska").count(), 2);
     }
 }


### PR DESCRIPTION
Prod-inert seams the local on-device models plug into — deterministic stubs, **zero behaviour change**, no heavy ML deps. **NameRedactor** in the redaction firewall (no-op default → egress byte-identical; real GLiNER is the Phase-3b drop-in that closes the name-redaction gap); **correction_log** flywheel table (LoRA dataset substrate, unwired); **LocalReasoner** trait + StubReasoner + a robust balanced-{...} JSON extractor. Verified: cargo test 238/0; clippy clean; adversarial PASS (no-op identity + restore RED-before-GREEN); lock-security PASS (egress byte-identical, consent gate + regex firewall intact, nothing wired into egress/read/export/log).