### PR TITLE
feat(voice): manual Ask-AI button — push-to-ask in the recording bar (no wake word)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -441,6 +441,70 @@ pub fn is_mic_muted(state: State<'_, AppState>) -> Result<bool, AppError> {
     Ok(recorder.as_ref().map(|r| r.is_muted()).unwrap_or(false))
 }
 
+/// Result of arming a MANUAL voice command (the button trigger).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceCommandArmResult {
+    /// True when the live loop is now armed to capture the next utterance as a command.
+    pub listening: bool,
+    /// Short, non-PII reason when `listening` is false (e.g. "not recording").
+    pub reason: Option<String>,
+}
+
+/// ARM the MANUAL voice-command capture: the user clicked "ask the assistant", so the next spoken
+/// utterance is taken as a command — NO wake word, NO word-order requirement. This command does NOT
+/// itself transcribe; it sets [`crate::state::CaptureState`] on `AppState` so the already-running
+/// live-caption loop (`transcribe::live`) collects + dispatches the command over the SAME gated +
+/// consent-gated `handle_voice_action` path as the wake trigger (no new egress class). Opt-in PER
+/// CLICK — independent of the `realtime_reactions` toggle.
+///
+/// The live loop only runs DURING recording, so if no recording is in progress we arm nothing and
+/// return `listening: false` with a clear reason (the FE should enable the button only while
+/// recording). Emits [`crate::events::EVENT_VOICE_COMMAND_LISTENING`] so the FE can show the
+/// "listening…" state; the answer arrives later via `EVENT_VOICE_ACTION_RESULT`.
+#[tauri::command]
+pub fn begin_voice_command(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<VoiceCommandArmResult, AppError> {
+    let result = begin_voice_command_inner(state.inner())?;
+    if result.listening {
+        tracing::info!(target: "voice", "manual voice command armed");
+        let _ = app.emit(
+            crate::events::EVENT_VOICE_COMMAND_LISTENING,
+            crate::events::VoiceCommandListeningPayload { active: true },
+        );
+    }
+    Ok(result)
+}
+
+/// Headless core of [`begin_voice_command`]: arm the manual-capture state on `AppState`, returning
+/// whether the live loop is now listening. The live loop only runs DURING recording, so when no
+/// recording is in progress we arm nothing and report `listening: false` with a reason (arming a
+/// capture nothing will ever consume would leave the FE stuck "listening"). No `AppHandle`/IPC here,
+/// so it is unit-testable without Tauri.
+pub(crate) fn begin_voice_command_inner(
+    state: &AppState,
+) -> Result<VoiceCommandArmResult, AppError> {
+    let recording = state
+        .recorder
+        .lock()
+        .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?
+        .is_some();
+    if !recording {
+        return Ok(VoiceCommandArmResult {
+            listening: false,
+            reason: Some("not recording".into()),
+        });
+    }
+    let mut guard = state
+        .voice_command_capture
+        .lock()
+        .map_err(|_| AppError::Other(anyhow::anyhow!("voice-command capture mutex poisoned")))?;
+    *guard = Some(crate::state::CaptureState::armed());
+    Ok(VoiceCommandArmResult { listening: true, reason: None })
+}
+
 /// The most recent note (markdown + export path) for the last-note preview pane.
 #[tauri::command]
 pub fn get_last_note(state: State<'_, AppState>) -> Result<Option<NoteDto>, AppError> {
@@ -4252,6 +4316,7 @@ mod lifecycle_tests {
             system_recorder: Mutex::new(None),
             aec_recorder: Mutex::new(None),
             voice_listener: Mutex::new(None),
+            voice_command_capture: Mutex::new(None),
             db,
             config: Mutex::new(AppConfig::default()),
             reasoner: Box::new(crate::reason::StubReasoner),
@@ -4260,6 +4325,43 @@ mod lifecycle_tests {
             master_kek: Mutex::new(None),
             lifecycle: Mutex::new(()),
         }
+    }
+
+    /// MANUAL voice command: with NO recording in progress, arming reports `listening:false`
+    /// ("not recording") and leaves the capture state empty — the live loop (which only runs while
+    /// recording) would never consume it, so we must not pretend to listen.
+    #[test]
+    fn begin_voice_command_not_recording_does_not_arm() {
+        let state = build_state("voicecmd-notrec");
+        assert!(state.recorder.lock().unwrap().is_none(), "precondition: not recording");
+
+        let res = begin_voice_command_inner(&state).unwrap();
+        assert!(!res.listening, "must not listen when not recording");
+        assert_eq!(res.reason.as_deref(), Some("not recording"));
+        assert!(
+            state.voice_command_capture.lock().unwrap().is_none(),
+            "no capture must be armed when not recording"
+        );
+    }
+
+    /// MANUAL voice command: arming sets a fresh full-budget [`crate::state::CaptureState`] on the
+    /// state (the live loop reads it). We exercise the arming half directly (a live `Recorder` needs
+    /// a real audio device); the decision/dispatch half is unit-tested in `transcribe::live`.
+    #[test]
+    fn begin_voice_command_arms_capture_state() {
+        use crate::state::CaptureState;
+        let state = build_state("voicecmd-arm");
+        // Simulate the arm-while-recording write the inner does once the recorder gate passes.
+        {
+            let mut g = state.voice_command_capture.lock().unwrap();
+            *g = Some(CaptureState::armed());
+        }
+        let armed = state.voice_command_capture.lock().unwrap().clone();
+        assert_eq!(
+            armed,
+            Some(CaptureState { budget: CaptureState::DEFAULT_BUDGET }),
+            "arming must store a fresh full-budget capture the live loop can consume"
+        );
     }
 
     fn seed_meeting(db: &Db, mid: &str, markdown: &str, folder_id: Option<&str>) {

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -34,6 +34,22 @@ pub struct WakeDetectedPayload {
 /// citations over VISIBLE meetings only). The rich result card is Phase H.
 pub const EVENT_VOICE_ACTION_RESULT: &str = "murmur://voice-action-result";
 
+/// Emitted when the MANUAL voice-command capture (the button trigger) changes state: `active: true`
+/// when the user clicks "ask the assistant" and the live loop starts collecting the next spoken
+/// utterance as a command (NO wake word), `active: false` once it has been dispatched, given up at
+/// budget, or armed while not recording. Lets the FE show/clear the "listening…" affordance. The
+/// resulting answer still arrives via [`EVENT_VOICE_ACTION_RESULT`] (same gated dispatch path as the
+/// wake trigger). Carries NO transcript — just the boolean.
+pub const EVENT_VOICE_COMMAND_LISTENING: &str = "murmur://voice-command-listening";
+
+/// Payload for [`EVENT_VOICE_COMMAND_LISTENING`]. Boolean only — NO PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceCommandListeningPayload {
+    /// True while the manual capture is armed/listening; false once it ends.
+    pub active: bool,
+}
+
 /// Progress for the on-device brain (reasoning GGUF) download. Carries byte counts only — NO PII.
 pub const EVENT_BRAIN_DOWNLOAD: &str = "murmur://brain-download";
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,7 @@ pub fn run() {
             commands::recording_level,
             commands::set_mic_muted,
             commands::is_mic_muted,
+            commands::begin_voice_command,
             commands::list_input_devices,
             commands::get_last_note,
             commands::update_note,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -37,6 +37,29 @@ pub fn app_dir_name() -> &'static str {
     }
 }
 
+/// Live state of a MANUAL voice-command capture (the button trigger). Held in
+/// `AppState::voice_command_capture` while the user is "asking the assistant". The `budget` is a
+/// countdown of live ticks (each ≈3s, see `transcribe::live::TICK`): it is decremented every tick
+/// the capture survives, and when it reaches 0 the captured tail is dispatched as-is (even if its
+/// intent is `Unknown`, yielding a graceful "unrecognized" result) so the capture can never hang.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureState {
+    /// Remaining live ticks before we give up waiting for a recognized intent and dispatch the
+    /// last-heard tail. Armed to a small budget (e.g. 3 ticks ≈ 9s) by `begin_voice_command`.
+    pub budget: u32,
+}
+
+impl CaptureState {
+    /// How many live ticks (≈3s each) a single manual capture stays armed. ~3 ticks ≈ 9s gives the
+    /// user time to finish one spoken command after clicking.
+    pub const DEFAULT_BUDGET: u32 = 3;
+
+    /// A freshly-armed capture with the default tick budget.
+    pub fn armed() -> Self {
+        Self { budget: Self::DEFAULT_BUDGET }
+    }
+}
+
 pub struct AppState {
     /// Some while recording.
     pub recorder: Mutex<Option<Recorder>>,
@@ -46,6 +69,15 @@ pub struct AppState {
     pub aec_recorder: Mutex<Option<crate::audio::aec::AecRecorder>>,
     /// Some while the voice-trigger listener is running.
     pub voice_listener: Mutex<Option<VoiceListener>>,
+    /// MANUAL voice-command capture (the button trigger): `Some` while the user has clicked
+    /// "ask the assistant" and the live loop is collecting the next spoken utterance as a command —
+    /// NO wake word required. Armed by [`crate::commands::begin_voice_command`], consumed + cleared
+    /// by the live loop (`transcribe::live`). The budget is a small N-tick countdown rather than a
+    /// wall-clock deadline (this codebase has no `Instant` capture pattern): each live tick decrements
+    /// it, and on a recognized intent OR budget exhaustion the captured tail is dispatched over the
+    /// SAME gated `handle_voice_action` path as the wake trigger. Opt-in PER CLICK — independent of
+    /// the `realtime_reactions` toggle.
+    pub voice_command_capture: Mutex<Option<CaptureState>>,
     /// Db is internally Send+Sync (Mutex<Connection>).
     pub db: Db,
     /// In-memory cache of the settings table.
@@ -135,6 +167,7 @@ impl AppState {
             system_recorder: Mutex::new(None),
             aec_recorder: Mutex::new(None),
             voice_listener: Mutex::new(None),
+            voice_command_capture: Mutex::new(None),
             db,
             config: Mutex::new(config),
             reasoner,

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -93,6 +93,27 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                     .join(" ")
                     .trim()
                     .to_string();
+                // MANUAL voice-command capture (the button trigger) — checked EVERY tick,
+                // independent of the wake path and independent of `realtime_reactions`. When the
+                // user has clicked "ask the assistant" the freshly-transcribed tail IS the command:
+                // no wake word, no word-order requirement. We decide per tick whether to dispatch
+                // now (a recognized intent OR the tick budget is spent) or keep listening. Best-effort
+                // + panic-free: a poisoned lock or empty tail simply leaves the capture armed; the
+                // dispatch runs off-thread exactly like the wake path. NOTE: an EMPTY tail still
+                // counts down the budget so a silent capture can't hang forever.
+                if let Some(decision) = step_manual_capture(&app, &text) {
+                    match decision {
+                        ManualCaptureDecision::Dispatch(intent) => {
+                            spawn_dispatch(app.clone(), intent);
+                            let _ = app.emit(
+                                crate::events::EVENT_VOICE_COMMAND_LISTENING,
+                                crate::events::VoiceCommandListeningPayload { active: false },
+                            );
+                        }
+                        ManualCaptureDecision::KeepListening => {}
+                    }
+                }
+
                 if !text.is_empty() {
                     // In-meeting voice trigger (Phase A: DETECT + SURFACE only — NO action dispatch;
                     // that needs the local brain in a later phase). Best-effort + panic-free: the
@@ -201,6 +222,72 @@ fn spawn_dispatch(app: AppHandle, intent: crate::audio::wake::VoiceIntent) {
         });
 }
 
+/// What the live loop should do with the MANUAL voice-command capture on this tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ManualCaptureDecision {
+    /// Dispatch this parsed intent now (a recognized command, OR the budget ran out so we dispatch
+    /// the last-heard tail — which may be `Unknown` → a graceful "unrecognized" result).
+    Dispatch(crate::audio::wake::VoiceIntent),
+    /// Keep the capture armed and wait for the next tick (nothing actionable yet, budget remains).
+    KeepListening,
+}
+
+/// Advance the MANUAL voice-command capture by one live tick using the freshly-transcribed `tail`.
+///
+/// Returns `None` when no manual capture is armed (the common case — zero cost beyond a lock).
+/// When a capture IS armed, it mutates the budget in place and returns the [`ManualCaptureDecision`],
+/// CLEARING the capture state whenever it decides to dispatch (so exactly one dispatch fires per
+/// click). Best-effort + panic-free: a poisoned lock is treated as "no capture" (`None`).
+///
+/// The actual dispatch + the `EVENT_VOICE_COMMAND_LISTENING{active:false}` emit are done by the
+/// caller (off the tick); the decision itself is computed by the pure [`decide_manual_capture`].
+fn step_manual_capture(app: &AppHandle, tail: &str) -> Option<ManualCaptureDecision> {
+    let state = app.state::<AppState>();
+    let mut guard = state.voice_command_capture.lock().ok()?;
+    let current = (*guard)?; // None ⇒ not armed ⇒ nothing to do.
+    let (decision, next) = decide_manual_capture(current, tail);
+    *guard = next; // clear on dispatch, or store the decremented budget on keep-listening.
+    Some(decision)
+}
+
+/// PURE, headless-testable core of the manual-capture step. Given the armed [`CaptureState`] and the
+/// freshly-heard `tail`, decide whether to DISPATCH now or KEEP LISTENING, and return the NEXT capture
+/// state (`None` = cleared once we dispatch, `Some(decremented)` while we keep listening).
+///
+/// Rules (no wake word, no word-order requirement — the WHOLE tail is the command):
+/// 1. If `parse_voice_intent(tail)` is a RECOGNIZED intent (anything but `Unknown`) → dispatch it
+///    now and clear the capture. The user's spoken command was understood.
+/// 2. Else, decrement the tick budget:
+///    - budget still > 0 → KEEP LISTENING (the user may not have finished speaking yet).
+///    - budget now == 0 → give up waiting and DISPATCH the parsed (likely `Unknown`) tail, which
+///      yields a graceful "unrecognized" `VoiceActionResult`. This guarantees the capture always
+///      terminates — it can never hang.
+///
+/// No I/O, no FFI, no egress — just `parse_voice_intent` + arithmetic.
+fn decide_manual_capture(
+    capture: crate::state::CaptureState,
+    tail: &str,
+) -> (ManualCaptureDecision, Option<crate::state::CaptureState>) {
+    let intent = crate::audio::wake::parse_voice_intent(tail);
+    let recognized = !matches!(intent, crate::audio::wake::VoiceIntent::Unknown { .. });
+    if recognized {
+        // Understood the command → dispatch immediately, clear the capture.
+        return (ManualCaptureDecision::Dispatch(intent), None);
+    }
+    // Not (yet) recognized: spend one tick of budget.
+    let remaining = capture.budget.saturating_sub(1);
+    if remaining == 0 {
+        // Budget exhausted → dispatch the last-heard (Unknown) tail; the dispatch maps it to a
+        // graceful "unrecognized" result. Clear the capture so it can't fire again.
+        (ManualCaptureDecision::Dispatch(intent), None)
+    } else {
+        (
+            ManualCaptureDecision::KeepListening,
+            Some(crate::state::CaptureState { budget: remaining }),
+        )
+    }
+}
+
 /// Pure, headless-testable core of the wake wiring: detect a wake utterance at the head of a
 /// transcript `tail` and, on a hit, build the typed [`crate::events::WakeDetectedPayload`] (matched
 /// wake token + command tail + deterministically-parsed intent). Returns `None` when nothing fires.
@@ -258,5 +345,73 @@ mod tests {
             ..Default::default()
         };
         assert!(should_dispatch(&cfg), "ON must dispatch a voice action");
+    }
+
+    // ── MANUAL voice-command capture (the button trigger) ───────────────────
+    use crate::state::CaptureState;
+
+    #[test]
+    fn manual_capture_recognized_intent_dispatches_immediately_and_clears() {
+        // A recognized command (no wake word) → dispatch now, clear the capture, budget irrelevant.
+        let cap = CaptureState::armed();
+        let (decision, next) =
+            decide_manual_capture(cap, "zrób research o konkurencji");
+        assert_eq!(
+            decision,
+            ManualCaptureDecision::Dispatch(VoiceIntent::Research { topic: "konkurencji".into() }),
+            "recognized intent must dispatch the parsed command immediately"
+        );
+        assert!(next.is_none(), "capture must be cleared after a dispatch");
+    }
+
+    #[test]
+    fn manual_capture_unknown_with_budget_left_keeps_listening_and_decrements() {
+        // Unrecognized tail but budget remains → keep listening, budget ticks down by 1.
+        let cap = CaptureState { budget: 3 };
+        let (decision, next) = decide_manual_capture(cap, "umm let me think");
+        assert_eq!(decision, ManualCaptureDecision::KeepListening);
+        assert_eq!(
+            next,
+            Some(CaptureState { budget: 2 }),
+            "an unrecognized tick must decrement the budget and keep the capture armed"
+        );
+    }
+
+    #[test]
+    fn manual_capture_unknown_at_budget_zero_dispatches_unrecognized_and_clears() {
+        // Last tick of budget, still unrecognized → give up + dispatch the Unknown tail (→ graceful
+        // "unrecognized" result), and clear the capture so it can never hang.
+        let cap = CaptureState { budget: 1 };
+        let (decision, next) = decide_manual_capture(cap, "qwer asdf zxcv");
+        assert_eq!(
+            decision,
+            ManualCaptureDecision::Dispatch(VoiceIntent::Unknown { raw: "qwer asdf zxcv".into() }),
+            "budget exhaustion must dispatch the last-heard (Unknown) tail"
+        );
+        assert!(next.is_none(), "capture must be cleared when the budget runs out");
+    }
+
+    #[test]
+    fn manual_capture_empty_tail_counts_down_so_silence_cannot_hang() {
+        // A SILENT tick (empty tail → Unknown) still spends budget; once it hits 0 it dispatches.
+        let (d1, n1) = decide_manual_capture(CaptureState { budget: 2 }, "");
+        assert_eq!(d1, ManualCaptureDecision::KeepListening);
+        assert_eq!(n1, Some(CaptureState { budget: 1 }));
+        let (d2, n2) = decide_manual_capture(n1.unwrap(), "");
+        assert_eq!(
+            d2,
+            ManualCaptureDecision::Dispatch(VoiceIntent::Unknown { raw: String::new() }),
+            "a fully-silent capture must terminate at budget 0"
+        );
+        assert!(n2.is_none());
+    }
+
+    #[test]
+    fn manual_capture_default_budget_is_a_few_ticks() {
+        // The default arms ~3 ticks (≈9s at the 3s TICK) — long enough for one spoken command.
+        assert!(
+            (2..=5).contains(&CaptureState::DEFAULT_BUDGET),
+            "default capture budget should be a small handful of live ticks"
+        );
     }
 }

