### PR TITLE
feat(ai): model-role resolver — Notes/Ask/Live roles over the provider seam

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -177,6 +177,36 @@ pub struct AppConfigDto {
     /// `AppConfig::default` — an older FE payload must not silently flip the backend mute.
     #[serde(default = "default_true")]
     pub proactive_hints_enabled: bool,
+    /// Model-role override — the connection serving the NOTES role (see
+    /// `crate::summarize::roles`). Settable from the DTO (a future Settings UI owns the rows).
+    /// `""` (and an omitted key, `#[serde(default)]`) = inherit the legacy mapping — so an older
+    /// FE payload can never flip a role.
+    #[serde(default)]
+    pub role_notes_connection: String,
+    /// Model-role override — the model for the Notes role (`""` = connection default).
+    #[serde(default)]
+    pub role_notes_model: String,
+    /// Model-role override — the effort for the Notes role (`""` = provider default).
+    #[serde(default)]
+    pub role_notes_effort: String,
+    /// Model-role override — the connection serving the ASK role. Same semantics as the Notes keys.
+    #[serde(default)]
+    pub role_ask_connection: String,
+    /// Model-role override — the model for the Ask role.
+    #[serde(default)]
+    pub role_ask_model: String,
+    /// Model-role override — the effort for the Ask role.
+    #[serde(default)]
+    pub role_ask_effort: String,
+    /// Model-role override — the connection serving the LIVE role. Same semantics as the Notes keys.
+    #[serde(default)]
+    pub role_live_connection: String,
+    /// Model-role override — the model for the Live role.
+    #[serde(default)]
+    pub role_live_model: String,
+    /// Model-role override — the effort for the Live role.
+    #[serde(default)]
+    pub role_live_effort: String,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
@@ -1244,7 +1274,9 @@ pub async fn chat_meeting(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
+    // default provider as before (the legacy chat path always ignored `brain_backend`).
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Ask, &config)?;
     let (system, user) = crate::summarize::chat::build(&transcript, &history, &question);
     provider.complete(&system, &user).await
 }
