### PR TITLE
feat(record): agent proposes notes (you accept) + thread UX + ✨ ask-brain

### DIFF
--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -15,6 +15,9 @@
 //! `create_reminder`) live on [`GatedToolExecutor`] (NOT [`execute_tool`]): they run only when the
 //! executor was built with `allow_writes`, and `save_note` re-checks `meeting_is_visible` against the
 //! live `unlocked` set BEFORE it appends to `manual_notes` — a sealed-not-unlocked meeting refuses.
+//! The `propose_note` tool (always advertised) writes NO DB AT ALL — it only records a note DRAFT in
+//! interior-mutable scratch for the FE to offer "Add to notes"; the user commits it on Accept. So it
+//! needs no gate (it touches no content store) and carries no leak surface.
 //!
 //! ## Egress
 //! [`execute_tool`] EGRESSES NOTHING — it only reads the local SQLite DB and (for semantic search)
@@ -78,10 +81,12 @@ pub struct ToolSpec {
     pub write: bool,
 }
 
-/// The model-facing tool catalog. Built per call (cheap; ~10 entries). The read tools map 1:1 onto
-/// gated `execute_tool` / connector dispatchers; the two `write: true` entries (`save_note`,
-/// `create_reminder`) map onto the gated write arms of `GatedToolExecutor::run` and are advertised to
-/// the model ONLY when the executor was built with `allow_writes` (the in-meeting loop).
+/// The model-facing tool catalog. Built per call (cheap; ~11 entries). The read tools map 1:1 onto
+/// gated `execute_tool` / connector dispatchers. `propose_note` is `write: false` (ALWAYS advertised):
+/// it has NO DB side effect — it only RECORDS a note DRAFT for the user to review/accept via the FE,
+/// so it is the model-driven "the user asked for a note" signal that needs no write capability. The two
+/// `write: true` entries (`save_note`, `create_reminder`) map onto the gated write arms of
+/// `GatedToolExecutor::run` and are advertised ONLY when the executor was built with `allow_writes`.
 pub fn tool_specs() -> Vec<ToolSpec> {
     let str_arg = |prop: &'static str, desc: &str| -> serde_json::Value {
         serde_json::json!({
@@ -143,6 +148,17 @@ pub fn tool_specs() -> Vec<ToolSpec> {
             name: "calendar_lookup",
             description: "Look up the user's local (on-device) calendar for recent/upcoming events.",
             parameters: str_arg("query", "What meeting / agenda detail to find."),
+            write: false,
+        },
+        ToolSpec {
+            name: "propose_note",
+            description: "When the user asks you to MAKE / SAVE / DRAFT / WRITE a note (e.g. \"make me \
+                          a note about the decisions\", \"save that we ship Friday\", \"zapisz notatkę \
+                          o …\"), call this with the note content, enriched with the relevant meeting \
+                          context. This DRAFTS a note for the user to review and accept — it does NOT \
+                          save anything itself. Do NOT call it for plain questions or conversation — \
+                          just answer those normally.",
+            parameters: str_arg("content", "The drafted note content, in the user's own language, enriched with meeting context."),
             write: false,
         },
         ToolSpec {
@@ -511,6 +527,11 @@ fn format_hits_and_docs(
 /// surfaces). A write executes ONLY when `allow_writes` AND the target meeting is visible to the live
 /// `unlocked` set — a sealed-not-unlocked meeting refuses (`AppError::Locked`), never resurrecting
 /// plaintext behind a lock.
+///
+/// `proposed_note` is interior-mutable scratch for the always-on `propose_note` tool: when the model
+/// decides the user asked for a NOTE (vs a plain answer), it calls `propose_note(content)`, which
+/// records the draft HERE (no DB write). The caller (`run_informational`) reads it after the loop and
+/// threads it onto the result so the FE can offer "Add to notes" — the user commits on Accept.
 pub struct GatedToolExecutor<'a> {
     pub db: &'a Db,
     pub unlocked: &'a std::sync::Mutex<HashSet<String>>,
@@ -518,6 +539,9 @@ pub struct GatedToolExecutor<'a> {
     pub meeting_id: &'a str,
     pub app: Option<&'a tauri::AppHandle>,
     pub allow_writes: bool,
+    /// The note draft the model proposed this turn (via `propose_note`), if any. `None` ⇒ the reply
+    /// is a plain ANSWER; `Some(content)` ⇒ a NOTE PROPOSAL the FE should offer to add. No DB effect.
+    pub proposed_note: std::sync::Mutex<Option<String>>,
 }
 
 impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
@@ -578,6 +602,10 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                 Some(app) => block_on_tool(execute_calendar_search(&s("query"), app)),
                 None => Err(AppError::InvalidArg("calendar_lookup needs an AppHandle".into())),
             },
+            // ── PROPOSE (always-on, NO DB side effect): the model signals the user asked for a note.
+            //    Records the draft in interior-mutable scratch; the caller threads it onto the result so
+            //    the FE can offer "Add to notes". Writes NOTHING — the user commits on Accept.
+            "propose_note" => self.propose_note(&s("content")),
             // ── WRITE tools (advertised only when `allow_writes`; the allowlist check above already
             //    refused them otherwise). Each is GATED to a VISIBLE/unlocked meeting before it mutates.
             "save_note" => self.save_note(&s("text"), &unlocked),
@@ -591,6 +619,26 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
 }
 
 impl GatedToolExecutor<'_> {
+    /// PROPOSE (no DB side effect) — the model decided the user asked for a NOTE: record the drafted
+    /// `content` in the interior-mutable `proposed_note` scratch so the caller can thread it onto the
+    /// result and the FE can offer "Add to notes". This NEVER writes `manual_notes` or any DB row — the
+    /// user commits the draft on Accept (→ `save_manual_notes`). PII rule: log id/len ONLY, never the
+    /// proposed content. The LAST proposal wins if the model (mistakenly) proposes twice in one turn.
+    fn propose_note(&self, content: &str) -> Result<String> {
+        let content = content.trim();
+        if content.is_empty() {
+            return Err(AppError::InvalidArg("nothing to propose".into()));
+        }
+        // Record the draft (no DB write). A poisoned mutex is a programming error, not a leak.
+        *self
+            .proposed_note
+            .lock()
+            .map_err(|_| AppError::Other(anyhow::anyhow!("proposed_note mutex poisoned")))? =
+            Some(content.to_string());
+        tracing::debug!(target: "agent", len = content.len(), "agent proposed a note draft (not written)");
+        Ok("Drafted a note for the user to review.".to_string())
+    }
+
     /// WRITE — append the agent's note to the CURRENT meeting's durable typed-notes buffer
     /// (`meetings.manual_notes`, Feature A): the sealed-and-restored, folds-into-the-note home. Read
     /// the existing buffer, append the new line, and write it back — a non-destructive append (the
@@ -877,6 +925,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: true,
+            proposed_note: Mutex::new(None),
         };
         let names: Vec<&str> = writeable.specs().iter().map(|s| s.name).collect();
         assert!(names.contains(&"save_note"), "the write loop must advertise save_note: {names:?}");
@@ -884,12 +933,28 @@ mod tests {
             names.contains(&"create_reminder"),
             "the write loop must advertise create_reminder: {names:?}"
         );
+        // propose_note is always advertised (write: false), regardless of allow_writes.
+        assert!(names.contains(&"propose_note"), "propose_note must always be advertised: {names:?}");
 
-        let readonly = GatedToolExecutor { allow_writes: false, ..writeable };
+        let readonly = GatedToolExecutor {
+            db: &db,
+            unlocked: &unlocked,
+            config: &cfg,
+            meeting_id: "live1",
+            app: None,
+            allow_writes: false,
+            proposed_note: Mutex::new(None),
+        };
         let ro_names: Vec<&str> = readonly.specs().iter().map(|s| s.name).collect();
         assert!(
             !ro_names.iter().any(|n| *n == "save_note" || *n == "create_reminder"),
             "a read-only executor must NOT advertise write tools: {ro_names:?}"
+        );
+        // propose_note (write: false, no DB effect) is STILL advertised on a read-only executor — it is
+        // the always-on path the model uses to signal a note draft.
+        assert!(
+            ro_names.contains(&"propose_note"),
+            "propose_note must be advertised even when allow_writes is false: {ro_names:?}"
         );
     }
 
