### PR TITLE
fix(transcribe): disable ggml-metal residency sets — fixes whisper abort on macOS 15+

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,23 @@ const SUMMON_SHORTCUT: &str = "CmdOrCtrl+Shift+R";
 
 /// Builds the tauri::Builder, manages AppState, registers commands + the floating bar, runs.
 pub fn run() {
+    // ── Whisper/ggml-metal residency-set abort guard (macOS 15+ / Apple-silicon) ──
+    // whisper.cpp 1.8.3's ggml-metal "residency sets" path (compiled only on macOS >= 15.0)
+    // asserts `[rsets->data count] == 0` when the Metal device is freed
+    // (ggml-metal-device.m `ggml_metal_rsets_free` → GGML_ASSERT). The teardown ordering on
+    // Apple-silicon frees the device while a buffer's residency set is still registered, so the
+    // assert fires and `ggml_abort` ABORTS the process at whisper's per-transcription Metal free.
+    // GGML_ASSERT (ggml.h:288) is NOT NDEBUG-gated, so this aborts in RELEASE too — it is not a
+    // debug-only crash. The upstream-sanctioned switch is the `GGML_METAL_NO_RESIDENCY` env var,
+    // read live inside `ggml_metal_device_init` (ggml-metal-device.m:768): when set, the device's
+    // residency-set collection is never created (`dev->rsets = nil`), so `ggml_metal_rsets_free`
+    // returns early and the assert can never fire. Residency sets are only a GPU-memory residency
+    // *hint* (keep buffers wired to avoid OS reclamation); disabling them does not change
+    // transcription output — it only forgoes a minor perf optimization. Set here at process entry,
+    // strictly before any ggml-Metal device can be initialized. SAFETY: single-threaded at
+    // startup, before any thread that could read the env. (Mirror guard in `Transcriber::load`.)
+    std::env::set_var("GGML_METAL_NO_RESIDENCY", "1");
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -86,6 +86,18 @@ impl Transcriber {
             AppError::Transcribe("whisper model path is not valid UTF-8".into())
         })?;
 
+        // Disable ggml-metal residency sets BEFORE the Metal device is created (read live in
+        // `ggml_metal_device_init`). On macOS 15+/Apple-silicon the residency-set teardown asserts
+        // `[rsets->data count] == 0` at device free (`ggml_metal_rsets_free`, GGML_ASSERT — NOT
+        // NDEBUG-gated, so it aborts in release too) and `ggml_abort`s the process at whisper's
+        // per-transcription Metal free. Setting `GGML_METAL_NO_RESIDENCY` makes ggml skip the
+        // residency-set collection entirely (`dev->rsets = nil`), bypassing the assert with no
+        // effect on transcription output (residency sets are a pure GPU-memory residency hint).
+        // Idempotent mirror of the process-entry guard in `lib::run` — also covers test/bench and
+        // any non-`run()` caller that loads a model. Set before `new_with_params` creates the
+        // WhisperContext (and thus the Metal device).
+        std::env::set_var("GGML_METAL_NO_RESIDENCY", "1");
+
         let ctx = WhisperContext::new_with_params(path_str, WhisperContextParameters::default())
             .map_err(|e| AppError::Transcribe(format!("failed to load whisper model: {e}")))?;
 


### PR DESCRIPTION
whisper.cpp/ggml-metal residency-set path (macOS 15+) aborts at device free: `GGML_ASSERT([rsets->data count]==0)` — a **release blocker** (assert NOT NDEBUG-gated). Fix: upstream-sanctioned `GGML_METAL_NO_RESIDENCY=1` at process entry + in Transcriber::load. Residency sets are only a GPU residency hint — disabling never changes transcription, bypasses every assert path. **Confirmed on M4 Max: real recording = 18 Metal frees, 0 ggml_abort** (RED: aborted on the 1st free). test 341/0; whisper-rs unchanged.