### PR TITLE
fix(audio): AEC mic feed could desync the timeline from playback — guard + mono helper + runaway cap

### DIFF
--- a/src-tauri/aeccap/aeccap.swift
+++ b/src-tauri/aeccap/aeccap.swift
@@ -33,6 +33,8 @@ final class AecCapturer {
     private let engine = AVAudioEngine()
     private let lock = NSLock()
     private var file: AVAudioFile?
+    private var monoFormat: AVAudioFormat?
+    private var converter: AVAudioConverter?
 
     init(outURL: URL) { self.outURL = outURL }
 
@@ -43,24 +45,56 @@ final class AecCapturer {
         // to the raw cpal mic.
         try input.setVoiceProcessingEnabled(true)
 
-        let format = input.outputFormat(forBus: 0)
-        input.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
-            self?.write(buffer, format: format)
+        let tapFormat = input.outputFormat(forBus: 0)
+        // ALWAYS persist a single MONO channel. VPIO can hand us a MULTI-CHANNEL device format (a
+        // 9-channel aggregate input was seen in the field) — writing that verbatim ballooned the WAV
+        // ~9x (a stuck session once stranded a 91 GB scratch file) AND the downstream Rust ASR feed
+        // expects a compact mono track aligned with the raw mic. Downmix every buffer to mono so the
+        // output is small, well-formed, and duration-faithful regardless of the device channel count.
+        let mono = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: tapFormat.sampleRate,
+            channels: 1,
+            interleaved: false)
+        monoFormat = mono
+        if tapFormat.channelCount > 1, let mono = mono {
+            converter = AVAudioConverter(from: tapFormat, to: mono)
+        }
+
+        input.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { [weak self] buffer, _ in
+            self?.write(buffer)
         }
         engine.prepare()
         try engine.start()
-        FileHandle.standardError.write(Data("aeccap: capturing\n".utf8))
+        FileHandle.standardError.write(
+            Data(
+                "aeccap: capturing (\(Int(tapFormat.sampleRate)) Hz, \(tapFormat.channelCount) ch in → 1 ch out)\n"
+                    .utf8))
     }
 
