### PR TITLE
feat(commitments): cross-meeting open-commitments rollup + gated MCP tool + reminder due-date fix (Phase 5a)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,7 +9,7 @@ use crate::settings::AppConfig;
 use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarEvent, ChatTurn,
-    DigestResult, EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
+    Commitment, DigestResult, EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
     MeetingTimeline, NoteRecord, PinResult, RecipeRecord, SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
@@ -823,6 +823,22 @@ pub fn get_action_items(
     })
 }
 
+/// OPEN-COMMITMENTS rollup ("what did I promise / what's still open"): deterministically aggregate
+/// every OPEN (`- [ ]`) action item across the VISIBLE library, with each item's meeting context.
+/// No model — pure aggregation over the gated readers. `owner` (optional) filters case-insensitively.
+/// GATED: routes through `Db::list_open_commitments`, which pushes the LIVE session unlock set
+/// through `list_meetings_visible` + `get_note_if_visible` (the same predicate as `ask_vault` /
+/// `generate_digest` / MCP) — a sealed-and-not-session-unlocked meeting contributes nothing.
+#[tauri::command]
+pub fn list_open_commitments(
+    state: State<'_, AppState>,
+    owner: Option<String>,
+) -> Result<Vec<Commitment>, AppError> {
+    let unlocked = unlocked_snapshot(state.inner())?;
+    let owner = owner.as_deref().map(str::trim).filter(|o| !o.is_empty());
+    state.db.list_open_commitments(&unlocked, owner)
+}
+
 /// Rewrite the note's action items into Obsidian Tasks format (📅 due dates) + re-write the
 /// vault file in place. Returns the updated note.
 #[tauri::command]
@@ -861,21 +877,69 @@ pub fn patch_note_tasks(
     })
 }
 
+/// Escape a string for embedding inside an AppleScript `"…"` literal: backslash + double-quote are
+/// escaped, and raw CR/LF are flattened to spaces (an AppleScript string literal cannot span lines).
+/// This is what stops the item text from breaking out of the quoted literal or injecting extra
+/// statements (`"`, `end tell`, …) into the osascript program.
+fn escape_applescript(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace(['\n', '\r'], " ")
+}
+
+/// Parse a strict ISO `YYYY-MM-DD` into `(year, month, day)`; `None` for anything else.
+fn parse_iso_ymd(s: &str) -> Option<(i32, u32, u32)> {
+    let s = s.trim();
+    let b = s.as_bytes();
+    if b.len() != 10 || b[4] != b'-' || b[7] != b'-' {
+        return None;
+    }
+    let y: i32 = s.get(0..4)?.parse().ok()?;
+    let m: u32 = s.get(5..7)?.parse().ok()?;
+    let d: u32 = s.get(8..10)?.parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some((y, m, d))
+}
+
+/// Build the osascript program that creates a Reminder named `name`. When `due_date` is a valid
+/// ISO `YYYY-MM-DD`, attach `remind me date`/`due date` (defaulted to 9am local) so the date
+/// actually lands in Reminders — previously the date was dropped. The name is
+/// `escape_applescript`-escaped so its text can never break out of the string literal. The date is
+/// built by setting `day` to 1 FIRST (so a year/month change can't overflow the current day-of-month),
+/// then year, then month, then the real day.
+fn build_reminder_script(name: &str, due_date: Option<&str>) -> String {
+    let esc = escape_applescript(name);
+    match due_date.and_then(parse_iso_ymd) {
+        Some((y, m, d)) => format!(
+            "set theDate to current date\n\
+             set day of theDate to 1\n\
+             set year of theDate to {y}\n\
+             set month of theDate to {m}\n\
+             set day of theDate to {d}\n\
+             set hours of theDate to 9\n\
+             set minutes of theDate to 0\n\
+             set seconds of theDate to 0\n\
+             tell application \"Reminders\" to make new reminder with properties {{name:\"{esc}\", remind me date:theDate, due date:theDate}}"
+        ),
+        None => format!(
+            "tell application \"Reminders\" to make new reminder with properties {{name:\"{esc}\"}}"
+        ),
+    }
+}
+
 /// Add a macOS Reminder (via osascript) for an action item. A denied Reminders permission
