### PR TITLE
chore(release): version files to 0.5.0 (PR #81 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The four rule files below are **imported into context automatically** via the `@
 
 ## What Murmur is
 
-A **local-first macOS desktop app** that records meetings, transcribes on-device, turns the transcript into a clean note via a pluggable LLM provider, and lives inside the user's **Obsidian vault**. Currently shipped at **v0.7.0**.
+A **local-first macOS desktop app** that records meetings, transcribes on-device, turns the transcript into a clean note via a pluggable LLM provider, and lives inside the user's **Obsidian vault**. Currently shipped at **0.5.0**.
 
 - **Stack:** Tauri 2.11 (Rust crate `murmur`, lib `meetnotes_lib`, bin `Murmur`) + Angular 18 **zoneless** (standalone, signals). IPC = Tauri commands (registered in `src-tauri/src/lib.rs` `generate_handler!`) + events. The FE talks to the backend through `src/app/core/ipc.service.ts` — **there is no NgRx**.
 - **Pipeline:** capture (mic via `cpal` + system audio via a Swift **ScreenCaptureKit** sidecar) → **dual-stream** (transcribed separately, merged by wall-clock → `Me`/`Others`) → **whisper.cpp** (`whisper-rs`, Metal; default model **large-v3**) → segments → **SQLite (canonical source of truth, SQLCipher-encrypted)** → `SummarizerProvider` → note markdown → atomic **Obsidian `.md`** export.

--- a/docs/V050-RELEASE-HANDOFF.md
+++ b/docs/V050-RELEASE-HANDOFF.md
@@ -1,16 +1,16 @@
-<!-- The 0.7.0 release handoff. Supersedes V060-RELEASE-HANDOFF.md. Read this to ship. Pairs with .claude/skills/release-murmur. -->
-# v0.7.0 — release handoff (brain + voice + connectors + semantic)
+<!-- The 0.5.0 release handoff. Supersedes V060-RELEASE-HANDOFF.md. Read this to ship. Pairs with .claude/skills/release-murmur. -->
+# 0.5.0 — release handoff (brain + voice + connectors + semantic)
 
-**Status:** trunk `murmur` @ **0.7.0** (PR #74), all headless gates green — `cargo test --lib` **431/0** ·
-`cargo clippy --all-targets -D warnings` clean · `ng lint` + `ng build` clean · `cargo build --lib` clean at 0.7.0.
+**Status:** trunk `murmur` @ **0.5.0** (PR #74), all headless gates green — `cargo test --lib` **431/0** ·
+`cargo clippy --all-targets -D warnings` clean · `ng lint` + `ng build` clean · `cargo build --lib` clean at 0.5.0.
 Every change shipped via build → adversarial-verify → (lock-security-review where lock/egress was touched) → PR-merge.
 **The only things left are your build-feature choice + the signed release** (sign/notarize/publish need your Mac + auth).
 
 ---
 
-## What shipped in 0.7.0 (PRs #54–#74, on top of 0.6.0)
+## What shipped in 0.5.0 (PRs #54–#74, on top of 0.6.0)
 
-| Area | 0.7.0 |
+| Area | 0.5.0 |
 |---|---|
 | **Brain** | real orchestration (brain decides context via gated tools) + **model + effort picker** (Settings → Brain/AI: Default/Opus 4.8/Sonnet 4.6/Haiku 4.5; effort low/med/high — Anthropic-only, honestly gated) |
 | **In-meeting voice assistant** | wake "Klaudku" (recall-first shape-gate, **fires anywhere in the live window + dedup**) **+ the ✨ click-to-stop button** (you control when you're done — no fixed-timeout cutoff) **+ a PROCESSING state** + an **animated AI orb** (idle → listening/audio-reactive → processing/conic+shimmer → answer; pure CSS/SVG, reduced-motion-aware) |
@@ -42,7 +42,7 @@ MISTRALRS_METAL_PRECOMPILE=0 npx tauri build --target universal-apple-darwin --b
 ## Release steps (your Mac — sign/notarize/publish need your auth)
 
 ```bash
-# clean tree on murmur @ 0.7.0:
+# clean tree on murmur @ 0.5.0:
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 pkill -x Murmur ; pkill -f 'tauri dev' || true            # free the cargo target lock
 # build (full product = the default build; no --features):
@@ -52,7 +52,7 @@ bash scripts/macos-sign-notarize.sh        # signs each nested helper FIRST, the
 # notarize + staple + verify + publish (notarytool keychain profile "murmur"):
 xcrun notarytool submit <dmg> --keychain-profile murmur --wait
 xcrun stapler staple <dmg> ; spctl -a -vvv -t open --context context:primary-signature <dmg>   # expect "Notarized Developer ID"
-gh release create v0.7.0 -R JakubGawr/murmur <dmg>
+gh release create 0.5.0 -R JakubGawr/murmur <dmg>
 ```
 **Hard rules (do not repeat the 2026-06-27 mess):** notarization is MANDATORY; sign INSIDE-OUT, never `--deep` (it skips the `Contents/Resources/` helpers → notarization `Invalid`); get the identity by HASH (the cert CN has "Gawroński"); run any `security`/keychain/`notarytool store-credentials` op YOURSELF interactively (the agent shell hangs them); merge via PR only.
 
@@ -65,9 +65,9 @@ gh release create v0.7.0 -R JakubGawr/murmur <dmg>
 6. **Bielik local brain** in a RELEASE build (debug was ~min/token) + the model/effort picker against the live API/CLI (confirm the exact model-id strings are accepted).
 7. **Touch ID / lock-at-rest / screen-share auto-relock** — signed-build-only.
 
-## Deferred (clean follow-ups, not in 0.7.0)
+## Deferred (clean follow-ups, not in 0.5.0)
 - Slack/Jira/Google connectors (OAuth) — the framework + the Local/External seam are ready.
 - The LoRA fine-tune of the local brain on the now-lock-safe flywheel (premature until clean correction pairs accrue).
 - Trim the `record.component.ts` (+292 B) / `detail.component.ts` (+1.51 kB) per-component style WARNs (both under the 16 kB ERROR budget; cosmetic).
 
-The product is on `murmur` @ 0.7.0, green and reviewed. Pick a build option and ship. 🚀
+The product is on `murmur` @ 0.5.0, green and reviewed. Pick a build option and ship. 🚀

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.7.0",
+  "version": "0.5.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.7.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.7.0"
+version = "0.5.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.7.0",
+  "version": "0.5.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
PR #81 merged only the doc rename (a git-add slip dropped the version edits). This commits package.json + tauri.conf.json + Cargo.toml + Cargo.lock = 0.5.0 + CLAUDE.md. cargo build --lib clean.