### PR TITLE
feat(brain): proactive brain — zero-egress recall cards while recording

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,6 +172,11 @@ pub struct AppConfigDto {
     /// Model id to send to the gateway (e.g. `"gpt-4o"`). Settable from the DTO. Default `""`.
     #[serde(default)]
     pub gateway_model: String,
+    /// Proactive brain P1 — the recall-card mute toggle (`crate::proactive`). Settable from the
+    /// DTO (the Settings UI owns it). Defaults ON when omitted (`default_true`), matching
+    /// `AppConfig::default` — an older FE payload must not silently flip the backend mute.
+    #[serde(default = "default_true")]
+    pub proactive_hints_enabled: bool,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
@@ -2434,6 +2439,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         claude_code_inherit_env: c.claude_code_inherit_env,
         gateway_base_url: c.gateway_base_url.clone(),
         gateway_model: c.gateway_model.clone(),
+        proactive_hints_enabled: c.proactive_hints_enabled,
     }
 }
 
@@ -2531,6 +2537,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // deserializes to `""` (`#[serde(default)]`), which is a valid "unset" state.
         gateway_base_url: d.gateway_base_url,
         gateway_model: d.gateway_model,
+        // Proactive brain P1: the recall-card mute IS settable from the DTO (Settings owns the
+        // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default —
+        // the backend mute is an explicit user choice, never a partial-save side effect.
+        proactive_hints_enabled: d.proactive_hints_enabled,
     }
 }
 
@@ -6726,6 +6736,29 @@ mod lifecycle_tests {
         assert!(dto.lock_require_biometric, "Stage-E flags default ON");
         assert!(dto.relock_on_screenshare, "Stage-E flags default ON");
         assert!(!dto.cloud_egress_consented, "consent defaults OFF (fail-closed)");
+        assert!(
+            dto.proactive_hints_enabled,
+            "omitted proactiveHintsEnabled defaults ON (matches AppConfig::default)"
+        );
+    }
+
+    /// Proactive brain P1 — the mute toggle round-trips through the settings DTO: `config_to_dto`
+    /// carries it OUT (the FE reads `proactiveHintsEnabled`) and `dto_to_config` takes it IN (the
+    /// FE sets it), so Settings can actually mute the backend scanner.
+    #[test]
+    fn dto_round_trips_proactive_hints_toggle() {
+        // OUT: the DTO reflects the live value.
+        let cfg = AppConfig { proactive_hints_enabled: false, ..Default::default() };
+        assert!(!config_to_dto(&cfg).proactive_hints_enabled);
+
+        // IN: the DTO value lands in the merged config (proven from a differing `current`).
+        let mut dto = config_to_dto(&AppConfig::default());
+        dto.proactive_hints_enabled = false;
+        let current = AppConfig::default(); // ON
+        assert!(
+            !dto_to_config(dto, &current).proactive_hints_enabled,
+            "a settings save must be able to mute the backend scanner"
+        );
     }
 
     /// BLK-4: `save_config`'s merge (`dto_to_config`) NEVER lets the DTO set cloud-egress consent —

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -96,6 +96,32 @@ pub struct AssistantToolPayload {
     pub thread_id: Option<String>,
 }
 
+/// Emitted when the PROACTIVE brain (P1, zero-egress) surfaces one recall card during a
+/// recording: "you discussed this before → [[meeting]]" / "open commitment: …" / a current fact.
+/// Deterministic LOCAL matching only (spec D1) — no LLM, no provider, no egress, no consent
+/// needed. Throttled at the SOURCE (spec D2: ≥120 s cooldown, session dedup, and the
+/// `proactive_hints_enabled` backend mute), so the FE never has to rate-limit it.
+pub const EVENT_PROACTIVE_HINT: &str = "murmur://proactive-hint";
+
+/// Payload for [`EVENT_PROACTIVE_HINT`]. IDs + a SHORT title from an already-VISIBLE row only —
+/// never sealed content, never content bodies. `kind` is `"past_meeting"` | `"open_commitment"`
+/// | `"fact"`; `target_id` is the dedup/click-through id (the meeting id for past-meeting and
+/// commitment cards, the fact id for fact cards); `meeting_id` is the source meeting to open.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProactiveHintPayload {
+    /// "past_meeting" | "open_commitment" | "fact".
+    pub kind: String,
+    /// Short display title (meeting title / commitment line / fact triple) from a VISIBLE row.
+    pub title: String,
+    /// The dedup/click-through id for this card.
+    pub target_id: String,
+    /// The source meeting to open, when known.
+    pub meeting_id: Option<String>,
+    /// The matcher's relevance score (already ≥ the emission threshold).
+    pub score: f32,
+}
+
 /// Progress for the on-device brain (reasoning GGUF) download. Carries byte counts only — NO PII.
 pub const EVENT_BRAIN_DOWNLOAD: &str = "murmur://brain-download";
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod facts;
 pub mod mcp;
 pub mod orchestrate;
 pub mod pipeline;
+pub mod proactive;
 pub mod reason;
 pub mod screenshare;
 pub mod secrets;

