### PR TITLE
feat(embed): Phase C — real CandleBertEmbedder behind the local-embed feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "accelerate-src"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,12 +725,14 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
+ "accelerate-src",
  "byteorder",
  "candle-metal-kernels",
  "candle-ug",
  "float8",
  "gemm 0.19.0",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -762,6 +770,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
+ "accelerate-src",
  "candle-core",
  "candle-metal-kernels",
  "half",
@@ -772,6 +781,26 @@ dependencies = [
  "safetensors 0.7.0",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+dependencies = [
+ "accelerate-src",
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex 0.17.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
 ]
 
 [[package]]
@@ -1876,6 +1905,9 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "exr"
@@ -1926,6 +1958,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -4209,6 +4252,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "block2",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
  "chrono",
  "core-foundation 0.10.1",
  "cpal",
@@ -4240,6 +4286,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "thiserror 1.0.69",
  "tiny_http",
+ "tokenizers 0.21.4",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -7616,10 +7663,12 @@ dependencies = [
  "esaxx-rs",
  "fancy-regex 0.14.0",
  "getrandom 0.3.4",
+ "indicatif 0.17.11",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
+ "onig",
  "paste",
  "rand 0.9.4",
  "rayon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,19 @@ mistralrs = { version = "0.8.1", features = ["metal"], optional = true }
 # model is a deliberate later swap (the `Embedder` seam ships with a deterministic StubEmbedder).
 sqlite-vec = "0.1.9"
 
+# ── Local embedding model (Phase C — OPTIONAL: compiled ONLY under `--features local-embed`) ──
+# In-process BERT embedding (candle-transformers, Metal) for the REAL multilingual-e5-small encoder
+# behind `embed::active_embedder`. A build-proof PROVED candle 0.10.2 (BERT) links cleanly in-process
+# with ZERO second onnxruntime — it SHARES candle with the `local-brain` graph, and sherpa stays the
+# only ORT. `optional` so the DEFAULT build (and the fast `cargo test --lib` loop) NEVER compiles
+# candle; `embed::active_embedder` returns the dependency-free `StubEmbedder` unless this feature is
+# on AND the e5 model dir is present. The `metal`/`accelerate` features mirror the candle already in
+# the brain graph. Build: `cargo build --features local-embed`.
+candle-core = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
+candle-nn = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
+candle-transformers = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
+tokenizers = { version = "0.21", optional = true }
+
 # ── Serde ──
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -130,3 +143,9 @@ default = []
 # present at the resolved path, `reason::active_reasoner` returns the real MistralReasoner; otherwise it
 # gracefully degrades to the StubReasoner. Build: `MISTRALRS_METAL_PRECOMPILE=0 cargo build --features local-brain`.
 local-brain = ["dep:mistralrs"]
+# Phase C — the REAL on-device embedding model (CandleBertEmbedder, `embed/candle_bert.rs`). OFF by
+# default so the fast `cargo test --lib` loop never compiles candle. With it ON *and* the e5 model dir
+# present at the resolved path, `embed::active_embedder` returns the real CandleBertEmbedder; otherwise
+# it gracefully degrades to the StubEmbedder. Target model = multilingual-e5-small (384-dim ⇒ EMBED_DIM
+# is unchanged, ZERO vec0 schema migration). Build: `cargo build --features local-embed`.
+local-embed = ["dep:candle-transformers", "dep:candle-core", "dep:candle-nn", "dep:tokenizers"]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1236,8 +1236,9 @@ pub async fn ask_vault(
     // FTS when no vectors exist, and the flag-off branch is byte-for-byte the prior behavior).
     let (corpus, sources) = if config.semantic_search_enabled {
         let embedder = crate::embed::active_embedder();
+        // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
         let query_vec = embedder
-            .embed(std::slice::from_ref(&question))?
+            .embed_query(std::slice::from_ref(&question))?
             .into_iter()
             .next()
             .unwrap_or_default();
@@ -2132,6 +2133,57 @@ pub async fn download_brain_model(
         },
     );
     Ok(dest.to_string_lossy().to_string())
+}
+
+/// `true` when all three multilingual-e5-small files are present in the shared models dir's embed
+/// sub-dir — i.e. the REAL embedder (under `--features local-embed`) would load. Cheap existence
+/// probe; NEVER errors on a missing models dir (treats it as "not present").
+#[tauri::command]
+pub fn embed_model_present() -> Result<bool, AppError> {
+    Ok(crate::embed::embed_model_present())
+}
+
+/// Download the multilingual-e5-small model (3 HF files) into the shared models dir, INBOUND-ONLY,
+/// emitting [`crate::events::EVENT_EMBED_DOWNLOAD`] progress (throttled per file). Sends NO meeting
+/// content (no egress). The downloaded model is NOT loaded here — it is picked up lazily by
+/// `embed::active_embedder` on the next embed (feature-gated by `local-embed`). Returns the model dir.
+#[tauri::command]
+pub async fn download_embed_model(app: AppHandle) -> Result<String, AppError> {
+    let file_count = crate::embed::EMBED_MODEL_FILES.len();
+    // Throttle progress to roughly every 2 MB so the (small) model download doesn't flood the FE.
+    const EMIT_EVERY: u64 = 2 * 1024 * 1024;
+    let mut last_emit: u64 = 0;
+    let mut last_index: usize = usize::MAX;
+    let dir = crate::embed::download_embed_model(|file_index, downloaded, total| {
+        // Always emit on a file boundary; otherwise throttle by bytes.
+        if file_index != last_index || downloaded - last_emit >= EMIT_EVERY {
+            last_index = file_index;
+            last_emit = downloaded;
+            let _ = app.emit(
+                crate::events::EVENT_EMBED_DOWNLOAD,
+                crate::events::EmbedDownloadPayload {
+                    file_index,
+                    file_count,
+                    downloaded,
+                    total,
+                    done: false,
+                },
+            );
+        }
+    })
+    .await?;
+
+    let _ = app.emit(
+        crate::events::EVENT_EMBED_DOWNLOAD,
+        crate::events::EmbedDownloadPayload {
+            file_index: file_count,
+            file_count,
+            downloaded: 0,
+            total: None,
+            done: true,
+        },
+    );
+    Ok(dir.to_string_lossy().to_string())
 }
 
 /// Show/hide the floating recorder bar window (also bound to the global ⌘⇧R shortcut).

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -15,6 +15,12 @@
 
 use crate::error::Result;
 use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// The REAL on-device embedder (Phase C), compiled ONLY under `--features local-embed`. The default
+/// build never pulls candle, keeping the fast `cargo test --lib` loop intact.
+#[cfg(feature = "local-embed")]
+pub mod candle_bert;
 
 /// Embedding dimensionality of the vector layer. The `vec0` column is declared `float[EMBED_DIM]`,
 /// so this MUST match the real model's output width when it lands (BGE-M3 = 1024; the stub uses a
@@ -35,7 +41,69 @@ pub trait Embedder {
     /// Output vector width. MUST equal [`EMBED_DIM`] for vectors destined for the `vec0` table.
     fn dim(&self) -> usize;
     /// Embed a batch of texts → one `dim()`-length vector each (same order as the input).
+    ///
+    /// This is the RAW encode — no asymmetric prefix. Document-indexing and query callers SHOULD
+    /// prefer [`Embedder::embed_passage`] / [`Embedder::embed_query`] so the e5 family's required
+    /// asymmetric prefix convention is applied; the existing index/query sites that call `embed`
+    /// directly still work (the stub ignores prefixes, and the real model treats a prefix-less text
+    /// as a generic passage). See the e5 prefix note on [`PASSAGE_PREFIX`]/[`QUERY_PREFIX`].
     fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+
+    /// Embed DOCUMENT/passage texts (the index side). Default impl prefixes each text with
+    /// [`PASSAGE_PREFIX`] then calls [`Embedder::embed`]. The stub's output is prefix-invariant in
+    /// practice (the prefix tokens add a tiny constant bag), so this is safe to route through the
+    /// stub; the real `CandleBertEmbedder` relies on it for correct e5 retrieval quality.
+    fn embed_passage(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let prefixed: Vec<String> = texts.iter().map(|t| format!("{PASSAGE_PREFIX}{t}")).collect();
+        self.embed(&prefixed)
+    }
+
+    /// Embed QUERY texts (the search side). Default impl prefixes each text with [`QUERY_PREFIX`]
+    /// then calls [`Embedder::embed`]. e5 REQUIRES the query/passage asymmetry for good recall.
+    fn embed_query(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let prefixed: Vec<String> = texts.iter().map(|t| format!("{QUERY_PREFIX}{t}")).collect();
+        self.embed(&prefixed)
+    }
+}
+
+/// e5 ASYMMETRIC PREFIX (passage side). The intfloat e5 family was trained with `"passage: "` on
+/// documents and `"query: "` on queries; using the right prefix is load-bearing for retrieval recall
+/// (incl. Polish). This is a Mac-eval TUNABLE — the exact prefix string and whether the bake-off
+/// prefers symmetric encoding is validated @Mac, not by `cargo test`.
+pub const PASSAGE_PREFIX: &str = "passage: ";
+
+/// e5 ASYMMETRIC PREFIX (query side). See [`PASSAGE_PREFIX`].
+pub const QUERY_PREFIX: &str = "query: ";
+
+/// Sub-directory under the shared models dir holding the multilingual-e5-small files
+/// (`model.safetensors` + `tokenizer.json` + `config.json`). 384-dim ⇒ [`EMBED_DIM`] is unchanged,
+/// so swapping the real model in costs ZERO vec0 schema migration.
+pub const EMBED_MODEL_SUBDIR: &str = "embed-multilingual-e5-small";
+
+/// The three Hugging Face files the real e5 embedder needs, fetched INBOUND-ONLY by
+/// `download_embed_model`. Order is irrelevant; each is downloaded into [`EMBED_MODEL_SUBDIR`].
+pub const EMBED_MODEL_FILES: &[&str] = &["model.safetensors", "tokenizer.json", "config.json"];
+
+/// Hugging Face `resolve/main` base for intfloat/multilingual-e5-small. INBOUND ONLY — fetched,
+/// never sent meeting content.
+pub const EMBED_MODEL_HF_BASE: &str =
+    "https://huggingface.co/intfloat/multilingual-e5-small/resolve/main";
+
+/// Resolve the on-disk dir the real e5 embedder loads from: `<models_dir>/embed-multilingual-e5-small/`.
+/// Creating the models dir can fail (returns `Err`); the dir itself may not yet exist (that is fine —
+/// the caller checks [`embed_model_present`]). NEVER panics.
+pub fn embed_model_dir() -> Result<PathBuf> {
+    Ok(crate::transcribe::models_dir()?.join(EMBED_MODEL_SUBDIR))
+}
+
+/// `true` when all three e5 model files exist in [`embed_model_dir`]. Pure existence probe (the only
+/// I/O is `is_file`); a models-dir resolution error is treated as "not present" (graceful — falls
+/// back to the stub), never propagated as a hard error.
+pub fn embed_model_present() -> bool {
+    match embed_model_dir() {
+        Ok(dir) => EMBED_MODEL_FILES.iter().all(|f| dir.join(f).is_file()),
+        Err(_) => false,
+    }
 }
 
 /// Deterministic, model-free embedder: a hashed bag-of-tokens projected into [`EMBED_DIM`] and
@@ -56,14 +124,40 @@ impl Embedder for StubEmbedder {
 
 /// The single active embedding backend used by BOTH the index path (chunking a note on creation)
 /// and the query path (Ask-My-Vault / MCP `search_semantic`). Returning a boxed trait object keeps
-/// the model a swappable seam: today it is the deterministic [`StubEmbedder`]; Phase 2c swaps in the
-/// real BGE-M3 model here. NOTE: if the real model's output dimension differs from [`EMBED_DIM`],
-/// that is a `vec_chunks float[N]` SCHEMA change — an additive migration to a new-width vec0 table
-/// plus a full re-index of every meeting, NOT a code one-liner. A mismatched-width insert fails
-/// loud (dimension error), never silently. Cheap to construct (the stub is zero-sized), so callers
-/// build one per operation rather than caching. NEVER invoked when `semantic_search_enabled` is off
-/// (the gate short-circuits before this is called).
+/// the model a swappable seam.
+///
+/// Graceful degradation (mirrors [`crate::reason::active_reasoner`]), in priority order:
+/// - the `local-embed` feature is ON **and** the e5 model dir is present at [`embed_model_dir`]
+///   ([`embed_model_present`]) → the real [`candle_bert::CandleBertEmbedder`] (lazy: the model loads
+///   on first `embed`, not here, so this never blocks startup and never panics);
+/// - otherwise (feature off, no model, or a construction error) → the dependency-free
+///   [`StubEmbedder`]. The app works either way; semantic, WHEN enabled, just uses real vectors once
+///   the model is present.
+///
+/// NEVER panics and NEVER blocks. Target model = multilingual-e5-small (384-dim), so the real model's
+/// width EQUALS [`EMBED_DIM`] — ZERO `vec_chunks` schema migration. (A future model whose dimension
+/// differs would be a `vec_chunks float[N]` SCHEMA change — an additive migration to a new-width vec0
+/// table plus a full re-index, NOT a code one-liner; a mismatched-width insert fails loud, never
+/// silently.) Cheap to construct (the stub is zero-sized; the candle backend defers the heavy load),
+/// so callers build one per operation. NEVER invoked when `semantic_search_enabled` is off (the gate
+/// short-circuits before this is called) — building the real embedder does NOT flip that flag.
 pub fn active_embedder() -> Box<dyn Embedder> {
+    #[cfg(feature = "local-embed")]
+    {
+        if embed_model_present() {
+            match embed_model_dir().and_then(candle_bert::CandleBertEmbedder::new) {
+                Ok(e) => {
+                    tracing::info!(target: "embed", "local embed model ready (lazy load)");
+                    return Box::new(e);
+                }
+                Err(e) => {
+                    tracing::warn!(target: "embed", error = %e, "local embed init failed; using stub embedder");
+                }
+            }
+        } else {
+            tracing::info!(target: "embed", "no local embed model present; using stub embedder");
+        }
+    }
     Box::new(StubEmbedder)
 }
 
@@ -164,6 +258,79 @@ pub fn rrf_fuse(lists: &[Vec<String>], k: f64) -> Vec<(String, f64)> {
     fused
 }
 
+/// Download the three e5 model files into [`embed_model_dir`], INBOUND-ONLY, with progress.
+///
+/// Mirrors [`crate::reason::download_brain_model`]: each file streams to `<file>.part` then renames
+/// atomically; `on_progress(file_index, downloaded, total)` fires as bytes arrive (`total` is `None`
+/// when the server omits `Content-Length`). A file already present on disk is SKIPPED. INBOUND ONLY:
+/// fetches model files and sends NO request body / NO meeting content (no egress). NO PII logged —
+/// filenames + byte counts only.
+pub async fn download_embed_model<F>(mut on_progress: F) -> Result<PathBuf>
+where
+    F: FnMut(usize, u64, Option<u64>),
+{
+    use crate::error::AppError;
+    use tokio::io::AsyncWriteExt;
+
+    let dir = embed_model_dir()?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AppError::Storage(format!("create embed model dir: {e}")))?;
+
+    for (idx, file) in EMBED_MODEL_FILES.iter().enumerate() {
+        let dest = dir.join(file);
+        if dest.is_file() {
+            continue;
+        }
+        let url = format!("{EMBED_MODEL_HF_BASE}/{file}");
+        tracing::info!(target: "embed", file = %file, "downloading embed model file");
+
+        let mut resp = reqwest::get(&url)
+            .await
+            .map_err(|e| AppError::Storage(format!("embed model download request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AppError::Storage(format!(
+                "embed model download HTTP {} for {file}",
+                resp.status()
+            )));
+        }
+        let total = resp.content_length();
+
+        let part = dest.with_extension("part");
+        let mut out = tokio::fs::File::create(&part)
+            .await
+            .map_err(|e| AppError::Storage(format!("create embed model temp file: {e}")))?;
+        let mut downloaded: u64 = 0;
+        while let Some(chunk) = resp
+            .chunk()
+            .await
+            .map_err(|e| AppError::Storage(format!("embed model download body failed: {e}")))?
+        {
+            out.write_all(&chunk)
+                .await
+                .map_err(|e| AppError::Storage(format!("write embed model chunk: {e}")))?;
+            downloaded += chunk.len() as u64;
+            on_progress(idx, downloaded, total);
+        }
+        out.flush()
+            .await
+            .map_err(|e| AppError::Storage(format!("flush embed model file: {e}")))?;
+        drop(out);
+
+        if downloaded == 0 {
+            let _ = tokio::fs::remove_file(&part).await;
+            return Err(AppError::Storage(format!(
+                "embed model download returned empty body for {file}"
+            )));
+        }
+        tokio::fs::rename(&part, &dest)
+            .await
+            .map_err(|e| AppError::Storage(format!("rename embed model file: {e}")))?;
+        tracing::info!(target: "embed", file = %file, bytes = downloaded, "embed model file ready");
+    }
+
+    Ok(dir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,5 +390,69 @@ mod tests {
         let pos = |want: &str| fused.iter().position(|(id, _)| id == want).unwrap();
         assert!(pos("m2") < pos("m3"), "m2 (in both lists) must outrank m3 (one list)");
         assert!(pos("m1") < pos("m3"), "m1 (in both lists) must outrank m3 (one list)");
+    }
+
+    #[test]
+    fn embed_query_and_passage_apply_the_e5_prefix() {
+        // The default trait methods prefix the text; we assert the prefix reaches `embed` by using a
+        // capture embedder that records exactly what it was handed.
+        struct CaptureEmbedder(std::sync::Mutex<Vec<String>>);
+        impl Embedder for CaptureEmbedder {
+            fn dim(&self) -> usize {
+                EMBED_DIM
+            }
+            fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+                *self.0.lock().unwrap() = texts.to_vec();
+                Ok(texts.iter().map(|_| vec![0f32; EMBED_DIM]).collect())
+            }
+        }
+        let e = CaptureEmbedder(std::sync::Mutex::new(Vec::new()));
+        e.embed_passage(&["a budget note".to_string()]).unwrap();
+        assert_eq!(e.0.lock().unwrap().as_slice(), &["passage: a budget note".to_string()]);
+        e.embed_query(&["how much budget".to_string()]).unwrap();
+        assert_eq!(e.0.lock().unwrap().as_slice(), &["query: how much budget".to_string()]);
+    }
+
+    #[test]
+    fn embed_model_dir_is_under_models_dir() {
+        let dir = embed_model_dir().unwrap();
+        assert!(dir.ends_with(EMBED_MODEL_SUBDIR));
+        // The three e5 files are the documented set.
+        assert_eq!(EMBED_MODEL_FILES, &["model.safetensors", "tokenizer.json", "config.json"]);
+        assert!(EMBED_MODEL_HF_BASE.contains("intfloat/multilingual-e5-small"));
+    }
+
+    #[test]
+    fn embed_model_present_false_when_any_file_missing() {
+        // On a clean machine the e5 dir is absent ⇒ not present. Even with a partial dir (only one of
+        // the three files), `present` must be false — the loader needs all three.
+        let dir = embed_model_dir().unwrap();
+        let had_dir = dir.is_dir();
+        // If a real model happens to be installed, this assertion is vacuously satisfied; otherwise
+        // assert the absent/partial cases without clobbering a real install.
+        if !had_dir {
+            assert!(!embed_model_present(), "absent e5 dir must report not-present");
+        }
+    }
+
+    /// The embedder factory's graceful-degradation contract: with NO e5 model dir present,
+    /// `active_embedder` returns the deterministic StubEmbedder (dim == EMBED_DIM, byte-stable). With
+    /// the `local-embed` feature OFF this is unconditional; with it ON it still holds whenever the
+    /// model dir is absent. Headless proof of the swap wiring's fallback (mirrors
+    /// `active_reasoner_falls_back_to_stub_without_model`).
+    #[test]
+    fn active_embedder_falls_back_to_stub_without_model() {
+        // Only meaningful as a fallback assertion when no real model is installed; on a clean
+        // machine/CI the e5 dir is absent, so a feature-on build also yields the stub.
+        if !embed_model_present() {
+            let e = active_embedder();
+            assert_eq!(e.dim(), EMBED_DIM);
+            // Deterministic + L2-normalized like the stub (the real model would not be byte-stable).
+            let a = e.embed(&["budżet planowanie".to_string()]).unwrap();
+            let b = e.embed(&["budżet planowanie".to_string()]).unwrap();
+            assert_eq!(a, b, "stub fallback must be byte-deterministic");
+            let norm: f32 = a[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+            assert!((norm - 1.0).abs() < 1e-5);
+        }
     }
 }

--- a/src-tauri/src/embed/candle_bert.rs
+++ b/src-tauri/src/embed/candle_bert.rs
@@ -1,0 +1,238 @@
+//! Real on-device embedding model (Phase C) — an [`Embedder`] backed by candle-transformers 0.10.2
+//! BERT inference (Metal). Compiled ONLY under `--features local-embed`; the default build ships the
+//! dependency-free `StubEmbedder` instead.
+//!
+//! ## Honest scope (READ THIS)
+//!
+//! Everything here is **COMPILE-proven only** in the headless CI loop. What can ONLY be verified on a
+//! signed/dev build on a real Mac, with the multilingual-e5-small files actually present:
+//! - real embedding quality (do the vectors retrieve sanely at all);
+//! - the **mean-pool + L2-normalize** producing useful e5 embeddings;
+//! - the **e5 asymmetric prefix** (`"query: "` / `"passage: "`) being the right convention for recall
+//!   (a Mac-eval TUNABLE — see [`crate::embed::QUERY_PREFIX`]/[`crate::embed::PASSAGE_PREFIX`]);
+//! - **Polish** recall;
+//! - **Metal** performance + correctness (load time, throughput, the Metal-vs-CPU fallback).
+//!
+//! `cargo test --lib` NEVER runs a forward pass here. Treat a green `--features local-embed` build as
+//! proof the impl typechecks/links against candle 0.10.2 — NOT as proof embedding works. The real
+//! quality/Metal/Polish-recall bake-off is @Mac.
+//!
+//! ## Graceful + crash-safe
+//!
+//! Every fallible step returns [`AppError`] — config parse, model load, tokenize, forward, and pooling
+//! NEVER panic or `unwrap`. Construction ([`CandleBertEmbedder::new`]) is cheap and infallible-by-design
+//! beyond holding the dir: the heavy safetensors+tokenizer load is **lazy** (first `embed` call) and
+//! cached behind a `Mutex`, so this can back `active_embedder` without ever blocking or aborting app
+//! startup. `Device::new_metal(0)` is tried first with a CPU fallback so a Metal-less context still
+//! works.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use candle_core::{Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::bert::{BertModel, Config, DTYPE};
+use tokenizers::Tokenizer;
+
+use crate::embed::{Embedder, EMBED_DIM, EMBED_MODEL_FILES};
+use crate::error::{AppError, Result};
+
+/// An [`Embedder`] running multilingual-e5-small in-process via candle BERT (Metal, CPU fallback).
+/// The model + tokenizer load lazily on the first `embed` and are cached behind an `Arc` so repeated
+/// calls reuse one engine. Output is mean-pooled over tokens then L2-normalized (the e5 contract).
+pub struct CandleBertEmbedder {
+    /// Directory holding `model.safetensors` + `tokenizer.json` + `config.json`.
+    model_dir: PathBuf,
+    /// Lazily-built, cached `(model, tokenizer, device)`. `None` until the first `embed` call.
+    inner: Mutex<Option<Arc<Loaded>>>,
+}
+
+/// The loaded engine: the BERT weights, its tokenizer, and the device they live on.
+struct Loaded {
+    model: BertModel,
+    tokenizer: Tokenizer,
+    device: Device,
+}
+
+impl CandleBertEmbedder {
+    /// Build an embedder for the e5 files in `model_dir`. CHEAP + non-blocking: it only validates the
+    /// three files exist and stores the dir — the safetensors/tokenizer load is deferred to first use,
+    /// so this is safe to call from `active_embedder` on the startup path. Returns `Err` (never panics)
+    /// if a required file is missing.
+    pub fn new(model_dir: PathBuf) -> Result<Self> {
+        for f in EMBED_MODEL_FILES {
+            let p = model_dir.join(f);
+            if !p.is_file() {
+                return Err(AppError::Storage(format!(
+                    "embed model missing required file: {f}"
+                )));
+            }
+        }
+        Ok(Self {
+            model_dir,
+            inner: Mutex::new(None),
+        })
+    }
+
+    /// Pick a compute device: Metal first (the Mac fast path), CPU as a graceful fallback. NEVER
+    /// panics — a Metal-init failure logs (no PII) and falls back to CPU.
+    fn pick_device() -> Device {
+        match Device::new_metal(0) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(target: "embed", error = %e, "metal device init failed; falling back to CPU");
+                Device::Cpu
+            }
+        }
+    }
+
+    /// Lazily load (once) + return the cached engine. Serializes concurrent first-loads behind the
+    /// mutex; a load failure surfaces as `Err` and leaves the cache empty (a later call may retry).
+    fn loaded(&self) -> Result<Arc<Loaded>> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| AppError::Storage("embed model mutex poisoned".into()))?;
+        if let Some(l) = guard.as_ref() {
+            return Ok(l.clone());
+        }
+
+        let config_path = self.model_dir.join("config.json");
+        let tokenizer_path = self.model_dir.join("tokenizer.json");
+        let weights_path = self.model_dir.join("model.safetensors");
+
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| AppError::Storage(format!("read embed config.json: {e}")))?;
+        let config: Config = serde_json::from_str(&config_str)
+            .map_err(|e| AppError::Storage(format!("parse embed config.json: {e}")))?;
+
+        let tokenizer = Tokenizer::from_file(&tokenizer_path)
+            .map_err(|e| AppError::Storage(format!("load embed tokenizer.json: {e}")))?;
+
+        let device = Self::pick_device();
+        // SAFETY: `from_mmaped_safetensors` mmaps the weights read-only; the file is a trusted model
+        // artifact we downloaded ourselves into the app models dir. The `VarBuilder` borrows the mmap
+        // for the lifetime of the load (the tensors are copied onto `device`).
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[&weights_path], DTYPE, &device)
+                .map_err(|e| AppError::Storage(format!("mmap embed safetensors: {e}")))?
+        };
+        let model = BertModel::load(vb, &config)
+            .map_err(|e| AppError::Storage(format!("load embed BERT weights: {e}")))?;
+
+        // e5-small is a 384-hidden model; guard the contract so a wrong-width model fails LOUD here
+        // rather than producing off-width vectors the vec0 insert would silently mishandle.
+        if config.hidden_size != EMBED_DIM {
+            return Err(AppError::Storage(format!(
+                "embed model hidden_size {} != EMBED_DIM {EMBED_DIM} (vec0 schema mismatch)",
+                config.hidden_size
+            )));
+        }
+
+        let arc = Arc::new(Loaded {
+            model,
+            tokenizer,
+            device,
+        });
+        *guard = Some(arc.clone());
+        tracing::info!(target: "embed", "embed model loaded");
+        Ok(arc)
+    }
+}
+
+impl Embedder for CandleBertEmbedder {
+    fn dim(&self) -> usize {
+        EMBED_DIM
+    }
+
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let loaded = self.loaded()?;
+        let device = &loaded.device;
+
+        // Tokenize the batch (padding to the longest sequence so the batch is one rectangular tensor).
+        let encodings = loaded
+            .tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| AppError::Storage(format!("embed tokenize failed: {e}")))?;
+
+        let mut id_rows: Vec<Vec<u32>> = Vec::with_capacity(encodings.len());
+        let mut mask_rows: Vec<Vec<u32>> = Vec::with_capacity(encodings.len());
+        let max_len = encodings.iter().map(|e| e.get_ids().len()).max().unwrap_or(0);
+        for enc in &encodings {
+            let mut ids = enc.get_ids().to_vec();
+            let mut mask = enc.get_attention_mask().to_vec();
+            // Right-pad to the batch max so all rows share a shape (token id 0 + mask 0 are ignored
+            // by the attention mask anyway).
+            ids.resize(max_len, 0);
+            mask.resize(max_len, 0);
+            id_rows.push(ids);
+            mask_rows.push(mask);
+        }
+
+        let batch = id_rows.len();
+        let flat_ids: Vec<u32> = id_rows.into_iter().flatten().collect();
+        let flat_mask: Vec<u32> = mask_rows.iter().flatten().copied().collect();
+
+        let input_ids = Tensor::from_vec(flat_ids, (batch, max_len), device)
+            .map_err(|e| AppError::Storage(format!("embed input tensor: {e}")))?;
+        let attention_mask = Tensor::from_vec(flat_mask.clone(), (batch, max_len), device)
+            .map_err(|e| AppError::Storage(format!("embed mask tensor: {e}")))?;
+        let token_type_ids = input_ids
+            .zeros_like()
+            .map_err(|e| AppError::Storage(format!("embed token-type tensor: {e}")))?;
+
+        // [batch, seq, hidden]
+        let sequence = loaded
+            .model
+            .forward(&input_ids, &token_type_ids, Some(&attention_mask))
+            .map_err(|e| AppError::Storage(format!("embed forward failed: {e}")))?;
+
+        // MEAN-POOL over tokens with the attention mask (e5 requires mean-pooling, NOT the CLS token),
+        // then L2-normalize each row.
+        let pooled = mean_pool(&sequence, &attention_mask)
+            .map_err(|e| AppError::Storage(format!("embed mean-pool failed: {e}")))?;
+        let normed = l2_normalize(&pooled)
+            .map_err(|e| AppError::Storage(format!("embed normalize failed: {e}")))?;
+
+        let out: Vec<Vec<f32>> = normed
+            .to_vec2::<f32>()
+            .map_err(|e| AppError::Storage(format!("embed extract vectors: {e}")))?;
+
+        // Width contract: every vector MUST be EMBED_DIM (the vec0 column width).
+        for v in &out {
+            if v.len() != EMBED_DIM {
+                return Err(AppError::Storage(format!(
+                    "embed produced width {} != EMBED_DIM {EMBED_DIM}",
+                    v.len()
+                )));
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Masked mean-pool a `[batch, seq, hidden]` tensor over the sequence dimension, weighting each token
+/// by its attention mask, to a `[batch, hidden]` tensor. Pad tokens (mask 0) contribute nothing.
+fn mean_pool(sequence: &Tensor, attention_mask: &Tensor) -> candle_core::Result<Tensor> {
+    // mask: [batch, seq] → [batch, seq, 1] float, broadcast over hidden.
+    let mask = attention_mask
+        .to_dtype(DTYPE)?
+        .unsqueeze(2)?; // [batch, seq, 1]
+    let masked = sequence.broadcast_mul(&mask)?; // [batch, seq, hidden]
+    let summed = masked.sum(1)?; // [batch, hidden]
+    // Per-row token count (clamped to >=1 to avoid div-by-zero on an all-pad row).
+    let counts = mask.sum(1)?; // [batch, 1]
+    let counts = counts.clamp(1f32, f32::INFINITY)?;
+    summed.broadcast_div(&counts)
+}
+
+/// L2-normalize each row of a `[batch, hidden]` tensor (e5 vectors are unit-length; cosine == dot).
+fn l2_normalize(x: &Tensor) -> candle_core::Result<Tensor> {
+    let norm = x.sqr()?.sum_keepdim(1)?.sqrt()?; // [batch, 1]
+    // Clamp the norm away from 0 so an all-zero row stays finite (no NaN).
+    let norm = norm.clamp(1e-12f32, f32::INFINITY)?;
+    x.broadcast_div(&norm)
+}

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -49,6 +49,26 @@ pub struct BrainDownloadPayload {
     pub done: bool,
 }
 
+/// Progress for the on-device EMBED model (multilingual-e5-small) download. Carries byte/file counts
+/// only — NO PII. The e5 model is three small files, so progress is reported per-file.
+pub const EVENT_EMBED_DOWNLOAD: &str = "murmur://embed-download";
+
+/// Payload for [`EVENT_EMBED_DOWNLOAD`]. `total` is `None` when the server omits `Content-Length`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedDownloadPayload {
+    /// Index of the file currently downloading (0-based, into the 3-file e5 set).
+    pub file_index: usize,
+    /// Total number of files in the set (3).
+    pub file_count: usize,
+    /// Bytes written so far for the CURRENT file.
+    pub downloaded: u64,
+    /// Total bytes expected for the current file, when known.
+    pub total: Option<u64>,
+    /// True on the final event once all three files are written + renamed into place.
+    pub done: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusPayload {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,8 @@ pub fn run() {
             commands::list_brain_models,
             commands::select_brain_model,
             commands::download_brain_model,
+            commands::embed_model_present,
+            commands::download_embed_model,
             commands::toggle_bar,
             commands::list_folders,
             commands::create_folder,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -812,10 +812,12 @@ impl Db {
         // Always purge this meeting's prior rows first (clean replace), then insert the fresh set in
         // ONE transaction. A meeting with a now-empty note simply ends up with zero chunks.
         let provider_id = note.provider_id.clone();
+        // DOCUMENT side: chunks are passages → use the e5 `passage:` prefix convention. The stub
+        // ignores the prefix; the real CandleBertEmbedder needs it for retrieval recall.
         let vectors = if chunks.is_empty() {
             Vec::new()
         } else {
-            embedder.embed(&chunks)?
+            embedder.embed_passage(&chunks)?
         };
 
         let this_meeting = [meeting_id.to_string()];

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -81,7 +81,8 @@ pub fn execute_tool(
             // Embed the query with the SAME active embedder used to index, then HYBRID-search through
             // the SAME visibility gate as `search_meetings` (both FTS + vector legs are gated).
             let embedder = crate::embed::active_embedder();
-            let query_vec = match embedder.embed(std::slice::from_ref(&q.to_string())) {
+            // QUERY side: e5 `query:` prefix (asymmetric with the `passage:` index side).
+            let query_vec = match embedder.embed_query(std::slice::from_ref(&q.to_string())) {
                 Ok(v) => v.into_iter().next().unwrap_or_default(),
                 Err(e) => return Err(AppError::Summarize(format!("embed failed: {e}"))),
             };


### PR DESCRIPTION
The embedder becomes **real** — candle-transformers BERT (multilingual-e5-small, 384-dim = no schema change) behind a `local-embed` feature, **zero second onnxruntime** (shares candle; sherpa stays the only ORT). Default build stays fast (candle gated out: test 326/0). CandleBertEmbedder (lazy load, masked mean-pool + L2-norm, Metal+CPU, no panic); embed_query/embed_passage (e5 prefixes); active_embedder graceful fallback; download_embed_model (inbound-only). Verified: default 326/0; feature build COMPILES+LINKS 29s (no 2nd ORT); clippy clean both; adversarial PASS; lock-security PASS (no widened surface). Real quality/Metal/Polish/bake-off = @Mac.