### PR TITLE
feat(retrieval): enable real semantic search — reindex (e5) + toggle + hybrid

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -123,6 +123,12 @@ pub struct AppConfigDto {
     /// bogus model id. `select_brain_model` remains the other supported mutator.
     #[serde(default)]
     pub brain_model_id: Option<String>,
+    /// brain2 RAG — the SEMANTIC SEARCH master flag. Settable from the DTO (the Settings UI owns the
+    /// toggle), unlike `cloud_egress_consented` which is preserved-only. Plain bool; an omitted value
+    /// deserializes to `false` (`#[serde(default)]`), so a partial/older save can never silently
+    /// enable it. Flipping it on does NOT auto-index — the user runs `reindex_embeddings` to backfill.
+    #[serde(default)]
+    pub semantic_search_enabled: bool,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
@@ -1745,6 +1751,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         brain_backend: c.brain_backend,
         realtime_reactions: c.realtime_reactions,
         brain_model_id: c.brain_model_id.clone(),
+        semantic_search_enabled: c.semantic_search_enabled,
     }
 }
 
@@ -1799,9 +1806,11 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // BLK-4: consent is NEVER set from the DTO. Preserve the live value; only the dedicated
         // `consent_to_cloud_egress` command may flip it. This makes an omitting/zeroed save inert.
         cloud_egress_consented: current.cloud_egress_consented,
-        // Phase 2b: the semantic-search master flag is not (yet) carried on the settings DTO, so a
-        // settings save can neither set nor clobber it — preserve the live value (default OFF).
-        semantic_search_enabled: current.semantic_search_enabled,
+        // brain2 RAG: the semantic-search master flag IS carried on the settings DTO (the Settings
+        // UI owns the toggle). Plain bool; an omitted value already defaulted to OFF on the DTO
+        // (`#[serde(default)]`), so a partial/older save can never silently enable it. Unlike
+        // `cloud_egress_consented` (preserved-only), this one is settable.
+        semantic_search_enabled: d.semantic_search_enabled,
         // Phase B: the brain model path is not carried on the settings DTO (it is resolved from the
         // shared models dir by default), so a settings save preserves the live value (default None).
         brain_model_path: current.brain_model_path.clone(),
@@ -2287,6 +2296,125 @@ pub async fn download_embed_model(app: AppHandle) -> Result<String, AppError> {
         },
     );
     Ok(dir.to_string_lossy().to_string())
