### PR TITLE
feat(record): realtime typed @brain notes

### DIFF
--- a/docs/research/2026-06-30-brain-verification-realtime-notes-doc-ingestion.md
+++ b/docs/research/2026-06-30-brain-verification-realtime-notes-doc-ingestion.md
@@ -1,0 +1,77 @@
+<!-- Generated 2026-06-30 via /research (murmur-researcher fan-out, 3 angles). Pricing/versions = point-in-time. -->
+# Research: What Murmur's "brain" actually is today + feasibility of (A) realtime @brain notes and (B) whole-brain view + doc ingestion
+
+## TL;DR / Verdict
+
+**Verification (the priority): the user's model — "our notes are turned into the brain = a vector DB" — is aspirationally true but operationally OFF by default.** A real on-device vector store exists and is well-built (`sqlite-vec` `vec0` KNN over `multilingual-e5-small` 384-d embeddings, hybrid RRF-fused with FTS5 + the entity graph), but it is **dormant on a fresh install** behind three independent switches. **Today's actual brain = FTS5/BM25 full-text + an LLM-extracted entity graph + a bitemporal facts layer + a (cloud-by-default) reasoner.** The vector layer is a real-but-opt-in, bring-your-own-model upgrade on top — and its real-world quality (incl. Polish) is **unproven** (the only smoke test is `#[ignore]`d; the RAG bake-off is unrun).
+
+**Both planned features are feasible and well-supported by the existing code** — but both implicitly assume a *working* semantic brain, which today it is not. So the correct sequence is: **(0) make the vector brain real + proven, THEN (A) realtime @brain notes, THEN (B) doc ingestion, and DEFER the bespoke "brain-atlas" UI** (the useful 95% already exists as our entity directory; a global map is mostly eye-candy at our scale and needs a new FE dep).
+
+## Co już mamy (the corrected brain map, code-grounded)
+
+**The always-on substrate (no flag, no model needed):**
+- **FTS5/BM25** over titles + segments + notes, trigger-maintained (`db.rs:423-494`). This is what powers search + the "notes compound" RAG note-grounding — which is **lexical, NOT vector** (`summarize/related_context.rs:1-8` "Uses the LIVE FTS5 retrieval … NO embedding model").
+- **Entity graph** (`entities`/`entity_mentions`, `db.rs:240-258`), extracted by the **cloud summarizer LLM** (not local NER), best-effort (`summarize/graph.rs:24-34`, `commands.rs:1406-1421`).
+- **Bitemporal facts** (entity·predicate·object triples, two time axes, supersession-not-delete; `facts.rs:114`), gated read via `list_facts_visible`.
+- **Reasoner** defaults to **Cloud** (`config.rs:47,237`) through the `make_provider` redaction firewall.
+
+**The vector layer — SHIPPED but GATED OFF by default (all real, not stubs):**
+- Embedder: `multilingual-e5-small`, **384-dim**, multilingual incl. Polish, e5 `query:`/`passage:` prefixes (`embed.rs:30,75-92`; real candle impl `embed/candle_bert.rs:148-214`). **Downloaded-not-bundled** (`embed.rs:91,104`); with no model on disk, `active_embedder()` falls back to a hash-bag `StubEmbedder` that is **explicitly NOT semantic** (`embed.rs:111-113,146-161`).
+- Store: `vec_chunks(chunk_id, embedding float[384])` `vec0` virtual table (`db.rs:384-388`), 1:1 with plaintext `note_chunks` (`db.rs:369-379`); real ANN KNN inside SQLCipher (`db.rs:997-1000`).
+- Retrieval: hybrid `search_hybrid_visible` = RRF fusion of FTS ∪ vector-KNN ∪ entity-graph, each `visibility_clause`-gated (`db.rs:1138-1193`). Chunks **purged on seal** (`purge_chunks_tx`, `db.rs:942-958`).
+- What's embedded: the **note markdown, chunked ~800 chars** (`embed.rs:214-238`) — NOT transcript segments. Auto only `if semantic_search_enabled` at note-finalize (`pipeline.rs:594-606`), else only via manual `reindex_embeddings` (`commands.rs:2676`, which refuses the stub: `commands.rs:2757`).
+
+**Fresh-install default state** (`config.rs:234-241`): `semantic_search_enabled=false`, `brain_model_id=None`, `brain_backend=Cloud`, `web_search_enabled=false`, `cloud_egress_consented=false`, e5 absent. **⇒ the vector brain is dormant; the FTS+graph+facts brain is live.**
+
+## Findings
+
+### Gap vs the user's mental model (Angle 1 — VERIFY)
+- "Notes → vector DB" is the *opt-in upgrade*, not the substrate. Out of the box the brain is **lexical + graph + facts + cloud LLM**.
+- The single biggest correction: the always-on "make notes compound" grounding is **FTS, not embeddings** (`related_context.rs:86`).
+- **Real bug found (medium-confidence, code-read not reproduced):** the pipeline auto-index gates on the flag but **NOT on `embed_model_present()`** (`pipeline.rs:594,600`) — so enabling the flag *without* the model writes **stub-hash vectors** into `vec_chunks` (while the manual backfill correctly refuses). This silently pollutes the index. ~3-line fix + RED-before-GREEN test.
+- Real semantic quality / Metal / **Polish recall = UNVERIFIED** (ignored smoke test `candle_bert.rs:254`; bake-off `docs/RAG-BAKEOFF.md` unrun). Needs a signed build + e5 on a real Mac.
+
+### (A) Realtime @brain inline notes — feasible, foundation ~90% ready
+- The **@brain-ask half is shipped:** `ask_assistant_text` (`commands.rs:610`) already routes a typed question through the gated, redacted, consent-gated agentic brain (`run_assistant_query`, `live.rs:318`); the record screen already has a text composer (the just-merged unified assistant, `assistant-actions.component.ts:113`).
+- **New work = a persistent typed-notes store** + wiring into (a) live brain context (exactly like the 0.6.2 `live_transcript` injection, `live.rs:417-422,891-908`) and (b) the finalized `notes.markdown`.
+- **Latent home + a lock gap:** the unused `notes_asides` table (`db.rs:271`, written only by the voice "note aside" intent, `list_note_asides` has **zero non-test callers**) — but it is **NOT sealed/purged on lock** (`db.rs:900-916`), so an aside's plaintext **survives a folder seal**. Typed notes are *primary user content* → they need **seal-and-restore** (like `notes.markdown`), not purge. **Cleanest:** fold typed notes into `notes.markdown` (`## My notes`) at finalize so they inherit the correct `seal_note` path, and use `notes_asides` only as the transient live buffer (+ close its lock gap).
+- **Prior art:** Granola (your typed notes *steer* the summarizer; your text black, AI gray for attribution); ClickUp `@Brain` (private-until-insert); Notion `/ai` (`@` reserved for context-mention). The differentiated combo: typed emphasis as first-class context for a **local-first** brain + `@`-invoke insert. Category itself is table-stakes.
+- **Fully headless-verifiable** (persistence + injection + finalize + seal round-trip = `cargo test --lib`) — rare for content work.
+
+### (B) Whole-brain view + doc ingestion — two halves, very different value
+- **Doc ingestion = the high-value half (build it).** ~80% exists: `chunk_note` (`embed.rs:214`) generalizes to any text; `active_embedder` + `note_chunks`/`vec_chunks` + `reindex_embeddings` reuse directly. `note_chunks.source_type` (`db.rs:374`) already anticipates multi-source but is **write-only today** ('voice', never read). md/txt = **zero new deps**; **PDF = a new crate (needs approval)** → defer.
+  - **Storage fork:** synthetic-meeting row (cheap, pollutes Library/graph) vs a clean `documents`/`sources` table + source-polymorphic chunks (brain2-native, matches the "source-agnostic from day one" memory). Lean clean; the FK `note_chunks.meeting_id NOT NULL ON DELETE CASCADE` (`db.rs:167,377`) is the load-bearing constraint.
+  - **Lock fit (load-bearing):** embeddings are **invertible to text** (vec2text) → doc chunks MUST be `visibility_clause`-gated + purged-on-lock. Cheapest safe model: **assign each doc to a folder** → the existing per-folder lock + purge + gating cover it. lock-security-reviewer gated. **Zero new egress** (local parse + local embed).
+- **The "great-UI whole-brain map" = the lower-value half (defer).** Prior art is decisive: global node-link graphs are "beautiful but useless" past a few hundred nodes; our **entity directory already does the useful 95%** and beats Obsidian (we have typed nodes + typed edges). A 2D embedding atlas is a gadget at our ~10²–10³-chunk scale (already concluded in `docs/research/2026-06-29-embedding-visualization-graph-tab.md`; raw embeddings must never leave Rust). A polished animated force-graph needs a **new npm dep** (force-graph/d3/sigma → your approval) and fights the zoneless no-rAF rule. Escape hatch if we do it: compute layout in **Rust**, render **static SVG** (no deps, headless-testable).
+
+## Fit z ograniczeniami Murmur
+- **Local-first / privacy:** embedding + ingestion are on-device; e5 download is inbound-only. The default-cloud reasoner + entity/facts extraction already egress note text through the redaction firewall + consent — existing behavior, no new egress class added by either feature.
+- **SQLite-canonical:** vectors/chunks/entities/facts/typed-notes all in the one SQLCipher DB; `vec0` registered before `PRAGMA key` (encryption intact).
+- **Lock model:** every semantic/graph/facts read is `visibility_clause`-gated + purged-on-seal. **Both features are lock-touching** (typed notes = seal-and-restore; doc chunks = folder-gated + purge) → **lock-security-reviewer mandatory**.
+- **Obsidian-native:** typed notes fold into `.md`; ingested docs can export as `.md` — owned files, no lock-in.
+- **CI honesty:** ingestion + typed-notes + gating are fully headless-testable; **semantic quality + Polish recall are NOT** (need a real Mac + e5 + the bake-off).
+
+## Opcje i tradeoffy
+- **Step 0 — make the vector brain real (S, ~½ day):** (a) gate auto-index on `embed_model_present()` (`pipeline.rs:594`) + RED test; (b) run the e5 bake-off on a real Mac (does vector beat FTS5 at our scale; Polish recall). De-risks A and B before UX work.
+- **Feature A:** A1 persistent typed-notes + injection + finalize (S–M, headless) → A2 inline `@brain` autocomplete + attributed insert (M, FE) → skip A3 (full `@`-everything).
+- **Feature B:** I-1 md/txt ingestion, folder-gated, reuse pipeline, surface in existing `/graph` (S–M) → I-2 clean `documents` table (M–L) → I-3 PDF (needs dep approval). Viz: V-1 static node-link in `/graph` (M, no deps) ≫ V-2 animated atlas (needs dep) / V-3 embedding map (defer).
+
+## Rekomendacja i pierwszy krok
+1. **First, fix + prove the foundation (Step 0).** Close the stub-vector gap and run the bake-off. Cheap, and everything downstream assumes "semantic actually works."
+2. **Then Feature A1** (typed notes → live brain context + into the `.md`) — highest value/effort ratio, fully testable, and it's the Granola-style differentiator delivered locally. Fold into `notes.markdown` to inherit the correct seal path; close the `notes_asides` lock gap.
+3. **Then Feature B I-1** (md/txt doc ingestion, folder-gated) — makes the brain demonstrably know more, reusing `embed.rs` end-to-end.
+4. **Defer the bespoke brain-atlas UI** (V-1+) until there's enough content and a passed bake-off; the entity directory + a future "Documents" tab cover the real need first.
+
+Each of A1 / I-1 is its own ship-feature cycle (plan → build → adversarial-verify + lock-security-reviewer → PR), batched toward a release.
+
+## Otwarte pytania / czego nie udało się zweryfikować
+- **Real semantic quality + Polish recall** — unproven by design; needs a signed build + e5 on a real Mac + the bake-off.
+- **Stub-vector-on-flag-without-model** — read in code, not runtime-reproduced (medium confidence); also unconfirmed whether the Settings toggle is disabled until the model is present.
+- **`vec0` read-back** (`SELECT embedding`) — only the KNN path is used in-tree (`db.rs:1047` avoids reading vectors back); matters only for an embedding-map viz, needs a 1-line spike.
+- **Storage fork ripple** — decoupling `note_chunks` from the meeting FK touches every `visibility_clause` join (`note_chunks → meetings → folders`); contained but needs a careful pass.
+- **ClickUp `@Brain` exact insert/attribution mechanics** — deep help page 403'd; corroborated from the section index.
+
+## Sources
+**Code (current tree):** `embed.rs:30,75-92,104,146-161,214-238`; `embed/candle_bert.rs:148-214,254`; `storage/db.rs:240-315,369-390,423-494,831-916,942-958,983-1041,1138-1193,167,377,271-278,2499,2511`; `pipeline.rs:594-606`; `tools.rs:165-204,458-528`; `agent.rs:72-156`; `summarize/related_context.rs:1-8,86`; `summarize/graph.rs:24-34`; `summarize/redact.rs:344-357`; `facts.rs:114,231-244`; `reason.rs:257-297,462-468`; `settings/config.rs:47,234-241`; `commands.rs:610,669,1389-1606,2676,2710,2757`; `transcribe/live.rs:318-454,417-422,891-908`; `state.rs:122`; `voice_action.rs:531-552,1093`; FE `features/record/assistant-actions.component.ts:113`, `features/graph/graph.component.ts:25-38`, `entity-neighborhood.component.ts:330-372`, `core/ipc.service.ts:478-553`.
+**Web:** Granola (wondertools.substack.com/p/granolaguide; granola.ai); ClickUp @Brain (help.clickup.com/.../20658787666071); Notion AI (notion.com/help/guides/using-slash-commands; storylane.io); Obsidian graph critique (codeculture.store/.../obsidian-graph-view-useful; eleanorkonik.com); Nomic Atlas / UMAP (docs.nomic.ai/.../how-to-visualize-embeddings); Apple Embedding Atlas (arxiv.org/abs/2505.06386); graph perf (pmc.ncbi.nlm.nih.gov/articles/PMC12061801; medium.com/neo4j d3+PIXI).
+**Internal prior art:** `docs/research/2026-06-29-embedding-visualization-graph-tab.md`; `docs/RAG-BAKEOFF.md` (unrun).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -788,6 +788,65 @@ pub fn update_note(
     })
 }
 
