### PR TITLE
feat(release): de-flag local models — Bielik/e5/DeBERTa ship by DEFAULT (no cargo features)

### DIFF
--- a/.claude/rules/rust-tauri.md
+++ b/.claude/rules/rust-tauri.md
@@ -124,6 +124,12 @@ at launch ("Rust cannot catch foreign exceptions"). See the header doc in
 
 - Inner dev/verify loop: `cargo test --lib` (the ~128 unit tests live in `src-tauri/src/**`).
   Run it from `src-tauri/` (or `source ~/.cargo/env` first).
+- The on-device brain (mistralrs) + embedder/NER (candle/tokenizers) are now ALWAYS compiled (the
+  feature gates were removed so the real impls ship by default, selected at runtime on model
+  presence). So `cargo test --lib` now DOES compile the heavy ML tree: the FIRST build after a clean
+  checkout (or a deps bump) is slow (hundreds of MB), but the incremental loop stays fast once warm —
+  let a slow first build finish, don't bail. `MISTRALRS_METAL_PRECOMPILE=0` is baked into
+  `src-tauri/.cargo/config.toml [env]` (CLT-only Mac defers Metal-shader compile to first run).
 - Do NOT run `cargo clippy --all-targets` in the iterative loop — it thrashes the
   openssl/sqlcipher build profile and times out. The full gate `scripts/ci.sh` (which DOES run
   clippy `-D warnings` + tests + `ng lint` + `ng build` + headless E2E) is the FINAL check, run

--- a/.claude/skills/release-murmur/SKILL.md
+++ b/.claude/skills/release-murmur/SKILL.md
@@ -136,9 +136,15 @@ pkill -f 'tauri dev' ; pkill -x Murmur ; pkill -f 'target/debug/Murmur' || true
 
 ## Stage 7 — Universal build
 
+The full product IS the default build — the local-model cargo features were removed, so the
+on-device brain (mistralrs) + embedder/NER (candle) are always compiled and activate at runtime on
+model-presence. NO `--features` flag. `MISTRALRS_METAL_PRECOMPILE=0` is baked into
+`src-tauri/.cargo/config.toml [env]` (CLT-only Mac → defer Metal-shader compile to first run); keep
+it on the command line too as a guard.
+
 ```bash
 source "$HOME/.cargo/env"
-npx tauri build --target universal-apple-darwin --bundles app
+MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app
 APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/Murmur.app"
 lipo -archs "$APP/Contents/MacOS/Murmur"     # MUST print: x86_64 arm64
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The four rule files below are **imported into context automatically** via the `@
 
 ## What Murmur is
 
-A **local-first macOS desktop app** that records meetings, transcribes on-device, turns the transcript into a clean note via a pluggable LLM provider, and lives inside the user's **Obsidian vault**. Currently shipped at **v0.3.0**.
+A **local-first macOS desktop app** that records meetings, transcribes on-device, turns the transcript into a clean note via a pluggable LLM provider, and lives inside the user's **Obsidian vault**. Currently shipped at **v0.7.0**.
 
 - **Stack:** Tauri 2.11 (Rust crate `murmur`, lib `meetnotes_lib`, bin `Murmur`) + Angular 18 **zoneless** (standalone, signals). IPC = Tauri commands (registered in `src-tauri/src/lib.rs` `generate_handler!`) + events. The FE talks to the backend through `src/app/core/ipc.service.ts` — **there is no NgRx**.
 - **Pipeline:** capture (mic via `cpal` + system audio via a Swift **ScreenCaptureKit** sidecar) → **dual-stream** (transcribed separately, merged by wall-clock → `Me`/`Others`) → **whisper.cpp** (`whisper-rs`, Metal; default model **large-v3**) → segments → **SQLite (canonical source of truth, SQLCipher-encrypted)** → `SummarizerProvider` → note markdown → atomic **Obsidian `.md`** export.
@@ -32,12 +32,18 @@ A **local-first macOS desktop app** that records meetings, transcribes on-device
 
 ```bash
 # Dev (the MURMUR_DEV_DEK hatch avoids per-rebuild Keychain re-prompts; see .claude/skills/tauri-dev)
+# No --features needed: the on-device brain/embedder/NER are ALWAYS compiled and activate at runtime
+# on model-presence. `MISTRALRS_METAL_PRECOMPILE=0` is baked into src-tauri/.cargo/config.toml [env]
+# (this Mac has only the Command Line Tools, not full Xcode → defer Metal-shader compile to first run),
+# so `npm run dev` just works.
 source ~/.cargo/env
 MURMUR_DEV_DEK=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef npm run dev
 #   → ng on http://localhost:1420, MCP on 127.0.0.1:8765
 
 # Quality gates
 ( cd src-tauri && cargo test --lib )   # the test loop — NEVER `cargo clippy --all-targets` (openssl/sqlcipher profile thrash)
+#   NOTE: the heavy mistralrs/candle ML tree is now ALWAYS compiled (no feature gate), so a COLD
+#   first build is slow (hundreds of MB of ML deps); the incremental loop stays fast once warm.
 npx ng lint
 npx ng build
 bash scripts/ci.sh                      # full: clippy -D warnings + tests + lint + build + headless E2E

--- a/docs/V070-RELEASE-HANDOFF.md
+++ b/docs/V070-RELEASE-HANDOFF.md
@@ -27,14 +27,17 @@ Every change shipped via build → adversarial-verify → (lock-security-review 
 
 ---
 
-## ⚠️ THE BUILD DECISION (same as 0.6.0)
+## THE BUILD (no feature decision — the full product IS the default build)
 
-Local models are opt-in cargo features (`local-brain`, `local-embed`, `local-ner`). For the full product you built, use **Option C**:
+The local-model cargo features were REMOVED: mistralrs (brain) + candle/tokenizers (embedder + NER)
+are now ALWAYS compiled and the real impls activate at runtime on model-presence. So the full product
+is just the plain default build — no `--features` needed. `MISTRALRS_METAL_PRECOMPILE=0` is baked into
+`src-tauri/.cargo/config.toml [env]`, but keep it on the command line too as a belt-and-braces guard
+(this Mac has only the Command Line Tools, not full Xcode → defer Metal-shader compile to first run):
 
 ```bash
-MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app -- --features local-brain,local-embed,local-ner
+MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app
 ```
-(Option B = `--features local-embed,local-ner` — semantic + NER + Claude brain, no Xcode/metal step. Option A = default, Claude-only.)
 
 ## Release steps (your Mac — sign/notarize/publish need your auth)
 
@@ -42,8 +45,8 @@ MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --b
 # clean tree on murmur @ 0.7.0:
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 pkill -x Murmur ; pkill -f 'tauri dev' || true            # free the cargo target lock
-# build (Option C example):
-MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app -- --features local-brain,local-embed,local-ner
+# build (full product = the default build; no --features):
+MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --bundles app
 # sign INSIDE-OUT by identity HASH — FOUR bundled helpers (3 audio + meetnotes-calendar):
 bash scripts/macos-sign-notarize.sh        # signs each nested helper FIRST, then the .app (NO --deep), then the DMG
 # notarize + staple + verify + publish (notarytool keychain profile "murmur"):

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -8,6 +8,12 @@ source "$HOME/.cargo/env" 2>/dev/null || true
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
+# mistralrs/metal is ALWAYS compiled (the local brain ships by default). Its build script precompiles
+# Metal shaders via `xcrun metal`, which needs the FULL Xcode toolchain — this machine has only the
+# Command Line Tools, so we defer shader compile to first runtime use. Without this the cargo steps
+# below fail at link time. Safe to always set (it only changes WHEN shaders compile, not whether).
+export MISTRALRS_METAL_PRECOMPILE=0
+
 echo "── swiftc: system-audio sidecar typecheck ──"
 if command -v swiftc >/dev/null 2>&1; then
   swiftc -typecheck src-tauri/sysaudio/sysaudio.swift \

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -3,3 +3,8 @@
 # (tauri.conf.json minimumSystemVersion = 13.4) instead of emitting a linker-version mismatch.
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.4"
+# mistralrs/metal (the on-device brain, ALWAYS compiled) precompiles Metal shaders via `xcrun metal`,
+# which needs the FULL Xcode toolchain. On a Command-Line-Tools-only Mac that step fails, so we defer
+# shader compile to first runtime use. Set here (not force) so every cargo invocation — `npm run dev`,
+# `cargo test --lib`, `tauri build` — gets it automatically; an explicit env override still wins.
+MISTRALRS_METAL_PRECOMPILE = "0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,14 +45,15 @@ async-trait = "0.1"
 # bundled-sqlcipher-vendored-openssl: whole-DB at-rest encryption, no system OpenSSL dependency
 # (universal-capable). Fallback if the universal build breaks: "bundled-sqlcipher".
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
-# ── Local reasoning brain (Phase B — OPTIONAL: compiled ONLY under `--features local-brain`) ──
+# ── Local reasoning brain (always compiled; the real impl activates at runtime when the model is present) ──
 # In-process GGUF inference (Metal). A build-proof PROVED this links cleanly alongside whisper.cpp +
-# sherpa's static onnxruntime + bundled SQLCipher (zero ORT/ggml/openssl conflict). It is `optional`
-# so the DEFAULT build (and the fast `cargo test --lib` loop) NEVER compiles the heavy mistralrs tree;
-# `reason::active_reasoner` returns the dependency-free `StubReasoner` unless this feature is on AND a
-# GGUF model is present. The `metal` feature precompiles shaders via xcrun (needs full Xcode, or env
-# `MISTRALRS_METAL_PRECOMPILE=0` to defer). NOT wired into any pipeline path yet (Phase B step 3).
-mistralrs = { version = "0.8.1", features = ["metal"], optional = true }
+# sherpa's static onnxruntime + bundled SQLCipher (zero ORT/ggml/openssl conflict). Always compiled:
+# `reason::active_reasoner` (BrainBackend::Local) returns the real `MistralReasoner` when a GGUF model
+# is present on disk, else gracefully degrades to the dependency-free `StubReasoner` (model presence is
+# the ONLY switch — no cargo feature). The `metal` feature precompiles shaders via xcrun (needs full
+# Xcode, or env `MISTRALRS_METAL_PRECOMPILE=0` to defer shader compile to first run — REQUIRED on a
+# Mac with only the Command Line Tools).
+mistralrs = { version = "0.8.1", features = ["metal"] }
 
 # ── Vector retrieval (Phase 2a) ──
 # sqlite-vec `vec0` virtual table for on-device KNN, registered into the SAME bundled SQLCipher
@@ -62,18 +63,20 @@ mistralrs = { version = "0.8.1", features = ["metal"], optional = true }
 # model is a deliberate later swap (the `Embedder` seam ships with a deterministic StubEmbedder).
 sqlite-vec = "0.1.9"
 
-# ── Local embedding model (Phase C — OPTIONAL: compiled ONLY under `--features local-embed`) ──
+# ── Local embedding model + NER (always compiled; the real impls activate at runtime when the model is present) ──
 # In-process BERT embedding (candle-transformers, Metal) for the REAL multilingual-e5-small encoder
-# behind `embed::active_embedder`. A build-proof PROVED candle 0.10.2 (BERT) links cleanly in-process
-# with ZERO second onnxruntime — it SHARES candle with the `local-brain` graph, and sherpa stays the
-# only ORT. `optional` so the DEFAULT build (and the fast `cargo test --lib` loop) NEVER compiles
-# candle; `embed::active_embedder` returns the dependency-free `StubEmbedder` unless this feature is
-# on AND the e5 model dir is present. The `metal`/`accelerate` features mirror the candle already in
-# the brain graph. Build: `cargo build --features local-embed`.
-candle-core = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
-candle-nn = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
-candle-transformers = { version = "0.10.2", features = ["metal", "accelerate"], optional = true }
-tokenizers = { version = "0.21", optional = true }
+# behind `embed::active_embedder`, AND the mDeBERTa-v3 PERSON-name NER behind
+# `summarize::redact::active_name_redactor`. A build-proof PROVED candle 0.10.2 links cleanly
+# in-process with ZERO second onnxruntime — it SHARES candle with the mistralrs brain graph, and
+# sherpa stays the only ORT. Always compiled: `embed::active_embedder` returns the real
+# `CandleBertEmbedder` when the e5 model dir is present on disk, else the dependency-free
+# `StubEmbedder`; likewise `active_name_redactor` returns the real `DebertaNameRedactor` when the NER
+# model dir is present, else the byte-identical `NoopNameRedactor` (model presence is the ONLY switch —
+# no cargo feature). The `metal`/`accelerate` features mirror the candle in the brain graph.
+candle-core = { version = "0.10.2", features = ["metal", "accelerate"] }
+candle-nn = { version = "0.10.2", features = ["metal", "accelerate"] }
+candle-transformers = { version = "0.10.2", features = ["metal", "accelerate"] }
+tokenizers = { version = "0.21" }
 
 # ── Serde ──
 serde = { version = "1", features = ["derive"] }
@@ -136,25 +139,9 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 security-framework-sys = { version = "2.17", features = ["OSX_10_15"] }
 
 [features]
-# default keeps Metal on for whisper; nothing else conditional in P0
+# default keeps Metal on for whisper; nothing else conditional. The on-device brain (mistralrs),
+# embedder + NER (candle/tokenizers) are ALWAYS compiled — the real impls activate at runtime on
+# model-presence (see `reason::active_reasoner`, `embed::active_embedder`,
+# `summarize::redact::active_name_redactor`), so there is no longer a cargo feature to flip; a fresh
+# install with no downloaded model still boots and runs on the stub/no-op floor.
 default = []
-# Phase B — the REAL on-device reasoning brain (MistralReasoner, `reason/mistral.rs`). OFF by default
-# so the fast `cargo test --lib` loop never compiles the heavy mistralrs tree. With it ON *and* a GGUF
-# present at the resolved path, `reason::active_reasoner` returns the real MistralReasoner; otherwise it
-# gracefully degrades to the StubReasoner. Build: `MISTRALRS_METAL_PRECOMPILE=0 cargo build --features local-brain`.
-local-brain = ["dep:mistralrs"]
-# Phase C — the REAL on-device embedding model (CandleBertEmbedder, `embed/candle_bert.rs`). OFF by
-# default so the fast `cargo test --lib` loop never compiles candle. With it ON *and* the e5 model dir
-# present at the resolved path, `embed::active_embedder` returns the real CandleBertEmbedder; otherwise
-# it gracefully degrades to the StubEmbedder. Target model = multilingual-e5-small (384-dim ⇒ EMBED_DIM
-# is unchanged, ZERO vec0 schema migration). Build: `cargo build --features local-embed`.
-local-embed = ["dep:candle-transformers", "dep:candle-core", "dep:candle-nn", "dep:tokenizers"]
-# Phase D — the REAL on-device name-redaction NER (DebertaNameRedactor, `summarize/ner_deberta.rs`).
-# OFF by default so the fast `cargo test --lib` loop never compiles candle. REUSES the SAME optional
-# candle/tokenizers deps `local-embed` added (candle-transformers 0.10.2 ships a built-in
-# `models::debertav2::DebertaV2NERModel` that links with ZERO second onnxruntime — sherpa stays the
-# only ORT). With it ON *and* the NER model dir present, `summarize::redact::active_name_redactor`
-# returns the real DebertaNameRedactor (PERSON spans → ⟪NAME_n⟫ tokens before cloud egress);
-# otherwise it gracefully degrades to the byte-identical NoopNameRedactor. Build:
-# `cargo build --features local-ner --lib`.
-local-ner = ["dep:candle-transformers", "dep:candle-core", "dep:candle-nn", "dep:tokenizers"]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2259,8 +2259,8 @@ pub async fn download_model(state: State<'_, AppState>) -> Result<String, AppErr
 
 /// Whether a usable on-device brain (reasoning GGUF) is present at the resolved path — the
 /// configured custom `brain_model_path`, else the selected `brain_model_id`'s file in the shared
-/// models dir. Lets the UI offer a download. Independent of the `local-brain` feature: this only
-/// checks the file on disk.
+/// models dir. Lets the UI offer a download. Purely a file-on-disk check (mistralrs is always
+/// compiled; the real brain activates on model presence).
 #[tauri::command]
 pub fn brain_model_present(state: State<'_, AppState>) -> Result<bool, AppError> {
     let (configured, selected) = {
@@ -2393,8 +2393,8 @@ pub async fn download_brain_model(
 }
 
 /// `true` when all three multilingual-e5-small files are present in the shared models dir's embed
-/// sub-dir — i.e. the REAL embedder (under `--features local-embed`) would load. Cheap existence
-/// probe; NEVER errors on a missing models dir (treats it as "not present").
+/// sub-dir — i.e. the REAL embedder would load (candle is always compiled; it activates on model
+/// presence). Cheap existence probe; NEVER errors on a missing models dir (treats it as "not present").
 #[tauri::command]
 pub fn embed_model_present() -> Result<bool, AppError> {
     Ok(crate::embed::embed_model_present())
@@ -2403,7 +2403,7 @@ pub fn embed_model_present() -> Result<bool, AppError> {
 /// Download the multilingual-e5-small model (3 HF files) into the shared models dir, INBOUND-ONLY,
 /// emitting [`crate::events::EVENT_EMBED_DOWNLOAD`] progress (throttled per file). Sends NO meeting
 /// content (no egress). The downloaded model is NOT loaded here — it is picked up lazily by
-/// `embed::active_embedder` on the next embed (feature-gated by `local-embed`). Returns the model dir.
+/// `embed::active_embedder` on the next embed (selected on model presence). Returns the model dir.
 #[tauri::command]
 pub async fn download_embed_model(app: AppHandle) -> Result<String, AppError> {
     let file_count = crate::embed::EMBED_MODEL_FILES.len();
@@ -2563,8 +2563,9 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
 }
 
 /// True iff the on-device PERSON-name NER model (Phase D) is present on disk. Pure existence probe;
-/// NEVER errors on a missing models dir (treats it as "not present"). When false (or the `local-ner`
-/// feature is off), the redaction firewall uses the byte-identical NoopNameRedactor.
+/// NEVER errors on a missing models dir (treats it as "not present"). When false, the redaction
+/// firewall uses the byte-identical NoopNameRedactor (candle NER is always compiled; it activates on
+/// model presence).
 #[tauri::command]
 pub fn ner_model_present() -> Result<bool, AppError> {
     Ok(crate::summarize::redact::ner_model_present())
@@ -2573,8 +2574,8 @@ pub fn ner_model_present() -> Result<bool, AppError> {
 /// Download the multilingual mDeBERTa-v3 NER model (3 HF files) into the shared models dir,
 /// INBOUND-ONLY, emitting [`crate::events::EVENT_NER_DOWNLOAD`] progress (throttled per file). Sends
 /// NO meeting content (no egress). The downloaded model is NOT loaded here — it is picked up lazily by
-/// `summarize::redact::active_name_redactor` on the next cloud summarization (feature-gated by
-/// `local-ner`). Returns the model dir.
+/// `summarize::redact::active_name_redactor` on the next cloud summarization (selected on model
+/// presence). Returns the model dir.
 #[tauri::command]
 pub async fn download_ner_model(app: AppHandle) -> Result<String, AppError> {
     let file_count = crate::summarize::redact::NER_MODEL_FILES.len();

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -1,9 +1,11 @@
 //! Embedding seam + pure retrieval helpers for the Phase 2a vector layer.
 //!
-//! Everything here is RUNTIME-AGNOSTIC and dependency-light: the real embedding model (BGE-M3,
-//! bundled, multilingual incl. Polish) is a deliberate LATER swap. Until it lands, [`StubEmbedder`]
-//! — a deterministic hash-bag embedder — backs the [`Embedder`] trait so the whole index/search/
-//! fusion pipeline is exercisable headless (`cargo test --lib`) with byte-stable vectors.
+//! Everything here is RUNTIME-AGNOSTIC and dependency-light: the real embedding model
+//! (multilingual-e5-small, 384-dim, multilingual incl. Polish — downloaded on first use, NOT bundled)
+//! is selected at runtime by [`active_embedder`] when its model dir is present. Until the model is
+//! downloaded, [`StubEmbedder`] — a deterministic hash-bag embedder — backs the [`Embedder`] trait so
+//! the whole index/search/fusion pipeline is exercisable headless (`cargo test --lib`) with
+//! byte-stable vectors.
 //!
 //! The DB-side wiring (the `vec0` virtual table, indexing, the GATED semantic search, purge-on-
 //! lock) lives in `storage/db.rs` because it needs `Db`'s private connection. This module holds
@@ -17,14 +19,14 @@ use crate::error::Result;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// The REAL on-device embedder (Phase C), compiled ONLY under `--features local-embed`. The default
-/// build never pulls candle, keeping the fast `cargo test --lib` loop intact.
-#[cfg(feature = "local-embed")]
+/// The REAL on-device embedder (multilingual-e5-small via candle). ALWAYS compiled; the real impl is
+/// selected at runtime by [`active_embedder`] when the e5 model dir is present, else the stub.
 pub mod candle_bert;
 
 /// Embedding dimensionality of the vector layer. The `vec0` column is declared `float[EMBED_DIM]`,
-/// so this MUST match the real model's output width when it lands (BGE-M3 = 1024; the stub uses a
-/// smaller 384 so test vectors stay cheap). Changing it is a schema change (new `vec0` table).
+/// so this MUST match the real model's output width. multilingual-e5-small = 384, and the stub also
+/// emits 384, so the real model swaps in with ZERO vec0 schema migration. Changing it is a schema
+/// change (new `vec0` table).
 pub const EMBED_DIM: usize = 384;
 
 /// Target character size for one note chunk (paragraphs are merged up to roughly this width).
@@ -35,8 +37,8 @@ const CHUNK_CHAR_TARGET: usize = 800;
 pub const RRF_K: f64 = 60.0;
 
 /// The swappable embedding backend. Pure + synchronous: `embed` maps a batch of texts to a batch
-/// of `dim()`-length vectors. The real model implements this over BGE-M3; tests + the current
-/// default use [`StubEmbedder`].
+/// of `dim()`-length vectors. The real model implements this over multilingual-e5-small; tests +
+/// the no-model floor use [`StubEmbedder`].
 pub trait Embedder {
     /// Output vector width. MUST equal [`EMBED_DIM`] for vectors destined for the `vec0` table.
     fn dim(&self) -> usize;
@@ -127,12 +129,12 @@ impl Embedder for StubEmbedder {
 /// the model a swappable seam.
 ///
 /// Graceful degradation (mirrors [`crate::reason::active_reasoner`]), in priority order:
-/// - the `local-embed` feature is ON **and** the e5 model dir is present at [`embed_model_dir`]
-///   ([`embed_model_present`]) → the real [`candle_bert::CandleBertEmbedder`] (lazy: the model loads
-///   on first `embed`, not here, so this never blocks startup and never panics);
-/// - otherwise (feature off, no model, or a construction error) → the dependency-free
-///   [`StubEmbedder`]. The app works either way; semantic, WHEN enabled, just uses real vectors once
-///   the model is present.
+/// - the e5 model dir is present at [`embed_model_dir`] ([`embed_model_present`]) → the real
+///   [`candle_bert::CandleBertEmbedder`] (lazy: the model loads on first `embed`, not here, so this
+///   never blocks startup and never panics);
+/// - otherwise (no model, or a construction error) → the dependency-free [`StubEmbedder`]. The app
+///   works either way; semantic, WHEN enabled, just uses real vectors once the model is present.
+///   Selection keys ONLY on model presence — the candle backend is always compiled (no cargo feature).
 ///
 /// NEVER panics and NEVER blocks. Target model = multilingual-e5-small (384-dim), so the real model's
 /// width EQUALS [`EMBED_DIM`] — ZERO `vec_chunks` schema migration. (A future model whose dimension
@@ -142,21 +144,18 @@ impl Embedder for StubEmbedder {
 /// so callers build one per operation. NEVER invoked when `semantic_search_enabled` is off (the gate
 /// short-circuits before this is called) — building the real embedder does NOT flip that flag.
 pub fn active_embedder() -> Box<dyn Embedder> {
-    #[cfg(feature = "local-embed")]
-    {
-        if embed_model_present() {
-            match embed_model_dir().and_then(candle_bert::CandleBertEmbedder::new) {
-                Ok(e) => {
-                    tracing::info!(target: "embed", "local embed model ready (lazy load)");
-                    return Box::new(e);
-                }
-                Err(e) => {
-                    tracing::warn!(target: "embed", error = %e, "local embed init failed; using stub embedder");
-                }
+    if embed_model_present() {
+        match embed_model_dir().and_then(candle_bert::CandleBertEmbedder::new) {
+            Ok(e) => {
+                tracing::info!(target: "embed", "local embed model ready (lazy load)");
+                return Box::new(e);
             }
-        } else {
-            tracing::info!(target: "embed", "no local embed model present; using stub embedder");
+            Err(e) => {
+                tracing::warn!(target: "embed", error = %e, "local embed init failed; using stub embedder");
+            }
         }
+    } else {
+        tracing::info!(target: "embed", "no local embed model present; using stub embedder");
     }
     Box::new(StubEmbedder)
 }
@@ -436,14 +435,14 @@ mod tests {
     }
 
     /// The embedder factory's graceful-degradation contract: with NO e5 model dir present,
-    /// `active_embedder` returns the deterministic StubEmbedder (dim == EMBED_DIM, byte-stable). With
-    /// the `local-embed` feature OFF this is unconditional; with it ON it still holds whenever the
-    /// model dir is absent. Headless proof of the swap wiring's fallback (mirrors
+    /// `active_embedder` returns the deterministic StubEmbedder (dim == EMBED_DIM, byte-stable). The
+    /// candle backend is always compiled now, so selection keys ONLY on model presence — absent model
+    /// ⇒ stub. Headless proof of the swap wiring's fallback (mirrors
     /// `active_reasoner_falls_back_to_stub_without_model`).
     #[test]
     fn active_embedder_falls_back_to_stub_without_model() {
         // Only meaningful as a fallback assertion when no real model is installed; on a clean
-        // machine/CI the e5 dir is absent, so a feature-on build also yields the stub.
+        // machine/CI the e5 dir is absent, so the always-compiled candle backend still yields the stub.
         if !embed_model_present() {
             let e = active_embedder();
             assert_eq!(e.dim(), EMBED_DIM);

--- a/src-tauri/src/embed/candle_bert.rs
+++ b/src-tauri/src/embed/candle_bert.rs
@@ -1,6 +1,6 @@
 //! Real on-device embedding model (Phase C) — an [`Embedder`] backed by candle-transformers 0.10.2
-//! BERT inference (Metal). Compiled ONLY under `--features local-embed`; the default build ships the
-//! dependency-free `StubEmbedder` instead.
+//! BERT inference (Metal). ALWAYS compiled; [`crate::embed::active_embedder`] selects it at runtime
+//! when the multilingual-e5-small model dir is present, else ships the dependency-free `StubEmbedder`.
 //!
 //! ## Honest scope (READ THIS)
 //!
@@ -13,9 +13,9 @@
 //! - **Polish** recall;
 //! - **Metal** performance + correctness (load time, throughput, the Metal-vs-CPU fallback).
 //!
-//! `cargo test --lib` NEVER runs a forward pass here. Treat a green `--features local-embed` build as
-//! proof the impl typechecks/links against candle 0.10.2 — NOT as proof embedding works. The real
-//! quality/Metal/Polish-recall bake-off is @Mac.
+//! `cargo test --lib` NEVER runs a forward pass here (the smoke test is `#[ignore]`d). Treat a green
+//! build as proof the impl typechecks/links against candle 0.10.2 — NOT as proof embedding works. The
+//! real quality/Metal/Polish-recall bake-off is @Mac.
 //!
 //! ## Graceful + crash-safe
 //!
