### PR TITLE
chore(settings): drop the redundant experimental VPIO echo toggle

### DIFF
--- a/src/app/features/settings/sections/settings-audio-section.component.ts
+++ b/src/app/features/settings/sections/settings-audio-section.component.ts
@@ -106,22 +106,6 @@ import { SettingsStore } from "../settings.store";
                 </label>
               </div>
 
-              <!-- Echo cancellation (experimental) — toggle row -->
-              <div class="card">
-                <label class="toggle-row">
-                  <span class="toggle-copy">
-                    <span class="toggle-title">Cancel speaker echo (experimental)</span>
-                    <span class="text-secondary toggle-sub">
-                      Experimental Apple voice processing on the transcription mic. May not
-                      remove echo on all setups (macOS gives it no reference signal) — echoed
-                      lines are also removed automatically after each recording. Headphones
-                      remain the most reliable fix.
-                    </span>
-                  </span>
-                  <input type="checkbox" formControlName="aecEnabled" />
-                </label>
-              </div>
-
               <!-- Voice trigger — toggle row -->
               <div class="card">
                 <label class="toggle-row">


### PR DESCRIPTION
The offline AEC3 toggle (**Remove speaker echo from recordings**, default ON) supersedes the experimental VPIO toggle (**Cancel speaker echo (experimental)**, default OFF).

The pipeline runs offline AEC on the RAW mic and overwrites the ASR feed / archive input regardless of whether VPIO ran — so with the new option on (the default), the VPIO output is simply discarded. Two echo toggles were only confusing (research also measured VPIO at ~0 dB — no reference signal). Removes the experimental toggle from Settings → Audio; the `aec_enabled` flag + `aeccap` helper stay in the code (unrendered, control still round-trips) pending a real-Mac ERLE verdict before full removal.

FE-only, template-only change. `ng lint` + `ng build` green.