### PR TITLE
feat(notes): retrieval-augmented note generation — gated related context (Phase 4)

### DIFF
--- a/src-tauri/examples/e2e_core.rs
+++ b/src-tauri/examples/e2e_core.rs
@@ -65,6 +65,7 @@ async fn main() {
         },
         template: String::new(),
         vault_titles,
+        related_context: None,
     };
 
     let provider = ClaudeCodeProvider::new();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1634,6 +1634,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // Phase 2b: the semantic-search master flag is not (yet) carried on the settings DTO, so a
         // settings save can neither set nor clobber it — preserve the live value (default OFF).
         semantic_search_enabled: current.semantic_search_enabled,
+        // Phase 4: the retrieval-augmented-notes master flag is not (yet) carried on the settings
+        // DTO, so a settings save can neither set nor clobber it — preserve the live value
+        // (default OFF). Dormant in prod until an FE setter is added.
+        augment_notes_with_context: current.augment_notes_with_context,
     }
 }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -483,6 +483,53 @@ async fn summarize_and_export(
         _ => Vec::new(),
     };
 
+    // brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION. When `augment_notes_with_context`
+    // is ON, ground the new note in related PRIOR notes so notes compound. GATED twofold:
+    //   1. the master flag (default OFF ⇒ `related_context = None` ⇒ `render_user_content` is
+    //      BYTE-IDENTICAL to today — zero prod regression);
+    //   2. the LIVE session unlock set — the retrieval routes through `search_visible` +
+    //      `get_note_if_visible`, so a sealed-and-not-session-unlocked prior note contributes
+    //      NOTHING. This matters because the corpus EGRESSES to the cloud provider in the prompt
+    //      (lock-model invariant).
+    // Best-effort: a retrieval error logs (target rag, no PII) and proceeds with NO context — it
+    // NEVER fails the pipeline.
+    let related_context: Option<String> = if config.augment_notes_with_context {
+        let unlocked = state
+            .unlocked_folders
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let title = state
+            .db
+            .get_meeting(meeting_id)
+            .ok()
+            .flatten()
+            .and_then(|m| m.title);
+        let query = crate::summarize::related_context::salient_query(
+            title.as_deref(),
+            transcript_text,
+        );
+        match crate::summarize::related_context::build_related_context(
+            &state.db,
+            meeting_id,
+            &query,
+            &unlocked,
+            &config.provider_id,
+        ) {
+            Ok((corpus, sources)) if !corpus.trim().is_empty() => {
+                tracing::info!(target: "rag", related = sources.len(), "grounding note in related prior notes");
+                Some(corpus)
+            }
+            Ok(_) => None,
+            Err(e) => {
+                tracing::warn!(target: "rag", error = %e, "related-context retrieval failed (note unaffected)");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let request = SummarizeRequest {
         transcript: transcript_text.to_string(),
         meta: MeetingMeta {
@@ -493,6 +540,7 @@ async fn summarize_and_export(
         },
         template: template::build_template(&config.note_style, &config.note_language),
         vault_titles,
+        related_context,
     };
 
     let provider = make_provider(&config.provider_id, config)?;

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -84,6 +84,17 @@ pub struct AppConfig {
     /// (Phase 2c) replaces the stub; until then the only embedder is the deterministic `StubEmbedder`.
     #[serde(default)]
     pub semantic_search_enabled: bool,
+    /// brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION. When ON, each new meeting note is
+    /// grounded in a small, GATED corpus of related PRIOR notes (built from the LIVE FTS retrieval
+    /// plus the existing provider, no local model) so notes compound ("last time you decided X").
+    /// Default OFF via `#[serde(default)]`, so a config persisted before this field existed loads
+    /// as `false`. When OFF, the summarization request carries `related_context = None` and the
+    /// rendered prompt is BYTE-IDENTICAL to today — shipping it changes NOTHING in prod. The related
+    /// context EGRESSES to the cloud provider, so the retrieval is gated by the live session unlock
+    /// set through `search_visible` and `get_note_if_visible`: a sealed-not-unlocked prior note can
+    /// never reach the prompt.
+    #[serde(default)]
+    pub augment_notes_with_context: bool,
 }
 
 impl Default for AppConfig {
@@ -115,6 +126,7 @@ impl Default for AppConfig {
             relock_on_screenshare: true,
             cloud_egress_consented: false,
             semantic_search_enabled: false,
+            augment_notes_with_context: false,
         }
     }
 }
@@ -146,6 +158,7 @@ const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 const K_CLOUD_EGRESS_CONSENTED: &str = "cloud_egress_consented";
 const K_SEMANTIC_SEARCH_ENABLED: &str = "semantic_search_enabled";
+const K_AUGMENT_NOTES_WITH_CONTEXT: &str = "augment_notes_with_context";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -238,6 +251,9 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_SEMANTIC_SEARCH_ENABLED)? {
             cfg.semantic_search_enabled = v == "true";
         }
+        if let Some(v) = db.get_setting(K_AUGMENT_NOTES_WITH_CONTEXT)? {
+            cfg.augment_notes_with_context = v == "true";
+        }
 
         Ok(cfg)
     }
@@ -313,6 +329,10 @@ impl AppConfig {
             K_SEMANTIC_SEARCH_ENABLED,
             if self.semantic_search_enabled { "true" } else { "false" },
         )?;
+        db.set_setting(
+            K_AUGMENT_NOTES_WITH_CONTEXT,
+            if self.augment_notes_with_context { "true" } else { "false" },
+        )?;
         Ok(())
     }
 
