### PR TITLE
feat(ask): unify the Ask page onto the agentic loop

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1935,11 +1935,22 @@ pub fn get_entity_detail(
 }
 
 /// Ask-My-Vault: answer a question across ALL past meetings' notes (grounded, with sources).
+///
+/// PR G (ask-unify): on the CLOUD brain backend this routes through the SAME model-driven agentic
+/// loop as the in-meeting assistant — a VAULT-SCOPED gated executor (no meeting, read-only, NO
+/// `propose_note`; web/calendar participate under their existing consent/availability gates) with
+/// the live tool-trace on `EVENT_ASK_TOOL`. On the local/off backend, loop non-convergence, or ANY
+/// loop error (incl. `Unavailable` = no cloud consent) it falls through to THE FLOOR
+/// ([`ask_vault_floor`]) — exactly the pre-agentic corpus-pack + one-completion path with its
+/// original error/consent semantics. `ask_thread_id` (FE camelCase `askThreadId`) is the OPTIONAL
+/// thread identity stamped on every trace chip; absent ⇒ backend-generated (UUID v4).
 #[tauri::command]
 pub async fn ask_vault(
+    app: AppHandle,
     state: State<'_, AppState>,
     question: String,
     history: Vec<ChatTurn>,
+    ask_thread_id: Option<String>,
 ) -> Result<AskVaultResult, AppError> {
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
@@ -1951,48 +1962,645 @@ pub async fn ask_vault(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
+    // The same 12-message discipline as the chat panel (CHAT_CONTEXT_TURNS): bounds prompt growth +
+    // cloud egress on BOTH paths. The LATEST question still drives retrieval either way.
+    let history: Vec<ChatTurn> = capped_ask_history(&history).to_vec();
+
+    // Agentic path — CLOUD backend only (the same rule as the in-meeting brain: local-GGUF
+    // multi-step tool-call reliability is unproven). The loop is blocking (scoped-thread
+    // connectors), so it runs on a blocking thread like `ask_assistant_chat`.
+    if config.brain_backend == BrainBackend::Cloud {
+        let thread_id = crate::transcribe::live::ensure_thread_id(ask_thread_id);
+        let handle = app.clone();
+        let q = question.clone();
+        let h = history.clone();
+        let attempt = tokio::task::spawn_blocking(move || {
+            ask_vault_agentic_attempt(&handle, &q, &h, &thread_id)
+        })
+        .await
+        .map_err(|e| AppError::Other(anyhow::anyhow!("ask task join failed: {e}")))?;
+        if let Some(result) = attempt {
+            return Ok(result);
+        }
+    }
+
+    // THE FLOOR — the pre-agentic behavior, unchanged (RED-first equivalence-tested).
     // Pass the LIVE session unlock set (E9): a folder the user has session-unlocked is included
     // again, while sealed-and-NOT-unlocked content stays excluded by the same visibility predicate.
     let unlocked = unlocked_snapshot(state.inner())?;
-    // Phase 2b (gated): when semantic search is ON, pick candidates by HYBRID retrieval (FTS ∪ vector
-    // KNN, RRF-fused) — embedding the query with the active embedder — then pack with the SAME
-    // budget/citation logic and the SAME visibility gate. When OFF (the default) OR the index is
-    // empty, this falls back to the existing FTS-only path UNCHANGED (the hybrid query degenerates to
-    // FTS when no vectors exist, and the flag-off branch is byte-for-byte the prior behavior).
+    ask_vault_floor(&state.db, &config, &unlocked, &question, &history).await
+}
+
+/// Max agentic rounds for the Ask surface. Not live-latency-bound like the in-meeting loop
+/// (`CLOUD_MAX_STEPS` = 4), so it gets a little more room to search + read before answering —
+/// still strictly bounded.
+const ASK_MAX_STEPS: usize = 6;
+
+/// Cap the incoming Ask history to the last [`CHAT_CONTEXT_TURNS`] turns — the same discipline as
+/// the in-meeting chat panel, closing the unbounded-prompt-growth gap the pre-agentic `ask_vault`
+/// had (it rendered the whole history uncapped).
+fn capped_ask_history(history: &[ChatTurn]) -> &[ChatTurn] {
+    let start = history.len().saturating_sub(CHAT_CONTEXT_TURNS);
+    &history[start..]
+}
+
+/// Run the vault-scoped agentic attempt for [`ask_vault`]. Returns `Some(result)` ONLY when the
+/// loop CONVERGED; `None` on non-convergence or ANY loop error — incl. `Unavailable` (no cloud
+/// consent) — so the caller floors to the pre-agentic path with its original semantics.
+fn ask_vault_agentic_attempt(
+    app: &AppHandle,
+    question: &str,
+    history: &[ChatTurn],
+    thread_id: &str,
+) -> Option<AskVaultResult> {
+    let state = app.state::<AppState>();
+    let config = match state.config.lock() {
+        Ok(c) => c.clone(),
+        Err(_) => return None, // poisoned config ⇒ floor (which will surface its own error)
+    };
+    // Re-resolved per turn (never a startup snapshot): consent/provider/backend changes apply.
+    let reasoner = state.reasoner.current();
+    // VAULT-SCOPED executor: no live meeting, READ-ONLY, and NO note drafts (the Ask page has no
+    // notes flow / Accept affordance, so `propose_note` is not advertised on this surface). The
+    // AppHandle is present so web_search / calendar_lookup participate under their existing
+    // consent/availability gates. Every read re-checks the LIVE unlocked set per call (C6).
+    let executor = crate::tools::GatedToolExecutor {
+        db: &state.db,
+        unlocked: &state.unlocked_folders,
+        config: &config,
+        meeting_id: "",
+        app: Some(app),
+        allow_writes: false,
+        note_drafts: false,
+        proposed_note: std::sync::Mutex::new(None),
+    };
+    let sink = crate::transcribe::live::ToolEventSink {
+        app: app.clone(),
+        event: crate::events::EVENT_ASK_TOOL,
+        thread_id: thread_id.to_string(),
+    };
+    match ask_vault_loop(
+        &*reasoner,
+        &executor,
+        &state.db,
+        &state.unlocked_folders,
+        question,
+        history,
+        Some(&sink as &dyn crate::agent::DeltaSink),
+    ) {
+        Ok(converged) => converged,
+        Err(e) => {
+            // PII rule: the error only — never the question/history text.
+            tracing::debug!(
+                target: "ask",
+                error = %e,
+                "ask agentic loop unavailable/failed; flooring to corpus completion"
+            );
+            None
+        }
+    }
+}
+
+/// The testable core of the agentic Ask path: drive [`crate::agent::run_agentic_loop`] with the
+/// vault-QA persona over the rendered conversation, then map a converged outcome onto the Ask DTO.
+/// `Ok(None)` = non-convergence (caller floors); `Err` propagates (caller floors) — the loop
+/// contract of `run_informational`, applied to the Ask surface.
+fn ask_vault_loop(
+    reasoner: &dyn crate::reason::LocalReasoner,
+    executor: &dyn crate::agent::ToolExecutor,
+    db: &crate::storage::Db,
+    unlocked: &std::sync::Mutex<std::collections::HashSet<String>>,
+    question: &str,
+    history: &[ChatTurn],
+    sink: Option<&dyn crate::agent::DeltaSink>,
+) -> Result<Option<AskVaultResult>, AppError> {
+    let system = crate::summarize::vault_chat::agentic_system();
+    let user = crate::summarize::vault_chat::render_conversation(history, question);
+    let Some(outcome) =
+        crate::agent::run_agentic_loop(reasoner, &system, &user, executor, ASK_MAX_STEPS, sink)?
+    else {
+        return Ok(None);
+    };
+    // Resolve sources against the LIVE unlocked set (fail-closed on a poisoned lock: no source
+    // chips rather than an ungated resolution).
+    let unlocked_now = unlocked.lock().map(|g| g.clone()).unwrap_or_default();
+    Ok(Some(agent_outcome_to_ask_result(db, &unlocked_now, outcome)))
+}
+
+/// Map a converged [`crate::agent::AgentOutcome`] onto the Ask DTO. `citations` carries the loop's
+/// gated citation strings verbatim (`[[Title]]` / `(web) …`); `sources` additionally resolves each
+/// `[[Title]]` to its VISIBLE meeting (id + date) so the existing source chips keep working. A
+/// title that doesn't resolve to a visible meeting simply contributes no source — never an error,
+/// never an ungated read (`meeting_by_title_visible` applies the same visibility predicate as
+/// every gated reader).
+fn agent_outcome_to_ask_result(
+    db: &crate::storage::Db,
+    unlocked: &std::collections::HashSet<String>,
+    outcome: crate::agent::AgentOutcome,
+) -> AskVaultResult {
+    let mut sources: Vec<crate::storage::models::VaultSource> = Vec::new();
+    for cite in &outcome.citations {
+        let Some(title) = cite.strip_prefix("[[").and_then(|c| c.strip_suffix("]]")) else {
+            continue; // "(web) …" / "(calendar) …" attributions have no meeting to resolve.
+        };
+        match db.meeting_by_title_visible(title, unlocked) {
+            Ok(Some(m)) if !sources.iter().any(|s| s.meeting_id == m.id) => {
+                sources.push(crate::storage::models::VaultSource {
+                    meeting_id: m.id,
+                    title: m.title.unwrap_or_else(|| title.to_string()),
+                    started_at: m.started_at,
+                });
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::debug!(target: "ask", error = %e, "citation source resolution failed")
+            }
+        }
+    }
+    AskVaultResult { answer: outcome.answer, sources, citations: outcome.citations }
+}
+
+/// The floor's prompt assembly, split from the provider call so the floor-equivalence test can
+/// prove it byte-identical to the pre-agentic implementation without a live provider.
+enum AskFloorPrompt {
+    /// Nothing to search — the canned early-return result (identical to the pre-change string).
+    Empty(AskVaultResult),
+    /// The assembled corpus prompt, ready for ONE provider completion.
+    Ready { system: String, user: String, sources: Vec<crate::storage::models::VaultSource> },
+}
+
+/// Everything the pre-agentic `ask_vault` did BEFORE its provider call, verbatim: gated corpus
+/// assembly (hybrid when semantic search is ON, FTS otherwise — Phase 2b semantics unchanged), the
+/// empty-corpus early return, and the corpus prompt build. The floor-equivalence test binds this
+/// to the original statement sequence.
+fn build_ask_vault_floor_prompt(
+    db: &crate::storage::Db,
+    config: &AppConfig,
+    unlocked: &std::collections::HashSet<String>,
+    question: &str,
+    history: &[ChatTurn],
+) -> Result<AskFloorPrompt, AppError> {
+    // Phase 2b (gated): when semantic search is ON, pick candidates by HYBRID retrieval (FTS ∪
+    // vector KNN, RRF-fused) — embedding the query with the active embedder — then pack with the
+    // SAME budget/citation logic and the SAME visibility gate. When OFF (the default) OR the index
+    // is empty, this falls back to the existing FTS-only path UNCHANGED (the hybrid query
+    // degenerates to FTS when no vectors exist; the flag-off branch is byte-for-byte the prior
+    // behavior).
     let (corpus, sources) = if config.semantic_search_enabled {
         let embedder = crate::embed::active_embedder();
         // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
         let query_vec = embedder
-            .embed_query(std::slice::from_ref(&question))?
+            .embed_query(std::slice::from_ref(&question.to_string()))?
             .into_iter()
             .next()
             .unwrap_or_default();
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
-            &state.db,
-            &question,
+            db,
+            question,
             &config.provider_id,
             &query_vec,
-            &unlocked,
+            unlocked,
         )?
     } else {
         crate::summarize::vault_context::build_vault_context_visible(
-            &state.db,
-            &question,
+            db,
+            question,
             &config.provider_id,
-            &unlocked,
+            unlocked,
         )?
     };
     if corpus.trim().is_empty() {
-        return Ok(AskVaultResult {
+        return Ok(AskFloorPrompt::Empty(AskVaultResult {
             answer: "No meeting notes to search yet — record and summarize a meeting first."
                 .to_string(),
             sources: Vec::new(),
-        });
+            citations: Vec::new(),
+        }));
     }
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
-    let (system, user) = crate::summarize::vault_chat::build(&corpus, &history, &question);
-    let answer = provider.complete(&system, &user).await?;
-    Ok(AskVaultResult { answer, sources })
+    let (system, user) = crate::summarize::vault_chat::build(&corpus, history, question);
+    Ok(AskFloorPrompt::Ready { system, user, sources })
+}
+
+/// THE FLOOR — the pre-agentic Ask-My-Vault implementation: gated corpus pack + ONE provider
+/// completion, with the original error/consent semantics (`make_provider`'s fail-closed consent
+/// gate errors exactly as before). Runs on the local/off brain backend and whenever the agentic
+/// attempt did not converge or errored.
+async fn ask_vault_floor(
+    db: &crate::storage::Db,
+    config: &AppConfig,
+    unlocked: &std::collections::HashSet<String>,
+    question: &str,
+    history: &[ChatTurn],
+) -> Result<AskVaultResult, AppError> {
+    match build_ask_vault_floor_prompt(db, config, unlocked, question, history)? {
+        AskFloorPrompt::Empty(result) => Ok(result),
+        AskFloorPrompt::Ready { system, user, sources } => {
+            let provider = crate::summarize::make_provider(&config.provider_id, config)?;
+            let answer = provider.complete(&system, &user).await?;
+            Ok(AskVaultResult { answer, sources, citations: Vec::new() })
+        }
+    }
+}
+
+#[cfg(test)]
+mod ask_vault_tests {
+    use super::*;
+    use crate::agent::ToolExecutor;
+    use crate::reason::LocalReasoner;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+    use crate::storage::Db;
+    use serde_json::Value;
+    use std::collections::{HashSet, VecDeque};
+    use std::sync::Mutex;
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn tmp_db() -> Db {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-askvault-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    fn seed_note(db: &Db, id: &str, title: &str, markdown: &str, folder: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: id.into(),
+            started_at: "2026-06-26T09:00:00Z".into(),
+            ended_at: None,
+            title: Some(title.into()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: id.into(),
+            provider_id: "claude_code".into(),
+            markdown: markdown.into(),
+            created_at: "2026-06-26T09:05:00Z".into(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder(id, folder).unwrap();
+    }
+
+    /// A LOCKED folder + a blanked-note meeting inside it — the sealed-and-not-unlocked at-rest
+    /// shape (title still indexed; the visibility gate is what must hide it).
+    fn seed_sealed(db: &Db, meeting_id: &str, folder_id: &str, title: &str) {
+        db.insert_folder(&Folder {
+            id: folder_id.into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-06-26T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_note(db, meeting_id, title, "", Some(folder_id));
+    }
+
+    /// A reasoner whose `structured()` returns canned JSON in sequence (a test double — the
+    /// production loop drives the real ReasonerCell dispatch). Exhaustion yields an empty answer,
+    /// which the loop treats as non-convergence.
+    struct ScriptReasoner {
+        script: Mutex<VecDeque<crate::error::Result<Value>>>,
+    }
+    impl ScriptReasoner {
+        fn ok(steps: Vec<Value>) -> Self {
+            Self { script: Mutex::new(steps.into_iter().map(Ok).collect()) }
+        }
+    }
+    impl LocalReasoner for ScriptReasoner {
+        fn id(&self) -> &str {
+            "script"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> crate::error::Result<String> {
+            Ok("unused".into())
+        }
+        fn structured(&self, _s: &str, _u: &str, _schema: &Value) -> crate::error::Result<Value> {
+            self.script
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Ok(serde_json::json!({ "answer": "" })))
+        }
+    }
+
+    /// The VAULT-SCOPED executor exactly as `ask_vault_agentic_attempt` builds it (no meeting,
+    /// read-only, NO note drafts), minus the AppHandle (headless: connectors unavailable).
+    fn ask_executor<'a>(
+        db: &'a Db,
+        unlocked: &'a Mutex<HashSet<String>>,
+        cfg: &'a AppConfig,
+    ) -> crate::tools::GatedToolExecutor<'a> {
+        crate::tools::GatedToolExecutor {
+            db,
+            unlocked,
+            config: cfg,
+            meeting_id: "",
+            app: None,
+            allow_writes: false,
+            note_drafts: false,
+            proposed_note: Mutex::new(None),
+        }
+    }
+
+    /// RED-first floor equivalence (the binding test of "the floor is today's behavior"): the
+    /// extracted floor prompt must be BYTE-IDENTICAL to the pre-change statement sequence —
+    /// `build_vault_context_visible` → `vault_chat::build` — for the same inputs, and the
+    /// empty-corpus early return must keep the exact canned string. RED-proven: perturbing the
+    /// floor (e.g. swapping the corpus builder for the fail-closed shim, or reordering sections)
+    /// fails the byte equality here.
+    #[test]
+    fn ask_floor_prompt_matches_pre_change_implementation() {
+        let db = tmp_db();
+        seed_note(&db, "m1", "Atlas Kickoff", "We decided to ship atlas on Friday.", None);
+        seed_note(&db, "m2", "Weekly Sync", "Anna owns QA for atlas.", None);
+        let cfg = AppConfig::default(); // semantic_search_enabled = false → the FTS floor branch
+        let unlocked = HashSet::new();
+        let history = vec![
+            ChatTurn { role: "user".into(), content: "earlier question".into() },
+            ChatTurn { role: "assistant".into(), content: "earlier answer".into() },
+        ];
+        let q = "what did we decide about atlas?";
+
+        // The PRE-CHANGE implementation, replicated statement-for-statement.
+        let (corpus, want_sources) = crate::summarize::vault_context::build_vault_context_visible(
+            &db,
+            q,
+            &cfg.provider_id,
+            &unlocked,
+        )
+        .unwrap();
+        assert!(!corpus.trim().is_empty(), "fixture must produce a non-empty corpus");
+        let (want_system, want_user) = crate::summarize::vault_chat::build(&corpus, &history, q);
+
+        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history).unwrap() {
+            AskFloorPrompt::Ready { system, user, sources } => {
+                assert_eq!(system, want_system, "floor system prompt diverged from pre-change");
+                assert_eq!(user, want_user, "floor user prompt diverged from pre-change");
+                assert_eq!(
+                    sources.iter().map(|s| s.meeting_id.as_str()).collect::<Vec<_>>(),
+                    want_sources.iter().map(|s| s.meeting_id.as_str()).collect::<Vec<_>>(),
+                    "floor sources diverged from pre-change"
+                );
+            }
+            AskFloorPrompt::Empty(_) => panic!("a non-empty corpus must yield Ready"),
+        }
+
+        // The empty-vault early return keeps the EXACT pre-change canned answer.
+        let empty = tmp_db();
+        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[]).unwrap() {
+            AskFloorPrompt::Empty(r) => {
+                assert_eq!(
+                    r.answer,
+                    "No meeting notes to search yet — record and summarize a meeting first."
+                );
+                assert!(r.sources.is_empty() && r.citations.is_empty());
+            }
+            AskFloorPrompt::Ready { .. } => panic!("an empty vault must yield the canned Empty"),
+        }
+    }
+
+    /// The floor's ERROR/CONSENT semantics are untouched: an unconsented cloud provider is refused
+    /// by `make_provider`'s fail-closed gate with `AppError::Unavailable` — exactly the pre-change
+    /// behavior the FE consent flow keys on.
+    #[test]
+    fn ask_floor_preserves_no_consent_error_semantics() {
+        let db = tmp_db();
+        seed_note(&db, "m1", "Atlas Kickoff", "We decided to ship atlas on Friday.", None);
+        let mut cfg = AppConfig::default();
+        cfg.provider_id = "anthropic".into();
+        assert!(!cfg.cloud_egress_consented, "fresh config defaults to consent OFF");
+        let res = block_on(ask_vault_floor(&db, &cfg, &HashSet::new(), "atlas?", &[]));
+        assert!(
+            matches!(res, Err(AppError::Unavailable(_))),
+            "no-consent floor must keep the Unavailable refusal: {res:?}"
+        );
+    }
+
+    /// The Cloud loop path: a scripted brain calls a GATED tool, answers, and the tool-derived
+    /// `[[Title]]` citations flow into the DTO — verbatim in `citations` AND resolved (gated) into
+    /// the structured `sources` chips.
+    #[test]
+    fn ask_loop_tool_citations_flow_into_dto() {
+        let db = tmp_db();
+        seed_note(
+            &db,
+            "m1",
+            "Atlas Kickoff",
+            "## Action items\n- [ ] Anna — ship the deck 2026-07-10\n",
+            None,
+        );
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = ask_executor(&db, &unlocked, &cfg);
+        let brain = ScriptReasoner::ok(vec![
+            serde_json::json!({ "tool": "get_open_commitments", "args": {} }),
+            serde_json::json!({ "answer": "Anna ships the deck by 2026-07-10 [[Atlas Kickoff]]." }),
+        ]);
+        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "who owns the deck?", &[], None)
+            .unwrap()
+            .expect("scripted brain converged");
+        assert_eq!(out.answer, "Anna ships the deck by 2026-07-10 [[Atlas Kickoff]].");
+        assert!(
+            out.citations.contains(&"[[Atlas Kickoff]]".to_string()),
+            "tool-derived citation must reach the DTO verbatim: {:?}",
+            out.citations
+        );
+        assert_eq!(out.sources.len(), 1, "the citation resolves to ONE source chip");
+        assert_eq!(out.sources[0].meeting_id, "m1");
+        assert_eq!(out.sources[0].title, "Atlas Kickoff");
+        assert_eq!(out.sources[0].started_at, "2026-06-26T09:00:00Z");
+    }
+
+    /// The loop contract at this surface: non-convergence → `Ok(None)` (the command floors); a
+    /// reasoner error — the no-consent `Unavailable` — PROPAGATES (the command's attempt wrapper
+    /// converts it to a floor, whose semantics `ask_floor_preserves_no_consent_error_semantics`
+    /// pins).
+    #[test]
+    fn ask_loop_non_convergence_floors_and_errors_propagate() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = ask_executor(&db, &unlocked, &cfg);
+
+        // Script exhaustion yields an empty answer → the loop bails without converging.
+        let stuck = ScriptReasoner::ok(vec![
+            serde_json::json!({ "tool": "search_meetings", "args": { "query": "a" } }),
+        ]);
+        let out = ask_vault_loop(&stuck, &exec, &db, &unlocked, "q", &[], None).unwrap();
+        assert!(out.is_none(), "non-convergence must return Ok(None) for the command to floor");
+
+        struct Refuses;
+        impl LocalReasoner for Refuses {
+            fn id(&self) -> &str {
+                "refuses"
+            }
+            fn reason(&self, _s: &str, _u: &str) -> crate::error::Result<String> {
+                Ok("unused".into())
+            }
+            fn structured(
+                &self,
+                _s: &str,
+                _u: &str,
+                _schema: &Value,
+            ) -> crate::error::Result<Value> {
+                Err(AppError::Unavailable("no consent".into()))
+            }
+        }
+        let res = ask_vault_loop(&Refuses, &exec, &db, &unlocked, "q", &[], None);
+        assert!(
+            matches!(res, Err(AppError::Unavailable(_))),
+            "a loop error must propagate so the attempt wrapper can floor: {res:?}"
+        );
+    }
+
+    /// The 12-message history discipline (CHAT_CONTEXT_TURNS) now applies to Ask: a 13th message
+    /// is dropped from both the capped slice and the rendered conversation. RED vs the pre-change
+    /// code, which rendered the history uncapped.
+    #[test]
+    fn ask_history_cap_enforced() {
+        let msgs: Vec<ChatTurn> = (0..13)
+            .map(|i| ChatTurn { role: "user".into(), content: format!("turn-{i}-text") })
+            .collect();
+        let capped = capped_ask_history(&msgs);
+        assert_eq!(capped.len(), CHAT_CONTEXT_TURNS);
+        assert_eq!(capped[0].content, "turn-1-text", "the oldest message beyond the cap is dropped");
+        let rendered = crate::summarize::vault_chat::render_conversation(capped, "final question");
+        assert!(!rendered.contains("turn-0-text"), "turn beyond the cap must not render");
+        assert!(rendered.contains("turn-12-text"), "the newest capped turn renders");
+        assert!(rendered.trim_end().ends_with("Assistant:"), "render keeps the completion cue");
+
+        // A short history passes through untouched.
+        assert_eq!(capped_ask_history(&msgs[..3]).len(), 3);
+    }
+
+    /// SURFACE SPLIT: the vault executor must NOT advertise `propose_note` (the Ask page has no
+    /// notes flow / Accept affordance) and must REFUSE to run it (the allowlist fails closed);
+    /// the in-meeting executor (note_drafts: true) still advertises it. RED-able: drop the
+    /// `"propose_note" => self.note_drafts` filter arm and the first assertion fails.
+    #[test]
+    fn propose_note_hidden_on_ask_surface_but_kept_in_meeting() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+
+        let vault = ask_executor(&db, &unlocked, &cfg);
+        let names: Vec<&str> = vault.specs().iter().map(|s| s.name).collect();
+        assert!(
+            !names.contains(&"propose_note"),
+            "the Ask surface must not advertise propose_note: {names:?}"
+        );
+        let res = vault.run("propose_note", &serde_json::json!({ "content": "draft" }));
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "an un-advertised propose_note must be refused by the allowlist: {res:?}"
+        );
+
+        let in_meeting = crate::tools::GatedToolExecutor {
+            db: &db,
+            unlocked: &unlocked,
+            config: &cfg,
+            meeting_id: "live1",
+            app: None,
+            allow_writes: false,
+            note_drafts: true,
+            proposed_note: Mutex::new(None),
+        };
+        assert!(
+            in_meeting.specs().iter().any(|s| s.name == "propose_note"),
+            "the in-meeting surface keeps propose_note advertised"
+        );
+    }
+
+    /// LOCK INVARIANT at the Ask surface: a scripted brain that tries to exfiltrate a
+    /// sealed-not-unlocked meeting through the vault executor surfaces NOTHING sealed — not in the
+    /// direct tool reads, not in the DTO's citations, not in the resolved `sources` (the
+    /// citation→source resolver applies the same visibility predicate and only resolves once the
+    /// folder is session-unlocked).
+    #[test]
+    fn ask_loop_never_surfaces_sealed_content() {
+        let db = tmp_db();
+        seed_note(&db, "open1", "Atlas Kickoff", "We decided to ship atlas on Friday.", None);
+        seed_sealed(&db, "sealed1", "fsec", "Atlas Secret Terms");
+
+        // Seed self-check: the fixture must be sealed-not-unlocked BEFORE we prove the gate.
+        let nothing = HashSet::new();
+        assert!(db.meeting_is_visible("open1", &nothing).unwrap());
+        assert!(
+            !db.meeting_is_visible("sealed1", &nothing).unwrap(),
+            "seed fixture: sealed1 must be gated"
+        );
+
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = ask_executor(&db, &unlocked, &cfg);
+
+        // Direct gate proof on THIS surface's executor shape.
+        let got = exec.run("get_meeting", &serde_json::json!({ "meetingId": "sealed1" })).unwrap();
+        assert!(got.starts_with("No data"), "sealed fetch must be gated: {got}");
+
+        // The full loop, driven by an exfiltrating script.
+        let brain = ScriptReasoner::ok(vec![
+            serde_json::json!({ "tool": "get_meeting", "args": { "meetingId": "sealed1" } }),
+            serde_json::json!({ "tool": "search_meetings", "args": { "query": "Atlas Secret Terms" } }),
+            serde_json::json!({ "answer": "Here is what I found." }),
+        ]);
+        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "the secret terms?", &[], None)
+            .unwrap()
+            .expect("converged");
+        assert!(
+            out.citations.iter().all(|c| !c.contains("Secret")),
+            "sealed title must never be cited: {:?}",
+            out.citations
+        );
+        assert!(
+            out.sources.iter().all(|s| s.meeting_id != "sealed1"),
+            "sealed meeting must never resolve into sources: {:?}",
+            out.sources
+        );
+
+        // The resolver itself is gated: the sealed title resolves ONLY once session-unlocked.
+        assert!(
+            db.meeting_by_title_visible("Atlas Secret Terms", &nothing).unwrap().is_none(),
+            "sealed-not-unlocked title must not resolve"
+        );
+        let mut open = HashSet::new();
+        open.insert("fsec".to_string());
+        assert_eq!(
+            db.meeting_by_title_visible("Atlas Secret Terms", &open)
+                .unwrap()
+                .expect("session-unlocked title resolves")
+                .id,
+            "sealed1"
+        );
+    }
+
+    /// The Ask trace stream is its OWN event — record-screen stores must never see Ask chips.
+    #[test]
+    fn ask_tool_event_is_distinct() {
+        assert_ne!(crate::events::EVENT_ASK_TOOL, crate::events::EVENT_ASSISTANT_TOOL);
+        assert_ne!(crate::events::EVENT_ASK_TOOL, crate::events::EVENT_CHAT_TOOL);
+    }
 }
 
 /// Entity DOSSIER (brain2 Phase 5b): synthesize the "state of [[entity]]" across all meetings —

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -77,6 +77,12 @@ pub const EVENT_ASSISTANT_TOOL: &str = "murmur://assistant-tool";
 /// card and vice-versa. Payload is [`AssistantToolPayload`] (tool name + state + count, NO PII).
 pub const EVENT_CHAT_TOOL: &str = "murmur://chat-tool";
 
