### PR TITLE
docs(release): 0.7.0 release handoff + AI-orb research

### DIFF
--- a/docs/V070-RELEASE-HANDOFF.md
+++ b/docs/V070-RELEASE-HANDOFF.md
@@ -1,0 +1,70 @@
+<!-- The 0.7.0 release handoff. Supersedes V060-RELEASE-HANDOFF.md. Read this to ship. Pairs with .claude/skills/release-murmur. -->
+# v0.7.0 — release handoff (brain + voice + connectors + semantic)
+
+**Status:** trunk `murmur` @ **0.7.0** (PR #74), all headless gates green — `cargo test --lib` **431/0** ·
+`cargo clippy --all-targets -D warnings` clean · `ng lint` + `ng build` clean · `cargo build --lib` clean at 0.7.0.
+Every change shipped via build → adversarial-verify → (lock-security-review where lock/egress was touched) → PR-merge.
+**The only things left are your build-feature choice + the signed release** (sign/notarize/publish need your Mac + auth).
+
+---
+
+## What shipped in 0.7.0 (PRs #54–#74, on top of 0.6.0)
+
+| Area | 0.7.0 |
+|---|---|
+| **Brain** | real orchestration (brain decides context via gated tools) + **model + effort picker** (Settings → Brain/AI: Default/Opus 4.8/Sonnet 4.6/Haiku 4.5; effort low/med/high — Anthropic-only, honestly gated) |
+| **In-meeting voice assistant** | wake "Klaudku" (recall-first shape-gate, **fires anywhere in the live window + dedup**) **+ the ✨ click-to-stop button** (you control when you're done — no fixed-timeout cutoff) **+ a PROCESSING state** + an **animated AI orb** (idle → listening/audio-reactive → processing/conic+shimmer → answer; pure CSS/SVG, reduced-motion-aware) |
+| **Assistant Q&A** | interactions **persisted per-meeting** (gated, purged-on-seal) + a **"🎙 Asystent — Q&A" detail section** (question → answer + [[vault]]/via-web sources); the summarizer **excludes** "Klaud/Klaudku" utterances from action items |
+| **Semantic search** | **real e5 multilingual** turned on (Settings toggle + a **re-index** backfill); cross-lingual ("weather"→"pogoda") + paraphrase; hybrid FTS ∪ vector ∪ graph |
+| **Connectors** | a **Connector framework** (live agentic tools, not vectorized) + **web search (Brave, BYO key, consent-gated NEW egress, redacted, "via web")** + a **calendar connector** (Local/EventKit, on-device, no egress) |
+| **Privacy/consent** | redaction firewall + DeBERTa NER; **proactive cloud-consent prompt** when enabling the assistant with a cloud brain; web-search consent fail-closed + preserve-only |
+| **Dev/stability** | **whisper ggml-metal residency abort fixed** (GGML_METAL_NO_RESIDENCY=1) · **dev-secrets file store** (no keychain prompt/-34018 in unsigned dev) · isolated MeetNotes-dev data dir |
+
+### Final prod-readiness (holistic, 2026-06-29)
+- **Lock-security: PASS** across every lock-touching change — assistant Q&A double-gated + purged-on-seal in the same atomic tx as vec_chunks/correction_log; semantic re-index indexes ONLY visible content (sealed never embedded); the web connector is the only new egress and it is **fail-closed** (enable ∧ consent ∧ keyed), query-redacted, and loud; the calendar connector is Local/no-egress; the dev-secrets store is `#[cfg(debug_assertions)]`-only (release uses data-protection keychain, byte-for-byte unchanged). *No leak, no loss found.*
+- **Constraints UPHELD:** one new cloud-egress destination (web search) — loud, consent-gated, redacted, justified; SQLite-canonical (Q&A/chunks are derived + purged on seal); provider seam + redaction intact; single onnxruntime (candle, no 2nd ORT); `com.meetnotes.app` immutable; additive guarded migration (assistant_interactions).
+- **Prod-readiness: READY-WITH-CAVEATS.** The caveats are **runtime/Mac-gated, not bugs** — see the residual below. Nothing aborts, leaks, or loses content. Headless-green; the felt UX (mic, orb, web results) is the human-glance step.
+
+---
+
+## ⚠️ THE BUILD DECISION (same as 0.6.0)
+
+Local models are opt-in cargo features (`local-brain`, `local-embed`, `local-ner`). For the full product you built, use **Option C**:
+
+```bash
+MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app -- --features local-brain,local-embed,local-ner
+```
+(Option B = `--features local-embed,local-ner` — semantic + NER + Claude brain, no Xcode/metal step. Option A = default, Claude-only.)
+
+## Release steps (your Mac — sign/notarize/publish need your auth)
+
+```bash
+# clean tree on murmur @ 0.7.0:
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+pkill -x Murmur ; pkill -f 'tauri dev' || true            # free the cargo target lock
+# build (Option C example):
+MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app -- --features local-brain,local-embed,local-ner
+# sign INSIDE-OUT by identity HASH — FOUR bundled helpers (3 audio + meetnotes-calendar):
+bash scripts/macos-sign-notarize.sh        # signs each nested helper FIRST, then the .app (NO --deep), then the DMG
+# notarize + staple + verify + publish (notarytool keychain profile "murmur"):
+xcrun notarytool submit <dmg> --keychain-profile murmur --wait
+xcrun stapler staple <dmg> ; spctl -a -vvv -t open --context context:primary-signature <dmg>   # expect "Notarized Developer ID"
+gh release create v0.7.0 -R JakubGawr/murmur <dmg>
+```
+**Hard rules (do not repeat the 2026-06-27 mess):** notarization is MANDATORY; sign INSIDE-OUT, never `--deep` (it skips the `Contents/Resources/` helpers → notarization `Invalid`); get the identity by HASH (the cert CN has "Gawroński"); run any `security`/keychain/`notarytool store-credentials` op YOURSELF interactively (the agent shell hangs them); merge via PR only.
+
+## What still needs YOU on a real signed Mac (the honest residual — none are bugs)
+1. **Boot the signed Option-C build** — the local models run signed (Metal at runtime; local-brain first-run compiles shaders once via the `…PRECOMPILE=0` defer; models download in-app via the picker).
+2. **Voice flow end-to-end on a real mic:** the wake "Klaudku" + the ✨ click-to-stop + the orb's audio-reactive feel + the ~60s backstop + dedup of a 2nd "Klaudku" — all proven at the logic level; the acoustics + feel are the human glance.
+3. **Web search:** add a free Brave Search API key (Settings → Web search → key + Allow), ask "zrób research o pogodzie" → confirm real "via web" results.
+4. **Semantic:** enable the toggle + Re-index notes → confirm cross-lingual recall on your real vault (does e5 beat FTS — the bake-off call).
+5. **Calendar connector:** grant macOS Calendars (TCC) on the signed build → confirm `fetch_events` returns real events.
+6. **Bielik local brain** in a RELEASE build (debug was ~min/token) + the model/effort picker against the live API/CLI (confirm the exact model-id strings are accepted).
+7. **Touch ID / lock-at-rest / screen-share auto-relock** — signed-build-only.
+
+## Deferred (clean follow-ups, not in 0.7.0)
+- Slack/Jira/Google connectors (OAuth) — the framework + the Local/External seam are ready.
+- The LoRA fine-tune of the local brain on the now-lock-safe flywheel (premature until clean correction pairs accrue).
+- Trim the `record.component.ts` (+292 B) / `detail.component.ts` (+1.51 kB) per-component style WARNs (both under the 16 kB ERROR budget; cosmetic).
+
+The product is on `murmur` @ 0.7.0, green and reviewed. Pick a build option and ship. 🚀

--- a/docs/research/2026-06-28-ai-assistant-orb-ui.md
+++ b/docs/research/2026-06-28-ai-assistant-orb-ui.md
@@ -1,0 +1,51 @@
+<!-- Generated 2026-06-28 via murmur-researcher fan-out (2 angles: prior-art + Angular feasibility). Pricing/UI = point-in-time. -->
+# Research: the in-meeting AI-assistant state "orb" — how leading apps do it + how we build it
+
+## TL;DR / Verdict
+Build a **single morphing gradient orb** whose STATE is expressed by changing **motion + color**, not by swapping widgets — the convergent pattern across ClickUp Brain, ChatGPT Advanced Voice, Apple Intelligence/Siri, and Gemini Live. The interaction the user wants for #28 — **click-to-start → click-to-stop toggle with an explicit Stop affordance** — is exactly ClickUp's "Talk to Text" floating-bar model, so it's the right call. **Fully buildable in our zoneless Angular stack with ZERO new deps**, ~2–4 kB CSS against the 16 kB budget; the repo already ships every primitive (the `[style.--level]` audio→CSS-var wave, a conic spinner, a pulse ring, thinking-dots, a shimmer). Biggest current gap = the **PROCESSING/"thinking" state** ("you don't know what it's doing") → solve with a **breathing orb + a shimmer label naming the substep** ("Szukam w notatkach… / Szukam w sieci…").
+
+## The canonical 4-state model (industry-convergent; Gemini Live spells it out)
+```
+idle ──click──▶ listening ──click(stop)──▶ processing ──▶ answer ──▶ idle
+ slow            mic-amplitude              NO amplitude:    settle to a
+ breathe         reactive scale/bars        breathe + spin   steady glow
+                                            + shimmer label
+                                  error → static red
+```
+- **listening & speaking share the SAME amplitude widget** — only the source differs (mic-in vs playback-out). **processing is the one state that drops amplitude** for a pulse/spin (there's nothing to react to).
+- Keep **ONE orb element and cross-fade its animation/color per state** (200–280 ms, spring ease) so it reads as one living entity morphing — not mounting/unmounting widgets (the ChatGPT/Siri lesson).
+
+## What leading apps do (cited)
+- **ClickUp Brain** = pink→purple gradient **star/✨ orb** + "animated loading indicators help users understand when the AI is processing"; **voice = a floating bar with hotkey/click toggle to start AND a Stop button to end** ([ClickUp Help — Talk to Text](https://help.clickup.com/hc/en-us/articles/37457270037271-Use-Talk-to-Text-in-Brain-MAX)). Validates our click-to-stop + floating-bar model. (Exact bar motion unverified — pages 403'd.)
+- **ChatGPT Advanced Voice** = a glowing **breathing blue orb**; state = motion (pulse/breathe), not named colors; inline-in-chat since 2025-11-25 ([Croma](https://www.croma.com/unboxed/chatgpt-in-chat-voice-live-visuals-update)).
+- **Apple Intelligence/Siri** = the orb became a **reactive screen-edge glow** — same idea (continuous audio-reactive gradient light), orb form fits a small bar ([iDownloadBlog](https://www.idownloadblog.com/2024/07/30/how-to-get-apple-intelligence/)).
+- **Gemini Live** = explicit idle/listening/processing/speaking/error → visual spec ([gemini-cli #21109](https://github.com/google-gemini/gemini-cli/issues/21109)).
+- **Processing treatments worth stealing:** breathing orb (ChatGPT) + **shimmer-text** (`background-clip:text` moving gradient, ~2 s loop — [Vercel AI SDK Shimmer](https://elements.ai-sdk.dev/components/shimmer), Raycast) + Notion's principle that a **custom on-brand motion beats a stock spinner** ([Fast Company](https://www.fastcompany.com/91192119/notions-new-animated-ai-assistant-looks-more-new-yorker-than-clippy)).
+- **Reproducible orb recipe:** SmoothUI "Siri Orb" = layered `conic-gradient`s + animated `@property --angle` + `filter: blur()` (blur turns hard gradients into a liquid lava-lamp orb) ([source](https://github.com/educlopez/smoothui/blob/main/packages/smoothui/components/siri-orb/index.tsx)).
+
+## Fit + feasibility (our stack — all grounded file:line)
+- **Zero new deps** (no Lottie/GSAP/three.js) — pure CSS + inline SVG. ✅ rule §7.
+- **Already shipped primitives:** `[style.--level]="store.level()"` signal→CSS-var audio binding (`record.component.ts:129-134`, CSS `:608-636`) = the listening-reactive pattern; `.orb.proc` conic spin (`:842-852`); `ask-pulse` ring (`:714-722`); thinking-dots (`assistant-actions.component.ts:192-218`); shimmer (`:778-792`). `RecorderStore.level()` is a **signal polled inside `toSignal`** — no component timer (`recorder.store.ts:52-66`).
+- **One `computed()` state machine** collapses existing signals (`assistant.listening()`, `manualAskInFlight()`, top interaction `status`) → `idle|listening|processing|answer`, bound as `[class]="'is-'+orbState()"`. Pure computed → no NG0600.
+- **Budget/a11y:** ~2–4 kB inline CSS (16 kB budget); orb `aria-hidden`, state announced via paired `role="status" aria-live="polite"`; `aria-busy` during processing.
+- **prefers-reduced-motion:** global rule zeroes `animation` duration; ADD an explicit guard for the value-driven `transform: scale(calc(1 + var(--level)…))` and conic rotation (mirror `record.component.ts:751-757`).
+- **WebView:** this Mac = macOS 26.5 → WKWebView well past Safari 16.4 (`@property`) + 12.1 (conic). Namespace `@property --orb-spin` (at-rules aren't view-scoped) OR use the simpler `transform: rotate()` element-spin (matches existing `.orb.proc`) to sidestep it.
+
+## The concrete design (Option B — recommended)
+A standalone `app-ai-orb` (`state = input<OrbState>()`, optional `level = input<number>()`), 56–72 px, in the recording bar + the assistant card head:
+- **IDLE** — gradient orb (`--accent-gradient` core + breathing halo), slow `transform: scale` breathe.
+- **LISTENING** — `transform: scale(calc(1 + var(--level)*0.18))` driven by `level()` + a reactive ring (opacity/scale ∝ level). Voice-reactive, the ClickUp/Siri look.
+- **PROCESSING** — rotating conic-gradient ring (carved with `mask: radial-gradient`) + a **shimmer status label** naming the substep ("Szukam w notatkach…" → "Szukam w sieci…" → "Piszę odpowiedź…"). This is the loud disclosure point for **web egress**.
+- **ANSWER** — settle to a steady gently-breathing accent orb (CSS entry-animation keyed on the class change — no component timer per rule §5).
+
+## Recommendation & first step
+Build **Option B**, scaffolded from the existing primitives, as part of **#28** (click-to-stop + processing state). First verifiable slice: the `app-ai-orb` component driven by a dev toggle → Playwright on `:1420` cycles all 4 states + synthetic `level` 0→1; assert distinct motion, `ng build` under budget, reduced-motion collapses to static. The animation *quality* wants a 30-s real-Mac glance (not a headless gate).
+
+## Open questions
+- ClickUp's exact recording-bar motion (waveform vs orb) — unverified (pages 403'd); the interaction model (toggle + Stop) IS verified.
+- `@property` through Angular's CSS pipeline in THIS build — low-risk but unverified; the `transform: rotate()` variant avoids it.
+- ANSWER motion = steady glow vs a one-shot flourish — confirm with the user (a CSS entry-animation gives a flourish with no timer).
+- Audio-reactive *feel* of the 100 ms `level()` poll smoothed by a 90 ms CSS transition — wants a real mic.
+
+## Sources
+Prior-art: ClickUp Help/marketing, Croma/justainews (ChatGPT orb), iDownloadBlog (Siri glow), gemini-cli #21109/#22436 (state spec), SmoothUI Siri Orb source, Vercel AI SDK Shimmer, Raycast changelog, Fast Company (Notion). Feasibility: web.dev @property-baseline, animationpatterns.art conic spinner, Pyxofy @property+conic, CSS-Tricks conic almanac. Repo: `record.component.ts:129/608/714/778/842`, `recorder.store.ts:52`, `assistant.store.ts:97/106/37`, `assistant-actions.component.ts:192`, `styles.css:55/478`, `angular.json:51`.


### PR DESCRIPTION
The 0.7.0 release handoff (feature wave, prod-readiness verdict, Option-C build, sign-inside-out steps, Mac-gated residual) + the AI-orb UI research doc.