### PR TITLE
feat(brain): Brain/AI model picker + Anthropic-only effort selector

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -65,6 +65,16 @@ pub struct AppConfigDto {
     pub whisper_model_path: Option<String>,
     pub language: Option<String>,
     pub anthropic_model: String,
+    /// Brain/AI MODEL override for the active cloud provider. Settable from the DTO (the Settings
+    /// UI owns the picker), like `anthropic_model` — a plain string, NOT preserve-only. Empty `""`
+    /// = provider default. An omitted key deserializes to `""` (`#[serde(default)]`).
+    #[serde(default)]
+    pub provider_model: String,
+    /// Brain/AI reasoning EFFORT (`""`/`low`/`medium`/`high`). Settable from the DTO. Honored ONLY
+    /// by the direct `anthropic` provider (adaptive thinking); the `claude_code` CLI ignores it.
+    /// An omitted key deserializes to `""` (`#[serde(default)]`).
+    #[serde(default)]
+    pub provider_effort: String,
     pub ollama_base_url: String,
     pub ollama_model: String,
     pub claude_binary: String,
@@ -1813,6 +1823,8 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         whisper_model_path: c.whisper_model_path.clone(),
         language: c.language.clone(),
         anthropic_model: c.anthropic_model.clone(),
+        provider_model: c.provider_model.clone(),
+        provider_effort: c.provider_effort.clone(),
         ollama_base_url: c.ollama_base_url.clone(),
         ollama_model: c.ollama_model.clone(),
         claude_binary: c.claude_binary.clone(),
@@ -1858,6 +1870,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         whisper_model_path: norm(d.whisper_model_path),
         language: norm(d.language),
         anthropic_model: d.anthropic_model,
+        // Brain/AI model + effort ARE settable from the DTO (the Settings UI owns the pickers),
+        // exactly like `anthropic_model` — plain strings, NOT preserve-only. `""` = provider default.
+        provider_model: d.provider_model,
+        provider_effort: d.provider_effort,
         ollama_base_url: d.ollama_base_url,
         ollama_model: d.ollama_model,
         claude_binary: d.claude_binary,
@@ -5045,6 +5061,49 @@ mod lifecycle_tests {
             !dto_to_config(dto_off, &current_on).semantic_search_enabled,
             "semantic_search_enabled MUST be settable from the DTO (turn off)"
         );
+    }
+
+    /// Brain/AI picker: `provider_model` + `provider_effort` round-trip through the settings DTO
+    /// BOTH ways. OUT: `config_to_dto` carries the live values so the FE pickers reflect them. IN:
+    /// `dto_to_config` TAKES them from the DTO (settable — like `anthropic_model`, NOT preserve-only),
+    /// proven by starting from a different `current` so the merged value can only have come from the DTO.
+    #[test]
+    fn dto_round_trips_provider_model_and_effort_both_ways() {
+        // OUT.
+        let cfg = AppConfig {
+            provider_model: "claude-sonnet-4-6".to_string(),
+            provider_effort: "high".to_string(),
+            ..AppConfig::default()
+        };
+        let dto = config_to_dto(&cfg);
+        assert_eq!(dto.provider_model, "claude-sonnet-4-6");
+        assert_eq!(dto.provider_effort, "high");
+
+        // IN (set): DTO values over a DIFFERENT current ⇒ merged values come from the DTO.
+        let mut dto_in = config_to_dto(&AppConfig::default());
+        dto_in.provider_model = "claude-haiku-4-5".to_string();
+        dto_in.provider_effort = "low".to_string();
+        let current = AppConfig {
+            provider_model: "claude-opus-4-8".to_string(),
+            provider_effort: "medium".to_string(),
+            ..AppConfig::default()
+        };
+        let merged = dto_to_config(dto_in, &current);
+        assert_eq!(merged.provider_model, "claude-haiku-4-5");
+        assert_eq!(merged.provider_effort, "low");
+
+        // IN (clear to provider default): DTO="" over current set ⇒ merged "" (settable both ways).
+        let mut dto_clear = config_to_dto(&AppConfig::default());
+        dto_clear.provider_model = String::new();
+        dto_clear.provider_effort = String::new();
+        let current2 = AppConfig {
+            provider_model: "claude-opus-4-8".to_string(),
+            provider_effort: "high".to_string(),
+            ..AppConfig::default()
+        };
+        let merged2 = dto_to_config(dto_clear, &current2);
+        assert_eq!(merged2.provider_model, "");
+        assert_eq!(merged2.provider_effort, "");
     }
 
     /// Phase H graceful degradation: a DTO carrying an UNKNOWN `brain_model_id` must NOT be stored —

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -61,6 +61,18 @@ pub struct AppConfig {
     pub language: Option<String>,
     /// default "claude-opus-4-8"
     pub anthropic_model: String,
+    /// Brain/AI model OVERRIDE for the active cloud provider. Empty `""` (the default) means
+    /// "use the provider's own default". For `claude_code` it is passed as `--model <id>`; for
+    /// `anthropic` it takes precedence over `anthropic_model`. `#[serde(default)]` ⇒ a config
+    /// persisted before this field existed loads as `""` (provider default).
+    #[serde(default)]
+    pub provider_model: String,
+    /// Brain/AI reasoning EFFORT for the active cloud provider: `""` (provider default), `"low"`,
+    /// `"medium"`, or `"high"`. ONLY the direct `anthropic` HTTP provider honors it (adaptive
+    /// thinking + output effort); the `claude_code` CLI has NO effort flag, so it is a no-op there.
+    /// `#[serde(default)]` ⇒ a config persisted before this field existed loads as `""`.
+    #[serde(default)]
+    pub provider_effort: String,
     /// default "http://localhost:11434"
     pub ollama_base_url: String,
     /// default "llama3.1"
@@ -187,6 +199,8 @@ impl Default for AppConfig {
             whisper_model_path: None,
             language: None,
             anthropic_model: "claude-opus-4-8".to_string(),
+            provider_model: String::new(),
+            provider_effort: String::new(),
             ollama_base_url: "http://localhost:11434".to_string(),
             ollama_model: "llama3.1".to_string(),
             claude_binary: "claude".to_string(),
@@ -224,6 +238,8 @@ const K_VAULT_SUBFOLDER: &str = "vault_subfolder";
 const K_WHISPER_MODEL_PATH: &str = "whisper_model_path";
 const K_LANGUAGE: &str = "language";
 const K_ANTHROPIC_MODEL: &str = "anthropic_model";
+const K_PROVIDER_MODEL: &str = "provider_model";
+const K_PROVIDER_EFFORT: &str = "provider_effort";
 const K_OLLAMA_BASE_URL: &str = "ollama_base_url";
 const K_OLLAMA_MODEL: &str = "ollama_model";
 const K_CLAUDE_BINARY: &str = "claude_binary";
@@ -271,6 +287,14 @@ impl AppConfig {
             if !v.is_empty() {
                 cfg.anthropic_model = v;
             }
+        }
+        // `""` is a VALID value (= provider default) and also the default, so the stored value
+        // is taken verbatim — no non-empty guard (unlike anthropic_model, whose default is a real id).
+        if let Some(v) = db.get_setting(K_PROVIDER_MODEL)? {
+            cfg.provider_model = v;
+        }
+        if let Some(v) = db.get_setting(K_PROVIDER_EFFORT)? {
+            cfg.provider_effort = v;
         }
         if let Some(v) = db.get_setting(K_OLLAMA_BASE_URL)? {
             if !v.is_empty() {
@@ -377,6 +401,8 @@ impl AppConfig {
         )?;
         db.set_setting(K_LANGUAGE, self.language.as_deref().unwrap_or(""))?;
         db.set_setting(K_ANTHROPIC_MODEL, &self.anthropic_model)?;
+        db.set_setting(K_PROVIDER_MODEL, &self.provider_model)?;
+        db.set_setting(K_PROVIDER_EFFORT, &self.provider_effort)?;
         db.set_setting(K_OLLAMA_BASE_URL, &self.ollama_base_url)?;
         db.set_setting(K_OLLAMA_MODEL, &self.ollama_model)?;
         db.set_setting(K_CLAUDE_BINARY, &self.claude_binary)?;
@@ -717,6 +743,36 @@ mod tests {
         assert_eq!(loaded.provider_id, "ollama");
         assert_eq!(loaded.vault_path.as_deref(), Some("/vault"));
         assert_eq!(loaded.language.as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn provider_model_and_effort_round_trip_and_default_empty() {
+        let db = temp_db();
+        // Absent keys ⇒ `""` (provider default) for fresh + pre-existing installs.
+        let fresh = AppConfig::load(&db).unwrap();
+        assert_eq!(fresh.provider_model, "");
+        assert_eq!(fresh.provider_effort, "");
+
+        let cfg = AppConfig {
+            provider_model: "claude-sonnet-4-6".to_string(),
+            provider_effort: "high".to_string(),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert_eq!(loaded.provider_model, "claude-sonnet-4-6");
+        assert_eq!(loaded.provider_effort, "high");
+
+        // Clearing back to `""` (provider default) also round-trips — not a one-way latch.
+        let cleared = AppConfig {
+            provider_model: String::new(),
+            provider_effort: String::new(),
+            ..Default::default()
+        };
+        cleared.save(&db).unwrap();
+        let reloaded = AppConfig::load(&db).unwrap();
+        assert_eq!(reloaded.provider_model, "");
+        assert_eq!(reloaded.provider_effort, "");
     }
 
     #[test]

--- a/src-tauri/src/summarize/anthropic.rs
+++ b/src-tauri/src/summarize/anthropic.rs
@@ -20,12 +20,22 @@ pub struct AnthropicProvider {
     client: reqwest::Client,
     model: String,
     api_key: Option<String>,
+    /// Reasoning EFFORT: `""`/`"default"` (provider default — no thinking config sent), or
+    /// `"low"`/`"medium"`/`"high"`. When set, ADAPTIVE thinking + an output effort tier is added to
+    /// the request body. Opus 4.8 requires `thinking.type = "adaptive"`; sending the older
+    /// `thinking.enabled`/`budget_tokens` shape would 400, so we deliberately never do that.
+    effort: String,
 }
 
 impl AnthropicProvider {
     /// `api_key` already resolved from Keychain by the factory. `model` defaults to
-    /// `claude-opus-4-8` when empty.
+    /// `claude-opus-4-8` when empty. Effort defaults to provider-default (`""`).
     pub fn new(api_key: Option<String>, model: String) -> Self {
+        Self::with_effort(api_key, model, String::new())
+    }
+
+    /// Like [`new`], plus an explicit reasoning-effort tier (`""`/`"default"` = provider default).
+    pub fn with_effort(api_key: Option<String>, model: String, effort: String) -> Self {
         let model = if model.trim().is_empty() {
             DEFAULT_MODEL.to_string()
         } else {
@@ -35,7 +45,29 @@ impl AnthropicProvider {
             client: build_client(),
             model,
             api_key,
+            effort,
         }
+    }
+}
+
+/// Inject ADAPTIVE thinking + an output-effort tier into a `/v1/messages` request `body` when
+/// `effort` is a real tier. Empty `""` or `"default"` ⇒ the body is left UNTOUCHED (provider
+/// default — no thinking config sent at all). An UNKNOWN tier is also left untouched (fail-safe:
+/// never send a malformed effort that would 400). `body` must be a JSON object.
+///
+/// Shape (Opus 4.8): `"thinking": {"type": "adaptive"}` + `"output_config": {"effort": <tier>}`.
+/// NEVER `thinking.enabled`/`budget_tokens` — that legacy shape 400s on the 4.x adaptive models.
+fn apply_effort(body: &mut serde_json::Value, effort: &str) {
+    let tier = effort.trim();
+    if tier.is_empty() || tier.eq_ignore_ascii_case("default") {
+        return;
+    }
+    if !matches!(tier, "low" | "medium" | "high") {
+        return;
+    }
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("thinking".to_string(), json!({ "type": "adaptive" }));
+        obj.insert("output_config".to_string(), json!({ "effort": tier }));
     }
 }
 
@@ -102,7 +134,7 @@ impl SummarizerProvider for AnthropicProvider {
         };
         let user_content = template::render_user_content(req);
 
-        let body = json!({
+        let mut body = json!({
             "model": self.model,
             "max_tokens": MAX_TOKENS,
             "system": system_prompt,
@@ -110,6 +142,7 @@ impl SummarizerProvider for AnthropicProvider {
                 { "role": "user", "content": user_content }
             ],
         });
+        apply_effort(&mut body, &self.effort);
 
         let resp = self
             .client
@@ -170,12 +203,13 @@ impl SummarizerProvider for AnthropicProvider {
             .filter(|k| !k.trim().is_empty())
             .ok_or_else(|| AppError::Unavailable("Anthropic API key is not set".to_string()))?;
 
-        let body = json!({
+        let mut body = json!({
             "model": self.model,
             "max_tokens": MAX_TOKENS,
             "system": system,
             "messages": [ { "role": "user", "content": user } ],
         });
+        apply_effort(&mut body, &self.effort);
 
         let resp = self
             .client
@@ -217,4 +251,69 @@ impl SummarizerProvider for AnthropicProvider {
 fn extract_api_error(body: &str) -> Option<String> {
     let v: serde_json::Value = serde_json::from_str(body).ok()?;
     v.get("error")?.get("message")?.as_str().map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_body() -> serde_json::Value {
+        json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": MAX_TOKENS,
+            "system": "sys",
+            "messages": [ { "role": "user", "content": "u" } ],
+        })
+    }
+
+    #[test]
+    fn effort_set_injects_adaptive_thinking_and_output_effort() {
+        for tier in ["low", "medium", "high"] {
+            let mut body = base_body();
+            apply_effort(&mut body, tier);
+            // Adaptive thinking (the ONLY shape Opus 4.8 accepts) — never enabled/budget_tokens.
+            assert_eq!(body["thinking"]["type"], "adaptive");
+            assert!(body["thinking"].get("enabled").is_none());
+            assert!(body["thinking"].get("budget_tokens").is_none());
+            // Output effort tier carried through verbatim.
+            assert_eq!(body["output_config"]["effort"], tier);
+        }
+    }
+
+    #[test]
+    fn effort_empty_or_default_omits_thinking_and_effort() {
+        for tier in ["", "   ", "default", "Default"] {
+            let mut body = base_body();
+            apply_effort(&mut body, tier);
+            assert!(
+                body.get("thinking").is_none(),
+                "effort {tier:?} must NOT add thinking (provider default)"
+            );
+            assert!(
+                body.get("output_config").is_none(),
+                "effort {tier:?} must NOT add output_config"
+            );
+        }
+    }
+
+    #[test]
+    fn effort_unknown_tier_is_inert() {
+        // A garbage tier must never produce a malformed body that would 400 — leave it untouched.
+        let mut body = base_body();
+        apply_effort(&mut body, "ultra");
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn with_effort_threads_model_and_effort() {
+        let p = AnthropicProvider::with_effort(None, String::new(), "high".to_string());
+        // Empty model falls back to the default; effort is retained.
+        assert_eq!(p.model, DEFAULT_MODEL);
+        assert_eq!(p.effort, "high");
+        // The plain constructor defaults effort to provider-default (empty).
+        let p = AnthropicProvider::new(None, "claude-haiku-4-5".to_string());
+        assert_eq!(p.model, "claude-haiku-4-5");
+        assert_eq!(p.effort, "");
+    }
 }

--- a/src-tauri/src/summarize/claude_code.rs
+++ b/src-tauri/src/summarize/claude_code.rs
@@ -171,6 +171,10 @@ extern "C" {
 pub struct ClaudeCodeProvider {
     binary: String,
     system_prompt: String,
+    /// Optional model OVERRIDE passed to the CLI as `--model <id>`. Empty `""` (the default) means
+    /// "let the `claude` CLI pick its own default model" — no `--model` flag is added in that case.
+    /// (The CLI has no reasoning-effort flag, so `provider_effort` is intentionally NOT wired here.)
+    model: String,
 }
 
 impl ClaudeCodeProvider {
@@ -178,6 +182,7 @@ impl ClaudeCodeProvider {
         Self {
             binary: DEFAULT_BINARY.to_string(),
             system_prompt: template::default_template(),
+            model: String::new(),
         }
     }
 
@@ -190,7 +195,14 @@ impl ClaudeCodeProvider {
         Self {
             binary,
             system_prompt: template::default_template(),
+            model: String::new(),
         }
+    }
+
+    /// Set the model override (builder-style). Empty/blank ⇒ no `--model` flag (CLI default).
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
     }
 }
 
@@ -259,6 +271,9 @@ impl SummarizerProvider for ClaudeCodeProvider {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true); // F6: a dropped future (cancel/panic) reaps the child.
+        // Brain/AI model override: only add `--model` when the user picked a specific model;
+        // an empty value lets the CLI use its own default.
+        cmd.args(model_args(&self.model));
         harden_env(&mut cmd); // F2: env_clear + minimal PATH.
         let mut child = cmd
             .spawn()
@@ -337,6 +352,8 @@ impl SummarizerProvider for ClaudeCodeProvider {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true); // F6
+        // Brain/AI model override (mirrors `summarize`): add `--model` only when set.
+        cmd.args(model_args(&self.model));
         harden_env(&mut cmd); // F2
         let mut child = cmd
             .spawn()
@@ -387,6 +404,17 @@ impl SummarizerProvider for ClaudeCodeProvider {
     }
 }
 
+/// The `--model <id>` argument pair to append for a given model override, or `&[]` when the
+/// override is empty/blank (let the CLI use its default). Pure + unit-testable — the exact
+/// branch used at both call sites in `summarize`/`complete` (`if !self.model.trim().is_empty()`).
+fn model_args(model: &str) -> Vec<String> {
+    if model.trim().is_empty() {
+        Vec::new()
+    } else {
+        vec!["--model".to_string(), model.to_string()]
+    }
+}
+
 /// True iff `text`'s first non-empty line is exactly a three-dash YAML fence (allowing
 /// trailing whitespace on the line).
 fn starts_with_frontmatter(text: &str) -> bool {
@@ -399,6 +427,32 @@ fn starts_with_frontmatter(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_args_adds_flag_only_when_set() {
+        // Empty/blank ⇒ no flag (CLI default).
+        assert!(model_args("").is_empty());
+        assert!(model_args("   ").is_empty());
+        // A real id ⇒ the `--model <id>` pair.
+        assert_eq!(
+            model_args("claude-opus-4-8"),
+            vec!["--model".to_string(), "claude-opus-4-8".to_string()]
+        );
+    }
+
+    #[test]
+    fn with_model_threads_the_override() {
+        // The builder stores the override; the empty default leaves it unset (no flag).
+        let p = ClaudeCodeProvider::with_binary("claude".to_string());
+        assert!(p.model.is_empty());
+        let p = ClaudeCodeProvider::with_binary("claude".to_string())
+            .with_model("claude-sonnet-4-6".to_string());
+        assert_eq!(p.model, "claude-sonnet-4-6");
+        assert_eq!(
+            model_args(&p.model),
+            vec!["--model".to_string(), "claude-sonnet-4-6".to_string()]
+        );
+    }
 
     #[test]
     fn frontmatter_detection() {

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -76,13 +76,27 @@ pub fn make_provider(
     }
 
     let inner: Arc<dyn SummarizerProvider> = match id {
-        PROVIDER_CLAUDE_CODE => Arc::new(ClaudeCodeProvider::with_binary(
-            config.claude_binary.clone(),
-        )),
+        PROVIDER_CLAUDE_CODE => Arc::new(
+            ClaudeCodeProvider::with_binary(config.claude_binary.clone())
+                // Brain/AI model picker: a chosen model is passed as `--model`; an empty value
+                // (the default) lets the CLI use its own default. Effort is N/A for the CLI.
+                .with_model(config.provider_model.clone()),
+        ),
         PROVIDER_ANTHROPIC => {
             // Resolve the key from the Keychain here so providers never touch secrets.
             let api_key = crate::secrets::get_secret(ANTHROPIC_KEY_ACCOUNT)?;
-            Arc::new(AnthropicProvider::new(api_key, config.anthropic_model.clone()))
+            // Brain/AI model picker takes precedence over the legacy `anthropic_model`; effort is
+            // the adaptive-thinking tier (provider default when empty).
+            let model = if config.provider_model.trim().is_empty() {
+                config.anthropic_model.clone()
+            } else {
+                config.provider_model.clone()
+            };
+            Arc::new(AnthropicProvider::with_effort(
+                api_key,
+                model,
+                config.provider_effort.clone(),
+            ))
         }
         PROVIDER_OLLAMA => {
             return Ok(Arc::new(OllamaProvider::new(
@@ -125,11 +139,20 @@ pub fn all_providers(config: &AppConfig) -> Vec<Arc<dyn SummarizerProvider>> {
         .ok()
         .flatten();
 
+    let anthropic_model = if config.provider_model.trim().is_empty() {
+        config.anthropic_model.clone()
+    } else {
+        config.provider_model.clone()
+    };
     vec![
-        Arc::new(ClaudeCodeProvider::with_binary(config.claude_binary.clone())),
-        Arc::new(AnthropicProvider::new(
+        Arc::new(
+            ClaudeCodeProvider::with_binary(config.claude_binary.clone())
+                .with_model(config.provider_model.clone()),
+        ),
+        Arc::new(AnthropicProvider::with_effort(
             anthropic_key,
-            config.anthropic_model.clone(),
+            anthropic_model,
+            config.provider_effort.clone(),
         )),
         Arc::new(OllamaProvider::new(
             config.ollama_base_url.clone(),

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -32,6 +32,16 @@ export interface AppConfigDto {
   whisperModelPath: string | null;
   language: string | null;
   anthropicModel: string;
+  /**
+   * Brain/AI MODEL override for the active cloud provider (settable, mirrors Rust
+   * `AppConfigDto.provider_model`). Empty `""` = provider default.
+   */
+  providerModel: string;
+  /**
+   * Brain/AI reasoning EFFORT (`""`/`low`/`medium`/`high`, mirrors Rust
+   * `AppConfigDto.provider_effort`). Honored ONLY by the `anthropic` provider.
+   */
+  providerEffort: string;
   ollamaBaseUrl: string;
   ollamaModel: string;
   claudeBinary: string;

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1251,6 +1251,10 @@ export class OnboardingComponent implements OnInit {
       whisperModelPath: base?.whisperModelPath ?? null,
       language: this.language() || null,
       anthropicModel: base?.anthropicModel ?? "claude-opus-4-8",
+      // Brain/AI model + effort overrides — preserve-only here (the Settings panel owns
+      // the pickers); send the snapshot back unchanged so onboarding never clobbers them.
+      providerModel: base?.providerModel ?? "",
+      providerEffort: base?.providerEffort ?? "",
       ollamaBaseUrl: base?.ollamaBaseUrl ?? "http://localhost:11434",
       ollamaModel: base?.ollamaModel ?? "llama3.1",
       claudeBinary: base?.claudeBinary ?? "claude",

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -300,6 +300,39 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
           <input type="checkbox" formControlName="realtimeReactions" />
         </label>
 
+        <!-- Model + reasoning-effort overrides for the active cloud provider. -->
+        <div class="brain-tuning">
+          <label class="field">
+            <span class="field-label">Model</span>
+            <select formControlName="providerModel">
+              <option value="">Default (provider's pick)</option>
+              <option value="claude-opus-4-8">Opus 4.8</option>
+              <option value="claude-sonnet-4-6">Sonnet 4.6</option>
+              <option value="claude-haiku-4-5">Haiku 4.5</option>
+            </select>
+            <span class="field-help text-muted">
+              Overrides the model used for grounded answers — leave on Default to
+              let the provider choose.
+            </span>
+          </label>
+
+          @if (form.controls.providerId.value === "anthropic") {
+            <label class="field">
+              <span class="field-label">Reasoning effort</span>
+              <select formControlName="providerEffort">
+                <option value="">Default</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+              <span class="field-help text-muted">
+                Applies to the Anthropic provider — higher effort spends more
+                thinking on harder questions.
+              </span>
+            </label>
+          }
+        </div>
+
         <!-- Local model picker — only meaningful for the local backend. -->
         @if (form.controls.brainBackend.value === "local") {
           <div class="brain-models">
@@ -1317,6 +1350,11 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
         font-size: 0.875rem;
         line-height: 1.55;
       }
+      .brain-tuning {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
       .brain-models {
         display: flex;
         flex-direction: column;
@@ -1915,6 +1953,10 @@ export class SettingsComponent implements OnInit {
     whisperModelPath: "",
     language: "",
     anthropicModel: "claude-opus-4-8",
+    // Brain/AI model + reasoning-effort overrides ("" = provider default). Effort is
+    // honored only by the anthropic provider; the picker is gated on providerId below.
+    providerModel: "",
+    providerEffort: "",
     ollamaBaseUrl: "http://localhost:11434",
     ollamaModel: "llama3.1",
     claudeBinary: "claude",
@@ -2094,6 +2136,8 @@ export class SettingsComponent implements OnInit {
         whisperModelPath: cfg.whisperModelPath ?? "",
         language: cfg.language ?? "",
         anthropicModel: cfg.anthropicModel,
+        providerModel: cfg.providerModel ?? "",
+        providerEffort: cfg.providerEffort ?? "",
         ollamaBaseUrl: cfg.ollamaBaseUrl,
         ollamaModel: cfg.ollamaModel,
         claudeBinary: cfg.claudeBinary,
@@ -2294,6 +2338,8 @@ export class SettingsComponent implements OnInit {
       whisperModelPath: v.whisperModelPath || null,
       language: v.language || null,
       anthropicModel: v.anthropicModel,
+      providerModel: v.providerModel,
+      providerEffort: v.providerEffort,
       ollamaBaseUrl: v.ollamaBaseUrl,
       ollamaModel: v.ollamaModel,
       claudeBinary: v.claudeBinary,


### PR DESCRIPTION
Settable provider_model (claude_code --model / anthropic request model — Default/Opus 4.8/Sonnet 4.6/Haiku 4.5) + provider_effort (anthropic adaptive thinking + output_config.effort, low/med/high, omitted when empty so no 400 on Opus; claude CLI has no effort flag so FE hides it unless anthropic). Same consent-gated make_provider — no new egress. Verified: test 412/0 (RED-before-GREEN); clippy clean; ng lint+build clean; adversarial PASS.