### PR TITLE
feat(connectors): connector framework + web-search connector (Brave) — the brain can go to the web

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -129,6 +129,19 @@ pub struct AppConfigDto {
     /// enable it. Flipping it on does NOT auto-index — the user runs `reindex_embeddings` to backfill.
     #[serde(default)]
     pub semantic_search_enabled: bool,
+    /// brain2 connector framework — the WEB SEARCH master toggle. Settable from the DTO (the Settings
+    /// UI owns the toggle). An omitted value deserializes to `false` (`#[serde(default)]`), so a
+    /// partial/older save can never silently enable it. Even ON, the web connector is exposed only
+    /// once `web_search_consented` is granted AND a key is stored.
+    #[serde(default)]
+    pub web_search_enabled: bool,
+    /// brain2 connector framework — one-time WEB SEARCH egress consent. PRESERVE-ONLY on this DTO,
+    /// exactly like `cloud_egress_consented`: `get_config` carries the current value OUT (so the FE can
+    /// show consent status), but `dto_to_config` IGNORES the incoming value and PRESERVES the stored
+    /// one. The ONLY mutator is the dedicated `consent_to_web_search` command, so a settings save can
+    /// neither grant nor clear web-search egress consent. `#[serde(default)]` = false (fail-closed).
+    #[serde(default)]
+    pub web_search_consented: bool,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
@@ -1721,6 +1734,22 @@ pub fn consent_to_cloud_egress(state: State<'_, AppState>) -> Result<(), AppErro
     Ok(())
 }
 
+/// brain2 connectors — grant the one-time WEB SEARCH egress consent. The web connector reaches an
+/// EXTERNAL service (a NEW EGRESS CLASS): the redacted query leaves the device. This is the ONLY
+/// supported way to flip `web_search_consented` true; it persists the flag AND updates the in-memory
+/// config cache, so the next `ConnectorRegistry::build` exposes the web tool (provided web search is
+/// also enabled and a key is stored). Idempotent. Until granted, the web connector is absent from the
+/// brain's tool registry and the redacted query never leaves the device.
+#[tauri::command]
+pub fn consent_to_web_search(state: State<'_, AppState>) -> Result<(), AppError> {
+    let mut cache = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    cache.grant_web_search_consent(&state.db)?;
+    Ok(())
+}
+
 fn config_to_dto(c: &AppConfig) -> AppConfigDto {
     AppConfigDto {
         provider_id: c.provider_id.clone(),
@@ -1752,6 +1781,10 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         realtime_reactions: c.realtime_reactions,
         brain_model_id: c.brain_model_id.clone(),
         semantic_search_enabled: c.semantic_search_enabled,
+        web_search_enabled: c.web_search_enabled,
+        // DISPLAY-ONLY out: lets the FE show "consented" status; the FE cannot set it back (preserved
+        // in `dto_to_config`).
+        web_search_consented: c.web_search_consented,
     }
 }
 
@@ -1830,6 +1863,13 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // Settings UI owns the toggle). Plain bool; an omitted value already defaulted to OFF on the
         // DTO (`#[serde(default)]`), so the opt-in can never be silently enabled by a partial save.
         realtime_reactions: d.realtime_reactions,
+        // brain2 connectors: the web-search master toggle IS settable from the DTO (Settings owns it).
+        // An omitted value already defaulted to OFF on the DTO, so a partial save can't enable it.
+        web_search_enabled: d.web_search_enabled,
+        // brain2 connectors (NEW EGRESS CLASS): consent is NEVER set from the DTO — preserved from the
+        // live value (BLK-4 mirror). Only `consent_to_web_search` may flip it, so a settings save can
+        // neither grant nor clear web-search egress consent.
+        web_search_consented: current.web_search_consented,
     }
 }
 