@@ -909,6 +974,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: true,
+            proposed_note: Mutex::new(None),
         };
 
         // First note SEEDS the empty buffer.
@@ -957,6 +1023,7 @@ mod tests {
             meeting_id: "sealed1",
             app: None,
             allow_writes: true,
+            proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "secret note" }));
         assert!(
@@ -985,6 +1052,7 @@ mod tests {
             meeting_id: "", // no active recording
             app: None,
             allow_writes: true,
+            proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "orphan note" }));
         assert!(
@@ -1008,6 +1076,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false, // read-only — write tools not advertised
+            proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "should not run" }));
         assert!(
@@ -1016,5 +1085,128 @@ mod tests {
         );
         // Nothing was written.
         assert_eq!(db.get_manual_notes("live1").unwrap(), "");
+    }
+
+    // ── propose_note: the always-on, DB-free NOTE-DRAFT signal (propose-then-accept, Rev 2) ─────────
+    // The model DECIDES (no regex in our code) whether its reply is a plain answer or a note proposal;
+    // when it proposes, the FE shows "Add to notes". The executor only RECORDS the draft — no DB write.
+
+    /// `propose_note` is ADVERTISED regardless of `allow_writes` (it is `write: false` — no DB effect),
+    /// on BOTH a read-only and a write-capable executor. The model-driven note-draft path is always on.
+    #[test]
+    fn propose_note_advertised_regardless_of_allow_writes() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        for allow_writes in [false, true] {
+            let exec = GatedToolExecutor {
+                db: &db,
+                unlocked: &unlocked,
+                config: &cfg,
+                meeting_id: "live1",
+                app: None,
+                allow_writes,
+                proposed_note: Mutex::new(None),
+            };
+            let names: Vec<&str> = exec.specs().iter().map(|s| s.name).collect();
+            assert!(
+                names.contains(&"propose_note"),
+                "propose_note must be advertised with allow_writes={allow_writes}: {names:?}"
+            );
+            // It is a read tool (write: false), so it is NOT gated out on the read surface.
+            let spec = tool_specs().into_iter().find(|s| s.name == "propose_note").unwrap();
+            assert!(!spec.write, "propose_note must be write: false (no DB side effect)");
+        }
+    }
+
+    /// The `propose_note` arm RECORDS the drafted content into the executor's `proposed_note` scratch
+    /// and writes NO DB — `manual_notes` is unchanged, NOTHING is persisted. RED-able: were the arm to
+    /// call `set_manual_notes`, the assertion that the buffer stays empty would fail.
+    #[test]
+    fn propose_note_records_draft_and_writes_no_db() {
+        let db = tmp_db();
+        seed_live_meeting(&db, "live1");
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = GatedToolExecutor {
+            db: &db,
+            unlocked: &unlocked,
+            config: &cfg,
+            meeting_id: "live1",
+            app: None,
+            allow_writes: false, // propose works even read-only
+            proposed_note: Mutex::new(None),
+        };
+
+        // Before any call the scratch is None ⇒ the reply would be a plain ANSWER.
+        assert!(exec.proposed_note.lock().unwrap().is_none(), "no proposal until propose_note is called");
+
+        let out = exec
+            .run("propose_note", &serde_json::json!({ "content": "Decision: ship Friday; Anna owns QA." }))
+            .unwrap();
+        assert!(out.to_lowercase().contains("draft"), "confirmation mentions a draft: {out}");
+
+        // The draft is RECORDED in scratch (this is what the caller threads onto the result).
+        assert_eq!(
+            exec.proposed_note.lock().unwrap().as_deref(),
+            Some("Decision: ship Friday; Anna owns QA."),
+            "propose_note must record the drafted content"
+        );
+        // And NOTHING was written to the DB — manual_notes is untouched (no persistence on propose).
+        assert_eq!(
+            db.get_manual_notes("live1").unwrap(),
+            "",
+            "propose_note must NOT write manual_notes (the user commits on Accept)"
+        );
+        assert!(
+            db.list_note_asides("live1").unwrap().is_empty(),
+            "propose_note must NOT write notes_asides either"
+        );
+    }
+
+    /// `proposed_note` stays None when the model does NOT call `propose_note` (a plain answer turn) —
+    /// only a read tool ran, so the scratch is never set.
+    #[test]
+    fn proposed_note_is_none_when_propose_not_called() {
+        let db = tmp_db();
+        seed_live_meeting(&db, "live1");
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = GatedToolExecutor {
+            db: &db,
+            unlocked: &unlocked,
+            config: &cfg,
+            meeting_id: "live1",
+            app: None,
+            allow_writes: false,
+            proposed_note: Mutex::new(None),
+        };
+        // A plain read tool (the kind a question would use) does NOT set a proposal.
+        let _ = exec.run("search_meetings", &serde_json::json!({ "query": "anything" })).unwrap();
+        assert!(
+            exec.proposed_note.lock().unwrap().is_none(),
+            "an answer turn (no propose_note) must leave proposed_note None"
+        );
+    }
+
+    /// An empty/whitespace `content` is refused (`InvalidArg`) and records NO draft — we never surface
+    /// an empty proposal the FE would render as a blank "Add to notes".
+    #[test]
+    fn propose_note_refuses_empty_content() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = GatedToolExecutor {
+            db: &db,
+            unlocked: &unlocked,
+            config: &cfg,
+            meeting_id: "live1",
+            app: None,
+            allow_writes: false,
+            proposed_note: Mutex::new(None),
+        };
+        let res = exec.run("propose_note", &serde_json::json!({ "content": "   " }));
+        assert!(matches!(res, Err(AppError::InvalidArg(_))), "empty proposal refused: {res:?}");
+        assert!(exec.proposed_note.lock().unwrap().is_none(), "no draft recorded for an empty proposal");
     }
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -410,6 +410,9 @@ fn run_informational(
             // for a future structured "agent acts" iteration. The dispatch still routes EVERY request
             // through this loop (no hardcoded write classifier), so the model decides answer-vs-draft.
             allow_writes: false,
+            // The always-on `propose_note` tool records its draft HERE (no DB write). We read it after
+            // the loop to mark the reply as a NOTE PROPOSAL vs a plain ANSWER. The model decides which.
+            proposed_note: std::sync::Mutex::new(None),
         };
         let sink = ToolEventSink { app: app.clone(), event: tool_event };
         // Inject the LIVE transcript of the recording IN PROGRESS so the brain can answer questions