+/// Same shape again but scoped to the ASK-MY-VAULT page (the vault-wide agentic Q&A surface),
+/// deliberately separate from [`EVENT_ASSISTANT_TOOL`] / [`EVENT_CHAT_TOOL`] so the record-screen
+/// stores never see Ask chips and vice-versa. Payload is [`AssistantToolPayload`] (tool name +
+/// state + count + the turn's opaque `thread_id`, NO PII).
+pub const EVENT_ASK_TOOL: &str = "murmur://ask-tool";
+
 /// Payload for [`EVENT_ASSISTANT_TOOL`]. `state` is "running" | "done"; `ok` is false when the tool
 /// call errored; `count` is a coarse result-size signal for the "✓ N" badge (NEVER the content).
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -3546,6 +3546,40 @@ impl Db {
         Ok(out)
     }
 
+    /// The most recent VISIBLE meeting titled exactly `title` — the Ask surface's citation→source
+    /// resolution (a `[[Title]]` wikilink back to a meeting id/date chip). Applies the SAME
+    /// visibility predicate as [`Self::list_meetings_visible`], so a sealed-and-not-session-unlocked
+    /// meeting can never resolve — a citation string can't become an existence/date leak. Exact
+    /// (case-sensitive) title match; newest first when titles collide.
+    pub fn meeting_by_title_visible(
+        &self,
+        title: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<Meeting>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
+                    (SELECT nf.folder_id FROM notes nf
+                      WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1)
+                      AS folder_id
+               FROM meetings m
+              WHERE m.title = ?1
+                AND (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                     OR EXISTS (
+                          SELECT 1 FROM notes n
+                           LEFT JOIN folders f ON f.id = n.folder_id
+                           WHERE n.meeting_id = m.id AND {visible}
+                        ))
+              ORDER BY m.started_at DESC, m.id DESC
+              LIMIT 1"
+        );
+        conn.query_row(&sql, rusqlite::params![title], row_to_meeting)
+            .optional()
+            .map_err(map_err)?
+            .transpose()
+    }
+
     /// The latest visible note for a meeting (MCP `get_meeting`); `None` if the meeting's note
     /// is sealed-and-not-session-unlocked.
     pub fn get_note_if_visible(

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -420,6 +420,11 @@ pub struct VaultSource {
 pub struct AskVaultResult {
     pub answer: String,
     pub sources: Vec<VaultSource>,
+    /// ADDITIVE (PR G, ask-unify): the agentic loop's gated citation strings verbatim —
+    /// `[[Title]]` vault wikilinks plus loud `(web)` / `(calendar)` attributions the structured
+    /// `sources` chips can't carry. Empty on the corpus-floor path; FE may ignore it.
+    #[serde(default)]
+    pub citations: Vec<String>,
 }
 
 /// Result of generating a vault digest: the markdown + the path written into the vault.

--- a/src-tauri/src/summarize/vault_chat.rs
+++ b/src-tauri/src/summarize/vault_chat.rs
@@ -21,6 +21,13 @@ Never output YAML or front-matter.\n\n\
 MEETING NOTES:\n{corpus}"
     );
 
+    (system, render_conversation(history, question))
+}
+
+/// Render the running conversation + latest question into the user message. Shared VERBATIM by the
+/// corpus floor ([`build`]) and the agentic Ask loop, so both brains see the exact same conversation
+/// (the floor stays byte-identical to the pre-agentic implementation).
+pub fn render_conversation(history: &[ChatTurn], question: &str) -> String {
     let mut user = String::new();
     for turn in history {
         let who = if turn.role == "assistant" {
@@ -31,8 +38,28 @@ MEETING NOTES:\n{corpus}"
         user.push_str(&format!("{who}: {}\n", turn.content.trim()));
     }
     user.push_str(&format!("User: {}\nAssistant:", question.trim()));
+    user
+}
 
-    (system, user)
+/// The vault-QA persona for the AGENTIC Ask surface (PR G, ask-unify): the same grounded / cited /
+/// concise rules as the corpus prompt, but the grounding arrives through GATED TOOLS instead of a
+/// pre-packed corpus (the agentic loop appends the tool catalog + JSON protocol itself). Deliberately
+/// NO live-transcript / typed-notes injection — the Ask page is not a recording surface.
+pub fn agentic_system() -> String {
+    "You answer questions across a user's PAST MEETINGS, imported documents, and brain notes \
+     (their private, on-device vault).\n\
+     Rules:\n\
+     - Ground every claim in tool results — search before answering unless you already have \
+     enough grounding. If the answer isn't in the vault, say you don't know. Never invent \
+     facts, decisions, or attributions.\n\
+     - Cite the meetings you rely on inline using their [[Title]] exactly as the tools return \
+     it; attribute web facts as \"(via web)\".\n\
+     - When something evolved across meetings, trace it chronologically.\n\
+     - Be concise and concrete.\n\
+     - Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight \
+     bullets or short `##` sections. A tasteful emoji in a section header is welcome (e.g. \
+     ## ✅ Decisions). Never output YAML or front-matter."
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -15,9 +15,10 @@
 //! `create_reminder`) live on [`GatedToolExecutor`] (NOT [`execute_tool`]): they run only when the
 //! executor was built with `allow_writes`, and `save_note` re-checks `meeting_is_visible` against the
 //! live `unlocked` set BEFORE it appends to `manual_notes` — a sealed-not-unlocked meeting refuses.
-//! The `propose_note` tool (always advertised) writes NO DB AT ALL — it only records a note DRAFT in
-//! interior-mutable scratch for the FE to offer "Add to notes"; the user commits it on Accept. So it
-//! needs no gate (it touches no content store) and carries no leak surface.
+//! The `propose_note` tool (advertised on note-capable surfaces via `note_drafts`) writes NO DB AT
+//! ALL — it only records a note DRAFT in interior-mutable scratch for the FE to offer "Add to
+//! notes"; the user commits it on Accept. So it needs no gate (it touches no content store) and
+//! carries no leak surface.
 //!
 //! ## Egress
 //! [`execute_tool`] EGRESSES NOTHING — it only reads the local SQLite DB and (for semantic search)
@@ -82,9 +83,11 @@ pub struct ToolSpec {
 }
 
 /// The model-facing tool catalog. Built per call (cheap; ~11 entries). The read tools map 1:1 onto
-/// gated `execute_tool` / connector dispatchers. `propose_note` is `write: false` (ALWAYS advertised):
-/// it has NO DB side effect — it only RECORDS a note DRAFT for the user to review/accept via the FE,
-/// so it is the model-driven "the user asked for a note" signal that needs no write capability. The two
+/// gated `execute_tool` / connector dispatchers. `propose_note` is `write: false` (advertised on
+/// surfaces built with `note_drafts` — the in-meeting loops; NOT the vault-wide Ask page, which has
+/// no Accept affordance): it has NO DB side effect — it only RECORDS a note DRAFT for the user to
+/// review/accept via the FE, so it is the model-driven "the user asked for a note" signal that
+/// needs no write capability. The two
 /// `write: true` entries (`save_note`, `create_reminder`) map onto the gated write arms of
 /// `GatedToolExecutor::run` and are advertised ONLY when the executor was built with `allow_writes`.
 pub fn tool_specs() -> Vec<ToolSpec> {
@@ -567,6 +570,11 @@ pub struct GatedToolExecutor<'a> {
     pub meeting_id: &'a str,
     pub app: Option<&'a tauri::AppHandle>,
     pub allow_writes: bool,
+    /// Advertise the DB-free `propose_note` DRAFT tool on this surface. TRUE for the in-meeting
+    /// surfaces (they have a notes flow + an "Add to notes" Accept affordance); FALSE for surfaces
+    /// with no notes flow (the vault-wide Ask page), where a drafted note could never be accepted.
+    /// The tool stays implemented either way — un-advertised, the `run()` allowlist refuses it.
+    pub note_drafts: bool,
     /// The note draft the model proposed this turn (via `propose_note`), if any. `None` ⇒ the reply
     /// is a plain ANSWER; `Some(content)` ⇒ a NOTE PROPOSAL the FE should offer to add. No DB effect.
     pub proposed_note: std::sync::Mutex<Option<String>>,
@@ -581,6 +589,9 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             .filter(|s| match s.name {
                 // Connectors require the AppHandle (async sidecar / consent path).
                 "web_search" | "calendar_lookup" => has_app,
+                // The draft tool is advertised only on surfaces with a notes flow / Accept
+                // affordance (in-meeting yes, the vault-wide Ask page no).
+                "propose_note" => self.note_drafts,
                 // Write actions require explicit allow_writes (off in the v1 loop).
                 _ if s.write => allow_writes,
                 _ => true,
@@ -956,6 +967,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: true,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let names: Vec<&str> = writeable.specs().iter().map(|s| s.name).collect();
@@ -974,6 +986,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let ro_names: Vec<&str> = readonly.specs().iter().map(|s| s.name).collect();
@@ -1005,6 +1018,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: true,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
 
@@ -1054,6 +1068,7 @@ mod tests {
             meeting_id: "sealed1",
             app: None,
             allow_writes: true,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "secret note" }));
@@ -1083,6 +1098,7 @@ mod tests {
             meeting_id: "", // no active recording
             app: None,
             allow_writes: true,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "orphan note" }));
@@ -1107,6 +1123,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false, // read-only — write tools not advertised
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "should not run" }));
@@ -1137,6 +1154,7 @@ mod tests {
                 meeting_id: "live1",
                 app: None,
                 allow_writes,
+                note_drafts: true,
                 proposed_note: Mutex::new(None),
             };
             let names: Vec<&str> = exec.specs().iter().map(|s| s.name).collect();