+}
+
+/// Result of [`reindex_embeddings`]. `status` is `"model_missing"` when the real e5 model is absent
+/// (no indexing was attempted — re-indexing with the deterministic STUB embedder would poison the
+/// index with garbage vectors, worse than nothing), else `"indexed"`. On `"indexed"`, `indexed` is
+/// the count of VISIBLE meetings whose chunks were (re)built. NO PII — counts + a status string only.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReindexResult {
+    pub status: String,
+    pub indexed: usize,
+    pub total: usize,
+}
+
+/// brain2 RAG — BACKFILL the semantic vector index for ALL VISIBLE meetings (the one-shot the user
+/// runs after turning `semantic_search_enabled` on, or after installing the e5 model so the old
+/// STUB-embedded chunks get replaced by real e5 vectors).
+///
+/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked)` — a sealed-and-not-
+/// session-unlocked meeting is NEVER returned, so its plaintext is never chunked/embedded, and its
+/// chunks STAY purged (the seal already purged them; we don't touch them). For each visible meeting
+/// we re-fetch its note through `get_note_if_visible(unlocked)` (defense-in-depth: skip if the note
+/// is not visible) and call `index_meeting_chunks`, which PURGES-then-reinserts — so any stale stub
+/// vectors are replaced with e5 ones. No new read path: every read routes through `visibility_clause`.
+///
+/// MODEL GUARD: if the real e5 model is absent (`!embed_model_present()` ⇒ `active_embedder` is the
+/// stub), we DO NOTHING and return `{ status: "model_missing" }`. Re-indexing with garbage stub
+/// vectors is strictly worse than leaving the (old, possibly-stub) chunks alone — the FE prompts the
+/// user to download e5 first via `download_embed_model`.
+///
+/// Emits [`crate::events::EVENT_REINDEX`] `{ done, total }` progress (counts only, NO PII).
+/// EMBED_DIM stays 384 (e5 == stub width) ⇒ NO `vec_chunks` schema migration.
+#[tauri::command]
+pub async fn reindex_embeddings(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ReindexResult, AppError> {
+    // Snapshot the LIVE session unlock set — visibility is evaluated against exactly this set, so a
+    // sealed-not-unlocked folder's meetings are invisible and never indexed.
+    let unlocked = state
+        .unlocked_folders
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+
+    reindex_embeddings_inner(
+        &state.db,
+        &unlocked,
+        crate::embed::embed_model_present(),
+        crate::embed::active_embedder().as_ref(),
+        |done, total| {
+            let _ = app.emit(
+                crate::events::EVENT_REINDEX,
+                crate::events::ReindexPayload { done, total },
+            );
+        },
+    )
+}
+
+/// Pure, AppHandle-free core of [`reindex_embeddings`] so the model-missing guard + the
+/// visibility-gated loop are unit-testable headless. Takes the `Db`, the live `unlocked` session set,
+/// whether the REAL e5 model is present (`model_present`), the active embedder, and a progress sink.
+///
+/// MODEL GUARD: `model_present == false` ⇒ return `{ status: "model_missing" }` and index NOTHING
+/// (re-indexing with the deterministic STUB embedder would poison the index with garbage vectors —
+/// strictly worse than leaving the old chunks alone).
+///
+/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked)` — a sealed-and-not-
+/// session-unlocked meeting is NEVER returned, so its plaintext is never chunked/embedded and its
+/// chunks STAY purged. Each meeting's note is re-checked through `get_note_if_visible(unlocked)`
+/// before `index_meeting_chunks` (PURGE-then-reinsert, so stale stub vectors are replaced).
+pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
+    db: &crate::storage::Db,
+    unlocked: &std::collections::HashSet<String>,
+    model_present: bool,
+    embedder: &dyn crate::embed::Embedder,
+    mut on_progress: F,
+) -> Result<ReindexResult, AppError> {
+    if !model_present {
+        tracing::info!(target: "rag", "reindex_embeddings: e5 model missing; skipping (no stub indexing)");
+        return Ok(ReindexResult {
+            status: "model_missing".to_string(),
+            indexed: 0,
+            total: 0,
+        });
+    }
+
+    // The corpus is the visibility-gated meeting list. `list_meetings_visible` already excludes
+    // sealed-and-not-session-unlocked meetings (their notes are not visible under `visibility_clause`).
+    let meetings = db.list_meetings_visible(100_000, unlocked)?;
+    let total = meetings.len();
+
+    let mut indexed = 0usize;
+    for m in &meetings {
+        // Defense-in-depth: only index a meeting whose latest note is currently visible.
+        match db.get_note_if_visible(&m.id, unlocked) {
+            Ok(Some(_note)) => {
+                if let Err(e) = db.index_meeting_chunks(&m.id, embedder) {
+                    // Never abort the whole backfill on one bad note — log (no PII) and continue.
+                    tracing::warn!(target: "rag", error = %e, "reindex: indexing one meeting failed (skipped)");
+                }
+            }
+            Ok(None) => {
+                // No visible note (sealed sibling, or no note yet) — skip; do NOT index.
+            }
+            Err(e) => {
+                tracing::warn!(target: "rag", error = %e, "reindex: visibility check failed (skipped)");
+            }
+        }
+        indexed += 1;
+        on_progress(indexed, total);
+    }
+
+    tracing::info!(target: "rag", indexed, total, "reindex_embeddings complete");
+    Ok(ReindexResult {
+        status: "indexed".to_string(),
+        indexed,
+        total,
+    })
 }
 
 /// True iff the on-device PERSON-name NER model (Phase D) is present on disk. Pure existence probe;
@@ -4680,6 +4808,38 @@ mod lifecycle_tests {
         }
     }
 
