### PR TITLE
feat: enhance-my-notes — typed notes become the summary skeleton

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -100,6 +100,11 @@ pub struct AppConfigDto {
     pub voice_trigger: bool,
     pub onboarded: bool,
     pub note_style: String,
+    /// ENHANCE-MY-NOTES mode: "enhance" | "append" ("" from an older FE ⇒ "enhance").
+    /// `#[serde(default)]` ⇒ an older FE payload that omits `notesMode` deserializes to `""`
+    /// (the `dto_to_config` empty-guard then falls back to `"enhance"`).
+    #[serde(default)]
+    pub notes_mode: String,
     pub auto_organize: bool,
     pub note_language: String,
     /// E3/security: default true (matches AppConfig::default) when the FE omits it on an older
@@ -3109,6 +3114,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         voice_trigger: c.voice_trigger,
         onboarded: c.onboarded,
         note_style: c.note_style.clone(),
+        notes_mode: c.notes_mode.clone(),
         auto_organize: c.auto_organize,
         note_language: c.note_language.clone(),
         mcp_require_token: c.mcp_require_token,
@@ -3183,6 +3189,14 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
             "standard".to_string()
         } else {
             d.note_style
+        },
+        // ENHANCE-MY-NOTES: an older FE that omits `notesMode` (or sends `""`) falls back to
+        // `"enhance"` — the mode that makes the feature do something, and the safe default for
+        // new installs. `#[serde(default)]` on the DTO field ensures an omitted key gives `""`.
+        notes_mode: if d.notes_mode.trim().is_empty() {
+            "enhance".to_string()
+        } else {
+            d.notes_mode
         },
         auto_organize: d.auto_organize,
         note_language: if d.note_language.trim().is_empty() {

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -679,6 +679,7 @@ async fn summarize_and_export(
         template: template::build_template(&config.note_style, &config.note_language),
         vault_titles,
         related_context,
+        user_notes: None, // ENHANCE-MY-NOTES: Task 4 replaces this with the conditional wiring
     };
 
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -668,6 +668,14 @@ async fn summarize_and_export(
         config,
     );
 
+    // ENHANCE-MY-NOTES: fetch the typed-notes buffer BEFORE building the request — in
+    // "enhance" mode the notes ride INSIDE the prompt as the skeleton (a NEW, deliberate,
+    // REDACTED egress of user-typed content — see summarize/redact.rs); in "append" mode
+    // (or with an empty buffer) they stay out of the prompt exactly as before. The buffer
+    // read is ungated by design here (the pipeline is the producer of the note plaintext;
+    // resummarize is gated upstream by meeting_is_unlocked).
+    let manual_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
+
     let request = SummarizeRequest {
         transcript: transcript_text.to_string(),
         meta: MeetingMeta {
@@ -679,20 +687,20 @@ async fn summarize_and_export(
         template: template::build_template(&config.note_style, &config.note_language),
         vault_titles,
         related_context,
-        user_notes: None, // ENHANCE-MY-NOTES: Task 4 replaces this with the conditional wiring
+        user_notes: if config.notes_mode == "enhance" && !manual_notes.trim().is_empty() {
+            Some(manual_notes.clone())
+        } else {
+            None
+        },
     };
 
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;
 
-    // brain2 realtime notes FOLD: append the user's OWN typed in-meeting notes to the generated note
-    // under a `## My notes` section, BEFORE the note is persisted/exported/sealed. The `manual_notes`
-    // buffer is the DURABLE CANONICAL store of the typed notes — it is NOT blanked here, so this fold
-    // re-runs on EVERY (re)summarize: a regenerated note (which has no `## My notes` yet) gets one
-    // clean append, and a Resummarize can never drop the typed notes. Empty buffer ⇒ `markdown` is
-    // byte-identical to the generated note (no behavior change). The buffer's at-rest protection on a
-    // locked folder is the seal-and-restore lifecycle (`seal_manual_notes` + unseal), not blanking.
-    let manual_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
-    let markdown = fold_manual_notes(&generated, &manual_notes);
+    // brain2 realtime notes FINALIZE: `finalize_note_markdown` either stamps the enhance
+    // marker (notes were in the prompt) or appends `## My notes` verbatim (append mode).
+    // The `manual_notes` buffer stays the DURABLE CANONICAL store — never blanked here, so
+    // every (re)summarize re-reads it fresh in EITHER mode; empty buffer ⇒ byte-identical.
+    let markdown = finalize_note_markdown(&generated, &manual_notes, &config.notes_mode);
 
     state
         .db
@@ -917,6 +925,35 @@ fn fold_manual_notes(markdown: &str, manual_notes: &str) -> String {
         return markdown.to_string();
     }
     format!("{markdown}\n\n## My notes\n\n{notes}\n")
+}
+
+/// ENHANCE-MY-NOTES finalize: decide how the typed notes reach the stored note.
+/// - "enhance" + non-blank notes ⇒ the notes were already IN the prompt as the skeleton
+///   (Task: user_notes on SummarizeRequest); do NOT append them again — stamp the
+///   `murmur_enhanced: true` front-matter marker instead (the FE badge + honest provenance).
+/// - anything else (append mode, empty buffer, unknown mode) ⇒ the legacy verbatim fold,
+///   whose empty case is byte-identical passthrough. Pure + Db-free (unit-testable).
+fn finalize_note_markdown(generated: &str, manual_notes: &str, notes_mode: &str) -> String {
+    if notes_mode == "enhance" && !manual_notes.trim().is_empty() {
+        mark_enhanced(generated)
+    } else {
+        fold_manual_notes(generated, manual_notes)
+    }
+}
+
+/// Insert `murmur_enhanced: true` as the first YAML front-matter line — a DETERMINISTIC
+/// backend stamp (never model-generated, so it can't be forgotten or hallucinated).
+/// No/unterminated front-matter ⇒ returned unchanged; already stamped ⇒ unchanged.
+fn mark_enhanced(markdown: &str) -> String {
+    if markdown.contains("murmur_enhanced:") {
+        return markdown.to_string();
+    }
+    match markdown.strip_prefix("---\n") {
+        Some(rest) if rest.contains("\n---") => {
+            format!("---\nmurmur_enhanced: true\n{rest}")
+        }
+        _ => markdown.to_string(),
+    }
 }
 
 /// brain2 RAG Phase 2b — the GATED entry point for indexing a note into the vector layer. Pure +
@@ -1459,6 +1496,50 @@ mod tests {
         assert!(folded.starts_with(note), "preserves the generated note");
         assert!(folded.contains("## My notes"), "adds the My notes heading: {folded}");
         assert!(folded.contains("ship Friday; Anna owns QA"), "embeds the typed notes verbatim");
+    }
+
+    /// ENHANCE-MY-NOTES: the mode switch. Empty notes ⇒ byte-identical in BOTH modes (the hard
+    /// invariant); append + notes ⇒ exactly today's verbatim fold; enhance + notes ⇒ the
+    /// front-matter marker is stamped, NO verbatim `## My notes` section, body preserved;
+    /// unknown mode ⇒ defensive fall-back to the legacy fold.
+    #[test]
+    fn finalize_note_markdown_switches_between_enhance_and_append() {
+        let note = "---\ntitle: Sync\n---\n# Sync\n\n- decided X";
+        assert_eq!(finalize_note_markdown(note, "", "enhance"), note);
+        assert_eq!(finalize_note_markdown(note, "", "append"), note);
+        assert_eq!(finalize_note_markdown(note, "   \n\t ", "enhance"), note);
+        assert_eq!(
+            finalize_note_markdown(note, "ship Friday", "append"),
+            fold_manual_notes(note, "ship Friday"),
+            "append mode is byte-identical to today's fold"
+        );
+        let enhanced = finalize_note_markdown(note, "ship Friday", "enhance");
+        assert!(enhanced.contains("murmur_enhanced: true"), "marker stamped: {enhanced}");
+        assert!(!enhanced.contains("## My notes"), "no verbatim section in enhance mode");
+        assert!(enhanced.contains("# Sync"), "generated body preserved");
+        assert_eq!(
+            finalize_note_markdown(note, "x", "banana"),
+            fold_manual_notes(note, "x"),
+            "unknown mode falls back to the legacy fold"
+        );
+    }
+
+    /// The marker is a deterministic backend stamp: inserted as the first front-matter line,
+    /// idempotent, and a no-op when the provider output has no front-matter (defensive —
+    /// ollama output may lack it).
+    #[test]
+    fn mark_enhanced_stamps_front_matter_idempotently() {
+        let note = "---\ntitle: T\n---\n# T";
+        let stamped = mark_enhanced(note);
+        assert!(
+            stamped.starts_with("---\nmurmur_enhanced: true\ntitle: T\n"),
+            "marker is the first front-matter line: {stamped}"
+        );
+        assert_eq!(mark_enhanced(&stamped), stamped, "idempotent");
+        let bare = "# No front matter";
+        assert_eq!(mark_enhanced(bare), bare, "no front-matter ⇒ unchanged");
+        let unterminated = "---\ntitle: broken";
+        assert_eq!(mark_enhanced(unterminated), unterminated, "unterminated fm ⇒ unchanged");
     }
 
     /// brain2 realtime notes FOLD + COUNTEREXAMPLE B (the seam `summarize_and_export` runs, minus

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -114,6 +114,14 @@ pub struct AppConfig {
     pub onboarded: bool,
     /// Summary style preset: "standard" | "brief" | "detailed" | "action".
     pub note_style: String,
+    /// ENHANCE-MY-NOTES: how the user's typed in-meeting notes shape the summary.
+    /// "enhance" (default) — the notes become the SKELETON of the generated note (they ride
+    /// INSIDE the redacted provider prompt — a deliberate, loud, consent-riding egress);
+    /// "append" — legacy: transcript-only summary + verbatim `## My notes` section.
+    /// Empty/unknown values fall back to "enhance".
+    /// `#[serde(default)]` ⇒ a config persisted before this field existed loads as `"enhance"`.
+    #[serde(default)]
+    pub notes_mode: String,
     /// When true, Claude files each note into a thematic subfolder of the vault.
     pub auto_organize: bool,
     /// Summary note language: "auto" (match the meeting) | "en" | "pl" | "de" | ... .
@@ -298,6 +306,7 @@ impl Default for AppConfig {
             voice_trigger: false,
             onboarded: false,
             note_style: "standard".to_string(),
+            notes_mode: "enhance".to_string(),
             auto_organize: false,
             note_language: "auto".to_string(),
             mcp_require_token: true,
@@ -351,6 +360,7 @@ const K_MODEL_SIZE: &str = "model_size";
 const K_VOICE_TRIGGER: &str = "voice_trigger";
 const K_ONBOARDED: &str = "onboarded";
 const K_NOTE_STYLE: &str = "note_style";
+const K_NOTES_MODE: &str = "notes_mode";
 const K_AUTO_ORGANIZE: &str = "auto_organize";
 const K_NOTE_LANGUAGE: &str = "note_language";
 const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
@@ -455,6 +465,11 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_NOTE_STYLE)? {
             if !v.is_empty() {
                 cfg.note_style = v;
+            }
+        }
+        if let Some(v) = db.get_setting(K_NOTES_MODE)? {
+            if !v.is_empty() {
+                cfg.notes_mode = v;
             }
         }
         if let Some(v) = db.get_setting(K_AUTO_ORGANIZE)? {
@@ -595,6 +610,7 @@ impl AppConfig {
         )?;
         db.set_setting(K_ONBOARDED, if self.onboarded { "true" } else { "false" })?;
         db.set_setting(K_NOTE_STYLE, &self.note_style)?;
+        db.set_setting(K_NOTES_MODE, &self.notes_mode)?;
         db.set_setting(
             K_AUTO_ORGANIZE,
             if self.auto_organize { "true" } else { "false" },
@@ -733,6 +749,13 @@ mod tests {
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         )
         .unwrap()
+    }
+
+    /// ENHANCE-MY-NOTES: the mode defaults to "enhance" for fresh installs AND for existing
+    /// users (AppConfig::load falls back to Default for a never-written key).
+    #[test]
+    fn notes_mode_defaults_to_enhance() {
+        assert_eq!(AppConfig::default().notes_mode, "enhance");
     }
 
     #[test]

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -38,6 +38,13 @@ pub struct SummarizeRequest {
     /// (not sealed-not-unlocked) prior notes — see `summarize::related_context::build_related_context`.
     /// It is redacted by `RedactingProvider` alongside the transcript before egress.
     pub related_context: Option<String>,
+    /// ENHANCE-MY-NOTES: the user's own typed in-meeting notes (the `manual_notes` buffer —
+    /// raw `\n`-joined lines, NOT markdown bullets), present ONLY when `notes_mode == "enhance"`
+    /// AND the buffer is non-blank. `None` ⇒ `render_user_content` is byte-identical to before
+    /// this field existed (same contract as `related_context`). SECURITY: this string EGRESSES
+    /// to the provider in the prompt — `RedactingProvider` MUST scrub it alongside the
+    /// transcript (summarize/redact.rs) before egress. Today's append mode never egresses it.
+    pub user_notes: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -217,6 +224,7 @@ mod tests {
             template: String::new(),
             vault_titles: vec![],
             related_context: None,
+            user_notes: None,
         };
         let (text, meta) = p.summarize_with_meta(&req).await.unwrap();
         assert_eq!(text, "note body");

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -406,6 +406,13 @@ impl SummarizerProvider for RedactingProvider {
             .related_context
             .as_ref()
             .map(|c| redact_into(c, &mut map, &mut rev));
+        // ENHANCE-MY-NOTES: the typed notes ride the prompt in enhance mode — scrub them
+        // through the SAME shared map as the transcript so a value redacted anywhere
+        // restores consistently in the reply.
+        let red_notes = req
+            .user_notes
+            .as_ref()
+            .map(|c| redact_into(c, &mut map, &mut rev));
         // Name layer (default no-op → text unchanged, `name_pairs` empty → byte-identical egress).
         let (red_transcript, mut name_pairs) = self.names.redact_names(&red_transcript);
         let red_related = red_related.map(|c| {
@@ -413,12 +420,19 @@ impl SummarizerProvider for RedactingProvider {
             name_pairs.extend(more);
             c2
         });
+        let red_notes = red_notes.map(|c| {
+            let (c2, more) = self.names.redact_names(&c);
+            name_pairs.extend(more);
+            c2
+        });
         // Byte sizes of the REDACTED content (sizes, never the text itself).
         let user_bytes = red_transcript.len()
-            + red_related.as_ref().map(|c| c.len()).unwrap_or(0);
+            + red_related.as_ref().map(|c| c.len()).unwrap_or(0)
+            + red_notes.as_ref().map(|c| c.len()).unwrap_or(0);
         let mut r = req.clone();
         r.transcript = red_transcript;
         r.related_context = red_related;
+        r.user_notes = red_notes;
         let (out, meta) = self.inner.summarize_with_meta(&r).await?;
         // Restore both layers in the reply (disjoint token namespaces; order-independent).
         let out = restore_names(&out, &name_pairs);
@@ -1074,6 +1088,53 @@ mod tests {
         assert!(
             !debug.contains("contact"),
             "response content must NOT appear in the egress entry debug output: {debug}"
+        );
+    }
+
+    // ── ENHANCE-MY-NOTES: user_notes redaction firewall ─────────────────────
+
+    /// Captures the exact SummarizeRequest the wrapped (i.e. EGRESSING) provider receives.
+    struct CapturingInner(std::sync::Mutex<Option<SummarizeRequest>>);
+
+    #[async_trait]
+    impl SummarizerProvider for CapturingInner {
+        fn id(&self) -> &str {
+            "capture-full"
+        }
+        async fn availability(&self) -> Availability {
+            Availability::Available
+        }
+        async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+            *self.0.lock().unwrap() = Some(req.clone());
+            Ok("---\ntitle: T\n---\n# T\n".to_string())
+        }
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    /// ENHANCE-MY-NOTES: user_notes EGRESSES in enhance mode, so it MUST pass the same
+    /// redaction firewall as the transcript — emails/phones never leave un-scrubbed.
+    ///
+    /// RED evidence (before fix): `r.user_notes = red_notes;` was absent; `req.clone()` forwarded
+    /// the raw `user_notes` verbatim to the inner provider → email present in egressed request.
+    /// GREEN after fix: the same shared map + name-layer pass applied, email replaced with token.
+    #[test]
+    fn user_notes_are_redacted_before_egress() {
+        let mut req = sample_req("no PII in transcript");
+        req.user_notes = Some("ping bob@corp.com about the deck".to_string());
+        let inner = std::sync::Arc::new(CapturingInner(std::sync::Mutex::new(None)));
+        let provider = RedactingProvider::new(inner.clone());
+        block_on(provider.summarize(&req)).unwrap();
+        let egressed = inner.0.lock().unwrap().clone().expect("inner was called");
+        let notes = egressed.user_notes.expect("user_notes forwarded to inner");
+        assert!(
+            !notes.contains("bob@corp.com"),
+            "email must not egress un-redacted: {notes}"
+        );
+        assert!(
+            notes.contains("about the deck"),
+            "non-PII text must pass through: {notes}"
         );
     }
 }

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -629,6 +629,7 @@ mod tests {
             template: String::new(),
             vault_titles: Vec::new(),
             related_context: None,
+            user_notes: None,
         }
     }
 

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -214,6 +214,33 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
         }
     }
 
+    // ENHANCE-MY-NOTES: the user's typed notes become the SKELETON of the note. The block is
+    // instruction + verbatim notes; absent/blank ⇒ byte-identical output (mirrors
+    // related_context above). Each raw line = one user item (the buffer is \n-joined lines).
+    if let Some(notes) = &req.user_notes {
+        if !notes.trim().is_empty() {
+            out.push_str(
+                "\n## The user's own in-meeting notes (SKELETON — build the note around these)\n\
+                 The user typed these during the meeting, one item per line, in order. They are \
+                 the strongest signal of what mattered. Requirements:\n\
+                 - Use them as the outline: cover EVERY item, in the user's order, keeping the \
+                 user's wording (fix only obvious typos).\n\
+                 - Expand each item with concrete detail from the transcript — decisions, owners, \
+                 dates, numbers.\n\
+                 - After covering every item, add one section headed exactly `## Also discussed` \
+                 for significant transcript topics the notes missed; omit it when nothing \
+                 significant remains.\n\
+                 - Never invent content that is not grounded in the transcript or these notes.\n\
+                 - Never output a section titled `My notes`.\n\
+                 - Never repeat a section heading; keep every formatting requirement from the \
+                 instructions above (front-matter first, section structure, wikilinks).\n\
+                 USER NOTES:\n",
+            );
+            out.push_str(notes.trim());
+            out.push('\n');
+        }
+    }
+
     out.push_str("\nTRANSCRIPT\n");
     out.push_str(&req.transcript);
     out.push('\n');
@@ -238,6 +265,7 @@ mod tests {
             template: "TEMPLATE".to_string(),
             vault_titles: vec!["Roadmap".to_string()],
             related_context: related,
+            user_notes: None,
         }
     }
 
@@ -276,5 +304,39 @@ mod tests {
             render_user_content(&req(Some("   \n".to_string()))),
             render_user_content(&req(None))
         );
+    }
+
+    /// ENHANCE-MY-NOTES: `user_notes: None` (and blank) render a prompt byte-identical to the
+    /// pre-field behavior — the same contract `related_context` established.
+    #[test]
+    fn user_notes_none_or_blank_renders_without_skeleton_block() {
+        let base = render_user_content(&req(None));
+        assert!(
+            !base.contains("SKELETON"),
+            "no skeleton block without notes: {base}"
+        );
+        let mut blank = req(None);
+        blank.user_notes = Some("   \n\t ".to_string());
+        assert_eq!(
+            render_user_content(&blank),
+            base,
+            "blank notes must be byte-identical to None"
+        );
+    }
+
+    /// The skeleton block lands AFTER the related-notes block and BEFORE the transcript,
+    /// carries the notes verbatim, and instructs the `## Also discussed` / no-`My notes` contract.
+    #[test]
+    fn user_notes_block_renders_between_related_and_transcript() {
+        let mut r = req(Some("### [[Prior]] · 2026-06-01 · id:x\nprior body".to_string()));
+        r.user_notes = Some("ship Friday\nAnna owns QA".to_string());
+        let s = render_user_content(&r);
+        let related_at = s.find("## Related prior notes").expect("related block present");
+        let notes_at = s.find("ship Friday\nAnna owns QA").expect("notes verbatim");
+        let transcript_at = s.find("\nTRANSCRIPT\n").expect("transcript section");
+        assert!(related_at < notes_at, "skeleton after related notes");
+        assert!(notes_at < transcript_at, "skeleton before transcript");
+        assert!(s.contains("## Also discussed"), "instructs the Also discussed section");
+        assert!(s.contains("Never output a section titled"), "forbids a My notes section");
     }
 }

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -203,6 +203,11 @@ export class MeetingConversationStore {
   readonly notes = this._notes.asReadonly();
   /** Whether anything exists yet (drives the empty-state copy). */
   readonly hasNotes = computed(() => this._notes().length > 0);
+  /** ENHANCE-MY-NOTES: true once at least one REAL persisted note line exists — i.e. what
+   *  the summarizer will actually see (un-accepted @brain anchors are persisted:false). */
+  readonly hasPersistedNotes = computed(() =>
+    this._notes().some((n) => n.persisted && n.text.trim().length > 0),
+  );
 
   /**
    * True once the active meeting's notes have finished hydrating from

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -86,6 +86,9 @@ export interface AppConfigDto {
   voiceTrigger: boolean;
   onboarded: boolean;
   noteStyle: string;
+  /** ENHANCE-MY-NOTES: how typed in-meeting notes shape the summary — "enhance" (they
+   *  become the skeleton of the note) | "append" (verbatim `## My notes` section). */
+  notesMode: string;
   autoOrganize: boolean;
   noteLanguage: string;
   /**

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -91,6 +91,9 @@ interface ParsedNote {
   sections: NoteSection[];
   /** Set only when the body contained no `## ` sections — raw fallback. */
   raw: string | null;
+  /** ENHANCE-MY-NOTES: true when the backend stamped `murmur_enhanced: true` (the note's
+   *  skeleton was the user's typed notes). Derived ONLY from note.markdown — lock-safe. */
+  enhanced: boolean;
 }
 
 @Component({
@@ -180,6 +183,17 @@ interface ParsedNote {
                   <app-lock-badge [exposure]="fb.exposure" />
                   {{ fb.name }}
                 </span>
+              }
+              <!-- ENHANCE-MY-NOTES: provenance badge — shown only when the backend
+                   stamped murmur_enhanced: true in the front-matter. Derives from
+                   the note() computed (parseNote over markdown) — nil for locked/
+                   masked meetings where markdown is null, so no leak. -->
+              @if (note()?.enhanced) {
+                <span class="meta-sep" aria-hidden="true">·</span>
+                <span
+                  class="pill pill-enhanced"
+                  title="Your typed notes were used as the skeleton of this summary"
+                >✨ Enhanced from your notes</span>
               }
             </div>
 
@@ -631,7 +645,7 @@ interface ParsedNote {
           }
 
           <!-- 2) RICH ANALYSIS ---------------------------------------------- -->
-          <section class="block print-keep">
+          <section class="block print-keep" [class.is-resummarizing]="busy()">
             <div class="block-head">
               <h3>Analysis</h3>
               @if (!editing() && note()?.tags?.length) {
@@ -1844,6 +1858,13 @@ interface ParsedNote {
           animation: none !important;
         }
       }
+
+      /* ── ENHANCE-MY-NOTES: re-summarize working overlay ── */
+      .is-resummarizing {
+        opacity: .55;
+        pointer-events: none;
+        transition: opacity var(--transition);
+      }
     `,
   ],
 })
@@ -2373,7 +2394,12 @@ export class DetailComponent implements OnInit {
     this.msg.set("Re-summarizing…");
     try {
       await this.ipc.resummarize(id);
-      this.detail.set(await this.ipc.getMeetingDetail(id));
+      const fresh = await this.ipc.getMeetingDetail(id);
+      // Drop late responses: the user may have navigated (openRelated) mid-flight —
+      // never clobber a different meeting's detail with this closure's re-fetch.
+      if (this.detail()?.meeting?.id === id) {
+        this.detail.set(fresh);
+      }
       this.msg.set("Done.");
     } catch (e) {
       this.msg.set("Error: " + String(e));
@@ -3022,6 +3048,7 @@ export class DetailComponent implements OnInit {
 
     let tags: string[] = [];
     let participants: string[] = [];
+    let enhanced = false;
     let bodyStart = 0;
 
     // Front-matter must be the very first non-empty content.
@@ -3031,6 +3058,7 @@ export class DetailComponent implements OnInit {
         const fm = lines.slice(1, end);
         tags = this.readFrontMatterList(fm, "tags");
         participants = this.readFrontMatterList(fm, "participants");
+        enhanced = fm.some((l) => /^murmur_enhanced\s*:\s*true\b/i.test(l.trim()));
         bodyStart = end + 1;
       }
     }
@@ -3057,10 +3085,10 @@ export class DetailComponent implements OnInit {
     if (sections.length === 0) {
       // No structured sections — surface the body (sans front-matter) raw.
       const raw = body.join("\n").trim();
-      return { tags, participants, sections: [], raw: raw || markdown.trim() };
+      return { tags, participants, sections: [], raw: raw || markdown.trim(), enhanced };
     }
 
-    return { tags, participants, sections, raw: null };
+    return { tags, participants, sections, raw: null, enhanced };
   }
 
   /** Classify a section by its heading + content, then shape its data. */

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1535,6 +1535,7 @@ export class OnboardingComponent implements OnInit {
       voiceTrigger: base?.voiceTrigger ?? false,
       onboarded: markOnboarded ? true : (base?.onboarded ?? false),
       noteStyle: base?.noteStyle ?? "standard",
+      notesMode: base?.notesMode ?? "enhance",
       autoOrganize: base?.autoOrganize ?? false,
       noteLanguage: base?.noteLanguage ?? "auto",
       // Stage E security flags — read the current values from the snapshot and send

--- a/src/app/features/record/meeting-conversation.component.ts
+++ b/src/app/features/record/meeting-conversation.component.ts
@@ -79,10 +79,24 @@ export function parseBrainLine(text: string): string | null {
   template: `
     <div class="card surface" role="group" aria-label="In-meeting notes">
       <div class="surface-head">
-        <app-ai-orb class="head-orb" [state]="store.orbState()" />
+        <app-ai-orb class="head-orb" [state]="orbStateView()" />
         <span class="surface-title">Notes</span>
-        <span class="surface-hint">
-          Type <span class="kbd">&#64;brain</span> to ask in a thread
+        <span
+          class="surface-hint"
+          role="status"
+          aria-live="polite"
+          [class.is-enhancing]="enhancing()"
+          [class.is-settled]="settled()"
+        >
+          @if (enhancing()) {
+            Enhancing your notes…
+          } @else if (settled()) {
+            ✨ Notes enhanced — your bullets became the outline.
+          } @else if (enhanceAware() && store.hasPersistedNotes()) {
+            ✨ These bullets will shape your summary
+          } @else {
+            Type <span class="kbd">&#64;brain</span> to ask in a thread
+          }
         </span>
       </div>
 
@@ -94,7 +108,7 @@ export function parseBrainLine(text: string): string | null {
         <app-proactive-hint-card [hint]="h" (dismissed)="store.dismissHint()" />
       }
 
-      <div class="flow" #flow>
+      <div class="flow" #flow [class.is-enhancing]="enhancing()">
         @if (!store.hasNotes()) {
           <p class="flow-empty text-muted">
             Jot your notes here — they're saved with the meeting. Type
@@ -102,8 +116,12 @@ export function parseBrainLine(text: string): string | null {
             assistant answers there and you choose what to add to your notes.
           </p>
         }
-        @for (n of store.notes(); track n.id) {
-          <app-note-item [note]="n" (followed)="scrollToBottom()" />
+        @for (n of store.notes(); track n.id; let i = $index) {
+          <app-note-item
+            [note]="n"
+            (followed)="scrollToBottom()"
+            [style.animation-delay.ms]="enhancing() ? sweepDelay(i) : null"
+          />
         }
       </div>
 
@@ -142,7 +160,7 @@ export function parseBrainLine(text: string): string | null {
             [disabled]="!store.loaded()"
             [placeholder]="
               store.loaded()
-                ? 'pisz notatkę… (@brain to open a thread)'
+                ? 'write a note… (@brain to open a thread)'
                 : 'Loading notes…'
             "
             [value]="draft()"
@@ -413,6 +431,50 @@ export function parseBrainLine(text: string): string | null {
           animation: none;
         }
       }
+
+      /* ── ENHANCE-MY-NOTES: one-shot Quiet-Weave sweep over the note lines ── */
+      .flow app-note-item {
+        display: block;
+        transition: box-shadow var(--transition);
+      }
+      .flow.is-enhancing app-note-item {
+        border-radius: var(--radius-sm);
+        background-image: linear-gradient(
+          100deg,
+          transparent 32%,
+          color-mix(in srgb, var(--accent) 12%, transparent) 50%,
+          transparent 68%
+        );
+        background-size: 250% 100%;
+        background-repeat: no-repeat;
+        background-position: 200% 0; /* parked off-canvas after the single pass */
+        animation: enhance-sweep 900ms ease-in-out both;
+        box-shadow: inset 2px 0 0
+          color-mix(in srgb, var(--accent) 35%, transparent);
+      }
+      @keyframes enhance-sweep {
+        from {
+          background-position: -150% 0;
+        }
+        to {
+          background-position: 200% 0;
+        }
+      }
+      .surface-hint.is-enhancing,
+      .surface-hint.is-settled {
+        color: var(--accent);
+        animation: rise 200ms var(--transition) both;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .flow.is-enhancing app-note-item {
+          animation: none;
+          background-image: none; /* the static inset accent edge remains as the cue */
+        }
+        .surface-hint.is-enhancing,
+        .surface-hint.is-settled {
+          animation: none;
+        }
+      }
     `,
   ],
 })
@@ -435,6 +497,21 @@ export class MeetingConversationComponent implements OnInit {
    * the backend default.
    */
   readonly hintsEnabled = input<boolean>(true);
+
+  /** ENHANCE-MY-NOTES presentation inputs (pure; all state lives in root stores). */
+  readonly enhancing = input(false);
+  readonly settled = input(false);
+  readonly enhanceAware = input(false);
+
+  /** During the enhance pass the orb shows its shipped 'processing' choreography. */
+  readonly orbStateView = computed(() =>
+    this.enhancing() ? ("processing" as const) : this.store.orbState(),
+  );
+
+  /** Stagger for the one-shot sweep — capped so short summarizes still show a full pass. */
+  sweepDelay(i: number): number {
+    return Math.min(i, 10) * 180;
+  }
 
   /** The composer draft (signal-backed — zoneless). */
   protected readonly draft = signal("");

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -225,6 +225,9 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
           class="conversation"
           [meetingId]="store.meetingId()"
           [hintsEnabled]="hintsEnabled()"
+          [enhancing]="enhancingNotes()"
+          [settled]="enhanceSettled()"
+          [enhanceAware]="enhanceMode()"
         />
       }
 
@@ -1050,6 +1053,25 @@ export class RecordComponent implements OnInit {
     () => this.config()?.proactiveHintsEnabled ?? true,
   );
 
+  /** ENHANCE-MY-NOTES: mode from config; missing/empty ⇒ enhance (the backend default). */
+  readonly enhanceMode = computed(
+    () => (this.config()?.notesMode ?? "enhance") === "enhance",
+  );
+  /** The hero trigger: summarizing a meeting whose notes will be the skeleton. */
+  readonly enhancingNotes = computed(
+    () =>
+      this.enhanceMode() &&
+      this.assistant.hasPersistedNotes() &&
+      this.store.stage() === "summarizing",
+  );
+  /** Settled: done + the notes were enhanced — keeps the surface up through "Saved ✓". */
+  readonly enhanceSettled = computed(
+    () =>
+      this.enhanceMode() &&
+      this.assistant.hasPersistedNotes() &&
+      this.store.stage() === "done",
+  );
+
   /**
    * Show the conversation thread — the full-height main surface of the
    * conversation-first record screen. It is the home for BOTH note-taking AND
@@ -1071,7 +1093,11 @@ export class RecordComponent implements OnInit {
       this.store.isRecording() ||
       this.assistant.listening() ||
       this.assistant.processing() ||
-      this.assistant.manualAskInFlight()
+      this.assistant.manualAskInFlight() ||
+      (this.enhanceMode() &&
+        this.isProcessing() &&
+        this.assistant.hasPersistedNotes()) ||
+      this.enhanceSettled()
     );
   });
 
@@ -1199,12 +1225,20 @@ export class RecordComponent implements OnInit {
         return "Mic muted — still capturing others. Press ⌘R or Stop when done.";
       return "Recording — press ⌘R or Stop when done.";
     }
-    if (this.isProcessing()) return "Transcribing on-device, then summarizing…";
+    if (this.isProcessing())
+      return this.enhanceMode() && this.assistant.hasPersistedNotes()
+        ? "Transcribing on-device, then enhancing your notes…"
+        : "Transcribing on-device, then summarizing…";
     if (this.modelPresent() === false) return "Download the model to start.";
-    if (this.store.stage() === "done")
+    if (this.store.stage() === "done") {
+      if (this.enhanceSettled())
+        return this.vaultMissing()
+          ? "Saved ✓ — your enhanced note is in Murmur."
+          : "Saved ✓ — your enhanced note is in the vault.";
       return this.vaultMissing()
         ? "Saved ✓ — your note is in Murmur."
         : "Saved ✓ — your note is in the vault.";
+    }
     return "On-device transcription · your audio never leaves this Mac.";
   });
 

--- a/src/app/features/settings/sections/settings-notes-section.component.ts
+++ b/src/app/features/settings/sections/settings-notes-section.component.ts
@@ -52,6 +52,32 @@ import { SettingsStore } from "../settings.store";
                 </label>
 
                 <label class="field">
+                  <span class="field-label">Your typed notes</span>
+                  <select formControlName="notesMode">
+                    <option value="enhance">
+                      Enhance — your notes become the outline (recommended)
+                    </option>
+                    <option value="append">Append — keep them verbatim below</option>
+                  </select>
+                  <span class="field-help text-muted">
+                    @switch (form.controls.notesMode.value) {
+                      @case ("append") {
+                        The summary is written from the transcript alone; your typed
+                        notes are added verbatim as a "My notes" section at the end.
+                      }
+                      @default {
+                        Your in-meeting bullets become the skeleton of the note — kept
+                        in your words and order, expanded with detail from the
+                        transcript, plus an "Also discussed" section for anything you
+                        didn't jot down. Notes pass the same redaction firewall as the
+                        transcript before any cloud call.
+                      }
+                    }
+                    Meetings where you typed nothing are identical in both modes.
+                  </span>
+                </label>
+
+                <label class="field">
                   <span class="field-label">Notes language</span>
                   <select formControlName="noteLanguage">
                     <option value="auto">Auto — match the meeting</option>

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -37,7 +37,7 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   { id: "general", label: "General", keywords: "vault folder subfolder whisper model path setup onboarding" },
   { id: "transcription", label: "Transcription", keywords: "language quality whisper model download on-device size accuracy" },
   { id: "audio", label: "Audio & Capture", keywords: "microphone input device system audio vad smart speech detection high fidelity masters diarization remote speakers echo cancellation aec voice trigger hands-free" },
-  { id: "notes", label: "Notes", keywords: "summary style brief detailed action language auto organize subfolders thematic" },
+  { id: "notes", label: "Notes", keywords: "summary style brief detailed action language auto organize subfolders thematic enhance skeleton typed notes append" },
   // Stage-2 hub: Brain & AI + Providers collapsed into ONE section (keywords merged).
   { id: "ai", label: "AI & Models", keywords: "provider assistant backend cloud local gguf model reasoning effort semantic search embedding reindex in-meeting voice assistant wake anthropic ollama claude code gateway openai api key availability binary default consent revoke privacy egress" },
   { id: "connectors", label: "Connectors", keywords: "web search brave egress api key internet" },

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -128,6 +128,7 @@ export class SettingsStore {
     modelSize: "large-v3",
     voiceTrigger: false,
     noteStyle: "standard",
+    notesMode: "enhance",
     autoOrganize: false,
     noteLanguage: "auto",
     // Phase H — brain / in-meeting voice assistant.
@@ -846,6 +847,7 @@ export class SettingsStore {
         modelSize: cfg.modelSize ?? "large-v3",
         voiceTrigger: cfg.voiceTrigger ?? false,
         noteStyle: cfg.noteStyle ?? "standard",
+        notesMode: cfg.notesMode ?? "enhance",
         autoOrganize: cfg.autoOrganize ?? false,
         noteLanguage: cfg.noteLanguage ?? "auto",
         brainBackend: cfg.brainBackend ?? "cloud",
@@ -1119,6 +1121,7 @@ export class SettingsStore {
       voiceTrigger: v.voiceTrigger,
       onboarded: this.loadedOnboarded,
       noteStyle: v.noteStyle,
+      notesMode: v.notesMode,
       autoOrganize: v.autoOrganize,
       noteLanguage: v.noteLanguage,
       // Phase H — brain / in-meeting voice assistant.

--- a/src/styles.css
+++ b/src/styles.css
@@ -445,6 +445,8 @@ legend { padding: 0 var(--space-2); color: var(--text-secondary); font-size: 0.8
 .pill.is-danger { background: var(--danger-soft); border-color: transparent; color: var(--danger); }
 .pill.is-warning { background: var(--warning-soft); border-color: transparent; color: var(--warning); }
 .pill.is-live { background: var(--live-soft); border-color: transparent; color: var(--live-hover); }
+/* ENHANCE-MY-NOTES provenance badge (detail header). */
+.pill.pill-enhanced { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 35%, transparent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
 
 /* --- Banner ---------------------------------------------------------------- */
 .banner {


### PR DESCRIPTION
## Enhance my notes — typed notes become the summary skeleton

Adds a **notes_mode** setting (`enhance` default | `append` legacy). In **enhance** mode the user's typed
in-meeting notes (the `manual_notes` buffer) become the *skeleton* of the generated summary — kept in the
user's wording/order, expanded from the transcript, plus an "Also discussed" section — instead of today's
verbatim `## My notes` append. The note is stamped with a deterministic `murmur_enhanced: true` front-matter
marker. **Append** mode = today's behaviour. A meeting with **no typed notes is byte-identical in both modes.**

Closes the biggest craft gap vs Granola (their signature "enhance my bullets" merge), but live, local, and in
your vault — combined with our in-meeting @brain, which Granola has no equivalent of.
See `docs/research/2026-07-02-murmur-vs-granola.md`.

### What's in it (7 commits, backend → FE → verify)
- **config** — additive `notes_mode` key (`#[serde(default)]`, default `enhance`; 0 fixture edits).
- **summarize** — `SummarizeRequest.user_notes` + a conditional "skeleton" prompt block (byte-identical when absent).
- **redact** — `user_notes` scrubbed through the SAME firewall as the transcript before any cloud egress (this is
  a NEW egress of user-typed content — it now rides the existing redaction + consent gate; on ollama/local nothing leaves).
- **pipeline** — `finalize_note_markdown` + `mark_enhanced`: enhance→stamp marker, append/empty→legacy `## My notes` fold.
- **settings** — "Your typed notes" enhance/append toggle (across the split settings store + notes section).
- **record** — "Quiet Weave": a calm, one-shot CSS sweep over the note lines during summarize + a settled state, all
  pure computeds over root-store signals (PR #108-safe), reduced-motion collapses to a static edge.
- **detail** — ✨ "Enhanced from your notes" badge (derived only from the marker → null on a masked meeting = no leak),
  a dim overlay during Re-summarize, and a drop-late-responses stale-guard on `resummarize()`.

### Verification (Definition of Done)
- `cargo test --lib` **726/0**, `npx ng lint` clean, `npx ng build` clean (detail.component 13.34 kB, under the 16 kB error budget).
- **adversarial-verifier: PASS** — RED-before-GREEN on empty-notes byte-identity, marker determinism, and user_notes
  redaction; no leak/crash/content-loss/NG0600.
- **lock-security-reviewer: PASS** — new egress redacted (shared map) + consent-gated + fail-closed; `resummarize`
  stays `meeting_is_unlocked`-gated; badge cannot render on a masked meeting; no PII in logs.

### Honest gaps (need a signed build / real Mac)
- Enhance **quality** (that typed notes actually shape a better note) is model behaviour — needs a real summarize on
  `claude_code` **and** `ollama`.
- The sweep + `color-mix` badge render in `ng build` but the packaged-WKWebView + real-CSP render was not tested (T4 lesson).
- NER name-scrub of `user_notes` only removes person-names when the on-device model is present; the email/card/phone
  regex layer always runs.
