### PR TITLE
feat(voice): wake fires anywhere + dedup (#23) + cloud-consent prompt for the in-meeting assistant (#20)

### DIFF
--- a/src-tauri/src/audio/wake.rs
+++ b/src-tauri/src/audio/wake.rs
@@ -30,21 +30,28 @@ pub struct WakeHit {
     pub command: String,
 }
 
-/// Short interjections that may precede the wake name ("hej claude"). NOT a wake anchor on their
-/// own ("hej"/"ok" alone are far too common).
-const INTERJECTIONS: [&str; 11] = [
-    "hej", "ej", "ok", "okej", "okay", "hey", "hi", "halo", "sluchaj", "dobra", "no",
-];
-
-/// Detect the assistant wake name at the head of `text` and split off the command tail.
+/// Detect the assistant wake name ANYWHERE in `text` and split off the command tail.
 ///
-/// Returns `Some(WakeHit)` only when a [`matches_wake`] vocative ("Claudku"/"Klauku") match sits at
-/// an utterance boundary:
-/// - at token index 0 (absolute start of an utterance), or
-/// - at token index 1 IF token 0 is an [`INTERJECTIONS`] member ("hej"/"ok"/"okej" …).
+/// Returns `Some(WakeHit)` at the FIRST token position whose [`matches_wake`] vocative
+/// ("Claudku"/"Klauku") fires — regardless of where it sits in the tail:
+/// - at token index 0 (absolute start of an utterance),
+/// - after an interjection ("hej"/"ok"/"okej" …), OR
+/// - MID-tail (anywhere else in a multi-second rolling window).
+///
+/// ## Why fire anywhere (the #23 recall fix)
+/// The live caption loop feeds a rolling ~14s window. The old anchor only fired at index 0 / right
+/// after an interjection, so on a SECOND "Klaudku" spoken later in the same recording the vocative
+/// landed MID-tail and was MISSED (the demonstrated bug: two asks, one wake hit). The distinctive
+/// "Klaudku/Klauku" SHAPE-GATE in [`matches_wake`] (starts `kl`, vowel/`d`-only nucleus, ends `-ku`/
+/// `-ko`, length ≥ 5) is precise enough to carry firing on its own — the boundary anchor is no
+/// longer load-bearing for precision, so we drop it for recall. Ordinary words ("kroku"/"klocku"/
+/// "kłódka"/…) still fail the shape-gate at EVERY position, so widening the search window does not
+/// re-open any demonstrated false fire. The command tail = everything after the matched vocative.
+/// Overlapping-tail RE-FIRES of the same spoken wake are de-duplicated by the STATEFUL caller
+/// ([`crate::transcribe::live`]), not here — `detect_wake` stays pure.
 ///
 /// Pure + deterministic. RECALL-FIRST (the user's requirement: the wake MUST always catch),
-/// precision held by the shape-gate in [`matches_wake`] + the boundary anchor here.
+/// precision held entirely by the shape-gate in [`matches_wake`].
 ///
 /// ## Recall + the d-LESS vocative (the real fix)
 /// The firing anchor is the distinctive Polish vocative the user actually utters — including the
@@ -60,27 +67,24 @@ const INTERJECTIONS: [&str; 11] = [
 /// (→"klodka"/"klodke") stays silent via the vocative-ending guard (ends `a`/`e`, not `ku`/`ko`).
 ///
 /// ## Residual false-fire risk (real-mic only, NOT covered by unit tests)
-/// On real audio the live tail is a multi-second window, not a clean single utterance; the
-/// integration must feed the trailing sentence so the boundary anchor holds. This fix eliminates
-/// the demonstrated TEXT-level false fires only — real-mic acoustic precision still needs tuning
-/// of `WAKE_THRESHOLD` / the lexicon on a real Mac.
+/// On real audio the live tail is a multi-second window, not a clean single utterance. Firing
+/// anywhere widens recall (the user's "to ma zawsze łapać"); the shape-gate keeps ordinary speech
+/// silent, but real-mic acoustic precision still needs tuning of `WAKE_THRESHOLD` / the lexicon on a
+/// real Mac. This fix eliminates the demonstrated TEXT-level MISS (a 2nd, mid-tail "Klaudku").
 pub fn detect_wake(text: &str) -> Option<WakeHit> {
     let words: Vec<&str> = text.split_whitespace().collect();
     if words.is_empty() {
         return None;
     }
 
-    // Index 0: the distinctive vocative at the absolute start of an utterance.
-    let n0 = normalize_name(words[0]);
-    if matches_wake(&n0) {
-        return Some(make_hit(&words, 0));
-    }
-
-    // Index 1: the same vocative, after an interjection that clearly addresses the assistant.
-    if words.len() >= 2 && is_interjection(words[0]) {
-        let n1 = normalize_name(words[1]);
-        if matches_wake(&n1) {
-            return Some(make_hit(&words, 1));
+    // RECALL-FIRST: fire at the FIRST token (any position) whose normalized form matches the
+    // distinctive vocative shape. The shape-gate in `matches_wake` is the only precision guard —
+    // the old index-0 / after-interjection anchor is dropped so a vocative MID-tail (the rolling
+    // ~14s window's 2nd ask) still catches. The interjection list now only matters as ordinary
+    // words that never match the shape-gate.
+    for (idx, word) in words.iter().enumerate() {
+        if matches_wake(&normalize_name(word)) {
+            return Some(make_hit(&words, idx));
         }
     }
 
@@ -148,13 +152,6 @@ fn matches_wake(cand: &str) -> bool {
         }
     }
     d_count <= 1
-}
-
-/// Whether `word` (raw) is a leading interjection that may precede the wake name.
-fn is_interjection(word: &str) -> bool {
-    let w = strip_diacritics(&word.to_lowercase());
-    let w = w.trim_matches(|c: char| !c.is_alphanumeric());
-    INTERJECTIONS.contains(&w)
 }
 
 /// PHONETIC normalizer for a single candidate NAME token. Lowercases, keeps only letters, collapses
@@ -497,6 +494,47 @@ mod tests {
         for (input, want_cmd) in cases {
             let hit = detect_wake(input).unwrap_or_else(|| panic!("expected wake fire on {input:?}"));
             assert_eq!(hit.command, *want_cmd, "wrong command tail for {input:?}");
+        }
+    }
+
+    // ── #23 RECALL: detect_wake fires on a vocative NOT at index 0 (mid-tail) ─
+
+    #[test]
+    fn recall_fires_on_vocative_mid_tail_not_only_at_index_0() {
+        // The #23 bug: the live caption loop feeds a rolling ~14s window, so a SECOND "Klaudku"
+        // spoken later in the same recording lands MID-tail (not at index 0, not after an
+        // interjection) and was MISSED by the old boundary anchor. It MUST now fire, with the
+        // command tail = everything after the vocative. (RED on the old index-0/interjection anchor.)
+        let cases: &[(&str, &str)] = &[
+            ("ok więc tak, klaudku zrób research", "zrób research"),
+            ("no dobra to teraz klołku co wiemy o atlasie", "co wiemy o atlasie"),
+            ("a jeszcze jedno klałdku przypomnij mi o spotkaniu", "przypomnij mi o spotkaniu"),
+            // the demonstrated 2nd-ask shape: prior sentence + a fresh vocative deep in the tail.
+            (
+                "zrobiłem już research o cenach klauku zrób research o konkurencji",
+                "zrób research o konkurencji",
+            ),
+        ];
+        for (input, want_cmd) in cases {
+            let hit =
+                detect_wake(input).unwrap_or_else(|| panic!("expected mid-tail wake fire on {input:?}"));
+            assert_eq!(hit.command, *want_cmd, "wrong command tail for mid-tail wake {input:?}");
+        }
+    }
+
+    #[test]
+    fn precision_near_collisions_stay_silent_even_mid_tail() {
+        // Firing ANYWHERE must NOT re-open the near-collision false fires when they sit mid-sentence
+        // (the shape-gate, not the position anchor, is what holds precision). All None.
+        for n in [
+            "przejdźmy do kroku drugiego",              // "kroku" mid-sentence (step)
+            "wróćmy do klocka na stole",                // "klocka" mid-sentence (block)
+            "ok zamknij teraz tę kłódkę proszę",        // "kłódkę" mid-sentence (padlock)
+            "myślę że klaudia z hr to ogarnie",         // "klaudia" mid-sentence (name)
+            "everything is moving to the cloud this year", // "cloud" mid-sentence
+            "i think we should close this deal today",  // "close" mid-sentence
+        ] {
+            assert!(detect_wake(n).is_none(), "FALSE FIRE on mid-tail near-collision: {n:?}");
         }
     }
 

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -24,9 +24,75 @@ const TICK: Duration = Duration::from_millis(3000);
 /// How many trailing seconds of audio to transcribe each tick (overlapping window).
 const WINDOW_SECS: usize = 14;
 
+/// How many consecutive ticks the SAME spoken wake stays de-duplicated. Consecutive ~14s tails
+/// OVERLAP heavily (a `TICK` of 3s into a `WINDOW_SECS` of 14s ⇒ the same vocative is visible for
+/// ~4-5 ticks), so without dedup one spoken "Klaudku" would re-fire every tick. A window of 5 ticks
+/// (≈ 15s ≈ one full tail) collapses the overlapping re-detections of ONE utterance into a single
+/// dispatch, while a fresh "Klaudku" later — or the same command after the window lapses — DOES
+/// fire again. Recall is preserved (a NEW ask always catches); only the duplicate echo is dropped.
+const WAKE_DEDUP_TICKS: u32 = 5;
+
 #[derive(serde::Serialize, Clone)]
 struct LiveCaption {
     text: String,
+}
+
+/// DEDUP state for the in-meeting wake trigger (the #23 fix). [`detect_wake`] now fires ANYWHERE in
+/// the rolling, OVERLAPPING ~14s tail, so the SAME spoken "Klaudku zrób research" would otherwise
+/// re-fire on every tick it remains visible. This collapses the overlapping re-detections of ONE
+/// utterance into a SINGLE dispatch: it remembers the last fired wake (its normalized command text)
+/// and a tick countdown, skipping a detection that matches the remembered one while the countdown is
+/// live. A DIFFERENT command, or the SAME command after the window lapses, fires again — so one
+/// spoken wake = one dispatch, but a fresh ask later in the same recording still catches.
+///
+/// Pure + stateful — held by the live loop, advanced once per tick via [`Self::tick`] and consulted
+/// per wake hit via [`Self::should_fire`]. No I/O. Headless-testable.
+#[derive(Default)]
+struct WakeDedup {
+    /// The normalized command of the last FIRED wake, while it is still suppressing repeats.
+    last: Option<String>,
+    /// Ticks remaining before `last` stops suppressing a matching repeat (0 = no active suppression).
+    cooldown: u32,
+}
+
+impl WakeDedup {
+    /// Advance one live tick: age out an expired suppression window. Call once per loop iteration,
+    /// BEFORE the wake check, so the countdown reflects ticks elapsed since the last fire.
+    fn tick(&mut self) {
+        if self.cooldown > 0 {
+            self.cooldown -= 1;
+            if self.cooldown == 0 {
+                self.last = None;
+            }
+        }
+    }
+
+    /// Decide whether a wake hit with normalized command `cmd` should FIRE (dispatch+emit) on this
+    /// tick. Fires when it is a NEW/different command, or the suppression window for the same command
+    /// has lapsed. On a fire it arms the suppression window ([`WAKE_DEDUP_TICKS`]); on a suppressed
+    /// repeat it leaves the window untouched (so the cooldown counts from the FIRST fire, not the
+    /// last echo — the overlap of one utterance can't extend the window indefinitely).
+    fn should_fire(&mut self, cmd: &str) -> bool {
+        let key = normalize_command(cmd);
+        if self.cooldown > 0 && self.last.as_deref() == Some(key.as_str()) {
+            return false; // overlapping re-detection of the same just-fired wake → skip.
+        }
+        self.last = Some(key);
+        self.cooldown = WAKE_DEDUP_TICKS;
+        true
+    }
+}
+
+/// Normalize a wake command for dedup comparison: lowercase, collapse whitespace, drop surrounding
+/// punctuation. So the SAME utterance transcribed with slightly different trailing punctuation /
+/// spacing / casing across overlapping tails still compares equal and is de-duplicated.
+fn normalize_command(cmd: &str) -> String {
+    cmd.to_lowercase()
+        .split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|w| !w.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Spawn the live-caption loop for the current recording. Returns immediately; the loop
@@ -46,8 +112,14 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
         }
     };
 
+    // DEDUP state for the wake trigger (#23): detect_wake now fires ANYWHERE in the overlapping tail,
+    // so without this the same spoken wake re-fires every tick it stays visible. Lives across ticks.
+    let mut wake_dedup = WakeDedup::default();
+
     loop {
         std::thread::sleep(TICK);
+        // Age out an expired wake-suppression window once per tick (before this tick's wake check).
+        wake_dedup.tick();
 
         // Snapshot the recent tail; stop as soon as the recording is gone.
         let snapshot = {
@@ -141,7 +213,15 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                     // that needs the local brain in a later phase). Best-effort + panic-free: the
                     // detection is a pure function and the emit error is ignored, so a wake miss/hit
                     // can NEVER disrupt the caption or the authoritative record/transcribe flow.
-                    if let Some(payload) = wake_event_for(&text) {
+                    // DEDUP (#23): the rolling tail OVERLAPS, so a single spoken "Klaudku …" is
+                    // visible for several ticks and `detect_wake` (now firing anywhere) would re-hit
+                    // it each tick. `should_fire` collapses those overlapping re-detections of the
+                    // SAME command into ONE dispatch, while a DIFFERENT command — or the same one
+                    // after the suppression window lapses — still fires. Skipped repeats produce
+                    // neither a dispatch nor an `EVENT_WAKE_DETECTED`, but the caption still emits.
+                    if let Some(payload) =
+                        wake_event_for(&text).filter(|p| wake_dedup.should_fire(&p.command))
+                    {
                         // PII rule (§8): NEVER log the spoken command text — only the
                         // non-PII wake token and a coarse intent KIND (variant
                         // discriminant, no content). The full payload goes to the FE
@@ -658,6 +738,82 @@ mod tests {
         assert_eq!(p.matched_phrase, "klodku");
         assert_eq!(p.command, "zrób research o konkurencji");
         assert_eq!(p.intent, VoiceIntent::Research { topic: "konkurencji".into() });
+    }
+
+    // ── #23 DEDUP: one spoken wake = one dispatch; a fresh wake later DOES fire ───────────────────
+
+    #[test]
+    fn wake_dedup_collapses_overlapping_repeats_of_the_same_wake() {
+        // The #23 echo: the same "Klaudku zrób research" stays visible across several overlapping
+        // ~14s tails. The FIRST tick fires; the next ticks (within the window) are SKIPPED.
+        let mut d = WakeDedup::default();
+        assert!(d.should_fire("zrób research o konkurencji"), "first detection must fire");
+        for _ in 0..WAKE_DEDUP_TICKS - 1 {
+            d.tick();
+            assert!(
+                !d.should_fire("zrób research o konkurencji"),
+                "an overlapping re-detection of the SAME command within the window must be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn wake_dedup_normalizes_punctuation_and_case_across_tails() {
+        // The same utterance re-transcribed with different trailing punctuation / casing across
+        // overlapping tails still compares equal and is de-duplicated.
+        let mut d = WakeDedup::default();
+        assert!(d.should_fire("zrób research o konkurencji"));
+        d.tick();
+        assert!(
+            !d.should_fire("Zrób research o konkurencji."),
+            "case/punctuation-only differences must still dedup as the same command"
+        );
+    }
+
+    #[test]
+    fn wake_dedup_allows_a_different_command_immediately() {
+        // RECALL: a DIFFERENT wake command in the same recording must fire right away, even while the
+        // previous one's suppression window is still live (the user's "to ma zawsze łapać").
+        let mut d = WakeDedup::default();
+        assert!(d.should_fire("zrób research o konkurencji"), "first command fires");
+        d.tick();
+        assert!(
+            d.should_fire("co wiemy o atlasie"),
+            "a fresh, different command must fire even within the prior window"
+        );
+    }
+
+    #[test]
+    fn wake_dedup_allows_the_same_command_again_after_the_window_lapses() {
+        // The user genuinely asks the SAME thing again, later. Once the suppression window has fully
+        // aged out, the same command fires again — dedup suppresses the echo, not a real re-ask.
+        let mut d = WakeDedup::default();
+        assert!(d.should_fire("zrób research o konkurencji"), "first ask fires");
+        for _ in 0..WAKE_DEDUP_TICKS {
+            d.tick();
+        }
+        assert!(
+            d.should_fire("zrób research o konkurencji"),
+            "after the window lapses the same command must be allowed to fire again"
+        );
+    }
+
+    #[test]
+    fn wake_dedup_window_counts_from_the_first_fire_not_the_last_echo() {
+        // A suppressed echo must NOT re-arm the window, else a long overlap would suppress forever.
+        let mut d = WakeDedup::default();
+        assert!(d.should_fire("zrób research"), "first fire arms the window");
+        // Echo once mid-window: suppressed, and must not extend the cooldown.
+        d.tick();
+        assert!(!d.should_fire("zrób research"), "echo suppressed");
+        // Age out the REMAINDER of the window counted from the FIRST fire.
+        for _ in 0..WAKE_DEDUP_TICKS - 1 {
+            d.tick();
+        }
+        assert!(
+            d.should_fire("zrób research"),
+            "the window must expire on schedule from the first fire, not be extended by echoes"
+        );
     }
 
     #[test]

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -300,6 +300,52 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
           <input type="checkbox" formControlName="realtimeReactions" />
         </label>
 
+        <!--
+          Proactive cloud-egress consent (issue 20). The in-meeting assistant
+          dispatches voice actions through the active provider. With a cloud
+          provider (claude_code or anthropic, mirroring the backend is_cloud
+          gate) it uploads mid-meeting context, and the dispatch is fail-closed
+          behind cloud_egress_consented. Surface the requirement at enable time.
+          Condition: realtime on, cloud provider, brain not off, not consented.
+          Reuses the existing consent flow (allowCloudProcessing). In-flow
+          warning, so the frosted banner is correct (no opaque overlay needed).
+        -->
+        @if (
+          form.controls.realtimeReactions.value &&
+          form.controls.brainBackend.value === "cloud" &&
+          (form.controls.providerId.value === "claude_code" ||
+            form.controls.providerId.value === "anthropic") &&
+          !cloudConsented()
+        ) {
+          <div class="banner is-warning realtime-consent">
+            <span class="realtime-consent-copy">
+              ⚠ Asystent w spotkaniu wysyła kontekst do chmury — zezwól na
+              przetwarzanie w chmurze, inaczej odpowiedzi na żywo nie zadziałają.
+            </span>
+            <div class="cloud-consent-row">
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="allowCloudProcessing()"
+                [disabled]="consenting()"
+              >
+                @if (consenting()) {
+                  <span class="spin-ring" aria-hidden="true"></span>
+                  Enabling…
+                } @else {
+                  Allow
+                }
+              </button>
+              <span class="text-muted cloud-consent-hint">
+                One-time, redacted first. Same consent as cloud summaries.
+              </span>
+            </div>
+            @if (consentError(); as cerr) {
+              <p class="text-danger privacy-note">{{ cerr }}</p>
+            }
+          </div>
+        }
+
         <!-- Model + reasoning-effort overrides for the active cloud provider. -->
         <div class="brain-tuning">
           <label class="field">
@@ -1354,6 +1400,14 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
         display: flex;
         flex-direction: column;
         gap: var(--space-4);
+      }
+      /* #20 — proactive cloud-egress consent warning under the assistant toggle. */
+      .realtime-consent {
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .realtime-consent-copy {
+        line-height: 1.55;
       }
       .brain-models {
         display: flex;


### PR DESCRIPTION
**#23** detect_wake fires at the first vocative ANYWHERE in the rolling tail (fixes the 2nd-Klaudku-missed bug) + live.rs dedups overlapping re-detections (~15s window); precision negatives stay silent mid-tail. **#20** inline cloud-consent warning under the assistant toggle when enabled with a CLOUD brain + not consented (reuses consent_to_cloud_egress; gated on brainBackend==='cloud' ∧ cloud provider — local/off shows nothing; the adversarial caught + I fixed the original local-brain false-positive). Verified: test 431/0 (#23 RED-before-GREEN); clippy clean; ng lint+build clean; adversarial PASS on #23.