+    /// brain2 RAG: `semantic_search_enabled` round-trips BOTH ways through the settings DTO. OUT:
+    /// `config_to_dto` carries the live value so the FE toggle reflects it. IN: `dto_to_config` TAKES
+    /// it from the DTO (settable — unlike `cloud_egress_consented`), proven by starting from a
+    /// different `current` so the merged value can only have come from the DTO.
+    #[test]
+    fn dto_round_trips_semantic_search_enabled_both_ways() {
+        // OUT: true and false both surface on the DTO.
+        let cfg_on = AppConfig { semantic_search_enabled: true, ..AppConfig::default() };
+        assert!(config_to_dto(&cfg_on).semantic_search_enabled);
+        let cfg_off = AppConfig { semantic_search_enabled: false, ..AppConfig::default() };
+        assert!(!config_to_dto(&cfg_off).semantic_search_enabled);
+
+        // IN (set true): DTO=true over current=false ⇒ merged true (the DTO is authoritative).
+        let mut dto_on = config_to_dto(&AppConfig::default());
+        dto_on.semantic_search_enabled = true;
+        let current_off = AppConfig { semantic_search_enabled: false, ..AppConfig::default() };
+        assert!(
+            dto_to_config(dto_on, &current_off).semantic_search_enabled,
+            "semantic_search_enabled MUST be settable from the DTO (turn on)"
+        );
+
+        // IN (clear): DTO=false over current=true ⇒ merged false (settable both directions — NOT
+        // preserve-only like cloud_egress_consented).
+        let mut dto_off = config_to_dto(&AppConfig::default());
+        dto_off.semantic_search_enabled = false;
+        let current_on = AppConfig { semantic_search_enabled: true, ..AppConfig::default() };
+        assert!(
+            !dto_to_config(dto_off, &current_on).semantic_search_enabled,
+            "semantic_search_enabled MUST be settable from the DTO (turn off)"
+        );
+    }
+
     /// Phase H graceful degradation: a DTO carrying an UNKNOWN `brain_model_id` must NOT be stored —
     /// the live selection is preserved (no error, no bogus id) — while an unknown/omitted
     /// `brain_backend` deserializes to the default `Cloud` rather than crashing the save.
@@ -5014,6 +5174,81 @@ mod lifecycle_tests {
         assert!(matches!(res, Err(AppError::InvalidArg(_))), "must refuse, got {res:?}");
         assert!(state.db.folder_by_id("parent").unwrap().is_some(), "parent NOT deleted");
         assert!(state.db.folder_by_id("child").unwrap().is_some(), "child NOT orphaned");
+    }
+
+    // ── reindex_embeddings (semantic backfill) ──────────────────────────────────────────────────
+
+    /// True iff `mid` surfaces in the GATED semantic read for `text` under `unlocked` — i.e. it has
+    /// vec0 chunks AND is visible. Uses the stub embedder (this test asserts WHICH meetings are
+    /// indexed, not retrieval QUALITY, so the deterministic stub is sufficient plumbing).
+    fn reindex_semantic_finds(db: &Db, mid: &str, text: &str, unlocked: &HashSet<String>) -> bool {
+        use crate::embed::Embedder;
+        let emb = crate::embed::StubEmbedder;
+        let qv = emb.embed(std::slice::from_ref(&text.to_string())).unwrap();
+        let qvec = qv.into_iter().next().unwrap_or_default();
+        db.search_semantic_visible(&qvec, 50, unlocked)
+            .unwrap()
+            .iter()
+            .any(|h| h.meeting.id == mid)
+    }
+
+    /// GATING: `reindex_embeddings_inner` over a corpus of two OPEN (visible) meetings + one SEALED
+    /// (locked, not-session-unlocked) meeting indexes ONLY the two visible ones. The sealed meeting
+    /// is never returned by `list_meetings_visible`, its plaintext is never chunked/embedded, and its
+    /// chunks STAY purged (the seal already removed them) — RED if the gate were dropped.
+    #[test]
+    fn reindex_indexes_only_visible_meetings_skips_sealed() {
+        let state = build_state("reindex-gate");
+        make_open_folder(&state.db, "f-lock", "Confidential");
+
+        // Two open meetings (no folder ⇒ always visible) + one in a folder we will SEAL.
+        seed_meeting(&state.db, "m-open-1", "Quarterly budget planning and hiring runway.", None);
+        seed_meeting(&state.db, "m-open-2", "Roadmap review for the next sprint.", None);
+        seed_meeting(&state.db, "m-sealed", "Secret acquisition numbers and the term sheet.", Some("f-lock"));
+
+        // Seal the folder (verify-before-destroy seal + chunk purge) — m-sealed is now invisible.
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+
+        let nothing = HashSet::new();
+        let stub = crate::embed::StubEmbedder;
+        // model_present = true so the guard passes (we deliberately use the stub here for plumbing).
+        let res = reindex_embeddings_inner(&state.db, &nothing, true, &stub, |_, _| {}).unwrap();
+        assert_eq!(res.status, "indexed");
+        // Only the two VISIBLE meetings were processed (the sealed one is absent from the corpus).
+        assert_eq!(res.total, 2, "sealed meeting must NOT be in the reindex corpus");
+        assert_eq!(res.indexed, 2);
+
+        // The two open meetings are now semantically findable; the sealed one is NOT — even under the
+        // same empty unlock set (it has no chunks, and is gated out).
+        assert!(reindex_semantic_finds(&state.db, "m-open-1", "budget planning hiring", &nothing));
+        assert!(reindex_semantic_finds(&state.db, "m-open-2", "roadmap sprint review", &nothing));
+        assert!(
+            !reindex_semantic_finds(&state.db, "m-sealed", "secret acquisition term sheet", &nothing),
+            "a sealed-not-unlocked meeting must never be indexed by reindex (gate violation)"
+        );
+    }
+
+    /// MODEL GUARD: with the real e5 model ABSENT (`model_present = false`), `reindex_embeddings_inner`
+    /// returns `{ status: "model_missing" }` and indexes NOTHING — it must NOT poison the index with
+    /// the deterministic STUB embedder. RED if the guard were dropped (the open meeting would gain
+    /// stub chunks).
+    #[test]
+    fn reindex_model_missing_indexes_nothing() {
+        let state = build_state("reindex-nomodel");
+        seed_meeting(&state.db, "m-open", "Quarterly budget planning.", None);
+
+        let nothing = HashSet::new();
+        let stub = crate::embed::StubEmbedder;
+        // model_present = false → the guard short-circuits BEFORE any indexing.
+        let res = reindex_embeddings_inner(&state.db, &nothing, false, &stub, |_, _| {}).unwrap();
+        assert_eq!(res.status, "model_missing");
+        assert_eq!(res.indexed, 0);
+        assert_eq!(res.total, 0);
+        // No chunks were written — the meeting is NOT semantically findable.
+        assert!(
+            !reindex_semantic_finds(&state.db, "m-open", "budget planning", &nothing),
+            "model_missing guard must index NOTHING (no stub poisoning)"
+        );
     }
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -105,6 +105,20 @@ pub struct NerDownloadPayload {
     pub done: bool,
 }
 
