### PR TITLE
feat(ui): rich assistant Q&A card — sanitized markdown + compact deduped sources

### DIFF
--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -28,6 +28,8 @@ import {
   type FolderExposure,
 } from "../../services/folders.service";
 import { ToastService } from "../../services/toast.service";
+import { MarkdownComponent } from "../../shared/markdown.component";
+import { AssistantSourcesComponent } from "../../shared/assistant-sources.component";
 import { LockBadgeComponent } from "../folders/lock-badge.component";
 import { MoveToMenuComponent } from "../folders/move-to-menu.component";
 import { MeetingActionsComponent } from "./meeting-actions.component";
@@ -102,6 +104,8 @@ interface ParsedNote {
     MeetingRecipesComponent,
     LockBadgeComponent,
     MoveToMenuComponent,
+    MarkdownComponent,
+    AssistantSourcesComponent,
   ],
   template: `
     <section class="detail">
@@ -814,45 +818,15 @@ interface ParsedNote {
                     </div>
 
                     @if (q.answer) {
-                      <p class="qa-answer">{{ q.answer }}</p>
+                      <app-markdown
+                        class="qa-answer"
+                        [markdown]="q.answer"
+                        compact
+                      />
                     }
 
                     @if (q.citations.length) {
-                      <div class="qa-cites" aria-label="Źródła">
-                        @for (c of q.citations; track $index) {
-                          @if (c.kind === "web") {
-                            @if (c.url) {
-                              <a
-                                class="cite-chip is-web"
-                                [href]="c.url"
-                                target="_blank"
-                                rel="noreferrer noopener"
-                                [title]="c.url"
-                              >
-                                <span class="cite-web-mark" aria-hidden="true"
-                                  >⊕</span
-                                >
-                                <span class="cite-web-label">{{
-                                  c.label
-                                }}</span>
-                                <span class="cite-web-via">via web</span>
-                              </a>
-                            } @else {
-                              <span class="cite-chip is-web">
-                                <span class="cite-web-mark" aria-hidden="true"
-                                  >⊕</span
-                                >
-                                <span class="cite-web-label">{{
-                                  c.label
-                                }}</span>
-                                <span class="cite-web-via">via web</span>
-                              </span>
-                            }
-                          } @else {
-                            <span class="cite-chip">[[{{ c.label }}]]</span>
-                          }
-                        }
-                      </div>
+                      <app-assistant-sources [citations]="q.citations" />
                     }
 
                     @if (q.sourceLabel) {
@@ -1517,8 +1491,7 @@ interface ParsedNote {
         padding: var(--space-3) var(--space-4);
         animation: rise 360ms var(--transition) both;
       }
-      .qa-heard,
-      .qa-cites {
+      .qa-heard {
         display: flex;
         align-items: center;
         flex-wrap: wrap;
@@ -1535,61 +1508,15 @@ interface ParsedNote {
       .qa-heard .pill {
         margin-left: auto;
       }
+      /* The answer is now rendered by app-markdown; just give the block room. */
       .qa-answer {
-        margin: 0;
-        color: var(--text-primary);
+        display: block;
         font-size: 0.9rem;
-        line-height: 1.55;
-        white-space: pre-wrap;
       }
       .qa-source {
         font-size: 0.72rem;
         text-transform: uppercase;
         letter-spacing: 0.03em;
-      }
-      .cite-chip {
-        padding: 2px var(--space-2);
-        border-radius: var(--radius-sm);
-        background: var(--accent-soft);
-        color: var(--accent-hover);
-        font-family: var(--font-mono);
-        font-size: 0.78rem;
-      }
-      /* A web source — visibly distinct from the [[vault]] chips, with a loud
-         "via web" tag for the off-device origin (mirrors assistant-actions). */
-      .cite-chip.is-web {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-1);
-        max-width: 100%;
-        background: var(--surface-input);
-        border: 1px solid var(--border-subtle);
-        color: var(--text-secondary);
-        font-family: inherit;
-        text-decoration: none;
-      }
-      a.cite-chip.is-web:hover {
-        border-color: var(--accent-soft);
-        color: var(--text-primary);
-      }
-      .cite-web-mark {
-        color: var(--accent);
-        line-height: 1;
-      }
-      .cite-web-label {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        max-width: 220px;
-      }
-      .cite-web-via {
-        padding: 0 var(--space-1);
-        border-radius: var(--radius-sm);
-        background: var(--accent-soft);
-        color: var(--accent-hover);
-        font-size: 0.7rem;
-        font-weight: 600;
-        text-transform: uppercase;
       }
       @media (prefers-reduced-motion: reduce) {
         .qa-row {

--- a/src/app/features/record/assistant-actions.component.ts
+++ b/src/app/features/record/assistant-actions.component.ts
@@ -6,16 +6,20 @@ import {
 } from "@angular/core";
 import { AssistantStore } from "../../core/assistant.store";
 import type { AssistantInteraction } from "../../core/assistant.store";
+import { MarkdownComponent } from "../../shared/markdown.component";
+import { AssistantSourcesComponent } from "../../shared/assistant-sources.component";
 import { AiOrbComponent } from "./ai-orb.component";
 
 /**
  * Phase H — the live "assistant actions" card on the record surface. Subscribes
  * (once, via AssistantStore.init()) to the in-meeting voice assistant's wake +
  * result event streams and renders a newest-first list of recent interactions:
- * a pending "🎙 usłyszano: {command}" row on a wake, resolved to {summary} +
- * citation chips with a status pill when the result arrives. Vault sources render
- * as `[[Title]]` chips; web sources (when the web-search connector contributed)
- * render as a distinct "via web" link to the URL — the off-device origin is loud.
+ * a pending "🎙 usłyszano: {command}" row on a wake, resolved when the result
+ * arrives to a SANITIZED-markdown answer (shared `app-markdown`: marked →
+ * DOMPurify → [innerHTML], with [[wikilink]] prose chips) plus a compact, deduped
+ * "🔗 Źródła" block (shared `app-assistant-sources`: web rows show the extracted
+ * domain + title as an external link, vault rows a distinct chip, capped with a
+ * "Pokaż wszystkie" toggle so there is no giant flat list).
  *
  * The card is in-flow on the record page (not a floating overlay), so it uses
  * the frosted `.card` like the other record-surface panels. If it were ever
@@ -26,7 +30,7 @@ import { AiOrbComponent } from "./ai-orb.component";
   selector: "app-assistant-actions",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AiOrbComponent],
+  imports: [AiOrbComponent, MarkdownComponent, AssistantSourcesComponent],
   template: `
     <div class="card assistant" role="group" aria-label="Voice assistant">
       <div class="assistant-head">