@@ -1166,6 +1184,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false, // propose works even read-only
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
 
@@ -1210,6 +1229,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         // A plain read tool (the kind a question would use) does NOT set a proposal.
@@ -1234,6 +1254,7 @@ mod tests {
             meeting_id: "live1",
             app: None,
             allow_writes: false,
+            note_drafts: true,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("propose_note", &serde_json::json!({ "content": "   " }));

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -479,7 +479,10 @@ fn run_informational(
             // for a future structured "agent acts" iteration. The dispatch still routes EVERY request
             // through this loop (no hardcoded write classifier), so the model decides answer-vs-draft.
             allow_writes: false,
-            // The always-on `propose_note` tool records its draft HERE (no DB write). We read it after
+            // In-meeting surfaces HAVE the notes flow + "Add to notes" Accept affordance, so the
+            // draft tool is advertised here (the vault-wide Ask page sets this false).
+            note_drafts: true,
+            // The `propose_note` tool records its draft HERE (no DB write). We read it after
             // the loop to mark the reply as a NOTE PROPOSAL vs a plain ANSWER. The model decides which.
             proposed_note: std::sync::Mutex::new(None),
         };
@@ -561,14 +564,16 @@ fn floor_intent_for(
 }
 
 /// The live tool-trace sink: emits a per-tool-call event (`EVENT_ASSISTANT_TOOL` for the card,
-/// `EVENT_CHAT_TOOL` for the chat panel — chosen by `event`) so the FE can render the "Searching
-/// notes… ✓" chips. NO PII — tool NAME + a coarse result-size count + the turn's OPAQUE thread id.
-struct ToolEventSink {
-    app: AppHandle,
-    event: &'static str,
+/// `EVENT_CHAT_TOOL` for the chat panel, `EVENT_ASK_TOOL` for the Ask page — chosen by `event`) so
+/// the FE can render the "Searching notes… ✓" chips. NO PII — tool NAME + a coarse result-size
+/// count + the turn's OPAQUE thread id. `pub(crate)` so `ask_vault` (commands.rs) reuses the SAME
+/// payload contract instead of duplicating it.
+pub(crate) struct ToolEventSink {
+    pub(crate) app: AppHandle,
+    pub(crate) event: &'static str,
     /// The turn's thread identity — stamped on every chip so simultaneous threads never
     /// cross-attribute their traces (the documented v1 gap this closes).
-    thread_id: String,
+    pub(crate) thread_id: String,
 }
 impl crate::agent::DeltaSink for ToolEventSink {
     fn tool_running(&self, tool: &str) {

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -954,6 +954,7 @@ mod tests {
             meeting_id: "",
             app: None,
             allow_writes: false,
+            note_drafts: true,
             proposed_note: std::sync::Mutex::new(None),
         };
 

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -66,6 +66,8 @@ export const EVENT_VOICE_COMMAND_PROCESSING =
 export const EVENT_ASSISTANT_TOOL = "murmur://assistant-tool";
 // The chat panel's own tool-trace stream (kept separate from the assistant card's).
 export const EVENT_CHAT_TOOL = "murmur://chat-tool";
+// The Ask page's own tool-trace stream (separate from the record-screen streams).
+export const EVENT_ASK_TOOL = "murmur://ask-tool";
 // Whisper transcribe-model download progress stream.
 export const EVENT_MODEL_DOWNLOAD = "murmur://model-download";
 // Proactive brain (P2) — one zero-egress recall hint from the live-loop matcher.
@@ -434,9 +436,25 @@ export class IpcService {
     return invoke<void>("delete_document", { id });
   }
 
-  /** Ask-My-Vault: grounded Q&A across ALL meetings, with source meetings. */
-  askVault(question: string, history: ChatTurn[]): Promise<AskVaultResult> {
-    return invoke<AskVaultResult>("ask_vault", { question, history });
+  /**
+   * Ask-My-Vault: grounded Q&A across ALL meetings, with source meetings.
+   * `askThreadId` (optional, FE-minted per question) keys this turn's live
+   * tool-trace: the backend stamps it onto the `murmur://ask-tool` events it
+   * emits while answering, so the Ask page routes chips to the in-flight
+   * question only. NOTE: the backend caps the effective history at the LAST
+   * 12 messages — send the full conversation and let it truncate; do NOT
+   * trim FE-side.
+   */
+  askVault(
+    question: string,
+    history: ChatTurn[],
+    askThreadId?: string,
+  ): Promise<AskVaultResult> {
+    return invoke<AskVaultResult>("ask_vault", {
+      question,
+      history,
+      askThreadId,
+    });
   }
 
   /** Generate a Weekly Vault Digest over the last `days` days (writes to vault Digests/). */
@@ -891,6 +909,15 @@ export class IpcService {
   /** The CHAT panel's own live tool-trace (separate from the assistant card's). */
   onChatTool(cb: (p: AssistantToolPayload) => void): Promise<UnlistenFn> {
     return listen<AssistantToolPayload>(EVENT_CHAT_TOOL, (e) => cb(e.payload));
+  }
+
+  /**
+   * The ASK page's own live tool-trace (separate from the record-screen
+   * streams): one event per tool call the `ask_vault` agentic loop makes,
+   * stamped with the `askThreadId` the FE passed to {@link askVault}.
+   */
+  onAskTool(cb: (p: AssistantToolPayload) => void): Promise<UnlistenFn> {
+    return listen<AssistantToolPayload>(EVENT_ASK_TOOL, (e) => cb(e.payload));
   }
 
   /** Fires with progress for the in-flight Whisper transcribe-model download. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -329,7 +329,9 @@ export interface VoiceCommandProcessingPayload {
  * Fired once per TOOL CALL the in-meeting brain makes during an agentic turn
  * (`EVENT_ASSISTANT_TOOL`), so the assistant card can render the live tool-trace
  * chips ("Searching notes… ✓", "Checking the web…"). NO PII — the tool NAME +
- * a coarse result-size count only (never args, results, or content).
+ * a coarse result-size count only (never args, results, or content). The same
+ * shape rides the chat panel's `EVENT_CHAT_TOOL` and the Ask page's
+ * `EVENT_ASK_TOOL` streams (each surface subscribes to its OWN stream).
  */
 export interface AssistantToolPayload {
   /** The tool name (search_meetings / search_semantic / web_search / calendar_lookup / …). */
@@ -740,6 +742,12 @@ export interface EntityDetail {
 export interface AskVaultResult {
   answer: string;
   sources: VaultSource[];
+  /**
+   * Agentic-loop grounding citations, verbatim ("[[Title]]" wikilinks from
+   * GATED tool output). Empty/absent on the deterministic floor path — the
+   * backend serializes it with a serde default, so older payloads parse fine.
+   */
+  citations?: string[];
 }
 
 export interface DigestResult {

--- a/src/app/features/ask/ask.component.ts
+++ b/src/app/features/ask/ask.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   Injector,
   OnInit,
@@ -11,8 +12,13 @@ import {
   viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../core/ipc.service";
-import type { ChatTurn, VaultSource } from "../../core/models";
+import type {
+  AssistantToolPayload,
+  ChatTurn,
+  VaultSource,
+} from "../../core/models";
 import { MarkdownComponent } from "../../shared/markdown.component";
 import { SourcesComponent } from "../../shared/sources.component";
 
@@ -26,6 +32,21 @@ interface AskTurn {
   content: string;
   /** Present on assistant turns only — the meetings that grounded the answer. */
   sources?: VaultSource[];
+}
+
+/**
+ * One tool the `ask_vault` agentic loop used while answering the IN-FLIGHT
+ * question — drives the live trace chips in the typing row ("Searching
+ * notes… ✓"). Tool name + a coarse count only (no PII), same visual language
+ * as the record-screen thread chips. Cleared when the answer lands.
+ */
+interface AskTraceStep {
+  /** Stable id for `@for` tracking (never key a trace chip on $index). */
+  id: number;
+  tool: string;
+  state: "running" | "done";
+  ok: boolean;
+  count: number | null;
 }
 
 /** The starter prompts shown in the empty state — tap to ask immediately. */
@@ -156,14 +177,46 @@ const STARTERS: readonly string[] = [
                 </div>
               }
 
-              <!-- "Thinking…" typing indicator while a reply is in flight. -->
+              <!-- In-flight reply: live tool-trace chips once the agentic loop
+                   starts calling tools, the "Thinking…" dots until then. -->
               @if (pending()) {
                 <div class="ask-row is-assistant">
-                  <div class="ask-bubble ask-typing" aria-label="Thinking">
-                    <span class="ask-dot"></span>
-                    <span class="ask-dot"></span>
-                    <span class="ask-dot"></span>
-                  </div>
+                  @if (trace().length > 0) {
+                    <div
+                      class="ask-bubble ask-trace"
+                      role="status"
+                      aria-label="Tool use"
+                    >
+                      @for (t of trace(); track t.id) {
+                        <span
+                          class="ask-trace-chip"
+                          [class.is-running]="t.state === 'running'"
+                          [class.is-web]="t.tool === 'web_search'"
+                          [class.is-failed]="!t.ok"
+                        >
+                          <span class="ask-trace-ico" aria-hidden="true">
+                            @if (t.state === "running") {
+                              <span class="ask-trace-spin"></span>
+                            } @else if (!t.ok) {
+                              ⚠
+                            } @else {
+                              ✓
+                            }
+                          </span>
+                          {{ toolLabel(t.tool) }}
+                          @if (t.state === "done" && t.count) {
+                            <span class="ask-trace-count">{{ t.count }}</span>
+                          }
+                        </span>
+                      }
+                    </div>
+                  } @else {
+                    <div class="ask-bubble ask-typing" aria-label="Thinking">
+                      <span class="ask-dot"></span>
+                      <span class="ask-dot"></span>
+                      <span class="ask-dot"></span>
+                    </div>
+                  }
                 </div>
               }
             }
@@ -475,6 +528,59 @@ const STARTERS: readonly string[] = [
         font-size: 0.6875rem;
       }
 
+      /* --- Live tool-trace chips (in-flight question only) --- */
+      .ask-trace {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-1);
+      }
+      .ask-trace-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+        font-size: 0.74rem;
+        line-height: 1.2;
+      }
+      .ask-trace-chip.is-running {
+        color: var(--text-primary);
+      }
+      .ask-trace-chip.is-web {
+        background: color-mix(in srgb, var(--live) 16%, transparent);
+        border-color: color-mix(in srgb, var(--live) 35%, transparent);
+      }
+      .ask-trace-chip.is-failed {
+        opacity: 0.6;
+      }
+      .ask-trace-ico {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 11px;
+        height: 11px;
+        font-size: 0.66rem;
+        color: var(--accent);
+      }
+      .ask-trace-chip.is-web .ask-trace-ico {
+        color: var(--live);
+      }
+      .ask-trace-count {
+        color: var(--text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .ask-trace-spin {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        border: 1.5px solid var(--accent-ring);
+        border-top-color: var(--accent);
+        animation: ask-spin 0.7s linear infinite;
+      }
+
       /* --- Typing indicator --- */
       .ask-typing {
         display: inline-flex;
@@ -596,7 +702,8 @@ const STARTERS: readonly string[] = [
           animation: none;
         }
         .ask-dot,
-        .ask-send-spin {
+        .ask-send-spin,
+        .ask-trace-spin {
           animation-duration: 0.01ms;
         }
         .ask-log {
@@ -609,6 +716,7 @@ const STARTERS: readonly string[] = [
 export class AskComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
 
   /** True while the initial "any meetings?" probe is in flight. */
   readonly loading = signal(true);
@@ -624,6 +732,18 @@ export class AskComponent implements OnInit {
   /** Working copy of the composer text (textarea (input) → signal). */
   readonly draft = signal("");
 
+  /** Live tool-trace chips for the IN-FLIGHT question (cleared when it lands). */
+  readonly trace = signal<AskTraceStep[]>([]);
+  /**
+   * The FE-minted thread id of the in-flight question — `murmur://ask-tool`
+   * payloads are routed STRICTLY by it (anything else, including unstamped
+   * events, is dropped: never mis-file a chip). Plumbing only, never rendered.
+   */
+  private activeAskId: string | null = null;
+  /** Monotonic id source for trace chips (stable `@for` keys). */
+  private nextTraceId = 1;
+  private unlistenAskTool: UnlistenFn | null = null;
+
   /** Starter prompts for the empty state. */
   protected readonly starters = STARTERS;
 
@@ -638,6 +758,7 @@ export class AskComponent implements OnInit {
    * so we only flip to the empty state on a confirmed empty list.
    */
   async ngOnInit(): Promise<void> {
+    void this.listenAskTool();
     try {
       const meetings = await this.ipc.listMeetings();
       this.isEmpty.set(meetings.length === 0);
@@ -645,6 +766,94 @@ export class AskComponent implements OnInit {
       this.isEmpty.set(false);
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  /**
+   * Subscribe ONCE to the Ask page's own tool-trace stream and store the
+   * unlisten so DestroyRef can release it (no leaked listener). Best-effort:
+   * a failure just means no trace chips — asking still works.
+   */
+  private async listenAskTool(): Promise<void> {
+    try {
+      this.unlistenAskTool = await this.ipc.onAskTool((p) => this.onAskTool(p));
+      this.destroyRef.onDestroy(() => this.unlistenAskTool?.());
+    } catch {
+      // Not running under Tauri (browser smoke without the mock): no chips.
+    }
+  }
+
+  /**
+   * Land one `murmur://ask-tool` payload as a trace chip on the in-flight
+   * question. Routed STRICTLY by threadId — a payload for another turn (a
+   * stale event from the previous question, or an unstamped one) is dropped.
+   * A "running" event pushes a new chip; a "done" event resolves the most
+   * recent matching running chip (or appends one, if "running" was missed).
+   * Plain event callback writing signals — not an effect, so no NG0600.
+   */
+  private onAskTool(p: AssistantToolPayload): void {
+    if (this.activeAskId === null || p.threadId !== this.activeAskId) {
+      return;
+    }
+    // Internal plumbing tools are not user-facing work — never chip them
+    // (mirrors the record-screen thread's visibleTrace filter).
+    if (p.tool === "propose_note") {
+      return;
+    }
+    this.trace.update((trace) => {
+      if (p.state === "running") {
+        return [
+          ...trace,
+          {
+            id: this.nextTraceId++,
+            tool: p.tool,
+            state: "running",
+            ok: true,
+            count: p.count,
+          },
+        ];
+      }
+      const next = trace.slice();
+      for (let i = next.length - 1; i >= 0; i--) {
+        if (next[i].tool === p.tool && next[i].state === "running") {
+          next[i] = { ...next[i], state: "done", ok: p.ok, count: p.count };
+          return next;
+        }
+      }
+      next.push({
+        id: this.nextTraceId++,
+        tool: p.tool,
+        state: "done",
+        ok: p.ok,
+        count: p.count,
+      });
+      return next;
+    });
+    // Keep the growing chip row pinned in view like every other new message.
+    this.scrollToLatest();
+  }
+
+  /** Human label for a tool-trace chip (same wording as the record screen). */
+  protected toolLabel(tool: string): string {
+    switch (tool) {
+      case "search_meetings":
+        return "Searching notes";
+      case "search_semantic":
+        return "Searching by meaning";
+      case "get_meeting":
+        return "Reading a meeting";
+      case "list_recent_meetings":
+        return "Listing meetings";
+      case "get_open_commitments":
+        return "Checking action items";
+      case "get_entity_dossier":
+        return "Looking up an entity";
+      case "web_search":
+        return "Searching the web";
+      case "calendar_lookup":
+        return "Checking the calendar";
+      default:
+        return tool;
     }
   }
 
@@ -709,6 +918,12 @@ export class AskComponent implements OnInit {
    * {@link ChatTurn}s the backend expects), optimistically appends the user
    * turn, awaits the grounded reply, then appends the assistant turn with its
    * source meetings. On failure the user's question is kept (Retry re-runs it).
+   *
+   * Each question mints a fresh `askThreadId` that keys its live tool-trace
+   * (`murmur://ask-tool` chips route strictly by it); the chips are cleared
+   * when the turn lands — the answer's source chips remain the durable record.
+   * We ship the FULL conversation as history: the backend caps it at the last
+   * 12 messages itself, so no FE-side truncation.
    */
   async send(): Promise<void> {
     const question = this.draft().trim();
@@ -723,6 +938,9 @@ export class AskComponent implements OnInit {
       content: t.content,
     }));
 
+    const askThreadId = crypto.randomUUID();
+    this.activeAskId = askThreadId;
+    this.trace.set([]);
     this.error.set(null);
     this.draft.set("");
     this.conversation.update((turns) => [
@@ -733,7 +951,11 @@ export class AskComponent implements OnInit {
     this.scrollToLatest();
 
     try {
-      const result = await this.ipc.askVault(question, priorHistory);
+      const result = await this.ipc.askVault(
+        question,
+        priorHistory,
+        askThreadId,
+      );
       this.conversation.update((turns) => [
         ...turns,
         {
@@ -746,6 +968,9 @@ export class AskComponent implements OnInit {
       // Keep the user's question in the log so Retry can re-send it.
       this.error.set("Couldn’t get an answer: " + String(e));
     } finally {
+      // Retire this turn's trace: late tool events for it are dropped.
+      this.activeAskId = null;
+      this.trace.set([]);
       this.pending.set(false);
       this.scrollToLatest();
     }


### PR DESCRIPTION
Kills the split-brain (brain-analysis weakness #6; ClickUp-gap reprioritization #2: the AI-knowledge-manager class is judged on the ask-anything surface, and ours was weakest exactly there).

**What changes.** `ask_vault` runs the agentic tool-use loop on the Cloud backend (ASK_MAX_STEPS=6) with a **vault-scoped** `GatedToolExecutor` (no meeting, `allow_writes:false`, new `note_drafts:false` ⇒ propose_note neither advertised nor runnable; web/calendar under existing consent gates; unlocked set re-read per tool call). **The floor is today's behavior** — non-Cloud / non-convergence / any Err incl. no-consent falls through to the pre-change corpus-pack path, byte-equality-pinned. History capped at 12 both paths (was unbounded). Loop citations resolve to sources via new gated `meeting_by_title_visible` (sealed ≡ nonexistent — no existence oracle). New `EVENT_ASK_TOOL` trace; FE renders house-style tool chips with strict threadId routing.

**Verification.** `cargo test --lib` **655/0**; `ng lint`/`ng build` green; **19/19 live-Chromium smoke** (wire-level askThreadId, strict routing, chip lifecycle, error path). **adversarial-verifier: PASS** — three RED binds re-proven independently (floor one-byte perturbation, note_drafts gate removal, resolver gate removal), single-chip-emission-site audit (no unstamped emitter — the FE's zero-chips risk is structurally closed), event-stream isolation grep. **lock-security-reviewer: PASS** — allowlist enforced at run() not just specs(); no injection path (bound params); trust chain for citations explicit (model context contains zero sealed-derived bytes); no new egress class (same RedactingProvider envelope, ≤4000 B × 6 steps).

**Noted (non-blocking):** relock-vs-in-flight-answer race is inherent session-unlock semantics (identical to the in-meeting loop); `(web)` strip-prefix arm currently dead (extract_citations emits wikilinks only); Ask conversations not persisted (out of scope — meeting-scoped table doesn't fit vault turns).

**Not verifiable headless:** the loop against a real cloud model (convergence rate, real citations); packaged-WKWebView render; live consent-gate wire behavior.