@@ -1853,6 +1893,25 @@ pub fn set_anthropic_key(key: String) -> Result<(), AppError> {
 #[tauri::command]
 pub fn has_anthropic_key() -> Result<bool, AppError> {
     Ok(secrets::get_secret(ANTHROPIC_KEY_ACCOUNT)?.is_some())
+}
+
+/// Store/replace the BYO web-search (Brave) API key in the Keychain (account "web_search_api_key").
+/// An empty input clears it. The key is NEVER logged and NEVER returned to the FE — only `has_*`
+/// reports presence. Mirrors `set_anthropic_key`.
+#[tauri::command]
+pub fn set_web_search_api_key(key: String) -> Result<(), AppError> {
+    if key.trim().is_empty() {
+        return secrets::delete_secret(crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT);
+    }
+    secrets::set_secret(crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT, key.trim())
+}
+
+/// Whether a web-search API key is currently stored (UI shows "set"/"not set"; never the value).
+#[tauri::command]
+pub fn has_web_search_key() -> Result<bool, AppError> {
+    Ok(secrets::get_secret(crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT)?
+        .filter(|k| !k.trim().is_empty())
+        .is_some())
 }
 
 /// availability() fan-out across all three providers for the Settings UI.
@@ -4773,6 +4832,49 @@ mod lifecycle_tests {
             !dto_to_config(dto2, &current2).cloud_egress_consented,
             "a settings save must NEVER grant consent — only the dedicated command may (BLK-4)"
         );
+    }
+
+    /// brain2 connectors (NEW EGRESS CLASS): `web_search_consented` is PRESERVE-ONLY on the settings
+    /// DTO exactly like `cloud_egress_consented` — an omitting/false save can't clear an existing
+    /// grant, and a save carrying `true` can't grant it. Only `consent_to_web_search` may flip it.
+    #[test]
+    fn save_config_merge_never_clobbers_or_grants_web_search_consent() {
+        // (a) preserve an existing grant even when the DTO carries false.
+        let mut dto = config_to_dto(&AppConfig::default());
+        dto.web_search_consented = false;
+        let current = AppConfig { web_search_consented: true, ..AppConfig::default() };
+        assert!(
+            dto_to_config(dto, &current).web_search_consented,
+            "an omitting/false save must NOT clobber an existing web-search consent"
+        );
+
+        // (b) a save carrying true cannot GRANT consent (default-off stays off).
+        let mut dto2 = config_to_dto(&AppConfig::default());
+        dto2.web_search_consented = true;
+        let current2 = AppConfig::default(); // consent off
+        assert!(
+            !dto_to_config(dto2, &current2).web_search_consented,
+            "a settings save must NEVER grant web-search consent — only the dedicated command may"
+        );
+    }
+
+    /// `web_search_enabled` IS settable from the DTO (unlike the consent flag): config_to_dto carries
+    /// it out, dto_to_config takes it in (proven by starting from a different `current`).
+    #[test]
+    fn dto_takes_web_search_enabled_from_payload() {
+        let dto_on = {
+            let mut d = config_to_dto(&AppConfig::default());
+            d.web_search_enabled = true;
+            d
+        };
+        let current_off = AppConfig::default(); // enabled off
+        assert!(
+            dto_to_config(dto_on, &current_off).web_search_enabled,
+            "web_search_enabled is settable from the DTO"
+        );
+        // And OUT: config_to_dto reflects the live value.
+        let cfg = AppConfig { web_search_enabled: true, ..AppConfig::default() };
+        assert!(config_to_dto(&cfg).web_search_enabled);
     }
 
     /// Phase H: the three brain toggles round-trip through the settings DTO. `config_to_dto` carries

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -1,0 +1,312 @@
+//! CONNECTOR FRAMEWORK — live, on-demand external tools the brain can call (brain2, Phase F).
+//!
+//! A **connector** is a swappable source of "research about the world" that the brain reaches through
+//! the SAME gated tool registry as the vault reads ([`crate::tools::execute_tool`]). Unlike the vault
+//! tools (which read the local, visibility-gated SQLite store and EGRESS NOTHING), a connector may
+//! reach an EXTERNAL service — so it carries a NEW EGRESS CLASS that this framework gates,
+//! fail-closed, before anything leaves the device.
+//!
+//! Connectors are LIVE tools, NOT vectorized: the brain calls them on demand and turns the
+//! [`ConnectorHit`]s into cited answers ("via web"), exactly as it does with vault hits.
+//!
+//! ## The three load-bearing disciplines (audited by the lock-security reviewer)
+//! 1. **Consent-gated, fail-closed.** An [`EgressClass::External`] connector is exposed to the brain
+//!    ONLY when it is BOTH enabled AND consented (`web_search_enabled` + `web_search_consented`, the
+//!    latter preserve-only, flipped solely by the dedicated `consent_to_web_search` command). With no
+//!    consent the connector is ABSENT from the registry; if it is somehow invoked anyway, it returns
+//!    [`ConnectorError::NeedsConsent`] and EGRESSES NOTHING (see [`Connector::search`] contract).
+//! 2. **Redacted.** The outgoing query passes the SAME redaction firewall
+//!    ([`crate::summarize::redact::redact`]) as any cloud-bound text BEFORE it leaves — emails / cards
+//!    / phones are scrubbed. The redaction is applied by the FRAMEWORK ([`ConnectorRegistry::search`])
+//!    so an individual connector can never forget it.
+//! 3. **Loud.** Every [`ConnectorHit`] carries a `source_label` (e.g. "web · Brave") so the answer is
+//!    visibly attributed to the external source — the user always knows a result came from off-device.
+//!
+//! ## No PII in logs
+//! Connector code logs the connector id, hit counts, and HTTP status — never the query text, the
+//! result snippets, or the API key.
+
+pub mod web;
+
+use crate::settings::AppConfig;
+
+/// Whether a connector reaches OFF the device. The framework gates every [`External`] connector
+/// behind enable + consent; a [`Local`] connector (none yet) would be exempt, exactly as `ollama` is
+/// exempt from the cloud-egress gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EgressClass {
+    /// Reads only on-device data — no network. Never consent-gated.
+    Local,
+    /// Sends the (redacted) query to an EXTERNAL service. Consent-gated, fail-closed.
+    External,
+}
+
+/// One result from a connector search. Deliberately small + provider-agnostic so every connector
+/// (and every future provider behind one) maps onto the same shape the brain consumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorHit {
+    /// Short human title of the result.
+    pub title: String,
+    /// A 1–2 sentence snippet/description the brain grounds its answer on.
+    pub snippet: String,
+    /// The source URL (the citation the answer is attributed to). May be empty if the provider omits
+    /// it, but providers SHOULD supply it so the answer is auditable.
+    pub url: String,
+    /// LOUD attribution shown to the user, e.g. "web · Brave". Never empty — the framework asserts a
+    /// connector sets it so a result can never be silently passed off as vault knowledge.
+    pub source_label: String,
+}
+
+/// Failure modes of a connector search, kept distinct so the brain/caller can react precisely.
+#[derive(Debug)]
+pub enum ConnectorError {
+    /// External egress is not consented (or the connector is disabled). NOTHING was sent. The brain
+    /// surfaces a "needs consent" status; it is NEVER an error that leaks the query.
+    NeedsConsent,
+    /// The connector is enabled + consented but cannot run (missing API key, etc.). NOTHING was sent.
+    Unconfigured(String),
+    /// The external request itself failed (network / HTTP / parse). The message is non-PII (status +
+    /// context only).
+    Failed(String),
+}
+
+impl std::fmt::Display for ConnectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectorError::NeedsConsent => write!(f, "needs_consent"),
+            ConnectorError::Unconfigured(m) => write!(f, "unconfigured: {m}"),
+            ConnectorError::Failed(m) => write!(f, "failed: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for ConnectorError {}
+
+/// Map a connector error into the app's error domain. `NeedsConsent`/`Unconfigured` become
+/// [`crate::error::AppError::Unavailable`] (graceful, the caller treats it like the cloud-no-consent
+/// fail-closed case); a real `Failed` becomes [`crate::error::AppError::Summarize`] (a runtime
+/// external failure), never a `Storage`/`Locked` — this is NOT a content-gate refusal.
+impl From<ConnectorError> for crate::error::AppError {
+    fn from(e: ConnectorError) -> Self {
+        match e {
+            ConnectorError::NeedsConsent => crate::error::AppError::Unavailable(
+                "web search needs your one-time consent (Settings ▸ Privacy)".to_string(),
+            ),
+            ConnectorError::Unconfigured(m) => crate::error::AppError::Unavailable(m),
+            ConnectorError::Failed(m) => crate::error::AppError::Summarize(m),
+        }
+    }
+}
+
+/// A connector's search result type — `Vec<ConnectorHit>` or a typed [`ConnectorError`].
+pub type ConnectorResult = std::result::Result<Vec<ConnectorHit>, ConnectorError>;
+
+/// The connector seam. Each impl DECLARES its [`EgressClass`] and runs a single async `search`.
+///
+/// CONTRACT (load-bearing): an `External` connector MUST NOT egress anything until it has confirmed
+/// it is consented + configured; on a missing prerequisite it returns [`ConnectorError::NeedsConsent`]
+/// / [`ConnectorError::Unconfigured`] WITHOUT sending the query. The framework
+/// ([`ConnectorRegistry`]) also enforces the consent gate at the registry boundary, so a connector
+/// is the second line, not the only line.
+#[async_trait::async_trait]
+pub trait Connector: Send + Sync {
+    /// Stable id, e.g. `"web"`.
+    fn id(&self) -> &str;
+
+    /// The egress class — `External` connectors are consent-gated by the framework.
+    fn egress_class(&self) -> EgressClass;
+
+    /// Run the search for an ALREADY-REDACTED query (the registry redacts before calling this — see
+    /// [`ConnectorRegistry::search`]). Returns the hits, each carrying a loud `source_label`.
+    async fn search(&self, redacted_query: &str) -> ConnectorResult;
+}
+
+/// The registry of connectors AVAILABLE to the brain for the current config. It exposes ONLY the
+/// connectors that are enabled and (for `External` ones) consented + configured — so a disabled /
+/// unconsented / un-keyed web connector is simply not present, and the brain's tool list never offers
+/// it. Built per call from the live [`AppConfig`] (cheap).
+pub struct ConnectorRegistry {
+    connectors: Vec<Box<dyn Connector>>,
+}
+
+impl ConnectorRegistry {
+    /// Build the registry of connectors EXPOSED for `config`. Today the only connector is the web
+    /// search connector; it is included ONLY when `web_search_enabled && web_search_consented && a key
+    /// is present`. Any future `Local` connector would be included unconditionally (no egress to gate).
+    ///
+    /// Note: the API-key presence check reads the Keychain — kept here (not in `search`) so an
+    /// un-keyed connector is ABSENT from the brain's tool list entirely (it never even appears as a
+    /// callable tool), matching how an un-consented cloud provider is simply not built.
+    pub fn build(config: &AppConfig) -> Self {
+        let mut connectors: Vec<Box<dyn Connector>> = Vec::new();
+        if let Some(c) = web::WebConnector::from_config_if_available(config) {
+            connectors.push(Box::new(c));
+        }
+        Self { connectors }
+    }
+
+    /// Is a connector with this id currently exposed (enabled + consented + configured)?
+    pub fn has(&self, id: &str) -> bool {
+        self.connectors.iter().any(|c| c.id() == id)
+    }
+
+    /// The ids of every exposed connector (for the brain's tool-availability decision / tests).
+    pub fn ids(&self) -> Vec<&str> {
+        self.connectors.iter().map(|c| c.id()).collect()
+    }
+
+    /// Run a search through the connector `id`, REDACTING the query through the firewall first.
+    ///
+    /// The redaction is applied HERE (not inside the connector) so every connector inherits the
+    /// firewall and cannot forget it. An `id` that is not exposed (disabled / unconsented / un-keyed)
+    /// returns [`ConnectorError::NeedsConsent`] WITHOUT touching the network — the fail-closed default.
+    pub async fn search(&self, id: &str, query: &str) -> ConnectorResult {
+        let Some(connector) = self.connectors.iter().find(|c| c.id() == id) else {
+            // Not exposed → fail closed. NOTHING egresses.
+            return Err(ConnectorError::NeedsConsent);
+        };
+        // REDACT before egress: scrub emails/cards/phones out of the outgoing query (the same
+        // firewall any cloud-bound text passes). We discard the token→value map — web results are
+        // attributed to the source as-is and never de-tokenized back into vault content.
+        let (redacted, _map) = crate::summarize::redact::redact(query);
+        connector.search(&redacted).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fake connector that CAPTURES the query it was handed, so a test can prove the framework
+    /// redacted it BEFORE the connector saw it (the connector itself does no redaction).
+    struct CaptureConnector {
+        last_query: std::sync::Mutex<Option<String>>,
+    }
+    #[async_trait::async_trait]
+    impl Connector for CaptureConnector {
+        fn id(&self) -> &str {
+            "capture"
+        }
+        fn egress_class(&self) -> EgressClass {
+            EgressClass::External
+        }
+        async fn search(&self, redacted_query: &str) -> ConnectorResult {
+            *self.last_query.lock().unwrap() = Some(redacted_query.to_string());
+            Ok(vec![ConnectorHit {
+                title: "t".into(),
+                snippet: "s".into(),
+                url: "https://example.com".into(),
+                source_label: "web · fake".into(),
+            }])
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    #[test]
+    fn registry_redacts_query_before_the_connector_sees_it() {
+        // Drive ConnectorRegistry::search directly with a captured connector to prove the framework
+        // applies the firewall: an email in the query must be a ⟪EMAIL_…⟫ token by the time the
+        // connector runs — the connector never sees the raw PII.
+        let cap = std::sync::Arc::new(CaptureConnector {
+            last_query: std::sync::Mutex::new(None),
+        });
+        let registry = ConnectorRegistry {
+            connectors: vec![Box::new(CaptureConnectorRef(cap.clone()))],
+        };
+        let hits = block_on(registry.search("capture", "email bob@acme.com about weather")).unwrap();
+        assert_eq!(hits.len(), 1);
+        let seen = cap.last_query.lock().unwrap().clone().unwrap();
+        assert!(!seen.contains("bob@acme.com"), "raw email must be redacted before egress: {seen}");
+        assert!(seen.contains("\u{27ea}EMAIL_"), "the query must carry the redaction token: {seen}");
+        assert!(seen.contains("weather"), "non-PII terms survive redaction: {seen}");
+    }
+
+    /// Thin wrapper so the test can share one `CaptureConnector` between the registry and the
+    /// assertion (the registry owns `Box<dyn Connector>`).
+    struct CaptureConnectorRef(std::sync::Arc<CaptureConnector>);
+    #[async_trait::async_trait]
+    impl Connector for CaptureConnectorRef {
+        fn id(&self) -> &str {
+            self.0.id()
+        }
+        fn egress_class(&self) -> EgressClass {
+            self.0.egress_class()
+        }
+        async fn search(&self, redacted_query: &str) -> ConnectorResult {
+            self.0.search(redacted_query).await
+        }
+    }
+
+    #[test]
+    fn unexposed_connector_id_fails_closed_without_egress() {
+        // An empty registry (the disabled/unconsented state) returns NeedsConsent for any id and
+        // never reaches a network path.
+        let registry = ConnectorRegistry { connectors: vec![] };
+        let res = block_on(registry.search("web", "what's the weather"));
+        assert!(matches!(res, Err(ConnectorError::NeedsConsent)));
+        assert!(!registry.has("web"));
+        assert!(registry.ids().is_empty());
+    }
+
+    #[test]
+    fn registry_excludes_web_when_disabled_or_unconsented_failclosed() {
+        use crate::settings::AppConfig;
+        // Default config: web search OFF + unconsented → the web connector is NOT exposed, and a
+        // `search("web", …)` fails closed WITHOUT egress. (RED if the gate were dropped: the connector
+        // would be present and would attempt a network call.)
+        let off = AppConfig::default();
+        let registry = ConnectorRegistry::build(&off);
+        assert!(!registry.has("web"), "web connector must be absent when disabled/unconsented");
+        let res = block_on(registry.search("web", "what's the weather"));
+        assert!(
+            matches!(res, Err(ConnectorError::NeedsConsent)),
+            "an unexposed web connector must fail closed (needs_consent), egressing nothing"
+        );
+
+        // Enabled but STILL unconsented → also excluded (consent is the second required gate).
+        let enabled_unconsented = AppConfig {
+            web_search_enabled: true,
+            web_search_consented: false,
+            ..AppConfig::default()
+        };
+        let registry = ConnectorRegistry::build(&enabled_unconsented);
+        assert!(
+            !registry.has("web"),
+            "enabled-but-unconsented web search must STILL be excluded (fail-closed on consent)"
+        );
+
+        // Consented but DISABLED → also excluded (enable is the first required gate).
+        let consented_disabled = AppConfig {
+            web_search_enabled: false,
+            web_search_consented: true,
+            ..AppConfig::default()
+        };
+        assert!(
+            !ConnectorRegistry::build(&consented_disabled).has("web"),
+            "consented-but-disabled web search must be excluded (fail-closed on enable)"
+        );
+    }
+
+    #[test]
+    fn connector_error_maps_to_unavailable_or_summarize() {
+        assert!(matches!(
+            crate::error::AppError::from(ConnectorError::NeedsConsent),
+            crate::error::AppError::Unavailable(_)
+        ));
+        assert!(matches!(
+            crate::error::AppError::from(ConnectorError::Unconfigured("no key".into())),
+            crate::error::AppError::Unavailable(_)
+        ));
+        assert!(matches!(
+            crate::error::AppError::from(ConnectorError::Failed("HTTP 500".into())),
+            crate::error::AppError::Summarize(_)
+        ));
+    }
+}

--- a/src-tauri/src/connectors/web.rs
+++ b/src-tauri/src/connectors/web.rs
@@ -1,0 +1,369 @@
+//! WEB SEARCH connector — the first connector (brain2, Phase F). Lets "research about the world"
+//! (weather, facts, who-won-X) reach the web instead of only the user's vault.
+//!
+//! ## Egress posture (NEW EGRESS CLASS — audited by the lock-security reviewer)
+//! This connector is [`EgressClass::External`]. It is exposed to the brain ONLY when ALL of:
+//! - `config.web_search_enabled` is true (the master toggle), AND
+//! - `config.web_search_consented` is true (one-time consent, preserve-only, flipped solely by the
+//!   `consent_to_web_search` command), AND
+//! - a Brave API key is present in the Keychain (`web_search_api_key`).
+//!
+//! Otherwise [`WebConnector::from_config_if_available`] returns `None` and the connector is ABSENT
+//! from the registry, so the brain never even offers the tool (fail-closed). The framework
+//! ([`crate::connectors::ConnectorRegistry::search`]) REDACTS the query through the firewall before
+//! it reaches [`WebConnector::search`], so the outgoing query is scrubbed of emails/cards/phones.
+//!
+//! ## The provider sub-seam — Brave today, swappable tomorrow
+//! [`WebSearchProvider`] is a sub-seam so the HTTP backend (Brave) is swappable for Tavily /
+//! DuckDuckGo / etc. with zero change to the connector or the brain. The default impl is
+//! [`BraveSearch`] (GET `https://api.search.brave.com/res/v1/web/search` with the
+//! `X-Subscription-Token` header). The key is BYO and lives in the Keychain — NEVER logged, NEVER
+//! handed to the FE.
+//!
+//! ## No PII in logs
+//! Logs carry the connector id + hit count + HTTP status only — never the query, the snippets, or the
+//! API key.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Connector, ConnectorError, ConnectorHit, ConnectorResult, EgressClass};
+use crate::settings::AppConfig;
+
+/// Keychain account holding the BYO web-search API key (Brave). A non-gated string secret, stored via
+/// the same data-protection keychain seam as the Anthropic key. NEVER logged / NEVER sent to the FE.
+pub const WEB_SEARCH_KEY_ACCOUNT: &str = "web_search_api_key";
+
+/// The loud attribution label every web hit carries, so the brain's answer is visibly "via web".
+const SOURCE_LABEL: &str = "web · Brave";
+
+/// Sub-seam: a swappable web-search backend. Takes an ALREADY-REDACTED query (the connector relies on
+/// the framework having redacted it) + the API key, returns provider-agnostic [`ConnectorHit`]s.
+///
+/// Swapping Brave for Tavily/DuckDuckGo later means one new impl here — the connector, the registry,
+/// and the brain are untouched.
+#[async_trait]
+pub trait WebSearchProvider: Send + Sync {
+    /// Stable provider id (for the source label / diagnostics), e.g. `"brave"`.
+    fn id(&self) -> &str;
+
+    /// Run the web search. `api_key` is resolved by the connector from the Keychain (never logged);
+    /// `redacted_query` is post-firewall. Returns the parsed hits or a [`ConnectorError::Failed`] on a
+    /// network/HTTP/parse failure (non-PII message).
+    async fn search(&self, redacted_query: &str, api_key: &str) -> ConnectorResult;
+}
+
+/// The default web-search provider: Brave Search API.
+///
+/// `GET https://api.search.brave.com/res/v1/web/search?q=…` with `X-Subscription-Token: <key>` and
+/// `Accept: application/json`. Parses `web.results[].{title, description, url}` into [`ConnectorHit`]s.
+/// Uses the crate's existing rustls `reqwest` — no new dependency.
+pub struct BraveSearch {
+    base_url: String,
+}
+
+impl Default for BraveSearch {
+    fn default() -> Self {
+        Self {
+            base_url: "https://api.search.brave.com/res/v1/web/search".to_string(),
+        }
+    }
+}
+
+impl BraveSearch {
+    /// Parse a Brave `/web/search` JSON body into [`ConnectorHit`]s. Pulled out of `search` so it can
+    /// be unit-tested with a fixture body and NO network. Missing `web`/`results` → empty vec (a clean
+    /// "no results"), never an error. Each result without a usable title is skipped.
+    fn parse_results(body: &str) -> ConnectorResult {
+        let parsed: BraveResponse = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("brave response parse: {e}")))?;
+        let results = parsed.web.map(|w| w.results).unwrap_or_default();
+        let hits = results
+            .into_iter()
+            .filter_map(|r| {
+                let title = r.title.trim().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                Some(ConnectorHit {
+                    title,
+                    snippet: r.description.unwrap_or_default().trim().to_string(),
+                    url: r.url.unwrap_or_default().trim().to_string(),
+                    source_label: SOURCE_LABEL.to_string(),
+                })
+            })
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[async_trait]
+impl WebSearchProvider for BraveSearch {
+    fn id(&self) -> &str {
+        "brave"
+    }
+
+    async fn search(&self, redacted_query: &str, api_key: &str) -> ConnectorResult {
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(&self.base_url)
+            .query(&[("q", redacted_query)])
+            .header("X-Subscription-Token", api_key)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            // `without_url()` strips the request URL (which carries the query string) from the
+            // reqwest error — no query text leaks into the error/logs/FE (no-PII rule).
+            .map_err(|e| ConnectorError::Failed(format!("brave request: {}", e.without_url())))?;
+        let status = resp.status();
+        if !status.is_success() {
+            // Non-PII: status code only, never the query or the key.
+            tracing::warn!(target: "connector", provider = "brave", status = status.as_u16(), "web search HTTP error");
+            return Err(ConnectorError::Failed(format!("brave HTTP {status}")));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("brave body: {}", e.without_url())))?;
+        Self::parse_results(&body)
+    }
+}
+
+/// Shape of the Brave `/web/search` JSON we consume — only `web.results[].{title,description,url}`.
+/// `#[serde(default)]` everywhere so a missing field never fails the parse.
+#[derive(Debug, Deserialize)]
+struct BraveResponse {
+    #[serde(default)]
+    web: Option<BraveWeb>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveWeb {
+    #[serde(default)]
+    results: Vec<BraveResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+/// The web-search connector — wires a [`WebSearchProvider`] + the BYO API key behind the
+/// [`Connector`] seam. Built ONLY when enabled + consented + keyed (see
+/// [`WebConnector::from_config_if_available`]).
+pub struct WebConnector {
+    provider: Box<dyn WebSearchProvider>,
+    api_key: String,
+}
+
+impl WebConnector {
+    /// Build the web connector IF AND ONLY IF the config enables web search, consent is granted, AND a
+    /// Brave API key is in the Keychain. Any missing prerequisite ⇒ `None` (the connector is absent
+    /// from the registry → the brain never offers the tool). This is the FAIL-CLOSED gate: no consent
+    /// or no key means the tool simply does not exist for the session.
+    ///
+    /// Reads the Keychain for the key here; a Keychain error degrades to `None` (no connector) rather
+    /// than surfacing — a missing/unreadable key just means "not available", never a crash.
+    pub fn from_config_if_available(config: &AppConfig) -> Option<Self> {
+        if !config.web_search_enabled || !config.web_search_consented {
+            return None;
+        }
+        let key = crate::secrets::get_secret(WEB_SEARCH_KEY_ACCOUNT)
+            .ok()
+            .flatten()
+            .filter(|k| !k.trim().is_empty())?;
+        Some(Self {
+            provider: Box::<BraveSearch>::default(),
+            api_key: key,
+        })
+    }
+
+    /// TEST-ONLY: build a connector around an injected provider + key, so the egress/parse path can be
+    /// exercised with a fake provider and NO network. Never compiled into release.
+    #[cfg(test)]
+    fn with_provider(provider: Box<dyn WebSearchProvider>, api_key: &str) -> Self {
+        Self {
+            provider,
+            api_key: api_key.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl Connector for WebConnector {
+    fn id(&self) -> &str {
+        "web"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        EgressClass::External
+    }
+
+    async fn search(&self, redacted_query: &str) -> ConnectorResult {
+        let trimmed = redacted_query.trim();
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
+        }
+        let hits = self.provider.search(trimmed, &self.api_key).await?;
+        tracing::info!(target: "connector", provider = self.provider.id(), hits = hits.len(), "web search returned");
+        Ok(hits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    /// A fake provider that captures the query + key it was handed and returns canned hits, so the
+    /// connector's egress/wiring is exercised with NO real HTTP.
+    struct FakeProvider {
+        last_query: std::sync::Mutex<Option<String>>,
+        last_key: std::sync::Mutex<Option<String>>,
+    }
+    #[async_trait]
+    impl WebSearchProvider for FakeProvider {
+        fn id(&self) -> &str {
+            "fake"
+        }
+        async fn search(&self, redacted_query: &str, api_key: &str) -> ConnectorResult {
+            *self.last_query.lock().unwrap() = Some(redacted_query.to_string());
+            *self.last_key.lock().unwrap() = Some(api_key.to_string());
+            Ok(vec![ConnectorHit {
+                title: "Weather today".into(),
+                snippet: "Sunny, 22°C".into(),
+                url: "https://example.com/weather".into(),
+                source_label: SOURCE_LABEL.to_string(),
+            }])
+        }
+    }
+
+    #[test]
+    fn brave_parser_maps_json_to_hits() {
+        // The exact shape the Brave /web/search API returns: web.results[].{title,description,url}.
+        let body = r#"{
+            "web": {
+                "results": [
+                    {"title":"Kraków weather","description":"Sunny and 22°C today.","url":"https://w.example/krakow"},
+                    {"title":"Forecast","description":"Rain tomorrow.","url":"https://w.example/fc"}
+                ]
+            }
+        }"#;
+        let hits = BraveSearch::parse_results(body).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Kraków weather");
+        assert_eq!(hits[0].snippet, "Sunny and 22°C today.");
+        assert_eq!(hits[0].url, "https://w.example/krakow");
+        // LOUD: every hit is attributed to the web source.
+        assert_eq!(hits[0].source_label, "web · Brave");
+    }
+
+    #[test]
+    fn brave_parser_tolerates_missing_fields_and_empty_results() {
+        // No `web` key → empty (clean "no results"), never an error.
+        assert!(BraveSearch::parse_results(r#"{}"#).unwrap().is_empty());
+        // `web.results` empty → empty.
+        assert!(BraveSearch::parse_results(r#"{"web":{"results":[]}}"#).unwrap().is_empty());
+        // A result missing description/url still maps (snippet/url default to empty); a result with
+        // an empty title is skipped.
+        let body = r#"{"web":{"results":[{"title":"Only Title"},{"title":""}]}}"#;
+        let hits = BraveSearch::parse_results(body).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Only Title");
+        assert_eq!(hits[0].snippet, "");
+        assert_eq!(hits[0].url, "");
+    }
+
+    #[test]
+    fn brave_parser_rejects_malformed_json() {
+        assert!(matches!(
+            BraveSearch::parse_results("not json at all"),
+            Err(ConnectorError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn connector_forwards_query_and_key_to_provider() {
+        // The connector hands the (already-redacted, by the framework) query + the BYO key to the
+        // provider and labels the hits "via web".
+        let provider = FakeProvider {
+            last_query: std::sync::Mutex::new(None),
+            last_key: std::sync::Mutex::new(None),
+        };
+        let connector = WebConnector::with_provider(Box::new(provider), "test-api-key");
+        let hits = block_on(connector.search("what's the weather in Kraków")).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source_label, "web · Brave");
+        assert_eq!(connector.egress_class(), EgressClass::External);
+        assert_eq!(connector.id(), "web");
+    }
+
+    /// REDACTION SEAM end-to-end: a query carrying an EMAIL, redacted through the firewall (exactly as
+    /// `ConnectorRegistry::search` does) before it reaches the connector, arrives at the WEB PROVIDER
+    /// with the email scrubbed to a ⟪EMAIL_…⟫ token. The fake provider captures what it actually
+    /// received, proving the PII never leaves toward the external service. (RED if the registry
+    /// stopped redacting: the raw email would reach the provider.)
+    #[test]
+    fn redacted_query_reaches_provider_with_pii_scrubbed() {
+        let captured = std::sync::Arc::new(FakeProvider {
+            last_query: std::sync::Mutex::new(None),
+            last_key: std::sync::Mutex::new(None),
+        });
+        // Mirror the framework's pre-egress redaction step.
+        let (redacted, _map) =
+            crate::summarize::redact::redact("email bob@acme.com what's the weather");
+        let connector = WebConnector {
+            provider: Box::new(FakeProviderRef(captured.clone())),
+            api_key: "key".into(),
+        };
+        let _ = block_on(connector.search(&redacted));
+        let seen = captured.last_query.lock().unwrap().clone().unwrap();
+        assert!(!seen.contains("bob@acme.com"), "raw email must not reach the provider: {seen}");
+        assert!(seen.contains("\u{27ea}EMAIL_"), "redaction token must reach the provider: {seen}");
+        assert!(seen.contains("weather"), "non-PII terms survive: {seen}");
+        // The BYO key is forwarded to the provider (never logged / FE-exposed).
+        assert_eq!(captured.last_key.lock().unwrap().as_deref(), Some("key"));
+    }
+
+    /// Share one `FakeProvider` between the connector and the assertion.
+    struct FakeProviderRef(std::sync::Arc<FakeProvider>);
+    #[async_trait]
+    impl WebSearchProvider for FakeProviderRef {
+        fn id(&self) -> &str {
+            self.0.id()
+        }
+        async fn search(&self, redacted_query: &str, api_key: &str) -> ConnectorResult {
+            self.0.search(redacted_query, api_key).await
+        }
+    }
+
+    #[test]
+    fn connector_empty_query_egresses_nothing() {
+        // An empty/whitespace query returns no hits WITHOUT calling the provider (no egress).
+        struct PanicProvider;
+        #[async_trait]
+        impl WebSearchProvider for PanicProvider {
+            fn id(&self) -> &str {
+                "panic"
+            }
+            async fn search(&self, _q: &str, _k: &str) -> ConnectorResult {
+                panic!("provider must not be called for an empty query");
+            }
+        }
+        let connector = WebConnector::with_provider(Box::new(PanicProvider), "k");
+        let hits = block_on(connector.search("   ")).unwrap();
+        assert!(hits.is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 pub mod calendar;
 pub mod commands;
+pub mod connectors;
 pub mod crypto;
 pub mod embed;
 pub mod error;
@@ -80,8 +81,11 @@ pub fn run() {
             commands::get_config,
             commands::save_config,
             commands::consent_to_cloud_egress,
+            commands::consent_to_web_search,
             commands::set_anthropic_key,
             commands::has_anthropic_key,
+            commands::set_web_search_api_key,
+            commands::has_web_search_key,
             commands::provider_statuses,
             commands::resummarize,
             commands::list_meetings,

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -221,6 +221,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::GetOpenCommitments { .. } => "Open commitments",
         ToolCall::GetMeeting { .. } => "Meeting",
         ToolCall::ListRecentMeetings { .. } => "Recent meetings",
+        ToolCall::WebSearch { .. } => "Web search",
     }
 }
 

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -25,6 +25,11 @@ pub const ACCOUNT_MCP_TOKEN: &str = "murmur_mcp_token";
 /// fixed account (no per-call string leak in [`leak_account`]).
 pub const ACCOUNT_ANTHROPIC_KEY: &str = "anthropic_api_key";
 
+/// Keychain account holding the BYO web-search API key (Brave). Mirrors
+/// [`crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT`]. Named here so the data-protection routing
+/// recognizes it as a known fixed account (no per-call string leak in [`leak_account`]).
+pub const ACCOUNT_WEB_SEARCH_KEY: &str = "web_search_api_key";
+
 /// Default reason string shown on the Touch ID / passcode sheet when releasing the master KEK.
 /// Callers may override per call-site (e.g. "Unlock this folder").
 pub const KEK_DEFAULT_REASON: &str = "Unlock this folder";
@@ -875,6 +880,7 @@ fn leak_account(account: &str) -> &'static str {
         ACCOUNT_MASTER_KEK => ACCOUNT_MASTER_KEK,
         ACCOUNT_MCP_TOKEN => ACCOUNT_MCP_TOKEN,
         ACCOUNT_ANTHROPIC_KEY => ACCOUNT_ANTHROPIC_KEY,
+        ACCOUNT_WEB_SEARCH_KEY => ACCOUNT_WEB_SEARCH_KEY,
         other => Box::leak(other.to_string().into_boxed_str()),
     }
 }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -159,6 +159,23 @@ pub struct AppConfig {
     /// live loop behaves EXACTLY as before (wake detected + surfaced, NO dispatch).
     #[serde(default)]
     pub realtime_reactions: bool,
+    /// brain2 connector framework (Phase F) — master toggle for the WEB SEARCH connector. Default
+    /// OFF (`#[serde(default)]` ⇒ a config persisted before this field existed loads as `false`).
+    /// When OFF the web connector is ABSENT from the brain's tool registry (no web tool offered), so
+    /// shipping this changes NOTHING vs today. Settable from the settings DTO (the Settings UI owns
+    /// the toggle). Even when ON, the connector is exposed only once `web_search_consented` is granted
+    /// AND a Brave API key is stored — see `connectors::web::WebConnector::from_config_if_available`.
+    #[serde(default)]
+    pub web_search_enabled: bool,
+    /// brain2 connector framework — one-time WEB SEARCH egress consent. The web connector reaches an
+    /// EXTERNAL service (a NEW EGRESS CLASS): the outgoing (redacted) query leaves the device. Default
+    /// OFF (fail-closed): no query egresses until the user explicitly consents once via the dedicated
+    /// `consent_to_web_search` command. Like `cloud_egress_consented`, this is PRESERVE-ONLY on the
+    /// settings DTO — `dto_to_config` ignores the incoming value and keeps the stored one, so a normal
+    /// settings save can neither grant nor clear it. `#[serde(default)]` ⇒ pre-existing configs load
+    /// as `false`.
+    #[serde(default)]
+    pub web_search_consented: bool,
 }
 
 impl Default for AppConfig {
@@ -194,6 +211,8 @@ impl Default for AppConfig {
             brain_model_id: None,
             brain_backend: BrainBackend::default(),
             realtime_reactions: false,
+            web_search_enabled: false,
+            web_search_consented: false,
         }
     }
 }
@@ -229,6 +248,8 @@ const K_BRAIN_MODEL_PATH: &str = "brain_model_path";
 const K_BRAIN_MODEL_ID: &str = "brain_model_id";
 const K_BRAIN_BACKEND: &str = "brain_backend";
 const K_REALTIME_REACTIONS: &str = "realtime_reactions";
+const K_WEB_SEARCH_ENABLED: &str = "web_search_enabled";
+const K_WEB_SEARCH_CONSENTED: &str = "web_search_consented";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -331,6 +352,12 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_REALTIME_REACTIONS)? {
             cfg.realtime_reactions = v == "true";
         }
+        if let Some(v) = db.get_setting(K_WEB_SEARCH_ENABLED)? {
+            cfg.web_search_enabled = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_WEB_SEARCH_CONSENTED)? {
+            cfg.web_search_consented = v == "true";
+        }
 
         Ok(cfg)
     }
@@ -419,6 +446,14 @@ impl AppConfig {
             K_REALTIME_REACTIONS,
             if self.realtime_reactions { "true" } else { "false" },
         )?;
+        db.set_setting(
+            K_WEB_SEARCH_ENABLED,
+            if self.web_search_enabled { "true" } else { "false" },
+        )?;
+        db.set_setting(
+            K_WEB_SEARCH_CONSENTED,
+            if self.web_search_consented { "true" } else { "false" },
+        )?;
         Ok(())
     }
 
@@ -434,6 +469,16 @@ impl AppConfig {
     pub fn grant_cloud_egress_consent(&mut self, db: &Db) -> Result<()> {
         self.cloud_egress_consented = true;
         db.set_setting(K_CLOUD_EGRESS_CONSENTED, "true")
+    }
+
+    /// brain2 connector framework — record the user's one-time consent to send the (redacted) web
+    /// search query to an EXTERNAL search service. Mirrors [`grant_cloud_egress_consent`]: flips the
+    /// in-memory flag AND persists it. This is the ONLY supported mutator (deliberately separate from
+    /// `save_config`), so web-search egress consent can never be granted as an incidental side effect
+    /// of a settings write. Until granted, the web connector is absent from the brain's tool registry.
+    pub fn grant_web_search_consent(&mut self, db: &Db) -> Result<()> {
+        self.web_search_consented = true;
+        db.set_setting(K_WEB_SEARCH_CONSENTED, "true")
     }
 }
 
@@ -587,6 +632,37 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(AppConfig::load(&db).unwrap().realtime_reactions);
+    }
+
+    #[test]
+    fn web_search_flags_default_off_and_round_trip() {
+        let db = temp_db();
+        // Fail-closed defaults: both OFF until explicitly set/granted.
+        let cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.web_search_enabled, "web search master toggle defaults OFF");
+        assert!(!cfg.web_search_consented, "web search egress consent fail-closed OFF");
+
+        // `web_search_enabled` is a settable flag; consent is granted via its dedicated method.
+        let cfg = AppConfig {
+            web_search_enabled: true,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert!(loaded.web_search_enabled);
+        // Consent was NOT granted by a plain save.
+        assert!(!loaded.web_search_consented);
+    }
+
+    #[test]
+    fn web_search_consent_grant_persists() {
+        let db = temp_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.web_search_consented);
+        cfg.grant_web_search_consent(&db).unwrap();
+        assert!(cfg.web_search_consented);
+        // Survives a reload from the settings table.
+        assert!(AppConfig::load(&db).unwrap().web_search_consented);
     }
 
     #[test]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -44,6 +44,13 @@ pub enum ToolCall {
     GetOpenCommitments { owner: Option<String> },
     /// Assemble the gated structured dossier for one entity (caller must pass a non-empty name/id).
     GetEntityDossier { entity: String },
+    /// CONNECTOR — live WEB SEARCH ("research about the world"). This is the ONE [`ToolCall`] that can
+    /// EGRESS: it reaches an external search service through the consent-gated, redacting connector
+    /// framework ([`crate::connectors`]). It is NOT runnable through the synchronous [`execute_tool`]
+    /// (which is egress-free, and is the MCP surface's only entry) — it is dispatched ONLY via the
+    /// async [`execute_web_search`], and ONLY when the web connector is exposed (enabled + consented +
+    /// keyed). The brain decides web-vs-vault; see `orchestrate.rs` / `voice_action.rs`.
+    WebSearch { query: String },
 }
 
 /// Execute a read-only tool against an OPEN `Db`, gated on the live session `unlocked` set.
@@ -163,7 +170,77 @@ pub fn execute_tool(
                 Err(e) => Err(AppError::Storage(format!("dossier build failed: {e}"))),
             }
         }
+        ToolCall::WebSearch { .. } => {
+            // EGRESS GUARD: the synchronous, egress-free `execute_tool` is the MCP surface's only
+            // entry, so it MUST NOT run a connector (which reaches off-device). Web search is
+            // dispatched exclusively via the async `execute_web_search`. Reaching here is a
+            // programming error in a caller, never a leak — refuse loudly, egress nothing.
+            Err(AppError::InvalidArg(
+                "WebSearch is an egress connector and cannot run through the egress-free tool path; \
+                 use execute_web_search"
+                    .to_string(),
+            ))
+        }
     }
+}
+
+/// CONNECTOR DISPATCH — run a live WEB SEARCH through the consent-gated, redacting connector
+/// framework, returning the same text-payload shape the vault tools return (so the brain treats web
+/// hits and vault hits identically). ASYNC + egress-bearing, kept OUT of [`execute_tool`] so the
+/// synchronous MCP surface can never reach it.
+///
+/// EGRESS DISCIPLINE (all three enforced before anything leaves the device):
+/// - **Consent-gated, fail-closed:** the registry exposes the web connector ONLY when
+///   `web_search_enabled && web_search_consented && a key is present`. When it is not exposed this
+///   returns the explicit `"Web search is not available …"` sentinel and EGRESSES NOTHING (the
+///   underlying [`crate::connectors::ConnectorError::NeedsConsent`]).
+/// - **Redacted:** [`crate::connectors::ConnectorRegistry::search`] scrubs the query through the
+///   redaction firewall BEFORE the provider call.
+/// - **Loud:** every line carries the hit's `source_label` (e.g. "web · Brave") so the answer is
+///   attributed to the web.
+///
+/// Returns a `"No web results …"` / `"Web search is not available …"` sentinel (matched by the
+/// brain's `is_empty_result`) when nothing usable comes back, so an unavailable/empty web tool never
+/// pollutes the grounding. A real network failure surfaces as `Err`.
+pub async fn execute_web_search(query: &str, config: &AppConfig) -> Result<String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok("No web results for an empty query.".to_string());
+    }
+    let registry = crate::connectors::ConnectorRegistry::build(config);
+    match registry.search("web", q).await {
+        Ok(hits) if hits.is_empty() => Ok(format!("No web results for \"{q}\".")),
+        Ok(hits) => Ok(format_web_hits(&hits)),
+        // Fail-closed / not-exposed → a graceful sentinel (NOT an error), so the brain just skips it.
+        Err(crate::connectors::ConnectorError::NeedsConsent) => {
+            Ok("Web search is not available (not enabled, not consented, or no API key set).".to_string())
+        }
+        Err(crate::connectors::ConnectorError::Unconfigured(_)) => {
+            Ok("Web search is not available (not configured).".to_string())
+        }
+        // A real external failure (network/HTTP/parse) is surfaced; the caller logs + skips it.
+        Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
+    }
+}
+
+/// Render web connector hits into the tool text payload — one line per result, each LOUD with its
+/// source label + URL: `- [web · Brave] Title — snippet (url)`.
+fn format_web_hits(hits: &[crate::connectors::ConnectorHit]) -> String {
+    hits.iter()
+        .map(|h| {
+            let mut line = format!("- [{}] {}", h.source_label, h.title.trim());
+            let snippet = h.snippet.trim();
+            if !snippet.is_empty() {
+                line.push_str(&format!(" — {snippet}"));
+            }
+            let url = h.url.trim();
+            if !url.is_empty() {
+                line.push_str(&format!(" ({url})"));
+            }
+            line
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Render the open-commitments rollup into the tool text payload — one line per item:
@@ -201,4 +278,97 @@ fn format_hits(hits: &[crate::storage::models::SearchHit]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::AppConfig;
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn tmp_db() -> Db {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-tools-web-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    /// EGRESS GUARD: the synchronous, egress-free `execute_tool` (the MCP surface's only entry) MUST
+    /// refuse a `WebSearch` call — it can never run a connector that reaches off-device.
+    #[test]
+    fn sync_execute_tool_refuses_websearch() {
+        let db = tmp_db();
+        let nothing = HashSet::new();
+        let cfg = AppConfig::default();
+        let res = execute_tool(
+            &ToolCall::WebSearch { query: "weather".into() },
+            &db,
+            &nothing,
+            &cfg,
+        );
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "the egress-free tool path must refuse WebSearch (no connector through MCP)"
+        );
+    }
+
+    /// FAIL-CLOSED: with the default config (web search disabled + unconsented), `execute_web_search`
+    /// returns the graceful "not available" sentinel and EGRESSES NOTHING — no key, no network.
+    #[test]
+    fn web_search_fail_closed_returns_sentinel_no_egress() {
+        let cfg = AppConfig::default(); // web_search_enabled = false, consented = false
+        let out = block_on(execute_web_search("what's the weather in Kraków", &cfg)).unwrap();
+        assert!(
+            out.starts_with("Web search is not available"),
+            "unexposed web search must return the not-available sentinel: {out}"
+        );
+    }
+
+    /// An empty query never builds the registry / reaches a connector.
+    #[test]
+    fn web_search_empty_query_is_inert() {
+        let cfg = AppConfig::default();
+        let out = block_on(execute_web_search("   ", &cfg)).unwrap();
+        assert!(out.starts_with("No web results"));
+    }
+
+    /// LOUD: web hits render with their source label + URL, so the answer is attributed "via web".
+    #[test]
+    fn format_web_hits_is_loud_with_source_and_url() {
+        let hits = vec![
+            crate::connectors::ConnectorHit {
+                title: "Kraków weather".into(),
+                snippet: "Sunny, 22°C".into(),
+                url: "https://w.example/krakow".into(),
+                source_label: "web · Brave".into(),
+            },
+            crate::connectors::ConnectorHit {
+                title: "No URL result".into(),
+                snippet: String::new(),
+                url: String::new(),
+                source_label: "web · Brave".into(),
+            },
+        ];
+        let out = format_web_hits(&hits);
+        assert!(out.contains("[web · Brave] Kraków weather"), "loud source label: {out}");
+        assert!(out.contains("Sunny, 22°C"), "snippet present: {out}");
+        assert!(out.contains("(https://w.example/krakow)"), "url present: {out}");
+        // A hit with no snippet/url still renders its labelled title.
+        assert!(out.contains("[web · Brave] No URL result"), "labelled even without url: {out}");
+    }
 }

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -314,6 +314,47 @@ fn rag_answer(
             ),
         }
     }
+    // WEB LEG (research about the WORLD): for a `research` intent, if the web connector is exposed
+    // (enabled + consented + keyed), ALSO run a live web search and fold its LOUD, source-labelled
+    // hits into the grounding. This is the brain CHOOSING web vs vault — the vault legs above always
+    // run (so "what do we know about project X" still works); the web leg adds "what's the weather /
+    // who won Y" coverage when the vault has nothing to say. When the connector is not exposed the
+    // call returns a graceful sentinel (no egress) that is filtered out below, so behavior is
+    // unchanged from before for users without web search. Recall (entity dossier) stays vault-only.
+    let mut web_lines: Vec<String> = Vec::new();
+    if intent_kind == "research" {
+        let web_query = if !topic.is_empty() {
+            topic.to_string()
+        } else {
+            literal_command.trim().to_string()
+        };
+        if !web_query.is_empty() {
+            match web_search_blocking(&web_query, config) {
+                Ok(text) => {
+                    let text = text.trim();
+                    if !text.is_empty() && !is_empty_tool_result(text) {
+                        // Capture the loud "[web · …]" lines for citations, and add to grounding.
+                        for line in text.lines() {
+                            if line.trim_start().starts_with("- [") {
+                                web_lines.push(line.to_string());
+                            }
+                        }
+                        if !grounding.is_empty() {
+                            grounding.push_str("\n\n");
+                        }
+                        grounding.push_str(text);
+                        grounding.push_str("\n\n");
+                    }
+                }
+                // A web failure is non-fatal — the vault grounding still answers.
+                Err(e) => tracing::debug!(
+                    target: "voice",
+                    error = %e,
+                    "voice-action web search failed; continuing with vault grounding"
+                ),
+            }
+        }
+    }
     let grounding = grounding.trim();
 
     // CITATIONS: derived from a GATED `search_visible` over the SAME live unlocked set — every hit
@@ -347,6 +388,14 @@ fn rag_answer(
     for c in extract_citations(grounding) {
         push_cite(c);
     }
+    // WEB citations: each loud "- [web · …] Title — … (url)" line becomes a "(web) Title — url"
+    // citation, so the card visibly attributes the web-sourced facts (LOUD). Kept distinct from the
+    // `[[Title]]` vault wikilinks.
+    for line in &web_lines {
+        if let Some(c) = web_citation_from_line(line) {
+            push_cite(c);
+        }
+    }
 
     // No grounding at all → don't burn a brain call; return a clean "nothing found".
     if grounding.is_empty() {
@@ -357,10 +406,14 @@ fn rag_answer(
         );
     }
 
+    // The brain may now ground its answer on BOTH the user's vault notes AND any web results. The
+    // prompt allows web facts (attributed) so a "what's the weather" question the vault can't answer
+    // is still answered from the web leg, while vault-answerable questions stay vault-grounded.
     let system = "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 \
-                  sentences) using ONLY the provided notes from the user's own meeting vault. Cite \
-                  the meetings you used by their [[Title]] wikilink. If the notes don't cover it, \
-                  say so plainly. Do not invent facts.";
+                  sentences) using ONLY the provided context: the user's own meeting notes AND any \
+                  WEB results (lines beginning \"[web\"). Cite vault meetings by their [[Title]] \
+                  wikilink and attribute web facts as \"(via web)\". If the context doesn't cover \
+                  it, say so plainly. Do not invent facts.";
     let user = format!("Request: {display_query}\n\nNotes from the vault:\n{grounding}");
 
     // EGRESS SEAM: a Cloud reasoner routes through make_provider (consent gate + RedactingProvider).
@@ -429,6 +482,54 @@ fn note_aside(
     }
 }
 
+/// Run the async web-search connector to completion from this SYNCHRONOUS dispatch (the live loop
+/// spawns `handle_voice_action` off-thread). Mirrors `reason::block_on_complete`: a dedicated scoped
+/// OS thread with its own current-thread runtime, so we never "start a runtime within a runtime" and
+/// the future never crosses a thread boundary (only the `Result<String>` does). The egress/consent/
+/// redaction discipline all lives inside `execute_web_search` → the connector registry.
+fn web_search_blocking(query: &str, config: &AppConfig) -> crate::error::Result<String> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| AppError::Summarize(format!("web search runtime build: {e}")))?;
+                rt.block_on(crate::tools::execute_web_search(query, config))
+            })
+            .join()
+            .map_err(|_| AppError::Summarize("web search worker thread panicked".into()))?
+    })
+}
+
+/// Turn a loud web grounding line `- [web · Brave] Title — snippet (https://…)` into a compact
+/// citation `(web) Title — https://…`. Returns `None` for a non-web line. Deterministic, no regex.
+fn web_citation_from_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    let after_label = line.strip_prefix("- [")?;
+    let close = after_label.find(']')?;
+    let rest = after_label[close + 1..].trim();
+    // Title is everything up to the first " — " (snippet sep) or " (" (url); whichever comes first.
+    let title_end = [rest.find(" — "), rest.find(" (")]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(rest.len());
+    let title = rest[..title_end].trim();
+    if title.is_empty() {
+        return None;
+    }
+    // Extract a trailing "(url)" if present.
+    let url = rest
+        .rfind('(')
+        .and_then(|i| rest[i + 1..].strip_suffix(')').map(str::trim))
+        .filter(|u| u.starts_with("http"));
+    Some(match url {
+        Some(u) => format!("(web) {title} — {u}"),
+        None => format!("(web) {title}"),
+    })
+}
+
 /// Whether a tool result is a "nothing found" / "disabled" placeholder rather than real content,
 /// so it can be excluded from the brain grounding (an included placeholder would falsely count as
 /// grounding and trigger a brain call on an empty vault). Matches the deterministic prefixes
