### PR TITLE
feat(privacy): Phase D — real DebertaNameRedactor (candle NER) — closes the name-redaction gap

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -149,3 +149,12 @@ local-brain = ["dep:mistralrs"]
 # it gracefully degrades to the StubEmbedder. Target model = multilingual-e5-small (384-dim ⇒ EMBED_DIM
 # is unchanged, ZERO vec0 schema migration). Build: `cargo build --features local-embed`.
 local-embed = ["dep:candle-transformers", "dep:candle-core", "dep:candle-nn", "dep:tokenizers"]
+# Phase D — the REAL on-device name-redaction NER (DebertaNameRedactor, `summarize/ner_deberta.rs`).
+# OFF by default so the fast `cargo test --lib` loop never compiles candle. REUSES the SAME optional
+# candle/tokenizers deps `local-embed` added (candle-transformers 0.10.2 ships a built-in
+# `models::debertav2::DebertaV2NERModel` that links with ZERO second onnxruntime — sherpa stays the
+# only ORT). With it ON *and* the NER model dir present, `summarize::redact::active_name_redactor`
+# returns the real DebertaNameRedactor (PERSON spans → ⟪NAME_n⟫ tokens before cloud egress);
+# otherwise it gracefully degrades to the byte-identical NoopNameRedactor. Build:
+# `cargo build --features local-ner --lib`.
+local-ner = ["dep:candle-transformers", "dep:candle-core", "dep:candle-nn", "dep:tokenizers"]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2186,6 +2186,57 @@ pub async fn download_embed_model(app: AppHandle) -> Result<String, AppError> {
     Ok(dir.to_string_lossy().to_string())
 }
 
