### PR TITLE
fix(ui): restore Angular component styles in prod — Tauri style-src nonce killed 'unsafe-inline'

### DIFF
--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -213,6 +213,56 @@ dropdowns, the lock gate's chrome) must use `var(--surface-overlay)` +
 `backdrop-filter: none` or the underlying list bleeds through. Rationale comment
 lives at `move-to-menu.component.ts:140-148`.
 
+### T4 — prod WKWebView drops ALL component styles: Tauri's `style-src` nonce kills `'unsafe-inline'`
+**Symptom (shipped in 0.5.0, see screenshot in PR history):** the packaged/notarized
+`.dmg` renders with the GLOBAL stylesheet working (nav/header/`.btn`/`.card` — anything
+in `styles.css`, loaded via `<link>`) but EVERY component's encapsulated styles missing —
+folder chips bare, meeting rows run title+date together, lists show raw `•` bullets.
+**`ng serve` (dev) is always fine**, so a green `ng build` proves nothing here.
+
+**Root cause (proven 3 ways — empirical WebKit repro + Tauri source + CSP3 spec):**
+Angular emulated encapsulation injects each component's styles at RUNTIME as
+`document.createElement("style")` `<style>` nodes (there are NO per-component `.css` files —
+the prod `dist` has exactly ONE css file, the global `styles.css`). At build time Tauri
+(`tauri-utils/html.rs` `inject_nonce_token` → `inject_nonce(document, "style", STYLE_NONCE_TOKEN)`,
+then `tauri/src/manager/mod.rs` `replace_csp_nonce` for `"style-src"`) stamps a nonce on every
+inline `<style>` in `index.html` and appends `'nonce-<perload>'` to the served `style-src`.
+**Per CSP3 §6.7.3.2, once `style-src` contains a nonce/hash source, `'unsafe-inline'` is
+IGNORED** — so Angular's runtime `<style>` nodes (which carry NO nonce, because `<app-root>`
+has no `ngCspNonce`) are refused. The `<link>` global sheet survives (it's `'self'`, not inline).
+Console shows: *"Refused to apply a stylesheet because its hash, its nonce, or 'unsafe-inline'
+does not appear in the style-src directive."* This is independent of `inlineCritical` and of
+the window/`visible:false` reveal.
+
+**THE FIX (one line, maintainer-recommended, applied 2026-06-29):** in
+`src-tauri/tauri.conf.json` `app.security`, tell Tauri NOT to touch `style-src`:
+```json
+"security": {
+  "csp": "… style-src 'self' 'unsafe-inline'; …",
+  "dangerousDisableAssetCspModification": ["style-src"]
+}
+```
+Tauri then leaves the declared `'unsafe-inline'` effective → component `<style>` apply.
+`script-src` stays strict (hashes + nonce — the real XSS surface is untouched). Do NOT instead
+move every component's CSS into the global `styles.css` (doesn't scale, abandons encapsulation —
+that was only ever a shell-only stopgap).
+
+**Disproven theories — do NOT chase these again** (they cost 3 failed fixes before the real one):
+it is NOT "WKWebView doesn't apply runtime-injected `<style>` until the viewport is invalidated"
+(a window RESIZE does not fix it — decisive: a blocked style stays blocked through any reflow),
+NOT an `inlineCritical`/`<link media=print onload>` issue (that's a *separate*, real `script-src`
+bug fixed by `inlineCritical:false`, but it only affects the GLOBAL sheet, never component styles),
+and NOT a hide-until-ready/`window.show()` timing bug. 0.4.0 "worked" only because its different
+build masked the always-present CSP conflict.
+
+**How to diagnose this class fast (no full Tauri build):** (1) the RESIZE test — resize the broken
+window; if styles do NOT snap in, it's CSP-blocked, not a paint/timing bug. (2) Reproduce on the
+real engine: serve `dist/meetnotes/browser` and load it in Playwright **WebKit** with the
+`style-src` nonce added to a `Content-Security-Policy` header; check per-`<style>` `el.sheet === null`
+(blocked) and read the console for the CSP refusal. A green `ng build` / a Chromium check will NOT
+reproduce it — only WebKit + the real CSP does. Verify the actual fix in the REAL packaged WKWebView
+build (notarized `.dmg`), never just `ng serve`.
+
 ---
 
 ## Quality gate (a change is not done until these are green)