+/// Progress for the semantic-search backfill (`reindex_embeddings`) over all visible meetings.
+/// Carries COUNTS ONLY — no meeting ids, titles, or content (NO PII).
+pub const EVENT_REINDEX: &str = "murmur://reindex-embeddings";
+
+/// Payload for [`EVENT_REINDEX`]. Counts only — NO PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReindexPayload {
+    /// Visible meetings indexed so far.
+    pub done: usize,
+    /// Total visible meetings to index this run.
+    pub total: usize,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusPayload {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,7 @@ pub fn run() {
             commands::download_brain_model,
             commands::embed_model_present,
             commands::download_embed_model,
+            commands::reindex_embeddings,
             commands::ner_model_present,
             commands::download_ner_model,
             commands::toggle_bar,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -7,6 +7,9 @@ import type {
   AppConfigDto,
   BrainDownloadProgress,
   BrainModelDto,
+  EmbedDownloadProgress,
+  ReindexProgress,
+  ReindexResult,
   InputDeviceInfo,
   AskVaultResult,
   BriefResult,
@@ -47,6 +50,9 @@ export const EVENT_WAKE_DETECTED = "murmur://wake-detected";
 export const EVENT_VOICE_ACTION_RESULT = "murmur://voice-action-result";
 export const EVENT_VOICE_COMMAND_LISTENING = "murmur://voice-command-listening";
 export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
+// brain2 RAG — semantic-search model download + reindex backfill event streams.
+export const EVENT_EMBED_DOWNLOAD = "murmur://embed-download";
+export const EVENT_REINDEX = "murmur://reindex-embeddings";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -417,6 +423,39 @@ export class IpcService {
     return invoke<void>("download_brain_model", { modelId });
   }
 
+  // ── brain2 RAG — semantic search (embedding model + reindex backfill) ───
+
+  /**
+   * Whether the on-device embedding model (multilingual-e5-small) is present —
+   * i.e. the REAL embedder would load. Cheap existence check; semantic search /
+   * reindex are no-ops (stub) without it.
+   */
+  embedModelPresent(): Promise<boolean> {
+    return invoke<boolean>("embed_model_present");
+  }
+
+  /**
+   * Download the on-device embedding model (multilingual-e5-small, 3 small files).
+   * Progress streams over {@link onEmbedDownload} (EVENT_EMBED_DOWNLOAD); the
+   * promise resolves with the model dir when the download finishes. Sends NO
+   * meeting content (inbound-only, no egress).
+   */
+  downloadEmbedModel(): Promise<string> {
+    return invoke<string>("download_embed_model");
+  }
+
+  /**
+   * brain2 RAG — backfill the semantic vector index for ALL VISIBLE meetings (the
+   * one-shot run after turning semantic search on, or after installing the e5
+   * model). Progress streams over {@link onReindex} (EVENT_REINDEX). Resolves with
+   * a {@link ReindexResult}: `status: "model_missing"` when the e5 model is absent
+   * (nothing indexed → the FE nudges the user to download it first), else
+   * `"indexed"`. Sealed-not-unlocked meetings are never indexed (gated).
+   */
+  reindexEmbeddings(): Promise<ReindexResult> {
+    return invoke<ReindexResult>("reindex_embeddings");
+  }
+
   /** Show/hide the floating always-on-top recorder bar window. */
   toggleBar(): Promise<void> {
     return invoke<void>("toggle_bar");
@@ -558,5 +597,19 @@ export class IpcService {
     return listen<BrainDownloadProgress>(EVENT_BRAIN_DOWNLOAD, (e) =>
       cb(e.payload),
     );
+  }
+
+  /** Fires with per-file progress for the in-flight embedding-model download. */
+  onEmbedDownload(
+    cb: (p: EmbedDownloadProgress) => void,
+  ): Promise<UnlistenFn> {
+    return listen<EmbedDownloadProgress>(EVENT_EMBED_DOWNLOAD, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /** Fires with COUNT-only progress for the in-flight semantic reindex backfill. */
+  onReindex(cb: (p: ReindexProgress) => void): Promise<UnlistenFn> {
+    return listen<ReindexProgress>(EVENT_REINDEX, (e) => cb(e.payload));
   }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -87,6 +87,14 @@ export interface AppConfigDto {
    * `brainBackend === "local"`. Null = none selected yet.
    */
   brainModelId: string | null;
+  /**
+   * brain2 RAG — the semantic-search master flag. When on, Ask-My-Vault retrieves
+   * candidates by HYBRID (FTS ∪ vector-KNN) retrieval over the on-device embedding
+   * model; off falls back to lexical-only. Flipping it on does NOT auto-index — the
+   * user runs `reindexEmbeddings()` to backfill. Round-tripped on every `save_config`
+   * like the other flags. Default false. Mirrors Rust `AppConfigDto.semantic_search_enabled`.
+   */
+  semanticSearchEnabled: boolean;
 }
 
 /** Phase H — which backend powers the brain / in-meeting voice assistant. */
@@ -128,6 +136,43 @@ export interface BrainDownloadProgress {
   downloaded: number;
   total: number | null;
   done: boolean;
+}
+
+/**
+ * brain2 RAG — progress for the on-device embedding-model (multilingual-e5-small)
+ * download (`EVENT_EMBED_DOWNLOAD`). Mirrors the backend `EmbedDownloadPayload`:
+ * the e5 model is 3 small files, so progress is reported per-file (`fileIndex` /
+ * `fileCount`). `total` is null when the server omits Content-Length; `done` fires
+ * once all files are written + renamed into place.
+ */
+export interface EmbedDownloadProgress {
+  fileIndex: number;
+  fileCount: number;
+  downloaded: number;
+  total: number | null;
+  done: boolean;
+}
+
+/**
+ * brain2 RAG — progress for the semantic-search backfill (`EVENT_REINDEX`). Counts
+ * only, NO PII. Mirrors the backend `ReindexPayload`: visible meetings indexed so
+ * far (`done`) out of the run total (`total`).
+ */
+export interface ReindexProgress {
+  done: number;
+  total: number;
+}
+
+/**
+ * brain2 RAG — result of `reindexEmbeddings()`. Mirrors the backend `ReindexResult`
+ * (camelCase). `status` is `"model_missing"` when the real e5 model is absent (no
+ * indexing was attempted — the FE nudges the user to download it first), else
+ * `"indexed"`; `indexed` is the count of VISIBLE meetings whose chunks were rebuilt.
+ */
+export interface ReindexResult {
+  status: string;
+  indexed: number;
+  total: number;
 }
 
 /**

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1279,6 +1279,8 @@ export class OnboardingComponent implements OnInit {
       brainBackend: base?.brainBackend ?? "cloud",
       realtimeReactions: base?.realtimeReactions ?? false,
       brainModelId: base?.brainModelId ?? null,
+      // brain2 RAG — semantic-search master flag; round-trip the snapshot, default off.
+      semanticSearchEnabled: base?.semanticSearchEnabled ?? false,
     };
     await this.ipc.saveConfig(cfg);
     // Keep the snapshot current so successive saves don't clobber fresh choices.

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -17,6 +17,7 @@ import type {
   BrainModelDto,
   InputDeviceInfo,
   ProviderStatus,
+  ReindexResult,
 } from "../../core/models";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 
@@ -413,6 +414,116 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
             }
           </div>
         }
+
+        <!-- brain2 RAG — semantic search over your notes (embedding model + reindex) -->
+        <div class="semantic">
+          <label class="toggle-row">
+            <span class="toggle-copy">
+              <span class="toggle-title">Semantic search (multilingual)</span>
+              <span class="text-secondary toggle-sub">
+                Finds notes by meaning + across languages — needs the embedding
+                model.
+              </span>
+            </span>
+            <input type="checkbox" formControlName="semanticSearchEnabled" />
+          </label>
+
+          <!-- Embedding model: present pill, or a download control with progress -->
+          <div class="semantic-model-row">
+            @if (embedModelPresent() === true) {
+              <span class="pill is-success">
+                <span class="pill-dot"></span>
+                Embedding model ready ✓
+              </span>
+              <span class="text-muted semantic-note">
+                Stored on this Mac — used to index + search your notes.
+              </span>
+            } @else if (embedModelPresent() === false) {
+              @if (downloadingEmbedModel()) {
+                <div class="semantic-progress" role="status">
+                  <div class="semantic-progress-track" aria-hidden="true">
+                    <div
+                      class="semantic-progress-fill"
+                      [style.width.%]="embedDownloadFrac() * 100"
+                    ></div>
+                  </div>
+                  <span class="semantic-progress-label text-muted">
+                    Downloading embedding model… {{ embedPct() }}
+                  </span>
+                </div>
+              } @else {
+                <button
+                  type="button"
+                  class="btn btn-primary btn-sm"
+                  (click)="downloadEmbedModel()"
+                >
+                  Download embedding model (~120 MB)
+                </button>
+                <span class="text-muted semantic-note">
+                  One time, on-device — required before semantic search can index.
+                </span>
+              }
+            } @else {
+              <span class="pill">
+                <span class="pill-dot"></span>
+                Checking…
+              </span>
+            }
+          </div>
+          @if (embedDownloadError(); as eerr) {
+            <p class="text-danger brain-error">{{ eerr }}</p>
+          }
+
+          <!-- Re-index notes: backfill the semantic vector index over all notes -->
+          <div class="semantic-reindex">
+            <button
+              type="button"
+              class="btn btn-sm"
+              (click)="reindexEmbeddings()"
+              [disabled]="reindexing()"
+            >
+              @if (reindexing()) {
+                <span class="spin-ring" aria-hidden="true"></span>
+                Re-indexing…
+              } @else {
+                Re-index notes
+              }
+            </button>
+            <span class="text-muted semantic-note">
+              Builds the semantic index over your notes — run it after turning
+              this on, or after downloading the model.
+            </span>
+          </div>
+          @if (reindexing()) {
+            <div class="semantic-progress" role="status">
+              <div class="semantic-progress-track" aria-hidden="true">
+                <div
+                  class="semantic-progress-fill"
+                  [style.width.%]="reindexFrac() * 100"
+                ></div>
+              </div>
+              <span class="semantic-progress-label text-muted">
+                Indexing notes… {{ reindexPct() }}
+              </span>
+            </div>
+          }
+          @if (reindexResult(); as rr) {
+            @if (rr.status === "model_missing") {
+              <p class="semantic-nudge text-secondary">
+                Download the embedding model above first — semantic search can't
+                index without it.
+              </p>
+            } @else {
+              <span class="pill is-success semantic-done-pill">
+                <span class="pill-dot"></span>
+                Indexed {{ rr.indexed }} of {{ rr.total }} notes
+              </span>
+            }
+          }
+          @if (reindexError(); as rerr) {
+            <p class="text-danger brain-error">{{ rerr }}</p>
+          }
+        </div>
       </div>
 
       <!-- Works with Obsidian — optional vault companion -->
@@ -1206,6 +1317,63 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
         font-size: 0.8125rem;
       }
 
+      /* --- brain2 RAG — semantic-search subsection --- */
+      .semantic {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .semantic-model-row,
+      .semantic-reindex {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        min-height: 36px;
+      }
+      .semantic-reindex .btn,
+      .semantic-model-row .btn {
+        flex: none;
+      }
+      .semantic-note {
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+      .semantic-progress {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 180px;
+        flex: 1 1 auto;
+      }
+      .semantic-progress-track {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--surface-raised);
+        overflow: hidden;
+      }
+      .semantic-progress-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: 3px;
+        transition: width var(--transition);
+      }
+      .semantic-progress-label {
+        font-size: 0.75rem;
+      }
+      .semantic-nudge {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.5;
+      }
+      .semantic-done-pill {
+        align-self: flex-start;
+      }
+
       /* --- Works-with-Obsidian card --- */
       .obsidian-card {
         display: flex;
@@ -1627,6 +1795,8 @@ export class SettingsComponent implements OnInit {
     realtimeReactions: false,
     /** Custom GGUF model path (or registry id). Empty → null on save. */
     brainModelId: "",
+    // brain2 RAG — semantic-search master flag (round-tripped on save).
+    semanticSearchEnabled: false,
   });
   readonly keyControl = new FormControl("", { nonNullable: true });
 
@@ -1710,6 +1880,41 @@ export class SettingsComponent implements OnInit {
   /** Release handle for the EVENT_BRAIN_DOWNLOAD subscription. */
   private unlistenBrainDownload: UnlistenFn | null = null;
 
+  // ── brain2 RAG — semantic search (embedding model + reindex) ────────────
+
+  /**
+   * Whether the on-device embedding model is present.
+   * `null` = not yet checked, `true`/`false` = detected via ipc.embedModelPresent().
+   */
+  readonly embedModelPresent = signal<boolean | null>(null);
+  /** True while the embedding model is downloading — disables its button. */
+  readonly downloadingEmbedModel = signal(false);
+  /** 0..1 download progress for the in-flight embed-model download. */
+  readonly embedDownloadFrac = signal(0);
+  /** Whole-percent label for the in-flight embed-model download. */
+  readonly embedPct = computed(
+    () => Math.round(this.embedDownloadFrac() * 100) + "%",
+  );
+  /** Surfaced if ipc.downloadEmbedModel() rejects. */
+  readonly embedDownloadError = signal<string | null>(null);
+
+  /** True while a reindex backfill is running — disables the button + shows progress. */
+  readonly reindexing = signal(false);
+  /** 0..1 progress for the in-flight reindex backfill. */
+  readonly reindexFrac = signal(0);
+  /** Whole-percent label for the in-flight reindex backfill. */
+  readonly reindexPct = computed(
+    () => Math.round(this.reindexFrac() * 100) + "%",
+  );
+  /** Last reindex outcome — drives the "model_missing" nudge / "indexed" confirmation. */
+  readonly reindexResult = signal<ReindexResult | null>(null);
+  /** Surfaced if ipc.reindexEmbeddings() rejects. */
+  readonly reindexError = signal<string | null>(null);
+
+  /** Release handles for the embed-download + reindex event streams. */
+  private unlistenEmbedDownload: UnlistenFn | null = null;
+  private unlistenReindex: UnlistenFn | null = null;
+
   async ngOnInit(): Promise<void> {
     try {
       const cfg = await this.ipc.getConfig();
@@ -1745,6 +1950,7 @@ export class SettingsComponent implements OnInit {
         brainBackend: cfg.brainBackend ?? "cloud",
         realtimeReactions: cfg.realtimeReactions ?? false,
         brainModelId: cfg.brainModelId ?? "",
+        semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
       });
       this.updateDownloadHint();
       this.inputDevices.set(await this.ipc.listInputDevices().catch(() => []));
@@ -1754,6 +1960,11 @@ export class SettingsComponent implements OnInit {
       // Phase H — brain model registry + download-progress stream (best-effort).
       await this.subscribeBrainDownload();
       await this.refreshBrainModels();
+      // brain2 RAG — embedding-model presence + reindex/download progress streams.
+      await this.subscribeSemanticStreams();
+      this.embedModelPresent.set(
+        await this.ipc.embedModelPresent().catch(() => false),
+      );
     } catch (e) {
       this.loadError.set(String(e));
     }
@@ -1829,6 +2040,77 @@ export class SettingsComponent implements OnInit {
     }
   }
 
+  // ── brain2 RAG — semantic search (embedding model + reindex backfill) ───
+
+  /**
+   * Subscribe ONCE to the embed-download + reindex progress streams and store the
+   * unlisten handles so DestroyRef can release them (no leaked listeners).
+   * Best-effort: a missing backend stream just leaves the relevant bar inert.
+   */
+  private async subscribeSemanticStreams(): Promise<void> {
+    try {
+      this.unlistenEmbedDownload = await this.ipc.onEmbedDownload((p) => {
+        // Per-file progress: blend the completed files + the current file's fraction
+        // across the whole set so the single bar advances smoothly.
+        if (p.fileCount > 0) {
+          const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
+          this.embedDownloadFrac.set(
+            Math.min(1, (p.fileIndex + cur) / p.fileCount),
+          );
+        }
+        if (p.done) this.embedDownloadFrac.set(1);
+      });
+      this.unlistenReindex = await this.ipc.onReindex((p) => {
+        if (p.total > 0) {
+          this.reindexFrac.set(Math.min(1, p.done / p.total));
+        }
+      });
+      this.destroyRef.onDestroy(() => {
+        this.unlistenEmbedDownload?.();
+        this.unlistenReindex?.();
+      });
+    } catch {
+      // No stream available — progress bars stay inert; commands still resolve.
+    }
+  }
+
+  /** Download the on-device embedding model, then re-check presence. */
+  async downloadEmbedModel(): Promise<void> {
+    this.embedDownloadError.set(null);
+    this.embedDownloadFrac.set(0);
+    this.downloadingEmbedModel.set(true);
+    try {
+      await this.ipc.downloadEmbedModel();
+      this.embedModelPresent.set(await this.ipc.embedModelPresent());
+    } catch (e) {
+      this.embedDownloadError.set(String(e));
+    } finally {
+      this.downloadingEmbedModel.set(false);
+    }
+  }
+
+  /**
+   * Backfill the semantic vector index over all visible meetings. A
+   * `"model_missing"` result means the e5 model isn't installed yet — surfaced as
+   * a nudge to download it first (no indexing was attempted).
+   */
+  async reindexEmbeddings(): Promise<void> {
+    this.reindexError.set(null);
+    this.reindexResult.set(null);
+    this.reindexFrac.set(0);
+    this.reindexing.set(true);
+    try {
+      const res = await this.ipc.reindexEmbeddings();
+      this.reindexResult.set(res);
+      // The model could have been (un)installed between the presence probe and now.
+      if (res.status === "model_missing") this.embedModelPresent.set(false);
+    } catch (e) {
+      this.reindexError.set(String(e));
+    } finally {
+      this.reindexing.set(false);
+    }
+  }
+
   async pickVault(): Promise<void> {
     const dir = await open({ directory: true, multiple: false });
     if (typeof dir === "string") this.form.patchValue({ vaultPath: dir });
@@ -1868,6 +2150,8 @@ export class SettingsComponent implements OnInit {
       brainBackend: v.brainBackend,
       realtimeReactions: v.realtimeReactions,
       brainModelId: v.brainModelId || null,
+      // brain2 RAG — semantic-search master flag (round-tripped so a save preserves it).
+      semanticSearchEnabled: v.semanticSearchEnabled,
       // Round-trip the Stage E security flags so a settings save never silently
       // resets them. Cloud-egress consent is GRANTED only via the dedicated
       // command (allowCloudProcessing) — here we just carry the current value back.


### PR DESCRIPTION
Makes cross-lingual + paraphrase recall real. **reindex_embeddings** (gated e5 backfill over visible notes, purge-then-reindex, sealed skipped, model_missing guard, EVENT_REINDEX progress); **semantic_search_enabled** settable; FE **Semantic search toggle + Re-index button**. Verified: test 365/0; clippy clean; ng lint+build clean; adversarial PASS (gate+guard+DTO RED-before-GREEN); lock-security PASS (only visibility-gated content embedded, sealed never, no new egress). Real e5 quality = @Mac run.