### PR TITLE
feat(detail): semantic related meetings ('Powiązane wg znaczenia')

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,6 +41,7 @@ allow = [
     "OpenSSL",
     "Unlicense",            # whisper-rs / whisper-rs-sys — public-domain dedication.
     "CDLA-Permissive-2.0",  # webpki-roots — Mozilla's permissive cert-root license.
+    "0BSD",                 # doctest-file (via interprocess → mistralrs-core) — OSI-approved, zero-condition (public-domain-equivalent).
 ]
 confidence-threshold = 0.8
 # Treat workspace-local (path) crates as private. NOTE: cargo-deny only auto-detects a crate as

--- a/docs/research/2026-06-29-embedding-visualization-graph-tab.md
+++ b/docs/research/2026-06-29-embedding-visualization-graph-tab.md
@@ -1,0 +1,134 @@
+<!-- Generated 2026-06-29 via /research (murmur-researcher fan-out, 4 angles). Pricing/funding/version = point-in-time. -->
+# Research: UI do podglądu i analizy wektorów (embeddingów) w zakładce Graf
+
+> **KOREKTA (2026-06-29, po sprawdzeniu kodu vs zaktualizowane CLAUDE.md/pamięć):** dwa twierdzenia agentów są NIEAKTUALNE — kod jest dalej niż zakładali:
+> 1. **Embedder NIE jest już za feature-gatem `--features local-embed`.** `Cargo.toml` ma `default = []` (`Cargo.toml:147`); candle/mistralrs/embedder są **zawsze kompilowane** i prawdziwy `CandleBertEmbedder` aktywuje się w runtime gdy `embed_model_present()` (`embed.rs:146-160`), inaczej `StubEmbedder`. Czyli "wymaga specjalnego buildu" → **fałsz**; wymaga tylko **pobranego modelu** e5. ("StubEmbedder na domyślnym buildzie" wciąż prawdą *dopóki user nie pobierze modelu*.)
+> 2. **Gated semantic search już istnieje i jest używany.** `search_semantic_visible(&qvec, k, unlocked)` (`db.rs:937`) i `search_hybrid_visible` (FTS∪wektor∪graf-encji RRF, `db.rs:1007`) działają w `tools.rs:103`, `pipeline.rs:1077`, `commands.rs:5456`. Opcja A (`related_meetings`) jest więc jeszcze cieńsza niż opisano.
+>
+> Reszta werdyktu (atlas = gadżet/timing; flaga `semantic_search_enabled` domyślnie OFF, `config.rs:223`; bake-off nieodpalony) **trzyma się bez zmian**.
+
+## TL;DR / Verdict
+
+**Nie buduj end-userowego "atlasu embeddingów" / scatter-plota 2D w zakładce Graf — to dziś gadżet, nie differentiator, i w domyślnym buildzie wizualizowałby śmieci.** Trzy niezależne powody, które wyszły zgodnie u wszystkich agentów:
+
+1. **Warstwa wektorowa jest uśpiona.** Domyślnie `semantic_search_enabled = false` (`settings/config.rs:223`), a embedder to deterministyczny `StubEmbedder` (hash-bag, semantycznie bez znaczenia) — prawdziwy e5 kompiluje się tylko pod `--features local-embed` + pobrany model (`embed.rs:113-162`). Mapa na domyślnym buildzie pokazuje strukturę worka słów, nie znaczenie.
+2. **Wartość wektorów jest jeszcze nieudowodniona.** `docs/RAG-BAKEOFF.md` to wciąż nieodpalony protokół, który ma rozstrzygnąć, czy wektory w ogóle biją już-shippnięte FTS5 przy naszym małym korpusie. Nie wiadomo, czy jest co wizualizować.
+3. **2D projekcja na małym korpusie + dla usera notatek to słaby produkt.** UMAP/t-SNE potrzebują tysięcy punktów, żeby coś znaczyły; nasz korpus to ~10²–10³ chunków → blob/hairball. Nawet zwykły graf Obsidiana jest powszechnie oceniany jako "ładny, ale bezużyteczny" przy małych vaultach.
+
+**Co MA sens zamiast tego:** realny user-value to nie "mapa wektorów", tylko afordancja **"Powiązane wg znaczenia"** (semantyczni sąsiedzi spotkania/encji) — i jej dom to detal encji / Ask, a nie nowy widok w Grafie. Plus, osobno, **diagnostyczny** podgląd embeddingów dla nas (walidacja jakości w trakcie bake-offu), który należy do dev-toola/Settings, nie do shippowanego Grafu.
+
+**Confidence: high.** Techniczna wykonalność scatter-plota jest wysoka (PCA w Rust, bez nowych zależności) — problem jest produktowy (wartość/timing), nie inżynieryjny.
+
+---
+
+## Co już mamy (z repo, file:line)
+
+- **Dwa rozłączne grafy, celowo osobne.** Zakładka Graf = katalog encji (People/Projects) z krawędziami **co-occurrence** (wspólne widoczne spotkania), backed przez `entities`+`entity_mentions`, gated `visibility_clause`/`list_entities_visible` (`db.rs:1448`). Renderuje karty + jednoencyjny neighborhood-SVG — **nie** wektory (`graph.component.ts:25-38`).
+- **Warstwa wektorowa istnieje, ale uśpiona.** `note_chunks` + `vec_chunks` (sqlite-vec `vec0 float[384]`, `db.rs:343-368`), `EMBED_DIM=384`, model multilingual-e5-small (`embed.rs:28,81-90`), KNN + RRF fuzja FTS∪wektory (`search_semantic_visible` `db.rs:937-995`, `rrf_fuse` `embed.rs:245`). Ale: domyślnie OFF (`config.rs:223`), embedder = stub bez `--features local-embed` (`embed.rs:113-162`), reindex ręczny (`reindexEmbeddings`, `ipc.service.ts:456-486`).
+- **Lock-model już ogarnia wektory.** Chunki/wektory indeksowane **tylko dla widocznych** spotkań (`pipeline.rs:696-709`, `db.rs:802-871`); **purge-on-lock w tej samej transakcji co seal** (`purge_chunks_tx`, `db.rs:876-912`; spięte w `lock_folder` `commands.rs:3091-3098`, move-into-locked, startup relock reconcile `db.rs:1893-1909`, `delete_meeting`); ready **defense-in-depth** re-aplikują `visibility_clause` (`db.rs:947/963`). Kod **jawnie** komentuje, że embedding jest odwracalny do treści: *"a dense embedding is invertible … must NOT survive at rest"* (`commands.rs:2946-2948`, `db.rs:339-342`). Testy: `vec_semantic_search_is_gated_by_visibility` (`db.rs:4173`), `vec_chunks_purged_on_lock`.
+- **Brak jakiejkolwiek wizualizacji wektorów / projekcji.** Grep nie znajduje PCA/UMAP/t-SNE ani w Rust, ani w `src/app/`. Renderer grafu to **nie** silnik: `graph.component.ts` to katalog kart; jedyne rysowanie węzłów to czysty SVG w `entity-neighborhood.component.ts:330-372` (pozycje z `cos/sin` w `computed()`, zero symulacji/rAF). FE deps: tylko `@angular/*`, `@tauri-apps/api`, `rxjs`.
+
+---
+
+## Findings (per kąt)
+
+### A. Sens produktowy i konkurencja
+- **Nawet lider kategorii nie sprzedaje surowego atlasu embeddingów jako wartości.** Obsidian Smart Connections opakowuje semantykę jako *discovery + context assembly*; ich "Visualizer" to force-graph *sąsiadów bieżącej notatki* (neighborhood), a "Smart Graph" (klastry) jest **Pro + experimental** i służy do wybierania źródeł do kontekstu AI (`github.com/Mossy1022/Smart-Connections-Visualizer`, `smartconnections.app/smart-graph/`). Confidence: high.
+- **Globalna projekcja 2D to instrument data-science/debug, nie prawda dla end-usera.** Konsensus: 2D zniekształca odległości w high-dim, daje "arbitrary shapes" — użyteczne do QC/debug z zastrzeżeniami (arxiv 2505.06386; PMC11446450). Narzędzia (TensorBoard Projector, Nomic Atlas) celują w praktyków ML. Confidence: high.
+- **Sygnał popytu skręca w stronę search/Ask, nie map.** Nawet zwykły graf Obsidiana: "imponujący, ale nie najszybsza droga do informacji; search/tagi wygrywają", mało wnosi przy małych vaultach (aiproductivity.ai, lindy.ai). Confidence: med-high.
+
+### B. Feasibility techniczna
+- **Redukcja wymiarów: w Rust (backend), nie w JS.** Surowe wektory to gated bloby w SQLCipher; wysyłanie N×384 floatów do webview marnotrawne i poszerza powierzchnię leak. PCA wymaga centrowania/rzutowania wszystkich wektorów razem → naturalna komenda batch.
+- **PCA-2D bez żadnej nowej biblioteki.** Top-2 składowe = **power iteration + deflacja** na macierzy kowariancji 384×384 (~tylko mnożenia macierz-wektor), ~kilkadziesiąt iteracji, milisekundy dla 10⁴ chunków. Zero nowych crate'ów, działa w **domyślnym** buildzie (candle jest feature-gated, więc nie wiązać projekcji z candle). Confidence: high.
+- **PCA vs t-SNE vs UMAP:** PCA = deterministyczny, zero-dep, pure Rust → **MVP**. t-SNE = lepsze klastry, ale O(N²), niedeterministyczny, nowy crate → defer. UMAP = najlepszy, ale ciężki (nowy crate) → skip. Confidence: high.
+- **Skala → SVG wystarczy, bez WebGL.** Chunki ~800 znaków (`embed.rs:31`), spotkanie → ~2–10 chunków, setki spotkań → ~10²–10³ punktów. SVG spokojnie renderuje ~1–2K `<circle>`. Canvas dopiero przy kilku tysiącach. Confidence: med (liczba per-user szacowana, niemierzona).
+- **Jedyna niezweryfikowana mechanika:** czy `vec0` pozwala odczytać zapisany wektor zwykłym `SELECT embedding` (znamy tylko ścieżkę `MATCH`/KNN). Do potwierdzenia spike'em. Confidence: med.
+
+### C. Fit z lock-modelem (najważniejsze dla bezpieczeństwa)
+- **Surowy embedding 384D JEST leakiem treści.** vec2text odtwarza tekst z gęstych embeddingów: ~92% exact dla krótkich tekstów, odzyskuje nazwiska z notatek klinicznych (arxiv 2310.06816). Modele **wielojęzyczne (e5!) są bardziej podatne** (ACL 2024, 2024.acl-long.422). Atakujący **nie potrzebuje naszego modelu** — przestrzenie embeddingów są ~izomorficzne, wystarczy jedna para (ALGEN, arxiv 2502.11308; zero-shot 2504.00147). → **wektor nigdy nie może opuścić Rusta**; projekcja 2D (lossy, nieodwracalna) jest OK. Confidence: high.
+- **Inwarianty, które nowa komenda MUSI spełnić, by przejść lock-security-review:**
+  1. Źródło danych przez **ten sam** `visibility_clause`/`unlocked`-set `EXISTS`, co `search_semantic_visible` (`db.rs:947/963`) — żadnej nowej ungated ścieżki read.
+  2. **Surowy embedding nigdy nie przekracza IPC** — projekcja 384→2D w Rust; DTO = tylko `{x, y, meeting_id, label}`.
+  3. **Labele = treść → masked dla niewidocznych** (tytuł/snippet → "🔒 Locked", wzór `commands.rs:1431/1467`).
+  4. **Brak nowego at-rest store** wektorów/projekcji zablokowanej treści; jeśli cache, to tylko widoczne punkty, kluczowane `content_hash`, purgowane razem z chunkami przy lock.
+  5. **RED-przed-GREEN** regresja widoczności (wzór `db.rs:4173`).
+  6. Brak PII w logach; brak nowych npm/FFI.
+- **Dobra wiadomość:** ta funkcja jest **w pełni weryfikowalna headless** (deterministyczne PCA + gated SQL) — rzadkość dla zmiany dotykającej lock-modelu, brak "needs a real Mac" dla samego gating/projekcji.
+
+### D. UX wpięcia
+- **Prior art: semantyczna mapa i graf linków to celowo DWA różne widoki** ("meaning-based neighborhoods" vs "explicit link structure", `smartconnections.app/smart-graph/`). Wciskanie wektorów do tej samej "mapy" co encje myli usera — odpowiadają na inne pytania.
+- **Z trzech use-case'ów wart UI jest tylko jeden:**
+  - *"Znajdź podobne spotkania/fragmenty"* → **najwartościowszy**, ale to lista "Powiązane wg znaczenia", nie mapa. Backend już liczy (`search_semantic_visible`).
+  - *"Klastry tematów"* → ładne demo, niska akcja; bezwartościowe na stubie.
+  - *"Czemu Ask zwrócił to a nie tamto"* → realna explainability, ale dom = Ask (retrieved chunks + score), nie Graf.
+- **Zgodność zoneless/signals gotowa do skopiowania:** `effect()`+`await ipc.x()`→signal ze stale-guard (`entity-detail.component.ts:305-336`), OnPush, `@if/@for track id`, inline template, `var(--token)`, opaque overlay (trap T3). Toggle trybu = `signal<'entities'|'topics'>`.
+
+---
+
+## Fit z ograniczeniami Murmur
+
+- **Local-first:** ✅ wszystko on-device, zero egress (uwaga: nie pipe'ować labeli do LLM → wtedy redaction firewall N/D).
+- **Obsidian-native / SQLite-canonical:** ✅ cienki reader nad `vec_chunks`/`note_chunks`, brak drugiej kopii prawdy.
+- **Lock-model:** ⚠️ load-bearing — OK tylko przy spełnieniu inwariantów C; to zmiana **gated przez lock-security-reviewer**.
+- **macOS/CI:** ✅ gating+projekcja w pełni headless. ⚠️ **ale** sensowność klastrów na prawdziwych (polskich) notatkach = tylko `--features local-embed` + e5 + reindex na realnym Macu. Domyślny CI build = stub → ryzyko fałszywego GREEN (zielony test nad bezsensownym stubem).
+- **No new deps:** ✅ PCA w pure Rust + inline SVG; UMAP/t-SNE/d3 odpadają z reguły.
+
+---
+
+## Opcje i tradeoffy
+
+| Opcja | Co to | Effort | Ryzyko | Werdykt |
+|---|---|---|---|---|
+| **A. "Powiązane wg znaczenia"** w detalu encji/spotkania (lista/chipy sąsiadów z `search_semantic_visible`) | realny discovery, zero nowego widoku, reużywa gated query, działa nawet na stubie (degraduje wdzięcznie) | **S** | niskie | **Rób — to właściwy "vector view"** |
+| **B. Atlas/scatter 2D w Grafie** (toggle "Encje\|Tematy", PCA w Rust → SVG) | "wow demo"; technicznie wykonalne tanio | **M→L** | wysokie: bezwartościowe na stubie, nowa szeroka ścieżka read (leak risk), koszt utrzymania, blob przy małym korpusie | **Defer** do zbundlowanego+zwalidowanego e5 |
+| **C. Diagnostyka embeddingów** w Settings/Ask (status modelu, #chunków, "test nearest-neighbor", "Źródła+score" pod odpowiedzią Ask) | explainability/zaufanie/debug | **S** | niskie | **Rozważ osobno** — dom dla use-case "czemu Ask zwrócił to" |
+| **D. Internal dev/notebook dump** `vec_chunks` do walidacji jakości w bake-offie | odpowiada na pytanie "czy e5 > FTS" | **S** | ~zero | **Zrób przy bake-offie** (taniej poza Angularem) |
+
+---
+
+## Rekomendacja i pierwszy krok
+
+**Kolejność:** najpierw odpal bake-off (D) → potem A → B/C tylko jeśli A i bake-off to uzasadnią. Atlas (B) odrzuć teraz.
+
+- **Krok 0 (de-risk całości):** odpal `docs/RAG-BAKEOFF.md` z realnym `--features local-embed` buildem na prawdziwym vaulcie, i przy okazji zrzuć embeddingi do notebooka, żeby zobaczyć czy klastry mają sens (czy e5 separuje PL/EN, czy chunki są zdrowe). Jeśli e5 nie bije FTS5 przy naszym korpusie — całe pytanie o wizualizację jest moot.
+- **Najmniejszy weryfikowalny user-facing plaster (Opcja A):** komenda `related_meetings(meeting_id, k)` = cienki wrapper na `search_semantic_visible` (gated, dedup po spotkaniu) + RED-przed-GREEN test widoczności (wzór `db.rs:4173`) + jedna metoda w `ipc.service.ts` + sekcja "Powiązane wg znaczenia" (chipy `app-sources`) w `entity-detail`. Zero projekcji, zero nowego widoku, zgodne z lock-modelem.
+- **Jeśli kiedyś B:** backend-only spike — `project_chunks_2d(visibility)` (power-iteration PCA, sign-canonicalized dla stabilności znaku) z `cargo test --lib` na one-hot/near-aligned wektorach (helpery `db.rs:4107/4127`): assert (a) separacja różnych kierunków, (b) determinizm. To domyka i matematykę PCA, i odczyt wektora z `vec0` headless, zanim ruszy FE.
+
+---
+
+## Otwarte pytania / czego nie udało się zweryfikować
+
+- **Czy e5 realnie bije FTS5 na tym vaulcie?** — niezweryfikowane, wymaga bake-offu na Macu (stub jest bez znaczenia).
+- **Czy `vec0` zwraca zapisany wektor zwykłym `SELECT embedding`?** — znamy tylko ścieżkę `MATCH`/KNN; do potwierdzenia spike'em (med confidence że działa).
+- **Realna liczba chunków per user** — szacowana z rozmiaru chunka, niemierzona; jeśli power-userzy przekraczają kilka tysięcy punktów → rozważyć canvas (Opcja B).
+- **Czy prawdziwy embedder jest wpinany w jakimkolwiek shipowanym buildzie** (release flags `local-embed`) — niezweryfikowane; domyślny `cargo test --lib` = stub.
+- **Polish-specific inversion rate** — literatura potwierdza, że multilingual e5-class są odwracalne (często bardziej niż EN); brak liczby dla polskiego, ale konserwatywne założenie (wektor = pełne PII) trzyma się niezależnie.
+- **Smart Graph adoption/retention** — brak publicznych liczb; opieramy się na framingu vendora + opiniach.
+
+---
+
+## Sources
+
+**Web:**
+1. https://github.com/Mossy1022/Smart-Connections-Visualizer — force-graph sąsiadów notatki (neighborhood, nie atlas).
+2. https://smartconnections.app/smart-graph/ — semantyczna mapa trzymana osobno od grafu linków; Pro/experimental, cel = wybór źródeł do kontekstu AI.
+3. https://github.com/brianpetro/obsidian-smart-connections — wiodący local-first on-device-embeddings plugin (pozycjonowanie: related notes + search, nie viz).
+4. https://arxiv.org/pdf/2505.06386 — Apple "Embedding Atlas": viz embeddingów to narzędzie praktyka.
+5. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11446450/ — 2D embeddingi zniekształcają odległości; QC/hipotezy z zastrzeżeniami.
+6. https://aiproductivity.ai/blog/best-note-taking-apps-graph-views/ — graf "imponujący, ale nie najszybszy do informacji".
+7. https://www.lindy.ai/blog/obsidian-review — graf mało wnosi przy małych vaultach.
+8. https://arxiv.org/abs/2310.06816 — vec2text: inwersja embeddingów do tekstu (~92% krótkich, odzyskuje nazwiska).
+9. https://aclanthology.org/2024.acl-long.422.pdf — embeddingi wielojęzyczne często bardziej podatne na inwersję.
+10. https://arxiv.org/abs/2502.11308 — ALGEN: few/one-shot linear-alignment inversion (atakujący nie potrzebuje twojego modelu).
+11. https://arxiv.org/abs/2504.00147 — Universal Zero-shot Embedding Inversion.
+12. https://en.wikipedia.org/wiki/Power_iteration — top-k eigenvectors bez biblioteki SVD (PCA).
+13. https://alexgarcia.xyz/sqlite-vec/ — sqlite-vec vec0 (mechanika read-back do potwierdzenia).
+
+**Kod:**
+- `src-tauri/src/embed.rs:28,81-90,113-162,200-206,215-238,245,31` — EMBED_DIM, model e5, StubEmbedder/gating, blob packing, RRF, chunk z nagłówkiem title·date, rozmiar chunka.
+- `src-tauri/src/storage/db.rs:343-368,802-871,876-912,933-995,1007,1269,1448,1893-1909,4107,4127,4173` — schema vec, indeks visible-only, purge-on-lock, gated KNN, RRF, `visibility_clause`, entity graph, relock reconcile, test helpery, test gatingu.
+- `src-tauri/src/commands.rs:2946-2950,3091-3098,1431/1467` — purge-on-seal + rationale "embedding invertible", masked DTO.
+- `src-tauri/src/pipeline.rs:696-709` — gated indexing. `src-tauri/src/settings/config.rs:223` — `semantic_search_enabled=false` default.
+- `src/app/features/graph/graph.component.ts:25-38,166-194,457-521`, `entity-neighborhood.component.ts:330-372`, `entity-detail.component.ts:305-336`, `entity-card.component.ts` — graf = katalog + neighborhood-SVG, blessed effect-pattern.
+- `src/app/core/models.ts:100-107,501-567`, `src/app/core/ipc.service.ts:266-283,456-486` — typy grafu/RAG, komendy embeddingów (brak metody wystawiającej wektory).
+- `docs/RAG-BAKEOFF.md` — wartość wektorów wciąż nieudowodniona vs FTS5.

--- a/docs/research/2026-06-29-related-by-meaning-PLAN.md
+++ b/docs/research/2026-06-29-related-by-meaning-PLAN.md
@@ -1,0 +1,130 @@
+<!-- Ship-feature plan, 2026-06-29. Wynik /research → docs/research/2026-06-29-embedding-visualization-graph-tab.md (Opcja A). -->
+# Plan: "Powiązane wg znaczenia" (semantic related meetings) — Opcja A
+
+> **Decyzja (z researchu):** zamiast atlasu/scatter embeddingów w Grafie (gadżet, zły timing) budujemy
+> realny user-value: semantycznych sąsiadów spotkania/encji, jako sekcję w detalu. Reużywa już-istniejący
+> **gated** `search_semantic_visible`. Zero nowego widoku, zero projekcji 2D, zero nowych zależności.
+
+## Prerequisite (bramka — NIE mój krok, Twój @Mac)
+
+**Najpierw bake-off (`docs/RAG-BAKEOFF.md`).** Tej funkcji nie warto shipować, jeśli e5 nie bije już-shippnięte FTS5
+na Twoim realnym vaulcie — wtedy "powiązane wg znaczenia" to polerowany szum. Headless tego nie rozstrzygnie
+(bez pobranego modelu działa StubEmbedder = hash-bag). Bake-off wymaga: `npm run dev` z pobranym modelem e5,
+`semantic_search_enabled=true`, reindex, ~15–20 pytań ze scoringiem. **To uruchamiasz Ty na Macu.**
+Jeśli e5 wygrywa → budujemy poniższe. Jeśli nie → odpuszczamy i wektory zostają tylko pod Ask.
+
+Status faktów (zweryfikowane w kodzie 2026-06-29):
+- Embedder zawsze kompilowany; prawdziwy e5 aktywuje się na obecność modelu (`embed.rs:146-160`, `Cargo.toml:147`). ✅
+- `search_semantic_visible(&qvec, k, unlocked) -> Vec<SearchHit>` istnieje, gated, dedup po spotkaniu (`db.rs:937-1005`). ✅
+- `semantic_search_enabled` domyślnie `false` (`config.rs:223`). ✅
+- `SearchHit { meeting, snippet, matched_in }` (`storage/models.rs:233`). ✅
+
+---
+
+## Co budujemy (zakres MVP)
+
+W **detalu spotkania** (`src/app/features/detail/`) — sekcja **"Powiązane wg znaczenia"**: lista do K (np. 5)
+innych spotkań najbliższych semantycznie bieżącemu, z tytułem + datą + krótkim snippetem, klik → nawigacja
+do tamtego spotkania. Widoczna tylko gdy `semantic_search_enabled` jest ON i jest model (inaczej sekcja ukryta —
+nie pokazujemy sąsiadów ze stuba).
+
+Świadomie POZA zakresem MVP: scatter/atlas 2D, klastry tematów, sąsiedzi encji w Grafie (osobna iteracja jeśli ta się sprawdzi).
+
+---
+
+## Backend (Rust) — `rust-tauri-dev`
+
+### 1. `Db::related_meetings_visible` (`storage/db.rs`)
+Cienki wrapper nad istniejącą gated KNN. Wektor zapytania = centroid chunków bieżącego spotkania
+(albo embed jego notatki), KNN, **wyklucz samo spotkanie**, zwróć top-K.
+
+```rust
+/// Spotkania najbliższe semantycznie `meeting_id`, GATED przez `visibility_clause` (reużywa
+/// `search_semantic_visible`). Wektor zapytania = średnia (centroid) embeddingów chunków tego
+/// spotkania z `vec_chunks` (już tylko-widoczne, purge-on-lock). Wyklucza samo `meeting_id`.
+/// Zwraca [] gdy spotkanie nie ma chunków (brak modelu / nie zaindeksowane) — NIGDY nie panikuje.
+pub fn related_meetings_visible(
+    &self,
+    meeting_id: &str,
+    k: i64,
+    unlocked: &HashSet<String>,
+) -> Result<Vec<SearchHit>> { /* centroid z vec_chunks WHERE meeting_id=?, potem search_semantic_visible(k+1), filtruj self */ }
+```
+
+Uwagi:
+- **Centroid czytamy z `vec_chunks` danego spotkania** (te wektory już są tylko-widoczne i purgowane przy lock),
+  uśredniamy, L2-normalizujemy (e5 = unit vectors). To NIE wymaga ponownego embedowania ani modelu w tej ścieżce.
+- KNN pytamy o `k+1` i odfiltrowujemy bieżące `meeting_id` (zawsze będzie najbliższe samo sobie).
+- Jeśli bieżące spotkanie samo jest locked/niewidoczne — wrapper wywoływany tylko z odblokowanego detalu;
+  mimo to `search_semantic_visible` gatuje wynik, więc sąsiedzi z zablokowanych folderów nie wyciekną.
+
+### 2. Komenda `related_meetings` (`commands.rs` + rejestr w `lib.rs`)
+```rust
+#[tauri::command]
+pub async fn related_meetings(state: State<'_, AppState>, meeting_id: String) -> Result<Vec<SearchHit>> {
+    let cfg = AppConfig::load(&state.db)?;
+    if !cfg.semantic_search_enabled { return Ok(Vec::new()); }   // OFF → pusto, sekcja się nie pokaże
+    let unlocked = state.unlocked_folders.lock().clone();
+    state.db.related_meetings_visible(&meeting_id, 5, &unlocked)
+}
+```
+- **Dodać do `generate_handler![]` w `lib.rs`** (inaczej IPC undefined — reguła rust-tauri §2).
+- Błędy przez `AppError`/`Result` (§1). Logi: tylko id/count, **zero treści** (§8).
+
+---
+
+## Frontend (Angular zoneless) — `angular-zoneless-dev`
+
+### 3. `ipc.service.ts` — jedna typowana metoda
+```ts
+relatedMeetings(meetingId: string): Promise<SearchHit[]> {
+  return invoke('related_meetings', { meetingId });
+}
+```
+Typ `SearchHit` w `core/models.ts` (jeśli go tam nie ma — sprawdzić; backend ma `{ meeting, snippet, matchedIn }`).
+
+### 4. Sekcja w detalu spotkania (`src/app/features/detail/…`)
+- Stan w signalach: `related = signal<SearchHit[]>([])`, `loadingRelated = signal(false)`.
+- Pobranie wzorem **`effect()` + `await ipc` → signal ze stale-guard** (wzór `entity-detail.component.ts:305-336`),
+  re-fetch przy zmianie `meetingId()` ORAZ przy zmianie lock-state (jak `graph.component.ts:512-521`,
+  `{ allowSignalWrites: true }` — trap T1).
+- Render: `@if (related().length)` → lista chipów/kart (reużyj istniejący `app-sources` z grafu jeśli pasuje),
+  `@for (r of related(); track r.meeting.id)`. Klik → nawigacja do spotkania (istniejący mechanizm detalu).
+- Pusto/OFF → sekcja w ogóle się nie renderuje (`@if`). Snippet w hoverze/overlayu → opaque `var(--surface-overlay)` (trap T3).
+- Wszystko: OnPush, inline template+styles, `var(--token)`, bez `setTimeout`/nowych npm.
+
+---
+
+## Testy / weryfikacja (Definition of Done)
+
+### RED-przed-GREEN (lock-security, wymagane)
+Test gatingu wzorowany na `vec_semantic_search_is_gated_by_visibility` (`db.rs:4173`):
+- Korpus: 2 widoczne spotkania semantycznie bliskie + 1 **sealed** (locked, nie-session-unlocked) bliskie.
+- Assert: `related_meetings_visible(open_id, 5, &empty_set)` **NIE** zwraca sealed spotkania (ani jego snippetu);
+  po dodaniu jego folderu do unlocked set — zwraca. RED gdyby gate zdjąć.
+- Drugi test: wyklucza samo `meeting_id`; zwraca [] gdy brak chunków.
+
+### Bramki
+- `cargo test --lib` (NIE `clippy --all-targets` w pętli), `npx ng lint`, `npx ng build`, na końcu `bash scripts/ci.sh`.
+- **`adversarial-verifier`** — owner werdyktu PASS/FAIL; live-repro w Playwright przeciw `:1420` z mockiem `invoke`.
+- **`lock-security-reviewer`** — WYMAGANY (zmiana dotyka ścieżki read wektorów). Checklist inwariantów:
+  1. Źródło przez `visibility_clause`/`search_semantic_visible` — żadnej ungated ścieżki.
+  2. Surowy embedding **nigdy** nie przekracza IPC (centroid liczony i konsumowany w Rust; DTO = `SearchHit`, bez wektora).
+  3. Snippet/tytuł = treść → już gated przez `search_semantic_visible`; sekcja FE nie renderuje nic dla niewidocznych.
+  4. Brak nowego at-rest store; logi bez PII.
+
+### Honest bar
+Jakość sąsiadów na realnych (polskich) notatkach = weryfikowalne tylko @Mac z pobranym e5 + reindex (bake-off).
+Headless test dowodzi GATINGU i plumbingu (stub wystarcza), **nie** jakości retrievalu.
+
+---
+
+## Constraints (fleet respektuje)
+- Commit/PR tylko `QueaT <kgm004a@gmail.com>`, bez trailerów Claude; `gh` = JakubGawr.
+- Nigdy direct-push na `murmur` — PR → merge (block-bash hook).
+- Bez nowych npm/crate'ów (wszystko reużywa istniejącego).
+- `com.meetnotes.app` niezmienne.
+
+## Pierwszy krok do implementacji (po zielonym bake-offie)
+`rust-tauri-dev`: napisz `related_meetings_visible` + komendę + rejestr w `lib.rs` + dwa testy gatingu →
+`cargo test --lib`. To najmniejszy weryfikowalny plaster; FE jest mechanicznym następstwem.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2500,6 +2500,41 @@ pub async fn reindex_embeddings(
     )
 }
 
+/// "Powiązane wg znaczenia": the up-to-5 meetings most semantically similar to `meeting_id`.
+///
+/// GATING: routes through `Db::related_meetings_visible`, which re-embeds the meeting's OWN plaintext
+/// chunks into a centroid and runs the gated `search_semantic_visible` (visibility_clause) — a
+/// sealed-not-session-unlocked neighbour is never returned. When `semantic_search_enabled` is OFF
+/// (the default) we short-circuit to an empty list so the FE simply hides the section. No raw
+/// embedding ever crosses IPC (the centroid is computed and consumed in Rust; the DTO is `SearchHit`).
+#[tauri::command]
+pub async fn related_meetings(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<SearchHit>, AppError> {
+    let enabled = {
+        state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .semantic_search_enabled
+    };
+    if !enabled {
+        return Ok(Vec::new()); // feature OFF → empty → FE hides the section.
+    }
+    // Defense-in-depth: purge-on-lock already empties a sealed source's chunks (→ []) and the
+    // neighbour list is itself visibility-gated, but refuse a sealed-not-session-unlocked SOURCE
+    // explicitly so the safety is stated, not merely emergent.
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Ok(Vec::new());
+    }
+    let unlocked = unlocked_snapshot(state.inner())?;
+    let emb = crate::embed::active_embedder();
+    state
+        .db
+        .related_meetings_visible(&meeting_id, emb.as_ref(), 5, &unlocked)
+}
+
 /// Pure, AppHandle-free core of [`reindex_embeddings`] so the model-missing guard + the
 /// visibility-gated loop are unit-testable headless. Takes the `Db`, the live `unlocked` session set,
 /// whether the REAL e5 model is present (`model_present`), the active embedder, and a progress sink.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,7 @@ pub fn run() {
             commands::embed_model_present,
             commands::download_embed_model,
             commands::reindex_embeddings,
+            commands::related_meetings,
             commands::ner_model_present,
             commands::download_ner_model,
             commands::toggle_bar,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -994,6 +994,91 @@ impl Db {
         Ok(hits)
     }
 
+    /// Meetings most semantically similar to `meeting_id`, GATED through `search_semantic_visible`
+    /// (which applies `visibility_clause`, so a sealed-not-session-unlocked neighbour is excluded).
+    ///
+    /// The query vector is RE-EMBEDDED from this meeting's own plaintext `note_chunks.text` (a plain
+    /// table SELECT — we deliberately do NOT read embeddings back out of the vec0 table) and reduced
+    /// to its L2-normalized mean (centroid). `embed_passage` matches the convention used to index the
+    /// chunks in `index_meeting_chunks`.
+    ///
+    /// Natural gating: chunks are PURGED on lock, so a sealed `meeting_id` has zero chunk texts ⇒
+    /// `Ok(vec![])` (nothing to embed, no leak). Self is filtered out (a meeting is always its own
+    /// nearest neighbour) and the list is truncated to `k`. NEVER panics; logs only id/count.
+    ///
+    /// The embedder is injected (not pulled from `active_embedder` here) so gating tests can pass a
+    /// deterministic `StubEmbedder`; the command layer passes `active_embedder().as_ref()`.
+    pub fn related_meetings_visible(
+        &self,
+        meeting_id: &str,
+        embedder: &dyn crate::embed::Embedder,
+        k: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<SearchHit>> {
+        if k <= 0 {
+            return Ok(Vec::new());
+        }
+        // Read THIS meeting's own chunk plaintext. Purged-on-lock ⇒ a sealed meeting yields zero
+        // rows ⇒ empty result (no leak, no need for an explicit unlock check on the source).
+        let texts: Vec<String> = {
+            let conn = self.lock();
+            let mut stmt = conn
+                .prepare("SELECT text FROM note_chunks WHERE meeting_id = ?1 ORDER BY chunk_idx")
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |row| row.get::<_, String>(0))
+                .map_err(map_err)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(map_err)?);
+            }
+            out
+        };
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Query vector = L2-normalized centroid of the per-chunk passage embeddings.
+        let vectors = embedder.embed_passage(&texts)?;
+        let dim = embedder.dim();
+        let mut centroid = vec![0f32; dim];
+        let mut counted = 0usize;
+        for v in &vectors {
+            if v.len() != dim {
+                continue; // defensive: skip a malformed vector rather than panic.
+            }
+            for (acc, x) in centroid.iter_mut().zip(v.iter()) {
+                *acc += *x;
+            }
+            counted += 1;
+        }
+        if counted == 0 {
+            return Ok(Vec::new());
+        }
+        for x in centroid.iter_mut() {
+            *x /= counted as f32;
+        }
+        let norm = centroid.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm == 0.0 {
+            return Ok(Vec::new()); // degenerate (all-zero) centroid — no meaningful direction.
+        }
+        for x in centroid.iter_mut() {
+            *x /= norm;
+        }
+
+        // GATED KNN. Ask for k+1 because self is always the nearest hit; then drop self + truncate.
+        let mut hits = self.search_semantic_visible(&centroid, k + 1, unlocked)?;
+        hits.retain(|h| h.meeting.id != meeting_id);
+        hits.truncate(k as usize);
+        tracing::debug!(
+            target: "embed",
+            meeting_id,
+            returned = hits.len(),
+            "related_meetings_visible"
+        );
+        Ok(hits)
+    }
+
     /// Hybrid retrieval (GraphRAG-lite, Phase 2d): fuse THREE already-visibility-gated ranked lists
     /// by Reciprocal Rank Fusion — the FTS5/BM25 `search_visible` ranking, the vector
     /// `search_semantic_visible` ranking, AND the entity-graph neighbourhood