--- a/.claude/rules/rust-tauri.md
+++ b/.claude/rules/rust-tauri.md
@@ -113,6 +113,20 @@ at launch ("Rust cannot catch foreign exceptions"). See the header doc in
   (`biometric.rs:7`/`29`/`46`). Touch ID + lock-at-rest + screen-share only TRULY verify on a
   signed build — typecheck/`cargo test` is not proof for FFI/permission code.
 
+## 7b. CSP in `tauri.conf.json` — keep `style-src` nonce-FREE or Angular styles vanish in prod
+
+- Tauri injects a per-load nonce into `style-src` (and stamps `nonce=` on every inline `<style>`
+  in `index.html`): `tauri-utils/html.rs` `inject_nonce_token` + `tauri/src/manager/mod.rs`
+  `replace_csp_nonce`. A nonce in `style-src` makes the browser IGNORE `'unsafe-inline'` (CSP3
+  §6.7.3.2), which BLOCKS Angular's runtime-injected emulated-encapsulation component `<style>`
+  nodes → the packaged WKWebView build renders every component unstyled while the global
+  `styles.css` `<link>` still works. (`ng serve` never reproduces it — green `ng build` ≠ shipped.)
+- **REQUIRED:** `app.security` keeps `"dangerousDisableAssetCspModification": ["style-src"]`
+  (added 2026-06-29). Do NOT remove it, and do NOT add a nonce/hash to `style-src`. `script-src`
+  stays strict. Full root-cause + diagnostics + the disproven theories: `angular-zoneless.md` **T4**.
+- `identifier` `com.meetnotes.app` and the rest of the `csp` string are immutable for the usual
+  TCC/Keychain-continuity reasons — change `security` only with a real WKWebView render-test.
+
 ## 8. No PII in logs
 
 - Never log note text, transcript segments, titles, attendee names, file paths that embed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; media-src 'self' asset:; object-src 'none'; frame-ancestors 'none'; connect-src 'self' ipc: http://ipc.localhost",
+      "dangerousDisableAssetCspModification": ["style-src"],
       "assetProtocol": {
         "enable": true,
         "scope": {


### PR DESCRIPTION
## Root cause
The shipped/notarized 0.5.0 `.dmg` rendered the global stylesheet fine but every Angular component's encapsulated styles were missing (folder chips bare, meeting rows run together, raw bullets). Dev (`ng serve`) was always fine.

Angular emulated encapsulation injects component styles at runtime as inline `<style>` nodes. Tauri stamps a nonce on every inline `<style>` in `index.html` and appends `'nonce-<perload>'` to the served `style-src`. Per CSP3 §6.7.3.2, a nonce in `style-src` makes the browser **ignore `'unsafe-inline'`**, so Angular's nonce-less runtime `<style>` are refused. The global `styles.css` `<link>` survives (`'self'`) — hence shell styled, route content bare.

Proven 3 ways: WebKit reproduction (exact CSP refusal), Tauri source (`tauri-utils/html.rs` `inject_nonce_token` + `manager/mod.rs` `replace_csp_nonce`), CSP3 spec. The earlier 'WKWebView viewport-invalidation FOUC' theory was wrong — a window resize does not fix it.

## Fix
`dangerousDisableAssetCspModification: ["style-src"]` in `tauri.conf.json` → Tauri leaves `style-src` alone, declared `'unsafe-inline'` stays effective, component styles apply. `script-src` stays strict. Verified in the real notarized universal `.dmg` (v0.5.0 re-uploaded).

Documents the trap as a binding rule: `angular-zoneless.md` **T4** + `rust-tauri.md` §7b.