@@ -73,28 +77,10 @@ import { AiOrbComponent } from "./ai-orb.component";
                 <!-- the nudge label above is the whole message; no summary row -->
               } @else {
                 @if (a.summary) {
-                  <p class="action-summary">{{ a.summary }}</p>
+                  <app-markdown class="action-summary" [markdown]="a.summary" compact />
                 }
                 @if (a.citations.length > 0) {
-                  <div class="action-cites" aria-label="Sources">
-                    @for (c of a.citations; track $index) {
-                      @if (c.kind === "web") {
-                        <a
-                          class="cite-chip is-web"
-                          [href]="c.url ?? null"
-                          target="_blank"
-                          rel="noreferrer noopener"
-                          [title]="c.url ?? c.label"
-                        >
-                          <span class="cite-web-mark" aria-hidden="true">⊕</span>
-                          <span class="cite-web-label">{{ c.label }}</span>
-                          <span class="cite-web-via">via web</span>
-                        </a>
-                      } @else {
-                        <span class="cite-chip">[[{{ c.label }}]]</span>
-                      }
-                    }
-                  </div>
+                  <app-assistant-sources [citations]="a.citations" />
                 }
               }
             </li>
@@ -218,62 +204,10 @@ import { AiOrbComponent } from "./ai-orb.component";
         }
       }
 