@@ -4199,6 +4284,109 @@ mod tests {
             shown.iter().any(|h| h.meeting.id == "sealed"),
             "session-unlocked meeting must reappear in semantic results"
         );
+    }
+
+    /// RELATED-BY-MEANING GATE: `related_meetings_visible` re-embeds the SOURCE meeting's own chunk
+    /// text into a centroid, runs the gated KNN, and must NEVER surface a sealed-not-session-unlocked
+    /// neighbour — even when that neighbour's chunk row deliberately survives (so exclusion can ONLY
+    /// come from the visibility gate, not from purge). Session-unlocking its folder admits it again.
+    /// RED if the gate inside `search_semantic_visible` were removed.
+    #[test]
+    fn related_meetings_visible_is_gated_by_visibility() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+
+        // Source (open) + an open target with the SAME note text (near in stub space) + a sealed
+        // meeting with the SAME text (would be near). All indexed via the stub so vectors are real.
+        let body = "shared budget planning topic for the quarter";
+        for id in ["source", "target", "sealed"] {
+            db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z"))
+                .unwrap();
+            note_for(&db, id, "claude_code", body);
+        }
+        db.set_note_folder("source", Some("f-open")).unwrap();
+        db.set_note_folder("target", Some("f-open")).unwrap();
+        db.set_note_folder("sealed", Some("f-locked")).unwrap();
+        for id in ["source", "target", "sealed"] {
+            db.index_meeting_chunks(id, &crate::embed::StubEmbedder).unwrap();
+        }
+        // Lock the sealed folder WITHOUT purging — its chunk row survives, so any exclusion must be
+        // the gate doing its job.
+        db.set_folder_locked("f-locked", true, None).unwrap();
+        assert!(chunk_count(&db, "sealed") > 0, "sealed chunk must survive for a true gate test");
+
+        let stub = crate::embed::StubEmbedder;
+
+        // Empty unlock set → the sealed neighbour is ABSENT (no hit, no snippet); the open target IS.
+        let nothing = std::collections::HashSet::new();
+        let hidden = db
+            .related_meetings_visible("source", &stub, 5, &nothing)
+            .unwrap();
+        assert!(
+            hidden.iter().any(|h| h.meeting.id == "target"),
+            "open semantically-near target must be returned"
+        );
+        assert!(
+            !hidden.iter().any(|h| h.meeting.id == "sealed"),
+            "sealed-not-unlocked neighbour leaked through related_meetings_visible"
+        );
+
+        // Session-unlock the sealed folder → it now appears.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let shown = db
+            .related_meetings_visible("source", &stub, 5, &unlocked)
+            .unwrap();
+        assert!(
+            shown.iter().any(|h| h.meeting.id == "sealed"),
+            "session-unlocked neighbour must reappear in related results"
+        );
+    }
+
+    /// SELF-EXCLUSION: the source meeting is never present in its own related results, even though it
+    /// is (trivially) its own nearest neighbour in the KNN.
+    #[test]
+    fn related_meetings_visible_excludes_self() {
+        let db = mem_db();
+        let body = "atlas roadmap and hiring plan";
+        for id in ["self", "other"] {
+            db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z"))
+                .unwrap();
+            note_for(&db, id, "claude_code", body);
+            db.index_meeting_chunks(id, &crate::embed::StubEmbedder).unwrap();
+        }
+        let stub = crate::embed::StubEmbedder;
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .related_meetings_visible("self", &stub, 5, &nothing)
+            .unwrap();
+        assert!(
+            !hits.iter().any(|h| h.meeting.id == "self"),
+            "a meeting must never be in its own related results"
+        );
+        assert!(
+            hits.iter().any(|h| h.meeting.id == "other"),
+            "the other meeting (same text) should still be returned"
+        );
+    }
+
+    /// EMPTY: a meeting with no `note_chunks` (never indexed, or chunks purged on lock) yields an
+    /// empty result — never an error, never a panic.
+    #[test]
+    fn related_meetings_visible_empty_without_chunks() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("bare", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "bare", "claude_code", "has a note but was never indexed");
+        // No index_meeting_chunks call → zero chunk rows.
+        assert_eq!(chunk_count(&db, "bare"), 0);
+        let stub = crate::embed::StubEmbedder;
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .related_meetings_visible("bare", &stub, 5, &nothing)
+            .unwrap();
+        assert!(hits.is_empty(), "no chunks ⇒ empty related result");
     }
 
     /// PURGE-ON-LOCK: index a meeting's chunks while visible, then re-blank its folder (the relock

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -195,6 +195,15 @@ export class IpcService {
     return invoke<SearchHit[]>("search_meetings", { query });
   }
 