-/// surfaces a clear, actionable error rather than crashing the UI.
+/// surfaces a clear, actionable error rather than crashing the UI. When the item carries an ISO
+/// due date, it is set as the reminder's due/remind date (best-effort; verify on a real Mac).
 #[tauri::command]
 pub async fn add_reminder(text: String, due_date: Option<String>) -> Result<(), AppError> {
-    let name = match due_date.as_deref().filter(|d| !d.is_empty()) {
-        Some(d) => format!("{} 📅 {}", text.trim(), d),
-        None => text.trim().to_string(),
-    };
+    let name = text.trim().to_string();
     if name.is_empty() {
         return Err(AppError::InvalidArg("empty reminder".into()));
     }
-    let esc = name.replace('\\', "\\\\").replace('"', "\\\"");
-    let script = format!(
-        "tell application \"Reminders\" to make new reminder with properties {{name:\"{esc}\"}}"
-    );
+    let due = due_date.as_deref().filter(|d| !d.is_empty());
+    let script = build_reminder_script(&name, due);
     let out = tokio::task::spawn_blocking(move || {
         std::process::Command::new("osascript")
             .arg("-e")
@@ -4324,5 +4388,89 @@ mod lifecycle_tests {
         assert!(matches!(res, Err(AppError::InvalidArg(_))), "must refuse, got {res:?}");
         assert!(state.db.folder_by_id("parent").unwrap().is_some(), "parent NOT deleted");
         assert!(state.db.folder_by_id("child").unwrap().is_some(), "child NOT orphaned");
+    }
+}
+
+#[cfg(test)]
+mod reminder_script_tests {
+    use super::{build_reminder_script, escape_applescript, parse_iso_ymd};
+
+    #[test]
+    fn parses_strict_iso_only() {
+        assert_eq!(parse_iso_ymd("2026-07-01"), Some((2026, 7, 1)));
+        assert_eq!(parse_iso_ymd(" 2026-12-31 "), Some((2026, 12, 31)));
+        assert_eq!(parse_iso_ymd("2026-13-01"), None); // month out of range
+        assert_eq!(parse_iso_ymd("2026-07-32"), None); // day out of range
+        assert_eq!(parse_iso_ymd("2026/07/01"), None); // wrong separators
+        assert_eq!(parse_iso_ymd("26-07-01"), None); // not 4-digit year
+        assert_eq!(parse_iso_ymd(""), None);
+    }
+
+    #[test]
+    fn due_date_sets_the_date_properties() {
+        let s = build_reminder_script("Ship the deck", Some("2026-07-01"));
+        // The date is actually attached now (the bug was: only `name` was set).
+        assert!(s.contains("set year of theDate to 2026"));
+        assert!(s.contains("set month of theDate to 7"));
+        assert!(s.contains("set day of theDate to 1"));
+        assert!(s.contains("remind me date:theDate"));
+        assert!(s.contains("due date:theDate"));
+        assert!(s.contains("name:\"Ship the deck\""));
+        // `day` is reset to 1 BEFORE year/month so a month change can't overflow the day.
+        let reset = s.find("set day of theDate to 1").unwrap();
+        let yr = s.find("set year of theDate").unwrap();
+        assert!(reset < yr, "day must be reset to 1 before changing year/month");
+    }
+
+    #[test]
+    fn no_due_date_is_name_only() {
+        let s = build_reminder_script("Call Bob", None);
+        assert!(s.contains("name:\"Call Bob\""));
+        assert!(!s.contains("due date"));
+        assert!(!s.contains("theDate"));
+    }
+
+    #[test]
+    fn invalid_due_date_falls_back_to_name_only() {
+        let s = build_reminder_script("Task", Some("not-a-date"));
+        assert!(!s.contains("due date"), "an unparseable date must not produce date props");
+        assert!(s.contains("name:\"Task\""));
+    }
+
+    #[test]
+    fn item_text_cannot_break_out_of_the_applescript_literal() {
+        // A name carrying a quote + a forged statement must stay INSIDE the string literal: the
+        // `"` is escaped to `\"`, so `end tell` / the injected `make` never become real statements.
+        let evil = "pwn\", remind me date:theDate}\nend tell\ntell application \"Finder\" to delete";
+        let esc = escape_applescript(evil);
+        assert!(!esc.contains('\n'), "raw newlines flattened (literals can't span lines)");
+        // Every `"` in the payload is preceded by a backslash — no bare quote survives to close
+        // the literal early. (Checked by scanning: each `"` byte has a `\` immediately before it.)
+        let bytes = esc.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'"' {
+                assert!(i > 0 && bytes[i - 1] == b'\\', "unescaped quote survived at {i}");
+            }
+        }
+        let s = build_reminder_script(evil, Some("2026-07-01"));
+        // The ONE real `tell` statement (unescaped quotes around Reminders) is intact...
+        assert!(
+            s.contains("tell application \"Reminders\""),
+            "the real Reminders statement must survive"
+        );
+        // ...and the injected Finder `tell` never becomes real code: its quotes are escaped, so it
+        // stays as inert data inside the name literal (no `tell application "Finder"` with REAL quotes).
+        assert!(
+            !s.contains("tell application \"Finder\""),
+            "injected statement must remain escaped data, not executable code"
+        );
+        // The whole program is a single line (newlines in the payload were flattened), so a forged
+        // `end tell` can never start its own statement line.
+        assert!(
+            !s.lines().any(|l| l.trim() == "end tell"),
+            "no standalone injected `end tell` statement line"
+        );
+        // Every embedded double-quote from the payload is backslash-escaped in the program.
+        assert!(s.contains("\\\""), "payload quotes are escaped");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             commands::delete_recipe,
             commands::run_recipe,
             commands::get_action_items,
+            commands::list_open_commitments,
             commands::patch_note_tasks,
             commands::add_reminder,
             commands::pin_moment,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -238,6 +238,11 @@ fn tools_spec() -> Value {
             "name": "search_semantic",
             "description": "Semantic (meaning-based) search across your meeting notes, fused with full-text search. Finds relevant meetings even when they don't share the exact words. Requires semantic search to be enabled in Murmur settings.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
+        },
+        {
+            "name": "get_open_commitments",
+            "description": "Roll up every OPEN action item ('- [ ]', still open / not done) across your meetings, with each item's owner, due date and source meeting. Answers 'what did I promise / what is still open'. Optionally filter by owner (case-insensitive). Sealed-and-locked meetings are excluded.",
+            "inputSchema": { "type": "object", "properties": { "owner": { "type": "string" } } }
         }
     ])
 }