@@ -441,6 +542,8 @@ fn is_empty_tool_result(text: &str) -> bool {
         || t.starts_with("No open commitments")
         || t.starts_with("No visible entity")
         || t.starts_with("Semantic search is disabled")
+        || t.starts_with("No web results")
+        || t.starts_with("Web search is not available")
 }
 
 /// Pull distinct `[[Title]]` wikilinks out of the gated tool grounding text, in first-seen order.

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -148,6 +148,33 @@ export class IpcService {
     return invoke<boolean>("has_anthropic_key");
   }
 
+  /**
+   * brain2 connectors — grant the one-time consent for WEB-SEARCH egress. This is
+   * the ONLY supported way to flip `webSearchConsented` true: the backend persists
+   * the flag AND updates its in-memory config cache, so the next brain/Ask answer
+   * may expose the web connector (provided web search is enabled AND a key is
+   * stored). Idempotent. Until granted, the redacted query never leaves the device.
+   * Mirrors {@link consentToCloudEgress}.
+   */
+  consentToWebSearch(): Promise<void> {
+    return invoke<void>("consent_to_web_search");
+  }
+
+  /**
+   * brain2 connectors — store/replace the BYO web-search (Brave) API key in the
+   * Keychain. An empty string clears it. The key is NEVER logged and NEVER returned
+   * to the FE — only {@link hasWebSearchKey} reports presence. Mirrors
+   * {@link setAnthropicKey}.
+   */
+  setWebSearchApiKey(key: string): Promise<void> {
+    return invoke<void>("set_web_search_api_key", { key });
+  }
+
+  /** Whether a web-search (Brave) API key is currently stored. Never the value. */
+  hasWebSearchKey(): Promise<boolean> {
+    return invoke<boolean>("has_web_search_key");
+  }
+
   providerStatuses(): Promise<ProviderStatus[]> {
     return invoke<ProviderStatus[]>("provider_statuses");
   }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -95,6 +95,23 @@ export interface AppConfigDto {
    * like the other flags. Default false. Mirrors Rust `AppConfigDto.semantic_search_enabled`.
    */
   semanticSearchEnabled: boolean;
+  /**
+   * brain2 connectors — the web-search connector MASTER toggle. NEW CLOUD EGRESS:
+   * when on (AND `webSearchConsented` AND a Brave key is stored), the brain/Ask
+   * answer may send a REDACTED query off-device to the search provider. A settable
+   * flag: round-tripped on every `save_config` like the other flags. Default false.
+   * Mirrors Rust `AppConfigDto.web_search_enabled`.
+   */
+  webSearchEnabled: boolean;
+  /**
+   * brain2 connectors — one-time consent for the web-search egress. Like
+   * `cloudEgressConsented`, this is PRESERVE-ONLY on `save_config` (a normal save
+   * carries the current value back, never flips it) and is granted SOLELY by the
+   * dedicated `consent_to_web_search` command. Default false (fail-closed): no
+   * query leaves the device until the user has consented once. Mirrors Rust
+   * `AppConfigDto.web_search_consented`.
+   */
+  webSearchConsented: boolean;
 }
 
 /** Phase H — which backend powers the brain / in-meeting voice assistant. */