@@ -374,6 +394,28 @@ mod tests {
         assert!(!cfg.cloud_egress_consented);
         // Phase 2b semantic search is OFF by default — shipping it changes nothing.
         assert!(!cfg.semantic_search_enabled);
+        // Phase 4 retrieval-augmented notes is OFF by default — shipping it changes nothing.
+        assert!(!cfg.augment_notes_with_context);
+    }
+
+    /// Phase 4: a config persisted before `augment_notes_with_context` existed (key absent from the
+    /// settings table) must load with the flag defaulting to `false` — the prod-safe default for
+    /// existing installs.
+    #[test]
+    fn missing_augment_flag_defaults_off() {
+        let db = temp_db();
+        assert!(!AppConfig::load(&db).unwrap().augment_notes_with_context);
+    }
+
+    #[test]
+    fn augment_notes_flag_round_trips() {
+        let db = temp_db();
+        let cfg = AppConfig {
+            augment_notes_with_context: true,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert!(AppConfig::load(&db).unwrap().augment_notes_with_context);
     }
 
     /// A config persisted before `semantic_search_enabled` existed (key absent from both the JSON

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -19,6 +19,7 @@ pub mod organize;
 pub mod provider;
 pub mod recipes;
 pub mod redact;
+pub mod related_context;
 pub mod template;
 pub mod threads;
 pub mod timeline;

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -21,6 +21,14 @@ pub struct SummarizeRequest {
     pub template: String,
     /// existing note titles → [[link]] targets
     pub vault_titles: Vec<String>,
+    /// brain2 RAG Phase 4 — a small, GATED corpus of related PRIOR notes (each headed by a
+    /// `### [[Title]] · date · id:` citation) so the model can ground the new note in past
+    /// decisions/owed items. `None` (the default + flag-OFF case) ⇒ `render_user_content` is
+    /// byte-identical to before this field existed. SECURITY: this string EGRESSES to the cloud
+    /// provider in the summarization prompt, so it MUST be assembled only from VISIBLE
+    /// (not sealed-not-unlocked) prior notes — see `summarize::related_context::build_related_context`.
+    /// It is redacted by `RedactingProvider` alongside the transcript before egress.
+    pub related_context: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -163,11 +163,29 @@ impl SummarizerProvider for RedactingProvider {
     }
 
     async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
-        let (red, map) = redact(&req.transcript);
-        // Name layer (default no-op → `red` unchanged, `name_pairs` empty → byte-identical egress).
-        let (red, name_pairs) = self.names.redact_names(&red);
+        // Shared regex map across the transcript AND the Phase-4 `related_context` so a value
+        // redacted in either restores consistently in the reply. With `related_context = None`
+        // (the default + flag-OFF case) the map is built from the transcript alone, exactly as the
+        // old `redact(&req.transcript)` did — egress stays byte-identical.
+        let mut map = HashMap::new();
+        let mut rev = HashMap::new();
+        let red_transcript = redact_into(&req.transcript, &mut map, &mut rev);
+        // The related-context corpus EGRESSES to the provider in the prompt — scrub it through the
+        // SAME firewall as the transcript so emails/cards/phones never leave un-redacted.
+        let red_related = req
+            .related_context
+            .as_ref()
+            .map(|c| redact_into(c, &mut map, &mut rev));
+        // Name layer (default no-op → text unchanged, `name_pairs` empty → byte-identical egress).
+        let (red_transcript, mut name_pairs) = self.names.redact_names(&red_transcript);
+        let red_related = red_related.map(|c| {
+            let (c2, more) = self.names.redact_names(&c);
+            name_pairs.extend(more);
+            c2
+        });
         let mut r = req.clone();
-        r.transcript = red;
+        r.transcript = red_transcript;
+        r.related_context = red_related;
         let out = self.inner.summarize(&r).await?;
         // Restore both layers in the reply (disjoint token namespaces; order-independent).
         let out = restore_names(&out, &name_pairs);
@@ -277,6 +295,7 @@ mod tests {
             },
             template: String::new(),
             vault_titles: Vec::new(),
+            related_context: None,
         }
     }
 

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -1,0 +1,364 @@
+//! brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION.
+//!
+//! Ground each NEW meeting note in a small corpus of related PRIOR notes so notes compound
+//! ("last time you decided X / you still owe Y") instead of being isolated. Uses the LIVE FTS5
+//! retrieval (already shipped) + the existing provider — NO local/embedding model. The whole path
+//! is gated behind the default-OFF `augment_notes_with_context` config flag.
+//!
+//! LOCK INVARIANT (load-bearing): the corpus this builds is injected into the summarization prompt
+//! and therefore EGRESSES to the cloud provider. It MUST contain ONLY visible (not
+//! sealed-and-not-session-unlocked) prior notes. We enforce that exactly like `vault_context.rs`:
+//! candidate selection goes through `Db::search_visible` and EVERY note body is pulled through the
+//! second gate `Db::get_note_if_visible` — both keyed on the live `unlocked` session set. A
+//! sealed-not-unlocked related meeting contributes NOTHING. We also EXCLUDE the meeting being
+//! summarized itself, so a note is never grounded in its own (yet-to-exist) prior self.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::error::Result;
+use crate::storage::models::VaultSource;
+use crate::storage::Db;
+
+/// Max related notes to pack into the grounding corpus. Kept small (focused, high-precision
+/// grounding) and well under the Ask-My-Vault corpus size — this is context, not a research dump.
+const MAX_RELATED_NOTES: usize = 4;
+
+/// Min token length kept for the salient query (drops "the", "do", "i", short filler).
+const MIN_TERM_LEN: usize = 3;
+
+/// Cap on the number of salient terms in the derived FTS query.
+const MAX_QUERY_TERMS: usize = 8;
+
+/// Char budget for the grounding corpus, by provider. Smaller than the Ask-My-Vault budget on
+/// purpose — this rides ON TOP of the full transcript in the same prompt, so it must stay lean.
+/// Local quantized models (Ollama) have tiny context windows → cap much tighter.
+fn budget_for(provider_id: &str) -> usize {
+    if provider_id == "ollama" {
+        3_000
+    } else {
+        24_000
+    }
+}
+
+/// Basic EN + PL stopword set. Deliberately small + deterministic (no external word-list dep); it
+/// strips the highest-frequency function words so the salient query keys off content terms.
+fn is_stopword(t: &str) -> bool {
+    const STOP: &[&str] = &[
+        // English
+        "the", "and", "for", "are", "but", "not", "you", "your", "all", "can", "had", "her", "was",
+        "one", "our", "out", "has", "him", "his", "how", "man", "new", "now", "old", "see", "two",
+        "way", "who", "did", "get", "may", "she", "use", "that", "this", "with", "have", "from",
+        "they", "will", "would", "there", "their", "what", "about", "which", "when", "were", "been",
+        "them", "then", "than", "some", "into", "just", "like", "also", "well", "yeah", "okay",
+        "going", "gonna", "really", "actually", "think", "know", "want", "need", "let", "yes",
+        "kind", "sort", "thing", "things", "stuff", "much", "very", "more", "most", "such", "only",
+        // Polish
+        "nie", "tak", "jest", "się", "sie", "tego", "tym", "tych", "tam", "jak", "czy", "ale",
+        "lub", "albo", "oraz", "dla", "tylko", "też", "tez", "już", "juz", "bez", "być", "byc",
+        "jako", "który", "ktory", "która", "ktora", "które", "ktore", "tutaj", "teraz", "wtedy",
+        "bardzo", "trochę", "troche", "może", "moze", "żeby", "zeby", "przez", "przy", "pod", "nad",
+        "tu", "to", "co", "na", "we", "do", "od", "po", "za", "ze", "oraz", "więc", "wiec",
+    ];
+    STOP.contains(&t)
+}
+
+/// Tokenize to lowercased alphanumeric tokens (Unicode-aware; handles PL diacritics).
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+/// Derive a short, deterministic FTS query from a meeting: the title's content tokens first (the
+/// strongest signal), then the top-frequency non-stopword tokens from the transcript, deduped and
+/// capped at [`MAX_QUERY_TERMS`]. Pure + unit-testable. Ties in frequency break by first-appearance
+/// order, so the output is fully deterministic for a given input. An empty/`None` title is fine —
+/// the transcript alone drives the query.
+pub fn salient_query(title: Option<&str>, transcript: &str) -> String {
+    let mut terms: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    // 1. Title content tokens, in order — the most salient signal for "what is this about".
+    if let Some(t) = title {
+        for tok in tokenize(t) {
+            if terms.len() >= MAX_QUERY_TERMS {
+                break;
+            }
+            if tok.chars().count() < MIN_TERM_LEN || is_stopword(&tok) {
+                continue;
+            }
+            if seen.insert(tok.clone()) {
+                terms.push(tok);
+            }
+        }
+    }
+
+    // 2. Top-frequency transcript content tokens (count desc, then first-seen asc for determinism).
+    let mut counts: Vec<(String, usize, usize)> = Vec::new(); // (token, count, first_index)
+    let mut index: HashMap<String, usize> = HashMap::new();
+    for (i, tok) in tokenize(transcript).into_iter().enumerate() {
+        if tok.chars().count() < MIN_TERM_LEN || is_stopword(&tok) {
+            continue;
+        }
+        match index.get(&tok) {
+            Some(&pos) => counts[pos].1 += 1,
+            None => {
+                index.insert(tok.clone(), counts.len());
+                counts.push((tok, 1, i));
+            }
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
+    for (tok, _, _) in counts {
+        if terms.len() >= MAX_QUERY_TERMS {
+            break;
+        }
+        if seen.insert(tok.clone()) {
+            terms.push(tok);
+        }
+    }
+
+    terms.join(" ")
+}
+
+/// Build the GATED related-prior-notes corpus for grounding a new note. Returns `(corpus, sources)`.
+///
+/// - Candidate meetings come from [`Db::search_visible`] against the live `unlocked` set (FIRST
+///   gate) — a sealed-not-unlocked meeting is never even a candidate.
+/// - The meeting being summarized (`this_meeting_id`) is EXCLUDED — a note is never grounded in
+///   itself.
+/// - Each note body is pulled through [`Db::get_note_if_visible`] (SECOND gate) before any of its
+///   content enters the corpus, so a sealed-not-unlocked note contributes nothing even if it
+///   slipped through the candidate filter.
+/// - The top [`MAX_RELATED_NOTES`] visible notes are packed under [`budget_for`], each headed by a
+///   `### [[Title]] · date · id:` citation so the model can cite `[[Title]]`.
+///
+/// An empty/whitespace `query` (e.g. a transcript that was all stopwords) yields an empty corpus —
+/// `search_visible` returns nothing for a query with no usable terms.
+pub fn build_related_context(
+    db: &Db,
+    this_meeting_id: &str,
+    query: &str,
+    unlocked: &HashSet<String>,
+    provider_id: &str,
+) -> Result<(String, Vec<VaultSource>)> {
+    let budget = budget_for(provider_id);
+    // Over-fetch a little: the self-meeting and any second-gate misses are dropped below, so ask for
+    // more candidates than we intend to keep.
+    let hits = db.search_visible(query, (MAX_RELATED_NOTES as i64) + 6, unlocked)?;
+
+    let mut corpus = String::new();
+    let mut sources: Vec<VaultSource> = Vec::new();
+    for hit in hits {
+        if sources.len() >= MAX_RELATED_NOTES || corpus.len() >= budget {
+            break;
+        }
+        let m = hit.meeting;
+        // Never ground a note in itself.
+        if m.id == this_meeting_id {
+            continue;
+        }
+        // Second gate: only pull the body if the note is visible under the live unlock set.
+        let Some(note) = db.get_note_if_visible(&m.id, unlocked)? else {
+            continue;
+        };
+        let title = m.title.clone().unwrap_or_else(|| "(untitled)".to_string());
+        let date = m
+            .started_at
+            .split(['T', ' '])
+            .next()
+            .unwrap_or("")
+            .to_string();
+        let header = format!("\n\n### [[{title}]] · {date} · id:{}\n", m.id);
+        let remaining = budget.saturating_sub(corpus.len() + header.len());
+        if remaining < 200 {
+            break;
+        }
+        let chunk: String = note.markdown.chars().take(remaining).collect();
+        corpus.push_str(&header);
+        corpus.push_str(&chunk);
+        sources.push(VaultSource {
+            meeting_id: m.id,
+            title,
+            started_at: m.started_at,
+        });
+    }
+
+    Ok((corpus, sources))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn temp_db() -> Db {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "meetnotes-relctx-test-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn seed_note(db: &Db, id: &str, title: &str, markdown: &str, folder: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: id.to_string(),
+            started_at: "2026-06-20T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some(title.to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: id.to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-20T09:05:00Z".to_string(),
+            exported_path: None,
+        })
+        .unwrap();
+        db.set_note_folder(id, folder).unwrap();
+    }
+
+    fn seed_folder(db: &Db, id: &str, locked: bool) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: id.to_string(),
+            parent_id: None,
+            locked,
+            created_at: "2026-06-19T00:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
+    // ── salient_query: deterministic, stopword-stripped, capped ──────────────────────────────────
+
+    #[test]
+    fn salient_query_strips_stopwords_and_keeps_content() {
+        let q = salient_query(
+            Some("Budget Planning"),
+            "We decided the budget and the runway for hiring. The budget matters for hiring.",
+        );
+        // Title content terms appear; stopwords ("the", "and", "for", "we") are gone.
+        assert!(q.contains("budget"));
+        assert!(q.contains("planning"));
+        assert!(q.contains("hiring"));
+        for stop in ["the", "and", "for", " we "] {
+            assert!(!format!(" {q} ").contains(stop), "stopword leaked: {stop}");
+        }
+    }
+
+    #[test]
+    fn salient_query_caps_term_count() {
+        let transcript = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima";
+        let q = salient_query(Some("Mike November Oscar Papa Quebec"), transcript);
+        assert!(
+            q.split_whitespace().count() <= MAX_QUERY_TERMS,
+            "query must be capped at {MAX_QUERY_TERMS} terms, got: {q}"
+        );
+    }
+
+    #[test]
+    fn salient_query_handles_empty_title() {
+        let q = salient_query(None, "Apollo migration migration migration deadline");
+        // Most frequent content term ("migration") leads; deterministic for the same input.
+        assert!(q.starts_with("migration"), "got: {q}");
+        assert_eq!(q, salient_query(None, "Apollo migration migration migration deadline"));
+    }
+
+    #[test]
+    fn salient_query_empty_when_all_stopwords() {
+        assert_eq!(salient_query(Some("the and"), "the and for we to do"), "");
+    }
+
+    // ── build_related_context: GATED retrieval + self-exclusion ──────────────────────────────────
+
+    /// Flag-ON happy path: a related VISIBLE note is retrieved + cited, and the meeting being
+    /// summarized is EXCLUDED (never grounds itself).
+    #[test]
+    fn build_related_context_cites_visible_and_excludes_self() {
+        let db = temp_db();
+        // The meeting we're "summarizing" (its own note already exists in this test fixture).
+        seed_note(&db, "this", "Q3 Planning", "ACME quarterly planning roadmap", None);
+        // A genuinely related prior, open folder → visible.
+        seed_note(&db, "prior", "Q2 Planning", "ACME quarterly planning roadmap decisions", None);
+
+        let nothing = HashSet::new();
+        let (corpus, sources) =
+            build_related_context(&db, "this", "ACME quarterly planning", &nothing, "anthropic")
+                .unwrap();
+
+        assert!(corpus.contains("[[Q2 Planning]]"), "related note must be cited");
+        assert!(corpus.contains("id:prior"));
+        assert!(sources.iter().any(|s| s.meeting_id == "prior"));
+        // Self-exclusion: the meeting being summarized is never in its own grounding corpus.
+        assert!(!corpus.contains("id:this"), "a note must never be grounded in itself");
+        assert!(sources.iter().all(|s| s.meeting_id != "this"));
+    }
+
+    /// LOCK INVARIANT (RED-if-ungated): a sealed-and-NOT-session-unlocked related meeting must
+    /// contribute NOTHING to the corpus (it would otherwise egress to the cloud provider), and must
+    /// reappear once its folder is session-unlocked. This is the gate that an ungated `search` +
+    /// `get_latest_note_for_meeting` would fail.
+    #[test]
+    fn build_related_context_excludes_sealed_until_unlocked() {
+        let db = temp_db();
+        seed_note(&db, "this", "Acquisition Talk", "PROJECT atlas acquisition terms", None);
+        seed_folder(&db, "f-locked", false);
+        seed_note(
+            &db,
+            "sealed",
+            "Secret Acquisition",
+            "PROJECT atlas acquisition price 5_000_000 SEALED-SECRET",
+            Some("f-locked"),
+        );
+        // Seal the folder (flip locked=1). visibility_clause keys off folders.locked.
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        // Not session-unlocked → the sealed related note MUST be absent from the cloud-bound corpus.
+        let nothing = HashSet::new();
+        let (corpus, sources) =
+            build_related_context(&db, "this", "PROJECT atlas acquisition", &nothing, "anthropic")
+                .unwrap();
+        assert!(
+            !corpus.contains("SEALED-SECRET"),
+            "sealed-not-unlocked related content leaked into the cloud grounding corpus (gate violation)"
+        );
+        assert!(sources.iter().all(|s| s.meeting_id != "sealed"));
+
+        // Session-unlock the folder → the related note is now legitimately available + cited.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let (corpus2, sources2) =
+            build_related_context(&db, "this", "PROJECT atlas acquisition", &unlocked, "anthropic")
+                .unwrap();
+        assert!(corpus2.contains("SEALED-SECRET"), "unlocked related content must reappear");
+        assert!(sources2.iter().any(|s| s.meeting_id == "sealed"));
+    }
+
+    /// An empty query (transcript was all stopwords) yields an empty corpus — never a panic, never
+    /// a leak.
+    #[test]
+    fn build_related_context_empty_query_is_empty() {
+        let db = temp_db();
+        seed_note(&db, "this", "Standup", "daily standup notes", None);
+        seed_note(&db, "prior", "Old Standup", "older standup notes", None);
+        let nothing = HashSet::new();
+        let (corpus, sources) =
+            build_related_context(&db, "this", "", &nothing, "anthropic").unwrap();
+        assert!(corpus.is_empty());
+        assert!(sources.is_empty());
+    }
+}

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -199,9 +199,82 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
         }
     }
 