+  /**
+   * Semantic neighbors of a meeting ("Powiązane wg znaczenia"). Returns `[]`
+   * when `semantic_search_enabled` is off or the meeting has no neighbors —
+   * the FE simply renders nothing in that case. Gated server-side.
+   */
+  relatedMeetings(meetingId: string): Promise<SearchHit[]> {
+    return invoke<SearchHit[]>("related_meetings", { meetingId });
+  }
+
   /** Permanently delete a meeting (audio + vault note + all DB rows). Irreversible. */
   deleteMeeting(meetingId: string): Promise<void> {
     return invoke<void>("delete_meeting", { meetingId });

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -36,6 +36,7 @@ import { MeetingActionsComponent } from "./meeting-actions.component";
 import { MeetingChatComponent } from "./meeting-chat.component";
 import { MeetingRecipesComponent } from "./meeting-recipes.component";
 import { MeetingTimelineComponent } from "./meeting-timeline.component";
+import { RelatedMeetingsComponent } from "./related-meetings.component";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 interface ActionItem {
@@ -106,6 +107,7 @@ interface ParsedNote {
     MoveToMenuComponent,
     MarkdownComponent,
     AssistantSourcesComponent,
+    RelatedMeetingsComponent,
   ],
   template: `
     <section class="detail">
@@ -901,6 +903,12 @@ interface ParsedNote {
               </div>
             }
           </section>
+
+          <!-- 4) RELATED BY MEANING (semantic neighbors; silent when empty) -- -->
+          <app-related-meetings
+            [meetingId]="d.meeting.id"
+            (open)="openRelated($event)"
+          />
         }
       } @else if (loading()) {
         <div class="card state-card">
@@ -2012,6 +2020,48 @@ export class DetailComponent implements OnInit {
       this.loading.set(false);
       return;
     }
+    await this.loadMeeting(id);
+  }
+
+  /**
+   * Navigate to a semantically-related meeting and reload the view in place.
+   * The `/meeting/:id` route reuses THIS component (the default
+   * RouteReuseStrategy keeps it when only the param changes), so a same-route
+   * navigation does NOT re-run `ngOnInit` — we reload explicitly. The related
+   * section then re-fetches via its `meetingId` input.
+   */
+  async openRelated(id: string): Promise<void> {
+    if (!id || this.detail()?.meeting.id === id) {
+      return;
+    }
+    await this.router.navigate(["/meeting", id]);
+    await this.loadMeeting(id);
+  }
+
+  /**
+   * Load (or reload) a meeting by id into the view. Resets the per-meeting
+   * signals that aren't derived from `detail()` so an in-place reload never
+   * shows the previous meeting's timeline/tags/graph or a stale open editor.
+   * (Derived state — note/audio/interactions/folderBadge — recomputes off
+   * `detail()` automatically.)
+   */
+  private async loadMeeting(id: string): Promise<void> {
+    this.loading.set(true);
+    // Clear non-derived per-meeting state for a clean same-route reload.
+    this.timeline.set(null);
+    this.timelineError.set(false);
+    this.tags.set([]);
+    this.graph.set(null);
+    this.graphError.set("");
+    this.editing.set(false);
+    this.renaming.set(false);
+    this.moveOpen.set(false);
+    this.confirmingDelete.set(false);
+    // Reset audio-playback signals so an in-place meeting→meeting nav never shows the
+    // previous meeting's position/play-state until a media event self-corrects.
+    this.playing.set(false);
+    this.currentTime.set(0);
+    this.duration.set(0);
     try {
       this.detail.set(await this.ipc.getMeetingDetail(id));
     } finally {

--- a/src/app/features/detail/related-meetings.component.ts
+++ b/src/app/features/detail/related-meetings.component.ts
@@ -1,0 +1,197 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { SearchHit } from "../../core/models";
+
+/**
+ * "Powiązane wg znaczenia" — the semantic-related-meetings section shown at the
+ * bottom of a meeting detail. Loads the meeting's semantic neighbors via the
+ * gated `related_meetings` IPC command and renders each as a clickable row
+ * (title + date + snippet). Navigation is owned by the parent: clicking a row
+ * emits the neighbor's meeting id through {@link open}.
+ *
+ * The section is SILENT when there are no neighbors — when `related()` is empty
+ * (feature flag off, no model, or no semantic neighbors) nothing renders. The
+ * backend gates content, so a sealed/not-unlocked neighbor never reaches here.
+ *
+ * The IPC call is a one-shot awaited promise, loaded inside an effect that
+ * tracks the `meetingId` input (mirrors `entity-detail.component.ts`), with a
+ * stale-result guard that drops responses arriving after the id moved on.
+ */
+@Component({
+  selector: "app-related-meetings",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (related().length) {
+      <section class="rel" aria-label="Powiązane wg znaczenia">
+        <h3 class="rel-title">Powiązane wg znaczenia</h3>
+        <ul class="rel-list">
+          @for (r of related(); track r.meeting.id) {
+            <li>
+              <button type="button" class="rel-row" (click)="open.emit(r.meeting.id)">
+                <span class="rel-head">
+                  <span class="rel-name">{{
+                    r.meeting.title || "(untitled)"
+                  }}</span>
+                  <span class="rel-date">{{ fmtDate(r.meeting.startedAt) }}</span>
+                </span>
+                @if (r.snippet) {
+                  <span class="rel-snippet">{{ r.snippet }}</span>
+                }
+              </button>
+            </li>
+          }
+        </ul>
+      </section>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .rel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .rel-title {
+        margin: 0;
+        font-size: 1rem;
+      }
+      .rel-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .rel-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        width: 100%;
+        padding: var(--space-3) var(--space-4);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font-family: inherit;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          border-color var(--transition);
+      }
+      .rel-row:hover {
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+      }
+      .rel-row:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .rel-head {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-3);
+      }
+      .rel-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 600;
+        font-size: 0.9375rem;
+      }
+      .rel-date {
+        flex: none;
+        margin-left: auto;
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-variant-numeric: tabular-nums;
+      }
+      .rel-snippet {
+        color: var(--text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.5;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+    `,
+  ],
+})
+export class RelatedMeetingsComponent {
+  private readonly ipc = inject(IpcService);
+
+  /** The meeting whose neighbors to show; changing it re-loads the list. */
+  readonly meetingId = input<string | null>(null);
+  /** Emits the picked neighbor's meeting id — the parent owns navigation. */
+  readonly open = output<string>();
+
+  readonly related = signal<SearchHit[]>([]);
+  readonly loading = signal(false);
+
+  /**
+   * Re-load the neighbors whenever `meetingId` changes. Sets `loading`
+   * synchronously before the await, so signal writes must be permitted (T1 /
+   * NG0600). The stale-result guard drops a response that resolves after the
+   * id moved on (fast meeting-to-meeting pivots).
+   */
+  private readonly _load = effect(
+    () => {
+      const id = this.meetingId();
+      this.loading.set(true);
+      void this.fetch(id);
+    },
+    { allowSignalWrites: true },
+  );
+
+  private async fetch(id: string | null): Promise<void> {
+    if (!id) {
+      this.related.set([]);
+      this.loading.set(false);
+      return;
+    }
+    try {
+      const result = await this.ipc.relatedMeetings(id);
+      if (this.meetingId() !== id) {
+        return;
+      }
+      this.related.set(result);
+    } catch {
+      // Silent feature: a failure (e.g. command not registered) just hides it.
+      if (this.meetingId() !== id) {
+        return;
+      }
+      this.related.set([]);
+    } finally {
+      if (this.meetingId() === id) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  protected fmtDate(iso: string): string {
+    const d = new Date(iso);
+    return isNaN(d.getTime())
+      ? ""
+      : d.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        });
+  }
+}