@@ -365,8 +370,47 @@ fn dispatch_tool(
                 Err(e) => Err((-32000, format!("list failed: {e}"))),
             }
         }
+        "get_open_commitments" => {
+            // GATE: routes through `list_open_commitments`, which double-gates on the same
+            // `unlocked_set` (`list_meetings_visible` + `get_note_if_visible`) — a sealed-and-not-
+            // unlocked meeting's commitments are never read here, so they can never surface.
+            let owner = args
+                .get("owner")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|o| !o.is_empty());
+            match db.list_open_commitments(unlocked_set, owner) {
+                Ok(items) if items.is_empty() => Ok(match owner {
+                    Some(o) => format!("No open commitments for \"{o}\"."),
+                    None => "No open commitments.".to_string(),
+                }),
+                Ok(items) => Ok(format_commitments(&items)),
+                Err(e) => Err((-32000, format!("commitments rollup failed: {e}"))),
+            }
+        }
         other => Err((-32602, format!("unknown tool: {other}"))),
     }
+}
+
+/// Render the open-commitments rollup into the MCP text payload — one line per item:
+/// `- owner · due · "text" · [[Title]]` (owner/due omitted when absent).
+fn format_commitments(items: &[crate::storage::models::Commitment]) -> String {
+    items
+        .iter()
+        .map(|c| {
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(o) = c.owner.as_deref().map(str::trim).filter(|o| !o.is_empty()) {
+                parts.push(o.to_string());
+            }
+            if let Some(d) = c.due_date.as_deref().filter(|d| !d.is_empty()) {
+                parts.push(format!("due {d}"));
+            }
+            parts.push(format!("\"{}\"", c.text.trim()));
+            parts.push(format!("[[{}]]", c.meeting_title));
+            format!("- {}", parts.join(" · "))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Render a list of search hits (FTS or hybrid) into the MCP text payload — one line per meeting.
@@ -411,14 +455,14 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_four_tools() {
+    fn tools_list_has_five_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 4);
+        assert_eq!(tools.len(), 5);
         // The Phase 2b semantic tool is advertised.
-        assert!(tools
-            .iter()
-            .any(|t| t["name"] == "search_semantic"));
+        assert!(tools.iter().any(|t| t["name"] == "search_semantic"));
+        // The Phase 5a open-commitments rollup tool is advertised.
+        assert!(tools.iter().any(|t| t["name"] == "get_open_commitments"));
     }
 
     #[test]
@@ -620,6 +664,75 @@ mod tests {
         unlocked.insert("f-lock".to_string());
         let out2 = dispatch_tool(&db, "search_semantic", &args, &unlocked).unwrap();
         assert!(out2.contains("id:sealed"), "unlocked meeting must reappear in semantic results");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// Phase 5a: `get_open_commitments` is visibility-gated exactly like the other tools. A sealed-
+    /// and-not-unlocked meeting's open action items NEVER appear; they reappear once the folder is
+    /// session-unlocked. The payload renders owner · due · "text" · [[Title]].
+    #[test]
+    fn get_open_commitments_is_visibility_gated() {
+        use crate::storage::models::Folder;
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-lock".to_string(),
+            name: "Secret".to_string(),
+            path: "Secret".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        seed(
+            &db,
+            "open",
+            "Open Sync",
+            "## Action items\n- [ ] Anna — ship the deck 2026-07-01\n- [x] Bob — already done\n",
+            None,
+        );
+        seed(
+            &db,
+            "sealed",
+            "Secret Sync",
+            "## Action items\n- [ ] Carol — sign the contract 2026-07-05\n",
+            Some("f-lock"),
+        );
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        // Not unlocked → only the open meeting's open item; sealed item invisible; done item dropped.
+        let out = dispatch_tool(&db, "get_open_commitments", &json!({}), &HashSet::new()).unwrap();
+        assert!(out.contains("ship the deck"), "open commitment must surface");
+        assert!(out.contains("[[Open Sync]]"), "source title must render");
+        assert!(out.contains("due 2026-07-01"), "due date must render");
+        assert!(out.contains("Anna"), "owner must render");
+        assert!(
+            !out.contains("already done"),
+            "checked-off item must not be a commitment"
+        );
+        assert!(
+            !out.contains("sign the contract") && !out.contains("Secret Sync"),
+            "sealed-not-unlocked meeting's commitments leaked (gate violation)"
+        );
+
+        // Session-unlock → the sealed meeting's commitment reappears.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let out2 = dispatch_tool(&db, "get_open_commitments", &json!({}), &unlocked).unwrap();
+        assert!(out2.contains("sign the contract"), "unlocked commitment must reappear");
+
+        // Owner filter (case-insensitive).
+        let out3 = dispatch_tool(
+            &db,
+            "get_open_commitments",
+            &json!({ "owner": "anna" }),
+            &unlocked,
+        )
+        .unwrap();
+        assert!(out3.contains("ship the deck"), "owner filter must keep Anna's item");
+        assert!(
+            !out3.contains("sign the contract"),
+            "owner filter must drop Carol's item"
+        );
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8,9 +8,9 @@ use crate::error::{AppError, Result};
 use std::collections::HashSet;
 
 use crate::storage::models::{
-    Analytics, CorrectionRecord, DayCount, EntityDetail, EntityKind, EntityNeighbor, Folder,
-    GraphData, GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord,
-    SearchHit, StatusCount, VaultSource,
+    Analytics, Commitment, CorrectionRecord, DayCount, EntityDetail, EntityKind, EntityNeighbor,
+    Folder, GraphData, GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord,
+    RecipeRecord, SearchHit, StatusCount, VaultSource,
 };
 use crate::embed::Embedder;
 use crate::transcribe::types::Segment;
@@ -2252,6 +2252,57 @@ impl Db {
         Ok(!has_notes || has_visible)
     }
 
+    /// OPEN-COMMITMENTS rollup (deterministic, no model): every OPEN (`- [ ]`) action item across
+    /// the VISIBLE meetings, with its meeting context. DOUBLE-GATED — the meeting list is filtered
+    /// by `list_meetings_visible(unlocked)` and each note is re-fetched through
+    /// `get_note_if_visible(unlocked)`, so a sealed-and-not-session-unlocked meeting contributes
+    /// NOTHING (its note markdown is never read here). Checked-off (`- [x]`) items are dropped.
+    /// `owner`, when Some, filters case-insensitively. Sorted by due date (None last), then recency.
+    pub fn list_open_commitments(
+        &self,
+        unlocked: &HashSet<String>,
+        owner: Option<&str>,
+    ) -> Result<Vec<Commitment>> {
+        let owner_lc = owner
+            .map(|o| o.trim().to_lowercase())
+            .filter(|o| !o.is_empty());
+        let mut out: Vec<Commitment> = Vec::new();
+        // GATE 1: only VISIBLE meetings. GATE 2: only the VISIBLE note (None for sealed-not-unlocked).
+        for m in self.list_meetings_visible(1000, unlocked)? {
+            let Some(note) = self.get_note_if_visible(&m.id, unlocked)? else {
+                continue;
+            };
+            let title = m.title.clone().unwrap_or_else(|| "(untitled)".to_string());
+            for item in crate::summarize::action_items::parse_action_items(&note.markdown) {
+                if item.done {
+                    continue; // `- [x]` — already done, not an open commitment.
+                }
+                if let Some(want) = owner_lc.as_deref() {
+                    match item.owner.as_deref() {
+                        Some(o) if o.trim().to_lowercase() == want => {}
+                        _ => continue,
+                    }
+                }
+                out.push(Commitment {
+                    meeting_id: m.id.clone(),
+                    meeting_title: title.clone(),
+                    started_at: m.started_at.clone(),
+                    owner: item.owner,
+                    due_date: item.due_date,
+                    text: item.text,
+                });
+            }
+        }
+        // Due date ascending (soonest first), items with no date last; ties broken by recency.
+        out.sort_by(|a, b| match (a.due_date.as_deref(), b.due_date.as_deref()) {
+            (Some(x), Some(y)) => x.cmp(y).then_with(|| b.started_at.cmp(&a.started_at)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => b.started_at.cmp(&a.started_at),
+        });
+        Ok(out)
+    }
+
     // ── self-assembling graph (entities + mentions) ───────────────────────────
     //
     // Sink A of the dual-sink: the encrypted DB is the source of truth for the in-app
@@ -4124,6 +4175,57 @@ mod lock_tests {
             db.restore_note_markdown(&n.meeting_id, &n.provider_id, &String::from_utf8(pt).unwrap())
                 .unwrap();
         }
+    }
+
+    #[test]
+    fn list_open_commitments_aggregates_attaches_context_and_gates() {
+        let db = file_db("commitments");
+        seed_folder(&db, "f-lock", "Secret");
+        // open1: one open item w/ owner+due, one DONE item, one loose open item (no owner/date).
+        seed_note(
+            &db,
+            "open1",
+            "## Action items\n- [ ] Anna — ship the deck 2026-07-01\n- [x] Bob — done thing\n- [ ] just a loose task\n",
+            None,
+        );
+        // open2: one open item, an earlier due date (sorts first).
+        seed_note(&db, "open2", "- [ ] Carol — review 2026-06-15\n", None);
+        // sealed: in a folder we lock → must contribute NOTHING until session-unlocked.
+        seed_note(&db, "sealed", "- [ ] Dave — secret task 2026-07-02\n", Some("f-lock"));
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        // GATED: folder locked, not session-unlocked → sealed meeting excluded; DONE item excluded.
+        let open = db.list_open_commitments(&HashSet::new(), None).unwrap();
+        assert!(
+            open.iter().all(|c| c.meeting_id != "sealed"),
+            "sealed-not-unlocked meeting leaked into the rollup (gate violation)"
+        );
+        assert!(open.iter().all(|c| !c.text.contains("done thing")), "checked `- [x]` item must be excluded");
+        assert_eq!(open.len(), 3, "two open meetings → 3 open items (Carol, Anna, loose)");
+
+        // Sort: due dates ascending, then None last.
+        assert_eq!(open[0].due_date.as_deref(), Some("2026-06-15"));
+        assert_eq!(open[0].owner.as_deref(), Some("Carol"));
+        assert_eq!(open[0].meeting_title, "title-open2", "meeting context attached");
+        assert_eq!(open[1].due_date.as_deref(), Some("2026-07-01"));
+        assert_eq!(open[1].owner.as_deref(), Some("Anna"));
+        assert_eq!(open[2].due_date, None, "the dateless loose task sorts last");
+        assert_eq!(open[2].owner, None);
+
+        // Session-unlock → the sealed meeting's open commitment reappears.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let all = db.list_open_commitments(&unlocked, None).unwrap();
+        assert!(
+            all.iter().any(|c| c.meeting_id == "sealed" && c.text.contains("secret task")),
+            "unlocked folder's commitment must reappear"
+        );
+
+        // Owner filter (case-insensitive) keeps only Anna's item.
+        let anna = db.list_open_commitments(&unlocked, Some("ANNA")).unwrap();
+        assert_eq!(anna.len(), 1);
+        assert!(anna[0].text.contains("ship the deck"));
+        assert_eq!(anna[0].meeting_title, "title-open1");
     }
 
     #[test]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -275,6 +275,22 @@ pub struct ActionItem {
     pub due_date: Option<String>,
 }
 
+/// One OPEN action item ("commitment") rolled up across the whole library, carrying its meeting
+/// context. Produced by the deterministic `Db::list_open_commitments` aggregation: only OPEN
+/// (`- [ ]`, not `- [x]`) items from VISIBLE meetings contribute — a sealed-and-not-unlocked
+/// meeting yields nothing (excluded by both `list_meetings_visible` and `get_note_if_visible`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Commitment {
+    pub meeting_id: String,
+    pub meeting_title: String,
+    /// ISO 8601 meeting start (used for recency ordering + the [[Title]] context).
+    pub started_at: String,
+    pub owner: Option<String>,
+    pub due_date: Option<String>,
+    pub text: String,
+}
+
 /// Result of pinning a meeting moment: the ^block-ref id + an obsidian:// deep link.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
The 'what do I owe / what is still open across my meetings' feature (research's #1 'shows up done' surface) — deterministic, no local model. **Db::list_open_commitments** double-gated (list_meetings_visible + get_note_if_visible) over OPEN action items; a **Tauri command** (registered) + an **MCP get_open_commitments tool** (gated); **add_reminder due-date fix** (ISO → AppleScript remind/due-date, injection-proof escaping). Verified: cargo test 245/0; clippy clean; adversarial PASS (gate RED-before-GREEN + AppleScript injection tests); lock-security PASS (double-gated, live unlock set, no PII). Reminder date landing needs a real Mac (Reminders TCC).