### PR TITLE
fix(ci): clippy conformance + justified quick-xml RUSTSEC exceptions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,18 @@ yanked = "deny"
 unmaintained = "workspace"
 # No blanket ignores — add a specific RUSTSEC id here ONLY with a written justification if a
 # fix is genuinely unavailable. An empty list means "no exceptions".
-ignore = []
+#
+# 2026-07-02 — quick-xml 0.39.4 DoS advisories (published 2026-06-29), fix = quick-xml >=0.41:
+# quick-xml is reachable ONLY via plist (Apple property-list parsing inside tauri/tauri-codegen);
+# plist 1.9.0 (latest) pins ^0.39, so no upgrade path exists yet. plist parses only OUR OWN
+# bundle/config metadata — never network- or user-supplied XML — and both advisories are
+# DoS-class (memory exhaustion / quadratic time) on attacker-controlled XML, so they are not
+# exploitable in this app. REMOVE both ids as soon as a plist release depends on quick-xml >=0.41
+# (`cargo update -p plist` then `cargo audit` clean).
+ignore = [
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]
 
 [licenses]
 version = 2

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit exceptions — keep in lockstep with the [advisories].ignore list in /deny.toml
+# (both gates run in scripts/ci.sh; cargo-audit does not read deny.toml).
+#
+# 2026-07-02 — quick-xml 0.39.4 DoS advisories (published 2026-06-29), fix = quick-xml >=0.41:
+# reachable ONLY via plist 1.9.0 (pins ^0.39; no fixed release yet) inside tauri/tauri-codegen;
+# plist parses only our own bundle/config metadata, never untrusted XML, and both advisories are
+# DoS-class on attacker-controlled input — not exploitable here. REMOVE as soon as a plist
+# release depends on quick-xml >=0.41.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6313,7 +6313,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2387,8 +2387,10 @@ mod ask_vault_tests {
     fn ask_floor_preserves_no_consent_error_semantics() {
         let db = tmp_db();
         seed_note(&db, "m1", "Atlas Kickoff", "We decided to ship atlas on Friday.", None);
-        let mut cfg = AppConfig::default();
-        cfg.provider_id = "anthropic".into();
+        let cfg = AppConfig {
+            provider_id: "anthropic".into(),
+            ..AppConfig::default()
+        };
         assert!(!cfg.cloud_egress_consented, "fresh config defaults to consent OFF");
         let res = block_on(ask_vault_floor(&db, &cfg, &HashSet::new(), "atlas?", &[]));
         assert!(

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -275,6 +275,10 @@ pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
 /// The LIVE reasoner dispatch held in `AppState` — resolves which brain handles each call from the
 /// CURRENT config, not a startup snapshot.
 ///
+/// The LOCAL-reasoner cache slot: the resolved GGUF path it was built from (`None` = nothing
+/// resolved ⇒ the stub) paired with the loaded instance. Factored out per clippy::type_complexity.
+type CachedLocalReasoner = Option<(Option<PathBuf>, Arc<dyn LocalReasoner>)>;
+
 /// `AppState.reasoner` used to be a `Box<dyn LocalReasoner>` resolved ONCE at startup, which made
 /// consent grants, consent revocations, provider switches, and `brain_backend` flips require an app
 /// restart (and kept a REVOKED consent egressing — the privacy-critical direction). `ReasonerCell`
@@ -296,7 +300,7 @@ pub struct ReasonerCell {
     /// the stub). The loaded model is expensive, so the instance is reused across calls and rebuilt
     /// only when the resolved path changes — which also means a model downloaded or selected
     /// mid-session activates on the next call.
-    local: Mutex<Option<(Option<PathBuf>, Arc<dyn LocalReasoner>)>>,
+    local: Mutex<CachedLocalReasoner>,
     /// TEST-ONLY pinned reasoner (mirrors `CloudReasoner::provider_override`): `Some` makes
     /// `current()` always return this instance, so command tests keep a deterministic stub.
     /// `None` in every production path (the only non-test constructor is [`new`]).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -199,7 +199,7 @@ impl AppState {
         // those columns (the blobs remain the source of truth) and re-seal any stray plaintext WAV
         // whose `.enc` already exists, so plaintext never survives a crash into the next session.
         // Best-effort: a reconciliation error is logged, never fatal to startup.
-        reconcile_locked_at_rest(&*db);
+        reconcile_locked_at_rest(&db);
 
         tracing::info!(target: "state", "app state initialized");
 

--- a/src-tauri/src/summarize/gateway.rs
+++ b/src-tauri/src/summarize/gateway.rs
@@ -236,7 +236,7 @@ pub(crate) fn parse_models_response(body: &str) -> Result<Vec<String>> {
 ///   - empty / root (`""`)  → `{scheme}://{host}/chat/completions`
 ///   - `/v1`                → `{scheme}://{host}/v1/chat/completions`
 ///   - anything else (e.g. `/test`, a Kong route, or already `/…/chat/completions`)
-///                          → use the base URL path AS-IS (it IS the full chat endpoint)
+///     → use the base URL path AS-IS (it IS the full chat endpoint)
 ///
 /// Preserves scheme, host, port, and query. Never fails.
 pub(crate) fn resolve_chat_endpoint(base: &reqwest::Url) -> reqwest::Url {
@@ -688,8 +688,7 @@ mod tests {
             String::new(),
             None,
         )
-        .err()
-        .expect("expected InvalidArg for remote http URL");
+        .map(|_| ()).expect_err("expected InvalidArg for remote http URL");
         assert!(
             matches!(err, AppError::InvalidArg(_)),
             "expected InvalidArg, got: {err}"
@@ -700,8 +699,7 @@ mod tests {
             String::new(),
             None,
         )
-        .err()
-        .expect("expected InvalidArg for file:// URL");
+        .map(|_| ()).expect_err("expected InvalidArg for file:// URL");
         assert!(
             matches!(err2, AppError::InvalidArg(_)),
             "expected InvalidArg for bad scheme, got: {err2}"
@@ -804,16 +802,14 @@ mod tests {
     fn validate_gateway_url_rejects_embedded_credentials() {
         // username + empty password (common key-in-URL pattern).
         let err = validate_gateway_url("https://mykey:@gw.example.com/v1")
-            .err()
-            .expect("embedded creds must be rejected");
+            .expect_err("embedded creds must be rejected");
         assert!(
             matches!(err, AppError::InvalidArg(_)),
             "expected InvalidArg for embedded creds, got: {err}"
         );
         // username + password.
         let err2 = validate_gateway_url("https://user:pass@gw.example.com/v1")
-            .err()
-            .expect("embedded user:pass must be rejected");
+            .expect_err("embedded user:pass must be rejected");
         assert!(matches!(err2, AppError::InvalidArg(_)));
         // No credentials → still valid.
         assert!(validate_gateway_url("https://gw.example.com/v1").is_ok());

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -258,18 +258,24 @@ mod tests {
         assert!(egress_is_cloud(PROVIDER_ANTHROPIC, &cfg));
 
         // ollama with default loopback URL is NOT cloud.
-        let mut local_cfg = AppConfig::default();
-        local_cfg.ollama_base_url = "http://localhost:11434".into();
+        let local_cfg = AppConfig {
+            ollama_base_url: "http://localhost:11434".into(),
+            ..AppConfig::default()
+        };
         assert!(!egress_is_cloud(PROVIDER_OLLAMA, &local_cfg));
 
         // ollama with a remote URL IS cloud.
-        let mut remote_cfg = AppConfig::default();
-        remote_cfg.ollama_base_url = "https://ollama.remote.example/api".into();
+        let remote_cfg = AppConfig {
+            ollama_base_url: "https://ollama.remote.example/api".into(),
+            ..AppConfig::default()
+        };
         assert!(egress_is_cloud(PROVIDER_OLLAMA, &remote_cfg));
 
         // ollama with an unparseable URL fails safe (treated as cloud).
-        let mut bad_cfg = AppConfig::default();
-        bad_cfg.ollama_base_url = "not a url".into();
+        let bad_cfg = AppConfig {
+            ollama_base_url: "not a url".into(),
+            ..AppConfig::default()
+        };
         assert!(egress_is_cloud(PROVIDER_OLLAMA, &bad_cfg));
 
         // Unknown provider ids default to cloud (fail-safe).
@@ -278,9 +284,11 @@ mod tests {
 
     #[test]
     fn remote_ollama_requires_consent() {
-        let mut cfg = AppConfig::default();
-        cfg.ollama_base_url = "https://ollama.remote.example/api".into();
-        cfg.cloud_egress_consented = false;
+        let cfg = AppConfig {
+            ollama_base_url: "https://ollama.remote.example/api".into(),
+            cloud_egress_consented: false,
+            ..AppConfig::default()
+        };
         let res = make_provider(PROVIDER_OLLAMA, &cfg);
         assert!(
             matches!(res, Err(crate::error::AppError::Unavailable(_))),
@@ -290,9 +298,11 @@ mod tests {
 
     #[test]
     fn local_ollama_stays_unwrapped_and_ungated() {
-        let mut cfg = AppConfig::default();
-        cfg.ollama_base_url = "http://localhost:11434".into();
-        cfg.cloud_egress_consented = false;
+        let cfg = AppConfig {
+            ollama_base_url: "http://localhost:11434".into(),
+            cloud_egress_consented: false,
+            ..AppConfig::default()
+        };
         // local ollama must build without consent
         assert!(make_provider(PROVIDER_OLLAMA, &cfg).is_ok());
     }
@@ -346,12 +356,14 @@ mod tests {
     /// R1 — gateway is refused when cloud-egress consent has not been granted.
     #[test]
     fn gateway_refused_without_consent() {
-        let mut c = AppConfig::default();
-        c.gateway_base_url = "https://gw.example.com/v1".into();
-        c.cloud_egress_consented = false;
+        let c = AppConfig {
+            gateway_base_url: "https://gw.example.com/v1".into(),
+            cloud_egress_consented: false,
+            ..AppConfig::default()
+        };
         let err = make_provider(PROVIDER_GATEWAY, &c)
-            .err()
-            .expect("expected Err for gateway without consent");
+            .map(|_| ())
+            .expect_err("expected Err for gateway without consent");
         assert!(
             matches!(err, crate::error::AppError::Unavailable(_)),
             "expected Unavailable, got: {err}"
@@ -364,9 +376,11 @@ mod tests {
     /// tests in redact.rs and by the lock-security-reviewer audit.)
     #[test]
     fn gateway_localhost_is_still_redaction_wrapped() {
-        let mut c = AppConfig::default();
-        c.gateway_base_url = "http://127.0.0.1:4000/v1".into();
-        c.cloud_egress_consented = true;
+        let c = AppConfig {
+            gateway_base_url: "http://127.0.0.1:4000/v1".into(),
+            cloud_egress_consented: true,
+            ..AppConfig::default()
+        };
         // Must build without error — the make_provider consent gate + URL validation passed.
         assert!(
             make_provider(PROVIDER_GATEWAY, &c).is_ok(),
@@ -377,12 +391,14 @@ mod tests {
     /// R4 — a remote http:// URL is rejected at provider-construction time (InvalidArg).
     #[test]
     fn gateway_remote_http_rejected() {
-        let mut c = AppConfig::default();
-        c.gateway_base_url = "http://gw.example.com/v1".into();
-        c.cloud_egress_consented = true;
+        let c = AppConfig {
+            gateway_base_url: "http://gw.example.com/v1".into(),
+            cloud_egress_consented: true,
+            ..AppConfig::default()
+        };
         let err = make_provider(PROVIDER_GATEWAY, &c)
-            .err()
-            .expect("expected Err for remote http gateway");
+            .map(|_| ())
+            .expect_err("expected Err for remote http gateway");
         assert!(
             matches!(err, crate::error::AppError::InvalidArg(_)),
             "expected InvalidArg for remote http://, got: {err}"
@@ -392,12 +408,14 @@ mod tests {
     /// Empty base URL → InvalidArg (before even trying to validate the URL).
     #[test]
     fn gateway_empty_url_rejected() {
-        let mut c = AppConfig::default();
-        c.gateway_base_url = String::new(); // empty — not set
-        c.cloud_egress_consented = true;
+        let c = AppConfig {
+            gateway_base_url: String::new(), // empty — not set
+            cloud_egress_consented: true,
+            ..AppConfig::default()
+        };
         let err = make_provider(PROVIDER_GATEWAY, &c)
-            .err()
-            .expect("expected Err for empty gateway URL");
+            .map(|_| ())
+            .expect_err("expected Err for empty gateway URL");
         assert!(
             matches!(err, crate::error::AppError::InvalidArg(_)),
             "expected InvalidArg for empty URL, got: {err}"
@@ -412,8 +430,10 @@ mod tests {
             egress_is_cloud(PROVIDER_GATEWAY, &cfg),
             "gateway must always be cloud regardless of base URL"
         );
-        let mut cfg_loopback = AppConfig::default();
-        cfg_loopback.gateway_base_url = "http://127.0.0.1:4000/v1".into();
+        let cfg_loopback = AppConfig {
+            gateway_base_url: "http://127.0.0.1:4000/v1".into(),
+            ..AppConfig::default()
+        };
         assert!(
             egress_is_cloud(PROVIDER_GATEWAY, &cfg_loopback),
             "a loopback gateway is still cloud-classified"


### PR DESCRIPTION
Closes the batch: the inner loop never runs `clippy --all-targets` (by rule), so 16 deny-warnings lints accumulated across the batch + #111 — all mechanical (type alias for the ReasonerCell cache slot, auto-deref, doc indent, struct-update syntax in tests, `.map(|_| ()).expect_err(..)` where the Ok type is a non-Debug trait object).

Plus: two **DoS-class RUSTSEC advisories published 2026-06-29** against transitive `quick-xml 0.39.4` (via `plist 1.9.0` ← tauri; plist pins `^0.39`, no fixed release exists yet). Added narrowly-scoped, dated, justified ignores to `deny.toml` + matching `src-tauri/.cargo/audit.toml` — per deny.toml's own written-justification rule. plist parses only our own bundle metadata, never untrusted XML; both advisories require attacker-controlled XML input. **Remove both ids once plist depends on quick-xml ≥0.41** (`cargo update -p plist` then `cargo audit` clean).

**Verification: `scripts/ci.sh` → ✅ CI: all gates green** on the integrated trunk — clippy -D warnings, **665 lib tests / 0 failed**, ng lint, ng build, cargo audit, cargo deny, headless E2E (mix/transcribe).