+      /* The answer is now rendered by app-markdown; just give the block room. */
       .action-summary {
-        margin: 0;
-        color: var(--text-primary);
+        display: block;
         font-size: 0.9rem;
-        line-height: 1.55;
-      }
-      .action-cites {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-2);
-      }
-      .cite-chip {
-        padding: 2px var(--space-2);
-        border-radius: var(--radius-sm);
-        background: var(--accent-soft);
-        color: var(--accent-hover);
-        font-family: var(--font-mono);
-        font-size: 0.78rem;
-        letter-spacing: -0.01em;
-      }
-      /* A web source — visibly distinct from the [[vault]] chips: a link, not a
-         monospace wikilink, with an "via web" tag so the off-device origin is loud. */
-      a.cite-chip.is-web {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-1);
-        background: var(--surface-input);
-        border: 1px solid var(--border-subtle);
-        color: var(--text-secondary);
-        font-family: inherit;
-        text-decoration: none;
-        max-width: 100%;
-      }
-      a.cite-chip.is-web:hover {
-        border-color: var(--accent-soft);
-        color: var(--text-primary);
-      }
-      .cite-web-mark {
-        color: var(--accent);
-        line-height: 1;
-      }
-      .cite-web-label {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        max-width: 220px;
-      }
-      .cite-web-via {
-        padding: 0 var(--space-1);
-        border-radius: var(--radius-sm);
-        background: var(--accent-soft);
-        color: var(--accent-hover);
-        font-size: 0.7rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.02em;
       }
 
       @media (prefers-reduced-motion: reduce) {

--- a/src/app/shared/assistant-sources.component.ts
+++ b/src/app/shared/assistant-sources.component.ts
@@ -1,0 +1,270 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from "@angular/core";
+
+/**
+ * One grounding source for the assistant-answer "🔗 Źródła" block. Both the live
+ * record-surface card ({@link AssistantCitation}) and the persisted detail Q&A
+ * ({@link ParsedCitation}) already parse the backend's flat citation strings into
+ * a vault-vs-web shape — this is the common subset they both feed in.
+ */
+export interface AssistantSource {
+  kind: "vault" | "web";
+  /** Display label: the bare vault title, or the web result's title. */
+  label: string;
+  /** Destination URL for a web source (absent/empty for vault). */
+  url?: string | null;
+}
+
+/** A deduped source enriched for rendering (stable key + extracted domain). */
+interface RichSource extends AssistantSource {
+  /** Stable `@for` key — the URL for web, the bracketed label for vault. */
+  key: string;
+  /** The extracted hostname (e.g. "accuweather.com"), web sources only. */
+  domain: string | null;
+}
+
+/**
+ * Compact, rich, deduped "🔗 Źródła" block shared by BOTH assistant surfaces
+ * (the live `app-assistant-actions` card and the persisted detail Q&A section).
+ * Replaces the old giant flat list of near-duplicate "VIA WEB" chips:
+ *
+ * - DEDUPE on URL (web) / label (vault) — exact duplicates collapse.
+ * - GROUP a small "via web" / "vault" affordance per row instead of a per-chip
+ *   "VIA WEB" tag; the header carries the unique count.
+ * - CAP to the first {@link AssistantSourcesComponent.PREVIEW} rows; the rest
+ *   hide behind a "Pokaż wszystkie ({N})" toggle (a signal + `@if`, no wall).
+ * - Each web row shows a link glyph + the extracted **domain** + truncated
+ *   title, the whole row a clickable external link. Vault rows are a distinct
+ *   no-URL chip.
+ *
+ * In-flow (not floated), so the frosted-surface tokens are fine — no overlay
+ * (trap T3 does not apply here). Tokens only; no new deps.
+ */
+@Component({
+  selector: "app-assistant-sources",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="src-block" aria-label="Źródła">
+      <div class="src-head">
+        <span class="src-ico" aria-hidden="true">🔗</span>
+        <span class="src-title">Źródła</span>
+        <span class="count">{{ sources().length }}</span>
+      </div>
+
+      <div class="src-rows">
+        @for (s of visible(); track s.key) {
+          @if (s.kind === "web" && s.url) {
+            <a
+              class="src-row is-web"
+              [href]="s.url"
+              target="_blank"
+              rel="noreferrer noopener"
+              [title]="s.url"
+            >
+              <span class="src-glyph" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="13" height="13" fill="none">
+                  <path
+                    d="M6.5 9.5l3-3M7 4.5l.8-.8a2.5 2.5 0 0 1 3.5 3.5l-.8.8M9 11.5l-.8.8a2.5 2.5 0 0 1-3.5-3.5l.8-.8"
+                    stroke="currentColor"
+                    stroke-width="1.4"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </span>
+              <span class="src-domain">{{ s.domain ?? "web" }}</span>
+              @if (s.label && s.label !== s.domain) {
+                <span class="src-label">{{ s.label }}</span>
+              }
+              <span class="src-extern" aria-hidden="true">↗</span>
+            </a>
+          } @else {
+            <span class="src-row is-vault" [title]="s.label">
+              <span class="src-glyph" aria-hidden="true">📄</span>
+              <span class="src-label">{{ s.label }}</span>
+            </span>
+          }
+        }
+      </div>
+
+      @if (hiddenCount() > 0) {
+        <button
+          type="button"
+          class="src-toggle"
+          (click)="toggle()"
+          [attr.aria-expanded]="expanded()"
+        >
+          @if (expanded()) {
+            Pokaż mniej
+          } @else {
+            Pokaż wszystkie ({{ sources().length }})
+          }
+        </button>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .src-block {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .src-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .src-ico {
+        font-size: 0.85rem;
+        line-height: 1;
+      }
+      .src-title {
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .src-rows {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .src-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        min-width: 0;
+        padding: 4px var(--space-2);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-subtle);
+        background: var(--surface-input);
+        font-size: 0.82rem;
+        text-decoration: none;
+        transition: border-color var(--transition), background var(--transition);
+      }
+      a.src-row.is-web {
+        color: var(--text-secondary);
+      }
+      a.src-row.is-web:hover {
+        border-color: var(--accent-soft);
+        background: var(--accent-soft);
+        color: var(--text-primary);
+      }
+      .src-glyph {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        color: var(--accent);
+        line-height: 1;
+      }
+      .src-domain {
+        flex: 0 0 auto;
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+      .src-label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--text-muted);
+      }
+      .src-extern {
+        flex: 0 0 auto;
+        color: var(--text-muted);
+        font-size: 0.78rem;
+      }
+      .src-row.is-vault {
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+        border-color: transparent;
+      }
+      .src-row.is-vault .src-label {
+        color: var(--accent-hover);
+        flex: 0 1 auto;
+        font-weight: 500;
+      }
+      .src-toggle {
+        align-self: flex-start;
+        padding: 2px var(--space-2);
+        border: none;
+        background: none;
+        color: var(--accent-hover);
+        font-size: 0.78rem;
+        font-weight: 600;
+        cursor: pointer;
+        border-radius: var(--radius-sm);
+      }
+      .src-toggle:hover {
+        text-decoration: underline;
+      }
+    `,
+  ],
+})
+export class AssistantSourcesComponent {
+  /** Number of sources shown before the "Pokaż wszystkie" toggle. */
+  private static readonly PREVIEW = 4;
+
+  /** Raw parsed citations from either surface (vault/web shape). */
+  readonly citations = input<readonly AssistantSource[]>([]);
+
+  /** Deduped + domain-enriched sources (exact URL/label duplicates collapse). */
+  readonly sources = computed<RichSource[]>(() => {
+    const seen = new Set<string>();
+    const out: RichSource[] = [];
+    for (const c of this.citations()) {
+      const url = c.url ?? null;
+      const isWeb = c.kind === "web" && !!url;
+      const domain = isWeb ? this.domainOf(url) : null;
+      // Dedup key: the URL for web hits, the bracketed label for vault.
+      const key = isWeb ? `w:${url}` : `v:${c.label.trim().toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({
+        kind: isWeb ? "web" : "vault",
+        label: c.label.trim(),
+        url: isWeb ? url : null,
+        domain,
+        key,
+      });
+    }
+    return out;
+  });
+
+  private readonly _expanded = signal(false);
+  readonly expanded = this._expanded.asReadonly();
+
+  /** The visible slice — first PREVIEW rows unless expanded. */
+  readonly visible = computed<RichSource[]>(() => {
+    const all = this.sources();
+    return this._expanded()
+      ? all
+      : all.slice(0, AssistantSourcesComponent.PREVIEW);
+  });
+
+  /** How many sources are hidden behind the toggle (0 → no toggle). */
+  readonly hiddenCount = computed(() =>
+    Math.max(0, this.sources().length - AssistantSourcesComponent.PREVIEW),
+  );
+
+  toggle(): void {
+    this._expanded.update((v) => !v);
+  }
+
+  /** Extract a clean hostname ("www." stripped) — null if unparseable. */
+  private domainOf(url: string): string | null {
+    try {
+      return new URL(url).hostname.replace(/^www\./i, "");
+    } catch {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Real feedback: raw markdown (**bold**/[[wikilink]] literal) + a giant 20-source flat list. Now: answer via shared app-markdown (marked→DOMPurify→innerHTML; **XSS RED-before-GREEN + live headless repro**) with [[wikilinks]] as chips; new app-assistant-sources (single header, dedupe, cap-4 + expand, domain extraction, web/vault distinct). Both surfaces. ng lint+build clean (reduced detail CSS); adversarial PASS. No new deps.