-    private func write(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat) {
+    private func write(_ buffer: AVAudioPCMBuffer) {
         lock.lock()
         defer { lock.unlock() }
+        // Downmix to mono when the input has >1 channel (same sample rate → no SRC); else write as-is.
+        let outBuffer: AVAudioPCMBuffer
+        if let converter = converter, let mono = monoFormat,
+            let out = AVAudioPCMBuffer(pcmFormat: mono, frameCapacity: buffer.frameLength)
+        {
+            do {
+                try converter.convert(to: out, from: buffer)
+            } catch {
+                return  // skip this buffer rather than write a malformed frame
+            }
+            outBuffer = out
+        } else {
+            outBuffer = buffer
+        }
         if file == nil {
             file = try? AVAudioFile(
-                forWriting: outURL, settings: format.settings,
+                forWriting: outURL, settings: outBuffer.format.settings,
                 commonFormat: .pcmFormatFloat32, interleaved: false)
         }
-        try? file?.write(from: buffer)
+        try? file?.write(from: outBuffer)
     }
 
     func stop() {

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -18,6 +18,49 @@ use crate::error::{AppError, Result};
 
 const AEC_HELPER_NAME: &str = "meetnotes-aeccap";
 
+/// Hard wall-clock cap (seconds) on a single AEC capture, passed to the helper so it self-stops.
+/// A meeting longer than this loses AEC and falls back to the raw cpal mic for ASR (the pipeline's
+/// duration guard does the same) — far better than an UNBOUNDED VPIO capture, which once stranded a
+/// 91 GB scratch WAV after a stuck/never-stopped session. 4 h covers any realistic meeting.
+const MAX_CAPTURE_SECONDS: u64 = 4 * 60 * 60;
+
+/// Best-effort: delete stale capture scratch WAVs (`meetnotes-aec-*.wav` / `meetnotes-sys-*.wav`)
+/// left in the temp dir by a previous crashed/stuck/never-stopped session. Called once at startup,
+/// where nothing is recording yet, so any scratch older than an hour is an orphan — removing it
+/// reclaims disk (a stuck VPIO helper once left a 91 GB file). Touches ONLY the OS temp dir, never
+/// the app-data audio dir; logs IDs/counts only, no PII.
+pub fn sweep_stale_scratch() {
+    let dir = std::env::temp_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let is_scratch = (name.starts_with("meetnotes-aec-")
+            || name.starts_with("meetnotes-sys-"))
+            && name.ends_with(".wav");
+        if !is_scratch {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|age| age.as_secs() > 3600)
+            .unwrap_or(false);
+        if stale && std::fs::remove_file(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(target: "audio", removed, "swept stale capture scratch WAVs at startup");
+    }
+}
+
 /// Path to the bundled VPIO AEC helper (resource dir, then the dev `AECCAP_BIN` fallback).
 pub fn aec_helper_path(app: &AppHandle) -> Option<PathBuf> {
     if let Ok(p) = app
@@ -51,6 +94,9 @@ impl AecRecorder {
             aec_helper_path(app).ok_or_else(|| AppError::Audio("AEC helper not bundled".into()))?;
         let mut cmd = Command::new(&bin);
         cmd.arg(&wav_path)
+            // Wall-clock cap so a stuck/never-stopped helper self-terminates instead of growing an
+            // unbounded scratch WAV (the 91 GB incident). Normal Stop SIGTERMs it long before this.
+            .arg(MAX_CAPTURE_SECONDS.to_string())
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,10 @@ pub fn run() {
             };
             app.manage(state);
 
+            // Reclaim any capture scratch WAVs stranded by a previous crashed/stuck session
+            // (a stuck VPIO/AEC helper once left a 91 GB temp file). Nothing records yet at setup.
+            crate::audio::aec::sweep_stale_scratch();
+
             create_bar_window(app.handle())?;
             if let Err(e) = app.global_shortcut().register(SUMMON_SHORTCUT) {
                 tracing::warn!(target: "shortcut", error = %e, "could not register global shortcut");

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -26,6 +26,24 @@ pub struct PipelineResult {
 /// installed release's `MeetNotes` — the same split as the DB dir.
 const AUDIO_SUBDIR: &str = "audio";
 
+/// Max allowed gap between the AEC ASR feed and the raw mic, in seconds. Beyond this the AEC feed
+/// is rejected (raw mic used for ASR) so the transcript timestamps stay aligned with the played
+/// archive. VPIO startup latency is sub-second; the bug this guards (a malformed multi-channel VPIO
+/// capture decoding to ~8 s for a 51 s recording → an 8 s timeline over 51 s of audio) is tens of
+/// seconds off.
+const AEC_FEED_MAX_DRIFT_S: f64 = 2.0;
+
+/// Whether the AEC ASR feed (16 kHz) covers the same span as the raw mic (16 kHz) within tolerance.
+/// `false` → the feed is malformed/short (e.g. a 9-channel VPIO device format, or cpal/VPIO
+/// coexistence starvation) and using it for ASR would desync the timeline from playback, so the
+/// caller MUST fall back to the raw mic. AEC is best-effort; timeline correctness beats echo
+/// cancellation.
+fn aec_feed_matches_raw(raw_16k_len: usize, aec_16k_len: usize) -> bool {
+    let raw_s = raw_16k_len as f64 / audio::TARGET_RATE_HZ as f64;
+    let aec_s = aec_16k_len as f64 / audio::TARGET_RATE_HZ as f64;
+    (raw_s - aec_s).abs() <= AEC_FEED_MAX_DRIFT_S
+}
+
 /// RAII guard that deletes a transient sidecar scratch WAV (AEC mic / system-audio) when it
 /// drops — on EVERY exit path of the pipeline, success OR error OR panic-unwind. These helper
 /// outputs are PLAINTEXT audio fragments in `$TMPDIR`; the old code removed them only on the
@@ -210,7 +228,21 @@ async fn run_inner(
         match audio::read_wav_mono(aec) {
             Ok((a, rate)) => {
                 let asr = audio::resample_to_16k(&a, rate)?;
-                mic_16k_archive = Some(std::mem::replace(&mut mic_16k, asr));
+                // GUARD: the AEC feed MUST span the same wall-clock as the raw mic, or the segment
+                // timestamps (derived from the AEC feed) desync from the played archive (the raw
+                // mic) — the bug where a 51 s recording rendered an 8 s timeline. VPIO yielded a
+                // malformed multi-channel/short capture; reject any divergent feed and keep the raw
+                // mic for ASR. The matching `mic_16k_archive = None` means archive == ASR feed.
+                if aec_feed_matches_raw(mic_16k.len(), asr.len()) {
+                    mic_16k_archive = Some(std::mem::replace(&mut mic_16k, asr));
+                } else {
+                    tracing::warn!(
+                        target: "audio",
+                        raw_s = mic_16k.len() as f64 / audio::TARGET_RATE_HZ as f64,
+                        aec_s = asr.len() as f64 / audio::TARGET_RATE_HZ as f64,
+                        "AEC feed duration diverges from raw mic; using raw mic for ASR to keep the timeline in sync with playback"
+                    );
+                }
             }
             Err(e) => {
                 tracing::warn!(target: "audio", error = %e, "AEC mic unreadable; raw mic for ASR")
@@ -900,6 +932,39 @@ mod tests {
     fn derive_title_prefers_frontmatter() {
         let md = "---\ntitle: Q3 Planning\ndate: 2026-06-24\n---\n# Heading\n";
         assert_eq!(derive_title(md, "2026-06-24"), "Q3 Planning");
+    }
+
+    const HZ: usize = crate::audio::TARGET_RATE_HZ as usize;
+
+    /// RED-before-GREEN: the shipped 51 s recording produced an 8 s AEC ASR feed (malformed 9-ch
+    /// VPIO capture) and the OLD code accepted it unconditionally → the timeline desynced from the
+    /// played raw-mic archive. The guard MUST reject a feed this far off.
+    #[test]
+    fn aec_feed_51s_recording_8s_feed_is_rejected() {
+        assert!(
+            !aec_feed_matches_raw(52 * HZ, 8 * HZ),
+            "an 8 s AEC feed for a 52 s recording must be rejected (would desync the timeline)"
+        );
+    }
+
+    #[test]
+    fn aec_feed_matching_raw_is_accepted() {
+        // Same length, and a sub-second VPIO startup gap, are both fine.
+        assert!(aec_feed_matches_raw(52 * HZ, 52 * HZ));
+        assert!(aec_feed_matches_raw(52 * HZ, 52 * HZ - HZ / 2)); // 0.5 s shorter
+    }
+
+    #[test]
+    fn aec_feed_just_past_tolerance_is_rejected() {
+        // > 2 s shorter → reject; exactly within 2 s → accept (boundary either side of the const).
+        assert!(aec_feed_matches_raw(60 * HZ, 60 * HZ - 2 * HZ)); // exactly 2 s → within tolerance
+        assert!(!aec_feed_matches_raw(60 * HZ, 60 * HZ - 3 * HZ)); // 3 s → rejected
+    }
+
+    /// A longer-than-raw feed (e.g. a multi-channel mis-decode inflating the buffer) is also rejected.
+    #[test]
+    fn aec_feed_longer_than_raw_is_rejected() {
+        assert!(!aec_feed_matches_raw(10 * HZ, 90 * HZ));
     }
 
     #[test]


### PR DESCRIPTION
## Symptom
A 51 s recording rendered an **8 s timeline** (player 0:51 / timeline axis 0:08 / 'Me' 0:08). On-disk evidence: the archive `.wav` and the raw mic master are both **~51.8 s**, but the transcript segments span only **~8 s**.

## Root cause (experimental opt-in AEC path)
The VPIO helper's input format on the affected Mac is **multi-channel** (a **9-channel** device format was found in a stranded scratch WAV). `aeccap` wrote that verbatim, so the AEC ASR feed was malformed and its decoded duration (~8 s) didn't match the raw mic (~51 s). The pipeline transcribes the **AEC feed** but plays the **raw-mic archive**, so the segment timestamps — hence the LLM-derived timeline — desynced from playback. A stuck/never-stopped helper had also stranded a **91 GB** 9-channel scratch WAV.

## Fixes (whole AEC/capture path hardened)
- **`pipeline.rs` — guard:** if the AEC feed's duration diverges from the raw mic by >2 s, reject it and use the raw mic for ASR → the timeline always matches the played audio. AEC is best-effort; correctness beats echo cancellation. (4 unit tests.)
- **`aeccap.swift` — always MONO:** downmix to 1 channel via `AVAudioConverter` regardless of the VPIO device channel count → well-formed, duration-faithful, ~9× smaller feed.
- **`aec.rs` — runaway cap:** pass a 4 h wall-clock cap so a stuck capture self-terminates instead of growing unbounded (the 91 GB incident).
- **`aec.rs` + `lib.rs` — startup sweep:** delete stale `meetnotes-{aec,sys}-*.wav` scratch files at startup to reclaim disk from a previous crashed/stuck session.

## Verification
`cargo test --lib` green (456 passed; 4 new guard tests). `swiftc` compiles the mono helper (universal arm64+x86_64). **Honest bar:** the VPIO runtime + real echo cancellation need a signed build on a real Mac with a live call — not verifiable headless. The guard/cap/sweep ARE verified (unit tests + logic).