### PR TITLE
fix(nav): keep the primary rail hidden on a meeting's detail

### DIFF
--- a/src/app/core/nav-history.service.ts
+++ b/src/app/core/nav-history.service.ts
@@ -7,14 +7,21 @@ import { filter, map, scan, startWith } from "rxjs";
 const DEFAULT_APP_ROUTE = "/record";
 
 /**
- * A "drill-down" is an L2 overlay route that HIDES the primary rail and owns the
- * full window with its own back-affordance (Settings and Meetings/Library both).
- * The "← Murmur" back target must be a NON-drill-down route, so both this service
- * and app-shell's rail-hide gate share this single predicate. Keep the two in
- * lockstep — a new drill-down route added here must also be hidden in app-shell.
+ * A "drill-down" is a route that HIDES the primary rail so the current flow owns
+ * the window with its own back-affordance: Settings, Meetings/Library, AND a
+ * meeting's detail (`/meeting/:id`) — opening a meeting stays "inside" the
+ * Meetings flow (its own "← Meetings" back), so the primary rail must NOT
+ * reappear there. The "← Murmur" back target must be a NON-drill-down route, so
+ * both this service and app-shell's rail-hide gate share this single predicate.
+ * Keep the two in lockstep — a new drill-down route added here is also hidden in
+ * app-shell.
  */
 export function isDrilldownRoute(url: string): boolean {
-  return url.startsWith("/settings") || url.startsWith("/library");
+  return (
+    url.startsWith("/settings") ||
+    url.startsWith("/library") ||
+    url.startsWith("/meeting")
+  );
 }
 
 /**


### PR DESCRIPTION
Opening a meeting from the Meetings drill-down navigated to `/meeting/:id`, where the **primary nav rail reappeared** — jarring, since the detail belongs to the Meetings flow (it already has its own "← Meetings" back). One-line fix: add `/meeting` to `isDrilldownRoute` — the predicate shared by app-shell's rail-hide gate (`inDrilldown`) and `NavHistoryService` — so the rail stays hidden on the detail and "← Murmur" still skips it.

## How verified
- `scripts/ci.sh` → ✅ all gates green.
- **Adversarial-verifier PASS** with RED-before-GREEN: reverting the predicate makes **only** `/meeting/:id` fail (rail reappears = the bug); restored → all 10 routes correct (`/record` present; `/library`/`/settings`/`/meeting` absent; `/analytics`/`/graph`/`/brain`/`/ask` present; unknown → `/record` present). Full in-app chain coherent (`/library` → meeting → "← Meetings" → `/library` → "← Murmur" → `/record`; back never lands on a `/meeting` url); detail renders centered with "← Meetings", console clean (no NG0600/ɵcmp).

Known INFO (pre-existing, out of scope): a **cold deep-link** to `/meeting/:id` briefly flashes the rail during boot (app renders `/record` first, then resolves the drill-down); **in-app navigation — the normal path — has no flash.**