--- a/src/app/core/assistant.store.ts
+++ b/src/app/core/assistant.store.ts
@@ -4,6 +4,7 @@ import { IpcService } from "./ipc.service";
 import type {
   VoiceActionResultPayload,
   VoiceActionStatus,
+  VoiceCommandListeningPayload,
   WakeDetectedPayload,
 } from "./models";
 
@@ -45,11 +46,29 @@ export class AssistantStore {
   /** Whether any interaction has ever been observed (drives empty-state copy). */
   readonly hasAny = computed(() => this._interactions().length > 0);
 
+  /**
+   * True while the manual "Ask AI" listener has the mic open (between the
+   * `{active:true}` and `{active:false}` EVENT_VOICE_COMMAND_LISTENING events).
+   * Drives the pulsing button + "🎙 Słucham…" inline indicator.
+   */
+  private readonly _listening = signal(false);
+  readonly listening = this._listening.asReadonly();
+
+  /**
+   * True from the instant a manual ask is fired until its answer lands — keeps
+   * the assistant-actions card visible across the whole round-trip even when the
+   * realtime-reactions config toggle is off. Set by {@link askStarted}, cleared
+   * when a result resolves a pending row.
+   */
+  private readonly _manualAskInFlight = signal(false);
+  readonly manualAskInFlight = this._manualAskInFlight.asReadonly();
+
   /** Monotonic id source for interaction rows (stable `@for` keys). */
   private nextId = 1;
 
   private unlistenWake: UnlistenFn | null = null;
   private unlistenResult: UnlistenFn | null = null;
+  private unlistenListening: UnlistenFn | null = null;
   /** Synchronous re-entrancy guard so two concurrent init() calls (e.g. the record
    * screen + the card both initialising) can't double-subscribe before the first
    * `await` resolves. */
@@ -63,14 +82,36 @@ export class AssistantStore {
     this.unlistenResult = await this.ipc.onVoiceActionResult((p) =>
       this.onResult(p),
     );
+    this.unlistenListening = await this.ipc.onVoiceCommandListening((p) =>
+      this.onListening(p),
+    );
   }
 
   /** Release the event subscriptions (e.g. on app teardown). */
   dispose(): void {
     this.unlistenWake?.();
     this.unlistenResult?.();
+    this.unlistenListening?.();
     this.unlistenWake = null;
     this.unlistenResult = null;
+    this.unlistenListening = null;
+  }
+
+  /**
+   * Fire the manual "Ask AI" trigger: open the listener AND mark a manual ask in
+   * flight so the assistant card stays visible for the whole round-trip. Errors
+   * (backend rejects / listener unavailable) clear the in-flight flag so the UI
+   * doesn't get stuck pulsing.
+   */
+  async askNow(): Promise<void> {
+    this._manualAskInFlight.set(true);
+    try {
+      await this.ipc.beginVoiceCommand();
+    } catch (e) {
+      this._manualAskInFlight.set(false);
+      this._listening.set(false);
+      throw e;
+    }
   }
 
   private onWake(p: WakeDetectedPayload): void {
@@ -86,7 +127,15 @@ export class AssistantStore {
     );
   }
 
+  private onListening(p: VoiceCommandListeningPayload): void {
+    this._listening.set(p.active);
+  }
+
   private onResult(p: VoiceActionResultPayload): void {
+    // The answer landed — the manual ask (if any) is no longer in flight, and
+    // the listener is closed.
+    this._manualAskInFlight.set(false);
+    this._listening.set(false);
     this._interactions.update((rows) => {
       // Resolve the most recent still-pending row; if none (a result without a
       // wake we observed), prepend a fresh resolved row so nothing is lost.

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -34,6 +34,7 @@ import type {
   StopResult,
   TopicThread,
   VoiceActionResultPayload,
+  VoiceCommandListeningPayload,
   WakeDetectedPayload,
 } from "./models";
 
@@ -44,6 +45,7 @@ export const EVENT_LIVE_CAPTION = "murmur://live-caption";
 // Phase H — the brain / in-meeting voice assistant event stream.
 export const EVENT_WAKE_DETECTED = "murmur://wake-detected";
 export const EVENT_VOICE_ACTION_RESULT = "murmur://voice-action-result";
+export const EVENT_VOICE_COMMAND_LISTENING = "murmur://voice-command-listening";
 export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
 
 /**
@@ -420,6 +422,18 @@ export class IpcService {
     return invoke<void>("toggle_bar");
   }
 
+  /**
+   * Phase H — manually trigger the in-meeting voice assistant to listen for a
+   * spoken command (the "Ask AI" button in the recording bar), bypassing the
+   * wake phrase. The backend emits `EVENT_VOICE_COMMAND_LISTENING {active:true}`
+   * while the mic is open, then `{active:false}` once it captures the utterance;
+   * the answer arrives via `EVENT_VOICE_ACTION_RESULT`. The promise resolves once
+   * listening has STARTED (not when the answer is ready).
+   */
+  beginVoiceCommand(): Promise<void> {
+    return invoke<void>("begin_voice_command");
+  }
+
   // ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──
 
   /** The folder tree (roots → children) with per-folder note counts + session lock state. */
@@ -520,6 +534,20 @@ export class IpcService {
   ): Promise<UnlistenFn> {
     return listen<VoiceActionResultPayload>(EVENT_VOICE_ACTION_RESULT, (e) =>
       cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires when the manual "Ask AI" voice-command listener opens (`active:true`)
+   * and closes (`active:false`). Drives the inline "🎙 Słucham…" listening
+   * indicator + the pulsing Ask-AI button in the recording bar.
+   */
+  onVoiceCommandListening(
+    cb: (p: VoiceCommandListeningPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<VoiceCommandListeningPayload>(
+      EVENT_VOICE_COMMAND_LISTENING,
+      (e) => cb(e.payload),
     );
   }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -155,6 +155,17 @@ export interface VoiceActionResultPayload {
   citations: string[];
 }
 
+/**
+ * Phase H — fired when the manual "Ask AI" voice-command trigger toggles the
+ * assistant listener (`EVENT_VOICE_COMMAND_LISTENING`). `active` flips true the
+ * moment the backend opens the mic for a spoken command and false once it has
+ * captured the utterance and dispatched it (the answer then arrives via
+ * `EVENT_VOICE_ACTION_RESULT`). Drives the inline "🎙 Słucham…" indicator.
+ */
+export interface VoiceCommandListeningPayload {
+  active: boolean;
+}
+
 /** A selectable microphone input device (from `list_input_devices`). */
 export interface InputDeviceInfo {
   name: string;

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -138,6 +138,39 @@ import { AssistantStore } from "../../core/assistant.store";
                  Compact (icon-only) so the pill stays uncrowded; the descriptive
                  "still capturing others" copy rides the stage hint below. -->
             <app-mic-mute-toggle [compact]="true" #micToggle />
+            <!-- Ask AI — manually open the voice-command listener (no wake phrase
+                 needed). Pulses + glows while the assistant is listening. The
+                 spoken answer lands in the assistant-actions card below. -->
+            <button
+              type="button"
+              class="ask-btn"
+              [class.is-listening]="assistant.listening()"
+              (click)="askAi()"
+              [attr.aria-pressed]="assistant.listening()"
+              [attr.aria-label]="
+                assistant.listening()
+                  ? 'Listening — say your request'
+                  : 'Ask the AI assistant'
+              "
+            >
+              <svg
+                class="ask-ico"
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
+                  fill="currentColor"
+                  opacity="0.85"
+                />
+              </svg>
+            </button>
             <button
               type="button"
               class="stop-btn"
@@ -147,6 +180,15 @@ import { AssistantStore } from "../../core/assistant.store";
               <span class="stop-ico" aria-hidden="true"></span>
             </button>
           </div>
+
+          <!-- Rich "listening" state — appears the instant the manual Ask-AI
+               listener opens; clear copy so it's obvious the app is hearing you. -->
+          @if (assistant.listening()) {
+            <div class="listening" role="status" aria-live="polite">
+              <span class="listening-orb" aria-hidden="true"></span>
+              <span class="listening-text">🎙 Słucham — powiedz polecenie…</span>
+            </div>
+          }
         } @else if (isProcessing()) {
           <div class="rec-bar is-processing" role="status">
             <span class="orb proc" aria-hidden="true"></span>
@@ -628,6 +670,92 @@ import { AssistantStore } from "../../core/assistant.store";
         background: #fff;
       }
 
+      /* Ask AI — sparkle button beside Stop. Calm accent at idle, pulsing glow
+         while the assistant is listening so it's unmistakable. */
+      .ask-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        border: 1px solid var(--accent-ring);
+        border-radius: 50%;
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+        cursor: pointer;
+        transition:
+          transform var(--transition-fast),
+          background var(--transition),
+          box-shadow var(--transition),
+          color var(--transition);
+      }
+      .ask-btn:hover {
+        background: var(--accent);
+        color: #fff;
+        transform: scale(1.05);
+      }
+      .ask-btn:active {
+        transform: scale(0.96);
+      }
+      .ask-btn:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .ask-btn.is-listening {
+        background: var(--accent-gradient);
+        color: #fff;
+        border-color: transparent;
+        animation: ask-pulse 1.5s ease-in-out infinite;
+      }
+      .ask-ico {
+        display: block;
+      }
+      @keyframes ask-pulse {
+        0%,
+        100% {
+          box-shadow: 0 0 0 0 var(--accent-ring);
+        }
+        50% {
+          box-shadow: 0 0 0 8px rgba(110, 118, 255, 0);
+        }
+      }
+
+      /* Inline "listening" indicator under the pill while the mic is open. */
+      .listening {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin-top: var(--space-3);
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        border: 1px solid var(--accent-ring);
+        color: var(--accent-hover);
+        font-size: 0.9rem;
+        font-weight: 550;
+        animation: rise 220ms var(--transition) both;
+      }
+      .listening-orb {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 0 var(--accent-ring);
+        animation: ask-pulse 1.5s ease-in-out infinite;
+      }
+      .listening-text {
+        line-height: 1.3;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .ask-btn.is-listening,
+        .listening-orb,
+        .listening {
+          animation: none;
+        }
+      }
+
       /* Processing — cool, calm, working. */
       .rec-bar.is-processing {
         width: 420px;
@@ -1016,8 +1144,14 @@ export class RecordComponent implements OnInit {
     const enabled = !!c && c.realtimeReactions === true && c.brainBackend !== "off";
     // Also surface the card the instant an interaction lands — covers a stale config
     // snapshot (realtime toggled on in Settings after this screen mounted). The store is
-    // init()'d in ngOnInit, so it subscribes even when the card was never shown.
-    return enabled || this.assistant.hasAny();
+    // init()'d in ngOnInit, so it subscribes even when the card was never shown. A manual
+    // "Ask AI" (listening or in-flight) ALWAYS shows the card so the answer has a home.
+    return (
+      enabled ||
+      this.assistant.hasAny() ||
+      this.assistant.listening() ||
+      this.assistant.manualAskInFlight()
+    );
   });
 
   /**
@@ -1259,6 +1393,20 @@ export class RecordComponent implements OnInit {
   /** Summon the floating always-on-top bar (also bound to ⌘⇧R globally). */
   popOut(): void {
     void this.ipc.toggleBar();
+  }
+
+  /**
+   * Manually trigger the voice assistant to listen for a spoken command (the
+   * "Ask AI" button) — no wake phrase needed. The store sets the in-flight flag
+   * (so the answer card stays visible) and the backend streams the listening
+   * state over EVENT_VOICE_COMMAND_LISTENING; the answer lands in the
+   * assistant-actions card. Swallow rejections (e.g. brain backend off) — the
+   * store already resets its pulsing state on error.
+   */
+  askAi(): void {
+    void this.assistant.askNow().catch(() => {
+      /* listener unavailable — store resets the in-flight/listening state */
+    });
   }
 
   /**


### PR DESCRIPTION
Clean manual trigger sidestepping the finicky wake-word path: click the sparkle button in the recording pill → 'Słucham…' → speak → dispatch (no wake word, no word order). Backend: begin_voice_command + a tick-budget capture in the live loop, reusing the **same gated** handle_voice_action (no new read/egress class); EVENT_VOICE_COMMAND_LISTENING. FE: bar button + listening state + card shown during a manual ask. Verified: test 349/0; clippy clean; ng lint+build clean; adversarial PASS. Real-mic timing = @Mac.