### PR TITLE
fix(voice): recall quality — literal-term retrieval + forced clip language + drop garbage

### DIFF
--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -60,6 +60,12 @@ fn is_stopword(t: &str) -> bool {
         "jako", "który", "ktory", "która", "ktora", "które", "ktore", "tutaj", "teraz", "wtedy",
         "bardzo", "trochę", "troche", "może", "moze", "żeby", "zeby", "przez", "przy", "pod", "nad",
         "tu", "to", "co", "na", "we", "do", "od", "po", "za", "ze", "oraz", "więc", "wiec",
+        // Polish question words + the "być" copula's inflected forms — high-frequency function words
+        // that over-constrain an exact-term FTS query for a spoken question ("jaka była pogoda" must
+        // key off "pogoda", not the auxiliary "jaka"/"była"). Diacritic-stripped forms too.
+        "jaka", "jaki", "jakie", "jacy", "jakas", "jakaś", "kto", "kogo", "kim", "gdzie", "kiedy",
+        "ile", "dlaczego", "czyj", "czyja", "był", "byl", "była", "byla", "było", "bylo", "były",
+        "byly", "byłem", "bylem", "byłam", "bylam", "jestem", "jesteś", "jestes", "będzie", "bedzie",
     ];
     STOP.contains(&t)
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -219,6 +219,9 @@ fn spawn_dispatch(app: AppHandle, intent: crate::audio::wake::VoiceIntent) {
                 .and_then(|m| m.map(|id| id.to_string()))
                 .unwrap_or_default();
 
+            // The wake parser does NOT translate — the intent's own topic/entity IS the user's
+            // literal words, so retrieval already keys off them. Pass them as the literal command.
+            let literal = literal_command_of(&intent);
             let result = crate::voice_action::handle_voice_action(
                 &intent,
                 &*state.reasoner,
@@ -226,6 +229,7 @@ fn spawn_dispatch(app: AppHandle, intent: crate::audio::wake::VoiceIntent) {
                 &unlocked,
                 &config,
                 &meeting_id,
+                &literal,
             );
             // PII rule: log only the coarse intent kind + status, never the summary/citations.
             tracing::info!(
@@ -266,6 +270,8 @@ fn spawn_command_dispatch(app: AppHandle, command: String) {
 
             // Keyword fast-path → BRAIN interpret (consent-gated, same reasoner) → keyword fallback.
             let intent = resolve_command_intent(&*state.reasoner, &command);
+            // RETRIEVAL keys off the user's LITERAL dictated `command` (their own language/words),
+            // NOT the brain-interpreted topic — so a Polish note matches a Polish question.
             let result = crate::voice_action::handle_voice_action(
                 &intent,
                 &*state.reasoner,
@@ -273,6 +279,7 @@ fn spawn_command_dispatch(app: AppHandle, command: String) {
                 &unlocked,
                 &config,
                 &meeting_id,
+                &command,
             )
             // Surface the user's OWN dictated command onto the result for the FE card.
             .with_command(&command);
@@ -323,10 +330,18 @@ fn step_manual_capture(
     // Read the armed capture (and release the lock before any transcription work).
     let current = { (*state.voice_command_capture.lock().ok()?)? };
 
+    // FORCE the command-clip language. A ~3s clip is far too short for Whisper to reliably
+    // auto-detect — it routinely mis-detects a short Polish command as Russian/Slovak, which then
+    // mangles the transcript. Resolve the forced language from `config.language` (the user's
+    // setting), which is the SAME language the meeting transcription uses this session. When it is
+    // unset/auto we keep `None` (whisper auto-detects) — the user can fix that in Settings ▸ Language.
+    let clip_lang = resolve_clip_lang(lang, &state);
+    let clip_lang_ref = clip_lang.as_deref();
+
     // Transcribe ONLY the post-click window when an offset was latched; otherwise fall back to the
     // rolling-tail caption the live loop already produced (degenerate arm path with no recorder).
     let command = match current.start_sample {
-        Some(offset) => transcribe_since(app, transcriber, lang, offset).unwrap_or_default(),
+        Some(offset) => transcribe_since(app, transcriber, clip_lang_ref, offset).unwrap_or_default(),
         None => caption.trim().to_string(),
     };
 
@@ -380,6 +395,91 @@ fn transcribe_since(
     }
 }
 
+/// Resolve the forced language for a manual-capture command clip from the live-loop `lang` (which is
+/// `config.language` at spawn time) and the CURRENT config (re-read from `state` in case the user
+/// changed it mid-recording). Side-effecting only in that it reads the config lock; the decision is
+/// the pure [`resolve_clip_lang_core`].
+fn resolve_clip_lang(loop_lang: Option<&str>, state: &AppState) -> Option<String> {
+    let cfg_lang = state
+        .config
+        .lock()
+        .ok()
+        .and_then(|c| c.language.clone());
+    resolve_clip_lang_core(loop_lang, cfg_lang.as_deref())
+}
+
+/// PURE, headless-testable core: pick the forced clip language. Prefer the freshest configured
+/// language (the user may have set/changed it after the recording started), else the loop's spawn-
+/// time language. A blank/whitespace value (`Some("")`) counts as UNSET → `None` (auto-detect). The
+/// returned `Some(lang)` is what gets passed to Whisper for the short clip so it does NOT free-
+/// auto-detect a 3s utterance into the wrong Slavic language.
+fn resolve_clip_lang_core(loop_lang: Option<&str>, config_lang: Option<&str>) -> Option<String> {
+    let norm = |s: Option<&str>| -> Option<String> {
+        s.map(str::trim)
+            .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("auto"))
+            .map(str::to_string)
+    };
+    norm(config_lang).or_else(|| norm(loop_lang))
+}
+
+/// Standalone filler/backchannel utterances Whisper emits for a near-silent / noise-only clip, in
+/// EN + PL. Normalized (lowercased, diacritics stripped, inner non-alphanumerics removed) before the
+/// lookup, so "Uh," / "Eee…" / "Yyy" all collapse onto a member. A command consisting ONLY of these
+/// (after splitting on whitespace) is NOT a real command.
+const FILLERS: &[&str] = &[
+    // English
+    "uh", "uhh", "uhm", "um", "umm", "er", "err", "erm", "hmm", "hm", "hmmm", "ah", "aha", "ahh",
+    "oh", "ohh", "eh", "ehh", "mm", "mmm", "mhm", "huh", "yeah", "ok", "okay",
+    // Polish fillers / backchannels
+    "eee", "ee", "yyy", "yy", "yhy", "ehe",
+];
+
+/// Whether a normalized token is a pure filler/backchannel (after stripping inner punctuation).
+fn is_filler_token(tok: &str) -> bool {
+    let t: String = tok
+        .to_lowercase()
+        .chars()
+        .map(|c| match c {
+            'ą' => 'a',
+            'ć' => 'c',
+            'ę' => 'e',
+            'ł' => 'l',
+            'ń' => 'n',
+            'ó' => 'o',
+            'ś' => 's',
+            'ź' | 'ż' => 'z',
+            other => other,
+        })
+        .filter(|c| c.is_alphanumeric())
+        .collect();
+    t.is_empty() || FILLERS.contains(&t.as_str())
+}
+
+/// Whether the heard `command` is a MEANINGFUL command worth dispatching, vs garbage/filler. PURE +
+/// headless-testable. A command is garbage when, after trimming, EITHER:
+/// - it has fewer than 2 tokens that are not pure filler, OR
+/// - its non-filler alphanumeric content is shorter than ~8 chars (a single short word like "Uh").
+///
+/// So "Uh," / "eee" / "." / "a" / "ok" → NOT meaningful (keep listening); but real commands like
+/// "zrób research o pogodzie" / "co wiemy o atlasie" → meaningful (dispatch). Conservative on the
+/// short side so we never DROP a real one-word command that carries enough signal (≥8 non-filler
+/// chars, e.g. "pogoda?" is 6 → borderline; we require it ride with a verb in practice — the manual
+/// path's whole utterance is the command, which is virtually always ≥2 words).
+fn is_meaningful_command(command: &str) -> bool {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    let non_filler: Vec<&str> = tokens.iter().copied().filter(|t| !is_filler_token(t)).collect();
+    // Count of meaningful (non-filler) tokens.
+    let meaningful_tokens = non_filler.len();
+    // Total non-filler alphanumeric chars (diacritic-insensitive count via char count of the kept
+    // alphanumerics — we don't need the normalized form, just the length signal).
+    let non_filler_chars: usize = non_filler
+        .iter()
+        .flat_map(|t| t.chars())
+        .filter(|c| c.is_alphanumeric())
+        .count();
+    meaningful_tokens >= 2 || non_filler_chars >= 8
+}
+
 /// PURE, headless-testable core of the manual-capture step. Given the armed [`CaptureState`] and the
 /// `command` heard SINCE the click (the post-click window's transcript), decide the outcome and the
 /// NEXT capture state (`None` = cleared on a terminal outcome, `Some(decremented)` while listening).
@@ -399,14 +499,18 @@ fn decide_manual_capture(
     command: &str,
 ) -> (ManualCaptureDecision, Option<crate::state::CaptureState>) {
     let command = command.trim();
-    if !command.is_empty() {
+    // GARBAGE FILTER: a too-short / pure-filler clip ("Uh,", "eee", "hmm", a lone char or
+    // punctuation) is NOT a real command — Whisper emits these for a ~3s silent/noise clip. Treat
+    // it exactly like a silent tick (KEEP LISTENING / NOTHING_HEARD at budget end) rather than
+    // dispatching a Research on "Uh,". The user gets a clean "nothing_heard", never a garbage card.
+    if !command.is_empty() && is_meaningful_command(command) {
         // Real speech heard since the click → dispatch it, clear the capture.
         return (
             ManualCaptureDecision::Dispatch { command: command.to_string() },
             None,
         );
     }
-    // Silence this tick: spend one tick of budget.
+    // Silence OR garbage/filler this tick: spend one tick of budget.
     let remaining = capture.budget.saturating_sub(1);
     if remaining == 0 {
         // Budget exhausted with nothing ever heard → graceful give-up, clear the capture.
@@ -441,6 +545,22 @@ fn resolve_command_intent(
     }
     // Brain unavailable / no mapping → Research over the literal command is a fine default.
     crate::audio::wake::VoiceIntent::Research { topic: command.trim().to_string() }
+}
+
+/// The user's LITERAL words carried by an intent, for use as the retrieval-side literal command on
+/// the WAKE path (where the deterministic parser already kept the user's own language — it never
+/// translates). For non-RAG intents this is the payload text; the Research/Recall topics ARE the
+/// literal command tail. Empty `String` for `Unknown` (nothing actionable).
+fn literal_command_of(intent: &crate::audio::wake::VoiceIntent) -> String {
+    use crate::audio::wake::VoiceIntent as VI;
+    match intent {
+        VI::Research { topic } => topic.clone(),
+        VI::Recall { entity } => entity.clone(),
+        VI::SlackSearch { query } => query.clone(),
+        VI::CreateReminder { text, .. } => text.clone(),
+        VI::NoteAside { text } => text.clone(),
+        VI::Unknown { .. } => String::new(),
+    }
 }
 
 /// Pure, headless-testable core of the wake wiring: detect a wake utterance at the head of a
@@ -624,5 +744,82 @@ mod tests {
             VoiceIntent::Research { topic: "find me the latest on widgets".into() },
             "a non-empty command with no brain must default to Research over the literal text"
         );
+    }
+
+    // ── FIX 3: GARBAGE / FILLER filter — "Uh," / "eee" / single char must NOT dispatch ───────────
+
+    #[test]
+    fn is_meaningful_command_rejects_filler_and_too_short() {
+        // Pure fillers / single short tokens / punctuation → NOT meaningful.
+        for junk in ["Uh,", "uh", "eee", "Hmm", "yyy", "aha", "ok", ".", ",", "a", "—", "  uh  ", "eh"] {
+            assert!(
+                !is_meaningful_command(junk),
+                "garbage/filler {junk:?} must NOT be a meaningful command"
+            );
+        }
+        // Real commands → meaningful.
+        for good in [
+            "zrób research o pogodzie",
+            "co wiemy o atlasie",
+            "jaka była pogoda",
+            "do research on pricing",
+            "przypomnij mi o spotkaniu",
+        ] {
+            assert!(is_meaningful_command(good), "real command {good:?} must be meaningful");
+        }
+    }
+
+    #[test]
+    fn decide_manual_capture_drops_garbage_keeps_listening_then_nothing_heard() {
+        // "Uh," is garbage → treat like a silent tick: KEEP LISTENING (budget −1), NOT a dispatch.
+        let (d1, n1) = decide_manual_capture(armed(2), "Uh,");
+        assert_eq!(d1, ManualCaptureDecision::KeepListening, "garbage must not dispatch");
+        assert_eq!(n1, Some(CaptureState { budget: 1, start_sample: Some(0) }));
+        // A second garbage tick exhausts the budget → NothingHeard (graceful), never a dispatch.
+        let (d2, n2) = decide_manual_capture(n1.unwrap(), "eee");
+        assert_eq!(
+            d2,
+            ManualCaptureDecision::NothingHeard,
+            "a fully-garbage capture ends as NothingHeard, never a garbage dispatch"
+        );
+        assert!(n2.is_none(), "capture cleared once it gives up");
+    }
+
+    #[test]
+    fn decide_manual_capture_dispatches_a_real_command() {
+        // A genuine command dispatches with the heard (trimmed) command verbatim.
+        let (d, n) = decide_manual_capture(armed(5), "  zrób research o pogodzie  ");
+        assert_eq!(
+            d,
+            ManualCaptureDecision::Dispatch { command: "zrób research o pogodzie".into() },
+            "a real command must dispatch"
+        );
+        assert!(n.is_none(), "capture cleared on dispatch");
+    }
+
+    // ── FIX 2: forced clip language threading (config.language reaches the clip) ──────────────────
+
+    #[test]
+    fn resolve_clip_lang_core_forces_configured_language() {
+        // A configured language is forced for the short command clip (the param that reaches
+        // `transcribe_since` → Whisper), so a 3s Polish clip is NOT free-auto-detected as Russian.
+        assert_eq!(
+            resolve_clip_lang_core(None, Some("pl")).as_deref(),
+            Some("pl"),
+            "config.language must force the clip language even when the loop lang was None"
+        );
+        // The freshest config language wins over the spawn-time loop language.
+        assert_eq!(
+            resolve_clip_lang_core(Some("en"), Some("pl")).as_deref(),
+            Some("pl"),
+            "the freshest configured language must win"
+        );
+        // Loop lang is used when config is unset.
+        assert_eq!(resolve_clip_lang_core(Some("de"), None).as_deref(), Some("de"));
+        // Blank / "auto" / both-unset → None (whisper auto-detects; user can set it in Settings).
+        assert_eq!(resolve_clip_lang_core(None, Some("")), None);
+        assert_eq!(resolve_clip_lang_core(None, Some("auto")), None);
+        assert_eq!(resolve_clip_lang_core(Some("  "), Some("  ")), None);
+        assert_eq!(resolve_clip_lang_core(None, None), None);
     }
 }

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -98,6 +98,12 @@ impl VoiceActionResult {
 ///
 /// `unlocked` is the LIVE session unlock set (so Research/Recall see exactly what the session can
 /// see); `meeting_id` is the in-progress recording (for `NoteAside`).
+///
+/// `literal_command` is the user's OWN dictated words (the raw heard command), used ONLY for
+/// Research/Recall RETRIEVAL so the vault FTS keys off the user's actual language (e.g. Polish
+/// "pogoda"), NOT a brain-translated/normalized topic that the exact-term FTS would miss. The brain
+/// topic is still used for SYNTHESIS + as an additional retrieval leg; the literal terms are the
+/// must-have. Empty/whitespace falls back to the intent topic alone.
 pub fn handle_voice_action(
     intent: &VoiceIntent,
     reasoner: &dyn LocalReasoner,
@@ -105,13 +111,14 @@ pub fn handle_voice_action(
     unlocked: &HashSet<String>,
     config: &AppConfig,
     meeting_id: &str,
+    literal_command: &str,
 ) -> VoiceActionResult {
     match intent {
         VoiceIntent::Research { topic } => {
-            rag_answer("research", topic, reasoner, db, unlocked, config)
+            rag_answer("research", topic, literal_command, reasoner, db, unlocked, config)
         }
         VoiceIntent::Recall { entity } => {
-            rag_answer("recall", entity, reasoner, db, unlocked, config)
+            rag_answer("recall", entity, literal_command, reasoner, db, unlocked, config)
         }
         VoiceIntent::CreateReminder { text, due } => {
             let text = text.trim();
@@ -211,31 +218,80 @@ pub fn interpret_with_brain(reasoner: &dyn LocalReasoner, command: &str) -> Opti
     }
 }
 
+/// Build the set of RETRIEVAL queries for a Research/Recall, must-have-first:
+///
+/// 1. The user's LITERAL salient terms (`salient_query` over their raw dictated command) — the
+///    cross-lingual fix: the vault FTS is EXACT-TERM, so a Polish note ("pogoda") only matches when
+///    we search the user's ACTUAL Polish words, NOT a brain-translated English topic
+///    ("yesterday's weather"). This is the must-have leg.
+/// 2. The brain/parser `topic` (which may be normalized/translated) — kept as an ADDITIONAL leg so a
+///    well-formed topic still helps, but never at the expense of the literal terms.
+///
+/// De-duped, first-seen order (literal terms first). Both legs feed the SAME gated
+/// `execute_tool`/`search_visible` — no new read path. An empty result is dropped.
+fn retrieval_queries(topic: &str, literal_command: &str) -> Vec<String> {
+    let mut queries: Vec<String> = Vec::new();
+    let mut push = |q: String| {
+        let q = q.trim().to_string();
+        if !q.is_empty() && !queries.contains(&q) {
+            queries.push(q);
+        }
+    };
+    // MUST-HAVE: the user's literal salient terms (their own language/words).
+    push(crate::summarize::related_context::salient_query(None, literal_command));
+    // ADDITIONAL: the brain/parser topic verbatim, and its salient terms.
+    push(topic.to_string());
+    push(crate::summarize::related_context::salient_query(None, topic));
+    queries
+}
+
 /// Local-first RAG over the user's OWN gated vault (NOT a web search): run the gated read tools for
 /// the topic/entity, feed ONLY the gated results to the brain, return a brief cited answer.
+///
+/// RETRIEVAL keys off the user's LITERAL terms first (see [`retrieval_queries`]) so same-language
+/// recall works (Polish query ↔ Polish note); the brain `topic` is still used for the answer
+/// SYNTHESIS prompt.
 fn rag_answer(
     intent_kind: &str,
-    query: &str,
+    topic: &str,
+    literal_command: &str,
     reasoner: &dyn LocalReasoner,
     db: &Db,
     unlocked: &HashSet<String>,
     config: &AppConfig,
 ) -> VoiceActionResult {
-    let query = query.trim();
-    if query.is_empty() {
+    let topic = topic.trim();
+    if topic.is_empty() && literal_command.trim().is_empty() {
         return VoiceActionResult::new(intent_kind, "error", "No topic to look up.");
     }
+    // The queries we RETRIEVE with — literal user terms first, brain topic added. The `topic` is
+    // still what we hand the brain for SYNTHESIS below.
+    let queries = retrieval_queries(topic, literal_command);
+    // A coherent display query for the "couldn't find" / "found notes about" lines: prefer the brain
+    // topic (human-readable), else the first literal query.
+    let display_query = if !topic.is_empty() {
+        topic.to_string()
+    } else {
+        queries.first().cloned().unwrap_or_default()
+    };
 
     // GATE: every tool below routes through visibility_clause over the live `unlocked` set.
     // SemanticSearch is itself gated behind `config.semantic_search_enabled` inside `execute_tool`
     // (it returns a "disabled" string when off, never an ungated read). For `recall` we also pull
-    // the entity dossier; for `research` we add open commitments for grounding.
-    let mut tool_calls: Vec<ToolCall> = vec![
-        ToolCall::SearchMeetings { query: query.to_string() },
-        ToolCall::SearchSemantic { query: query.to_string() },
-    ];
+    // the entity dossier; for `research` we add open commitments for grounding. Each retrieval query
+    // (literal terms + brain topic) gets its own gated FTS + semantic leg; the gated results are
+    // UNIONED into the grounding below.
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    for q in &queries {
+        tool_calls.push(ToolCall::SearchMeetings { query: q.clone() });
+        tool_calls.push(ToolCall::SearchSemantic { query: q.clone() });
+    }
     if intent_kind == "recall" {
-        tool_calls.push(ToolCall::GetEntityDossier { entity: query.to_string() });
+        // The dossier resolves an ENTITY by name — use the literal terms first (most likely the
+        // user's actual entity word), then the brain topic.
+        for q in &queries {
+            tool_calls.push(ToolCall::GetEntityDossier { entity: q.clone() });
+        }
     }
 
     let mut grounding = String::new();
@@ -270,17 +326,22 @@ fn rag_answer(
             citations.push(c);
         }
     };
-    match db.search_visible(query, 8, unlocked) {
-        Ok(hits) => {
-            for h in &hits {
-                if let Some(t) = h.meeting.title.as_deref().map(str::trim).filter(|t| !t.is_empty())
-                {
-                    push_cite(format!("[[{t}]]"));
+    // Cite over EVERY retrieval query (literal terms + brain topic) so a hit found via the user's
+    // literal Polish terms is still cited even when the brain topic missed.
+    for q in &queries {
+        match db.search_visible(q, 8, unlocked) {
+            Ok(hits) => {
+                for h in &hits {
+                    if let Some(t) =
+                        h.meeting.title.as_deref().map(str::trim).filter(|t| !t.is_empty())
+                    {
+                        push_cite(format!("[[{t}]]"));
+                    }
                 }
             }
-        }
-        Err(e) => {
-            tracing::debug!(target: "voice", error = %e, "voice-action citation search failed");
+            Err(e) => {
+                tracing::debug!(target: "voice", error = %e, "voice-action citation search failed");
+            }
         }
     }
     for c in extract_citations(grounding) {
@@ -292,7 +353,7 @@ fn rag_answer(
         return VoiceActionResult::new(
             intent_kind,
             "ok",
-            format!("I couldn't find anything in your vault about \"{query}\"."),
+            format!("I couldn't find anything in your vault about \"{display_query}\"."),
         );
     }
 
@@ -300,7 +361,7 @@ fn rag_answer(
                   sentences) using ONLY the provided notes from the user's own meeting vault. Cite \
                   the meetings you used by their [[Title]] wikilink. If the notes don't cover it, \
                   say so plainly. Do not invent facts.";
-    let user = format!("Request: {query}\n\nNotes from the vault:\n{grounding}");
+    let user = format!("Request: {display_query}\n\nNotes from the vault:\n{grounding}");
 
     // EGRESS SEAM: a Cloud reasoner routes through make_provider (consent gate + RedactingProvider).
     // A no-consent refusal comes back as AppError::Unavailable → graceful "needs consent", no leak.
@@ -308,7 +369,7 @@ fn rag_answer(
         Ok(answer) => {
             let answer = answer.trim();
             let summary = if answer.is_empty() {
-                format!("Found notes about \"{query}\" in your vault.")
+                format!("Found notes about \"{display_query}\" in your vault.")
             } else {
                 answer.to_string()
             };
@@ -583,6 +644,7 @@ mod tests {
             &empty_unlocked(),
             &cfg,
             "live-mtg",
+            "",
         );
 
         assert_eq!(res.intent_kind, "research");
@@ -620,6 +682,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live-mtg",
+            "",
         );
         assert_eq!(res.intent_kind, "recall");
         assert_eq!(res.status, "ok");
@@ -639,6 +702,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live-mtg",
+            "",
         );
         assert_eq!(res.status, "ok");
         assert!(res.summary.contains("couldn't find"));
@@ -669,6 +733,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live1",
+            "",
         );
         assert_eq!(res.intent_kind, "note_aside");
         assert_eq!(res.status, "ok");
@@ -690,6 +755,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "sealed1",
+            "",
         );
         assert_eq!(res.status, "error");
         assert!(db.list_note_asides("sealed1").unwrap().is_empty(), "no aside written to a sealed meeting");
@@ -706,6 +772,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live1",
+            "",
         );
         assert_eq!(res.intent_kind, "slack_search");
         assert_eq!(res.status, "unavailable");
@@ -722,6 +789,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live1",
+            "",
         );
         assert_eq!(res.status, "unrecognized");
         assert!(!res.summary.contains("secret-thing"), "raw command must not be echoed back");
@@ -740,6 +808,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live1",
+            "",
         );
         assert_eq!(res.status, "error");
         assert!(!res.summary.contains("boom internal detail"), "internal error detail must not leak");
@@ -759,6 +828,7 @@ mod tests {
             &empty_unlocked(),
             &AppConfig::default(),
             "live1",
+            "",
         );
         assert_eq!(res.status, "needs_consent");
         // Gated citations are still useful even when the brain can't run.
@@ -831,5 +901,111 @@ mod tests {
         let text = "- A ([id:1]) — x [[One]]\n- B — y [[Two]]\nagain [[One]]";
         let cites = extract_citations(text);
         assert_eq!(cites, vec!["[[One]]".to_string(), "[[Two]]".to_string()]);
+    }
+
+    // ── FIX 1: cross-lingual RETRIEVAL uses the user's LITERAL terms, not the brain topic ─────────
+
+    #[test]
+    fn retrieval_queries_uses_literal_terms_first() {
+        // The user's literal Polish words drive retrieval; the salient term "pogoda" survives (the
+        // stopword "jaka"/"byla" are dropped). The brain-translated English topic is an ADDITIONAL
+        // leg, never a replacement.
+        let qs = retrieval_queries("yesterday's weather", "jaka była pogoda");
+        let joined = qs.join(" | ");
+        assert!(
+            qs.iter().any(|q| q.contains("pogoda")),
+            "literal Polish term 'pogoda' MUST be a retrieval query; got: {joined}"
+        );
+        // The literal-terms leg comes FIRST (must-have).
+        assert!(
+            qs[0].contains("pogoda"),
+            "the literal salient terms must be the FIRST retrieval query; got: {joined}"
+        );
+        // The brain topic is still present as an additional leg.
+        assert!(
+            qs.iter().any(|q| q.contains("weather")),
+            "the brain topic should still be an additional retrieval leg; got: {joined}"
+        );
+    }
+
+    /// THE BUG, end-to-end: a Polish note ("pogoda") seeded into the vault, a Research dispatched
+    /// with the brain's ENGLISH-translated topic ("yesterday's weather") but the user's LITERAL
+    /// Polish command "jaka była pogoda". With the literal-terms retrieval the note is FOUND; with
+    /// ONLY the translated topic (literal command empty) it MISSES — proving the fix is load-bearing.
+    #[test]
+    fn research_uses_literal_polish_terms_not_translation() {
+        let db = tmp_db();
+        // A Polish weather note — exact-term FTS only matches the Polish word "pogoda".
+        db.insert_meeting(&Meeting {
+            id: "pl1".into(),
+            started_at: "2026-06-27T09:00:00Z".into(),
+            ended_at: None,
+            title: Some("Notatka o pogodzie".into()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: "pl1".into(),
+            provider_id: "claude_code".into(),
+            markdown: "Dzisiaj pogoda była słoneczna i ciepła, bez deszczu.".into(),
+            created_at: "2026-06-27T09:05:00Z".into(),
+            exported_path: None,
+        })
+        .unwrap();
+
+        let reasoner = MockReasoner::new("Pogoda była słoneczna; zobacz [[Notatka o pogodzie]].");
+        let cfg = AppConfig::default();
+
+        // WITH the literal Polish command → the Polish note is FOUND, brain is called, cited.
+        let res = handle_voice_action(
+            &VoiceIntent::Research { topic: "yesterday's weather".into() },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &cfg,
+            "live-mtg",
+            "jaka była pogoda",
+        );
+        assert_eq!(res.status, "ok");
+        assert!(
+            res.citations.contains(&"[[Notatka o pogodzie]]".to_string()),
+            "the Polish note must be cited when retrieval uses the literal Polish terms"
+        );
+        let grounding = reasoner
+            .last_user
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("brain MUST be called — the Polish note was found via the literal terms");
+        assert!(
+            grounding.contains("pogoda"),
+            "the found Polish note must be in the brain grounding"
+        );
+
+        // CONTROL: the SAME English-translated topic with NO literal command misses the Polish note
+        // entirely (the exact-term FTS can't match "weather" against "pogoda") → no grounding, no
+        // brain call. This is the bug the user hit.
+        let reasoner2 = MockReasoner::new("SHOULD-NOT-BE-CALLED");
+        let res2 = handle_voice_action(
+            &VoiceIntent::Research { topic: "yesterday's weather".into() },
+            &reasoner2,
+            &db,
+            &empty_unlocked(),
+            &cfg,
+            "live-mtg",
+            "",
+        );
+        assert_eq!(res2.status, "ok");
+        assert!(
+            res2.summary.contains("couldn't find"),
+            "the English-only topic must MISS the Polish note (the demonstrated bug)"
+        );
+        assert!(
+            reasoner2.last_user.lock().unwrap().is_none(),
+            "no grounding ⇒ no brain call on the translated-only path"
+        );
     }
 }


### PR DESCRIPTION
Real-mic: 'jaka była pogoda' → 'couldn't find yesterday's weather' (brain translated to English; FTS can't match Polish 'pogoda'); short clips mis-detected as Russian/Slovak; 'Uh,' dispatched. Fixes: retrieval keys off the **literal user words** (salient 'pogoda', not the brain translation) through the same gated execute_tool; **forced clip language** (config.language); **garbage filter** (Uh/eee → nothing_heard). Verified: test 362/0; clippy clean; adversarial PASS (3× RED-before-GREEN; no new read path). Full cross-lingual = real semantic (next).