### PR TITLE
chore(polish): post-0.5.0-audit cleanups (MCP unwrap + stale docs)

### DIFF
--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -57,9 +57,12 @@ impl Embedder for StubEmbedder {
 /// The single active embedding backend used by BOTH the index path (chunking a note on creation)
 /// and the query path (Ask-My-Vault / MCP `search_semantic`). Returning a boxed trait object keeps
 /// the model a swappable seam: today it is the deterministic [`StubEmbedder`]; Phase 2c swaps in the
-/// real BGE-M3 model here and NOTHING else changes. Cheap to construct (the stub is zero-sized), so
-/// callers build one per operation rather than caching. NEVER invoked when `semantic_search_enabled`
-/// is off (the gate short-circuits before this is called).
+/// real BGE-M3 model here. NOTE: if the real model's output dimension differs from [`EMBED_DIM`],
+/// that is a `vec_chunks float[N]` SCHEMA change — an additive migration to a new-width vec0 table
+/// plus a full re-index of every meeting, NOT a code one-liner. A mismatched-width insert fails
+/// loud (dimension error), never silently. Cheap to construct (the stub is zero-sized), so callers
+/// build one per operation rather than caching. NEVER invoked when `semantic_search_enabled` is off
+/// (the gate short-circuits before this is called).
 pub fn active_embedder() -> Box<dyn Embedder> {
     Box::new(StubEmbedder)
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -130,12 +130,22 @@ fn run(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
         }
         match handle_rpc(&db_path, &body, &unlocked, expected_token.as_deref(), auth.as_deref()) {
             Some(resp) => {
-                let h = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
-                let _ = req.respond(
-                    Response::from_string(resp.to_string())
-                        .with_status_code(200)
-                        .with_header(h),
-                );
+                // The header pair is a compile-time ASCII constant so this never errors, but we do
+                // NOT unwrap on the per-request server loop (a panic here would kill the MCP thread
+                // for the whole session). Fall back to a header-less 200 in the impossible Err case.
+                let resp_body = resp.to_string();
+                match Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]) {
+                    Ok(h) => {
+                        let _ = req.respond(
+                            Response::from_string(resp_body)
+                                .with_status_code(200)
+                                .with_header(h),
+                        );
+                    }
+                    Err(_) => {
+                        let _ = req.respond(Response::from_string(resp_body).with_status_code(200));
+                    }
+                }
             }
             // Notification (no id) → 202, no body.
             None => {

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -33,12 +33,10 @@ fn budget_for(provider_id: &str) -> usize {
 /// Backward-compatible entry point (original 3-arg signature). Delegates to the
 /// visibility-aware [`build_vault_context_visible`] with an EMPTY unlock set, i.e. it is
 /// **fail-closed**: every sealed folder is treated as not-unlocked, so no sealed content can
-/// reach the cloud prompt (E9) even from a caller that hasn't yet been migrated.
-///
-/// TODO(owner of commands.rs): migrate `ask_vault` / `pre_meeting_brief` to call
-/// [`build_vault_context_visible`] with the live `state.unlocked_folders` snapshot, so a folder
-/// the user has *session-unlocked* is included again. Until then those flows simply omit
-/// session-unlocked folders from Ask-My-Vault — the safe (no-leak) direction.
+/// reach the cloud prompt (E9). The live callers (`ask_vault` / `pre_meeting_brief`) now call
+/// [`build_vault_context_visible`] directly with the live `state.unlocked_folders` snapshot, so
+/// session-unlocked folders ARE included; this empty-set shim remains only as a fail-closed
+/// default for any caller that does not have an unlock set to pass.
 pub fn build_vault_context(
     db: &Db,
     query: &str,


### PR DESCRIPTION
Cleanups from the comprehensive 0.5.0 verification: drop the MCP per-request-loop `unwrap()` (rule: no unwrap in non-test; would kill the server thread), correct the stale vault_context TODO (live unlock set is now passed), clarify the EMBED_DIM-swap is a vec0 schema migration. cargo test 273/0; clippy clean.