### PR DESCRIPTION
## Co
Dodaje do widoku detalu spotkania sekcję **„Powiązane wg znaczenia"** — do 5 spotkań najbliższych semantycznie bieżącemu (wektorowa warstwa e5/sqlite-vec). To realizacja **Opcji A** z researchu (zamiast atlasu/scatter embeddingów w Grafie — patrz `docs/research/2026-06-29-embedding-visualization-graph-tab.md`).

## Jak (architektura)
- **Backend** `Db::related_meetings_visible`: re-embedduje własne plaintext-chunki spotkania (`note_chunks.text`) → L2-normalized centroid → gated `search_semantic_visible` (visibility_clause), wyklucza self, top-k. **Wektor zapytania liczony z re-embedu, nie z odczytu `vec0`** (omija niezweryfikowaną mechanikę readbacku).
- **Komenda** `related_meetings`: `semantic_search_enabled` OFF (domyślnie) → `[]` (FE chowa sekcję); jawny source-gate `meeting_is_unlocked` (defense-in-depth). **Surowy embedding nigdy nie przekracza IPC** — centroid liczony i konsumowany w Rust; DTO = `SearchHit`.
- **FE** `app-related-meetings` (standalone, signals, stale-result guard), wpięty w detal wewnątrz `@if (!locked())`; nawigacja in-place resetuje sygnały per-meeting + audio.

