### PR TITLE
feat(voice): persist in-meeting assistant Q&A + detail section + keep out of action items

### DIFF
--- a/src-tauri/src/audio/wake.rs
+++ b/src-tauri/src/audio/wake.rs
@@ -225,6 +225,29 @@ fn squeeze_repeats(s: &str) -> String {
     out
 }
 
+/// Whether a transcript `line` is ADDRESSED TO THE ASSISTANT — i.e. it opens with the "Klaud/
+/// Klaudku/Claude" vocative wake form ("Klaudku, sprawdź pogodę"). Reuses [`detect_wake`] (the
+/// same recall-first, shape-gated vocative matcher the live loop uses), so the SUMMARIZER recognizes
+/// exactly the utterances the in-meeting assistant treats as commands. Deterministic + pure.
+///
+/// WHY: the user's spoken assistant commands land verbatim in the transcript. Fed to the summarizer
+/// they get MANGLED into owner-less action items ("(właściciel nieokreślony) — Sprawdzić pogodę").
+/// Excluding these lines from the summarization input keeps them OUT of the note's action items; the
+/// assistant's ANSWER is carried by the persisted Q&A log instead.
+pub fn is_assistant_directed(line: &str) -> bool {
+    detect_wake(line).is_some()
+}
+
+/// Filter a list of transcript LINES, dropping every one [`is_assistant_directed`] flags (a line the
+/// user spoke TO the assistant). Returns the kept lines in order. Pure + deterministic. Used to build
+/// the summarization input so assistant-directed utterances never reach the action-items extraction.
+pub fn strip_assistant_directed_lines<'a>(lines: impl IntoIterator<Item = &'a str>) -> Vec<&'a str> {
+    lines
+        .into_iter()
+        .filter(|l| !is_assistant_directed(l))
+        .collect()
+}
+
 // ───────────────────────────── intent parser ─────────────────────────────
 
 /// A structured, deterministic interpretation of a wake command tail. The dispatch/execution of
@@ -654,6 +677,46 @@ mod tests {
             VoiceIntent::Unknown { raw: "asdf qwer zxcv".into() }
         );
         assert_eq!(parse_voice_intent("   "), VoiceIntent::Unknown { raw: String::new() });