@@ -1487,7 +1519,7 @@ pub async fn run_recipe(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let (system, user) = crate::summarize::recipes::build_recipe_prompt(
         &transcript,
         &prompt,
@@ -1772,7 +1804,7 @@ pub async fn build_and_persist_entities(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let payload =
         crate::summarize::graph::extract_entities(provider.as_ref(), title, markdown).await?;
 
@@ -1854,7 +1886,7 @@ fn persist_facts_for_meeting(
     // 1) Best-effort extraction (panic-free, empty on stub/no model/decode failure). The reasoner
     //    is re-resolved from the LIVE config, so a consent/backend change applies without restart.
     let candidates = crate::facts::extract_fact_candidates(
-        &*state.reasoner.current(),
+        &*state.reasoner.current_for(crate::summarize::roles::Role::Notes),
         title,
         markdown,
         entity_refs,
@@ -1966,10 +1998,15 @@ pub async fn ask_vault(
     // cloud egress on BOTH paths. The LATEST question still drives retrieval either way.
     let history: Vec<ChatTurn> = capped_ask_history(&history).to_vec();
 
-    // Agentic path — CLOUD backend only (the same rule as the in-meeting brain: local-GGUF
-    // multi-step tool-call reliability is unproven). The loop is blocking (scoped-thread
-    // connectors), so it runs on a blocking thread like `ask_assistant_chat`.
-    if config.brain_backend == BrainBackend::Cloud {
+    // Agentic path — CLOUD-connection roles only (the same rule as the in-meeting brain:
+    // local-GGUF multi-step tool-call reliability is unproven). The eligibility gate keys on the
+    // ASK role's resolved target: with role keys absent, `!is_reasoner_only()` is EXACTLY the
+    // legacy `brain_backend == Cloud` predicate (Cloud → provider connection, Local → "local",
+    // Off → "off"). The loop is blocking (scoped-thread connectors), so it runs on a blocking
+    // thread like `ask_assistant_chat`.
+    if !crate::summarize::roles::resolve(crate::summarize::roles::Role::Ask, &config)
+        .is_reasoner_only()
+    {
         let thread_id = crate::transcribe::live::ensure_thread_id(ask_thread_id);
         let handle = app.clone();
         let q = question.clone();
@@ -2019,7 +2056,8 @@ fn ask_vault_agentic_attempt(
         Err(_) => return None, // poisoned config ⇒ floor (which will surface its own error)
     };
     // Re-resolved per turn (never a startup snapshot): consent/provider/backend changes apply.
-    let reasoner = state.reasoner.current();
+    // ASK role — under the legacy fallback this dispatches exactly like the pre-role `current()`.
+    let reasoner = state.reasoner.current_for(crate::summarize::roles::Role::Ask);
     // VAULT-SCOPED executor: no live meeting, READ-ONLY, and NO note drafts (the Ask page has no
     // notes flow / Accept affordance, so `propose_note` is not advertised on this surface). The
     // AppHandle is present so web_search / calendar_lookup participate under their existing
@@ -2146,6 +2184,12 @@ fn build_ask_vault_floor_prompt(
     // is empty, this falls back to the existing FTS-only path UNCHANGED (the hybrid query
     // degenerates to FTS when no vectors exist; the flag-off branch is byte-for-byte the prior
     // behavior).
+    // Budget on the ASK-role provider's RESOLVED connection — the corpus egresses to it. With
+    // role keys absent this is the legacy `provider_id` for EVERY brain_backend (the pre-role
+    // floor always ignored `brain_backend`), so the packed corpus is byte-identical.
+    let ask_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, config)
+            .connection;
     let (corpus, sources) = if config.semantic_search_enabled {
         let embedder = crate::embed::active_embedder();
         // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
@@ -2157,7 +2201,7 @@ fn build_ask_vault_floor_prompt(
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
             db,
             question,
-            &config.provider_id,
+            &ask_conn,
             &query_vec,
             unlocked,
         )?
@@ -2165,7 +2209,7 @@ fn build_ask_vault_floor_prompt(
         crate::summarize::vault_context::build_vault_context_visible(
             db,
             question,
-            &config.provider_id,
+            &ask_conn,
             unlocked,
         )?
     };
@@ -2195,7 +2239,10 @@ async fn ask_vault_floor(
     match build_ask_vault_floor_prompt(db, config, unlocked, question, history)? {
         AskFloorPrompt::Empty(result) => Ok(result),
         AskFloorPrompt::Ready { system, user, sources } => {
-            let provider = crate::summarize::make_provider(&config.provider_id, config)?;
+            // ASK role. With role keys absent this builds the legacy default provider for EVERY
+            // brain_backend (the pre-role floor ignored it) — original error/consent semantics.
+            let provider =
+                crate::summarize::provider_for(crate::summarize::roles::Role::Ask, config)?;
             let answer = provider.complete(&system, &user).await?;
             Ok(AskVaultResult { answer, sources, citations: Vec::new() })
         }
@@ -2633,11 +2680,15 @@ pub async fn entity_dossier(
         .ok_or_else(|| AppError::InvalidArg(format!("no visible entity matching \"{entity}\"")))?;
     let data = crate::summarize::dossier::build_dossier_data(&state.db, &entity_id, &unlocked)?
         .ok_or_else(|| AppError::InvalidArg(format!("no visible entity matching \"{entity}\"")))?;
-    // Build the provider (firewall + consent gate) BEFORE synthesizing — make_provider refuses a
-    // cloud provider until the user has consented to egress.
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    // Build the provider (firewall + consent gate) BEFORE synthesizing — the factory refuses a
+    // cloud provider until the user has consented to egress. NOTES role (the dossier is a
+    // written synthesis); the corpus budget keys on the same resolved connection.
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let notes_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, &config)
+            .connection;
     let system = crate::summarize::dossier::dossier_system_prompt(&config.note_language);
-    let user = crate::summarize::dossier::render_dossier_user(&data, &config.provider_id);
+    let user = crate::summarize::dossier::render_dossier_user(&data, &notes_conn);
     provider.complete(&system, &user).await
 }
 
@@ -2657,11 +2708,12 @@ pub async fn generate_digest(
             .clone()
     };
     let cutoff = (chrono::Utc::now() - chrono::Duration::days(days)).to_rfc3339();
-    let budget = if config.provider_id == "ollama" {
-        4_000
-    } else {
-        80_000
-    };
+    // Budget on the NOTES-role provider's RESOLVED connection — the corpus egresses to it
+    // (identical to `provider_id` while role keys are absent).
+    let notes_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, &config)
+            .connection;
+    let budget = if notes_conn == "ollama" { 4_000 } else { 80_000 };
     // Finding 2 + BLK-2b: build the cloud corpus from VISIBLE meetings + VISIBLE notes only, so a
     // sealed-and-not-unlocked meeting's TITLE (the `### [[title]]` header) AND markdown never leave
     // the device. `list_meetings_visible` + `get_note_if_visible` push the session unlock set
@@ -2696,7 +2748,7 @@ pub async fn generate_digest(
         )));
     }
     let range_label = format!("the last {days} days");
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let (system, user) =
         crate::summarize::digest::build_digest_prompt(&corpus, &range_label, &config.note_language);
     let markdown = provider.complete(&system, &user).await?;
@@ -2845,13 +2897,18 @@ pub async fn pre_meeting_brief(
     // Pass the LIVE session unlock set (E9), same as ask_vault: session-unlocked folders included,
     // sealed-and-not-unlocked excluded.
     let unlocked = unlocked_snapshot(state.inner())?;
+    // NOTES role (a written brief); the corpus budget keys on the same resolved connection the
+    // corpus egresses to (identical to `provider_id` while role keys are absent).
+    let notes_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, &config)
+            .connection;
     let (corpus, sources) = crate::summarize::vault_context::build_vault_context_visible(
         &state.db,
         &subject,
-        &config.provider_id,
+        &notes_conn,
         &unlocked,
     )?;
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let (system, user) =
         crate::summarize::brief::build_brief_prompt(&corpus, &subject, &config.note_language);
     let markdown = provider.complete(&system, &user).await?;
@@ -3050,6 +3107,15 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         gateway_base_url: c.gateway_base_url.clone(),
         gateway_model: c.gateway_model.clone(),
         proactive_hints_enabled: c.proactive_hints_enabled,
+        role_notes_connection: c.role_notes_connection.clone(),
+        role_notes_model: c.role_notes_model.clone(),
+        role_notes_effort: c.role_notes_effort.clone(),
+        role_ask_connection: c.role_ask_connection.clone(),
+        role_ask_model: c.role_ask_model.clone(),
+        role_ask_effort: c.role_ask_effort.clone(),
+        role_live_connection: c.role_live_connection.clone(),
+        role_live_model: c.role_live_model.clone(),
+        role_live_effort: c.role_live_effort.clone(),
     }
 }
 
@@ -3151,6 +3217,18 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default —
         // the backend mute is an explicit user choice, never a partial-save side effect.
         proactive_hints_enabled: d.proactive_hints_enabled,
+        // Model-role keys ARE settable from the DTO (a future Settings UI owns the rows), like
+        // `gateway_model` — plain strings, `""` = inherit legacy. An omitted key deserializes to
+        // `""` (`#[serde(default)]`), so an older FE payload can never flip a role.
+        role_notes_connection: d.role_notes_connection,
+        role_notes_model: d.role_notes_model,
+        role_notes_effort: d.role_notes_effort,
+        role_ask_connection: d.role_ask_connection,
+        role_ask_model: d.role_ask_model,
+        role_ask_effort: d.role_ask_effort,
+        role_live_connection: d.role_live_connection,
+        role_live_model: d.role_live_model,
+        role_live_effort: d.role_live_effort,
     }
 }
 
@@ -3584,7 +3662,7 @@ pub async fn get_timeline(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         c.clone()
     };
-    let provider = crate::summarize::make_provider(&config.provider_id, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let timeline =
         crate::summarize::timeline::generate(provider.as_ref(), &segments, duration_s).await?;
     if let Ok(json) = serde_json::to_string(&timeline) {
@@ -7544,6 +7622,68 @@ mod lifecycle_tests {
         let merged2 = dto_to_config(dto_clear, &current2);
         assert_eq!(merged2.provider_model, "");
         assert_eq!(merged2.provider_effort, "");
+    }
+
+    /// Model roles: the 9 role keys round-trip through the settings DTO BOTH ways (settable, like
+    /// `gateway_model` — NOT preserve-only), and an OLDER FE payload that omits them entirely
+    /// deserializes to `""` (inherit-legacy) — a partial save can never flip a role.
+    #[test]
+    fn dto_round_trips_role_keys_and_omitted_keys_default_empty() {
+        // OUT: config_to_dto carries the live values.
+        let cfg = AppConfig {
+            role_notes_connection: "anthropic".to_string(),
+            role_notes_model: "claude-opus-4-8".to_string(),
+            role_notes_effort: "high".to_string(),
+            role_ask_connection: "ollama".to_string(),
+            role_ask_model: "mistral-small".to_string(),
+            role_live_connection: "off".to_string(),
+            ..AppConfig::default()
+        };
+        let dto = config_to_dto(&cfg);
+        assert_eq!(dto.role_notes_connection, "anthropic");
+        assert_eq!(dto.role_notes_model, "claude-opus-4-8");
+        assert_eq!(dto.role_notes_effort, "high");
+        assert_eq!(dto.role_ask_connection, "ollama");
+        assert_eq!(dto.role_ask_model, "mistral-small");
+        assert_eq!(dto.role_ask_effort, "");
+        assert_eq!(dto.role_live_connection, "off");
+
+        // IN: dto_to_config takes them from the DTO (start from a DIFFERENT current to prove the
+        // value comes from the DTO, not preservation) — including clearing back to "".
+        let current = AppConfig {
+            role_notes_connection: "gateway".to_string(),
+            role_ask_connection: "claude_code".to_string(),
+            role_live_connection: "local".to_string(),
+            role_live_model: "bielik-11b-v3".to_string(),
+            ..AppConfig::default()
+        };
+        let merged = dto_to_config(dto, &current);
+        assert_eq!(merged.role_notes_connection, "anthropic");
+        assert_eq!(merged.role_ask_connection, "ollama");
+        assert_eq!(merged.role_live_connection, "off");
+        assert_eq!(merged.role_live_model, "", "a \"\" role key from the DTO clears the override");
+
+        // An older FE payload OMITTING the role keys deserializes them to "" (#[serde(default)]).
+        let json = serde_json::to_string(&config_to_dto(&AppConfig::default())).unwrap();
+        let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        for k in [
+            "roleNotesConnection",
+            "roleNotesModel",
+            "roleNotesEffort",
+            "roleAskConnection",
+            "roleAskModel",
+            "roleAskEffort",
+            "roleLiveConnection",
+            "roleLiveModel",
+            "roleLiveEffort",
+        ] {
+            assert!(obj.remove(k).is_some(), "DTO must serialize {k}");
+        }
+        let dto_old: AppConfigDto = serde_json::from_value(v).unwrap();
+        assert_eq!(dto_old.role_notes_connection, "");
+        assert_eq!(dto_old.role_ask_connection, "");
+        assert_eq!(dto_old.role_live_connection, "");
     }
 
     /// Phase H graceful degradation: a DTO carrying an UNKNOWN `brain_model_id` must NOT be stored —

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -175,7 +175,10 @@ fn deterministic(
         meeting_id,
         title,
         transcript,
-        &config.provider_id,
+        // The corpus egresses to the NOTES-role provider — budget on its RESOLVED connection
+        // (identical to `provider_id` while role keys are absent).
+        &crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, config)
+            .connection,
     )
 }
 
@@ -244,7 +247,12 @@ fn assemble_brain_corpus(
     unlocked: &HashSet<String>,
     config: &AppConfig,
 ) -> String {
-    let budget = crate::summarize::related_context::budget_for(&config.provider_id);
+    // Budget on the NOTES-role provider's RESOLVED connection — the corpus rides in ITS prompt
+    // (identical to `provider_id` while role keys are absent).
+    let budget = crate::summarize::related_context::budget_for(
+        &crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, config)
+            .connection,
+    );
     // The self id appears in tool payloads as `[id:<id>]` (hits) or `id:<id>` (lists); matching the
     // `id:<id>` token covers both, so a note is never grounded in its own prior self.
     let self_tag = format!("id:{meeting_id}");

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -8,7 +8,8 @@ use crate::settings::AppConfig;
 use crate::state::AppState;
 use crate::storage::models::{MeetingStatus, NoteRecord};
 use crate::summarize::provider::{MeetingMeta, SummarizeRequest};
-use crate::summarize::{make_provider, template};
+use crate::summarize::roles::Role;
+use crate::summarize::{provider_for, template};
 use crate::transcribe::{self, Transcriber};
 use crate::{audio, export};
 
@@ -506,10 +507,15 @@ async fn summarize_and_export(
     date_iso: &str,
     when_iso: &str,
 ) -> Result<PipelineResult> {
+    // The NOTES-role provider target — with role keys absent this is EXACTLY the legacy
+    // (provider_id, provider_model, provider_effort) triple, so every use below is byte-identical
+    // to the pre-role code. Resolved ONCE so the status line, the corpus budget, and the
+    // provenance row all name the SAME connection the summarize call actually uses.
+    let notes_target = crate::summarize::roles::provider_target(Role::Notes, config);
     emit_status(
         app,
         "summarizing",
-        &format!("Summarizing with provider '{}'…", config.provider_id),
+        &format!("Summarizing with provider '{}'…", notes_target.connection),
         meeting_id,
     );
 
@@ -547,7 +553,7 @@ async fn summarize_and_export(
     // salient-query path stays the FALLBACK FLOOR. The reasoner call is synchronous, so this keeps
     // the existing inline shape (no extra await). Best-effort + GATED: same egress/consent envelope.
     let related_context = crate::orchestrate::orchestrate_context(
-        &*state.reasoner.current(),
+        &*state.reasoner.current_for(Role::Notes),
         &state.db,
         meeting_id,
         related_title.as_deref(),
@@ -569,7 +575,7 @@ async fn summarize_and_export(
         related_context,
     };
 
-    let provider = make_provider(&config.provider_id, config)?;
+    let provider = provider_for(Role::Notes, config)?;
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;
 
     // brain2 realtime notes FOLD: append the user's OWN typed in-meeting notes to the generated note
@@ -588,29 +594,20 @@ async fn summarize_and_export(
 
     let created_at = chrono::Utc::now().to_rfc3339();
     // Phase 5 — model provenance: capture the requested model ID and (when available) the model
-    // actually served by the gateway/API. `model_requested` is derived from the config exactly like
-    // `make_provider` computes it for the egress ledger (same source-of-truth, different sink).
-    // `gateway_host` is present ONLY for the `gateway` provider so it's non-PII and identifies the
-    // endpoint (not the content). All three are optional and omitted for providers that don't return
-    // model metadata (the default `*_with_meta` falls back to empty `CallMeta`).
-    let model_requested = match config.provider_id.as_str() {
-        crate::summarize::PROVIDER_GATEWAY => {
-            let m = config.gateway_model.trim().to_string();
-            if m.is_empty() { None } else { Some(m) }
-        }
-        crate::summarize::PROVIDER_OLLAMA => {
-            let m = config.ollama_model.trim().to_string();
-            if m.is_empty() { None } else { Some(m) }
-        }
-        _ => {
-            // claude_code + anthropic: use provider_model override if set; anthropic falls back
-            // to anthropic_model. The pipeline doesn't distinguish them further here — both are
-            // logged as-is (a "" stays None so legacy notes don't get a blank string).
-            let m = config.provider_model.trim().to_string();
-            if m.is_empty() { None } else { Some(m) }
-        }
+    // actually served by the gateway/API. `model_requested` is the resolved EFFECTIVE model —
+    // shared source-of-truth with the egress ledger (`effective_model_requested`), which also
+    // fixes the anthropic gap: with `provider_model` empty the request carries `anthropic_model`,
+    // and that is now what gets recorded (previously None). `gateway_host` is present ONLY for the
+    // `gateway` provider so it's non-PII and identifies the endpoint (not the content). All three
+    // are optional and omitted for providers that don't return model metadata (the default
+    // `*_with_meta` falls back to empty `CallMeta`).
+    let model_requested = {
+        let m = crate::summarize::effective_model_requested(&notes_target, config);
+        let m = m.trim().to_string();
+        // A "" stays None so legacy notes don't get a blank string.
+        if m.is_empty() { None } else { Some(m) }
     };
-    let gateway_host = if config.provider_id == crate::summarize::PROVIDER_GATEWAY {
+    let gateway_host = if notes_target.connection == crate::summarize::PROVIDER_GATEWAY {
         reqwest::Url::parse(&config.gateway_base_url)
             .ok()
             .and_then(|u| u.host_str().map(|h| {
@@ -626,10 +623,12 @@ async fn summarize_and_export(
     // Save clones for frontmatter injection (the NoteRecord takes ownership below).
     let model_served_for_fm = call_meta.model_served.clone();
     let model_requested_for_fm = model_requested.clone();
-    let provider_id_for_fm = config.provider_id.clone();
+    // Provenance names the RESOLVED connection that actually served the note (identical to
+    // `provider_id` while role keys are absent).
+    let provider_id_for_fm = notes_target.connection.clone();
     state.db.upsert_note(&NoteRecord {
         meeting_id: meeting_id.to_string(),
-        provider_id: config.provider_id.clone(),
+        provider_id: notes_target.connection.clone(),
         markdown: markdown.clone(),
         created_at,
         exported_path: None,
@@ -728,11 +727,7 @@ async fn summarize_and_export(
         &markdown,
     )?;
 
-    state.db.set_note_exported_path(
-        meeting_id,
-        &config.provider_id,
-        &exported_path.to_string_lossy(),
-    )?;
+    persist_note_exported_path(&state.db, config, meeting_id, &exported_path)?;
     state.db.set_meeting_title(meeting_id, &title)?;
     state
         .db
@@ -766,6 +761,25 @@ async fn summarize_and_export(
         exported_path: Some(exported_path),
         meeting_id: meeting_id.to_string(),
     })
+}
+
+/// Point the note row `summarize_and_export` just upserted at its exported vault `.md`.
+///
+/// PAIRED-WRITE INVARIANT (seal-critical): the row key MUST be the RESOLVED notes connection —
+/// the SAME key the `upsert_note` above used (`provider_target(Role::Notes, …).connection`) —
+/// NEVER the raw `config.provider_id`. Under an explicit `role_notes_connection` override the two
+/// differ, the `UPDATE … WHERE meeting_id AND provider_id` matches 0 rows silently, and a NULL
+/// `exported_path` means the seal path (which collects its vault-`.md` deletion targets from
+/// `exported_path`) leaves the plaintext `.md` alive in the vault after a lock.
+/// Regression: `exported_path_lands_on_the_role_overridden_note_row`.
+fn persist_note_exported_path(
+    db: &crate::storage::Db,
+    config: &AppConfig,
+    meeting_id: &str,
+    exported_path: &Path,
+) -> Result<()> {
+    let connection = crate::summarize::roles::provider_target(Role::Notes, config).connection;
+    db.set_note_exported_path(meeting_id, &connection, &exported_path.to_string_lossy())
 }
 
 /// Finalize a summarized note when NO vault folder is configured. By this point the caller
@@ -1136,6 +1150,90 @@ mod tests {
                 .as_nanos()
         ));
         p
+    }
+
+    /// REGRESSION (adversarial find, seal content-leak class): `summarize_and_export` upserts the
+    /// note row keyed on the RESOLVED notes connection (`provider_target(Role::Notes, …)`), so the
+    /// export-path update MUST use the SAME key. The pre-fix code passed the raw
+    /// `config.provider_id`: under an explicit `role_notes_connection` override the keys differ,
+    /// the `UPDATE … WHERE meeting_id AND provider_id` matches 0 rows SILENTLY, `exported_path`
+    /// stays NULL — and the seal path (`seal_meeting_into_folder` / `lock_folder`) collects its
+    /// vault-`.md` deletion targets from `exported_path`, so the plaintext `.md` would SURVIVE a
+    /// seal. This drives the REAL paired write (`upsert_note` with the pipeline's key +
+    /// `persist_note_exported_path`) and asserts the path lands on the row AND that the seal
+    /// path's deletion-target view (`sealable_notes_for_meeting`) sees it.
+    #[test]
+    fn exported_path_lands_on_the_role_overridden_note_row() {
+        use crate::storage::models::Meeting;
+
+        let db = crate::storage::Db::open_with_key(&temp_db_path("role-export"), TEST_DEK).unwrap();
+        let meeting = |id: &str| Meeting {
+            id: id.to_string(),
+            started_at: "2026-07-02T09:00:00Z".to_string(),
+            ended_at: Some("2026-07-02T09:10:00Z".to_string()),
+            title: Some("Role export".to_string()),
+            duration_s: 600,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        };
+        let note_row = |id: &str, connection: &str| NoteRecord {
+            meeting_id: id.to_string(),
+            provider_id: connection.to_string(),
+            markdown: "# body".to_string(),
+            created_at: "2026-07-02T09:11:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        };
+
+        // (a) EXPLICIT role override: the pipeline's row key is the resolved connection
+        // ("anthropic"), NOT provider_id ("claude_code").
+        let config = AppConfig {
+            provider_id: "claude_code".to_string(),
+            role_notes_connection: "anthropic".to_string(),
+            ..AppConfig::default()
+        };
+        let notes_target = crate::summarize::roles::provider_target(Role::Notes, &config);
+        assert_eq!(notes_target.connection, "anthropic");
+        let mid = "m-role-export";
+        db.insert_meeting(&meeting(mid)).unwrap();
+        db.upsert_note(&note_row(mid, &notes_target.connection)).unwrap();
+
+        // The REAL production paired write.
+        persist_note_exported_path(&db, &config, mid, Path::new("/vault/Role export.md")).unwrap();
+
+        let note = db.get_latest_note_for_meeting(mid).unwrap().expect("note row");
+        assert_eq!(note.provider_id, "anthropic");
+        assert_eq!(
+            note.exported_path.as_deref(),
+            Some("/vault/Role export.md"),
+            "exported_path must land on the row the pipeline upserted — NULL here means the seal \
+             path never sees the vault .md and the plaintext survives a lock"
+        );
+        // The seal path's deletion-target collection view sees the .md.
+        assert!(
+            db.sealable_notes_for_meeting(mid)
+                .unwrap()
+                .iter()
+                .any(|n| n.exported_path.as_deref() == Some("/vault/Role export.md")),
+            "the seal deletion-target collection must see the exported .md"
+        );
+
+        // (b) LEGACY fallback (no role keys): the key is provider_id — unchanged behavior.
+        let legacy_cfg = AppConfig::default(); // provider_id = claude_code, keys absent
+        let mid2 = "m-legacy-export";
+        db.insert_meeting(&meeting(mid2)).unwrap();
+        db.upsert_note(&note_row(
+            mid2,
+            &crate::summarize::roles::provider_target(Role::Notes, &legacy_cfg).connection,
+        ))
+        .unwrap();
+        persist_note_exported_path(&db, &legacy_cfg, mid2, Path::new("/vault/Legacy.md")).unwrap();
+        let legacy_note = db.get_latest_note_for_meeting(mid2).unwrap().expect("note row");
+        assert_eq!(legacy_note.provider_id, "claude_code");
+        assert_eq!(legacy_note.exported_path.as_deref(), Some("/vault/Legacy.md"));
     }
 
     /// The no-vault branch of `summarize_and_export`: with no vault configured the note is saved

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -20,6 +20,7 @@ use serde_json::Value;
 use crate::error::{AppError, Result};
 use crate::settings::{AppConfig, BrainBackend};
 use crate::summarize::provider::SummarizerProvider;
+use crate::summarize::roles::{self, Role};
 
 /// The REAL on-device reasoner (mistral.rs / GGUF). ALWAYS compiled; the real impl is selected at
 /// runtime by [`local_reasoner`] when a GGUF resolves on disk, else the dependency-free stub.
@@ -303,7 +304,9 @@ pub struct ReasonerCell {
     local: Mutex<CachedLocalReasoner>,
     /// TEST-ONLY pinned reasoner (mirrors `CloudReasoner::provider_override`): `Some` makes
     /// `current()` always return this instance, so command tests keep a deterministic stub.
-    /// `None` in every production path (the only non-test constructor is [`new`]).
+    /// `#[cfg(test)]` makes "no fixed reasoner in production" STRUCTURAL — the field does not
+    /// exist in a release build, so no production path can ever pin a dispatch.
+    #[cfg(test)]
     fixed: Option<Arc<dyn LocalReasoner>>,
 }
 
@@ -311,7 +314,12 @@ impl ReasonerCell {
     /// Build the live dispatch over the shared config handle. Cheap: nothing is resolved until the
     /// first [`current`](Self::current) call.
     pub fn new(config: Arc<Mutex<AppConfig>>) -> Self {
-        Self { config, local: Mutex::new(None), fixed: None }
+        Self {
+            config,
+            local: Mutex::new(None),
+            #[cfg(test)]
+            fixed: None,
+        }
     }
 
     /// TEST-ONLY: pin `current()` to a fixed reasoner instance (the old `Box<StubReasoner>` test
@@ -326,7 +334,18 @@ impl ReasonerCell {
     }
 
     /// The reasoner for THIS call, resolved from the CURRENT config — never a startup snapshot.
+    /// Legacy shape: dispatches the NOTES role (whose fallback is exactly the pre-role
+    /// `brain_backend` mapping). Role-aware call sites use [`current_for`](Self::current_for).
     pub fn current(&self) -> Arc<dyn LocalReasoner> {
+        self.current_for(Role::Notes)
+    }
+
+    /// The reasoner serving `role` for THIS call, resolved from the CURRENT config — never a
+    /// startup snapshot. Dispatch keys on [`roles::reasoner_target`]: with role keys absent it is
+    /// the EXACT legacy `brain_backend` mapping for every role (byte-identical dispatch); with a
+    /// role's connection key set, that role dispatches its own target.
+    pub fn current_for(&self, role: Role) -> Arc<dyn LocalReasoner> {
+        #[cfg(test)]
         if let Some(f) = &self.fixed {
             return Arc::clone(f);
         }
@@ -339,21 +358,30 @@ impl ReasonerCell {
                 return Arc::new(StubReasoner);
             }
         };
-        match cfg.brain_backend {
+        let target = roles::reasoner_target(role, &cfg);
+        match target.connection.as_str() {
+            roles::CONN_OFF => Arc::new(StubReasoner),
+            roles::CONN_LOCAL => self.local_cached(&cfg, &target),
             // Cheap per call: the provider (+ consent gate) is built lazily inside, from a fresh
             // config read, so this instance can never pin a stale provider/consent state.
-            BrainBackend::Cloud => Arc::new(CloudReasoner::new(Arc::clone(&self.config))),
-            BrainBackend::Local => self.local_cached(&cfg),
-            BrainBackend::Off => Arc::new(StubReasoner),
+            _ => Arc::new(CloudReasoner::for_role(Arc::clone(&self.config), role)),
         }
     }
 
     /// The LOCAL dispatch: reuse the cached instance while the resolved GGUF path is unchanged;
     /// rebuild (inside the cache lock, so concurrent callers never double-load a model) only when
     /// it changes. Resolution is a cheap filesystem probe per call — never a model load.
-    fn local_cached(&self, cfg: &AppConfig) -> Arc<dyn LocalReasoner> {
+    /// The effective model id comes from the resolved role target (`""` = the persisted
+    /// `brain_model_id`, exactly the legacy resolution), so the cache stays keyed on the resolved
+    /// GGUF path even when a role key names a different registry model.
+    fn local_cached(&self, cfg: &AppConfig, target: &roles::RoleTarget) -> Arc<dyn LocalReasoner> {
         let configured = cfg.brain_model_path.as_deref().map(Path::new);
-        let key = resolve_brain_model(configured, cfg.brain_model_id.as_deref())
+        let model_id = if target.model.trim().is_empty() {
+            cfg.brain_model_id.clone()
+        } else {
+            Some(target.model.clone())
+        };
+        let key = resolve_brain_model(configured, model_id.as_deref())
             .ok()
             .flatten();
         let mut cache = match self.local.lock() {
@@ -367,7 +395,8 @@ impl ReasonerCell {
                 return Arc::clone(cached);
             }
         }
-        let built: Arc<dyn LocalReasoner> = Arc::from(local_reasoner(cfg));
+        let built: Arc<dyn LocalReasoner> =
+            Arc::from(local_reasoner_resolved(configured, model_id.as_deref()));
         *cache = Some((key, Arc::clone(&built)));
         built
     }
@@ -378,8 +407,20 @@ impl ReasonerCell {
 /// [`StubReasoner`]. Used only for [`BrainBackend::Local`]; with no model present it always yields
 /// the stub (selection keys ONLY on model presence — mistralrs is always compiled).
 fn local_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
-    let configured = config.brain_model_path.as_deref().map(Path::new);
-    match resolve_brain_model(configured, config.brain_model_id.as_deref()) {
+    local_reasoner_resolved(
+        config.brain_model_path.as_deref().map(Path::new),
+        config.brain_model_id.as_deref(),
+    )
+}
+
+/// The parameterized core of [`local_reasoner`]: build from an explicit custom path override +
+/// registry model id (the role layer supplies the effective id; the legacy path passes
+/// `brain_model_path`/`brain_model_id` verbatim).
+fn local_reasoner_resolved(
+    configured: Option<&Path>,
+    model_id: Option<&str>,
+) -> Box<dyn LocalReasoner> {
+    match resolve_brain_model(configured, model_id) {
         Ok(Some(path)) => match mistral::MistralReasoner::new(path) {
             Ok(r) => {
                 tracing::info!(target: "reason", id = r.id(), "local brain ready (lazy model load)");
@@ -534,45 +575,58 @@ pub struct CloudReasoner {
     /// consent grant/revocation or a provider switch applies to the very next provider call —
     /// even on a held instance mid-turn. Never snapshotted.
     config: Arc<Mutex<AppConfig>>,
+    /// The model ROLE this reasoner serves — `build_provider` resolves the provider FOR THIS ROLE
+    /// (with role keys absent that is exactly the legacy default provider, byte-identical).
+    role: Role,
     /// TEST-ONLY injected provider. When `Some`, `build_provider` returns it instead of calling
-    /// `make_provider`, so the wiring/parse can be exercised with a mock — NO real Claude/network.
-    /// `None` in every production path (the only constructor reachable in release is [`new`]).
+    /// the factory, so the wiring/parse can be exercised with a mock — NO real Claude/network.
+    /// `None` in every production path (the only constructors reachable in release are [`new`] /
+    /// [`for_role`](Self::for_role)).
     provider_override: Option<Arc<dyn SummarizerProvider>>,
 }
 
 impl CloudReasoner {
-    /// Build the cloud brain over the shared live config handle. Cheap + infallible: the provider
+    /// Build the cloud brain over the shared live config handle for the legacy default role
+    /// (Notes — whose fallback is the default provider triple). Cheap + infallible: the provider
     /// (and thus the consent gate) is constructed lazily, per call, from the config AS IT IS THEN.
     pub fn new(config: Arc<Mutex<AppConfig>>) -> Self {
-        let provider_id = config
+        Self::for_role(config, Role::Notes)
+    }
+
+    /// Build the cloud brain serving `role`. The id names the connection the role RESOLVES to
+    /// (`cloud:<connection>`) — under the legacy fallback that is `provider_id`, unchanged.
+    pub fn for_role(config: Arc<Mutex<AppConfig>>, role: Role) -> Self {
+        let connection = config
             .lock()
-            .map(|c| c.provider_id.clone())
-            .unwrap_or_else(|p| p.into_inner().provider_id.clone());
+            .map(|c| roles::provider_target(role, &c).connection)
+            .unwrap_or_else(|p| roles::provider_target(role, &p.into_inner()).connection);
         Self {
-            id: format!("cloud:{provider_id}"),
+            id: format!("cloud:{connection}"),
             config,
+            role,
             provider_override: None,
         }
     }
 
     /// TEST-ONLY: build a CloudReasoner that delegates to an injected provider instead of the real
-    /// `make_provider`, so `reason`/`structured` can be asserted without a network/CLI call. NOT
+    /// factory, so `reason`/`structured` can be asserted without a network/CLI call. NOT
     /// compiled in non-test builds, so production can never inject a provider that skips the gate.
     #[cfg(test)]
     fn with_provider(config: AppConfig, provider: Arc<dyn SummarizerProvider>) -> Self {
         Self {
             id: format!("cloud:{}", config.provider_id),
             config: Arc::new(Mutex::new(config)),
+            role: Role::Notes,
             provider_override: Some(provider),
         }
     }
 
     /// Resolve the provider for this call. THE egress seam: in production this is ALWAYS
-    /// `make_provider` (consent gate + RedactingProvider) over a FRESH read of the shared config —
-    /// never a construction-time snapshot — so a consent grant unblocks, and a consent REVOCATION
-    /// refuses, on the very next call (fail-closed both directions, no restart). A poisoned config
-    /// mutex makes the consent state unknowable, so it refuses too. A test override short-circuits
-    /// only under `#[cfg(test)]`.
+    /// `provider_for(self.role, …)` (role resolution → the same consent gate + RedactingProvider
+    /// as every factory build) over a FRESH read of the shared config — never a construction-time
+    /// snapshot — so a consent grant unblocks, and a consent REVOCATION refuses, on the very next
+    /// call (fail-closed both directions, no restart). A poisoned config mutex makes the consent
+    /// state unknowable, so it refuses too. A test override short-circuits only under `#[cfg(test)]`.
     fn build_provider(&self) -> Result<Arc<dyn SummarizerProvider>> {
         if let Some(p) = &self.provider_override {
             return Ok(p.clone());
@@ -582,7 +636,7 @@ impl CloudReasoner {
             .lock()
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone();
-        crate::summarize::make_provider(&cfg.provider_id, &cfg)
+        crate::summarize::provider_for(self.role, &cfg)
     }
 }
 
@@ -1145,6 +1199,104 @@ mod tests {
             Arc::ptr_eq(&a, &c),
             "the cached local instance must survive a backend excursion (same resolved path)"
         );
+    }
+
+    // ---- model roles: current_for / CloudReasoner::for_role ----------------------------------
+
+    /// FALLBACK IDENTITY at the dispatch level: with role keys absent, `current_for(role)`
+    /// dispatches EXACTLY like the legacy `current()` — the `brain_backend` mapping — for EVERY
+    /// role, Notes included (a Notes reasoner resolved from `provider_id` instead would
+    /// cloud-dispatch an Off/Local install's pre-analysis: an egress change).
+    #[test]
+    fn current_for_matches_legacy_dispatch_under_fallback() {
+        use crate::summarize::roles::Role;
+        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            let cfg = shared(AppConfig {
+                brain_backend: backend,
+                // Local resolves nothing on a clean machine (absent custom path, no selection)
+                // ⇒ the stub — same shape as the legacy Local tests above.
+                brain_model_path: Some(
+                    std::env::temp_dir()
+                        .join("murmur-rolecell-absent-model-xyz.gguf")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                brain_model_id: None,
+                ..Default::default()
+            });
+            let cell = ReasonerCell::new(Arc::clone(&cfg));
+            let legacy = cell.current().id().to_string();
+            for role in [Role::Notes, Role::Ask, Role::Live] {
+                assert_eq!(
+                    cell.current_for(role).id(),
+                    legacy,
+                    "{backend:?}/{role:?} must dispatch identically to the legacy current()"
+                );
+            }
+            match backend {
+                BrainBackend::Cloud => assert!(legacy.starts_with("cloud:"), "got {legacy}"),
+                _ => assert_eq!(legacy, "stub"),
+            }
+        }
+    }
+
+    /// EXPLICIT role keys re-route ONLY their role: Ask→off dispatches the stub while Notes (no
+    /// key) keeps the legacy Cloud dispatch — per-role steering without a restart.
+    #[test]
+    fn current_for_dispatches_explicit_role_targets_independently() {
+        use crate::summarize::roles::Role;
+        let cfg = shared(AppConfig {
+            brain_backend: BrainBackend::Cloud,
+            provider_id: "claude_code".to_string(),
+            role_ask_connection: "off".to_string(),
+            ..Default::default()
+        });
+        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        assert_eq!(cell.current_for(Role::Ask).id(), "stub", "explicit Ask→off is the stub");
+        assert_eq!(cell.current_for(Role::Notes).id(), "cloud:claude_code");
+        assert_eq!(cell.current_for(Role::Live).id(), "cloud:claude_code");
+
+        // Clearing the key mid-session restores the legacy dispatch on the next call.
+        cfg.lock().unwrap().role_ask_connection = String::new();
+        assert_eq!(cell.current_for(Role::Ask).id(), "cloud:claude_code");
+    }
+
+    /// A role key pointing at a DIFFERENT cloud connection names it in the reasoner id (and
+    /// `build_provider` resolves THAT role — proven by the gate-probe test below).
+    #[test]
+    fn cloud_reasoner_for_role_names_the_resolved_connection() {
+        use crate::summarize::roles::Role;
+        let cfg = AppConfig {
+            provider_id: "claude_code".to_string(),
+            role_ask_connection: "anthropic".to_string(),
+            ..Default::default()
+        };
+        let r = CloudReasoner::for_role(shared(cfg), Role::Ask);
+        assert_eq!(r.id(), "cloud:anthropic");
+    }
+
+    /// EGRESS POSTURE per role (by construction): a role-keyed CloudReasoner builds its provider
+    /// through `provider_for(role)` → the SAME fail-closed consent gate. Discriminated exactly
+    /// like the legacy gate probes: no consent ⇒ `Unavailable` (the gate), consent ⇒ `InvalidArg`
+    /// (past the gate, the bogus connection id fails construction).
+    #[test]
+    fn cloud_reasoner_role_target_rides_the_same_consent_gate() {
+        use crate::summarize::roles::Role;
+        let cfg = shared(AppConfig {
+            role_live_connection: BOGUS_PROVIDER.to_string(),
+            cloud_egress_consented: false,
+            ..Default::default()
+        });
+        let r = CloudReasoner::for_role(Arc::clone(&cfg), Role::Live);
+        match r.reason("s", "u") {
+            Err(AppError::Unavailable(_)) => {}
+            other => panic!("role-keyed cloud call must be consent-gated, got {other:?}"),
+        }
+        cfg.lock().unwrap().cloud_egress_consented = true;
+        match r.reason("s", "u") {
+            Err(AppError::InvalidArg(_)) => {} // past the gate — the bogus id is now the error
+            other => panic!("consented role-keyed call must reach the factory, got {other:?}"),
+        }
     }
 
     // ---- active_reasoner backend selection --------------------------------------------------

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -221,6 +221,43 @@ pub struct AppConfig {
     /// as `true`.
     #[serde(default = "default_true")]
     pub proactive_hints_enabled: bool,
+    /// Model-role override — the CONNECTION serving the **Notes** role (everything Murmur writes).
+    /// `""` (the default, and every pre-role install) = inherit the legacy mapping EXACTLY — see
+    /// [`crate::summarize::roles::resolve`]. Values: `claude_code`/`anthropic`/`ollama`/`gateway`
+    /// (or `local`/`off` for the reasoner-only roles). ADDITIVE: the legacy keys are never
+    /// rewritten; `#[serde(default)]` ⇒ pre-existing configs load as `""` (zero behavior change).
+    #[serde(default)]
+    pub role_notes_connection: String,
+    /// Model-role override — the MODEL for the Notes role. `""` = the connection's own default.
+    /// Consulted only when `role_notes_connection` is set (the connection key is the override
+    /// switch). `#[serde(default)]` ⇒ `""`.
+    #[serde(default)]
+    pub role_notes_model: String,
+    /// Model-role override — the reasoning EFFORT for the Notes role (`""`/`low`/`medium`/`high`;
+    /// honored by the `anthropic` provider only, like `provider_effort`). Consulted only when
+    /// `role_notes_connection` is set. `#[serde(default)]` ⇒ `""`.
+    #[serde(default)]
+    pub role_notes_effort: String,
+    /// Model-role override — the CONNECTION serving the **Ask** role (vault Q&A + meeting chat).
+    /// Same semantics as `role_notes_connection`.
+    #[serde(default)]
+    pub role_ask_connection: String,
+    /// Model-role override — the MODEL for the Ask role. Same semantics as `role_notes_model`.
+    #[serde(default)]
+    pub role_ask_model: String,
+    /// Model-role override — the EFFORT for the Ask role. Same semantics as `role_notes_effort`.
+    #[serde(default)]
+    pub role_ask_effort: String,
+    /// Model-role override — the CONNECTION serving the **Live** role (the in-meeting assistant,
+    /// @brain threads, voice). Same semantics as `role_notes_connection`.
+    #[serde(default)]
+    pub role_live_connection: String,
+    /// Model-role override — the MODEL for the Live role. Same semantics as `role_notes_model`.
+    #[serde(default)]
+    pub role_live_model: String,
+    /// Model-role override — the EFFORT for the Live role. Same semantics as `role_notes_effort`.
+    #[serde(default)]
+    pub role_live_effort: String,
 }
 
 /// serde default for flags that default ON (mirrors `commands::default_true` for the DTO side).
@@ -269,6 +306,15 @@ impl Default for AppConfig {
             gateway_base_url: String::new(),
             gateway_model: String::new(),
             proactive_hints_enabled: true,
+            role_notes_connection: String::new(),
+            role_notes_model: String::new(),
+            role_notes_effort: String::new(),
+            role_ask_connection: String::new(),
+            role_ask_model: String::new(),
+            role_ask_effort: String::new(),
+            role_live_connection: String::new(),
+            role_live_model: String::new(),
+            role_live_effort: String::new(),
         }
     }
 }
@@ -312,6 +358,15 @@ const K_CLAUDE_CODE_INHERIT_ENV: &str = "claude_code_inherit_env";
 const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
 const K_PROACTIVE_HINTS_ENABLED: &str = "proactive_hints_enabled";
+const K_ROLE_NOTES_CONNECTION: &str = "role_notes_connection";
+const K_ROLE_NOTES_MODEL: &str = "role_notes_model";
+const K_ROLE_NOTES_EFFORT: &str = "role_notes_effort";
+const K_ROLE_ASK_CONNECTION: &str = "role_ask_connection";
+const K_ROLE_ASK_MODEL: &str = "role_ask_model";
+const K_ROLE_ASK_EFFORT: &str = "role_ask_effort";
+const K_ROLE_LIVE_CONNECTION: &str = "role_live_connection";
+const K_ROLE_LIVE_MODEL: &str = "role_live_model";
+const K_ROLE_LIVE_EFFORT: &str = "role_live_effort";
 
 impl AppConfig {
     /// Read all known keys from the settings table, falling back to `Default` for any
@@ -442,6 +497,35 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_PROACTIVE_HINTS_ENABLED)? {
             cfg.proactive_hints_enabled = v == "true";
         }
+        // Model-role keys: `""` is a VALID value (= inherit legacy) and also the default, so the
+        // stored value is taken verbatim (mirrors `provider_model`, not `anthropic_model`).
+        if let Some(v) = db.get_setting(K_ROLE_NOTES_CONNECTION)? {
+            cfg.role_notes_connection = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_NOTES_MODEL)? {
+            cfg.role_notes_model = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_NOTES_EFFORT)? {
+            cfg.role_notes_effort = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_ASK_CONNECTION)? {
+            cfg.role_ask_connection = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_ASK_MODEL)? {
+            cfg.role_ask_model = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_ASK_EFFORT)? {
+            cfg.role_ask_effort = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_LIVE_CONNECTION)? {
+            cfg.role_live_connection = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_LIVE_MODEL)? {
+            cfg.role_live_model = v;
+        }
+        if let Some(v) = db.get_setting(K_ROLE_LIVE_EFFORT)? {
+            cfg.role_live_effort = v;
+        }
 
         Ok(cfg)
     }
@@ -550,6 +634,15 @@ impl AppConfig {
             K_PROACTIVE_HINTS_ENABLED,
             if self.proactive_hints_enabled { "true" } else { "false" },
         )?;
+        db.set_setting(K_ROLE_NOTES_CONNECTION, &self.role_notes_connection)?;
+        db.set_setting(K_ROLE_NOTES_MODEL, &self.role_notes_model)?;
+        db.set_setting(K_ROLE_NOTES_EFFORT, &self.role_notes_effort)?;
+        db.set_setting(K_ROLE_ASK_CONNECTION, &self.role_ask_connection)?;
+        db.set_setting(K_ROLE_ASK_MODEL, &self.role_ask_model)?;
+        db.set_setting(K_ROLE_ASK_EFFORT, &self.role_ask_effort)?;
+        db.set_setting(K_ROLE_LIVE_CONNECTION, &self.role_live_connection)?;
+        db.set_setting(K_ROLE_LIVE_MODEL, &self.role_live_model)?;
+        db.set_setting(K_ROLE_LIVE_EFFORT, &self.role_live_effort)?;
         Ok(())
     }
 
@@ -924,6 +1017,72 @@ mod tests {
         let cfg = AppConfig { proactive_hints_enabled: false, ..Default::default() };
         cfg.save(&db).unwrap();
         assert!(!AppConfig::load(&db).unwrap().proactive_hints_enabled);
+    }
+
+    /// Model roles — the 9 role keys default `""` (inherit-legacy) for fresh installs AND for
+    /// configs persisted before the keys existed (both the settings-table path and the serde
+    /// path), and set values round-trip — including clearing back to `""` (not a one-way latch).
+    /// `""`-on-absent is the ZERO-BEHAVIOR-CHANGE guarantee for existing installs.
+    #[test]
+    fn role_keys_default_empty_and_round_trip() {
+        // In-memory struct default + empty settings table (keys never written) ⇒ "" everywhere.
+        let d = AppConfig::default();
+        let db = temp_db();
+        let fresh = AppConfig::load(&db).unwrap();
+        for cfg in [&d, &fresh] {
+            assert_eq!(cfg.role_notes_connection, "");
+            assert_eq!(cfg.role_notes_model, "");
+            assert_eq!(cfg.role_notes_effort, "");
+            assert_eq!(cfg.role_ask_connection, "");
+            assert_eq!(cfg.role_ask_model, "");
+            assert_eq!(cfg.role_ask_effort, "");
+            assert_eq!(cfg.role_live_connection, "");
+            assert_eq!(cfg.role_live_model, "");
+            assert_eq!(cfg.role_live_effort, "");
+        }
+
+        // serde path: a pre-role JSON payload (fields omitted) loads "" (#[serde(default)]).
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.role_notes_connection, "");
+        assert_eq!(cfg.role_ask_connection, "");
+        assert_eq!(cfg.role_live_connection, "");
+
+        // Set values persist + reload verbatim.
+        let cfg = AppConfig {
+            role_notes_connection: "anthropic".to_string(),
+            role_notes_model: "claude-opus-4-8".to_string(),
+            role_notes_effort: "high".to_string(),
+            role_ask_connection: "ollama".to_string(),
+            role_ask_model: "mistral-small".to_string(),
+            role_live_connection: "off".to_string(),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert_eq!(loaded.role_notes_connection, "anthropic");
+        assert_eq!(loaded.role_notes_model, "claude-opus-4-8");
+        assert_eq!(loaded.role_notes_effort, "high");
+        assert_eq!(loaded.role_ask_connection, "ollama");
+        assert_eq!(loaded.role_ask_model, "mistral-small");
+        assert_eq!(loaded.role_ask_effort, "");
+        assert_eq!(loaded.role_live_connection, "off");
+
+        // Clearing back to "" (inherit legacy) also round-trips.
+        AppConfig::default().save(&db).unwrap();
+        let cleared = AppConfig::load(&db).unwrap();
+        assert_eq!(cleared.role_notes_connection, "");
+        assert_eq!(cleared.role_ask_connection, "");
+        assert_eq!(cleared.role_live_connection, "");
     }
 
     /// Task 1.1 — serde: a payload omitting the gateway fields loads with empty defaults.

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -27,6 +27,7 @@ pub mod provider;
 pub mod recipes;
 pub mod redact;
 pub mod related_context;
+pub mod roles;
 pub mod template;
 pub mod threads;
 pub mod timeline;
@@ -75,10 +76,81 @@ pub(crate) fn egress_is_cloud(id: &str, config: &AppConfig) -> bool {
 /// in [`RedactingProvider`] so high-confidence PII is scrubbed before any content leaves the
 /// device, and is refused entirely until the user has granted one-time cloud-egress consent.
 /// `ollama` is local-only and bypasses both.
+///
+/// Thin wrapper: delegates to [`make_provider_resolved`] with the LEGACY (model, effort) for `id`
+/// — `provider_model`/`provider_effort` for the arms that historically read them, the
+/// connection's own default otherwise — so every remaining direct caller is byte-identical to the
+/// pre-role factory. Role-aware call sites use [`provider_for`] instead.
 pub fn make_provider(
     id: &str,
     config: &AppConfig,
 ) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
+    // The legacy per-arm model semantics: only claude_code/anthropic ever read `provider_model`;
+    // ollama/gateway resolve from ollama_model/gateway_model ("" = inherit below).
+    let model = match id {
+        PROVIDER_CLAUDE_CODE | PROVIDER_ANTHROPIC => config.provider_model.clone(),
+        _ => String::new(),
+    };
+    let target = roles::RoleTarget {
+        connection: id.to_string(),
+        model,
+        effort: config.provider_effort.clone(),
+    };
+    make_provider_resolved(&target, config)
+}
+
+/// Build the `SummarizerProvider` serving `role`, resolved through the role layer
+/// ([`roles::provider_target`] — with role keys absent this is EXACTLY the legacy default
+/// provider, so pre-role installs are byte-identical).
+///
+/// The consent gate, `egress_is_cloud` classification, `RedactingProvider` wrap, and the egress
+/// ledger all live INSIDE [`make_provider_resolved`], keyed off the RESOLVED connection — a role
+/// can never bypass them. An EXPLICIT reasoner-only target (`local`/`off` role keys) is refused
+/// with `Unavailable`: those are `LocalReasoner` dispatch targets, never SummarizerProviders.
+pub fn provider_for(
+    role: roles::Role,
+    config: &AppConfig,
+) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
+    let target = roles::provider_target(role, config);
+    if target.is_reasoner_only() {
+        return Err(crate::error::AppError::Unavailable(format!(
+            "the {} role targets the on-device reasoner ({}); no summarizer provider is available \
+             for it",
+            role.as_str(),
+            target.connection
+        )));
+    }
+    make_provider_resolved(&target, config)
+}
+
+/// The EFFECTIVE model id a resolved target sends: the target's own model, or — when empty —
+/// the connection's default (`anthropic_model` / `ollama_model` / `gateway_model`). For
+/// `claude_code` an empty model stays `""` (the CLI's own default is unknowable here). This is
+/// the single source of truth for provenance: the egress-ledger `model_requested` AND the note's
+/// provenance row both derive from it, fixing the gap where anthropic-with-empty-`provider_model`
+/// recorded an empty model even though the request carried `anthropic_model`.
+pub(crate) fn effective_model_requested(target: &roles::RoleTarget, config: &AppConfig) -> String {
+    let m = target.model.trim();
+    if !m.is_empty() {
+        return m.to_string();
+    }
+    match target.connection.as_str() {
+        PROVIDER_ANTHROPIC => config.anthropic_model.clone(),
+        PROVIDER_OLLAMA => config.ollama_model.clone(),
+        PROVIDER_GATEWAY => config.gateway_model.clone(),
+        _ => String::new(),
+    }
+}
+
+/// The parameterized factory core: build a provider for a RESOLVED (connection, model, effort)
+/// triple. ALL egress invariants live here, keyed off the resolved connection:
+/// the fail-closed consent gate, the [`egress_is_cloud`] classification, the
+/// [`RedactingProvider`] wrap, and the egress-ledger fields.
+fn make_provider_resolved(
+    target: &roles::RoleTarget,
+    config: &AppConfig,
+) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
+    let id = target.connection.as_str();
     // E10 — fail-closed consent gate, now classification-aware: no cloud provider is built (so no
     // content can be sent) until the user has explicitly consented once. ollama is gated ONLY when
     // its base URL is non-loopback (remote) — closing the gap where a remote ollama_base_url would
@@ -94,33 +166,35 @@ pub fn make_provider(
     let inner: Arc<dyn SummarizerProvider> = match id {
         PROVIDER_CLAUDE_CODE => Arc::new(
             ClaudeCodeProvider::with_binary(config.claude_binary.clone())
-                // Brain/AI model picker: a chosen model is passed as `--model`; an empty value
-                // (the default) lets the CLI use its own default. Effort is N/A for the CLI.
-                .with_model(config.provider_model.clone())
+                // A resolved model is passed as `--model`; an empty value (the default) lets the
+                // CLI use its own default. Effort is N/A for the CLI.
+                .with_model(target.model.clone())
                 // Opt-in: inherit the shell env (restores env ANTHROPIC_API_KEY); DB keys stay stripped.
                 .with_inherit_env(config.claude_code_inherit_env),
         ),
         PROVIDER_ANTHROPIC => {
             // Resolve the key from the Keychain here so providers never touch secrets.
             let api_key = crate::secrets::get_secret(ANTHROPIC_KEY_ACCOUNT)?;
-            // Brain/AI model picker takes precedence over the legacy `anthropic_model`; effort is
+            // A resolved model takes precedence over the legacy `anthropic_model`; effort is
             // the adaptive-thinking tier (provider default when empty).
-            let model = if config.provider_model.trim().is_empty() {
+            let model = if target.model.trim().is_empty() {
                 config.anthropic_model.clone()
             } else {
-                config.provider_model.clone()
+                target.model.clone()
             };
             Arc::new(AnthropicProvider::with_effort(
                 api_key,
                 model,
-                config.provider_effort.clone(),
+                target.effort.clone(),
             ))
         }
         PROVIDER_OLLAMA => {
-            let ollama = Arc::new(OllamaProvider::new(
-                config.ollama_base_url.clone(),
-                config.ollama_model.clone(),
-            ));
+            let model = if target.model.trim().is_empty() {
+                config.ollama_model.clone()
+            } else {
+                target.model.clone()
+            };
+            let ollama = Arc::new(OllamaProvider::new(config.ollama_base_url.clone(), model));
             if !egress_is_cloud(id, config) {
                 return Ok(ollama); // LOCAL ollama: unwrapped, unchanged behavior
             }
@@ -134,14 +208,17 @@ pub fn make_provider(
             }
             // R3 — resolve the GATEWAY key only; NEVER falls back to the Anthropic key.
             let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT).ok().flatten();
+            let model = if target.model.trim().is_empty() {
+                config.gateway_model.clone()
+            } else {
+                target.model.clone()
+            };
             // R1/R4 enforced at construction via `validate_gateway_url` inside `new()`.
-            Arc::new(
-                crate::summarize::gateway::OpenAiCompatProvider::new(
-                    config.gateway_base_url.clone(),
-                    config.gateway_model.clone(),
-                    api_key,
-                )?,
-            )
+            Arc::new(crate::summarize::gateway::OpenAiCompatProvider::new(
+                config.gateway_base_url.clone(),
+                model,
+                api_key,
+            )?)
             // Falls through to the RedactingProvider wrap below (R2).
         }
         other => {
@@ -179,12 +256,9 @@ pub fn make_provider(
             .unwrap_or_else(|| "ollama".to_string()),
         _ => id.to_string(),
     };
-    let model_requested = match id {
-        PROVIDER_CLAUDE_CODE | PROVIDER_ANTHROPIC => config.provider_model.clone(),
-        PROVIDER_GATEWAY => config.gateway_model.clone(),
-        PROVIDER_OLLAMA => config.ollama_model.clone(),
-        _ => String::new(),
-    };
+    // Provenance fix: record the EFFECTIVE model — for anthropic with an empty resolved model
+    // that is `anthropic_model` (previously recorded as empty even though the request carried it).
+    let model_requested = effective_model_requested(target, config);
     Ok(Arc::new(
         crate::summarize::redact::RedactingProvider::with_name_redactor_and_sink(
             inner,
@@ -420,6 +494,137 @@ mod tests {
             matches!(err, crate::error::AppError::InvalidArg(_)),
             "expected InvalidArg for empty URL, got: {err}"
         );
+    }
+
+    // ─── Model roles — provider_for keeps every factory invariant, keyed off the RESOLVED
+    //     connection, and is byte-identical to make_provider under the legacy fallback ─────────
+
+    /// FALLBACK IDENTITY at the factory level: with role keys absent, `provider_for` builds the
+    /// SAME default provider as `make_provider(&provider_id, …)` for EVERY role and EVERY
+    /// `brain_backend` — including Local/Off, where the legacy Ask provider paths (meeting chat,
+    /// the ask_vault floor) always ignored `brain_backend`.
+    #[test]
+    fn provider_for_matches_legacy_factory_under_fallback() {
+        use crate::settings::BrainBackend;
+        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            let cfg = AppConfig {
+                cloud_egress_consented: true,
+                brain_backend: backend,
+                ..AppConfig::default()
+            };
+            for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
+                let p = provider_for(role, &cfg)
+                    .unwrap_or_else(|e| panic!("{role:?}/{backend:?} must build: {e}"));
+                assert_eq!(p.id(), PROVIDER_CLAUDE_CODE, "{role:?}/{backend:?}");
+            }
+        }
+    }
+
+    /// CONSENT INVARIANCE across roles: every cloud-classified resolution — explicit role keys
+    /// included — is refused fail-closed without consent, exactly like `make_provider`. The gate
+    /// keys off the RESOLVED connection inside the factory, so a role can never bypass it.
+    #[test]
+    fn provider_for_is_consent_gated_for_every_cloud_resolution() {
+        // (a) fallback (default claude_code), all roles.
+        let cfg = AppConfig::default(); // consent OFF
+        for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
+            assert!(
+                matches!(provider_for(role, &cfg), Err(crate::error::AppError::Unavailable(_))),
+                "fallback {role:?} must be consent-gated"
+            );
+        }
+        // (b) explicit role keys onto each cloud connection (incl. REMOTE ollama).
+        type ConfigTweak = fn(&mut AppConfig);
+        let cases: [(&str, ConfigTweak); 4] = [
+            ("claude_code", |_| {}),
+            ("anthropic", |_| {}),
+            ("gateway", |c| c.gateway_base_url = "http://127.0.0.1:4000/v1".into()),
+            ("ollama", |c| c.ollama_base_url = "https://ollama.remote.example/api".into()),
+        ];
+        for (conn, extra) in cases {
+            let mut cfg = AppConfig {
+                role_ask_connection: conn.to_string(),
+                cloud_egress_consented: false,
+                ..AppConfig::default()
+            };
+            extra(&mut cfg);
+            assert!(
+                matches!(
+                    provider_for(roles::Role::Ask, &cfg),
+                    Err(crate::error::AppError::Unavailable(_))
+                ),
+                "explicit Ask→{conn} must be consent-gated"
+            );
+            // With consent granted the SAME resolution builds (and the RedactingProvider wrap is
+            // transparent to id(), which reports the inner connection — the wrap itself is proven
+            // by the redact.rs tests, exactly like the legacy factory tests above).
+            cfg.cloud_egress_consented = true;
+            let p = provider_for(roles::Role::Ask, &cfg)
+                .unwrap_or_else(|e| panic!("consented Ask→{conn} must build: {e}"));
+            assert_eq!(p.id(), conn);
+        }
+    }
+
+    /// A LOOPBACK ollama role target stays consent-exempt and unwrapped — the classification is
+    /// on the resolved connection + its URL, identical to the legacy factory.
+    #[test]
+    fn provider_for_local_ollama_role_is_ungated() {
+        let cfg = AppConfig {
+            role_ask_connection: "ollama".to_string(),
+            ollama_base_url: "http://localhost:11434".into(),
+            cloud_egress_consented: false,
+            ..AppConfig::default()
+        };
+        let p = provider_for(roles::Role::Ask, &cfg).expect("loopback ollama needs no consent");
+        assert_eq!(p.id(), PROVIDER_OLLAMA);
+    }
+
+    /// EXPLICIT reasoner-only role keys (`local`/`off`) can never build a SummarizerProvider —
+    /// `provider_for` refuses with `Unavailable` (they are LocalReasoner dispatch targets). Only
+    /// the LEGACY brain_backend fallback defers to the default provider (the floor nuance above).
+    #[test]
+    fn provider_for_refuses_explicit_reasoner_only_targets() {
+        for conn in [roles::CONN_LOCAL, roles::CONN_OFF] {
+            let cfg = AppConfig {
+                role_ask_connection: conn.to_string(),
+                cloud_egress_consented: true,
+                ..AppConfig::default()
+            };
+            let err = provider_for(roles::Role::Ask, &cfg)
+                .map(|_| ())
+                .expect_err("explicit reasoner-only target must not build a provider");
+            assert!(
+                matches!(err, crate::error::AppError::Unavailable(_)),
+                "expected Unavailable for explicit {conn}, got: {err}"
+            );
+        }
+    }
+
+    /// PROVENANCE — `effective_model_requested` names the model the request actually carries:
+    /// the resolved model when set, else the CONNECTION's own default. This is the anthropic
+    /// provenance fix: an empty resolved model records `anthropic_model` (previously empty).
+    #[test]
+    fn effective_model_requested_resolves_connection_defaults() {
+        let cfg = AppConfig {
+            anthropic_model: "claude-opus-4-8".to_string(),
+            ollama_model: "llama3.1".to_string(),
+            gateway_model: "gpt-4o".to_string(),
+            ..AppConfig::default()
+        };
+        let t = |conn: &str, model: &str| roles::RoleTarget {
+            connection: conn.to_string(),
+            model: model.to_string(),
+            effort: String::new(),
+        };
+        // An explicit resolved model always wins.
+        assert_eq!(effective_model_requested(&t("anthropic", "claude-sonnet-4-6"), &cfg), "claude-sonnet-4-6");
+        // Empty model → the connection's own default (THE anthropic fix).
+        assert_eq!(effective_model_requested(&t("anthropic", ""), &cfg), "claude-opus-4-8");
+        assert_eq!(effective_model_requested(&t("ollama", ""), &cfg), "llama3.1");
+        assert_eq!(effective_model_requested(&t("gateway", ""), &cfg), "gpt-4o");
+        // claude_code's default is the CLI's own — unknowable here, stays "".
+        assert_eq!(effective_model_requested(&t("claude_code", ""), &cfg), "");
+        assert_eq!(effective_model_requested(&t("claude_code", "claude-haiku-4-5"), &cfg), "claude-haiku-4-5");
     }
 
     /// Task 1.3 — `egress_is_cloud` explicitly classifies `PROVIDER_GATEWAY` as cloud.

--- a/src-tauri/src/summarize/roles.rs
+++ b/src-tauri/src/summarize/roles.rs
@@ -1,0 +1,413 @@
+//! Model ROLES — the one pure resolution layer between "what feature is asking" and "which
+//! connection/model/effort serves it".
+//!
+//! Murmur steers every LLM call with exactly two legacy knobs today: `provider_id` (+
+//! `provider_model`/`provider_effort`) for the SummarizerProvider factory, and `brain_backend`
+//! (+ `brain_model_id`) for the reasoner dispatch. This module introduces three user-meaningful
+//! roles — **Notes** (everything Murmur writes: summaries, digests, dossiers, briefs, recipes,
+//! timelines, graph extraction), **Ask** (vault Q&A + meeting chat), and **Live** (the in-meeting
+//! assistant / @brain threads / voice) — each resolvable to a [`RoleTarget`] by [`resolve`].
+//!
+//! ## The zero-behavior-change contract (load-bearing)
+//! Nine additive config keys (`role_{notes,ask,live}_{connection,model,effort}`) override the
+//! legacy knobs PER ROLE. A role whose CONNECTION key is empty (every install today) falls back to
+//! the legacy mapping EXACTLY, so with the keys absent every call path behaves byte-identically to
+//! the pre-role code. The legacy config is never rewritten — it stays the resolver's bottom layer
+//! (downgrade-safe).
+//!
+//! ## Why THREE resolution views (not one)
+//! The legacy code answers "which model serves feature X" with TWO DIFFERENT knobs depending on
+//! the engine, and a single mapping cannot reproduce both:
+//! - [`resolve`] — the role's user-facing target (the contract mapping): Notes → the default
+//!   provider triple; Ask/Live → the `brain_backend` mapping (`cloud` inherits the default
+//!   provider, `local`/`off` are reasoner-only targets).
+//! - [`provider_target`] — "which **SummarizerProvider** serves this role". Legacy nuance: the
+//!   pre-role Ask provider paths (`chat_meeting`, the `ask_vault` floor) IGNORE `brain_backend`
+//!   and always use the default provider — so a reasoner-only target reached VIA LEGACY FALLBACK
+//!   defers to the default provider triple (byte-identical floors), while an EXPLICIT
+//!   `local`/`off` role key stays reasoner-only (the factory refuses it — see
+//!   [`crate::summarize::provider_for`]).
+//! - [`reasoner_target`] — "which **LocalReasoner** serves this role". Legacy nuance: EVERY
+//!   pre-role reasoner dispatch (pre-analysis, facts, the agentic loops) keys on `brain_backend`
+//!   — including the Notes-role sites — so under fallback ALL roles map `brain_backend` here.
+//!   Resolving the Notes reasoner from `provider_id` instead would silently turn a
+//!   `brain_backend = Off/Local` install's pre-analysis into a CLOUD call — an egress regression.
+//!
+//! With a role's connection key SET, all three views coincide (the role's explicit triple).
+//! Everything here is pure (config in, target out): consent, redaction, and the egress ledger
+//! stay inside the factory ([`crate::summarize::make_provider`]-family), keyed off the RESOLVED
+//! connection — roles can never bypass them.
+
+use crate::settings::{AppConfig, BrainBackend};
+
+/// Reasoner-only connection id: the on-device GGUF brain ([`crate::reason::mistral`]).
+pub const CONN_LOCAL: &str = "local";
+/// Reasoner-only connection id: no model — the deterministic [`crate::reason::StubReasoner`] floor.
+pub const CONN_OFF: &str = "off";
+
+/// A model role — the fixed, user-meaningful set of "what Murmur uses AI for".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// Everything Murmur WRITES: note summaries, auto-organize, graph extraction, recipes,
+    /// digests, dossiers, briefs, timelines — plus the note pipeline's pre-analysis/facts brain.
+    Notes,
+    /// Vault Q&A (`ask_vault` agentic loop + floor) and per-meeting chat.
+    Ask,
+    /// The in-meeting assistant: wake-word/voice turns, typed @brain threads, the live loop.
+    Live,
+}
+
+impl Role {
+    /// Stable lowercase token for logs (`notes` | `ask` | `live`). Never PII.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Notes => "notes",
+            Role::Ask => "ask",
+            Role::Live => "live",
+        }
+    }
+}
+
+/// A resolved (connection, model, effort) triple for one role. `connection` is a provider id
+/// (`claude_code` / `anthropic` / `ollama` / `gateway`) or a reasoner-only target
+/// ([`CONN_LOCAL`] / [`CONN_OFF`]). An empty `model`/`effort` means "inherit that connection's
+/// own default" (the factory arms already resolve those — e.g. anthropic → `anthropic_model`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoleTarget {
+    pub connection: String,
+    pub model: String,
+    pub effort: String,
+}
+
+impl RoleTarget {
+    /// `true` when this target is served by a [`crate::reason::LocalReasoner`] only (`local`/
+    /// `off`) — it can never build a `SummarizerProvider`, and the agentic loops don't run on it.
+    pub fn is_reasoner_only(&self) -> bool {
+        self.connection == CONN_LOCAL || self.connection == CONN_OFF
+    }
+}
+
+/// The raw role keys for `role` (connection, model, effort) — `""` everywhere = "inherit"
+/// (the legacy fallback applies).
+fn role_keys(role: Role, cfg: &AppConfig) -> (&str, &str, &str) {
+    match role {
+        Role::Notes => (
+            &cfg.role_notes_connection,
+            &cfg.role_notes_model,
+            &cfg.role_notes_effort,
+        ),
+        Role::Ask => (
+            &cfg.role_ask_connection,
+            &cfg.role_ask_model,
+            &cfg.role_ask_effort,
+        ),
+        Role::Live => (
+            &cfg.role_live_connection,
+            &cfg.role_live_model,
+            &cfg.role_live_effort,
+        ),
+    }
+}
+
+/// Whether `role`'s connection key is explicitly set. The CONNECTION key is the override switch:
+/// with it empty the role inherits the WHOLE legacy mapping (a lone model/effort key is ignored —
+/// "" would be ambiguous between "CLI default" and "legacy provider_model" otherwise).
+fn is_explicit(role: Role, cfg: &AppConfig) -> bool {
+    !role_keys(role, cfg).0.trim().is_empty()
+}
+
+/// The role's EXPLICIT target from its own keys. Caller guarantees [`is_explicit`].
+fn explicit_target(role: Role, cfg: &AppConfig) -> RoleTarget {
+    let (connection, model, effort) = role_keys(role, cfg);
+    RoleTarget {
+        connection: connection.trim().to_string(),
+        model: model.trim().to_string(),
+        effort: effort.trim().to_string(),
+    }
+}
+
+/// The LEGACY default-provider triple — what every pre-role `make_provider(&cfg.provider_id, …)`
+/// call site effectively targeted.
+///
+/// `model` carries `provider_model` ONLY for the arms that historically read it (`claude_code`,
+/// `anthropic`); the `ollama`/`gateway` arms have always resolved their model from
+/// `ollama_model`/`gateway_model` and IGNORED `provider_model` (the Brain&AI picker is inert
+/// there), so their fallback model is `""` = inherit-connection-default. Carrying
+/// `provider_model` verbatim would make a stale Claude id from the picker suddenly reach an
+/// ollama/gateway request — a real behavior change for existing configs.
+fn legacy_default_target(cfg: &AppConfig) -> RoleTarget {
+    let model = match cfg.provider_id.as_str() {
+        crate::summarize::PROVIDER_CLAUDE_CODE | crate::summarize::PROVIDER_ANTHROPIC => {
+            cfg.provider_model.clone()
+        }
+        _ => String::new(),
+    };
+    RoleTarget {
+        connection: cfg.provider_id.clone(),
+        model,
+        effort: cfg.provider_effort.clone(),
+    }
+}
+
+/// The LEGACY `brain_backend` mapping — what every pre-role `ReasonerCell::current()` dispatch
+/// (and the agentic-eligibility gates) keyed on.
+fn legacy_brain_target(cfg: &AppConfig) -> RoleTarget {
+    match cfg.brain_backend {
+        BrainBackend::Cloud => legacy_default_target(cfg),
+        BrainBackend::Local => RoleTarget {
+            connection: CONN_LOCAL.to_string(),
+            model: cfg.brain_model_id.clone().unwrap_or_default(),
+            effort: String::new(),
+        },
+        BrainBackend::Off => RoleTarget {
+            connection: CONN_OFF.to_string(),
+            model: String::new(),
+            effort: String::new(),
+        },
+    }
+}
+
+/// Resolve `role` to its target — PURE, the role architecture's single source of truth.
+///
+/// Explicit role keys win; otherwise the EXACT legacy fallback:
+/// - **Notes** → the default provider triple (`provider_id` + `provider_model`/`provider_effort`
+///   where the arm reads them — see [`legacy_default_target`]).
+/// - **Ask / Live** → the `brain_backend` mapping: `Cloud` inherits the default provider triple,
+///   `Local` → ([`CONN_LOCAL`], `brain_model_id`, ""), `Off` → ([`CONN_OFF`], "", "").
+pub fn resolve(role: Role, cfg: &AppConfig) -> RoleTarget {
+    if is_explicit(role, cfg) {
+        return explicit_target(role, cfg);
+    }
+    match role {
+        Role::Notes => legacy_default_target(cfg),
+        Role::Ask | Role::Live => legacy_brain_target(cfg),
+    }
+}
+
+/// The target whose **SummarizerProvider** serves `role` — what
+/// [`crate::summarize::provider_for`] builds, and what corpus BUDGETS must key on (the corpus
+/// egresses to THIS connection).
+///
+/// Same as [`resolve`], with the one legacy nuance: a reasoner-only target reached VIA THE LEGACY
+/// FALLBACK (i.e. `brain_backend = Local/Off` with no explicit role key) defers to the legacy
+/// default provider triple — because the pre-role provider paths for Ask (`chat_meeting`, the
+/// `ask_vault` floor) always used `provider_id` and IGNORED `brain_backend`. An EXPLICIT
+/// `local`/`off` role key is returned as-is (reasoner-only); the factory refuses to build a
+/// provider for it.
+pub fn provider_target(role: Role, cfg: &AppConfig) -> RoleTarget {
+    let target = resolve(role, cfg);
+    if target.is_reasoner_only() && !is_explicit(role, cfg) {
+        return legacy_default_target(cfg);
+    }
+    target
+}
+
+/// The target whose **LocalReasoner** serves `role` — what [`crate::reason::ReasonerCell::current_for`]
+/// dispatches on.
+///
+/// Explicit role keys win (all three views coincide). Under the legacy fallback EVERY role maps
+/// `brain_backend` — including Notes, whose reasoner sites (note-pipeline pre-analysis, facts)
+/// have always dispatched on `brain_backend`. Mapping the Notes reasoner from `provider_id`
+/// instead would turn a `brain_backend = Off/Local` install's pre-analysis into a cloud call —
+/// an egress change this behavior-identical layer must not make.
+pub fn reasoner_target(role: Role, cfg: &AppConfig) -> RoleTarget {
+    if is_explicit(role, cfg) {
+        return explicit_target(role, cfg);
+    }
+    legacy_brain_target(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A discriminating legacy config: every legacy knob set to a distinct value so the identity
+    /// matrix can tell exactly which knob each resolution read.
+    fn legacy_cfg(provider_id: &str, backend: BrainBackend) -> AppConfig {
+        AppConfig {
+            provider_id: provider_id.to_string(),
+            provider_model: "picker-model".to_string(),
+            provider_effort: "high".to_string(),
+            brain_backend: backend,
+            brain_model_id: Some("bielik-11b-v3".to_string()),
+            ..AppConfig::default()
+        }
+    }
+
+    fn target(connection: &str, model: &str, effort: &str) -> RoleTarget {
+        RoleTarget {
+            connection: connection.to_string(),
+            model: model.to_string(),
+            effort: effort.to_string(),
+        }
+    }
+
+    /// The RESOLVER IDENTITY MATRIX — with role keys absent, `resolve` reproduces the documented
+    /// legacy mapping for every provider_id × brain_backend combination. This is the
+    /// zero-behavior-change proof at the resolution layer.
+    #[test]
+    fn resolve_identity_matrix_with_keys_absent() {
+        for provider_id in ["claude_code", "anthropic", "ollama", "gateway"] {
+            // The legacy arms read `provider_model` only for claude_code/anthropic; ollama and
+            // gateway resolve their model from ollama_model/gateway_model (provider_model is
+            // inert there), so their fallback model is "" = inherit-connection-default.
+            let legacy_model = match provider_id {
+                "claude_code" | "anthropic" => "picker-model",
+                _ => "",
+            };
+            let notes_want = target(provider_id, legacy_model, "high");
+            for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+                let cfg = legacy_cfg(provider_id, backend);
+                // Notes ignores brain_backend entirely.
+                assert_eq!(resolve(Role::Notes, &cfg), notes_want, "{provider_id}/{backend:?}");
+                // Ask and Live map brain_backend identically.
+                let brain_want = match backend {
+                    BrainBackend::Cloud => notes_want.clone(),
+                    BrainBackend::Local => target(CONN_LOCAL, "bielik-11b-v3", ""),
+                    BrainBackend::Off => target(CONN_OFF, "", ""),
+                };
+                for role in [Role::Ask, Role::Live] {
+                    assert_eq!(
+                        resolve(role, &cfg),
+                        brain_want,
+                        "{provider_id}/{backend:?}/{role:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Local fallback with NO selected brain model resolves model to "" (the reasoner then
+    /// falls back to the stub, exactly like today's `local_reasoner`).
+    #[test]
+    fn resolve_local_fallback_without_model_id_is_empty_model() {
+        let cfg = AppConfig {
+            brain_backend: BrainBackend::Local,
+            brain_model_id: None,
+            ..AppConfig::default()
+        };
+        assert_eq!(resolve(Role::Ask, &cfg), target(CONN_LOCAL, "", ""));
+    }
+
+    /// Explicit role keys WIN over every legacy knob; a set connection with an empty model keeps
+    /// the model "" (= that connection's own default — the factory arms resolve it).
+    #[test]
+    fn explicit_role_keys_win_and_empty_model_inherits_connection_default() {
+        let cfg = AppConfig {
+            role_ask_connection: "ollama".to_string(),
+            role_ask_model: "mistral-small".to_string(),
+            role_ask_effort: "low".to_string(),
+            role_live_connection: "anthropic".to_string(),
+            // live model/effort left "" — inherit anthropic's own defaults.
+            ..legacy_cfg("claude_code", BrainBackend::Off)
+        };
+        assert_eq!(resolve(Role::Ask, &cfg), target("ollama", "mistral-small", "low"));
+        assert_eq!(resolve(Role::Live, &cfg), target("anthropic", "", ""));
+        // Notes has no explicit key → still the legacy default triple.
+        assert_eq!(resolve(Role::Notes, &cfg), target("claude_code", "picker-model", "high"));
+    }
+
+    /// The CONNECTION key is the override switch: a lone model/effort key with the connection
+    /// empty is ignored (full legacy inherit) — never a half-override.
+    #[test]
+    fn model_key_without_connection_key_is_ignored() {
+        let cfg = AppConfig {
+            role_notes_model: "sneaky-model".to_string(),
+            role_notes_effort: "low".to_string(),
+            ..legacy_cfg("claude_code", BrainBackend::Cloud)
+        };
+        assert_eq!(resolve(Role::Notes, &cfg), target("claude_code", "picker-model", "high"));
+    }
+
+    /// GATE EQUIVALENCE — the agentic-eligibility gates replace `brain_backend == Cloud` with
+    /// `!resolve(role).is_reasoner_only()`. Under the legacy fallback the two predicates are
+    /// identical for every backend (the RED/GREEN proof for the gate swap).
+    #[test]
+    fn reasoner_only_matches_legacy_cloud_gate_under_fallback() {
+        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            let cfg = legacy_cfg("claude_code", backend);
+            let legacy_gate_open = backend == BrainBackend::Cloud;
+            for role in [Role::Ask, Role::Live] {
+                assert_eq!(
+                    !resolve(role, &cfg).is_reasoner_only(),
+                    legacy_gate_open,
+                    "{backend:?}/{role:?}"
+                );
+            }
+        }
+    }
+
+    /// PROVIDER-TARGET LEGACY NUANCE — under fallback the SummarizerProvider question always
+    /// answers with the default provider triple, for EVERY role and EVERY brain_backend: the
+    /// pre-role Ask provider paths (chat_meeting, the ask_vault floor) ignored `brain_backend`.
+    #[test]
+    fn provider_target_is_default_triple_under_fallback_for_all_backends() {
+        for provider_id in ["claude_code", "anthropic", "ollama", "gateway"] {
+            for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+                let cfg = legacy_cfg(provider_id, backend);
+                let want = legacy_default_target(&cfg);
+                for role in [Role::Notes, Role::Ask, Role::Live] {
+                    assert_eq!(
+                        provider_target(role, &cfg),
+                        want,
+                        "{provider_id}/{backend:?}/{role:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// An EXPLICIT local/off role key stays reasoner-only on the provider question (the factory
+    /// then refuses it) — only the LEGACY fallback defers to the default provider.
+    #[test]
+    fn provider_target_keeps_explicit_reasoner_only_targets() {
+        let cfg = AppConfig {
+            role_ask_connection: CONN_LOCAL.to_string(),
+            role_live_connection: CONN_OFF.to_string(),
+            ..legacy_cfg("claude_code", BrainBackend::Cloud)
+        };
+        assert_eq!(provider_target(Role::Ask, &cfg).connection, CONN_LOCAL);
+        assert_eq!(provider_target(Role::Live, &cfg).connection, CONN_OFF);
+        // Notes stays on the default provider.
+        assert_eq!(provider_target(Role::Notes, &cfg).connection, "claude_code");
+    }
+
+    /// REASONER-TARGET LEGACY NUANCE — under fallback EVERY role (Notes included) maps
+    /// `brain_backend`, because every pre-role reasoner dispatch did. A Notes reasoner resolved
+    /// from `provider_id` instead would cloud-dispatch an Off/Local install's pre-analysis.
+    #[test]
+    fn reasoner_target_maps_brain_backend_for_all_roles_under_fallback() {
+        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            let cfg = legacy_cfg("claude_code", backend);
+            let want = legacy_brain_target(&cfg);
+            for role in [Role::Notes, Role::Ask, Role::Live] {
+                assert_eq!(reasoner_target(role, &cfg), want, "{backend:?}/{role:?}");
+            }
+        }
+    }
+
+    /// With explicit keys all three views coincide on the role's own triple.
+    #[test]
+    fn explicit_keys_unify_all_three_views() {
+        let cfg = AppConfig {
+            role_ask_connection: "gateway".to_string(),
+            role_ask_model: "gpt-4o".to_string(),
+            ..legacy_cfg("claude_code", BrainBackend::Off)
+        };
+        let want = target("gateway", "gpt-4o", "");
+        assert_eq!(resolve(Role::Ask, &cfg), want);
+        assert_eq!(provider_target(Role::Ask, &cfg), want);
+        assert_eq!(reasoner_target(Role::Ask, &cfg), want);
+    }
+
+    /// Role/connection tokens are stable (they go into logs + the reasoner cache key).
+    #[test]
+    fn role_tokens_are_stable() {
+        assert_eq!(Role::Notes.as_str(), "notes");
+        assert_eq!(Role::Ask.as_str(), "ask");
+        assert_eq!(Role::Live.as_str(), "live");
+        assert!(target(CONN_LOCAL, "", "").is_reasoner_only());
+        assert!(target(CONN_OFF, "", "").is_reasoner_only());
+        assert!(!target("claude_code", "", "").is_reasoner_only());
+    }
+}

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -401,8 +401,11 @@ pub fn run_assistant_query(
     // Resolve an intent for the FLOOR only (its read fan-out + surfaced kind) — it NO LONGER routes
     // writes. The agentic loop (with writes) is the single executive path; the agent DECIDES.
     // The reasoner is re-resolved for THIS turn (never a startup snapshot), so a consent /
-    // provider / backend change since the last turn is already in effect.
-    let reasoner = state.reasoner.current();
+    // provider / backend change since the last turn is already in effect. LIVE role — the whole
+    // in-meeting assistant (wake/voice turns AND typed @brain threads funnel through this core).
+    let reasoner = state
+        .reasoner
+        .current_for(crate::summarize::roles::Role::Live);
     let intent = resolve_command_intent(&*reasoner, command);
     let result = run_informational(
         app,
@@ -456,14 +459,20 @@ fn run_informational(
     tool_event: &'static str,
     thread_id: &str,
 ) -> crate::voice_action::VoiceActionResult {
-    // The agentic loop runs only on the CLOUD brain — local-GGUF multi-step tool-call reliability is
-    // unproven (Q4 + the Bielik 32K-overflow lesson), so the local + stub backends use the
-    // deterministic floor: honest, fast, and a strict no-regression vs today.
+    // The agentic loop runs only on CLOUD-connection targets — local-GGUF multi-step tool-call
+    // reliability is unproven (Q4 + the Bielik 32K-overflow lesson), so the local + stub targets
+    // use the deterministic floor: honest, fast, and a strict no-regression vs today.
     // Resolve the reasoner for THIS request from the LIVE config — a consent/provider/backend
     // change since the branch snapshot above dispatches correctly on the next turn either way
     // (the consent gate itself re-checks fresh config on every provider call inside).
-    let reasoner = state.reasoner.current();
-    if config.brain_backend == crate::settings::BrainBackend::Cloud {
+    // The eligibility gate keys on the LIVE role's resolved target: with role keys absent,
+    // `!is_reasoner_only()` is EXACTLY the legacy `brain_backend == Cloud` predicate.
+    let reasoner = state
+        .reasoner
+        .current_for(crate::summarize::roles::Role::Live);
+    if !crate::summarize::roles::resolve(crate::summarize::roles::Role::Live, config)
+        .is_reasoner_only()
+    {
         let executor = crate::tools::GatedToolExecutor {
             db: &state.db,
             // The LIVE set behind its Mutex — re-read per tool call (C6), so a mid-loop relock is gated


### PR DESCRIPTION
Stage 3 of the model-settings unification (`docs/research/2026-07-02-unify-model-settings.md`). **Behavior-identical for every existing install** — the new role keys are absent by default and the resolver falls back to today's `provider_id`/`provider_model`/`brain_backend` semantics 1:1.

## What
- `summarize/roles.rs`: `Role{Notes,Ask,Live}` + `RoleTarget{connection,model,effort}` + pure `resolve()`/`provider_target()`/`reasoner_target()` with an exact legacy fallback.
- `make_provider` internals → `make_provider_resolved(&RoleTarget, cfg)`; `make_provider(id, cfg)` stays a thin wrapper; new `provider_for(role, cfg)` (refuses reasoner-only `local`/`off` targets on provider-backed surfaces).
- `ReasonerCell::current_for(role)`; `CloudReasoner` carries its role, still reads config fresh per call (PR #116 consent-revoke discipline); `ReasonerCell::fixed` now structurally `#[cfg(test)]`.
- ~14 call sites resolved per role (notes pipeline/recipes/graph/dossier/digest/brief/timeline → Notes; chat + ask floor + ask agentic → Ask; in-meeting assistant incl. typed @brain → Live); eligibility gates + corpus budgets keyed on the resolved connection.
- 9 additive settings keys `role_{notes,ask,live}_{connection,model,effort}` + `#[serde(default)]` DTO fields; consent flags stay preserve-only.
- Provenance fix: ledger + note provenance record the EFFECTIVE model (anthropic with empty `provider_model` used to record nothing).
- Paired-write fix (found by the adversarial pass): `exported_path` now persists under the same resolved connection as the note-row upsert — pre-fix, a role override would leave the vault `.md` deletion target NULL and a plaintext `.md` could survive a seal. Regression test proven RED on the pre-fix key.

## Documented fallback deviations (each mutation-proven to SERVE identity)
1. `resolve(Notes)` carries `provider_model` only for claude_code/anthropic (ollama/gateway arms always ignored it).
2. Legacy `brain_backend=Local/Off` still builds the default provider for chat/ask-floor (they ignored `brain_backend` on trunk); explicit role-key `local`/`off` refuses.
3. `current_for(Notes)` dispatches on the `brain_backend` mapping (pre-analysis/facts stay local/stub on Local/Off — no new cloud egress).

## How verified
- `cargo test --lib`: **687 / 0 / 2** (+identity matrix, consent matrix incl. remote-ollama, DTO omitted-keys safety, provenance, paired-write regression).
- **Adversarial verifier: PASS** — initial FAIL on the paired-write leak, fix re-verified with a mutation revert (test goes RED on the old key); the three deviations verified against trunk pre-images; missed-call-site sweep clean.
- **Lock-security reviewer: PASS** — consent gate unavoidable for every cloud resolution, redaction wrap structural, ledger truthful, no content-read/seal path touched, no PII in logs.
- `scripts/ci.sh` → ✅ all gates green on the integrated tree (incl. clippy -D warnings).