### PR TITLE
feat(settings): drill-down (L2) navigation — hide the primary rail in Settings

### DIFF
--- a/docs/superpowers/specs/2026-07-02-settings-drilldown-nav-design.md
+++ b/docs/superpowers/specs/2026-07-02-settings-drilldown-nav-design.md
@@ -1,0 +1,37 @@
+# Settings drill-down (L2) navigation — design
+
+## Problem
+Settings shows THREE columns at once: the primary app rail (`app-shell` — Record/Meetings/Analytics/Graph/Brain/Ask + Settings/Collapse footer), a separate settings-section list (`app-settings`'s own `settings-sidebar` card, added in the #133 split), and the content pane. Three columns leave the content (e.g. the AI & Models connection cards) cramped.
+
+## Decision
+**Full drill-down (Option A, user-approved).** Entering `/settings` hides the primary app rail; the settings-section list becomes the leftmost column (level 2), leaving two columns `[settings sections | content]` and giving content back ~230px. A "← Murmur" affordance at the top of the L2 rail returns to wherever the user was.
+
+## Interaction
+- Navigate to any `/settings*` route → the `app-shell` primary `<aside>` is hidden (`display:none`); the router-outlet (`app-settings`) spans full width and renders its own `[section rail | content]`.
+- The settings section rail gains a **"← Murmur"** back item at the very top (above search). It navigates to the **last non-settings route** (e.g. came from Meetings → returns to Meetings); fallback `/record` when there is no such history (deep-link straight to `/settings`). The `murmur` brand/logo does the same.
+- The section rail restyles from a floating card to a **full-height left rail** (flush-left, matching the primary rail's role) so it reads as a first-class column, not a popover. Search at top (under Back), Save at bottom — unchanged.
+- Subtle slide-in on the rail when entering settings; honor `@media (prefers-reduced-motion: reduce)`.
+- `Esc` while in settings triggers the same back navigation (nice-to-have).
+- The primary rail's "Collapse" toggle and "unlocked" lock indicator are NOT shown at the settings level (they return on exit). No collapse of the settings rail.
+
+## Architecture (no state coupling)
+- **`NavHistoryService`** (`providedIn:'root'`, the only new unit): tracks the last URL that does not start with `/settings` via `toSignal(router.events …)` filtered to `NavigationEnd`. Exposes `lastAppRoute()` (default `/record`) and a `back()` that `router.navigateByUrl(lastAppRoute())`. Owns the router subscription lifecycle (framework-managed via `toSignal`).
+- **`app-shell.component.ts`**: `inject(Router)`; `inSettings = computed(() => currentUrl().startsWith('/settings'))` where `currentUrl` is a `toSignal` of router `NavigationEnd`/`router.url`. The primary `<aside>` is hidden (`@if (!inSettings())` or a `[class.hidden]` with `display:none`) when in settings, so the outlet gets full width. No settings state enters the shell.
+- **`app-settings.component.ts`**: prepend a "← Murmur" back button to the `settings-sidebar` that calls `NavHistoryService.back()` (label can read the target section name or just "Murmur"); restyle `settings-shell`/`settings-sidebar` to a full-height flush-left rail; add the reduced-motion-aware slide.
+
+Rationale for Approach 2 (shell hides its rail; settings keeps owning its sidebar) over "shell renders the settings nav itself": zero coupling — `app-shell` never learns the settings sections/active-section/Save; `app-settings` already owns that sidebar after #133.
+
+## Constraints (binding)
+Angular zoneless: signals/`computed`/`toSignal` (never subscribe-for-state in a component), `@if`/`@for`, `inject()`, `input()/output()`, no `setTimeout` in components, `var(--token)` styling, ≤16 kB per-component style budget, no new npm deps. Nav is path-routing (already). `com.meetnotes.app` immutable.
+
+## Testing (headless, mocked IPC)
+Playwright against a built dist with mocked `__TAURI_INTERNALS__`:
+1. `/settings` renders **two** columns, not three — the primary app rail (Record/Meetings/…) is absent from the DOM/hidden.
+2. From `/library` (Meetings) → open Settings → "← Murmur" returns to `/library`.
+3. Deep-link straight to `/settings` → back navigates to `/record`.
+4. Section switching, search filtering, and Save still work (payload unchanged).
+5. Console clean: no NG0600, no `ɵcmp`.
+6. `ng lint` + `ng build` green; per-component style budgets respected.
+
+## Out of scope (v1)
+Route transition animations beyond a simple rail slide; showing the unlocked/lock indicator at the settings level; a persistent icon rail (that was Option B, rejected).

--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -1,11 +1,20 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   signal,
 } from "@angular/core";
-import { RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
+import { toSignal } from "@angular/core/rxjs-interop";
+import {
+  NavigationEnd,
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from "@angular/router";
+import { filter, map } from "rxjs";
 import { FoldersService } from "./services/folders.service";
 import { ToastService, type Toast } from "./services/toast.service";
 
@@ -43,6 +52,10 @@ interface NavItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterOutlet, RouterLink, RouterLinkActive],
   template: `
+    <!-- Primary rail is HIDDEN under /settings: settings drills down to its own
+         two-column [section rail | content] layout (see settings.component). The
+         @if removes the aside from the DOM so the outlet's flex row fills. -->
+    @if (!inSettings()) {
     <aside class="app-sidebar" [class.collapsed]="collapsed()">
       <!-- Top drag strip: reserves room for the overlay traffic lights and lets
            the user move the window (data-tauri-drag-region). Empty on purpose so
@@ -198,6 +211,7 @@ interface NavItem {
         </button>
       </div>
     </aside>
+    }
 
     <main class="app-main">
       <router-outlet></router-outlet>
@@ -257,6 +271,28 @@ interface NavItem {
 export class AppShellComponent {
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly router = inject(Router);
+
+  /**
+   * The current URL, updated on every completed navigation. Seeded from
+   * `router.url` so `inSettings` is correct on a cold deep-link to `/settings`
+   * (before the first `NavigationEnd`). The subscription is framework-managed by
+   * `toSignal` — no hand-rolled `.subscribe()`.
+   */
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map(() => this.router.url),
+    ),
+    { initialValue: this.router.url },
+  );
+
+  /**
+   * True while on any `/settings*` route. When true the primary rail is removed
+   * from the DOM so the settings drill-down owns the full width with its own
+   * two-column layout.
+   */
+  readonly inSettings = computed(() => this.currentUrl().startsWith("/settings"));
 
   /** Primary sidebar destinations (Settings lives in the footer as its own icon). */
   readonly navItems: readonly NavItem[] = [

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { NavigationEnd, Router, RouterOutlet } from "@angular/router";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { filter, map } from "rxjs";
 import { IpcService } from "./core/ipc.service";
+import { NavHistoryService } from "./core/nav-history.service";
 import { FoldersService } from "./services/folders.service";
 import { ScreenShareService } from "./services/screen-share.service";
 import { ThemeService } from "./services/theme.service";
@@ -37,6 +38,11 @@ export class AppComponent implements OnInit {
   // before the main window is revealed — no flash of the wrong theme.
   private readonly theme = inject(ThemeService);
   private readonly updates = inject(UpdateService);
+  // Injected at bootstrap purely so it starts observing router events from the
+  // FIRST navigation — its "last non-settings route" (used by the settings
+  // drill-down "← Murmur" back button) must be recorded before the user reaches
+  // settings, so it cannot wait for lazy construction inside SettingsComponent.
+  private readonly navHistory = inject(NavHistoryService);
 
   /** True in the floating-bar window (route /bar) — the app chrome is hidden there. */
   readonly isBar = toSignal(

--- a/src/app/core/nav-history.service.ts
+++ b/src/app/core/nav-history.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { NavigationEnd, Router } from "@angular/router";
+import { filter, map, scan, startWith } from "rxjs";
+
+/** Fallback destination when the user deep-links straight into settings. */
+const DEFAULT_APP_ROUTE = "/record";
+
+/**
+ * Tracks the last app route the user was on that is NOT under `/settings`, so the
+ * settings drill-down "← Murmur" affordance can return them to where they were
+ * (Meetings → back to Meetings), falling back to `/record` when there is no such
+ * history (a fresh deep-link to `/settings`).
+ *
+ * The router subscription lifecycle is framework-managed via `toSignal` — this
+ * service never hand-rolls a `.subscribe()` that writes a field (zoneless rule).
+ * The "last NON-settings" carry-over is done inside the rxjs `scan` (so we never
+ * need a signal that reads its own previous value, which Angular 18.2's
+ * `computed` cannot express and which would trip NG0600 inside an `effect`).
+ */
+@Injectable({ providedIn: "root" })
+export class NavHistoryService {
+  private readonly router = inject(Router);
+
+  /**
+   * The last completed navigation whose URL is NOT under `/settings`. `scan`
+   * keeps the prior value while the current URL is a settings route, so once
+   * inside settings this reports the pre-entry route rather than resetting.
+   * Seeded from `router.url` (via `startWith`) so a cold deep-link is handled.
+   */
+  private readonly _lastAppRoute = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map(() => this.router.url),
+      startWith(this.router.url),
+      scan(
+        (last, url) => (url.startsWith("/settings") ? last : url),
+        DEFAULT_APP_ROUTE,
+      ),
+    ),
+    { initialValue: DEFAULT_APP_ROUTE },
+  );
+
+  /** The route "← Murmur" returns to; defaults to `/record`. */
+  readonly lastAppRoute = this._lastAppRoute;
+
+  /** Navigate back to the last non-settings route (or the default). */
+  back(): void {
+    void this.router.navigateByUrl(this.lastAppRoute());
+  }
+}

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -9,6 +9,7 @@ import {
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { startWith } from "rxjs";
+import { NavHistoryService } from "../../core/nav-history.service";
 import { SettingsStore } from "./settings.store";
 import { SettingsAppearanceSectionComponent } from "./sections/settings-appearance-section.component";
 import { SettingsGeneralSectionComponent } from "./sections/settings-general-section.component";
@@ -58,6 +59,10 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   selector: "app-settings",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // Esc in settings backs out ("← Murmur") — but NOT while you're typing: in the
+  // search box Esc clears/blurs it first, and it never hijacks another form field.
+  // Declarative host listener — Angular owns its lifecycle (no manual DOM listener).
+  host: { "(document:keydown.escape)": "onEscape()" },
   providers: [SettingsStore],
   imports: [
     ReactiveFormsModule,
@@ -74,8 +79,34 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   ],
   template: `
     <section class="settings-shell">
-      <!-- macOS-style left rail: search over sections, then the section list. -->
+      <!-- macOS-style left rail: Back, search over sections, then the section list. -->
       <aside class="settings-sidebar" aria-label="Settings">
+        <!-- Drag strip mirrors the primary rail so the overlay traffic lights
+             stay clear of the Back button when the rail is flush to the edge. -->
+        <div class="rail-drag" data-tauri-drag-region></div>
+
+        <!-- Drill-down "up": returns to the last non-settings route (or /record). -->
+        <button
+          type="button"
+          class="rail-back"
+          (click)="nav.back()"
+          aria-label="Back to Murmur"
+        >
+          <svg
+            class="rail-back-icon"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9.5 3.5 5 8l4.5 4.5" />
+          </svg>
+          <span class="rail-back-label">Murmur</span>
+        </button>
+
         <div class="sidebar-search">
           <svg
             class="sidebar-search-icon"
@@ -218,27 +249,99 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   `,
   styles: [
     `
-      /* ── macOS-style two-pane shell: sidebar + content ── */
-      .settings-shell {
-        display: grid;
-        grid-template-columns: 216px minmax(0, 1fr);
-        gap: var(--space-5);
-        align-items: start;
+      /* Settings is a full drill-down (L2): the primary app rail is hidden
+         (app-shell) and this host fills the whole window as a flush-left
+         [section rail | content] layout. Fixed so it ignores .app-main's
+         centered max-width + padding and hugs the viewport edges; below the
+         toast viewport (z-index 60). */
+      :host {
+        position: fixed;
+        inset: 0;
+        z-index: 5;
+        display: block;
+        background: var(--surface-base);
       }
 
-      /* Left rail — sticky under the app header, its own quiet frosted panel. */
+      /* ── Two-pane shell: full-height section rail + scrolling content ── */
+      .settings-shell {
+        display: grid;
+        grid-template-columns: 232px minmax(0, 1fr);
+        height: 100vh;
+        height: 100dvh;
+      }
+
+      /* Left rail — a first-class full-height column flush to the window edge,
+         same visual weight as the primary rail it replaces (frosted in-flow
+         chrome, right border, NOT a floating card). */
       .settings-sidebar {
-        position: sticky;
-        top: calc(var(--space-8) + var(--space-2));
         display: flex;
         flex-direction: column;
         gap: var(--space-3);
-        padding: var(--space-3);
-        border-radius: var(--radius-lg);
+        height: 100%;
+        padding: 0 var(--space-3) var(--space-4);
         background: var(--surface-raised);
-        border: 1px solid var(--glass-border);
+        -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+        backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+        border-right: 1px solid var(--border-subtle);
         box-shadow: var(--glass-highlight);
-        animation: rise 380ms var(--transition) both;
+        overflow: hidden;
+        animation: settings-rail-in 320ms var(--transition) both;
+      }
+
+      /* Slide-in when entering settings; disabled under reduced-motion below. */
+      @keyframes settings-rail-in {
+        from {
+          transform: translateX(-14px);
+          opacity: 0;
+        }
+        to {
+          transform: none;
+          opacity: 1;
+        }
+      }
+
+      /* Top drag strip — mirrors the primary rail so the overlay traffic lights
+         have somewhere to float and the window stays draggable up here. */
+      .rail-drag {
+        flex: none;
+        height: 30px;
+      }
+
+      /* "← Murmur" drill-down up-affordance. */
+      .rail-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+        height: 34px;
+        padding: 0 var(--space-2);
+        border: 0;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.9rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition-fast),
+          color var(--transition-fast);
+      }
+      .rail-back:hover {
+        background: var(--surface-hover);
+        color: var(--text-primary);
+      }
+      .rail-back:focus-visible {
+        outline: none;
+        color: var(--text-primary);
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .rail-back-icon {
+        flex: none;
+        width: 16px;
+        height: 16px;
       }
 
       .sidebar-search {
@@ -283,6 +386,9 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         display: flex;
         flex-direction: column;
         gap: 2px;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
       }
       .nav-item {
         display: flex;
@@ -340,6 +446,7 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         display: flex;
         align-items: center;
         gap: var(--space-2);
+        flex: none;
         flex-wrap: wrap;
         margin-top: var(--space-1);
         padding-top: var(--space-3);
@@ -352,12 +459,22 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         flex: none;
       }
 
-      /* Right pane — the section title + its stacked cards. */
+      /* Right pane — scrolls independently of the fixed rail. It provides its own
+         padding (the shell no longer sits inside .app-main's padded column). */
       .settings-content {
         display: flex;
         flex-direction: column;
         gap: var(--space-5);
         min-width: 0;
+        height: 100%;
+        overflow-y: auto;
+        padding: var(--space-7) var(--space-6) var(--space-8);
+      }
+      /* Cap the reading width so cards don't stretch across an ultrawide window. */
+      .content-header,
+      .section-body {
+        width: 100%;
+        max-width: var(--content-max);
       }
       .content-header h2 {
         margin: 0;
@@ -372,20 +489,35 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         animation: rise 320ms var(--transition) both;
       }
 
-      /* Collapse to a single column on narrow widths (sidebar stacks on top). */
+      /* Narrow widths: stack the rail on top of the content (rows), each
+         scrolling within the fixed full-height shell. */
       @media (max-width: 640px) {
         .settings-shell {
           grid-template-columns: 1fr;
+          grid-template-rows: auto minmax(0, 1fr);
         }
         .settings-sidebar {
-          position: static;
+          border-right: 0;
+          border-bottom: 1px solid var(--border-subtle);
         }
         .sidebar-nav {
           flex-direction: row;
           flex-wrap: wrap;
+          overflow-y: visible;
         }
         .nav-item {
           width: auto;
+        }
+        .settings-content {
+          padding: var(--space-5) var(--space-4) var(--space-6);
+        }
+      }
+
+      /* Honor reduced-motion: no rail slide, no section rise. */
+      @media (prefers-reduced-motion: reduce) {
+        .settings-sidebar,
+        .section-body {
+          animation: none;
         }
       }
 
@@ -409,6 +541,31 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
 export class SettingsComponent implements OnInit {
   /** Shared settings state — provided on this component (see class JSDoc). */
   private readonly store = inject(SettingsStore);
+
+  /** Drill-down back navigation ("← Murmur" + Esc) — no settings state coupling. */
+  readonly nav = inject(NavHistoryService);
+
+  /**
+   * Esc while in settings. Backs out to where you came from — EXCEPT while you're
+   * typing: in the search box the first Esc clears it (or blurs when empty), and
+   * Esc is ignored inside any other form field, so it never ejects you mid-edit.
+   */
+  onEscape(): void {
+    const el = document.activeElement as HTMLElement | null;
+    if (el?.classList.contains("sidebar-search-input")) {
+      if (this.searchControl.value) {
+        this.searchControl.setValue("");
+      } else {
+        el.blur();
+      }
+      return;
+    }
+    const tag = el?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+      return;
+    }
+    this.nav.back();
+  }
 
   // ── macOS-style navigation: sidebar sections + search ───────────────────
 


### PR DESCRIPTION
Settings showed **three columns** (primary app rail + settings-section list + content), cramping the content (e.g. the AI & Models connection cards). This makes Settings a **full drill-down**: entering `/settings` hides the primary app rail so the settings-section list becomes the leftmost column (level 2), returning ~230px to the content. User-approved design in `docs/superpowers/specs/2026-07-02-settings-drilldown-nav-design.md`.

## What
- **NEW `NavHistoryService`** (`providedIn:root`, eager-injected in `app.component` so it observes router events from boot): tracks the last non-`/settings` URL via `toSignal(router.events → NavigationEnd)` + an rxjs `scan` (default `/record`); `back()` returns there. A cold deep-link straight to `/settings` backs to `/record`.
- **`app-shell`**: `inSettings = computed()` over a `toSignal` of the current URL; the primary `<aside>` is wrapped in `@if (!inSettings())` so it leaves the DOM and the `<router-outlet>` fills the row.
- **`settings.component`**: a **"← Murmur"** back button + Esc to back out; the section list restyles from a floating card to a **full-height flush-left rail** (reduced-motion-aware slide). Esc does **not** eject while typing — in the search box it clears/blurs first, and it never hijacks another form field.
- **Zero settings-state coupling**: `app-shell` never learns the settings sections / active section / Save — `app-settings` keeps owning its own sidebar (from the #133 split).

## How verified
- `scripts/ci.sh` → ✅ all gates green.
- **Adversarial verifier PASS** on the base drill-down — RED-before-GREEN (stashing the `@if` re-exposes the 3rd column and the `/library` nav link): 2-columns-not-3, came-from Back destination via **soft** nav (the nav-history singleton only accrues across router-link nav — a `page.goto` test false-fails, flagged), cold-deep-link→`/record`, toast still overlays settings (z-60 > z-5), scroll-to-Save works, no NG0600/ɵcmp.
- **Esc guard delta independently PASS'd** — RED-before-GREEN on the host binding (reverting to `nav.back()` reproduces the eject-while-typing regression), 9/9 live incl. Esc while a real `<select>` is focused → no-op.

Honest gap: all browser verification was headless Chromium with mocked Tauri IPC; the packaged WKWebView render + traffic-light/drag-strip alignment need a signed build.