### PR TITLE
fix(settings): consent grant fail-closed, live custom-GGUF path, kill test-db flake

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -139,6 +139,14 @@ pub struct AppConfigDto {
     /// bogus model id. `select_brain_model` remains the other supported mutator.
     #[serde(default)]
     pub brain_model_id: Option<String>,
+    /// Phase H — a CUSTOM on-device brain model file path (a `.gguf` NOT in the registry). Settable
+    /// from the DTO (the "Custom GGUF model" input, sent as camelCase `brainModelPath`). Unlike
+    /// `brain_model_id` this is stored VERBATIM (a local file path, not a registry id) — `dto_to_config`
+    /// only normalizes empty→`None` (clears the custom path). `resolve_brain_model` (reason.rs) prefers
+    /// this path when it points at an existing file and falls back safely to the registry id / cloud if
+    /// the file is gone, so a stale path can never break load. Not egress — a local file, not a network.
+    #[serde(default)]
+    pub brain_model_path: Option<String>,
     /// brain2 RAG — the SEMANTIC SEARCH master flag. Settable from the DTO (the Settings UI owns the
     /// toggle), unlike `cloud_egress_consented` which is preserved-only. Plain bool; an omitted value
     /// deserializes to `false` (`#[serde(default)]`), so a partial/older save can never silently
@@ -2264,15 +2272,7 @@ mod ask_vault_tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn tmp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-askvault-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("murmur-askvault", "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 
@@ -3115,6 +3115,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         brain_backend: c.brain_backend,
         realtime_reactions: c.realtime_reactions,
         brain_model_id: c.brain_model_id.clone(),
+        brain_model_path: c.brain_model_path.clone(),
         semantic_search_enabled: c.semantic_search_enabled,
         web_search_enabled: c.web_search_enabled,
         // DISPLAY-ONLY out: lets the FE show "consented" status; the FE cannot set it back (preserved
@@ -3196,9 +3197,16 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // (`#[serde(default)]`), so a partial/older save can never silently enable it. Unlike
         // `cloud_egress_consented` (preserved-only), this one is settable.
         semantic_search_enabled: d.semantic_search_enabled,
-        // Phase B: the brain model path is not carried on the settings DTO (it is resolved from the
-        // shared models dir by default), so a settings save preserves the live value (default None).
-        brain_model_path: current.brain_model_path.clone(),
+        // Phase H (custom GGUF): a CUSTOM brain model file path IS carried on the settings DTO (the
+        // "Custom GGUF model" input, camelCase `brainModelPath`). Unlike `brain_model_id` there is NO
+        // registry validation — it is a local file path, stored VERBATIM. An empty/absent value clears
+        // it (→ None, i.e. fall back to the registry id). `resolve_brain_model` (reason.rs) validates
+        // the file's existence at load and falls back safely if the path is stale, so a bad/removed
+        // path can never break startup.
+        brain_model_path: match d.brain_model_path.as_deref() {
+            Some(p) if !p.is_empty() => d.brain_model_path.clone(),
+            _ => None,
+        },
         // Phase H (registry): the selected brain model id IS carried on the settings DTO, but it is
         // VALIDATED against the registry first. A `Some(known-id)` is taken; an unknown id or `None`
         // is IGNORED — the live selection is preserved (no error, no bogus id stored). This mirrors
@@ -6505,15 +6513,7 @@ mod lifecycle_tests {
     }
 
     fn tmp_db_path(tag: &str) -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-lifecycle-{tag}-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-lifecycle-{tag}"), "sqlite");
         let _ = std::fs::remove_file(&p);
         p
     }
@@ -7800,6 +7800,50 @@ mod lifecycle_tests {
             dto_to_config(dto_none, &current_some).brain_model_id.as_deref(),
             Some("qwen3-14b")
         );
+
+        // (d) FIX D: a CUSTOM brain_model_path IS settable verbatim (no registry validation — it's a
+        // local file path). It round-trips OUT (config_to_dto) and IN (dto_to_config) unchanged, even
+        // while a bogus brain_model_id is (correctly) ignored on the same save.
+        let cfg_with_path = AppConfig {
+            brain_model_path: Some("/models/custom.gguf".to_string()),
+            ..AppConfig::default()
+        };
+        let dto_path = config_to_dto(&cfg_with_path);
+        assert_eq!(
+            dto_path.brain_model_path.as_deref(),
+            Some("/models/custom.gguf"),
+            "config_to_dto carries the custom path OUT to the FE"
+        );
+        let merged_path = dto_to_config(dto_path, &AppConfig::default());
+        assert_eq!(
+            merged_path.brain_model_path.as_deref(),
+            Some("/models/custom.gguf"),
+            "dto_to_config stores the custom path verbatim (settable, not preserve-only)"
+        );
+
+        // (e) an EMPTY brainModelPath clears the custom path (→ None, fall back to the registry id).
+        let mut dto_empty = config_to_dto(&AppConfig::default());
+        dto_empty.brain_model_path = Some(String::new());
+        let current_path = AppConfig {
+            brain_model_path: Some("/models/old.gguf".to_string()),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            dto_to_config(dto_empty, &current_path).brain_model_path, None,
+            "an empty brainModelPath clears the custom path"
+        );
+
+        // (f) the FE sends camelCase `brainModelPath`; it must deserialize into the field (and an
+        // omitted value defaults to None). Same minimal-but-valid JSON shape as case (c) below.
+        let json_path = r#"{
+            "providerId":"claude_code","anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "captureSystemAudio":false,"modelSize":"large-v3","voiceTrigger":false,"onboarded":true,
+            "noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "brainModelPath":"/m/x.gguf"
+        }"#;
+        let parsed: AppConfigDto = serde_json::from_str(json_path).unwrap();
+        assert_eq!(parsed.brain_model_path.as_deref(), Some("/m/x.gguf"));
 
         // (c) an unknown/omitted brainBackend token deserializes to the default Cloud (no crash),
         // then flows through dto_to_config as Cloud.

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -477,15 +477,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db() -> (Db, PathBuf) {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-mcp-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("murmur-mcp-test", "sqlite");
         let db = Db::open_with_key(&p, TEST_DEK).unwrap();
         (db, p)
     }

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -308,16 +308,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db(label: &str) -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-orchestrate-{}-{}-{}.sqlite",
-            label,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-orchestrate-{label}"), "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1071,15 +1071,7 @@ mod tests {
     /// rejecting the bogus id — i.e. a real provider would have egressed).
     #[test]
     fn summarize_egress_resolution_honors_revoke_landed_after_stop_snapshot() {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-pipeline-revoke-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("murmur-pipeline-revoke", "sqlite");
         let state = AppState::init_at(
             &p,
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -1226,17 +1218,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db_path(label: &str) -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-pipeline-test-{}-{}-{}.sqlite",
-            label,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        p
+        crate::storage::db::unique_temp_path(&format!("murmur-pipeline-test-{label}"), "sqlite")
     }
 
     /// REGRESSION (adversarial find, seal content-leak class): `summarize_and_export` upserts the

--- a/src-tauri/src/proactive.rs
+++ b/src-tauri/src/proactive.rs
@@ -605,15 +605,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn tmp_db(tag: &str) -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-proactive-{tag}-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-proactive-{tag}"), "sqlite");
         let _ = std::fs::remove_file(&p);
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -1301,15 +1301,7 @@ mod tests {
         // REVOKE mid-session through the REAL mutator (`revoke_cloud_egress`, persisted): the
         // provider factory reads the live config per call, so the very NEXT call is refused
         // fail-closed again — no restart, no cached grant.
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-reason-revoke-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-reason-revoke-test", "sqlite");
         let db = crate::storage::Db::open_with_key(
             &p,
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -655,9 +655,15 @@ impl AppConfig {
     /// Tauri command before the first claude_code/anthropic run. Until the user confirms, the egress
     /// path returns `AppError::Unavailable("cloud egress not consented …")`, which the FE detects to
     /// surface the consent dialog.
+    ///
+    /// FAIL-CLOSED ORDERING — persist FIRST, flip the in-memory flag ONLY on a durable success. If
+    /// the write fails we return the error with the session still UNCONSENTED, so we never egress on
+    /// a consent that isn't durably recorded. (The inverse — `revoke_cloud_egress` — deliberately
+    /// flips first; see its doc.)
     pub fn grant_cloud_egress_consent(&mut self, db: &Db) -> Result<()> {
+        db.set_setting(K_CLOUD_EGRESS_CONSENTED, "true")?;
         self.cloud_egress_consented = true;
-        db.set_setting(K_CLOUD_EGRESS_CONSENTED, "true")
+        Ok(())
     }
 
     /// E10 — REVOKE the cloud-egress consent. Mirror of [`grant_cloud_egress_consent`]: flips the
@@ -666,6 +672,11 @@ impl AppConfig {
     /// revoke). After revoke, every cloud-classified provider build is refused fail-closed
     /// (`AppError::Unavailable`) again — the gate reads the live config per call, so the very next
     /// summarize/ask/reasoner call refuses without a restart.
+    ///
+    /// FAIL-CLOSED ORDERING (opposite of the grants) — flip the in-memory flag FIRST, THEN persist.
+    /// Revoke's safe-failure direction is "stop egressing immediately", so the session must go
+    /// unconsented even if the durable write then fails; persist-first would keep the session
+    /// egressing on a write error. Both grant and revoke thus fail toward NOT egressing.
     pub fn revoke_cloud_egress(&mut self, db: &Db) -> Result<()> {
         self.cloud_egress_consented = false;
         db.set_setting(K_CLOUD_EGRESS_CONSENTED, "false")
@@ -676,9 +687,13 @@ impl AppConfig {
     /// in-memory flag AND persists it. This is the ONLY supported mutator (deliberately separate from
     /// `save_config`), so web-search egress consent can never be granted as an incidental side effect
     /// of a settings write. Until granted, the web connector is absent from the brain's tool registry.
+    ///
+    /// FAIL-CLOSED ORDERING — persist FIRST, flip the in-memory flag ONLY on a durable success, so a
+    /// failed write leaves the session unconsented (no web egress on a consent that wasn't recorded).
     pub fn grant_web_search_consent(&mut self, db: &Db) -> Result<()> {
+        db.set_setting(K_WEB_SEARCH_CONSENTED, "true")?;
         self.web_search_consented = true;
-        db.set_setting(K_WEB_SEARCH_CONSENTED, "true")
+        Ok(())
     }
 }
 
@@ -693,15 +708,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn temp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-config-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-config-test", "sqlite");
         // Tests use an explicit key (NOT the Keychain) — Db::open would hit macOS Keychain and
         // prompt/block depending on the test-binary signature.
         Db::open_with_key(
@@ -900,6 +907,44 @@ mod tests {
         assert!(!cfg.cloud_egress_consented, "in-memory flag must flip immediately");
         // Survives a reload from the settings table.
         assert!(!AppConfig::load(&db).unwrap().cloud_egress_consented);
+    }
+
+    /// FAIL-CLOSED ORDERING (grants persist-then-flip). On the normal path the durable record and
+    /// the in-memory flag must AGREE after a grant — the durable write landed and only then did the
+    /// session flip. (The failure branch — a `set_setting` error leaving the flag false — is a
+    /// STRUCTURAL guarantee: the grant returns `?` before touching `self`, so a write error can never
+    /// flip the flag. We can't force a `set_setting` error without a Db mock the crate doesn't have,
+    /// so we pin the observable agreement of the two sides here.)
+    #[test]
+    fn cloud_egress_grant_durable_record_and_flag_agree() {
+        let db = temp_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        // Pre-grant: neither side consents.
+        assert!(!cfg.cloud_egress_consented);
+        assert_ne!(db.get_setting(K_CLOUD_EGRESS_CONSENTED).unwrap().as_deref(), Some("true"));
+        // Grant: the durable record is written FIRST, then the flag flips — both true afterwards.
+        cfg.grant_cloud_egress_consent(&db).unwrap();
+        assert!(cfg.cloud_egress_consented, "session flag flipped");
+        assert_eq!(
+            db.get_setting(K_CLOUD_EGRESS_CONSENTED).unwrap().as_deref(),
+            Some("true"),
+            "durable consent record persisted (persist-first)"
+        );
+    }
+
+    /// Same fail-closed agreement for the web-search grant.
+    #[test]
+    fn web_search_grant_durable_record_and_flag_agree() {
+        let db = temp_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.web_search_consented);
+        cfg.grant_web_search_consent(&db).unwrap();
+        assert!(cfg.web_search_consented);
+        assert_eq!(
+            db.get_setting(K_WEB_SEARCH_CONSENTED).unwrap().as_deref(),
+            Some("true"),
+            "durable web-search consent record persisted (persist-first)"
+        );
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -383,15 +383,7 @@ mod tests {
     }
 
     fn tmp_path(tag: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-state-{tag}-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-state-{tag}"), "sqlite");
         let _ = std::fs::remove_file(&p);
         p
     }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -4482,6 +4482,26 @@ impl Db {
     }
 }
 
+/// Collision-proof unique temp path for file-backed tests.
+///
+/// `cargo test` runs the tests in ONE process as parallel THREADS, so `process::id()` is identical
+/// across every test and `SystemTime::now().as_nanos()` can repeat within a single OS clock tick —
+/// two tests then build the SAME `.sqlite` path and race `migrate()` on one file
+/// (`Storage("database is locked")` / `duplicate column name`). The process-unique monotone
+/// `COUNTER` guarantees no two calls in this process ever collide, regardless of the clock.
+#[cfg(test)]
+pub(crate) fn unique_temp_path(prefix: &str, ext: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{nanos}-{n}.{ext}"))
+}
+
 /// One note row needed to seal/unseal a folder.
 #[derive(Debug, Clone)]
 pub struct SealableNote {
@@ -7017,17 +7037,7 @@ mod lock_tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db_path(label: &str) -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-lock-test-{}-{}-{}.sqlite",
-            label,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        p
+        super::unique_temp_path(&format!("meetnotes-lock-test-{label}"), "sqlite")
     }
 
     fn file_db(label: &str) -> Db {
@@ -7823,17 +7833,7 @@ mod graph_tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db_path(label: &str) -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-graph-test-{}-{}-{}.sqlite",
-            label,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        p
+        super::unique_temp_path(&format!("meetnotes-graph-test-{label}"), "sqlite")
     }
 
     fn file_db(label: &str) -> Db {

--- a/src-tauri/src/summarize/dossier.rs
+++ b/src-tauri/src/summarize/dossier.rs
@@ -337,15 +337,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-dossier-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-dossier-test", "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -430,15 +430,7 @@ mod tests {
     /// both the legacy factory AND the role resolver refuse with `Unavailable`.
     #[test]
     fn cloud_providers_refused_after_consent_revoked() {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-revoke-gate-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-revoke-gate-test", "sqlite");
         // Explicit key (NOT the Keychain) — Db::open would prompt/block in a test binary.
         let db = crate::storage::Db::open_with_key(
             &p,

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -204,15 +204,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-relctx-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-relctx-test", "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -212,15 +212,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn temp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "meetnotes-vaultctx-test-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("meetnotes-vaultctx-test", "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -762,15 +762,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn tmp_db() -> Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-tools-web-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path("murmur-tools-web", "sqlite");
         Db::open_with_key(&p, TEST_DEK).unwrap()
     }
 

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -1659,15 +1659,7 @@ mod tests {
     const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn tmp_db(tag: &str) -> crate::storage::Db {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-live-gate-{tag}-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-live-gate-{tag}"), "sqlite");
         let _ = std::fs::remove_file(&p);
         crate::storage::Db::open_with_key(&p, TEST_DEK).unwrap()
     }

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -770,18 +770,7 @@ mod tests {
     const KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     fn tmp_db() -> Db {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static SEQ: AtomicU64 = AtomicU64::new(0);
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "murmur-voiceaction-{}-{}-{}.sqlite",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos(),
-            SEQ.fetch_add(1, Ordering::Relaxed),
-        ));
+        let p = crate::storage::db::unique_temp_path("murmur-voiceaction", "sqlite");
         let _ = std::fs::remove_file(&p);
         Db::open_with_key(&p, KEY).unwrap()
     }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -117,10 +117,21 @@ export interface AppConfigDto {
   realtimeReactions: boolean;
   /**
    * Phase H — the selected local brain model id (a registry id like
-   * `"bielik-11b"`, or a custom GGUF file path). Only meaningful when
-   * `brainBackend === "local"`. Null = none selected yet.
+   * `"bielik-11b"`). Only meaningful when `brainBackend === "local"`. Null =
+   * none selected yet. A custom GGUF FILE PATH goes in `brainModelPath` (below),
+   * NOT here — the backend validates this against the fixed registry and
+   * discards a typed non-registry value.
    */
   brainModelId: string | null;
+  /**
+   * An explicit custom GGUF FILE PATH the resolver honors verbatim (bypasses the
+   * `brainModelId` registry validation). Settable and round-tripped on every
+   * `save_config`; empty → null. When set it WINS over `brainModelId` in the
+   * backend's `resolve_brain_model`, so the two are mutually exclusive from the
+   * UI (picking a registry model clears the path; typing a path clears the id).
+   * Mirrors Rust `AppConfigDto.brain_model_path`.
+   */
+  brainModelPath: string | null;
   /**
    * brain2 RAG — the semantic-search master flag. When on, Ask-My-Vault retrieves
    * candidates by HYBRID (FTS ∪ vector-KNN) retrieval over the on-device embedding

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1551,6 +1551,9 @@ export class OnboardingComponent implements OnInit {
       brainBackend: base?.brainBackend ?? "cloud",
       realtimeReactions: base?.realtimeReactions ?? false,
       brainModelId: base?.brainModelId ?? null,
+      // Custom GGUF file path — preserve-only here (the AI & Models hub owns it);
+      // round-trip the snapshot so onboarding never clears a user's custom path.
+      brainModelPath: base?.brainModelPath ?? null,
       // Proactive brain hints — round-trip the snapshot, default ON (fresh install).
       proactiveHintsEnabled: base?.proactiveHintsEnabled ?? true,
       // brain2 RAG — semantic-search master flag; round-trip the snapshot, default off.

--- a/src/app/features/settings/sections/ai/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows.component.ts
@@ -309,15 +309,24 @@ interface RoleRowVm {
                 }
               }
 
+              <!--
+                One shared input driving TWO mutually-exclusive controls
+                (brainModelPath for a file path, brainModelId for a registry id),
+                so it can't be a formControlName — it's a store-backed
+                [value]/(input) pair. A registry pick above clears the path.
+              -->
               <label class="field brain-custom">
                 <span class="field-label">Custom GGUF model</span>
                 <input
-                  formControlName="brainModelId"
+                  [value]="customGgufValue()"
+                  (input)="setCustomGguf($any($event.target).value)"
                   placeholder="/path/to/model.gguf or a registry id"
+                  autocomplete="off"
+                  spellcheck="false"
                 />
                 <span class="field-help text-muted">
-                  Advanced: point at your own GGUF file (or a registry id).
-                  Saved with your settings.
+                  Point at your own .gguf file, or type a registry id. Saved with
+                  your settings.
                 </span>
               </label>
 
@@ -553,6 +562,8 @@ export class AiRoleRowsComponent {
   private readonly store = inject(SettingsStore);
 
   readonly form = this.store.form;
+  /** The shared custom-GGUF input's value (path-or-id) — drives two controls. */
+  readonly customGgufValue = this.store.customGgufValue;
   readonly brainModels = this.store.brainModels;
   readonly brainModelsLoading = this.store.brainModelsLoading;
   readonly brainError = this.store.brainError;
@@ -686,6 +697,10 @@ export class AiRoleRowsComponent {
 
   useBrainModel(id: string): void {
     void this.store.useBrainModel(id);
+  }
+
+  setCustomGguf(v: string): void {
+    this.store.setCustomGguf(v);
   }
 
   downloadBrainModel(id: string): void {

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -32,6 +32,24 @@ const PROVIDER_CONNECTION_IDS: readonly string[] = [
   "gateway",
 ];
 
+/**
+ * Heuristic: does this string look like a filesystem PATH to a `.gguf` file
+ * (vs a bare registry id like `qwen3-14b`)? True when it contains a path
+ * separator, ends `.gguf` (case-insensitive), or starts with `~`. Drives which
+ * of the two mutually-exclusive brain-model controls a typed custom value fills
+ * (`brainModelPath` for a path, else `brainModelId`).
+ */
+export function looksLikeGgufPath(v: string): boolean {
+  const s = v.trim();
+  if (!s) return false;
+  return (
+    s.includes("/") ||
+    s.includes("\\") ||
+    s.startsWith("~") ||
+    s.toLowerCase().endsWith(".gguf")
+  );
+}
+
 /** Display names for the connection ids (matches the connection cards). */
 const CONNECTION_LABELS: Readonly<Record<string, string>> = {
   claude_code: "Claude Code",
@@ -116,8 +134,10 @@ export class SettingsStore {
     realtimeReactions: false,
     // Proactive brain (P2) — zero-egress recall cards while recording; default ON.
     proactiveHintsEnabled: true,
-    /** Custom GGUF model path (or registry id). Empty → null on save. */
+    /** Selected registry brain-model id. Empty → null on save. */
     brainModelId: "",
+    /** Explicit custom GGUF file PATH (wins over brainModelId). Empty → null on save. */
+    brainModelPath: "",
     // brain2 RAG — semantic-search master flag (round-tripped on save).
     semanticSearchEnabled: false,
     // brain2 connectors — web-search master toggle (NEW EGRESS; round-tripped).
@@ -707,6 +727,44 @@ export class SettingsStore {
   /** Release handle for the EVENT_BRAIN_DOWNLOAD subscription. */
   private unlistenBrainDownload: UnlistenFn | null = null;
 
+  /**
+   * Live signals of the two custom-GGUF controls — the same `valueChanges`
+   * bridge as the role controls above — so `customGgufValue` re-derives when
+   * either is patched (from load(), a registry pick, or the shared input).
+   */
+  private readonly _brainModelIdValue = toSignal(
+    this.form.controls.brainModelId.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+  private readonly _brainModelPathValue = toSignal(
+    this.form.controls.brainModelPath.valueChanges.pipe(startWith("")),
+    { initialValue: "" },
+  );
+
+  /**
+   * The single value shown in the shared "Custom GGUF model" input: the explicit
+   * custom PATH when one is set, otherwise the registry id. The input drives BOTH
+   * `brainModelPath` and `brainModelId` via `setCustomGguf`, so it can't be a
+   * plain `formControlName` — this computed is its `[value]`.
+   */
+  readonly customGgufValue = computed(
+    () => this._brainModelPathValue() || this._brainModelIdValue(),
+  );
+
+  /**
+   * Route a typed custom value to the RIGHT control by shape and clear the other,
+   * keeping `brainModelPath` (a file path, honored verbatim) and `brainModelId`
+   * (a validated registry id) mutually exclusive. A path-shaped value fills
+   * `brainModelPath`; anything else fills `brainModelId`.
+   */
+  setCustomGguf(v: string): void {
+    const isPath = looksLikeGgufPath(v);
+    this.form.patchValue({
+      brainModelPath: isPath ? v : "",
+      brainModelId: isPath ? "" : v,
+    });
+  }
+
   // ── brain2 RAG — semantic search (embedding model + reindex) ────────────
 
   /**
@@ -792,6 +850,7 @@ export class SettingsStore {
         realtimeReactions: cfg.realtimeReactions ?? false,
         proactiveHintsEnabled: cfg.proactiveHintsEnabled ?? true,
         brainModelId: cfg.brainModelId ?? "",
+        brainModelPath: cfg.brainModelPath ?? "",
         semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
         webSearchEnabled: cfg.webSearchEnabled ?? false,
         // AI Gateway (Phase 1) — base URL + model, default "" for pre-existing configs.
@@ -924,7 +983,9 @@ export class SettingsStore {
     this._brainError.set(null);
     try {
       await this.ipc.selectBrainModel(id);
-      this.form.patchValue({ brainModelId: id });
+      // Clear any custom PATH: it wins over the id in resolve_brain_model, so a
+      // stale path would silently override the registry model just picked.
+      this.form.patchValue({ brainModelId: id, brainModelPath: "" });
       await this.refreshBrainModels();
     } catch (e) {
       this._brainError.set(String(e));
@@ -1063,6 +1124,8 @@ export class SettingsStore {
       // Proactive brain hints — round-tripped so a save preserves the mute.
       proactiveHintsEnabled: v.proactiveHintsEnabled,
       brainModelId: v.brainModelId || null,
+      // A custom GGUF file path (settable; wins over brainModelId in the resolver).
+      brainModelPath: v.brainModelPath || null,
       // brain2 RAG — semantic-search master flag (round-tripped so a save preserves it).
       semanticSearchEnabled: v.semanticSearchEnabled,
       // brain2 connectors — web-search toggle is settable from the form; its consent


### PR DESCRIPTION
Residual hardening after the model-settings unification (`docs/research/2026-07-02-unify-model-settings.md`, PRs #128/#132/#133/#138/#140). Three flagged loose ends closed.

## What
- **Consent GRANT is now fail-closed.** `grant_cloud_egress_consent` + `grant_web_search_consent` persist the durable key BEFORE flipping the in-memory flag — a settings-write failure now leaves the session **unconsented** (was flip-then-persist, which left the session egressing with no durable record). `revoke_cloud_egress` stays flip-first on purpose (its safe failure is to stop egressing immediately). Both consent flags stay preserve-only on the DTO.
- **The "Custom GGUF model" input is no longer dead.** `brain_model_path` is now settable (`AppConfigDto.brainModelPath` round-trips; `resolve_brain_model` already prefers it). The single input routes by shape — a path (`/`, `\`, `~`, `.gguf`) → `brainModelPath`, a registry id → `brainModelId`, mutually exclusive; a registry pick from the list clears any stale path. Before, a typed `/path/to/model.gguf` was silently discarded on save (the research flagged this as inconsistency #5).
- **Killed the parallel-test-DB flake.** A shared `#[cfg(test)] unique_temp_path` helper (storage/db.rs) appends a process-monotone `AtomicU64` after `pid+nanos`, so two same-process test threads can't collide on a `.sqlite` path (the cause of intermittent `database is locked` / `duplicate column name` racing `migrate()`). 14 test-db helpers across 13 files migrated; non-db temp-path helpers untouched.

## How verified
- `scripts/ci.sh` → ✅ all gates green (clippy -D warnings + **700** lib tests + lint + build + headless E2E).
- **Adversarial verifier**: B PASS (flake reproduced RED then killed + 16-thread stress = no lock/dup errors), C PASS (fail-closed ordering + revoke still safe + DTO still preserve-only, mutation-checked), D-backend PASS, D-FE logic PASS.
- **Lock-security reviewer: PASS** — grant fail-closed, revoke unchanged/safe, both consent flags preserve-only, `brain_model_path` is a purely-local file path with safe stale-path fallback (no egress/lock/content surface), no PII.
- **D-FE live browser round-trip** (the leg the verifier couldn't run — no browser tool): driven against a fresh dist with mocked IPC — load shows the path, path→`brainModelPath`, registry id→`brainModelId`, registry pick clears the path, registry renders for `brainBackend=local`, **zero console errors (no NG0600)**.
- Separately: the stage-4 post-review fixes (#140) were **independently re-verified PASS** with real RED-before-GREEN in isolated worktree builds.