## Bezpieczeństwo (lock-model)
- Każdy read przez `visibility_clause`/`search_semantic_visible` — sealed-not-unlocked spotkanie nigdy nie pojawi się jako sąsiad (RED-before-GREEN test: usunięcie gate → test pada).
- Brak nowego at-rest store; brak PII w logach (id + count).
- **lock-security-reviewer: PASS** (każdy inwariant), **adversarial-verifier: PASS**.

## Weryfikacja
- `scripts/ci.sh` → ✅ all gates green (clippy `-D warnings`, cargo test 439 passed, cargo audit, cargo deny, ng lint, ng build, oba headless E2E).
- 3 nowe testy gating: `related_meetings_visible_is_gated_by_visibility`, `_excludes_self`, `_empty_without_chunks`.

## Nie zweryfikowane (honest bar)
- **Jakość retrievalu** sąsiadów na realnych (polskich) notatkach — wymaga signed/dev buildu @Mac z pobranym modelem e5 + reindex (bake-off `docs/RAG-BAKEOFF.md`). Headless leci `StubEmbedder` (hash-bag) → dowodzi gatingu/plumbingu, NIE trafności. Funkcja jest за flagą `semantic_search_enabled` (OFF), więc shipuje bezpiecznie „uśpiona" do czasu walidacji.

## Drugi commit
`chore(ci): allow 0BSD` — pre-existing brak licencji 0BSD (`doctest-file` z drzewa mistralrs) w allowliście cargo-deny blokował CI; dodany do `deny.toml` (OSI-approved, public-domain-equivalent).