### PR TITLE
feat(brain): whole-brain view — document upload + visualization

### DIFF
--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -131,6 +131,7 @@ import { ToastService } from "./services/toast.service";
             <a routerLink="/library" routerLinkActive="active">Meetings</a>
             <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
             <a routerLink="/graph" routerLinkActive="active">Graph</a>
+            <a routerLink="/brain" routerLinkActive="active">Brain</a>
             <a routerLink="/ask" routerLinkActive="active">Ask</a>
             <a routerLink="/settings" routerLinkActive="active">Settings</a>
           </nav>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -68,6 +68,13 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "brain",
+        loadComponent: () =>
+          import("./features/brain/brain.component").then(
+            (m) => m.BrainComponent,
+          ),
+      },
+      {
         path: "onboarding",
         loadComponent: () =>
           import("./features/onboarding/onboarding.component").then(

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -19,6 +19,7 @@ import type {
   CalendarContext,
   ChatTurn,
   DigestResult,
+  DocumentInfo,
   EntityDetail,
   Folder,
   FolderNode,
@@ -295,6 +296,49 @@ export class IpcService {
   /** Detail for one entity: the entity + its visible backlinked meetings + top neighbors. */
   getEntityDetail(entityId: string): Promise<EntityDetail> {
     return invoke<EntityDetail>("get_entity_detail", { entityId });
+  }
+
+  // ── brain2 documents — expand the brain with imported .md/.txt files ────
+
+  /**
+   * Import a `.md`/`.txt` document into `folderId` to expand the brain: the
+   * backend reads it as UTF-8 text, stores it, and (when the on-device embedding
+   * model is present) indexes it into the vector layer. Resolves with the new
+   * document id. Rejects with `AppError::Locked` when the folder is
+   * sealed-and-NOT-session-unlocked (never resurrect plaintext behind a lock),
+   * and with `AppError::InvalidArg` for a non-`.md`/`.txt` or unreadable file —
+   * surface both as friendly messages. The path comes from the native file
+   * dialog (`@tauri-apps/plugin-dialog` `open`); only `.md`/`.txt` are accepted.
+   */
+  importDocument(path: string, folderId: string): Promise<string> {
+    return invoke<string>("import_document", { path, folderId });
+  }
+
+  /**
+   * A folder's documents (metadata only — name + created_at; NO text). GATED
+   * server-side: a sealed-and-NOT-session-unlocked folder returns an EMPTY array
+   * (masked — never even a document name behind the lock), so re-fetch on a
+   * FoldersService lock-state change to drop masked docs live.
+   */
+  listDocuments(folderId: string): Promise<DocumentInfo[]> {
+    return invoke<DocumentInfo[]>("list_documents", { folderId });
+  }
+
+  /**
+   * Read ONE document's full text. GATED: a sealed-and-NOT-session-unlocked
+   * folder returns "" (masked — never the stored text), like `getManualNotes`.
+   */
+  getDocument(id: string): Promise<string> {
+    return invoke<string>("get_document", { id });
+  }
+
+  /**
+   * Permanently delete a document (cascade-deletes its chunks + vectors). GATED:
+   * a sealed-and-NOT-session-unlocked folder is refused (`AppError::Locked`);
+   * an unknown id is an idempotent no-op.
+   */
+  deleteDocument(id: string): Promise<void> {
+    return invoke<void>("delete_document", { id });
   }
 
   /** Ask-My-Vault: grounded Q&A across ALL meetings, with source meetings. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -479,6 +479,20 @@ export interface SearchHit {
   matchedIn: string;
 }
 
+/**
+ * brain2 documents — lightweight metadata for one uploaded document (the Brain
+ * view's document list DTO). Mirrors the Rust `DocumentInfo` (serde camelCase):
+ * carries NO text (the text is gated content surfaced only by `getDocument`,
+ * never in the list). `createdAt` is epoch MILLISECONDS (i64), so format it via
+ * `new Date(createdAt)`. A sealed-and-NOT-session-unlocked folder returns an
+ * EMPTY list (masked — never even a document name behind the lock).
+ */
+export interface DocumentInfo {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
 export interface ChatTurn {
   role: "user" | "assistant";
   content: string;

--- a/src/app/features/brain/brain-map.component.ts
+++ b/src/app/features/brain/brain-map.component.ts
@@ -1,0 +1,720 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import type { GraphData, GraphNode } from "../../core/models";
+
+/** A node placed by the deterministic layout (SVG user-space coordinates). */
+interface PlacedNode {
+  id: string;
+  name: string;
+  kind: GraphNode["kind"];
+  mentionCount: number;
+  x: number;
+  y: number;
+  /** Node radius ∝ mention count (clamped). */
+  r: number;
+}
+
+/** An edge resolved to its two endpoints' placed coordinates. */
+interface PlacedEdge {
+  /** `${source}::${target}` — stable @for track key. */
+  key: string;
+  source: string;
+  target: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  /** Stroke width ∝ co-occurrence weight (clamped). */
+  width: number;
+  /** Stroke opacity ∝ weight (clamped). */
+  opacity: number;
+}
+
+/** The current pan/zoom window, mapped straight to the SVG `viewBox`. */
+interface ViewBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Logical layout canvas (user units). The viewBox pans/zooms over this. */
+const WORLD = 1000;
+/** Cap on rendered nodes — the strongest top-K by mention count. Big graphs
+ *  cluster down to this so the layout + DOM stay bounded. */
+const MAX_NODES = 60;
+/** Fixed force-directed iteration count — run ONCE, synchronously, no loop. */
+const ITERATIONS = 240;
+/** Zoom clamp (× the world size visible). */
+const MIN_W = WORLD * 0.18;
+const MAX_W = WORLD * 1.6;
+
+/**
+ * The interactive BRAIN MAP — `get_graph()` rendered as a hand-rolled node-link
+ * SVG (no graph library, no new dependency).
+ *
+ * LAYOUT (deterministic, one-shot, zoneless-safe): nodes are SEEDED on a
+ * golden-angle spiral keyed by their sort index (stable across renders), then a
+ * fixed {@link ITERATIONS}-iteration Fruchterman-Reingold-style force pass runs
+ * SYNCHRONOUSLY inside a `computed()` — pairwise repulsion + per-edge spring
+ * attraction + a gentle pull to centre, with a cooling schedule. There is NO
+ * `requestAnimationFrame`, NO `setInterval`, NO animation loop: positions are a
+ * pure, cached function of the (capped) graph data, so the same data always
+ * lays out identically. Large graphs cluster to the top-{@link MAX_NODES} by
+ * mention count (with a `has-hidden`/`capped` disclosure surfaced by the parent).
+ *
+ * PAN/ZOOM is a single {@link ViewBox} signal bound to the SVG `viewBox`: wheel
+ * zooms toward the cursor, pointer-drag pans. Clicking a node highlights its
+ * one-hop neighbourhood (dimming the rest); clicking empty space clears it.
+ *
+ * HONESTY: a polished ANIMATED force graph (live tick simulation, drag-to-reflow
+ * individual nodes, WebGL for thousands of nodes) would want a real graph lib
+ * (d3-force / cytoscape / sigma) — a new npm dependency, which is forbidden here
+ * without approval. This is the best STATIC, no-dep, one-shot-layout version.
+ */
+@Component({
+  selector: "app-brain-map",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="bm">
+      <div class="bm-toolbar" role="toolbar" aria-label="Map controls">
+        <div class="bm-legend" aria-hidden="true">
+          <span class="bm-legend-item">
+            <span class="bm-dot is-person"></span>People
+          </span>
+          <span class="bm-legend-item">
+            <span class="bm-dot is-project"></span>Projects
+          </span>
+        </div>
+        <div class="bm-zoom">
+          <button
+            type="button"
+            class="btn btn-ghost bm-zbtn"
+            aria-label="Zoom in"
+            (click)="zoomBy(0.8)"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost bm-zbtn"
+            aria-label="Zoom out"
+            (click)="zoomBy(1.25)"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost bm-zbtn bm-zreset"
+            aria-label="Reset view"
+            (click)="resetView()"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <svg
+        #canvas
+        class="bm-canvas"
+        [class.is-panning]="panning()"
+        [attr.viewBox]="viewBoxStr()"
+        role="img"
+        [attr.aria-label]="ariaLabel()"
+        (wheel)="onWheel($event)"
+        (pointerdown)="onPointerDown($event)"
+        (pointermove)="onPointerMove($event)"
+        (pointerup)="onPointerUp($event)"
+        (pointercancel)="onPointerUp($event)"
+        (click)="onCanvasClick($event)"
+      >
+        <!-- Edges first, beneath the nodes. -->
+        <g class="bm-edges">
+          @for (e of placedEdges(); track e.key) {
+            <line
+              class="bm-edge"
+              [class.is-dim]="isEdgeDim(e)"
+              [attr.x1]="e.x1"
+              [attr.y1]="e.y1"
+              [attr.x2]="e.x2"
+              [attr.y2]="e.y2"
+              [attr.stroke-width]="e.width"
+              [style.opacity]="isEdgeDim(e) ? 0.06 : e.opacity"
+            />
+          }
+        </g>
+
+        <!-- Nodes: each a clickable group (dot + label). -->
+        <g class="bm-nodes">
+          @for (n of placedNodes(); track n.id) {
+            <g
+              class="bm-node"
+              [class.is-project]="n.kind === 'project'"
+              [class.is-selected]="selectedId() === n.id"
+              [class.is-dim]="isNodeDim(n.id)"
+              role="button"
+              tabindex="0"
+              [attr.aria-label]="nodeLabel(n)"
+              [attr.aria-pressed]="selectedId() === n.id"
+              (click)="onNodeClick($event, n.id)"
+              (keydown.enter)="onNodeActivate(n.id)"
+              (keydown.space)="onNodeSpace($event, n.id)"
+            >
+              <circle
+                class="bm-dot-hit"
+                [attr.cx]="n.x"
+                [attr.cy]="n.y"
+                [attr.r]="n.r + 8"
+              />
+              <circle
+                class="bm-dot"
+                [attr.cx]="n.x"
+                [attr.cy]="n.y"
+                [attr.r]="n.r"
+              />
+              <text
+                class="bm-label"
+                [attr.x]="n.x"
+                [attr.y]="n.y + n.r + 13"
+                text-anchor="middle"
+              >
+                {{ n.name }}
+              </text>
+            </g>
+          }
+        </g>
+      </svg>
+
+      <p class="bm-hint">
+        Scroll to zoom · drag to pan · click a node to focus its connections.
+      </p>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .bm {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+
+      .bm-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+      }
+      .bm-legend {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-4);
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+      }
+      .bm-legend-item {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .bm-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      .bm-dot.is-project {
+        background: #9d7bff;
+        box-shadow: 0 0 0 3px rgba(157, 123, 255, 0.18);
+      }
+      .bm-zoom {
+        display: inline-flex;
+        gap: var(--space-2);
+      }
+      .bm-zbtn {
+        min-width: 36px;
+        height: 32px;
+        padding: 0 var(--space-2);
+        font-size: 1rem;
+        line-height: 1;
+      }
+      .bm-zreset {
+        font-size: 0.8125rem;
+      }
+
+      .bm-canvas {
+        display: block;
+        width: 100%;
+        height: clamp(360px, 60vh, 620px);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-lg);
+        background:
+          radial-gradient(
+            120% 120% at 50% 0%,
+            rgba(110, 118, 255, 0.06),
+            transparent 60%
+          ),
+          var(--surface-input);
+        touch-action: none;
+        cursor: grab;
+        user-select: none;
+      }
+      .bm-canvas.is-panning {
+        cursor: grabbing;
+      }
+
+      .bm-edge {
+        stroke: var(--border-strong);
+        stroke-linecap: round;
+        transition: opacity var(--transition);
+      }
+
+      .bm-node {
+        cursor: pointer;
+      }
+      .bm-dot-hit {
+        fill: transparent;
+      }
+      .bm-dot {
+        fill: var(--accent);
+        stroke: var(--surface-base);
+        stroke-width: 2;
+        transition:
+          fill var(--transition),
+          opacity var(--transition);
+      }
+      .bm-node.is-project .bm-dot {
+        fill: #9d7bff;
+      }
+      .bm-label {
+        fill: var(--text-secondary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        font-weight: 550;
+        pointer-events: none;
+        paint-order: stroke;
+        stroke: var(--surface-base);
+        stroke-width: 3px;
+        transition:
+          fill var(--transition),
+          opacity var(--transition);
+      }
+      .bm-node:hover .bm-dot,
+      .bm-node:focus-visible .bm-dot {
+        fill: var(--accent-hover);
+      }
+      .bm-node.is-project:hover .bm-dot,
+      .bm-node.is-project:focus-visible .bm-dot {
+        fill: #b69bff;
+      }
+      .bm-node:hover .bm-label,
+      .bm-node:focus-visible .bm-label {
+        fill: var(--text-primary);
+      }
+      .bm-node:focus-visible {
+        outline: none;
+      }
+      .bm-node:focus-visible .bm-dot {
+        stroke: var(--accent-ring);
+        stroke-width: 3;
+      }
+      .bm-node.is-selected .bm-dot {
+        stroke: var(--accent-hover);
+        stroke-width: 3;
+      }
+      .bm-node.is-selected .bm-label {
+        fill: var(--text-primary);
+      }
+      .bm-node.is-dim .bm-dot {
+        opacity: 0.18;
+      }
+      .bm-node.is-dim .bm-label {
+        opacity: 0.1;
+      }
+
+      .bm-hint {
+        margin: 0;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+      }
+    `,
+  ],
+})
+export class BrainMapComponent {
+  private readonly injector = inject(Injector);
+
+  /** The graph to visualise. Re-laying out when it changes (pure derivation). */
+  readonly data = input<GraphData | null>(null);
+
+  /** The currently focused node id, or null. Drives neighbourhood highlight. */
+  readonly selectedId = signal<string | null>(null);
+
+  private readonly canvas =
+    viewChild<ElementRef<SVGSVGElement>>("canvas");
+
+  /** The pan/zoom window → the SVG viewBox. Starts centred on the world. */
+  private readonly _viewBox = signal<ViewBox>({
+    x: 0,
+    y: 0,
+    w: WORLD,
+    h: WORLD,
+  });
+  readonly viewBoxStr = computed(() => {
+    const v = this._viewBox();
+    return `${v.x} ${v.y} ${v.w} ${v.h}`;
+  });
+
+  /** True while a pointer-drag pan is in flight (toggles the grab cursor). */
+  readonly panning = signal(false);
+  /** Last pointer position during a pan, in CLIENT pixels. */
+  private panStart: { px: number; py: number } | null = null;
+  /** Measured SVG client size (for px→user-unit conversion). Updated on demand. */
+  private readonly clientSize = signal<{ w: number; h: number }>({
+    w: WORLD,
+    h: WORLD,
+  });
+
+  constructor() {
+    // Measure the SVG once after first render so wheel/drag deltas convert from
+    // client px to user units accurately. afterNextRender — never setTimeout.
+    afterNextRender(() => this.measure(), { injector: this.injector });
+  }
+
+  /**
+   * The capped, laid-out nodes. Pure function of {@link data}: take the top-K by
+   * mention count, seed them deterministically, then run a FIXED-iteration force
+   * pass synchronously. Cached by `computed`; no simulation loop.
+   */
+  protected readonly placedNodes = computed<PlacedNode[]>(() => {
+    const d = this.data();
+    if (!d || d.nodes.length === 0) {
+      return [];
+    }
+
+    // Deterministic order: most-mentioned first, name as a stable tiebreak.
+    const ordered = [...d.nodes].sort(
+      (a, b) =>
+        b.mentionCount - a.mentionCount || a.name.localeCompare(b.name),
+    );
+    const nodes = ordered.slice(0, MAX_NODES);
+    const n = nodes.length;
+    const ids = nodes.map((x) => x.id);
+    const idIndex = new Map(ids.map((id, i) => [id, i]));
+
+    // Mention-count → radius (10…34 user units), sqrt-scaled so big counts
+    // don't dominate. A lone node still reads.
+    const maxM = Math.max(1, ...nodes.map((x) => x.mentionCount));
+    const radii = nodes.map(
+      (x) => 10 + (Math.sqrt(x.mentionCount) / Math.sqrt(maxM)) * 24,
+    );
+
+    // SEED: golden-angle spiral, keyed by index → identical every render.
+    const cx = WORLD / 2;
+    const cy = WORLD / 2;
+    const golden = Math.PI * (3 - Math.sqrt(5));
+    const xs = new Float64Array(n);
+    const ys = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      const radius = (WORLD * 0.42) * Math.sqrt((i + 0.5) / n);
+      const angle = i * golden;
+      xs[i] = cx + radius * Math.cos(angle);
+      ys[i] = cy + radius * Math.sin(angle);
+    }
+
+    // Only edges whose endpoints both survived the cap participate.
+    const edges = d.edges.filter(
+      (e) => idIndex.has(e.source) && idIndex.has(e.target),
+    );
+
+    // Fruchterman-Reingold-ish constants. k = ideal edge length.
+    const area = WORLD * WORLD;
+    const k = Math.sqrt(area / Math.max(1, n)) * 0.62;
+    const k2 = k * k;
+    let temp = WORLD * 0.16;
+    const cool = temp / (ITERATIONS + 1);
+
+    const dispX = new Float64Array(n);
+    const dispY = new Float64Array(n);
+
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      dispX.fill(0);
+      dispY.fill(0);
+
+      // Repulsion between every pair (n ≤ MAX_NODES so O(n²) is bounded).
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          let dx = xs[i] - xs[j];
+          let dy = ys[i] - ys[j];
+          let dist2 = dx * dx + dy * dy;
+          if (dist2 < 0.01) {
+            // Deterministic nudge for coincident seeds (no Math.random).
+            dx = ((i * 31 + j) % 7) - 3 + 0.5;
+            dy = ((i * 17 + j) % 5) - 2 + 0.5;
+            dist2 = dx * dx + dy * dy;
+          }
+          const dist = Math.sqrt(dist2);
+          const force = k2 / dist;
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          dispX[i] += fx;
+          dispY[i] += fy;
+          dispX[j] -= fx;
+          dispY[j] -= fy;
+        }
+      }
+
+      // Attraction along edges (spring), weighted by co-occurrence.
+      for (const e of edges) {
+        const i = idIndex.get(e.source)!;
+        const j = idIndex.get(e.target)!;
+        const dx = xs[i] - xs[j];
+        const dy = ys[i] - ys[j];
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        const w = 1 + Math.log2(1 + e.weight);
+        const force = ((dist * dist) / k) * w;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        dispX[i] -= fx;
+        dispY[i] -= fy;
+        dispX[j] += fx;
+        dispY[j] += fy;
+      }
+
+      // Apply displacement, capped by the cooling temperature; gentle pull to
+      // centre keeps disconnected components from drifting off-canvas.
+      for (let i = 0; i < n; i++) {
+        const dlen = Math.sqrt(dispX[i] * dispX[i] + dispY[i] * dispY[i]) || 1;
+        xs[i] += (dispX[i] / dlen) * Math.min(dlen, temp);
+        ys[i] += (dispY[i] / dlen) * Math.min(dlen, temp);
+        xs[i] += (cx - xs[i]) * 0.012;
+        ys[i] += (cy - ys[i]) * 0.012;
+      }
+      temp = Math.max(0, temp - cool);
+    }
+
+    return nodes.map((node, i) => ({
+      id: node.id,
+      name: node.name,
+      kind: node.kind,
+      mentionCount: node.mentionCount,
+      x: Math.round(xs[i] * 100) / 100,
+      y: Math.round(ys[i] * 100) / 100,
+      r: Math.round(radii[i] * 100) / 100,
+    }));
+  });
+
+  /** Edges resolved to placed endpoints (only those between surviving nodes). */
+  protected readonly placedEdges = computed<PlacedEdge[]>(() => {
+    const d = this.data();
+    if (!d) {
+      return [];
+    }
+    const pos = new Map(this.placedNodes().map((p) => [p.id, p]));
+    const maxW = Math.max(1, ...d.edges.map((e) => e.weight));
+    const out: PlacedEdge[] = [];
+    for (const e of d.edges) {
+      const a = pos.get(e.source);
+      const b = pos.get(e.target);
+      if (!a || !b) {
+        continue;
+      }
+      const ratio = e.weight / maxW;
+      out.push({
+        key: `${e.source}::${e.target}`,
+        source: e.source,
+        target: e.target,
+        x1: a.x,
+        y1: a.y,
+        x2: b.x,
+        y2: b.y,
+        width: Math.round((0.8 + ratio * 4.2) * 100) / 100,
+        opacity: Math.round((0.22 + ratio * 0.5) * 100) / 100,
+      });
+    }
+    return out;
+  });
+
+  /** Ids in the focused node's one-hop neighbourhood (the node + its peers). */
+  private readonly neighborhood = computed<Set<string> | null>(() => {
+    const sel = this.selectedId();
+    if (!sel) {
+      return null;
+    }
+    const set = new Set<string>([sel]);
+    for (const e of this.placedEdges()) {
+      if (e.source === sel) {
+        set.add(e.target);
+      } else if (e.target === sel) {
+        set.add(e.source);
+      }
+    }
+    return set;
+  });
+
+  protected readonly ariaLabel = computed(() => {
+    const n = this.placedNodes().length;
+    if (n === 0) {
+      return "Brain map — empty.";
+    }
+    return `Brain map of ${n} ${n === 1 ? "entity" : "entities"} and their connections. Scroll to zoom, drag to pan.`;
+  });
+
+  protected isNodeDim(id: string): boolean {
+    const nb = this.neighborhood();
+    return nb !== null && !nb.has(id);
+  }
+
+  protected isEdgeDim(e: PlacedEdge): boolean {
+    const nb = this.neighborhood();
+    return nb !== null && !(nb.has(e.source) && nb.has(e.target));
+  }
+
+  protected nodeLabel(n: PlacedNode): string {
+    const kind = n.kind === "project" ? "Project" : "Person";
+    const m =
+      n.mentionCount === 1 ? "1 mention" : `${n.mentionCount} mentions`;
+    return `${n.name} — ${kind}, ${m}. Focus its connections.`;
+  }
+
+  // ── interaction ────────────────────────────────────────────────────────
+
+  protected onNodeClick(event: Event, id: string): void {
+    event.stopPropagation();
+    this.toggleSelect(id);
+  }
+
+  protected onNodeActivate(id: string): void {
+    this.toggleSelect(id);
+  }
+
+  protected onNodeSpace(event: Event, id: string): void {
+    event.preventDefault();
+    this.toggleSelect(id);
+  }
+
+  private toggleSelect(id: string): void {
+    this.selectedId.update((cur) => (cur === id ? null : id));
+  }
+
+  /** A bare canvas click (not on a node) clears the neighbourhood focus. */
+  protected onCanvasClick(event: Event): void {
+    // Node clicks stopPropagation, so anything reaching here is empty space.
+    if (event.target === this.canvas()?.nativeElement) {
+      this.selectedId.set(null);
+    }
+  }
+
+  /** Wheel = zoom toward the cursor (clamped). */
+  protected onWheel(event: WheelEvent): void {
+    event.preventDefault();
+    const factor = event.deltaY > 0 ? 1.12 : 1 / 1.12;
+    this.zoomAt(event.clientX, event.clientY, factor);
+  }
+
+  protected onPointerDown(event: PointerEvent): void {
+    // Left button (or touch/pen) starts a pan; node clicks are handled
+    // separately and don't reach a meaningful pan because we record the start.
+    if (event.button !== 0) {
+      return;
+    }
+    this.measure();
+    this.panning.set(true);
+    this.panStart = { px: event.clientX, py: event.clientY };
+    (event.target as Element).setPointerCapture?.(event.pointerId);
+  }
+
+  protected onPointerMove(event: PointerEvent): void {
+    if (!this.panning() || !this.panStart) {
+      return;
+    }
+    const v = this._viewBox();
+    const cs = this.clientSize();
+    // Convert client-px delta → user-unit delta via the current scale.
+    const scaleX = v.w / Math.max(1, cs.w);
+    const scaleY = v.h / Math.max(1, cs.h);
+    const dx = (event.clientX - this.panStart.px) * scaleX;
+    const dy = (event.clientY - this.panStart.py) * scaleY;
+    this._viewBox.set({ x: v.x - dx, y: v.y - dy, w: v.w, h: v.h });
+    this.panStart = { px: event.clientX, py: event.clientY };
+  }
+
+  protected onPointerUp(event: PointerEvent): void {
+    this.panning.set(false);
+    this.panStart = null;
+    (event.target as Element).releasePointerCapture?.(event.pointerId);
+  }
+
+  /** Toolbar +/− : zoom about the viewBox centre. */
+  protected zoomBy(factor: number): void {
+    const v = this._viewBox();
+    const cx = v.x + v.w / 2;
+    const cy = v.y + v.h / 2;
+    this.applyZoom(cx, cy, factor);
+  }
+
+  protected resetView(): void {
+    this._viewBox.set({ x: 0, y: 0, w: WORLD, h: WORLD });
+  }
+
+  /** Zoom about a CLIENT (px) anchor — keeps the point under the cursor fixed. */
+  private zoomAt(clientX: number, clientY: number, factor: number): void {
+    const el = this.canvas()?.nativeElement;
+    if (!el) {
+      this.zoomBy(factor);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const v = this._viewBox();
+    const userX = v.x + ((clientX - rect.left) / Math.max(1, rect.width)) * v.w;
+    const userY = v.y + ((clientY - rect.top) / Math.max(1, rect.height)) * v.h;
+    this.applyZoom(userX, userY, factor);
+  }
+
+  /** Apply a clamped zoom about a USER-space anchor point. */
+  private applyZoom(anchorX: number, anchorY: number, factor: number): void {
+    const v = this._viewBox();
+    let newW = v.w * factor;
+    let newH = v.h * factor;
+    // Clamp width; keep the aspect by scaling height with the applied ratio.
+    const clampedW = Math.min(MAX_W, Math.max(MIN_W, newW));
+    const ratio = clampedW / newW;
+    newW = clampedW;
+    newH = newH * ratio;
+    // Keep the anchor point fixed on screen.
+    const tx = (anchorX - v.x) / v.w;
+    const ty = (anchorY - v.y) / v.h;
+    this._viewBox.set({
+      x: anchorX - tx * newW,
+      y: anchorY - ty * newH,
+      w: newW,
+      h: newH,
+    });
+  }
+
+  /** Cache the SVG's client size for px→user-unit conversion. */
+  private measure(): void {
+    const el = this.canvas()?.nativeElement;
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        this.clientSize.set({ w: rect.width, h: rect.height });
+      }
+    }
+  }
+}

--- a/src/app/features/brain/brain.component.ts
+++ b/src/app/features/brain/brain.component.ts
@@ -1,0 +1,244 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { GraphData } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+import { BrainMapComponent } from "./brain-map.component";
+import { DocumentPanelComponent } from "./document-panel.component";
+
+/** The hard cap the map applies — kept in sync with BrainMapComponent's MAX_NODES. */
+const MAP_NODE_CAP = 60;
+
+/**
+ * The `/brain` page — the "whole brain" view.
+ *
+ * Two halves over one local-first store:
+ *  1. DOCUMENTS — upload `.md`/`.txt` files into a folder to EXPAND the brain,
+ *     list + delete them (delegated to {@link DocumentPanelComponent}).
+ *  2. BRAIN MAP — the entity co-occurrence graph from `get_graph()`, rendered as
+ *     an interactive node-link SVG (delegated to {@link BrainMapComponent}).
+ *
+ * Like the /graph page, the map is lock-aware: the backend returns only VISIBLE
+ * entities + a `hasHidden` flag, and we re-fetch `getGraph()` whenever the
+ * {@link FoldersService} tree changes (a session unlock/relock / screen-share
+ * relock shifts visibility), so sealed entities drop out — or reappear — live.
+ *
+ * SCOPE NOTE (v1): the map is ENTITY-focused. Imported documents expand the
+ * brain's retrieval corpus (and its entity extraction as notes reference them),
+ * but the backend's `get_graph()` exposes only person/project entity nodes — it
+ * has no per-document node kind — so documents are NOT yet a distinct node kind
+ * on the map. Adding a document node kind would need a backend graph change
+ * (out of scope for this FE-only task).
+ */
+@Component({
+  selector: "app-brain",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DocumentPanelComponent, BrainMapComponent],
+  template: `
+    <section class="brain">
+      <header class="b-head">
+        <div class="b-head-text">
+          <h2 class="b-title">Brain</h2>
+          <p class="b-intro">
+            Everything Murmur knows — the documents you’ve added and the people
+            and projects it has connected across your meetings.
+          </p>
+        </div>
+      </header>
+
+      <!-- 1 — Documents: expand the brain. -->
+      <app-document-panel />
+
+      <!-- 2 — The brain map. -->
+      <section class="b-map-wrap">
+        <header class="b-map-head">
+          <div class="b-map-head-text">
+            <h3 class="b-map-title">Map</h3>
+            <p class="b-map-sub">
+              People and projects, linked by the meetings they share.
+            </p>
+          </div>
+          @if (!loading() && nodeCount() > 0) {
+            <span class="count" [attr.title]="nodeCount() + ' entities'">
+              {{ nodeCount() }}
+            </span>
+          }
+        </header>
+
+        @if (loading()) {
+          <div class="card state-card">
+            <p class="empty">Loading the map…</p>
+          </div>
+        } @else if (error()) {
+          <div class="card empty-state">
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">Couldn’t load the map</p>
+            <p class="empty">{{ error() }}</p>
+          </div>
+        } @else if (nodeCount() === 0) {
+          <div class="card empty-state">
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">The map builds itself as you record</p>
+            <p class="empty">
+              As Murmur recognises the people and projects you talk about,
+              they’ll appear here — connected by the meetings they share.
+            </p>
+          </div>
+        } @else {
+          @if (disclosure(); as msg) {
+            <div class="banner is-accent b-banner" role="status">
+              <span class="b-banner-glyph" aria-hidden="true"></span>
+              <span>{{ msg }}</span>
+            </div>
+          }
+          <app-brain-map [data]="graphData()" />
+        }
+      </section>
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .brain {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-6);
+      }
+
+      .b-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .b-title {
+        margin: 0;
+      }
+      .b-intro {
+        margin: 0;
+        max-width: 64ch;
+        color: var(--text-secondary);
+        font-size: 0.9375rem;
+      }
+
+      .b-map-wrap {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .b-map-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+      .b-map-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .b-map-title {
+        margin: 0;
+        font-size: 1.0625rem;
+      }
+      .b-map-sub {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+      }
+
+      .b-banner {
+        align-items: center;
+        animation: rise 320ms var(--transition) both;
+      }
+      .b-banner-glyph {
+        flex: none;
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-hover);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .b-banner {
+          animation: none;
+        }
+      }
+    `,
+  ],
+})
+export class BrainComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+
+  readonly graphData = signal<GraphData | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  /** VISIBLE entity count from the backend (before the map's display cap). */
+  protected readonly nodeCount = computed(
+    () => this.graphData()?.nodes.length ?? 0,
+  );
+
+  /**
+   * One honest disclosure line, or null. Combines TWO truths:
+   *  - `hasHidden` — the backend withheld ≥1 sealed entity (unlock to include).
+   *  - the map's display cap — when more than {@link MAP_NODE_CAP} entities are
+   *    visible, the map shows only the strongest top-K (the rest are still in
+   *    Documents/search; just not drawn).
+   */
+  protected readonly disclosure = computed<string | null>(() => {
+    const d = this.graphData();
+    if (!d) {
+      return null;
+    }
+    const capped = d.nodes.length > MAP_NODE_CAP;
+    if (d.hasHidden && capped) {
+      return `Showing the ${MAP_NODE_CAP} most-connected entities. More are hidden in locked folders — unlock to include them.`;
+    }
+    if (capped) {
+      return `Showing the ${MAP_NODE_CAP} most-connected of ${d.nodes.length} entities.`;
+    }
+    if (d.hasHidden) {
+      return "Some entities are hidden — unlock a folder to include them.";
+    }
+    return null;
+  });
+
+  /**
+   * Load the graph, and re-load it whenever the folder lock-state changes.
+   * Mirrors GraphComponent: reading the folders `tree` signal registers this
+   * effect as its dependent, so the initial value drives the first fetch and a
+   * later unlock/relock re-runs it (sealed entities drop out / reappear live).
+   * `fetchGraph` writes loading/error/data synchronously before its first await,
+   * so this tracked effect must be allowed to write (NG0600 guard).
+   */
+  private readonly _refetchOnLock = effect(
+    () => {
+      this.folders.tree();
+      void this.fetchGraph();
+    },
+    { allowSignalWrites: true },
+  );
+
+  private async fetchGraph(): Promise<void> {
+    this.error.set(null);
+    try {
+      this.graphData.set(await this.ipc.getGraph());
+    } catch (e) {
+      this.graphData.set(null);
+      this.error.set(String(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/src/app/features/brain/document-panel.component.ts
+++ b/src/app/features/brain/document-panel.component.ts
@@ -1,0 +1,502 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { IpcService } from "../../core/ipc.service";
+import type { DocumentInfo, FolderNode } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
+
+/** A flattened folder option for the selector (indent reflects tree depth). */
+interface FolderOption {
+  id: string;
+  /** Display label with a depth-indent prefix + a lock glyph when sealed. */
+  label: string;
+  /** Sealed-and-NOT-session-unlocked → import/list/delete are blocked. */
+  blocked: boolean;
+}
+
+/**
+ * The DOCUMENTS panel of the Brain view: pick a folder, upload `.md`/`.txt`
+ * documents into it to expand the brain, list them, delete them.
+ *
+ * Upload flow: the native file dialog (`@tauri-apps/plugin-dialog` `open`,
+ * filtered to `.md`/`.txt`) → on a chosen path, `importDocument(path, folderId)`
+ * → refresh the list + a success toast. The backend is the authority on the
+ * lock gate: a sealed folder rejects with `AppError::Locked`, surfaced as a
+ * clear danger toast (and the affordance is pre-disabled for a sealed-selected
+ * folder).
+ *
+ * The list re-fetches whenever the selected folder OR the folder lock-state
+ * changes (a session unlock/relock shifts what `list_documents` returns — a
+ * sealed folder is masked to empty), so it never shows stale docs.
+ */
+@Component({
+  selector: "app-document-panel",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    <section class="dp card">
+      <header class="dp-head">
+        <div class="dp-head-text">
+          <h3 class="dp-title">Documents</h3>
+          <p class="dp-sub">
+            Add Markdown or text files to expand what the brain knows. They’re
+            indexed alongside your meeting notes.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-primary dp-add"
+          [disabled]="importing() || !selectedFolderId() || selectedBlocked()"
+          (click)="pickAndImport()"
+        >
+          @if (importing()) {
+            Adding…
+          } @else {
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M8 3.5v9M3.5 8h9"
+                stroke="currentColor"
+                stroke-width="1.7"
+                stroke-linecap="round"
+              />
+            </svg>
+            Add document
+          }
+        </button>
+      </header>
+
+      <label class="dp-folder">
+        <span class="dp-folder-label">Folder</span>
+        <select
+          class="dp-folder-select"
+          aria-label="Choose a folder"
+          [value]="selectedFolderId() ?? ''"
+          (change)="onFolderChange($event)"
+        >
+          @for (o of folderOptions(); track o.id) {
+            <option [value]="o.id">{{ o.label }}</option>
+          }
+        </select>
+      </label>
+
+      @if (selectedBlocked()) {
+        <div class="banner is-accent dp-locked" role="status">
+          <span class="dp-locked-glyph" aria-hidden="true"></span>
+          <span>
+            This folder is locked. Unlock it (in Meetings → folders) to add or
+            view its documents.
+          </span>
+        </div>
+      }
+
+      @if (loading()) {
+        <p class="empty dp-state">Loading documents…</p>
+      } @else if (error()) {
+        <p class="empty dp-state">{{ error() }}</p>
+      } @else if (documents().length === 0) {
+        <div class="empty-state dp-empty">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">No documents in this folder yet</p>
+          <p class="empty">
+            Add a Markdown or text file to give the brain more to reason over.
+          </p>
+        </div>
+      } @else {
+        <ul class="dp-list" role="list">
+          @for (doc of documents(); track doc.id) {
+            <li class="dp-item">
+              <span class="dp-doc-glyph" aria-hidden="true">
+                <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                  <path
+                    d="M4 1.75h5L12.25 5v9.25H4z"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 1.75V5h3.25"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span class="dp-doc-text">
+                <span class="dp-doc-name">{{ doc.name }}</span>
+                <span class="dp-doc-date">{{ formatDate(doc.createdAt) }}</span>
+              </span>
+              <button
+                type="button"
+                class="btn btn-ghost dp-del"
+                [attr.aria-label]="'Delete ' + doc.name"
+                [disabled]="deletingId() === doc.id"
+                (click)="remove(doc)"
+              >
+                <svg
+                  viewBox="0 0 16 16"
+                  width="14"
+                  height="14"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M3 4.5h10M6.5 4.5V3.2c0-.4.3-.7.7-.7h1.6c.4 0 .7.3.7.7v1.3M5 4.5l.5 8.3h5L11 4.5"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+            </li>
+          }
+        </ul>
+      }
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .dp {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .dp-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+      .dp-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .dp-title {
+        margin: 0;
+        font-size: 1.0625rem;
+      }
+      .dp-sub {
+        margin: 0;
+        max-width: 46ch;
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+      }
+      .dp-add {
+        flex: none;
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+
+      .dp-folder {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .dp-folder-label {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .dp-folder-select {
+        width: 100%;
+        height: 38px;
+      }
+
+      .dp-locked {
+        align-items: center;
+      }
+      .dp-locked-glyph {
+        flex: none;
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-hover);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+
+      .dp-state {
+        margin: 0;
+        padding: var(--space-4) 0;
+      }
+      .dp-empty {
+        padding: var(--space-6) var(--space-4);
+      }
+      .dp-empty .empty-title {
+        margin: 0 0 var(--space-1);
+      }
+      .dp-empty .empty {
+        margin: 0;
+      }
+
+      .dp-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .dp-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        transition: border-color var(--transition);
+      }
+      .dp-item:hover {
+        border-color: var(--border-strong);
+      }
+      .dp-doc-glyph {
+        flex: none;
+        display: inline-flex;
+        color: var(--accent-hover);
+      }
+      .dp-doc-text {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        min-width: 0;
+        flex: 1 1 auto;
+      }
+      .dp-doc-name {
+        color: var(--text-primary);
+        font-size: 0.9375rem;
+        font-weight: 550;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .dp-doc-date {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+      }
+      .dp-del {
+        flex: none;
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        color: var(--text-muted);
+      }
+      .dp-del:hover {
+        color: var(--danger);
+      }
+    `,
+  ],
+})
+export class DocumentPanelComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+
+  /** The user-chosen folder, or null until the first folder option resolves. */
+  readonly selectedFolderId = signal<string | null>(null);
+
+  readonly documents = signal<DocumentInfo[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly importing = signal(false);
+  readonly deletingId = signal<string | null>(null);
+
+  /** Flattened folder tree → selector options (indented, lock-flagged). */
+  protected readonly folderOptions = computed<FolderOption[]>(() => {
+    const out: FolderOption[] = [];
+    const walk = (nodes: FolderNode[], depth: number): void => {
+      for (const node of nodes) {
+        const sealed = node.locked && !node.unlocked;
+        const indent = depth > 0 ? "  ".repeat(depth) + "↳ " : "";
+        out.push({
+          id: node.id,
+          label: `${indent}${node.name}${sealed ? " 🔒" : ""}`,
+          blocked: sealed,
+        });
+        if (node.children?.length) {
+          walk(node.children, depth + 1);
+        }
+      }
+    };
+    walk(this.folders.tree(), 0);
+    return out;
+  });
+
+  /** Whether the currently selected folder is sealed-and-not-unlocked. */
+  protected readonly selectedBlocked = computed(() => {
+    const id = this.selectedFolderId();
+    return this.folderOptions().some((o) => o.id === id && o.blocked);
+  });
+
+  constructor() {
+    // Ensure the folder tree is loaded so the selector has options.
+    void this.folders.load();
+
+    // Default the selection to the first folder once options resolve, and keep
+    // it valid if the tree changes (a deleted/renamed folder shouldn't strand
+    // the selection). Tracked effect that writes the selection signal.
+    effect(
+      () => {
+        const opts = this.folderOptions();
+        const cur = this.selectedFolderId();
+        if (opts.length === 0) {
+          if (cur !== null) {
+            this.selectedFolderId.set(null);
+          }
+          return;
+        }
+        if (cur === null || !opts.some((o) => o.id === cur)) {
+          this.selectedFolderId.set(opts[0].id);
+        }
+      },
+      { allowSignalWrites: true },
+    );
+
+    // (Re)load the document list whenever the selected folder OR the folder
+    // lock-state changes — a session unlock/relock changes what
+    // `list_documents` returns (a sealed folder is masked to empty). Reading
+    // both signals registers the dependency; the fetch sets loading/error
+    // synchronously before its first await, so writes must be allowed (NG0600).
+    effect(
+      () => {
+        const id = this.selectedFolderId();
+        // Establish a dependency on the lock-state too (drops masked docs live).
+        this.folders.tree();
+        if (!id) {
+          this.documents.set([]);
+          this.loading.set(false);
+          return;
+        }
+        this.loading.set(true);
+        this.error.set(null);
+        void this.fetchDocuments(id);
+      },
+      { allowSignalWrites: true },
+    );
+  }
+
+  private async fetchDocuments(folderId: string): Promise<void> {
+    try {
+      const docs = await this.ipc.listDocuments(folderId);
+      // Stale-result guard: drop a response for a folder we've since left.
+      if (this.selectedFolderId() !== folderId) {
+        return;
+      }
+      this.documents.set(docs);
+    } catch (e) {
+      if (this.selectedFolderId() !== folderId) {
+        return;
+      }
+      this.documents.set([]);
+      this.error.set(String(e));
+    } finally {
+      if (this.selectedFolderId() === folderId) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  protected onFolderChange(event: Event): void {
+    this.selectedFolderId.set((event.target as HTMLSelectElement).value);
+  }
+
+  /** Open the native file dialog (md/txt) → import the chosen path. */
+  async pickAndImport(): Promise<void> {
+    const folderId = this.selectedFolderId();
+    if (!folderId || this.selectedBlocked() || this.importing()) {
+      return;
+    }
+    const chosen = await open({
+      multiple: false,
+      filters: [{ name: "Documents", extensions: ["md", "txt"] }],
+    });
+    // `open` returns string | string[] | null; we requested a single file.
+    if (typeof chosen !== "string") {
+      return;
+    }
+
+    this.importing.set(true);
+    try {
+      await this.ipc.importDocument(chosen, folderId);
+      this.toast.success("Document added to the brain.");
+      // Re-fetch the list (only if we're still on the same folder).
+      if (this.selectedFolderId() === folderId) {
+        await this.fetchDocuments(folderId);
+      }
+    } catch (e) {
+      this.toast.danger(this.friendlyImportError(e));
+    } finally {
+      this.importing.set(false);
+    }
+  }
+
+  /** Permanently delete a document, then refresh the list + toast. */
+  async remove(doc: DocumentInfo): Promise<void> {
+    const folderId = this.selectedFolderId();
+    if (this.deletingId()) {
+      return;
+    }
+    this.deletingId.set(doc.id);
+    try {
+      await this.ipc.deleteDocument(doc.id);
+      this.toast.info(`Removed “${doc.name}”.`);
+      if (folderId && this.selectedFolderId() === folderId) {
+        await this.fetchDocuments(folderId);
+      }
+    } catch (e) {
+      this.toast.danger(this.friendlyDeleteError(e));
+    } finally {
+      this.deletingId.set(null);
+    }
+  }
+
+  /** Epoch-millis → a short local date string. */
+  protected formatDate(epochMs: number): string {
+    return new Date(epochMs).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  /** Map a backend import error to a clear user message (Locked is the common one). */
+  private friendlyImportError(e: unknown): string {
+    const msg = String(e);
+    if (/lock/i.test(msg)) {
+      return "That folder is locked — unlock it first to add a document.";
+    }
+    if (/\.md and \.txt|only .*md|invalid/i.test(msg)) {
+      return "Only Markdown (.md) and text (.txt) files can be imported.";
+    }
+    return "Couldn’t add that document. Please try again.";
+  }
+
+  private friendlyDeleteError(e: unknown): string {
+    const msg = String(e);
+    if (/lock/i.test(msg)) {
+      return "That folder is locked — unlock it first to delete a document.";
+    }
+    return "Couldn’t remove that document. Please try again.";
+  }
+}


### PR DESCRIPTION
New /brain view: upload md/txt docs into a folder (ingested into the vector brain) + an interactive node-link brain map (no-dep, one-shot layout, pan/zoom, neighborhood-highlight). ng gates green; adversarial-verifier PASS (live mocked-IPC smoke). FE-only, no version bump.