--- a/src-tauri/src/proactive.rs
+++ b/src-tauri/src/proactive.rs
@@ -1,0 +1,1100 @@
+//! Proactive brain P1 — ZERO-EGRESS recall surfacing during a recording.
+//!
+//! While a recording is live, the deterministic matcher here periodically scans the NEW portion
+//! of the live-caption tail against the local substrates (entities, open commitments, current
+//! facts, FTS over past meetings) and surfaces AT MOST one dismissible recall card
+//! ("you discussed this on Jun 12 → [[meeting]]", "open commitment: Anna — pricing doc") via
+//! [`crate::events::EVENT_PROACTIVE_HINT`].
+//!
+//! Design contract (spec `docs/superpowers/specs/2026-07-02-proactive-brain-design.md`):
+//! - **D1 — deterministic, zero egress.** NO LLM call, NO provider, NO consent gate anywhere in
+//!   this path: candidate generation and ranking are pure local reads. Nothing leaves the process.
+//! - **D2 — the throttle IS the contract.** At most one card per [`COOLDOWN_TICKS`] (≥120 s),
+//!   session-level dedup by `(kind, target_id)`, a minimum relevance score
+//!   ([`SCORE_THRESHOLD`]), and a backend-side mute (`proactive_hints_enabled` OFF ⇒ the matcher
+//!   never runs — not just UI hiding). All state is per-recording.
+//! - **D3 — every surfaced item is visibility-gated at the source.** All DB reads go through the
+//!   EXISTING gated helpers (`list_entities_visible`, `search_visible`, `list_open_commitments`,
+//!   `list_facts_visible`, `entity_mentions_visible`) — a sealed-and-not-session-unlocked meeting
+//!   contributes NOTHING. The unlocked set is re-read fresh per scan (same discipline as
+//!   `GatedToolExecutor`).
+//! - **D4 — piggyback the live loop.** [`scan_tick`] runs inside `transcribe::live::run()` every
+//!   tick; a scan only happens every [`SCAN_EVERY_TICKS`] ticks over the tail DELTA since the
+//!   last scan. The payload carries IDs + a SHORT title from an already-visible row — never
+//!   content bodies.
+//!
+//! The matcher core ([`gather_candidates`] + [`ProactiveState::step`]) is pure over injected
+//! inputs (a `Db`, the unlocked set, the buffer, an injected `now`), so the whole contract is
+//! headless-testable without the audio loop.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+
+use crate::events::ProactiveHintPayload;
+use crate::storage::{Commitment, Db, GraphNode, Meeting};
+
+// ── Throttle constants (D2) ────────────────────────────────────────────────────────────────────
+
+/// Scan every K live ticks. The live loop ticks every ~3 s (`transcribe::live::TICK`), so 10
+/// ticks ≈ 30 s — the spec D4 default cadence. Ticks are the deterministic clock here (no
+/// wall-clock reads inside the matcher), which keeps the throttle headless-testable.
+pub const SCAN_EVERY_TICKS: u32 = 10;
+
+/// Minimum ticks between two EMISSIONS: 40 × 3 s = 120 s — the spec D2 hard cooldown. While the
+/// cooldown is live the scan is skipped entirely (the delta simply accrues for the next scan).
+pub const COOLDOWN_TICKS: u32 = 40;
+
+/// Minimum relevance for ANY emission (D2: noise is the #1 product risk — conservative). On the
+/// weight scale below: an entity-exact match always clears it while fresh; a term-only FTS match
+/// clears it only at rank 0 on a recent meeting; everything weaker is dropped.
+pub const SCORE_THRESHOLD: f32 = 0.4;
+
+// ── Matcher constants ──────────────────────────────────────────────────────────────────────────
+
+/// Max chars of freshly-accumulated live text one scan looks at (spec §2 perf envelope: an
+/// entity scan over a ≤2 kB delta). When scans were skipped (cooldown / flag off) and more text
+/// accrued, the most RECENT tail wins — recency is what a live hint is for.
+const MAX_DELTA_CHARS: usize = 2_000;
+
+/// Trailing chars remembered from the previous scan position, used to RE-LOCATE the scan point
+/// after the live buffer front-trims at its cap (`MAX_LIVE_TRANSCRIPT_CHARS` in
+/// `transcribe::live`) — once trimmed, plain offset arithmetic silently points at the WRONG text.
+const ANCHOR_CHARS: usize = 120;
+
+/// Top-N rare tokens of the delta run through gated FTS — bounds the scan at ≤5 `search_visible`
+/// queries (spec §2 perf envelope).
+const MAX_TERMS: usize = 5;
+
+/// FTS candidates kept per term (spec §2: `search_visible(t, limit 3)`).
+const FTS_LIMIT: i64 = 3;
+
+/// Max entities matched per scan — bounds the per-entity fact/mention queries. The gated entity
+/// list is ordered by visible mention count DESC, so the cap keeps the most prominent matches.
+const MAX_MATCHED_ENTITIES: usize = 3;
+
+/// Max open-commitment candidates per scan (they are pre-sorted by due date, soonest first).
+const MAX_COMMITMENT_CANDIDATES: usize = 5;
+
+/// Minimum token length (chars) for the rare-term FTS leg — shorter tokens are noise.
+const MIN_TERM_CHARS: usize = 5;
+
+/// Minimum entity-name length eligible for delta matching (mirrors the GraphRAG-lite resolver's
+/// guard in `storage::db`): 1–2 char names are too noisy as spoken-text matches.
+const MIN_ENTITY_CHARS: usize = 3;
+
+/// Max chars of a card title. Titles come from already-visible rows (meeting title / commitment
+/// line / fact triple) — short display strings, never content bodies.
+const TITLE_MAX_CHARS: usize = 120;
+
+// ── Scoring (spec §2: specificity × recency decay × rank) ─────────────────────────────────────
+
+/// An OPEN commitment for a matched entity. No recency decay: an open item stays relevant until
+/// checked off (the gated reader already drops `- [x]` lines), and surfacing a forgotten old one
+/// is exactly the value.
+const W_COMMITMENT: f32 = 1.0;
+
+/// The last VISIBLE meeting that mentioned a matched entity ("you discussed this on …"). Entity
+/// exact > term, decayed by meeting age.
+const W_ENTITY_MEETING: f32 = 0.9;
+
+/// A CURRENT fact (`valid_to IS NULL`) about a matched entity. Flat — a currently-valid fact is
+/// current by definition; slightly under the meeting/commitment legs so it surfaces when it is
+/// the only signal.
+const W_FACT: f32 = 0.8;
+
+/// A rare-term FTS hit (BM25) — the weakest specificity; additionally decayed by meeting age and
+/// divided by (1 + rank), so only a rank-0 hit on a recent meeting clears [`SCORE_THRESHOLD`].
+const W_TERM: f32 = 0.5;
+
+/// Recency half-life in days for the decaying legs. 90 days keeps a last-quarter discussion
+/// surfaceable while pushing year-old term noise under the threshold. Tuning this (and the
+/// threshold) is the planned dogfooding pass — see the spec's honesty bar.
+const RECENCY_HALF_LIFE_DAYS: f32 = 90.0;
+
+/// Decay floor, so an ancient-but-exact signal is dampened, not annihilated (it still needs the
+/// kind weight to clear the threshold).
+const RECENCY_FLOOR: f32 = 0.2;
+
+/// What a card points at. Serialized as the payload's `kind` string — the FE switch key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HintKind {
+    /// A past VISIBLE meeting relevant to what is being said ("you discussed this on …").
+    PastMeeting,
+    /// An OPEN `- [ ]` action item from a visible meeting, owned by / mentioning a matched entity.
+    OpenCommitment,
+    /// A currently-valid (`valid_to IS NULL`) fact about a matched entity.
+    Fact,
+}
+
+impl HintKind {
+    /// Stable lowercase token carried in [`ProactiveHintPayload::kind`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HintKind::PastMeeting => "past_meeting",
+            HintKind::OpenCommitment => "open_commitment",
+            HintKind::Fact => "fact",
+        }
+    }
+}
+
+/// One scored candidate produced by [`gather_candidates`]. `target_id` is the session-dedup key
+/// (meeting id for past-meeting + commitment cards, fact id for fact cards); `title` is a short
+/// display string taken from an already-VISIBLE row.
+#[derive(Debug, Clone)]
+pub struct HintCandidate {
+    pub kind: HintKind,
+    pub title: String,
+    pub target_id: String,
+    pub meeting_id: Option<String>,
+    pub score: f32,
+}
+
+impl HintCandidate {
+    fn into_payload(self) -> ProactiveHintPayload {
+        ProactiveHintPayload {
+            kind: self.kind.as_str().to_string(),
+            title: self.title,
+            target_id: self.target_id,
+            meeting_id: self.meeting_id,
+            score: self.score,
+        }
+    }
+}
+
+// ── The per-recording scanner state (throttle + dedup + delta tracking) ───────────────────────
+
+/// Tracks how far into the live buffer the scanner has already looked, surviving the buffer's
+/// front-trim at its cap. Offsets are in CHARS (the buffer is trimmed on char boundaries).
+#[derive(Default)]
+struct DeltaTracker {
+    /// Chars of the buffer already scanned — valid only while the buffer is append-only.
+    offset: usize,
+    /// The last ≤[`ANCHOR_CHARS`] chars ending at `offset` at the previous scan. When the buffer
+    /// front-trims (offset arithmetic then lies), the scan point is re-located by finding this
+    /// text; when even the anchor was trimmed away, the scan falls back to the bounded recent
+    /// tail — the session dedup + cooldown absorb any re-scan of already-seen text.
+    anchor: String,
+}
+
+impl DeltaTracker {
+    /// The NEW text since the last scan (most recent ≤[`MAX_DELTA_CHARS`] of it), advancing the
+    /// tracker. Never returns stale text as "new" on a plain append; on a front-trim/rewrite it
+    /// degrades to a bounded recent-tail re-scan rather than ever slicing at a lying offset.
+    fn take_delta(&mut self, buf: &str) -> String {
+        let chars: Vec<char> = buf.chars().collect();
+        let total = chars.len();
+        let anchor: Vec<char> = self.anchor.chars().collect();
+        // Fast path: append-only growth — the remembered anchor still sits right before `offset`.
+        let anchored = self.offset <= total
+            && anchor.len() <= self.offset
+            && chars[self.offset - anchor.len()..self.offset] == anchor[..];
+        let start = if anchored {
+            self.offset
+        } else if !anchor.is_empty() {
+            // The buffer front-trimmed at its cap (or was rewritten): re-locate the previous
+            // scan point by its anchor text; if the anchor itself was trimmed away, scan only
+            // the bounded recent tail.
+            match find_last_run(&chars, &anchor) {
+                Some(pos) => pos + anchor.len(),
+                None => total.saturating_sub(MAX_DELTA_CHARS),
+            }
+        } else {
+            0 // first scan of this recording — everything is new.
+        };
+        // Keep the most RECENT window when more than the per-scan budget accrued.
+        let start = start.min(total).max(total.saturating_sub(MAX_DELTA_CHARS));
+        let delta: String = chars[start..].iter().collect();
+        self.offset = total;
+        self.anchor = chars[total.saturating_sub(ANCHOR_CHARS)..].iter().collect();
+        delta
+    }
+}
+
+/// Rightmost index where `needle` occurs in `hay` as a contiguous run of chars.
+fn find_last_run(hay: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > hay.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len()).rev().find(|&i| hay[i..i + needle.len()] == needle[..])
+}
+
+/// Per-recording state of the proactive scanner: the tick/cooldown clock, the session dedup set,
+/// and the delta tracker. Created fresh by the live loop at every recording start, so nothing
+/// (cooldown, dedup, offsets) leaks across recordings.
+#[derive(Default)]
+pub struct ProactiveState {
+    /// Live ticks seen this recording (~3 s each).
+    tick: u32,
+    /// Ticks remaining until the next emission is allowed (0 = free).
+    cooldown: u32,
+    /// `(kind, target_id)` pairs already emitted this recording — never emitted twice (D2).
+    emitted: HashSet<(HintKind, String)>,
+    delta: DeltaTracker,
+}
+
+impl ProactiveState {
+    /// One live-loop tick. Advances the clock every call; on every [`SCAN_EVERY_TICKS`]-th tick —
+    /// when `enabled` and outside the cooldown — extracts the new delta, gathers gated candidates,
+    /// and returns at most one payload to emit. `enabled == false` mutes the matcher at the
+    /// source: no delta is consumed, no DB read happens (D2 backend-side mute).
+    pub fn step(
+        &mut self,
+        enabled: bool,
+        db: &Db,
+        unlocked: &HashSet<String>,
+        current_meeting_id: &str,
+        live_buf: &str,
+        now: DateTime<Utc>,
+    ) -> Option<ProactiveHintPayload> {
+        self.tick = self.tick.wrapping_add(1);
+        if self.cooldown > 0 {
+            self.cooldown -= 1;
+        }
+        if !enabled {
+            return None; // muted: the matcher never runs (the delta accrues untouched).
+        }
+        if self.tick % SCAN_EVERY_TICKS != 0 {
+            return None;
+        }
+        if self.cooldown > 0 {
+            return None; // D2 cooldown: skip the whole scan; the delta accrues for the next one.
+        }
+        let delta = self.delta.take_delta(live_buf);
+        if delta.trim().is_empty() {
+            return None; // nothing new was said — no reads, no event.
+        }
+        let candidates = gather_candidates(db, unlocked, current_meeting_id, &delta, now);
+        self.pick(candidates)
+    }
+
+    /// Threshold + session-dedup + best-of selection (the D2 emission contract): the highest-
+    /// scoring candidate that clears [`SCORE_THRESHOLD`] and was not already emitted this
+    /// recording. On an emission the cooldown re-arms and the `(kind, target_id)` is recorded;
+    /// a rejected candidate is NOT recorded (a stronger later signal for the same target may
+    /// still surface it).
+    fn pick(&mut self, candidates: Vec<HintCandidate>) -> Option<ProactiveHintPayload> {
+        let best = candidates
+            .into_iter()
+            .filter(|c| c.score >= SCORE_THRESHOLD)
+            .filter(|c| !self.emitted.contains(&(c.kind, c.target_id.clone())))
+            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap_or(std::cmp::Ordering::Equal))?;
+        self.emitted.insert((best.kind, best.target_id.clone()));
+        self.cooldown = COOLDOWN_TICKS;
+        Some(best.into_payload())
+    }
+}
+
+/// One live-loop tick of the proactive scanner, wired to the running app: snapshot the LIVE
+/// config flag + unlocked set + current meeting + live buffer (re-read per scan — the same
+/// freshness discipline as `GatedToolExecutor`), then run the deterministic matcher. The caller
+/// (the live loop) emits the returned payload. Best-effort + panic-free: a poisoned config lock
+/// counts as DISABLED and a poisoned unlocked-set lock as EMPTY (fail-closed on both).
+pub fn scan_tick(
+    app: &tauri::AppHandle,
+    state: &mut ProactiveState,
+) -> Option<ProactiveHintPayload> {
+    use tauri::Manager;
+    let app_state = app.state::<crate::state::AppState>();
+    let enabled = app_state
+        .config
+        .lock()
+        .map(|c| c.proactive_hints_enabled)
+        .unwrap_or(false);
+    let unlocked = app_state
+        .unlocked_folders
+        .lock()
+        .map(|u| u.clone())
+        .unwrap_or_default();
+    let meeting_id = app_state
+        .current_meeting
+        .lock()
+        .ok()
+        .and_then(|m| m.map(|id| id.to_string()))
+        .unwrap_or_default();
+    let buf = app_state
+        .live_transcript
+        .lock()
+        .map(|b| b.clone())
+        .unwrap_or_default();
+    state.step(enabled, &app_state.db, &unlocked, &meeting_id, &buf, Utc::now())
+}
+
+// ── Candidate gathering (D3: every read through an EXISTING gated helper) ─────────────────────
+
+/// Gather scored candidates for one delta. ALL reads are through the existing visibility-gated
+/// helpers over the injected `unlocked` set — a sealed-and-not-session-unlocked meeting can
+/// contribute neither a candidate nor a title. The CURRENT meeting is excluded everywhere (a
+/// live hint must point at the PAST). Best-effort per leg: a failed read skips that leg (logged
+/// non-PII), never the scan.
+pub fn gather_candidates(
+    db: &Db,
+    unlocked: &HashSet<String>,
+    current_meeting_id: &str,
+    delta: &str,
+    now: DateTime<Utc>,
+) -> Vec<HintCandidate> {
+    let mut candidates = Vec::new();
+
+    // (a) Entity leg — the GATED entity list (an entity mentioned only in sealed meetings is
+    // already absent from it). Ordered by visible mention count DESC → the cap keeps prominent ones.
+    let entities = db.list_entities_visible(unlocked).unwrap_or_else(|e| {
+        tracing::debug!(target: "proactive", error = %e, "entity list read failed; skipping leg");
+        Vec::new()
+    });
+    let matched = match_entities(delta, &entities);
+
+    if !matched.is_empty() {
+        // Open commitments: ONE gated pass, filtered in-memory to the matched entities (owner
+        // match or a whole-token mention in the item text).
+        match db.list_open_commitments(unlocked, None) {
+            Ok(commitments) => {
+                let mut kept = 0usize;
+                for c in commitments {
+                    if c.meeting_id == current_meeting_id || kept >= MAX_COMMITMENT_CANDIDATES {
+                        continue;
+                    }
+                    let hit = matched.iter().any(|e| {
+                        c.owner.as_deref().is_some_and(|o| fold(o) == fold(&e.name))
+                            || contains_token_run(&fold_tokens(&c.text), &fold_tokens(&e.name))
+                    });
+                    if !hit {
+                        continue;
+                    }
+                    kept += 1;
+                    candidates.push(HintCandidate {
+                        kind: HintKind::OpenCommitment,
+                        title: commitment_title(&c),
+                        target_id: c.meeting_id.clone(),
+                        meeting_id: Some(c.meeting_id),
+                        score: W_COMMITMENT,
+                    });
+                }
+            }
+            Err(e) => {
+                tracing::debug!(target: "proactive", error = %e, "commitments read failed; skipping leg");
+            }
+        }
+
+        for entity in &matched {
+            // Current facts (`valid_to IS NULL`) about the entity — gated + fail-closed on
+            // unattributed rows inside `list_facts_visible`.
+            match db.list_facts_visible(&entity.id, unlocked) {
+                Ok(facts) => {
+                    if let Some(f) = facts
+                        .iter()
+                        .filter(|f| f.valid_to.is_none())
+                        .find(|f| f.meeting_id.as_deref() != Some(current_meeting_id))
+                    {
+                        candidates.push(HintCandidate {
+                            kind: HintKind::Fact,
+                            title: truncate_chars(
+                                &format!("{} {} {}", f.subject, f.predicate, f.object),
+                                TITLE_MAX_CHARS,
+                            ),
+                            target_id: f.id.clone(),
+                            meeting_id: f.meeting_id.clone(),
+                            score: W_FACT,
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(target: "proactive", error = %e, "facts read failed; skipping leg");
+                }
+            }
+            // Last VISIBLE meeting that mentioned the entity (newest first) — "you discussed
+            // this on …".
+            match db.entity_mentions_visible(&entity.id, unlocked) {
+                Ok(mentions) => {
+                    if let Some(m) =
+                        mentions.iter().find(|m| m.meeting_id != current_meeting_id)
+                    {
+                        candidates.push(HintCandidate {
+                            kind: HintKind::PastMeeting,
+                            title: truncate_chars(
+                                if m.title.trim().is_empty() { "(untitled)" } else { &m.title },
+                                TITLE_MAX_CHARS,
+                            ),
+                            target_id: m.meeting_id.clone(),
+                            meeting_id: Some(m.meeting_id.clone()),
+                            score: W_ENTITY_MEETING * recency(&m.started_at, now),
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(target: "proactive", error = %e, "mentions read failed; skipping leg");
+                }
+            }
+        }
+    }
+
+    // (b) Term leg — top-N rare tokens of the delta through gated FTS/BM25.
+    for term in extract_rare_terms(delta, MAX_TERMS) {
+        let hits = match db.search_visible(&term, FTS_LIMIT, unlocked) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!(target: "proactive", error = %e, "term search failed; skipping term");
+                continue;
+            }
+        };
+        for (rank, hit) in hits.iter().enumerate() {
+            if hit.meeting.id == current_meeting_id {
+                continue;
+            }
+            candidates.push(HintCandidate {
+                kind: HintKind::PastMeeting,
+                title: meeting_title(&hit.meeting),
+                target_id: hit.meeting.id.clone(),
+                meeting_id: Some(hit.meeting.id.clone()),
+                score: W_TERM * recency(&hit.meeting.started_at, now) / (1.0 + rank as f32),
+            });
+        }
+    }
+
+    candidates
+}
+
+// ── Pure text matching helpers ─────────────────────────────────────────────────────────────────
+
+/// Entities whose name occurs in the delta as a contiguous, in-order WHOLE-TOKEN run, matched
+/// case- and (Polish-)diacritic-insensitively — "z Gawronskim" does not match, "z Gawroński" does
+/// via its token; "atlasian" never matches "Atlas" (no substring matching). Capped at
+/// [`MAX_MATCHED_ENTITIES`] in the input order (visible mention count DESC).
+fn match_entities<'a>(delta: &str, entities: &'a [GraphNode]) -> Vec<&'a GraphNode> {
+    let delta_tokens = fold_tokens(delta);
+    let mut out = Vec::new();
+    for entity in entities {
+        if entity.name.chars().count() < MIN_ENTITY_CHARS {
+            continue;
+        }
+        let name_tokens = fold_tokens(&entity.name);
+        if name_tokens.is_empty() {
+            continue;
+        }
+        if contains_token_run(&delta_tokens, &name_tokens) {
+            out.push(entity);
+            if out.len() >= MAX_MATCHED_ENTITIES {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Whether `needle` occurs in `hay` as a contiguous in-order run (whole tokens only).
+fn contains_token_run(hay: &[String], needle: &[String]) -> bool {
+    !needle.is_empty()
+        && needle.len() <= hay.len()
+        && hay.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Unicode-lowercase + fold Polish diacritics (the codebase's PL-first normalization — mirrors
+/// `transcribe::live::is_filler_token`). COMPARISON ONLY — displayed text keeps original bytes.
+fn fold(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .map(|c| match c {
+            'ą' => 'a',
+            'ć' => 'c',
+            'ę' => 'e',
+            'ł' => 'l',
+            'ń' => 'n',
+            'ó' => 'o',
+            'ś' => 's',
+            'ź' | 'ż' => 'z',
+            other => other,
+        })
+        .collect()
+}
+
+/// Fold + tokenize on non-alphanumeric boundaries; empty tokens dropped.
+fn fold_tokens(s: &str) -> Vec<String> {
+    fold(s)
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// High-signal rare tokens of the delta for the FTS leg: ≥[`MIN_TERM_CHARS`] chars, not a
+/// stopword, not all-numeric, deduped case/diacritic-insensitively; CAPITALIZED tokens first
+/// (likely proper nouns — spec §2 "prefer capitalized"), then encounter order; first `n` kept.
+/// Original casing is preserved (the FTS tokenizer is diacritics-insensitive anyway).
+fn extract_rare_terms(delta: &str, n: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut capitalized = Vec::new();
+    let mut plain = Vec::new();
+    for raw in delta.split(|c: char| !c.is_alphanumeric()) {
+        if raw.chars().count() < MIN_TERM_CHARS || raw.chars().all(|c| c.is_numeric()) {
+            continue;
+        }
+        let key = fold(raw);
+        if STOPWORDS.contains(&key.as_str()) || !seen.insert(key) {
+            continue;
+        }
+        if raw.chars().next().is_some_and(char::is_uppercase) {
+            capitalized.push(raw.to_string());
+        } else {
+            plain.push(raw.to_string());
+        }
+    }
+    capitalized.into_iter().chain(plain).take(n).collect()
+}
+
+/// Common PL + EN words (≥5 chars, stored in FOLDED form) that carry no recall signal. Small and
+/// conservative on purpose — a missed stopword costs one wasted (still gated, still local) FTS
+/// query, never a leak.
+const STOPWORDS: &[&str] = &[
+    // English
+    "about", "above", "actually", "after", "again", "always", "anything", "because", "before",
+    "being", "below", "between", "could", "different", "doing", "during", "every", "everything",
+    "first", "going", "gonna", "having", "little", "maybe", "might", "nothing", "other", "people",
+    "pretty", "probably", "really", "right", "should", "since", "something", "sometimes", "still",
+    "their", "there", "these", "thing", "things", "think", "those", "through", "today", "under",
+    "until", "where", "which", "while", "would",
+    // Polish (folded: diacritics stripped)
+    "bardzo", "bedzie", "bedziemy", "chyba", "czyli", "dlatego", "dobra", "dobrze", "dzisiaj",
+    "jakas", "jakies", "jakis", "jednak", "jeszcze", "jutro", "kazdy", "kiedy", "ktora", "ktore",
+    "ktorego", "ktorej", "ktory", "mozemy", "mozna", "musimy", "nawet", "potem", "przeciez",
+    "robimy", "rowniez", "sobie", "swoje", "szybko", "takze", "teraz", "troche", "trzeba",
+    "tutaj", "wiadomo", "wlasciwie", "wlasnie", "wszyscy", "wszystko", "wtedy", "zaraz", "zeby",
+];
+
+// ── Scoring helpers ────────────────────────────────────────────────────────────────────────────
+
+/// Exponential recency decay with a floor: `0.5^(age_days / half_life)`, clamped to
+/// [`RECENCY_FLOOR`]. An unparseable timestamp scores the FLOOR (never a boost).
+fn recency(started_at: &str, now: DateTime<Utc>) -> f32 {
+    let Ok(t) = DateTime::parse_from_rfc3339(started_at) else {
+        return RECENCY_FLOOR;
+    };
+    let age_days = (now - t.with_timezone(&Utc)).num_seconds().max(0) as f32 / 86_400.0;
+    0.5f32.powf(age_days / RECENCY_HALF_LIFE_DAYS).max(RECENCY_FLOOR)
+}
+
+/// Short display title for a meeting row (already visible — it came out of a gated reader).
+fn meeting_title(m: &Meeting) -> String {
+    let t = m.title.as_deref().map(str::trim).filter(|t| !t.is_empty()).unwrap_or("(untitled)");
+    truncate_chars(t, TITLE_MAX_CHARS)
+}
+
+/// Short display title for a commitment: `owner: text` when owned, else the item text.
+fn commitment_title(c: &Commitment) -> String {
+    let base = match c.owner.as_deref().map(str::trim).filter(|o| !o.is_empty()) {
+        Some(owner) => format!("{owner}: {}", c.text),
+        None => c.text.clone(),
+    };
+    truncate_chars(&base, TITLE_MAX_CHARS)
+}
+
+/// First `n` chars of `s`, `…`-suffixed when truncated (char-boundary safe).
+fn truncate_chars(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(n).collect();
+        format!("{head}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{EntityKind, Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn tmp_db(tag: &str) -> Db {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-proactive-{tag}-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&p);
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn seed_folder(db: &Db, id: &str, name: &str) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
+    fn seed_note(db: &Db, meeting_id: &str, title: &str, markdown: &str, folder_id: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: meeting_id.to_string(),
+            started_at: "2026-06-26T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some(title.to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: meeting_id.to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: markdown.to_string(),
+            created_at: "2026-06-26T09:05:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder(meeting_id, folder_id).unwrap();
+    }
+
+    fn seed_entity(db: &Db, name: &str, meeting_id: &str) -> String {
+        let id = db.upsert_entity(name, EntityKind::Project).unwrap();
+        db.add_mention(&id, meeting_id).unwrap();
+        id
+    }
+
+    fn seed_fact(db: &Db, entity_id: &str, predicate: &str, object: &str, meeting_id: &str) {
+        db.apply_fact_ops(&[crate::facts::FactOp::Add(crate::facts::NewFact {
+            entity_id: entity_id.to_string(),
+            subject: "Atlas".to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: "2026-06-20T00:00:00Z".to_string(),
+            recorded_at: "2026-06-20T00:00:00Z".to_string(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })])
+        .unwrap();
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-07-02T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn cand(kind: HintKind, target: &str, score: f32) -> HintCandidate {
+        HintCandidate {
+            kind,
+            title: "t".to_string(),
+            target_id: target.to_string(),
+            meeting_id: Some(target.to_string()),
+            score,
+        }
+    }
+
+    // ── D3: a sealed-and-not-session-unlocked meeting NEVER surfaces (the P1 leak test) ────────
+
+    /// RED evidence: swapping the term leg's `search_visible` for the ungated `search` (or
+    /// dropping the gated entity list) makes this fail — the sealed Kraken meeting surfaces.
+    /// GREEN: every leg reads through the existing gated helpers, so the sealed meeting
+    /// contributes nothing; a session unlock makes it eligible again (the gate is the LIVE set,
+    /// not a wipe).
+    #[test]
+    fn sealed_candidate_never_surfaces_and_reappears_on_unlock() {
+        let db = tmp_db("sealed");
+        // Visible meeting about Atlas.
+        seed_note(&db, "m-open", "Atlas sync", "Atlas roadmap review", None);
+        seed_entity(&db, "Atlas", "m-open");
+        // Sealed meeting about Kraken (lock the folder flag directly — the rows survive at rest,
+        // so this proves the READ GATE, independent of purge-on-seal).
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m-sealed", "Kraken sync", "Kraken pricing plan", Some("f-lock"));
+        seed_entity(&db, "Kraken", "m-sealed");
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let delta = "we should sync on Atlas and Kraken pricing this week";
+        let sealed_set = HashSet::new();
+        let candidates = gather_candidates(&db, &sealed_set, "m-cur", delta, now());
+        assert!(!candidates.is_empty(), "the visible Atlas candidate must be found");
+        for c in &candidates {
+            assert_ne!(c.target_id, "m-sealed", "sealed meeting id leaked as a target");
+            assert_ne!(
+                c.meeting_id.as_deref(),
+                Some("m-sealed"),
+                "sealed meeting id leaked as a source"
+            );
+            assert!(
+                !c.title.contains("Kraken"),
+                "sealed content leaked into a title: {}",
+                c.title
+            );
+        }
+
+        // Session unlock → the same scan MAY now surface the Kraken meeting (reversible gate).
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let candidates = gather_candidates(&db, &unlocked, "m-cur", delta, now());
+        assert!(
+            candidates.iter().any(|c| c.meeting_id.as_deref() == Some("m-sealed")),
+            "an unlocked folder's meeting must be eligible again"
+        );
+    }
+
+    // ── D2: cooldown ≥120 s (40 ticks) between emissions ───────────────────────────────────────
+
+    /// RED evidence: removing the cooldown skip in `step` (or zeroing `COOLDOWN_TICKS`) emits the
+    /// second hint at tick 20 and fails the `50` assertion.
+    #[test]
+    fn cooldown_enforces_forty_ticks_between_emissions() {
+        let db = tmp_db("cooldown");
+        seed_note(&db, "m-a", "Anna 1:1", "- [ ] Anna — send the pricing document", None);
+        seed_entity(&db, "Anna", "m-a");
+        seed_note(&db, "m-b", "Robert 1:1", "- [ ] Robert — prepare the budget review", None);
+        seed_entity(&db, "Robert", "m-b");
+
+        let mut st = ProactiveState::default();
+        let unlocked = HashSet::new();
+        let mut buf = String::new();
+        let mut emissions: Vec<(u32, ProactiveHintPayload)> = Vec::new();
+        for tick in 1..=60u32 {
+            if tick == 5 {
+                buf.push_str("Anna wspominała o dokumencie cenowym");
+            }
+            if tick == 15 {
+                buf.push_str(" Robert mówił o przeglądzie budżetu");
+            }
+            if let Some(p) = st.step(true, &db, &unlocked, "m-cur", &buf, now()) {
+                emissions.push((tick, p));
+            }
+        }
+        assert_eq!(emissions.len(), 2, "exactly two hints across 60 ticks");
+        assert_eq!(emissions[0].0, 10, "first hint on the first scan tick");
+        assert_eq!(
+            emissions[1].0, 50,
+            "second hint only after the 40-tick (≥120 s) cooldown — not at the tick-20/30/40 scans"
+        );
+        assert_eq!(emissions[0].1.kind, "open_commitment");
+        assert_eq!(emissions[0].1.target_id, "m-a");
+        assert_eq!(emissions[1].1.target_id, "m-b", "the delta-scoped scan surfaces Robert next");
+    }
+
+    // ── D2: session dedup by (kind, target_id) ─────────────────────────────────────────────────
+
+    /// RED evidence: removing the `emitted.insert` (or the dedup filter) in `pick` re-emits the
+    /// same commitment and fails both assertions.
+    #[test]
+    fn session_dedup_never_reemits_same_kind_and_target() {
+        let mut st = ProactiveState::default();
+        assert!(
+            st.pick(vec![cand(HintKind::OpenCommitment, "m-1", 1.0)]).is_some(),
+            "first emission goes out"
+        );
+        st.cooldown = 0; // force the cooldown out of the way — this test isolates dedup.
+        assert!(
+            st.pick(vec![cand(HintKind::OpenCommitment, "m-1", 1.0)]).is_none(),
+            "the SAME (kind, target_id) must never emit twice in one recording"
+        );
+        // A different KIND for the same target is a different dedup key (a meeting card and a
+        // commitment card about the same meeting are different information).
+        assert!(
+            st.pick(vec![cand(HintKind::PastMeeting, "m-1", 0.9)]).is_some(),
+            "a different kind for the same target is not deduped"
+        );
+    }
+
+    /// Integration flavor: across a long run with the same entity re-mentioned in every scan
+    /// window, no (kind, target_id) pair is ever emitted twice.
+    #[test]
+    fn session_dedup_holds_across_repeated_mentions() {
+        let db = tmp_db("dedup");
+        seed_note(&db, "m-a", "Anna 1:1", "- [ ] Anna — send the pricing document", None);
+        seed_entity(&db, "Anna", "m-a");
+
+        let mut st = ProactiveState::default();
+        let unlocked = HashSet::new();
+        let mut buf = String::new();
+        let mut emitted_keys = Vec::new();
+        for tick in 1..=200u32 {
+            if tick % 9 == 0 {
+                buf.push_str(" znowu rozmawiamy o Anna i dokumencie");
+            }
+            if let Some(p) = st.step(true, &db, &unlocked, "m-cur", &buf, now()) {
+                emitted_keys.push((p.kind.clone(), p.target_id.clone()));
+            }
+        }
+        assert!(!emitted_keys.is_empty(), "the repeated mention emits at least once");
+        let unique: HashSet<_> = emitted_keys.iter().cloned().collect();
+        assert_eq!(
+            unique.len(),
+            emitted_keys.len(),
+            "a (kind, target_id) pair re-emitted within one recording: {emitted_keys:?}"
+        );
+    }
+
+    // ── D2: flag OFF ⇒ the matcher never runs (backend-side mute) ──────────────────────────────
+
+    /// RED evidence: removing the `enabled` early-return in `step` emits at tick 10 and fails the
+    /// first assertion.
+    #[test]
+    fn flag_off_never_scans_and_delta_is_not_consumed() {
+        let db = tmp_db("flag-off");
+        seed_note(&db, "m-a", "Anna 1:1", "- [ ] Anna — send the pricing document", None);
+        seed_entity(&db, "Anna", "m-a");
+
+        let mut st = ProactiveState::default();
+        let unlocked = HashSet::new();
+        let buf = "Anna wspominała o dokumencie cenowym".to_string();
+        for _ in 1..=40u32 {
+            assert!(
+                st.step(false, &db, &unlocked, "m-cur", &buf, now()).is_none(),
+                "flag OFF must never emit"
+            );
+        }
+        assert!(st.emitted.is_empty(), "flag OFF must not record any emission state");
+        // Flipping the flag ON mid-recording: the very next scan tick sees the text accrued while
+        // muted as its delta — proof the muted ticks never consumed it.
+        let mut emitted = None;
+        for _ in 41..=50u32 {
+            if let Some(p) = st.step(true, &db, &unlocked, "m-cur", &buf, now()) {
+                emitted = Some(p);
+            }
+        }
+        assert!(
+            emitted.is_some(),
+            "after unmuting, the accrued (unconsumed) delta must produce the hint"
+        );
+    }
+
+    // ── Empty / unchanged delta ⇒ no reads, no event ───────────────────────────────────────────
+
+    /// RED evidence: scanning the WHOLE buffer instead of the delta makes the post-cooldown scan
+    /// at tick 50 re-match "Anna" and emit her FACT card (a different, non-deduped kind) —
+    /// failing the second assertion. The delta-scoped scan sees nothing new and stays silent.
+    #[test]
+    fn unchanged_buffer_yields_no_second_event() {
+        let db = tmp_db("empty-delta");
+        seed_note(&db, "m-a", "Anna 1:1", "- [ ] Anna — send the pricing document", None);
+        let anna = seed_entity(&db, "Anna", "m-a");
+        seed_fact(&db, &anna, "role", "QA owner", "m-a");
+
+        let mut st = ProactiveState::default();
+        let unlocked = HashSet::new();
+        let buf = "Anna wspominała o dokumencie cenowym".to_string();
+        let mut emissions = Vec::new();
+        for tick in 1..=120u32 {
+            if let Some(p) = st.step(true, &db, &unlocked, "m-cur", &buf, now()) {
+                emissions.push((tick, p));
+            }
+        }
+        assert_eq!(emissions.len(), 1, "an UNCHANGED buffer must never produce a second event");
+        assert_eq!(emissions[0].0, 10);
+    }
+
+    #[test]
+    fn empty_buffer_never_emits() {
+        let db = tmp_db("empty-buf");
+        let mut st = ProactiveState::default();
+        let unlocked = HashSet::new();
+        for _ in 1..=30u32 {
+            assert!(st.step(true, &db, &unlocked, "m-cur", "", now()).is_none());
+        }
+    }
+
+    // ── Spec §3: an entity match surfaces its open commitment ──────────────────────────────────
+
+    #[test]
+    fn entity_match_surfaces_open_commitment() {
+        let db = tmp_db("commitment");
+        seed_note(
+            &db,
+            "m-a",
+            "Anna 1:1",
+            "# Notes\n- [ ] Anna — send the pricing document\n- [x] Anna — book the room",
+            None,
+        );
+        seed_entity(&db, "Anna", "m-a");
+
+        let candidates =
+            gather_candidates(&db, &HashSet::new(), "m-cur", "co z dokumentem od Anna?", now());
+        let commitment = candidates
+            .iter()
+            .find(|c| c.kind == HintKind::OpenCommitment)
+            .expect("the entity match must surface its OPEN commitment");
+        assert_eq!(commitment.target_id, "m-a");
+        assert!(commitment.title.contains("pricing document"), "title: {}", commitment.title);
+        assert!(
+            commitment.score >= SCORE_THRESHOLD,
+            "an open commitment for an exact entity match must clear the threshold"
+        );
+        assert!(
+            !candidates.iter().any(|c| c.title.contains("book the room")),
+            "a checked-off `- [x]` item is not an open commitment"
+        );
+
+        // Composed: the live-loop step emits it as the best candidate.
+        let mut st = ProactiveState::default();
+        let mut payload = None;
+        for _ in 1..=10u32 {
+            if let Some(p) =
+                st.step(true, &db, &HashSet::new(), "m-cur", "co z dokumentem od Anna?", now())
+            {
+                payload = Some(p);
+            }
+        }
+        let p = payload.expect("step must emit on the first scan tick");
+        assert_eq!(p.kind, "open_commitment");
+        assert_eq!(p.meeting_id.as_deref(), Some("m-a"));
+    }
+
+    // ── Spec §3: the threshold rejects weak matches ─────────────────────────────────────────────
+
+    /// RED evidence: removing the `score >= SCORE_THRESHOLD` filter in `pick` emits the weak
+    /// candidate and fails the first assertion.
+    #[test]
+    fn sub_threshold_match_is_rejected_and_not_dedup_poisoned() {
+        let mut st = ProactiveState::default();
+        assert!(
+            st.pick(vec![cand(HintKind::PastMeeting, "m-1", SCORE_THRESHOLD - 0.01)]).is_none(),
+            "a sub-threshold candidate must not emit"
+        );
+        // The rejection did NOT record the pair — a later, stronger signal still surfaces it.
+        assert!(
+            st.pick(vec![cand(HintKind::PastMeeting, "m-1", 0.9)]).is_some(),
+            "a rejected candidate must stay eligible for a stronger later match"
+        );
+    }
+
+    /// The weakest leg end-to-end: a term-only FTS hit clears the threshold ONLY at rank 0 on a
+    /// recent meeting; rank ≥1 falls under it.
+    #[test]
+    fn term_leg_scores_rank_zero_above_threshold_and_rank_one_below() {
+        let db = tmp_db("term");
+        seed_note(&db, "m-t", "Q3 planning", "the Kwantyfikator initiative kickoff", None);
+
+        let candidates = gather_candidates(
+            &db,
+            &HashSet::new(),
+            "m-cur",
+            "wracamy do tematu Kwantyfikator",
+            now(),
+        );
+        let hit = candidates
+            .iter()
+            .find(|c| c.kind == HintKind::PastMeeting && c.target_id == "m-t")
+            .expect("the rare term must surface the meeting through gated FTS");
+        assert!(hit.score >= SCORE_THRESHOLD, "rank-0 recent term hit clears: {}", hit.score);
+        // Rank 1 with the same recency is halved — under the threshold by construction.
+        assert!(hit.score / 2.0 < SCORE_THRESHOLD, "a rank-1 term hit must fall under");
+    }
+
+    // ── Delta tracker: append, cap, front-trim relocation, reset ───────────────────────────────
+
+    #[test]
+    fn delta_tracker_returns_only_new_text_on_append() {
+        let mut t = DeltaTracker::default();
+        let a = "alpha bravo charlie".to_string();
+        assert_eq!(t.take_delta(&a), a, "first scan sees everything");
+        let b = format!("{a} delta echo");
+        assert_eq!(t.take_delta(&b), " delta echo", "second scan sees only the appended tail");
+        assert_eq!(t.take_delta(&b), "", "unchanged buffer yields an empty delta");
+    }
+
+    /// The live buffer front-trims at its 16k cap: the old offset then points at the WRONG text.
+    /// The tracker re-locates the scan point via its anchor and returns ONLY the new tail. RED
+    /// evidence: slicing at the raw offset returns a mid-word fragment of OLD text here.
+    #[test]
+    fn delta_tracker_survives_front_trim_via_anchor() {
+        let mut t = DeltaTracker::default();
+        // A buffer comfortably longer than the anchor, so the anchor survives the trim.
+        let long: String = (0..40).map(|i| format!("word{i} ")).collect();
+        let _ = t.take_delta(&long);
+        // Front-trim 60 chars off (as the cap does) and append genuinely-new text.
+        let trimmed = format!("{} FRESH tail here", &long[60..].trim_end());
+        let delta = t.take_delta(&trimmed);
+        assert_eq!(
+            delta.trim_start(),
+            "FRESH tail here",
+            "only the new tail after relocation, got {delta:?}"
+        );
+        assert!(!delta.contains("word"), "no already-scanned text re-surfaced as new: {delta:?}");
+    }
+
+    #[test]
+    fn delta_tracker_falls_back_to_bounded_tail_when_anchor_is_gone() {
+        let mut t = DeltaTracker::default();
+        let _ = t.take_delta("completely original first buffer content");
+        // The buffer was fully replaced (anchor nowhere): degrade to a bounded re-scan of the
+        // new content — never a panic, never a lying-offset slice.
+        let replaced = "entirely different second buffer";
+        assert_eq!(t.take_delta(replaced), replaced);
+    }
+
+    #[test]
+    fn delta_tracker_caps_delta_to_recent_window() {
+        let mut t = DeltaTracker::default();
+        let _ = t.take_delta("start");
+        let huge = format!("start{}", " x".repeat(3 * MAX_DELTA_CHARS));
+        let delta = t.take_delta(&huge);
+        assert_eq!(delta.chars().count(), MAX_DELTA_CHARS, "delta bounded to the recent window");
+    }
+
+    // ── Pure matching helpers ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn match_entities_is_case_and_diacritic_insensitive_whole_token() {
+        let node = |id: &str, name: &str| GraphNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: EntityKind::Project,
+            mention_count: 1,
+        };
+        let entities = vec![node("e1", "Atlas"), node("e2", "Gawroński"), node("e3", "Anna Kowalska")];
+        // Case-insensitive token match.
+        assert_eq!(match_entities("mówiliśmy o atlas wczoraj", &entities).len(), 1);
+        // Diacritic-insensitive both ways.
+        assert_eq!(match_entities("dzwonił Gawronski rano", &entities)[0].id, "e2");
+        // Multi-token names need the contiguous in-order run.
+        assert_eq!(match_entities("spotkanie z Anna Kowalska jutro", &entities)[0].id, "e3");
+        assert!(match_entities("Kowalska Anna odwrotnie", &entities).is_empty());
+        // NEVER a substring: "atlasian" must not match "Atlas".
+        assert!(match_entities("we use atlasian tools", &entities).is_empty());
+    }
+
+    #[test]
+    fn extract_rare_terms_prefers_capitalized_filters_noise() {
+        let terms = extract_rare_terms(
+            "Właśnie rozmawiamy o Kwantyfikator i jeszcze about 12345 harmonogramie",
+            3,
+        );
+        assert_eq!(terms[0], "Kwantyfikator", "capitalized proper noun ranked first: {terms:?}");
+        assert!(terms.contains(&"harmonogramie".to_string()), "long plain token kept: {terms:?}");
+        assert!(!terms.contains(&"Właśnie".to_string()), "stopword dropped (folded match)");
+        assert!(!terms.contains(&"about".to_string()), "EN stopword dropped");
+        assert!(!terms.contains(&"12345".to_string()), "all-numeric token dropped");
+        assert!(terms.len() <= 3, "top-N cap respected");
+    }
+
+    #[test]
+    fn recency_decays_with_floor_and_handles_garbage() {
+        let n = now();
+        assert!(recency("2026-07-02T11:00:00Z", n) > 0.99, "an hour old ≈ no decay");
+        let quarter = recency("2026-04-03T12:00:00Z", n); // ~90 days = one half-life
+        assert!((0.45..0.55).contains(&quarter), "one half-life ≈ 0.5, got {quarter}");
+        assert_eq!(recency("2020-01-01T00:00:00Z", n), RECENCY_FLOOR, "ancient hits the floor");
+        assert_eq!(recency("not-a-date", n), RECENCY_FLOOR, "garbage timestamp = floor, no panic");
+    }
+
+    // ── Payload contract (FE consumes verbatim) ────────────────────────────────────────────────
+
+    #[test]
+    fn payload_serializes_camel_case_for_the_fe() {
+        let p = cand(HintKind::OpenCommitment, "m-1", 0.8).into_payload();
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(json.get("kind").and_then(|v| v.as_str()), Some("open_commitment"));
+        assert_eq!(json.get("targetId").and_then(|v| v.as_str()), Some("m-1"));
+        assert_eq!(json.get("meetingId").and_then(|v| v.as_str()), Some("m-1"));
+        assert!(json.get("title").is_some());
+        assert!(json.get("score").is_some());
+        assert!(json.get("target_id").is_none(), "snake_case must not leak over IPC");
+    }
+}

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -211,6 +211,21 @@ pub struct AppConfig {
     /// configs load as `""`.
     #[serde(default)]
     pub gateway_model: String,
+    /// Proactive brain P1 — while recording, the deterministic ZERO-EGRESS matcher
+    /// (`crate::proactive`) surfaces dismissible recall cards ("you discussed this on … →
+    /// [[meeting]]", "open commitment: …") from the live-caption tail. Default ON (spec D2: the
+    /// conservative threshold + the hard ≥120 s cooldown keep the default quiet); flipping it OFF
+    /// mutes the scanner IN THE BACKEND — the matcher never runs, not just UI hiding. No egress
+    /// either way: this path never touches a provider or a consent gate.
+    /// `#[serde(default = "default_true")]` ⇒ a config persisted before this field existed loads
+    /// as `true`.
+    #[serde(default = "default_true")]
+    pub proactive_hints_enabled: bool,
+}
+
+/// serde default for flags that default ON (mirrors `commands::default_true` for the DTO side).
+fn default_true() -> bool {
+    true
 }
 
 impl Default for AppConfig {
@@ -253,6 +268,7 @@ impl Default for AppConfig {
             claude_code_inherit_env: false,
             gateway_base_url: String::new(),
             gateway_model: String::new(),
+            proactive_hints_enabled: true,
         }
     }
 }
@@ -295,6 +311,7 @@ const K_WEB_SEARCH_CONSENTED: &str = "web_search_consented";
 const K_CLAUDE_CODE_INHERIT_ENV: &str = "claude_code_inherit_env";
 const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
+const K_PROACTIVE_HINTS_ENABLED: &str = "proactive_hints_enabled";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -422,6 +439,9 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_GATEWAY_MODEL)? {
             cfg.gateway_model = v;
         }
+        if let Some(v) = db.get_setting(K_PROACTIVE_HINTS_ENABLED)? {
+            cfg.proactive_hints_enabled = v == "true";
+        }
 
         Ok(cfg)
     }
@@ -526,6 +546,10 @@ impl AppConfig {
         )?;
         db.set_setting(K_GATEWAY_BASE_URL, &self.gateway_base_url)?;
         db.set_setting(K_GATEWAY_MODEL, &self.gateway_model)?;
+        db.set_setting(
+            K_PROACTIVE_HINTS_ENABLED,
+            if self.proactive_hints_enabled { "true" } else { "false" },
+        )?;
         Ok(())
     }
 
@@ -869,6 +893,37 @@ mod tests {
         let reloaded = AppConfig::load(&db).unwrap();
         assert_eq!(reloaded.gateway_base_url, "");
         assert_eq!(reloaded.gateway_model, "");
+    }
+
+    /// Proactive brain P1 — the mute flag defaults ON (spec D2: default-on with conservative
+    /// thresholds), for fresh installs AND for configs persisted before the field existed (both
+    /// the settings-table path and the serde path), and an explicit OFF round-trips (the backend
+    /// mute is a real, persistable choice — not a one-way latch).
+    #[test]
+    fn proactive_hints_defaults_on_and_round_trips() {
+        // In-memory default + empty settings table (key never written) ⇒ ON.
+        assert!(AppConfig::default().proactive_hints_enabled);
+        let db = temp_db();
+        assert!(AppConfig::load(&db).unwrap().proactive_hints_enabled);
+
+        // serde path: a JSON payload omitting the field entirely loads ON (default_true).
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.proactive_hints_enabled, "an omitted key must default ON");
+
+        // Explicit OFF persists + reloads OFF (the backend-side mute).
+        let cfg = AppConfig { proactive_hints_enabled: false, ..Default::default() };
+        cfg.save(&db).unwrap();
+        assert!(!AppConfig::load(&db).unwrap().proactive_hints_enabled);
     }
 
     /// Task 1.1 — serde: a payload omitting the gateway fields loads with empty defaults.

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -121,10 +121,30 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
     // so without this the same spoken wake re-fires every tick it stays visible. Lives across ticks.
     let mut wake_dedup = WakeDedup::default();
 
+    // PROACTIVE brain P1 state — FRESH per recording (its cooldown, session dedup, and scan
+    // offset must never leak across recordings). See `crate::proactive` for the D1-D4 contract.
+    let mut proactive = crate::proactive::ProactiveState::default();
+
     loop {
         std::thread::sleep(TICK);
         // Age out an expired wake-suppression window once per tick (before this tick's wake check).
         wake_dedup.tick();
+
+        // PROACTIVE HINTS (zero-egress): advance the per-recording throttle every tick; on every
+        // K-th tick — only while `proactive_hints_enabled` is ON — the deterministic matcher scans
+        // the NEW live-tail delta against the gated local substrates (entities / commitments /
+        // facts / FTS) and surfaces AT MOST one recall card. Fully local: no provider, no consent,
+        // no egress. Best-effort — it can never disrupt the caption or the recording.
+        if let Some(hint) = crate::proactive::scan_tick(&app, &mut proactive) {
+            // PII rule (§8): log the kind + score only — never the title or any content.
+            tracing::info!(
+                target: "proactive",
+                kind = %hint.kind,
+                score = hint.score,
+                "proactive hint emitted"
+            );
+            let _ = app.emit(crate::events::EVENT_PROACTIVE_HINT, hint);
+        }
 
         // Snapshot the recent tail; stop as soon as the recording is gone.
         let snapshot = {

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -48,6 +48,7 @@ import type {
   VoiceCommandProcessingPayload,
   AssistantToolPayload,
   ChatMsg,
+  ProactiveHintPayload,
   WakeDetectedPayload,
 } from "./models";
 
@@ -67,6 +68,8 @@ export const EVENT_ASSISTANT_TOOL = "murmur://assistant-tool";
 export const EVENT_CHAT_TOOL = "murmur://chat-tool";
 // Whisper transcribe-model download progress stream.
 export const EVENT_MODEL_DOWNLOAD = "murmur://model-download";
+// Proactive brain (P2) — one zero-egress recall hint from the live-loop matcher.
+export const EVENT_PROACTIVE_HINT = "murmur://proactive-hint";
 export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
 // brain2 RAG — semantic-search model download + reindex backfill event streams.
 export const EVENT_EMBED_DOWNLOAD = "murmur://embed-download";
@@ -895,6 +898,17 @@ export class IpcService {
     cb: (p: ModelDownloadProgress) => void,
   ): Promise<UnlistenFn> {
     return listen<ModelDownloadProgress>(EVENT_MODEL_DOWNLOAD, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires when the proactive-brain matcher surfaces a recall hint during a
+   * recording (≤1 per cooldown window — throttled + deduped + visibility-gated
+   * in the backend). IDs + a display title only, never content bodies.
+   */
+  onProactiveHint(cb: (p: ProactiveHintPayload) => void): Promise<UnlistenFn> {
+    return listen<ProactiveHintPayload>(EVENT_PROACTIVE_HINT, (e) =>
       cb(e.payload),
     );
   }

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -5,6 +5,7 @@ import type {
   AssistantThreadRow,
   AssistantToolPayload,
   ChatMsg,
+  ProactiveHintPayload,
   VoiceActionResultPayload,
   VoiceActionStatus,
   VoiceCommandListeningPayload,
@@ -287,6 +288,25 @@ export class MeetingConversationStore {
     return "idle";
   });
 
+  /**
+   * The current proactive recall hint (`EVENT_PROACTIVE_HINT`), or null. At most
+   * ONE card: a newer hint REPLACES the visible one (the backend throttles to
+   * ≤1 per cooldown, so replacement is the spec'd queue-of-1). Cleared on a
+   * genuinely-new recording (same lifecycle as the conversation flow) and by
+   * {@link dismissHint}. No FE timer anywhere — the cooldown lives backend-side.
+   */
+  private readonly _hint = signal<ProactiveHintPayload | null>(null);
+  readonly hint = this._hint.asReadonly();
+
+  /**
+   * Hints the user dismissed THIS app session, keyed `kind:targetId` — a
+   * dismissed card never resurfaces even if an event for the same target slips
+   * through (the backend session-dedups too; this is the FE half of the belt
+   * and braces). Deliberately NOT cleared per recording: "dismissed" is a
+   * session-scoped user choice, mirroring the backend's session-level dedup.
+   */
+  private readonly dismissedHints = new Set<string>();
+
   /** Monotonic id source for note items (stable `@for` keys). */
   private nextNoteId = 1;
   /** Monotonic id source for thread turns (stable `@for` keys). */
@@ -300,6 +320,7 @@ export class MeetingConversationStore {
   private unlistenProcessing: UnlistenFn | null = null;
   private unlistenTool: UnlistenFn | null = null;
   private unlistenChatTool: UnlistenFn | null = null;
+  private unlistenHint: UnlistenFn | null = null;
   /** Synchronous re-entrancy guard so two concurrent init() calls can't double-subscribe. */
   private initializing = false;
 
@@ -322,6 +343,7 @@ export class MeetingConversationStore {
     // chip lands on the most recent pending agent turn (no backend change).
     this.unlistenTool = await this.ipc.onAssistantTool((p) => this.onTool(p));
     this.unlistenChatTool = await this.ipc.onChatTool((p) => this.onTool(p));
+    this.unlistenHint = await this.ipc.onProactiveHint((p) => this.onHint(p));
   }
 
   /** Release the event subscriptions (e.g. on app teardown). */
@@ -332,18 +354,21 @@ export class MeetingConversationStore {
     this.unlistenProcessing?.();
     this.unlistenTool?.();
     this.unlistenChatTool?.();
+    this.unlistenHint?.();
     this.unlistenWake = null;
     this.unlistenResult = null;
     this.unlistenListening = null;
     this.unlistenProcessing = null;
     this.unlistenTool = null;
     this.unlistenChatTool = null;
+    this.unlistenHint = null;
   }
 
-  /** Empty the notes + threads (called on each new recording). */
+  /** Empty the notes + threads + the proactive hint (called on each new recording). */
   clear(): void {
     this._notes.set([]);
     this.voiceTargetNoteId = null;
+    this._hint.set(null);
   }
 
   /**
@@ -371,6 +396,9 @@ export class MeetingConversationStore {
     // record effect mis-fired on re-mount because its edge state reset to false).
     this._notes.set([]);
     this.voiceTargetNoteId = null;
+    // A stale recall hint must not carry into the new meeting's conversation
+    // (dismissedHints stays — a dismissal is session-scoped, like the backend dedup).
+    this._hint.set(null);
     this._loaded.set(false);
     void this.hydrate(id, token);
   }
@@ -1138,6 +1166,40 @@ export class MeetingConversationStore {
       };
       return next;
     });
+  }
+
+  /**
+   * A proactive recall hint landed. A hint the user already dismissed this
+   * session is dropped (belt and braces over the backend's own dedup);
+   * otherwise it REPLACES the visible card — at most one, the backend
+   * throttles the stream to ≤1 per cooldown window.
+   */
+  private onHint(p: ProactiveHintPayload): void {
+    if (this.dismissedHints.has(`${p.kind}:${p.targetId}`)) return;
+    this._hint.set(p);
+  }
+
+  /**
+   * Hide the visible recall hint WITHOUT marking it dismissed (unlike
+   * {@link dismissHint}). Called by the screen-share privacy guard
+   * (`ScreenShareService`): the backend has just auto-relocked, and a recall
+   * title from a possibly just-sealed meeting must not linger on the very
+   * surface being shared. The same hint may legitimately resurface later —
+   * the backend re-gates visibility on every emit.
+   */
+  clearHint(): void {
+    this._hint.set(null);
+  }
+
+  /**
+   * Dismiss the visible recall hint: hide the card and remember the
+   * `kind:targetId` for the rest of the session so it never resurfaces.
+   */
+  dismissHint(): void {
+    const h = this._hint();
+    if (!h) return;
+    this.dismissedHints.add(`${h.kind}:${h.targetId}`);
+    this._hint.set(null);
   }
 
   private onListening(p: VoiceCommandListeningPayload): void {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -143,6 +143,15 @@ export interface AppConfigDto {
    * Mirrors Rust `AppConfigDto.gateway_model`.
    */
   gatewayModel: string;
+  /**
+   * Proactive brain (P2) — the GLOBAL MUTE for in-meeting recall hints
+   * (`EVENT_PROACTIVE_HINT` cards). Off silences the event source in the
+   * BACKEND (the live-loop matcher never runs), and the FE additionally never
+   * renders a card (belt and braces). Settable flag, round-tripped on every
+   * `save_config` like the other flags. Default TRUE (conservative thresholds).
+   * Mirrors Rust `AppConfigDto.proactive_hints_enabled`.
+   */
+  proactiveHintsEnabled: boolean;
 }
 
 /** Phase H — which backend powers the brain / in-meeting voice assistant. */
@@ -338,6 +347,29 @@ export interface AssistantToolPayload {
    * threads are in flight simultaneously.
    */
   threadId?: string | null;
+}
+
+/** Proactive brain — what a recall hint points at (drives the card's icon + label). */
+export type ProactiveHintKind = "past_meeting" | "open_commitment" | "fact";
+
+/**
+ * Proactive brain (P2) — one zero-egress recall hint surfaced by the live-loop
+ * matcher (`EVENT_PROACTIVE_HINT`). IDs + a display title only — never content
+ * bodies (the matcher reads only visibility-gated sources, and the payload
+ * carries no more than a card must show). The backend enforces the throttle
+ * (≤1 per 120 s cooldown + session dedup by kind/targetId + a relevance
+ * threshold) — the FE renders at most ONE card, newest replacing the previous.
+ */
+export interface ProactiveHintPayload {
+  kind: ProactiveHintKind;
+  /** The card's display line (a meeting title / commitment / fact headline). */
+  title: string;
+  /** Stable id of the surfaced item (dedup key together with `kind`). */
+  targetId: string;
+  /** The meeting to open on click-through; absent/null → no navigation. */
+  meetingId?: string | null;
+  /** The matcher's relevance score (already ≥ the backend threshold). */
+  score: number;
 }
 
 /**

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1351,6 +1351,8 @@ export class OnboardingComponent implements OnInit {
       brainBackend: base?.brainBackend ?? "cloud",
       realtimeReactions: base?.realtimeReactions ?? false,
       brainModelId: base?.brainModelId ?? null,
+      // Proactive brain hints — round-trip the snapshot, default ON (fresh install).
+      proactiveHintsEnabled: base?.proactiveHintsEnabled ?? true,
       // brain2 RAG — semantic-search master flag; round-trip the snapshot, default off.
       semanticSearchEnabled: base?.semanticSearchEnabled ?? false,
       // brain2 connectors — web-search toggle + its preserve-only consent; round-trip

--- a/src/app/features/record/meeting-conversation.component.ts
+++ b/src/app/features/record/meeting-conversation.component.ts
@@ -15,6 +15,7 @@ import {
 import { MeetingConversationStore } from "../../core/meeting-conversation.store";
 import { AiOrbComponent } from "./ai-orb.component";
 import { NoteItemComponent } from "./note-item.component";
+import { ProactiveHintCardComponent } from "./proactive-hint-card.component";
 
 /** The inline mention marker that turns a composer line into a `@brain` thread. */
 const BRAIN_MARKER = "@brain";
@@ -74,7 +75,7 @@ export function parseBrainLine(text: string): string | null {
   selector: "app-meeting-conversation",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AiOrbComponent, NoteItemComponent],
+  imports: [AiOrbComponent, NoteItemComponent, ProactiveHintCardComponent],
   template: `
     <div class="card surface" role="group" aria-label="In-meeting notes">
       <div class="surface-head">
@@ -84,6 +85,14 @@ export function parseBrainLine(text: string): string | null {
           Type <span class="kbd">&#64;brain</span> to ask in a thread
         </span>
       </div>
+
+      <!-- Proactive recall card — PINNED above the notes flow (not inside the
+           scroller, so it can't scroll away mid-meeting). At most ONE: the store
+           keeps only the newest; hintsEnabled is the FE half of the global mute
+           (the backend silences the event source too — belt and braces). -->
+      @if (hintsEnabled() && store.hint(); as h) {
+        <app-proactive-hint-card [hint]="h" (dismissed)="store.dismissHint()" />
+      }
 
       <div class="flow" #flow>
         @if (!store.hasNotes()) {
@@ -418,6 +427,14 @@ export class MeetingConversationComponent implements OnInit {
    * into the store so a note line appends to THIS meeting's `manual_notes`.
    */
   readonly meetingId = input<string | null>(null);
+
+  /**
+   * The `proactiveHintsEnabled` config flag (the record screen passes its config
+   * snapshot down). False ⇒ the recall card NEVER renders, even if an event
+   * slips through before the backend mute takes effect. Defaults true, matching
+   * the backend default.
+   */
+  readonly hintsEnabled = input<boolean>(true);
 
   /** The composer draft (signal-backed — zoneless). */
   protected readonly draft = signal("");

--- a/src/app/features/record/proactive-hint-card.component.ts
+++ b/src/app/features/record/proactive-hint-card.component.ts
@@ -1,0 +1,165 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+import type { ProactiveHintPayload } from "../../core/models";
+
+/**
+ * Proactive brain (P2) — ONE dismissible, system-style recall card in the
+ * record screen's conversation surface: "the brain volunteers what you'd have
+ * asked for" (a related past meeting / an open commitment / a known fact
+ * matched against the live transcript, all from LOCAL reads). Purely
+ * presentational: the parent owns visibility (the store's `hint` signal +
+ * the `proactiveHintsEnabled` mute) and dismissal; this renders the payload's
+ * IDs + title only — it never fetches content.
+ *
+ * Sits IN-FLOW inside the conversation surface (pinned above the notes flow),
+ * NOT floating over content — so a translucent accent block is correct here;
+ * the opaque `--surface-overlay` rule (trap T3) applies only to overlays.
+ * "Open" navigates to the source meeting's detail view (`/meeting/:id`) when
+ * the hint carries one; a hint without a meeting id offers no navigation.
+ */
+@Component({
+  selector: "app-proactive-hint-card",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  template: `
+    <div class="hint-card" role="status" aria-label="Brain hint">
+      <span class="hint-ico" aria-hidden="true">{{ icon() }}</span>
+      <span class="hint-body">
+        <span class="hint-kind">{{ kindLabel() }}</span>
+        <span class="hint-title" [title]="hint().title">{{
+          hint().title
+        }}</span>
+      </span>
+      @if (hint().meetingId; as mid) {
+        <a class="btn btn-ghost hint-open" [routerLink]="['/meeting', mid]">
+          Open
+        </a>
+      }
+      <button
+        type="button"
+        class="hint-dismiss"
+        (click)="dismissed.emit()"
+        aria-label="Dismiss hint"
+        title="Dismiss"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+          <path
+            d="M6 6l12 12M18 6L6 18"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  `,
+  styles: [
+    `
+      .hint-card {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex: none;
+        padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+        border: 1px solid var(--accent-ring);
+        border-radius: var(--radius-md);
+        background: var(--accent-soft);
+        animation: rise 320ms var(--transition) both;
+      }
+      .hint-ico {
+        font-size: 1.05rem;
+        line-height: 1;
+        flex: none;
+      }
+      .hint-body {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .hint-kind {
+        color: var(--text-muted);
+        font-size: 0.68rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .hint-title {
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        line-height: 1.4;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+      .hint-open {
+        flex: none;
+        height: 30px;
+        padding: 0 var(--space-3);
+        font-size: 0.82rem;
+      }
+      .hint-dismiss {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        flex: none;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          color var(--transition);
+      }
+      .hint-dismiss:hover {
+        background: var(--surface-hover);
+        color: var(--text-primary);
+      }
+      .hint-dismiss:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+    `,
+  ],
+})
+export class ProactiveHintCardComponent {
+  /** The hint to render (the parent gates on null / the global mute). */
+  readonly hint = input.required<ProactiveHintPayload>();
+  /** The user clicked ✕ — the parent hides + session-dedups the hint. */
+  readonly dismissed = output<void>();
+
+  /** Kind glyph — matches the house `@brain` emoji style (mention popover). */
+  readonly icon = computed(() => {
+    switch (this.hint().kind) {
+      case "open_commitment":
+        return "📌";
+      case "fact":
+        return "ℹ️";
+      default:
+        return "🧠";
+    }
+  });
+
+  /** The subtle "why am I seeing this" label above the title. */
+  readonly kindLabel = computed(() => {
+    switch (this.hint().kind) {
+      case "open_commitment":
+        return "Open commitment";
+      case "fact":
+        return "Known fact";
+      default:
+        return "Related meeting";
+    }
+  });
+}

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -224,6 +224,7 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
         <app-meeting-conversation
           class="conversation"
           [meetingId]="store.meetingId()"
+          [hintsEnabled]="hintsEnabled()"
         />
       }
 
@@ -1035,6 +1036,15 @@ export class RecordComponent implements OnInit {
   /** Headphones hint: capturing system audio through speakers echoes into the mic (rec #5). */
   readonly headphonesHint = computed(
     () => this.config()?.captureSystemAudio ?? false,
+  );
+
+  /**
+   * Proactive brain hints (the global mute, default ON). Gates the recall card
+   * in the conversation surface; the backend mutes the event source too when
+   * off — this is the render-side half of the belt and braces.
+   */
+  readonly hintsEnabled = computed(
+    () => this.config()?.proactiveHintsEnabled ?? true,
   );
 
   /**

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -616,6 +616,19 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
                   <input type="checkbox" formControlName="realtimeReactions" />
                 </label>
 
+                <label class="toggle-row">
+                  <span class="toggle-copy">
+                    <span class="toggle-title">Proactive brain hints</span>
+                    <span class="text-secondary toggle-sub">
+                      While recording, surface a dismissible recall card when the
+                      conversation touches a past meeting, an open commitment, or a
+                      known fact. 100% on-device — no cloud calls; at most one card
+                      every two minutes.
+                    </span>
+                  </span>
+                  <input type="checkbox" formControlName="proactiveHintsEnabled" />
+                </label>
+
                 <!--
                   Proactive cloud-egress consent (issue 20). The in-meeting assistant
                   dispatches voice actions through the active provider. With a cloud
@@ -2768,6 +2781,8 @@ export class SettingsComponent implements OnInit {
     // Phase H — brain / in-meeting voice assistant.
     brainBackend: "cloud" as BrainBackend,
     realtimeReactions: false,
+    // Proactive brain (P2) — zero-egress recall cards while recording; default ON.
+    proactiveHintsEnabled: true,
     /** Custom GGUF model path (or registry id). Empty → null on save. */
     brainModelId: "",
     // brain2 RAG — semantic-search master flag (round-tripped on save).
@@ -3059,6 +3074,7 @@ export class SettingsComponent implements OnInit {
         noteLanguage: cfg.noteLanguage ?? "auto",
         brainBackend: cfg.brainBackend ?? "cloud",
         realtimeReactions: cfg.realtimeReactions ?? false,
+        proactiveHintsEnabled: cfg.proactiveHintsEnabled ?? true,
         brainModelId: cfg.brainModelId ?? "",
         semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
         webSearchEnabled: cfg.webSearchEnabled ?? false,
@@ -3291,6 +3307,8 @@ export class SettingsComponent implements OnInit {
       // Phase H — brain / in-meeting voice assistant.
       brainBackend: v.brainBackend,
       realtimeReactions: v.realtimeReactions,
+      // Proactive brain hints — round-tripped so a save preserves the mute.
+      proactiveHintsEnabled: v.proactiveHintsEnabled,
       brainModelId: v.brainModelId || null,
       // brain2 RAG — semantic-search master flag (round-tripped so a save preserves it).
       semanticSearchEnabled: v.semanticSearchEnabled,

--- a/src/app/services/screen-share.service.ts
+++ b/src/app/services/screen-share.service.ts
@@ -1,5 +1,6 @@
 import { DestroyRef, Injectable, inject } from "@angular/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { MeetingConversationStore } from "../core/meeting-conversation.store";
 import { FoldersService } from "./folders.service";
 import { ToastService } from "./toast.service";
 
@@ -20,6 +21,7 @@ export const EVENT_SCREEN_SHARE_STARTED = "murmur://screen-share-started";
 export class ScreenShareService {
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly conversation = inject(MeetingConversationStore);
   private readonly destroyRef = inject(DestroyRef);
 
   /** Live event-listener handle (null when not yet initialised / torn down). */
@@ -59,6 +61,11 @@ export class ScreenShareService {
    * security action happened in the backend before this event fired.
    */
   private async onScreenShareStarted(): Promise<void> {
+    // Drop the proactive recall card FIRST (synchronously): its title can come
+    // from a meeting the backend just re-sealed, and the record screen is
+    // exactly the surface now being shared. Not a dismissal — the backend
+    // re-gates visibility, so the hint may legitimately resurface later.
+    this.conversation.clearHint();
     await this.folders.load();
     this.toast.info("Locked your private folders — screen sharing started");
   }


### PR DESCRIPTION
Tier-3 item 5 of the brain analysis, promoted by the ClickUp-Brain competitive frame (docs/research/2026-07-02-clickup-brain-gap-analysis.md: proactive/ambient is their differentiator-in-progress; ours is the local-first analog — no cloud, no consent friction, no per-seat fee). Spec: docs/superpowers/specs/2026-07-02-proactive-brain-design.md (P1+P2).

**What it does.** While recording, a deterministic matcher scans the live-caption tail delta every ~30 s against entities / open commitments / current facts / rare-term FTS and surfaces at most one dismissible card per 120 s: *"you discussed ⟨X⟩ on Jun 12 →"*, *"open commitment: …"*, *"known fact: …"*. Zero egress — no provider, no reasoner, no consent gate anywhere in the path (D1).

**Discipline.** Every read via the existing gated helpers (`visibility_clause`), unlocked set re-read per scan, zero new SQL; titles only from already-visible rows; score threshold + cooldown + session dedup; `proactive_hints_enabled` (default on) is a real backend-side mute. FE: pinned in-flow card, Settings toggle, cleared on new recording **and the instant screen-share starts** (lock-review hardening; clear ≠ dismiss).

**Verification.** `cargo test --lib` **647/0** (+20, every RED verified by mutation — sealed-leak, cooldown, dedup, mute-not-consuming-delta, threshold, DeltaTracker trim/anchor). `ng lint`+`ng build` green. **12/12 live-Chromium smoke** (render/replace/dismiss/mute/clear-on-recording/clear-on-share). **adversarial-verifier: PASS** (incl. a 3000-step multibyte fuzz of the DeltaTracker — no panic, no stale text, structurally always a suffix of the current buffer). **lock-security-reviewer: PASS** (all title sources traced to gated readers; poison postures fail closed; no persistence, no egress — grep-proven).

**Known accepted residuals:** per-scan unlocked-set snapshot (ms-scale TOCTOU, same discipline as GatedToolExecutor); anchor-relocation can skip one hint on verbatim-repeated captions (LOW, self-heals next scan); one scan may run ≤3 s after Stop (gated, UX-only); worst case 13 gated queries/scan.

**Not verifiable headless:** real event delivery through the Tauri runtime on a live recording; whether hints FEEL relevant vs noisy — the spec's threshold-tuning dogfooding pass on a real vault; screen-share relock interplay needs a signed build.