@@ -242,15 +242,15 @@ fn l2_normalize(x: &Tensor) -> candle_core::Result<Tensor> {
 /// on disk + Metal), so it never runs in the normal `cargo test` loop. Run:
 ///
 /// ```text
-/// cargo test --features local-embed embed::candle_bert::smoke -- --ignored --nocapture
+/// cargo test embed::candle_bert::smoke -- --ignored --nocapture
 /// ```
-#[cfg(all(test, feature = "local-embed"))]
+#[cfg(test)]
 mod smoke {
     use super::CandleBertEmbedder;
     use crate::embed::{embed_model_dir, Embedder, EMBED_DIM};
 
     #[test]
-    #[ignore = "needs the e5 model on disk + Metal; run manually with --features local-embed"]
+    #[ignore = "needs the e5 model on disk + Metal; run manually on a Mac"]
     fn e5_loads_and_embeds() {
         let dir = embed_model_dir().expect("embed_model_dir");
         assert!(

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -21,9 +21,8 @@ use crate::error::{AppError, Result};
 use crate::settings::{AppConfig, BrainBackend};
 use crate::summarize::provider::SummarizerProvider;
 
-/// The REAL on-device reasoner (Phase B), compiled ONLY under `--features local-brain`. The default
-/// build never pulls mistralrs, keeping the fast `cargo test --lib` loop intact.
-#[cfg(feature = "local-brain")]
+/// The REAL on-device reasoner (mistral.rs / GGUF). ALWAYS compiled; the real impl is selected at
+/// runtime by [`local_reasoner`] when a GGUF resolves on disk, else the dependency-free stub.
 pub mod mistral;
 
 /// A curated, mistral.rs-arch-SAFE on-device reasoning model the user can pick from. The app must
@@ -240,11 +239,11 @@ where
 /// The single active reasoning backend, used wherever the app needs local on-device reasoning.
 ///
 /// Graceful degradation, in priority order:
-/// - the `local-brain` feature is ON **and** a GGUF is present at the resolved [`resolve_brain_model`]
-///   → the real [`mistral::MistralReasoner`] (lazy: the model loads on first use, not here, so this
-///   never blocks startup and never panics);
-/// - otherwise (feature off, no model, or a path-resolution error) → the dependency-free
-///   [`StubReasoner`]. The app works either way — just less smart without the model.
+/// - a GGUF is present at the resolved [`resolve_brain_model`] → the real
+///   [`mistral::MistralReasoner`] (lazy: the model loads on first use, not here, so this never blocks
+///   startup and never panics);
+/// - otherwise (no model, or a path-resolution error) → the dependency-free [`StubReasoner`]. The app
+///   works either way — just less smart without the model.
 ///
 /// NEVER panics and NEVER blocks: a missing/failed model is logged (no PII) and falls back to stub.
 ///
@@ -252,8 +251,8 @@ where
 /// - **`Cloud`** → [`CloudReasoner`] — the cloud LLM via the SAME `make_provider` egress envelope
 ///   as the note summary. Construction is cheap + infallible; the consent gate fires at CALL time
 ///   (a no-consent / no-CLI / offline failure degrades to the deterministic floor in `orchestrate.rs`).
-/// - **`Local`** → the real `MistralReasoner` when the `local-brain` feature is on AND a GGUF is
-///   present ([`local_reasoner`]), else the dependency-free `StubReasoner`.
+/// - **`Local`** → the real `MistralReasoner` when a GGUF is present on disk ([`local_reasoner`]),
+///   else the dependency-free `StubReasoner`.
 /// - **`Off`** → `StubReasoner` (the deterministic floor).
 pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
     match config.brain_backend {
@@ -271,35 +270,28 @@ pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
     }
 }
 
-/// Resolve the LOCAL on-device reasoner: the real [`mistral::MistralReasoner`] when the
-/// `local-brain` feature is compiled in AND a GGUF resolves on disk (lazy load — never blocks or
-/// panics at startup), otherwise the dependency-free [`StubReasoner`]. Used only for
-/// [`BrainBackend::Local`]; the default build (feature off) always yields the stub.
+/// Resolve the LOCAL on-device reasoner: the real [`mistral::MistralReasoner`] when a GGUF resolves
+/// on disk (lazy load — never blocks or panics at startup), otherwise the dependency-free
+/// [`StubReasoner`]. Used only for [`BrainBackend::Local`]; with no model present it always yields
+/// the stub (selection keys ONLY on model presence — mistralrs is always compiled).
 fn local_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
-    #[cfg(feature = "local-brain")]
-    {
-        let configured = config.brain_model_path.as_deref().map(Path::new);
-        match resolve_brain_model(configured, config.brain_model_id.as_deref()) {
-            Ok(Some(path)) => match mistral::MistralReasoner::new(path) {
-                Ok(r) => {
-                    tracing::info!(target: "reason", id = r.id(), "local brain ready (lazy model load)");
-                    return Box::new(r);
-                }
-                Err(e) => {
-                    tracing::warn!(target: "reason", error = %e, "local brain init failed; using stub reasoner");
-                }
-            },
-            Ok(None) => {
-                tracing::info!(target: "reason", "no local brain model present; using stub reasoner");
+    let configured = config.brain_model_path.as_deref().map(Path::new);
+    match resolve_brain_model(configured, config.brain_model_id.as_deref()) {
+        Ok(Some(path)) => match mistral::MistralReasoner::new(path) {
+            Ok(r) => {
+                tracing::info!(target: "reason", id = r.id(), "local brain ready (lazy model load)");
+                return Box::new(r);
             }
             Err(e) => {
-                tracing::warn!(target: "reason", error = %e, "local brain path resolution failed; using stub reasoner");
+                tracing::warn!(target: "reason", error = %e, "local brain init failed; using stub reasoner");
             }
+        },
+        Ok(None) => {
+            tracing::info!(target: "reason", "no local brain model present; using stub reasoner");
         }
-    }
-    #[cfg(not(feature = "local-brain"))]
-    {
-        let _ = config; // model path is only consulted when the feature is compiled in.
+        Err(e) => {
+            tracing::warn!(target: "reason", error = %e, "local brain path resolution failed; using stub reasoner");
+        }
     }
     Box::new(StubReasoner)
 }
@@ -740,14 +732,14 @@ mod tests {
 
     /// The LOCAL backend's graceful-degradation contract: with NO usable model (a configured path
     /// that doesn't exist, and — on a clean machine — no default model) `active_reasoner` returns the
-    /// StubReasoner. With the `local-brain` feature OFF this is unconditional; with it ON it still
-    /// holds as long as no GGUF is present. (`brain_backend` is pinned to `Local` here — the default
-    /// is now `Cloud`.) This is the headless proof of the swap wiring's fallback.
+    /// StubReasoner. mistralrs is always compiled now, so selection keys ONLY on model presence —
+    /// no GGUF ⇒ stub. (`brain_backend` is pinned to `Local` here — the default is now `Cloud`.) This
+    /// is the headless proof of the swap wiring's fallback.
     #[test]
     fn active_reasoner_falls_back_to_stub_without_model() {
         // No custom path (a non-existent one) AND no selected brain_model_id ⇒ nothing resolves, so
-        // even a feature-on build returns the stub. With no selection there is no registry file to
-        // probe, so this holds regardless of what GGUFs happen to live in the shared models dir.
+        // the always-compiled mistralrs backend returns the stub. With no selection there is no
+        // registry file to probe, so this holds regardless of what GGUFs live in the shared models dir.
         let cfg = AppConfig {
             brain_backend: BrainBackend::Local,
             brain_model_path: Some(
@@ -909,8 +901,7 @@ mod tests {
     #[test]
     fn active_reasoner_local_backend_without_model_yields_stub() {
         // Local backend with a configured path that does not exist AND no selected model id ⇒
-        // nothing resolves, so even a `local-brain` build returns the stub (and the default build
-        // unconditionally does).
+        // nothing resolves, so the always-compiled mistralrs backend returns the stub.
         let cfg = AppConfig {
             brain_backend: BrainBackend::Local,
             brain_model_path: Some(

--- a/src-tauri/src/reason/mistral.rs
+++ b/src-tauri/src/reason/mistral.rs
@@ -1,6 +1,7 @@
 //! Real on-device reasoning brain (Phase B) — a [`LocalReasoner`] backed by mistralrs 0.8.1 GGUF
-//! inference (Metal). Compiled ONLY under `--features local-brain`; the default build ships the
-//! dependency-free `StubReasoner` instead.
+//! inference (Metal). ALWAYS compiled; [`crate::reason::active_reasoner`] (BrainBackend::Local)
+//! selects it at runtime when a GGUF is present on disk, else ships the dependency-free
+//! `StubReasoner` instead.
 //!
 //! ## Honest scope (READ THIS)
 //!
@@ -12,8 +13,8 @@
 //! - Polish-language quality;
 //! - Metal performance (load time, tokens/sec, memory).
 //!
-//! `cargo test --lib` NEVER runs a forward pass here. Treat a green `--features local-brain` build as
-//! proof the impl typechecks/links against mistralrs 0.8.1 — NOT as proof inference works.
+//! `cargo test --lib` NEVER runs a forward pass here. Treat a green build as proof the impl
+//! typechecks/links against mistralrs 0.8.1 — NOT as proof inference works.
 //!
 //! ## Graceful + crash-safe
 //!

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -10,8 +10,8 @@ use crate::storage::Db;
 ///   ([`crate::reason::CloudReasoner`]) reasons via the SAME `make_provider` factory the note
 ///   summary uses, so the egress posture is IDENTICAL (RedactingProvider + fail-closed
 ///   `cloud_egress_consented` gate). No local model required.
-/// - **`Local`**: the on-device GGUF (`MistralReasoner`, e.g. Bielik) when the `local-brain`
-///   feature is compiled in AND the selected model file is present; otherwise the `StubReasoner`.
+/// - **`Local`**: the on-device GGUF (`MistralReasoner`, e.g. Bielik) when the selected model file
+///   is present on disk (mistralrs is always compiled); otherwise the `StubReasoner`.
 /// - **`Off`**: the dependency-free `StubReasoner` (the deterministic floor — zero brain).
 ///
 /// `#[serde(default)]` on the field ⇒ a config persisted before this field existed loads as
@@ -144,16 +144,16 @@ pub struct AppConfig {
     pub semantic_search_enabled: bool,
     /// Phase B — optional explicit path to a local reasoning GGUF for the on-device brain
     /// (`MistralReasoner`). `None` (the default) means the resolver falls back to the default model
-    /// filename inside the shared models dir. Consulted ONLY when the `local-brain` feature is
-    /// compiled in; the default build never loads it. `#[serde(default)]` ⇒ a config persisted before
-    /// this field existed loads as `None`.
+    /// filename inside the shared models dir. Consulted at runtime when `brain_backend == Local`;
+    /// with no model on disk the resolver falls back to the stub. `#[serde(default)]` ⇒ a config
+    /// persisted before this field existed loads as `None`.
     #[serde(default)]
     pub brain_model_path: Option<String>,
     /// Phase B (model registry) — the SELECTED on-device brain model id (from `reason::BRAIN_MODELS`,
     /// e.g. `bielik-11b-v3` / `qwen3-14b` / `qwen2.5-3b`). `None` (the default) means no model is
     /// chosen ⇒ the resolver falls back to the `StubReasoner`. Set via the `select_brain_model`
-    /// command. Consulted only when the `local-brain` feature is compiled in. `#[serde(default)]` ⇒
-    /// a config persisted before this field existed loads as `None`.
+    /// command. Consulted at runtime when `brain_backend == Local`. `#[serde(default)]` ⇒ a config
+    /// persisted before this field existed loads as `None`.
     #[serde(default)]
     pub brain_model_id: Option<String>,
     /// Which reasoning backend powers the brain pre-analysis (Flow A). Default `Cloud` — the

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -110,10 +110,9 @@ pub struct AppState {
     /// In-memory cache of the settings table.
     pub config: Mutex<AppConfig>,
     /// The active on-device reasoning backend (Phase B). Resolved ONCE at startup by
-    /// [`crate::reason::active_reasoner`]: the real `MistralReasoner` when the `local-brain` feature
-    /// is on AND a GGUF is present, else the dependency-free `StubReasoner`. The trait is `Send +
-    /// Sync` and all methods take `&self`, so no `Mutex` is needed. NOT yet called from any pipeline
-    /// path (wired but inert until Phase B step 3 / orchestrate.rs).
+    /// [`crate::reason::active_reasoner`]: the real `MistralReasoner` when a GGUF is present on disk
+    /// (mistralrs is always compiled), else the dependency-free `StubReasoner`. The trait is `Send +
+    /// Sync` and all methods take `&self`, so no `Mutex` is needed.
     pub reasoner: Box<dyn crate::reason::LocalReasoner>,
     pub current_meeting: Mutex<Option<uuid::Uuid>>,
     /// Folder ids unlocked in the current session: sealed folders decrypted for in-app view +

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -14,10 +14,9 @@ pub mod claude_code;
 pub mod digest;
 pub mod dossier;
 pub mod graph;
-/// The REAL on-device PERSON-name NER redactor (Phase D), compiled ONLY under `--features local-ner`.
-/// The default build never pulls candle, keeping the fast `cargo test --lib` loop intact and name
-/// egress byte-identical to today (the no-op). Wired via `redact::active_name_redactor`.
-#[cfg(feature = "local-ner")]
+/// The REAL on-device PERSON-name NER redactor (Phase D). ALWAYS compiled; the real impl is selected
+/// at runtime by `redact::active_name_redactor` when the NER model dir is present, else the
+/// byte-identical `NoopNameRedactor` (so a no-model build's name egress is unchanged).
 pub mod ner_deberta;
 pub mod ollama;
 pub mod organize;
@@ -116,11 +115,11 @@ pub fn make_provider(
     // CLI, but that CLI uploads to Anthropic's cloud, so it needs the firewall exactly as the
     // direct HTTP `anthropic` provider does. ollama (local) already returned above, unwrapped.
     //
-    // Phase D — the name layer is now the ACTIVE on-device redactor: with `--features local-ner`
-    // ON and the NER model present, `active_name_redactor()` returns the real DebertaNameRedactor
-    // (PERSON names → ⟪NAME_n⟫ before egress, restored in the reply); otherwise it is the
-    // byte-identical NoopNameRedactor, so default-build egress is unchanged. The redactor only ever
-    // REMOVES content (a NER miss leaks no more than the no-op).
+    // Phase D — the name layer is now the ACTIVE on-device redactor: when the NER model is present,
+    // `active_name_redactor()` returns the real DebertaNameRedactor (PERSON names → ⟪NAME_n⟫ before
+    // egress, restored in the reply); otherwise it is the byte-identical NoopNameRedactor, so a
+    // no-model build's egress is unchanged. The redactor only ever REMOVES content (a NER miss leaks
+    // no more than the no-op).
     Ok(Arc::new(
         crate::summarize::redact::RedactingProvider::with_name_redactor(
             inner,

--- a/src-tauri/src/summarize/ner_deberta.rs
+++ b/src-tauri/src/summarize/ner_deberta.rs
@@ -1,6 +1,7 @@
 //! Real on-device PERSON-name redaction (Phase D) — a [`NameRedactor`](crate::summarize::redact::NameRedactor)
-//! backed by candle-transformers 0.10.2 token-classification NER (DeBERTa-v2, Metal). Compiled ONLY
-//! under `--features local-ner`; the default build ships the dependency-free
+//! backed by candle-transformers 0.10.2 token-classification NER (DeBERTa-v2, Metal). ALWAYS compiled;
+//! [`active_name_redactor`](crate::summarize::redact::active_name_redactor) selects it at runtime when
+//! the NER model dir is present, else ships the dependency-free
 //! [`NoopNameRedactor`](crate::summarize::redact::NoopNameRedactor) instead.
 //!
 //! ## What this does (and why it is SAFE-BY-DESIGN)
@@ -31,8 +32,8 @@
 //!
 //! ## Honest scope (READ THIS)
 //!
-//! Everything here is **COMPILE-proven only** in the headless CI loop (`cargo build --features
-//! local-ner --lib`). What can ONLY be verified on a signed/dev build on a real Mac, with the NER
+//! Everything here is **COMPILE-proven only** in the headless CI loop (`cargo build --lib`). What can
+//! ONLY be verified on a signed/dev build on a real Mac, with the NER
 //! files actually present, is: real NER quality, **Polish PERSON recall**, the BIO decode against the
 //! real tokenizer's subword offsets, and **Metal** correctness/perf (Metal-vs-CPU fallback). The pure
 //! BIO→span decode + distinct-name→token mapping IS unit-tested headless via injected logits — that
@@ -398,8 +399,8 @@ mod tests {
     /// Build (label_ids, offsets, special) for a sequence of (token_text, label_id) over a source
     /// string, prepending a CLS and appending a SEP special token (offsets (0,0), special=1) like a
     /// real DeBERTa encoding. Token offsets are located by scanning the source left-to-right.
-    fn fixture<'a>(
-        src: &'a str,
+    fn fixture(
+        src: &str,
         toks: &[(&str, u32)],
     ) -> (Vec<u32>, Vec<(usize, usize)>, Vec<u32>) {
         let mut labels = vec![0u32]; // CLS
@@ -511,15 +512,15 @@ mod tests {
 /// normal `cargo test` loop. Run:
 ///
 /// ```text
-/// cargo test --features local-ner summarize::ner_deberta::smoke -- --ignored --nocapture
+/// cargo test summarize::ner_deberta::smoke -- --ignored --nocapture
 /// ```
-#[cfg(all(test, feature = "local-ner"))]
+#[cfg(test)]
 mod smoke {
     use super::DebertaNameRedactor;
     use crate::summarize::redact::{ner_model_dir, NameRedactor};
 
     #[test]
-    #[ignore = "needs the NER model on disk + Metal; run manually with --features local-ner"]
+    #[ignore = "needs the NER model on disk + Metal; run manually on a Mac"]
     fn deberta_masks_polish_person() {
         let dir = ner_model_dir().expect("ner_model_dir");
         assert!(

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -15,16 +15,13 @@ use regex::Regex;
 use crate::error::Result;
 use crate::summarize::provider::{Availability, SummarizeRequest, SummarizerProvider};
 
-// ── Phase D model plumbing (shared by the feature-gated redactor + the download command) ──────────
-// The real DebertaNameRedactor lives in the sibling `crate::summarize::ner_deberta` module (declared
-// in `summarize/mod.rs`, `#[cfg(feature = "local-ner")]`); this file holds only the model resolver,
-// the active-redactor factory, and the inbound-only downloader.
+// ── Phase D model plumbing (shared by the runtime-selected redactor + the download command) ──────
+// The real DebertaNameRedactor lives in the sibling `crate::summarize::ner_deberta` module (always
+// compiled, declared in `summarize/mod.rs`); this file holds only the model resolver, the
+// active-redactor factory, and the inbound-only downloader.
 
 /// The stable `⟪NAME_` token prefix the [`NameRedactor`] family emits (closed by the index + `⟫`).
-/// Centralized so the real redactor and the fixtures/tests agree byte-for-byte. The sole runtime
-/// consumer (`ner_deberta`) is feature-gated behind `local-ner`, so the default build sees it as
-/// "unused" outside of `#[cfg(test)]` — allow that rather than feature-gate the constant itself.
-#[allow(dead_code)]
+/// Centralized so the real redactor and the fixtures/tests agree byte-for-byte.
 pub(crate) const NER_NAME_TOKEN_PREFIX: &str = "\u{27ea}NAME_";
 
 /// Sub-directory under the shared models dir holding the multilingual DeBERTa NER files
@@ -67,30 +64,28 @@ pub fn ner_model_present() -> bool {
 
 /// The single active name-redactor used by [`RedactingProvider`] (mirrors
 /// [`crate::embed::active_embedder`]). Graceful degradation, in priority order:
-/// - the `local-ner` feature is ON **and** the NER model dir is present at [`ner_model_dir`]
-///   ([`ner_model_present`]) → the real [`ner_deberta::DebertaNameRedactor`] (lazy: the model loads on
-///   first `redact_names`, not here, so this never blocks startup and never panics);
-/// - otherwise (feature off, no model, or a construction error) → the dependency-free
-///   [`NoopNameRedactor`]. Egress is then byte-identical to before this seam existed (ZERO regression).
+/// - the NER model dir is present at [`ner_model_dir`] ([`ner_model_present`]) → the real
+///   [`crate::summarize::ner_deberta::DebertaNameRedactor`] (lazy: the model loads on first
+///   `redact_names`, not here, so this never blocks startup and never panics);
+/// - otherwise (no model, or a construction error) → the dependency-free [`NoopNameRedactor`]. Egress
+///   is then byte-identical to before this seam existed (ZERO regression).
 ///
-/// NEVER panics and NEVER blocks. A NER miss leaks no more than the no-op (the redactor only ever
-/// REMOVES content), so the worst case == today's behaviour.
+/// Selection keys ONLY on model presence — the candle NER backend is always compiled (no cargo
+/// feature). NEVER panics and NEVER blocks. A NER miss leaks no more than the no-op (the redactor only
+/// ever REMOVES content), so the worst case == the no-op behaviour.
 pub fn active_name_redactor() -> Arc<dyn NameRedactor> {
-    #[cfg(feature = "local-ner")]
-    {
-        if ner_model_present() {
-            match ner_model_dir().and_then(crate::summarize::ner_deberta::DebertaNameRedactor::new) {
-                Ok(r) => {
-                    tracing::info!(target: "ner", "local NER name-redactor ready (lazy load)");
-                    return Arc::new(r);
-                }
-                Err(e) => {
-                    tracing::warn!(target: "ner", error = %e, "local NER init failed; using no-op name redactor");
-                }
+    if ner_model_present() {
+        match ner_model_dir().and_then(crate::summarize::ner_deberta::DebertaNameRedactor::new) {
+            Ok(r) => {
+                tracing::info!(target: "ner", "local NER name-redactor ready (lazy load)");
+                return Arc::new(r);
             }
-        } else {
-            tracing::info!(target: "ner", "no local NER model present; using no-op name redactor");
+            Err(e) => {
+                tracing::warn!(target: "ner", error = %e, "local NER init failed; using no-op name redactor");
+            }
         }
+    } else {
+        tracing::info!(target: "ner", "no local NER model present; using no-op name redactor");
     }
     Arc::new(NoopNameRedactor)
 }
@@ -573,8 +568,8 @@ mod tests {
     #[test]
     fn active_name_redactor_falls_back_to_noop_without_model() {
         // The graceful-degradation contract: with NO NER model present, `active_name_redactor`
-        // returns a redactor that leaves text byte-identical (the no-op). With `local-ner` OFF this
-        // is unconditional; with it ON it still holds whenever the model dir is absent.
+        // returns a redactor that leaves text byte-identical (the no-op). The candle NER backend is
+        // always compiled now, so selection keys ONLY on model presence — absent model ⇒ no-op.
         if !ner_model_present() {
             let r = active_name_redactor();
             let text = "Anna Kowalska met Bob Smith on Friday.";


### PR DESCRIPTION
Deep-analysis R1 (highest ROI) + user directive: remove the local-brain/local-embed/local-ner cargo features so the real on-device impls ship by default → the release does **real semantic RAG (e5) + real name redaction (DeBERTa)** instead of stub-vectors + Noop. Deps non-optional; 9 cfg-gates removed; real impls selected at runtime on model-presence (fresh install → graceful stub fallback). Fixed BGE-M3→e5 docstring drift; baked MISTRALRS_METAL_PRECOMPILE=0 into .cargo/config.toml + ci.sh; CLAUDE.md→v0.7.0; runbook drops the build-option decision. Verified: test 436/0; clippy clean; ng build clean; adversarial PASS (zero flags, fresh-install fallback verified); **lock-security PASS** (no gate/egress change; real NER strictly REDUCES PII egress).