### PR TITLE
feat(brain): curated EN+PL model registry + download-by-id + select + RAM-gating

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1637,6 +1637,9 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // Phase B: the brain model path is not carried on the settings DTO (it is resolved from the
         // shared models dir by default), so a settings save preserves the live value (default None).
         brain_model_path: current.brain_model_path.clone(),
+        // Phase B (registry): the selected brain model id is set ONLY via `select_brain_model`, never
+        // through a settings save — preserve the live value so a save can't clobber the selection.
+        brain_model_id: current.brain_model_id.clone(),
     }
 }
 
@@ -1920,50 +1923,115 @@ pub async fn download_model(state: State<'_, AppState>) -> Result<String, AppErr
 }
 
 /// Whether a usable on-device brain (reasoning GGUF) is present at the resolved path — the
-/// configured `brain_model_path`, else the default model in the shared models dir. Lets the UI offer
-/// a download. Independent of the `local-brain` feature: this only checks the file on disk.
+/// configured custom `brain_model_path`, else the selected `brain_model_id`'s file in the shared
+/// models dir. Lets the UI offer a download. Independent of the `local-brain` feature: this only
+/// checks the file on disk.
 #[tauri::command]
 pub fn brain_model_present(state: State<'_, AppState>) -> Result<bool, AppError> {
-    let configured = {
+    let (configured, selected) = {
         let c = state
             .config
             .lock()
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-        c.brain_model_path.clone()
+        (c.brain_model_path.clone(), c.brain_model_id.clone())
     };
     let p = configured.as_deref().map(std::path::Path::new);
-    Ok(crate::reason::brain_model_path(p)?.is_some())
+    Ok(crate::reason::resolve_brain_model(p, selected.as_deref())?.is_some())
 }
 
-/// Download the on-device brain (reasoning GGUF) into the shared models dir if missing; returns its
-/// path. No-op (returns the existing path) when already present. INBOUND ONLY — fetches a model file
-/// and sends NO meeting content (no egress). Emits [`crate::events::EVENT_BRAIN_DOWNLOAD`] progress
-/// events (throttled). The downloaded file is NOT loaded here — wiring the brain is Phase B step 3.
+/// macOS total physical RAM in whole GB via `sysctl -n hw.memsize` (no new FFI/crate). Returns
+/// `None` on any error — the caller then treats every model as fitting rather than HIDING it behind
+/// a failed probe.
+fn total_ram_gb() -> Option<u64> {
+    let out = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.memsize")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let bytes: u64 = String::from_utf8(out.stdout).ok()?.trim().parse().ok()?;
+    Some(bytes / (1024 * 1024 * 1024))
+}
+
+/// The curated on-device brain model registry, each row carrying the picker flags `downloaded`
+/// (file present in the shared models dir), `fits_ram` (min RAM within the machine's total RAM —
+/// `true` when total RAM can't be read), and `selected` (the persisted `brain_model_id`). Feeds the
+/// Phase-H model picker. No content read / no egress — static metadata + on-disk existence only.
+#[tauri::command]
+pub fn list_brain_models(
+    state: State<'_, AppState>,
+) -> Result<Vec<crate::reason::BrainModelDto>, AppError> {
+    let selected = {
+        let c = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        c.brain_model_id.clone()
+    };
+    let dir = crate::transcribe::models_dir()?;
+    Ok(crate::reason::brain_model_dtos(
+        &dir,
+        total_ram_gb(),
+        selected.as_deref(),
+    ))
+}
+
+/// Persist the user's SELECTED on-device brain model id. Validates `model_id` against the registry
+/// (unknown id ⇒ `AppError::InvalidArg`) and saves it to config; the next `active_reasoner` build
+/// resolves this model when its GGUF is present. Does NOT download — the FE calls
+/// `download_brain_model(model_id)` for that.
+#[tauri::command]
+pub fn select_brain_model(state: State<'_, AppState>, model_id: String) -> Result<(), AppError> {
+    select_brain_model_inner(&state, model_id)
+}
+
+/// Testable core of [`select_brain_model`]: validate the id against the registry, persist it.
+fn select_brain_model_inner(state: &AppState, model_id: String) -> Result<(), AppError> {
+    if crate::reason::brain_model_by_id(&model_id).is_none() {
+        return Err(AppError::InvalidArg(format!(
+            "unknown brain model id: {model_id}"
+        )));
+    }
+    let mut c = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    c.brain_model_id = Some(model_id);
+    c.save(&state.db)?;
+    Ok(())
+}
+
+/// Download the on-device brain model identified by `model_id` (from the curated registry) into the
+/// shared models dir if missing; returns its path. No-op (returns the existing path) when already
+/// present. Unknown id ⇒ `AppError::InvalidArg`. INBOUND ONLY — fetches a model file and sends NO
+/// meeting content (no egress). Emits [`crate::events::EVENT_BRAIN_DOWNLOAD`] progress events
+/// (throttled). The downloaded file is NOT loaded here — wiring the brain is a later step.
+/// Resolve a registry `model_id` to its `(download url, on-disk dest)`. Unknown id ⇒
+/// `AppError::InvalidArg` (the rejection [`download_brain_model`] enforces). Testable sync core.
+fn brain_download_target(model_id: &str) -> Result<(&'static str, std::path::PathBuf), AppError> {
+    let model = crate::reason::brain_model_by_id(model_id).ok_or_else(|| {
+        AppError::InvalidArg(format!("unknown brain model id: {model_id}"))
+    })?;
+    Ok((model.url, crate::transcribe::models_dir()?.join(model.filename)))
+}
+
 #[tauri::command]
 pub async fn download_brain_model(
     app: AppHandle,
-    state: State<'_, AppState>,
+    model_id: String,
 ) -> Result<String, AppError> {
-    let configured = {
-        let c = state
-            .config
-            .lock()
-            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-        c.brain_model_path.clone()
-    };
-    let p = configured.as_deref().map(std::path::Path::new);
-    if let Some(found) = crate::reason::brain_model_path(p)? {
-        return Ok(found.to_string_lossy().to_string());
-    }
+    let (url, dest) = brain_download_target(&model_id)?;
 
-    let dest =
-        crate::transcribe::models_dir()?.join(crate::reason::DEFAULT_BRAIN_MODEL_FILE);
-    let url = crate::reason::default_brain_model_url();
+    if dest.is_file() {
+        return Ok(dest.to_string_lossy().to_string());
+    }
 
     // Throttle progress events to roughly every 8 MB so a multi-GB download doesn't flood the FE.
     const EMIT_EVERY: u64 = 8 * 1024 * 1024;
     let mut last_emit: u64 = 0;
-    crate::reason::download_brain_model(&url, &dest, |downloaded, total| {
+    crate::reason::download_brain_model(url, &dest, |downloaded, total| {
         if downloaded - last_emit >= EMIT_EVERY {
             last_emit = downloaded;
             let _ = app.emit(
@@ -4256,6 +4324,52 @@ mod lifecycle_tests {
             !dto_to_config(dto2, &current2).cloud_egress_consented,
             "a settings save must NEVER grant consent — only the dedicated command may (BLK-4)"
         );
+    }
+
+    // ── brain model registry: select + download-target resolution ───────────────────────────────
+
+    /// `select_brain_model` validates the id against the registry and PERSISTS it; reloading config
+    /// from the DB returns the chosen id. An unknown id is rejected with `InvalidArg` and leaves the
+    /// stored selection untouched.
+    #[test]
+    fn select_brain_model_persists_valid_and_rejects_unknown() {
+        let state = build_state("brain-select");
+
+        select_brain_model_inner(&state, "bielik-11b-v3".to_string()).unwrap();
+        assert_eq!(
+            state.config.lock().unwrap().brain_model_id.as_deref(),
+            Some("bielik-11b-v3")
+        );
+        // Survives a reload from the settings table.
+        assert_eq!(
+            AppConfig::load(&state.db).unwrap().brain_model_id.as_deref(),
+            Some("bielik-11b-v3")
+        );
+
+        // Unknown id ⇒ InvalidArg, selection unchanged.
+        let err = select_brain_model_inner(&state, "not-a-real-model".to_string()).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+        assert_eq!(
+            state.config.lock().unwrap().brain_model_id.as_deref(),
+            Some("bielik-11b-v3")
+        );
+    }
+
+    /// The download-target resolver rejects an unknown id (the exact guard `download_brain_model`
+    /// enforces before any network I/O) and resolves a known id to its registry URL + a path inside
+    /// the shared models dir.
+    #[test]
+    fn brain_download_target_rejects_unknown_and_resolves_known() {
+        assert!(matches!(
+            brain_download_target("bogus-id"),
+            Err(AppError::InvalidArg(_))
+        ));
+        let (url, dest) = brain_download_target("qwen2.5-3b").unwrap();
+        assert_eq!(
+            url,
+            "https://huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF/resolve/main/Qwen2.5-3B-Instruct-Q4_K_M.gguf"
+        );
+        assert!(dest.ends_with("Qwen2.5-3B-Instruct-Q4_K_M.gguf"));
     }
 
     // ── rename_folder / delete_folder (folder lifecycle) ────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,8 @@ pub fn run() {
             commands::model_present,
             commands::download_model,
             commands::brain_model_present,
+            commands::list_brain_models,
+            commands::select_brain_model,
             commands::download_brain_model,
             commands::toggle_bar,
             commands::list_folders,

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -13,6 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::error::{AppError, Result};
@@ -23,37 +24,155 @@ use crate::settings::AppConfig;
 #[cfg(feature = "local-brain")]
 pub mod mistral;
 
-/// Default brain model filename (a small instruct GGUF) placed under the shared models dir. The
-/// actual model choice + download is the user's on-device step; only the path resolution + download
-/// plumbing is exercised headless here. Mirrors `transcribe::model`'s filename convention.
-pub const DEFAULT_BRAIN_MODEL_FILE: &str = "Qwen2.5-3B-Instruct-Q4_K_M.gguf";
-
-/// Hugging Face mirror serving the default brain GGUF (raw file via `resolve/main`). INBOUND ONLY —
-/// the brain download fetches a model; it NEVER sends meeting content anywhere (no egress).
-pub fn default_brain_model_url() -> String {
-    format!(
-        "https://huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF/resolve/main/{DEFAULT_BRAIN_MODEL_FILE}"
-    )
+/// A curated, mistral.rs-arch-SAFE on-device reasoning model the user can pick from. The app must
+/// serve BOTH English and Polish, so the brain offers a CHOICE — not one hardcoded GGUF. Every entry
+/// here is a `Q4_K_M` GGUF whose architecture mistral.rs parses today (`llama` / `qwen2` / `qwen3`,
+/// NOT `qwen35` / `qwen3vl`). Static, compile-time data — no I/O, no allocation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrainModel {
+    /// Stable id used by `download_brain_model` / `select_brain_model` and persisted in config.
+    pub id: &'static str,
+    /// Human-friendly display name for the Phase-H picker.
+    pub name: &'static str,
+    /// On-disk filename inside the shared models dir.
+    pub filename: &'static str,
+    /// Hugging Face `resolve/main` raw-file URL. INBOUND ONLY — fetched, never sent meeting content.
+    pub url: &'static str,
+    /// Approximate download / on-disk size in bytes (for the picker; not a verification hash).
+    pub approx_size_bytes: u64,
+    /// Minimum system RAM (whole GB) the model realistically needs — drives RAM-gating in the picker.
+    pub min_ram_gb: u32,
+    /// Language tags the model serves (`pl`, `en`, `multi`).
+    pub languages: &'static [&'static str],
+    /// mistral.rs architecture key (`llama` / `qwen2` / `qwen3`) — all parse-safe.
+    pub arch: &'static str,
 }
 
-/// Resolve the GGUF the local brain should load, or `Ok(None)` when none is present.
+/// The curated registry. Order is display order (Polish-native first, then multilingual, then small).
+pub static BRAIN_MODELS: &[BrainModel] = &[
+    BrainModel {
+        id: "bielik-11b-v3",
+        name: "Bielik 11B v3 (Polish-native)",
+        filename: "Bielik-11B-v3.0-Instruct.Q4_K_M.gguf",
+        url: "https://huggingface.co/speakleash/Bielik-11B-v3.0-Instruct-GGUF/resolve/main/Bielik-11B-v3.0-Instruct.Q4_K_M.gguf",
+        approx_size_bytes: 7_215_545_057, // ~6.72 GB
+        min_ram_gb: 10,
+        languages: &["pl", "en"],
+        arch: "llama",
+    },
+    BrainModel {
+        id: "qwen3-14b",
+        name: "Qwen3 14B (multilingual/English)",
+        filename: "Qwen_Qwen3-14B-Q4_K_M.gguf",
+        url: "https://huggingface.co/bartowski/Qwen_Qwen3-14B-GGUF/resolve/main/Qwen_Qwen3-14B-Q4_K_M.gguf",
+        approx_size_bytes: 9_663_676_416, // ~9 GB
+        min_ram_gb: 14,
+        languages: &["en", "multi"],
+        arch: "qwen3",
+    },
+    BrainModel {
+        id: "qwen2.5-3b",
+        name: "Qwen2.5 3B (small / low-RAM)",
+        filename: "Qwen2.5-3B-Instruct-Q4_K_M.gguf",
+        url: "https://huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF/resolve/main/Qwen2.5-3B-Instruct-Q4_K_M.gguf",
+        approx_size_bytes: 2_147_483_648, // ~2 GB
+        min_ram_gb: 4,
+        languages: &["en", "multi", "pl"],
+        arch: "qwen2",
+    },
+];
+
+/// Look up a registry entry by id. `None` for an unknown id (the caller rejects with `InvalidArg`).
+pub fn brain_model_by_id(id: &str) -> Option<&'static BrainModel> {
+    BRAIN_MODELS.iter().find(|m| m.id == id)
+}
+
+/// IPC view of a [`BrainModel`] for the picker: the static metadata plus the two runtime flags the
+/// FE needs — `downloaded` (file present in the models dir) and `fits_ram` (the model's `min_ram_gb`
+/// is within the machine's total RAM). `selected` mirrors the persisted `brain_model_id`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrainModelDto {
+    pub id: String,
+    pub name: String,
+    pub filename: String,
+    pub url: String,
+    pub approx_size_bytes: u64,
+    pub min_ram_gb: u32,
+    pub languages: Vec<String>,
+    pub arch: String,
+    /// The GGUF already exists in the shared models dir.
+    pub downloaded: bool,
+    /// `min_ram_gb` fits the machine. When total RAM is unknown this is `true` (never HIDE a model
+    /// behind a failed probe — the user can still try it).
+    pub fits_ram: bool,
+    /// This id is the persisted `brain_model_id` selection.
+    pub selected: bool,
+}
+
+/// Build the picker DTOs from the registry against a given models dir + (optional) total RAM in GB +
+/// the current selection. Pure (the only I/O is the per-file `is_file` existence probe) so it is
+/// unit-testable with a fake models dir + a tiny RAM threshold. Unknown RAM ⇒ `fits_ram = true`.
+pub fn brain_model_dtos(
+    models_dir: &Path,
+    total_ram_gb: Option<u64>,
+    selected_id: Option<&str>,
+) -> Vec<BrainModelDto> {
+    BRAIN_MODELS
+        .iter()
+        .map(|m| BrainModelDto {
+            id: m.id.to_string(),
+            name: m.name.to_string(),
+            filename: m.filename.to_string(),
+            url: m.url.to_string(),
+            approx_size_bytes: m.approx_size_bytes,
+            min_ram_gb: m.min_ram_gb,
+            languages: m.languages.iter().map(|s| s.to_string()).collect(),
+            arch: m.arch.to_string(),
+            downloaded: models_dir.join(m.filename).is_file(),
+            fits_ram: total_ram_gb.map(|g| u64::from(m.min_ram_gb) <= g).unwrap_or(true),
+            selected: selected_id == Some(m.id),
+        })
+        .collect()
+}
+
+/// Resolve a user-supplied CUSTOM brain GGUF path override, or `Ok(None)`.
 ///
-/// Resolution order (mirrors [`crate::transcribe::resolve_model_path`]):
-/// 1. `configured` — an explicit path from settings (`brain_model_path`); used verbatim if it
-///    points at an existing file.
-/// 2. [`DEFAULT_BRAIN_MODEL_FILE`] inside the shared models dir, if it already exists on disk.
-///
-/// Creating the models dir can fail (returns `Err`); a missing model is `Ok(None)`, NOT an error —
-/// the app runs fine without the brain (it falls back to the stub). NEVER panics.
+/// `configured` is the explicit path from settings (`brain_model_path`), used verbatim if it points
+/// at an existing file. This is ONLY the custom-override layer; registry-id resolution is layered on
+/// top by [`resolve_brain_model`]. A missing file is `Ok(None)`, never an error. NEVER panics.
 pub fn brain_model_path(configured: Option<&Path>) -> Result<Option<PathBuf>> {
     if let Some(p) = configured {
         if p.is_file() {
             return Ok(Some(p.to_path_buf()));
         }
     }
-    let derived = crate::transcribe::models_dir()?.join(DEFAULT_BRAIN_MODEL_FILE);
-    if derived.is_file() {
-        return Ok(Some(derived));
+    Ok(None)
+}
+
+/// Resolve the GGUF the local brain should load, or `Ok(None)` when none is present.
+///
+/// Resolution order:
+/// 1. `configured` — an explicit custom path override (`brain_model_path`); used verbatim if the
+///    file exists ([`brain_model_path`]).
+/// 2. The file for the selected `model_id` (from the registry) inside the shared models dir, if it
+///    already exists on disk.
+///
+/// Creating the models dir can fail (returns `Err`); a missing/unselected model is `Ok(None)`, NOT
+/// an error — the app falls back to the stub. NEVER panics.
+pub fn resolve_brain_model(
+    configured: Option<&Path>,
+    model_id: Option<&str>,
+) -> Result<Option<PathBuf>> {
+    if let Some(p) = brain_model_path(configured)? {
+        return Ok(Some(p));
+    }
+    if let Some(m) = model_id.and_then(brain_model_by_id) {
+        let derived = crate::transcribe::models_dir()?.join(m.filename);
+        if derived.is_file() {
+            return Ok(Some(derived));
+        }
     }
     Ok(None)
 }
@@ -119,7 +238,7 @@ where
 /// The single active reasoning backend, used wherever the app needs local on-device reasoning.
 ///
 /// Graceful degradation, in priority order:
-/// - the `local-brain` feature is ON **and** a GGUF is present at the resolved [`brain_model_path`]
+/// - the `local-brain` feature is ON **and** a GGUF is present at the resolved [`resolve_brain_model`]
 ///   → the real [`mistral::MistralReasoner`] (lazy: the model loads on first use, not here, so this
 ///   never blocks startup and never panics);
 /// - otherwise (feature off, no model, or a path-resolution error) → the dependency-free
@@ -130,7 +249,7 @@ pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
     #[cfg(feature = "local-brain")]
     {
         let configured = config.brain_model_path.as_deref().map(Path::new);
-        match brain_model_path(configured) {
+        match resolve_brain_model(configured, config.brain_model_id.as_deref()) {
             Ok(Some(path)) => match mistral::MistralReasoner::new(path) {
                 Ok(r) => {
                     tracing::info!(target: "reason", id = r.id(), "local brain ready (lazy model load)");
@@ -364,27 +483,107 @@ mod tests {
     }
 
     #[test]
-    fn brain_model_path_none_when_configured_missing_and_no_default() {
-        // A configured path that does not exist must NOT be returned; with no default model present
-        // in the (test) models dir the resolver reports None — the graceful "use the stub" signal.
+    fn brain_model_path_none_when_configured_missing() {
+        // A configured custom path that does not exist must NOT be returned — the graceful
+        // "use the stub" signal. (Custom-override layer only; no registry/default fallback here.)
         let missing = std::env::temp_dir().join("murmur-brain-does-not-exist-xyz.gguf");
         let _ = std::fs::remove_file(&missing);
-        // Only assert the configured-missing branch is skipped; the derived-default branch depends on
-        // the shared models dir, which a dev machine may legitimately have populated.
-        if !crate::transcribe::models_dir()
-            .map(|d| d.join(DEFAULT_BRAIN_MODEL_FILE).is_file())
-            .unwrap_or(false)
-        {
-            assert!(brain_model_path(Some(&missing)).unwrap().is_none());
+        assert!(brain_model_path(Some(&missing)).unwrap().is_none());
+        assert!(brain_model_path(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn registry_lookup_by_id() {
+        // Every advertised id resolves; an unknown id is None.
+        for m in BRAIN_MODELS {
+            assert_eq!(brain_model_by_id(m.id).map(|x| x.id), Some(m.id));
+        }
+        let bielik = brain_model_by_id("bielik-11b-v3").unwrap();
+        assert_eq!(bielik.arch, "llama");
+        assert_eq!(bielik.min_ram_gb, 10);
+        assert!(bielik.languages.contains(&"pl"));
+        assert!(brain_model_by_id("does-not-exist").is_none());
+        assert!(brain_model_by_id("").is_none());
+    }
+
+    #[test]
+    fn registry_archs_are_mistralrs_safe() {
+        // Guardrail: only the arch keys mistral.rs parses today — never qwen35 / qwen3vl.
+        for m in BRAIN_MODELS {
+            assert!(
+                matches!(m.arch, "llama" | "qwen2" | "qwen3"),
+                "unsafe arch in registry: {}",
+                m.arch
+            );
         }
     }
 
     #[test]
-    fn default_brain_url_points_at_hf_mirror() {
+    fn resolve_brain_model_prefers_custom_path_then_selected_id() {
+        // (a) custom path override wins.
+        let f = tmp_file("resolve-custom", b"GGUF");
         assert_eq!(
-            default_brain_model_url(),
-            "https://huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF/resolve/main/Qwen2.5-3B-Instruct-Q4_K_M.gguf"
+            resolve_brain_model(Some(&f), Some("qwen2.5-3b")).unwrap().as_deref(),
+            Some(f.as_path())
         );
+        let _ = std::fs::remove_file(&f);
+
+        // (b) selected id resolves to the registry file IN the models dir when present. We place the
+        // qwen2.5-3b file in the real models dir, assert it resolves, then clean it up.
+        let model = brain_model_by_id("qwen2.5-3b").unwrap();
+        let dir = crate::transcribe::models_dir().unwrap();
+        let dest = dir.join(model.filename);
+        let pre_existing = dest.is_file();
+        if !pre_existing {
+            std::fs::write(&dest, b"GGUF").unwrap();
+        }
+        assert_eq!(
+            resolve_brain_model(None, Some("qwen2.5-3b")).unwrap().as_deref(),
+            Some(dest.as_path())
+        );
+        if !pre_existing {
+            let _ = std::fs::remove_file(&dest);
+        }
+
+        // (c) no custom path + no selection ⇒ None (stub).
+        assert!(resolve_brain_model(None, None).unwrap().is_none());
+        // unknown id resolves to None (no models dir hit for it).
+        assert!(resolve_brain_model(None, Some("nope-bad-id")).unwrap().is_none());
+    }
+
+    #[test]
+    fn brain_model_dtos_mark_downloaded_fits_ram_and_selected() {
+        // Fake models dir holding ONLY the small model's file.
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-brain-dtos-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let small = brain_model_by_id("qwen2.5-3b").unwrap();
+        std::fs::write(dir.join(small.filename), b"GGUF").unwrap();
+
+        // RAM threshold of 10 GB: bielik(10) fits, qwen3-14b(14) does NOT, qwen2.5-3b(4) fits.
+        let dtos = brain_model_dtos(&dir, Some(10), Some("qwen2.5-3b"));
+        let by = |id: &str| dtos.iter().find(|d| d.id == id).unwrap();
+        assert!(by("qwen2.5-3b").downloaded);
+        assert!(!by("bielik-11b-v3").downloaded);
+        assert!(by("bielik-11b-v3").fits_ram);
+        assert!(!by("qwen3-14b").fits_ram);
+        assert!(by("qwen2.5-3b").fits_ram);
+        // selection mirrors the passed id.
+        assert!(by("qwen2.5-3b").selected);
+        assert!(!by("bielik-11b-v3").selected);
+
+        // Unknown RAM ⇒ everything fits (never hide behind a probe failure).
+        let unknown = brain_model_dtos(&dir, None, None);
+        assert!(unknown.iter().all(|d| d.fits_ram));
+        assert!(unknown.iter().all(|d| !d.selected));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The factory's graceful-degradation contract: with NO usable model (a configured path that
@@ -393,6 +592,9 @@ mod tests {
     /// holds as long as no GGUF is present. This is the headless proof of the swap wiring's fallback.
     #[test]
     fn active_reasoner_falls_back_to_stub_without_model() {
+        // No custom path (a non-existent one) AND no selected brain_model_id ⇒ nothing resolves, so
+        // even a feature-on build returns the stub. With no selection there is no registry file to
+        // probe, so this holds regardless of what GGUFs happen to live in the shared models dir.
         let cfg = AppConfig {
             brain_model_path: Some(
                 std::env::temp_dir()
@@ -400,15 +602,9 @@ mod tests {
                     .to_string_lossy()
                     .to_string(),
             ),
+            brain_model_id: None,
             ..Default::default()
         };
-        // Skip the assertion only if a real default model happens to be installed on this machine
-        // (then the feature-on build would legitimately return the real reasoner).
-        let default_present = crate::transcribe::models_dir()
-            .map(|d| d.join(DEFAULT_BRAIN_MODEL_FILE).is_file())
-            .unwrap_or(false);
-        if cfg!(not(feature = "local-brain")) || !default_present {
-            assert_eq!(active_reasoner(&cfg).id(), "stub");
-        }
+        assert_eq!(active_reasoner(&cfg).id(), "stub");
     }
 }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -91,6 +91,13 @@ pub struct AppConfig {
     /// this field existed loads as `None`.
     #[serde(default)]
     pub brain_model_path: Option<String>,
+    /// Phase B (model registry) — the SELECTED on-device brain model id (from `reason::BRAIN_MODELS`,
+    /// e.g. `bielik-11b-v3` / `qwen3-14b` / `qwen2.5-3b`). `None` (the default) means no model is
+    /// chosen ⇒ the resolver falls back to the `StubReasoner`. Set via the `select_brain_model`
+    /// command. Consulted only when the `local-brain` feature is compiled in. `#[serde(default)]` ⇒
+    /// a config persisted before this field existed loads as `None`.
+    #[serde(default)]
+    pub brain_model_id: Option<String>,
 }
 
 impl Default for AppConfig {
@@ -123,6 +130,7 @@ impl Default for AppConfig {
             cloud_egress_consented: false,
             semantic_search_enabled: false,
             brain_model_path: None,
+            brain_model_id: None,
         }
     }
 }
@@ -155,6 +163,7 @@ const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 const K_CLOUD_EGRESS_CONSENTED: &str = "cloud_egress_consented";
 const K_SEMANTIC_SEARCH_ENABLED: &str = "semantic_search_enabled";
 const K_BRAIN_MODEL_PATH: &str = "brain_model_path";
+const K_BRAIN_MODEL_ID: &str = "brain_model_id";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -248,6 +257,7 @@ impl AppConfig {
             cfg.semantic_search_enabled = v == "true";
         }
         cfg.brain_model_path = opt(db.get_setting(K_BRAIN_MODEL_PATH)?);
+        cfg.brain_model_id = opt(db.get_setting(K_BRAIN_MODEL_ID)?);
 
         Ok(cfg)
     }
@@ -326,6 +336,10 @@ impl AppConfig {
         db.set_setting(
             K_BRAIN_MODEL_PATH,
             self.brain_model_path.as_deref().unwrap_or(""),
+        )?;
+        db.set_setting(
+            K_BRAIN_MODEL_ID,
+            self.brain_model_id.as_deref().unwrap_or(""),
         )?;
         Ok(())
     }
@@ -413,6 +427,22 @@ mod tests {
         // Settings-table path: an empty DB (no key written) loads false.
         let db = temp_db();
         assert!(!AppConfig::load(&db).unwrap().semantic_search_enabled);
+    }
+
+    #[test]
+    fn brain_model_id_round_trips_and_defaults_none() {
+        let db = temp_db();
+        // Absent key ⇒ None (prod-safe default for existing installs).
+        assert!(AppConfig::load(&db).unwrap().brain_model_id.is_none());
+        let cfg = AppConfig {
+            brain_model_id: Some("bielik-11b-v3".to_string()),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert_eq!(
+            AppConfig::load(&db).unwrap().brain_model_id.as_deref(),
+            Some("bielik-11b-v3")
+        );
     }
 
     #[test]


### PR DESCRIPTION
The app serves EN **and** PL → the brain offers a **choice** of model, not one hardcoded. Curated registry of 3 mistral.rs-arch-safe GGUFs (**Bielik-11B** PL / **Qwen3-14B** EN-multi / **Qwen2.5-3B** small) + `list_brain_models` (downloaded/fits_ram/selected) + `download_brain_model(model_id)` (inbound-only) + `select_brain_model(model_id)` + RAM-gating via sysctl. Verified: test 296/0; clippy clean; adversarial PASS (unknown-id + RAM-fail guards RED-before-GREEN). FE picker = Phase H.