+    }
+
+    // ── SUMMARIZER EXCLUSION: assistant-directed line detection ──────────────
+
+    #[test]
+    fn is_assistant_directed_flags_vocative_lines_only() {
+        // Lines the user spoke TO the assistant (vocative wake form) → directed.
+        for directed in [
+            "Klaudku, sprawdź jaka była pogoda",
+            "klaudku jakie masz informacje w moich notatkach",
+            "klauku zrób research o cenach", // d-less vocative
+            "hej klałdku wyszukaj raport",
+        ] {
+            assert!(is_assistant_directed(directed), "{directed:?} must be assistant-directed");
+        }
+        // Ordinary meeting speech → NOT directed (must reach the summarizer).
+        for ordinary in [
+            "Janek wyśle raport w piątek",
+            "let's talk about the budget for friday",
+            "klaudia z działu hr dołączy do nas", // name, not the vocative
+            "cloud computing is the future",
+            "",
+        ] {
+            assert!(!is_assistant_directed(ordinary), "{ordinary:?} must NOT be assistant-directed");
+        }
+    }
+
+    #[test]
+    fn strip_assistant_directed_lines_keeps_meeting_content() {
+        let lines = [
+            "Janek wyśle raport w piątek",
+            "Klaudku, sprawdź jaka była pogoda",
+            "Ustaliliśmy termin na poniedziałek",
+        ];
+        let kept = strip_assistant_directed_lines(lines.iter().copied());
+        assert_eq!(
+            kept,
+            vec!["Janek wyśle raport w piątek", "Ustaliliśmy termin na poniedziałek"],
+            "assistant commands dropped; real meeting content kept in order"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,6 +172,11 @@ pub struct MeetingDetailDto {
     pub meeting: Meeting,
     pub note: Option<NoteDto>,
     pub segments: Vec<Segment>,
+    /// In-meeting voice-assistant interactions (the persisted Q&A: the user's spoken command + the
+    /// assistant's answer + citations). EMPTY when the meeting is locked-and-not-session-unlocked
+    /// (gated by `meeting_is_unlocked`, exactly like `note`/`segments`) — and also empty for a sealed
+    /// meeting at rest because the rows were PURGED on seal (purge-on-seal, like the correction-log).
+    pub assistant_interactions: Vec<crate::storage::models::AssistantInteraction>,
     /// Phase 0.5 — `true` when the meeting's folder is sealed AND not session-unlocked. The FE
     /// renders a locked state (Touch-ID-to-unlock) instead of content; `note`/`segments` are
     /// empty in that case (the content is encrypted at rest, decrypted only on session-unlock).
@@ -2103,10 +2108,22 @@ pub fn get_meeting_detail(
             exported_path: n.exported_path,
         });
     let segments = state.db.get_segments(&meeting_id)?;
+    // GATED read: only past the `meeting_is_unlocked` gate above do we surface the persisted
+    // assistant Q&A. The DB read is ALSO `visibility_clause`-gated (it returns empty for a sealed-
+    // not-unlocked meeting) — defense-in-depth, double-gated exactly like the rest of the DTO.
+    let unlocked = state
+        .unlocked_folders
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+    let assistant_interactions = state
+        .db
+        .list_assistant_interactions_visible(&meeting_id, &unlocked)?;
     Ok(Some(MeetingDetailDto {
         meeting,
         note,
         segments,
+        assistant_interactions,
         locked: false,
     }))
 }
@@ -2127,6 +2144,9 @@ fn masked_detail(meeting: Meeting) -> MeetingDetailDto {
         },
         note: None,
         segments: Vec::new(),
+        // The Q&A log is masked too — a sealed-not-unlocked meeting surfaces NOTHING here (and at
+        // rest the rows were purged on seal anyway).
+        assistant_interactions: Vec::new(),
         locked: true,
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -418,11 +418,14 @@ async fn run_inner(
         .db
         .update_meeting_status(meeting_id, MeetingStatus::Transcribed)?;
 
-    // Rebuild the full transcript text from the merged, time-ordered segments.
+    // Rebuild the full transcript text from the merged, time-ordered segments — EXCLUDING segments
+    // the user spoke TO the assistant ("Klaudku, sprawdź pogodę"). Those are assistant commands, not
+    // meeting content: fed to the summarizer they get mangled into owner-less action items. The
+    // assistant's ANSWER lives in the persisted Q&A log (assistant_interactions), not the note.
     let mut full_text = String::new();
     for seg in &merged_segments {
         let t = seg.text.trim();
-        if t.is_empty() {
+        if t.is_empty() || crate::audio::wake::is_assistant_directed(t) {
             continue;
         }
         if !full_text.is_empty() {
@@ -801,11 +804,12 @@ pub async fn resummarize_existing(
         ));
     }
 
-    // Rebuild full text from segments (same joining as the transcriber).
+    // Rebuild full text from segments (same joining as the transcriber), EXCLUDING assistant-
+    // directed utterances ("Klaudku, …") so they never reach the action-items extraction.
     let mut full_text = String::new();
     for seg in &segments {
         let t = seg.text.trim();
-        if t.is_empty() {
+        if t.is_empty() || crate::audio::wake::is_assistant_directed(t) {
             continue;
         }
         if !full_text.is_empty() {

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8,9 +8,9 @@ use crate::error::{AppError, Result};
 use std::collections::HashSet;
 
 use crate::storage::models::{
-    Analytics, Commitment, CorrectionRecord, DayCount, EntityDetail, EntityKind, EntityNeighbor,
-    Folder, GraphData, GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord,
-    RecipeRecord, SearchHit, StatusCount, VaultSource,
+    Analytics, AssistantInteraction, Commitment, CorrectionRecord, DayCount, EntityDetail,
+    EntityKind, EntityNeighbor, Folder, GraphData, GraphEdge, GraphEntity, GraphNode, Meeting,
+    MeetingStatus, NoteRecord, RecipeRecord, SearchHit, StatusCount, VaultSource,
 };
 use crate::embed::Embedder;
 use crate::transcribe::types::Segment;
@@ -275,7 +275,20 @@ impl Db {
                created_at TEXT NOT NULL,
                FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
              );
-             CREATE INDEX IF NOT EXISTS idx_notes_asides_meeting ON notes_asides(meeting_id);",
+             CREATE INDEX IF NOT EXISTS idx_notes_asides_meeting ON notes_asides(meeting_id);
+             CREATE TABLE IF NOT EXISTS assistant_interactions (
+               id INTEGER PRIMARY KEY,
+               meeting_id TEXT NOT NULL,
+               command TEXT NOT NULL,
+               answer TEXT NOT NULL,
+               citations TEXT NOT NULL DEFAULT '[]',
+               status TEXT NOT NULL,
+               source_label TEXT,
+               created_at TEXT NOT NULL,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_assistant_interactions_meeting
+               ON assistant_interactions(meeting_id);",
         )
         .map_err(map_err)?;
         // Guarded ALTERs — notes gain a folder association + a sealed-content blob (AES-GCM
@@ -870,6 +883,9 @@ impl Db {
         // Phase F0: the seal-into-locked callers (lock_folder, move-into-locked) also drop the
         // sealed meetings' correction-log rows in the SAME tx — a sealed meeting feeds no flywheel.
         Self::purge_corrections_tx(&tx, meeting_ids)?;
+        // Voice-assistant Q&A log is plaintext-derived convenience data mirroring sealed content —
+        // drop it in the SAME seal tx (purge-on-seal, like corrections). Dropped by design.
+        Self::purge_assistant_interactions_tx(&tx, meeting_ids)?;
         tx.commit().map_err(map_err)?;
         Ok(())
     }
@@ -1899,6 +1915,15 @@ impl Db {
             [],
         )
         .map_err(map_err)?;
+        // LOCK-SAFETY: purge the voice-assistant Q&A log for every meeting in a locked folder, in
+        // this same reconciliation transaction — so a crash-while-unlocked (which may have persisted
+        // an interaction against a since-sealed meeting) cannot leave the plaintext Q&A at rest after
+        // a restart. Same purge-on-seal contract as the correction-log above.
+        tx.execute(
+            &format!("DELETE FROM assistant_interactions WHERE meeting_id IN ({LOCKED_MEETINGS})"),
+            [],
+        )
+        .map_err(map_err)?;
         // Collect the at-rest audio columns of locked meetings for the caller's filesystem re-seal
         // pass — the playback WAV AND both hi-res masters (B1). A meeting is surfaced if ANY of the
         // three columns is set; each path is reconciled independently by the caller.
@@ -2361,6 +2386,118 @@ impl Db {
             out.push(r.map_err(map_err)?);
         }
         Ok(out)
+    }
+
+    /// Persist one in-meeting voice-assistant interaction (the Q&A) against `meeting_id`. PURELY
+    /// ADDITIVE: it never touches note/transcript/timeline plaintext or blobs, so it can never blank
+    /// or clobber sealed content. `citations` is stored as a JSON array string. The CALLER is the
+    /// off-thread voice dispatch, which is best-effort + panic-free — a persist failure there is
+    /// logged (non-PII) and never disrupts recording/dispatch. Derived convenience data: it is PURGED
+    /// (not sealed) when the meeting's folder is sealed (see `purge_assistant_interactions_tx`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_assistant_interaction(
+        &self,
+        meeting_id: &str,
+        command: &str,
+        answer: &str,
+        citations: &[String],
+        status: &str,
+        source_label: Option<&str>,
+        created_at: &str,
+    ) -> Result<i64> {
+        let citations_json = serde_json::to_string(citations)
+            .map_err(|e| AppError::Storage(format!("serialize interaction citations: {e}")))?;
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO assistant_interactions
+                (meeting_id, command, answer, citations, status, source_label, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                meeting_id,
+                command,
+                answer,
+                citations_json,
+                status,
+                source_label,
+                created_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Read every persisted assistant interaction for `meeting_id`, oldest first, ONLY when the
+    /// meeting is VISIBLE to the session `unlocked` set (a sealed-and-not-session-unlocked meeting
+    /// returns an EMPTY list — never its rows). This is the gated read the detail DTO uses; it mirrors
+    /// the `meeting_is_visible` predicate so the interaction log is gated exactly like the note /
+    /// segments / timeline. Note: on seal the rows are PURGED (see `purge_assistant_interactions_tx`),
+    /// so a sealed meeting has no rows to read anyway — the gate is defense-in-depth.
+    pub fn list_assistant_interactions_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<AssistantInteraction>> {
+        if !self.meeting_is_visible(meeting_id, unlocked)? {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT command, answer, citations, status, source_label, created_at
+                   FROM assistant_interactions
+                  WHERE meeting_id = ?1 ORDER BY id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                let citations_json: String = r.get(2)?;
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    citations_json,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, String>(5)?,
+                ))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (command, answer, citations_json, status, source_label, created_at) =
+                r.map_err(map_err)?;
+            // A malformed citations blob must never break the read — fall back to an empty list.
+            let citations: Vec<String> = serde_json::from_str(&citations_json).unwrap_or_default();
+            out.push(AssistantInteraction {
+                command,
+                answer,
+                citations,
+                status,
+                source_label,
+                created_at,
+            });
+        }
+        Ok(out)
+    }
+
+    /// LOCK-SAFETY: delete every `assistant_interactions` row for `meeting_ids` within an EXISTING
+    /// transaction, so the purge lands in the SAME atomic unit as the plaintext blanking on a seal
+    /// (and on the startup reconcile). The Q&A log is plaintext-derived convenience data that mirrors
+    /// content of a sealed meeting (the user's spoken question + the answer grounded on the vault); a
+    /// sealed meeting must surface NOTHING, so — exactly like `correction_log` / `note_chunks` — we
+    /// DELETE rather than seal. This is INTENTIONAL: the Q&A log is dropped on seal by design and is
+    /// not recoverable (it was never keyed); the underlying transcript is still sealed + restorable.
+    fn purge_assistant_interactions_tx(
+        tx: &rusqlite::Transaction<'_>,
+        meeting_ids: &[String],
+    ) -> Result<()> {
+        for mid in meeting_ids {
+            tx.execute(
+                "DELETE FROM assistant_interactions WHERE meeting_id = ?1",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
     }
 
     /// OPEN-COMMITMENTS rollup (deterministic, no model): every OPEN (`- [ ]`) action item across
@@ -3385,6 +3522,131 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap()
+    }
+
+    fn interaction_count(db: &Db, meeting_id: &str) -> i64 {
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM assistant_interactions WHERE meeting_id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// PERSIST → READ round-trips a voice-assistant interaction (command + answer + citations +
+    /// status + source_label) for a VISIBLE (unfoldered) meeting.
+    #[test]
+    fn assistant_interaction_round_trips_for_visible_meeting() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z")).unwrap();
+        db.insert_assistant_interaction(
+            "m1",
+            "Klaudku, sprawdź jaka była pogoda",
+            "Wczoraj było słonecznie. Zobacz [[Notatka o pogodzie]].",
+            &["[[Notatka o pogodzie]]".to_string(), "(web) Weather — http://x".to_string()],
+            "ok",
+            Some("research"),
+            "2026-06-24T10:05:00Z",
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let got = db.list_assistant_interactions_visible("m1", &nothing).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].command, "Klaudku, sprawdź jaka była pogoda");
+        assert!(got[0].answer.contains("słonecznie"));
+        assert_eq!(
+            got[0].citations,
+            vec![
+                "[[Notatka o pogodzie]]".to_string(),
+                "(web) Weather — http://x".to_string()
+            ]
+        );
+        assert_eq!(got[0].status, "ok");
+        assert_eq!(got[0].source_label.as_deref(), Some("research"));
+        assert_eq!(got[0].created_at, "2026-06-24T10:05:00Z");
+    }
+
+    /// GATE: a sealed-and-NOT-session-unlocked meeting's interactions are NEVER returned by the gated
+    /// read (empty), even if a row exists at rest. RED-able: drop the `meeting_is_visible` guard in
+    /// `list_assistant_interactions_visible` and this fails (the row leaks through the read).
+    #[test]
+    fn assistant_interactions_gated_for_sealed_meeting() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z")).unwrap();
+        note_for(&db, "m1", "claude_code", "note"); // gives the meeting a note in the folder
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.insert_assistant_interaction(
+            "m1",
+            "secret command",
+            "secret answer",
+            &[],
+            "ok",
+            Some("research"),
+            "2026-06-24T10:05:00Z",
+        )
+        .unwrap();
+        // Seal the folder (visibility_clause keys off folders.locked); session-unlock set is empty.
+        db.set_folder_locked("f-locked", true, Some(b"wrapped")).unwrap();
+
+        let empty = std::collections::HashSet::new();
+        assert!(
+            db.list_assistant_interactions_visible("m1", &empty).unwrap().is_empty(),
+            "a sealed-not-unlocked meeting must surface NO interactions through the gated read"
+        );
+        // …and once the folder is session-unlocked, the row is visible again.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        assert_eq!(
+            db.list_assistant_interactions_visible("m1", &unlocked).unwrap().len(),
+            1,
+            "a session-unlocked folder's interactions ARE visible"
+        );
+    }
+
+    /// PURGE-ON-SEAL: the interactions of a meeting in a folder are GONE after the seal purge tx
+    /// (`purge_chunks_for_meetings`, which lock_folder runs). RED-able: drop the
+    /// `purge_assistant_interactions_tx` call and the row survives at rest in a locked folder.
+    #[test]
+    fn assistant_interactions_purged_on_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z")).unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.insert_assistant_interaction(
+            "m1", "cmd", "answer", &[], "ok", Some("research"), "2026-06-24T10:05:00Z",
+        )
+        .unwrap();
+        assert_eq!(interaction_count(&db, "m1"), 1, "row present before seal");
+
+        // The seal purge runs in the SAME tx that drops chunks + corrections for the sealed meetings.
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(
+            interaction_count(&db, "m1"),
+            0,
+            "assistant_interactions must be purged on seal (Q&A log dropped on seal by design)"
+        );
+    }
+
+    /// PURGE-ON-DELETE: deleting a meeting also removes its interactions (FK ON DELETE CASCADE).
+    #[test]
+    fn assistant_interactions_purged_on_delete_meeting() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z")).unwrap();
+        db.insert_assistant_interaction(
+            "m1", "cmd", "answer", &[], "ok", Some("research"), "2026-06-24T10:05:00Z",
+        )
+        .unwrap();
+        assert_eq!(interaction_count(&db, "m1"), 1);
+        db.delete_meeting("m1").unwrap();
+        assert_eq!(
+            interaction_count(&db, "m1"),
+            0,
+            "delete_meeting must purge the meeting's assistant_interactions rows"
+        );
     }
 
     #[test]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -140,6 +140,29 @@ pub struct NoteRecord {
     pub exported_path: Option<String>,
 }
 
