### PR TITLE
feat(ux): Phase H — brain/AI settings + live assistant-actions card (FE)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,7 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::audio::Recorder;
 use crate::error::AppError;
 use crate::events::{StatusPayload, EVENT_STATUS};
-use crate::settings::AppConfig;
+use crate::settings::{AppConfig, BrainBackend};
 use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarEvent, ChatTurn,
@@ -103,11 +103,46 @@ pub struct AppConfigDto {
     /// clear consent — even a partial/omitting payload (`#[serde(default)]` = false) is inert here.
     #[serde(default)]
     pub cloud_egress_consented: bool,
+    /// Phase H — which reasoner powers the on-device "brain" pre-analysis (Flow A): `cloud` |
+    /// `local` | `off`. Unlike `cloud_egress_consented`, this IS settable from the DTO (the Settings
+    /// UI owns the brain toggle). An omitted/unknown value deserializes to the default `Cloud`
+    /// (`deserialize_with` tolerates an unknown token → `Cloud`, and `default` covers an omitted
+    /// key), so a partial OR malformed save can never select an invalid backend.
+    #[serde(default, deserialize_with = "deserialize_brain_backend_lenient")]
+    pub brain_backend: BrainBackend,
+    /// Phase H — the in-meeting VOICE ACTION DISPATCH master gate (Flow B). Settable from the DTO
+    /// (the Settings UI owns the toggle). OPT-IN: an omitted value deserializes to `false`
+    /// (`#[serde(default)]`), so a partial/older save can never silently enable the always-on
+    /// in-meeting assistant.
+    #[serde(default)]
+    pub realtime_reactions: bool,
+    /// Phase H — the SELECTED on-device brain model id (from `reason::BRAIN_MODELS`). Settable from
+    /// the DTO, but `dto_to_config` VALIDATES it against the registry: an unknown/`None` id is
+    /// IGNORED (the live selection is preserved, no error) so a settings save can never store a
+    /// bogus model id. `select_brain_model` remains the other supported mutator.
+    #[serde(default)]
+    pub brain_model_id: Option<String>,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
 fn default_true() -> bool {
     true
+}
+
+/// Lenient `brain_backend` deserialization for the settings DTO: an UNKNOWN/garbage token
+/// degrades to the default `Cloud` instead of failing the whole `save_config` payload (the derived
+/// enum would reject `"bogus"` with an error). Mirrors `BrainBackend::from_str_or_default`, so the
+/// FE can never wedge a settings save with a stale/typo'd backend value. A non-string (e.g. null)
+/// also falls back to `Cloud`.
+fn deserialize_brain_backend_lenient<'de, D>(deserializer: D) -> std::result::Result<BrainBackend, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let token = Option::<String>::deserialize(deserializer)?;
+    Ok(token
+        .as_deref()
+        .map(BrainBackend::from_str_or_default)
+        .unwrap_or_default())
 }
 
 /// A meeting + its latest note + transcript segments (Library Detail view).
@@ -1603,6 +1638,9 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         lock_require_biometric: c.lock_require_biometric,
         relock_on_screenshare: c.relock_on_screenshare,
         cloud_egress_consented: c.cloud_egress_consented,
+        brain_backend: c.brain_backend,
+        realtime_reactions: c.realtime_reactions,
+        brain_model_id: c.brain_model_id.clone(),
     }
 }
 
@@ -1663,17 +1701,22 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // Phase B: the brain model path is not carried on the settings DTO (it is resolved from the
         // shared models dir by default), so a settings save preserves the live value (default None).
         brain_model_path: current.brain_model_path.clone(),
-        // Phase B (registry): the selected brain model id is set ONLY via `select_brain_model`, never
-        // through a settings save — preserve the live value so a save can't clobber the selection.
-        brain_model_id: current.brain_model_id.clone(),
-        // Phase B (brain backend): which reasoner powers the brain (cloud/local/off). Not carried on
-        // the settings DTO yet — preserve the live value (default Cloud) so a settings save can
-        // neither change nor clobber the backend selection.
-        brain_backend: current.brain_backend,
-        // Phase E (Flow B): the in-meeting voice-action dispatch gate is not carried on the settings
-        // DTO yet — preserve the live value (default OFF) so a normal settings save can neither
-        // enable nor clobber the opt-in.
-        realtime_reactions: current.realtime_reactions,
+        // Phase H (registry): the selected brain model id IS carried on the settings DTO, but it is
+        // VALIDATED against the registry first. A `Some(known-id)` is taken; an unknown id or `None`
+        // is IGNORED — the live selection is preserved (no error, no bogus id stored). This mirrors
+        // `select_brain_model`'s registry guard without crashing a settings save on a stale/typo'd id.
+        brain_model_id: match d.brain_model_id.as_deref() {
+            Some(id) if crate::reason::brain_model_by_id(id).is_some() => d.brain_model_id.clone(),
+            _ => current.brain_model_id.clone(),
+        },
+        // Phase H (brain backend): which reasoner powers the brain (cloud/local/off) IS taken from
+        // the DTO (the Settings UI owns the toggle). `BrainBackend` deserializes an unknown/omitted
+        // token to the default `Cloud`, so the value here is always a valid enum variant.
+        brain_backend: d.brain_backend,
+        // Phase H (Flow B): the in-meeting voice-action dispatch gate IS taken from the DTO (the
+        // Settings UI owns the toggle). Plain bool; an omitted value already defaulted to OFF on the
+        // DTO (`#[serde(default)]`), so the opt-in can never be silently enabled by a partial save.
+        realtime_reactions: d.realtime_reactions,
     }
 }
 
