### PR TITLE
feat(voice): click-to-stop capture + processing state + animated AI orb

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -533,6 +533,56 @@ pub(crate) fn begin_voice_command_inner(
     Ok(VoiceCommandArmResult { listening: true, reason: None })
 }
 
+/// STOP the MANUAL voice-command capture (CLICK-TO-STOP): the user clicked "stop" / "done", so the
+/// FULL accumulated post-click utterance is the command. This does NOT itself transcribe or dispatch;
+/// it flips the armed [`crate::state::CaptureState`]'s `ended` flag so the already-running live loop
+/// (`transcribe::live`) dispatches the FULL accumulated command over the SAME gated + consent-gated
+/// `handle_voice_action` path on its next tick (no new read/egress class).
+///
+/// The dispatch + the "thinking…" PROCESSING event are emitted by the live loop, so the answer still
+/// arrives via [`crate::events::EVENT_VOICE_ACTION_RESULT`]. On a NOT-armed state (no capture in
+/// progress — the user double-clicked, or it already auto-stopped at the backstop) this is a graceful
+/// no-op (`stopped: false`), never an error.
+#[tauri::command]
+pub fn end_voice_command(
+    state: State<'_, AppState>,
+) -> Result<VoiceCommandEndResult, AppError> {
+    let result = end_voice_command_inner(state.inner())?;
+    if result.stopped {
+        tracing::info!(target: "voice", "manual voice command stopped by user — dispatching");
+    }
+    Ok(result)
+}
+
+/// Result of stopping a MANUAL voice command (the "stop" click).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceCommandEndResult {
+    /// True when an armed capture was found and flagged to dispatch; false when nothing was armed
+    /// (graceful no-op — the live loop already cleared it via dispatch or the backstop).
+    pub stopped: bool,
+}
+
+/// Headless core of [`end_voice_command`]: flip the armed capture's `ended` flag so the live loop
+/// dispatches the FULL accumulated utterance on its next tick. A NOT-armed state is a graceful no-op
+/// (`stopped: false`). No `AppHandle`/IPC here, so it is unit-testable without Tauri.
+pub(crate) fn end_voice_command_inner(
+    state: &AppState,
+) -> Result<VoiceCommandEndResult, AppError> {
+    let mut guard = state
+        .voice_command_capture
+        .lock()
+        .map_err(|_| AppError::Other(anyhow::anyhow!("voice-command capture mutex poisoned")))?;
+    match guard.as_mut() {
+        Some(capture) => {
+            capture.ended = true;
+            Ok(VoiceCommandEndResult { stopped: true })
+        }
+        // Nothing armed (already dispatched / backstop-stopped / never started) → graceful no-op.
+        None => Ok(VoiceCommandEndResult { stopped: false }),
+    }
+}
+
 /// The most recent note (markdown + export path) for the last-note preview pane.
 #[tauri::command]
 pub fn get_last_note(state: State<'_, AppState>) -> Result<Option<NoteDto>, AppError> {
@@ -4570,8 +4620,43 @@ mod lifecycle_tests {
         let armed = *state.voice_command_capture.lock().unwrap();
         assert_eq!(
             armed,
-            Some(CaptureState { budget: CaptureState::DEFAULT_BUDGET, start_sample: None }),
+            Some(CaptureState { budget: CaptureState::DEFAULT_BUDGET, start_sample: None, ended: false }),
             "arming must store a fresh full-budget capture the live loop can consume"
+        );
+    }
+
+    /// CLICK-TO-STOP: `end_voice_command` on an ARMED capture flips `ended` so the live loop
+    /// dispatches the FULL accumulated utterance on its next tick — it does NOT clear the capture
+    /// itself (the live loop owns the terminal clear-on-dispatch).
+    #[test]
+    fn end_voice_command_flags_armed_capture_to_dispatch() {
+        use crate::state::CaptureState;
+        let state = build_state("voicecmd-end-armed");
+        {
+            let mut g = state.voice_command_capture.lock().unwrap();
+            *g = Some(CaptureState::armed_from(1000));
+        }
+
+        let res = end_voice_command_inner(&state).unwrap();
+        assert!(res.stopped, "an armed capture must report stopped:true");
+
+        let after = state.voice_command_capture.lock().unwrap().expect("capture still present");
+        assert!(after.ended, "the user's stop must flip `ended` so the live loop dispatches");
+        assert_eq!(after.start_sample, Some(1000), "the latched offset is preserved");
+    }
+
+    /// CLICK-TO-STOP: `end_voice_command` on a NOT-armed state (double-click, already auto-stopped at
+    /// the backstop, or never started) is a graceful no-op (`stopped: false`), never an error.
+    #[test]
+    fn end_voice_command_not_armed_is_graceful_noop() {
+        let state = build_state("voicecmd-end-noop");
+        assert!(state.voice_command_capture.lock().unwrap().is_none(), "precondition: not armed");
+
+        let res = end_voice_command_inner(&state).unwrap();
+        assert!(!res.stopped, "a not-armed end must be a graceful no-op (stopped:false)");
+        assert!(
+            state.voice_command_capture.lock().unwrap().is_none(),
+            "a no-op end must not fabricate a capture"
         );
     }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -50,6 +50,22 @@ pub struct VoiceCommandListeningPayload {
     pub active: bool,
 }
 
+/// Emitted when a MANUAL voice-command capture has STOPPED listening and the accumulated utterance is
+/// being DISPATCHED (the gated `handle_voice_action` round-trip — RAG + brain — can take seconds).
+/// `active: true` lets the FE show a "thinking…" state in the gap between capture-end and the answer
+/// (the user's complaint: "you don't know what it's doing"). It is cleared (`active: false` is
+/// implied) by the arrival of [`EVENT_VOICE_ACTION_RESULT`] — the FE clears "processing" when the
+/// result lands. Carries NO transcript — just the boolean.
+pub const EVENT_VOICE_COMMAND_PROCESSING: &str = "murmur://voice-command-processing";
+
+/// Payload for [`EVENT_VOICE_COMMAND_PROCESSING`]. Boolean only — NO PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceCommandProcessingPayload {
+    /// True while the dispatch is in flight (between capture-stop and the result event).
+    pub active: bool,
+}
+
 /// Progress for the on-device brain (reasoning GGUF) download. Carries byte counts only — NO PII.
 pub const EVENT_BRAIN_DOWNLOAD: &str = "murmur://brain-download";
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,7 @@ pub fn run() {
             commands::set_mic_muted,
             commands::is_mic_muted,
             commands::begin_voice_command,
+            commands::end_voice_command,
             commands::list_input_devices,
             commands::get_last_note,
             commands::update_note,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -40,41 +40,50 @@ pub fn app_dir_name() -> &'static str {
 /// Live state of a MANUAL voice-command capture (the button trigger). Held in
 /// `AppState::voice_command_capture` while the user is "asking the assistant".
 ///
-/// The capture isolates the POST-CLICK utterance: at arm time it latches the recorder's current
-/// total-sample offset (`start_sample`), and each live tick transcribes ONLY the audio captured
-/// SINCE that offset (a growing window) — so the command is exactly what the user said after the
-/// click, never the rolling tail of prior speech. `budget` is a countdown of live ticks (each ≈3s,
-/// see `transcribe::live::TICK`): it is decremented every tick that hears NOTHING (silence), and
-/// when it reaches 0 with nothing heard the capture is cleared gracefully ("nothing_heard"). An
-/// EMPTY window is NEVER dispatched.
+/// CLICK-TO-STOP: the user controls when they are done. At arm time we latch the recorder's current
+/// total-sample offset (`start_sample`); each live tick transcribes ONLY the audio captured SINCE
+/// that offset (a GROWING window) — the whole post-click utterance, never the rolling tail of prior
+/// speech — but we do NOT auto-dispatch on hearing speech. We keep listening (accumulating) until
+/// the user clicks "stop" (`end_voice_command` flips `ended` to true → dispatch the FULL accumulated
+/// utterance). `budget` is now a generous BACKSTOP cap (a countdown of live ticks, each ≈3s, see
+/// `transcribe::live::TICK`): the primary end is the user's click; the cap only prevents listening
+/// forever if no stop ever arrives. An all-silent / garbage-only capture is NEVER dispatched — it
+/// ends gracefully as "nothing_heard".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CaptureState {
-    /// Remaining live ticks of SILENCE before we give up waiting for the user to speak and clear the
-    /// capture with a graceful "nothing_heard". Armed to a small budget by `begin_voice_command`.
+    /// Remaining live ticks of BACKSTOP before we auto-stop a capture the user never explicitly ended
+    /// (so it can't listen forever). Decremented EVERY tick. Armed to [`Self::DEFAULT_BUDGET`] by
+    /// `begin_voice_command`. The PRIMARY end is the user's `end_voice_command` click; this is just
+    /// the safety cap.
     pub budget: u32,
     /// The recorder's total-sample offset latched at arm time. Each tick transcribes the audio
     /// captured since this offset (`Recorder::snapshot_from`), so the command = what was said AFTER
     /// the click. `None` only in degenerate paths (no recorder / poisoned lock at arm time), in which
     /// case the loop falls back to the rolling-tail window so the capture still functions.
     pub start_sample: Option<usize>,
+    /// Set true by `end_voice_command` (the user's "stop" click). On the next tick the live loop
+    /// dispatches the FULL accumulated post-click utterance (or surfaces "nothing_heard" if silent).
+    pub ended: bool,
 }
 
 impl CaptureState {
-    /// How many live ticks (≈3s each) of SILENCE a single manual capture tolerates before giving up.
-    /// ~5 ticks ≈ 15s gives the user a comfortable window to click and then speak one command.
-    pub const DEFAULT_BUDGET: u32 = 5;
+    /// BACKSTOP cap: how many live ticks (≈3s each) a manual capture may listen with NO explicit stop
+    /// before it auto-stops + dispatches so it can never listen forever. ~20 ticks ≈ 60s is generous —
+    /// the user's `end_voice_command` click is the primary end; this is only the safety backstop and
+    /// must not feel like a cutoff for a normal-length question.
+    pub const DEFAULT_BUDGET: u32 = 20;
 
-    /// A freshly-armed capture with the default tick budget and no latched offset (the offset is set
+    /// A freshly-armed capture with the default backstop and no latched offset (the offset is set
     /// by `armed_from` at the call site that has the recorder). Kept for the headless tests that
     /// don't have a recorder; the live loop falls back to the rolling tail when `start_sample` is None.
     pub fn armed() -> Self {
-        Self { budget: Self::DEFAULT_BUDGET, start_sample: None }
+        Self { budget: Self::DEFAULT_BUDGET, start_sample: None, ended: false }
     }
 
     /// A freshly-armed capture that latches the recorder's total-sample `offset` at arm time, so the
     /// live loop transcribes only the POST-CLICK utterance.
     pub fn armed_from(offset: usize) -> Self {
-        Self { budget: Self::DEFAULT_BUDGET, start_sample: Some(offset) }
+        Self { budget: Self::DEFAULT_BUDGET, start_sample: Some(offset), ended: false }
     }
 }
 

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -93,26 +93,32 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                     .join(" ")
                     .trim()
                     .to_string();