+/// One persisted in-meeting voice-assistant interaction (Q&A): the user's spoken command, the
+/// assistant's answer, the grounding citations, and the dispatch status. PERSISTED so the meeting
+/// note can surface the assistant exchange that was previously ephemeral (only the live card). It is
+/// DERIVED convenience data — purged (not sealed) when the meeting's folder is sealed, exactly like
+/// `correction_log` / `note_chunks`; the underlying transcript is still sealed + restorable.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssistantInteraction {
+    /// The HEARD command — the user's own dictated words ("Klaudku, sprawdź pogodę").
+    pub command: String,
+    /// The assistant's answer (the dispatch `summary`): research/recall result or a status line.
+    pub answer: String,
+    /// `[[Title]]` wikilink / "(web)" citations the answer was grounded on (VISIBLE meetings only).
+    pub citations: Vec<String>,
+    /// Dispatch status: `ok` | `unavailable` | `unrecognized` | `needs_consent` | `error` |
+    /// `nothing_heard`.
+    pub status: String,
+    /// Coarse source label for the FE card style (the intent kind), e.g. `research` / `recall`.
+    pub source_label: Option<String>,
+    /// RFC3339 timestamp the interaction was recorded.
+    pub created_at: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusCount {

--- a/src-tauri/src/summarize/action_items.rs
+++ b/src-tauri/src/summarize/action_items.rs
@@ -5,11 +5,21 @@
 use crate::storage::models::ActionItem;
 
 /// Parse all action-item checklist lines from a note's markdown.
+///
+/// DEFENSE-IN-DEPTH against the assistant-command leak: a checklist line whose text is ADDRESSED TO
+/// THE ASSISTANT ("Klaudku, sprawdź pogodę") is DROPPED — it is a voice command the user gave the
+/// in-meeting assistant, not a real task. The primary fix excludes these lines from the summarizer
+/// input (so they never become action items), but a model could still echo one; this guarantees the
+/// owner-less "(właściciel nieokreślony) — Sprawdzić pogodę" item never survives into the task list.
 pub fn parse_action_items(markdown: &str) -> Vec<ActionItem> {
     let mut out = Vec::new();
     let mut idx = 0usize;
     for line in markdown.lines() {
         if let Some((done, text)) = parse_item_line(line) {
+            // Drop a task that is really an assistant command (vocative wake form).
+            if crate::audio::wake::is_assistant_directed(&text) {
+                continue;
+            }
             let owner = extract_owner(&text);
             let due_date = find_date(&text);
             out.push(ActionItem {
@@ -126,5 +136,19 @@ mod tests {
     fn no_date_no_change() {
         let md = "- [ ] just a task\n";
         assert_eq!(patch_tasks_markdown(md), md);
+    }
+
+    /// The assistant-command leak: a checklist line addressed to the assistant ("Klaudku, …") must be
+    /// DROPPED, while a real action item ("Janek wyśle raport w piątek") is KEPT. This is the
+    /// owner-less "(właściciel nieokreślony) — Sprawdzić pogodę" item the user reported.
+    #[test]
+    fn drops_assistant_directed_item_keeps_real_task() {
+        let md = "## Action items\n\
+                  - [ ] Klaudku, sprawdź jaka była pogoda\n\
+                  - [ ] Janek wyśle raport w piątek\n\
+                  - [ ] klaudku, jakie masz informacje w moich notatkach\n";
+        let items = parse_action_items(md);
+        assert_eq!(items.len(), 1, "only the real task survives; assistant commands are dropped");
+        assert_eq!(items[0].text, "Janek wyśle raport w piątek");
     }
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -238,8 +238,48 @@ fn spawn_dispatch(app: AppHandle, intent: crate::audio::wake::VoiceIntent) {
                 status = %result.status,
                 "voice action dispatched"
             );
+            // PERSIST the interaction against the CURRENT recording (best-effort + panic-free): the
+            // wake-path command lives in the intent's literal words. A persist failure NEVER disrupts
+            // the dispatch — it is logged (non-PII) and dropped.
+            persist_interaction(&state, &meeting_id, &literal, &result);
             let _ = app.emit(crate::events::EVENT_VOICE_ACTION_RESULT, result);
         });
+}
+
+/// Persist one dispatched voice interaction against the CURRENT recording meeting — best-effort +
+/// PANIC-FREE so a persist failure can NEVER disrupt recording/dispatch. Skips when there is no
+/// active recording (`meeting_id` empty). `command` is the user's own dictated words (the heard
+/// command for the manual path, the intent's literal words for the wake path). The `summary`/
+/// `citations`/`status`/`intent_kind` come straight off the dispatch result. Derived convenience
+/// data: it is PURGED on seal (it mirrors sealed content), never surfaced for a sealed meeting.
+fn persist_interaction(
+    state: &AppState,
+    meeting_id: &str,
+    command: &str,
+    result: &crate::voice_action::VoiceActionResult,
+) {
+    if meeting_id.is_empty() {
+        return; // no active recording → nothing to attach the interaction to.
+    }
+    let created_at = chrono::Utc::now().to_rfc3339();
+    match state.db.insert_assistant_interaction(
+        meeting_id,
+        command,
+        &result.summary,
+        &result.citations,
+        &result.status,
+        Some(result.intent_kind.as_str()),
+        &created_at,
+    ) {
+        Ok(_) => {}
+        // PII rule: log only that a persist failed + the coarse status — never the command/answer.
+        Err(e) => tracing::debug!(
+            target: "voice",
+            error = %e,
+            status = %result.status,
+            "persisting assistant interaction failed; continuing"
+        ),
+    }
 }
 
 /// Resolve a NON-EMPTY heard `command` to an intent (keyword → brain → fallback) and dispatch it
@@ -291,6 +331,10 @@ fn spawn_command_dispatch(app: AppHandle, command: String) {
                 status = %result.status,
                 "manual voice command dispatched"
             );
+            // PERSIST the interaction against the CURRENT recording (best-effort + panic-free): the
+            // manual-path command is the user's HEARD dictation. A persist failure NEVER disrupts the
+            // dispatch — it is logged (non-PII) and dropped.
+            persist_interaction(&state, &meeting_id, &command, &result);
             let _ = app.emit(crate::events::EVENT_VOICE_ACTION_RESULT, result);
         });
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -329,10 +329,42 @@ export interface Segment {
   speaker?: "me" | "others" | string | null;
 }
 
+/**
+ * One persisted in-meeting voice-assistant interaction (Q&A): the user's spoken
+ * command, the assistant's answer, the grounding citations, and the dispatch
+ * status. Surfaced in the meeting detail's "Asystent — Q&A" section. EMPTY when
+ * the meeting is locked-and-not-session-unlocked (gated, like note/segments) and
+ * also empty for a sealed meeting at rest (the rows are PURGED on seal). Mirrors
+ * the Rust `AssistantInteraction` (serde camelCase).
+ */
+export interface AssistantInteraction {
+  /** The HEARD command — the user's own dictated words. */
+  command: string;
+  /** The assistant's answer (research/recall result or a status line). */
+  answer: string;
+  /** `[[Title]]` wikilink / "(web)" citations the answer was grounded on. */
+  citations: string[];
+  /**
+   * Dispatch status: `ok` | `unavailable` | `unrecognized` | `needs_consent` |
+   * `error` | `nothing_heard`.
+   */
+  status: string;
+  /** Coarse source label / intent kind, e.g. `research` / `recall`. */
+  sourceLabel: string | null;
+  /** RFC3339 timestamp the interaction was recorded. */
+  createdAt: string;
+}
+
 export interface MeetingDetail {
   meeting: Meeting;
   note: NoteDto | null;
   segments: Segment[];
+  /**
+   * Persisted in-meeting assistant Q&A for this meeting. Present (gated) only
+   * when the meeting is unlocked; empty otherwise. The FE renders these in the
+   * "🎙 Asystent — Q&A" detail section.
+   */
+  assistantInteractions: AssistantInteraction[];
   /**
    * True when this meeting lives in a sealed-and-NOT-session-unlocked folder.
    * The backend MASKS the payload in that case (title "🔒 Locked", note null,

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -16,6 +16,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import type {
+  AssistantInteraction,
   FolderNode,
   GraphPayload,
   MeetingDetail,
@@ -51,6 +52,33 @@ interface NoteSection {
   bullets: string[];
   /** Checklist entries (kind === 'actions'). */
   actions: ActionItem[];
+}
+
+/**
+ * One grounding citation, parsed from the persisted `string[]` the backend
+ * stores per interaction. The backend writes `[[Title]]` for a vault source and
+ * a `(web)` / `(https://…)` form for a web source — we split the two so the FE
+ * can render `[[vault]]` chips vs distinct "via web" links (mirroring the live
+ * assistant-actions card, whose live store carries structured citations).
+ */
+interface ParsedCitation {
+  kind: "vault" | "web";
+  /** Display label (vault title, or the host/label for a web source). */
+  label: string;
+  /** Resolved URL for a web source; null for a vault citation. */
+  url: string | null;
+}
+
+/** A persisted assistant Q&A interaction enriched with parsed citations. */
+interface AssistantQa {
+  /** Stable id for `@for` tracking (createdAt + index — interactions are append-only). */
+  id: string;
+  command: string;
+  answer: string;
+  citations: ParsedCitation[];
+  status: string;
+  sourceLabel: string | null;
+  createdAt: string;
 }
 
 /** The whole note, decomposed into front-matter + body sections. */
@@ -757,6 +785,87 @@ interface ParsedNote {
             }
           </section>
 
+          <!-- 2·25) ASSISTANT Q&A (persisted in-meeting voice exchanges) ------- -->
+          @if (interactions().length) {
+            <section class="block print-keep">
+              <div class="block-head">
+                <h3>🎙 Asystent — Q&amp;A</h3>
+                <span class="count">{{ interactions().length }}</span>
+              </div>
+
+              <ul class="qa-list">
+                @for (q of interactions(); track q.id) {
+                  <li
+                    class="card qa-row"
+                    [class.is-pending]="q.status === 'pending'"
+                  >
+                    <div class="qa-heard">
+                      <span class="qa-ico" aria-hidden="true">🎙</span>
+                      <span class="qa-heard-text">
+                        Pytałeś:
+                        <strong>{{ q.command || "…" }}</strong>
+                      </span>
+                      @if (qaStatusLabel(q.status)) {
+                        <span class="pill" [class]="qaStatusPillClass(q.status)">
+                          <span class="pill-dot"></span>
+                          {{ qaStatusLabel(q.status) }}
+                        </span>
+                      }
+                    </div>
+
+                    @if (q.answer) {
+                      <p class="qa-answer">{{ q.answer }}</p>
+                    }
+
+                    @if (q.citations.length) {
+                      <div class="qa-cites" aria-label="Źródła">
+                        @for (c of q.citations; track $index) {
+                          @if (c.kind === "web") {
+                            @if (c.url) {
+                              <a
+                                class="cite-chip is-web"
+                                [href]="c.url"
+                                target="_blank"
+                                rel="noreferrer noopener"
+                                [title]="c.url"
+                              >
+                                <span class="cite-web-mark" aria-hidden="true"
+                                  >⊕</span
+                                >
+                                <span class="cite-web-label">{{
+                                  c.label
+                                }}</span>
+                                <span class="cite-web-via">via web</span>
+                              </a>
+                            } @else {
+                              <span class="cite-chip is-web">
+                                <span class="cite-web-mark" aria-hidden="true"
+                                  >⊕</span
+                                >
+                                <span class="cite-web-label">{{
+                                  c.label
+                                }}</span>
+                                <span class="cite-web-via">via web</span>
+                              </span>
+                            }
+                          } @else {
+                            <span class="cite-chip">[[{{ c.label }}]]</span>
+                          }
+                        }
+                      </div>
+                    }
+
+                    @if (q.sourceLabel) {
+                      <span class="qa-source text-muted">{{
+                        q.sourceLabel
+                      }}</span>
+                    }
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+
           <!-- 2·5) ACTION ITEMS (Reminders + Obsidian Tasks; hidden when none) - -->
           <app-meeting-actions [meetingId]="d.meeting.id" />
 
@@ -1392,6 +1501,102 @@ interface ParsedNote {
         line-height: 1.7;
       }
 
+      /* Assistant — Q&A section (mirrors the live assistant-actions card) */
+      .qa-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .qa-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3) var(--space-4);
+        animation: rise 360ms var(--transition) both;
+      }
+      .qa-heard,
+      .qa-cites {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+      }
+      .qa-heard-text {
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+      }
+      .qa-heard-text strong {
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+      .qa-heard .pill {
+        margin-left: auto;
+      }
+      .qa-answer {
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 0.9rem;
+        line-height: 1.55;
+        white-space: pre-wrap;
+      }
+      .qa-source {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+      .cite-chip {
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-sm);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-family: var(--font-mono);
+        font-size: 0.78rem;
+      }
+      /* A web source — visibly distinct from the [[vault]] chips, with a loud
+         "via web" tag for the off-device origin (mirrors assistant-actions). */
+      .cite-chip.is-web {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        max-width: 100%;
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+        font-family: inherit;
+        text-decoration: none;
+      }
+      a.cite-chip.is-web:hover {
+        border-color: var(--accent-soft);
+        color: var(--text-primary);
+      }
+      .cite-web-mark {
+        color: var(--accent);
+        line-height: 1;
+      }
+      .cite-web-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 220px;
+      }
+      .cite-web-via {
+        padding: 0 var(--space-1);
+        border-radius: var(--radius-sm);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.7rem;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .qa-row {
+          animation: none;
+        }
+      }
+
       /* Saved-to-vault line */
       .saved {
         display: flex;
@@ -1816,6 +2021,16 @@ export class DetailComponent implements OnInit {
   readonly note = computed<ParsedNote | null>(() => {
     const md = this.detail()?.note?.markdown;
     return md ? this.parseNote(md) : null;
+  });
+
+  /**
+   * The persisted in-meeting assistant Q&A for this meeting, citations parsed
+   * into vault/web shapes for rendering. Empty when the meeting is locked (the
+   * backend gates `assistantInteractions` exactly like `note`/`segments`).
+   */
+  readonly interactions = computed<AssistantQa[]>(() => {
+    const raw = this.detail()?.assistantInteractions ?? [];
+    return raw.map((i, idx) => this.parseInteraction(i, idx));
   });
 
   // --- Interactive timeline (speaker + topic viz) -------------------------
@@ -2667,6 +2882,99 @@ export class DetailComponent implements OnInit {
    * body into `## ` sections. Falls back to raw markdown when no section is
    * found.
    */
+  /**
+   * Enrich a raw persisted interaction with a stable id + parsed citations. The
+   * backend stores citations as plain strings: `[[Title]]` for a vault source,
+   * or a bare URL / `(web)` marker for a web source. We split the two so the
+   * template can render `[[vault]]` chips vs distinct "via web" links.
+   */
+  private parseInteraction(i: AssistantInteraction, idx: number): AssistantQa {
+    return {
+      id: `${i.createdAt}#${idx}`,
+      command: i.command,
+      answer: i.answer,
+      citations: (i.citations ?? []).map((c) => this.parseCitation(c)),
+      status: i.status,
+      sourceLabel: i.sourceLabel,
+      createdAt: i.createdAt,
+    };
+  }
+
+  /** Split one persisted citation string into a vault- vs web-shaped chip. */
+  private parseCitation(raw: string): ParsedCitation {
+    const c = raw.trim();
+    // A bare http(s) URL → web link.
+    if (/^https?:\/\//i.test(c)) {
+      return { kind: "web", label: this.hostOf(c) ?? c, url: c };
+    }
+    // `[[Title]]` (or `Title`) → vault chip; strip the wikilink brackets.
+    const wiki = /^\[\[(.+?)\]\]$/.exec(c);
+    if (wiki) {
+      return { kind: "vault", label: wiki[1].trim(), url: null };
+    }
+    // `(web)` / `web` marker with no URL → a labelless web source.
+    if (/^\(?web\)?$/i.test(c)) {
+      return { kind: "web", label: "web", url: null };
+    }
+    // `Label (https://…)` form → web link with a friendly label.
+    const labelled = /^(.*?)\s*\((https?:\/\/[^)]+)\)$/i.exec(c);
+    if (labelled) {
+      return {
+        kind: "web",
+        label: labelled[1].trim() || this.hostOf(labelled[2]) || labelled[2],
+        url: labelled[2],
+      };
+    }
+    // Fallback: treat as a vault title (no off-device origin implied).
+    return { kind: "vault", label: c, url: null };
+  }
+
+  /** Best-effort host extraction for a web citation label; null if unparseable. */
+  private hostOf(url: string): string | null {
+    try {
+      return new URL(url).host;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Map an interaction status to a global `.pill` variant (mirrors the live card). */
+  protected qaStatusPillClass(status: string): string {
+    switch (status) {
+      case "ok":
+        return "is-success";
+      case "needs_consent":
+        return "is-warning";
+      case "unavailable":
+      case "unrecognized":
+        return "is-accent";
+      case "nothing_heard":
+        return "";
+      default:
+        return "is-danger";
+    }
+  }
+
+  /** Short human label for the status pill. */
+  protected qaStatusLabel(status: string): string {
+    switch (status) {
+      case "ok":
+        return "Odpowiedziano";
+      case "needs_consent":
+        return "Wymaga zgody";
+      case "unavailable":
+        return "Niedostępne";
+      case "unrecognized":
+        return "Nierozpoznane";
+      case "nothing_heard":
+        return "Nic nie usłyszano";
+      case "error":
+        return "Błąd";
+      default:
+        return status;
+    }
+  }
+
   private parseNote(markdown: string): ParsedNote {
     const lines = markdown.replace(/\r\n/g, "\n").split("\n");
 


### PR DESCRIPTION
Real feedback: in-meeting assistant Q&A was ephemeral (lost after recording) + the summarizer mangled questions to the AI into owner-less action items. Fix: gated **assistant_interactions** table (double-gated read, purged-on-seal in the same atomic tx as chunks/corrections), persist on dispatch with the active meeting_id, a **'🎙 Asystent — Q&A' detail section** (Pytałeś→answer + [[vault]]/via-web), and the summarizer **excludes 'Klaud/Klaudku' utterances** from the LLM + action items. Verified: test 399/0; clippy clean; ng lint+build clean; adversarial PASS; **lock-security PASS** (sealed Q&A unreadable + not plaintext-at-rest).