--- a/src/app/features/record/assistant-actions.component.ts
+++ b/src/app/features/record/assistant-actions.component.ts
@@ -12,7 +12,9 @@ import type { AssistantInteraction } from "../../core/assistant.store";
  * (once, via AssistantStore.init()) to the in-meeting voice assistant's wake +
  * result event streams and renders a newest-first list of recent interactions:
  * a pending "🎙 usłyszano: {command}" row on a wake, resolved to {summary} +
- * [[Title]] citation chips with a status pill when the result arrives.
+ * citation chips with a status pill when the result arrives. Vault sources render
+ * as `[[Title]]` chips; web sources (when the web-search connector contributed)
+ * render as a distinct "via web" link to the URL — the off-device origin is loud.
  *
  * The card is in-flow on the record page (not a floating overlay), so it uses
  * the frosted `.card` like the other record-surface panels. If it were ever
@@ -73,8 +75,22 @@ import type { AssistantInteraction } from "../../core/assistant.store";
                 }
                 @if (a.citations.length > 0) {
                   <div class="action-cites" aria-label="Sources">
-                    @for (c of a.citations; track c) {
-                      <span class="cite-chip">[[{{ c }}]]</span>
+                    @for (c of a.citations; track $index) {
+                      @if (c.kind === "web") {
+                        <a
+                          class="cite-chip is-web"
+                          [href]="c.url ?? null"
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          [title]="c.url ?? c.label"
+                        >
+                          <span class="cite-web-mark" aria-hidden="true">⊕</span>
+                          <span class="cite-web-label">{{ c.label }}</span>
+                          <span class="cite-web-via">via web</span>
+                        </a>
+                      } @else {
+                        <span class="cite-chip">[[{{ c.label }}]]</span>
+                      }
                     }
                   </div>
                 }
@@ -220,6 +236,43 @@ import type { AssistantInteraction } from "../../core/assistant.store";
         font-family: var(--font-mono);
         font-size: 0.78rem;
         letter-spacing: -0.01em;
+      }
+      /* A web source — visibly distinct from the [[vault]] chips: a link, not a
+         monospace wikilink, with an "via web" tag so the off-device origin is loud. */
+      a.cite-chip.is-web {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+        font-family: inherit;
+        text-decoration: none;
+        max-width: 100%;
+      }
+      a.cite-chip.is-web:hover {
+        border-color: var(--accent-soft);
+        color: var(--text-primary);
+      }
+      .cite-web-mark {
+        color: var(--accent);
+        line-height: 1;
+      }
+      .cite-web-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 220px;
+      }
+      .cite-web-via {
+        padding: 0 var(--space-1);
+        border-radius: var(--radius-sm);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.7rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
       }
 
       @media (prefers-reduced-motion: reduce) {

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -526,6 +526,125 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
         </div>
       </div>
 
+      <!-- Connectors — web search (NEW CLOUD EGRESS, surfaced loudly) -->
+      <div class="card connectors-card">
+        <div class="brain-copy">
+          <h3>Connectors</h3>
+          <p class="text-secondary brain-sub">
+            Let the brain reach beyond your notes. Connectors are
+            <strong>off by default</strong> — each one that leaves this Mac asks
+            for an explicit, one-time consent first.
+          </p>
+        </div>
+
+        <!-- Web search (Brave) connector -->
+        <label class="toggle-row">
+          <span class="toggle-copy">
+            <span class="toggle-title">Web search</span>
+            <span class="text-secondary toggle-sub">
+              When enabled (and allowed below, with a key), the assistant can
+              look facts up on the web and cite them. Answers stay grounded in
+              your notes first; web results are added as “via web” sources.
+            </span>
+          </span>
+          <input type="checkbox" formControlName="webSearchEnabled" />
+        </label>
+
+        @if (form.controls.webSearchEnabled.value) {
+          <!-- Egress banner — make the new off-device path impossible to miss. -->
+          <p class="banner is-warning connector-egress" role="note">
+            <strong>This sends data off your Mac.</strong> When the brain runs a
+            web search, your (redacted) query leaves the device and goes to the
+            search provider (Brave). Only the query is sent — never your notes or
+            transcript. Disable this, or skip the consent below, to keep
+            everything local.
+          </p>
+
+          <!-- BYO API key (Brave) -->
+          <fieldset class="connector-fieldset">
+            <legend>Brave Search API key</legend>
+            <div class="key-status">
+              <span class="text-secondary">Status</span>
+              @if (hasWebKey()) {
+                <span class="pill is-success">
+                  <span class="pill-dot"></span>
+                  Key set ✓
+                </span>
+              } @else {
+                <span class="pill">
+                  <span class="pill-dot"></span>
+                  Not set
+                </span>
+              }
+            </div>
+            <span class="row">
+              <input
+                type="password"
+                [formControl]="webKeyControl"
+                placeholder="Brave Search API key"
+                autocomplete="off"
+              />
+              <button
+                type="button"
+                class="btn"
+                (click)="saveWebKey()"
+                [disabled]="savingWebKey()"
+              >
+                {{ savingWebKey() ? "Saving…" : "Save key" }}
+              </button>
+            </span>
+            <span class="field-help text-muted">
+              Bring your own key — it's stored in your macOS Keychain, never
+              logged, and never leaves with your notes.
+            </span>
+            @if (webKeyError(); as wkerr) {
+              <p class="text-danger brain-error">{{ wkerr }}</p>
+            }
+          </fieldset>
+
+          <!-- One-time egress consent (mirrors the Cloud-processing UX) -->
+          <div class="privacy-section connector-consent">
+            <span class="privacy-section-label text-muted"
+              >Allow web search</span
+            >
+            <p class="text-secondary privacy-note">
+              Your search query leaves this device for the search provider
+              (redacted first). Until you allow this once, web search stays off
+              and no query is ever sent.
+            </p>
+            @if (webConsented()) {
+              <span class="pill is-success cloud-consent-pill">
+                <span class="pill-dot"></span>
+                Web search allowed
+              </span>
+            } @else {
+              <div class="cloud-consent-row">
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  (click)="allowWebSearch()"
+                  [disabled]="webConsenting()"
+                >
+                  @if (webConsenting()) {
+                    <span class="spin-ring" aria-hidden="true"></span>
+                    Enabling…
+                  } @else {
+                    Allow web search
+                  }
+                </button>
+                <span class="text-muted cloud-consent-hint">
+                  One-time. The brain works fully offline on your notes without
+                  it.
+                </span>
+              </div>
+            }
+            @if (webConsentError(); as wcerr) {
+              <p class="text-danger privacy-note">{{ wcerr }}</p>
+            }
+          </div>
+        }
+      </div>
+
       <!-- Works with Obsidian — optional vault companion -->
       <div class="card obsidian-card">
         <div class="obsidian-head">
@@ -1609,6 +1728,26 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
         font-size: 0.8125rem;
       }
 
