### PR TITLE
fix(release): disable inlineCritical — prod app was unstyled (CSP blocks the onload media-switch)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -53,7 +53,12 @@
                   "maximumError": "16kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "optimization": {
+                "scripts": true,
+                "fonts": true,
+                "styles": { "minify": true, "inlineCritical": false }
+              }
             },
             "development": {
               "optimization": false,


### PR DESCRIPTION
Angular's default inlineCritical defers the stylesheet via `<link media=print onload=...>`; the inline onload is blocked by CSP `script-src 'self'` → unstyled production app (the v0.5.0 raw-HTML bug). Fix: inlineCritical:false → plain `<link rel=stylesheet>`. Render-verified: 253 rules applied, tokens resolved, flex layout.