@@ -444,7 +447,14 @@ fn run_informational(
             CLOUD_MAX_STEPS,
             Some(&sink as &dyn crate::agent::DeltaSink),
         ) {
-            Ok(Some(outcome)) => return crate::voice_action::VoiceActionResult::from_agent(intent, outcome),
+            Ok(Some(outcome)) => {
+                // Read the model's NOTE PROPOSAL (if it called `propose_note` this turn) off the
+                // executor scratch and thread it onto the result — `Some` ⇒ a note draft, `None` ⇒ a
+                // plain answer. No DB write happened; the FE commits the draft on Accept.
+                let proposed = executor.proposed_note.lock().ok().and_then(|g| g.clone());
+                return crate::voice_action::VoiceActionResult::from_agent(intent, outcome)
+                    .with_proposed_note(proposed);
+            }
             Ok(None) => tracing::debug!(
                 target: "voice",
                 "agentic loop did not converge; flooring to deterministic retrieval"
@@ -932,7 +942,12 @@ fn tail_chars(s: &str, n: usize) -> String {
 /// (`RedactingProvider::complete` scrubs `system` + `user`) — they are NOT a new egress class.
 fn assistant_system_prompt(live_transcript: &str, typed_notes: &str) -> String {
     let base = "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 \
-                sentences). Do not invent facts; if you cannot find the answer, say so plainly.";
+                sentences). Do not invent facts; if you cannot find the answer, say so plainly. \
+                Decide what the user wants: for a plain QUESTION or conversation, just ANSWER it. \
+                ONLY when the user asks you to MAKE / SAVE / DRAFT / WRITE a note (e.g. \"make me a \
+                note about the decisions\", \"save that we ship Friday\"), call the propose_note tool \
+                with the note content enriched from the meeting context — that drafts a note for the \
+                user to review and accept; do NOT call propose_note for ordinary questions.";
     let t = live_transcript.trim();
     let mut prompt = if t.is_empty() {
         format!(
@@ -1409,6 +1424,25 @@ mod tests {
         assert!(with.contains("LIVE TRANSCRIPT"), "names the transcript section: {with}");
         assert!(with.contains("assigned the deck to Anna"), "embeds the transcript text");
         assert!(with.to_lowercase().contains("current"), "tells the brain it's the current meeting");
+    }
+
+    /// The system prompt instructs the model to DECIDE answer-vs-propose: name the `propose_note` tool
+    /// and tell it to call it ONLY when the user asks for a note (the model decides; no regex in code).
+    /// Present in BOTH the no-transcript and with-transcript branches (it lives in the shared base).
+    #[test]
+    fn assistant_system_prompt_instructs_propose_note_decision() {
+        for prompt in [
+            assistant_system_prompt("", ""),
+            assistant_system_prompt("we shipped the beta", ""),
+        ] {
+            assert!(prompt.contains("propose_note"), "names the propose_note tool: {prompt}");
+            assert!(
+                prompt.to_lowercase().contains("note"),
+                "tells the model when to draft a note: {prompt}"
+            );
+            // Both an answer path and a note-draft path are described (decide between them).
+            assert!(prompt.to_lowercase().contains("answer"), "describes plain answering too: {prompt}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -60,6 +60,11 @@ pub struct VoiceActionResult {
     /// `[[Title]]` wikilink citations the answer was grounded on (VISIBLE meetings only). Empty for
     /// non-RAG intents.
     pub citations: Vec<String>,
+    /// The model's NOTE DRAFT for this turn, set ONLY when the agent decided the user asked for a note
+    /// (it called the `propose_note` tool). `None` ⇒ the reply is a plain ANSWER (a conversation);
+    /// `Some(content)` ⇒ a NOTE PROPOSAL the FE shows "Add to notes" on. No DB write happens server-side
+    /// — the FE commits the accepted draft via `save_manual_notes`. Serializes to `proposedNote`.
+    pub proposed_note: Option<String>,
 }
 
 impl VoiceActionResult {
@@ -70,6 +75,7 @@ impl VoiceActionResult {
             summary: summary.into(),
             command: String::new(),
             citations: Vec::new(),
+            proposed_note: None,
         }
     }
 
@@ -77,6 +83,19 @@ impl VoiceActionResult {
     /// surface what the user actually said without re-plumbing each constructor.
     pub fn with_command(mut self, command: &str) -> Self {
         self.command = command.to_string();
+        self
+    }
+
+    /// Thread a model NOTE PROPOSAL onto a result (builder-style). `Some(content)` marks the reply as
+    /// a note draft (the FE offers "Add to notes"); `None` is a no-op (plain answer). The caller reads
+    /// the proposal off the executor after the agentic loop and threads it here.
+    pub fn with_proposed_note(mut self, proposed: Option<String>) -> Self {
+        if let Some(content) = proposed {
+            let content = content.trim();
+            if !content.is_empty() {
+                self.proposed_note = Some(content.to_string());
+            }
+        }
         self
     }
 
@@ -94,6 +113,9 @@ impl VoiceActionResult {
             summary: outcome.answer,
             command: String::new(),
             citations: outcome.citations,
+            // The caller (`run_informational`) threads any `propose_note` draft on via
+            // `with_proposed_note` after reading the executor; the loop outcome itself has none.
+            proposed_note: None,
         }
     }
 
@@ -503,6 +525,7 @@ fn rag_answer(
                 summary,
                 command: String::new(),
                 citations,
+                proposed_note: None,
             }
         }
         Err(AppError::Unavailable(_)) => VoiceActionResult {
@@ -514,6 +537,7 @@ fn rag_answer(
                 .to_string(),
             command: String::new(),
             citations,
+            proposed_note: None,
         },
         Err(e) => VoiceActionResult {
             intent_kind: intent_kind.to_string(),
@@ -521,6 +545,7 @@ fn rag_answer(
             summary: non_pii_error(&e),
             command: String::new(),
             citations,
+            proposed_note: None,
         },
     }
 }
@@ -903,6 +928,7 @@ mod tests {
             meeting_id: "",
             app: None,
             allow_writes: false,
+            proposed_note: std::sync::Mutex::new(None),
         };
 
         // (1) Direct gate proof on the executor (RED-able).
@@ -1230,6 +1256,36 @@ mod tests {
         assert_eq!(r.command, "zrób research o X");
         // nothing_heard carries an empty command (nothing was heard).
         assert!(VoiceActionResult::nothing_heard().command.is_empty());
+    }
+
+    /// `proposed_note` round-trips through `VoiceActionResult`: defaults to None (a plain ANSWER),
+    /// `with_proposed_note(Some(..))` marks the reply as a NOTE PROPOSAL, and it serializes to the
+    /// camelCase `proposedNote` field the FE reads (so it can show "Add to notes" only when present).
+    #[test]
+    fn voice_action_result_round_trips_proposed_note() {
+        // Default: no proposal ⇒ plain answer.
+        let plain = VoiceActionResult::new("research", "ok", "an answer");
+        assert_eq!(plain.proposed_note, None, "a result defaults to no note proposal (a plain answer)");
+
+        // With a proposal: the reply IS a note draft.
+        let proposed = plain
+            .clone()
+            .with_proposed_note(Some("Decision: ship Friday.".to_string()));
+        assert_eq!(proposed.proposed_note.as_deref(), Some("Decision: ship Friday."));
+
+        // None / whitespace are no-ops (still a plain answer).
+        assert_eq!(plain.clone().with_proposed_note(None).proposed_note, None);
+        assert_eq!(plain.with_proposed_note(Some("   ".into())).proposed_note, None);
+
+        // Serializes to the camelCase `proposedNote` field the FE consumes; absent (null) ⇒ plain.
+        let json = serde_json::to_value(
+            VoiceActionResult::new("research", "ok", "draft reply")
+                .with_proposed_note(Some("note body".into())),
+        )
+        .unwrap();
+        assert_eq!(json.get("proposedNote").and_then(|v| v.as_str()), Some("note body"));
+        let null_json = serde_json::to_value(VoiceActionResult::new("research", "ok", "x")).unwrap();
+        assert!(null_json.get("proposedNote").unwrap().is_null(), "no proposal ⇒ proposedNote is null");
     }
 
     #[test]

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -56,10 +56,13 @@ export interface ToolTraceStep {
  * One turn inside a note's `@brain` THREAD (Slack-style). A thread is a small
  * multi-turn conversation anchored UNDER a note line:
  *   - `user`  — the user's question (the `@brain` marker stripped), or a typed
- *               follow-up inside the thread (no marker needed there);
- *   - `agent` — the brain's reply, with its live tool-trace + citations. Every
- *               agent turn offers "✓ Add to notes" (the agent PROPOSES; the user
- *               ACCEPTS — the only path content enters the main notes).
+ *               follow-up inside the thread (no marker needed there). The FIRST
+ *               user turn IS the anchor question — the surface renders it ONCE on
+ *               the anchor line and skips it inside the thread (no duplication);
+ *   - `agent` — the brain's reply, with its live tool-trace + citations. An agent
+ *               turn offers "✓ Add to notes" ONLY when it carries a `proposedNote`
+ *               (the model decided the user asked it to MAKE a note); a plain
+ *               answer has `proposedNote: null` and NO add affordance.
  */
 export interface ThreadTurn {
   /** Stable id for `@for` tracking (never key on $index). */
@@ -73,8 +76,21 @@ export interface ThreadTurn {
   trace: ToolTraceStep[];
   /** Agent only: grounding citations (vault `[[Title]]` + "via web"). */
   citations: AssistantCitation[];
-  /** Agent only: true once the user has accepted this turn into the main notes. */
+  /**
+   * Agent only: the proposed NOTE draft, or `null`. NON-null ONLY when the model
+   * called `propose_note` (the user asked it to make/save a note). Drives the
+   * "✓ Add to notes" affordance: shown ONLY when this is non-null; on accept THIS
+   * draft (not the whole reply) is appended to the notes.
+   */
+  proposedNote: string | null;
+  /** Agent only: true once the user has ACCEPTED this turn's draft into the main notes. */
   accepted: boolean;
+  /**
+   * Agent only: true once the user DISMISSED this turn's proposal. Distinct from
+   * `accepted` so the surface shows "Dismissed" (not "✓ Added to notes") — both
+   * paths clear the affordance, but only a real accept committed content.
+   */
+  dismissed: boolean;
 }
 
 /**
@@ -135,9 +151,11 @@ export function parseCitations(raw: string[]): AssistantCitation[] {
  * The in-meeting NOTES + `@brain` THREADS store (Slack-style; the agent PROPOSES,
  * the user ACCEPTS). The MAIN flow is the user's notes — a vertical list of
  * {@link NoteItem} lines persisted to `manual_notes`. An `@brain` line opens an
- * anchored, multi-turn {@link ThreadTurn} thread under that note; every agent
- * reply offers "✓ Add to notes" — the ONLY path content enters the main notes
- * (the agent never auto-writes; the backend in-meeting loop is READ-ONLY).
+ * anchored, multi-turn {@link ThreadTurn} thread under that note; an agent reply
+ * that carries a `proposedNote` (the model decided the user asked it to MAKE a
+ * note) offers "✓ Add to notes" — the ONLY path content enters the main notes
+ * (the agent never auto-writes; the backend in-meeting loop is READ-ONLY). A
+ * plain answer has no proposal and no add affordance — it reads as conversation.
  *
  * Subscribes ONCE (the RecorderStore.init() pattern) to the wake + result +
  * listening + processing + BOTH tool-trace streams and lands every payload in a
@@ -418,7 +436,9 @@ export class MeetingConversationStore {
       status: "ok",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     const agentTurn: ThreadTurn = {
       id: this.nextTurnId++,
@@ -427,7 +447,9 @@ export class MeetingConversationStore {
       status: "pending",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     this._notes.update((ns) => [
       ...ns,
@@ -440,6 +462,65 @@ export class MeetingConversationStore {
         persisted: false,
       },
     ]);
+    await this.runAgentTurn(noteId, agentTurn.id);
+  }
+
+  /**
+   * "✨ ask brain" on an EXISTING plain note: retroactively open a thread on a
+   * note that has none yet, seeding the agent from the NOTE'S OWN TEXT as context.
+   * The note line STAYS the user's note (NOT converted/deleted, still `persisted`)
+   * — the thread just hangs under it like a `@brain` thread.
+   *
+   * The seeded first user turn carries the note text as the question so the agent
+   * can ANSWER about it or PROPOSE a note from it; it ships through the same
+   * `runAgentTurn` / `ask_assistant_chat` path as `@brain`, so the tool-trace,
+   * `proposedNote`-gated Add-to-notes, and follow-ups all behave identically. A
+   * no-op for a missing note, a note that ALREADY has a thread, or blank text.
+   */
+  async askBrainOnNote(noteId: number): Promise<void> {
+    const note = this._notes().find((n) => n.id === noteId);
+    if (!note || note.thread) return; // only notes WITHOUT a thread yet
+    const subject = note.text.trim();
+    if (!subject) return;
+    const userTurn: ThreadTurn = {
+      id: this.nextTurnId++,
+      role: "user",
+      // Seed the agent from the note's own words (this becomes the thread's first
+      // user turn → shipped as the question). It's sliced from the rendered thread
+      // by visibleTurns() because the note line already shows the text above.
+      text: subject,
+      status: "ok",
+      trace: [],
+      citations: [],
+      proposedNote: null,
+      accepted: false,
+      dismissed: false,
+    };
+    const agentTurn: ThreadTurn = {
+      id: this.nextTurnId++,
+      role: "agent",
+      text: "",
+      status: "pending",
+      trace: [],
+      citations: [],
+      proposedNote: null,
+      accepted: false,
+      dismissed: false,
+    };
+    this._notes.update((ns) =>
+      ns.map((n) =>
+        n.id === noteId
+          ? {
+              ...n,
+              // The note stays exactly as it is (text + persisted unchanged); we
+              // only attach the thread + open it.
+              thread: [userTurn, agentTurn],
+              threadOpen: true,
+              threadPending: true,
+            }
+          : n,
+      ),
+    );
     await this.runAgentTurn(noteId, agentTurn.id);
   }
 
@@ -461,7 +542,9 @@ export class MeetingConversationStore {
       status: "ok",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     const agentTurn: ThreadTurn = {
       id: this.nextTurnId++,
@@ -470,7 +553,9 @@ export class MeetingConversationStore {
       status: "pending",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     this._notes.update((ns) =>
       ns.map((n) =>
@@ -519,17 +604,23 @@ export class MeetingConversationStore {
         status: reply.status,
         text: reply.summary || "(no answer)",
         citations: parseCitations(reply.citations),
+        proposedNote: reply.proposedNote,
       });
     } catch {
       this.resolveTurn(noteId, agentTurnId, {
         status: "error",
         text: "Couldn't reach the assistant.",
         citations: [],
+        proposedNote: null,
       });
     }
   }
 
-  /** Resolve a pending agent turn + clear its thread's pending flag (immutable). */
+  /**
+   * Resolve a pending agent turn + clear its thread's pending flag (immutable).
+   * Captures `proposedNote` — the agent's note draft (or null) — which drives the
+   * "✓ Add to notes" affordance ONLY when non-null.
+   */
   private resolveTurn(
     noteId: number,
     agentTurnId: number,
@@ -537,6 +628,7 @@ export class MeetingConversationStore {
       status: VoiceActionStatus;
       text: string;
       citations: AssistantCitation[];
+      proposedNote: string | null;
     },
   ): void {
     this._notes.update((ns) =>
@@ -547,7 +639,13 @@ export class MeetingConversationStore {
           threadPending: false,
           thread: n.thread.map((turn) =>
             turn.id === agentTurnId
-              ? { ...turn, status: patch.status, text: patch.text, citations: patch.citations }
+              ? {
+                  ...turn,
+                  status: patch.status,
+                  text: patch.text,
+                  citations: patch.citations,
+                  proposedNote: patch.proposedNote,
+                }
               : turn,
           ),
         };
@@ -565,17 +663,19 @@ export class MeetingConversationStore {
   }
 
   /**
-   * ACCEPT an agent turn into the MAIN notes (the agent PROPOSES; this is the
-   * user's accept — the only path content enters the notes). Append a NEW plain,
-   * PERSISTED note line carrying the agent's text + mark the source turn accepted
-   * (so its "✓ Add to notes" affordance flips to "Added"), then persist. A no-op
-   * for an already-accepted / empty turn.
+   * ACCEPT an agent turn's PROPOSED NOTE into the MAIN notes (the agent PROPOSES;
+   * this is the user's accept — the only path content enters the notes). Append a
+   * NEW plain, PERSISTED note line carrying the turn's `proposedNote` DRAFT (NOT
+   * the whole reply) + mark the source turn accepted (so its "✓ Add to notes"
+   * affordance flips to "Added"), then persist. A no-op for an already-accepted
+   * turn or a turn with NO proposed note (a plain answer — nothing to add).
    */
   acceptIntoNotes(noteId: number, agentTurnId: number): void {
     const note = this._notes().find((n) => n.id === noteId);
     const turn = note?.thread?.find((t) => t.id === agentTurnId);
     if (!turn || turn.role !== "agent" || turn.accepted) return;
-    const text = turn.text.trim();
+    // Append the PROPOSED note draft, never the whole conversational reply.
+    const text = (turn.proposedNote ?? "").trim();
     if (!text) return;
     this._notes.update((ns) => {
       const marked = ns.map((n) => {
@@ -603,9 +703,12 @@ export class MeetingConversationStore {
   }
 
   /**
-   * DISMISS an agent turn (the propose-accept "reject"). The reply is discarded:
-   * the turn's text is blanked to a quiet placeholder + marked accepted so the
-   * "✓ Add to notes" affordance disappears. Nothing enters the notes.
+   * DISMISS an agent turn's note PROPOSAL (the propose-accept "reject"). Only the
+   * "✓ Add to notes" affordance is dismissed — the reply text STAYS in the thread
+   * (it's still a useful answer); we just drop the proposal (`proposedNote: null`)
+   * and mark it `dismissed` so the affordance disappears WITHOUT claiming a save.
+   * `dismissed` (not `accepted`) is what makes the surface show "Dismissed" rather
+   * than "✓ Added to notes". Nothing enters the notes.
    */
   dismissTurn(noteId: number, agentTurnId: number): void {
     this._notes.update((ns) =>
@@ -615,7 +718,7 @@ export class MeetingConversationStore {
           ...n,
           thread: n.thread.map((t) =>
             t.id === agentTurnId
-              ? { ...t, accepted: true, citations: [], text: "" }
+              ? { ...t, dismissed: true, proposedNote: null }
               : t,
           ),
         };
@@ -641,7 +744,9 @@ export class MeetingConversationStore {
       status: "ok",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     const agentTurn: ThreadTurn = {
       id: this.nextTurnId++,
@@ -650,7 +755,9 @@ export class MeetingConversationStore {
       status: "pending",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     this.voiceTargetNoteId = noteId;
     this._notes.update((ns) => [
@@ -674,6 +781,7 @@ export class MeetingConversationStore {
         status: "error",
         text: "Couldn't start the listener.",
         citations: [],
+        proposedNote: null,
       });
       throw e;
     }
@@ -710,7 +818,9 @@ export class MeetingConversationStore {
       status: "ok",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     const agentTurn: ThreadTurn = {
       id: this.nextTurnId++,
@@ -719,7 +829,9 @@ export class MeetingConversationStore {
       status: "pending",
       trace: [],
       citations: [],
+      proposedNote: null,
       accepted: false,
+      dismissed: false,
     };
     this.voiceTargetNoteId = noteId;
     this._notes.update((ns) => [
@@ -837,7 +949,9 @@ export class MeetingConversationStore {
         status: "ok",
         trace: [],
         citations: [],
+        proposedNote: null,
         accepted: false,
+        dismissed: false,
       };
       const agentTurn: ThreadTurn = {
         id: this.nextTurnId++,
@@ -846,7 +960,9 @@ export class MeetingConversationStore {
         status: p.status,
         trace: [],
         citations: parseCitations(p.citations),
+        proposedNote: p.proposedNote,
         accepted: false,
+        dismissed: false,
       };
       // Only include the user turn when something was actually heard (a manual ask
       // that caught nothing must not leave an empty user bubble).
@@ -879,6 +995,7 @@ export class MeetingConversationStore {
               status: p.status,
               text: p.summary,
               citations: parseCitations(p.citations),
+              proposedNote: p.proposedNote,
             };
             // Backfill the heard command onto the preceding empty user turn.
             const prev = thread[i - 1];

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -249,6 +249,15 @@ export interface VoiceActionResultPayload {
   /** What the user actually said (their OWN dictation). Empty when nothing was heard. */
   command: string;
   citations: string[];
+  /**
+   * The agent's PROPOSED note draft, or `null`. NON-null ONLY when the model
+   * decided the user asked it to MAKE/SAVE a note (it called the `propose_note`
+   * tool) — for a plain answer/question it is `null`. The FE shows the quiet
+   * "✓ Add to notes" affordance ONLY when this is non-null, and on accept appends
+   * THIS draft (not the whole reply) to the user's notes. The agent never
+   * auto-writes; accept is the only path content enters the notes.
+   */
+  proposedNote: string | null;
 }
 
 /**

--- a/src/app/features/record/note-item.component.ts
+++ b/src/app/features/record/note-item.component.ts
@@ -17,16 +17,27 @@ import { MarkdownComponent } from "../../shared/markdown.component";
 import { AssistantSourcesComponent } from "../../shared/assistant-sources.component";
 
 /**
- * ONE line of the user's notes + its anchored `@brain` THREAD (Slack-style). The
- * note line is the main-flow content; when the line opened a `@brain` thread, the
- * nested, collapsible Q&A renders INDENTED below it (a connector + offset).
+ * ONE line of the user's notes + its anchored `@brain` THREAD (Slack-style).
  *
- * Each AGENT turn in the thread carries the propose-accept affordance —
- * "✓ Add to notes" / dismiss — wired to {@link MeetingConversationStore}: accept
- * appends the agent's text as a NEW persisted note line (the only path content
- * enters the notes); dismiss discards it. The thread has its OWN small follow-up
- * input so a follow-up goes to the agent WITHOUT re-typing `@brain` (it ships the
- * thread's own history → multi-turn).
+ *  - A PLAIN note line is the user's own jotting — a quiet "note" treatment (a
+ *    subtle note glyph + token styling) so it reads clearly as the user's note,
+ *    distinct from a thread/agent line.
+ *  - A `@brain` THREAD renders as a Slack-style chat: a collapsible "▸ Thread (N)"
+ *    toggle (collapsed → a short snippet of the question); expanded → the user's
+ *    question as the FIRST right-aligned (purple) user bubble, then the brain's
+ *    replies LEFT-aligned with a friendly "🧠 brain" identity, follow-up user
+ *    bubbles on the right, and the thread's own Reply input. The question shows
+ *    ONCE — the leading anchor turn is sliced out of the loop (no duplication).
+ *
+ * Propose → accept: an agent reply shows a DRAFT-NOTE card with a readable preview
+ * of the proposed draft + "✓ Add to notes" / "Dismiss" ONLY when it carries a
+ * `proposedNote` (the model decided the user asked it to MAKE a note); accept
+ * appends THAT draft (not the whole reply) to the main notes; dismiss drops the
+ * proposal (showing "Dismissed", never "✓ Added to notes"). A plain answer has no
+ * proposal → no card, so the surface reads as a conversation, not a notes app with
+ * a button under everything. The internal `propose_note` tool chip is filtered out
+ * of the trace (it's plumbing, not a user-facing tool). The thread has its OWN
+ * follow-up input so a follow-up goes to the agent WITHOUT re-typing `@brain`.
  *
  * Presentational — all state lives in the store; this component holds only its
  * follow-up draft. A note line holds TURNS, not notes, so there is NO mutual
@@ -40,150 +51,224 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
   imports: [MarkdownComponent, AssistantSourcesComponent],
   template: `
     @let n = note();
-    <div class="note">
-      <!-- ── The note line — the main-flow content. A thread anchor shows the
-           @brain glyph + a collapse toggle; a plain note shows a quiet bullet. ── -->
-      <div class="note-line" [class.is-anchor]="!!n.thread">
-        @if (n.thread) {
-          <button
-            type="button"
-            class="line-toggle"
-            (click)="store.toggleThread(n.id)"
-            [attr.aria-expanded]="n.threadOpen"
-            [attr.aria-label]="n.threadOpen ? 'Collapse thread' : 'Expand thread'"
-          >
-            <span class="brain-glyph" aria-hidden="true">🧠</span>
-            <span class="line-text">{{ n.text }}</span>
-            <span
-              class="caret"
-              [class.is-open]="n.threadOpen"
-              aria-hidden="true"
-            >
-              ▸
-            </span>
-            @if (!n.threadOpen && replyCount() > 0) {
-              <span class="reply-count">{{ replyCount() }}</span>
-            }
-          </button>
-        } @else {
-          <span class="bullet" aria-hidden="true"></span>
+    <div class="note" [class.is-thread]="!!n.thread">
+      <!-- ── A PERSISTED note line — the user's own jotting. It STAYS a note even
+           after "✨ ask brain" attaches a thread (the thread hangs BELOW). A
+           non-persisted @brain anchor instead shows its question as the thread's
+           first bubble, so it has no note line. ─────────────────────────────── -->
+      @if (n.persisted) {
+        <div class="note-line">
+          <span class="note-glyph" aria-hidden="true">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M5 4h11l3 3v13H5z"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M8 10h8M8 14h6"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+              />
+            </svg>
+          </span>
           <span class="line-text">{{ n.text }}</span>
-        }
-      </div>
+          <!-- ✨ ask brain — only on a note that has NO thread yet (retroactively
+               open a thread seeded from this note's text). Quiet; reveals on
+               hover/focus of the row. A note WITH a thread shows its toggle below. -->
+          @if (!n.thread) {
+            <button
+              type="button"
+              class="ask-brain"
+              (click)="store.askBrainOnNote(n.id)"
+              [disabled]="!store.loaded()"
+              title="Ask brain about this note"
+              aria-label="Ask brain about this note"
+            >
+              <span class="ask-spark" aria-hidden="true">✨</span>
+              <span class="ask-label">ask brain</span>
+            </button>
+          }
+        </div>
+      }
 
-      <!-- ── The nested, collapsible thread — indented under the line ───────── -->
-      @if (n.thread && n.threadOpen) {
-        <div class="thread" role="group" aria-label="@brain thread">
-          @for (turn of n.thread; track turn.id) {
-            @if (turn.role === "user") {
+      @if (n.thread) {
+        <!-- ── THREAD: a Slack-style collapsible toggle. Collapsed shows a short
+             snippet (the @brain question, or the note text for an ✨ thread). ─── -->
+        <button
+          type="button"
+          class="thread-toggle"
+          (click)="store.toggleThread(n.id)"
+          [attr.aria-expanded]="n.threadOpen"
+        >
+          <span class="caret" [class.is-open]="n.threadOpen" aria-hidden="true">
+            ▸
+          </span>
+          <span class="toggle-label">Thread</span>
+          @if (replyCount() > 0) {
+            <span class="reply-count">{{ replyCount() }}</span>
+          }
+          @if (!n.threadOpen) {
+            <span class="toggle-snippet">{{ snippet() }}</span>
+          }
+        </button>
+
+        <!-- ── The nested, collapsible thread — indented under the toggle ────── -->
+        @if (n.threadOpen) {
+          <div class="thread" role="group" aria-label="brain thread">
+            <!-- A @brain anchor shows its QUESTION as the user's first right-aligned
+                 bubble (the leading turn is sliced from visibleTurns → no duplicate).
+                 An ✨ thread on a persisted note already shows the text in the note
+                 line above, so it does NOT repeat it as a bubble. -->
+            @if (!n.persisted) {
               <div class="turn turn-user">
-                <div class="turn-bubble turn-bubble-user">{{ turn.text }}</div>
+                <div class="turn-bubble turn-bubble-user">{{ n.text }}</div>
               </div>
-            } @else {
-              <div class="turn turn-agent">
-                <div class="turn-bubble turn-bubble-agent">
-                  @if (turn.trace.length > 0) {
-                    <div class="trace" role="status" aria-label="Tool use">
-                      @for (t of turn.trace; track t.id) {
-                        <span
-                          class="trace-chip"
-                          [class.is-running]="t.state === 'running'"
-                          [class.is-web]="t.tool === 'web_search'"
-                          [class.is-failed]="!t.ok"
-                        >
-                          <span class="trace-ico" aria-hidden="true">
-                            @if (t.state === "running") {
-                              <span class="trace-spin"></span>
-                            } @else if (!t.ok) {
-                              ⚠
-                            } @else {
-                              ✓
+            }
+
+            @for (turn of visibleTurns(); track turn.id) {
+              @if (turn.role === "user") {
+                <div class="turn turn-user">
+                  <div class="turn-bubble turn-bubble-user">{{ turn.text }}</div>
+                </div>
+              } @else {
+                <div class="turn turn-agent">
+                  <div class="agent-id" aria-hidden="true">
+                    <span class="agent-mark">🧠</span>
+                    <span class="agent-name">brain</span>
+                  </div>
+                  <div class="turn-bubble turn-bubble-agent">
+                    @let trace = visibleTrace(turn.trace);
+                    @if (trace.length > 0) {
+                      <div class="trace" role="status" aria-label="Tool use">
+                        @for (t of trace; track t.id) {
+                          <span
+                            class="trace-chip"
+                            [class.is-running]="t.state === 'running'"
+                            [class.is-web]="t.tool === 'web_search'"
+                            [class.is-failed]="!t.ok"
+                          >
+                            <span class="trace-ico" aria-hidden="true">
+                              @if (t.state === "running") {
+                                <span class="trace-spin"></span>
+                              } @else if (!t.ok) {
+                                ⚠
+                              } @else {
+                                ✓
+                              }
+                            </span>
+                            {{ toolLabel(t.tool) }}
+                            @if (t.state === "done" && t.count) {
+                              <span class="trace-count">{{ t.count }}</span>
                             }
                           </span>
-                          {{ toolLabel(t.tool) }}
-                          @if (t.state === "done" && t.count) {
-                            <span class="trace-count">{{ t.count }}</span>
-                          }
+                        }
+                      </div>
+                    }
+                    @if (turn.status === "pending" && trace.length === 0) {
+                      <span class="thinking" role="status">
+                        <span class="dots" aria-hidden="true">
+                          <span></span><span></span><span></span>
                         </span>
-                      }
-                    </div>
-                  }
-                  @if (turn.status === "pending" && turn.trace.length === 0) {
-                    <span class="dots" aria-hidden="true">
-                      <span></span><span></span><span></span>
-                    </span>
-                  } @else if (turn.text) {
-                    <app-markdown [markdown]="turn.text" compact />
-                  } @else if (turn.status !== "pending") {
-                    <span class="agent-note">{{ emptyNote(turn.status) }}</span>
-                  }
-                  @if (turn.citations.length > 0) {
-                    <app-assistant-sources [citations]="turn.citations" />
-                  }
+                        <span class="thinking-label">Thinking…</span>
+                      </span>
+                    } @else if (turn.text) {
+                      <app-markdown [markdown]="turn.text" compact />
+                    } @else if (turn.status !== "pending") {
+                      <span class="agent-note">{{ emptyNote(turn.status) }}</span>
+                    }
+                    @if (turn.citations.length > 0) {
+                      <app-assistant-sources [citations]="turn.citations" />
+                    }
 
-                  <!-- Propose → accept: the agent NEVER auto-writes; "Add to
-                       notes" is the only path content enters the main notes. -->
-                  @if (canAccept(turn)) {
-                    <div class="turn-actions">
-                      <button
-                        type="button"
-                        class="accept-btn"
-                        (click)="store.acceptIntoNotes(n.id, turn.id)"
-                      >
-                        <span aria-hidden="true">✓</span> Add to notes
-                      </button>
-                      <button
-                        type="button"
-                        class="dismiss-btn"
-                        (click)="store.dismissTurn(n.id, turn.id)"
-                        aria-label="Dismiss this reply"
-                      >
-                        Dismiss
-                      </button>
-                    </div>
-                  } @else if (turn.accepted && turn.text) {
-                    <span class="added-tag" aria-hidden="true">✓ Added to notes</span>
-                  }
+                    <!-- Propose → accept: shown ONLY when the agent proposed a
+                         NOTE (proposedNote != null). The DRAFT CONTENT is the
+                         point — show it prominently so the user can review it
+                         before accepting. A plain answer has no proposal. -->
+                    @if (canAccept(turn)) {
+                      <div class="proposal">
+                        <span class="proposal-tag" aria-hidden="true">
+                          📝 Draft note
+                        </span>
+                        <!-- The actual draft the user is accepting — rendered as a
+                             readable quoted preview (not just the meta summary). -->
+                        <div class="draft-preview">
+                          <app-markdown [markdown]="turn.proposedNote!" compact />
+                        </div>
+                        <div class="turn-actions">
+                          <button
+                            type="button"
+                            class="accept-btn"
+                            (click)="store.acceptIntoNotes(n.id, turn.id)"
+                          >
+                            <span aria-hidden="true">✓</span> Add to notes
+                          </button>
+                          <button
+                            type="button"
+                            class="dismiss-btn"
+                            (click)="store.dismissTurn(n.id, turn.id)"
+                            aria-label="Dismiss this draft"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </div>
+                    } @else if (turn.accepted) {
+                      <span class="added-tag" aria-hidden="true">
+                        ✓ Added to notes
+                      </span>
+                    } @else if (turn.dismissed) {
+                      <span class="dismissed-tag" aria-hidden="true">Dismissed</span>
+                    }
+                  </div>
                 </div>
-              </div>
-            }
-          }
-
-          <!-- The thread's OWN follow-up input — no @brain needed here. -->
-          <form class="follow" (submit)="submitFollow($event)">
-            <input
-              #fin
-              type="text"
-              class="follow-input"
-              autocomplete="off"
-              [value]="followDraft()"
-              [disabled]="n.threadPending"
-              [placeholder]="n.threadPending ? 'Thinking…' : 'Reply to @brain…'"
-              (input)="onFollowInput($event)"
-              aria-label="Reply in this thread"
-            />
-            <button
-              type="submit"
-              class="follow-send"
-              [disabled]="!canFollow()"
-              aria-label="Send follow-up"
-            >
-              @if (n.threadPending) {
-                <span class="follow-spin" aria-hidden="true"></span>
-              } @else {
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path
-                    d="M5 12h14M13 6l6 6-6 6"
-                    stroke="currentColor"
-                    stroke-width="2.4"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
               }
-            </button>
-          </form>
-        </div>
+            }
+
+            <!-- The thread's OWN follow-up input — no @brain needed here. -->
+            <form class="follow" (submit)="submitFollow($event)">
+              <input
+                #fin
+                type="text"
+                class="follow-input"
+                autocomplete="off"
+                [value]="followDraft()"
+                [disabled]="n.threadPending"
+                [placeholder]="n.threadPending ? 'Thinking…' : 'Reply to brain…'"
+                (input)="onFollowInput($event)"
+                aria-label="Reply in this thread"
+              />
+              <button
+                type="submit"
+                class="follow-send"
+                [disabled]="!canFollow()"
+                aria-label="Send follow-up"
+              >
+                @if (n.threadPending) {
+                  <span class="follow-spin" aria-hidden="true"></span>
+                } @else {
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M5 12h14M13 6l6 6-6 6"
+                      stroke="currentColor"
+                      stroke-width="2.4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                }
+              </button>
+            </form>
+          </div>
+        }
       }
     </div>
   `,
@@ -198,22 +283,25 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
         gap: var(--space-1);
       }
 
-      /* ── The note line — the user's main flow ──────────────────────────── */
+      /* ── A plain note — the user's own jotting, quiet + clearly "a note" ──── */
       .note-line {
         display: flex;
         align-items: baseline;
         gap: var(--space-2);
-        font-size: 0.95rem;
+        padding: var(--space-1) var(--space-2);
+        border-left: 2px solid var(--border-subtle);
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        font-size: 0.92rem;
         line-height: 1.55;
-        color: var(--text-primary);
+        color: var(--text-secondary);
       }
-      .bullet {
+      .note-glyph {
         flex: 0 0 auto;
-        width: 5px;
-        height: 5px;
-        margin-top: 0.55em;
-        border-radius: 50%;
-        background: var(--text-muted);
+        display: inline-flex;
+        align-items: center;
+        color: var(--text-muted);
+        transform: translateY(2px);
       }
       .line-text {
         flex: 1 1 auto;
@@ -222,43 +310,100 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
         word-break: break-word;
       }
 
-      /* A @brain anchor line: the whole line toggles the thread. */
-      .line-toggle {
-        display: flex;
-        align-items: baseline;
-        gap: var(--space-2);
-        width: 100%;
-        padding: var(--space-1) var(--space-2);
-        margin: 0;
-        border: none;
-        border-radius: var(--radius-sm);
-        background: transparent;
-        color: var(--text-primary);
-        font: inherit;
-        text-align: left;
+      /* ── "✨ ask brain" — a quiet affordance on a plain note (no thread yet).
+         Revealed on row hover OR keyboard focus (a11y); stays clear of floating
+         overlays (it's in-flow, so trap T3 N/A). var(--token) only. ──────────── */
+      .ask-brain {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        align-self: center;
+        padding: 2px var(--space-2);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.72rem;
+        font-weight: 600;
         cursor: pointer;
-        transition: background var(--transition);
+        opacity: 0;
+        transition:
+          opacity var(--transition),
+          background var(--transition),
+          color var(--transition);
       }
-      .line-toggle:hover {
-        background: var(--surface-hover);
+      /* Reveal on hover of the whole note line, or whenever the button is focused. */
+      .note-line:hover .ask-brain,
+      .ask-brain:focus-visible {
+        opacity: 1;
       }
-      .line-toggle:focus-visible {
+      .ask-brain:hover {
+        background: var(--accent);
+        color: #fff;
+      }
+      .ask-brain:focus-visible {
         outline: none;
         box-shadow: 0 0 0 2px var(--accent-ring);
       }
-      .brain-glyph {
-        flex: 0 0 auto;
-        font-size: 0.95rem;
-        line-height: 1.4;
+      /* While notes are still hydrating (loaded() false) the affordance is inert;
+         keep it muted + non-interactive even if the row is hovered. */
+      .note-line:hover .ask-brain:disabled {
+        opacity: 0.4;
+        cursor: default;
+      }
+      .ask-spark {
+        font-size: 0.78rem;
+        line-height: 1;
+      }
+      /* Touch / coarse-pointer devices have no hover — keep it always visible. */
+      @media (hover: none) {
+        .ask-brain {
+          opacity: 0.7;
+        }
+      }
+
+      /* ── @brain THREAD toggle (Slack-style header): caret + "Thread (N)" + a
+         short snippet of the user's question when collapsed. The question itself
+         renders as the user's first RIGHT-aligned bubble once expanded. ───────── */
+      .thread-toggle {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        width: 100%;
+        padding: var(--space-1) var(--space-2);
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        font: inherit;
+        font-size: 0.78rem;
+        font-weight: 600;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          color var(--transition),
+          background var(--transition);
+      }
+      .thread-toggle:hover {
+        color: var(--accent-hover);
+        background: var(--surface-hover);
+      }
+      .thread-toggle:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--accent-ring);
       }
       .caret {
         flex: 0 0 auto;
-        color: var(--text-muted);
         font-size: 0.7rem;
         transition: transform var(--transition);
       }
       .caret.is-open {
         transform: rotate(90deg);
+      }
+      .toggle-label {
+        flex: 0 0 auto;
+        letter-spacing: 0.01em;
       }
       .reply-count {
         flex: 0 0 auto;
@@ -270,24 +415,52 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
         font-weight: 600;
         font-variant-numeric: tabular-nums;
       }
+      /* A muted one-line preview of the question while collapsed. */
+      .toggle-snippet {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 450;
+        color: var(--text-muted);
+      }
 
-      /* ── The nested thread — indented under the line (Slack-style) ─────── */
+      /* ── The nested thread — indented under the toggle (Slack-style) ─────── */
       .thread {
         display: flex;
         flex-direction: column;
         gap: var(--space-2);
-        margin-left: var(--space-4);
+        margin-left: var(--space-3);
         padding-left: var(--space-3);
         border-left: 2px solid var(--border-subtle);
       }
       .turn {
         display: flex;
+        flex-direction: column;
       }
       .turn-user {
-        justify-content: flex-end;
+        align-items: flex-end;
       }
       .turn-agent {
-        justify-content: flex-start;
+        align-items: flex-start;
+      }
+      .agent-id {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        margin: 0 0 3px 2px;
+      }
+      .agent-mark {
+        font-size: 0.8rem;
+        line-height: 1;
+      }
+      .agent-name {
+        color: var(--accent-hover);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: lowercase;
       }
       .turn-bubble {
         max-width: 92%;
@@ -316,12 +489,47 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
         color: var(--text-secondary);
       }
 
-      /* ── propose → accept affordance ───────────────────────────────────── */
+      /* the clean "Thinking…" state */
+      .thinking {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--text-muted);
+      }
+      .thinking-label {
+        font-size: 0.82rem;
+      }
+
+      /* ── propose → accept affordance (only for a NOTE proposal) ──────────── */
+      .proposal {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-top: 2px;
+        padding-top: var(--space-2);
+        border-top: 1px solid var(--border-subtle);
+      }
+      .proposal-tag {
+        color: var(--text-muted);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      /* The actual draft the user reviews before accepting — a quiet quoted card
+         so the CONTENT (not just the agent's meta summary) is what they see. */
+      .draft-preview {
+        padding: var(--space-2) var(--space-3);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--radius-sm);
+        background: var(--accent-soft);
+        color: var(--text-primary);
+        font-size: 0.86rem;
+        line-height: 1.5;
+      }
       .turn-actions {
         display: flex;
         align-items: center;
         gap: var(--space-2);
-        margin-top: 2px;
       }
       .accept-btn {
         display: inline-flex;
@@ -361,6 +569,14 @@ import { AssistantSourcesComponent } from "../../shared/assistant-sources.compon
         color: var(--text-secondary);
       }
       .added-tag {
+        margin-top: 2px;
+        color: var(--accent-hover);
+        font-size: 0.74rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      /* Dismiss → a muted "Dismissed" tag (NOT "✓ Added to notes" — nothing saved). */
+      .dismissed-tag {
         margin-top: 2px;
         color: var(--text-muted);
         font-size: 0.74rem;
@@ -533,24 +749,62 @@ export class NoteItemComponent {
   /** This thread's follow-up draft (signal-backed — zoneless). */
   protected readonly followDraft = signal("");
 
+  /**
+   * The turns rendered INSIDE the expanded thread, EXCLUDING the leading user
+   * turn — that is the ANCHOR question, which the template renders explicitly as
+   * the user's first right-aligned bubble (so it shows ONCE, no duplication).
+   * Follow-up user turns + every agent turn still render here.
+   */
+  protected readonly visibleTurns = computed<ThreadTurn[]>(() => {
+    const thread = this.note().thread ?? [];
+    if (thread.length > 0 && thread[0].role === "user") {
+      return thread.slice(1);
+    }
+    return thread;
+  });
+
   /** Number of agent replies (for the collapsed "N" badge). */
   protected readonly replyCount = computed(
     () => this.note().thread?.filter((t) => t.role === "agent").length ?? 0,
   );
+
+  /** A short one-line preview of the question shown on the collapsed toggle. */
+  protected readonly snippet = computed(() => {
+    const q = this.note().text.replace(/\s+/g, " ").trim();
+    return q.length > 64 ? `${q.slice(0, 63)}…` : q;
+  });
 
   /** Follow-up send is allowed with non-blank text and no in-flight thread turn. */
   protected readonly canFollow = computed(
     () => !this.note().threadPending && this.followDraft().trim().length > 0,
   );
 
-  /** Whether an agent turn can still be accepted into the notes. */
+  /**
+   * Whether an agent turn can be accepted into the notes: ONLY when it carries a
+   * `proposedNote` (the agent decided the user asked for a note) and has NOT been
+   * accepted or dismissed. A plain answer (`proposedNote === null`) is never
+   * acceptable → no "Add to notes" button.
+   */
   protected canAccept(turn: ThreadTurn): boolean {
     return (
       turn.role === "agent" &&
       turn.status !== "pending" &&
       !turn.accepted &&
-      turn.text.trim().length > 0
+      !turn.dismissed &&
+      turn.proposedNote !== null &&
+      turn.proposedNote.trim().length > 0
     );
+  }
+
+  /**
+   * The tool-trace chips to RENDER. Filters out INTERNAL mechanisms the user
+   * should never see as "tools" — `propose_note` is the note-proposal plumbing,
+   * not a user-facing search/lookup; the Draft-note card already conveys it (and
+   * filtering it also drops the duplicated "propose_note" chips). Other tools
+   * (search_meetings, web_search, …) still surface.
+   */
+  protected visibleTrace(trace: ThreadTurn["trace"]): ThreadTurn["trace"] {
+    return trace.filter((t) => t.tool !== "propose_note");
   }
 
   protected onFollowInput(event: Event): void {
@@ -568,10 +822,9 @@ export class NoteItemComponent {
     });
     this.followed.emit();
     // Keep the focus in the thread input for a fast back-and-forth.
-    afterNextRender(
-      () => this.followInput()?.nativeElement.focus(),
-      { injector: this.injector },
-    );
+    afterNextRender(() => this.followInput()?.nativeElement.focus(), {
+      injector: this.injector,
+    });
   }
 
   /** Human label for a tool-trace chip. */


### PR DESCRIPTION
The in-meeting agent decides answer-vs-propose (model-driven, no regex); Add-to-notes shows ONLY on a real note proposal (new DB-free propose_note tool → proposedNote). FE: draft content shown for review, chat-style threads (you right / 🧠 left), hidden internal chip, Dismiss/Accept copy, and a ✨ ask-brain affordance on any note. Full ci.sh green (508 tests); adversarial-verifier PASS (live Chromium); @brain privacy preserved. No version bump.