### PR TITLE
feat(update): detect new releases — startup toast, manual check + About

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub mod storage;
 pub mod summarize;
 pub mod tools;
 pub mod transcribe;
+pub mod update;
 pub mod voice_action;
 
 use tauri::window::{Effect, EffectsBuilder};
@@ -172,6 +173,9 @@ pub fn run() {
             commands::relock_folder,
             commands::relock_all,
             commands::remove_lock,
+            update::check_for_update,
+            update::app_info,
+            update::open_release_page,
         ])
         .setup(|app| {
             // Open the encrypted library FIRST. If it fails (keychain access denied, or the DB

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,0 +1,300 @@
+//! GitHub-release-based update check (#112).
+//!
+//! Three Tauri commands:
+//! - [`check_for_update`] — GETs the latest GitHub release for `murmur-io/murmur`, compares its
+//!   tag against the compiled `CARGO_PKG_VERSION` by hand-rolled semver, and reports whether a
+//!   newer version exists. Sends NO user content — a plain unauthenticated GET to GitHub.
+//! - [`app_info`] — compile-time app identity (name/version/description/repository).
+//! - [`open_release_page`] — opens the release page in the default browser, host-validated to the
+//!   Murmur repo so it can never become an arbitrary-URL launcher.
+//!
+//! Rules: only [`AppError`] / `crate::error::Result`; no `unwrap`/`expect` in non-test code; no
+//! PII in logs (the update check carries none, but we still keep the URL/body out of logs).
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+use crate::error::Result;
+
+/// The canonical Murmur repository. The update check and the release-page launcher are both pinned
+/// to this — `open_release_page` refuses any URL not under it.
+const REPO_URL: &str = "https://github.com/murmur-io/murmur";
+/// GitHub API endpoint for the newest published release of the Murmur repo.
+const LATEST_RELEASE_API: &str = "https://api.github.com/repos/murmur-io/murmur/releases/latest";
+
+// ── IPC DTOs (camelCase mirrors) ──
+
+/// Result of an update check: the compiled version vs. the newest GitHub release.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    /// The running app version (`CARGO_PKG_VERSION`), e.g. `"0.6.3"`.
+    pub current_version: String,
+    /// The latest GitHub release tag with a leading `v`/`V` stripped, e.g. `"0.6.4"`.
+    pub latest_version: String,
+    /// `true` iff `latest_version` parses to a strictly-greater semver than `current_version`.
+    pub update_available: bool,
+    /// The release's `html_url` for the user to open.
+    pub release_url: String,
+    /// The release title (`name`), if any.
+    pub release_name: Option<String>,
+    /// The release body / changelog (`body`), if any.
+    pub release_notes: Option<String>,
+}
+
+/// Compile-time app identity for the About screen.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppInfo {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub repository: String,
+}
+
+/// Minimal mirror of the GitHub `releases/latest` response — only the fields we use.
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    #[serde(default)]
+    tag_name: String,
+    #[serde(default)]
+    html_url: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+/// Build the reqwest client for the update check: TLS 1.2 floor + a short (~10s) overall timeout so
+/// a stalled connection can't wedge the UI. Mirrors `summarize::anthropic::build_client`'s hardened
+/// builder pattern; falls back to `Client::new()` if the builder somehow fails so the check is
+/// never un-constructible.
+fn build_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .min_tls_version(reqwest::tls::Version::TLS_1_2)
+        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(8))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// Strip a single leading `v`/`V` from a release tag to get the bare version string.
+fn strip_v(tag: &str) -> &str {
+    tag.strip_prefix('v').or_else(|| tag.strip_prefix('V')).unwrap_or(tag)
+}
+
+/// Parse a version string into `(major, minor, patch)`. Splits on `.`; for each of the first three
+/// components it takes the leading numeric run before any `-`/`+` (pre-release/build) suffix.
+/// Returns `None` if the first three components are not all present-and-numeric — a malformed
+/// version must never panic and must be treated by the caller as "no update".
+fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = v.trim().split('.');
+    let major = parse_component(parts.next()?)?;
+    let minor = parse_component(parts.next()?)?;
+    let patch = parse_component(parts.next()?)?;
+    Some((major, minor, patch))
+}
+
+/// Parse one dotted component: take the leading numeric run before any non-digit (so `4-rc1` → 4,
+/// `4+build` → 4). Empty / non-numeric-leading → `None`.
+fn parse_component(s: &str) -> Option<u32> {
+    let digits: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse::<u32>().ok()
+}
+
+/// `true` iff `latest` is a strictly-greater semver than `current`. Defensive: if EITHER side fails
+/// to parse, return `false` (never claim an update on a version we can't understand).
+fn is_newer(current: &str, latest: &str) -> bool {
+    match (parse_version(current), parse_version(latest)) {
+        (Some(c), Some(l)) => l > c,
+        _ => false,
+    }
+}
+
+/// GET the latest GitHub release for `murmur-io/murmur` and report whether it is newer than the
+/// running build. Sends no user content. Network / non-2xx / rate-limit → `AppError::Unavailable`
+/// with a non-PII message (no tokens, no response body dumped).
+#[tauri::command]
+pub async fn check_for_update() -> Result<UpdateInfo> {
+    let current_version = env!("CARGO_PKG_VERSION").to_string();
+
+    let client = build_client();
+    // GitHub's API 403s without a User-Agent; also request the recommended media type.
+    let user_agent = format!("Murmur/{current_version}");
+    let resp = client
+        .get(LATEST_RELEASE_API)
+        .header(reqwest::header::USER_AGENT, user_agent)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!(target: "update", is_timeout = e.is_timeout(), "update check network error");
+            AppError::Unavailable("Could not reach GitHub to check for updates.".into())
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        tracing::warn!(target: "update", status = status.as_u16(), "update check non-2xx");
+        return Err(AppError::Unavailable(format!(
+            "GitHub update check failed (HTTP {}).",
+            status.as_u16()
+        )));
+    }
+
+    let release: GithubRelease = resp.json().await.map_err(|_| {
+        tracing::warn!(target: "update", "update check response parse error");
+        AppError::Unavailable("Could not parse the GitHub release response.".into())
+    })?;
+
+    let latest_version = strip_v(&release.tag_name).to_string();
+    let update_available = is_newer(&current_version, &latest_version);
+    tracing::info!(target: "update", update_available, "update check complete");
+
+    Ok(UpdateInfo {
+        current_version,
+        latest_version,
+        update_available,
+        release_url: release.html_url,
+        release_name: release.name,
+        release_notes: release.body,
+    })
+}
+
+/// Compile-time app identity for the About screen. Infallible.
+#[tauri::command]
+pub fn app_info() -> AppInfo {
+    let description = {
+        let d = env!("CARGO_PKG_DESCRIPTION");
+        if d.trim().is_empty() {
+            "Local-first meeting notes for macOS.".to_string()
+        } else {
+            d.to_string()
+        }
+    };
+    AppInfo {
+        name: "Murmur".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description,
+        repository: REPO_URL.to_string(),
+    }
+}
+
+/// Open a release page in the default browser via macOS `open`. SECURITY: only URLs under the
+/// Murmur repo are allowed — this must never become an arbitrary-URL launcher. Does not block on
+/// the spawned child.
+#[tauri::command]
+pub fn open_release_page(url: String) -> Result<()> {
+    // Require a path boundary after the repo root: the bare repo URL, or something strictly
+    // BELOW it (`<repo>/releases/...`). A plain `starts_with(REPO_URL)` would also accept a
+    // sibling repo whose name merely begins with "murmur" (e.g. `.../murmur-phish`) — pin the
+    // trailing `/` so only the real repo and its sub-paths pass.
+    let allowed = url == REPO_URL || url.starts_with(&format!("{REPO_URL}/"));
+    if !allowed {
+        return Err(AppError::InvalidArg(
+            "refused to open a URL outside the Murmur repository".into(),
+        ));
+    }
+    std::process::Command::new("open")
+        .arg(&url)
+        .spawn()
+        .map_err(|e| AppError::Unavailable(format!("could not open the browser: {e}")))?;
+    tracing::info!(target: "update", "opened release page");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_basics() {
+        assert_eq!(parse_version("0.6.3"), Some((0, 6, 3)));
+        assert_eq!(parse_version("0.10.0"), Some((0, 10, 0)));
+        assert_eq!(parse_version("1.2.3"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_version_with_suffix() {
+        assert_eq!(parse_version("0.6.4-rc1"), Some((0, 6, 4)));
+        assert_eq!(parse_version("0.6.4+build.7"), Some((0, 6, 4)));
+    }
+
+    #[test]
+    fn parse_version_malformed_is_none() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("0.6"), None);
+        assert_eq!(parse_version("v0.6.3"), None); // strip_v runs before parse
+        assert_eq!(parse_version("abc"), None);
+        assert_eq!(parse_version("0.x.3"), None);
+    }
+
+    #[test]
+    fn strip_v_variants() {
+        assert_eq!(strip_v("v0.6.4"), "0.6.4");
+        assert_eq!(strip_v("V0.6.4"), "0.6.4");
+        assert_eq!(strip_v("0.6.4"), "0.6.4");
+        assert_eq!(strip_v("vv0.6.4"), "v0.6.4"); // only one leading v stripped
+    }
+
+    #[test]
+    fn newer_true_when_latest_greater() {
+        assert!(is_newer("0.6.3", "0.6.4"));
+        assert!(is_newer("0.9.9", "0.10.0"));
+        assert!(is_newer("0.6.3", "1.0.0"));
+    }
+
+    #[test]
+    fn not_newer_when_equal_or_older() {
+        assert!(!is_newer("0.6.3", "0.6.3"));
+        assert!(!is_newer("0.6.3", "0.6.2"));
+        assert!(!is_newer("0.10.0", "0.9.9"));
+        assert!(!is_newer("1.0.0", "0.9.9"));
+    }
+
+    #[test]
+    fn newer_defensive_on_malformed() {
+        // Malformed latest → never claim an update.
+        assert!(!is_newer("0.6.3", "not-a-version"));
+        assert!(!is_newer("0.6.3", ""));
+        assert!(!is_newer("0.6.3", "0.6"));
+        // Malformed current → also no update (can't reason about it).
+        assert!(!is_newer("garbage", "0.6.4"));
+    }
+
+    #[test]
+    fn app_info_is_populated() {
+        let info = app_info();
+        assert_eq!(info.name, "Murmur");
+        assert!(!info.version.is_empty());
+        assert!(!info.description.trim().is_empty());
+        assert_eq!(info.repository, REPO_URL);
+    }
+
+    #[test]
+    fn open_release_page_rejects_foreign_host() {
+        // A URL outside the repo must be refused with InvalidArg — no process spawned.
+        let err = open_release_page("https://evil.example.com/x".into()).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+        let err = open_release_page("https://github.com/other/repo".into()).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+    }
+
+    #[test]
+    fn open_release_page_rejects_prefix_boundary_siblings() {
+        // A sibling repo whose name merely BEGINS with the repo URL (no path boundary) must be
+        // refused — the fix from a bare `starts_with`. These all stay on github.com but are NOT
+        // the Murmur repo.
+        for u in [
+            "https://github.com/murmur-io/murmur-phish",
+            "https://github.com/murmur-io/murmurEVIL/releases",
+            "https://github.com/murmur-io/murmur.evil.com",
+            "https://github.com/murmur-io/murmur@evil.com",
+        ] {
+            let err = open_release_page(u.into()).unwrap_err();
+            assert!(matches!(err, AppError::InvalidArg(_)), "should reject {u}");
+        }
+    }
+}

--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
 import { FoldersService } from "./services/folders.service";
-import { ToastService } from "./services/toast.service";
+import { ToastService, type Toast } from "./services/toast.service";
 
 /**
  * The app shell chrome — brand header, nav tabs, page layout (router-outlet) and
@@ -148,6 +148,15 @@ import { ToastService } from "./services/toast.service";
         @for (t of toasts(); track t.id) {
           <div class="toast" [class]="'is-' + t.kind" role="status">
             <span class="toast-msg">{{ t.message }}</span>
+            @if (t.action; as action) {
+              <button
+                type="button"
+                class="btn btn-primary toast-action"
+                (click)="runToastAction(t)"
+              >
+                {{ action.label }}
+              </button>
+            }
             <button
               type="button"
               class="toast-close"
@@ -173,6 +182,20 @@ import { ToastService } from "./services/toast.service";
       </div>
     }
   `,
+  styles: [
+    `
+      /* Compact inline action inside a toast (sits before the ✕ close). Uses the
+         global .btn/.btn-primary primitives; only the size is trimmed here so it
+         fits the toast strip. */
+      .toast-action {
+        flex: none;
+        height: auto;
+        padding: var(--space-1) var(--space-3);
+        font-size: 0.82rem;
+        white-space: nowrap;
+      }
+    `,
+  ],
 })
 export class AppShellComponent {
   private readonly folders = inject(FoldersService);
@@ -187,5 +210,11 @@ export class AppShellComponent {
   /** Dismiss a toast by id (also cancels its auto-dismiss timer in the service). */
   dismissToast(id: number): void {
     this.toast.dismiss(id);
+  }
+
+  /** Run a toast's inline action, then dismiss the toast. */
+  runToastAction(t: Toast): void {
+    t.action?.run();
+    this.dismissToast(t.id);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { IpcService } from "./core/ipc.service";
 import { FoldersService } from "./services/folders.service";
 import { ScreenShareService } from "./services/screen-share.service";
 import { ThemeService } from "./services/theme.service";
+import { UpdateService } from "./services/update.service";
 
 @Component({
   selector: "app-root",
@@ -35,6 +36,7 @@ export class AppComponent implements OnInit {
   // Injected at bootstrap so the theme is applied (in the service constructor)
   // before the main window is revealed — no flash of the wrong theme.
   private readonly theme = inject(ThemeService);
+  private readonly updates = inject(UpdateService);
 
   /** True in the floating-bar window (route /bar) — the app chrome is hidden there. */
   readonly isBar = toSignal(
@@ -111,6 +113,10 @@ export class AppComponent implements OnInit {
     // user on a blank app, so each is fire-and-forget with its own catch.
     void this.screenShare.init();
     void this.folders.load();
+    // Best-effort GitHub-release update check — fire-and-forget, non-blocking.
+    // The service swallows any failure (a background check must never nag), so
+    // this never traps the user; a found update surfaces as a sticky toast.
+    void this.updates.checkOnStartup();
 
     try {
       const cfg = await this.ipc.getConfig();

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -49,6 +49,8 @@ import type {
   AssistantToolPayload,
   ChatMsg,
   WakeDetectedPayload,
+  UpdateInfo,
+  AppInfo,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
@@ -798,6 +800,27 @@ export class IpcService {
   /** Permanently remove a folder's lock: decrypt to plaintext + re-export to the vault. */
   removeLock(folderId: string): Promise<void> {
     return invoke<void>("remove_lock", { folderId });
+  }
+
+  // ── Update check + product info (GitHub-release update flow) ────────────
+
+  /**
+   * Check GitHub for a newer release. Resolves with an {@link UpdateInfo}; the
+   * command REJECTS on network failure / rate-limit, so a thrown error means
+   * "couldn't check" (never treat it as "up to date").
+   */
+  checkForUpdate(): Promise<UpdateInfo> {
+    return invoke<UpdateInfo>("check_for_update");
+  }
+
+  /** Static product identity (name / version / description / repository) for About. */
+  appInfo(): Promise<AppInfo> {
+    return invoke<AppInfo>("app_info");
+  }
+
+  /** Open a GitHub release page in the user's default browser. */
+  openReleasePage(url: string): Promise<void> {
+    return invoke<void>("open_release_page", { url });
   }
 
   onStatus(cb: (payload: StatusPayload) => void): Promise<UnlistenFn> {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -15,6 +15,30 @@ export interface StatusPayload {
   meetingId: string | null;
 }
 
+/**
+ * GitHub-release update check (`check_for_update`). Mirrors the Rust `UpdateInfo`
+ * (serde camelCase). `updateAvailable` is the sole "should we nudge" flag;
+ * `releaseName` / `releaseNotes` are null when GitHub omits them. The command
+ * REJECTS (throws) on network failure / rate-limit — a thrown error means
+ * "couldn't check", not "up to date".
+ */
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  releaseUrl: string;
+  releaseName: string | null;
+  releaseNotes: string | null;
+}
+
+/** Static product identity for the Settings "About" section (`app_info`). */
+export interface AppInfo {
+  name: string;
+  version: string;
+  description: string;
+  repository: string;
+}
+
 export type Availability =
   | { Available: true }
   | { Unavailable: { reason: string } };

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -15,6 +15,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import type {
   AppConfigDto,
+  AppInfo,
   BrainBackend,
   BrainModelDto,
   GatewayHealth,
@@ -25,6 +26,7 @@ import type {
 } from "../../core/models";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { ThemeService, type ThemeMode } from "../../services/theme.service";
+import { UpdateService } from "../../services/update.service";
 
 /** One entry in the macOS-style Settings sidebar. `keywords` feeds the search box. */
 interface SettingsSection {
@@ -48,6 +50,7 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   { id: "providers", label: "Providers", keywords: "anthropic ollama claude code gateway openai api key availability model binary" },
   { id: "privacy", label: "Privacy & Integrations", keywords: "redaction firewall cloud processing consent locked folders mcp server claude desktop" },
   { id: "obsidian", label: "Obsidian", keywords: "vault markdown notes companion export wikilinks" },
+  { id: "about", label: "About", keywords: "about version update check for updates release changelog product info" },
 ];
 
 @Component({
@@ -123,6 +126,9 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
                   }
                   @case ("obsidian") {
                     <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M6 1.8 2.8 5.3 4.7 12 7 14l-.8-6z" /><path d="M6 1.8 6.2 8 7 14l3.4-2.6L12 5.4 9 2z" /></svg>
+                  }
+                  @case ("about") {
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6.2" /><path d="M8 7.4v3.6M8 5.1h.01" /></svg>
                   }
                 }
               </span>
@@ -1660,6 +1666,75 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
                 </div>
               </div>
             }
+
+            <!-- ── About — product identity + manual update check ── -->
+            @case ("about") {
+              <div class="card about-card">
+                @if (appInfo(); as info) {
+                  <div class="about-head">
+                    <span class="about-name">{{ info.name }}</span>
+                    <span class="about-version text-muted"
+                      >Version {{ info.version }}</span
+                    >
+                  </div>
+                  <p class="text-secondary about-desc">{{ info.description }}</p>
+                } @else {
+                  <p class="text-secondary about-desc">
+                    Loading product info…
+                  </p>
+                }
+
+                <div class="about-update">
+                  <span class="about-section-label text-muted"
+                    >Software update</span
+                  >
+                  <div class="about-update-row">
+                    <button
+                      type="button"
+                      class="btn"
+                      (click)="checkForUpdates()"
+                      [disabled]="updateStatus() === 'checking'"
+                    >
+                      @if (updateStatus() === "checking") {
+                        <span class="spin-ring" aria-hidden="true"></span>
+                        Checking…
+                      } @else {
+                        Check for updates
+                      }
+                    </button>
+
+                    @switch (updateStatus()) {
+                      @case ("available") {
+                        @if (latestUpdate(); as upd) {
+                          <span class="about-update-result">
+                            <span class="text-secondary"
+                              >Version {{ upd.latestVersion }} is available.</span
+                            >
+                            <button
+                              type="button"
+                              class="btn btn-primary"
+                              (click)="downloadUpdate(upd.releaseUrl)"
+                            >
+                              Download
+                            </button>
+                          </span>
+                        }
+                      }
+                      @case ("upToDate") {
+                        <span class="text-muted about-update-line"
+                          >You're up to date.</span
+                        >
+                      }
+                      @case ("error") {
+                        <span class="text-danger about-update-line"
+                          >Couldn't check for updates.</span
+                        >
+                      }
+                    }
+                  </div>
+                </div>
+              </div>
+            }
           }
         </div>
       </div>
@@ -1819,6 +1894,54 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         flex-direction: column;
         gap: var(--space-5);
         animation: rise 320ms var(--transition) both;
+      }
+
+      /* About — product identity + manual update check. */
+      .about-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .about-head {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .about-name {
+        font-size: 1.15rem;
+        font-weight: 650;
+        letter-spacing: -0.01em;
+      }
+      .about-version {
+        font-size: 0.9rem;
+      }
+      .about-desc {
+        margin: 0;
+        line-height: 1.55;
+      }
+      .about-update {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding-top: var(--space-3);
+        border-top: 1px solid var(--border-subtle);
+      }
+      .about-section-label {
+        font-size: 0.72rem;
+        font-weight: 650;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .about-update-row,
+      .about-update-result {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .about-update-line {
+        font-size: 0.9rem;
       }
 
       /* Collapse to a single column on narrow widths (sidebar stacks on top). */
@@ -2675,6 +2798,28 @@ export class SettingsComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly theme = inject(ThemeService);
+  private readonly updates = inject(UpdateService);
+
+  // ── About — product identity + shared update-check state ────────────────
+
+  /** Static product identity (name/version/description), loaded once in ngOnInit. */
+  readonly appInfo = signal<AppInfo | null>(null);
+
+  /** Update-check lifecycle from the shared service (drives the button + result line). */
+  readonly updateStatus = this.updates.status;
+
+  /** The most-recent update-check result (the Download button reads its releaseUrl). */
+  readonly latestUpdate = this.updates.latest;
+
+  /** Run the shared manual update check (surfaces both outcomes as toasts). */
+  checkForUpdates(): void {
+    void this.updates.checkManually();
+  }
+
+  /** Open the GitHub release page for an available update. */
+  downloadUpdate(url: string): void {
+    void this.ipc.openReleasePage(url);
+  }
 
   /** Current theme choice (Light / Dark / System) — drives the Appearance control. */
   readonly themeMode = this.theme.mode;
@@ -3083,6 +3228,8 @@ export class SettingsComponent implements OnInit {
       this.embedModelPresent.set(
         await this.ipc.embedModelPresent().catch(() => false),
       );
+      // About section — product identity (best-effort; null leaves a "loading" line).
+      this.appInfo.set(await this.ipc.appInfo().catch(() => null));
     } catch (e) {
       this.loadError.set(String(e));
     }

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -6,11 +6,24 @@ import {
   signal,
 } from "@angular/core";
 
+/**
+ * An optional inline action button on a toast (rendered before the ✕ close).
+ * `run` fires on click; the host then dismisses the toast. A toast carrying an
+ * action is typically sticky (`ttlMs: 0`) so it doesn't vanish before the user
+ * can act — but that is the caller's choice, not enforced here.
+ */
+export interface ToastAction {
+  label: string;
+  run: () => void;
+}
+
 /** A single live toast. `kind` tints the strip; `id` keys the @for + dismissal. */
 export interface Toast {
   id: number;
   message: string;
   kind: "info" | "success" | "danger";
+  /** Optional inline action button (e.g. "Download"); absent = message-only. */
+  action?: ToastAction;
 }
 
 /** How long a toast lingers before it auto-dismisses (ms). */
@@ -52,14 +65,18 @@ export class ToastService {
     });
   }
 
-  /** Push a toast; returns its id. Auto-dismisses after `ttlMs` (0 = sticky). */
+  /**
+   * Push a toast; returns its id. Auto-dismisses after `ttlMs` (0 = sticky).
+   * Pass `action` to render an inline action button (usually with `ttlMs: 0`).
+   */
   push(
     message: string,
     kind: Toast["kind"] = "info",
     ttlMs: number = DEFAULT_TTL_MS,
+    action?: ToastAction,
   ): number {
     const id = this.nextId++;
-    this._toasts.update((list) => [...list, { id, message, kind }]);
+    this._toasts.update((list) => [...list, { id, message, kind, action }]);
     if (ttlMs > 0) {
       const handle = setTimeout(() => this.dismiss(id), ttlMs);
       this.timers.set(id, handle);

--- a/src/app/services/update.service.ts
+++ b/src/app/services/update.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type { UpdateInfo } from "../core/models";
+import { ToastService } from "./toast.service";
+
+/** The lifecycle of an update check, surfaced to the Settings "About" section. */
+export type UpdateStatus =
+  | "idle"
+  | "checking"
+  | "upToDate"
+  | "available"
+  | "error";
+
+/**
+ * Central update-check logic, shared by the startup nudge (AppComponent) and the
+ * manual "Check for updates" button (Settings → About). It talks to the Rust
+ * `check_for_update` / `open_release_page` commands through {@link IpcService}
+ * and surfaces outcomes via {@link ToastService}.
+ *
+ * All state lives in signals (`status` / `latest`) so the Settings pane renders
+ * reactively under zoneless change detection — no plain fields for template-read
+ * state. Both public methods are async and never throw: the startup path is
+ * silent on failure (a background check must not nag), the manual path surfaces
+ * errors (it's user-initiated).
+ */
+@Injectable({ providedIn: "root" })
+export class UpdateService {
+  private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
+
+  private readonly _status = signal<UpdateStatus>("idle");
+  /** Current check lifecycle state (drives the Settings button label + result line). */
+  readonly status = this._status.asReadonly();
+
+  private readonly _latest = signal<UpdateInfo | null>(null);
+  /** The most-recent successful check result (null until a check succeeds). */
+  readonly latest = this._latest.asReadonly();
+
+  /**
+   * Best-effort startup check. If an update is available, push a STICKY info
+   * toast with a "Download" action that opens the release page. On ANY thrown
+   * error (network / rate-limit) it swallows silently — a failed background
+   * check must never nag the user. Never throws.
+   */
+  async checkOnStartup(): Promise<void> {
+    try {
+      const info = await this.ipc.checkForUpdate();
+      this._latest.set(info);
+      if (info.updateAvailable) {
+        this._status.set("available");
+        this.pushDownloadToast(info);
+      } else {
+        this._status.set("upToDate");
+      }
+    } catch {
+      // Silent on startup: a failed background check must not surface a toast.
+    }
+  }
+
+  /**
+   * User-initiated check (the Settings "About" button). Sets `status` to
+   * "checking", then to "upToDate" / "available" on success — showing a toast
+   * for BOTH outcomes — or "error" with a danger toast on failure. Never throws.
+   */
+  async checkManually(): Promise<void> {
+    this._status.set("checking");
+    try {
+      const info = await this.ipc.checkForUpdate();
+      this._latest.set(info);
+      if (info.updateAvailable) {
+        this._status.set("available");
+        this.pushDownloadToast(info);
+      } else {
+        this._status.set("upToDate");
+        this.toast.success("You're on the latest version.");
+      }
+    } catch {
+      this._status.set("error");
+      this.toast.danger("Couldn't check for updates.");
+    }
+  }
+
+  /** Push the sticky "New version …" toast with a Download action. */
+  private pushDownloadToast(info: UpdateInfo): void {
+    this.toast.push(
+      `New version ${info.latestVersion} is available.`,
+      "info",
+      0,
+      {
+        label: "Download",
+        run: () => void this.ipc.openReleasePage(info.releaseUrl),
+      },
+    );
+  }
+}


### PR DESCRIPTION
Closes #112.

## What

Adds an app-version update check backed by the GitHub Releases API.

- **On startup** the app checks whether a newer release exists. If so, a sticky toast appears with a **Download** button that opens the GitHub release page in the default browser.
- **Settings → About** (new section, at the bottom of the sidebar) shows the current version + product info and a **Check for updates** button for a manual check (surfaces both "up to date" and "update available" outcomes, plus an error toast if the check fails).

Per issue #112 this implements **Option 2** (open the GitHub release page). The full auto-download+install path (Option 1, `tauri-plugin-updater`) is intentionally deferred — it needs new dependencies, an updater signing keypair, and changes to the notarized release pipeline; it can follow as a separate PR.

## How

**Backend** (`src-tauri/src/update.rs`, new; registered in `lib.rs`):
- `check_for_update()` — GETs `repos/murmur-io/murmur/releases/latest` (sends a `User-Agent` to avoid GitHub's 403, ~10s timeout, reqwest client mirroring `summarize::anthropic::build_client`), then a hand-rolled numeric semver compare against `env!("CARGO_PKG_VERSION")`. Malformed/garbage tags never panic and never report a phantom update. Network/rate-limit failures return `AppError::Unavailable`.
- `app_info()` — product name / version / description / repo for the About panel.
- `open_release_page(url)` — opens the URL via macOS `open`, **host-pinned** to the Murmur repo (requires the bare repo URL or a strict `<repo>/` sub-path, so it can never become an arbitrary-URL launcher and won't accept sibling repos like `murmur-phish`).

**Frontend** (`src/app/`):
- `UpdateService` (`checkOnStartup` — silent on failure so a background check never nags; `checkManually` — surfaces every outcome), wired fire-and-forget into `AppComponent.ngOnInit` (main window only).
- `ToastService` gained an optional `action` (label + callback) rendered as a button in the existing signal-backed toast queue; existing call sites are unaffected.
- New **About** section in Settings.

No new dependencies (reqwest/serde_json already present; no npm additions).

## Verification

- `cargo test --lib` — green for this change; 10/10 `update::` tests pass (semver edge cases, malformed input, host-validation incl. prefix-boundary siblings). The one repo-wide failure (`import_text_round_trip_as_note`) is pre-existing/environmental (embed-model presence) — `commands.rs` is byte-identical to trunk on this branch.
- `npx ng lint` — clean. `npx ng build` — green (settings.component.ts style at 15.51 kB is a warning, under the 16 kB error budget).
- Independent **adversarial-verifier** pass: PASS. It flagged the original `starts_with` host check as a hardening gap (stayed on github.com but allowed sibling-repo prefixes); tightened to a path-boundary check with a RED-before-GREEN test in this PR. No lock/crypto/visibility surface is touched, so no lock-security review is required.

**Not verified headless** (honest bar): the live GitHub GET, the real browser launch, and the toast/About render in the packaged WKWebView build — these need a running/signed build on a real Mac.