### PR TITLE
feat(library): Meetings drill-down (L2) navigation — same as Settings

### DIFF
--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -15,6 +15,7 @@ import {
   RouterOutlet,
 } from "@angular/router";
 import { filter, map } from "rxjs";
+import { isDrilldownRoute } from "./core/nav-history.service";
 import { FoldersService } from "./services/folders.service";
 import { ToastService, type Toast } from "./services/toast.service";
 
@@ -52,10 +53,11 @@ interface NavItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterOutlet, RouterLink, RouterLinkActive],
   template: `
-    <!-- Primary rail is HIDDEN under /settings: settings drills down to its own
-         two-column [section rail | content] layout (see settings.component). The
-         @if removes the aside from the DOM so the outlet's flex row fills. -->
-    @if (!inSettings()) {
+    <!-- Primary rail is HIDDEN under any drill-down route (/settings, /library):
+         each drills down to its own two-column [rail | content] layout (see
+         settings.component / library.component). The @if removes the aside from
+         the DOM so the outlet's flex row fills. -->
+    @if (!inDrilldown()) {
     <aside class="app-sidebar" [class.collapsed]="collapsed()">
       <!-- Top drag strip: reserves room for the overlay traffic lights and lets
            the user move the window (data-tauri-drag-region). Empty on purpose so
@@ -275,9 +277,9 @@ export class AppShellComponent {
 
   /**
    * The current URL, updated on every completed navigation. Seeded from
-   * `router.url` so `inSettings` is correct on a cold deep-link to `/settings`
-   * (before the first `NavigationEnd`). The subscription is framework-managed by
-   * `toSignal` — no hand-rolled `.subscribe()`.
+   * `router.url` so `inDrilldown` is correct on a cold deep-link to a drill-down
+   * route (before the first `NavigationEnd`). The subscription is framework-
+   * managed by `toSignal` — no hand-rolled `.subscribe()`.
    */
   private readonly currentUrl = toSignal(
     this.router.events.pipe(
@@ -288,11 +290,13 @@ export class AppShellComponent {
   );
 
   /**
-   * True while on any `/settings*` route. When true the primary rail is removed
-   * from the DOM so the settings drill-down owns the full width with its own
-   * two-column layout.
+   * True while on any drill-down route (`/settings*`, `/library*`). When true the
+   * primary rail is removed from the DOM so the drill-down owns the full width
+   * with its own two-column layout. Shares `isDrilldownRoute` with
+   * NavHistoryService so the rail-hide and the "← Murmur" back target stay in
+   * lockstep.
    */
-  readonly inSettings = computed(() => this.currentUrl().startsWith("/settings"));
+  readonly inDrilldown = computed(() => isDrilldownRoute(this.currentUrl()));
 
   /** Primary sidebar destinations (Settings lives in the footer as its own icon). */
   readonly navItems: readonly NavItem[] = [

--- a/src/app/core/nav-history.service.ts
+++ b/src/app/core/nav-history.service.ts
@@ -3,19 +3,30 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { NavigationEnd, Router } from "@angular/router";
 import { filter, map, scan, startWith } from "rxjs";
 
-/** Fallback destination when the user deep-links straight into settings. */
+/** Fallback destination when the user deep-links straight into a drill-down. */
 const DEFAULT_APP_ROUTE = "/record";
 
 /**
- * Tracks the last app route the user was on that is NOT under `/settings`, so the
- * settings drill-down "← Murmur" affordance can return them to where they were
- * (Meetings → back to Meetings), falling back to `/record` when there is no such
- * history (a fresh deep-link to `/settings`).
+ * A "drill-down" is an L2 overlay route that HIDES the primary rail and owns the
+ * full window with its own back-affordance (Settings and Meetings/Library both).
+ * The "← Murmur" back target must be a NON-drill-down route, so both this service
+ * and app-shell's rail-hide gate share this single predicate. Keep the two in
+ * lockstep — a new drill-down route added here must also be hidden in app-shell.
+ */
+export function isDrilldownRoute(url: string): boolean {
+  return url.startsWith("/settings") || url.startsWith("/library");
+}
+
+/**
+ * Tracks the last app route the user was on that is NOT a drill-down, so a
+ * drill-down's "← Murmur" affordance can return them to where they were
+ * (Record → Meetings → back to Record), falling back to `/record` when there is
+ * no such history (a fresh deep-link to `/settings` or `/library`).
  *
  * The router subscription lifecycle is framework-managed via `toSignal` — this
  * service never hand-rolls a `.subscribe()` that writes a field (zoneless rule).
- * The "last NON-settings" carry-over is done inside the rxjs `scan` (so we never
- * need a signal that reads its own previous value, which Angular 18.2's
+ * The "last NON-drill-down" carry-over is done inside the rxjs `scan` (so we
+ * never need a signal that reads its own previous value, which Angular 18.2's
  * `computed` cannot express and which would trip NG0600 inside an `effect`).
  */
 @Injectable({ providedIn: "root" })
@@ -23,10 +34,10 @@ export class NavHistoryService {
   private readonly router = inject(Router);
 
   /**
-   * The last completed navigation whose URL is NOT under `/settings`. `scan`
-   * keeps the prior value while the current URL is a settings route, so once
-   * inside settings this reports the pre-entry route rather than resetting.
-   * Seeded from `router.url` (via `startWith`) so a cold deep-link is handled.
+   * The last completed navigation whose URL is NOT a drill-down. `scan` keeps the
+   * prior value while the current URL is a drill-down route, so once inside a
+   * drill-down this reports the pre-entry route rather than resetting. Seeded from
+   * `router.url` (via `startWith`) so a cold deep-link is handled.
    */
   private readonly _lastAppRoute = toSignal(
     this.router.events.pipe(
@@ -34,7 +45,7 @@ export class NavHistoryService {
       map(() => this.router.url),
       startWith(this.router.url),
       scan(
-        (last, url) => (url.startsWith("/settings") ? last : url),
+        (last, url) => (isDrilldownRoute(url) ? last : url),
         DEFAULT_APP_ROUTE,
       ),
     ),
@@ -44,7 +55,7 @@ export class NavHistoryService {
   /** The route "← Murmur" returns to; defaults to `/record`. */
   readonly lastAppRoute = this._lastAppRoute;
 
-  /** Navigate back to the last non-settings route (or the default). */
+  /** Navigate back to the last non-drill-down route (or the default). */
   back(): void {
     void this.router.navigateByUrl(this.lastAppRoute());
   }

--- a/src/app/features/library/library.component.ts
+++ b/src/app/features/library/library.component.ts
@@ -11,6 +11,7 @@ import {
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { IpcService } from "../../core/ipc.service";
+import { NavHistoryService } from "../../core/nav-history.service";
 import type {
   FolderNode,
   Meeting,
@@ -40,6 +41,10 @@ interface SnippetPart {
   selector: "app-library",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // Esc in Meetings backs out ("← Murmur") — but NOT while you're typing: in the
+  // search box Esc clears/blurs it first, and it never hijacks another form field.
+  // Declarative host listener — Angular owns its lifecycle (mirrors settings).
+  host: { "(document:keydown.escape)": "onEscape()" },
   imports: [
     RouterLink,
     FolderTreeComponent,
@@ -49,7 +54,33 @@ interface SnippetPart {
   template: `
     <section class="library">
       <!-- ============ LEFT PANE — folder tree (lock-aware) ============ -->