@@ -4357,6 +4400,87 @@ mod lifecycle_tests {
         assert!(
             !dto_to_config(dto2, &current2).cloud_egress_consented,
             "a settings save must NEVER grant consent — only the dedicated command may (BLK-4)"
+        );
+    }
+
+    /// Phase H: the three brain toggles round-trip through the settings DTO. `config_to_dto` carries
+    /// them OUT (so the FE can read them) and `dto_to_config` takes them IN (so the FE can set them),
+    /// for every `BrainBackend` variant + the bool + a known model id.
+    #[test]
+    fn dto_round_trips_brain_backend_realtime_reactions_and_model_id() {
+        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            let cfg = AppConfig {
+                brain_backend: backend,
+                realtime_reactions: true,
+                brain_model_id: Some("bielik-11b-v3".to_string()),
+                ..AppConfig::default()
+            };
+            // OUT: get_config carries the live values to the FE.
+            let dto = config_to_dto(&cfg);
+            assert_eq!(dto.brain_backend, backend);
+            assert!(dto.realtime_reactions);
+            assert_eq!(dto.brain_model_id.as_deref(), Some("bielik-11b-v3"));
+
+            // IN: a settings save sets them from the DTO (start from a DIFFERENT current to prove the
+            // value comes from the DTO, not preservation).
+            let current = AppConfig {
+                brain_backend: BrainBackend::Cloud,
+                realtime_reactions: false,
+                brain_model_id: Some("qwen2.5-3b".to_string()),
+                ..AppConfig::default()
+            };
+            let merged = dto_to_config(dto, &current);
+            assert_eq!(merged.brain_backend, backend);
+            assert!(merged.realtime_reactions);
+            assert_eq!(merged.brain_model_id.as_deref(), Some("bielik-11b-v3"));
+        }
+    }
+
+    /// Phase H graceful degradation: a DTO carrying an UNKNOWN `brain_model_id` must NOT be stored —
+    /// the live selection is preserved (no error, no bogus id) — while an unknown/omitted
+    /// `brain_backend` deserializes to the default `Cloud` rather than crashing the save.
+    #[test]
+    fn dto_unknown_brain_model_id_preserved_and_unknown_backend_defaults_cloud() {
+        // (a) unknown model id ⇒ ignored, current selection preserved.
+        let mut dto = config_to_dto(&AppConfig::default());
+        dto.brain_model_id = Some("totally-made-up-model".to_string());
+        let current = AppConfig {
+            brain_model_id: Some("qwen2.5-3b".to_string()),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            dto_to_config(dto, &current).brain_model_id.as_deref(),
+            Some("qwen2.5-3b"),
+            "an unknown brain_model_id must be ignored, preserving the live selection"
+        );
+
+        // (b) a None model id likewise preserves the current selection (a settings save without a
+        // brain pick must not clear an existing one).
+        let mut dto_none = config_to_dto(&AppConfig::default());
+        dto_none.brain_model_id = None;
+        let current_some = AppConfig {
+            brain_model_id: Some("qwen3-14b".to_string()),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            dto_to_config(dto_none, &current_some).brain_model_id.as_deref(),
+            Some("qwen3-14b")
+        );
+
+        // (c) an unknown/omitted brainBackend token deserializes to the default Cloud (no crash),
+        // then flows through dto_to_config as Cloud.
+        let json = r#"{
+            "providerId":"claude_code","anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "captureSystemAudio":false,"modelSize":"large-v3","voiceTrigger":false,"onboarded":true,
+            "noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto","brainBackend":"bogus"
+        }"#;
+        let dto_bad: AppConfigDto = serde_json::from_str(json).unwrap();
+        assert_eq!(dto_bad.brain_backend, BrainBackend::Cloud, "unknown token → Cloud");
+        assert!(!dto_bad.realtime_reactions, "omitted realtimeReactions defaults OFF");
+        assert_eq!(
+            dto_to_config(dto_bad, &AppConfig::default()).brain_backend,
+            BrainBackend::Cloud
         );
     }
 

