### PR TITLE
fix(settings): smooth opaque enter transition — no more black flash

### DIFF
--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -285,18 +285,22 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         border-right: 1px solid var(--border-subtle);
         box-shadow: var(--glass-highlight);
         overflow: hidden;
-        animation: settings-rail-in 320ms var(--transition) both;
+        animation: settings-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
       }
 
-      /* Slide-in when entering settings; disabled under reduced-motion below. */
-      @keyframes settings-rail-in {
+      /* Enter transition — the rail and the content pane share ONE cohesive,
+         smoothly-eased glide (content lags 40ms for a touch of depth). It is
+         TRANSFORM ONLY, never opacity: the position:fixed :host is opaque and
+         near-black (--surface-base), so any opacity fade shows through as a
+         "black background, then the UI jumps in" flash (the reported bug). Staying
+         opaque means the settings surface is painted from the very first frame and
+         simply settles into place. Disabled under reduced-motion below. */
+      @keyframes settings-enter {
         from {
-          transform: translateX(-14px);
-          opacity: 0;
+          transform: translateY(8px);
         }
         to {
           transform: none;
-          opacity: 1;
         }
       }
 
@@ -486,7 +490,10 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
         display: flex;
         flex-direction: column;
         gap: var(--space-5);
-        animation: rise 320ms var(--transition) both;
+        /* Shares the rail's cohesive transform-only glide (NOT the global 'rise',
+           which fades opacity 0→1 and would flash near-black over the :host — on
+           entry AND on every section switch). 40ms lag for a subtle stagger. */
+        animation: settings-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) 40ms both;
       }
 
       /* Narrow widths: stack the rail on top of the content (rows), each


### PR DESCRIPTION
Clicking Settings showed a **near-black background for ~0.3–0.5s before the UI "jumped in."** This makes it a smooth, opaque glide instead.

## Root cause
From the drill-down (#143), the settings `:host` is a `position:fixed; inset:0; background:var(--surface-base)` (#07070b, opaque near-black) **full-window overlay**. On entry the rail (`settings-rail-in`) and the content pane (the **global `rise`**) both animated in from `opacity:0` **over that near-black host** — so the whole window was near-black while the UI faded in. Measured deterministically: **31 frames** with both children at `opacity:0` over `rgb(7,7,11)`.

## Fix
The rail and content pane now share **one transform-only keyframe** `settings-enter` (`translateY(8px) → 0`, `cubic-bezier(0.22,1,0.36,1)`, content lagged 40ms) — **no opacity**. The settings surface is fully opaque from the first frame and simply glides into place. Reduced-motion still disables the glide (instant, no flash).

## How verified
- **Adversarial-verifier PASS** (deterministic rAF frame-capture, not screenshot luck): near-black entry frames **31 → 0**; min opacity 0 → 1 (opaque from t=7ms); the glide genuinely animates (`transform 8→0`, opacity ~1 every frame — motion not just killed); a 90ms mid-transition screenshot shows the fully-styled 2-column UI (RED counterpart showed the near-black screen with only the `<h2>Appearance</h2>` header).
- Section switch: 0 flash on both pre/post (the content pane is a stable element, so its animation never replayed on switch anyway — entry-only bug).
- Reduced-motion: instant, 0 animating frames, 0 flash. Drill-down (2-col, ← Murmur, Esc) unregressed; console clean (no NG0600/ɵcmp).
- `scripts/ci.sh` → ✅ all gates green.

Honest gap: verified in Chromium against the `ng build` dist (pure CSS-animation timing, no CSP dependency, so Chromium is faithful here); real WKWebView paint on a notarized build not covered.