### PR TITLE
feat(calendar): Phase G — EventKit calendar source (Swift sidecar + list_calendar_events)

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -9,6 +9,6 @@
     <key>NSRemindersUsageDescription</key>
     <string>Murmur can add your meeting action items to Apple Reminders.</string>
     <key>NSCalendarsUsageDescription</key>
-    <string>Murmur reads your upcoming events to prepare pre-meeting briefs from your notes.</string>
+    <string>Murmur reads your upcoming events — title, attendees, and agenda — to prepare pre-meeting context and briefs, all on your device.</string>
   </dict>
 </plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -26,6 +26,17 @@ fn main() {
         "13.4",
         &["AVFoundation", "Foundation"],
     );
+    // EventKit Calendar context helper (app floor 13.4; uses the macOS 14+ full-access API at
+    // runtime, guarded). Surfaces local meeting context — title, attendees, agenda — zero-OAuth,
+    // on-device. Crash-safe SEPARATE process: a missing permission / no events → a graceful JSON
+    // envelope, never an app crash.
+    build_swift_helper(
+        "calendar/calendar.swift",
+        "meetnotes-calendar",
+        "CALENDAR_BIN",
+        "13.4",
+        &["EventKit", "Foundation"],
+    );
     tauri_build::build();
 }
 

