### PR TITLE
feat(connectors): calendar connector (Local) — brain pulls your calendar as context

### DIFF
--- a/src-tauri/src/connectors/calendar.rs
+++ b/src-tauri/src/connectors/calendar.rs
@@ -1,0 +1,204 @@
+//! LOCAL CALENDAR connector — surfaces the user's on-device macOS calendar as live brain context
+//! ("who's in my next meeting", a pre-meeting brief). The CALENDAR leg of the multi-source roadmap.
+//!
+//! ## Egress posture (NO new egress class — audited by the lock-security reviewer)
+//! This connector is [`EgressClass::Local`]. Reading the local calendar is ON-DEVICE: the events
+//! are pulled by the bundled `meetnotes-calendar` EventKit sidecar ([`crate::calendar::fetch_events`])
+//! and handed to this connector as a plain `Vec<CalendarEventFull>` — NOTHING leaves the device.
+//! Therefore it is correctly NOT consent-gated (unlike the [`EgressClass::External`] web connector):
+//! there is no off-device request to gate. It needs the macOS Calendars (TCC) permission at runtime,
+//! but the upstream fetch degrades to an empty `Vec` on a denied/missing permission, so a denied
+//! permission simply yields no hits here (graceful, never an error).
+//!
+//! If the resulting context text is LATER folded into a CLOUD brain prompt, it rides the EXISTING
+//! `make_provider` redaction firewall + consent exactly like the transcript — this connector creates
+//! no network path of its own, and adds no new egress class.
+//!
+//! ## Stateless by design (blueprint Option A)
+//! The connector holds the already-fetched events; it does NOT itself touch EventKit or hold an
+//! `AppHandle`. This keeps the [`crate::connectors::ConnectorRegistry`] (which is built from the
+//! config alone) AppHandle-free, and keeps this connector unit-testable headless over a fixed event
+//! set with NO EventKit. The async fetch lives at the dispatch site ([`crate::tools::execute_calendar_search`]).
+//!
+//! ## No PII in logs
+//! This module logs nothing — the events carry attendee names + agenda text (PII). The match is
+//! purely in-memory; only hit counts (if logged at all by the caller) ever leave this seam.
+
+use async_trait::async_trait;
+
+use super::{Connector, ConnectorHit, ConnectorResult, EgressClass};
+use crate::storage::models::{CalendarContext, CalendarEventFull};
+
+/// The loud attribution label every calendar hit carries, so the brain's answer is visibly grounded
+/// on the user's calendar (and never silently passed off as vault knowledge).
+const SOURCE_LABEL: &str = "calendar";
+
+/// The local calendar connector — wraps a snapshot of the user's calendar events behind the
+/// [`Connector`] seam. Stateless w.r.t. EventKit: the events are fetched by the caller
+/// ([`crate::calendar::fetch_events`]) and passed in, so this type does no I/O and holds no handle.
+pub struct CalendarConnector {
+    events: Vec<CalendarEventFull>,
+}
+
+impl CalendarConnector {
+    /// Build a connector over an already-fetched event snapshot. An empty `Vec` (no calendar access,
+    /// denied permission, no events in the window) is a valid input → it simply yields no hits.
+    pub fn new(events: Vec<CalendarEventFull>) -> Self {
+        Self { events }
+    }
+
+    /// Does this event match `needle` (an already-lowercased query)? Matches against the event's
+    /// title, any attendee name, and the agenda/notes — the fields the brain would ground a
+    /// "who's in / what's the agenda" answer on. Pure + case-insensitive.
+    fn event_matches(ev: &CalendarEventFull, needle: &str) -> bool {
+        if ev.title.to_lowercase().contains(needle) {
+            return true;
+        }
+        if ev.notes.to_lowercase().contains(needle) {
+            return true;
+        }
+        ev.attendees
+            .iter()
+            .any(|a| a.to_lowercase().contains(needle))
+    }
+
+    /// Map an event to a [`ConnectorHit`] whose snippet is the bounded [`CalendarContext`] block
+    /// (Meeting / When / Attendees / Agenda). `url` is empty — a local calendar event has no URL;
+    /// the loud `source_label` is what attributes it.
+    fn hit_for(ev: &CalendarEventFull) -> ConnectorHit {
+        ConnectorHit {
+            title: ev.title.clone(),
+            snippet: CalendarContext::from_event(ev).text,
+            url: String::new(),
+            source_label: SOURCE_LABEL.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl Connector for CalendarConnector {
+    fn id(&self) -> &str {
+        "calendar"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        // ON-DEVICE: reading the local calendar reaches no external service → never consent-gated.
+        EgressClass::Local
+    }
+
+    async fn search(&self, query: &str) -> ConnectorResult {
+        let needle = query.trim().to_lowercase();
+        // DESIGN CHOICE: an empty/whitespace query returns ALL events in the fetched window (the
+        // "what's coming up / who's in my next meeting" case), rather than nothing — the caller
+        // already bounds the window (e.g. [now-60m, now+720m]) when it fetches, so "all of it" is a
+        // small, intentional set, not an unbounded dump. A non-empty query filters case-insensitively.
+        let hits = self
+            .events
+            .iter()
+            .filter(|ev| needle.is_empty() || Self::event_matches(ev, &needle))
+            .map(Self::hit_for)
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    /// A fixed event set — NO EventKit. Mirrors the calendar.rs sidecar-parser fixtures.
+    fn fixture_events() -> Vec<CalendarEventFull> {
+        vec![
+            CalendarEventFull {
+                id: "E1".into(),
+                title: "Sprint Planning".into(),
+                start: Some("2026-06-28T10:00:00Z".into()),
+                end: Some("2026-06-28T11:00:00Z".into()),
+                attendees: vec!["Alice".into(), "bob@example.com".into()],
+                notes: "Agenda:\n- velocity\n- scope".into(),
+            },
+            CalendarEventFull {
+                id: "E2".into(),
+                title: "1:1 with Carol".into(),
+                start: Some("2026-06-28T14:00:00Z".into()),
+                end: None,
+                attendees: vec!["Carol".into()],
+                notes: String::new(),
+            },
+        ]
+    }
+
+    #[test]
+    fn matches_query_against_title() {
+        let c = CalendarConnector::new(fixture_events());
+        let hits = block_on(c.search("sprint")).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Sprint Planning");
+        // The snippet is the bounded CalendarContext block (Meeting / When / Attendees / Agenda).
+        assert!(hits[0].snippet.contains("Meeting: Sprint Planning"));
+        assert!(hits[0].snippet.contains("Attendees: Alice, bob@example.com"));
+        assert!(hits[0].snippet.contains("velocity"));
+        // LOUD: every hit is attributed to the calendar; local events have no URL.
+        assert_eq!(hits[0].source_label, "calendar");
+        assert_eq!(hits[0].url, "");
+    }
+
+    #[test]
+    fn matches_query_against_attendee() {
+        let c = CalendarConnector::new(fixture_events());
+        // "carol" matches the attendee on E2 (case-insensitive), not the title.
+        let hits = block_on(c.search("CAROL")).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "1:1 with Carol");
+    }
+
+    #[test]
+    fn matches_query_against_agenda_notes() {
+        let c = CalendarConnector::new(fixture_events());
+        // "velocity" appears only in E1's agenda/notes.
+        let hits = block_on(c.search("velocity")).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Sprint Planning");
+    }
+
+    #[test]
+    fn no_match_yields_no_hits() {
+        let c = CalendarConnector::new(fixture_events());
+        let hits = block_on(c.search("nonexistent-topic-zzz")).unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn empty_events_yields_no_hits_gracefully() {
+        // The denied-permission / no-calendar-access shape: fetch_events returned an empty Vec.
+        let c = CalendarConnector::new(Vec::new());
+        assert!(block_on(c.search("anything")).unwrap().is_empty());
+        assert!(block_on(c.search("")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_query_returns_all_events_in_window() {
+        // Empty query = "what's coming up" → every fetched event (the caller already bounds the
+        // window), each as a loud calendar hit.
+        let c = CalendarConnector::new(fixture_events());
+        let hits = block_on(c.search("   ")).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|h| h.source_label == "calendar"));
+    }
+
+    #[test]
+    fn id_and_egress_class_are_local() {
+        let c = CalendarConnector::new(Vec::new());
+        assert_eq!(c.id(), "calendar");
+        // ON-DEVICE: Local, never consent-gated.
+        assert_eq!(c.egress_class(), EgressClass::Local);
+    }
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -26,6 +26,7 @@
 //! Connector code logs the connector id, hit counts, and HTTP status — never the query text, the
 //! result snippets, or the API key.
 
+pub mod calendar;
 pub mod web;
 
 use crate::settings::AppConfig;

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -222,6 +222,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::GetMeeting { .. } => "Meeting",
         ToolCall::ListRecentMeetings { .. } => "Recent meetings",
         ToolCall::WebSearch { .. } => "Web search",
+        ToolCall::CalendarLookup { .. } => "Calendar",
     }
 }
 

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -51,6 +51,13 @@ pub enum ToolCall {
     /// async [`execute_web_search`], and ONLY when the web connector is exposed (enabled + consented +
     /// keyed). The brain decides web-vs-vault; see `orchestrate.rs` / `voice_action.rs`.
     WebSearch { query: String },
+    /// CONNECTOR — LOCAL CALENDAR lookup ("who's in my next meeting", a pre-meeting brief). Reads the
+    /// user's on-device macOS calendar via the bundled EventKit sidecar. Unlike [`Self::WebSearch`]
+    /// this EGRESSES NOTHING (it is [`crate::connectors::EgressClass::Local`]) — but it still needs an
+    /// `AppHandle` to resolve + drive the sidecar, which the synchronous, AppHandle-free
+    /// [`execute_tool`] does not have. So, like `WebSearch`, it is dispatched ONLY via the async
+    /// [`execute_calendar_search`], NEVER through `execute_tool`.
+    CalendarLookup { query: String },
 }
 
 /// Execute a read-only tool against an OPEN `Db`, gated on the live session `unlocked` set.
@@ -181,6 +188,18 @@ pub fn execute_tool(
                     .to_string(),
             ))
         }
+        ToolCall::CalendarLookup { .. } => {
+            // The local-calendar connector egresses NOTHING, but it needs an `AppHandle` to drive
+            // the bundled EventKit sidecar — which the synchronous, AppHandle-free `execute_tool`
+            // (the MCP surface's only entry) does not have. It is dispatched exclusively via the
+            // async `execute_calendar_search`. Reaching here is a programming error in a caller —
+            // refuse loudly. (This is NOT a leak: nothing was read, nothing egressed.)
+            Err(AppError::InvalidArg(
+                "CalendarLookup needs the async AppHandle path and cannot run through the \
+                 synchronous tool path; use execute_calendar_search"
+                    .to_string(),
+            ))
+        }
     }
 }
 