-                // MANUAL voice-command capture (the button trigger) — checked EVERY tick,
-                // independent of the wake path and independent of `realtime_reactions`. When the
-                // user has clicked "ask the assistant" the freshly-transcribed tail IS the command:
-                // no wake word, no word-order requirement. We decide per tick whether to dispatch
-                // now (a recognized intent OR the tick budget is spent) or keep listening. Best-effort
-                // + panic-free: a poisoned lock or empty tail simply leaves the capture armed; the
-                // dispatch runs off-thread exactly like the wake path. NOTE: an EMPTY tail still
-                // counts down the budget so a silent capture can't hang forever.
+                // MANUAL voice-command capture (the button trigger) — CLICK-TO-STOP, checked EVERY
+                // tick, independent of the wake path and independent of `realtime_reactions`. When the
+                // user has clicked "ask the assistant" the growing post-click window IS the command:
+                // no wake word, no word-order requirement. We ACCUMULATE it tick by tick and keep
+                // listening until the user clicks "stop" (`end_voice_command` → dispatch the FULL
+                // utterance) — only a generous backstop cap forces an end so it can't listen forever.
+                // Best-effort + panic-free: a poisoned lock or empty tail simply leaves the capture
+                // armed; the dispatch runs off-thread exactly like the wake path.
                 if let Some(decision) =
                     step_manual_capture(&app, &transcriber, lang.as_deref(), &text)
                 {
                     match decision {
                         ManualCaptureDecision::Dispatch { command } => {
-                            // Resolve (keyword → brain → fallback) + dispatch OFF the tick, with the
-                            // heard command surfaced onto the result for the FE card.
-                            spawn_command_dispatch(app.clone(), command);
+                            // Capture ENDED (user stop click OR the backstop cap) with a real
+                            // utterance → stop "listening", show "thinking…", then resolve (keyword →
+                            // brain → fallback) + dispatch the FULL accumulated command OFF the tick.
+                            // PROCESSING is cleared by EVENT_VOICE_ACTION_RESULT when the answer lands.
                             let _ = app.emit(
                                 crate::events::EVENT_VOICE_COMMAND_LISTENING,
                                 crate::events::VoiceCommandListeningPayload { active: false },
                             );
+                            let _ = app.emit(
+                                crate::events::EVENT_VOICE_COMMAND_PROCESSING,
+                                crate::events::VoiceCommandProcessingPayload { active: true },
+                            );
+                            spawn_command_dispatch(app.clone(), command);
                         }
                         ManualCaptureDecision::NothingHeard => {
                             // Budget expired with nothing heard → graceful, NOT a confusing
@@ -342,13 +348,18 @@ fn spawn_command_dispatch(app: AppHandle, command: String) {
 /// What the live loop should do with the MANUAL voice-command capture on this tick.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ManualCaptureDecision {
-    /// A NON-EMPTY command was captured (real speech heard since the click) → resolve + dispatch it
-    /// (keyword fast-path, else brain interpret, else keyword fallback) and clear the capture.
+    /// The capture is DONE (the user clicked stop, OR the backstop cap was reached) AND the
+    /// accumulated post-click utterance is a real (non-empty, meaningful) command → resolve +
+    /// dispatch it (keyword fast-path, else brain interpret, else keyword fallback) and clear the
+    /// capture. Carries the FULL accumulated utterance, not a per-tick fragment.
     Dispatch { command: String },
-    /// Nothing heard yet but budget remains → keep the capture armed and wait for the next tick.
+    /// Still listening (the user has not stopped and the backstop cap is not yet reached) → keep the
+    /// capture armed, ACCUMULATING the growing post-click window, and wait for the next tick / the
+    /// user's stop click. Does NOT dispatch on hearing speech (CLICK-TO-STOP).
     KeepListening,
-    /// The whole budget expired with NOTHING heard (the user never spoke) → clear the capture and
-    /// surface a graceful "nothing_heard". NEVER dispatches an empty command.
+    /// The capture ended (user stop OR backstop) with NOTHING meaningful heard (the user never spoke,
+    /// or only silence/filler) → clear the capture and surface a graceful "nothing_heard". NEVER
+    /// dispatches an empty command.
     NothingHeard,
 }
 
@@ -358,12 +369,14 @@ enum ManualCaptureDecision {
 /// rolling 14s tail. Falls back to the rolling-tail `caption` text only when no offset was latched
 /// (degenerate arm path). Returns `None` when no manual capture is armed (the common case).
 ///
-/// When a capture IS armed it mutates the budget in place and returns the [`ManualCaptureDecision`],
-/// CLEARING the capture state on dispatch / nothing-heard (so exactly one outcome fires per click).
+/// When a capture IS armed it decrements the backstop budget in place and returns the
+/// [`ManualCaptureDecision`], CLEARING the capture state on dispatch / nothing-heard (so exactly one
+/// outcome fires per capture). CLICK-TO-STOP: it returns `Dispatch` only when the user has ended the
+/// capture (`ended`) or the backstop cap was reached — never merely on hearing speech.
 /// Best-effort + panic-free: a poisoned lock is treated as "no capture" (`None`).
 ///
-/// The transcription of the post-click window + the dispatch/emit are the caller's job (off the
-/// tick); the budget arithmetic + the no-empty guard are the pure [`decide_manual_capture`].
+/// The transcription of the GROWING post-click window + the dispatch/emit are the caller's job (off
+/// the tick); the backstop arithmetic + the no-empty guard are the pure [`decide_manual_capture`].
 fn step_manual_capture(
     app: &AppHandle,
     transcriber: &Transcriber,
@@ -524,42 +537,49 @@ fn is_meaningful_command(command: &str) -> bool {
     meaningful_tokens >= 2 || non_filler_chars >= 8
 }
 
-/// PURE, headless-testable core of the manual-capture step. Given the armed [`CaptureState`] and the
-/// `command` heard SINCE the click (the post-click window's transcript), decide the outcome and the
-/// NEXT capture state (`None` = cleared on a terminal outcome, `Some(decremented)` while listening).
+/// PURE, headless-testable core of the manual-capture step (CLICK-TO-STOP). Given the armed
+/// [`CaptureState`] and the FULL `command` accumulated SINCE the click (the growing post-click
+/// window's transcript), decide the outcome and the NEXT capture state (`None` = cleared on a
+/// terminal outcome, `Some(decremented)` while still listening).
 ///
-/// Rules (no wake word — the WHOLE post-click utterance is the command; NEVER dispatch empty):
-/// 1. If the command is NON-EMPTY (real speech heard) → `Dispatch{command}` now and clear the
-///    capture. The caller resolves it (keyword → brain → keyword fallback) and dispatches it with the
-///    heard command surfaced.
-/// 2. Else (silence this tick) → spend one tick of budget:
-///    - budget still > 0 → KEEP LISTENING (give the user time to start/finish speaking).
-///    - budget now == 0 → `NothingHeard`: clear the capture and surface a graceful "nothing_heard".
-///      The capture can never hang AND it never dispatches an empty/Unknown command.
+/// The capture ENDS only when the user clicked stop (`capture.ended == true`) OR the backstop cap is
+/// reached (`budget` hits 0) — NOT on merely hearing speech. Until then we KEEP LISTENING so the user
+/// can finish their whole question without being cut off mid-sentence. Rules (no wake word — the WHOLE
+/// post-click utterance is the command; NEVER dispatch empty):
+/// 1. The capture is DONE (`ended` set by the user's stop click, OR `budget` exhausted = backstop):
+///    - accumulated command is meaningful → `Dispatch{command}` with the FULL utterance, clear.
+///    - else (silent / pure filler) → `NothingHeard`, clear (graceful, never an empty dispatch).
+/// 2. Still going (not ended, backstop not reached) → spend one tick of the backstop budget and
+///    `KeepListening` (keep accumulating). On a non-`ended` capture this is the common path even when
+///    real speech is heard — we wait for the user's stop click, only the backstop forces an end.
 ///
-/// No I/O, no FFI, no egress — just emptiness check + arithmetic.
+/// No I/O, no FFI, no egress — just the meaningfulness check + arithmetic.
 fn decide_manual_capture(
     capture: crate::state::CaptureState,
     command: &str,
 ) -> (ManualCaptureDecision, Option<crate::state::CaptureState>) {
     let command = command.trim();
-    // GARBAGE FILTER: a too-short / pure-filler clip ("Uh,", "eee", "hmm", a lone char or
-    // punctuation) is NOT a real command — Whisper emits these for a ~3s silent/noise clip. Treat
-    // it exactly like a silent tick (KEEP LISTENING / NOTHING_HEARD at budget end) rather than
-    // dispatching a Research on "Uh,". The user gets a clean "nothing_heard", never a garbage card.
-    if !command.is_empty() && is_meaningful_command(command) {
-        // Real speech heard since the click → dispatch it, clear the capture.
-        return (
-            ManualCaptureDecision::Dispatch { command: command.to_string() },
-            None,
-        );
-    }
-    // Silence OR garbage/filler this tick: spend one tick of budget.
+    // Spend one tick of the backstop budget; 0 means the safety cap is now reached this tick.
     let remaining = capture.budget.saturating_sub(1);
-    if remaining == 0 {
-        // Budget exhausted with nothing ever heard → graceful give-up, clear the capture.
-        (ManualCaptureDecision::NothingHeard, None)
+    let backstop_reached = remaining == 0;
+
+    // The capture is DONE when the user clicked stop OR the backstop cap is reached.
+    if capture.ended || backstop_reached {
+        // GARBAGE FILTER: a too-short / pure-filler accumulation ("Uh,", "eee", "hmm", a lone char or
+        // punctuation) is NOT a real command — Whisper emits these for a silent/noise clip. Treat it
+        // as nothing heard rather than dispatching a Research on "Uh,". The user gets a clean
+        // "nothing_heard", never a garbage card.
+        if !command.is_empty() && is_meaningful_command(command) {
+            (
+                ManualCaptureDecision::Dispatch { command: command.to_string() },
+                None,
+            )
+        } else {
+            (ManualCaptureDecision::NothingHeard, None)
+        }
     } else {
+        // Still listening — accumulate the growing window, decrement the backstop, wait for the
+        // user's stop click. We do NOT dispatch on hearing speech (CLICK-TO-STOP).
         (
             ManualCaptureDecision::KeepListening,
             Some(crate::state::CaptureState { budget: remaining, ..capture }),
@@ -672,49 +692,99 @@ mod tests {
     use serde_json::Value;
 
     fn armed(budget: u32) -> CaptureState {
-        CaptureState { budget, start_sample: Some(0) }
+        CaptureState { budget, start_sample: Some(0), ended: false }
+    }
+
+    /// An armed capture the user has CLICKED STOP on (`end_voice_command` flipped `ended`).
+    fn ended(budget: u32) -> CaptureState {
+        CaptureState { budget, start_sample: Some(0), ended: true }
     }
 
     #[test]
-    fn manual_capture_nonempty_command_dispatches_with_the_heard_command_and_clears() {
-        // ANY non-empty post-click utterance is dispatched, carrying the heard command verbatim.
-        let cap = armed(5);
-        let (decision, next) = decide_manual_capture(cap, "  zrób research o konkurencji  ");
+    fn manual_capture_still_listening_does_not_dispatch_on_hearing_speech() {
+        // CLICK-TO-STOP: hearing a real, meaningful utterance while NOT ended (and under the backstop)
+        // must KEEP LISTENING — the user controls when they're done, not a per-tick auto-dispatch.
+        let cap = armed(20);
+        let (decision, next) = decide_manual_capture(cap, "Więc tak, zrób web");
         assert_eq!(
             decision,
-            ManualCaptureDecision::Dispatch { command: "zrób research o konkurencji".into() },
-            "a non-empty command must dispatch with the heard (trimmed) command"
+            ManualCaptureDecision::KeepListening,
+            "a non-ended capture must keep accumulating, not cut the user off mid-question"
+        );
+        assert_eq!(
+            next,
+            Some(CaptureState { budget: 19, start_sample: Some(0), ended: false }),
+            "a listening tick decrements the backstop and keeps the latched offset + ended flag"
+        );
+    }
+
+    #[test]
+    fn manual_capture_end_click_dispatches_full_accumulated_utterance_and_clears() {
+        // The user clicked STOP (`ended`) with a full accumulated utterance → dispatch the WHOLE
+        // trimmed command, clear the capture. This is the primary end of a CLICK-TO-STOP capture.
+        let cap = ended(15);
+        let (decision, next) =
+            decide_manual_capture(cap, "  Więc tak, zrób web research o konkurencji  ");
+        assert_eq!(
+            decision,
+            ManualCaptureDecision::Dispatch {
+                command: "Więc tak, zrób web research o konkurencji".into()
+            },
+            "the user's stop click must dispatch the FULL accumulated (trimmed) utterance"
         );
         assert!(next.is_none(), "capture must be cleared after a dispatch");
     }
 
     #[test]
+    fn manual_capture_backstop_cap_dispatches_a_real_utterance_as_a_backstop() {
+        // No stop click, but the backstop cap is reached (budget hits 0 this tick) with a real
+        // utterance accumulated → auto-stop + dispatch so the capture can't listen forever.
+        let cap = armed(1); // this tick takes budget 1 → 0 = backstop reached
+        let (decision, next) = decide_manual_capture(cap, "zrób research o konkurencji");
+        assert_eq!(
+            decision,
+            ManualCaptureDecision::Dispatch { command: "zrób research o konkurencji".into() },
+            "reaching the backstop cap with a real utterance must dispatch it (backstop)"
+        );
+        assert!(next.is_none(), "capture cleared at the backstop");
+    }
+
+    #[test]
+    fn manual_capture_end_click_on_silent_capture_is_nothing_heard_not_empty_dispatch() {
+        // The NO-EMPTY-DISPATCH guarantee: the user clicked stop but nothing was ever heard → graceful
+        // NothingHeard, NEVER an empty Unknown dispatch.
+        let (d, n) = decide_manual_capture(ended(15), "");
+        assert_eq!(
+            d,
+            ManualCaptureDecision::NothingHeard,
+            "an ended-but-silent capture must terminate as NothingHeard, never an empty dispatch"
+        );
+        assert!(n.is_none(), "capture must be cleared once it gives up");
+    }
+
+    #[test]
+    fn manual_capture_backstop_with_nothing_heard_is_nothing_heard() {
+        // No stop click, backstop reached, nothing ever heard → NothingHeard (graceful), never empty.
+        let (d, n) = decide_manual_capture(armed(1), "   ");
+        assert_eq!(
+            d,
+            ManualCaptureDecision::NothingHeard,
+            "the backstop with a fully-silent capture must give up gracefully"
+        );
+        assert!(n.is_none(), "capture cleared at the backstop");
+    }
+
+    #[test]
     fn manual_capture_silent_tick_with_budget_left_keeps_listening_and_decrements() {
-        // An EMPTY post-click window (no speech yet) but budget remains → keep listening, budget −1.
+        // An EMPTY post-click window (no speech yet) but backstop remains → keep listening, budget −1.
         let cap = armed(3);
         let (decision, next) = decide_manual_capture(cap, "   ");
         assert_eq!(decision, ManualCaptureDecision::KeepListening);
         assert_eq!(
             next,
-            Some(CaptureState { budget: 2, start_sample: Some(0) }),
-            "a silent tick must decrement the budget and keep the SAME latched offset"
+            Some(CaptureState { budget: 2, start_sample: Some(0), ended: false }),
+            "a silent tick must decrement the backstop and keep the SAME latched offset + flag"
         );
-    }
-
-    #[test]
-    fn manual_capture_budget_exhausted_silent_is_nothing_heard_not_empty_dispatch() {
-        // The NO-EMPTY-DISPATCH guarantee: a fully-silent capture ends in NothingHeard (graceful),
-        // NEVER an empty Unknown dispatch.
-        let (d1, n1) = decide_manual_capture(armed(2), "");
-        assert_eq!(d1, ManualCaptureDecision::KeepListening);
-        assert_eq!(n1, Some(CaptureState { budget: 1, start_sample: Some(0) }));
-        let (d2, n2) = decide_manual_capture(n1.unwrap(), "");
-        assert_eq!(
-            d2,
-            ManualCaptureDecision::NothingHeard,
-            "a fully-silent capture must terminate as NothingHeard, never an empty dispatch"
-        );
-        assert!(n2.is_none(), "capture must be cleared once it gives up");
     }
 
     #[test]
@@ -726,11 +796,13 @@ mod tests {
     }
 
     #[test]
-    fn manual_capture_default_budget_gives_a_reasonable_window() {
-        // The default arms ~5 ticks (≈15s at the 3s TICK) — comfortable to click then speak.
+    fn manual_capture_default_backstop_is_generous_not_a_felt_cutoff() {
+        // CLICK-TO-STOP: the default backstop must be GENEROUS (~20 ticks ≈ 60s at the 3s TICK) so a
+        // normal-length question never feels cut off — the user's stop click is the primary end, this
+        // is only the can't-listen-forever safety cap.
         assert!(
-            (3..=8).contains(&CaptureState::DEFAULT_BUDGET),
-            "default capture budget should give the user a reasonable window to speak"
+            (15..=30).contains(&CaptureState::DEFAULT_BUDGET),
+            "the backstop cap must be generous (~60s) so it never feels like a cutoff mid-question"
         );
     }
 
@@ -814,29 +886,26 @@ mod tests {
     }
 
     #[test]
-    fn decide_manual_capture_drops_garbage_keeps_listening_then_nothing_heard() {
-        // "Uh," is garbage → treat like a silent tick: KEEP LISTENING (budget −1), NOT a dispatch.
-        let (d1, n1) = decide_manual_capture(armed(2), "Uh,");
-        assert_eq!(d1, ManualCaptureDecision::KeepListening, "garbage must not dispatch");
-        assert_eq!(n1, Some(CaptureState { budget: 1, start_sample: Some(0) }));
-        // A second garbage tick exhausts the budget → NothingHeard (graceful), never a dispatch.
-        let (d2, n2) = decide_manual_capture(n1.unwrap(), "eee");
+    fn decide_manual_capture_end_click_on_garbage_only_is_nothing_heard() {
+        // The user clicked stop but only garbage/filler ("eee") was accumulated → NothingHeard
+        // (graceful), never a garbage Research dispatch.
+        let (d, n) = decide_manual_capture(ended(10), "eee");
         assert_eq!(
-            d2,
+            d,
             ManualCaptureDecision::NothingHeard,
-            "a fully-garbage capture ends as NothingHeard, never a garbage dispatch"
+            "an ended garbage-only capture ends as NothingHeard, never a garbage dispatch"
         );
-        assert!(n2.is_none(), "capture cleared once it gives up");
+        assert!(n.is_none(), "capture cleared once it gives up");
     }
 
     #[test]
-    fn decide_manual_capture_dispatches_a_real_command() {
-        // A genuine command dispatches with the heard (trimmed) command verbatim.
-        let (d, n) = decide_manual_capture(armed(5), "  zrób research o pogodzie  ");
+    fn decide_manual_capture_end_click_dispatches_a_real_command() {
+        // The user clicked stop with a genuine command → dispatch the (trimmed) command verbatim.
+        let (d, n) = decide_manual_capture(ended(15), "  zrób research o pogodzie  ");
         assert_eq!(
             d,
             ManualCaptureDecision::Dispatch { command: "zrób research o pogodzie".into() },
-            "a real command must dispatch"
+            "an ended real command must dispatch"
         );
         assert!(n.is_none(), "capture cleared on dispatch");
     }

--- a/src/app/core/assistant.store.ts
+++ b/src/app/core/assistant.store.ts
@@ -5,8 +5,17 @@ import type {
   VoiceActionResultPayload,
   VoiceActionStatus,
   VoiceCommandListeningPayload,
+  VoiceCommandProcessingPayload,
   WakeDetectedPayload,
 } from "./models";
+
+/**
+ * The 4-state visual model of the assistant orb (industry-convergent
+ * idle → listening → processing → answer). Pure presentation: derived from the
+ * store's listening/processing/in-flight signals + the newest interaction
+ * status by {@link AssistantStore.orbState}, never set directly.
+ */
+export type OrbState = "idle" | "listening" | "processing" | "answer";
 
 /**
  * Phase H — one recent in-meeting voice-assistant interaction. A wake creates a
@@ -105,12 +114,40 @@ export class AssistantStore {
   private readonly _manualAskInFlight = signal(false);
   readonly manualAskInFlight = this._manualAskInFlight.asReadonly();
 
+  /**
+   * True while a dispatched command is being processed (between the listener
+   * stopping and the answer landing) — the EVENT_VOICE_COMMAND_PROCESSING
+   * `{active}` boolean. Drives the orb's PROCESSING state + the "🧠 Przetwarzam…"
+   * shimmer label. Cleared by the result (or by the end-ask error path).
+   */
+  private readonly _processing = signal(false);
+  readonly processing = this._processing.asReadonly();
+
+  /**
+   * The 4-state orb model collapsed from the existing signals — a PURE
+   * `computed` (no signal writes → no NG0600 / trap T1):
+   *   processing → "processing" (highest priority: a dispatch is in flight)
+   *   listening  → "listening"  (the mic is open)
+   *   manual ask in flight (begin clicked, listener not yet open) → "listening"
+   *   newest interaction resolved → "answer" (a result is on screen)
+   *   otherwise → "idle".
+   * Bound on the orb as `[state]="orbState()"`.
+   */
+  readonly orbState = computed<OrbState>(() => {
+    if (this._processing()) return "processing";
+    if (this._listening() || this._manualAskInFlight()) return "listening";
+    const top = this._interactions()[0];
+    if (top && top.status !== "pending") return "answer";
+    return "idle";
+  });
+
   /** Monotonic id source for interaction rows (stable `@for` keys). */
   private nextId = 1;
 
   private unlistenWake: UnlistenFn | null = null;
   private unlistenResult: UnlistenFn | null = null;
   private unlistenListening: UnlistenFn | null = null;
+  private unlistenProcessing: UnlistenFn | null = null;
   /** Synchronous re-entrancy guard so two concurrent init() calls (e.g. the record
    * screen + the card both initialising) can't double-subscribe before the first
    * `await` resolves. */
@@ -127,6 +164,9 @@ export class AssistantStore {
     this.unlistenListening = await this.ipc.onVoiceCommandListening((p) =>
       this.onListening(p),
     );
+    this.unlistenProcessing = await this.ipc.onVoiceCommandProcessing((p) =>
+      this.onProcessing(p),
+    );
   }
 
   /** Release the event subscriptions (e.g. on app teardown). */
@@ -134,9 +174,11 @@ export class AssistantStore {
     this.unlistenWake?.();
     this.unlistenResult?.();
     this.unlistenListening?.();
+    this.unlistenProcessing?.();
     this.unlistenWake = null;
     this.unlistenResult = null;
     this.unlistenListening = null;
+    this.unlistenProcessing = null;
   }
 
   /**
@@ -152,6 +194,28 @@ export class AssistantStore {
     } catch (e) {
       this._manualAskInFlight.set(false);
       this._listening.set(false);
+      throw e;
+    }
+  }
+
+  /**
+   * CLICK-TO-STOP: stop the open listener so the FULL accumulated utterance is
+   * dispatched. Optimistically flip `listening` off + `processing` on so the orb
+   * morphs to PROCESSING the instant the user clicks (the backend's
+   * `{active:false}` listening + `{active:true}` processing events reconcile it
+   * shortly after); the answer clears processing via {@link onResult}. The manual
+   * ask stays in flight so the card keeps the answer's home. A no-op backend
+   * (nothing armed) is fine — `endVoiceCommand` is a graceful no-op there.
+   */
+  async endAsk(): Promise<void> {
+    this._listening.set(false);
+    this._processing.set(true);
+    try {
+      await this.ipc.endVoiceCommand();
+    } catch (e) {
+      // The stop call itself failed — don't leave the orb stuck "processing".
+      this._processing.set(false);
+      this._manualAskInFlight.set(false);
       throw e;
     }
   }
@@ -173,11 +237,18 @@ export class AssistantStore {
     this._listening.set(p.active);
   }
 
+  private onProcessing(p: VoiceCommandProcessingPayload): void {
+    this._processing.set(p.active);
+    // The backend stops the listener implicitly when it begins dispatching.
+    if (p.active) this._listening.set(false);
+  }
+
   private onResult(p: VoiceActionResultPayload): void {
-    // The answer landed — the manual ask (if any) is no longer in flight, and
-    // the listener is closed.
+    // The answer landed — the manual ask (if any) is no longer in flight, the
+    // listener is closed, and the dispatch is no longer processing.
     this._manualAskInFlight.set(false);
     this._listening.set(false);
+    this._processing.set(false);
     this._interactions.update((rows) => {
       // Resolve the most recent still-pending row; if none (a result without a
       // wake we observed), prepend a fresh resolved row so nothing is lost.

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -38,6 +38,7 @@ import type {
   TopicThread,
   VoiceActionResultPayload,
   VoiceCommandListeningPayload,
+  VoiceCommandProcessingPayload,
   WakeDetectedPayload,
 } from "./models";
 
@@ -49,6 +50,8 @@ export const EVENT_LIVE_CAPTION = "murmur://live-caption";
 export const EVENT_WAKE_DETECTED = "murmur://wake-detected";
 export const EVENT_VOICE_ACTION_RESULT = "murmur://voice-action-result";
 export const EVENT_VOICE_COMMAND_LISTENING = "murmur://voice-command-listening";
+export const EVENT_VOICE_COMMAND_PROCESSING =
+  "murmur://voice-command-processing";
 export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
 // brain2 RAG — semantic-search model download + reindex backfill event streams.
 export const EVENT_EMBED_DOWNLOAD = "murmur://embed-download";
@@ -500,6 +503,18 @@ export class IpcService {
     return invoke<void>("begin_voice_command");
   }
 
+  /**
+   * Phase H — CLICK-TO-STOP: stop the in-meeting voice-command listener the user
+   * started with {@link beginVoiceCommand}, so the FULL accumulated post-click
+   * utterance is dispatched (over the same gated `handle_voice_action` path). The
+   * backend emits `EVENT_VOICE_COMMAND_PROCESSING {active:true}` while the
+   * dispatch is in flight, then the answer arrives via `EVENT_VOICE_ACTION_RESULT`.
+   * A no-op when nothing is armed (double-click / already auto-stopped) — never throws.
+   */
+  endVoiceCommand(): Promise<void> {
+    return invoke<void>("end_voice_command");
+  }
+
   // ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──
 
   /** The folder tree (roots → children) with per-folder note counts + session lock state. */
@@ -613,6 +628,21 @@ export class IpcService {
   ): Promise<UnlistenFn> {
     return listen<VoiceCommandListeningPayload>(
       EVENT_VOICE_COMMAND_LISTENING,
+      (e) => cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires when a manual voice command has STOPPED listening and is being
+   * DISPATCHED (`active:true`) — the gap between capture-stop and the answer
+   * landing via {@link onVoiceActionResult}. Drives the "🧠 Przetwarzam…"
+   * processing state of the assistant orb.
+   */
+  onVoiceCommandProcessing(
+    cb: (p: VoiceCommandProcessingPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<VoiceCommandProcessingPayload>(
+      EVENT_VOICE_COMMAND_PROCESSING,
       (e) => cb(e.payload),
     );
   }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -244,6 +244,18 @@ export interface VoiceCommandListeningPayload {
   active: boolean;
 }
 
+/**
+ * Fired when a MANUAL voice-command capture has STOPPED listening and the
+ * accumulated utterance is being DISPATCHED (`EVENT_VOICE_COMMAND_PROCESSING`).
+ * `active` flips true the instant the backend stops capturing and the gated
+ * `handle_voice_action` round-trip (RAG + brain) begins, and is cleared (false
+ * is implied) when the answer lands via `EVENT_VOICE_ACTION_RESULT`. Drives the
+ * "🧠 Przetwarzam…" processing state in the gap between stop and answer.
+ */
+export interface VoiceCommandProcessingPayload {
+  active: boolean;
+}
+
 /** A selectable microphone input device (from `list_input_devices`). */
 export interface InputDeviceInfo {
   name: string;

--- a/src/app/features/record/ai-orb.component.ts
+++ b/src/app/features/record/ai-orb.component.ts
@@ -1,0 +1,230 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
+import type { OrbState } from "../../core/assistant.store";
+
+/**
+ * The in-meeting AI-assistant ORB — a single morphing gradient orb whose STATE is
+ * expressed by motion + color (the convergent ChatGPT/Siri/Gemini pattern), NOT
+ * by swapping widgets (research: 2026-06-28-ai-assistant-orb-ui.md, Option B):
+ *
+ *   IDLE       — calm `--accent-gradient` core, slow `transform: scale` breathe.
+ *   LISTENING  — audio-reactive scale driven by `level()` via `[style.--level]`
+ *                (mirrors the recorder's `[style.--level]="store.level()"` wave)
+ *                + a reactive ring whose scale/opacity track the level.
+ *   PROCESSING — a rotating conic-gradient ring carved with a radial-gradient
+ *                `mask`, spun with `transform: rotate()` (the element-spin variant
+ *                — NOT `@property --angle` — so it sidesteps the at-rule scoping
+ *                caveat through Angular's CSS pipeline; mirrors the existing
+ *                `.orb.proc` spinner in record.component.ts).
+ *   ANSWER     — settle to a steady gentle glow + a ONE-SHOT entry "pop" keyed on
+ *                the class change (a CSS entry-animation → no component timer,
+ *                rule §5). Re-keys per result since `[class]` re-applies.
+ *
+ * Pure presentational: `state` + `level` are `input()`s, everything else is a
+ * `computed`. The orb itself is `aria-hidden` (decorative); the spoken state is
+ * announced by a paired `role="status" aria-live` line OWNED BY THE PARENT (the
+ * recorder bar / the card) so this component stays a single focused visual unit.
+ *
+ * prefers-reduced-motion: an EXPLICIT guard kills the value-driven scale + the
+ * conic spin + the breathe/pop (the global rule zeroes `animation` duration, but
+ * the `transform: scale(calc(1 + var(--level)…))` is value-driven, not an
+ * animation — it MUST be neutralised here; mirrors record.component.ts:751).
+ */
+@Component({
+  selector: "app-ai-orb",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span
+      class="orb"
+      [class]="'is-' + state()"
+      [style.--level]="clampedLevel()"
+      aria-hidden="true"
+    >
+      <span class="orb-core"></span>
+      <span class="orb-ring"></span>
+    </span>
+  `,
+  styles: [
+    `
+      :host {
+        display: inline-flex;
+        flex: none;
+        line-height: 0;
+      }
+      .orb {
+        position: relative;
+        display: inline-block;
+        width: var(--orb-size, 56px);
+        height: var(--orb-size, 56px);
+      }
+
+      /* The living gradient core — its motion/color is the whole state language. */
+      .orb-core {
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background: var(--accent-gradient);
+        box-shadow: 0 0 18px rgba(110, 118, 255, 0.55);
+        /* blur softens the gradient into a liquid orb (Siri-orb recipe). */
+        filter: saturate(1.15);
+        transform: scale(1);
+        transition:
+          transform 90ms linear,
+          box-shadow var(--transition),
+          filter var(--transition);
+      }
+
+      /* The overlaid ring — repurposed per state (reactive halo / conic spinner). */
+      .orb-ring {
+        position: absolute;
+        inset: -4px;
+        border-radius: 50%;
+        pointer-events: none;
+        opacity: 0;
+        transition:
+          opacity var(--transition),
+          transform 90ms linear;
+      }
+
+      /* ── IDLE — slow breathe ──────────────────────────────────────────── */
+      .orb.is-idle .orb-core {
+        animation: orb-breathe 3s ease-in-out infinite;
+      }
+      .orb.is-idle .orb-ring {
+        border: 1.5px solid var(--accent);
+        opacity: 0.35;
+        animation: orb-halo 3s ease-in-out infinite;
+      }
+      @keyframes orb-breathe {
+        0%,
+        100% {
+          transform: scale(0.94);
+        }
+        50% {
+          transform: scale(1);
+        }
+      }
+      @keyframes orb-halo {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 0.35;
+        }
+        50% {
+          transform: scale(1.18);
+          opacity: 0;
+        }
+      }
+
+      /* ── LISTENING — audio-reactive scale + reactive ring ─────────────── */
+      .orb.is-listening .orb-core {
+        /* value-driven: grows with the live mic level (90ms CSS smoothing). */
+        transform: scale(calc(1 + var(--level, 0) * 0.18));
+        box-shadow: 0 0 26px rgba(110, 118, 255, 0.8);
+      }
+      .orb.is-listening .orb-ring {
+        border: 2px solid var(--accent-hover);
+        opacity: calc(0.25 + var(--level, 0) * 0.6);
+        transform: scale(calc(1.05 + var(--level, 0) * 0.22));
+      }
+
+      /* ── PROCESSING — conic-gradient ring, element-spin (no @property) ── */
+      .orb.is-processing .orb-core {
+        transform: scale(0.9);
+        animation: orb-breathe 1.6s ease-in-out infinite;
+      }
+      .orb.is-processing .orb-ring {
+        inset: -3px;
+        opacity: 1;
+        border: none;
+        background: conic-gradient(
+          from 0deg,
+          transparent 0deg,
+          var(--accent) 120deg,
+          var(--accent-hover) 240deg,
+          transparent 360deg
+        );
+        /* carve the disc into a ring */
+        -webkit-mask: radial-gradient(
+          farthest-side,
+          transparent calc(100% - 4px),
+          #000 calc(100% - 4px)
+        );
+        mask: radial-gradient(
+          farthest-side,
+          transparent calc(100% - 4px),
+          #000 calc(100% - 4px)
+        );
+        animation: orb-spin 0.9s linear infinite;
+      }
+      @keyframes orb-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      /* ── ANSWER — steady gentle glow + one-shot entry "pop" ───────────── */
+      .orb.is-answer .orb-core {
+        animation:
+          orb-pop 360ms var(--transition) both,
+          orb-breathe 3.4s ease-in-out 360ms infinite;
+        box-shadow: 0 0 22px rgba(110, 118, 255, 0.7);
+      }
+      .orb.is-answer .orb-ring {
+        border: 1.5px solid var(--accent);
+        opacity: 0.3;
+      }
+      @keyframes orb-pop {
+        0% {
+          transform: scale(0.7);
+        }
+        55% {
+          transform: scale(1.12);
+        }
+        100% {
+          transform: scale(1);
+        }
+      }
+
+      /* EXPLICIT reduced-motion guard — neutralise BOTH the animations AND the
+         value-driven listening scale (mirrors record.component.ts:751). */
+      @media (prefers-reduced-motion: reduce) {
+        .orb-core,
+        .orb-ring {
+          animation: none !important;
+          transition: none;
+        }
+        .orb.is-listening .orb-core,
+        .orb.is-processing .orb-core,
+        .orb.is-answer .orb-core {
+          transform: scale(1);
+        }
+        .orb.is-listening .orb-ring {
+          transform: scale(1.05);
+          opacity: 0.4;
+        }
+        /* keep the processing ring visible but static (no spin). */
+        .orb.is-processing .orb-ring {
+          opacity: 1;
+        }
+      }
+    `,
+  ],
+})
+export class AiOrbComponent {
+  /** The 4-state orb model (idle | listening | processing | answer). */
+  readonly state = input<OrbState>("idle");
+
+  /** Live mic level 0..1 (RecorderStore.level()); only used in LISTENING. */
+  readonly level = input<number>(0);
+
+  /** Defensive clamp — a malformed level never blows up the scale calc. */
+  protected readonly clampedLevel = computed(() =>
+    Math.max(0, Math.min(1, this.level() || 0)),
+  );
+}

--- a/src/app/features/record/assistant-actions.component.ts
+++ b/src/app/features/record/assistant-actions.component.ts
@@ -6,6 +6,7 @@ import {
 } from "@angular/core";
 import { AssistantStore } from "../../core/assistant.store";
 import type { AssistantInteraction } from "../../core/assistant.store";
+import { AiOrbComponent } from "./ai-orb.component";
 
 /**
  * Phase H — the live "assistant actions" card on the record surface. Subscribes
@@ -25,10 +26,11 @@ import type { AssistantInteraction } from "../../core/assistant.store";
   selector: "app-assistant-actions",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AiOrbComponent],
   template: `
     <div class="card assistant" role="group" aria-label="Voice assistant">
       <div class="assistant-head">
-        <span class="assistant-mark" aria-hidden="true">🎙</span>
+        <app-ai-orb class="head-orb" [state]="store.orbState()" />
         <span class="assistant-title">Voice assistant</span>
         <span class="pill is-live assistant-live" aria-hidden="true">
           <span class="pill-dot"></span>
@@ -118,9 +120,8 @@ import type { AssistantInteraction } from "../../core/assistant.store";
         align-items: center;
         gap: var(--space-2);
       }
-      .assistant-mark {
-        font-size: 1.05rem;
-        line-height: 1;
+      .head-orb {
+        --orb-size: 22px;
       }
       .assistant-title {
         color: var(--text-primary);

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -15,6 +15,7 @@ import type { Analytics, AppConfigDto } from "../../core/models";
 import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
 import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
 import { AssistantActionsComponent } from "./assistant-actions.component";
+import { AiOrbComponent } from "./ai-orb.component";
 import { AssistantStore } from "../../core/assistant.store";
 
 @Component({
@@ -26,6 +27,7 @@ import { AssistantStore } from "../../core/assistant.store";
     PreMeetingBriefComponent,
     MicMuteToggleComponent,
     AssistantActionsComponent,
+    AiOrbComponent,
   ],
   host: { "(document:keydown)": "onKey($event)" },
   template: `
@@ -138,18 +140,20 @@ import { AssistantStore } from "../../core/assistant.store";
                  Compact (icon-only) so the pill stays uncrowded; the descriptive
                  "still capturing others" copy rides the stage hint below. -->
             <app-mic-mute-toggle [compact]="true" #micToggle />
-            <!-- Ask AI — manually open the voice-command listener (no wake phrase
-                 needed). Pulses + glows while the assistant is listening. The
-                 spoken answer lands in the assistant-actions card below. -->
+            <!-- Ask AI — CLICK-TO-STOP toggle. First click opens the voice-command
+                 listener (no wake phrase); a SECOND click stops it so the full
+                 utterance is dispatched (→ processing). Pulses while listening.
+                 The spoken answer lands in the assistant-actions card below. -->
             <button
               type="button"
               class="ask-btn"
               [class.is-listening]="assistant.listening()"
-              (click)="askAi()"
+              [disabled]="assistant.processing()"
+              (click)="toggleAsk()"
               [attr.aria-pressed]="assistant.listening()"
               [attr.aria-label]="
                 assistant.listening()
-                  ? 'Listening — say your request'
+                  ? 'Stop listening and ask'
                   : 'Ask the AI assistant'
               "
             >
@@ -181,12 +185,38 @@ import { AssistantStore } from "../../core/assistant.store";
             </button>
           </div>
 
-          <!-- Rich "listening" state — appears the instant the manual Ask-AI
-               listener opens; clear copy so it's obvious the app is hearing you. -->
-          @if (assistant.listening()) {
-            <div class="listening" role="status" aria-live="polite">
-              <span class="listening-orb" aria-hidden="true"></span>
-              <span class="listening-text">🎙 Słucham — powiedz polecenie…</span>
+          <!-- The morphing assistant ORB + a state line. The orb expresses the
+               state by motion/color; the paired role="status" line announces it.
+               LISTENING → "Słucham (kliknij by zakończyć)"; PROCESSING → a shimmer
+               "🧠 Przetwarzam…" label. Idle/answer states stay silent here (the
+               answer has its home in the card below). -->
+          @if (
+            assistant.orbState() === "listening" ||
+            assistant.orbState() === "processing"
+          ) {
+            <div
+              class="orb-state"
+              [class.is-processing]="assistant.orbState() === 'processing'"
+            >
+              <app-ai-orb
+                class="bar-orb"
+                [state]="assistant.orbState()"
+                [level]="store.level()"
+              />
+              @if (assistant.orbState() === "listening") {
+                <span class="orb-state-text" role="status" aria-live="polite">
+                  🎙 Słucham
+                  <span class="orb-state-hint">— kliknij ✨ by zakończyć</span>
+                </span>
+              } @else {
+                <span
+                  class="orb-state-text shimmer-text"
+                  role="status"
+                  aria-live="polite"
+                  aria-busy="true"
+                  >🧠 Przetwarzam…</span
+                >
+              }
             </div>
           }
         } @else if (isProcessing()) {
@@ -721,13 +751,19 @@ import { AssistantStore } from "../../core/assistant.store";
         }
       }
 
-      /* Inline "listening" indicator under the pill while the mic is open. */
-      .listening {
+      .ask-btn:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+
+      /* The morphing-orb state row under the pill — orb + a status/shimmer line.
+         The orb element is the motion; this row provides the copy + framing. */
+      .orb-state {
         display: inline-flex;
         align-items: center;
-        gap: var(--space-2);
+        gap: var(--space-3);
         margin-top: var(--space-3);
-        padding: var(--space-2) var(--space-3);
+        padding: var(--space-2) var(--space-3) var(--space-2) var(--space-2);
         border-radius: var(--radius-pill);
         background: var(--accent-soft);
         border: 1px solid var(--accent-ring);
@@ -736,23 +772,58 @@ import { AssistantStore } from "../../core/assistant.store";
         font-weight: 550;
         animation: rise 220ms var(--transition) both;
       }
-      .listening-orb {
-        width: 9px;
-        height: 9px;
-        border-radius: 50%;
-        background: var(--accent);
-        box-shadow: 0 0 0 0 var(--accent-ring);
-        animation: ask-pulse 1.5s ease-in-out infinite;
+      .orb-state.is-processing {
+        border-color: var(--border-strong);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text-primary);
       }
-      .listening-text {
+      /* Compact orb for the bar (the orb defaults to 56px; here ~30px). */
+      .bar-orb {
+        --orb-size: 30px;
+      }
+      .orb-state-text {
         line-height: 1.3;
+      }
+      .orb-state-hint {
+        opacity: 0.8;
+        font-weight: 500;
+      }
+
+      /* Shimmer text — a moving gradient clipped to the glyphs (Raycast/Vercel
+         "thinking" treatment) naming the processing substep. */
+      .shimmer-text {
+        background: linear-gradient(
+          100deg,
+          var(--text-secondary) 30%,
+          var(--text-primary) 50%,
+          var(--text-secondary) 70%
+        );
+        background-size: 200% 100%;
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        animation: text-shimmer 1.8s linear infinite;
+      }
+      @keyframes text-shimmer {
+        0% {
+          background-position: 200% 0;
+        }
+        100% {
+          background-position: -200% 0;
+        }
       }
 
       @media (prefers-reduced-motion: reduce) {
         .ask-btn.is-listening,
-        .listening-orb,
-        .listening {
+        .orb-state,
+        .shimmer-text {
           animation: none;
+        }
+        .shimmer-text {
+          background: none;
+          -webkit-background-clip: border-box;
+          background-clip: border-box;
+          color: var(--text-primary);
         }
       }
 
@@ -1150,6 +1221,7 @@ export class RecordComponent implements OnInit {
       enabled ||
       this.assistant.hasAny() ||
       this.assistant.listening() ||
+      this.assistant.processing() ||
       this.assistant.manualAskInFlight()
     );
   });
@@ -1396,17 +1468,24 @@ export class RecordComponent implements OnInit {
   }
 
   /**
-   * Manually trigger the voice assistant to listen for a spoken command (the
-   * "Ask AI" button) — no wake phrase needed. The store sets the in-flight flag
-   * (so the answer card stays visible) and the backend streams the listening
-   * state over EVENT_VOICE_COMMAND_LISTENING; the answer lands in the
-   * assistant-actions card. Swallow rejections (e.g. brain backend off) — the
-   * store already resets its pulsing state on error.
+   * CLICK-TO-STOP toggle for the "Ask AI" (✨) button. First click opens the
+   * voice-command listener (no wake phrase); a second click — while listening —
+   * stops it so the FULL utterance is dispatched (→ processing). The backend
+   * streams listening/processing over EVENT_VOICE_COMMAND_LISTENING /
+   * EVENT_VOICE_COMMAND_PROCESSING and the answer lands in the assistant-actions
+   * card. Swallow rejections (e.g. brain backend off) — the store resets its
+   * listening/processing/in-flight state on error.
    */
-  askAi(): void {
-    void this.assistant.askNow().catch(() => {
-      /* listener unavailable — store resets the in-flight/listening state */
-    });
+  toggleAsk(): void {
+    if (this.assistant.listening()) {
+      void this.assistant.endAsk().catch(() => {
+        /* stop failed — store cleared processing/in-flight */
+      });
+    } else {
+      void this.assistant.askNow().catch(() => {
+        /* listener unavailable — store resets the in-flight/listening state */
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Real feedback: fixed ~15s capture cut the user off ('Więc tak, zrób web…' truncated) + 'you don't know what it's doing'. Now: **click-to-stop toggle** (begin→accumulate full utterance→end_voice_command dispatch, ~60s backstop, nothing_heard on silence), a **PROCESSING** state (EVENT_VOICE_COMMAND_PROCESSING), and an **animated AI orb** (idle/listening audio-reactive/processing conic+shimmer/answer; pure CSS+SVG, zero deps, reduced-motion guard). Verified: test 404/0 (RED-before-GREEN on the cut-off bug); clippy clean; ng lint+build clean; adversarial PASS (same gated dispatch, no NG0600/cycle/bleed).