+      /* --- Connectors card (web search — NEW EGRESS) --- */
+      .connectors-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .connector-egress {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }
+      .connector-fieldset {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .connector-consent {
+        margin-top: var(--space-1);
+      }
+
       /* --- Privacy & integrations card --- */
       .privacy-card {
         display: flex;
@@ -1797,8 +1936,12 @@ export class SettingsComponent implements OnInit {
     brainModelId: "",
     // brain2 RAG — semantic-search master flag (round-tripped on save).
     semanticSearchEnabled: false,
+    // brain2 connectors — web-search master toggle (NEW EGRESS; round-tripped).
+    webSearchEnabled: false,
   });
   readonly keyControl = new FormControl("", { nonNullable: true });
+  /** BYO Brave Search API key input (web-search connector). Cleared after save. */
+  readonly webKeyControl = new FormControl("", { nonNullable: true });
 
   readonly providers = signal<ProviderStatus[]>([]);
   /** Available mic input devices for the picker (loaded best-effort in ngOnInit). */
@@ -1860,6 +2003,21 @@ export class SettingsComponent implements OnInit {
   readonly consenting = signal(false);
   /** Surfaced if granting consent rejects. */
   readonly consentError = signal<string | null>(null);
+
+  // ── brain2 connectors — web search (NEW EGRESS) ────────────────────────
+
+  /** Web-search egress consent state — drives the "Allow web search" section; round-tripped on save. */
+  readonly webConsented = signal(false);
+  /** True while the one-time web-search consent command is in flight. */
+  readonly webConsenting = signal(false);
+  /** Surfaced if granting web-search consent rejects. */
+  readonly webConsentError = signal<string | null>(null);
+  /** Whether a Brave Search API key is stored (has-key check; never the value). */
+  readonly hasWebKey = signal(false);
+  /** True while the BYO key is being saved. */
+  readonly savingWebKey = signal(false);
+  /** Surfaced if storing the web-search key rejects. */
+  readonly webKeyError = signal<string | null>(null);
 
   // ── Phase H — brain (AI assistant) model registry ──────────────────────
 
@@ -1926,6 +2084,9 @@ export class SettingsComponent implements OnInit {
       this.loadedLockRequireBiometric = cfg.lockRequireBiometric ?? true;
       this.loadedRelockOnScreenshare = cfg.relockOnScreenshare ?? true;
       this.cloudConsented.set(cfg.cloudEgressConsented ?? false);
+      // brain2 connectors — web-search consent is preserve-only (granted only via
+      // consent_to_web_search); snapshot it so save() round-trips it unchanged.
+      this.webConsented.set(cfg.webSearchConsented ?? false);
       this.form.patchValue({
         providerId: cfg.providerId,
         vaultPath: cfg.vaultPath ?? "",
@@ -1951,10 +2112,12 @@ export class SettingsComponent implements OnInit {
         realtimeReactions: cfg.realtimeReactions ?? false,
         brainModelId: cfg.brainModelId ?? "",
         semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
+        webSearchEnabled: cfg.webSearchEnabled ?? false,
       });
       this.updateDownloadHint();
       this.inputDevices.set(await this.ipc.listInputDevices().catch(() => []));
       this.hasKey.set(await this.ipc.hasAnthropicKey());
+      this.hasWebKey.set(await this.ipc.hasWebSearchKey().catch(() => false));
       this.modelPresent.set(await this.ipc.modelPresent());
       await this.refreshProviders();
       // Phase H — brain model registry + download-progress stream (best-effort).
@@ -2152,6 +2315,11 @@ export class SettingsComponent implements OnInit {
       brainModelId: v.brainModelId || null,
       // brain2 RAG — semantic-search master flag (round-tripped so a save preserves it).
       semanticSearchEnabled: v.semanticSearchEnabled,
+      // brain2 connectors — web-search toggle is settable from the form; its consent
+      // is PRESERVE-ONLY (granted via allowWebSearch's dedicated command), so a save
+      // just carries the current value back instead of letting the backend default it.
+      webSearchEnabled: v.webSearchEnabled,
+      webSearchConsented: this.webConsented(),
       // Round-trip the Stage E security flags so a settings save never silently
       // resets them. Cloud-egress consent is GRANTED only via the dedicated
       // command (allowCloudProcessing) — here we just carry the current value back.
@@ -2203,6 +2371,48 @@ export class SettingsComponent implements OnInit {
       this.consentError.set(String(e));
     } finally {
       this.consenting.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors — store/replace the BYO Brave Search API key in the
+   * Keychain, then re-probe presence so the "Key set ✓" pill flips. The value is
+   * cleared from the input after saving (it's never shown back). Mirrors saveKey().
+   */
+  async saveWebKey(): Promise<void> {
+    const key = this.webKeyControl.value;
+    if (!key.trim()) return;
+    this.webKeyError.set(null);
+    this.savingWebKey.set(true);
+    try {
+      await this.ipc.setWebSearchApiKey(key);
+      this.webKeyControl.setValue("");
+      this.hasWebKey.set(await this.ipc.hasWebSearchKey());
+    } catch (e) {
+      this.webKeyError.set(String(e));
+    } finally {
+      this.savingWebKey.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors — grant the one-time web-search egress consent via the
+   * dedicated command (an explicit, auditable user act — NOT a side effect of a
+   * normal settings save). After it resolves the brain may expose the web
+   * connector (when web search is enabled AND a key is stored). There is no FE
+   * "revoke": save() simply carries the current value back so it isn't cleared.
+   * Mirrors allowCloudProcessing().
+   */
+  async allowWebSearch(): Promise<void> {
+    this.webConsentError.set(null);
+    this.webConsenting.set(true);
+    try {
+      await this.ipc.consentToWebSearch();
+      this.webConsented.set(true);
+    } catch (e) {
+      this.webConsentError.set(String(e));
+    } finally {
+      this.webConsenting.set(false);
     }
   }
 


### PR DESCRIPTION
External connectors = LIVE agentic tools the brain calls (extends gated execute_tool), NOT vectorized. First = **web search** so 'research about the world' goes to the web vs only the vault. Framework (redact-before-egress registry) + Brave connector (BYO key, swappable seam). **NEW EGRESS**: fail-closed (enable∧consent∧keyed), consent preserve-only via dedicated command, query redacted, LOUD 'via web', MCP can't invoke it. Verified: test 383/0; clippy clean; ng lint+build clean; adversarial PASS; **lock-security PASS** (new egress audited). Real results = @Mac+Brave key.