+/// True iff the on-device PERSON-name NER model (Phase D) is present on disk. Pure existence probe;
+/// NEVER errors on a missing models dir (treats it as "not present"). When false (or the `local-ner`
+/// feature is off), the redaction firewall uses the byte-identical NoopNameRedactor.
+#[tauri::command]
+pub fn ner_model_present() -> Result<bool, AppError> {
+    Ok(crate::summarize::redact::ner_model_present())
+}
+
+/// Download the multilingual mDeBERTa-v3 NER model (3 HF files) into the shared models dir,
+/// INBOUND-ONLY, emitting [`crate::events::EVENT_NER_DOWNLOAD`] progress (throttled per file). Sends
+/// NO meeting content (no egress). The downloaded model is NOT loaded here — it is picked up lazily by
+/// `summarize::redact::active_name_redactor` on the next cloud summarization (feature-gated by
+/// `local-ner`). Returns the model dir.
+#[tauri::command]
+pub async fn download_ner_model(app: AppHandle) -> Result<String, AppError> {
+    let file_count = crate::summarize::redact::NER_MODEL_FILES.len();
+    // Throttle progress to roughly every 2 MB so the model download doesn't flood the FE.
+    const EMIT_EVERY: u64 = 2 * 1024 * 1024;
+    let mut last_emit: u64 = 0;
+    let mut last_index: usize = usize::MAX;
+    let dir = crate::summarize::redact::download_ner_model(|file_index, downloaded, total| {
+        if file_index != last_index || downloaded - last_emit >= EMIT_EVERY {
+            last_index = file_index;
+            last_emit = downloaded;
+            let _ = app.emit(
+                crate::events::EVENT_NER_DOWNLOAD,
+                crate::events::NerDownloadPayload {
+                    file_index,
+                    file_count,
+                    downloaded,
+                    total,
+                    done: false,
+                },
+            );
+        }
+    })
+    .await?;
+
+    let _ = app.emit(
+        crate::events::EVENT_NER_DOWNLOAD,
+        crate::events::NerDownloadPayload {
+            file_index: file_count,
+            file_count,
+            downloaded: 0,
+            total: None,
+            done: true,
+        },
+    );
+    Ok(dir.to_string_lossy().to_string())
+}
+
 /// Show/hide the floating recorder bar window (also bound to the global ⌘⇧R shortcut).
 #[tauri::command]
 pub fn toggle_bar(app: AppHandle) {

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -69,6 +69,26 @@ pub struct EmbedDownloadPayload {
     pub done: bool,
 }
 
+/// Progress for the on-device NER name-redaction model (multilingual mDeBERTa-v3) download. Carries
+/// byte/file counts only — NO PII. The model is three files, so progress is reported per-file.
+pub const EVENT_NER_DOWNLOAD: &str = "murmur://ner-download";
+
+/// Payload for [`EVENT_NER_DOWNLOAD`]. `total` is `None` when the server omits `Content-Length`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NerDownloadPayload {
+    /// Index of the file currently downloading (0-based, into the 3-file NER set).
+    pub file_index: usize,
+    /// Total number of files in the set (3).
+    pub file_count: usize,
+    /// Bytes written so far for the CURRENT file.
+    pub downloaded: u64,
+    /// Total bytes expected for the current file, when known.
+    pub total: Option<u64>,
+    /// True on the final event once all three files are written + renamed into place.
+    pub done: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusPayload {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,8 @@ pub fn run() {
             commands::download_brain_model,
             commands::embed_model_present,
             commands::download_embed_model,
+            commands::ner_model_present,
+            commands::download_ner_model,
             commands::toggle_bar,
             commands::list_folders,
             commands::create_folder,

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -14,6 +14,11 @@ pub mod claude_code;
 pub mod digest;
 pub mod dossier;
 pub mod graph;
+/// The REAL on-device PERSON-name NER redactor (Phase D), compiled ONLY under `--features local-ner`.
+/// The default build never pulls candle, keeping the fast `cargo test --lib` loop intact and name
+/// egress byte-identical to today (the no-op). Wired via `redact::active_name_redactor`.
+#[cfg(feature = "local-ner")]
+pub mod ner_deberta;
 pub mod ollama;
 pub mod organize;
 pub mod provider;
@@ -96,9 +101,18 @@ pub fn make_provider(
     // reach the cloud (restored in the reply). `claude_code` shells out to the local `claude`
     // CLI, but that CLI uploads to Anthropic's cloud, so it needs the firewall exactly as the
     // direct HTTP `anthropic` provider does. ollama (local) already returned above, unwrapped.
-    Ok(Arc::new(crate::summarize::redact::RedactingProvider::new(
-        inner,
-    )))
+    //
+    // Phase D — the name layer is now the ACTIVE on-device redactor: with `--features local-ner`
+    // ON and the NER model present, `active_name_redactor()` returns the real DebertaNameRedactor
+    // (PERSON names → ⟪NAME_n⟫ before egress, restored in the reply); otherwise it is the
+    // byte-identical NoopNameRedactor, so default-build egress is unchanged. The redactor only ever
+    // REMOVES content (a NER miss leaks no more than the no-op).
+    Ok(Arc::new(
+        crate::summarize::redact::RedactingProvider::with_name_redactor(
+            inner,
+            crate::summarize::redact::active_name_redactor(),
+        ),
+    ))
 }
 
 /// All three provider instances (for availability fan-out in the Settings UI).

--- a/src-tauri/src/summarize/ner_deberta.rs
+++ b/src-tauri/src/summarize/ner_deberta.rs
@@ -1,0 +1,542 @@
+//! Real on-device PERSON-name redaction (Phase D) — a [`NameRedactor`](crate::summarize::redact::NameRedactor)
+//! backed by candle-transformers 0.10.2 token-classification NER (DeBERTa-v2, Metal). Compiled ONLY
+//! under `--features local-ner`; the default build ships the dependency-free
+//! [`NoopNameRedactor`](crate::summarize::redact::NoopNameRedactor) instead.
+//!
+//! ## What this does (and why it is SAFE-BY-DESIGN)
+//!
+//! The redaction firewall ([`RedactingProvider`](crate::summarize::redact::RedactingProvider)) scrubs
+//! emails/cards/phones with regex but, until now, let personal NAMES egress (the honest-scope note in
+//! `redact.rs`). This module is the real NER that closes that gap: it runs a multilingual DeBERTa NER
+//! over the prompt, decodes BIO **PERSON** spans (`B-PER`/`I-PER`), and replaces each DISTINCT person
+//! name with a stable `⟪NAME_n⟫` token per the [`NameRedactor`] contract, so the provider's reply
+//! de-tokenizes back to the real names.
+//!
+//! CRITICAL INVARIANT (lock-review): this redactor ONLY ever REMOVES/MASKS content (a matched PERSON
+//! span → a placeholder token). It NEVER adds text to the prompt. Therefore a NER **miss** leaks NO
+//! MORE than today's `NoopNameRedactor` — worst case == current production behaviour. It runs
+//! ON-DEVICE inside the firewall, BEFORE egress; there is no network in this path
+//! ([`download_ner_model`](crate::summarize::redact::download_ner_model) is the only I/O and is
+//! inbound-only).
+//!
+//! ## Model choice (DOCUMENTED — Polish recall is a @Mac eval)
+//!
+//! candle's `DebertaV2NERModel::load(vb, &config, Some(id2label))` loads a `DebertaV2Model` + a
+//! `classifier` linear head and is fully driven by the model's `id2label` (we detect PERSON purely by
+//! the `*-PER` label suffix), so this code is model-AGNOSTIC — only the download URL names the repo.
+//! The shipped target is a multilingual **mDeBERTa-v3 NER** (`MODEL_HF_BASE` in `redact.rs`) that
+//! exposes `model.safetensors` + `tokenizer.json` + a `config.json` carrying an `id2label` with
+//! `B-PER`/`I-PER`. If a perfectly turnkey safetensors+id2label mDeBERTa-v3 PER model is unavailable,
+//! the closest loadable DeBERTa-v2 token-classifier is used — the decode logic is identical.
+//!
+//! ## Honest scope (READ THIS)
+//!
+//! Everything here is **COMPILE-proven only** in the headless CI loop (`cargo build --features
+//! local-ner --lib`). What can ONLY be verified on a signed/dev build on a real Mac, with the NER
+//! files actually present, is: real NER quality, **Polish PERSON recall**, the BIO decode against the
+//! real tokenizer's subword offsets, and **Metal** correctness/perf (Metal-vs-CPU fallback). The pure
+//! BIO→span decode + distinct-name→token mapping IS unit-tested headless via injected logits — that
+//! is the part this module owns and the part most likely to regress.
+//!
+//! ## Graceful + crash-safe
+//!
+//! Every fallible step returns [`AppError`] — config parse, model load, tokenize, forward, argmax
+//! NEVER panic or `unwrap`. The heavy safetensors+tokenizer load is LAZY (first `redact_names` call)
+//! and cached behind a `Mutex`, so this can back `active_name_redactor` without blocking or aborting
+//! app startup. `Device::new_metal(0)` is tried first with a CPU fallback.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use candle_core::{Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::debertav2::{Config, DebertaV2NERModel, Id2Label};
+use tokenizers::Tokenizer;
+
+use crate::error::{AppError, Result};
+use crate::summarize::redact::{NameRedactor, NER_MODEL_FILES, NER_NAME_TOKEN_PREFIX};
+
+/// Float dtype the NER weights load in. The candle DeBERTa NER example uses F32 on CPU/Metal; we mirror
+/// that (the model is small enough that F32 is fine and avoids half-precision argmax surprises).
+const NER_DTYPE: candle_core::DType = candle_core::DType::F32;
+
+/// A [`NameRedactor`] running a multilingual DeBERTa NER in-process via candle (Metal, CPU fallback).
+/// The model + tokenizer load lazily on the first `redact_names` and are cached behind an `Arc`. The
+/// redact method tokenizes WITH char offsets, runs the classifier, argmaxes per token, decodes BIO
+/// PERSON spans, and maps each distinct name to a stable `⟪NAME_n⟫` token.
+pub struct DebertaNameRedactor {
+    /// Directory holding `model.safetensors` + `tokenizer.json` + `config.json`.
+    model_dir: PathBuf,
+    /// Lazily-built, cached engine. `None` until the first `redact_names` call.
+    inner: Mutex<Option<Arc<Loaded>>>,
+}
+
+/// The loaded engine: the DeBERTa NER weights, its tokenizer (with offsets), the `id` → label map, and
+/// the device they live on.
+struct Loaded {
+    model: DebertaV2NERModel,
+    tokenizer: Tokenizer,
+    /// `label_id` → label string (e.g. `1 -> "B-PER"`), from `config.json`'s `id2label`.
+    id2label: Id2Label,
+    device: Device,
+}
+
+impl DebertaNameRedactor {
+    /// Build a redactor for the NER files in `model_dir`. CHEAP + non-blocking: it only validates the
+    /// three files exist and stores the dir — the safetensors/tokenizer load is deferred to first use,
+    /// so this is safe to call from `active_name_redactor` on the startup path. Returns `Err` (never
+    /// panics) if a required file is missing.
+    pub fn new(model_dir: PathBuf) -> Result<Self> {
+        for f in NER_MODEL_FILES {
+            let p = model_dir.join(f);
+            if !p.is_file() {
+                return Err(AppError::Storage(format!(
+                    "ner model missing required file: {f}"
+                )));
+            }
+        }
+        Ok(Self {
+            model_dir,
+            inner: Mutex::new(None),
+        })
+    }
+
+    /// Pick a compute device: Metal first (the Mac fast path), CPU as a graceful fallback. NEVER
+    /// panics — a Metal-init failure logs (no PII) and falls back to CPU.
+    fn pick_device() -> Device {
+        match Device::new_metal(0) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(target: "ner", error = %e, "metal device init failed; falling back to CPU");
+                Device::Cpu
+            }
+        }
+    }
+
+    /// Lazily load (once) + return the cached engine. Serializes concurrent first-loads behind the
+    /// mutex; a load failure surfaces as `Err` and leaves the cache empty (a later call may retry).
+    fn loaded(&self) -> Result<Arc<Loaded>> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| AppError::Storage("ner model mutex poisoned".into()))?;
+        if let Some(l) = guard.as_ref() {
+            return Ok(l.clone());
+        }
+
+        let config_path = self.model_dir.join("config.json");
+        let tokenizer_path = self.model_dir.join("tokenizer.json");
+        let weights_path = self.model_dir.join("model.safetensors");
+
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| AppError::Storage(format!("read ner config.json: {e}")))?;
+        let config: Config = serde_json::from_str(&config_str)
+            .map_err(|e| AppError::Storage(format!("parse ner config.json: {e}")))?;
+
+        // id2label MUST be present in the config — the NER head width AND our B-PER/I-PER decode both
+        // depend on it. Fail LOUD here (no panic) rather than mis-decoding labels later.
+        let id2label = config.id2label.clone().ok_or_else(|| {
+            AppError::Storage("ner config.json missing id2label (need B-PER/I-PER labels)".into())
+        })?;
+
+        let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
+            .map_err(|e| AppError::Storage(format!("load ner tokenizer.json: {e}")))?;
+        // We need byte/char offsets to map a token span back to the exact substring to mask.
+        tokenizer.with_padding(None).with_truncation(None).ok();
+
+        let device = Self::pick_device();
+        // SAFETY: `from_mmaped_safetensors` mmaps the weights read-only; the file is a trusted model
+        // artifact we downloaded ourselves into the app models dir. The `VarBuilder` borrows the mmap
+        // for the lifetime of the load (the tensors are copied onto `device`).
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[&weights_path], NER_DTYPE, &device)
+                .map_err(|e| AppError::Storage(format!("mmap ner safetensors: {e}")))?
+        };
+        let model = DebertaV2NERModel::load(vb, &config, Some(id2label.clone()))
+            .map_err(|e| AppError::Storage(format!("load ner DeBERTa weights: {e}")))?;
+
+        let arc = Arc::new(Loaded {
+            model,
+            tokenizer,
+            id2label,
+            device,
+        });
+        *guard = Some(arc.clone());
+        tracing::info!(target: "ner", labels = id2label_will_log(&arc.id2label), "ner model loaded");
+        Ok(arc)
+    }
+
+    /// The real work: run the NER over `text` and return `(scrubbed, pairs)`. Any model/tensor error
+    /// surfaces as `Err` (the caller treats `Err` as "no-op, leak nothing extra" — see
+    /// [`NameRedactor::redact_names`] impl). NEVER panics.
+    fn run(&self, text: &str) -> Result<(String, Vec<(String, String)>)> {
+        if text.trim().is_empty() {
+            return Ok((text.to_string(), Vec::new()));
+        }
+        let loaded = self.loaded()?;
+        let device = &loaded.device;
+
+        // Tokenize WITH offsets so each subword token knows its [start,end) char span in `text`.
+        let encoding = loaded
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| AppError::Storage(format!("ner tokenize failed: {e}")))?;
+        let ids = encoding.get_ids();
+        if ids.is_empty() {
+            return Ok((text.to_string(), Vec::new()));
+        }
+        let offsets = encoding.get_offsets(); // &[(usize, usize)] char spans into `text`
+        let special = encoding.get_special_tokens_mask(); // 1 for [CLS]/[SEP]/pad
+
+        let seq = ids.len();
+        let input_ids = Tensor::from_vec(ids.to_vec(), (1, seq), device)
+            .map_err(|e| AppError::Storage(format!("ner input tensor: {e}")))?;
+        let attention_mask = Tensor::ones((1, seq), candle_core::DType::U32, device)
+            .map_err(|e| AppError::Storage(format!("ner mask tensor: {e}")))?;
+
+        // logits: [1, seq, num_labels]
+        let logits = loaded
+            .model
+            .forward(&input_ids, None, Some(attention_mask))
+            .map_err(|e| AppError::Storage(format!("ner forward failed: {e}")))?;
+        let logits = logits
+            .to_dtype(candle_core::DType::F32)
+            .and_then(|t| t.squeeze(0)) // [seq, num_labels]
+            .map_err(|e| AppError::Storage(format!("ner logits reshape: {e}")))?;
+        let label_ids: Vec<u32> = logits
+            .argmax(candle_core::D::Minus1)
+            .and_then(|t| t.to_vec1::<u32>())
+            .map_err(|e| AppError::Storage(format!("ner argmax failed: {e}")))?;
+
+        // Decode BIO PERSON spans into char ranges, then map distinct names → stable tokens.
+        let spans = decode_person_spans(&label_ids, offsets, special, &loaded.id2label);
+        Ok(apply_person_spans(text, &spans))
+    }
+}
+
+impl NameRedactor for DebertaNameRedactor {
+    fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>) {
+        // Fail-SAFE: a model error must NEVER add content or panic — it degrades to the no-op (text
+        // unchanged, empty pairs), which leaks no more than today's NoopNameRedactor. We only ever
+        // REMOVE content on the happy path.
+        match self.run(text) {
+            Ok(out) => out,
+            Err(e) => {
+                tracing::warn!(target: "ner", error = %e, "ner redact failed; passing text through unchanged (no-op)");
+                (text.to_string(), Vec::new())
+            }
+        }
+    }
+}
+
+/// A decoded PERSON span: the inclusive char range `[start, end)` in the source text and the exact
+/// substring it covers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersonSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// True iff `label` denotes a PERSON tag (`B-PER`/`I-PER`, case-insensitive, also `PERSON`/`B-PERSON`).
+/// We match on the SUFFIX so the scheme works across `PER`/`PERSON` label vocabularies.
+fn is_person_label(label: &str) -> bool {
+    let up = label.to_ascii_uppercase();
+    up.ends_with("PER") || up.ends_with("PERSON")
+}
+
+/// True iff `label` BEGINS a new entity (`B-`). Anything else inside a PERSON run (`I-PER`) continues.
+fn is_begin(label: &str) -> bool {
+    label.to_ascii_uppercase().starts_with("B-")
+}
+
+/// Decode argmax per-token label ids into PERSON char spans using BIO. Special tokens (CLS/SEP/pad)
+/// and `O` break any open span. A `B-PER` always starts a fresh span; an `I-PER` extends the current
+/// PERSON span (or, leniently, starts one if a model emits `I-PER` without a preceding `B-PER`).
+/// Pure + deterministic — this is the unit-tested core.
+pub(crate) fn decode_person_spans(
+    label_ids: &[u32],
+    offsets: &[(usize, usize)],
+    special: &[u32],
+    id2label: &Id2Label,
+) -> Vec<PersonSpan> {
+    let mut spans: Vec<PersonSpan> = Vec::new();
+    let mut open: Option<PersonSpan> = None;
+
+    let n = label_ids.len().min(offsets.len());
+    for i in 0..n {
+        // A special token (CLS/SEP/pad) is not real text — it ends any open span and is skipped.
+        if special.get(i).copied().unwrap_or(0) == 1 {
+            if let Some(s) = open.take() {
+                spans.push(s);
+            }
+            continue;
+        }
+        let label = id2label
+            .get(&label_ids[i])
+            .map(String::as_str)
+            .unwrap_or("O");
+        let (tok_start, tok_end) = offsets[i];
+        // A zero-width offset (some tokenizers emit (0,0) for added tokens) carries no text → skip,
+        // but do NOT break an open span on it.
+        let is_empty_offset = tok_start == tok_end;
+
+        if is_person_label(label) && !is_empty_offset {
+            match (&mut open, is_begin(label)) {
+                // New entity boundary, or a continuation with no span open → start a fresh span.
+                (None, _) | (Some(_), true) => {
+                    if is_begin(label) {
+                        if let Some(s) = open.take() {
+                            spans.push(s);
+                        }
+                    }
+                    open = Some(PersonSpan {
+                        start: tok_start,
+                        end: tok_end,
+                    });
+                }
+                // I-PER continuing the open span → extend its end.
+                (Some(s), false) => {
+                    s.end = tok_end;
+                }
+            }
+        } else if !is_empty_offset {
+            // A real, non-PERSON token (O / other entity) closes any open span.
+            if let Some(s) = open.take() {
+                spans.push(s);
+            }
+        }
+    }
+    if let Some(s) = open.take() {
+        spans.push(s);
+    }
+    spans
+}
+
+/// Replace each PERSON span's substring with a stable `⟪NAME_n⟫` token, mapping DISTINCT names to
+/// distinct stable tokens (so the same name anywhere in the text → the same token, satisfying the
+/// [`NameRedactor`] stable-token contract). Returns `(scrubbed_text, token→name pairs)`. The pairs
+/// are de-duplicated (one entry per distinct name) so [`restore_names`](crate::summarize::redact) maps
+/// cleanly. Pure + deterministic.
+///
+/// Rebuilds the string by walking the ORIGINAL text and substituting only the masked ranges, so
+/// non-PERSON text is byte-identical to the input (we only ever REMOVE PERSON spans).
+pub(crate) fn apply_person_spans(
+    text: &str,
+    spans: &[PersonSpan],
+) -> (String, Vec<(String, String)>) {
+    if spans.is_empty() {
+        return (text.to_string(), Vec::new());
+    }
+    // Sort + drop overlaps (defensive: a well-formed BIO decode yields disjoint ascending spans).
+    let mut spans: Vec<PersonSpan> = spans.to_vec();
+    spans.sort_by_key(|s| (s.start, s.end));
+    let mut clean: Vec<PersonSpan> = Vec::with_capacity(spans.len());
+    let mut last_end = 0usize;
+    for s in spans {
+        if s.start >= last_end && s.end > s.start && s.end <= text.len() {
+            last_end = s.end;
+            clean.push(s);
+        }
+    }
+
+    // Assign a stable token per DISTINCT name (by exact surface string). Insertion order → NAME_1,
+    // NAME_2, … in first-appearance order.
+    let mut name_to_tok: Vec<(String, String)> = Vec::new(); // name → token (preserves order)
+    let mut tok_to_name: Vec<(String, String)> = Vec::new(); // token → name (the returned pairs)
+
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for s in &clean {
+        // Char-boundary safety: only mask when both ends land on UTF-8 boundaries; otherwise skip this
+        // span (leave the text intact) rather than panic on a mid-char slice.
+        if !text.is_char_boundary(s.start) || !text.is_char_boundary(s.end) {
+            continue;
+        }
+        if s.start < cursor {
+            continue;
+        }
+        out.push_str(&text[cursor..s.start]);
+        let name = text[s.start..s.end].to_string();
+        let tok = match name_to_tok.iter().find(|(n, _)| n == &name) {
+            Some((_, t)) => t.clone(),
+            None => {
+                let t = format!("{NER_NAME_TOKEN_PREFIX}{}\u{27eb}", name_to_tok.len() + 1); // ⟪NAME_n⟫
+                name_to_tok.push((name.clone(), t.clone()));
+                tok_to_name.push((t.clone(), name.clone()));
+                t
+            }
+        };
+        out.push_str(&tok);
+        cursor = s.end;
+    }
+    out.push_str(&text[cursor..]);
+    (out, tok_to_name)
+}
+
+/// Non-PII log helper: the COUNT of labels in the model's id2label (never the labels themselves, in
+/// case a future model carries person-ish label text). Keeps the "no PII in logs" rule.
+fn id2label_will_log(id2label: &Id2Label) -> usize {
+    id2label.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn id2label() -> Id2Label {
+        // A canonical CoNLL-style PER scheme: 0=O, 1=B-PER, 2=I-PER, 3=B-ORG, 4=I-ORG.
+        let mut m: HashMap<u32, String> = HashMap::new();
+        m.insert(0, "O".into());
+        m.insert(1, "B-PER".into());
+        m.insert(2, "I-PER".into());
+        m.insert(3, "B-ORG".into());
+        m.insert(4, "I-ORG".into());
+        m
+    }
+
+    /// Build (label_ids, offsets, special) for a sequence of (token_text, label_id) over a source
+    /// string, prepending a CLS and appending a SEP special token (offsets (0,0), special=1) like a
+    /// real DeBERTa encoding. Token offsets are located by scanning the source left-to-right.
+    fn fixture<'a>(
+        src: &'a str,
+        toks: &[(&str, u32)],
+    ) -> (Vec<u32>, Vec<(usize, usize)>, Vec<u32>) {
+        let mut labels = vec![0u32]; // CLS
+        let mut offsets = vec![(0usize, 0usize)];
+        let mut special = vec![1u32];
+        let mut search_from = 0usize;
+        for (tok, lab) in toks {
+            let rel = src[search_from..]
+                .find(tok)
+                .expect("token must occur in src");
+            let start = search_from + rel;
+            let end = start + tok.len();
+            labels.push(*lab);
+            offsets.push((start, end));
+            special.push(0);
+            search_from = end;
+        }
+        labels.push(0); // SEP
+        offsets.push((0, 0));
+        special.push(1);
+        (labels, offsets, special)
+    }
+
+    #[test]
+    fn decodes_single_person_span() {
+        let src = "Anna met Carol";
+        // "Anna" = B-PER (split into subwords An/na to exercise span extension), rest O.
+        let (labels, offsets, special) =
+            fixture(src, &[("Ann", 1), ("a", 2), ("met", 0), ("Carol", 1)]);
+        let spans = decode_person_spans(&labels, &offsets, &special, &id2label());
+        assert_eq!(spans.len(), 2, "two distinct PERSON spans");
+        let (out, pairs) = apply_person_spans(src, &spans);
+        assert!(!out.contains("Anna"));
+        assert!(!out.contains("Carol"));
+        assert!(out.contains("\u{27ea}NAME_1\u{27eb}"));
+        assert!(out.contains("\u{27ea}NAME_2\u{27eb}"));
+        assert_eq!(pairs.len(), 2);
+        // Round-trip: restoring the pairs yields the original.
+        let restored = restore(&out, &pairs);
+        assert_eq!(restored, src);
+    }
+
+    #[test]
+    fn distinct_name_maps_to_stable_token_when_repeated() {
+        let src = "Bob called Bob again";
+        let (labels, offsets, special) =
+            fixture(src, &[("Bob", 1), ("called", 0), ("Bob", 1), ("again", 0)]);
+        let spans = decode_person_spans(&labels, &offsets, &special, &id2label());
+        let (out, pairs) = apply_person_spans(src, &spans);
+        // The SAME name → the SAME token both times (stable-token contract).
+        assert_eq!(out.matches("\u{27ea}NAME_1\u{27eb}").count(), 2);
+        assert!(!out.contains("\u{27ea}NAME_2\u{27eb}"));
+        assert_eq!(pairs.len(), 1, "one DISTINCT name → one pair");
+        assert_eq!(restore(&out, &pairs), src);
+    }
+
+    #[test]
+    fn multiword_person_is_one_span() {
+        let src = "Anna Kowalska spoke";
+        // B-PER "Anna", I-PER "Kowalska" → one merged span "Anna Kowalska".
+        let (labels, offsets, special) =
+            fixture(src, &[("Anna", 1), ("Kowalska", 2), ("spoke", 0)]);
+        let spans = decode_person_spans(&labels, &offsets, &special, &id2label());
+        assert_eq!(spans.len(), 1);
+        let (out, pairs) = apply_person_spans(src, &spans);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].1, "Anna Kowalska");
+        assert!(out.starts_with("\u{27ea}NAME_1\u{27eb} spoke"));
+        assert_eq!(restore(&out, &pairs), src);
+    }
+
+    #[test]
+    fn non_person_entities_are_not_masked() {
+        let src = "Acme shipped Atlas";
+        // Both ORG/O — NO person → text unchanged, empty pairs (leaks nothing extra, masks nothing).
+        let (labels, offsets, special) =
+            fixture(src, &[("Acme", 3), ("shipped", 0), ("Atlas", 4)]);
+        let spans = decode_person_spans(&labels, &offsets, &special, &id2label());
+        assert!(spans.is_empty());
+        let (out, pairs) = apply_person_spans(src, &spans);
+        assert_eq!(out, src, "no PERSON → byte-identical text");
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn b_per_boundary_splits_adjacent_people() {
+        // Two people back-to-back, each B-PER → TWO spans, not one merged span.
+        let src = "Anna Bob";
+        let (labels, offsets, special) = fixture(src, &[("Anna", 1), ("Bob", 1)]);
+        let spans = decode_person_spans(&labels, &offsets, &special, &id2label());
+        assert_eq!(spans.len(), 2);
+        let (out, pairs) = apply_person_spans(src, &spans);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(restore(&out, &pairs), src);
+    }
+
+    /// Mirror of `restore_names` (private in redact.rs) for round-trip assertions here.
+    fn restore(text: &str, pairs: &[(String, String)]) -> String {
+        let mut s = text.to_string();
+        for (tok, name) in pairs {
+            s = s.replace(tok, name);
+        }
+        s
+    }
+}
+
+/// On-Mac smoke test — does a real multilingual DeBERTa NER actually LOAD via candle + mask a Polish
+/// PERSON name before egress? `#[ignore]`d (needs the model on disk + Metal), so it never runs in the
+/// normal `cargo test` loop. Run:
+///
+/// ```text
+/// cargo test --features local-ner summarize::ner_deberta::smoke -- --ignored --nocapture
+/// ```
+#[cfg(all(test, feature = "local-ner"))]
+mod smoke {
+    use super::DebertaNameRedactor;
+    use crate::summarize::redact::{ner_model_dir, NameRedactor};
+
+    #[test]
+    #[ignore = "needs the NER model on disk + Metal; run manually with --features local-ner"]
+    fn deberta_masks_polish_person() {
+        let dir = ner_model_dir().expect("ner_model_dir");
+        assert!(
+            dir.join("model.safetensors").is_file(),
+            "ner model not found at {dir:?}"
+        );
+        let r = DebertaNameRedactor::new(dir).expect("construct DebertaNameRedactor");
+        let text = "Anna Kowalska spotkała się z Bobem w piątek.";
+        let (scrubbed, pairs) = r.redact_names(text);
+        println!("scrubbed={scrubbed:?} pairs={pairs:?}");
+        assert!(!scrubbed.contains("Anna Kowalska"), "PERSON must be masked");
+        assert!(!pairs.is_empty(), "at least one name detected");
+        // Round-trip restores the original.
+        let mut restored = scrubbed.clone();
+        for (tok, name) in &pairs {
+            restored = restored.replace(tok, name);
+        }
+        assert!(restored.contains("Anna Kowalska"));
+    }
+}

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -6,6 +6,7 @@
 //! NER (not in this stack) and are therefore NOT redacted here — surfaced in the Settings copy.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