-      <aside class="folders-pane card" aria-label="Folders">
+      <aside class="folders-pane" aria-label="Folders">
+        <!-- Drag strip mirrors the primary rail so the overlay traffic lights
+             stay clear of the Back button when the rail is flush to the edge. -->
+        <div class="rail-drag" data-tauri-drag-region></div>
+
+        <!-- Drill-down "up": returns to the last non-drill-down route (or /record). -->
+        <button
+          type="button"
+          class="rail-back"
+          (click)="nav.back()"
+          aria-label="Back to Murmur"
+        >
+          <svg
+            class="rail-back-icon"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9.5 3.5 5 8l4.5 4.5" />
+          </svg>
+          <span class="rail-back-label">Murmur</span>
+        </button>
+
         <div class="folders-head">
           <h3 class="folders-title">Folders</h3>
           @if (unlockedCount() > 0) {
@@ -90,16 +121,18 @@ interface SnippetPart {
             </button>
           }
         </div>
-        @if (foldersLoading()) {
-          <p class="folders-state empty">Loading folders…</p>
-        } @else {
-          <app-folder-tree
-            [nodes]="folderTree()"
-            [selectedId]="activeFolderId()"
-            (select)="selectFolder($event)"
-            (dropNote)="onDropNote($event)"
-          />
-        }
+        <div class="folders-body">
+          @if (foldersLoading()) {
+            <p class="folders-state empty">Loading folders…</p>
+          } @else {
+            <app-folder-tree
+              [nodes]="folderTree()"
+              [selectedId]="activeFolderId()"
+              (select)="selectFolder($event)"
+              (dropNote)="onDropNote($event)"
+            />
+          }
+        </div>
       </aside>
 
       <!-- ============ RIGHT PANE — search, filters, meeting list ============ -->
@@ -134,7 +167,6 @@ interface SnippetPart {
             aria-label="Search meetings"
             [value]="query()"
             (input)="onQueryInput($event)"
-            (keydown.escape)="clear()"
           />
           @if (query()) {
             <button
@@ -581,26 +613,111 @@ interface SnippetPart {
   `,
   styles: [
     `
-      /* Two-pane: folder tree (left) + meeting list (right). Collapses to a
-         single column on narrow widths so the list never gets squeezed. */
+      /* Meetings is a full drill-down (L2): app-shell hides the primary rail and
+         this fixed host fills the window as a flush-left [folders rail | content]
+         layout, below the toast viewport (z 60). Mirrors settings.component. */
+      :host {
+        position: fixed;
+        inset: 0;
+        z-index: 5;
+        display: block;
+        background: var(--surface-base);
+      }
+
+      /* Two-pane shell: full-height folders rail + scrolling meetings content.
+         Collapses to stacked rows on narrow widths so the list never squeezes. */
       .library {
         display: grid;
-        grid-template-columns: minmax(200px, 248px) minmax(0, 1fr);
-        align-items: start;
-        gap: var(--space-5);
+        grid-template-columns: 248px minmax(0, 1fr);
+        height: 100vh;
+        height: 100dvh;
       }
-      @media (max-width: 720px) {
-        .library {
-          grid-template-columns: 1fr;
+
+      /* --- Left pane: folder tree (lock-aware) ---
+         A first-class full-height column flush to the window edge, same visual
+         weight as the primary rail it replaces (frosted in-flow chrome, right
+         border, NOT a floating card). Mirrors .settings-sidebar. */
+      .folders-pane {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        height: 100%;
+        padding: 0 var(--space-3) var(--space-4);
+        background: var(--surface-raised);
+        -webkit-backdrop-filter: blur(var(--glass-blur))
+          saturate(var(--glass-saturate));
+        backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+        border-right: 1px solid var(--border-subtle);
+        box-shadow: var(--glass-highlight);
+        overflow: hidden;
+        animation: library-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      }
+
+      /* Enter transition — rail + meetings pane share ONE eased glide (content
+         lags 40ms). TRANSFORM ONLY, never opacity: the fixed :host is opaque
+         near-black (--surface-base), so an opacity fade would flash black then
+         jump the UI in (the bug fixed for settings). Painted opaque from frame 1,
+         it just settles into place. Disabled under reduced-motion below. */
+      @keyframes library-enter {
+        from {
+          transform: translateY(8px);
+        }
+        to {
+          transform: none;
         }
       }
 
-      /* --- Left pane: folder tree (lock-aware) --- */
-      .folders-pane {
-        position: sticky;
-        top: 0;
-        padding: var(--space-3);
+      /* Top drag strip — mirrors the primary rail so the overlay traffic lights
+         have somewhere to float and the window stays draggable up here. */
+      .rail-drag {
+        flex: none;
+        height: 30px;
       }
+
+      /* "← Murmur" drill-down up-affordance. */
+      .rail-back {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+        height: 34px;
+        padding: 0 var(--space-2);
+        border: 0;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.9rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition-fast),
+          color var(--transition-fast);
+      }
+      .rail-back:hover {
+        background: var(--surface-hover);
+        color: var(--text-primary);
+      }
+      .rail-back:focus-visible {
+        outline: none;
+        color: var(--text-primary);
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .rail-back-icon {
+        flex: none;
+        width: 16px;
+        height: 16px;
+      }
+
+      /* Folder tree scrolls independently within the fixed full-height rail. */
+      .folders-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
+      }
+
       .folders-head {
         display: flex;
         align-items: center;
@@ -657,12 +774,18 @@ interface SnippetPart {
         font-size: 0.8125rem;
       }
 
-      /* --- Right pane: stacks search, filters and the list --- */
+      /* --- Right pane: stacks search, filters and the list ---
+         Scrolls independently, with its own padding (no longer inside .app-main's
+         padded column). Shares the rail's transform-only glide (40ms lag). */
       .meetings-pane {
         display: flex;
         flex-direction: column;
         gap: var(--space-5);
         min-width: 0;
+        height: 100%;
+        overflow-y: auto;
+        padding: var(--space-6) var(--space-6) var(--space-8);
+        animation: library-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) 40ms both;
       }
 
       /* Masked title for a locked-folder note (hidden until session-unlock). */
@@ -774,11 +897,6 @@ interface SnippetPart {
         z-index: 40;
         animation: rise 160ms var(--transition) both;
       }
-      @media (prefers-reduced-motion: reduce) {
-        .move-anchor {
-          animation: none;
-        }
-      }
 
       /* --- Drag source: dim the row being dragged for a tidy affordance ---- */
       .row-item.is-dragging {
@@ -810,11 +928,6 @@ interface SnippetPart {
         white-space: nowrap;
         vertical-align: baseline;
       }
-      @media (prefers-reduced-motion: reduce) {
-        .empty-illo {
-          animation: none;
-        }
-      }
       .title--masked {
         color: var(--text-muted);
         letter-spacing: 0.12em;
@@ -833,10 +946,13 @@ interface SnippetPart {
         white-space: nowrap;
       }
 
-      /* --- Frosted search field (pinned, sticky to the scroll top) --- */
+      /* --- Frosted search field (pinned, sticky to the scroll top) ---
+         Sticks flush to the top of the meetings pane's scroll area; the negative
+         top pulls it over the pane's own top padding so it hugs the edge as the
+         list scrolls beneath it. */
       .search {
         position: sticky;
-        top: 0;
+        top: calc(var(--space-6) * -1);
         z-index: 5;
         display: flex;
         align-items: center;
@@ -1229,6 +1345,38 @@ interface SnippetPart {
           transform: rotate(360deg);
         }
       }
+
+      /* Narrow widths: stack the folders rail on top of the meetings content
+         (rows), each scrolling within the fixed full-height shell. Mirrors the
+         settings drill-down's narrow layout. */
+      @media (max-width: 720px) {
+        .library {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto minmax(0, 1fr);
+        }
+        .folders-pane {
+          border-right: 0;
+          border-bottom: 1px solid var(--border-subtle);
+        }
+        .meetings-pane {
+          padding: var(--space-5) var(--space-4) var(--space-6);
+        }
+        .search {
+          top: calc(var(--space-5) * -1);
+        }
+      }
+
+      /* Honor reduced-motion everywhere: no rail slide / content stagger (the
+         surface is opaque from frame 1, so entry is instant with no flash), and
+         no in-flow rise on the popover / empty illustration. */
+      @media (prefers-reduced-motion: reduce) {
+        .folders-pane,
+        .meetings-pane,
+        .move-anchor,
+        .empty-illo {
+          animation: none;
+        }
+      }
     `,
   ],
 })
@@ -1238,6 +1386,32 @@ export class LibraryComponent implements OnInit {
   private readonly folders = inject(FoldersService);
   private readonly drag = inject(NoteDragService);
   private readonly toast = inject(ToastService);
+
+  /** Drill-down back navigation ("← Murmur" + Esc) — no library state coupling. */
+  readonly nav = inject(NavHistoryService);
+
+  /**
+   * Esc while in Meetings. Backs out to where you came from — EXCEPT while you're
+   * typing: in the search box the first Esc clears it (or blurs when empty), and
+   * Esc is ignored inside any other form field, so it never ejects you mid-edit.
+   * Mirrors settings.component's onEscape.
+   */
+  onEscape(): void {
+    const el = document.activeElement as HTMLElement | null;
+    if (el?.classList.contains("search-input")) {
+      if (this.query().trim()) {
+        this.clear();
+      } else {
+        el.blur();
+      }
+      return;
+    }
+    const tag = el?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+      return;
+    }
+    this.nav.back();
+  }
 
   /** The meeting id whose "Move to…" folder-chip popover is open (null = none). */
   readonly movePopoverId = signal<string | null>(null);


### PR DESCRIPTION
Meetings showed **three columns** (primary app rail + a floating Folders card + the meetings list), cramping the list. Now it's a full drill-down like Settings: entering `/library` hides the primary rail so the Folders panel becomes a **full-height flush-left L2 rail** with a "← Murmur" back, and the meetings list gets the reclaimed width.

## What
- **app-shell**: `inSettings` → `inDrilldown` (`isDrilldownRoute` = `/settings` **or** `/library`); `@if (!inDrilldown())` gates the primary `<aside>`.
- **nav-history**: exported `isDrilldownRoute`; `lastAppRoute` skips **both** drill-down routes, so Back from either returns to the last non-drill-down screen (default `/record`).
- **library.component**: `:host` is now a `position:fixed; inset:0` near-black overlay; the Folders panel restyled from a floating `.card` to a full-height flush-left rail with a "← Murmur" back + Esc (search-safe `onEscape`, mirrors settings); the enter transition is a **transform-only** `library-enter` glide (`translateY 8px→0`, **no opacity**) so it never flashes near-black — the same fix shipped for the settings transition (#144). All pane internals (folder tree, filter, drag-drop, lock badges, relock pill, search, tags, list, move popover) untouched.

**Note:** like Settings, Meetings now hides the primary nav — switching to another primary tab is via "← Murmur" back to the hub.

## How verified
- `scripts/ci.sh` → ✅ all gates green.
- **Adversarial-verifier PASS** (all 6 attacks): RED-before-GREEN on the flash (patching `opacity:0` into the keyframe → 2 near-black flash frames; shipped transform-only → **0**, 44/44 frames opaque, glide animates `translateY 8→0`); `/library` shows 2 columns with the primary rail absent (present again on `/record`); Back destinations correct (`/record`, `/analytics`, cold deep-link→`/record`) **and the Settings drill-down still works** after the shared-mechanism generalization; Esc-in-search clears/blurs (doesn't eject); reduced-motion instant; folder select filters the list, lock badge + locked-note-title masking intact; **zero console errors** (no NG0600/ɵcmp).
- `library.component` styles 12.46 kB — 171 B over the 12.29 kB **warn** threshold, under the 16 kB error cap (same soft-warn class as the pre-existing `detail.component`).

Honest gap: verified in Chromium against the `ng build` dist; the real WKWebView paint on a notarized build isn't covered (no new CSP/nonce surface, so no divergence expected).