### PR TITLE
feat(settings): per-feature model overrides (Notes/Ask/Live) + unified list_models

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3311,17 +3311,14 @@ pub struct GatewayModelDto {
 }
 
 /// Fetch the model catalog from the configured AI Gateway (`GET {base}/v1/models`) and return
-/// the list of model ids the gateway exposes.
+/// the raw list of model ids. Shared core of `list_gateway_models` and `list_models("gateway")`.
 ///
 /// Inbound-only: this call sends NO meeting content — only an optional `Authorization: Bearer`
 /// header carrying the stored gateway key. It therefore does NOT need the redaction firewall or
 /// the cloud-egress consent gate.
 ///
 /// Returns `AppError::InvalidArg` when no gateway base URL is configured.
-#[tauri::command]
-pub async fn list_gateway_models(
-    state: State<'_, AppState>,
-) -> Result<Vec<GatewayModelDto>, AppError> {
+async fn gateway_model_ids(state: &AppState) -> Result<Vec<String>, AppError> {
     let (base_url, model, api_key) = {
         let config = state
             .config
@@ -3342,8 +3339,78 @@ pub async fn list_gateway_models(
     }
 
     let provider = crate::summarize::gateway::OpenAiCompatProvider::new(base_url, model, api_key)?;
-    let ids = provider.list_models().await?;
+    provider.list_models().await
+}
+
+/// Fetch the model catalog from the configured AI Gateway (`GET {base}/v1/models`) and return
+/// the list of model ids the gateway exposes. Thin DTO wrapper over [`gateway_model_ids`] —
+/// kept until the FE swaps to the unified `list_models("gateway")`.
+#[tauri::command]
+pub async fn list_gateway_models(
+    state: State<'_, AppState>,
+) -> Result<Vec<GatewayModelDto>, AppError> {
+    let ids = gateway_model_ids(&state).await?;
     Ok(ids.into_iter().map(|id| GatewayModelDto { id }).collect())
+}
+
+/// Model ids for the connections whose catalog is static, compile-time data — pure so it is
+/// unit-testable without state or network. `None`-network connections only:
+///   - `"claude_code"` / `"anthropic"` → the curated [`crate::summarize::provider::CLAUDE_MODELS`],
+///   - `"local"` → the on-device `reason::BRAIN_MODELS` registry ids,
+///   - `"off"` → empty (a valid connection that runs no models),
+///   - anything else → `AppError::InvalidArg`.
+fn static_connection_models(connection: &str) -> Result<Vec<String>, AppError> {
+    match connection {
+        "claude_code" | "anthropic" => Ok(crate::summarize::provider::CLAUDE_MODELS
+            .iter()
+            .map(|id| id.to_string())
+            .collect()),
+        "local" => Ok(crate::reason::BRAIN_MODELS
+            .iter()
+            .map(|m| m.id.to_string())
+            .collect()),
+        "off" => Ok(vec![]),
+        other => Err(AppError::InvalidArg(format!(
+            "unknown connection '{other}' — expected claude_code, anthropic, ollama, gateway, local, or off"
+        ))),
+    }
+}
+
+/// Unified model catalog for a connection — the ONE source of truth behind the FE per-role
+/// model dropdowns. Dispatch by `connection`:
+///   - `"gateway"` → `GET {gateway_base_url}/v1/models` (shares [`gateway_model_ids`] with
+///     `list_gateway_models`),
+///   - `"ollama"` → `GET {ollama_base_url}/api/tags`, model names only,
+///   - `"claude_code"` / `"anthropic"` / `"local"` / `"off"` → static lists
+///     (see [`static_connection_models`]),
+///   - anything else → `AppError::InvalidArg`.
+///
+/// Inbound-only on every arm: NO meeting content is sent — at most an `Authorization: Bearer`
+/// header to the configured gateway — so no redaction firewall / consent gate is needed (the
+/// `list_gateway_models` precedent). No content read → no lock-model surface.
+#[tauri::command]
+pub async fn list_models(
+    state: State<'_, AppState>,
+    connection: String,
+) -> Result<Vec<String>, AppError> {
+    match connection.as_str() {
+        "gateway" => gateway_model_ids(&state).await,
+        "ollama" => {
+            let base_url = {
+                let config = state
+                    .config
+                    .lock()
+                    .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+                config.ollama_base_url.clone()
+            };
+            // OllamaProvider::new normalizes an empty base URL to the localhost default and
+            // trims trailing slashes; the model arg is unused for a catalog fetch.
+            crate::summarize::ollama::OllamaProvider::new(base_url, String::new())
+                .list_models()
+                .await
+        }
+        other => static_connection_models(other),
+    }
 }
 
 /// DTO returned by `gateway_health`.
@@ -8164,6 +8231,59 @@ mod lifecycle_tests {
             "https://gw.example.com/v1",
             "valid URL must be persisted and visible in the in-memory config cache"
         );
+    }
+
+    // ─── list_models — static connection catalogs (pure, no network) ─────────────────────────
+
+    /// `claude_code` and `anthropic` both serve the curated CLAUDE_MODELS constant — the single
+    /// source of truth that replaced the FE-hardcoded dropdown list.
+    #[test]
+    fn list_models_claude_connections_return_curated_constant() {
+        for conn in ["claude_code", "anthropic"] {
+            let ids = static_connection_models(conn)
+                .unwrap_or_else(|e| panic!("{conn} must resolve statically: {e:?}"));
+            let want: Vec<String> = crate::summarize::provider::CLAUDE_MODELS
+                .iter()
+                .map(|id| id.to_string())
+                .collect();
+            assert_eq!(ids, want, "{conn} must serve CLAUDE_MODELS verbatim");
+            assert!(
+                ids.contains(&"claude-opus-4-8".to_string()),
+                "curated list must include the default Opus id"
+            );
+        }
+    }
+
+    /// `local` serves exactly the BRAIN_MODELS registry ids, in registry order.
+    #[test]
+    fn list_models_local_matches_brain_registry_ids() {
+        let ids = static_connection_models("local").expect("local must resolve statically");
+        let want: Vec<String> = crate::reason::BRAIN_MODELS
+            .iter()
+            .map(|m| m.id.to_string())
+            .collect();
+        assert_eq!(ids, want, "local must mirror the BRAIN_MODELS registry ids");
+        assert!(!ids.is_empty(), "the brain registry is never empty");
+    }
+
+    /// `off` is a valid connection with no models — empty list, not an error.
+    #[test]
+    fn list_models_off_returns_empty() {
+        let ids = static_connection_models("off").expect("off must resolve statically");
+        assert!(ids.is_empty(), "off runs no models");
+    }
+
+    /// An unknown connection id refuses with `InvalidArg` — never a panic, never an empty Ok.
+    #[test]
+    fn list_models_unknown_connection_refuses() {
+        for conn in ["", "openai", "GATEWAY", "claude"] {
+            let err = static_connection_models(conn)
+                .expect_err("unknown connection must be refused");
+            assert!(
+                matches!(err, AppError::InvalidArg(_)),
+                "expected InvalidArg for '{conn}', got: {err:?}"
+            );
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             commands::has_gateway_key,
             commands::clear_gateway_key,
             commands::list_gateway_models,
+            commands::list_models,
             commands::gateway_health,
             commands::get_egress_ledger,
             commands::set_web_search_api_key,

--- a/src-tauri/src/summarize/ollama.rs
+++ b/src-tauri/src/summarize/ollama.rs
@@ -13,6 +13,10 @@ const DEFAULT_MODEL: &str = "llama3.1";
 /// Ollama runs locally, so 500 ms is plenty when it's up and keeps the UI from
 /// stalling when it's down (review SF-2).
 const AVAILABILITY_TIMEOUT: Duration = Duration::from_millis(500);
+/// Timeout for the `/api/tags` catalog fetch feeding the Settings model dropdown — longer than
+/// the readiness probe (a cold Ollama can be slow to answer) but still bounded so the UI never
+/// hangs on a dead server.
+const LIST_MODELS_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Talks to a local Ollama server's HTTP API (default `http://localhost:11434`).
 pub struct OllamaProvider {
@@ -41,6 +45,45 @@ impl OllamaProvider {
             model,
         }
     }
+
+    /// `GET {base}/api/tags` → list of locally installed model names for the Settings dropdown.
+    ///
+    /// Inbound-only: sends NO meeting content — the request is a bare GET to the local (or
+    /// user-configured) Ollama server and the response carries only model names. It therefore
+    /// does NOT need the redaction firewall or the cloud-egress consent gate (same rationale as
+    /// the gateway `list_models` / `list_gateway_models` precedent).
+    ///
+    /// A transport failure or non-2xx status maps to `AppError::Unavailable`; a malformed body
+    /// degrades to an empty list (see [`parse_tags_response`]) — never a panic.
+    pub async fn list_models(&self) -> crate::error::Result<Vec<String>> {
+        let url = format!("{}/api/tags", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(LIST_MODELS_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| {
+                AppError::Unavailable(format!(
+                    "Ollama not reachable at {} ({e})",
+                    self.base_url
+                ))
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(AppError::Unavailable(format!(
+                "Ollama at {} returned {status}",
+                self.base_url
+            )));
+        }
+
+        let body = resp.text().await.map_err(|e| {
+            AppError::Unavailable(format!("failed to read Ollama /api/tags body: {e}"))
+        })?;
+
+        parse_tags_response(&body)
+    }
 }
 
 /// Mirror of the `/api/generate` non-streaming response (only the fields we use).
@@ -48,6 +91,28 @@ impl OllamaProvider {
 struct GenerateResponse {
     #[serde(default)]
     response: String,
+}
+
+/// Minimal mirror of the Ollama `/api/tags` response — only `models[].name` is extracted.
+/// A missing or unrecognised body degrades to an empty list, never a panic.
+#[derive(Debug, Deserialize, Default)]
+struct TagsResponse {
+    #[serde(default)]
+    models: Vec<TagEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TagEntry {
+    name: String,
+}
+
+/// Parse a raw Ollama `/api/tags` response body into a `Vec<String>` of model names.
+///
+/// A malformed or empty body returns `Ok(vec![])` — the caller (the FE model dropdown) handles
+/// an empty list gracefully. Inbound-only metadata: NO meeting content is sent to produce this.
+pub(crate) fn parse_tags_response(body: &str) -> crate::error::Result<Vec<String>> {
+    let parsed: TagsResponse = serde_json::from_str(body).unwrap_or_default();
+    Ok(parsed.models.into_iter().map(|m| m.name).collect())
 }
 
 #[async_trait::async_trait]
@@ -150,5 +215,49 @@ impl SummarizerProvider for OllamaProvider {
             .await
             .map_err(|e| AppError::Summarize(format!("failed to parse Ollama response: {e}")))?;
         Ok(parsed.response.trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real-shaped `/api/tags` body: names come back in order, extra fields are ignored.
+    #[test]
+    fn parse_tags_response_extracts_names() {
+        let body = r#"{"models":[
+            {"name":"llama3.1:latest","modified_at":"2026-01-01T00:00:00Z","size":4661224676},
+            {"name":"qwen2.5:7b","modified_at":"2026-02-01T00:00:00Z","size":4431231234}
+        ]}"#;
+        let names = parse_tags_response(body).unwrap();
+        assert_eq!(
+            names,
+            vec!["llama3.1:latest", "qwen2.5:7b"],
+            "names must match fixture order"
+        );
+    }
+
+    /// A malformed (non-JSON) body degrades to an empty list — never a panic.
+    #[test]
+    fn parse_tags_response_malformed_body_returns_empty() {
+        let names = parse_tags_response("not json at all").unwrap();
+        assert!(names.is_empty(), "malformed body must degrade to an empty list");
+    }
+
+    /// An empty models array returns an empty list cleanly.
+    #[test]
+    fn parse_tags_response_empty_models_returns_empty() {
+        let names = parse_tags_response(r#"{"models":[]}"#).unwrap();
+        assert!(names.is_empty(), "empty models must return an empty list");
+    }
+
+    /// A non-Ollama schema (e.g. the OpenAI `{"data":[…]}` shape) degrades to empty.
+    #[test]
+    fn parse_tags_response_non_ollama_schema_returns_empty() {
+        let names = parse_tags_response(r#"{"data":[{"id":"gpt-4o"}]}"#).unwrap();
+        assert!(
+            names.is_empty(),
+            "an OpenAI-shaped body must degrade to an empty list, not misparse"
+        );
     }
 }

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -5,6 +5,13 @@ use serde_json::Value;
 use crate::error::Result;
 use crate::summarize::meta::CallMeta;
 
+/// The curated Claude model ids offered for the `claude_code` and `anthropic` connections.
+///
+/// Single source of truth for the FE model dropdowns, served through the `list_models` command —
+/// this list previously lived hardcoded in the Settings template. Order is display order (most
+/// capable first). Static compile-time data — no I/O, no egress.
+pub const CLAUDE_MODELS: &[&str] = &["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeetingMeta {

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -219,6 +219,18 @@ export class IpcService {
   }
 
   /**
+   * Stage 4 — the model catalog for ONE connection: `claude_code`/`anthropic` →
+   * the backend's Claude-id constant (single source of truth — no more
+   * hardcoded ids in FE templates), `ollama` → the live `/api/tags` list,
+   * `gateway` → its `/v1/models`, `local` → the GGUF registry ids. Rejects when
+   * the connection's endpoint is unreachable — the FE falls back to a free-text
+   * model input (the {@link listGatewayModels} pattern).
+   */
+  listModels(connection: string): Promise<string[]> {
+    return invoke<string[]>("list_models", { connection });
+  }
+
+  /**
    * AI Gateway (Phase 4) — probe whether the configured gateway is reachable and
    * return the number of models in its catalog. The backend never errors on this
    * command (unreachable → `{ reachable: false, modelCount: 0 }`). The FE still

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -176,6 +176,24 @@ export interface AppConfigDto {
    * Mirrors Rust `AppConfigDto.proactive_hints_enabled`.
    */
   proactiveHintsEnabled: boolean;
+  /**
+   * Stage 4 — per-feature model-role overrides (Notes / Ask / Live), mirroring
+   * Rust `AppConfigDto.role_*` (camelCase). `""` = inherit: the role follows
+   * the legacy mapping (Notes → the Default AI triple; Ask/Live → the
+   * `brainBackend` fallback). The CONNECTION key is the override switch — a
+   * lone model/effort with an empty connection is ignored by the backend
+   * resolver. All nine are settable and MUST ride every `save_config` payload
+   * (like the Stage E flags above) so a save never clears a role override.
+   */
+  roleNotesConnection: string;
+  roleNotesModel: string;
+  roleNotesEffort: string;
+  roleAskConnection: string;
+  roleAskModel: string;
+  roleAskEffort: string;
+  roleLiveConnection: string;
+  roleLiveModel: string;
+  roleLiveEffort: string;
 }
 
 /** Phase H — which backend powers the brain / in-meeting voice assistant. */

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1565,6 +1565,18 @@ export class OnboardingComponent implements OnInit {
       // the model still round-trips from the snapshot untouched.
       gatewayBaseUrl: this.gatewayBaseUrl().trim(),
       gatewayModel: base?.gatewayModel ?? "",
+      // Stage 4 — per-feature role overrides are preserve-only here (the
+      // AI & Models hub owns the rows); round-trip the snapshot so onboarding
+      // never clears an override, "" (inherit) on a fresh install.
+      roleNotesConnection: base?.roleNotesConnection ?? "",
+      roleNotesModel: base?.roleNotesModel ?? "",
+      roleNotesEffort: base?.roleNotesEffort ?? "",
+      roleAskConnection: base?.roleAskConnection ?? "",
+      roleAskModel: base?.roleAskModel ?? "",
+      roleAskEffort: base?.roleAskEffort ?? "",
+      roleLiveConnection: base?.roleLiveConnection ?? "",
+      roleLiveModel: base?.roleLiveModel ?? "",
+      roleLiveEffort: base?.roleLiveEffort ?? "",
     };
     await this.ipc.saveConfig(cfg);
     // Keep the snapshot current so successive saves don't clobber fresh choices.

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -1058,7 +1058,11 @@ export class RecordComponent implements OnInit {
    */
   readonly showAssistant = computed(() => {
     const c = this.config();
-    const enabled = !!c && c.realtimeReactions === true && c.brainBackend !== "off";
+    // Mirror the LIVE role resolver: an explicit roleLiveConnection wins over
+    // the legacy brainBackend fallback (Ask=Off compat-writes brainBackend and
+    // must not hide a Live surface that is explicitly a cloud provider).
+    const liveConn = c ? c.roleLiveConnection || c.brainBackend : "";
+    const enabled = !!c && c.realtimeReactions === true && liveConn !== "off";
     return (
       enabled ||
       this.store.isRecording() ||

--- a/src/app/features/settings/sections/ai/ai-defaults-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-defaults-block.component.ts
@@ -1,34 +1,37 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { SettingsStore } from "../../settings.store";
+import { AiRoleRowsComponent } from "./ai-role-rows.component";
 
 /**
- * AI & Models → Block B: WHAT MURMUR USES. The "Default AI" row is the
- * Provider select moved from General (same control, same option labels),
- * followed by the stage-0 Default-model picker + reasoning effort, then the
- * old Brain & AI controls regrouped under "Ask & assistant" /
- * "Live during meetings" / "On-device intelligence" — copy kept verbatim
- * except pointers to the dissolved Providers/General sections, which now
- * point at the connection cards / Default AI row instead.
+ * AI & Models → Block B: WHAT MURMUR USES. The "Default AI" row (the Provider
+ * select moved from General) + the Default-model picker (options fetched via
+ * `list_models` — the backend constant is the single source of truth, no more
+ * hardcoded Claude ids) + reasoning effort, then the Stage-4 "Customize per
+ * feature" override rows (AiRoleRowsComponent — the Ask row SUPERSEDES the old
+ * "Assistant backend" select, and the GGUF registry lives there now), then
+ * "Live during meetings" (the voice-assistant + proactive toggles, unchanged)
+ * and "On-device intelligence" (fixed always-on-device badges + semantic
+ * search).
  */
 @Component({
   selector: "app-ai-defaults-block",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, AiRoleRowsComponent],
   template: `
     <div class="card defaults-card" [formGroup]="form">
       <div class="defaults-head">
         <h3>What Murmur uses</h3>
         <p class="text-secondary defaults-sub">
-          One default AI powers everything Murmur writes; Ask and live answers
+          One default AI powers everything Murmur writes; individual features
           can run differently below.
         </p>
       </div>
 
       <label class="field">
         <span class="field-label">Default AI</span>
-        <select formControlName="providerId">
+        <select formControlName="providerId" (change)="onDefaultAiChanged($event)">
           <option value="claude_code">Claude Code (default)</option>
           <option value="anthropic">Anthropic API</option>
           <option value="ollama">Ollama</option>
@@ -61,19 +64,61 @@ import { SettingsStore } from "../../settings.store";
             </p>
           }
           @default {
-            <label class="field">
+            <!-- div.field (not label) — the control sits in a nested row div,
+                 same as the gateway card's Model field. -->
+            <div class="field">
               <span class="field-label">Default model</span>
-              <select formControlName="providerModel">
-                <option value="">Default (provider's pick)</option>
-                <option value="claude-opus-4-8">Opus 4.8</option>
-                <option value="claude-sonnet-4-6">Sonnet 4.6</option>
-                <option value="claude-haiku-4-5">Haiku 4.5</option>
-              </select>
+              <!--
+                Options come from list_models (the backend Claude-id constant —
+                single source of truth, no hardcoded ids here). Empty catalog
+                (fetch failed / older backend) → free-text fallback; a saved
+                model missing from the catalog stays selectable as "(custom)"
+                — the gateway picker's keep-manually-typed pattern.
+              -->
+              <div class="default-model-row">
+                @if (defaultModelCatalog().length > 0) {
+                  <select
+                    formControlName="providerModel"
+                    class="default-model-select"
+                  >
+                    <option value="">Default (provider's pick)</option>
+                    @for (id of defaultModelCatalog(); track id) {
+                      <option [value]="id">{{ id }}</option>
+                    }
+                    @if (defaultModelIsCustom()) {
+                      <option [value]="form.controls.providerModel.value">
+                        {{ form.controls.providerModel.value }} (custom)
+                      </option>
+                    }
+                  </select>
+                } @else {
+                  <input
+                    formControlName="providerModel"
+                    placeholder="Model id (blank = provider's pick)"
+                    autocomplete="off"
+                    spellcheck="false"
+                    class="default-model-input"
+                  />
+                }
+                <button
+                  type="button"
+                  class="btn btn-ghost default-model-refresh"
+                  (click)="refreshDefaultModels()"
+                  [disabled]="defaultModelsLoading()"
+                  title="Fetch this provider's model list"
+                >
+                  @if (defaultModelsLoading()) {
+                    Loading…
+                  } @else {
+                    ↻ Refresh
+                  }
+                </button>
+              </div>
               <span class="field-help text-muted">
                 Used for everything Murmur writes with AI: meeting notes,
                 answers, digests and briefs. Default lets the provider choose.
               </span>
-            </label>
+            </div>
           }
         }
 
@@ -94,149 +139,13 @@ import { SettingsStore } from "../../settings.store";
         }
       </div>
 
-      <!-- ── Ask & assistant ─────────────────────────────────────────── -->
-      <div class="use-group">
-        <span class="use-group-label text-muted">Ask &amp; assistant</span>
-
-        <label class="field">
-          <span class="field-label">Assistant backend</span>
-          <select formControlName="brainBackend">
-            <option value="cloud">My default AI — recommended for live</option>
-            <option value="local">Local model — assistant reasoning on-device</option>
-            <option value="off">Off</option>
-          </select>
-          <span class="field-help text-muted">
-            @switch (form.controls.brainBackend.value) {
-              @case ("local") {
-                Runs assistant reasoning and note pre-analysis on-device (pick
-                a model below). Note summaries and Ask fallback still use your
-                default AI above.
-              }
-              @case ("off") {
-                Assistant answers become retrieval-only (no AI model). The
-                in-meeting voice assistant toggle below stays independent.
-              }
-              @default {
-                Uses your default AI above (redacted before any cloud call) —
-                lowest latency, best for the live voice assistant.
-              }
-            }
-          </span>
-        </label>
-
-        <!-- Local model picker — only meaningful for the local backend. -->
-        @if (form.controls.brainBackend.value === "local") {
-          <div class="brain-models">
-            <div class="brain-models-head">
-              <span class="brain-models-label text-muted">Local models</span>
-              <button
-                type="button"
-                class="btn btn-sm"
-                (click)="refreshBrainModels()"
-                [disabled]="brainModelsLoading()"
-              >
-                {{ brainModelsLoading() ? "Loading…" : "Refresh" }}
-              </button>
-            </div>
-
-            <p class="brain-note text-muted">
-              Big local models are slow for the realtime voice assistant —
-              your default AI is recommended for live answers. Local is best
-              for private, non-time-critical analysis.
-            </p>
-
-            @if (brainModels(); as models) {
-              @if (models.length === 0 && !brainModelsLoading()) {
-                <p class="brain-empty text-muted">No local models available.</p>
-              } @else {
-                <ul class="brain-model-list">
-                  @for (m of models; track m.id) {
-                    <li
-                      class="brain-model-row"
-                      [class.is-unfit]="!m.fitsRam"
-                      [class.is-selected]="m.selected"
-                    >
-                      <div class="brain-model-info">
-                        <span class="brain-model-name">
-                          {{ m.name }}
-                          @if (m.selected) {
-                            <span class="pill is-success brain-inline-pill">
-                              <span class="pill-dot"></span>
-                              In use
-                            </span>
-                          }
-                        </span>
-                        <span class="brain-model-meta text-muted">
-                          {{ m.sizeLabel }} · needs ≥{{ m.minRamGb }} GB RAM
-                          @if (m.languages.length > 0) {
-                            · {{ m.languages.join("/") }}
-                          }
-                        </span>
-                        @if (!m.fitsRam) {
-                          <span class="pill is-warning brain-fit-pill">
-                            <span class="pill-dot"></span>
-                            May not fit this Mac's RAM
-                          </span>
-                        }
-                      </div>
-
-                      <div class="brain-model-actions">
-                        @if (brainDownloadingId() === m.id) {
-                          <div class="brain-progress" role="status">
-                            <div class="brain-progress-track" aria-hidden="true">
-                              <div
-                                class="brain-progress-fill"
-                                [style.width.%]="brainDownloadFrac() * 100"
-                              ></div>
-                            </div>
-                            <span class="brain-progress-label text-muted">
-                              Downloading… {{ brainPct() }}
-                            </span>
-                          </div>
-                        } @else if (m.downloaded) {
-                          <button
-                            type="button"
-                            class="btn btn-sm"
-                            (click)="useBrainModel(m.id)"
-                            [disabled]="m.selected"
-                          >
-                            {{ m.selected ? "Selected" : "Use" }}
-                          </button>
-                        } @else {
-                          <button
-                            type="button"
-                            class="btn btn-primary btn-sm"
-                            (click)="downloadBrainModel(m.id)"
-                            [disabled]="brainDownloadingId() !== null"
-                          >
-                            Download
-                          </button>
-                        }
-                      </div>
-                    </li>
-                  }
-                </ul>
-              }
-            }
-
-            <label class="field brain-custom">
-              <span class="field-label">Custom GGUF model</span>
-              <input
-                formControlName="brainModelId"
-                placeholder="/path/to/model.gguf or a registry id"
-              />
-              <span class="field-help text-muted">
-                Advanced: point at your own GGUF file (or a registry id). Saved
-                with your settings.
-              </span>
-            </label>
-
-            @if (brainError(); as berr) {
-              <p class="text-danger brain-error">{{ berr }}</p>
-            }
-          </div>
-        }
-      </div>
+      <!--
+        Stage 4 — per-feature overrides (Notes / Ask / Live). The Ask row is
+        the SUCCESSOR of the old "Assistant backend" select (removed from this
+        block): Local/Off are selectable targets there, and the GGUF registry
+        renders inside the rows block when a row picks Local.
+      -->
+      <app-ai-role-rows />
 
       <!-- ── Live during meetings ────────────────────────────────────── -->
       <div class="use-group">
@@ -269,20 +178,19 @@ import { SettingsStore } from "../../settings.store";
 
         <!--
           Proactive cloud-egress consent (issue 20). The in-meeting assistant
-          dispatches voice actions through the active provider. With a
-          cloud-classified provider (providerIsCloud mirrors the backend's
-          egress_is_cloud: claude_code/anthropic/gateway, plus ollama on a
-          non-loopback base URL) it uploads mid-meeting context, and the
-          dispatch is fail-closed behind cloud_egress_consented. Surface the
-          requirement at enable time. Condition: realtime on, cloud-classified
-          provider, brain not off, not consented. Reuses the existing consent
-          flow (allowCloudProcessing). In-flow warning, so the frosted banner
-          is correct (no opaque overlay needed).
+          dispatches voice actions through the LIVE role's resolved target —
+          since Stage 4 that need not be brainBackend/the default provider, so
+          the condition keys on liveTargetIsCloud (the store's resolver
+          mirror: explicit roleLiveConnection wins, "" falls back to the
+          brainBackend mapping, ollama is cloud only off-loopback). Surface
+          the requirement at enable time: realtime on, live target
+          cloud-classified, not consented. Reuses the existing consent flow
+          (allowCloudProcessing). In-flow warning, so the frosted banner is
+          correct (no opaque overlay needed).
         -->
         @if (
           form.controls.realtimeReactions.value &&
-          form.controls.brainBackend.value === "cloud" &&
-          providerIsCloud() &&
+          liveTargetIsCloud() &&
           !cloudConsented()
         ) {
           <div class="banner is-warning realtime-consent">
@@ -319,6 +227,29 @@ import { SettingsStore } from "../../settings.store";
       <!-- ── On-device intelligence ──────────────────────────────────── -->
       <div class="use-group">
         <span class="use-group-label text-muted">On-device intelligence</span>
+
+        <!--
+          Fixed "always on-device" badges — these stages are NOT routable to
+          any provider (they activate on local model presence), so they stay
+          out of every picker above. Honesty line, not controls.
+        -->
+        <div class="ondevice-badges">
+          <span class="pill">
+            <span class="pill-dot"></span>
+            Embeddings
+          </span>
+          <span class="pill">
+            <span class="pill-dot"></span>
+            Name redaction
+          </span>
+          <span class="pill">
+            <span class="pill-dot"></span>
+            Transcription
+          </span>
+          <span class="text-muted ondevice-note">
+            Always run on this Mac — never sent to any provider.
+          </span>
+        </div>
 
         <!-- brain2 RAG — semantic search over your notes (embedding model + reindex) -->
         <div class="semantic">
@@ -486,118 +417,43 @@ import { SettingsStore } from "../../settings.store";
       .realtime-consent-copy {
         line-height: 1.55;
       }
-      .brain-models {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-3);
-        padding: var(--space-4);
-        border-radius: var(--radius-md);
-        background: var(--surface-input);
-        border: 1px solid var(--border-subtle);
-      }
-      .brain-models-head {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--space-3);
-      }
-      .brain-models-label {
-        font-size: 0.8125rem;
-        font-weight: 550;
-        letter-spacing: 0.01em;
-        text-transform: uppercase;
-      }
       .brain-note {
         margin: 0;
         font-size: 0.8125rem;
         line-height: 1.5;
       }
-      .brain-empty {
-        margin: 0;
-        font-size: 0.875rem;
-      }
-      .brain-model-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2);
-      }
-      .brain-model-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--space-3);
-        padding: var(--space-3);
-        border-radius: var(--radius-md);
-        background: var(--surface-raised);
-        border: 1px solid var(--glass-border);
-      }
-      .brain-model-row.is-selected {
-        border-color: var(--accent-hover);
-      }
-      .brain-model-row.is-unfit {
-        opacity: 0.78;
-      }
-      .brain-model-info {
-        display: flex;
-        flex-direction: column;
-        gap: 3px;
-        min-width: 0;
-      }
-      .brain-model-name {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-2);
-        color: var(--text-primary);
-        font-weight: 550;
-        font-size: 0.9rem;
-        flex-wrap: wrap;
-      }
-      .brain-model-meta {
-        font-size: 0.8125rem;
-      }
-      .brain-inline-pill,
-      .brain-fit-pill {
-        align-self: flex-start;
-      }
-      .brain-fit-pill {
-        margin-top: 2px;
-      }
-      .brain-model-actions {
-        flex: none;
-        display: flex;
-        align-items: center;
-        gap: var(--space-2);
-      }
-      .brain-progress {
-        display: flex;
-        flex-direction: column;
-        gap: 3px;
-        min-width: 120px;
-      }
-      .brain-progress-track {
-        height: 6px;
-        border-radius: 3px;
-        background: var(--surface-input);
-        overflow: hidden;
-      }
-      .brain-progress-fill {
-        height: 100%;
-        background: var(--accent);
-        border-radius: 3px;
-        transition: width var(--transition);
-      }
-      .brain-progress-label {
-        font-size: 0.75rem;
-      }
-      .brain-custom {
-        margin-top: var(--space-1);
-      }
       .brain-error {
         margin: 0;
         font-size: 0.85rem;
+      }
+
+      /* Default-model picker — select-or-input + the catalog refresh. */
+      .default-model-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .default-model-select,
+      .default-model-input {
+        flex: 1 1 220px;
+        min-width: 0;
+      }
+      .default-model-refresh {
+        flex: none;
+        white-space: nowrap;
+      }
+
+      /* Fixed always-on-device badges (not controls). */
+      .ondevice-badges {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .ondevice-note {
+        font-size: 0.8125rem;
+        line-height: 1.5;
       }
       .defaults-card .btn-sm {
         height: 32px;
@@ -750,16 +606,13 @@ export class AiDefaultsBlockComponent {
   private readonly store = inject(SettingsStore);
 
   readonly form = this.store.form;
-  readonly providerIsCloud = this.store.providerIsCloud;
   readonly cloudConsented = this.store.cloudConsented;
   readonly consenting = this.store.consenting;
   readonly consentError = this.store.consentError;
-  readonly brainModels = this.store.brainModels;
-  readonly brainModelsLoading = this.store.brainModelsLoading;
-  readonly brainError = this.store.brainError;
-  readonly brainDownloadingId = this.store.brainDownloadingId;
-  readonly brainDownloadFrac = this.store.brainDownloadFrac;
-  readonly brainPct = this.store.brainPct;
+  readonly liveTargetIsCloud = this.store.liveTargetIsCloud;
+  readonly defaultModelCatalog = this.store.defaultModelCatalog;
+  readonly defaultModelsLoading = this.store.defaultModelsLoading;
+  readonly defaultModelIsCustom = this.store.defaultModelIsCustom;
   readonly embedModelPresent = this.store.embedModelPresent;
   readonly downloadingEmbedModel = this.store.downloadingEmbedModel;
   readonly embedDownloadFrac = this.store.embedDownloadFrac;
@@ -775,16 +628,17 @@ export class AiDefaultsBlockComponent {
     void this.store.allowCloudProcessing();
   }
 
-  refreshBrainModels(): void {
-    void this.store.refreshBrainModels();
+  /** Prefetch the newly-picked Default AI's model catalog (claude_code/anthropic only). */
+  onDefaultAiChanged(e: Event): void {
+    const id = (e.target as HTMLSelectElement).value;
+    if (id === "claude_code" || id === "anthropic") {
+      void this.store.ensureModels(id);
+    }
   }
 
-  useBrainModel(id: string): void {
-    void this.store.useBrainModel(id);
-  }
-
-  downloadBrainModel(id: string): void {
-    void this.store.downloadBrainModel(id);
+  /** Re-fetch the Default-model catalog for the current provider. */
+  refreshDefaultModels(): void {
+    void this.store.refreshModels(this.form.controls.providerId.value);
   }
 
   downloadEmbedModel(): void {

--- a/src/app/features/settings/sections/ai/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows.component.ts
@@ -1,0 +1,694 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { SettingsStore } from "../../settings.store";
+
+/** Provider-backed connection ids (a per-role model select makes sense on these). */
+const PROVIDER_CONNECTION_IDS: readonly string[] = [
+  "claude_code",
+  "anthropic",
+  "ollama",
+  "gateway",
+];
+
+/** One rendered override row — everything the template needs, derived once. */
+interface RoleRowVm {
+  readonly role: "notes" | "ask" | "live";
+  readonly title: string;
+  readonly what: string;
+  readonly connCtrl: string;
+  readonly modelCtrl: string;
+  readonly effortCtrl: string;
+  /** Ask/Live only — the Notes row must NOT offer Local/Off (see template comment). */
+  readonly offersReasonerTargets: boolean;
+  readonly conn: string;
+  readonly isProviderConn: boolean;
+  readonly models: readonly string[];
+  readonly modelsLoading: boolean;
+  readonly modelValue: string;
+  readonly modelIsCustom: boolean;
+  readonly inheritSummary: string;
+}
+
+/**
+ * AI & Models → the "Customize per feature" progressive-disclosure block
+ * (Stage 4): three per-role override rows — Meeting notes / Ask & assistant /
+ * Live during meetings — each writing its `role{Notes,Ask,Live}{Connection,
+ * Model,Effort}` keys ("" = Inherit → the row shows a resolver-mirror summary
+ * instead). The Ask row is the successor of the old "Assistant backend"
+ * select (its Local/Off targets live here now, and changing it compat-writes
+ * the legacy `brainBackend` — see SettingsStore.setRoleConnection). The
+ * global GGUF registry block (owns `brainModelId`) renders below the rows
+ * whenever Ask or Live picks "Local model" — it is shared, not per-role.
+ */
+@Component({
+  selector: "app-ai-role-rows",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <div class="role-block" [formGroup]="form">
+      <button
+        type="button"
+        class="role-toggle"
+        (click)="toggleExpanded()"
+        [attr.aria-expanded]="expanded()"
+      >
+        <svg
+          class="role-chevron"
+          [class.is-open]="expanded()"
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 2l4 4-4 4"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        Customize per feature
+      </button>
+
+      @if (expanded()) {
+        <div class="role-rows">
+          @for (row of rows(); track row.role) {
+            <div class="role-row">
+              <div class="role-row-head">
+                <span class="role-title">{{ row.title }}</span>
+                <span class="role-what text-muted">{{ row.what }}</span>
+              </div>
+
+              <!--
+                The Notes row deliberately offers NO Local/Off: notes, digests,
+                briefs, recipes and the graph are SummarizerProvider surfaces,
+                and the backend's provider_for REFUSES reasoner-only targets
+                for them (every summary would hard-error) — the lock-security
+                carry-over from the stage-3 review. "Local notes" already has
+                a first-class answer: Ollama.
+              -->
+              <select
+                [formControlName]="row.connCtrl"
+                (change)="onConnectionChange(row.role, $event)"
+              >
+                <option value="">Inherit default</option>
+                <option value="claude_code">Claude Code</option>
+                <option value="anthropic">Anthropic API</option>
+                <option value="ollama">Ollama</option>
+                <option value="gateway">AI Gateway (OpenAI-compatible)</option>
+                @if (row.offersReasonerTargets) {
+                  <option value="local">Local model — on-device</option>
+                  <option value="off">Off — retrieval only</option>
+                }
+              </select>
+
+              @if (!row.conn) {
+                <span class="field-help text-muted">
+                  {{ row.inheritSummary }}
+                </span>
+              }
+
+              @if (row.isProviderConn) {
+                <div class="role-model-row">
+                  @if (row.models.length > 0) {
+                    <select
+                      [formControlName]="row.modelCtrl"
+                      class="role-model-select"
+                    >
+                      <option value="">Default (connection's pick)</option>
+                      @for (id of row.models; track id) {
+                        <option [value]="id">{{ id }}</option>
+                      }
+                      <!--
+                        Keep a manually-typed model selectable when it's not in
+                        the catalog — never silently lose it (the gateway
+                        picker's keep-manually-typed pattern).
+                      -->
+                      @if (row.modelIsCustom) {
+                        <option [value]="row.modelValue">
+                          {{ row.modelValue }} (custom)
+                        </option>
+                      }
+                    </select>
+                  } @else {
+                    <input
+                      [formControlName]="row.modelCtrl"
+                      placeholder="Model id (blank = connection default)"
+                      autocomplete="off"
+                      spellcheck="false"
+                      class="role-model-input"
+                    />
+                  }
+                  <button
+                    type="button"
+                    class="btn btn-ghost role-model-refresh"
+                    (click)="refreshModels(row.conn)"
+                    [disabled]="row.modelsLoading"
+                    title="Fetch this connection's model list"
+                  >
+                    @if (row.modelsLoading) {
+                      Loading…
+                    } @else {
+                      ↻ Refresh
+                    }
+                  </button>
+                </div>
+
+                @if (row.conn === "anthropic") {
+                  <label class="field">
+                    <span class="field-label">Reasoning effort</span>
+                    <select [formControlName]="row.effortCtrl">
+                      <option value="">Default</option>
+                      <option value="low">Low</option>
+                      <option value="medium">Medium</option>
+                      <option value="high">High</option>
+                    </select>
+                  </label>
+                }
+              }
+
+              @if (row.conn === "off") {
+                <span class="field-help text-muted">
+                  @if (row.role === "ask") {
+                    Ask answers become retrieval-only (no AI model). The
+                    in-meeting voice assistant toggle stays independent.
+                  } @else {
+                    Live answers become retrieval-only (no AI model). The
+                    in-meeting voice assistant toggle stays independent.
+                  }
+                </span>
+              }
+
+              @if (row.conn === "local") {
+                @if (row.role === "live") {
+                  <span class="field-help text-muted">
+                    Big local models are slow for the realtime voice assistant
+                    — your default AI is recommended for live answers. Local is
+                    best for private, non-time-critical analysis.
+                  </span>
+                } @else {
+                  <span class="field-help text-muted">
+                    Runs on-device with the shared local model — pick or
+                    download it under Local models below.
+                  </span>
+                }
+              }
+            </div>
+          }
+
+          <!--
+            The GGUF registry is GLOBAL (it owns brainModelId — the resolver's
+            local default for every role), so it renders once, shared by every
+            row set to "Local model", not per-row.
+          -->
+          @if (anyLocal()) {
+            <div class="brain-models">
+              <div class="brain-models-head">
+                <span class="brain-models-label text-muted">Local models</span>
+                <button
+                  type="button"
+                  class="btn btn-sm"
+                  (click)="refreshBrainModels()"
+                  [disabled]="brainModelsLoading()"
+                >
+                  {{ brainModelsLoading() ? "Loading…" : "Refresh" }}
+                </button>
+              </div>
+
+              <p class="brain-note text-muted">
+                Shared by every feature set to "Local model" — the selected
+                model runs fully on this Mac.
+              </p>
+
+              @if (brainModels(); as models) {
+                @if (models.length === 0 && !brainModelsLoading()) {
+                  <p class="brain-empty text-muted">
+                    No local models available.
+                  </p>
+                } @else {
+                  <ul class="brain-model-list">
+                    @for (m of models; track m.id) {
+                      <li
+                        class="brain-model-row"
+                        [class.is-unfit]="!m.fitsRam"
+                        [class.is-selected]="m.selected"
+                      >
+                        <div class="brain-model-info">
+                          <span class="brain-model-name">
+                            {{ m.name }}
+                            @if (m.selected) {
+                              <span class="pill is-success brain-inline-pill">
+                                <span class="pill-dot"></span>
+                                In use
+                              </span>
+                            }
+                          </span>
+                          <span class="brain-model-meta text-muted">
+                            {{ m.sizeLabel }} · needs ≥{{ m.minRamGb }} GB RAM
+                            @if (m.languages.length > 0) {
+                              · {{ m.languages.join("/") }}
+                            }
+                          </span>
+                          @if (!m.fitsRam) {
+                            <span class="pill is-warning brain-fit-pill">
+                              <span class="pill-dot"></span>
+                              May not fit this Mac's RAM
+                            </span>
+                          }
+                        </div>
+
+                        <div class="brain-model-actions">
+                          @if (brainDownloadingId() === m.id) {
+                            <div class="brain-progress" role="status">
+                              <div
+                                class="brain-progress-track"
+                                aria-hidden="true"
+                              >
+                                <div
+                                  class="brain-progress-fill"
+                                  [style.width.%]="brainDownloadFrac() * 100"
+                                ></div>
+                              </div>
+                              <span class="brain-progress-label text-muted">
+                                Downloading… {{ brainPct() }}
+                              </span>
+                            </div>
+                          } @else if (m.downloaded) {
+                            <button
+                              type="button"
+                              class="btn btn-sm"
+                              (click)="useBrainModel(m.id)"
+                              [disabled]="m.selected"
+                            >
+                              {{ m.selected ? "Selected" : "Use" }}
+                            </button>
+                          } @else {
+                            <button
+                              type="button"
+                              class="btn btn-primary btn-sm"
+                              (click)="downloadBrainModel(m.id)"
+                              [disabled]="brainDownloadingId() !== null"
+                            >
+                              Download
+                            </button>
+                          }
+                        </div>
+                      </li>
+                    }
+                  </ul>
+                }
+              }
+
+              <label class="field brain-custom">
+                <span class="field-label">Custom GGUF model</span>
+                <input
+                  formControlName="brainModelId"
+                  placeholder="/path/to/model.gguf or a registry id"
+                />
+                <span class="field-help text-muted">
+                  Advanced: point at your own GGUF file (or a registry id).
+                  Saved with your settings.
+                </span>
+              </label>
+
+              @if (brainError(); as berr) {
+                <p class="text-danger brain-error">{{ berr }}</p>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+
+      .role-block {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+
+      /* Progressive-disclosure trigger — a quiet inline text button. */
+      .role-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        align-self: flex-start;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        font-weight: 550;
+        transition: color var(--transition);
+      }
+      .role-toggle:hover {
+        color: var(--text-primary);
+      }
+      .role-chevron {
+        transition: transform var(--transition);
+      }
+      .role-chevron.is-open {
+        transform: rotate(90deg);
+      }
+
+      .role-rows {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .role-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .role-row-head {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .role-title {
+        color: var(--text-primary);
+        font-size: 0.9rem;
+        font-weight: 550;
+      }
+      .role-what {
+        font-size: 0.8125rem;
+      }
+
+      .role-model-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .role-model-select,
+      .role-model-input {
+        flex: 1 1 220px;
+        min-width: 0;
+      }
+      .role-model-refresh {
+        flex: none;
+        white-space: nowrap;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .field-label {
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        font-weight: 550;
+      }
+      .field-help {
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+
+      /* --- Local GGUF registry (moved verbatim from the defaults block) --- */
+      .brain-models {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .brain-models-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .brain-models-label {
+        font-size: 0.8125rem;
+        font-weight: 550;
+        letter-spacing: 0.01em;
+        text-transform: uppercase;
+      }
+      .brain-note {
+        margin: 0;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+      .brain-empty {
+        margin: 0;
+        font-size: 0.875rem;
+      }
+      .brain-model-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .brain-model-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-raised);
+        border: 1px solid var(--glass-border);
+      }
+      .brain-model-row.is-selected {
+        border-color: var(--accent-hover);
+      }
+      .brain-model-row.is-unfit {
+        opacity: 0.78;
+      }
+      .brain-model-info {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 0;
+      }
+      .brain-model-name {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--text-primary);
+        font-weight: 550;
+        font-size: 0.9rem;
+        flex-wrap: wrap;
+      }
+      .brain-model-meta {
+        font-size: 0.8125rem;
+      }
+      .brain-inline-pill,
+      .brain-fit-pill {
+        align-self: flex-start;
+      }
+      .brain-fit-pill {
+        margin-top: 2px;
+      }
+      .brain-model-actions {
+        flex: none;
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .brain-progress {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 120px;
+      }
+      .brain-progress-track {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--surface-input);
+        overflow: hidden;
+      }
+      .brain-progress-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: 3px;
+        transition: width var(--transition);
+      }
+      .brain-progress-label {
+        font-size: 0.75rem;
+      }
+      .brain-custom {
+        margin-top: var(--space-1);
+      }
+      .brain-error {
+        margin: 0;
+        font-size: 0.85rem;
+      }
+      .role-block .btn-sm {
+        height: 32px;
+        padding: 0 var(--space-3);
+        font-size: 0.8125rem;
+      }
+    `,
+  ],
+})
+export class AiRoleRowsComponent {
+  private readonly store = inject(SettingsStore);
+
+  readonly form = this.store.form;
+  readonly brainModels = this.store.brainModels;
+  readonly brainModelsLoading = this.store.brainModelsLoading;
+  readonly brainError = this.store.brainError;
+  readonly brainDownloadingId = this.store.brainDownloadingId;
+  readonly brainDownloadFrac = this.store.brainDownloadFrac;
+  readonly brainPct = this.store.brainPct;
+
+  /** Disclosure state — collapsed by default (overrides are the power path). */
+  readonly expanded = signal(false);
+
+  toggleExpanded(): void {
+    this.expanded.update((v) => !v);
+  }
+
+  /**
+   * Auto-open once when any override is active (loaded from config or just
+   * picked) so an active override is never invisible. A manual collapse sticks
+   * — the effect only re-runs when a connection value changes.
+   */
+  private readonly _autoExpand = effect(
+    () => {
+      if (
+        this.store.roleNotesConnValue() ||
+        this.store.roleAskConnValue() ||
+        this.store.roleLiveConnValue()
+      ) {
+        this.expanded.set(true);
+      }
+    },
+    { allowSignalWrites: true },
+  );
+
+  /**
+   * True when anything runs on the shared local GGUF — explicit role picks OR
+   * the legacy `brainBackend=local` fallback (a legacy local install with no
+   * role keys still runs Ask/Live fallback + Notes pre-analysis on the local
+   * model, and must keep the registry UI to switch/download models).
+   */
+  readonly anyLocal = computed(
+    () =>
+      this.store.roleAskConnValue() === "local" ||
+      this.store.roleLiveConnValue() === "local" ||
+      this.store.brainBackendValue() === "local",
+  );
+
+  /** The three override rows, derived from the store's role/catalog signals. */
+  readonly rows = computed<RoleRowVm[]>(() => [
+    this.buildRow(
+      "notes",
+      "Meeting notes",
+      "Summaries, digests, briefs, recipes, graph",
+      "roleNotesConnection",
+      "roleNotesModel",
+      "roleNotesEffort",
+      false,
+      this.store.roleNotesConnValue(),
+      this.store.roleNotesModelValue(),
+      this.store.notesInheritSummary(),
+    ),
+    this.buildRow(
+      "ask",
+      "Ask & assistant",
+      "Vault Q&A + meeting chat",
+      "roleAskConnection",
+      "roleAskModel",
+      "roleAskEffort",
+      true,
+      this.store.roleAskConnValue(),
+      this.store.roleAskModelValue(),
+      this.store.assistantInheritSummary(),
+    ),
+    this.buildRow(
+      "live",
+      "Live during meetings",
+      "@brain threads + the voice assistant",
+      "roleLiveConnection",
+      "roleLiveModel",
+      "roleLiveEffort",
+      true,
+      this.store.roleLiveConnValue(),
+      this.store.roleLiveModelValue(),
+      this.store.assistantInheritSummary(),
+    ),
+  ]);
+
+  private buildRow(
+    role: RoleRowVm["role"],
+    title: string,
+    what: string,
+    connCtrl: string,
+    modelCtrl: string,
+    effortCtrl: string,
+    offersReasonerTargets: boolean,
+    conn: string,
+    modelValue: string,
+    inheritSummary: string,
+  ): RoleRowVm {
+    const isProviderConn = PROVIDER_CONNECTION_IDS.includes(conn);
+    const models = isProviderConn
+      ? (this.store.modelCatalogs()[conn] ?? [])
+      : [];
+    return {
+      role,
+      title,
+      what,
+      connCtrl,
+      modelCtrl,
+      effortCtrl,
+      offersReasonerTargets,
+      conn,
+      isProviderConn,
+      models,
+      modelsLoading: isProviderConn && this.store.modelsLoading().has(conn),
+      modelValue,
+      modelIsCustom: !!modelValue && !models.includes(modelValue),
+      inheritSummary,
+    };
+  }
+
+  onConnectionChange(role: RoleRowVm["role"], e: Event): void {
+    this.store.setRoleConnection(role, (e.target as HTMLSelectElement).value);
+  }
+
+  refreshModels(connection: string): void {
+    void this.store.refreshModels(connection);
+  }
+
+  refreshBrainModels(): void {
+    void this.store.refreshBrainModels();
+  }
+
+  useBrainModel(id: string): void {
+    void this.store.useBrainModel(id);
+  }
+
+  downloadBrainModel(id: string): void {
+    void this.store.downloadBrainModel(id);
+  }
+}

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -20,6 +20,27 @@ import type {
 import type { UnlistenFn } from "@tauri-apps/api/event";
 
 /**
+ * The four provider-backed connection ids — the ones `list_models` serves a
+ * catalog for and a per-role model select makes sense on. `local`/`off` are
+ * reasoner-only targets (no SummarizerProvider, no per-role model select — the
+ * local model is the global GGUF registry selection).
+ */
+const PROVIDER_CONNECTION_IDS: readonly string[] = [
+  "claude_code",
+  "anthropic",
+  "ollama",
+  "gateway",
+];
+
+/** Display names for the connection ids (matches the connection cards). */
+const CONNECTION_LABELS: Readonly<Record<string, string>> = {
+  claude_code: "Claude Code",
+  anthropic: "Anthropic API",
+  ollama: "Ollama",
+  gateway: "AI Gateway",
+};
+
+/**
  * Shared state + IPC orchestration for the Settings page (Stage-1 split of the
  * former settings.component.ts monolith — moved here VERBATIM, no behavior
  * change).
@@ -104,6 +125,21 @@ export class SettingsStore {
     // AI Gateway (Phase 1) — base URL and model, round-tripped on save.
     gatewayBaseUrl: "",
     gatewayModel: "",
+    // Stage 4 — per-feature model-role overrides ("" = inherit the legacy
+    // mapping). The connection key is the override switch: the backend ignores
+    // a lone model/effort when the connection is empty. Always in the group so
+    // every save() includes all 9 — the role keys are settable by design, and
+    // with the FE always sending them the stage-3 review's "an older FE could
+    // clear them" concern is moot going forward.
+    roleNotesConnection: "",
+    roleNotesModel: "",
+    roleNotesEffort: "",
+    roleAskConnection: "",
+    roleAskModel: "",
+    roleAskEffort: "",
+    roleLiveConnection: "",
+    roleLiveModel: "",
+    roleLiveEffort: "",
   });
   readonly keyControl = new FormControl("", { nonNullable: true });
   /** BYO Brave Search API key input (web-search connector). Cleared after save. */
@@ -414,6 +450,239 @@ export class SettingsStore {
     },
   );
 
+  // ── Stage 4 — per-feature model roles (Notes / Ask / Live) ─────────────
+
+  /**
+   * Live signals of the role-connection controls + the model/effort context the
+   * role rows and the consent banner derive from — the same `valueChanges`
+   * bridge as `_gatewayBaseUrlValue` above, seeded with the form defaults.
+   */
+  readonly roleNotesConnValue = toSignal(
+    this.form.controls.roleNotesConnection.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  readonly roleAskConnValue = toSignal(
+    this.form.controls.roleAskConnection.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  readonly roleLiveConnValue = toSignal(
+    this.form.controls.roleLiveConnection.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  readonly roleNotesModelValue = toSignal(
+    this.form.controls.roleNotesModel.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  readonly roleAskModelValue = toSignal(
+    this.form.controls.roleAskModel.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  readonly roleLiveModelValue = toSignal(
+    this.form.controls.roleLiveModel.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  private readonly _providerModelValue = toSignal(
+    this.form.controls.providerModel.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  private readonly _ollamaModelValue = toSignal(
+    this.form.controls.ollamaModel.valueChanges.pipe(startWith("llama3.1")),
+    { initialValue: "llama3.1" },
+  );
+  private readonly _brainBackendValue = toSignal(
+    this.form.controls.brainBackend.valueChanges.pipe(
+      startWith("cloud" as BrainBackend),
+    ),
+    { initialValue: "cloud" as BrainBackend },
+  );
+  /**
+   * Public mirror of the legacy fallback value — the role rows need it to keep
+   * the shared GGUF registry reachable for a legacy `brainBackend=local`
+   * install that has no explicit role keys (its Notes pre-analysis + Ask/Live
+   * fallback still run on the local model).
+   */
+  readonly brainBackendValue = this._brainBackendValue;
+
+  /**
+   * `brainBackend` as last LOADED — restored when the Ask row returns to
+   * "Inherit" so Ask → anthropic → Inherit round-trips a legacy local/off
+   * fallback instead of ratcheting it to "cloud" (lock-security stage-4 nit).
+   */
+  private _loadedBrainBackend: BrainBackend = "cloud";
+
+  /**
+   * Per-connection model catalogs from `list_models` (backend constant for
+   * claude_code/anthropic, live endpoints for ollama/gateway). A key that is
+   * PRESENT with an empty array = "fetch tried, no catalog" → the pickers fall
+   * back to a free-text input (the gateway keep-manually-typed pattern).
+   */
+  private readonly _modelCatalogs = signal<
+    Readonly<Record<string, readonly string[]>>
+  >({});
+  readonly modelCatalogs = this._modelCatalogs.asReadonly();
+  /** Connections with a `list_models` fetch currently in flight. */
+  private readonly _modelsLoading = signal<ReadonlySet<string>>(new Set());
+  readonly modelsLoading = this._modelsLoading.asReadonly();
+
+  /** Fetch a connection's catalog once; later calls are no-ops (Refresh re-fetches). */
+  async ensureModels(connection: string): Promise<void> {
+    if (this._modelCatalogs()[connection] !== undefined) return;
+    await this.refreshModels(connection);
+  }
+
+  /**
+   * (Re-)fetch one connection's model catalog. A rejection (endpoint down, or
+   * a backend without `list_models` yet) records an EMPTY catalog so the UI
+   * shows the free-text fallback instead of a dead select — same contract as
+   * `refreshGatewayModels`. Button-driven or load-driven, never an effect.
+   */
+  async refreshModels(connection: string): Promise<void> {
+    if (!PROVIDER_CONNECTION_IDS.includes(connection)) return;
+    if (this._modelsLoading().has(connection)) return;
+    this._modelsLoading.set(new Set(this._modelsLoading()).add(connection));
+    let models: string[] = [];
+    try {
+      models = await this.ipc.listModels(connection);
+    } catch {
+      // Fall through with [] — free-text fallback.
+    }
+    this._modelCatalogs.set({ ...this._modelCatalogs(), [connection]: models });
+    const next = new Set(this._modelsLoading());
+    next.delete(connection);
+    this._modelsLoading.set(next);
+  }
+
+  /** The Default-model picker's catalog (claude_code/anthropic Default AI only). */
+  readonly defaultModelCatalog = computed(
+    () => this.modelCatalogs()[this._providerIdValue()] ?? [],
+  );
+  /** True while the Default-model picker's catalog fetch is in flight. */
+  readonly defaultModelsLoading = computed(() =>
+    this.modelsLoading().has(this._providerIdValue()),
+  );
+  /** Keep a manually-typed default model selectable when absent from the catalog. */
+  readonly defaultModelIsCustom = computed(() => {
+    const current = this._providerModelValue();
+    if (!current) return false;
+    return !this.defaultModelCatalog().includes(current);
+  });
+
+  /** "Claude Code · claude-opus-4-8"-style summary of the Default AI row. */
+  readonly defaultAiSummary = computed(() => {
+    const id = this._providerIdValue();
+    const label = CONNECTION_LABELS[id] ?? id;
+    let model: string;
+    switch (id) {
+      case "ollama":
+        model = this._ollamaModelValue() || "default model";
+        break;
+      case "gateway":
+        model = this._gatewayModelValue() || "gateway default";
+        break;
+      default:
+        model = this._providerModelValue() || "default model";
+    }
+    return `${label} · ${model}`;
+  });
+
+  /** Notes-row Inherit summary — Notes always falls back to the Default AI triple. */
+  readonly notesInheritSummary = computed(
+    () => `Follows Default AI: ${this.defaultAiSummary()}`,
+  );
+
+  /**
+   * Ask/Live-row Inherit summary — an honest mirror of the backend resolver:
+   * with the role key empty, Ask/Live fall back to the legacy `brainBackend`
+   * mapping, NOT unconditionally to the Default AI. Showing "Follows Default
+   * AI" to a legacy `brain_backend=local` install would be a lie.
+   */
+  readonly assistantInheritSummary = computed(() => {
+    switch (this._brainBackendValue()) {
+      case "local":
+        return "Follows the assistant fallback: Local model — on-device";
+      case "off":
+        return "Follows the assistant fallback: Off — retrieval only";
+      default:
+        return `Follows Default AI: ${this.defaultAiSummary()}`;
+    }
+  });
+
+  /**
+   * Whether the LIVE role's resolved connection is cloud-classified — the
+   * in-meeting-assistant consent banner keys on this (it egresses live meeting
+   * context to the LIVE target, which since Stage 4 need not be `brainBackend`).
+   * Mirrors the backend resolver: explicit role key wins; "" falls back to the
+   * `brainBackend` mapping (cloud → the default provider, local/off → no cloud).
+   */
+  readonly liveTargetIsCloud = computed(() => {
+    let conn = this.roleLiveConnValue();
+    if (!conn) {
+      const bb = this._brainBackendValue();
+      if (bb === "local" || bb === "off") return false;
+      conn = ""; // cloud → inherit the default provider
+    }
+    if (conn === "local" || conn === "off") return false;
+    if (conn === "") return this.providerIsCloud();
+    if (conn === "ollama") return this.ollamaIsRemote();
+    return true; // claude_code | anthropic | gateway | unknown → fail safe
+  });
+
+  /**
+   * Change one role's connection from the UI. Resets that role's model/effort
+   * ("" = connection default — a model id is meaningless across connections)
+   * and prefetches the new connection's catalog.
+   *
+   * COMPAT WRITE (Ask row only, REQUIRED): the Ask row is the successor of the
+   * old "Assistant backend" select, so it also writes the legacy `brainBackend`
+   * field — local→"local", off→"off", anything else (incl. Inherit)→"cloud".
+   * Rationale: note pre-analysis + fact extraction ride `reasoner_target(Notes)`,
+   * whose ONLY steering is the `brain_backend` fallback — without the compat
+   * write those paths would stay permanently stuck on the user's pre-stage-4
+   * value. Role keys win for Ask/Live; `brain_backend` remains the reasoner
+   * fallback for Notes. Deliberately a user-driven method, NOT a valueChanges
+   * subscription: load() must be able to patch role keys without clobbering a
+   * legacy `brainBackend`.
+   */
+  setRoleConnection(role: "notes" | "ask" | "live", connection: string): void {
+    switch (role) {
+      case "notes":
+        this.form.patchValue({
+          roleNotesConnection: connection,
+          roleNotesModel: "",
+          roleNotesEffort: "",
+        });
+        break;
+      case "ask":
+        this.form.patchValue({
+          roleAskConnection: connection,
+          roleAskModel: "",
+          roleAskEffort: "",
+          // "" (Inherit) restores the LOADED fallback rather than forcing
+          // "cloud" — a legacy local/off user who wanders to a cloud pick and
+          // back must round-trip, not ratchet (lock-security stage-4 nit).
+          brainBackend:
+            connection === "local"
+              ? "local"
+              : connection === "off"
+                ? "off"
+                : connection === ""
+                  ? this._loadedBrainBackend
+                  : "cloud",
+        });
+        break;
+      case "live":
+        this.form.patchValue({
+          roleLiveConnection: connection,
+          roleLiveModel: "",
+          roleLiveEffort: "",
+        });
+        break;
+    }
+    if (PROVIDER_CONNECTION_IDS.includes(connection)) {
+      void this.ensureModels(connection);
+    }
+  }
+
   // ── Phase H — brain (AI assistant) model registry ──────────────────────
 
   /** The selectable local brain models (from list_brain_models). */
@@ -528,7 +797,42 @@ export class SettingsStore {
         // AI Gateway (Phase 1) — base URL + model, default "" for pre-existing configs.
         gatewayBaseUrl: cfg.gatewayBaseUrl ?? "",
         gatewayModel: cfg.gatewayModel ?? "",
+        // Stage 4 — role overrides load verbatim ("" = inherit). Deliberately NOT
+        // seeded from a legacy brainBackend=local/off: materializing role keys on
+        // the next save would flip Ask from the legacy "provider floor ignores
+        // brain_backend" semantics to an explicit reasoner-only target (a real
+        // behavior change). Inherit rows instead show an honest resolver-mirror
+        // summary (assistantInheritSummary).
+        roleNotesConnection: cfg.roleNotesConnection ?? "",
+        roleNotesModel: cfg.roleNotesModel ?? "",
+        roleNotesEffort: cfg.roleNotesEffort ?? "",
+        roleAskConnection: cfg.roleAskConnection ?? "",
+        roleAskModel: cfg.roleAskModel ?? "",
+        roleAskEffort: cfg.roleAskEffort ?? "",
+        roleLiveConnection: cfg.roleLiveConnection ?? "",
+        roleLiveModel: cfg.roleLiveModel ?? "",
+        roleLiveEffort: cfg.roleLiveEffort ?? "",
       });
+      this._loadedBrainBackend = (cfg.brainBackend ?? "cloud") as BrainBackend;
+      // Prefetch the model catalogs the loaded config already renders selects
+      // for: the Default-model picker (claude_code/anthropic only — ollama/
+      // gateway keep their model on the connection card, so prefetching their
+      // REMOTE catalogs here would be network egress with zero UI payoff;
+      // lock-security stage-4 boundary condition) and any concrete per-role
+      // connection (those DO render a select). Best-effort: a failed fetch
+      // leaves an empty catalog and the pickers fall back to free-text inputs.
+      for (const conn of new Set(
+        [
+          cfg.providerId === "claude_code" || cfg.providerId === "anthropic"
+            ? cfg.providerId
+            : "",
+          cfg.roleNotesConnection ?? "",
+          cfg.roleAskConnection ?? "",
+          cfg.roleLiveConnection ?? "",
+        ].filter((c) => PROVIDER_CONNECTION_IDS.includes(c)),
+      )) {
+        void this.ensureModels(conn);
+      }
       this.updateDownloadHint();
       this._inputDevices.set(await this.ipc.listInputDevices().catch(() => []));
       this._hasKey.set(await this.ipc.hasAnthropicKey());
@@ -778,6 +1082,19 @@ export class SettingsStore {
       // AI Gateway (Phase 1) — base URL + model, round-tripped so a settings save preserves them.
       gatewayBaseUrl: v.gatewayBaseUrl,
       gatewayModel: v.gatewayModel,
+      // Stage 4 — ALL NINE role keys ride every save. They are settable by
+      // design ("" = inherit), and always including them makes the stage-3
+      // review's "an FE payload without the keys clears an override" concern
+      // moot going forward.
+      roleNotesConnection: v.roleNotesConnection,
+      roleNotesModel: v.roleNotesModel,
+      roleNotesEffort: v.roleNotesEffort,
+      roleAskConnection: v.roleAskConnection,
+      roleAskModel: v.roleAskModel,
+      roleAskEffort: v.roleAskEffort,
+      roleLiveConnection: v.roleLiveConnection,
+      roleLiveModel: v.roleLiveModel,
+      roleLiveEffort: v.roleLiveEffort,
     };
     try {
       await this.ipc.saveConfig(cfg);


### PR DESCRIPTION
Stage 4 (final) of the model-settings unification (`docs/research/2026-07-02-unify-model-settings.md`). Surfaces the Stage-3 role resolver in the AI & Models hub.

## What
**Backend** — one `list_models(connection) -> string[]` command (registered in lib.rs):
- `gateway` → shared `/v1/models` core (`list_gateway_models` refactored to a thin wrapper over `gateway_model_ids`, **DTO shape unchanged** so the merged gateway card keeps working); `ollama` → GET `/api/tags`; `claude_code`/`anthropic` → `CLAUDE_MODELS` constant (now the single source of truth, moved out of the FE template); `local` → BRAIN_MODELS ids; `off` → `[]`; unknown → `InvalidArg`.
- Inbound-only (content-free, user-configured endpoint) per the `list_gateway_models`/`gateway_health` precedent.

**Frontend** — "Customize per feature" progressive disclosure with **Notes / Ask / Live** override rows:
- each writes `role_{notes,ask,live}_{connection,model,effort}`; Inherit shows a resolver-mirror summary.
- **Notes row offers NO Local/Off** (`provider_for` refuses reasoner-only targets for summary surfaces — the lock-security carry-over from Stage 3).
- the **Ask row supersedes the old "Assistant backend" select**; it compat-writes the legacy `brain_backend` (local→local, off→off, else cloud), and Inherit **restores the loaded value** rather than ratcheting to cloud.
- model dropdowns fed by `list_models` with a free-text escape hatch; effort only for anthropic; the shared GGUF registry renders when any role is Local **or** the legacy `brain_backend` fallback is local.
- Default-model picker fed by `list_models('claude_code')` instead of hardcoded ids.

## Review follow-ups applied
- registry reachable for legacy `brain_backend=local` installs (adversarial MEDIUM);
- record-screen `showAssistant` mirrors the Live resolver so an explicit cloud Live target isn't hidden by an Ask=Off compat write (adversarial LOW);
- Settings-open model prefetch restricted to claude_code/anthropic — no network-on-open for gateway/ollama with no visible picker (lock-security WEAKNESS);
- `brain_backend` round-trips instead of ratcheting to cloud on Ask Inherit (lock-security NIT).

## How verified
- `scripts/ci.sh` → ✅ all gates green (clippy -D warnings + **698** lib tests + lint + build + headless E2E).
- **Adversarial verifier: PASS** on the substantive change — 85+ live Chromium checks: compat-write matrix (Ask=Local→local/local, Off→off/off, Inherit→""/cloud, gateway→gateway/cloud; Live no cross-talk), Notes-row guard, list_models-fed dropdowns + free-text hatch round-trip, save payload = 37 legacy + 9 role keys, no NG0600, `list_gateway_models` shape regression NONE.
- **Lock-security reviewer: PASS** — `list_models` blessed inbound-only with explicit boundary conditions (content-free, user-configured endpoint, user-initiated, never app-start/timer), consent gate keyed on the resolved connection, no PII.

## Honesty note
The 4 post-review fixes above were applied by the orchestrator after both builders went idle, and are **self-verified (static wiring + green gates)**; the Stage-4 verifier went unresponsive on the delta re-check, so those 4 fixes were **not independently adversarially re-verified**. The substantive Stage-4 change was.