@@ -221,6 +240,58 @@ pub async fn execute_web_search(query: &str, config: &AppConfig) -> Result<Strin
         // A real external failure (network/HTTP/parse) is surfaced; the caller logs + skips it.
         Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
     }
+}
+
+/// CONNECTOR DISPATCH — run a LOCAL CALENDAR lookup through the connector seam, returning the same
+/// text-payload shape the vault/web tools return (so the brain treats calendar context identically).
+/// ASYNC because it drives the bundled EventKit sidecar via [`crate::calendar::fetch_events`], which
+/// needs the [`AppHandle`] to resolve the bundled binary — kept OUT of the synchronous, AppHandle-free
+/// [`execute_tool`].
+///
+/// EGRESS: NONE. The macOS calendar is read ON-DEVICE; this is [`crate::connectors::EgressClass::Local`]
+/// and is therefore NOT consent-gated. `fetch_events` degrades to an empty `Vec` on EVERY failure
+/// (sidecar missing, denied Calendars permission, timeout, malformed JSON), so a denied permission
+/// just yields no hits — graceful, never an error. (If this text is later folded into a CLOUD brain
+/// prompt it rides the EXISTING make_provider redaction firewall + consent — no new egress class.)
+///
+/// Window: `[now - 60m, now + 720m]` (recent + the next ~12h), matching `commands.rs`'s
+/// `calendar_context_for`. Returns a `"No calendar events …"` sentinel (matched by the brain's
+/// `is_empty_result`) when nothing matches, so an empty calendar never pollutes the grounding.
+pub async fn execute_calendar_search(query: &str, app: &tauri::AppHandle) -> Result<String> {
+    let q = query.trim();
+    // ON-DEVICE read: drive the bundled sidecar; ANY failure → empty Vec (never an error).
+    let events = crate::calendar::fetch_events(app, 60, 720).await;
+    // `Connector::search` in scope for the call below (the connector impls the trait).
+    use crate::connectors::Connector as _;
+    let hits = crate::connectors::calendar::CalendarConnector::new(events)
+        .search(q)
+        .await?;
+    if hits.is_empty() {
+        return Ok(if q.is_empty() {
+            "No calendar events in the window.".to_string()
+        } else {
+            format!("No calendar events match \"{q}\".")
+        });
+    }
+    Ok(format_calendar_hits(&hits))
+}
+
+/// Render local-calendar connector hits into the tool text payload — one block per event, each LOUD
+/// with its source label: `[calendar] Title — <bounded Meeting/When/Attendees/Agenda context>`. The
+/// snippet already carries newlines (the CalendarContext block); we keep it intact so the brain sees
+/// the full who/when/agenda, just prefixed with the loud `[calendar]` attribution.
+fn format_calendar_hits(hits: &[crate::connectors::ConnectorHit]) -> String {
+    hits.iter()
+        .map(|h| {
+            let mut line = format!("[{}] {}", h.source_label, h.title.trim());
+            let snippet = h.snippet.trim();
+            if !snippet.is_empty() {
+                line.push_str(&format!(" — {snippet}"));
+            }
+            line
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 /// Render web connector hits into the tool text payload — one line per result, each LOUD with its
@@ -345,6 +416,50 @@ mod tests {
         let cfg = AppConfig::default();
         let out = block_on(execute_web_search("   ", &cfg)).unwrap();
         assert!(out.starts_with("No web results"));
+    }
+
+    /// EGRESS/PLUMBING GUARD: the synchronous, AppHandle-free `execute_tool` MUST refuse a
+    /// `CalendarLookup` (it needs the async sidecar/AppHandle path) — exactly like `WebSearch`.
+    #[test]
+    fn sync_execute_tool_refuses_calendar_lookup() {
+        let db = tmp_db();
+        let nothing = HashSet::new();
+        let cfg = AppConfig::default();
+        let res = execute_tool(
+            &ToolCall::CalendarLookup { query: "standup".into() },
+            &db,
+            &nothing,
+            &cfg,
+        );
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "the synchronous tool path must refuse CalendarLookup (needs the async AppHandle path)"
+        );
+    }
+
+    /// LOUD: calendar hits render with their `[calendar]` source label + the bounded context block,
+    /// so a calendar-grounded answer is visibly attributed to the user's calendar.
+    #[test]
+    fn format_calendar_hits_is_loud_with_source_and_context() {
+        let hits = vec![
+            crate::connectors::ConnectorHit {
+                title: "Sprint Planning".into(),
+                snippet: "Meeting: Sprint Planning\nAttendees: Alice, Bob\nAgenda:\n- velocity".into(),
+                url: String::new(),
+                source_label: "calendar".into(),
+            },
+            crate::connectors::ConnectorHit {
+                title: "1:1".into(),
+                snippet: "Meeting: 1:1".into(),
+                url: String::new(),
+                source_label: "calendar".into(),
+            },
+        ];
+        let out = format_calendar_hits(&hits);
+        assert!(out.contains("[calendar] Sprint Planning"), "loud source label: {out}");
+        assert!(out.contains("Attendees: Alice, Bob"), "context block preserved: {out}");
+        assert!(out.contains("velocity"), "agenda preserved: {out}");
+        assert!(out.contains("[calendar] 1:1"), "every event labelled: {out}");
     }
 
     /// LOUD: web hits render with their source label + URL, so the answer is attributed "via web".

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -236,6 +236,7 @@ fn spawn_dispatch(app: AppHandle, intent: crate::audio::wake::VoiceIntent) {
                 &config,
                 &meeting_id,
                 &literal,
+                Some(&app),
             );
             // PII rule: log only the coarse intent kind + status, never the summary/citations.
             tracing::info!(
@@ -326,6 +327,7 @@ fn spawn_command_dispatch(app: AppHandle, command: String) {
                 &config,
                 &meeting_id,
                 &command,
+                Some(&app),
             )
             // Surface the user's OWN dictated command onto the result for the FE card.
             .with_command(&command);

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -104,6 +104,7 @@ impl VoiceActionResult {
 /// "pogoda"), NOT a brain-translated/normalized topic that the exact-term FTS would miss. The brain
 /// topic is still used for SYNTHESIS + as an additional retrieval leg; the literal terms are the
 /// must-have. Empty/whitespace falls back to the intent topic alone.
+#[allow(clippy::too_many_arguments)] // cohesive dispatch surface: intent + gated state + the AppHandle.
 pub fn handle_voice_action(
     intent: &VoiceIntent,
     reasoner: &dyn LocalReasoner,
@@ -112,13 +113,14 @@ pub fn handle_voice_action(
     config: &AppConfig,
     meeting_id: &str,
     literal_command: &str,
+    app: Option<&tauri::AppHandle>,
 ) -> VoiceActionResult {
     match intent {
         VoiceIntent::Research { topic } => {
-            rag_answer("research", topic, literal_command, reasoner, db, unlocked, config)
+            rag_answer("research", topic, literal_command, reasoner, db, unlocked, config, app)
         }
         VoiceIntent::Recall { entity } => {
-            rag_answer("recall", entity, literal_command, reasoner, db, unlocked, config)
+            rag_answer("recall", entity, literal_command, reasoner, db, unlocked, config, app)
         }
         VoiceIntent::CreateReminder { text, due } => {
             let text = text.trim();
@@ -251,6 +253,7 @@ fn retrieval_queries(topic: &str, literal_command: &str) -> Vec<String> {
 /// RETRIEVAL keys off the user's LITERAL terms first (see [`retrieval_queries`]) so same-language
 /// recall works (Polish query ↔ Polish note); the brain `topic` is still used for the answer
 /// SYNTHESIS prompt.
+#[allow(clippy::too_many_arguments)] // cohesive RAG surface: topic/literal + gated state + AppHandle.
 fn rag_answer(
     intent_kind: &str,
     topic: &str,
@@ -259,6 +262,7 @@ fn rag_answer(
     db: &Db,
     unlocked: &HashSet<String>,
     config: &AppConfig,
+    app: Option<&tauri::AppHandle>,
 ) -> VoiceActionResult {
     let topic = topic.trim();
     if topic.is_empty() && literal_command.trim().is_empty() {
@@ -355,6 +359,48 @@ fn rag_answer(
             }
         }
     }
+    // CALENDAR LEG (LOCAL, on-device — NO egress, NEVER consent-gated): when the request reads like a
+    // calendar/meeting question ("who's in my next meeting", "what's on my agenda"), ALSO pull the
+    // user's local calendar context and fold its LOUD, source-labelled hits into the grounding. It is
+    // INTENT-GATED (not fired on every research) so a plain "what's the weather" doesn't drag in
+    // calendar noise. Requires an `AppHandle` to drive the bundled EventKit sidecar; when none is in
+    // scope (headless tests) the leg is simply skipped. `fetch_events` degrades to empty on ANY
+    // failure (denied Calendars permission, missing sidecar), so the deterministic vault floor stays
+    // intact and the brain call is unaffected when calendar is empty/unavailable.
+    let mut calendar_lines: Vec<String> = Vec::new();
+    if let Some(app) = app {
+        let cal_query = if !topic.is_empty() {
+            topic.to_string()
+        } else {
+            literal_command.trim().to_string()
+        };
+        if wants_calendar(&cal_query, literal_command) {
+            match calendar_search_blocking(&cal_query, app) {
+                Ok(text) => {
+                    let text = text.trim();
+                    if !text.is_empty() && !is_empty_tool_result(text) {
+                        // Capture the loud "[calendar] …" lines for citations, and add to grounding.
+                        for line in text.lines() {
+                            if line.trim_start().starts_with("[calendar]") {
+                                calendar_lines.push(line.to_string());
+                            }
+                        }
+                        if !grounding.is_empty() {
+                            grounding.push_str("\n\n");
+                        }
+                        grounding.push_str(text);
+                        grounding.push_str("\n\n");
+                    }
+                }
+                // A calendar failure is non-fatal — the vault (+ web) grounding still answers.
+                Err(e) => tracing::debug!(
+                    target: "voice",
+                    error = %e,
+                    "voice-action calendar lookup failed; continuing with vault grounding"
+                ),
+            }
+        }
+    }
     let grounding = grounding.trim();
 
     // CITATIONS: derived from a GATED `search_visible` over the SAME live unlocked set — every hit
@@ -393,6 +439,14 @@ fn rag_answer(
     // `[[Title]]` vault wikilinks.
     for line in &web_lines {
         if let Some(c) = web_citation_from_line(line) {
+            push_cite(c);
+        }
+    }
+    // CALENDAR citations: each loud "[calendar] Title — …" line becomes a "(calendar) Title"
+    // citation, so the card visibly attributes the calendar-sourced context (LOUD). Kept distinct
+    // from the `[[Title]]` vault wikilinks and the "(web) …" web citations.
+    for line in &calendar_lines {
+        if let Some(c) = calendar_citation_from_line(line) {
             push_cite(c);
         }
     }
@@ -502,6 +556,61 @@ fn web_search_blocking(query: &str, config: &AppConfig) -> crate::error::Result<
     })
 }
 
+/// INTENT GATE for the calendar leg: does this request read like a calendar/meeting question? We
+/// fire the local calendar lookup ONLY for these — so a plain "what's the weather" research never
+/// drags in calendar noise, while "who's in my next meeting" / "what's on my agenda" / "kto jest na
+/// spotkaniu" do. Case-insensitive substring match over a small bilingual (EN/PL) keyword set,
+/// checked against BOTH the brain topic and the user's literal command. Deterministic, no regex.
+fn wants_calendar(topic: &str, literal_command: &str) -> bool {
+    const KEYWORDS: &[&str] = &[
+        // English
+        "calendar", "meeting", "meetings", "agenda", "next meeting", "who's in", "who is in",
+        "attendee", "attendees", "schedule", "scheduled", "appointment", "invite",
+        // Polish
+        "kalendarz", "spotkanie", "spotkania", "spotkaniu", "agenda", "kto jest", "uczestnik",
+        "uczestnicy", "harmonogram", "termin",
+    ];
+    let hay = format!("{} {}", topic.to_lowercase(), literal_command.to_lowercase());
+    KEYWORDS.iter().any(|k| hay.contains(k))
+}
+
+/// Run the async LOCAL-CALENDAR connector to completion from this SYNCHRONOUS dispatch (the live loop
+/// spawns `handle_voice_action` off-thread). Mirrors [`web_search_blocking`]: a dedicated scoped OS
+/// thread with its own current-thread runtime, so we never "start a runtime within a runtime" and the
+/// future never crosses a thread boundary (only the `Result<String>` does). NO egress — the calendar
+/// read is on-device — and `fetch_events` degrades to empty on every failure inside
+/// `execute_calendar_search`.
+fn calendar_search_blocking(
+    query: &str,
+    app: &tauri::AppHandle,
+) -> crate::error::Result<String> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| AppError::Summarize(format!("calendar runtime build: {e}")))?;
+                rt.block_on(crate::tools::execute_calendar_search(query, app))
+            })
+            .join()
+            .map_err(|_| AppError::Summarize("calendar worker thread panicked".into()))?
+    })
+}
+
+/// Turn a loud calendar grounding line `[calendar] Title — <context block>` into a compact citation
+/// `(calendar) Title`. Returns `None` for a non-calendar line. Deterministic, no regex.
+fn calendar_citation_from_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    let rest = line.strip_prefix("[calendar]")?.trim();
+    // Title is everything up to the first " — " (the context-block separator).
+    let title = rest.split(" — ").next().unwrap_or(rest).trim();
+    if title.is_empty() {
+        return None;
+    }
+    Some(format!("(calendar) {title}"))
+}
+
 /// Turn a loud web grounding line `- [web · Brave] Title — snippet (https://…)` into a compact
 /// citation `(web) Title — https://…`. Returns `None` for a non-web line. Deterministic, no regex.
 fn web_citation_from_line(line: &str) -> Option<String> {
@@ -544,6 +653,7 @@ fn is_empty_tool_result(text: &str) -> bool {
         || t.starts_with("Semantic search is disabled")
         || t.starts_with("No web results")
         || t.starts_with("Web search is not available")
+        || t.starts_with("No calendar events")
 }
 
 /// Pull distinct `[[Title]]` wikilinks out of the gated tool grounding text, in first-seen order.
@@ -748,6 +858,7 @@ mod tests {
             &cfg,
             "live-mtg",
             "",
+            None,
         );
 
         assert_eq!(res.intent_kind, "research");
@@ -786,6 +897,7 @@ mod tests {
             &AppConfig::default(),
             "live-mtg",
             "",
+            None,
         );
         assert_eq!(res.intent_kind, "recall");
         assert_eq!(res.status, "ok");
@@ -806,6 +918,7 @@ mod tests {
             &AppConfig::default(),
             "live-mtg",
             "",
+            None,
         );
         assert_eq!(res.status, "ok");
         assert!(res.summary.contains("couldn't find"));
@@ -837,6 +950,7 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            None,
         );
         assert_eq!(res.intent_kind, "note_aside");
         assert_eq!(res.status, "ok");
@@ -859,6 +973,7 @@ mod tests {
             &AppConfig::default(),
             "sealed1",
             "",
+            None,
         );
         assert_eq!(res.status, "error");
         assert!(db.list_note_asides("sealed1").unwrap().is_empty(), "no aside written to a sealed meeting");
@@ -876,6 +991,7 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            None,
         );
         assert_eq!(res.intent_kind, "slack_search");
         assert_eq!(res.status, "unavailable");