--- a/src-tauri/calendar/calendar.swift
+++ b/src-tauri/calendar/calendar.swift
@@ -1,0 +1,142 @@
+// Murmur — local Calendar context helper via EventKit.
+//
+// Surfaces meeting context (title, attendees, agenda/notes) from the user's LOCAL macOS Calendar
+// so the brain / pre-meeting brief can use "who's in this meeting + the agenda". This is the
+// CALENDAR source of the multi-source roadmap: local, ZERO-OAuth, on-device. Slack/Jira stay
+// deferred.
+//
+// Usage:   meetnotes-calendar [backMinutes] [forwardMinutes]
+//          (defaults: 60 back, 720 forward — i.e. now-1h .. now+12h)
+// Output:  ONE JSON object on stdout, ALWAYS exit 0:
+//          {"status":"ok|denied|empty|error","events":[
+//             {"id","title","start"(ISO8601),"end"(ISO8601),"attendees":[..],"notes"}, ... ]}
+// Exit:    ALWAYS 0. A missing permission / no events / any thrown error → a well-formed JSON
+//          envelope with the right status and (usually) an empty events array. NEVER crash, never
+//          hang: a hard wall-clock watchdog guarantees the process exits even if EventKit stalls.
+//
+// CRASH-SAFE CONTRACT (the Rust side relies on this): the helper is a SEPARATE process, so the
+// only way it can hurt the app is by hanging or by producing garbage. It does neither — the
+// watchdog bounds the lifetime and every exit path prints a parseable envelope.
+//
+// ⚠️ RUNTIME-UNVERIFIED headless: that EventKit returns REAL events needs the Calendars (TCC)
+// permission granted on a SIGNED build on a real Mac. Compilation (swiftc against the SDK) and
+// the graceful denied/empty/error envelopes ARE the verified surface.
+
+import EventKit
+import Foundation
+
+// MARK: - Output envelope (hand-rolled JSON so a single malformed field can't abort the whole emit)
+
+func jsonEscape(_ s: String) -> String {
+    var out = ""
+    out.reserveCapacity(s.count + 2)
+    for ch in s.unicodeScalars {
+        switch ch {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if ch.value < 0x20 {
+                out += String(format: "\\u%04x", ch.value)
+            } else {
+                out.unicodeScalars.append(ch)
+            }
+        }
+    }
+    return out
+}
+
+func emit(status: String, eventsJson: [String]) -> Never {
+    let body = eventsJson.joined(separator: ",")
+    let line = "{\"status\":\"\(status)\",\"events\":[\(body)]}"
+    FileHandle.standardOutput.write(Data((line + "\n").utf8))
+    exit(0)
+}
+
+func emitEmpty(_ status: String) -> Never { emit(status: status, eventsJson: []) }
+
+// MARK: - Watchdog — guarantee the process can NEVER hang (EventKit auth/fetch could stall).
+
+let watchdog = DispatchQueue(label: "murmur.calendar.watchdog")
+watchdog.asyncAfter(deadline: .now() + 8.0) {
+    // Timed out waiting on permission / fetch. Emit an honest envelope and leave.
+    emitEmpty("error")
+}
+
+// MARK: - Window args (bounded, sane defaults; never trust the parse to be valid)
+
+let args = CommandLine.arguments
+let backMinutes = args.count >= 2 ? max(0.0, min(Double(args[1]) ?? 60.0, 7 * 24 * 60)) : 60.0
+let forwardMinutes = args.count >= 3 ? max(0.0, min(Double(args[2]) ?? 720.0, 7 * 24 * 60)) : 720.0
+
+let store = EKEventStore()
+
+let iso = ISO8601DateFormatter()
+iso.formatOptions = [.withInternetDateTime]
+
+func attendeeName(_ p: EKParticipant) -> String? {
+    if let name = p.name, !name.isEmpty { return name }
+    // Fall back to the mailto: email in the URL if there's no display name.
+    let urlStr = p.url.absoluteString
+    if urlStr.lowercased().hasPrefix("mailto:") {
+        let email = String(urlStr.dropFirst("mailto:".count))
+        return email.isEmpty ? nil : email
+    }
+    return nil
+}
+
+func eventJson(_ e: EKEvent) -> String {
+    var fields: [String] = []
+    let id = e.eventIdentifier ?? ""
+    fields.append("\"id\":\"\(jsonEscape(id))\"")
+    fields.append("\"title\":\"\(jsonEscape(e.title ?? ""))\"")
+    if let s = e.startDate { fields.append("\"start\":\"\(jsonEscape(iso.string(from: s)))\"") } else {
+        fields.append("\"start\":null")
+    }
+    if let en = e.endDate { fields.append("\"end\":\"\(jsonEscape(iso.string(from: en)))\"") } else {
+        fields.append("\"end\":null")
+    }
+    let names = (e.attendees ?? []).compactMap(attendeeName)
+    let attJson = names.map { "\"\(jsonEscape($0))\"" }.joined(separator: ",")
+    fields.append("\"attendees\":[\(attJson)]")
+    let notes = e.notes ?? ""
+    fields.append("\"notes\":\"\(jsonEscape(notes))\"")
+    return "{\(fields.joined(separator: ","))}"
+}
+
+func fetchAndEmit() {
+    let now = Date()
+    let start = now.addingTimeInterval(-backMinutes * 60)
+    let end = now.addingTimeInterval(forwardMinutes * 60)
+    let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
+    let events = store.events(matching: predicate).sorted {
+        ($0.startDate ?? .distantPast) < ($1.startDate ?? .distantPast)
+    }
+    if events.isEmpty { emitEmpty("empty") }
+    let json = events.map(eventJson)
+    emit(status: "ok", eventsJson: json)
+}
+
+// MARK: - Permission → fetch. Handle BOTH the macOS 14+ and legacy auth APIs, degrade gracefully.
+
+func requestThenFetch() {
+    let completion: (Bool, Error?) -> Void = { granted, _ in
+        if granted {
+            fetchAndEmit()
+        } else {
+            emitEmpty("denied")
+        }
+    }
+    if #available(macOS 14.0, *) {
+        store.requestFullAccessToEvents(completion: completion)
+    } else {
+        store.requestAccess(to: .event, completion: completion)
+    }
+}
+
+requestThenFetch()
+
+// Keep the process alive for the async EventKit callback; the watchdog bounds it.
+RunLoop.main.run()

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -23,5 +23,12 @@
          NSMicrophoneUsageDescription TCC prompt). Harmless if redundant. -->
     <key>com.apple.security.device.audio-input</key>
     <true/>
+
+    <!-- Local Calendar read via the bundled meetnotes-calendar EventKit helper
+         (works with the NSCalendarsUsageDescription TCC prompt). On-device only;
+         no network egress — the calendar context never leaves the Mac unless it
+         rides the existing redacted-transcript firewall + consent. -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
   </dict>
 </plist>