+    // brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION. When `related_context` is present
+    // (the flag is ON and the gated retrieval found visible prior notes), prepend it as a clearly
+    // labelled, read-only block BEFORE the transcript so the model can reference prior decisions /
+    // owed items and cite them as `[[Title]]`. When `None` (the default + flag-OFF case) this whole
+    // block is skipped, so the output is BYTE-IDENTICAL to before this field existed — no regression.
+    if let Some(ctx) = &req.related_context {
+        if !ctx.trim().is_empty() {
+            out.push_str(
+                "\n## Related prior notes (context only — do not copy, cite as [[Title]])\n",
+            );
+            out.push_str(ctx);
+            out.push('\n');
+        }
+    }
+
     out.push_str("\nTRANSCRIPT\n");
     out.push_str(&req.transcript);
     out.push('\n');
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::summarize::provider::{MeetingMeta, SummarizeRequest};
+
+    fn req(related: Option<String>) -> SummarizeRequest {
+        SummarizeRequest {
+            transcript: "We shipped v2 and agreed Anna owns the rollout.".to_string(),
+            meta: MeetingMeta {
+                date_iso: "2026-06-28".to_string(),
+                title_hint: None,
+                duration_s: 1800,
+                language: Some("en".to_string()),
+            },
+            template: "TEMPLATE".to_string(),
+            vault_titles: vec!["Roadmap".to_string()],
+            related_context: related,
+        }
+    }
+
+    /// No-regression proof: with `related_context = None` (the default + flag-OFF case) the rendered
+    /// user content is byte-identical to the pre-Phase-4 rendering — no Related-prior-notes block,
+    /// nothing before TRANSCRIPT changed.
+    #[test]
+    fn render_user_content_none_is_unchanged() {
+        let out = render_user_content(&req(None));
+        // The transcript section follows the vault-titles section directly, with no extra block.
+        assert!(out.contains("\nTRANSCRIPT\nWe shipped v2"));
+        assert!(!out.contains("Related prior notes"));
+        // Reconstruct the exact expected string to pin byte-identity.
+        let expected = "MEETING METADATA\n- date: 2026-06-28\n- duration_minutes: 30\n- language: en\n\nEXISTING NOTE TITLES (valid [[wikilink]] targets — link only these):\n- Roadmap\n\nTRANSCRIPT\nWe shipped v2 and agreed Anna owns the rollout.\n";
+        assert_eq!(out, expected);
+    }
+
+    /// Flag ON: a `Some(context)` prepends the labelled, read-only block BEFORE the transcript.
+    #[test]
+    fn render_user_content_some_prepends_block() {
+        let ctx = "\n\n### [[Q2 Planning]] · 2026-04-01 · id:m-prev\nWe decided to delay launch.";
+        let out = render_user_content(&req(Some(ctx.to_string())));
+        let block_at = out
+            .find("## Related prior notes (context only — do not copy, cite as [[Title]])")
+            .expect("related block present");
+        let transcript_at = out.find("\nTRANSCRIPT\n").expect("transcript present");
+        assert!(block_at < transcript_at, "related block must precede the transcript");
+        assert!(out.contains("Q2 Planning"));
+        assert!(out.contains("We decided to delay launch."));
+    }
+
+    /// An empty/whitespace context is treated as None (no block, byte-identical to the None path).
+    #[test]
+    fn render_user_content_empty_context_is_skipped() {
+        assert_eq!(
+            render_user_content(&req(Some("   \n".to_string()))),
+            render_user_content(&req(None))
+        );
+    }
 }


### PR DESCRIPTION
Ground each new note in related PRIOR notes (live FTS5) so notes compound, behind a **default-off** `augment_notes_with_context` flag (no local model). **salient_query** + **build_related_context** (GATED: search_visible + get_note_if_visible on the live unlock set, self-excluded, [[Title]]-cited). **SummarizeRequest.related_context** (None default; render byte-identical when off — pinned golden test). Pipeline injects it when on (best-effort, never fails the pipeline); the related context is scrubbed through the same redaction firewall. Verified: cargo test 260/0; clippy clean; adversarial PASS (gate + flag-off byte-identity RED-before-GREEN); lock-security PASS (two-gate, sealed-not-unlocked never reaches the prompt).