### PR TITLE
fix(brain): documents and brain notes are retrievable on a default install

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1000,14 +1000,14 @@ fn ingest_into_folder(
         .db
         .insert_document(&id, folder_id, name, text, kind, created_at)?;
 
-    // Index ONLY when the REAL e5 model is present (never write stub vectors). Best-effort: a failure
-    // logs (no PII) and does NOT fail the ingest (the row + plaintext are durable; a later unlock
-    // re-embed / reindex recovers the vectors).
-    if crate::embed::embed_model_present() {
-        let embedder = crate::embed::active_embedder();
-        if let Err(e) = state.db.index_document_chunks(&id, embedder.as_ref()) {
-            tracing::warn!(target: "rag", error = %e, "ingest: chunk/embed failed (content stored)");
-        }
+    // ALWAYS chunk (doc_chunks + the fts_doc_chunks triggers) so keyword retrieval works on a
+    // DEFAULT install — an ingested document must never be write-only memory. Vectors ONLY when the
+    // REAL e5 model is present (never write stub vectors). Best-effort: a failure logs (no PII) and
+    // does NOT fail the ingest (the row + plaintext are durable; a later unlock re-chunk / reindex
+    // recovers the index).
+    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    if let Err(e) = state.db.index_document_chunks(&id, embedder.as_deref()) {
+        tracing::warn!(target: "rag", error = %e, "ingest: chunk/embed failed (content stored)");
     }
 
     // PII rule: log only ids, the kind, and byte/char counts — never the text/name.
@@ -3282,9 +3282,11 @@ pub struct ReindexResult {
 /// vectors are replaced with e5 ones. No new read path: every read routes through `visibility_clause`.
 ///
 /// MODEL GUARD: if the real e5 model is absent (`!embed_model_present()` ⇒ `active_embedder` is the
-/// stub), we DO NOTHING and return `{ status: "model_missing" }`. Re-indexing with garbage stub
-/// vectors is strictly worse than leaving the (old, possibly-stub) chunks alone — the FE prompts the
-/// user to download e5 first via `download_embed_model`.
+/// stub), MEETING indexing does nothing and the result is `{ status: "model_missing" }` — re-indexing
+/// with garbage stub vectors is strictly worse than leaving the (old, possibly-stub) chunks alone;
+/// the FE prompts the user to download e5 first via `download_embed_model`. DOCUMENT chunk/FTS
+/// backfill still runs (chunk-only, zero vectors) so keyword retrieval over documents works
+/// regardless of the model.
 ///
 /// Emits [`crate::events::EVENT_REINDEX`] `{ done, total }` progress (counts only, NO PII).
 /// EMBED_DIM stays 384 (e5 == stub width) ⇒ NO `vec_chunks` schema migration.
@@ -3354,9 +3356,11 @@ pub async fn related_meetings(
 /// visibility-gated loop are unit-testable headless. Takes the `Db`, the live `unlocked` session set,
 /// whether the REAL e5 model is present (`model_present`), the active embedder, and a progress sink.
 ///
-/// MODEL GUARD: `model_present == false` ⇒ return `{ status: "model_missing" }` and index NOTHING
-/// (re-indexing with the deterministic STUB embedder would poison the index with garbage vectors —
-/// strictly worse than leaving the old chunks alone).
+/// MODEL GUARD: `model_present == false` ⇒ return `{ status: "model_missing" }` and index NO
+/// meeting and NO vector (re-indexing with the deterministic STUB embedder would poison the index
+/// with garbage vectors — strictly worse than leaving the old chunks alone). Document CHUNK/FTS
+/// backfill (zero vectors) still runs for visible documents that have no chunks yet, so keyword
+/// retrieval covers the write-only legacy rows.
 ///
 /// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked)` — a sealed-and-not-
 /// session-unlocked meeting is NEVER returned, so its plaintext is never chunked/embedded and its
@@ -3369,6 +3373,32 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
     embedder: &dyn crate::embed::Embedder,
     mut on_progress: F,
 ) -> Result<ReindexResult, AppError> {
+    // DOCUMENT backfill first — doc_chunks + the FTS index are model-INDEPENDENT (keyword retrieval
+    // must work on a default install), so this runs even when the e5 model is absent. Visible
+    // documents only (`visible_document_ids` applies `visibility_clause`; a sealed folder's docs
+    // stay purged). Model present ⇒ full purge-then-reinsert re-embed. Model ABSENT ⇒ chunk-only
+    // backfill of documents with NO chunks yet (the write-only legacy rows) — never a
+    // purge-then-reinsert of an already-chunked document, which would DESTROY its existing real
+    // vectors without replacing them.
+    let doc_embedder = model_present.then_some(embedder);
+    let mut docs_indexed = 0usize;
+    for did in db.visible_document_ids(unlocked)? {
+        let should_index = model_present || !db.document_has_chunks(&did)?;
+        if !should_index {
+            continue;
+        }
+        match db.index_document_chunks(&did, doc_embedder) {
+            Ok(()) => docs_indexed += 1,
+            Err(e) => {
+                // Never abort the whole backfill on one bad document — log (no PII) and continue.
+                tracing::warn!(target: "rag", error = %e, "reindex: indexing one document failed (skipped)");
+            }
+        }
+    }
+    if docs_indexed > 0 {
+        tracing::info!(target: "rag", docs_indexed, "reindex: document chunks backfilled");
+    }
+
     if !model_present {
         tracing::info!(target: "rag", "reindex_embeddings: e5 model missing; skipping (no stub indexing)");
         return Ok(ReindexResult {
@@ -5034,14 +5064,15 @@ fn unseal_folder_extras(state: &AppState, folder_id: &str, ck: &[u8; 32]) -> Res
             restored_doc_ids.push(d.id.clone());
         }
     }
-    // Re-embed the restored documents — ONLY when the REAL e5 model is present (never write stub
-    // vectors; mirrors `import_document` / `should_auto_index`). Best-effort: an embed failure logs
-    // (no PII) and does NOT fail the unlock — the plaintext text is already restored.
-    if !restored_doc_ids.is_empty() && crate::embed::embed_model_present() {
-        let embedder = crate::embed::active_embedder();
+    // Re-index the restored documents: chunks + the FTS index come back UNCONDITIONALLY (keyword
+    // retrieval must survive a lock/unlock cycle on a model-less install); vectors ONLY when the
+    // REAL e5 model is present (never stub vectors; mirrors `import_document`). Best-effort: a
+    // failure logs (no PII) and does NOT fail the unlock — the plaintext text is already restored.
+    if !restored_doc_ids.is_empty() {
+        let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
         for did in &restored_doc_ids {
-            if let Err(e) = state.db.index_document_chunks(did, embedder.as_ref()) {
-                tracing::warn!(target: "rag", error = %e, "document re-embed on unlock failed (text restored)");
+            if let Err(e) = state.db.index_document_chunks(did, embedder.as_deref()) {
+                tracing::warn!(target: "rag", error = %e, "document re-index on unlock failed (text restored)");
             }
         }
     }
@@ -5168,8 +5199,8 @@ fn unseal_folder_extras_permanent(
     // Document ingestion: PERMANENTLY restore each document's plaintext from its blob (or keep the
     // in-memory plaintext if the folder was session-unlocked and the blob is absent), then clear the
     // blob. NEVER lose the document — the plaintext is back before the blob is dropped (mirrors the
-    // note / manual-notes permanent restore). Then re-embed (model-present-gated) so the now-open
-    // folder's documents are semantically searchable again.
+    // note / manual-notes permanent restore). Then re-index (chunks + FTS always; vectors
+    // model-present-gated) so the now-open folder's documents are searchable again.
     let mut restored_doc_ids: Vec<String> = Vec::new();
     for d in state.db.raw_documents_in_folder(folder_id)? {
         if let Some(blob) = &d.blob {
@@ -5182,11 +5213,13 @@ fn unseal_folder_extras_permanent(
         state.db.clear_document_blob(&d.id)?;
         restored_doc_ids.push(d.id.clone());
     }
-    if !restored_doc_ids.is_empty() && crate::embed::embed_model_present() {
-        let embedder = crate::embed::active_embedder();
+    if !restored_doc_ids.is_empty() {
+        // Chunks + FTS come back unconditionally (keyword retrieval works model-less); vectors only
+        // when the REAL e5 model is present (never stub vectors).
+        let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
         for did in &restored_doc_ids {
-            if let Err(e) = state.db.index_document_chunks(did, embedder.as_ref()) {
-                tracing::warn!(target: "rag", error = %e, "document re-embed on remove-lock failed (text restored)");
+            if let Err(e) = state.db.index_document_chunks(did, embedder.as_deref()) {
+                tracing::warn!(target: "rag", error = %e, "document re-index on remove-lock failed (text restored)");
             }
         }
     }
@@ -5956,21 +5989,24 @@ mod lifecycle_tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, id);
         assert!(listed[0].name.ends_with(".md"));
-        // Embedding is MODEL-PRESENCE-gated in `import_document_inner` (never write stub vectors —
-        // mirrors `should_auto_index`'s no-stub contract). So the chunk count is environment-dependent
-        // and MUST be asserted per branch, or this test goes RED on a no-model CI machine / fresh
-        // checkout (the merge gate provisions no e5 model):
-        //   - model present → real e5 vectors indexed → ≥1 doc_chunks row;
-        //   - model ABSENT  → NO embedding → exactly 0 doc_chunks rows.
-        // The assertions above (row stored, text retrievable, listed) are model-INDEPENDENT.
+        // CHUNKING is unconditional (keyword/FTS retrieval must work on a default install);
+        // only the VECTORS stay model-presence-gated (never write stub vectors — mirrors
+        // `should_auto_index`'s no-stub contract). So:
+        //   - always          → ≥1 doc_chunks row;
+        //   - model present   → matching real e5 vectors;
+        //   - model ABSENT    → exactly 0 doc_vec_chunks rows (no stub poisoning).
+        assert!(
+            state.db.doc_chunk_count(&id).unwrap() >= 1,
+            "the document must be chunked regardless of model presence (always-chunk)"
+        );
         if crate::embed::embed_model_present() {
             assert!(
-                state.db.doc_chunk_count(&id).unwrap() >= 1,
-                "with the e5 model present, the document must be chunked + embedded"
+                state.db.doc_vec_count(&id).unwrap() >= 1,
+                "with the e5 model present, the chunks must carry real vectors"
             );
         } else {
             assert_eq!(
-                state.db.doc_chunk_count(&id).unwrap(),
+                state.db.doc_vec_count(&id).unwrap(),
                 0,
                 "with no e5 model, NO stub vectors are written (no-stub contract)"
             );
@@ -6219,6 +6255,197 @@ mod lifecycle_tests {
             state.db.doc_chunk_count(&id).unwrap(),
             0,
             "doc chunks cascade-deleted with the document"
+        );
+    }
+
+    /// PR B HEADLINE (write-only-memory bug): on a DEFAULT install (no e5 model, semantic flag OFF)
+    /// an ingested brain note/document MUST still be REACHABLE — chunked unconditionally, surfaced
+    /// by the FLAG-OFF Ask corpus builder, and surfaced through the advertised tool seam (which MCP
+    /// and the agentic loop share). RED on the old code: ingest skipped chunking without the model,
+    /// the flag-off corpus packed meetings only, and both search tools ignored documents.
+    #[test]
+    fn model_less_ingest_is_reachable_by_flag_off_ask_and_tools() {
+        let state = build_state("docs-default-reach");
+        make_open_folder(&state.db, "f-open", "Project");
+        let id = import_text_inner(
+            &state,
+            "Preferencje",
+            "Ulubiony kolor użytkownika to fioletowoszary.",
+            "f-open",
+        )
+        .unwrap();
+
+        // 1. ALWAYS-CHUNK: doc_chunks rows exist regardless of model presence (keyword retrieval
+        //    must work on a default install; vectors stay model-gated).
+        assert!(
+            state.db.doc_chunk_count(&id).unwrap() >= 1,
+            "ingest must store doc_chunks rows even without the e5 model"
+        );
+
+        // 2. The FLAG-OFF Ask corpus (the default `ask_vault` path) surfaces the token.
+        let nothing = HashSet::new();
+        let (corpus, _) = crate::summarize::vault_context::build_vault_context_visible(
+            &state.db,
+            "fioletowoszary",
+            "anthropic",
+            &nothing,
+        )
+        .unwrap();
+        assert!(
+            // Assert on a CONTENT word absent from the query — sentinels echo the query itself
+            // ("No meetings match \"fioletowoszary\"."), so a query-token check can self-satisfy.
+            corpus.contains("Ulubiony") && corpus.contains("fioletowoszary"),
+            "flag-off Ask corpus must surface ingested document/note content; got: {corpus:?}"
+        );
+
+        // 3. The tool seam (default config: semantic OFF) surfaces the token through BOTH advertised
+        //    search tools — the same seam MCP and the agentic loop dispatch through.
+        let cfg = AppConfig::default();
+        let out = crate::tools::execute_tool(
+            &crate::tools::ToolCall::SearchMeetings { query: "fioletowoszary".into() },
+            &state.db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("Ulubiony"),
+            "search_meetings must surface document CONTENT (not just echo the query in an \
+             empty-result sentinel); got: {out:?}"
+        );
+        let out2 = crate::tools::execute_tool(
+            &crate::tools::ToolCall::SearchSemantic { query: "fioletowoszary".into() },
+            &state.db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out2.contains("Ulubiony"),
+            "search_semantic (flag OFF) must fall back to gated keyword doc search and surface \
+             document CONTENT; got: {out2:?}"
+        );
+    }
+
+    /// SEAL/UNSEAL PARITY for the new keyword legs: locking a folder makes its document's unique
+    /// token INVISIBLE through EVERY read leg (the gated FTS helper, the flag-off Ask corpus, both
+    /// search tools), and a session unlock brings it back through the SAME legs — including on a
+    /// model-less install (the unlock re-chunk no longer requires the e5 model).
+    #[test]
+    fn sealed_folder_docs_invisible_through_every_leg_until_unlock() {
+        let state = build_state("docs-seal-legs");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        let id = import_text_inner(
+            &state,
+            "plan",
+            "TAJNYTOKEN kwartalny raport przejęcia",
+            "f-lock",
+        )
+        .unwrap();
+        assert!(state.db.doc_chunk_count(&id).unwrap() >= 1, "precondition: chunked on ingest");
+
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+
+        let nothing = HashSet::new();
+        let cfg = AppConfig::default();
+        // Leak assertions check "przejęcia" — a CONTENT word absent from the query — because the
+        // empty-result sentinels honestly ECHO the query text ("No meetings or documents match
+        // \"TAJNYTOKEN\"."), which is not a content leak.
+        let assert_leg_visibility = |unlocked: &HashSet<String>, expected: bool, phase: &str| {
+            let fts_hit = state
+                .db
+                .search_doc_chunks_fts_visible("TAJNYTOKEN", 10, unlocked)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == id);
+            assert_eq!(fts_hit, expected, "FTS helper leg, {phase}");
+            let (corpus, _) = crate::summarize::vault_context::build_vault_context_visible(
+                &state.db,
+                "TAJNYTOKEN",
+                "anthropic",
+                unlocked,
+            )
+            .unwrap();
+            assert_eq!(corpus.contains("przejęcia"), expected, "Ask corpus leg, {phase}");
+            for call in [
+                crate::tools::ToolCall::SearchMeetings { query: "TAJNYTOKEN".into() },
+                crate::tools::ToolCall::SearchSemantic { query: "TAJNYTOKEN".into() },
+            ] {
+                let out = crate::tools::execute_tool(&call, &state.db, unlocked, &cfg).unwrap();
+                assert_eq!(out.contains("przejęcia"), expected, "tool leg {call:?}, {phase}");
+            }
+        };
+
+        // Sealed-and-not-unlocked: the token leaks through NO leg.
+        assert_leg_visibility(&nothing, false, "sealed");
+
+        // Session-unlock (mirror unlock_folder's internals: KEK → unwrap CK → unseal extras, which
+        // re-chunks model-lessly), then evaluate every leg against the live unlock set.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-lock").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-lock")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-lock", &ck).unwrap();
+        assert!(
+            state.db.doc_chunk_count(&id).unwrap() >= 1,
+            "unlock must re-chunk the document even without the e5 model"
+        );
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        assert_leg_visibility(&unlocked, true, "session-unlocked");
+    }
+
+    /// REINDEX BACKFILL (PR B): `reindex_embeddings_inner` covers documents. Model ABSENT →
+    /// write-only (chunkless) documents gain chunks + FTS reachability with ZERO vectors, while an
+    /// already-chunked document's existing vectors are NOT purged (no downgrade). Model PRESENT →
+    /// the chunkless document is re-embedded with vectors too.
+    #[test]
+    fn reindex_backfills_documents_regardless_of_model() {
+        let state = build_state("reindex-docs");
+        make_open_folder(&state.db, "f-open", "Project");
+        // A write-only legacy row: document stored, never chunked (the pre-PR-B model-less ingest).
+        state
+            .db
+            .insert_document("d-legacy", "f-open", "legacy.md", "szmaragdowy raport roczny", "document", 100)
+            .unwrap();
+        // An already-indexed document WITH vectors (stub-deterministic).
+        state
+            .db
+            .insert_document("d-vec", "f-open", "vec.md", "vectored content here", "document", 200)
+            .unwrap();
+        state.db.index_document_chunks("d-vec", Some(&crate::embed::StubEmbedder)).unwrap();
+        let vec_before = state.db.doc_vec_count("d-vec").unwrap();
+        assert!(vec_before >= 1, "precondition: d-vec has vectors");
+        assert_eq!(state.db.doc_chunk_count("d-legacy").unwrap(), 0, "precondition: d-legacy chunkless");
+
+        // Model ABSENT: chunk/FTS backfill only.
+        let nothing = HashSet::new();
+        let stub = crate::embed::StubEmbedder;
+        let res = reindex_embeddings_inner(&state.db, &nothing, false, &stub, |_, _| {}).unwrap();
+        assert_eq!(res.status, "model_missing", "meeting semantics unchanged");
+        assert!(state.db.doc_chunk_count("d-legacy").unwrap() >= 1, "legacy doc backfilled");
+        assert_eq!(state.db.doc_vec_count("d-legacy").unwrap(), 0, "no stub vectors on backfill");
+        assert_eq!(
+            state.db.doc_vec_count("d-vec").unwrap(),
+            vec_before,
+            "model-absent reindex must NOT purge an indexed document's vectors"
+        );
+        assert!(
+            state
+                .db
+                .search_doc_chunks_fts_visible("szmaragdowy", 10, &nothing)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == "d-legacy"),
+            "backfilled document must be keyword-findable"
+        );
+
+        // Model PRESENT: the full purge-then-reinsert re-embed covers documents.
+        let res2 = reindex_embeddings_inner(&state.db, &nothing, true, &stub, |_, _| {}).unwrap();
+        assert_eq!(res2.status, "indexed");
+        assert!(
+            state.db.doc_vec_count("d-legacy").unwrap() >= 1,
+            "model-present reindex must (re)embed document chunks"
         );
     }
 

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -257,6 +257,31 @@ pub fn rrf_fuse(lists: &[Vec<String>], k: f64) -> Vec<(String, f64)> {
     fused
 }
 
+/// RRF-fuse the two gated document retrieval legs (vector KNN + keyword FTS) into one best-first,
+/// per-document-deduped hit list. Either leg may be empty (model absent ⇒ no KNN leg; punctuation
+/// query ⇒ no FTS leg) — RRF over the remaining list preserves its order. The snippet kept for a
+/// document is its first-seen one, KNN (nearest chunk) preferred over FTS (best-bm25 chunk). Pure
+/// fusion — both inputs were already visibility-gated by their Db readers.
+pub fn fuse_doc_hits(
+    knn: Vec<crate::storage::models::DocChunkHit>,
+    fts: Vec<crate::storage::models::DocChunkHit>,
+) -> Vec<crate::storage::models::DocChunkHit> {
+    if knn.is_empty() && fts.is_empty() {
+        return Vec::new();
+    }
+    let knn_ids: Vec<String> = knn.iter().map(|h| h.document_id.clone()).collect();
+    let fts_ids: Vec<String> = fts.iter().map(|h| h.document_id.clone()).collect();
+    let fused = rrf_fuse(&[knn_ids, fts_ids], RRF_K);
+    let mut by_id: HashMap<String, crate::storage::models::DocChunkHit> = HashMap::new();
+    for h in knn.into_iter().chain(fts) {
+        by_id.entry(h.document_id.clone()).or_insert(h);
+    }
+    fused
+        .into_iter()
+        .filter_map(|(id, _score)| by_id.remove(&id))
+        .collect()
+}
+
 /// Download the three e5 model files into [`embed_model_dir`], INBOUND-ONLY, with progress.
 ///
 /// Mirrors [`crate::reason::download_brain_model`]: each file streams to `<file>.part` then renames

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -231,7 +231,7 @@ fn tools_spec() -> Value {
     json!([
         {
             "name": "search_meetings",
-            "description": "Full-text search across your meeting titles, transcripts and notes. Returns matching meetings with snippets and ids.",
+            "description": "Full-text search across your meeting titles, transcripts, notes, and imported documents/brain notes. Returns matching meetings and documents with snippets and ids.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         },
         {
@@ -246,7 +246,7 @@ fn tools_spec() -> Value {
         },
         {
             "name": "search_semantic",
-            "description": "Semantic (meaning-based) search across your meeting notes, fused with full-text search. Finds relevant meetings even when they don't share the exact words. Requires semantic search to be enabled in Murmur settings.",
+            "description": "Semantic (meaning-based) search across your meeting notes and imported documents/brain notes, fused with full-text search. Finds relevant content even without the exact words. When semantic search is disabled in Murmur settings it falls back to keyword-only matching (the result says so).",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         },
         {
@@ -517,10 +517,12 @@ mod tests {
         db.set_note_folder(mid, folder).unwrap();
     }
 
-    /// Flag OFF (the default): `search_semantic` returns the explicit "disabled" result and does NOT
-    /// fall through to any vector read — the prod-safe default for the MCP surface.
+    /// Flag OFF (the default): `search_semantic` DEGRADES to gated keyword (FTS/BM25) matching —
+    /// no vector read ever runs — and the output is HONESTLY labelled as keyword matching, so the
+    /// MCP client is never told a semantic search happened. Content stays reachable on the default
+    /// install (the PR B write-only-memory fix).
     #[test]
-    fn search_semantic_disabled_when_flag_off() {
+    fn search_semantic_flag_off_degrades_to_labelled_keyword_match() {
         let (db, p) = temp_db();
         seed(&db, "m1", "Budget", "budget planning hiring quarter", None);
         // Flag defaults OFF (never written).
@@ -532,8 +534,12 @@ mod tests {
         )
         .unwrap();
         assert!(
-            out.contains("disabled"),
-            "flag-off semantic tool must report disabled, got: {out}"
+            out.contains("semantic search is off"),
+            "flag-off semantic tool must label its keyword degradation, got: {out}"
+        );
+        assert!(
+            out.contains("Budget"),
+            "flag-off fallback must still surface the gated keyword hit, got: {out}"
         );
         let _ = std::fs::remove_file(&p);
     }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -467,6 +467,10 @@ impl Db {
              );",
         )
         .map_err(map_err)?;
+        // Keyword (FTS5/BM25) retrieval over doc chunks so documents/brain notes are reachable on a
+        // DEFAULT install (no e5 model, semantic flag off). Additive + guarded so migrate() stays
+        // idempotent. Runs AFTER migrate_documents (the triggers reference doc_chunks).
+        Self::migrate_doc_fts(&conn)?;
         Ok(())
     }
 
@@ -522,6 +526,74 @@ impl Db {
             dim = crate::embed::EMBED_DIM
         ))
         .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Idempotent FTS5 index over `doc_chunks` (the SAME external-content + trigger pattern and the
+    /// SAME `unicode61 remove_diacritics 2` tokenizer as [`Db::migrate_fts`]), so documents and
+    /// typed brain notes are keyword-retrievable WITHOUT the e5 model.
+    ///
+    /// Lock model: the FTS index is DERIVED from `doc_chunks.text`, whose canonical copy while
+    /// sealed is the document's `text_blob` — so purging the index destroys nothing. The seal path
+    /// deletes a sealed folder's `doc_chunks` rows (`purge_doc_chunks_tx`), which fires the `_ad`
+    /// trigger and removes the sealed tokens from this index in the SAME statement; unseal
+    /// re-chunks, and the `_ai` trigger re-indexes. Gated reads go through
+    /// [`Db::search_doc_chunks_fts_visible`] (visibility_clause defense-in-depth on top).
+    fn migrate_doc_fts(conn: &Connection) -> Result<()> {
+        let already_built: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='fts_doc_chunks'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(map_err)?
+            .unwrap_or(false);
+
+        // One-time backfill from rows that predate the index (a model-present install already has
+        // doc_chunks). Only on first creation — later launches are trigger-maintained no-ops, so
+        // migrate() stays idempotent. The backfill rides the SAME transaction as the CREATEs: a
+        // crash between "table exists" and "backfill ran" would otherwise leave pre-existing chunks
+        // permanently keyword-dark (the `already_built` guard would skip the backfill forever).
+        let backfill = if already_built {
+            ""
+        } else {
+            "INSERT INTO fts_doc_chunks(rowid, text) SELECT id, text FROM doc_chunks;"
+        };
+        let batch = format!(
+            "BEGIN IMMEDIATE;
+             CREATE VIRTUAL TABLE IF NOT EXISTS fts_doc_chunks USING fts5(
+                 text,
+                 content='doc_chunks',
+                 content_rowid='id',
+                 tokenize = 'unicode61 remove_diacritics 2'
+             );
+
+             -- doc_chunks → fts_doc_chunks. Chunk text is write-once (purge-then-reinsert), but the
+             -- _au trigger is kept for parity with the meeting FTS trio (an UPDATE can never leave
+             -- stale tokens behind).
+             CREATE TRIGGER IF NOT EXISTS fts_doc_chunks_ai AFTER INSERT ON doc_chunks BEGIN
+                 INSERT INTO fts_doc_chunks(rowid, text) VALUES (new.id, new.text);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_doc_chunks_ad AFTER DELETE ON doc_chunks BEGIN
+                 INSERT INTO fts_doc_chunks(fts_doc_chunks, rowid, text)
+                   VALUES ('delete', old.id, old.text);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_doc_chunks_au AFTER UPDATE ON doc_chunks BEGIN
+                 INSERT INTO fts_doc_chunks(fts_doc_chunks, rowid, text)
+                   VALUES ('delete', old.id, old.text);
+                 INSERT INTO fts_doc_chunks(rowid, text) VALUES (new.id, new.text);
+             END;
+             {backfill}
+             COMMIT;"
+        );
+        let res = conn.execute_batch(&batch);
+        if res.is_err() {
+            // A failed batch leaves the explicit transaction open on this connection — roll it
+            // back so the error path hands later code a clean connection state.
+            let _ = conn.execute_batch("ROLLBACK;");
+        }
+        res.map_err(map_err)?;
         Ok(())
     }
 
@@ -1762,6 +1834,20 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// Number of `doc_vec_chunks` rows currently indexed for a document. Lets the tests assert the
+    /// no-stub-vector contract (chunk-only indexing writes ZERO vectors). Test-only.
+    #[cfg(test)]
+    pub(crate) fn doc_vec_count(&self, document_id: &str) -> Result<i64> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN
+               (SELECT id FROM doc_chunks WHERE document_id = ?1)",
+            rusqlite::params![document_id],
+            |r| r.get(0),
+        )
+        .map_err(map_err)
+    }
+
     /// A document's `(folder_id, name, plaintext text)`, or `None` if unknown. The COMMAND layer gates
     /// the folder before surfacing the text to the FE.
     pub fn get_document(&self, id: &str) -> Result<Option<(String, String, String)>> {
@@ -1883,22 +1969,28 @@ impl Db {
         Ok(())
     }
 
-    /// (Re)index a VISIBLE document's plaintext into `doc_chunks` + `doc_vec_chunks`. Old rows for the
-    /// document are purged first (clean replace). Caller MUST only invoke this for visible/unlocked
-    /// content — a sealed document's plaintext is blank, so chunking yields zero chunks (no-op).
+    /// (Re)index a VISIBLE document's plaintext into `doc_chunks` (always — the `fts_doc_chunks`
+    /// triggers keep keyword retrieval alive on a default install) and `doc_vec_chunks` (only when
+    /// `embedder` is `Some`, i.e. the REAL e5 model is present — `None` writes NO vectors, never
+    /// stub ones). Old rows for the document are purged first (clean replace). Caller MUST only
+    /// invoke this for visible/unlocked content — a sealed document's plaintext is blank, so
+    /// chunking yields zero chunks (the purge still runs, leaving the index dark).
     /// Mirrors [`Db::index_meeting_chunks`]; uses the same `chunk_note` + `embed_passage` convention
     /// so doc vectors are comparable to note vectors in the shared embedding space.
-    pub fn index_document_chunks(&self, document_id: &str, embedder: &dyn Embedder) -> Result<()> {
+    pub fn index_document_chunks(
+        &self,
+        document_id: &str,
+        embedder: Option<&dyn Embedder>,
+    ) -> Result<()> {
         let Some((_folder_id, name, text)) = self.get_document(document_id)? else {
             return Ok(()); // unknown document — nothing to index.
         };
         // Header carries the document name as provenance (the date axis is N/A for an upload, so the
         // header is just the name — `chunk_note` tolerates an empty date).
         let chunks = crate::embed::chunk_note(&name, "", &text);
-        let vectors = if chunks.is_empty() {
-            Vec::new()
-        } else {
-            embedder.embed_passage(&chunks)?
+        let vectors = match embedder {
+            Some(e) if !chunks.is_empty() => e.embed_passage(&chunks)?,
+            _ => Vec::new(), // model absent → chunk-only (FTS still covers it); vectors come later.
         };
 
         let this_doc = [document_id.to_string()];
@@ -1915,15 +2007,17 @@ impl Db {
             let mut ins_vec = tx
                 .prepare("INSERT INTO doc_vec_chunks(chunk_id, embedding) VALUES (?1, ?2)")
                 .map_err(map_err)?;
-            for (idx, (text, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
+            for (idx, text) in chunks.iter().enumerate() {
                 ins_chunk
                     .execute(rusqlite::params![document_id, idx as i64, text])
                     .map_err(map_err)?;
-                let chunk_id = tx.last_insert_rowid();
-                let blob = crate::embed::vec_to_blob(vector);
-                ins_vec
-                    .execute(rusqlite::params![chunk_id, blob])
-                    .map_err(map_err)?;
+                if let Some(vector) = vectors.get(idx) {
+                    let chunk_id = tx.last_insert_rowid();
+                    let blob = crate::embed::vec_to_blob(vector);
+                    ins_vec
+                        .execute(rusqlite::params![chunk_id, blob])
+                        .map_err(map_err)?;
+                }
             }
         }
         tx.commit().map_err(map_err)?;
@@ -2021,6 +2115,99 @@ impl Db {
             hits.push(hit);
         }
         Ok(hits)
+    }
+
+    /// GATED keyword (FTS5/BM25) search over DOCUMENT chunks — the model-free twin of
+    /// [`Db::search_doc_chunks_visible`], so documents/brain notes are reachable on a DEFAULT
+    /// install (no e5 model, semantic flag off). Applies EXACTLY the `visibility_clause` predicate
+    /// (joined doc_chunks → documents → folders) so a chunk in a sealed-and-not-session-unlocked
+    /// folder is EXCLUDED even if a stray chunk survived purge — defense-in-depth on top of the
+    /// trigger-purged FTS index. Dedups to one hit per document (best bm25), capped at `limit`.
+    pub fn search_doc_chunks_fts_visible(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<DocChunkHit>> {
+        if limit <= 0 {
+            return Ok(Vec::new());
+        }
+        let Some(match_expr) = fts_match_query(query.trim()) else {
+            return Ok(Vec::new()); // punctuation-only / empty query → no hits, never an FTS error.
+        };
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT d.id, d.name, d.folder_id, dc.text, bm25(fts_doc_chunks) AS rank
+               FROM fts_doc_chunks
+               JOIN doc_chunks dc ON dc.id = fts_doc_chunks.rowid
+               JOIN documents d ON d.id = dc.document_id
+               JOIN folders f ON f.id = d.folder_id
+              WHERE fts_doc_chunks MATCH ?1 AND {visible}
+              ORDER BY rank ASC, d.id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![match_expr], |row| {
+                Ok(DocChunkHit {
+                    document_id: row.get(0)?,
+                    name: row.get(1)?,
+                    folder_id: row.get(2)?,
+                    snippet: row.get(3)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut hits = Vec::new();
+        for r in rows {
+            let hit = r.map_err(map_err)?;
+            if !seen.insert(hit.document_id.clone()) {
+                continue; // already have a better-ranked chunk for this document.
+            }
+            hits.push(hit);
+            if hits.len() as i64 >= limit {
+                break;
+            }
+        }
+        Ok(hits)
+    }
+
+    /// Ids of every VISIBLE document (its folder open or session-unlocked), oldest-first. The
+    /// reindex-backfill corpus: a sealed-and-not-unlocked folder's documents are NEVER returned, so
+    /// their (blank) plaintext is never chunked and their index rows STAY purged.
+    pub fn visible_document_ids(&self, unlocked: &HashSet<String>) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT d.id FROM documents d
+               JOIN folders f ON f.id = d.folder_id
+              WHERE {visible}
+              ORDER BY d.created_at ASC, d.id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// True iff a document currently has `doc_chunks` rows. Lets the model-absent reindex backfill
+    /// SKIP documents that are already chunked (a purge-then-reinsert without vectors would DESTROY
+    /// their existing real vectors — chunk-only backfill is for write-only rows, never a downgrade).
+    pub fn document_has_chunks(&self, document_id: &str) -> Result<bool> {
+        let conn = self.lock();
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM doc_chunks WHERE document_id = ?1",
+                rusqlite::params![document_id],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
     }
 
     // ── segments ────────────────────────────────────────────────────────────
@@ -5860,7 +6047,7 @@ mod tests {
         seed_folder(&db, "f-open", "Project");
         db.insert_document("d1", "f-open", "spec.md", "budget planning for the quarter", "document", 100)
             .unwrap();
-        db.index_document_chunks("d1", &crate::embed::StubEmbedder).unwrap();
+        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder)).unwrap();
 
         // Metadata (no text) + full text read back.
         let listed = db.documents_in_folder("f-open").unwrap();
@@ -5902,7 +6089,7 @@ mod tests {
         seed_folder(&db, "f-locked", "Secret");
         db.insert_document("d1", "f-locked", "secret.md", "launch date is the 14th", "document", 100)
             .unwrap();
-        db.index_document_chunks("d1", &crate::embed::StubEmbedder).unwrap();
+        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder)).unwrap();
         // Query vector = the stub passage embedding of the doc's own chunk text → guaranteed nearest.
         let chunk_text: String = db
             .lock()
@@ -5947,6 +6134,137 @@ mod tests {
         );
     }
 
+    /// ALWAYS-CHUNK contract (PR B): indexing with NO embedder (`None` — the model-less default
+    /// install) stores `doc_chunks` rows and ZERO vectors, and the chunk text is immediately
+    /// keyword-findable via the gated FTS leg. Deterministic regardless of whether the dev machine
+    /// has the real e5 model.
+    #[test]
+    fn index_document_chunks_none_embedder_chunks_no_vectors_fts_finds() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Project");
+        db.insert_document("d1", "f-open", "spec.md", "the pistachio launch is in March", "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        assert!(db.doc_chunk_count("d1").unwrap() >= 1, "chunk rows stored without a model");
+        assert_eq!(db.doc_vec_count("d1").unwrap(), 0, "no vectors written without a model");
+
+        let nothing = std::collections::HashSet::new();
+        let hits = db.search_doc_chunks_fts_visible("pistachio", 10, &nothing).unwrap();
+        assert!(
+            hits.iter().any(|h| h.document_id == "d1" && h.snippet.contains("pistachio")),
+            "chunk-only document must be keyword-findable: {hits:?}"
+        );
+        // Punctuation-only query defuses to no hits (never an FTS syntax error).
+        assert!(db.search_doc_chunks_fts_visible("?!*(", 10, &nothing).unwrap().is_empty());
+    }
+
+    /// GATE twin of `doc_chunk_search_is_gated_by_visibility` for the KEYWORD leg: a doc chunk row
+    /// that deliberately SURVIVES in a sealed-not-unlocked folder is EXCLUDED by
+    /// `search_doc_chunks_fts_visible` (defense-in-depth `visibility_clause`) and reappears only
+    /// with the session unlock set. RED if the clause were dropped from the FTS join.
+    #[test]
+    fn doc_chunk_fts_search_is_gated_by_visibility() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_document("d1", "f-locked", "secret.md", "launch date is the 14th", "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        assert!(
+            db.search_doc_chunks_fts_visible("launch", 10, &nothing)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == "d1"),
+            "open-folder document chunk must be keyword-visible"
+        );
+
+        // Seal the folder (chunk row deliberately survives) → INVISIBLE with empty unlock set.
+        db.set_folder_locked("f-locked", true, None).unwrap();
+        assert!(
+            !db.search_doc_chunks_fts_visible("launch", 10, &nothing)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == "d1"),
+            "sealed-not-unlocked document chunk leaked through the FTS gate"
+        );
+
+        // Session-unlock → present again.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        assert!(
+            db.search_doc_chunks_fts_visible("launch", 10, &unlocked)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == "d1"),
+            "session-unlocked document chunk must reappear in FTS search"
+        );
+    }
+
+    /// SEAL-DARKNESS at the INDEX level: purging a document's chunks (what the lock path does)
+    /// removes its tokens from `fts_doc_chunks` in the same statement (the `_ad` trigger), so no
+    /// sealed token survives in the inverted index at rest; re-indexing restores them. Mirrors
+    /// `sealed_tokens_purged_from_fts_after_blank` for the meeting FTS trio.
+    #[test]
+    fn doc_fts_tokens_purged_with_chunks_and_restored_on_reindex() {
+        let db = mem_db();
+        seed_folder(&db, "f", "F");
+        db.insert_document("d1", "f", "n.md", "unicornfeather budget detail", "note", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        let fts_count = |db: &Db| -> i64 {
+            db.lock()
+                .query_row(
+                    "SELECT COUNT(*) FROM fts_doc_chunks WHERE fts_doc_chunks MATCH '\"unicornfeather\"'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert!(fts_count(&db) >= 1, "token indexed after chunking");
+
+        db.purge_doc_chunks_for_documents(&["d1".to_string()]).unwrap();
+        assert_eq!(fts_count(&db), 0, "sealed/purged token must not survive in the FTS index");
+        let nothing = std::collections::HashSet::new();
+        assert!(db.search_doc_chunks_fts_visible("unicornfeather", 10, &nothing).unwrap().is_empty());
+
+        db.index_document_chunks("d1", None).unwrap();
+        assert!(fts_count(&db) >= 1, "re-index restores the keyword index");
+    }
+
+    /// POLISH DIACRITICS: the doc FTS uses the SAME `unicode61 remove_diacritics 2` tokenizer as
+    /// the meeting tables, so an ASCII-folded query matches the diacritic original and vice versa
+    /// for NFD-decomposable marks (ż/ź/ę/ś/ą/ó/ć/ń — note ł, a stroked letter with NO Unicode
+    /// decomposition, is genuinely NOT foldable by any FTS5 remove_diacritics mode).
+    #[test]
+    fn doc_fts_matches_polish_diacritics_folded() {
+        let db = mem_db();
+        seed_folder(&db, "f", "F");
+        db.insert_document("d1", "f", "pl.md", "gęślą jaźń — budżet kwartalny", "note", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        for q in ["budzet", "jazn", "gesla"] {
+            assert!(
+                db.search_doc_chunks_fts_visible(q, 10, &nothing)
+                    .unwrap()
+                    .iter()
+                    .any(|h| h.document_id == "d1"),
+                "ASCII query {q:?} must match the diacritic original (remove_diacritics 2)"
+            );
+        }
+        assert!(
+            db.search_doc_chunks_fts_visible("gęślą", 10, &nothing)
+                .unwrap()
+                .iter()
+                .any(|h| h.document_id == "d1"),
+            "diacritic query must match too"
+        );
+    }
+
     /// SEAL ROUND-TRIP (verify-before-destroy, byte-identical): a document's text encrypts under a CK
     /// (AAD-less here for the unit, mirroring the `seal_*_round_trips_byte_identical` pattern), blanks,
     /// and decrypts back byte-identical via `seal_document` / `set_document_text` / `clear_document_blob`.
@@ -5983,7 +6301,7 @@ mod tests {
         let db = mem_db();
         seed_folder(&db, "f", "F");
         db.insert_document("d1", "f", "n.md", "alpha bravo charlie", "document", 100).unwrap();
-        db.index_document_chunks("d1", &crate::embed::StubEmbedder).unwrap();
+        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder)).unwrap();
         db.delete_document("d1").unwrap();
         assert!(db.get_document("d1").unwrap().is_none(), "document row deleted");
         let count: i64 = db

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -71,7 +71,13 @@ pub fn build_vault_context_visible(
         meetings = db.list_meetings_visible(30, unlocked)?;
     }
 
-    pack_meetings(db, meetings, budget, unlocked)
+    let (mut corpus, sources) = pack_meetings(db, meetings, budget, unlocked)?;
+    // Documents/brain notes must be reachable WITHOUT the e5 model too (the default install):
+    // append the gated `## Documents` section from the keyword (FTS/BM25) leg alone — an empty
+    // `query_vec` means no KNN leg. Same `visibility_clause` gate as every meeting leg, so a
+    // sealed-not-unlocked folder's document chunks never enter the cloud-bound corpus.
+    pack_doc_chunks(db, query, &[], budget, &mut corpus, unlocked)?;
+    Ok((corpus, sources))
 }
 
 /// brain2 RAG Phase 2b — HYBRID candidate selection for Ask-My-Vault, GATED by the caller (only
@@ -102,29 +108,35 @@ pub fn build_vault_context_hybrid_visible(
     }
     let (mut corpus, sources) = pack_meetings(db, meetings, budget, unlocked)?;
     // Document ingestion: APPEND a gated `## Documents` section so the brain/Ask can also ground on
-    // uploaded md/txt. `search_doc_chunks_visible` re-applies the SAME `visibility_clause` against
-    // `unlocked` (joined doc_chunks → documents → folders), so a sealed-and-not-session-unlocked
-    // folder's document chunks are NEVER returned — identical gate to the meeting legs. Each hit
-    // contributes its document name + the nearest chunk snippet (no meeting citation — documents are
-    // not meetings, so they don't add a `VaultSource`). Capped by the same `budget`.
-    pack_doc_chunks(db, query_vec, budget, &mut corpus, unlocked)?;
+    // uploaded md/txt. Both retrieval legs (vector KNN + keyword FTS) re-apply the SAME
+    // `visibility_clause` against `unlocked` (joined doc_chunks → documents → folders), so a
+    // sealed-and-not-session-unlocked folder's document chunks are NEVER returned — identical gate
+    // to the meeting legs. Each hit contributes its document name + best chunk snippet (no meeting
+    // citation — documents are not meetings, so they don't add a `VaultSource`). Same `budget`.
+    pack_doc_chunks(db, query, query_vec, budget, &mut corpus, unlocked)?;
     Ok((corpus, sources))
 }
 
 /// Append a budget-capped `## Documents` section of gated document-chunk snippets to `corpus`. The
-/// retrieval is `search_doc_chunks_visible` (KNN gated by `visibility_clause`); a locked-and-not-
-/// unlocked folder's chunks are invisible there. Best-effort: an empty doc index simply adds nothing.
+/// retrieval is the RRF fusion of `search_doc_chunks_visible` (vector KNN — skipped when
+/// `query_vec` is empty, i.e. the flag-off / model-less path) and `search_doc_chunks_fts_visible`
+/// (keyword BM25), both gated by `visibility_clause`; a locked-and-not-unlocked folder's chunks are
+/// invisible in either leg. Best-effort: an empty doc index simply adds nothing.
 fn pack_doc_chunks(
     db: &Db,
+    query: &str,
     query_vec: &[f32],
     budget: usize,
     corpus: &mut String,
     unlocked: &HashSet<String>,
 ) -> Result<()> {
-    if query_vec.is_empty() {
-        return Ok(());
-    }
-    let hits = db.search_doc_chunks_visible(query_vec, 20, unlocked)?;
+    let knn = if query_vec.is_empty() {
+        Vec::new()
+    } else {
+        db.search_doc_chunks_visible(query_vec, 20, unlocked)?
+    };
+    let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked)?;
+    let hits = crate::embed::fuse_doc_hits(knn, fts);
     if hits.is_empty() {
         return Ok(());
     }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -98,13 +98,16 @@ pub fn tool_specs() -> Vec<ToolSpec> {
     vec![
         ToolSpec {
             name: "search_meetings",
-            description: "Full-text search across the user's past meeting titles, notes and transcripts.",
+            description: "Full-text search across the user's past meeting titles, notes, transcripts, \
+                          and imported documents/brain notes.",
             parameters: str_arg("query", "Search terms, in the user's own language."),
             write: false,
         },
         ToolSpec {
             name: "search_semantic",
-            description: "Hybrid semantic + keyword search over meetings (finds related-by-meaning notes).",
+            description: "Hybrid semantic + keyword search over meetings and imported documents/brain \
+                          notes (finds related-by-meaning content). Falls back to keyword-only \
+                          matching when semantic search is disabled.",
             parameters: str_arg("query", "A natural-language description of what to find."),
             write: false,
         },
@@ -204,22 +207,43 @@ pub fn execute_tool(
     match call {
         ToolCall::SearchMeetings { query } => {
             let q = query.as_str();
+            // Documents/brain notes ride the SAME fan-out — the gated keyword (FTS/BM25) doc leg
+            // works WITHOUT the e5 model, so ingested content is reachable through the primary
+            // search tool on a default install. `search_doc_chunks_fts_visible` applies the SAME
+            // `visibility_clause` against `unlocked` as the meeting legs.
+            let docs = db
+                .search_doc_chunks_fts_visible(q, 20, unlocked)
+                .unwrap_or_default();
             match db.search_visible(q, 20, unlocked) {
-                Ok(hits) if hits.is_empty() => Ok(format!("No meetings match \"{q}\".")),
-                Ok(hits) => Ok(format_hits(&hits)),
+                Ok(hits) if hits.is_empty() && docs.is_empty() => {
+                    Ok(format!("No meetings or documents match \"{q}\"."))
+                }
+                Ok(hits) => Ok(format_hits_and_docs(&hits, &docs)),
                 Err(e) => Err(AppError::Storage(format!("search failed: {e}"))),
             }
         }
         ToolCall::SearchSemantic { query } => {
             let q = query.as_str();
             // GATE: the master flag lives in the (whole-DB-encrypted) settings table. When OFF,
-            // return an explicit "disabled" result — do NOT silently fall back to an ungated read.
-            // No `vec_chunks` row is ever touched.
+            // DEGRADE HONESTLY to gated keyword (BM25) matching — never an ungated read, and no
+            // `vec_chunks`/`doc_vec_chunks` row is ever touched (no stub-vector KNN). The output is
+            // labelled as keyword matching so the model is never told a semantic search ran.
             if !config.semantic_search_enabled {
-                return Ok(
-                    "Semantic search is disabled. Enable it in Murmur settings to use this tool."
-                        .to_string(),
-                );
+                let hits = db
+                    .search_visible(q, 20, unlocked)
+                    .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
+                let docs = db
+                    .search_doc_chunks_fts_visible(q, 20, unlocked)
+                    .unwrap_or_default();
+                if hits.is_empty() && docs.is_empty() {
+                    return Ok(format!(
+                        "No meetings or documents match \"{q}\" (keyword match — semantic search is off)."
+                    ));
+                }
+                return Ok(format!(
+                    "Keyword (exact-word) matches — semantic search is off:\n{}",
+                    format_hits_and_docs(&hits, &docs)
+                ));
             }
             // Embed the query with the SAME active embedder used to index, then HYBRID-search through
             // the SAME visibility gate as `search_meetings` (both FTS + vector legs are gated).
@@ -229,13 +253,17 @@ pub fn execute_tool(
                 Ok(v) => v.into_iter().next().unwrap_or_default(),
                 Err(e) => return Err(AppError::Summarize(format!("embed failed: {e}"))),
             };
-            // Document ingestion: ALSO surface uploaded md/txt that match — gated by
-            // `search_doc_chunks_visible` (the SAME `visibility_clause` against `unlocked`), so a
-            // locked-and-not-unlocked folder's documents are invisible here exactly like a sealed
-            // meeting. Append them as a `DOCUMENTS:` section so the model can ground on them too.
-            let docs = db
+            // Document ingestion: ALSO surface uploaded md/txt that match — the vector-KNN and
+            // keyword-FTS doc legs are RRF-fused, and BOTH are gated by the SAME `visibility_clause`
+            // against `unlocked`, so a locked-and-not-unlocked folder's documents are invisible here
+            // exactly like a sealed meeting. Appended as a `DOCUMENTS:` section.
+            let knn_docs = db
                 .search_doc_chunks_visible(&query_vec, 20, unlocked)
                 .unwrap_or_default();
+            let fts_docs = db
+                .search_doc_chunks_fts_visible(q, 20, unlocked)
+                .unwrap_or_default();
+            let docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
             match db.search_hybrid_visible(q, &query_vec, 20, unlocked) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -684,11 +684,14 @@ fn web_citation_from_line(line: &str) -> Option<String> {
 /// Whether a tool result is a "nothing found" / "disabled" placeholder rather than real content,
 /// so it can be excluded from the brain grounding (an included placeholder would falsely count as
 /// grounding and trigger a brain call on an empty vault). Matches the deterministic prefixes
-/// `execute_tool` emits (`No meetings match`, `No data`, `No open commitments`, `No visible
-/// entity`, and the `Semantic search is disabled` notice).
+/// `execute_tool` emits (`No meetings or documents match` — including `search_semantic`'s flag-off
+/// keyword-fallback variant — `No data`, `No open commitments`, `No visible entity`; the legacy
+/// `No meetings match` / `Semantic search is disabled` prefixes are kept so an old-shape sentinel
+/// can never miscount as grounding).
 fn is_empty_tool_result(text: &str) -> bool {
     let t = text.trim_start();
     t.starts_with("No meetings match")
+        || t.starts_with("No meetings or documents match")
         || t.starts_with("No data")
         || t.starts_with("No open commitments")
         || t.starts_with("No visible entity")


### PR DESCRIPTION
Tier-0b of the brain analysis (docs/research/2026-07-02-brain-full-analysis.md).

**Problem.** On a default install (no e5 model, semantic flag off) documents and Brain-page notes were **write-only memory**: chunks+vectors stored only when the model was present, no FTS over doc chunks, only flag-gated KNN readers, reindex backfilled meetings only. The Brain page listed content the brain could not recall through Ask, the agent tools, or MCP.

**Fix.** Always-chunk on ingest (vectors stay model-gated) · new `fts_doc_chunks` FTS5 external-content index (+triggers, one-time backfill, additive/idempotent/**atomic**) · gated read legs everywhere: `search_doc_chunks_fts_visible` (BM25 + visibility_clause), flag-off Ask corpus Documents section, hybrid doc-KNN+doc-FTS RRF fusion, SearchMeetings doc leg, SearchSemantic flag-off degrades to **honestly-labelled** gated keyword matches · reindex backfills documents (model-absent: chunk-only for chunkless docs, never purging real vectors).

**Verification.** RED-first headline test (`model_less_ingest_is_reachable_by_flag_off_ask_and_tools`) failed pre-fix with an empty corpus; adversarial verifier independently re-proved RED on 3 separate wiring hunks. `cargo test --lib`: **601 passed / 0 failed**. **adversarial-verifier: substance PASS** (sealed-token-at-rest probes clean incl. forced-backfill resurrection attempt; embed-failure-mid-reindex preserves old vectors; original FAIL was integration-only — the diff had been stashed by a concurrent session and needed a one-hunk rebase onto #111, resolved here exactly as the verifier proved green). **lock-security-reviewer: PASS** (every new leg through visibility_clause; purge fires the _ad trigger incl. FK-CASCADE, proven empirically; canonical text_blob verify-before-destroy untouched). Two reviewer MINORs fixed in this commit: atomic migrate backfill + content-word test assertions.

**Known limitation:** FTS5 `remove_diacritics` cannot fold Polish **ł** (no NFD decomposition) — documented in-test.

**Accepted residuals (pre-existing pattern):** initial-lock doc-chunk purge runs in a follow-on tx after seal (gate-first + startup reconciliation heal it — same as meeting chunks); FTS delete-markers linger physically in shadow tables until segment merge (query-invisible, SQLCipher-covered — same posture as fts_notes).