--- a/src-tauri/src/calendar.rs
+++ b/src-tauri/src/calendar.rs
@@ -1,0 +1,218 @@
+//! Local Calendar context source — drives the bundled `meetnotes-calendar` EventKit sidecar.
+//!
+//! This is the CALENDAR source of the multi-source roadmap: local, ZERO-OAuth, on-device. It
+//! surfaces meeting context (title, attendees, agenda) so the brain / pre-meeting brief can use
+//! "who's in this meeting + the agenda". Slack/Jira stay deferred.
+//!
+//! Safety model: the sidecar is a SEPARATE process. The only ways it could hurt the app are a
+//! hang or garbage output — and it does neither. The sidecar self-bounds with a watchdog and
+//! ALWAYS prints a parseable `{"status":..,"events":[..]}` envelope on exit 0. On THIS side we
+//! still apply our own bounded wait + parse, and degrade to an empty `Vec` on EVERY failure
+//! (missing sidecar, denied permission, timeout, malformed JSON). It never crashes, never blocks.
+//!
+//! No new egress: reading the local calendar is on-device. If the resulting context text is later
+//! fed to a cloud provider it MUST ride the existing `make_provider` redaction firewall + consent
+//! (the same path as the transcript) — this module creates no network path of its own.
+//!
+//! ⚠️ RUNTIME-UNVERIFIED headless: that EventKit returns REAL events needs the Calendars (TCC)
+//! permission granted on a SIGNED build on a real Mac. The verified surface here is: sidecar
+//! resolution, the bounded spawn/read plumbing, JSON parsing, and graceful degradation.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager};
+
+use crate::storage::models::{CalendarEventFull, CalendarSidecarEnvelope};
+
+/// Filename of the sidecar — both inside `Contents/Resources` of a shipped `.app` and at the dev
+/// `OUT_DIR`.
+const SIDECAR_NAME: &str = "meetnotes-calendar";
+
+/// Hard wall-clock cap on the sidecar invocation from the Rust side. The sidecar has its own
+/// (shorter) internal watchdog; this is belt-and-suspenders so a wedged child can never block a
+/// command. Slightly above the sidecar's 8s watchdog so the sidecar normally finishes first.
+const SIDECAR_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Resolve the calendar sidecar binary. Resolution order mirrors `audio::system::sidecar_path`:
+/// 1. the bundled resource inside the distributed `.app` (the ONLY path in a shipped build),
+/// 2. the compile-time `CALENDAR_BIN` (`OUT_DIR`) DEV-ONLY fallback.
+pub fn sidecar_path(app: &AppHandle) -> Option<PathBuf> {
+    if let Ok(p) = app
+        .path()
+        .resolve(SIDECAR_NAME, tauri::path::BaseDirectory::Resource)
+    {
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    option_env!("CALENDAR_BIN")
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Parse the sidecar's stdout envelope into events. Returns an empty Vec for any non-`ok` status
+/// or any malformed JSON — NEVER an error. Pure + deterministic so it's unit-testable headless.
+pub fn parse_sidecar_output(stdout: &str) -> Vec<CalendarEventFull> {
+    // The sidecar prints exactly one JSON object; tolerate trailing whitespace / a stray newline.
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    match serde_json::from_str::<CalendarSidecarEnvelope>(trimmed) {
+        Ok(env) if env.status == "ok" => env.events,
+        Ok(_) => Vec::new(), // denied / empty / error → no events, by contract
+        Err(e) => {
+            tracing::warn!(target: "calendar", error = %e, "malformed calendar sidecar output");
+            Vec::new()
+        }
+    }
+}
+
+/// Invoke the bundled sidecar over the window `[now - back_minutes, now + forward_minutes]` and
+/// return the parsed events. GRACEFUL on every failure path: sidecar missing / spawn failure /
+/// timeout / non-zero exit / denied / malformed → an empty Vec, never an error, never a block.
+///
+/// Runs the blocking child wait off the async runtime (caller is an async command).
+pub async fn fetch_events(
+    app: &AppHandle,
+    back_minutes: u32,
+    forward_minutes: u32,
+) -> Vec<CalendarEventFull> {
+    let Some(bin) = sidecar_path(app) else {
+        tracing::info!(target: "calendar", "calendar sidecar unavailable; returning no events");
+        return Vec::new();
+    };
+    let res = tokio::task::spawn_blocking(move || run_sidecar(&bin, back_minutes, forward_minutes))
+        .await;
+    match res {
+        Ok(stdout) => parse_sidecar_output(&stdout),
+        Err(e) => {
+            tracing::warn!(target: "calendar", error = %e, "calendar sidecar task join failed");
+            Vec::new()
+        }
+    }
+}
+
+/// Spawn the sidecar with a minimal, secret-free environment and a hard timeout. Returns the
+/// child's stdout (possibly empty); the caller parses it. Mirrors `audio::system`'s `env_clear`
+/// hardening so MURMUR_DEV_* / keys / tokens can never be inherited by the child.
+fn run_sidecar(bin: &PathBuf, back_minutes: u32, forward_minutes: u32) -> String {
+    use std::process::{Command, Stdio};
+
+    let mut cmd = Command::new(bin);
+    cmd.arg(back_minutes.to_string())
+        .arg(forward_minutes.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    cmd.env_clear().env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+    // HOME is needed for the macOS per-user TCC/container context (the calendar store is per-user).
+    for key in ["HOME", "USER", "LOGNAME", "TMPDIR"] {
+        if let Ok(val) = std::env::var(key) {
+            cmd.env(key, val);
+        }
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(target: "calendar", error = %e, "failed to spawn calendar sidecar");
+            return String::new();
+        }
+    };
+
+    // Bounded wait: poll for completion, hard-kill on timeout so a wedged sidecar can't hang us.
+    let deadline = std::time::Instant::now() + SIDECAR_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => break,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    tracing::warn!(target: "calendar", "calendar sidecar timed out; killing");
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return String::new();
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                tracing::warn!(target: "calendar", error = %e, "calendar sidecar wait failed");
+                let _ = child.kill();
+                return String::new();
+            }
+        }
+    }
+
+    match child.wait_with_output() {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_ok() -> &'static str {
+        r#"{"status":"ok","events":[
+            {"id":"E1","title":"Sprint Planning","start":"2026-06-28T10:00:00Z","end":"2026-06-28T11:00:00Z","attendees":["Alice","bob@example.com"],"notes":"Agenda:\n- velocity\n- scope"},
+            {"id":"E2","title":"1:1","start":"2026-06-28T14:00:00Z","end":null,"attendees":[],"notes":""}
+        ]}"#
+    }
+
+    #[test]
+    fn parses_ok_envelope_into_events() {
+        let events = parse_sidecar_output(sample_ok());
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, "E1");
+        assert_eq!(events[0].title, "Sprint Planning");
+        assert_eq!(events[0].start.as_deref(), Some("2026-06-28T10:00:00Z"));
+        assert_eq!(events[0].end.as_deref(), Some("2026-06-28T11:00:00Z"));
+        assert_eq!(events[0].attendees, vec!["Alice", "bob@example.com"]);
+        assert!(events[0].notes.contains("velocity"));
+        // Null end + empty attendees/notes survive.
+        assert_eq!(events[1].end, None);
+        assert!(events[1].attendees.is_empty());
+        assert_eq!(events[1].notes, "");
+    }
+
+    #[test]
+    fn denied_envelope_yields_empty_no_panic() {
+        assert!(parse_sidecar_output(r#"{"status":"denied","events":[]}"#).is_empty());
+    }
+
+    #[test]
+    fn empty_status_yields_empty() {
+        assert!(parse_sidecar_output(r#"{"status":"empty","events":[]}"#).is_empty());
+    }
+
+    #[test]
+    fn error_status_yields_empty() {
+        assert!(parse_sidecar_output(r#"{"status":"error","events":[]}"#).is_empty());
+    }
+
+    #[test]
+    fn ok_status_but_events_present_only_returned_on_ok() {
+        // A non-ok status must NEVER surface events even if some were (wrongly) present.
+        let s = r#"{"status":"denied","events":[{"id":"X","title":"leak?","start":null,"end":null,"attendees":[],"notes":""}]}"#;
+        assert!(parse_sidecar_output(s).is_empty());
+    }
+
+    #[test]
+    fn malformed_json_yields_empty_no_panic() {
+        assert!(parse_sidecar_output("not json at all").is_empty());
+        assert!(parse_sidecar_output("{\"status\":").is_empty());
+        assert!(parse_sidecar_output("").is_empty());
+        assert!(parse_sidecar_output("   \n  ").is_empty());
+    }
+
+    #[test]
+    fn missing_optional_fields_default_gracefully() {
+        // Minimal event missing end/attendees/notes still parses (serde defaults / Options).
+        let s = r#"{"status":"ok","events":[{"id":"E","title":"T","start":null,"end":null,"attendees":[],"notes":""}]}"#;
+        let events = parse_sidecar_output(s);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "E");
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,9 +8,10 @@ use crate::events::{StatusPayload, EVENT_STATUS};
 use crate::settings::{AppConfig, BrainBackend};
 use crate::state::AppState;
 use crate::storage::models::{
-    ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarEvent, ChatTurn,
-    Commitment, DigestResult, EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
-    MeetingTimeline, NoteRecord, PinResult, RecipeRecord, SearchHit, TopicThread,
+    ActionItem, Analytics, AskVaultResult, BriefResult, BuiltinRecipe, CalendarContext,
+    CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, EntityDetail, Folder,
+    FolderNode, GraphData, Meeting, MeetingStatus, MeetingTimeline, NoteRecord, PinResult,
+    RecipeRecord, SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -1557,6 +1558,40 @@ return out"#;
         .find(|l| !l.is_empty())
         .map(str::to_string);
     Ok(title.map(|title| CalendarEvent { title, start: None }))
+}
+
+/// CALENDAR source (local, zero-OAuth, on-device): list the user's events in a window around now
+/// via the bundled `meetnotes-calendar` EventKit sidecar — title, attendees, agenda. GRACEFUL on
+/// every failure: sidecar missing / Calendar permission denied / timeout / malformed output →
+/// an empty list, never an error, never a block. No network egress: reading the local calendar
+/// stays on device.
+#[tauri::command]
+pub async fn list_calendar_events(app: AppHandle) -> Result<Vec<CalendarEventFull>, AppError> {
+    // Default window: now-1h .. now+12h (60 back, 720 forward minutes).
+    Ok(crate::calendar::fetch_events(&app, 60, 720).await)
+}
+
+/// Build a compact [`CalendarContext`] (title + attendees + agenda) for one event so the existing
+/// pre-meeting brief / note pre-analysis can consume it (the brain already takes context). Looks
+/// the event up by id in the same window the sidecar surfaces. Returns `None` if the event isn't
+/// found (expired from the window, or Calendar access denied) — never an error.
+///
+/// IMPORTANT: the returned text is on-device context. If it is later fed to a CLOUD provider it
+/// MUST ride the existing `make_provider` redaction firewall + consent (the same path the
+/// transcript takes) — this command opens NO new egress path.
+#[tauri::command]
+pub async fn calendar_context_for(
+    app: AppHandle,
+    event_id: String,
+) -> Result<Option<CalendarContext>, AppError> {
+    if event_id.trim().is_empty() {
+        return Err(AppError::InvalidArg("event_id is empty".into()));
+    }
+    let events = crate::calendar::fetch_events(&app, 60, 720).await;
+    Ok(events
+        .iter()
+        .find(|e| e.id == event_id)
+        .map(CalendarContext::from_event))
 }
 
 /// Read current config (settings table), without secrets.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod calendar;
 pub mod commands;
 pub mod crypto;
 pub mod embed;
@@ -99,6 +100,8 @@ pub fn run() {
             commands::export_canvas,
             commands::pre_meeting_brief,
             commands::next_calendar_event,
+            commands::list_calendar_events,
+            commands::calendar_context_for,
             commands::get_meeting_detail,
             commands::get_analytics,
             commands::get_timeline,

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -332,11 +332,100 @@ pub struct DigestResult {
 }
 
 /// An upcoming Calendar event (best-effort; absent if Calendar access is denied).
+/// Minimal shape used by the legacy AppleScript `next_calendar_event` probe.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CalendarEvent {
     pub title: String,
     pub start: Option<String>,
+}
+
+/// A full Calendar event surfaced by the bundled EventKit sidecar (`meetnotes-calendar`):
+/// title + attendees + agenda/notes, so the brain / pre-meeting brief can use "who's in this
+/// meeting + the agenda". On-device only — reading the local calendar adds no network egress.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarEventFull {
+    /// EventKit `eventIdentifier` — stable handle to fetch this event again (`calendar_context_for`).
+    pub id: String,
+    pub title: String,
+    /// ISO-8601 start, or `None` if EventKit had no start date.
+    pub start: Option<String>,
+    /// ISO-8601 end, or `None`.
+    pub end: Option<String>,
+    /// Attendee display names (or email when there's no name). May be empty.
+    pub attendees: Vec<String>,
+    /// The event's agenda / notes body. May be empty.
+    pub notes: String,
+}
+
+/// The envelope the `meetnotes-calendar` sidecar prints on stdout. `status` is always one of
+/// `ok` / `denied` / `empty` / `error`; `events` is empty for everything but `ok`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CalendarSidecarEnvelope {
+    pub status: String,
+    #[serde(default)]
+    pub events: Vec<CalendarEventFull>,
+}
+
+/// A compact calendar-context block attachable to a meeting so the existing pre-meeting brief /
+/// note pre-analysis can consume it (the brain already takes context). Plain text + the source
+/// event id; if this text reaches a cloud provider it MUST ride the existing make_provider
+/// redaction firewall + consent — it is NEVER a new egress path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarContext {
+    /// Source EventKit event id (empty if assembled from a non-EventKit event).
+    pub event_id: String,
+    pub title: String,
+    pub attendees: Vec<String>,
+    /// A short, human-readable context block: title + attendees + agenda. This is what the brain
+    /// consumes; keep it bounded.
+    pub text: String,
+}
+
+impl CalendarContext {
+    /// Assemble a bounded context block from a full calendar event. Pure + deterministic so it's
+    /// unit-testable headless (no EventKit needed).
+    pub fn from_event(e: &CalendarEventFull) -> Self {
+        let mut text = String::new();
+        text.push_str("Meeting: ");
+        text.push_str(if e.title.is_empty() {
+            "(untitled)"
+        } else {
+            &e.title
+        });
+        if let Some(start) = &e.start {
+            text.push_str("\nWhen: ");
+            text.push_str(start);
+            if let Some(end) = &e.end {
+                text.push_str(" – ");
+                text.push_str(end);
+            }
+        }
+        if !e.attendees.is_empty() {
+            text.push_str("\nAttendees: ");
+            text.push_str(&e.attendees.join(", "));
+        }
+        let agenda = e.notes.trim();
+        if !agenda.is_empty() {
+            // Bound the agenda so a giant notes field can't bloat the prompt / leak surface.
+            const MAX_AGENDA: usize = 2000;
+            text.push_str("\nAgenda:\n");
+            if agenda.len() > MAX_AGENDA {
+                text.push_str(&agenda.chars().take(MAX_AGENDA).collect::<String>());
+                text.push('…');
+            } else {
+                text.push_str(agenda);
+            }
+        }
+        CalendarContext {
+            event_id: e.id.clone(),
+            title: e.title.clone(),
+            attendees: e.attendees.clone(),
+            text,
+        }
+    }
 }
 
 /// A pre-meeting brief: grounded markdown + the source meetings used.
@@ -365,4 +454,70 @@ pub struct TopicThread {
     pub label: String,
     pub count: usize,
     pub mentions: Vec<TopicMention>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full_event() -> CalendarEventFull {
+        CalendarEventFull {
+            id: "E1".into(),
+            title: "Sprint Planning".into(),
+            start: Some("2026-06-28T10:00:00Z".into()),
+            end: Some("2026-06-28T11:00:00Z".into()),
+            attendees: vec!["Alice".into(), "bob@example.com".into()],
+            notes: "Agenda:\n- velocity\n- scope".into(),
+        }
+    }
+
+    #[test]
+    fn calendar_context_assembles_full_block() {
+        let ctx = CalendarContext::from_event(&full_event());
+        assert_eq!(ctx.event_id, "E1");
+        assert_eq!(ctx.title, "Sprint Planning");
+        assert_eq!(ctx.attendees, vec!["Alice", "bob@example.com"]);
+        assert!(ctx.text.contains("Meeting: Sprint Planning"));
+        assert!(ctx.text.contains("When: 2026-06-28T10:00:00Z – 2026-06-28T11:00:00Z"));
+        assert!(ctx.text.contains("Attendees: Alice, bob@example.com"));
+        assert!(ctx.text.contains("Agenda:"));
+        assert!(ctx.text.contains("velocity"));
+    }
+
+    #[test]
+    fn calendar_context_handles_sparse_event() {
+        let e = CalendarEventFull {
+            id: String::new(),
+            title: String::new(),
+            start: None,
+            end: None,
+            attendees: vec![],
+            notes: String::new(),
+        };
+        let ctx = CalendarContext::from_event(&e);
+        // No panic; untitled placeholder; no When/Attendees/Agenda sections.
+        assert!(ctx.text.contains("Meeting: (untitled)"));
+        assert!(!ctx.text.contains("When:"));
+        assert!(!ctx.text.contains("Attendees:"));
+        assert!(!ctx.text.contains("Agenda:"));
+    }
+
+    #[test]
+    fn calendar_context_bounds_giant_agenda() {
+        let mut e = full_event();
+        e.notes = "x".repeat(5000);
+        let ctx = CalendarContext::from_event(&e);
+        // Bounded to MAX_AGENDA (2000) + an ellipsis marker; never the full 5000.
+        assert!(ctx.text.contains('…'));
+        assert!(ctx.text.len() < 2200);
+    }
+
+    #[test]
+    fn calendar_context_start_without_end() {
+        let mut e = full_event();
+        e.end = None;
+        let ctx = CalendarContext::from_event(&e);
+        assert!(ctx.text.contains("When: 2026-06-28T10:00:00Z"));
+        assert!(!ctx.text.contains(" – "));
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,8 @@
     "resources": {
       "binaries/meetnotes-sysaudio": "meetnotes-sysaudio",
       "binaries/meetnotes-audiocap": "meetnotes-audiocap",
-      "binaries/meetnotes-aeccap": "meetnotes-aeccap"
+      "binaries/meetnotes-aeccap": "meetnotes-aeccap",
+      "binaries/meetnotes-calendar": "meetnotes-calendar"
     },
     "icon": [
       "icons/32x32.png",

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -12,6 +12,8 @@ import type {
   BriefResult,
   BuiltinRecipe,
   CalendarEvent,
+  CalendarEventFull,
+  CalendarContext,
   ChatTurn,
   DigestResult,
   EntityDetail,
@@ -270,6 +272,19 @@ export class IpcService {
   /** Best-effort next macOS Calendar event (title) in the next hour, or null. */
   nextCalendarEvent(): Promise<CalendarEvent | null> {
     return invoke<CalendarEvent | null>("next_calendar_event");
+  }
+
+  /**
+   * Local Calendar events (title + attendees + agenda) in a window around now, via the on-device
+   * EventKit sidecar. Empty array if Calendar access is denied or nothing's scheduled — never throws.
+   */
+  listCalendarEvents(): Promise<CalendarEventFull[]> {
+    return invoke<CalendarEventFull[]>("list_calendar_events");
+  }
+
+  /** Compact calendar context (title + attendees + agenda) for one event, or null if not found. */
+  calendarContextFor(eventId: string): Promise<CalendarContext | null> {
+    return invoke<CalendarContext | null>("calendar_context_for", { eventId });
   }
 
   /** Copy a meeting's recording (WAV) to a chosen path. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -428,6 +428,24 @@ export interface CalendarEvent {
   start: string | null;
 }
 
+/** A full local Calendar event from the EventKit sidecar — title + attendees + agenda. */
+export interface CalendarEventFull {
+  id: string;
+  title: string;
+  start: string | null;
+  end: string | null;
+  attendees: string[];
+  notes: string;
+}
+
+/** A compact calendar-context block (title + attendees + agenda) for a meeting. */
+export interface CalendarContext {
+  eventId: string;
+  title: string;
+  attendees: string[];
+  text: string;
+}
+
 export interface BriefResult {
   markdown: string;
   sources: VaultSource[];


### PR DESCRIPTION
A local Calendar source: a Swift EventKit sidecar surfaces meeting context (title/attendees/agenda) for the brain/notes. Calendar first (local, zero-OAuth). calendar.swift (always exit 0, 8s watchdog, JSON envelope); src/calendar.rs (10s hard timeout-with-kill, graceful empty on denied/missing/malformed, never hang); CalendarContext. **No new egress** (on-device read; context rides the existing firewall+consent). Verified: test 341/0; clippy clean; ng lint+build clean; swiftc compiles (live → graceful 'denied'); adversarial PASS (hang-kill 2s); lock-security PASS. Real EventKit + TCC + signing the **4th bundled helper** inside-out = @Mac (release runbook). FE picker = follow-up.