@@ -893,6 +1009,7 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            None,
         );
         assert_eq!(res.status, "unrecognized");
         assert!(!res.summary.contains("secret-thing"), "raw command must not be echoed back");
@@ -912,6 +1029,7 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            None,
         );
         assert_eq!(res.status, "error");
         assert!(!res.summary.contains("boom internal detail"), "internal error detail must not leak");
@@ -932,6 +1050,7 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            None,
         );
         assert_eq!(res.status, "needs_consent");
         // Gated citations are still useful even when the brain can't run.
@@ -1006,6 +1125,45 @@ mod tests {
         assert_eq!(cites, vec!["[[One]]".to_string(), "[[Two]]".to_string()]);
     }
 
+    // ── CALENDAR connector leg: intent gate + loud citation extraction (headless, NO EventKit) ─────
+
+    #[test]
+    fn wants_calendar_fires_only_on_calendar_meeting_intent() {
+        // EN + PL calendar/meeting phrasings fire the leg.
+        assert!(wants_calendar("who's in my next meeting", "who's in my next meeting"));
+        assert!(wants_calendar("what's on my agenda", ""));
+        assert!(wants_calendar("", "kto jest na spotkaniu"));
+        assert!(wants_calendar("kalendarz na dziś", ""));
+        // A plain research question does NOT fire it (no calendar noise on "weather").
+        assert!(!wants_calendar("what's the weather in Kraków", "jaka jest pogoda"));
+        assert!(!wants_calendar("research the Atlas pricing model", ""));
+    }
+
+    #[test]
+    fn calendar_citation_from_line_extracts_title_and_skips_non_calendar() {
+        // A loud "[calendar] Title — <context>" line → "(calendar) Title".
+        let c = calendar_citation_from_line(
+            "[calendar] Sprint Planning — Meeting: Sprint Planning\nAttendees: Alice",
+        );
+        assert_eq!(c, Some("(calendar) Sprint Planning".to_string()));
+        // A title with no context separator still yields a citation.
+        assert_eq!(
+            calendar_citation_from_line("[calendar] 1:1"),
+            Some("(calendar) 1:1".to_string())
+        );
+        // A non-calendar line is ignored.
+        assert!(calendar_citation_from_line("- [web · Brave] Weather — Sunny").is_none());
+    }
+
+    #[test]
+    fn is_empty_tool_result_matches_calendar_sentinel() {
+        // The calendar "nothing found" sentinels are filtered out of the grounding.
+        assert!(is_empty_tool_result("No calendar events match \"standup\"."));
+        assert!(is_empty_tool_result("No calendar events in the window."));
+        // A real calendar block is NOT a sentinel.
+        assert!(!is_empty_tool_result("[calendar] Sprint Planning — Meeting: Sprint Planning"));
+    }
+
     // ── FIX 1: cross-lingual RETRIEVAL uses the user's LITERAL terms, not the brain topic ─────────
 
     #[test]
@@ -1071,6 +1229,7 @@ mod tests {
             &cfg,
             "live-mtg",
             "jaka była pogoda",
+            None,
         );
         assert_eq!(res.status, "ok");
         assert!(
@@ -1100,6 +1259,7 @@ mod tests {
             &cfg,
             "live-mtg",
             "",
+            None,
         );
         assert_eq!(res2.status, "ok");
         assert!(


### PR DESCRIPTION
Wires the existing EventKit sidecar into the connector registry as a **Local** connector (on-device calendar read → NOT consent-gated). Intent-gated calendar leg folds [calendar] hits into the brain grounding + citations; the sync execute_tool refuses CalendarLookup (MCP can't invoke). No new egress class, no new vault read. Verified: test 424/0 (RED-before-GREEN on the 2 guards); clippy clean; adversarial PASS. Real EventKit events = signed build + Calendars TCC.