+/// brain2 realtime typed @brain notes — persist the user's free-text notes typed DURING a meeting
+/// (the FE autosaves the whole buffer here). The buffer (a) feeds the in-meeting brain's system
+/// prompt while recording and (b) is folded into the finalized note at summarize time.
+///
+/// READ/WRITE-GATE: refuse to write a sealed-and-not-session-unlocked meeting's buffer
+/// (`AppError::Locked`). Its content is blanked while sealed, and an ungated write would resurrect
+/// typed plaintext at rest behind the lock. Fail closed — mirrors `update_note`'s D4 gate.
+#[tauri::command]
+pub fn save_manual_notes(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    text: String,
+) -> Result<(), AppError> {
+    save_manual_notes_inner(state.inner(), &meeting_id, &text)
+}
+
+/// Inner of [`save_manual_notes`] taking `&AppState` (so the gate is unit-testable without a
+/// `tauri::State`). GATED: a sealed-and-not-session-unlocked meeting is refused with
+/// `AppError::Locked` (mirrors `update_note`'s D4 write-gate — never resurrect typed plaintext
+/// behind a lock).
+pub(crate) fn save_manual_notes_inner(
+    state: &AppState,
+    meeting_id: &str,
+    text: &str,
+) -> Result<(), AppError> {
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to edit your notes".into(),
+        ));
+    }
+    state.db.set_manual_notes(meeting_id, text)?;
+    // PII rule: log only the meeting id + buffer length, never the typed text.
+    tracing::debug!(target: "notes", meeting_id = %meeting_id, len = text.len(), "manual notes saved");
+    Ok(())
+}
+
+/// brain2 realtime typed @brain notes — read the meeting's live typed-notes buffer (the FE rehydrates
+/// the editor from this). GATED by `meeting_is_unlocked`: a sealed-and-not-session-unlocked meeting
+/// returns "" (mask — never leak the buffer), exactly like the masked detail DTO drops note/segments.
+#[tauri::command]
+pub fn get_manual_notes(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<String, AppError> {
+    get_manual_notes_inner(state.inner(), &meeting_id)
+}
+
+/// Inner of [`get_manual_notes`] taking `&AppState` (unit-testable gate). A sealed-and-not-session-
+/// unlocked meeting returns "" (masked) — its buffer is never surfaced.
+pub(crate) fn get_manual_notes_inner(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<String, AppError> {
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Ok(String::new()); // sealed-not-unlocked ⇒ masked, never the stored buffer.
+    }
+    state.db.get_manual_notes(meeting_id)
+}
+
 /// Full-text-ish search across meeting titles, transcripts, and notes (Library search).
 #[tauri::command]
 pub fn search_meetings(
@@ -4278,6 +4337,24 @@ fn seal_meeting_extras(
     if let Some(enc) = seal_audio_at_rest(ck, sys, &aad_audio_role(mid, folder_id, StreamRole::Sys))? {
         state.db.set_meeting_sys_master_path(mid, Some(&enc))?;
     }
+
+    // brain2 realtime notes: SEAL the user's typed in-meeting notes (USER-AUTHORED PRIMARY content)
+    // exactly like the timeline — encrypt the plaintext under the folder CK, VERIFY it decrypts back
+    // byte-identical (verify-before-destroy), then blank the plaintext. NEVER blanked without the
+    // sealed copy, and reversed by the matching unseal (session-unlock / remove-lock). An empty
+    // buffer ⇒ nothing to seal (blob stays NULL); an already-sealed buffer (blank text) is skipped.
+    if let Some(rn) = state.db.raw_manual_notes(mid)? {
+        if !rn.text.is_empty() {
+            let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "manual_notes");
+            let blob = crate::crypto::encrypt(ck, rn.text.as_bytes(), &aad)?;
+            if crate::crypto::decrypt(ck, &blob, &aad)? != rn.text.as_bytes() {
+                return Err(AppError::Storage(
+                    "manual-notes seal verification failed (blob mismatch)".into(),
+                ));
+            }
+            state.db.seal_manual_notes(mid, &blob)?;
+        }
+    }
     Ok(())
 }
 
@@ -4302,6 +4379,17 @@ fn unseal_folder_extras(state: &AppState, folder_id: &str, ck: &[u8; 32]) -> Res
                 let data = String::from_utf8(pt)
                     .map_err(|_| AppError::Storage("decrypted timeline is not valid UTF-8".into()))?;
                 state.db.restore_timeline_data(mid, &data)?;
+            }
+        }
+        // Typed notes: decrypt the sealed blob back into the plaintext column for the session (the
+        // blob is kept — the folder is still locked on disk). Mirrors the timeline unseal.
+        if let Some(rn) = state.db.raw_manual_notes(mid)? {
+            if let Some(blob) = &rn.blob {
+                let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "manual_notes");
+                let pt = crate::crypto::decrypt(ck, blob, &aad)?;
+                let text = String::from_utf8(pt)
+                    .map_err(|_| AppError::Storage("decrypted manual notes is not valid UTF-8".into()))?;
+                state.db.set_manual_notes(mid, &text)?;
             }
         }
         // Audio at rest: materialize a playable WAV for the session (playback + both masters), each
@@ -4341,6 +4429,13 @@ fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppErr
         if let Some(tl) = state.db.raw_timeline(&mid)? {
             if tl.data_blob.is_some() && !tl.data.is_empty() {
                 state.db.restore_timeline_data(&mid, "")?;
+            }
+        }
+        // Typed notes: re-blank the plaintext ONLY when the sealed blob exists (never destroy the
+        // only copy). Mirrors the timeline reblank.
+        if let Some(rn) = state.db.raw_manual_notes(&mid)? {
+            if rn.blob.is_some() && !rn.text.is_empty() {
+                state.db.set_manual_notes(&mid, "")?;
             }
         }
         if let Some(enc) = reblank_audio(state.db.get_meeting(&mid)?.and_then(|m| m.audio_path))? {
@@ -4390,6 +4485,20 @@ fn unseal_folder_extras_permanent(
             }
         }
         state.db.clear_timeline_blob(&mid)?;