@@ -13,6 +14,159 @@ use regex::Regex;
 
 use crate::error::Result;
 use crate::summarize::provider::{Availability, SummarizeRequest, SummarizerProvider};
+
+// ── Phase D model plumbing (shared by the feature-gated redactor + the download command) ──────────
+// The real DebertaNameRedactor lives in the sibling `crate::summarize::ner_deberta` module (declared
+// in `summarize/mod.rs`, `#[cfg(feature = "local-ner")]`); this file holds only the model resolver,
+// the active-redactor factory, and the inbound-only downloader.
+
+/// The stable `⟪NAME_` token prefix the [`NameRedactor`] family emits (closed by the index + `⟫`).
+/// Centralized so the real redactor and the fixtures/tests agree byte-for-byte. The sole runtime
+/// consumer (`ner_deberta`) is feature-gated behind `local-ner`, so the default build sees it as
+/// "unused" outside of `#[cfg(test)]` — allow that rather than feature-gate the constant itself.
+#[allow(dead_code)]
+pub(crate) const NER_NAME_TOKEN_PREFIX: &str = "\u{27ea}NAME_";
+
+/// Sub-directory under the shared models dir holding the multilingual DeBERTa NER files
+/// (`model.safetensors` + `tokenizer.json` + `config.json`, the `config.json` carrying an `id2label`
+/// with `B-PER`/`I-PER`).
+pub const NER_MODEL_SUBDIR: &str = "ner-mdeberta-v3-multilingual";
+
+/// The three Hugging Face files the real NER redactor needs, fetched INBOUND-ONLY by
+/// [`download_ner_model`]. Each is downloaded into [`NER_MODEL_SUBDIR`].
+pub const NER_MODEL_FILES: &[&str] = &["model.safetensors", "tokenizer.json", "config.json"];
+
+/// Hugging Face `resolve/main` base for the chosen multilingual mDeBERTa-v3 token-classification NER.
+/// INBOUND ONLY — fetched, never sent meeting content.
+///
+/// MODEL CHOICE (documented): a multilingual mDeBERTa-v3 NER that ships `model.safetensors` +
+/// `tokenizer.json` + a `config.json` whose `id2label` uses CoNLL-style `B-PER`/`I-PER`. candle's
+/// `DebertaV2NERModel` is fully driven by that `id2label`, so the decode is model-agnostic; only this
+/// URL names the repo. Polish PERSON recall against this specific checkpoint is a @Mac eval (see the
+/// module header of `ner_deberta.rs`). Swap this base + re-download to evaluate an alternative
+/// loadable DeBERTa-v2 PER checkpoint with zero code change.
+pub const NER_MODEL_HF_BASE: &str =
+    "https://huggingface.co/Davlan/mdeberta-v3-base-ner-hrl/resolve/main";
+
+/// Resolve the on-disk dir the real NER redactor loads from: `<models_dir>/ner-mdeberta-v3-multilingual/`.
+/// Creating the models dir can fail (returns `Err`); the dir itself may not yet exist (that is fine —
+/// the caller checks [`ner_model_present`]). NEVER panics.
+pub fn ner_model_dir() -> Result<PathBuf> {
+    Ok(crate::transcribe::models_dir()?.join(NER_MODEL_SUBDIR))
+}
+
+/// `true` when all three NER model files exist in [`ner_model_dir`]. Pure existence probe; a
+/// models-dir resolution error is treated as "not present" (graceful — falls back to the no-op),
+/// never propagated as a hard error.
+pub fn ner_model_present() -> bool {
+    match ner_model_dir() {
+        Ok(dir) => NER_MODEL_FILES.iter().all(|f| dir.join(f).is_file()),
+        Err(_) => false,
+    }
+}
+
+/// The single active name-redactor used by [`RedactingProvider`] (mirrors
+/// [`crate::embed::active_embedder`]). Graceful degradation, in priority order:
+/// - the `local-ner` feature is ON **and** the NER model dir is present at [`ner_model_dir`]
+///   ([`ner_model_present`]) → the real [`ner_deberta::DebertaNameRedactor`] (lazy: the model loads on
+///   first `redact_names`, not here, so this never blocks startup and never panics);
+/// - otherwise (feature off, no model, or a construction error) → the dependency-free
+///   [`NoopNameRedactor`]. Egress is then byte-identical to before this seam existed (ZERO regression).
+///
+/// NEVER panics and NEVER blocks. A NER miss leaks no more than the no-op (the redactor only ever
+/// REMOVES content), so the worst case == today's behaviour.
+pub fn active_name_redactor() -> Arc<dyn NameRedactor> {
+    #[cfg(feature = "local-ner")]
+    {
+        if ner_model_present() {
+            match ner_model_dir().and_then(crate::summarize::ner_deberta::DebertaNameRedactor::new) {
+                Ok(r) => {
+                    tracing::info!(target: "ner", "local NER name-redactor ready (lazy load)");
+                    return Arc::new(r);
+                }
+                Err(e) => {
+                    tracing::warn!(target: "ner", error = %e, "local NER init failed; using no-op name redactor");
+                }
+            }
+        } else {
+            tracing::info!(target: "ner", "no local NER model present; using no-op name redactor");
+        }
+    }
+    Arc::new(NoopNameRedactor)
+}
+
+/// Download the three NER model files into [`ner_model_dir`], INBOUND-ONLY, with progress.
+///
+/// Mirrors [`crate::embed::download_embed_model`]: each file streams to `<file>.part` then renames
+/// atomically; `on_progress(file_index, downloaded, total)` fires as bytes arrive (`total` is `None`
+/// when the server omits `Content-Length`). A file already present on disk is SKIPPED. INBOUND ONLY:
+/// fetches model files and sends NO request body / NO meeting content (no egress). NO PII logged —
+/// filenames + byte counts only.
+pub async fn download_ner_model<F>(mut on_progress: F) -> Result<PathBuf>
+where
+    F: FnMut(usize, u64, Option<u64>),
+{
+    use crate::error::AppError;
+    use tokio::io::AsyncWriteExt;
+
+    let dir = ner_model_dir()?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AppError::Storage(format!("create ner model dir: {e}")))?;
+
+    for (idx, file) in NER_MODEL_FILES.iter().enumerate() {
+        let dest = dir.join(file);
+        if dest.is_file() {
+            continue;
+        }
+        let url = format!("{NER_MODEL_HF_BASE}/{file}");
+        tracing::info!(target: "ner", file = %file, "downloading ner model file");
+
+        let mut resp = reqwest::get(&url)
+            .await
+            .map_err(|e| AppError::Storage(format!("ner model download request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AppError::Storage(format!(
+                "ner model download HTTP {} for {file}",
+                resp.status()
+            )));
+        }
+        let total = resp.content_length();
+
+        let part = dest.with_extension("part");
+        let mut out = tokio::fs::File::create(&part)
+            .await
+            .map_err(|e| AppError::Storage(format!("create ner model temp file: {e}")))?;
+        let mut downloaded: u64 = 0;
+        while let Some(chunk) = resp
+            .chunk()
+            .await
+            .map_err(|e| AppError::Storage(format!("ner model download body failed: {e}")))?
+        {
+            out.write_all(&chunk)
+                .await
+                .map_err(|e| AppError::Storage(format!("write ner model chunk: {e}")))?;
+            downloaded += chunk.len() as u64;
+            on_progress(idx, downloaded, total);
+        }
+        out.flush()
+            .await
+            .map_err(|e| AppError::Storage(format!("flush ner model file: {e}")))?;
+        drop(out);
+
+        if downloaded == 0 {
+            let _ = tokio::fs::remove_file(&part).await;
+            return Err(AppError::Storage(format!(
+                "ner model download returned empty body for {file}"
+            )));
+        }
+        tokio::fs::rename(&part, &dest)
+            .await
+            .map_err(|e| AppError::Storage(format!("rename ner model file: {e}")))?;
+        tracing::info!(target: "ner", file = %file, bytes = downloaded, "ner model file ready");
+    }
+
+    Ok(dir)
+}
 
 fn email_re() -> &'static Regex {
     static R: OnceLock<Regex> = OnceLock::new();
