### PR TITLE
fix(voice): assistant card now shows — init store independently of card visibility

### DIFF
--- a/src/app/core/assistant.store.ts
+++ b/src/app/core/assistant.store.ts
@@ -50,10 +50,15 @@ export class AssistantStore {
 
   private unlistenWake: UnlistenFn | null = null;
   private unlistenResult: UnlistenFn | null = null;
+  /** Synchronous re-entrancy guard so two concurrent init() calls (e.g. the record
+   * screen + the card both initialising) can't double-subscribe before the first
+   * `await` resolves. */
+  private initializing = false;
 
-  /** Subscribe once to the wake + result streams. Idempotent. */
+  /** Subscribe once to the wake + result streams. Idempotent + concurrency-safe. */
   async init(): Promise<void> {
-    if (this.unlistenWake) return;
+    if (this.unlistenWake || this.initializing) return;
+    this.initializing = true;
     this.unlistenWake = await this.ipc.onWakeDetected((p) => this.onWake(p));
     this.unlistenResult = await this.ipc.onVoiceActionResult((p) =>
       this.onResult(p),

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -15,6 +15,7 @@ import type { Analytics, AppConfigDto } from "../../core/models";
 import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
 import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
 import { AssistantActionsComponent } from "./assistant-actions.component";
+import { AssistantStore } from "../../core/assistant.store";
 
 @Component({
   selector: "app-record",
@@ -969,6 +970,9 @@ import { AssistantActionsComponent } from "./assistant-actions.component";
 })
 export class RecordComponent implements OnInit {
   readonly store = inject(RecorderStore);
+  /** The in-meeting voice-assistant store. Injected + init()'d here (not only from the
+   * card) so it subscribes to the wake/result streams even before the card is shown. */
+  readonly assistant = inject(AssistantStore);
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -1009,7 +1013,11 @@ export class RecordComponent implements OnInit {
    */
   readonly showAssistant = computed(() => {
     const c = this.config();
-    return !!c && c.realtimeReactions === true && c.brainBackend !== "off";
+    const enabled = !!c && c.realtimeReactions === true && c.brainBackend !== "off";
+    // Also surface the card the instant an interaction lands — covers a stale config
+    // snapshot (realtime toggled on in Settings after this screen mounted). The store is
+    // init()'d in ngOnInit, so it subscribes even when the card was never shown.
+    return enabled || this.assistant.hasAny();
   });
 
   /**
@@ -1171,6 +1179,10 @@ export class RecordComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     await this.store.init();
+    // Subscribe the voice-assistant store to the wake/result streams now, regardless of
+    // whether the card is visible yet — otherwise events fired before the card renders
+    // (or while the config snapshot is stale) would be dropped.
+    void this.assistant.init();
     this.config.set(await this.ipc.getConfig());
     this.modelPresent.set(await this.ipc.modelPresent());
     // Stats are secondary — never let a failure here block the record screen.


### PR DESCRIPTION
The live assistant-actions card only subscribed via its own ngOnInit (runs only when rendered), and the card was gated on a STALE config snapshot → the store never subscribed → events dropped → no card. Fix: AssistantStore.init() is now called from record.component.ngOnInit (subscribes regardless of the card) + a sync re-entrancy guard; showAssistant() is true on `realtime || store.hasAny()`. **Confirmed live: the Voice assistant card now renders during recording.** ng lint + build clean.