+
+        // Typed notes: permanently restore the plaintext from the blob (or keep the in-memory
+        // plaintext if the folder was session-unlocked and the blob is absent), then clear the blob.
+        // NEVER lose the typed notes — the plaintext is back before the blob is dropped.
+        if let Some(rn) = state.db.raw_manual_notes(&mid)? {
+            if let Some(blob) = &rn.blob {
+                let aad = aad_content(folder_id, &mid, AAD_NO_PROVIDER, "manual_notes");
+                let pt = crate::crypto::decrypt(ck, blob, &aad)?;
+                let text = String::from_utf8(pt)
+                    .map_err(|_| AppError::Storage("decrypted manual notes is not valid UTF-8".into()))?;
+                state.db.set_manual_notes(&mid, &text)?;
+            }
+        }
+        state.db.clear_manual_notes_blob(&mid)?;
 
         // Audio at rest: permanently restore the playback WAV + both masters from their .enc, each
         // decrypted through the role→role-less AAD ladder (a pre-role master still decrypts); the
@@ -4954,6 +5063,111 @@ mod lifecycle_tests {
             created_at: "2026-06-27T08:00:00Z".to_string(),
         })
         .unwrap();
+    }
+
+    /// brain2 realtime notes: with the meeting in an OPEN folder (or no folder) the gate is open, so
+    /// `save`/`get` round-trip the buffer.
+    #[test]
+    fn manual_notes_save_get_round_trip_when_unlocked() {
+        let state = build_state("manual-notes-open");
+        seed_meeting(&state.db, "m1", "note", None); // no folder ⇒ always open
+
+        get_manual_notes_inner(&state, "m1").map(|s| assert_eq!(s, "")).unwrap();
+        save_manual_notes_inner(&state, "m1", "ship Friday; Anna owns QA").unwrap();
+        assert_eq!(
+            get_manual_notes_inner(&state, "m1").unwrap(),
+            "ship Friday; Anna owns QA",
+            "open-folder buffer round-trips through the gated commands"
+        );
+    }
+
+    /// LOCK-GATE: on a sealed-and-NOT-session-unlocked meeting, `save_manual_notes` is refused with
+    /// `AppError::Locked` (never resurrect typed plaintext behind a lock) and `get_manual_notes`
+    /// returns "" (masked) EVEN THOUGH the column still holds content — never leaking the buffer.
+    /// Unlocking the folder restores both read and write.
+    #[test]
+    fn manual_notes_save_refused_and_get_masked_when_sealed() {
+        let state = build_state("manual-notes-sealed");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "note", Some("f-lock"));
+        // The buffer holds content at rest (e.g. typed pre-seal); the gate must mask/refuse it.
+        state.db.set_manual_notes("m1", "secret typed plaintext").unwrap();
+        // Seal the folder (locked, NOT in the session unlock set).
+        state.db.set_folder_locked("f-lock", true, Some(&b"wrapped"[..])).unwrap();
+
+        // WRITE is refused with Locked.
+        let err = save_manual_notes_inner(&state, "m1", "new secret").unwrap_err();
+        assert!(matches!(err, AppError::Locked(_)), "sealed write must be AppError::Locked, got {err:?}");
+        // The refused write left the stored buffer untouched.
+        assert_eq!(state.db.get_manual_notes("m1").unwrap(), "secret typed plaintext", "refused write must not mutate");
+        // READ is masked to "" despite the column holding content.
+        assert_eq!(
+            get_manual_notes_inner(&state, "m1").unwrap(),
+            "",
+            "sealed-not-unlocked read must mask the buffer, never leak it"
+        );
+
+        // Session-unlock the folder ⇒ both read and write work again.
+        state.unlocked_folders.lock().unwrap().insert("f-lock".to_string());
+        assert_eq!(get_manual_notes_inner(&state, "m1").unwrap(), "secret typed plaintext");
+        save_manual_notes_inner(&state, "m1", "edited after unlock").unwrap();
+        assert_eq!(get_manual_notes_inner(&state, "m1").unwrap(), "edited after unlock");
+    }
+
+    /// COUNTEREXAMPLE A (verify-before-destroy): the user's typed notes SURVIVE a real lock→unlock
+    /// cycle — SEALED under the folder CK (plaintext blanked, blob present) on lock, RESTORED
+    /// byte-identical on unlock. Drives the PRODUCTION seal (`lock_folder_inner` →
+    /// `seal_meeting_extras`) and unseal (`unseal_folder_extras`), so the typed notes are never
+    /// blanked-and-lost. RED on the prior blank-on-seal code (no blob → nothing to restore).
+    #[test]
+    fn manual_notes_survive_lock_unlock_cycle_sealed_and_restored() {
+        let state = build_state("manual-notes-seal-cycle");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "# note", Some("f-lock"));
+        let typed = "zażółć 🔒 DECISION: ship Friday; Anna owns QA sign-off";
+        state.db.set_manual_notes("m1", typed).unwrap();
+
+        // LOCK → production seal: plaintext blanked at rest, manual_notes_blob present.
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        let sealed = state.db.raw_manual_notes("m1").unwrap().unwrap();
+        assert_eq!(sealed.text, "", "typed notes plaintext blanked while sealed");
+        assert!(sealed.blob.is_some(), "typed notes sealed under the folder CK (blob present)");
+
+        // UNLOCK (mirror unlock_folder's internals): KEK → unwrap CK → unseal extras.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-lock").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-lock")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-lock", &ck).unwrap();
+
+        assert_eq!(
+            state.db.get_manual_notes("m1").unwrap(),
+            typed,
+            "typed notes restored byte-identical on unlock — sealed-and-restored, never lost"
+        );
+    }
+
+    /// REMOVE-LOCK: permanently removing a folder's lock decrypts the typed notes back to plaintext
+    /// and clears the blob — the typed notes are NEVER lost.
+    #[test]
+    fn manual_notes_survive_remove_lock_permanently() {
+        let state = build_state("manual-notes-remove-lock");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "# note", Some("f-lock"));
+        let typed = "permanent: revisit auth next sprint";
+        state.db.set_manual_notes("m1", typed).unwrap();
+
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        assert_eq!(state.db.raw_manual_notes("m1").unwrap().unwrap().text, "", "blanked while sealed");
+
+        // Cache the KEK for remove_lock (it reads the gated master KEK), then permanently remove.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
+        remove_lock_inner(&state, "f-lock".to_string()).unwrap();
+
+        let rn = state.db.raw_manual_notes("m1").unwrap().unwrap();
+        assert_eq!(rn.text, typed, "typed notes permanently restored to plaintext on remove-lock");
+        assert!(rn.blob.is_none(), "manual_notes_blob cleared on remove-lock");
     }
 
     /// BLK-1: hammer the off-thread `relock_all_inner` (the blanker) WHILE `remove_lock_inner` runs

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,8 @@ pub fn run() {
             commands::list_input_devices,
             commands::get_last_note,
             commands::update_note,
+            commands::save_manual_notes,
+            commands::get_manual_notes,
             commands::get_config,
             commands::save_config,
             commands::consent_to_cloud_egress,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -570,7 +570,17 @@ async fn summarize_and_export(
     };
 
     let provider = make_provider(&config.provider_id, config)?;
-    let markdown = provider.summarize(&request).await?;
+    let generated = provider.summarize(&request).await?;
+
+    // brain2 realtime notes FOLD: append the user's OWN typed in-meeting notes to the generated note
+    // under a `## My notes` section, BEFORE the note is persisted/exported/sealed. The `manual_notes`
+    // buffer is the DURABLE CANONICAL store of the typed notes — it is NOT blanked here, so this fold
+    // re-runs on EVERY (re)summarize: a regenerated note (which has no `## My notes` yet) gets one
+    // clean append, and a Resummarize can never drop the typed notes. Empty buffer ⇒ `markdown` is
+    // byte-identical to the generated note (no behavior change). The buffer's at-rest protection on a
+    // locked folder is the seal-and-restore lifecycle (`seal_manual_notes` + unseal), not blanking.
+    let manual_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
+    let markdown = fold_manual_notes(&generated, &manual_notes);
 
     state
         .db
@@ -720,6 +730,19 @@ fn finalize_note_without_vault(
     let title = derive_title(markdown, date_iso);
     db.set_meeting_title(meeting_id, &title)?;
     Ok(title)
+}
+
+/// brain2 realtime notes FINALIZE-FOLD: append the user's typed in-meeting notes to the generated
+/// note markdown under a `## My notes` section. Empty / whitespace-only `manual_notes` ⇒ the markdown
+/// is returned UNCHANGED (byte-identical to the generated note), so a meeting with no typed notes
+/// produces exactly today's output. The folded notes then ride the EXISTING note seal (`content_blob`)
+/// — never a second plaintext copy. Pure + Db-free so it is unit-testable in isolation.
+fn fold_manual_notes(markdown: &str, manual_notes: &str) -> String {
+    let notes = manual_notes.trim();
+    if notes.is_empty() {
+        return markdown.to_string();
+    }
+    format!("{markdown}\n\n## My notes\n\n{notes}\n")
 }
 
 /// brain2 RAG Phase 2b — the GATED entry point for indexing a note into the vector layer. Pure +
@@ -1122,6 +1145,81 @@ mod tests {
             "no-vault recording must finish Summarized, never Error"
         );
         assert_ne!(meeting.status, MeetingStatus::Error);
+    }
+
+    /// brain2 realtime notes: `fold_manual_notes` appends a `## My notes` section with the typed
+    /// notes, and returns the note UNCHANGED (byte-identical) for an empty / whitespace-only buffer.
+    #[test]
+    fn fold_manual_notes_appends_section_and_empty_is_byte_identical() {
+        let note = "# Sync\n\n- decided X";
+        // Empty / whitespace-only ⇒ byte-identical to the generated note (no behavior change).
+        assert_eq!(fold_manual_notes(note, ""), note);
+        assert_eq!(fold_manual_notes(note, "   \n\t "), note);
+        // Present ⇒ appended under a `## My notes` heading, verbatim (trimmed).
+        let folded = fold_manual_notes(note, "ship Friday; Anna owns QA");
+        assert!(folded.starts_with(note), "preserves the generated note");
+        assert!(folded.contains("## My notes"), "adds the My notes heading: {folded}");
+        assert!(folded.contains("ship Friday; Anna owns QA"), "embeds the typed notes verbatim");
+    }
+
+    /// brain2 realtime notes FOLD + COUNTEREXAMPLE B (the seam `summarize_and_export` runs, minus
+    /// the AppHandle/provider): get buffer → fold into the generated note → upsert. The buffer is
+    /// the DURABLE canonical store — NOT blanked — so a RESUMMARIZE (which regenerates a fresh note
+    /// with no `## My notes`) re-reads the buffer and re-folds it, and the typed notes are NEVER
+    /// dropped. RED on the prior blank-at-finalize code: the buffer would be "" on resummarize and
+    /// the regenerated note would lose `## My notes`.
+    #[test]
+    fn finalize_folds_manual_notes_durably_and_resummarize_refolds() {
+        use crate::storage::models::Meeting;
+
+        let db = crate::storage::Db::open_with_key(&temp_db_path("fold-manual"), TEST_DEK).unwrap();
+        let mid = "m-fold";
+        db.insert_meeting(&Meeting {
+            id: mid.to_string(),
+            started_at: "2026-06-30T09:00:00Z".to_string(),
+            ended_at: Some("2026-06-30T09:10:00Z".to_string()),
+            title: None,
+            duration_s: 600,
+            audio_path: None,
+            status: MeetingStatus::Recording,
+            folder_id: None,
+        })
+        .unwrap();
+        let typed = "DECISION: cut scope to MVP; revisit auth next sprint";
+        db.set_manual_notes(mid, typed).unwrap();
+
+        // Helper mirroring the EXACT finalize fold seam (no blank — the buffer stays durable).
+        let finalize = |generated: &str| {
+            let manual_notes = db.get_manual_notes(mid).unwrap();
+            let markdown = fold_manual_notes(generated, &manual_notes);
+            db.upsert_note(&NoteRecord {
+                meeting_id: mid.to_string(),
+                provider_id: "claude_code".to_string(),
+                markdown,
+                created_at: "2026-06-30T09:11:00Z".to_string(),
+                exported_path: None,
+            })
+            .unwrap();
+        };
+
+        // First summarize: the note carries the typed notes under `## My notes`.
+        finalize("---\ntitle: Roadmap\n---\n# Roadmap\n\nBody.");
+        let note = db.get_note(mid, "claude_code").unwrap().expect("note saved");
+        assert!(note.markdown.contains("## My notes"), "folded section present: {}", note.markdown);
+        assert!(note.markdown.contains(typed), "typed notes folded into the note");
+        // The buffer is DURABLE — still holds the canonical typed notes (not blanked).
+        assert_eq!(db.get_manual_notes(mid).unwrap(), typed, "manual_notes buffer is the durable canonical store");
+
+        // COUNTEREXAMPLE B: Resummarize regenerates a FRESH note (no `## My notes`); the fold re-reads
+        // the durable buffer and re-appends it. The typed notes are NOT lost (and not duplicated).
+        finalize("---\ntitle: Roadmap v2\n---\n# Roadmap v2\n\nDifferent body.");
+        let resummarized = db.get_note(mid, "claude_code").unwrap().expect("note saved");
+        assert!(resummarized.markdown.contains("Roadmap v2"), "note regenerated");
+        assert!(resummarized.markdown.contains("## My notes"), "resummarize keeps the typed-notes section");
+        assert!(resummarized.markdown.contains(typed), "resummarize re-folds the durable typed notes (B fixed)");
+        assert_eq!(resummarized.markdown.matches("## My notes").count(), 1, "exactly one My notes section (no dup)");
+
+        let _ = std::fs::remove_file(temp_db_path("fold-manual"));
     }
 
     // ── Phase 2b: gated semantic indexing on note creation ──────────────────────────────────────

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -343,6 +343,21 @@ impl Db {
         // masked DTO; they are export-only via gated commands.
         Self::add_column_if_missing(&conn, "meetings", "mic_master_path", "TEXT")?;
         Self::add_column_if_missing(&conn, "meetings", "sys_master_path", "TEXT")?;
+        // brain2 realtime notes: the user's free-text notes typed DURING a meeting — the live
+        // editable buffer, ONE per meeting, and the DURABLE CANONICAL STORE of those typed notes.
+        // It is (a) injected into the in-meeting brain's system prompt while recording, and (b)
+        // re-read on EVERY (re)summarize and FOLDED into the note (`## My notes`) — so a resummarize
+        // never drops the typed notes. The buffer is USER-AUTHORED PRIMARY content, so it is
+        // SEALED-AND-RESTORED exactly like the note markdown / transcript / timeline (NEVER
+        // blanked-and-lost): on lock the plaintext is encrypted under the folder CK →
+        // `manual_notes_blob` with VERIFY-BEFORE-DESTROY, then the plaintext is blanked; on
+        // session-unlock / remove-lock the blob is decrypted back. The plaintext is re-blanked on
+        // relock/reconcile ONLY when the blob exists (never destroy the only copy). Guarded ALTER
+        // (idempotent); NULL for every legacy meeting → reads back as "" (zero behavior change). Kept
+        // OFF the `Meeting` struct + every meeting SELECT so it can never leak through a masked DTO —
+        // read only via the gated commands.
+        Self::add_column_if_missing(&conn, "meetings", "manual_notes", "TEXT")?;
+        Self::add_column_if_missing(&conn, "meetings", "manual_notes_blob", "BLOB")?;
         // Phase 1 — FTS5/BM25 full-text retrieval over the three text sources
         // (meeting titles, transcript segments, note markdown). Replaces the prior
         // substring LIKE search so word-order/term retrieval works ("alpha beta" == "beta alpha")
@@ -672,6 +687,92 @@ impl Db {
         conn.execute(
             "UPDATE meetings SET title = ?2 WHERE id = ?1",
             rusqlite::params![id, title],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    // ── brain2 realtime typed @brain notes (the `meetings.manual_notes` durable buffer) ────────
+    //
+    // One free-text buffer per meeting that the user types DURING recording — the DURABLE CANONICAL
+    // STORE of those typed notes (re-folded into the note on every (re)summarize; never the only
+    // copy is destroyed). The plaintext column is SEALED-AND-RESTORED under the folder CK exactly
+    // like the note `content_blob` / transcript / timeline: `seal_manual_notes` (verify-before-
+    // destroy at the call site) → `raw_manual_notes` (read for unseal/reblank) → `set_manual_notes`
+    // (restore plaintext) → `clear_manual_notes_blob` (permanent remove-lock). These are LOW-LEVEL
+    // helpers with NO lock gating — the COMMAND layer (`save_manual_notes`/`get_manual_notes`) does
+    // the `meeting_is_unlocked` gating; the internal seal/unseal paths drive these directly.
+
+    /// Upsert the meeting's typed-notes plaintext. Used by the FE autosave (write the whole buffer)
+    /// AND by the unseal/remove-lock RESTORE (write the decrypted plaintext back). No-op on an
+    /// unknown meeting.
+    pub fn set_manual_notes(&self, meeting_id: &str, text: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE meetings SET manual_notes = ?2 WHERE id = ?1",
+            rusqlite::params![meeting_id, text],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The meeting's typed-notes plaintext, or "" when never set / NULL (legacy rows) / unknown id /
+    /// sealed-and-blanked. UNGATED at the DB layer — callers that return this to a surface MUST gate
+    /// first (`meeting_is_unlocked` in commands / `meeting_is_visible` for the live brain). The
+    /// (re)summarize fold reads it raw (it is the producer of the note plaintext, not a leak surface).
+    pub fn get_manual_notes(&self, meeting_id: &str) -> Result<String> {
+        let conn = self.lock();
+        let text: Option<String> = conn
+            .query_row(
+                "SELECT manual_notes FROM meetings WHERE id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(map_err)?
+            .flatten();
+        Ok(text.unwrap_or_default())
+    }
+
+    /// The meeting's typed notes in EITHER seal state (plaintext + the AES-GCM blob under the folder
+    /// CK) — the read used by the unseal/reblank lifecycle. `None` only when the meeting row is
+    /// absent. Mirrors [`Db::raw_timeline`].
+    pub fn raw_manual_notes(&self, meeting_id: &str) -> Result<Option<RawManualNotes>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT COALESCE(manual_notes, ''), manual_notes_blob FROM meetings WHERE id = ?1",
+            rusqlite::params![meeting_id],
+            |r| {
+                Ok(RawManualNotes {
+                    text: r.get(0)?,
+                    blob: r.get(1)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Seal a meeting's typed notes: store the AES-GCM `manual_notes_blob`, blank the plaintext
+    /// `manual_notes`. The CALLER must verify the blob decrypts back byte-identical BEFORE calling
+    /// this (verify-before-destroy) — exactly like [`Db::seal_timeline`].
+    pub fn seal_manual_notes(&self, meeting_id: &str, blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE meetings SET manual_notes_blob = ?2, manual_notes = '' WHERE id = ?1",
+            rusqlite::params![meeting_id, blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Clear a meeting's sealed `manual_notes_blob` (permanent remove-lock, after the plaintext is
+    /// restored). Mirrors [`Db::clear_timeline_blob`].
+    pub fn clear_manual_notes_blob(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE meetings SET manual_notes_blob = NULL WHERE id = ?1",
+            rusqlite::params![meeting_id],
         )
         .map_err(map_err)?;
         Ok(())
@@ -1979,6 +2080,12 @@ impl Db {
             // re-blanked / sealed) folders in the SAME transaction — a sealed meeting contributes
             // nothing to the flywheel.
             Self::purge_corrections_tx(&tx, &meeting_ids)?;
+            // NOTE: the typed-notes (`manual_notes`) re-blank does NOT live here — it is SEALED-AND-
+            // RESTORED content (not a derived/purgeable artifact like chunks/corrections), so its
+            // plaintext is re-blanked only WHERE the `manual_notes_blob` exists, by
+            // `reblank_folder_extras` (relock) / `reblank_locked_folders_at_rest` (startup). Blanking
+            // it here (unconditionally, with no CK to re-seal) would destroy the only copy of a
+            // typed buffer that had not yet been sealed — the verify-before-destroy violation.
         }
         tx.commit().map_err(map_err)?;
         Ok(())
@@ -2061,6 +2168,16 @@ impl Db {
         // Same purge-on-seal contract as the correction-log / assistant-interactions above.
         tx.execute(
             &format!("DELETE FROM facts WHERE meeting_id IN ({LOCKED_MEETINGS})"),
+            [],
+        )
+        .map_err(map_err)?;
+        // brain2 realtime notes LOCK-SAFETY: re-blank the typed-notes plaintext of every meeting in a
+        // locked folder ONLY WHERE its `manual_notes_blob` exists (the sealed copy is present) — so a
+        // crash-while-unlocked (which restored the plaintext) cannot leave typed plaintext at rest
+        // after a restart, but a buffer that was NEVER sealed (no blob) is left intact (never destroy
+        // the only copy). Mirrors the `text_blob IS NOT NULL` / `data_blob IS NOT NULL` guards above.
+        tx.execute(
+            &format!("UPDATE meetings SET manual_notes = '' WHERE manual_notes_blob IS NOT NULL AND manual_notes != '' AND id IN ({LOCKED_MEETINGS})"),
             [],
         )
         .map_err(map_err)?;
@@ -3312,6 +3429,15 @@ pub struct RawTimeline {
     pub data_blob: Option<Vec<u8>>,
 }
 
+/// A meeting's typed in-meeting notes in either seal state (brain2 realtime-notes lock lifecycle).
+/// `text` is the plaintext column (blank while sealed); `blob` is the AES-GCM ciphertext under the
+/// folder CK (present while sealed). Mirrors [`RawTimeline`].
+#[derive(Debug, Clone)]
+pub struct RawManualNotes {
+    pub text: String,
+    pub blob: Option<Vec<u8>>,
+}
+
 /// Build the SQL predicate (no params) that selects notes whose folder is open or
 /// session-unlocked. `alias` is the notes-table alias (`n`); a sibling `folders f` join is
 /// assumed for the alias. The unlocked ids are inlined as quoted literals — safe because they
@@ -3625,6 +3751,100 @@ mod tests {
         let db = mem_db();
         db.migrate().unwrap();
         db.migrate().unwrap();
+    }
+
+    /// brain2 realtime notes: the `manual_notes` buffer round-trips (set → get), defaults to "" for a
+    /// meeting that never set it (NULL legacy column), and `set("")` clears it. The buffer is DURABLE
+    /// (canonical store) — it is not destroyed by any plain getter/setter.
+    #[test]
+    fn manual_notes_round_trip_and_default_empty() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-30T09:00:00Z")).unwrap();
+
+        // Default: never set ⇒ "" (NULL column reads back empty, no behavior change for legacy rows).
+        assert_eq!(db.get_manual_notes("m1").unwrap(), "");
+        // Unknown meeting ⇒ "" (no row), never an error.
+        assert_eq!(db.get_manual_notes("nope").unwrap(), "");
+
+        // Set → get round-trips verbatim.
+        db.set_manual_notes("m1", "ship the deck by Friday; Anna owns QA").unwrap();
+        assert_eq!(db.get_manual_notes("m1").unwrap(), "ship the deck by Friday; Anna owns QA");
+
+        // Overwrite replaces the whole buffer (FE owns the full text).
+        db.set_manual_notes("m1", "rewritten").unwrap();
+        assert_eq!(db.get_manual_notes("m1").unwrap(), "rewritten");
+    }
+
+    /// SEAL ROUND-TRIP (mirrors `seal_transcript_timeline_round_trips_byte_identical`): the typed
+    /// notes seal to a `manual_notes_blob` (plaintext blanked, ciphertext does NOT leak), and unlock
+    /// restores the plaintext BYTE-IDENTICAL. Uses the DB seal/restore primitives + crypto directly.
+    #[test]
+    fn seal_manual_notes_round_trips_byte_identical() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-30T09:00:00Z")).unwrap();
+        let typed = "zażółć gęślą jaźń 🔒 — DECISION: ship Friday; Anna owns QA";
+        db.set_manual_notes("m1", typed).unwrap();
+
+        let ck = crate::crypto::random_key().unwrap();
+        // SEAL: encrypt → verify-before-destroy → blank plaintext (the seal_meeting_extras pattern).
+        let rn = db.raw_manual_notes("m1").unwrap().unwrap();
+        let blob = crate::crypto::encrypt(&ck, rn.text.as_bytes(), b"aad").unwrap();
+        assert_eq!(crate::crypto::decrypt(&ck, &blob, b"aad").unwrap(), rn.text.as_bytes());
+        db.seal_manual_notes("m1", &blob).unwrap();
+
+        // At rest while sealed: plaintext blanked, blob present, ciphertext doesn't leak the plaintext.
+        let sealed = db.raw_manual_notes("m1").unwrap().unwrap();
+        assert_eq!(sealed.text, "", "plaintext blanked while sealed");
+        assert!(sealed.blob.is_some(), "manual_notes_blob present while sealed");
+        assert_eq!(db.get_manual_notes("m1").unwrap(), "", "the gated reader sees blank while sealed");
+        let cipher = sealed.blob.as_ref().unwrap();
+        let leaks = cipher
+            .windows(typed.len())
+            .any(|w| w == typed.as_bytes());
+        assert!(!leaks, "manual-notes ciphertext must not leak plaintext");
+
+        // UNLOCK: decrypt the blob → restore plaintext byte-identical.
+        let blob = sealed.blob.unwrap();
+        let pt = String::from_utf8(crate::crypto::decrypt(&ck, &blob, b"aad").unwrap()).unwrap();
+        db.set_manual_notes("m1", &pt).unwrap();
+        assert_eq!(db.get_manual_notes("m1").unwrap(), typed, "typed notes round-trip byte-identical");
+
+        // PERMANENT remove-lock: clear the blob after the plaintext is back.
+        db.clear_manual_notes_blob("m1").unwrap();
+        assert!(db.raw_manual_notes("m1").unwrap().unwrap().blob.is_none(), "blob cleared on remove-lock");
+        assert_eq!(db.get_manual_notes("m1").unwrap(), typed, "plaintext survives the blob clear");
+    }
+
+    /// LOCK-SAFETY (verify-before-destroy): startup reconciliation re-blanks the typed-notes
+    /// plaintext of a locked meeting ONLY when the sealed `manual_notes_blob` exists. A buffer that
+    /// was NEVER sealed (no blob) is LEFT INTACT — reconciliation must never destroy the only copy.
+    #[test]
+    fn reconcile_reblanks_manual_notes_only_when_blob_present() {
+        let db = mem_db();
+        seed_folder(&db, "f-lock", "Secret");
+        // Meeting A: sealed blob present + plaintext stranded by a crash-while-unlocked → MUST re-blank.
+        db.insert_meeting(&sample_meeting("m-sealed", "2026-06-30T09:00:00Z")).unwrap();
+        note_for(&db, "m-sealed", "claude_code", "");
+        db.set_note_folder("m-sealed", Some("f-lock")).unwrap();
+        db.seal_note("m-sealed", "claude_code", b"ciphertext").unwrap();
+        db.seal_manual_notes("m-sealed", b"ck-ciphertext-blob").unwrap(); // blob present
+        db.set_manual_notes("m-sealed", "restored plaintext stranded by the crash").unwrap();
+
+        // Meeting B: NO blob (buffer typed but never sealed) → MUST be left intact (no encrypted copy).
+        db.insert_meeting(&sample_meeting("m-unsealed", "2026-06-30T09:30:00Z")).unwrap();
+        note_for(&db, "m-unsealed", "claude_code", "note");
+        db.set_note_folder("m-unsealed", Some("f-lock")).unwrap();
+        db.set_manual_notes("m-unsealed", "typed but never sealed — must not be destroyed").unwrap();
+
+        db.set_folder_locked("f-lock", true, Some(b"wrapped")).unwrap();
+        db.reblank_locked_folders_at_rest().unwrap();
+
+        assert_eq!(db.get_manual_notes("m-sealed").unwrap(), "", "sealed meeting's stranded plaintext re-blanked");
+        assert_eq!(
+            db.get_manual_notes("m-unsealed").unwrap(),
+            "typed but never sealed — must not be destroyed",
+            "an unsealed buffer (no blob) must NEVER be blanked — that would destroy the only copy"
+        );
     }
 
     /// Test-only builder for a correction example tied to a meeting.

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -419,7 +419,21 @@ fn run_informational(
             .lock()
             .map(|t| t.clone())
             .unwrap_or_default();
-        let system = assistant_system_prompt(&live);
+        // brain2 realtime notes: ALSO inject the user's OWN typed notes for the CURRENT meeting so the
+        // brain weights their emphasis. GATED by `meeting_is_visible` on the LIVE per-turn `unlocked`
+        // set (fail-closed: a sealed-and-not-session-unlocked meeting injects NOTHING) — the in-progress
+        // recording has no note row yet, so it is trivially visible. This egresses through the SAME
+        // redaction firewall as `live`/`system` (`RedactingProvider::complete` scrubs `system` + `user`)
+        // and only on the Cloud branch (this whole block is Cloud-only, consent-gated) — NO new egress
+        // class. Best-effort: a read/gate error degrades to no typed-notes injection, never a failure.
+        let typed_notes = if !meeting_id.is_empty()
+            && state.db.meeting_is_visible(meeting_id, unlocked).unwrap_or(false)
+        {
+            state.db.get_manual_notes(meeting_id).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        let system = assistant_system_prompt(&live, &typed_notes);
         match crate::agent::run_agentic_loop(
             &*state.reasoner,
             &system,
@@ -886,25 +900,40 @@ fn tail_chars(s: &str, n: usize) -> String {
 /// Build the in-meeting assistant's system prompt. When the LIVE transcript of the current recording
 /// is present, inject its recent tail (≤ [`LIVE_TRANSCRIPT_INJECT_CHARS`]) so the brain can answer
 /// questions about the meeting IN PROGRESS; otherwise the base prompt is unchanged (no regression when
-/// not recording / before any caption). The injected transcript egresses through the SAME redaction
-/// firewall as every other prompt (`RedactingProvider::complete` scrubs `system` + `user`).
-fn assistant_system_prompt(live_transcript: &str) -> String {
+/// not recording / before any caption). When the user has typed their OWN notes for this meeting
+/// (`typed_notes`), inject them as their own bounded section (their emphasis — weight these),
+/// truncated to the recent tail like the transcript. EMPTY `typed_notes` ⇒ the prompt is BYTE-IDENTICAL
+/// to the pre-feature output (the section is simply absent). Both the injected transcript AND the typed
+/// notes egress through the SAME redaction firewall as every other prompt
+/// (`RedactingProvider::complete` scrubs `system` + `user`) — they are NOT a new egress class.
+fn assistant_system_prompt(live_transcript: &str, typed_notes: &str) -> String {
     let base = "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 \
                 sentences). Do not invent facts; if you cannot find the answer, say so plainly.";
     let t = live_transcript.trim();
-    if t.is_empty() {
-        return format!(
+    let mut prompt = if t.is_empty() {
+        format!(
             "{base} Ground answers in tool results from the user's own gated vault (and web / \
              calendar when you use them)."
-        );
+        )
+    } else {
+        let tail = tail_chars(t, LIVE_TRANSCRIPT_INJECT_CHARS);
+        format!(
+            "{base} You are CURRENTLY in a live meeting being recorded — use the LIVE TRANSCRIPT below \
+             to answer questions about THIS current meeting (its topic, decisions, who said what), and \
+             your gated tools for anything in the user's saved notes/vault.\n\nLIVE TRANSCRIPT (rough \
+             real-time captions, may be partial or slightly garbled):\n{tail}"
+        )
+    };
+    // The user's OWN typed notes for this meeting — their explicit emphasis, so the brain should
+    // weight them. Appended as a distinct bounded section; absent when empty (prompt unchanged).
+    let notes = typed_notes.trim();
+    if !notes.is_empty() {
+        let notes_tail = tail_chars(notes, LIVE_TRANSCRIPT_INJECT_CHARS);
+        prompt.push_str(&format!(
+            "\n\nUSER'S OWN TYPED NOTES for this meeting (their emphasis — weight these):\n{notes_tail}"
+        ));
     }
-    let tail = tail_chars(t, LIVE_TRANSCRIPT_INJECT_CHARS);
-    format!(
-        "{base} You are CURRENTLY in a live meeting being recorded — use the LIVE TRANSCRIPT below \
-         to answer questions about THIS current meeting (its topic, decisions, who said what), and \
-         your gated tools for anything in the user's saved notes/vault.\n\nLIVE TRANSCRIPT (rough \
-         real-time captions, may be partial or slightly garbled):\n{tail}"
-    )
+    prompt
 }
 
 #[cfg(test)]
@@ -1304,11 +1333,11 @@ mod tests {
     #[test]
     fn assistant_system_prompt_injects_transcript_only_when_present() {
         // No live transcript (not recording / no captions yet) ⇒ the base prompt, no transcript section.
-        let base = assistant_system_prompt("");
+        let base = assistant_system_prompt("", "");
         assert!(!base.contains("LIVE TRANSCRIPT"), "no transcript section when empty: {base}");
         assert!(base.contains("in-meeting assistant"));
         // With a transcript ⇒ it is embedded + the brain is told to use it for the current meeting.
-        let with = assistant_system_prompt("we shipped the beta and assigned the deck to Anna");
+        let with = assistant_system_prompt("we shipped the beta and assigned the deck to Anna", "");
         assert!(with.contains("LIVE TRANSCRIPT"), "names the transcript section: {with}");
         assert!(with.contains("assigned the deck to Anna"), "embeds the transcript text");
         assert!(with.to_lowercase().contains("current"), "tells the brain it's the current meeting");
@@ -1319,8 +1348,41 @@ mod tests {
         // A very long transcript is truncated to the RECENT tail (so a 2-hour meeting can't blow the
         // context) and marked elided.
         let long = "x ".repeat(LIVE_TRANSCRIPT_INJECT_CHARS); // way over the inject budget
-        let p = assistant_system_prompt(&long);
+        let p = assistant_system_prompt(&long, "");
         assert!(p.contains('…'), "elision marker present when truncated");
         assert!(p.chars().count() < long.chars().count(), "shorter than the raw transcript");
+    }
+
+    /// brain2 realtime notes: typed notes are injected as their own section when present, and the
+    /// EMPTY-typed-notes prompt is BYTE-IDENTICAL to the pre-feature output (no regression).
+    #[test]
+    fn assistant_system_prompt_injects_typed_notes_and_empty_is_byte_identical() {
+        // Empty typed notes ⇒ no typed-notes section, AND byte-identical to the no-notes prompt for
+        // BOTH the no-transcript and with-transcript branches.
+        let no_tx = assistant_system_prompt("", "");
+        assert!(!no_tx.contains("TYPED NOTES"), "no typed-notes section when empty: {no_tx}");
+        let tx = "we shipped the beta and assigned the deck to Anna";
+        assert_eq!(
+            assistant_system_prompt(tx, ""),
+            assistant_system_prompt(tx, "   "),
+            "whitespace-only typed notes must be byte-identical to none (no regression)"
+        );
+
+        // Present typed notes ⇒ embedded under the labeled section, alongside the transcript.
+        let with = assistant_system_prompt(tx, "DECISION: ship Friday. Anna owns QA sign-off.");
+        assert!(with.contains("TYPED NOTES"), "names the typed-notes section: {with}");
+        assert!(with.contains("Anna owns QA sign-off"), "embeds the typed-notes text");
+        assert!(with.contains("LIVE TRANSCRIPT"), "still injects the transcript too");
+
+        // Typed notes inject even with NO transcript (the user can type before any caption lands).
+        let notes_only = assistant_system_prompt("", "remember: budget cap is the blocker");
+        assert!(notes_only.contains("TYPED NOTES"), "typed notes inject without a transcript");
+        assert!(notes_only.contains("budget cap is the blocker"));
+        assert!(!notes_only.contains("LIVE TRANSCRIPT"), "no transcript section when transcript empty");
+
+        // A very long typed-notes buffer is truncated to the recent tail (bounded like the transcript).
+        let long = "y ".repeat(LIVE_TRANSCRIPT_INJECT_CHARS);
+        let p = assistant_system_prompt("", &long);
+        assert!(p.contains('…'), "elision marker present when typed notes truncated");
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -553,6 +553,28 @@ export class IpcService {
     return invoke<VoiceActionResultPayload>("ask_assistant_chat", { messages });
   }
 
+  // ── brain2 realtime typed @brain notes (record screen "My notes") ──────
+
+  /**
+   * Persist a meeting's live typed-notes buffer (debounced autosave from the
+   * record screen "My notes" editor). GATED server-side: a
+   * sealed-and-not-session-unlocked meeting is refused with `AppError::Locked`
+   * (never resurrect typed plaintext behind a lock) — the FE swallows that and
+   * keeps the local draft. The text is the user's OWN words (no new egress).
+   */
+  saveManualNotes(meetingId: string, text: string): Promise<void> {
+    return invoke<void>("save_manual_notes", { meetingId, text });
+  }
+
+  /**
+   * Read a meeting's live typed-notes buffer (the editor rehydrates from this on
+   * mount / when the active meeting changes). GATED server-side: a
+   * sealed-and-not-session-unlocked meeting returns "" (masked, never the buffer).
+   */
+  getManualNotes(meetingId: string): Promise<string> {
+    return invoke<string>("get_manual_notes", { meetingId });
+  }
+
   // ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──
 
   /** The folder tree (roots → children) with per-folder note counts + session lock state. */

--- a/src/app/features/record/meeting-notes.component.ts
+++ b/src/app/features/record/meeting-notes.component.ts
@@ -1,0 +1,620 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Injector,
+  OnInit,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../core/ipc.service";
+import { DebounceService } from "../../services/debounce.service";
+import type { VoiceActionResultPayload } from "../../core/models";
+
+/** Quiet window before a typed edit is autosaved to the backend. */
+const AUTOSAVE_MS = 800;
+/** The inline mention marker that arms an @brain ask. */
+const BRAIN_MARKER = "@brain";
+
+/**
+ * "My notes" — the record-screen surface where the user free-types notes DURING
+ * a recording (debounced autosave to the canonical buffer via
+ * `save_manual_notes`), plus an inline `@brain` affordance: typing `@` at a word
+ * boundary opens a caret-anchored OPAQUE popover offering "brain"; selecting it
+ * (or typing `@brain `) arms an ask, and Enter on the `@brain <question>` line
+ * sends the question to the in-meeting brain (`ask_assistant_text`). The answer —
+ * which arrives on the shared `EVENT_VOICE_ACTION_RESULT` stream — is inserted
+ * back into the notes as an attributed `> 🧠 …` blockquote (Granola-style: the
+ * user's own text stays plain, the AI answer is a distinct quote).
+ *
+ * Zoneless rules in play here:
+ * - the load-on-mount / load-on-meeting-change effect WRITES `draft` after an
+ *   await → `{ allowSignalWrites: true }` (trap T1 / NG0600), with a stale-token
+ *   guard so a late response for a previous meeting is dropped;
+ * - the debounced autosave uses the sanctioned root {@link DebounceService}
+ *   tracked-`setTimeout` pattern — NEVER a bare component `setTimeout`;
+ * - caret-set / focus after a programmatic draft edit runs in
+ *   `afterNextRender(fn, { injector })`, never `setTimeout`/`rAF`;
+ * - the `EVENT_VOICE_ACTION_RESULT` subscription is opened ONCE and released on
+ *   teardown; its payload lands in signals (never subscribed-into a plain field);
+ * - the floating `@brain` popover is the OPAQUE `--surface-overlay` (trap T3),
+ *   not the frosted `.card`.
+ */
+@Component({
+  selector: "app-meeting-notes",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="card notes" role="group" aria-label="My notes">
+      <div class="notes-head">
+        <span class="notes-title">My notes</span>
+        @if (statusText(); as s) {
+          <span class="notes-status" role="status">{{ s }}</span>
+        }
+      </div>
+
+      <div class="editor">
+        <textarea
+          #ta
+          class="notes-input"
+          rows="5"
+          autocomplete="off"
+          spellcheck="true"
+          placeholder="Jot your own notes here… type &#64;brain to ask the AI"
+          [value]="draft()"
+          (input)="onInput($event)"
+          (keydown)="onKeydown($event)"
+          (blur)="onBlur()"
+          aria-label="Meeting notes"
+        ></textarea>
+
+        @if (menuOpen()) {
+          <div
+            class="mention-menu"
+            role="listbox"
+            aria-label="Mention"
+            [style.top.px]="menuTop()"
+            [style.left.px]="menuLeft()"
+          >
+            <button
+              type="button"
+              class="mention-item"
+              role="option"
+              [attr.aria-selected]="true"
+              (mousedown)="$event.preventDefault()"
+              (click)="chooseBrain()"
+            >
+              <span class="mention-ico" aria-hidden="true">🧠</span>
+              <span class="mention-text">
+                <span class="mention-label">brain</span>
+                <span class="mention-hint">ask the meeting brain</span>
+              </span>
+            </button>
+          </div>
+        }
+      </div>
+
+      @if (pendingQuestion(); as q) {
+        <p class="brain-pending" role="status">
+          <span class="brain-spin" aria-hidden="true"></span>
+          Asking the brain — <span class="brain-q">{{ q }}</span>
+        </p>
+      } @else {
+        <p class="notes-foot text-muted">
+          Type <span class="kbd">&#64;brain</span> + a question, then press Enter —
+          the answer is added to your notes.
+        </p>
+      }
+    </section>
+  `,
+  styles: [
+    `
+      .notes {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .notes-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .notes-title {
+        color: var(--text-primary);
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      .notes-status {
+        margin-left: auto;
+        font-size: 0.78rem;
+        color: var(--text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* The textarea lives in a positioned wrapper so the caret-anchored popover
+         can be absolutely placed relative to it. */
+      .editor {
+        position: relative;
+      }
+      .notes-input {
+        width: 100%;
+        min-height: 120px;
+        max-height: 340px;
+        padding: var(--space-3);
+        resize: vertical;
+        line-height: 1.55;
+        font-size: 0.92rem;
+      }
+
+      /* ── @brain mention popover — FLOATS over the editor → OPAQUE (trap T3).
+         NOT the frosted .card: a translucent surface would bleed the notes
+         behind it through (a broken-looking menu). */
+      .mention-menu {
+        position: absolute;
+        z-index: 20;
+        min-width: 220px;
+        max-width: 280px;
+        padding: var(--space-1);
+        background: var(--surface-overlay);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-lg);
+        -webkit-backdrop-filter: none;
+        backdrop-filter: none;
+      }
+      .mention-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+        padding: var(--space-2) var(--space-3);
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-primary);
+        cursor: pointer;
+        text-align: left;
+        transition: background var(--transition);
+      }
+      .mention-item:hover,
+      .mention-item:focus-visible {
+        outline: none;
+        background: var(--accent-soft);
+      }
+      .mention-ico {
+        font-size: 1.05rem;
+        line-height: 1;
+      }
+      .mention-text {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+      }
+      .mention-label {
+        font-weight: 600;
+        font-size: 0.9rem;
+      }
+      .mention-hint {
+        font-size: 0.76rem;
+        color: var(--text-muted);
+      }
+
+      /* ── footer: the @brain hint + the pending indicator (muted/italic) ───── */
+      .notes-foot {
+        margin: 0;
+        font-size: 0.8rem;
+        line-height: 1.5;
+      }
+      .kbd {
+        font-family: var(--font-mono, ui-monospace, monospace);
+        font-size: 0.74rem;
+        padding: 1px 6px;
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+      }
+      .brain-pending {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin: 0;
+        font-size: 0.82rem;
+        font-style: italic;
+        color: var(--text-secondary);
+      }
+      .brain-q {
+        color: var(--text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 60%;
+      }
+      .brain-spin {
+        flex: 0 0 auto;
+        width: 11px;
+        height: 11px;
+        border-radius: 50%;
+        border: 1.6px solid var(--accent-ring);
+        border-top-color: var(--accent);
+        animation: notes-spin 0.7s linear infinite;
+      }
+      @keyframes notes-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brain-spin {
+          animation: none;
+        }
+      }
+    `,
+  ],
+})
+export class MeetingNotesComponent implements OnInit {
+  private readonly ipc = inject(IpcService);
+  private readonly autosave = inject(DebounceService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** The active recording's meeting id (null when there's no meeting yet). */
+  readonly meetingId = input<string | null>(null);
+
+  private readonly textarea =
+    viewChild<ElementRef<HTMLTextAreaElement>>("ta");
+
+  /** The notes buffer — the single source of truth the textarea binds to. */
+  protected readonly draft = signal("");
+
+  /** Autosave status line ("Saving…" → "Saved"). */
+  protected readonly saveState = signal<"idle" | "saving" | "saved">("idle");
+  protected readonly statusText = computed(() => {
+    switch (this.saveState()) {
+      case "saving":
+        return "Saving…";
+      case "saved":
+        return "Saved";
+      default:
+        return "";
+    }
+  });
+
+  /** Whether the @brain mention popover is open + its caret-anchored position. */
+  protected readonly menuOpen = signal(false);
+  protected readonly menuTop = signal(0);
+  protected readonly menuLeft = signal(0);
+  /** Index of the `@` that opened the current mention (replaced on select). */
+  private atIndex = -1;
+
+  /**
+   * The in-flight @brain question (null when none). Doubles as the correlation
+   * guard: a result is only inserted when its echoed `command` matches this, so
+   * an unrelated voice/assistant result on the shared stream never double-inserts.
+   */
+  protected readonly pendingQuestion = signal<string | null>(null);
+
+  /** Monotonic token so a late load for a previous meeting is dropped (stale guard). */
+  private loadToken = 0;
+  /** Released on teardown; set once the result subscription is live. */
+  private unlistenResult: UnlistenFn | null = null;
+  private destroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.unlistenResult?.();
+      this.unlistenResult = null;
+      // NOTE: a still-pending autosave is intentionally NOT cancelled here — the
+      // DebounceService is root-scoped + keyed per meeting, so the final edit
+      // flushes even after this component unmounts on recording-stop.
+    });
+
+    // Load the saved buffer on mount AND whenever the active meeting id changes.
+    // Writes `draft` after an await → allowSignalWrites REQUIRED (trap T1 /
+    // NG0600). A bumped token drops a response that arrives after the meeting
+    // changed mid-flight.
+    effect(
+      () => {
+        const id = this.meetingId();
+        const token = ++this.loadToken;
+        this.menuOpen.set(false);
+        if (!id) {
+          this.draft.set("");
+          this.saveState.set("idle");
+          return;
+        }
+        // Don't let a same-id save still pending from before clobber the load.
+        this.autosave.cancel(this.saveKey(id));
+        void this.load(id, token);
+      },
+      { allowSignalWrites: true },
+    );
+  }
+
+  ngOnInit(): void {
+    void this.subscribeResult();
+  }
+
+  /** Subscribe ONCE to the shared voice-action-result stream (released on teardown). */
+  private async subscribeResult(): Promise<void> {
+    const un = await this.ipc.onVoiceActionResult((p) => this.onActionResult(p));
+    if (this.destroyed) {
+      un();
+      return;
+    }
+    this.unlistenResult = un;
+  }
+
+  private saveKey(id: string): string {
+    return `manual-notes:${id}`;
+  }
+
+  /** Fetch the persisted buffer; drop the result if the meeting changed since. */
+  private async load(id: string, token: number): Promise<void> {
+    try {
+      const text = await this.ipc.getManualNotes(id);
+      if (token !== this.loadToken) return;
+      this.draft.set(text);
+      this.saveState.set("idle");
+    } catch {
+      if (token !== this.loadToken) return;
+      this.draft.set("");
+      this.saveState.set("idle");
+    }
+  }
+
+  /** Textarea input: update the draft, (re)arm autosave, recompute the @brain menu. */
+  protected onInput(event: Event): void {
+    const ta = event.target as HTMLTextAreaElement;
+    this.draft.set(ta.value);
+    this.scheduleSave();
+    this.updateMentionMenu(ta);
+  }
+
+  /** Debounced autosave — captures the (id, text) so a meeting switch can't misroute it. */
+  private scheduleSave(): void {
+    const id = this.meetingId();
+    if (!id) return;
+    const text = this.draft();
+    this.saveState.set("saving");
+    this.autosave.schedule(this.saveKey(id), () => void this.flush(id, text), AUTOSAVE_MS);
+  }
+
+  private async flush(id: string, text: string): Promise<void> {
+    try {
+      await this.ipc.saveManualNotes(id, text);
+      if (this.meetingId() === id) this.saveState.set("saved");
+    } catch {
+      // Locked/sealed or a transient backend error — keep the local draft, drop
+      // the "Saving…" label. Never noisy; the buffer stays in the editor.
+      if (this.meetingId() === id) this.saveState.set("idle");
+    }
+  }
+
+  /** Keyboard: drive the mention menu, then the @brain submit, else default. */
+  protected onKeydown(event: KeyboardEvent): void {
+    if (this.menuOpen()) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.menuOpen.set(false);
+        return;
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        this.chooseBrain();
+        return;
+      }
+      return;
+    }
+    // Enter (no Shift) on a `@brain <question>` line submits the ask.
+    if (event.key === "Enter" && !event.shiftKey) {
+      this.trySubmitBrain(event);
+    }
+  }
+
+  /** Close the menu when focus leaves the textarea (click-away). */
+  protected onBlur(): void {
+    this.menuOpen.set(false);
+  }
+
+  /**
+   * Re-evaluate the @brain popover from the live caret. Open it when the caret
+   * sits inside an `@`-token at a word boundary whose text is a prefix of
+   * "brain"; otherwise close it. Anchors the popover just below the caret.
+   */
+  private updateMentionMenu(ta: HTMLTextAreaElement): void {
+    const value = ta.value;
+    const caret = ta.selectionStart ?? value.length;
+    let at = -1;
+    for (let i = caret - 1; i >= 0; i--) {
+      const ch = value[i];
+      if (ch === "@") {
+        const prev = i === 0 ? " " : value[i - 1];
+        if (/\s/.test(prev)) at = i;
+        break;
+      }
+      if (/\s/.test(ch)) break; // whitespace before any '@' → not in a token
+    }
+    if (at === -1) {
+      this.menuOpen.set(false);
+      return;
+    }
+    const query = value.slice(at + 1, caret);
+    // Only letters, and a prefix of "brain" ("", "b", "br", … "brain").
+    if (!/^[a-z]*$/i.test(query) || !"brain".startsWith(query.toLowerCase())) {
+      this.menuOpen.set(false);
+      return;
+    }
+    this.atIndex = at;
+    const anchor = this.caretAnchor(ta, caret);
+    const left = Math.max(
+      0,
+      Math.min(anchor.left, ta.clientWidth - 220),
+    );
+    this.menuTop.set(ta.offsetTop + anchor.top + anchor.height);
+    this.menuLeft.set(ta.offsetLeft + left);
+    this.menuOpen.set(true);
+  }
+
+  /** Select "brain": replace the typed `@…` token with `@brain ` + re-focus. */
+  protected chooseBrain(): void {
+    const ta = this.textarea()?.nativeElement;
+    if (!ta || this.atIndex < 0) {
+      this.menuOpen.set(false);
+      return;
+    }
+    const value = this.draft();
+    const caret = ta.selectionStart ?? value.length;
+    const before = value.slice(0, this.atIndex);
+    const after = value.slice(caret);
+    const insert = `${BRAIN_MARKER} `;
+    const next = before + insert + after;
+    const pos = before.length + insert.length;
+    this.menuOpen.set(false);
+    this.draft.set(next);
+    this.scheduleSave();
+    this.focusAt(pos);
+  }
+
+  /**
+   * Submit the @brain ask on the caret's line. Captures the text after `@brain`,
+   * strips the marker (leaving the question as the user's own note line), fires
+   * the ask, and arms the correlation guard. No-op (returns, default newline) when
+   * the line has no `@brain <question>` or an ask is already in flight.
+   */
+  private trySubmitBrain(event: KeyboardEvent): void {
+    if (this.pendingQuestion()) return; // one in flight → let Enter add a newline
+    const ta = this.textarea()?.nativeElement;
+    if (!ta) return;
+    const value = this.draft();
+    const caret = ta.selectionStart ?? value.length;
+    const lineStart = value.lastIndexOf("\n", caret - 1) + 1;
+    let lineEnd = value.indexOf("\n", caret);
+    if (lineEnd === -1) lineEnd = value.length;
+    const line = value.slice(lineStart, lineEnd);
+    const markerIdx = line.indexOf(BRAIN_MARKER);
+    if (markerIdx === -1) return;
+    const question = line.slice(markerIdx + BRAIN_MARKER.length).trim();
+    if (!question) return; // bare "@brain" with no question → default newline
+    event.preventDefault();
+
+    // Strip the marker → keep just the question as the user's plain note line.
+    const newLine = line.slice(0, markerIdx) + question;
+    const next = value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+    const pos = lineStart + newLine.length;
+    this.draft.set(next);
+    this.scheduleSave();
+    this.focusAt(pos);
+    this.fireBrain(question);
+  }
+
+  /** Dispatch the @brain question to the shared in-meeting brain. */
+  private fireBrain(question: string): void {
+    this.pendingQuestion.set(question);
+    void this.ipc.askAssistantText(question).catch(() => {
+      // Dispatch failed (empty/backed-off) → clear the guard so a retry is possible.
+      this.pendingQuestion.set(null);
+    });
+  }
+
+  /**
+   * A voice-action result landed on the shared stream. Insert it ONLY when it
+   * answers OUR pending @brain ask (its echoed `command` matches) — the
+   * correlation guard so an unrelated assistant/voice result never double-inserts.
+   * The answer goes in as an attributed `> 🧠 …` blockquote, then autosaves.
+   */
+  private onActionResult(p: VoiceActionResultPayload): void {
+    const pending = this.pendingQuestion();
+    if (!pending) return;
+    if (p.command.trim() !== pending) return; // a stray result → ignore, stay pending
+    this.pendingQuestion.set(null);
+    const answer = (p.summary ?? "").trim();
+    if (!answer) return; // nothing_heard / empty → nothing to attribute
+    const block = `\n> 🧠 ${answer}\n`;
+    this.draft.update((d) => d + block);
+    this.scheduleSave();
+  }
+
+  /** Focus the textarea and place the caret at `pos` after the DOM updates. */
+  private focusAt(pos: number): void {
+    afterNextRender(
+      () => {
+        const ta = this.textarea()?.nativeElement;
+        if (!ta) return;
+        ta.focus();
+        ta.setSelectionRange(pos, pos);
+      },
+      { injector: this.injector },
+    );
+  }
+
+  /**
+   * Caret pixel position inside a textarea via the mirror-div technique: clone
+   * the textarea's box + text up to the caret into a hidden div, measure a marker
+   * span. Returns coords relative to the textarea's border box + the line height.
+   */
+  private caretAnchor(
+    ta: HTMLTextAreaElement,
+    caret: number,
+  ): { top: number; left: number; height: number } {
+    const style = getComputedStyle(ta);
+    const div = document.createElement("div");
+    const ds = div.style;
+    ds.position = "absolute";
+    ds.visibility = "hidden";
+    ds.whiteSpace = "pre-wrap";
+    ds.overflowWrap = "break-word";
+    ds.overflow = "hidden";
+    const copy = [
+      "box-sizing",
+      "padding-top",
+      "padding-right",
+      "padding-bottom",
+      "padding-left",
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width",
+      "font-family",
+      "font-size",
+      "font-weight",
+      "font-style",
+      "font-variant",
+      "letter-spacing",
+      "line-height",
+      "text-transform",
+      "word-spacing",
+      "text-indent",
+      "tab-size",
+    ];
+    for (const p of copy) ds.setProperty(p, style.getPropertyValue(p));
+    ds.width = `${ta.clientWidth}px`;
+    ds.height = "auto";
+    const value = ta.value;
+    div.textContent = value.slice(0, caret);
+    const marker = document.createElement("span");
+    marker.textContent = value.slice(caret) || ".";
+    div.appendChild(marker);
+    document.body.appendChild(div);
+    const lhRaw = parseFloat(style.lineHeight);
+    const height = Number.isNaN(lhRaw)
+      ? parseFloat(style.fontSize) * 1.4
+      : lhRaw;
+    const top =
+      marker.offsetTop + parseFloat(style.borderTopWidth || "0") - ta.scrollTop;
+    const left =
+      marker.offsetLeft +
+      parseFloat(style.borderLeftWidth || "0") -
+      ta.scrollLeft;
+    document.body.removeChild(div);
+    return { top, left, height };
+  }
+}

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -16,6 +16,7 @@ import type { Analytics, AppConfigDto } from "../../core/models";
 import { PreMeetingBriefComponent } from "./pre-meeting-brief.component";
 import { MicMuteToggleComponent } from "./mic-mute-toggle.component";
 import { AssistantActionsComponent } from "./assistant-actions.component";
+import { MeetingNotesComponent } from "./meeting-notes.component";
 import { AiOrbComponent } from "./ai-orb.component";
 import { AssistantStore } from "../../core/assistant.store";
 
@@ -28,6 +29,7 @@ import { AssistantStore } from "../../core/assistant.store";
     PreMeetingBriefComponent,
     MicMuteToggleComponent,
     AssistantActionsComponent,
+    MeetingNotesComponent,
     AiOrbComponent,
   ],
   host: { "(document:keydown)": "onKey($event)" },
@@ -272,6 +274,11 @@ import { AssistantStore } from "../../core/assistant.store";
             }
           </p>
         </div>
+      }
+
+      <!-- ── My notes — free-text + inline @brain, shown only while recording ── -->
+      @if (store.isRecording()) {
+        <app-meeting-notes [meetingId]="store.meetingId()" />
       }
 
       <!-- ── In-meeting voice assistant — recent actions (Phase H) ────────── -->

--- a/src/app/services/debounce.service.ts
+++ b/src/app/services/debounce.service.ts
@@ -1,0 +1,62 @@
+import { DestroyRef, Injectable, inject } from "@angular/core";
+
+/**
+ * App-wide keyed debounce. The ONLY sanctioned `setTimeout` outside a component
+ * (angular-zoneless §5): every pending timer handle is tracked in a `Map` keyed
+ * by caller-chosen id and cleared in `DestroyRef.onDestroy` — the exact pattern
+ * `toast.service.ts` uses for its auto-dismiss timers (never a bare component
+ * `setTimeout`).
+ *
+ * `schedule(key, fn, delayMs)` coalesces rapid calls under the SAME key (the
+ * classic debounced-autosave shape: each keystroke reschedules, only the last
+ * fires). Distinct keys are independent, so two callers (e.g. two meetings)
+ * never cancel each other — important for the record screen's per-meeting
+ * autosave, where a still-pending save for meeting A must outlive switching to
+ * meeting B and still fire.
+ *
+ * `providedIn: "root"`, so its `DestroyRef` is the root injector's and the
+ * timers live for the app's lifetime; the cleanup keeps it leak-clean + HMR-safe.
+ */
+@Injectable({ providedIn: "root" })
+export class DebounceService {
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Pending timers keyed by caller id, so each can be rescheduled / cancelled. */
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor() {
+    // Clear every pending timer on teardown — no orphaned timers.
+    this.destroyRef.onDestroy(() => {
+      for (const handle of this.timers.values()) {
+        clearTimeout(handle);
+      }
+      this.timers.clear();
+    });
+  }
+
+  /**
+   * Run `fn` after `delayMs` of quiet on `key`. A new call under the same key
+   * cancels the previous pending one (debounce). The handle is forgotten the
+   * instant it fires so a later `cancel(key)` can never clear an unrelated timer.
+   */
+  schedule(key: string, fn: () => void, delayMs: number): void {
+    const existing = this.timers.get(key);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+    }
+    const handle = setTimeout(() => {
+      this.timers.delete(key);
+      fn();
+    }, delayMs);
+    this.timers.set(key, handle);
+  }
+
+  /** Cancel a pending timer for `key` (no-op if none is scheduled). */
+  cancel(key: string): void {
+    const handle = this.timers.get(key);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      this.timers.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
Type free-text notes during a meeting (autosaved); they feed the live brain + fold into the finalized note; inline @brain inserts the brain's attributed answer. Typed notes are SEAL-AND-RESTORE (verify-before-destroy) under the folder CK. Full ci.sh green; lock-security PASS; adversarial-verifier PASS (live smoke). No version bump (batching toward 0.6.3).