@@ -390,6 +544,81 @@ mod tests {
         assert!(sent.contains("\u{27ea}NAME_1\u{27eb}"));
         // ...but the caller still gets the real names back.
         assert!(out.contains("Anna Kowalska") && out.contains("Bob Smith"));
+    }
+
+    // ── Phase D model plumbing + active factory ──────────────────────────────
+
+    #[test]
+    fn ner_model_dir_is_under_models_dir() {
+        let dir = ner_model_dir().unwrap();
+        assert!(dir.ends_with(NER_MODEL_SUBDIR));
+        assert_eq!(
+            NER_MODEL_FILES,
+            &["model.safetensors", "tokenizer.json", "config.json"]
+        );
+        assert!(NER_MODEL_HF_BASE.contains("mdeberta"));
+        // The token prefix the redactor emits matches the ⟪NAME_ tokens the tests assert on.
+        assert_eq!(NER_NAME_TOKEN_PREFIX, "\u{27ea}NAME_");
+    }
+
+    #[test]
+    fn ner_model_present_false_when_any_file_missing() {
+        // On a clean machine the NER dir is absent ⇒ not present.
+        let dir = ner_model_dir().unwrap();
+        if !dir.is_dir() {
+            assert!(!ner_model_present(), "absent NER dir must report not-present");
+        }
+    }
+
+    #[test]
+    fn active_name_redactor_falls_back_to_noop_without_model() {
+        // The graceful-degradation contract: with NO NER model present, `active_name_redactor`
+        // returns a redactor that leaves text byte-identical (the no-op). With `local-ner` OFF this
+        // is unconditional; with it ON it still holds whenever the model dir is absent.
+        if !ner_model_present() {
+            let r = active_name_redactor();
+            let text = "Anna Kowalska met Bob Smith on Friday.";
+            let (out, pairs) = r.redact_names(text);
+            assert_eq!(out, text, "no-op fallback must be byte-identical");
+            assert!(pairs.is_empty());
+        }
+    }
+
+    #[test]
+    fn default_make_provider_egress_byte_identical_with_active_redactor() {
+        // End-to-end through the PRODUCTION seam: `RedactingProvider::with_name_redactor(inner,
+        // active_name_redactor())` (what `make_provider` now wires). On a clean machine the active
+        // redactor is the no-op, so a names-only transcript reaches the inner provider verbatim —
+        // proving the wire change is zero-regression when no model is installed.
+        if !ner_model_present() {
+            let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+
+            struct CaptureProvider(std::sync::Arc<std::sync::Mutex<String>>);
+            #[async_trait]
+            impl SummarizerProvider for CaptureProvider {
+                fn id(&self) -> &str {
+                    "capture"
+                }
+                async fn availability(&self) -> Availability {
+                    Availability::Available
+                }
+                async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                    *self.0.lock().unwrap() = req.transcript.clone();
+                    Ok("done".to_string())
+                }
+                async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                    Ok(String::new())
+                }
+            }
+
+            let prov = RedactingProvider::with_name_redactor(
+                Arc::new(CaptureProvider(captured.clone())),
+                active_name_redactor(),
+            );
+            let transcript = "Anna Kowalska met Bob Smith on Friday to plan Atlas.";
+            block_on(prov.summarize(&sample_req(transcript))).unwrap();
+            assert_eq!(*captured.lock().unwrap(), transcript);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Scrubs PERSON names before cloud egress, replacing NoopNameRedactor (the one documented privacy gap). candle DebertaV2NERModel (multilingual PL+EN) behind a `local-ner` feature, **zero 2nd ORT** (reuses candle; gline-rs/ort would add one). **MASK-ONLY + fail-safe**: a NER miss leaks no more than the no-op. active_name_redactor factory (graceful Noop fallback) at the RedactingProvider firewall; download_ner_model inbound-only. Verified: default 330/0; feature build compiles+links (no 2nd ORT); clippy clean; adversarial PASS (mask-layer + egress-seam RED-before-GREEN); lock-security PASS (strictly reduces egress). Real NER/Polish/Metal = @Mac.