### PR TITLE
feat(brain): thread_id + @brain thread persistence (purged-on-seal)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -637,8 +637,15 @@ pub(crate) fn end_voice_command_inner(
 /// `EVENT_VOICE_ACTION_RESULT` with the live tool-trace on `EVENT_ASSISTANT_TOOL`. Runs OFF-thread
 /// (the brain can take seconds). The text is the user's OWN words — the SAME egress class as a
 /// dictated voice command (no new egress). Emits the "thinking…" processing affordance immediately.
+/// `thread_id` is OPTIONAL: the FE passes an @brain thread's id to keep the exchange in that
+/// thread; when absent (the voice/wake twin sends none) the backend GENERATES a UUID v4 inside the
+/// turn, so every persisted exchange carries a thread identity going forward.
 #[tauri::command]
-pub fn ask_assistant_text(app: AppHandle, text: String) -> Result<(), AppError> {
+pub fn ask_assistant_text(
+    app: AppHandle,
+    text: String,
+    thread_id: Option<String>,
+) -> Result<(), AppError> {
     let text = text.trim().to_string();
     if text.is_empty() {
         return Err(AppError::InvalidArg("empty question".into()));
@@ -647,7 +654,7 @@ pub fn ask_assistant_text(app: AppHandle, text: String) -> Result<(), AppError> 
         crate::events::EVENT_VOICE_COMMAND_PROCESSING,
         crate::events::VoiceCommandProcessingPayload { active: true },
     );
-    crate::transcribe::live::spawn_assistant_turn(app, text);
+    crate::transcribe::live::spawn_assistant_turn(app, text, thread_id);
     Ok(())
 }
 
@@ -696,22 +703,52 @@ fn format_chat(messages: &[ChatMsg]) -> Result<(String, String), AppError> {
 /// The FE sends the FULL conversation each turn, so the brain has multi-turn memory. The heavy agentic
 /// work runs on a blocking thread (it can take seconds) so the async runtime stays free. SAME gated +
 /// consent-gated + redacting brain as voice (no new egress class).
+/// `thread_id`/`anchor_text` are OPTIONAL thread identity (FE camelCase: `threadId`/`anchorText`):
+/// the @brain thread this exchange belongs to, and the note text the thread was anchored to. A
+/// missing `thread_id` is backend-generated (UUID v4) so every persisted exchange carries one. The
+/// PERSISTED row's `command` is `latest` — the user's newest message, never the rendered history.
 #[tauri::command]
 pub async fn ask_assistant_chat(
     app: AppHandle,
     messages: Vec<ChatMsg>,
+    thread_id: Option<String>,
+    anchor_text: Option<String>,
 ) -> Result<crate::voice_action::VoiceActionResult, AppError> {
     let (latest, conversation) = format_chat(&messages)?;
+    let thread_id = crate::transcribe::live::ensure_thread_id(thread_id);
     tokio::task::spawn_blocking(move || {
         crate::transcribe::live::run_assistant_query(
             &app,
             &latest,
             &conversation,
             crate::events::EVENT_CHAT_TOOL,
+            &thread_id,
+            anchor_text.as_deref(),
         )
     })
     .await
     .map_err(|e| AppError::Other(anyhow::anyhow!("chat task join failed: {e}")))
+}
+
+/// List the PERSISTED @brain thread exchanges for a meeting (only rows carrying a `thread_id`),
+/// oldest first — the durable substrate the FE rebuilds its thread panels from across meeting
+/// switches / restarts. GATED read: it routes through `list_assistant_threads_visible`
+/// (`visibility_clause`-backed), so a sealed-and-not-session-unlocked meeting returns EMPTY —
+/// never an error that leaks existence. On seal the rows are purged anyway
+/// (`purge_assistant_interactions_tx`); the gate is defense-in-depth.
+#[tauri::command]
+pub fn list_assistant_threads(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<crate::storage::models::AssistantThreadRow>, AppError> {
+    // Poisoned lock ⇒ empty unlock set ⇒ fail CLOSED (sealed meetings stay invisible) — the same
+    // posture as the `get_meeting_detail` interactions read.
+    let unlocked = state
+        .unlocked_folders
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+    state.db.list_assistant_threads_visible(&meeting_id, &unlocked)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -90,6 +90,10 @@ pub struct AssistantToolPayload {
     pub ok: bool,
     /// Coarse result-size signal for the done badge — NOT the content.
     pub count: Option<u32>,
+    /// Opaque id of the conversation THREAD this tool call belongs to (an @brain thread id or the
+    /// backend-generated voice-turn UUID), so simultaneous threads attribute their trace chips
+    /// without cross-bleed. `None` only for legacy emitters. NOT PII (an opaque UUID).
+    pub thread_id: Option<String>,
 }
 
 /// Progress for the on-device brain (reasoning GGUF) download. Carries byte counts only — NO PII.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ pub fn run() {
             commands::end_voice_command,
             commands::ask_assistant_text,
             commands::ask_assistant_chat,
+            commands::list_assistant_threads,
             commands::list_input_devices,
             commands::get_last_note,
             commands::update_note,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8,9 +8,9 @@ use crate::error::{AppError, Result};
 use std::collections::HashSet;
 
 use crate::storage::models::{
-    Analytics, AssistantInteraction, Commitment, CorrectionRecord, DayCount, DocChunkHit,
-    DocumentInfo, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData, GraphEdge,
-    GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
+    Analytics, AssistantInteraction, AssistantThreadRow, Commitment, CorrectionRecord, DayCount,
+    DocChunkHit, DocumentInfo, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData,
+    GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
     StatusCount, VaultSource,
 };
 use crate::embed::Embedder;
@@ -427,6 +427,14 @@ impl Db {
         Self::add_column_if_missing(&conn, "notes", "model_requested", "TEXT")?;
         Self::add_column_if_missing(&conn, "notes", "model_served", "TEXT")?;
         Self::add_column_if_missing(&conn, "notes", "gateway_host", "TEXT")?;
+        // @brain THREADS: scope each persisted assistant exchange to a conversation thread.
+        // `thread_id` is an OPAQUE id (FE-supplied for an @brain thread, backend-generated UUID for
+        // the voice/wake path); `anchor_text` is the note text an @brain thread was anchored to
+        // (row content, purged on seal with the rest of the row — see
+        // `purge_assistant_interactions_tx`). Guarded ALTERs (idempotent); NULL for legacy rows,
+        // which the gated thread reader EXCLUDES (`list_assistant_threads_visible`).
+        Self::add_column_if_missing(&conn, "assistant_interactions", "thread_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "assistant_interactions", "anchor_text", "TEXT")?;
         // Phase 1 — FTS5/BM25 full-text retrieval over the three text sources
         // (meeting titles, transcript segments, note markdown). Replaces the prior
         // substring LIKE search so word-order/term retrieval works ("alpha beta" == "beta alpha")
@@ -3638,6 +3646,8 @@ impl Db {
         citations: &[String],
         status: &str,
         source_label: Option<&str>,
+        thread_id: Option<&str>,
+        anchor_text: Option<&str>,
         created_at: &str,
     ) -> Result<i64> {
         let citations_json = serde_json::to_string(citations)
@@ -3645,8 +3655,9 @@ impl Db {
         let conn = self.lock();
         conn.execute(
             "INSERT INTO assistant_interactions
-                (meeting_id, command, answer, citations, status, source_label, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                (meeting_id, command, answer, citations, status, source_label,
+                 thread_id, anchor_text, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 meeting_id,
                 command,
@@ -3654,6 +3665,8 @@ impl Db {
                 citations_json,
                 status,
                 source_label,
+                thread_id,
+                anchor_text,
                 created_at
             ],
         )
@@ -3708,6 +3721,61 @@ impl Db {
                 citations,
                 status,
                 source_label,
+                created_at,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Read the persisted @brain THREAD exchanges for `meeting_id` — ONLY rows that carry a
+    /// `thread_id` (legacy voice rows with NULL are EXCLUDED), oldest first — and ONLY when the
+    /// meeting is VISIBLE to the session `unlocked` set. A sealed-and-not-session-unlocked meeting
+    /// returns an EMPTY list, never an error (existence must not leak) — the same gate as
+    /// `list_assistant_interactions_visible`. On seal the rows are PURGED anyway
+    /// (`purge_assistant_interactions_tx`), so the gate is defense-in-depth.
+    pub fn list_assistant_threads_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<AssistantThreadRow>> {
+        if !self.meeting_is_visible(meeting_id, unlocked)? {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT thread_id, anchor_text, command, answer, citations, status, created_at
+                   FROM assistant_interactions
+                  WHERE meeting_id = ?1 AND thread_id IS NOT NULL
+                  ORDER BY id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, String>(5)?,
+                    r.get::<_, String>(6)?,
+                ))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (thread_id, anchor_text, command, answer, citations_json, status, created_at) =
+                r.map_err(map_err)?;
+            // A malformed citations blob must never break the read — fall back to an empty list.
+            let citations: Vec<String> = serde_json::from_str(&citations_json).unwrap_or_default();
+            out.push(AssistantThreadRow {
+                thread_id,
+                anchor_text,
+                command,
+                answer,
+                citations,
+                status,
                 created_at,
             });
         }
@@ -5299,6 +5367,8 @@ mod tests {
             &["[[Notatka o pogodzie]]".to_string(), "(web) Weather — http://x".to_string()],
             "ok",
             Some("research"),
+            None,
+            None,
             "2026-06-24T10:05:00Z",
         )
         .unwrap();
@@ -5337,6 +5407,8 @@ mod tests {
             &[],
             "ok",
             Some("research"),
+            None,
+            None,
             "2026-06-24T10:05:00Z",
         )
         .unwrap();
@@ -5369,7 +5441,8 @@ mod tests {
         note_for(&db, "m1", "claude_code", "note");
         db.set_note_folder("m1", Some("f-locked")).unwrap();
         db.insert_assistant_interaction(
-            "m1", "cmd", "answer", &[], "ok", Some("research"), "2026-06-24T10:05:00Z",
+            "m1", "cmd", "answer", &[], "ok", Some("research"), None, None,
+            "2026-06-24T10:05:00Z",
         )
         .unwrap();
         assert_eq!(interaction_count(&db, "m1"), 1, "row present before seal");
@@ -5389,7 +5462,8 @@ mod tests {
         let db = mem_db();
         db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z")).unwrap();
         db.insert_assistant_interaction(
-            "m1", "cmd", "answer", &[], "ok", Some("research"), "2026-06-24T10:05:00Z",
+            "m1", "cmd", "answer", &[], "ok", Some("research"), None, None,
+            "2026-06-24T10:05:00Z",
         )
         .unwrap();
         assert_eq!(interaction_count(&db, "m1"), 1);
@@ -5399,6 +5473,139 @@ mod tests {
             0,
             "delete_meeting must purge the meeting's assistant_interactions rows"
         );
+    }
+
+    /// THREAD round-trip: exchanges persisted WITH a thread identity read back through the gated
+    /// thread reader — `thread_id` + `anchor_text` intact, `command` = the user's LATEST message
+    /// of each exchange, ordered by id ASC — while legacy rows (NULL `thread_id`) are EXCLUDED.
+    /// RED before PR D: `insert_assistant_interaction` had no thread params and
+    /// `list_assistant_threads_visible` did not exist (thread identity was FE-RAM-only).
+    #[test]
+    fn assistant_threads_round_trip_ordered_and_exclude_legacy() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-07-02T10:00:00Z")).unwrap();
+        // A legacy-shaped voice row (no thread) — must NOT surface in the thread reader.
+        db.insert_assistant_interaction(
+            "m1", "legacy voice cmd", "a0", &[], "ok", Some("research"), None, None,
+            "2026-07-02T10:01:00Z",
+        )
+        .unwrap();
+        // An @brain thread: two exchanges, the first anchored to a note.
+        db.insert_assistant_interaction(
+            "m1",
+            "what did we decide on pricing?",
+            "Tiered pricing.",
+            &["[[Pricing sync]]".to_string()],
+            "ok",
+            Some("research"),
+            Some("t-1"),
+            Some("• pricing: tiered, ship Friday"),
+            "2026-07-02T10:02:00Z",
+        )
+        .unwrap();
+        db.insert_assistant_interaction(
+            "m1", "and the timeline?", "Ships Friday.", &[], "ok", Some("research"),
+            Some("t-1"), None, "2026-07-02T10:03:00Z",
+        )
+        .unwrap();
+
+        let rows = db
+            .list_assistant_threads_visible("m1", &std::collections::HashSet::new())
+            .unwrap();
+        assert_eq!(rows.len(), 2, "only thread-carrying rows; the legacy NULL row is excluded");
+        assert_eq!(rows[0].thread_id, "t-1");
+        assert_eq!(rows[0].anchor_text.as_deref(), Some("• pricing: tiered, ship Friday"));
+        assert_eq!(
+            rows[0].command, "what did we decide on pricing?",
+            "command is the LATEST user message of the exchange, never the rendered history"
+        );
+        assert_eq!(rows[0].answer, "Tiered pricing.");
+        assert_eq!(rows[0].citations, vec!["[[Pricing sync]]".to_string()]);
+        assert_eq!(rows[0].status, "ok");
+        assert_eq!(rows[0].created_at, "2026-07-02T10:02:00Z");
+        // Ordered by id ASC — the follow-up comes second.
+        assert_eq!(rows[1].command, "and the timeline?");
+        assert_eq!(rows[1].thread_id, "t-1");
+        assert!(rows[1].anchor_text.is_none());
+    }
+
+    /// GATE: a sealed-and-NOT-session-unlocked meeting's threads are NEVER returned by the gated
+    /// thread reader (EMPTY, never an error) — even with rows at rest; a session-unlocked folder's
+    /// threads ARE. RED-able: drop the `meeting_is_visible` guard in
+    /// `list_assistant_threads_visible` and the first assertion fails (the row leaks).
+    #[test]
+    fn assistant_threads_gated_for_sealed_meeting() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-02T10:00:00Z")).unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.insert_assistant_interaction(
+            "m1", "secret thread question", "secret answer", &[], "ok", Some("research"),
+            Some("t-secret"), Some("secret anchor"), "2026-07-02T10:05:00Z",
+        )
+        .unwrap();
+        db.set_folder_locked("f-locked", true, Some(b"wrapped")).unwrap();
+
+        let empty = std::collections::HashSet::new();
+        assert!(
+            db.list_assistant_threads_visible("m1", &empty).unwrap().is_empty(),
+            "a sealed-not-unlocked meeting must surface NO threads through the gated read"
+        );
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        assert_eq!(
+            db.list_assistant_threads_visible("m1", &unlocked).unwrap().len(),
+            1,
+            "a session-unlocked folder's threads ARE visible"
+        );
+    }
+
+    /// PURGE-ON-SEAL: thread rows ride `purge_assistant_interactions_tx` (no new purge code) — after
+    /// the seal purge the raw rows are GONE and the thread reader returns EMPTY even for a session
+    /// that can see the meeting. RED-able: exclude thread-carrying rows from the purge DELETE and
+    /// both assertions fail (thread content would survive a seal at rest).
+    #[test]
+    fn assistant_threads_purged_on_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-02T10:00:00Z")).unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.insert_assistant_interaction(
+            "m1", "thread cmd", "thread answer", &[], "ok", Some("research"),
+            Some("t-1"), Some("anchor"), "2026-07-02T10:05:00Z",
+        )
+        .unwrap();
+        assert_eq!(interaction_count(&db, "m1"), 1, "row present before seal");
+
+        // The seal purge runs in the SAME tx that drops chunks + corrections for sealed meetings.
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(interaction_count(&db, "m1"), 0, "raw thread rows gone after the seal purge");
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        assert!(
+            db.list_assistant_threads_visible("m1", &unlocked).unwrap().is_empty(),
+            "the thread reader has nothing to return after the purge"
+        );
+    }
+
+    /// PR D migration: `assistant_interactions` carries the THREAD columns (`thread_id` +
+    /// `anchor_text`). RED before the guarded ALTERs land ("no such column"), GREEN after;
+    /// `migrate_is_idempotent` covers the re-run. Legacy rows read back NULL/NULL.
+    #[test]
+    fn assistant_interactions_have_thread_columns() {
+        let db = mem_db();
+        let n: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM assistant_interactions
+                  WHERE thread_id IS NOT NULL OR anchor_text IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 0, "fresh table: no thread rows yet, but the columns must exist");
     }
 
     #[test]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -174,6 +174,32 @@ pub struct AssistantInteraction {
     pub created_at: String,
 }
 
+/// One persisted @brain THREAD exchange — the durable substrate the FE rebuilds its thread panels
+/// from across meeting switches / restarts. Rows come from `assistant_interactions` and are
+/// returned ONLY when they carry a `thread_id` (legacy voice rows are excluded). Like
+/// [`AssistantInteraction`], it is DERIVED convenience data — purged (not sealed) when the
+/// meeting's folder is sealed, and the read is visibility-gated (sealed-not-unlocked ⇒ empty).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssistantThreadRow {
+    /// Opaque thread id: the FE-supplied @brain thread id, or a backend-generated UUID for the
+    /// voice/wake path. Groups the exchanges of one conversation.
+    pub thread_id: String,
+    /// The note text the @brain thread was ANCHORED to (the ✨ ask-brain seed), when any.
+    pub anchor_text: Option<String>,
+    /// The user's LATEST message of that exchange (never the rendered conversation history).
+    pub command: String,
+    /// The assistant's answer for that exchange.
+    pub answer: String,
+    /// `[[Title]]` wikilink / "(web)" citations the answer was grounded on (VISIBLE meetings only).
+    pub citations: Vec<String>,
+    /// Dispatch status: `ok` | `unavailable` | `unrecognized` | `needs_consent` | `error` |
+    /// `nothing_heard`.
+    pub status: String,
+    /// RFC3339 timestamp the exchange was recorded.
+    pub created_at: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusCount {

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -201,7 +201,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                                 crate::events::EVENT_VOICE_COMMAND_PROCESSING,
                                 crate::events::VoiceCommandProcessingPayload { active: true },
                             );
-                            spawn_assistant_turn(app.clone(), command);
+                            // No FE thread here (spoken turn) → the turn generates its own id.
+                            spawn_assistant_turn(app.clone(), command, None);
                         }
                         ManualCaptureDecision::NothingHeard => {
                             // Budget expired with nothing heard → graceful, NOT a confusing
@@ -262,7 +263,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                             "wake word detected in live caption"
                         );
                         if dispatch {
-                            spawn_assistant_turn(app.clone(), payload.command.clone());
+                            // No FE thread here (wake-word turn) → the turn generates its own id.
+                            spawn_assistant_turn(app.clone(), payload.command.clone(), None);
                         }
                         let _ = app.emit(crate::events::EVENT_WAKE_DETECTED, payload);
                     }
@@ -285,22 +287,42 @@ fn should_dispatch(config: &crate::settings::AppConfig) -> bool {
 /// Max agentic rounds on the cloud brain (decide → tool → … → answer). Bounded for live latency.
 const CLOUD_MAX_STEPS: usize = 4;
 
+/// Resolve the turn's THREAD id: the FE-supplied id when present (an @brain thread), else a fresh
+/// UUID v4 (the voice/wake path and the single-shot text composer send none), so EVERY persisted
+/// assistant exchange carries a thread identity going forward. Blank ids count as absent — an
+/// empty thread id must never be persisted. The id is OPAQUE — no PII (safe to log/emit).
+pub(crate) fn ensure_thread_id(explicit: Option<String>) -> String {
+    match explicit {
+        Some(t) if !t.trim().is_empty() => t,
+        _ => uuid::Uuid::new_v4().to_string(),
+    }
+}
+
 /// Spawn ONE assistant turn on a DETACHED OS thread — the SINGLE entry to the in-meeting brain for the
 /// wake path, the manual button, AND the text composer (all three funnel here with a `command` string).
 /// The brain + tools can take seconds, so it MUST run off-thread; the whole body is best-effort +
 /// panic-free and runs on its own thread, so even an unexpected panic is contained and can never
 /// disrupt recording or the caption.
-pub fn spawn_assistant_turn(app: AppHandle, command: String) {
+pub fn spawn_assistant_turn(app: AppHandle, command: String, thread_id: Option<String>) {
     let _ = std::thread::Builder::new()
         .name("murmur-assistant-turn".into())
-        .spawn(move || run_assistant_turn(&app, command));
+        .spawn(move || run_assistant_turn(&app, command, thread_id));
 }
 
 /// The CARD path (wake / manual button / single-shot text composer): run the shared query core, then
 /// EMIT `EVENT_VOICE_ACTION_RESULT` so the assistant card resolves the pending row. The per-tool trace
-/// streams via `EVENT_ASSISTANT_TOOL`.
-fn run_assistant_turn(app: &AppHandle, command: String) {
-    let result = run_assistant_query(app, &command, &command, crate::events::EVENT_ASSISTANT_TOOL);
+/// streams via `EVENT_ASSISTANT_TOOL`. A missing `thread_id` (voice/wake) is backend-generated here,
+/// so the persisted row + every emitted payload of this turn carry the SAME thread identity.
+fn run_assistant_turn(app: &AppHandle, command: String, thread_id: Option<String>) {
+    let thread_id = ensure_thread_id(thread_id);
+    let result = run_assistant_query(
+        app,
+        &command,
+        &command,
+        crate::events::EVENT_ASSISTANT_TOOL,
+        &thread_id,
+        None,
+    );
     let _ = app.emit(crate::events::EVENT_VOICE_ACTION_RESULT, result);
 }
 
@@ -318,21 +340,36 @@ fn run_assistant_turn(app: &AppHandle, command: String) {
 ///    floor no longer owns write routing; it is the informational safety net (ZERO read regression).
 /// 4. PERSIST the interaction (gated, purged-on-seal) + RETURN the result; the per-tool trace streams
 ///    to `tool_event` (card vs chat). The CALLER delivers the result (emit for the card, return for chat).
+///
+/// `thread_id` is the RESOLVED thread identity of this turn (callers run [`ensure_thread_id`] first)
+/// — it is threaded onto every trace payload, the returned result, and the persisted row, so
+/// simultaneous threads never cross-attribute. `anchor_text` is the note text an @brain thread was
+/// anchored to (persisted with the row; `None` for voice/unanchored turns).
 pub fn run_assistant_query(
     app: &AppHandle,
     command: &str,
     loop_user: &str,
     tool_event: &'static str,
+    thread_id: &str,
+    anchor_text: Option<&str>,
 ) -> crate::voice_action::VoiceActionResult {
     let state = app.state::<AppState>();
     let config = match state.config.lock() {
         Ok(c) => c.clone(),
-        Err(_) => return crate::voice_action::VoiceActionResult::nothing_heard().with_command(command),
+        Err(_) => {
+            return crate::voice_action::VoiceActionResult::nothing_heard()
+                .with_command(command)
+                .with_thread_id(thread_id)
+        }
     };
     // C6: re-snapshot the LIVE unlocked set for THIS turn (never trust a snapshot taken before it).
     let unlocked = match state.unlocked_folders.lock() {
         Ok(u) => u.clone(),
-        Err(_) => return crate::voice_action::VoiceActionResult::nothing_heard().with_command(command),
+        Err(_) => {
+            return crate::voice_action::VoiceActionResult::nothing_heard()
+                .with_command(command)
+                .with_thread_id(thread_id)
+        }
     };
     let meeting_id = state
         .current_meeting
@@ -357,17 +394,21 @@ pub fn run_assistant_query(
         loop_user,
         &intent,
         tool_event,
+        thread_id,
     )
-    .with_command(command);
+    .with_command(command)
+    .with_thread_id(thread_id);
 
-    // PII rule: log only the coarse intent kind + status, never the command/summary text.
+    // PII rule: log only the coarse intent kind + status + the OPAQUE thread id, never the
+    // command/summary/anchor text.
     tracing::info!(
         target: "voice",
         intent = %result.intent_kind,
         status = %result.status,
+        thread_id,
         "assistant query dispatched"
     );
-    persist_interaction(state.inner(), &meeting_id, command, &result);
+    persist_interaction(state.inner(), &meeting_id, command, &result, thread_id, anchor_text);
     result
 }
 
@@ -393,6 +434,7 @@ fn run_informational(
     loop_user: &str,
     intent: &crate::audio::wake::VoiceIntent,
     tool_event: &'static str,
+    thread_id: &str,
 ) -> crate::voice_action::VoiceActionResult {
     // The agentic loop runs only on the CLOUD brain — local-GGUF multi-step tool-call reliability is
     // unproven (Q4 + the Bielik 32K-overflow lesson), so the local + stub backends use the
@@ -421,7 +463,11 @@ fn run_informational(
             // the loop to mark the reply as a NOTE PROPOSAL vs a plain ANSWER. The model decides which.
             proposed_note: std::sync::Mutex::new(None),
         };
-        let sink = ToolEventSink { app: app.clone(), event: tool_event };
+        let sink = ToolEventSink {
+            app: app.clone(),
+            event: tool_event,
+            thread_id: thread_id.to_string(),
+        };
         // Inject the LIVE transcript of the recording IN PROGRESS + the user's OWN typed notes for
         // the CURRENT meeting (segments aren't persisted until Stop, and typed notes carry the
         // user's emphasis). Both are read through `gated_live_context` — gated by
@@ -496,33 +542,44 @@ fn floor_intent_for(
 
 /// The live tool-trace sink: emits a per-tool-call event (`EVENT_ASSISTANT_TOOL` for the card,
 /// `EVENT_CHAT_TOOL` for the chat panel — chosen by `event`) so the FE can render the "Searching
-/// notes… ✓" chips. NO PII — tool NAME + a coarse result-size count only.
+/// notes… ✓" chips. NO PII — tool NAME + a coarse result-size count + the turn's OPAQUE thread id.
 struct ToolEventSink {
     app: AppHandle,
     event: &'static str,
+    /// The turn's thread identity — stamped on every chip so simultaneous threads never
+    /// cross-attribute their traces (the documented v1 gap this closes).
+    thread_id: String,
 }
 impl crate::agent::DeltaSink for ToolEventSink {
     fn tool_running(&self, tool: &str) {
-        let _ = self.app.emit(
-            self.event,
-            crate::events::AssistantToolPayload {
-                tool: tool.to_string(),
-                state: "running".into(),
-                ok: true,
-                count: None,
-            },
-        );
+        let _ = self
+            .app
+            .emit(self.event, tool_trace_payload(&self.thread_id, tool, "running", true, None));
     }
     fn tool_done(&self, tool: &str, ok: bool, result_chars: usize) {
         let _ = self.app.emit(
             self.event,
-            crate::events::AssistantToolPayload {
-                tool: tool.to_string(),
-                state: "done".into(),
-                ok,
-                count: Some(result_chars as u32),
-            },
+            tool_trace_payload(&self.thread_id, tool, "done", ok, Some(result_chars as u32)),
         );
+    }
+}
+
+/// Build one tool-trace payload — pure (no AppHandle), so the payload contract is headless-testable:
+/// tool NAME + state + coarse count + the turn's opaque `thread_id`. NO PII (never the tool args,
+/// results, or any content).
+fn tool_trace_payload(
+    thread_id: &str,
+    tool: &str,
+    state: &str,
+    ok: bool,
+    count: Option<u32>,
+) -> crate::events::AssistantToolPayload {
+    crate::events::AssistantToolPayload {
+        tool: tool.to_string(),
+        state: state.to_string(),
+        ok,
+        count,
+        thread_id: Some(thread_id.to_string()),
     }
 }
 
@@ -537,6 +594,8 @@ fn persist_interaction(
     meeting_id: &str,
     command: &str,
     result: &crate::voice_action::VoiceActionResult,
+    thread_id: &str,
+    anchor_text: Option<&str>,
 ) {
     if meeting_id.is_empty() {
         return; // no active recording → nothing to attach the interaction to.
@@ -549,6 +608,8 @@ fn persist_interaction(
         &result.citations,
         &result.status,
         Some(result.intent_kind.as_str()),
+        Some(thread_id),
+        anchor_text,
         &created_at,
     ) {
         Ok(_) => {}
@@ -1044,6 +1105,47 @@ fn assistant_system_prompt(live_transcript: &str, typed_notes: &str) -> String {
 mod tests {
     use super::*;
     use crate::audio::wake::VoiceIntent;
+
+    // ── PR D thread identity: backend UUID fallback + thread-stamped trace payloads ───────────────
+
+    /// The voice/wake path (and a thread-less text turn) has no FE-supplied thread id → the backend
+    /// GENERATES a UUID v4, so every persisted exchange carries a thread identity going forward; an
+    /// explicit @brain thread id passes through untouched, and a blank one counts as absent (an
+    /// empty thread id is never persisted). RED before PR D: `ensure_thread_id` did not exist —
+    /// voice rows persisted with no thread identity at all.
+    #[test]
+    fn ensure_thread_id_generates_uuid_when_absent() {
+        let generated = ensure_thread_id(None);
+        assert!(
+            uuid::Uuid::parse_str(&generated).is_ok(),
+            "a missing thread id must become a real UUID"
+        );
+        assert_eq!(ensure_thread_id(Some("t-7".into())), "t-7", "explicit id passes through");
+        assert!(
+            uuid::Uuid::parse_str(&ensure_thread_id(Some("   ".into()))).is_ok(),
+            "a blank id counts as absent and is regenerated"
+        );
+    }
+
+    /// Every tool-trace chip payload carries the turn's thread id (camelCase `threadId` over IPC),
+    /// so simultaneous threads attribute their chips without cross-bleed — the documented v1 gap.
+    /// The payload stays non-PII: tool NAME + state + coarse count + an opaque UUID only. RED
+    /// before PR D: `AssistantToolPayload` had no thread field (chips were unattributable).
+    #[test]
+    fn tool_trace_payload_carries_thread_id() {
+        let running = tool_trace_payload("t-9", "search_meetings", "running", true, None);
+        assert_eq!(running.thread_id.as_deref(), Some("t-9"));
+        assert_eq!(running.state, "running");
+        assert!(running.count.is_none());
+
+        let done = tool_trace_payload("t-9", "search_meetings", "done", true, Some(3));
+        assert_eq!(done.thread_id.as_deref(), Some("t-9"));
+        assert_eq!(done.count, Some(3));
+        // The FE reads camelCase — the serialized event must expose `threadId`.
+        let json = serde_json::to_value(&done).unwrap();
+        assert_eq!(json.get("threadId").and_then(|v| v.as_str()), Some("t-9"));
+        assert_eq!(json.get("tool").and_then(|v| v.as_str()), Some("search_meetings"));
+    }
 
     #[test]
     fn wake_event_for_builds_payload_with_parsed_intent_on_hit() {

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -65,6 +65,11 @@ pub struct VoiceActionResult {
     /// `Some(content)` ⇒ a NOTE PROPOSAL the FE shows "Add to notes" on. No DB write happens server-side
     /// — the FE commits the accepted draft via `save_manual_notes`. Serializes to `proposedNote`.
     pub proposed_note: Option<String>,
+    /// Opaque id of the conversation THREAD this result belongs to (the FE-supplied @brain thread
+    /// id, or the backend-generated UUID for a voice/wake turn), so simultaneous threads resolve
+    /// the right pending bubble. Serializes to `threadId`; the dispatch threads it on via
+    /// [`Self::with_thread_id`]. NOT PII (an opaque UUID).
+    pub thread_id: Option<String>,
 }
 
 impl VoiceActionResult {
@@ -76,6 +81,7 @@ impl VoiceActionResult {
             command: String::new(),
             citations: Vec::new(),
             proposed_note: None,
+            thread_id: None,
         }
     }
 
@@ -83,6 +89,13 @@ impl VoiceActionResult {
     /// surface what the user actually said without re-plumbing each constructor.
     pub fn with_command(mut self, command: &str) -> Self {
         self.command = command.to_string();
+        self
+    }
+
+    /// Thread the turn's THREAD id onto a result (builder-style) — the FE uses it to attribute the
+    /// answer (and its trace chips) to the right open thread.
+    pub fn with_thread_id(mut self, thread_id: &str) -> Self {
+        self.thread_id = Some(thread_id.to_string());
         self
     }
 
@@ -116,6 +129,7 @@ impl VoiceActionResult {
             // The caller (`run_informational`) threads any `propose_note` draft on via
             // `with_proposed_note` after reading the executor; the loop outcome itself has none.
             proposed_note: None,
+            thread_id: None,
         }
     }
 
@@ -526,6 +540,7 @@ fn rag_answer(
                 command: String::new(),
                 citations,
                 proposed_note: None,
+                thread_id: None,
             }
         }
         Err(AppError::Unavailable(_)) => VoiceActionResult {
@@ -538,6 +553,7 @@ fn rag_answer(
             command: String::new(),
             citations,
             proposed_note: None,
+            thread_id: None,
         },
         Err(e) => VoiceActionResult {
             intent_kind: intent_kind.to_string(),
@@ -546,6 +562,7 @@ fn rag_answer(
             command: String::new(),
             citations,
             proposed_note: None,
+            thread_id: None,
         },
     }
 }
@@ -1295,6 +1312,24 @@ mod tests {
         assert_eq!(json.get("proposedNote").and_then(|v| v.as_str()), Some("note body"));
         let null_json = serde_json::to_value(VoiceActionResult::new("research", "ok", "x")).unwrap();
         assert!(null_json.get("proposedNote").unwrap().is_null(), "no proposal ⇒ proposedNote is null");
+    }
+
+    /// PR D: `thread_id` round-trips through `VoiceActionResult` — default None, threaded on via
+    /// `with_thread_id`, serialized to the camelCase `threadId` the FE uses to resolve the right
+    /// open thread's pending bubble.
+    #[test]
+    fn voice_action_result_round_trips_thread_id() {
+        let plain = VoiceActionResult::new("research", "ok", "an answer");
+        assert_eq!(plain.thread_id, None, "a result defaults to no thread identity");
+
+        let threaded = plain.with_thread_id("t-123");
+        assert_eq!(threaded.thread_id.as_deref(), Some("t-123"));
+        let json = serde_json::to_value(&threaded).unwrap();
+        assert_eq!(json.get("threadId").and_then(|v| v.as_str()), Some("t-123"));
+
+        let null_json =
+            serde_json::to_value(VoiceActionResult::new("research", "ok", "x")).unwrap();
+        assert!(null_json.get("threadId").unwrap().is_null(), "no thread ⇒ threadId is null");
     }
 
     #[test]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -15,6 +15,7 @@ import type {
   ReindexResult,
   InputDeviceInfo,
   AskVaultResult,
+  AssistantThreadRow,
   BrainOverview,
   BriefResult,
   BuiltinRecipe,
@@ -667,9 +668,12 @@ export class IpcService {
    * trace streams via {@link onAssistantTool}, and the answer arrives via
    * {@link onVoiceActionResult}. Resolves once the turn is dispatched (not when
    * the answer is ready). Rejects (InvalidArg) on an empty question.
+   *
+   * Pass `threadId` to persist the exchange under that thread (the result +
+   * tool-trace events come back stamped with it); omit it for an anchorless ask.
    */
-  askAssistantText(text: string): Promise<void> {
-    return invoke<void>("ask_assistant_text", { text });
+  askAssistantText(text: string, threadId?: string): Promise<void> {
+    return invoke<void>("ask_assistant_text", { text, threadId });
   }
 
   /**
@@ -678,9 +682,37 @@ export class IpcService {
    * the brain has multi-turn memory, and RESOLVES with the reply (summary +
    * citations + status) so the panel can resolve the in-flight assistant bubble.
    * The live tool-trace streams via {@link onChatTool}.
+   *
+   * Pass `threadId` (the FE-generated thread key) + `anchorText` (the note line
+   * the thread hangs under) so the exchange persists under THIS thread and
+   * rehydrates attached to its anchor via {@link listAssistantThreads}. Both
+   * optional — but an omitted `threadId` is NOT ephemeral: the backend generates
+   * a UUID itself and the exchange STILL persists (it then rehydrates as a
+   * standalone anchorless thread). Always pass the thread's own id so its
+   * exchanges stay grouped.
    */
-  askAssistantChat(messages: ChatMsg[]): Promise<VoiceActionResultPayload> {
-    return invoke<VoiceActionResultPayload>("ask_assistant_chat", { messages });
+  askAssistantChat(
+    messages: ChatMsg[],
+    threadId?: string,
+    anchorText?: string,
+  ): Promise<VoiceActionResultPayload> {
+    return invoke<VoiceActionResultPayload>("ask_assistant_chat", {
+      messages,
+      threadId,
+      anchorText,
+    });
+  }
+
+  /**
+   * A meeting's PERSISTED `@brain` thread exchanges, oldest → newest, ONLY rows
+   * that carry a threadId. GATED server-side: a sealed-and-not-session-unlocked
+   * meeting returns an EMPTY array (masked — never a question/answer behind the
+   * lock). The record screen groups rows by `threadId` to rebuild its threads.
+   */
+  listAssistantThreads(meetingId: string): Promise<AssistantThreadRow[]> {
+    return invoke<AssistantThreadRow[]>("list_assistant_threads", {
+      meetingId,
+    });
   }
 
   // ── brain2 realtime typed @brain notes (record screen "My notes") ──────

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -2,6 +2,7 @@ import { Injectable, computed, inject, signal } from "@angular/core";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "./ipc.service";
 import type {
+  AssistantThreadRow,
   AssistantToolPayload,
   ChatMsg,
   VoiceActionResultPayload,
@@ -109,6 +110,12 @@ export interface ThreadTurn {
  *                      `manual_notes` buffer. A thread-anchor question is NOT a
  *                      note until the user accepts an agent reply into the notes,
  *                      so it stays `false` (it doesn't pollute the saved buffer).
+ *   - `threadId`     — the PERSISTENT key of this line's thread (an FE-generated
+ *                      UUID, minted when the thread opens and shipped with every
+ *                      `ask_assistant_chat` call so the backend persists the
+ *                      exchanges). Null for a plain note line, and for a voice
+ *                      thread until the result payload stamps one. Also routes
+ *                      threadId-carrying tool/result events to the RIGHT thread.
  */
 export interface NoteItem {
   /** Stable id for `@for` tracking (never key on $index). */
@@ -118,6 +125,7 @@ export interface NoteItem {
   threadOpen: boolean;
   threadPending: boolean;
   persisted: boolean;
+  threadId: string | null;
 }
 
 /**
@@ -145,6 +153,28 @@ export function parseCitations(raw: string[]): AssistantCitation[] {
     const label = s.replace(/^\[\[/, "").replace(/\]\]$/, "");
     return { kind: "vault", label };
   });
+}
+
+/** The terminal statuses a persisted thread row may carry (mirrors VoiceActionStatus). */
+const VOICE_ACTION_STATUSES: ReadonlySet<string> = new Set([
+  "ok",
+  "needs_consent",
+  "unavailable",
+  "unrecognized",
+  "nothing_heard",
+  "error",
+]);
+
+/**
+ * Narrow a persisted thread row's `status` string (serialized loosely as
+ * `string`) back to a {@link VoiceActionStatus}. An unknown value (a future
+ * backend adding a status) degrades to "ok" — the turn still renders as a
+ * plain resolved answer rather than breaking the thread.
+ */
+function coerceStatus(s: string): VoiceActionStatus {
+  return (
+    VOICE_ACTION_STATUSES.has(s) ? s : "ok"
+  ) as VoiceActionStatus;
 }
 
 /**
@@ -342,7 +372,20 @@ export class MeetingConversationStore {
     this._notes.set([]);
     this.voiceTargetNoteId = null;
     this._loaded.set(false);
-    void this.loadNotes(id, token);
+    void this.hydrate(id, token);
+  }
+
+  /**
+   * Hydrate a genuinely-new meeting: the notes buffer FIRST (it seeds the note
+   * lines + re-enables the composer — timing unchanged), THEN the persisted
+   * `@brain` threads, which attach to the seeded lines by anchor text. Same-id
+   * re-entry never reaches here (RAM wins — see {@link setMeetingId}), so an
+   * in-progress conversation is never clobbered by its own persisted copy.
+   */
+  private async hydrate(id: string, token: number): Promise<void> {
+    await this.loadNotes(id, token);
+    if (token !== this.notesLoadToken) return;
+    await this.loadThreads(id, token);
   }
 
   /**
@@ -369,6 +412,7 @@ export class MeetingConversationStore {
             threadOpen: false,
             threadPending: false,
             persisted: true,
+            threadId: null,
           })),
         );
       }
@@ -382,6 +426,107 @@ export class MeetingConversationStore {
         this._loaded.set(true);
       }
     }
+  }
+
+  /**
+   * Rebuild the persisted `@brain` threads for a reopened meeting: fetch the
+   * meeting's thread rows (oldest → newest; a sealed-not-unlocked meeting
+   * returns [] — gated server-side), group them by `threadId` (insertion
+   * order), turn each row into a resolved user + agent turn pair, then ATTACH
+   * each group to the FIRST note line whose text equals the group's anchor and
+   * which has no thread yet (the ✨-ask-brain / anchored case). A group with no
+   * matching line (anchorless voice thread, an edited/deleted note, or an
+   * anchor another group already claimed) APPENDS as a standalone collapsed
+   * thread line at the end — never lost, never mis-attached.
+   *
+   * Hydrated turns are terminal history: `proposedNote: null` (no Add-to-notes
+   * affordance resurrects — an accepted draft already lives in `manual_notes`),
+   * empty trace, `accepted`/`dismissed` false. Threads stay CONTINUABLE: a
+   * follow-up ships the rebuilt RAM turn list + the SAME `threadId`, so new
+   * exchanges append as new rows backend-side. Stale-guarded like
+   * {@link loadNotes}: a response for a meeting we've since left is dropped.
+   * Failure (old backend without the command / transient) leaves the notes
+   * flow as-is — threads simply don't rehydrate.
+   */
+  private async loadThreads(id: string, token: number): Promise<void> {
+    let rows: AssistantThreadRow[];
+    try {
+      rows = await this.ipc.listAssistantThreads(id);
+    } catch {
+      return;
+    }
+    if (token !== this.notesLoadToken || rows.length === 0) return;
+
+    // Group rows by threadId, preserving first-seen (insertion) order.
+    const groups = new Map<string, AssistantThreadRow[]>();
+    for (const row of rows) {
+      if (!row.threadId) continue; // backend contract: never happens; stay safe
+      const group = groups.get(row.threadId);
+      if (group) group.push(row);
+      else groups.set(row.threadId, [row]);
+    }
+
+    this._notes.update((ns) => {
+      let next = ns.slice();
+      for (const [threadId, group] of groups) {
+        // A thread already in RAM under this id must not hydrate twice (can't
+        // happen off the fresh-id path, but the guard is cheap).
+        if (next.some((n) => n.threadId === threadId)) continue;
+        const thread: ThreadTurn[] = [];
+        for (const row of group) {
+          thread.push({
+            id: this.nextTurnId++,
+            role: "user",
+            text: row.command,
+            status: "ok",
+            trace: [],
+            citations: [],
+            proposedNote: null,
+            accepted: false,
+            dismissed: false,
+          });
+          thread.push({
+            id: this.nextTurnId++,
+            role: "agent",
+            text: row.answer,
+            status: coerceStatus(row.status),
+            trace: [],
+            citations: parseCitations(row.citations),
+            proposedNote: null,
+            accepted: false,
+            dismissed: false,
+          });
+        }
+        const anchorText = group[0].anchorText;
+        const anchorIdx =
+          anchorText === null
+            ? -1
+            : next.findIndex((n) => n.text === anchorText && !n.thread);
+        if (anchorIdx !== -1) {
+          next[anchorIdx] = {
+            ...next[anchorIdx],
+            thread,
+            threadOpen: false,
+            threadPending: false,
+            threadId,
+          };
+        } else {
+          next = [
+            ...next,
+            {
+              id: this.nextNoteId++,
+              text: group[0].command,
+              thread,
+              threadOpen: false,
+              threadPending: false,
+              persisted: false,
+              threadId,
+            },
+          ];
+        }
+      }
+      return next;
+    });
   }
 
   /**
@@ -420,6 +565,7 @@ export class MeetingConversationStore {
         threadOpen: false,
         threadPending: false,
         persisted: true,
+        threadId: null,
       },
     ]);
     this.persistNotes();
@@ -437,6 +583,9 @@ export class MeetingConversationStore {
     const q = question.trim();
     if (!q) return;
     const noteId = this.nextNoteId++;
+    // Mint the PERSISTENT thread key up front — every ask_assistant_chat call
+    // for this thread ships it, so the backend persists the exchanges under it.
+    const threadId = crypto.randomUUID();
     const userTurn: ThreadTurn = {
       id: this.nextTurnId++,
       role: "user",
@@ -468,6 +617,7 @@ export class MeetingConversationStore {
         threadOpen: true,
         threadPending: true,
         persisted: false,
+        threadId,
       },
     ]);
     await this.runAgentTurn(noteId, agentTurn.id);
@@ -490,6 +640,9 @@ export class MeetingConversationStore {
     if (!note || note.thread) return; // only notes WITHOUT a thread yet
     const subject = note.text.trim();
     if (!subject) return;
+    // A retroactive thread is a NEW thread → mint its persistent key. The note's
+    // text is the anchor, so hydration can re-attach the thread to this line.
+    const threadId = crypto.randomUUID();
     const userTurn: ThreadTurn = {
       id: this.nextTurnId++,
       role: "user",
@@ -525,6 +678,7 @@ export class MeetingConversationStore {
               thread: [userTurn, agentTurn],
               threadOpen: true,
               threadPending: true,
+              threadId,
             }
           : n,
       ),
@@ -543,6 +697,10 @@ export class MeetingConversationStore {
     if (!t) return;
     const note = this._notes().find((n) => n.id === noteId);
     if (!note || !note.thread || note.threadPending) return;
+    // A thread that somehow lacks a persistent key (a voice thread whose result
+    // never stamped one / pre-persistence RAM state) gets one NOW, so this and
+    // every later exchange persist under the same thread.
+    const threadId = note.threadId ?? crypto.randomUUID();
     const userTurn: ThreadTurn = {
       id: this.nextTurnId++,
       role: "user",
@@ -573,6 +731,7 @@ export class MeetingConversationStore {
               thread: [...(n.thread ?? []), userTurn, agentTurn],
               threadOpen: true,
               threadPending: true,
+              threadId,
             }
           : n,
       ),
@@ -583,8 +742,11 @@ export class MeetingConversationStore {
   /**
    * Ship a thread's OWN turns (its history) to `ask_assistant_chat` (multi-turn
    * memory scoped to THIS thread) and resolve the given pending agent turn with
-   * the reply. The live tool-trace lands via {@link onTool} (the most recent
-   * pending agent turn). Always clears the thread's `threadPending` flag.
+   * the reply. Ships the note's `threadId` + its anchor text (the note line) so
+   * the backend PERSISTS the exchange under the thread — a reopened meeting
+   * rebuilds it via `list_assistant_threads`. The live tool-trace lands via
+   * {@link onTool} (routed by the payload's threadId when stamped, else the most
+   * recent pending agent turn). Always clears the thread's `threadPending` flag.
    */
   private async runAgentTurn(noteId: number, agentTurnId: number): Promise<void> {
     const note = this._notes().find((n) => n.id === noteId);
@@ -607,7 +769,11 @@ export class MeetingConversationStore {
       }));
 
     try {
-      const reply = await this.ipc.askAssistantChat(payload);
+      const reply = await this.ipc.askAssistantChat(
+        payload,
+        note?.threadId ?? undefined,
+        note?.text.trim() || undefined,
+      );
       this.resolveTurn(noteId, agentTurnId, {
         status: reply.status,
         text: reply.summary || "(no answer)",
@@ -704,6 +870,7 @@ export class MeetingConversationStore {
           threadOpen: false,
           threadPending: false,
           persisted: true,
+          threadId: null,
         },
       ];
     });
@@ -768,6 +935,8 @@ export class MeetingConversationStore {
       dismissed: false,
     };
     this.voiceTargetNoteId = noteId;
+    // A voice thread starts WITHOUT a persistent key (begin_voice_command takes
+    // none) — the result payload's threadId is adopted when the answer lands.
     this._notes.update((ns) => [
       ...ns,
       {
@@ -777,6 +946,7 @@ export class MeetingConversationStore {
         threadOpen: true,
         threadPending: true,
         persisted: false,
+        threadId: null,
       },
     ]);
     try {
@@ -851,70 +1021,122 @@ export class MeetingConversationStore {
         threadOpen: true,
         threadPending: true,
         persisted: false,
+        threadId: null,
       },
     ]);
   }
 
   /**
-   * Attach a LIVE tool-trace chip to the in-flight (last pending) agent turn,
-   * across ALL threads. A "running" event pushes a new chip; a "done" event
-   * resolves the most recent matching running chip (or appends one). No pending
-   * agent turn → ignore. Pure immutable signal updates — no NG0600. Shared by the
-   * voice (EVENT_ASSISTANT_TOOL) + text (EVENT_CHAT_TOOL) tool-trace streams.
-   *
-   * KNOWN LIMITATION (v1, acceptable): the EVENT_CHAT_TOOL payload carries NO
-   * thread id, so when TWO text threads are pending SIMULTANEOUSLY a chip lands on
-   * the most-recently-opened pending agent turn — which may not be the one that
-   * actually made the call. This is non-PII + purely cosmetic (the trace chip is a
-   * coarse "Searching notes…" badge, never content) and is acceptable for v1;
-   * fixing it would need the backend to stamp a thread id on the tool event.
+   * Attach a LIVE tool-trace chip to the in-flight agent turn. When the payload
+   * carries a `threadId` (the backend now stamps the originating thread on both
+   * tool streams) the chip lands ONLY on that thread's pending agent turn — two
+   * simultaneously-pending threads no longer cross-attribute. A stamped id that
+   * matches NO thread is a VOICE/wake turn: the backend generates the UUID
+   * itself, so the FE-side voice thread still has `threadId: null` while the
+   * chips stream (the result hasn't landed yet). That chip ADOPTS: it lands on
+   * the pending voice-target thread (else the newest pending thread whose
+   * threadId is null — only voice threads qualify; text threads always carry an
+   * FE-minted id) and stamps the payload's id onto the note, so later chips +
+   * the result match it directly. Only when no null-threadId pending thread
+   * exists is a stamped chip DROPPED (never mis-filed onto a text thread).
+   * Without a threadId (old backend) the previous fallback applies: the most
+   * recent pending agent turn across the flow. A "running" event pushes a new
+   * chip; a "done" event resolves the most recent matching running chip (or
+   * appends one). No pending agent turn → ignore. Pure immutable signal updates
+   * — no NG0600. Shared by the voice (EVENT_ASSISTANT_TOOL) + text
+   * (EVENT_CHAT_TOOL) tool-trace streams.
    */
   private onTool(p: AssistantToolPayload): void {
+    const payloadThreadId = p.threadId ?? null;
+    const voiceTargetId = this.voiceTargetNoteId;
     this._notes.update((ns) => {
-      // Find the most recent pending agent turn across the flow (newest note first).
-      for (let ni = ns.length - 1; ni >= 0; ni--) {
-        const note = ns[ni];
-        if (!note.thread) continue;
-        for (let ti = note.thread.length - 1; ti >= 0; ti--) {
-          const turn = note.thread[ti];
-          if (turn.role === "agent" && turn.status === "pending") {
-            const trace = turn.trace.slice();
-            if (p.state === "running") {
-              trace.push({
-                id: this.nextTraceId++,
-                tool: p.tool,
-                state: "running",
-                ok: true,
-                count: p.count,
-              });
-            } else {
-              let resolved = false;
-              for (let i = trace.length - 1; i >= 0; i--) {
-                if (trace[i].tool === p.tool && trace[i].state === "running") {
-                  trace[i] = { ...trace[i], state: "done", ok: p.ok, count: p.count };
-                  resolved = true;
-                  break;
-                }
-              }
-              if (!resolved) {
-                trace.push({
-                  id: this.nextTraceId++,
-                  tool: p.tool,
-                  state: "done",
-                  ok: p.ok,
-                  count: p.count,
-                });
+      const hasPending = (n: NoteItem): boolean =>
+        n.thread?.some((t) => t.role === "agent" && t.status === "pending") ??
+        false;
+
+      // Phase 1 — pick the target note (and whether it adopts the payload id).
+      let ni = -1;
+      let adopt = false;
+      if (payloadThreadId !== null) {
+        ni = ns.findIndex(
+          (n) => n.threadId === payloadThreadId && hasPending(n),
+        );
+        if (ni === -1) {
+          // Voice/wake adoption: prefer the voice-target thread, else the
+          // newest pending thread still without a persistent key.
+          ni = ns.findIndex(
+            (n) =>
+              n.id === voiceTargetId && n.threadId === null && hasPending(n),
+          );
+          if (ni === -1) {
+            for (let i = ns.length - 1; i >= 0; i--) {
+              if (ns[i].threadId === null && hasPending(ns[i])) {
+                ni = i;
+                break;
               }
             }
-            const nextThread = note.thread.slice();
-            nextThread[ti] = { ...turn, trace };
-            const next = ns.slice();
-            next[ni] = { ...note, thread: nextThread };
-            return next;
+          }
+          if (ni !== -1) adopt = true;
+        }
+      } else {
+        for (let i = ns.length - 1; i >= 0; i--) {
+          if (hasPending(ns[i])) {
+            ni = i;
+            break;
           }
         }
       }
-      return ns;
+      if (ni === -1) return ns; // nothing eligible — drop, never mis-file
+
+      // Phase 2 — attach the chip to the note's last pending agent turn.
+      const note = ns[ni];
+      const thread = note.thread!;
+      let ti = -1;
+      for (let i = thread.length - 1; i >= 0; i--) {
+        if (thread[i].role === "agent" && thread[i].status === "pending") {
+          ti = i;
+          break;
+        }
+      }
+      if (ti === -1) return ns; // unreachable (hasPending guaranteed a turn)
+      const turn = thread[ti];
+      const trace = turn.trace.slice();
+      if (p.state === "running") {
+        trace.push({
+          id: this.nextTraceId++,
+          tool: p.tool,
+          state: "running",
+          ok: true,
+          count: p.count,
+        });
+      } else {
+        let resolved = false;
+        for (let i = trace.length - 1; i >= 0; i--) {
+          if (trace[i].tool === p.tool && trace[i].state === "running") {
+            trace[i] = { ...trace[i], state: "done", ok: p.ok, count: p.count };
+            resolved = true;
+            break;
+          }
+        }
+        if (!resolved) {
+          trace.push({
+            id: this.nextTraceId++,
+            tool: p.tool,
+            state: "done",
+            ok: p.ok,
+            count: p.count,
+          });
+        }
+      }
+      const nextThread = thread.slice();
+      nextThread[ti] = { ...turn, trace };
+      const next = ns.slice();
+      next[ni] = {
+        ...note,
+        thread: nextThread,
+        threadId: adopt ? payloadThreadId : note.threadId,
+      };
+      return next;
     });
   }
 
@@ -933,19 +1155,45 @@ export class MeetingConversationStore {
    * resolve the VOICE target thread's pending agent turn (summary + citations) +
    * backfill the heard command onto its (possibly empty) user turn / anchor line.
    *
-   * A voice result resolves ONLY the voice-originated thread (`voiceTargetNoteId`).
-   * If that target is gone (null — e.g. cleared by a new recording, or a race),
-   * we APPEND a fresh anchorless thread for the voice Q&A rather than STEALING the
-   * newest pending TEXT thread — clobbering a typed thread's anchor with the heard
-   * command would corrupt an unrelated `@brain` conversation.
+   * When the payload carries a `threadId` that matches a thread with a pending
+   * agent turn, the result routes THERE (a text ask fired with a threadId — e.g.
+   * `ask_assistant_text` — resolves its own thread even with a voice ask also in
+   * flight; a voice thread whose streamed chips already ADOPTED the backend's id
+   * in {@link onTool} matches here too). Otherwise it resolves ONLY the
+   * voice-originated thread (`voiceTargetNoteId`) — a fresh voice thread whose
+   * turn used no tools still has `threadId: null`, lands via that fallback, and
+   * ADOPTS the payload's stamped key — a later follow-up then continues the SAME
+   * persisted thread. If the target is gone
+   * (null — e.g. cleared by a new recording, or a race), we APPEND a fresh
+   * anchorless thread for the voice Q&A rather than STEALING the newest pending
+   * TEXT thread — clobbering a typed thread's anchor with the heard command would
+   * corrupt an unrelated `@brain` conversation.
    */
   private onResult(p: VoiceActionResultPayload): void {
     this._manualAskInFlight.set(false);
     this._listening.set(false);
     this._processing.set(false);
-    const targetId = this.voiceTargetNoteId;
-    this.voiceTargetNoteId = null;
+    const payloadThreadId = p.threadId ?? null;
     const heard = p.command.trim();
+
+    let targetId: number | null = null;
+    if (payloadThreadId !== null) {
+      const match = this._notes().find(
+        (n) =>
+          n.threadId === payloadThreadId &&
+          (n.thread?.some(
+            (t) => t.role === "agent" && t.status === "pending",
+          ) ??
+            false),
+      );
+      if (match) targetId = match.id;
+    }
+    if (targetId === null) {
+      targetId = this.voiceTargetNoteId;
+      this.voiceTargetNoteId = null;
+    } else if (targetId === this.voiceTargetNoteId) {
+      this.voiceTargetNoteId = null;
+    }
 
     if (targetId === null) {
       // No voice thread to resolve → append a fresh, already-resolved thread so
@@ -984,6 +1232,7 @@ export class MeetingConversationStore {
           threadOpen: true,
           threadPending: false,
           persisted: false,
+          threadId: payloadThreadId,
         },
       ]);
       return;
@@ -1022,6 +1271,9 @@ export class MeetingConversationStore {
             ? heard
             : n.text,
           thread,
+          // Adopt the backend-stamped persistent key (a voice thread starts with
+          // null) so a follow-up continues the SAME persisted thread.
+          threadId: n.threadId ?? payloadThreadId,
         };
       }),
     );

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -271,6 +271,13 @@ export interface VoiceActionResultPayload {
    * auto-writes; accept is the only path content enters the notes.
    */
   proposedNote: string | null;
+  /**
+   * The persistent thread this result belongs to, when the backend stamps one
+   * (a turn initiated with a `threadId`, or one the backend generated). Absent /
+   * null on an older backend — the FE then falls back to its voice-target
+   * routing. Lets the FE resolve the RIGHT thread when several are in flight.
+   */
+  threadId?: string | null;
 }
 
 /**
@@ -311,6 +318,13 @@ export interface AssistantToolPayload {
   ok: boolean;
   /** Coarse result-size signal for the "✓ N" badge — never the content. */
   count: number | null;
+  /**
+   * The thread whose agentic turn made this tool call, when the backend stamps
+   * one. Absent / null on an older backend — the FE then falls back to the
+   * most-recently-opened pending turn. Fixes cross-attribution when two
+   * threads are in flight simultaneously.
+   */
+  threadId?: string | null;
 }
 
 /**
@@ -321,6 +335,31 @@ export interface AssistantToolPayload {
 export interface ChatMsg {
   role: "user" | "assistant";
   text: string;
+}
+
+/**
+ * One persisted `@brain` thread EXCHANGE (`list_assistant_threads`): the user's
+ * `command` + the brain's `answer` for one turn of a thread, keyed by the
+ * FE-generated `threadId`. Rows arrive oldest → newest and ONLY for turns that
+ * carry a threadId; a sealed-and-not-session-unlocked meeting returns an EMPTY
+ * array (gated server-side — never a question or answer behind the lock). The
+ * record screen groups rows by `threadId` to rebuild the Slack-style threads
+ * when a meeting is reopened.
+ */
+export interface AssistantThreadRow {
+  threadId: string;
+  /** The note line the thread hangs under (null for an anchorless/voice thread). */
+  anchorText: string | null;
+  /** The user's question for this exchange. */
+  command: string;
+  /** The brain's reply markdown. */
+  answer: string;
+  /** Flat citation strings (same shape as `VoiceActionResultPayload.citations`). */
+  citations: string[];
+  /** The turn's terminal status (a `VoiceActionStatus` string). */
+  status: string;
+  /** ISO-8601 creation timestamp (ordering is already oldest → newest). */
+  createdAt: string;
 }
 
 /** A selectable microphone input device (from `list_input_devices`). */


### PR DESCRIPTION
Roadmap item 2 of the brain analysis (docs/research/2026-07-02-brain-full-analysis.md) — the episodic-memory substrate. Threads were FE-RAM-only (evaporated on switch/restart) and tool events had no thread scope (chip cross-attribution).

**Backend.** Additive `thread_id`/`anchor_text` on `assistant_interactions` (rows already purge-on-seal in the seal tx + CASCADE + startup reconcile); every exchange persists with a thread id (FE UUID or backend-generated for voice); new gated `list_assistant_threads` (sealed ⇒ EMPTY — no existence leak; poisoned lock ⇒ fail-closed); `threadId` on `AssistantToolPayload` + `VoiceActionResult` (opaque ids only; `anchor_text` never rides an event/log/MCP).

**Frontend.** Hydration on return to a meeting (anchor-attach by note-line text, else standalone; same-id re-entry keeps RAM — #108 semantics; stale-token guarded), continuable hydrated threads, strict chip routing by `threadId` with first-chip **adoption** by the pending voice-target thread and hard-drop-not-misfile otherwise.

**Verification.** RED-first both halves; `cargo test --lib` **627/0**; `ng lint`+`ng build` green. **adversarial-verifier: PASS** after one round-trip — its round-1 verdict was FAIL on a real find: the strict routing dropped 100% of voice-turn chips (backend stamps UUIDs; voice threads start null-id). Fixed via first-chip adoption; verifier re-proved RED on the pre-fix store and passed 25/25 on its independent harness (incl. text-threads-never-adopt). **lock-security-reviewer: PASS** (purge WHERE-clause escape hunt clean; no existence leak; no new egress class — anchorText persists locally only).

**Noted follow-ups (non-blocking):** pre-existing sub-second race — an in-flight turn persists under `current_meeting` at run-time, not dispatch-time (minimal fix: FE passes meeting id, drop on mismatch); thread exchanges also appear in the detail `assistantInteractions` list (cosmetic double-listing); backend accepts any non-blank string as thread id (FE only mints UUIDs — consider shape validation).

**Not verifiable headless:** live Tauri `invoke` round-trip + a real spoken voice turn with streaming chips (wire shapes test-pinned in Rust; camelCase convention proven against existing pairs).