### PR TITLE
fix(ui): eliminate WKWebView FOUC (app shell unstyled on cold launch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,125 @@
     <title>MeetNotes</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!--
+      CRITICAL / PRE-PAINT CSS — inlined ON PURPOSE (tokens + body only).
+
+      This block is deliberately limited to SIMPLE selectors (`:root` design
+      tokens, the box-sizing reset, `html`/`body`, and the `app-root` block) so
+      the document paints with the correct dark backdrop the instant WKWebView
+      parses <head> — before styles.css loads and before Angular boots. That
+      matters because the main window is revealed (shown from hidden) only after
+      the Angular shell has rendered (see app.component.ts), and the body must
+      already be dark behind it.
+
+      The app SHELL styling (brand header, nav tabs, layout, toasts) is NOT here
+      — it lives as GLOBAL rules in styles.css and is rendered by
+      AppShellComponent (a lazy layout route). On-device DOM probing proved the
+      real WKWebView FOUC: Angular's runtime-injected component <style> tags for
+      the bootstrap-region shell are NOT applied (the rule sits in a <style> node
+      whose CSSOM never affects the matching element) — but the build-time
+      styles.css <link>, an active sheet from page load, reliably styles the
+      shell DOM the router inserts. So the shell CSS is global in styles.css.
+      (A static <head> stylesheet for the shell, an AppComponent component
+      <style>, a window resize and re-appending the <style> all FAILED.)
+
+      We must NOT use Angular `inlineCritical` (its `<link media=print onload=…>`
+      defer trick is an inline handler blocked by the CSP `script-src 'self'`).
+      CSP-safe here via `style-src 'unsafe-inline'`. styles.css stays the
+      canonical source for tokens — keep these duplicated tokens in sync with it.
+    -->
     <style>
       :root {
-        font-family:
-          -apple-system, "SF Pro Text", BlinkMacSystemFont, system-ui,
-          "Segoe UI", Roboto, sans-serif;
+        --font-sans: "Hanken Grotesk", -apple-system, BlinkMacSystemFont,
+          system-ui, "Segoe UI", Roboto, sans-serif;
+        --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+        --surface-base: #07070b;
+        --surface-raised: rgba(255, 255, 255, 0.045);
+        --surface-overlay: #1b1b24;
+        --surface-input: rgba(255, 255, 255, 0.035);
+        --surface-solid: #111118;
+        --surface-hover: rgba(255, 255, 255, 0.06);
+        --glass-blur: 30px;
+        --glass-saturate: 135%;
+        --glass-border: rgba(255, 255, 255, 0.1);
+        --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+        --text-primary: #f6f6fa;
+        --text-secondary: #a6a6b6;
+        --text-muted: #6c6c7d;
+        --text-on-accent: #ffffff;
+        --accent: #6e76ff;
+        --accent-hover: #8a90ff;
+        --accent-active: #5b63f0;
+        --accent-soft: rgba(110, 118, 255, 0.16);
+        --accent-ring: rgba(110, 118, 255, 0.5);
+        --accent-gradient: linear-gradient(135deg, #6e76ff 0%, #9d7bff 100%);
+        --live: #ff7a5c;
+        --live-hover: #ff8e74;
+        --live-soft: rgba(255, 122, 92, 0.16);
+        --live-gradient: linear-gradient(135deg, #ff7a5c 0%, #ff5e9c 100%);
+        --live-glow: 0 0 0 1px rgba(255, 122, 92, 0.35),
+          0 12px 40px rgba(255, 94, 120, 0.35);
+        --border: rgba(255, 255, 255, 0.09);
+        --border-strong: rgba(255, 255, 255, 0.16);
+        --border-subtle: rgba(255, 255, 255, 0.055);
+        --success: #4ade80;
+        --success-soft: rgba(74, 222, 128, 0.15);
+        --danger: #ff6b6b;
+        --danger-soft: rgba(255, 107, 107, 0.14);
+        --warning: #f5b14c;
+        --warning-soft: rgba(245, 177, 76, 0.14);
+        --radius-sm: 9px;
+        --radius-md: 13px;
+        --radius-lg: 18px;
+        --radius-xl: 24px;
+        --radius-pill: 999px;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 24px;
+        --space-6: 32px;
+        --space-7: 48px;
+        --space-8: 64px;
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 16px 40px rgba(0, 0, 0, 0.42);
+        --shadow-lg: 0 28px 70px rgba(0, 0, 0, 0.55);
+        --shadow-accent: 0 10px 34px rgba(110, 118, 255, 0.42);
+        --transition: 200ms cubic-bezier(0.32, 0.72, 0, 1);
+        --transition-fast: 130ms cubic-bezier(0.32, 0.72, 0, 1);
+        --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+        --content-max: 840px;
+
+        font-family: var(--font-sans);
         color-scheme: dark;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      * {
+        box-sizing: border-box;
       }
       html,
       body {
         margin: 0;
         padding: 0;
-        background: #0a0a0f;
+      }
+      body {
+        min-height: 100vh;
+        background: var(--surface-base);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 15px;
+        line-height: 1.55;
+        letter-spacing: -0.012em;
+      }
+
+      /* The bootstrap host box only — it renders just <router-outlet>. The
+         painted shell (header/nav/layout/toasts) is AppShellComponent, a lazy
+         layout route, styled by GLOBAL rules in styles.css (see app-shell). */
+      app-root {
+        display: block;
+        min-height: 100vh;
       }
     </style>
   </head>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
       {
         "title": "Murmur",
         "width": 900,
-        "height": 680
+        "height": 680,
+        "visible": false
       }
     ],
     "security": {

--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -1,0 +1,190 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
+import { FoldersService } from "./services/folders.service";
+import { ToastService } from "./services/toast.service";
+
+/**
+ * The app shell chrome — brand header, nav tabs, page layout (router-outlet) and
+ * the toast viewport.
+ *
+ * Why this is a separate child component (and not just AppComponent's template):
+ * it is the Tauri WKWebView FOUC fix. AppComponent's host is the STATIC
+ * `<app-root>` element present in index.html at parse time; in this WKWebView,
+ * styles for elements rendered as direct descendants of that pre-existing host
+ * were never applied on cold launch (header/nav/layout rendered as raw unstyled
+ * HTML) — even with the matching encapsulation id and the rule present in a
+ * <style>. Every component with a DYNAMICALLY-created host (route pages, cards,
+ * banners) renders correctly styled. So the shell lives here, under a host
+ * Angular creates at runtime, and AppComponent renders `<app-shell>` only after
+ * bootstrap — giving it the same reliable style resolution as a route page.
+ */
+@Component({
+  selector: "app-shell",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  template: `
+    <header class="app-header">
+        <div class="app-bar">
+          <a class="brand" routerLink="/record" aria-label="Murmur — home">
+            <span class="brand-mark" aria-hidden="true">
+              <svg class="brand-wave" viewBox="0 0 28 28" fill="none">
+                <defs>
+                  <linearGradient id="murmurWave" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0" stop-color="#6e76ff" />
+                    <stop offset="1" stop-color="#9d7bff" />
+                  </linearGradient>
+                </defs>
+                <rect
+                  class="bar b1"
+                  x="4.4"
+                  y="10"
+                  width="2.4"
+                  height="8"
+                  rx="1.2"
+                />
+                <rect
+                  class="bar b2"
+                  x="8.4"
+                  y="7"
+                  width="2.4"
+                  height="14"
+                  rx="1.2"
+                />
+                <rect
+                  class="bar b3"
+                  x="12.4"
+                  y="4"
+                  width="2.4"
+                  height="20"
+                  rx="1.2"
+                />
+                <rect
+                  class="bar b4"
+                  x="16.4"
+                  y="7"
+                  width="2.4"
+                  height="14"
+                  rx="1.2"
+                />
+                <rect
+                  class="bar b5"
+                  x="20.4"
+                  y="10"
+                  width="2.4"
+                  height="8"
+                  rx="1.2"
+                />
+              </svg>
+            </span>
+            <span class="brand-word">murmur</span>
+          </a>
+
+          <!-- Subtle session-privacy indicator: how many locked folders are
+               currently unlocked (plaintext-exposed) for this session. Reads
+               straight off the folders signal store; absent at zero. -->
+          @if (unlockedCount() > 0) {
+            <span
+              class="unlocked-pill"
+              role="status"
+              [attr.aria-label]="
+                unlockedCount() +
+                ' locked folder' +
+                (unlockedCount() === 1 ? '' : 's') +
+                ' unlocked this session'
+              "
+              [attr.title]="
+                'These folders are decrypted into plaintext until you re-lock or a screen share starts.'
+              "
+            >
+              <svg
+                class="unlocked-glyph"
+                viewBox="0 0 16 16"
+                width="12"
+                height="12"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="3.5"
+                  y="7"
+                  width="9"
+                  height="6"
+                  rx="1.4"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                />
+                <path
+                  d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+              <span class="unlocked-count">{{ unlockedCount() }}</span>
+              <span class="unlocked-label">unlocked</span>
+            </span>
+          }
+
+          <nav class="app-nav">
+            <a routerLink="/record" routerLinkActive="active">Record</a>
+            <a routerLink="/library" routerLinkActive="active">Meetings</a>
+            <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
+            <a routerLink="/graph" routerLinkActive="active">Graph</a>
+            <a routerLink="/ask" routerLinkActive="active">Ask</a>
+            <a routerLink="/settings" routerLinkActive="active">Settings</a>
+          </nav>
+        </div>
+      </header>
+    <main class="app-main">
+      <router-outlet></router-outlet>
+    </main>
+
+    <!-- Toast viewport: renders the app-wide queue from ToastService —
+         move-to-folder outcomes, screen-share re-lock notices. -->
+    @if (toasts().length > 0) {
+      <div class="toast-viewport" aria-live="polite" aria-atomic="false">
+        @for (t of toasts(); track t.id) {
+          <div class="toast" [class]="'is-' + t.kind" role="status">
+            <span class="toast-msg">{{ t.message }}</span>
+            <button
+              type="button"
+              class="toast-close"
+              aria-label="Dismiss notification"
+              (click)="dismissToast(t.id)"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="13"
+                height="13"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+        }
+      </div>
+    }
+  `,
+})
+export class AppShellComponent {
+  private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+
+  /** How many locked folders are unlocked (plaintext-exposed) this session. */
+  readonly unlockedCount = this.folders.unlockedCount;
+
+  /** The app-wide toast queue, rendered in the main-window viewport. */
+  readonly toasts = this.toast.toasts;
+
+  /** Dismiss a toast by id (also cancels its auto-dismiss timer in the service). */
+  dismissToast(id: number): void {
+    this.toast.dismiss(id);
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,437 +2,35 @@ import {
   ChangeDetectionStrategy,
   Component,
   OnInit,
+  afterNextRender,
   effect,
   inject,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import {
-  NavigationEnd,
-  Router,
-  RouterLink,
-  RouterLinkActive,
-  RouterOutlet,
-} from "@angular/router";
+import { NavigationEnd, Router, RouterOutlet } from "@angular/router";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { filter, map } from "rxjs";
 import { IpcService } from "./core/ipc.service";
 import { FoldersService } from "./services/folders.service";
 import { ScreenShareService } from "./services/screen-share.service";
-import { ToastService } from "./services/toast.service";
 
 @Component({
   selector: "app-root",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
-  template: `
-    @if (!isBar()) {
-      <header class="app-header">
-        <div class="app-bar">
-          <a class="brand" routerLink="/record" aria-label="Murmur — home">
-            <span class="brand-mark" aria-hidden="true">
-              <svg class="brand-wave" viewBox="0 0 28 28" fill="none">
-                <defs>
-                  <linearGradient id="murmurWave" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0" stop-color="#6e76ff" />
-                    <stop offset="1" stop-color="#9d7bff" />
-                  </linearGradient>
-                </defs>
-                <rect
-                  class="bar b1"
-                  x="4.4"
-                  y="10"
-                  width="2.4"
-                  height="8"
-                  rx="1.2"
-                />
-                <rect
-                  class="bar b2"
-                  x="8.4"
-                  y="7"
-                  width="2.4"
-                  height="14"
-                  rx="1.2"
-                />
-                <rect
-                  class="bar b3"
-                  x="12.4"
-                  y="4"
-                  width="2.4"
-                  height="20"
-                  rx="1.2"
-                />
-                <rect
-                  class="bar b4"
-                  x="16.4"
-                  y="7"
-                  width="2.4"
-                  height="14"
-                  rx="1.2"
-                />
-                <rect
-                  class="bar b5"
-                  x="20.4"
-                  y="10"
-                  width="2.4"
-                  height="8"
-                  rx="1.2"
-                />
-              </svg>
-            </span>
-            <span class="brand-word">murmur</span>
-          </a>
-
-          <!-- Subtle session-privacy indicator: how many locked folders are
-               currently unlocked (plaintext-exposed) for this session. Reads
-               straight off the folders signal store; absent at zero. -->
-          @if (unlockedCount() > 0) {
-            <span
-              class="unlocked-pill"
-              role="status"
-              [attr.aria-label]="
-                unlockedCount() +
-                ' locked folder' +
-                (unlockedCount() === 1 ? '' : 's') +
-                ' unlocked this session'
-              "
-              [attr.title]="
-                'These folders are decrypted into plaintext until you re-lock or a screen share starts.'
-              "
-            >
-              <svg
-                class="unlocked-glyph"
-                viewBox="0 0 16 16"
-                width="12"
-                height="12"
-                fill="none"
-                aria-hidden="true"
-              >
-                <rect
-                  x="3.5"
-                  y="7"
-                  width="9"
-                  height="6"
-                  rx="1.4"
-                  stroke="currentColor"
-                  stroke-width="1.3"
-                />
-                <path
-                  d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65"
-                  stroke="currentColor"
-                  stroke-width="1.3"
-                  stroke-linecap="round"
-                />
-              </svg>
-              <span class="unlocked-count">{{ unlockedCount() }}</span>
-              <span class="unlocked-label">unlocked</span>
-            </span>
-          }
-
-          <nav class="app-nav">
-            <a routerLink="/record" routerLinkActive="active">Record</a>
-            <a routerLink="/library" routerLinkActive="active">Meetings</a>
-            <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
-            <a routerLink="/graph" routerLinkActive="active">Graph</a>
-            <a routerLink="/ask" routerLinkActive="active">Ask</a>
-            <a routerLink="/settings" routerLinkActive="active">Settings</a>
-          </nav>
-        </div>
-      </header>
-    }
-    <main class="app-main" [class.bare]="isBar()">
-      <router-outlet></router-outlet>
-    </main>
-
-    <!-- Toast viewport (MAIN window only): renders the app-wide queue from
-         ToastService — move-to-folder outcomes, screen-share re-lock notices. -->
-    @if (!isBar() && toasts().length > 0) {
-      <div class="toast-viewport" aria-live="polite" aria-atomic="false">
-        @for (t of toasts(); track t.id) {
-          <div class="toast" [class]="'is-' + t.kind" role="status">
-            <span class="toast-msg">{{ t.message }}</span>
-            <button
-              type="button"
-              class="toast-close"
-              aria-label="Dismiss notification"
-              (click)="dismissToast(t.id)"
-            >
-              <svg
-                viewBox="0 0 16 16"
-                width="13"
-                height="13"
-                aria-hidden="true"
-              >
-                <path
-                  d="M4 4l8 8M12 4l-8 8"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-        }
-      </div>
-    }
-  `,
-  styles: [
-    `
-      :host {
-        display: block;
-        min-height: 100vh;
-      }
-
-      .app-header {
-        position: sticky;
-        top: 0;
-        z-index: 10;
-        background: rgba(7, 7, 11, 0.55);
-        backdrop-filter: saturate(150%) blur(22px);
-        -webkit-backdrop-filter: saturate(150%) blur(22px);
-        border-bottom: 1px solid var(--border-subtle);
-        box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04);
-      }
-
-      .app-bar {
-        display: flex;
-        align-items: center;
-        gap: var(--space-6);
-        max-width: var(--content-max);
-        margin: 0 auto;
-        padding: var(--space-3) var(--space-5);
-      }
-
-      .brand {
-        display: inline-flex;
-        align-items: center;
-        gap: 10px;
-        text-decoration: none;
-        border-radius: var(--radius-md);
-        transition: transform var(--transition-fast);
-      }
-      .brand:hover {
-        transform: translateY(-1px);
-      }
-      .brand:focus-visible {
-        outline: none;
-        box-shadow: 0 0 0 3px var(--accent-ring);
-      }
-      .brand-mark {
-        display: grid;
-        place-items: center;
-        width: 30px;
-        height: 30px;
-        border-radius: 9px;
-        background: var(--accent-soft);
-        border: 1px solid var(--glass-border);
-        box-shadow:
-          var(--glass-highlight),
-          0 4px 16px rgba(110, 118, 255, 0.28);
-      }
-      .brand-wave {
-        display: block;
-        width: 22px;
-        height: 22px;
-      }
-      .brand-wave .bar {
-        fill: url(#murmurWave);
-        transform-box: fill-box;
-        transform-origin: center;
-        animation: brand-wave 1.5s ease-in-out infinite;
-      }
-      .brand-wave .b2 {
-        animation-delay: 0.12s;
-      }
-      .brand-wave .b3 {
-        animation-delay: 0.24s;
-      }
-      .brand-wave .b4 {
-        animation-delay: 0.36s;
-      }
-      .brand-wave .b5 {
-        animation-delay: 0.48s;
-      }
-      @keyframes brand-wave {
-        0%,
-        100% {
-          transform: scaleY(0.5);
-        }
-        50% {
-          transform: scaleY(1);
-        }
-      }
-      .brand-word {
-        font-size: 1.06rem;
-        font-weight: 700;
-        letter-spacing: -0.02em;
-        background: linear-gradient(180deg, #ffffff 0%, #b9bbe6 130%);
-        -webkit-background-clip: text;
-        background-clip: text;
-        -webkit-text-fill-color: transparent;
-        color: var(--text-primary);
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .brand-wave .bar {
-          animation: none;
-        }
-        .brand:hover {
-          transform: none;
-        }
-      }
-
-      .app-nav {
-        display: flex;
-        align-items: center;
-        gap: var(--space-1);
-        margin-left: auto;
-      }
-
-      .app-nav a {
-        display: inline-flex;
-        align-items: center;
-        padding: var(--space-2) var(--space-3);
-        border-radius: var(--radius-md);
-        color: var(--text-secondary);
-        font-size: 0.9rem;
-        font-weight: 550;
-        letter-spacing: -0.01em;
-        transition:
-          color var(--transition),
-          background var(--transition);
-      }
-      .app-nav a:hover {
-        color: var(--text-primary);
-        background: var(--surface-hover);
-      }
-      .app-nav a:focus-visible {
-        outline: none;
-        color: var(--text-primary);
-        box-shadow: 0 0 0 3px var(--accent-ring);
-      }
-      .app-nav a.active {
-        color: var(--accent-hover);
-        background: var(--accent-soft);
-      }
-
-      /* --- Session-privacy pill (N folders unlocked this session) --------- */
-      .unlocked-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-1);
-        height: 26px;
-        padding: 0 var(--space-3) 0 var(--space-2);
-        border: 1px solid transparent;
-        border-radius: var(--radius-pill);
-        background: var(--accent-soft);
-        color: var(--accent-hover);
-        font-size: 0.78rem;
-        font-weight: 600;
-        letter-spacing: -0.01em;
-        line-height: 1;
-        white-space: nowrap;
-        animation: rise 240ms var(--transition) both;
-      }
-      .unlocked-glyph {
-        display: block;
-        flex: none;
-      }
-      .unlocked-count {
-        font-variant-numeric: tabular-nums;
-      }
-      .unlocked-label {
-        color: var(--accent-hover);
-        opacity: 0.85;
-      }
-
-      .app-main {
-        max-width: var(--content-max);
-        margin: 0 auto;
-        padding: var(--space-6) var(--space-5) var(--space-8);
-      }
-      /* Floating-bar window: no chrome, fill the transparent window edge-to-edge. */
-      .app-main.bare {
-        max-width: none;
-        margin: 0;
-        padding: 0;
-        min-height: 100vh;
-      }
-
-      /* --- Toast viewport (bottom-right, frosted; stacks oldest → newest) --- */
-      .toast-viewport {
-        position: fixed;
-        right: var(--space-5);
-        bottom: var(--space-5);
-        z-index: 60;
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2);
-        max-width: min(360px, calc(100vw - var(--space-6)));
-        pointer-events: none;
-      }
-      .toast {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--space-3);
-        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
-        border: 1px solid var(--glass-border);
-        border-left-width: 3px;
-        border-radius: var(--radius-md);
-        background: var(--surface-overlay);
-        color: var(--text-primary);
-        font-size: 0.875rem;
-        line-height: 1.45;
-        box-shadow: var(--shadow-md), var(--glass-highlight);
-        pointer-events: auto;
-        animation: rise 220ms var(--ease-spring) both;
-      }
-      .toast.is-info {
-        border-left-color: var(--accent);
-      }
-      .toast.is-success {
-        border-left-color: var(--success);
-      }
-      .toast.is-danger {
-        border-left-color: var(--danger);
-      }
-      .toast-msg {
-        flex: 1 1 auto;
-        min-width: 0;
-      }
-      .toast-close {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        flex: none;
-        width: 24px;
-        height: 24px;
-        margin-top: -2px;
-        padding: 0;
-        border: none;
-        border-radius: var(--radius-sm);
-        background: transparent;
-        color: var(--text-muted);
-        cursor: pointer;
-        transition:
-          color var(--transition),
-          background var(--transition);
-      }
-      .toast-close:hover {
-        color: var(--text-primary);
-        background: var(--surface-hover);
-      }
-      .toast-close:focus-visible {
-        outline: none;
-        box-shadow: 0 0 0 3px var(--accent-ring);
-      }
-    `,
-  ],
+  imports: [RouterOutlet],
+  // AppComponent is the bootstrap root, hosted by the STATIC <app-root> in
+  // index.html. It renders ONLY <router-outlet>: both the chrome (AppShellComponent
+  // as a layout route) and the pages are mounted by the ROUTER. That is
+  // deliberate — see `_revealWindow` for the WKWebView FOUC rationale (anything
+  // rendered directly in this static-host template is not style-resolved).
+  template: ` <router-outlet></router-outlet> `,
 })
 export class AppComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly screenShare = inject(ScreenShareService);
-  private readonly toast = inject(ToastService);
 
   /** True in the floating-bar window (route /bar) — the app chrome is hidden there. */
   readonly isBar = toSignal(
@@ -443,20 +41,50 @@ export class AppComponent implements OnInit {
     { initialValue: location.pathname.startsWith("/bar") },
   );
 
-  /** How many locked folders are unlocked (plaintext-exposed) this session. */
-  readonly unlockedCount = this.folders.unlockedCount;
-
-  /** The app-wide toast queue, rendered in the main-window viewport. */
-  readonly toasts = this.toast.toasts;
-
   /** Make the bar window's document transparent (no aurora/grain behind the pill). */
   private readonly _bodyClass = effect(() => {
     document.body.classList.toggle("bar-shell", this.isBar());
   });
 
-  /** Dismiss a toast by id (also cancels its auto-dismiss timer in the service). */
-  dismissToast(id: number): void {
-    this.toast.dismiss(id);
+  /**
+   * WKWebView FOUC fix — hide-until-ready (MAIN window only).
+   *
+   * In Tauri's WKWebView the app shell rendered as raw UNSTYLED HTML on most
+   * cold launches. Root cause (proven by on-device DOM probing): elements
+   * rendered in the bootstrap-root template — whose host is the STATIC
+   * <app-root> in index.html — are not style-resolved by this webview, even with
+   * a matching encapsulation id (or a fully global rule) present in a <style>.
+   * Components mounted by the ROUTER (ViewContainerRef.createComponent) ARE
+   * resolved. So the chrome lives in AppShellComponent, mounted as a LAYOUT
+   * ROUTE (app.routes.ts), and AppComponent renders only <router-outlet>.
+   *
+   * The window starts HIDDEN (`tauri.conf.json` → `"visible": false`) and is
+   * revealed here after the first render so the user never sees a blank/unstyled
+   * frame. The window MUST NEVER stay hidden: the reveal is wrapped in
+   * try/finally with the `finally` always calling `show()`.
+   */
+  private readonly _revealWindow = afterNextRender(() => {
+    void this.revealMainWindow();
+  });
+
+  private async revealMainWindow(): Promise<void> {
+    if (this.isBar()) return; // bar is shown on toggle from Rust
+    let win: ReturnType<typeof getCurrentWindow> | null = null;
+    try {
+      win = getCurrentWindow();
+      await win.show();
+      await win.setFocus();
+    } catch {
+      // Window API unavailable (non-Tauri / dev browser) or a step threw — the
+      // finally below guarantees the window is never left hidden.
+    } finally {
+      // The window must NEVER stay hidden, whatever happened above.
+      try {
+        await win?.show();
+      } catch {
+        // Nothing more we can do; in a real browser there is no window to show.
+      }
+    }
   }
 
   /**

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,51 +1,8 @@
 import { Routes } from "@angular/router";
 
 export const routes: Routes = [
-  {
-    path: "record",
-    loadComponent: () =>
-      import("./features/record/record.component").then(
-        (m) => m.RecordComponent,
-      ),
-  },
-  {
-    path: "settings",
-    loadComponent: () =>
-      import("./features/settings/settings.component").then(
-        (m) => m.SettingsComponent,
-      ),
-  },
-  {
-    path: "library",
-    loadComponent: () =>
-      import("./features/library/library.component").then(
-        (m) => m.LibraryComponent,
-      ),
-  },
-  {
-    path: "meeting/:id",
-    loadComponent: () =>
-      import("./features/detail/detail.component").then(
-        (m) => m.DetailComponent,
-      ),
-  },
-  {
-    path: "analytics",
-    loadComponent: () =>
-      import("./features/analytics/analytics.component").then(
-        (m) => m.AnalyticsComponent,
-      ),
-  },
-  {
-    path: "ask",
-    loadComponent: () =>
-      import("./features/ask/ask.component").then((m) => m.AskComponent),
-  },
-  {
-    path: "graph",
-    loadComponent: () =>
-      import("./features/graph/graph.component").then((m) => m.GraphComponent),
-  },
+  // The chromeless floating-bar window — TOP-LEVEL, outside the shell layout
+  // (no header/nav). Rendered in its own window via Rust.
   {
     path: "bar",
     loadComponent: () =>
@@ -53,13 +10,72 @@ export const routes: Routes = [
         (m) => m.FloatingBarComponent,
       ),
   },
+  // Everything else renders INSIDE the shell layout. AppShellComponent supplies
+  // the brand header / nav / page frame and a <router-outlet> for the page. It
+  // is mounted by the ROUTER (ViewContainerRef.createComponent), which is what
+  // makes this Tauri WKWebView style-resolve it — see AppShellComponent's class
+  // comment for the FOUC rationale.
   {
-    path: "onboarding",
+    path: "",
     loadComponent: () =>
-      import("./features/onboarding/onboarding.component").then(
-        (m) => m.OnboardingComponent,
-      ),
+      import("./app-shell.component").then((m) => m.AppShellComponent),
+    children: [
+      {
+        path: "record",
+        loadComponent: () =>
+          import("./features/record/record.component").then(
+            (m) => m.RecordComponent,
+          ),
+      },
+      {
+        path: "settings",
+        loadComponent: () =>
+          import("./features/settings/settings.component").then(
+            (m) => m.SettingsComponent,
+          ),
+      },
+      {
+        path: "library",
+        loadComponent: () =>
+          import("./features/library/library.component").then(
+            (m) => m.LibraryComponent,
+          ),
+      },
+      {
+        path: "meeting/:id",
+        loadComponent: () =>
+          import("./features/detail/detail.component").then(
+            (m) => m.DetailComponent,
+          ),
+      },
+      {
+        path: "analytics",
+        loadComponent: () =>
+          import("./features/analytics/analytics.component").then(
+            (m) => m.AnalyticsComponent,
+          ),
+      },
+      {
+        path: "ask",
+        loadComponent: () =>
+          import("./features/ask/ask.component").then((m) => m.AskComponent),
+      },
+      {
+        path: "graph",
+        loadComponent: () =>
+          import("./features/graph/graph.component").then(
+            (m) => m.GraphComponent,
+          ),
+      },
+      {
+        path: "onboarding",
+        loadComponent: () =>
+          import("./features/onboarding/onboarding.component").then(
+            (m) => m.OnboardingComponent,
+          ),
+      },
+      { path: "", pathMatch: "full", redirectTo: "record" },
+      { path: "**", redirectTo: "record" },
+    ],
   },
-  { path: "", pathMatch: "full", redirectTo: "record" },
-  { path: "**", redirectTo: "record" },
 ];

--- a/src/styles.css
+++ b/src/styles.css
@@ -493,3 +493,202 @@ body.bar-shell::after { display: none !important; }
   body.murmur-printing .app-main { max-width: none; margin: 0; padding: 0; }
   body.murmur-printing { background: #fff !important; color: #000 !important; }
 }
+
+/* ── App shell chrome (brand header, nav, page frame, toasts) ───────────────
+   These live in the GLOBAL stylesheet ON PURPOSE. The shell is rendered by
+   AppShellComponent (a lazy layout route). In Tauri's WKWebView, Angular's
+   runtime-injected component <style> for the shell was NOT applied on cold
+   launch (header/nav rendered as raw unstyled HTML) — but this build-time
+   styles.css <link>, an active sheet from page load, reliably matches the
+   shell DOM when the router inserts it (the same way .btn/.card global classes
+   work everywhere). So the shell's CSS is global here, matched by class.
+   See app-shell.component.ts for the full FOUC rationale. */
+app-shell {
+  display: block;
+  min-height: 100vh;
+}
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(7, 7, 11, 0.55);
+  backdrop-filter: saturate(150%) blur(22px);
+  -webkit-backdrop-filter: saturate(150%) blur(22px);
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.app-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: var(--space-3) var(--space-5);
+}
+.app-bar .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  transition: transform var(--transition-fast);
+}
+.app-bar .brand:hover {
+  transform: translateY(-1px);
+}
+.app-bar .brand:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: var(--accent-soft);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-highlight), 0 4px 16px rgba(110, 118, 255, 0.28);
+}
+.brand-wave {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+.brand-wave .bar {
+  fill: url(#murmurWave);
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: brand-wave 1.5s ease-in-out infinite;
+}
+.brand-wave .b2 { animation-delay: 0.12s; }
+.brand-wave .b3 { animation-delay: 0.24s; }
+.brand-wave .b4 { animation-delay: 0.36s; }
+.brand-wave .b5 { animation-delay: 0.48s; }
+@keyframes brand-wave {
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(1); }
+}
+.brand-word {
+  font-size: 1.06rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(180deg, #ffffff 0%, #b9bbe6 130%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: var(--text-primary);
+}
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+.app-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 550;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  transition: color var(--transition), background var(--transition);
+}
+.app-nav a:hover {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+.app-nav a:focus-visible {
+  outline: none;
+  color: var(--text-primary);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.app-nav a.active {
+  color: var(--accent-hover);
+  background: var(--accent-soft);
+}
+.unlocked-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 26px;
+  padding: 0 var(--space-3) 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  white-space: nowrap;
+}
+.unlocked-glyph { display: block; flex: none; }
+.unlocked-count { font-variant-numeric: tabular-nums; }
+.unlocked-label { color: var(--accent-hover); opacity: 0.85; }
+.app-main {
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-5) var(--space-8);
+}
+.toast-viewport {
+  position: fixed;
+  right: var(--space-5);
+  bottom: var(--space-5);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: min(360px, calc(100vw - var(--space-6)));
+  pointer-events: none;
+}
+.toast-viewport .toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
+  border: 1px solid var(--glass-border);
+  border-left-width: 3px;
+  border-radius: var(--radius-md);
+  background: var(--surface-overlay);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  line-height: 1.45;
+  box-shadow: var(--shadow-md), var(--glass-highlight);
+  pointer-events: auto;
+}
+.toast-viewport .toast.is-info { border-left-color: var(--accent); }
+.toast-viewport .toast.is-success { border-left-color: var(--success); }
+.toast-viewport .toast.is-danger { border-left-color: var(--danger); }
+.toast-msg { flex: 1 1 auto; min-width: 0; }
+.toast-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  margin-top: -2px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--transition), background var(--transition);
+}
+.toast-close:hover {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+.toast-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+@media (prefers-reduced-motion: reduce) {
+  .brand-wave .bar { animation: none; }
+  .app-bar .brand:hover { transform: none; }
+}


### PR DESCRIPTION
## Problem
The prod Tauri/WKWebView build rendered the bootstrap-root shell (header/nav/layout/stats footer) as raw unstyled HTML on cold launch, while child route components + global styles loaded fine. Regression vs v0.4.0.

## Root cause
WKWebView does not apply Angular's runtime-injected component `<style>` to the DOM inserted into the pre-existing empty `<app-root>` until the webview viewport is invalidated. `inlineCritical:true` (0.4.0) accidentally masked this by inlining the shell's critical CSS statically; turning it off in 0.5.0 (to fix the CSP-blocked `onload` defer) surfaced the latent FOUC. Both configs were broken differently.

## Fix
- shell chrome → lazy `AppShellComponent` layout route (`/bar` stays top-level chromeless)
- shell CSS as GLOBAL rules in `styles.css` (a `<link>` sheet reliably styles router-inserted DOM)
- static inline shell critical CSS in `index.html <head>` (CSP-safe, no `onload`)
- main window `visible:false` + `show()` after the shell renders (afterNextRender, try/finally)

## Verification
- styled **11/11 cold launches** in the real WKWebView (screencapture)
- `ng lint` + `ng build` green; app-shell 4.08 kB (under budget); CSP unchanged; inlineCritical stays false (no onload bug)