--- a/src/app/core/assistant.store.ts
+++ b/src/app/core/assistant.store.ts
@@ -1,0 +1,109 @@
+import { Injectable, computed, inject, signal } from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "./ipc.service";
+import type {
+  VoiceActionResultPayload,
+  VoiceActionStatus,
+  WakeDetectedPayload,
+} from "./models";
+
+/**
+ * Phase H — one recent in-meeting voice-assistant interaction. A wake creates a
+ * `pending` row ("heard: {command}"); the matching result resolves it with a
+ * summary + citation chips + a status pill. Newest-first.
+ */
+export interface AssistantInteraction {
+  /** Stable id for `@for` tracking (we never key on $index). */
+  id: number;
+  /** What the user said after the wake phrase. */
+  command: string;
+  /** "pending" until the result arrives, then mirrors the result status. */
+  status: "pending" | VoiceActionStatus;
+  /** The assistant's answer (empty while pending). */
+  summary: string;
+  /** Grounding citations → rendered as [[Title]] chips. */
+  citations: string[];
+}
+
+/**
+ * Signal-based store for the in-meeting voice assistant. Subscribes ONCE (the
+ * RecorderStore.init() pattern) to the wake + result event streams and keeps a
+ * capped, newest-first list of interactions. No NgRx, no subscribe-into-a-field:
+ * the event payloads land in a `signal`.
+ */
+@Injectable({ providedIn: "root" })
+export class AssistantStore {
+  private readonly ipc = inject(IpcService);
+
+  /** Most recent N interactions kept; older ones drop off (no unbounded growth). */
+  private static readonly MAX = 12;
+
+  private readonly _interactions = signal<AssistantInteraction[]>([]);
+  /** Newest-first list of recent assistant interactions. */
+  readonly interactions = this._interactions.asReadonly();
+
+  /** Whether any interaction has ever been observed (drives empty-state copy). */
+  readonly hasAny = computed(() => this._interactions().length > 0);
+
+  /** Monotonic id source for interaction rows (stable `@for` keys). */
+  private nextId = 1;
+
+  private unlistenWake: UnlistenFn | null = null;
+  private unlistenResult: UnlistenFn | null = null;
+
+  /** Subscribe once to the wake + result streams. Idempotent. */
+  async init(): Promise<void> {
+    if (this.unlistenWake) return;
+    this.unlistenWake = await this.ipc.onWakeDetected((p) => this.onWake(p));
+    this.unlistenResult = await this.ipc.onVoiceActionResult((p) =>
+      this.onResult(p),
+    );
+  }
+
+  /** Release the event subscriptions (e.g. on app teardown). */
+  dispose(): void {
+    this.unlistenWake?.();
+    this.unlistenResult?.();
+    this.unlistenWake = null;
+    this.unlistenResult = null;
+  }
+
+  private onWake(p: WakeDetectedPayload): void {
+    const row: AssistantInteraction = {
+      id: this.nextId++,
+      command: p.command,
+      status: "pending",
+      summary: "",
+      citations: [],
+    };
+    this._interactions.update((rows) =>
+      [row, ...rows].slice(0, AssistantStore.MAX),
+    );
+  }
+
+  private onResult(p: VoiceActionResultPayload): void {
+    this._interactions.update((rows) => {
+      // Resolve the most recent still-pending row; if none (a result without a
+      // wake we observed), prepend a fresh resolved row so nothing is lost.
+      const idx = rows.findIndex((r) => r.status === "pending");
+      if (idx === -1) {
+        const row: AssistantInteraction = {
+          id: this.nextId++,
+          command: "",
+          status: p.status,
+          summary: p.summary,
+          citations: p.citations,
+        };
+        return [row, ...rows].slice(0, AssistantStore.MAX);
+      }
+      const next = rows.slice();
+      next[idx] = {
+        ...next[idx],
+        status: p.status,
+        summary: p.summary,
+        citations: p.citations,
+      };
+      return next;
+    });
+  }
+}

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -5,6 +5,8 @@ import type {
   ActionItem,
   Analytics,
   AppConfigDto,
+  BrainDownloadProgress,
+  BrainModelDto,
   InputDeviceInfo,
   AskVaultResult,
   BriefResult,
@@ -29,12 +31,18 @@ import type {
   StatusPayload,
   StopResult,
   TopicThread,
+  VoiceActionResultPayload,
+  WakeDetectedPayload,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
 export const EVENT_VOICE_START = "murmur://voice-start";
 export const EVENT_TOGGLE_RECORD = "murmur://toggle-record";
 export const EVENT_LIVE_CAPTION = "murmur://live-caption";
+// Phase H — the brain / in-meeting voice assistant event stream.
+export const EVENT_WAKE_DETECTED = "murmur://wake-detected";
+export const EVENT_VOICE_ACTION_RESULT = "murmur://voice-action-result";
+export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -368,6 +376,30 @@ export class IpcService {
     return invoke<string>("download_model");
   }
 
+  // ── Phase H — brain (AI assistant) model registry ──────────────────────
+
+  /**
+   * The selectable local brain models (Bielik / Qwen3-14B / Qwen2.5-3B …) with
+   * per-Mac `downloaded` / `fitsRam` / `selected` state computed by the backend.
+   */
+  listBrainModels(): Promise<BrainModelDto[]> {
+    return invoke<BrainModelDto[]>("list_brain_models");
+  }
+
+  /** Make `modelId` the active local brain model (also persisted to config). */
+  selectBrainModel(modelId: string): Promise<void> {
+    return invoke<void>("select_brain_model", { modelId });
+  }
+
+  /**
+   * Download a local brain model by id. Progress streams over
+   * {@link onBrainDownload} (EVENT_BRAIN_DOWNLOAD); the promise resolves when
+   * the download finishes (or rejects on failure).
+   */
+  downloadBrainModel(modelId: string): Promise<void> {
+    return invoke<void>("download_brain_model", { modelId });
+  }
+
   /** Show/hide the floating always-on-top recorder bar window. */
   toggleBar(): Promise<void> {
     return invoke<void>("toggle_bar");
@@ -451,6 +483,37 @@ export class IpcService {
   onLiveCaption(cb: (text: string) => void): Promise<UnlistenFn> {
     return listen<{ text: string }>(EVENT_LIVE_CAPTION, (e) =>
       cb(e.payload.text),
+    );
+  }
+
+  // ── Phase H — brain / in-meeting voice assistant event streams ─────────
+
+  /**
+   * Fires when the in-meeting voice assistant hears its wake phrase. The FE
+   * shows a pending "heard: {command}" row until the matching
+   * {@link onVoiceActionResult} arrives.
+   */
+  onWakeDetected(cb: (p: WakeDetectedPayload) => void): Promise<UnlistenFn> {
+    return listen<WakeDetectedPayload>(EVENT_WAKE_DETECTED, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /** Fires with the result of a voice action (summary + citations + status). */
+  onVoiceActionResult(
+    cb: (p: VoiceActionResultPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<VoiceActionResultPayload>(EVENT_VOICE_ACTION_RESULT, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /** Fires with progress for an in-flight local brain-model download. */
+  onBrainDownload(
+    cb: (p: BrainDownloadProgress) => void,
+  ): Promise<UnlistenFn> {
+    return listen<BrainDownloadProgress>(EVENT_BRAIN_DOWNLOAD, (e) =>
+      cb(e.payload),
     );
   }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -68,6 +68,91 @@ export interface AppConfigDto {
    * leaves the device for a cloud LLM until the user has consented once.
    */
   cloudEgressConsented: boolean;
+  /**
+   * Phase H — the "brain" (AI assistant) backend that answers questions /
+   * reacts in-meeting. `"cloud"` = Claude (recommended for live latency),
+   * `"local"` = an on-device GGUF model (`brainModelId`), `"off"` = no brain.
+   * Round-tripped on every `save_config` like the other flags.
+   */
+  brainBackend: BrainBackend;
+  /**
+   * Phase H — the in-meeting voice assistant ("realtime reactions"): listen for
+   * a wake phrase during a recording and answer grounded questions live.
+   * Default false (off) — it's a power feature with cost/latency tradeoffs.
+   */
+  realtimeReactions: boolean;
+  /**
+   * Phase H — the selected local brain model id (a registry id like
+   * `"bielik-11b"`, or a custom GGUF file path). Only meaningful when
+   * `brainBackend === "local"`. Null = none selected yet.
+   */
+  brainModelId: string | null;
+}
+
+/** Phase H — which backend powers the brain / in-meeting voice assistant. */
+export type BrainBackend = "cloud" | "local" | "off";
+
+/**
+ * Phase H — a selectable local brain model from the registry (`list_brain_models`).
+ * Mirrors the Rust `BrainModelDto` (camelCase). RAM-fit / download / selected
+ * state are computed by the backend against this Mac.
+ */
+export interface BrainModelDto {
+  id: string;
+  name: string;
+  /** Human size label (e.g. "6.7 GB") for display. */
+  sizeLabel: string;
+  /** Exact on-disk size in bytes (for progress math / precise display). */
+  bytes: number;
+  /** Minimum recommended RAM in GB to run this model. */
+  minRamGb: number;
+  /** Languages the model handles well (e.g. ["pl", "en"]). */
+  languages: string[];
+  /** Already downloaded on this Mac. */
+  downloaded: boolean;
+  /** Fits in this Mac's RAM (false → warn / discourage). */
+  fitsRam: boolean;
+  /** Currently the selected brain model. */
+  selected: boolean;
+}
+
+/**
+ * Phase H — progress payload for a local brain-model download
+ * (`EVENT_BRAIN_DOWNLOAD`). Matches the backend `BrainDownloadPayload`:
+ * `downloaded`/`total` (bytes; `total` is null when the server omits
+ * Content-Length) drive the progress bar; `done` ends the in-flight state.
+ * The backend downloads one model at a time, so the component tracks WHICH
+ * model it started locally (errors surface via the download command's promise).
+ */
+export interface BrainDownloadProgress {
+  downloaded: number;
+  total: number | null;
+  done: boolean;
+}
+
+/**
+ * Phase H — fired when the in-meeting voice assistant hears its wake phrase
+ * (`EVENT_WAKE_DETECTED`). The FE shows a pending "heard: {command}" row.
+ */
+export interface WakeDetectedPayload {
+  matchedPhrase: string;
+  command: string;
+  intent: string;
+}
+
+/** Phase H — status of a completed voice action. */
+export type VoiceActionStatus = "ok" | "needs_consent" | "unavailable" | "error";
+
+/**
+ * Phase H — the result of a voice action (`EVENT_VOICE_ACTION_RESULT`): a
+ * short summary + grounding citations (meeting titles → [[wikilink]] chips) +
+ * a status pill.
+ */
+export interface VoiceActionResultPayload {
+  intentKind: string;
+  status: VoiceActionStatus;
+  summary: string;
+  citations: string[];
 }
 
 /** A selectable microphone input device (from `list_input_devices`). */

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1274,6 +1274,11 @@ export class OnboardingComponent implements OnInit {
       lockRequireBiometric: base?.lockRequireBiometric ?? true,
       relockOnScreenshare: base?.relockOnScreenshare ?? true,
       cloudEgressConsented: base?.cloudEgressConsented ?? false,
+      // Phase H — brain / in-meeting voice assistant. Round-trip the snapshot so
+      // onboarding never resets a user's brain choices; defaults mirror a fresh install.
+      brainBackend: base?.brainBackend ?? "cloud",
+      realtimeReactions: base?.realtimeReactions ?? false,
+      brainModelId: base?.brainModelId ?? null,
     };
     await this.ipc.saveConfig(cfg);
     // Keep the snapshot current so successive saves don't clobber fresh choices.

--- a/src/app/features/record/assistant-actions.component.ts
+++ b/src/app/features/record/assistant-actions.component.ts
@@ -1,0 +1,264 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from "@angular/core";
+import { AssistantStore } from "../../core/assistant.store";
+import type { AssistantInteraction } from "../../core/assistant.store";
+
+/**
+ * Phase H — the live "assistant actions" card on the record surface. Subscribes
+ * (once, via AssistantStore.init()) to the in-meeting voice assistant's wake +
+ * result event streams and renders a newest-first list of recent interactions:
+ * a pending "🎙 usłyszano: {command}" row on a wake, resolved to {summary} +
+ * [[Title]] citation chips with a status pill when the result arrives.
+ *
+ * The card is in-flow on the record page (not a floating overlay), so it uses
+ * the frosted `.card` like the other record-surface panels. If it were ever
+ * floated OVER content it would have to switch to `var(--surface-overlay)`
+ * (trap T3) — it is intentionally NOT floated.
+ */
+@Component({
+  selector: "app-assistant-actions",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="card assistant" role="group" aria-label="Voice assistant">
+      <div class="assistant-head">
+        <span class="assistant-mark" aria-hidden="true">🎙</span>
+        <span class="assistant-title">Voice assistant</span>
+        <span class="pill is-live assistant-live" aria-hidden="true">
+          <span class="pill-dot"></span>
+          LIVE
+        </span>
+      </div>
+
+      @if (store.hasAny()) {
+        <ul class="actions-list">
+          @for (a of store.interactions(); track a.id) {
+            <li class="action-row" [class.is-pending]="a.status === 'pending'">
+              <div class="action-heard">
+                <span class="heard-ico" aria-hidden="true">🎙</span>
+                <span class="heard-text">
+                  usłyszano:
+                  <strong>{{ a.command || "…" }}</strong>
+                </span>
+                @if (a.status !== "pending") {
+                  <span class="pill" [class]="statusPillClass(a)">
+                    <span class="pill-dot"></span>
+                    {{ statusLabel(a) }}
+                  </span>
+                }
+              </div>
+
+              @if (a.status === "pending") {
+                <div class="action-pending" role="status">
+                  <span class="dots" aria-hidden="true">
+                    <span></span><span></span><span></span>
+                  </span>
+                  <span class="text-muted">Thinking…</span>
+                </div>
+              } @else {
+                @if (a.summary) {
+                  <p class="action-summary">{{ a.summary }}</p>
+                }
+                @if (a.citations.length > 0) {
+                  <div class="action-cites" aria-label="Sources">
+                    @for (c of a.citations; track c) {
+                      <span class="cite-chip">[[{{ c }}]]</span>
+                    }
+                  </div>
+                }
+              }
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="assistant-empty text-muted">
+          Say your wake phrase during a recording to ask the assistant a grounded
+          question. Answers and their sources will appear here.
+        </p>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .assistant {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .assistant-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .assistant-mark {
+        font-size: 1.05rem;
+        line-height: 1;
+      }
+      .assistant-title {
+        color: var(--text-primary);
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      .assistant-live {
+        margin-left: auto;
+      }
+      .assistant-empty {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }
+
+      .actions-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .action-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+        animation: rise 260ms var(--transition) both;
+      }
+      .action-row.is-pending {
+        border-color: var(--accent-soft);
+      }
+      .action-heard {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .heard-ico {
+        font-size: 0.85rem;
+        line-height: 1;
+      }
+      .heard-text {
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+      }
+      .heard-text strong {
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+      .action-heard .pill {
+        margin-left: auto;
+      }
+
+      .action-pending {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: 0.85rem;
+      }
+      .dots {
+        display: inline-flex;
+        gap: 3px;
+      }
+      .dots span {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: var(--accent);
+        animation: blink 1.2s ease-in-out infinite both;
+      }
+      .dots span:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+      .dots span:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+      @keyframes blink {
+        0%,
+        80%,
+        100% {
+          opacity: 0.3;
+        }
+        40% {
+          opacity: 1;
+        }
+      }
+
+      .action-summary {
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 0.9rem;
+        line-height: 1.55;
+      }
+      .action-cites {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+      }
+      .cite-chip {
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-sm);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+        letter-spacing: -0.01em;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .action-row {
+          animation: none;
+        }
+        .dots span {
+          animation: none;
+          opacity: 0.7;
+        }
+      }
+    `,
+  ],
+})
+export class AssistantActionsComponent implements OnInit {
+  protected readonly store = inject(AssistantStore);
+
+  ngOnInit(): void {
+    // Subscribe once to the wake/result event streams (idempotent). The store is
+    // a root singleton, so its subscriptions outlive this component — we don't
+    // unlisten on destroy here (the store owns lifetime; cf. RecorderStore).
+    void this.store.init();
+  }
+
+  /** Map a resolved status to a global `.pill` variant. */
+  protected statusPillClass(a: AssistantInteraction): string {
+    switch (a.status) {
+      case "ok":
+        return "is-success";
+      case "needs_consent":
+        return "is-warning";
+      case "unavailable":
+        return "is-accent";
+      default:
+        return "is-danger";
+    }
+  }
+
+  /** Short human label for the status pill. */
+  protected statusLabel(a: AssistantInteraction): string {
+    switch (a.status) {
+      case "ok":
+        return "Done";
+      case "needs_consent":
+        return "Needs consent";
+      case "unavailable":
+        return "Unavailable";
+      case "error":
+        return "Error";
+      default:
+        return "";
+    }
+  }
+}

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -14,12 +14,18 @@ import { IpcService } from "../../core/ipc.service";
 import type { Analytics, AppConfigDto } from "../../core/models";
 import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
 import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
+import { AssistantActionsComponent } from "./assistant-actions.component";
 
 @Component({
   selector: "app-record",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, PreMeetingBriefComponent, MicMuteToggleComponent],
+  imports: [
+    RouterLink,
+    PreMeetingBriefComponent,
+    MicMuteToggleComponent,
+    AssistantActionsComponent,
+  ],
   host: { "(document:keydown)": "onKey($event)" },
   template: `
     <section class="record">
@@ -192,6 +198,11 @@ import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
             }
           </p>
         </div>
+      }
+
+      <!-- ── In-meeting voice assistant — recent actions (Phase H) ────────── -->
+      @if (showAssistant()) {
+        <app-assistant-actions />
       }
 
       @if (store.error(); as err) {
@@ -989,6 +1000,17 @@ export class RecordComponent implements OnInit {
   readonly headphonesHint = computed(
     () => this.config()?.captureSystemAudio ?? false,
   );
+
+  /**
+   * Show the in-meeting voice-assistant card (Phase H): only when the user has
+   * enabled "realtime reactions" AND the brain backend isn't off. The card
+   * itself subscribes to the wake/result streams regardless of recording state
+   * (a wake can land any time the listener is active).
+   */
+  readonly showAssistant = computed(() => {
+    const c = this.config();
+    return !!c && c.realtimeReactions === true && c.brainBackend !== "off";
+  });
 
   /**
    * True when no Obsidian vault folder is configured. The vault is EXPORT-ONLY — every note

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   DestroyRef,
   OnInit,
+  computed,
   inject,
   signal,
 } from "@angular/core";
@@ -12,9 +13,12 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import type {
   AppConfigDto,
+  BrainBackend,
+  BrainModelDto,
   InputDeviceInfo,
   ProviderStatus,
 } from "../../core/models";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 
 @Component({
   selector: "app-settings",
@@ -246,6 +250,169 @@ import type {
           </span>
           <input type="checkbox" formControlName="autoOrganize" />
         </label>
+      </div>
+
+      <!-- Brain / AI — the assistant backend + in-meeting voice assistant (Phase H) -->
+      <div class="card brain-card">
+        <div class="brain-copy">
+          <h3>Brain / AI</h3>
+          <p class="text-secondary brain-sub">
+            Powers grounded answers across your notes and the optional in-meeting
+            voice assistant. Claude (cloud) is fastest for live use; local models
+            keep everything on-device but are slower in real time.
+          </p>
+        </div>
+
+        <label class="field">
+          <span class="field-label">Assistant backend</span>
+          <select formControlName="brainBackend">
+            <option value="cloud">Claude (cloud) — recommended for live</option>
+            <option value="local">Local model — fully on-device</option>
+            <option value="off">Off</option>
+          </select>
+          <span class="field-help text-muted">
+            @switch (form.controls.brainBackend.value) {
+              @case ("local") {
+                Runs a local GGUF model on this Mac — private, but large models
+                are slow for realtime. Pick a model below.
+              }
+              @case ("off") {
+                The brain and the in-meeting voice assistant are disabled.
+              }
+              @default {
+                Sends your (redacted) text to Anthropic's cloud — lowest latency,
+                best for the live voice assistant.
+              }
+            }
+          </span>
+        </label>
+
+        <label class="toggle-row">
+          <span class="toggle-copy">
+            <span class="toggle-title">In-meeting voice assistant</span>
+            <span class="text-secondary toggle-sub">
+              Listen for your wake phrase during a recording and answer grounded
+              questions live, with sources. Off by default — it adds listening
+              and (for cloud) sends audio-derived text mid-meeting.
+            </span>
+          </span>
+          <input type="checkbox" formControlName="realtimeReactions" />
+        </label>
+
+        <!-- Local model picker — only meaningful for the local backend. -->
+        @if (form.controls.brainBackend.value === "local") {
+          <div class="brain-models">
+            <div class="brain-models-head">
+              <span class="brain-models-label text-muted">Local models</span>
+              <button
+                type="button"
+                class="btn btn-sm"
+                (click)="refreshBrainModels()"
+                [disabled]="brainModelsLoading()"
+              >
+                {{ brainModelsLoading() ? "Loading…" : "Refresh" }}
+              </button>
+            </div>
+
+            <p class="brain-note text-muted">
+              Big local models are slow for the realtime voice assistant —
+              Claude (cloud) is recommended for live answers. Local is best for
+              private, non-time-critical analysis.
+            </p>
+
+            @if (brainModels(); as models) {
+              @if (models.length === 0 && !brainModelsLoading()) {
+                <p class="brain-empty text-muted">
+                  No local models available.
+                </p>
+              } @else {
+                <ul class="brain-model-list">
+                  @for (m of models; track m.id) {
+                    <li
+                      class="brain-model-row"
+                      [class.is-unfit]="!m.fitsRam"
+                      [class.is-selected]="m.selected"
+                    >
+                      <div class="brain-model-info">
+                        <span class="brain-model-name">
+                          {{ m.name }}
+                          @if (m.selected) {
+                            <span class="pill is-success brain-inline-pill">
+                              <span class="pill-dot"></span>
+                              In use
+                            </span>
+                          }
+                        </span>
+                        <span class="brain-model-meta text-muted">
+                          {{ m.sizeLabel }} · needs ≥{{ m.minRamGb }} GB RAM
+                          @if (m.languages.length > 0) {
+                            · {{ m.languages.join("/") }}
+                          }
+                        </span>
+                        @if (!m.fitsRam) {
+                          <span class="pill is-warning brain-fit-pill">
+                            <span class="pill-dot"></span>
+                            May not fit this Mac's RAM
+                          </span>
+                        }
+                      </div>
+
+                      <div class="brain-model-actions">
+                        @if (brainDownloadingId() === m.id) {
+                          <div class="brain-progress" role="status">
+                            <div class="brain-progress-track" aria-hidden="true">
+                              <div
+                                class="brain-progress-fill"
+                                [style.width.%]="brainDownloadFrac() * 100"
+                              ></div>
+                            </div>
+                            <span class="brain-progress-label text-muted">
+                              Downloading… {{ brainPct() }}
+                            </span>
+                          </div>
+                        } @else if (m.downloaded) {
+                          <button
+                            type="button"
+                            class="btn btn-sm"
+                            (click)="useBrainModel(m.id)"
+                            [disabled]="m.selected"
+                          >
+                            {{ m.selected ? "Selected" : "Use" }}
+                          </button>
+                        } @else {
+                          <button
+                            type="button"
+                            class="btn btn-primary btn-sm"
+                            (click)="downloadBrainModel(m.id)"
+                            [disabled]="brainDownloadingId() !== null"
+                          >
+                            Download
+                          </button>
+                        }
+                      </div>
+                    </li>
+                  }
+                </ul>
+              }
+            }
+
+            <label class="field brain-custom">
+              <span class="field-label">Custom GGUF model</span>
+              <input
+                formControlName="brainModelId"
+                placeholder="/path/to/model.gguf or a registry id"
+              />
+              <span class="field-help text-muted">
+                Advanced: point at your own GGUF file (or a registry id). Saved
+                with your settings.
+              </span>
+            </label>
+
+            @if (brainError(); as berr) {
+              <p class="text-danger brain-error">{{ berr }}</p>
+            }
+          </div>
+        }
       </div>
 
       <!-- Works with Obsidian — optional vault companion -->
@@ -901,6 +1068,144 @@ import type {
         line-height: 1.5;
       }
 
+      /* --- Brain / AI card (Phase H) --- */
+      .brain-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .brain-copy {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .brain-copy h3 {
+        margin: 0;
+      }
+      .brain-sub {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }
+      .brain-models {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .brain-models-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .brain-models-label {
+        font-size: 0.8125rem;
+        font-weight: 550;
+        letter-spacing: 0.01em;
+        text-transform: uppercase;
+      }
+      .brain-note {
+        margin: 0;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+      .brain-empty {
+        margin: 0;
+        font-size: 0.875rem;
+      }
+      .brain-model-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .brain-model-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-raised);
+        border: 1px solid var(--glass-border);
+      }
+      .brain-model-row.is-selected {
+        border-color: var(--accent-hover);
+      }
+      .brain-model-row.is-unfit {
+        opacity: 0.78;
+      }
+      .brain-model-info {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 0;
+      }
+      .brain-model-name {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--text-primary);
+        font-weight: 550;
+        font-size: 0.9rem;
+        flex-wrap: wrap;
+      }
+      .brain-model-meta {
+        font-size: 0.8125rem;
+      }
+      .brain-inline-pill,
+      .brain-fit-pill {
+        align-self: flex-start;
+      }
+      .brain-fit-pill {
+        margin-top: 2px;
+      }
+      .brain-model-actions {
+        flex: none;
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .brain-progress {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 120px;
+      }
+      .brain-progress-track {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--surface-input);
+        overflow: hidden;
+      }
+      .brain-progress-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: 3px;
+        transition: width var(--transition);
+      }
+      .brain-progress-label {
+        font-size: 0.75rem;
+      }
+      .brain-custom {
+        margin-top: var(--space-1);
+      }
+      .brain-error {
+        margin: 0;
+        font-size: 0.85rem;
+      }
+      .brain-card .btn-sm {
+        height: 32px;
+        padding: 0 var(--space-3);
+        font-size: 0.8125rem;
+      }
+
       /* --- Works-with-Obsidian card --- */
       .obsidian-card {
         display: flex;
@@ -1317,6 +1622,11 @@ export class SettingsComponent implements OnInit {
     noteStyle: "standard",
     autoOrganize: false,
     noteLanguage: "auto",
+    // Phase H — brain / in-meeting voice assistant.
+    brainBackend: "cloud" as BrainBackend,
+    realtimeReactions: false,
+    /** Custom GGUF model path (or registry id). Empty → null on save. */
+    brainModelId: "",
   });
   readonly keyControl = new FormControl("", { nonNullable: true });
 
@@ -1381,6 +1691,25 @@ export class SettingsComponent implements OnInit {
   /** Surfaced if granting consent rejects. */
   readonly consentError = signal<string | null>(null);
 
+  // ── Phase H — brain (AI assistant) model registry ──────────────────────
+
+  /** The selectable local brain models (from list_brain_models). */
+  readonly brainModels = signal<BrainModelDto[]>([]);
+  /** True while the model list is loading (best-effort). */
+  readonly brainModelsLoading = signal(false);
+  /** Surfaced if loading / selecting / downloading a brain model rejects. */
+  readonly brainError = signal<string | null>(null);
+  /** Model id currently downloading, or null. Drives the per-row progress UI. */
+  readonly brainDownloadingId = signal<string | null>(null);
+  /** 0..1 download progress for the in-flight model (best-effort from events). */
+  readonly brainDownloadFrac = signal(0);
+  /** Whole-percent label for the in-flight brain-model download. */
+  readonly brainPct = computed(
+    () => Math.round(this.brainDownloadFrac() * 100) + "%",
+  );
+  /** Release handle for the EVENT_BRAIN_DOWNLOAD subscription. */
+  private unlistenBrainDownload: UnlistenFn | null = null;
+
   async ngOnInit(): Promise<void> {
     try {
       const cfg = await this.ipc.getConfig();
@@ -1413,14 +1742,90 @@ export class SettingsComponent implements OnInit {
         noteStyle: cfg.noteStyle ?? "standard",
         autoOrganize: cfg.autoOrganize ?? false,
         noteLanguage: cfg.noteLanguage ?? "auto",
+        brainBackend: cfg.brainBackend ?? "cloud",
+        realtimeReactions: cfg.realtimeReactions ?? false,
+        brainModelId: cfg.brainModelId ?? "",
       });
       this.updateDownloadHint();
       this.inputDevices.set(await this.ipc.listInputDevices().catch(() => []));
       this.hasKey.set(await this.ipc.hasAnthropicKey());
       this.modelPresent.set(await this.ipc.modelPresent());
       await this.refreshProviders();
+      // Phase H — brain model registry + download-progress stream (best-effort).
+      await this.subscribeBrainDownload();
+      await this.refreshBrainModels();
     } catch (e) {
       this.loadError.set(String(e));
+    }
+  }
+
+  /**
+   * Subscribe ONCE to the brain-download progress stream and store the unlisten
+   * so DestroyRef can release it (no leaked listener). Best-effort: a missing
+   * backend command just leaves the progress bar inert.
+   */
+  private async subscribeBrainDownload(): Promise<void> {
+    try {
+      this.unlistenBrainDownload = await this.ipc.onBrainDownload((p) => {
+        // The backend emits one download at a time and the component already
+        // tracks which model it started (brainDownloadingId), so every progress
+        // event applies to it. (Download errors surface via the command promise.)
+        if (this.brainDownloadingId() === null) return;
+        if (p.total && p.total > 0) {
+          this.brainDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+        }
+        if (p.done) {
+          this.brainDownloadingId.set(null);
+          void this.refreshBrainModels();
+        }
+      });
+      this.destroyRef.onDestroy(() => this.unlistenBrainDownload?.());
+    } catch {
+      // No brain-download stream available — progress stays inert; downloads
+      // still resolve via the command promise.
+    }
+  }
+
+  /** Reload the brain model registry (downloaded / fits-RAM / selected state). */
+  async refreshBrainModels(): Promise<void> {
+    this.brainModelsLoading.set(true);
+    this.brainError.set(null);
+    try {
+      this.brainModels.set(await this.ipc.listBrainModels());
+    } catch (e) {
+      this.brainError.set(String(e));
+    } finally {
+      this.brainModelsLoading.set(false);
+    }
+  }
+
+  /** Make a registry model the active local brain model, then refresh the list. */
+  async useBrainModel(id: string): Promise<void> {
+    this.brainError.set(null);
+    try {
+      await this.ipc.selectBrainModel(id);
+      this.form.patchValue({ brainModelId: id });
+      await this.refreshBrainModels();
+    } catch (e) {
+      this.brainError.set(String(e));
+    }
+  }
+
+  /**
+   * Download a registry model. The promise resolves on completion; live
+   * progress (when available) rides the EVENT_BRAIN_DOWNLOAD stream.
+   */
+  async downloadBrainModel(id: string): Promise<void> {
+    this.brainError.set(null);
+    this.brainDownloadFrac.set(0);
+    this.brainDownloadingId.set(id);
+    try {
+      await this.ipc.downloadBrainModel(id);
+      await this.refreshBrainModels();
+    } catch (e) {
+      this.brainError.set(String(e));
+    } finally {
+      this.brainDownloadingId.set(null);
     }
   }
 
@@ -1459,6 +1864,10 @@ export class SettingsComponent implements OnInit {
       noteStyle: v.noteStyle,
       autoOrganize: v.autoOrganize,
       noteLanguage: v.noteLanguage,
+      // Phase H — brain / in-meeting voice assistant.
+      brainBackend: v.brainBackend,
+      realtimeReactions: v.realtimeReactions,
+      brainModelId: v.brainModelId || null,
       // Round-trip the Stage E security flags so a settings save never silently
       // resets them. Cloud-egress consent is GRANTED only via the dedicated
       // command (allowCloudProcessing) — here we just carry the current value back.


### PR DESCRIPTION
Makes the brain + in-meeting voice assistant **visible**. Backend: brain_backend/realtime_reactions/brain_model_id on the settings DTO (lenient validation). FE (zoneless, signals): Settings **Brain/AI** section (Claude/Local/Off selector + realtime toggle + model picker over the registry incl. custom GGUF + RAM-fit) and a **live assistant-actions card** (EVENT_WAKE_DETECTED + EVENT_VOICE_ACTION_RESULT → heard command + cited result). Verified: test 322/0; clippy clean; ng lint + ng build clean. Adversarial caught a download-progress event contract mismatch → fixed (FE aligned to backend {downloaded,total,done}). Live events + real Claude = @Mac.