### PR TITLE
release: v0.6.4 — timeline coverage + orphan-helper reaper + Kong AI Gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.6.3"
+version = "0.6.4"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -61,6 +61,92 @@ pub fn sweep_stale_scratch() {
     }
 }
 
+/// Basenames of the helper binaries the app spawns to CAPTURE audio. At app startup nothing is
+/// recording yet, so any of these still alive is an ORPHAN from a previous session that died
+/// without a clean Stop — a crash, a force-quit, or (in dev) a `tauri dev` hot-rebuild SIGKILLing
+/// the app mid-recording. An orphan reparents to launchd (ppid 1) and keeps capturing system audio
+/// to its temp WAV until its own 4h self-limit — gigabytes of dead-session audio.
+const CAPTURE_HELPERS: [&str; 3] = ["meetnotes-sysaudio", "meetnotes-audiocap", "meetnotes-aeccap"];
+
+/// SIGTERM any ORPHANED capture helper (a [`CAPTURE_HELPERS`] binary reparented to launchd) and
+/// delete its scratch WAV. Best-effort, called ONCE at startup. This closes the gap
+/// [`sweep_stale_scratch`] can't: a *live* orphan keeps its WAV mtime fresh, so the file-age sweep
+/// never reclaims it, and the child runs for hours.
+///
+/// PRECISE + SAFE: it targets ONLY processes with `ppid == 1` (launchd) — a helper freshly spawned
+/// by THIS running app is a child of our pid (never launchd), and a concurrently-running Murmur's
+/// live helper is a child of *its* pid — so neither is ever touched. Only a truly-orphaned,
+/// parentless helper matches.
+pub fn reap_orphaned_capture_helpers() {
+    let Ok(out) = std::process::Command::new("/bin/ps")
+        .args(["-axo", "pid=,ppid=,command="])
+        .output()
+    else {
+        return;
+    };
+    let mut reaped = 0u32;
+    for (pid, wav) in parse_orphan_helpers(&String::from_utf8_lossy(&out.stdout)) {
+        // SIGTERM (not SIGKILL): let the helper's signal handler close its file, then reclaim it.
+        let killed = std::process::Command::new("/bin/kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if killed {
+            reaped += 1;
+            if let Some(path) = wav {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
+    if reaped > 0 {
+        // WARN, not INFO: an orphan reaching startup means a prior session leaked a capture helper.
+        tracing::warn!(target: "audio", reaped, "reaped orphaned capture helper(s) at startup");
+    }
+}
+
+/// Pure parser for `ps -axo pid=,ppid=,command=` output: return `(pid, scratch_wav)` for every line
+/// that is an ORPHANED (`ppid == 1`) capture helper. `scratch_wav` is the helper's capture-scratch
+/// argument (`meetnotes-sys-*.wav` / `meetnotes-aec-*.wav`), when present, so the caller can delete
+/// it after the kill. Isolated from the process-spawning so the ppid==1 safety filter is unit-
+/// testable without live processes. (Assumes the scratch/binary paths carry no embedded spaces —
+/// true for the OS temp dir + the app resource dir; this is best-effort startup cleanup.)
+fn parse_orphan_helpers(ps_output: &str) -> Vec<(i32, Option<std::path::PathBuf>)> {
+    let mut out = Vec::new();
+    for line in ps_output.lines() {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        if tokens.len() < 3 {
+            continue;
+        }
+        let (Ok(pid), Ok(ppid)) = (tokens[0].parse::<i32>(), tokens[1].parse::<i32>()) else {
+            continue;
+        };
+        if ppid != 1 {
+            continue; // NOT an orphan — a child of a live app (ours or another). Never touch it.
+        }
+        // A command token whose basename IS one of our capture helpers.
+        let is_helper = tokens.iter().any(|t| {
+            let base = t.rsplit('/').next().unwrap_or(t);
+            CAPTURE_HELPERS.contains(&base)
+        });
+        if !is_helper {
+            continue;
+        }
+        // The scratch WAV arg (same pattern sweep_stale_scratch reclaims), if the helper carries one.
+        let wav = tokens
+            .iter()
+            .find(|t| {
+                let base = t.rsplit('/').next().unwrap_or(t);
+                (base.starts_with("meetnotes-sys-") || base.starts_with("meetnotes-aec-"))
+                    && base.ends_with(".wav")
+            })
+            .map(std::path::PathBuf::from);
+        out.push((pid, wav));
+    }
+    out
+}
+
 /// Path to the bundled VPIO AEC helper (resource dir, then the dev `AECCAP_BIN` fallback).
 pub fn aec_helper_path(app: &AppHandle) -> Option<PathBuf> {
     if let Ok(p) = app
@@ -148,5 +234,48 @@ impl AecRecorder {
             );
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // A realistic `ps -axo pid=,ppid=,command=` fixture: the actual orphan we found (audiocap,
+    // ppid 1) + a legit LIVE helper (child of a running app, ppid 32431) that MUST be spared +
+    // an unrelated launchd child + a sysaudio orphan with no scratch arg.
+    const PS: &str = "\
+ 5916     1 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-83191e88.wav 14400
+ 7001 32431 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-live-abc.wav 14400
+  412     1 /usr/libexec/somethingd
+ 8080     1 /Users/x/target/debug/meetnotes-sysaudio";
+
+    #[test]
+    fn selects_only_orphaned_helpers_and_extracts_scratch() {
+        let got = parse_orphan_helpers(PS);
+        // The audiocap orphan (with its scratch WAV) and the sysaudio orphan (no scratch arg).
+        assert_eq!(
+            got,
+            vec![
+                (5916, Some(PathBuf::from("/var/folders/sl/T/meetnotes-sys-83191e88.wav"))),
+                (8080, None),
+            ]
+        );
+    }
+
+    #[test]
+    fn never_reaps_a_live_child_helper() {
+        // SAFETY INVARIANT: pid 7001 is a live capture helper of a RUNNING app (ppid 32431). It is
+        // a byte-for-byte twin of the orphan except for its parent — it must NEVER be selected.
+        let ids: Vec<i32> = parse_orphan_helpers(PS).into_iter().map(|(p, _)| p).collect();
+        assert!(!ids.contains(&7001), "must not reap a helper still owned by a live app");
+    }
+
+    #[test]
+    fn ignores_non_helper_and_malformed_lines() {
+        assert!(parse_orphan_helpers("  412     1 /usr/libexec/somethingd").is_empty());
+        assert!(parse_orphan_helpers("garbage\n\n123 abc def").is_empty());
+        assert!(parse_orphan_helpers("").is_empty());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2824,8 +2824,12 @@ pub fn export_canvas(state: State<'_, AppState>, meeting_id: String) -> Result<S
     let json = state.db.get_timeline_data(&meeting_id)?.ok_or_else(|| {
         AppError::InvalidArg("open the meeting once to generate its timeline first".into())
     })?;
-    let tl: MeetingTimeline = serde_json::from_str(&json)
+    let mut tl: MeetingTimeline = serde_json::from_str(&json)
         .map_err(|e| AppError::InvalidArg(format!("bad timeline data: {e}")))?;
+    // Same coverage-repair the Detail view applies (heal a legacy cache that ends short of the
+    // recording) so the exported canvas spans the meeting instead of the provider's early cluster.
+    let segments = state.db.get_segments(&meeting_id)?;
+    crate::summarize::timeline::repair_coverage(&mut tl, &segments);
     let title = meeting.title.unwrap_or_else(|| "Meeting".to_string());
     let topics: Vec<(String, f64, f64)> = tl
         .topics
@@ -3748,12 +3752,16 @@ pub async fn get_timeline(
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
         return Ok(MeetingTimeline::default());
     }
+    // Fetch segments up-front: they anchor the coverage-repair for BOTH a cached timeline (so a
+    // legacy cache generated before the repair existed — e.g. one ending at 0:14 for a 0:45
+    // recording — heals on read) and a freshly-generated one.
+    let segments = state.db.get_segments(&meeting_id)?;
     if let Some(json) = state.db.get_timeline_data(&meeting_id)? {
-        if let Ok(t) = serde_json::from_str::<MeetingTimeline>(&json) {
+        if let Ok(mut t) = serde_json::from_str::<MeetingTimeline>(&json) {
+            crate::summarize::timeline::repair_coverage(&mut t, &segments);
             return Ok(t);
         }
     }
-    let segments = state.db.get_segments(&meeting_id)?;
     if segments.is_empty() {
         return Ok(MeetingTimeline::default());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -208,8 +208,13 @@ pub fn run() {
                 ));
             }
 
-            // Reclaim any capture scratch WAVs stranded by a previous crashed/stuck session
-            // (a stuck VPIO/AEC helper once left a 91 GB temp file). Nothing records yet at setup.
+            // Reap any capture helper ORPHANED by a previous session that died without a clean Stop
+            // (crash / force-quit / a `tauri dev` hot-rebuild SIGKILLing the app mid-record). Such a
+            // helper reparents to launchd and keeps capturing to a temp WAV for up to 4h — GBs of
+            // dead-session audio the file-age sweep below can't catch (its mtime stays fresh). Run
+            // FIRST so the kill releases the file, THEN reclaim any stale scratch left behind.
+            // Nothing records yet at setup, so any live capture helper is by definition an orphan.
+            crate::audio::aec::reap_orphaned_capture_helpers();
             crate::audio::aec::sweep_stale_scratch();
 
             create_bar_window(app.handle())?;

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -621,7 +621,10 @@ async fn summarize_and_export(
     emit_status(
         app,
         "summarizing",
-        &format!("Summarizing with provider '{}'…", notes_target.connection),
+        &format!(
+            "Summarizing with {}…",
+            crate::summarize::roles::connection_display_name(&notes_target.connection)
+        ),
         meeting_id,
     );
 

--- a/src-tauri/src/summarize/roles.rs
+++ b/src-tauri/src/summarize/roles.rs
@@ -45,6 +45,21 @@ pub const CONN_LOCAL: &str = "local";
 /// Reasoner-only connection id: no model — the deterministic [`crate::reason::StubReasoner`] floor.
 pub const CONN_OFF: &str = "off";
 
+/// Human-facing display name for a connection id — for USER-VISIBLE status lines
+/// (e.g. the pipeline's "Summarizing with …" line). Mirrors the FE connection
+/// labels (`CONNECTION_LABELS` in `settings.store.ts`) so the two never diverge.
+/// An unknown id falls back to itself, so a newly-added provider is never blank.
+pub fn connection_display_name(connection: &str) -> &str {
+    match connection {
+        "claude_code" => "Claude Code",
+        "anthropic" => "Anthropic API",
+        "ollama" => "Ollama",
+        "gateway" => "Kong AI Gateway",
+        CONN_LOCAL => "the on-device model",
+        other => other,
+    }
+}
+
 /// A model role — the fixed, user-meaningful set of "what Murmur uses AI for".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Role {
@@ -220,6 +235,19 @@ pub fn reasoner_target(role: Role, cfg: &AppConfig) -> RoleTarget {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connection_display_name_is_human_friendly() {
+        // The four real providers render as their user-facing labels (matches the FE).
+        assert_eq!(connection_display_name("claude_code"), "Claude Code");
+        assert_eq!(connection_display_name("anthropic"), "Anthropic API");
+        assert_eq!(connection_display_name("ollama"), "Ollama");
+        assert_eq!(connection_display_name("gateway"), "Kong AI Gateway");
+        // Never the raw id / underscore token in a user-visible status line.
+        assert_ne!(connection_display_name("claude_code"), "claude_code");
+        // Unknown id falls back to itself (never blank) so a new provider still shows.
+        assert_eq!(connection_display_name("brand_new"), "brand_new");
+    }
 
     /// A discriminating legacy config: every legacy knob set to a distinct value so the identity
     /// matrix can tell exactly which knob each resolution read.

--- a/src-tauri/src/summarize/timeline.rs
+++ b/src-tauri/src/summarize/timeline.rs
@@ -82,9 +82,99 @@ pub async fn generate(
         "additionalProperties": false
     });
     let v = provider.complete_json(SYSTEM, &transcript, &schema).await?;
-    serde_json::from_value(v).map_err(|e| {
+    let mut tl: MeetingTimeline = serde_json::from_value(v).map_err(|e| {
         crate::error::AppError::Summarize(format!("timeline: invalid JSON shape from provider: {e}"))
-    })
+    })?;
+    // The provider prompt asks it to "cover the whole timeline", but in practice — especially on
+    // SPARSE transcripts with silence gaps, and on smaller/local models — it drops the trailing
+    // segments and ends the timeline far short of the recording (and occasionally overshoots with
+    // a hallucinated endS). Repair deterministically so the derived timeline actually spans the
+    // transcript instead of collapsing into an early cluster.
+    repair_coverage(&mut tl, segments);
+    Ok(tl)
+}
+
+/// Small epsilon (seconds) below which a coverage gap is ignored — avoids extending a span for
+/// sub-second float noise while still catching the real "timeline ends at 0:14 for a 0:45
+/// recording" gap this repairs.
+const COVER_EPS: f64 = 0.25;
+
+/// Deterministically repair an AI-derived timeline so it COVERS the transcript.
+///
+/// The provider tends to (a) drop trailing/sparse segments — leaving the timeline ending well
+/// before the recording does — and occasionally (b) emit a wildly out-of-range `endS`. Both make
+/// the FE's shared scale disagree with the audio player (the "timeline shows only a few seconds of
+/// a 45s recording" bug). We anchor to the LAST TRANSCRIBED SEGMENT — deliberately NOT the raw
+/// recording duration — so a meeting with a genuinely silent tail still lets the FE zoom to the
+/// meaningful content rather than being stretched across dead air. Steps, per track:
+///   1. clamp every span to `[0, content_end]` (kills the hallucinated overshoot + inverted spans),
+///   2. drop spans left degenerate (`end <= start`) after clamping,
+///   3. extend the last (max-`end`) turn/topic to `content_end` when it falls meaningfully short,
+///      so both the speaker lanes and the topic ribbon reach the end of the transcript.
+///
+/// Idempotent (running it twice is a no-op) and pure over `(timeline, segments)`, so it can also
+/// heal a legacy cached timeline when read back, not just freshly-generated ones.
+pub fn repair_coverage(tl: &mut MeetingTimeline, segments: &[Segment]) {
+    let content_end = segments.iter().map(|s| s.end_s).fold(0.0_f64, f64::max);
+    if content_end <= 0.0 {
+        return; // no transcript span to anchor to — leave the timeline untouched.
+    }
+    cover(
+        &mut tl.speakers,
+        content_end,
+        |t| (t.start_s, t.end_s),
+        |t, s, e| {
+            t.start_s = s;
+            t.end_s = e;
+        },
+    );
+    cover(
+        &mut tl.topics,
+        content_end,
+        |t| (t.start_s, t.end_s),
+        |t, s, e| {
+            t.start_s = s;
+            t.end_s = e;
+        },
+    );
+}
+
+/// Clamp → drop-degenerate → extend-last for one track. Generic over the span type via
+/// get/set accessors so `SpeakerTurn` and `TopicSpan` share the exact same repair.
+fn cover<T>(
+    items: &mut Vec<T>,
+    content_end: f64,
+    get: impl Fn(&T) -> (f64, f64),
+    set: impl Fn(&mut T, f64, f64),
+) {
+    for it in items.iter_mut() {
+        let (s, e) = get(it);
+        let s = s.clamp(0.0, content_end);
+        let e = e.clamp(s, content_end);
+        set(it, s, e);
+    }
+    items.retain(|it| {
+        let (s, e) = get(it);
+        e > s
+    });
+    // Extend whichever span currently ends latest to the transcript end, so the track covers the
+    // recording. (Extending the LAST span — not inserting a synthetic one — keeps the real labels.)
+    let last = items
+        .iter()
+        .enumerate()
+        .max_by(|a, b| {
+            get(a.1)
+                .1
+                .partial_cmp(&get(b.1).1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(i, _)| i);
+    if let Some(i) = last {
+        let (s, e) = get(&items[i]);
+        if content_end - e > COVER_EPS {
+            set(&mut items[i], s, content_end);
+        }
+    }
 }
 
 /// Extract the first balanced JSON object from a reply and parse it into a [`MeetingTimeline`].
@@ -138,5 +228,125 @@ mod tests {
         assert_eq!(t.speakers.len(), 1);
         assert_eq!(t.speakers[0].speaker, "User 1");
         assert_eq!(t.topics[0].label, "Intro");
+    }
+
+    // ── repair_coverage: make the AI timeline actually span the transcript ────────────────
+
+    use crate::storage::models::{MeetingTimeline, SpeakerTurn, TopicSpan};
+
+    fn seg(start_s: f64, end_s: f64) -> Segment {
+        Segment {
+            idx: 0,
+            start_s,
+            end_s,
+            text: "x".into(),
+            speaker: Some("me".into()),
+        }
+    }
+    fn turn(start_s: f64, end_s: f64) -> SpeakerTurn {
+        SpeakerTurn {
+            speaker: "Jakub".into(),
+            start_s,
+            end_s,
+        }
+    }
+    fn topic(label: &str, start_s: f64, end_s: f64) -> TopicSpan {
+        TopicSpan {
+            label: label.into(),
+            start_s,
+            end_s,
+        }
+    }
+
+    /// RED-before-GREEN: the exact production bug (meeting fe25c4ee) — segments cover 0.2..44.5 but
+    /// the provider's timeline ends at 13.7. Before `repair_coverage`, the timeline stays at 13.7
+    /// (< 0.9× the 45s recording → the FE zooms the axis to ~0:14). After, both tracks reach 44.5.
+    #[test]
+    fn repair_extends_short_timeline_to_last_segment() {
+        let segments = vec![seg(0.2, 3.9), seg(9.9, 13.7), seg(29.4, 31.6), seg(43.5, 44.5)];
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.2, 3.9), turn(9.9, 13.7)],
+            topics: vec![topic("Test Brain Note", 0.2, 7.9), topic("Architecture Issue", 7.9, 13.7)],
+        };
+        repair_coverage(&mut tl, &segments);
+        let sp_max = tl.speakers.iter().map(|t| t.end_s).fold(0.0, f64::max);
+        let tp_max = tl.topics.iter().map(|t| t.end_s).fold(0.0, f64::max);
+        assert!((sp_max - 44.5).abs() < 1e-6, "speakers should reach 44.5, got {sp_max}");
+        assert!((tp_max - 44.5).abs() < 1e-6, "topics should reach 44.5, got {tp_max}");
+        // Labels + earlier spans are preserved; only the LAST span was extended.
+        assert_eq!(tl.topics.len(), 2);
+        assert_eq!(tl.topics[0].end_s, 7.9);
+        assert_eq!(tl.topics[1].label, "Architecture Issue");
+        assert_eq!(tl.topics[1].end_s, 44.5);
+    }
+
+    /// A hallucinated far-future `endS` is clamped back to the transcript end (the eee2e31e case:
+    /// segments to 82.6, provider emitted endS=1200).
+    #[test]
+    fn repair_clamps_hallucinated_overshoot() {
+        let segments = vec![seg(0.5, 40.0), seg(80.0, 82.6)];
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.5, 1200.0)],
+            topics: vec![topic("Intro", 0.0, 5.0), topic("Deep dive", 5.0, 1200.0)],
+        };
+        repair_coverage(&mut tl, &segments);
+        assert!((tl.speakers[0].end_s - 82.6).abs() < 1e-6);
+        assert!((tl.topics[1].end_s - 82.6).abs() < 1e-6);
+    }
+
+    /// Idempotent: repairing an already-repaired timeline changes nothing.
+    #[test]
+    fn repair_is_idempotent() {
+        let segments = vec![seg(0.0, 10.0), seg(40.0, 44.5)];
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.0, 10.0)],
+            topics: vec![topic("A", 0.0, 6.0), topic("B", 6.0, 10.0)],
+        };
+        repair_coverage(&mut tl, &segments);
+        let once = serde_json::to_string(&tl).unwrap();
+        repair_coverage(&mut tl, &segments);
+        assert_eq!(once, serde_json::to_string(&tl).unwrap());
+    }
+
+    /// When the timeline already covers the transcript, repair does not over-extend (no spurious
+    /// stretch past the real content).
+    #[test]
+    fn repair_noop_when_already_covers() {
+        let segments = vec![seg(0.0, 30.0)];
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.0, 30.0)],
+            topics: vec![topic("Whole", 0.0, 30.0)],
+        };
+        repair_coverage(&mut tl, &segments);
+        assert_eq!(tl.topics[0].end_s, 30.0);
+        assert_eq!(tl.speakers[0].end_s, 30.0);
+    }
+
+    /// A span entirely beyond the transcript end is dropped (clamps to a zero-width span, then
+    /// pruned); the remaining last span is extended to cover.
+    #[test]
+    fn repair_drops_span_entirely_beyond_content() {
+        let segments = vec![seg(0.0, 20.0)];
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.0, 5.0)],
+            topics: vec![topic("Real", 0.0, 8.0), topic("Ghost", 50.0, 60.0)],
+        };
+        repair_coverage(&mut tl, &segments);
+        assert_eq!(tl.topics.len(), 1, "the beyond-content ghost span is dropped");
+        assert_eq!(tl.topics[0].label, "Real");
+        assert!((tl.topics[0].end_s - 20.0).abs() < 1e-6, "the surviving span covers to 20.0");
+    }
+
+    /// No segments (or all zero-length) → nothing to anchor to → the timeline is left untouched
+    /// (no panic, no bogus extension).
+    #[test]
+    fn repair_noop_on_empty_segments() {
+        let mut tl = MeetingTimeline {
+            speakers: vec![turn(0.0, 5.0)],
+            topics: vec![topic("A", 0.0, 5.0)],
+        };
+        repair_coverage(&mut tl, &[]);
+        assert_eq!(tl.speakers[0].end_s, 5.0);
+        assert_eq!(tl.topics[0].end_s, 5.0);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -29,7 +29,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   claude_code: "Claude Code",
   anthropic: "Anthropic API",
   ollama: "Ollama",
-  gateway: "AI Gateway (OpenAI-compatible)",
+  gateway: "Kong AI Gateway (OpenAI-compatible)",
 };
 
 /**
@@ -368,7 +368,7 @@ const SIZE_HINTS: Record<string, string> = {
                 }
                 @case ("gateway") {
                   <div class="setup-well">
-                    <p class="setup-title">Connect your AI gateway</p>
+                    <p class="setup-title">Connect your Kong AI Gateway</p>
                     <p class="setup-text text-secondary">
                       Enter your gateway's OpenAI-compatible base URL (e.g.
                       https://…/v1). An API key can be added later in

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -185,9 +185,7 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
           @if (isProcessing()) {
             <div class="proc-inline" role="status">
               <span class="orb proc" aria-hidden="true"></span>
-              <span class="proc-label">{{
-                store.message() || store.stage()
-              }}</span>
+              <span class="proc-label">{{ procLabel() }}</span>
               <div class="proc-track" aria-hidden="true">
                 <div class="proc-shimmer"></div>
               </div>
@@ -710,7 +708,6 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
         color: var(--text-primary);
         font-size: 0.92rem;
         font-weight: 550;
-        text-transform: capitalize;
       }
       .proc-track {
         flex: 1;
@@ -1141,7 +1138,7 @@ export class RecordComponent implements OnInit {
       case "claude_code":
         return "Claude Code";
       case "gateway":
-        return "AI Gateway";
+        return "Kong AI Gateway";
       case "ollama":
         return "Ollama";
       default:
@@ -1162,7 +1159,7 @@ export class RecordComponent implements OnInit {
       case "claude_code":
         return "Anthropic's cloud";
       case "gateway":
-        return "your AI gateway";
+        return "your Kong AI Gateway";
       case "ollama":
         return "your remote Ollama server";
       default:
@@ -1182,6 +1179,30 @@ export class RecordComponent implements OnInit {
   readonly isProcessing = computed(
     () => this.store.isBusy() && !this.store.isRecording(),
   );
+
+  /**
+   * The processing status line. Prefer the backend's status message — it is
+   * already a clean, properly-cased sentence ("Summarizing with Claude Code…",
+   * "Writing note to vault…") — and fall back to a Title-cased stage word only
+   * when no message has been emitted yet. This replaces the old CSS
+   * `text-transform: capitalize` on `.proc-label`, which mangled the full
+   * sentence into "Summarizing With Provider 'Claude_code'…".
+   */
+  readonly procLabel = computed(() => {
+    const msg = this.store.message().trim();
+    if (msg) return msg;
+    const stage = this.store.stage();
+    const labels: Record<string, string> = {
+      recording: "Recording",
+      transcribing: "Transcribing",
+      summarizing: "Summarizing",
+      exporting: "Exporting",
+      saved: "Saved",
+      done: "Done",
+      error: "Error",
+    };
+    return labels[stage] ?? stage.charAt(0).toUpperCase() + stage.slice(1);
+  });
 
   /**
    * Whether the Record action is allowed right now. A missing vault does NOT block recording

--- a/src/app/features/settings/sections/ai/ai-connection-cards.component.ts
+++ b/src/app/features/settings/sections/ai/ai-connection-cards.component.ts
@@ -27,7 +27,7 @@ const CONNECTIONS: readonly ConnectionDef[] = [
   { id: "claude_code", name: "Claude Code" },
   { id: "anthropic", name: "Anthropic API" },
   { id: "ollama", name: "Ollama" },
-  { id: "gateway", name: "AI Gateway" },
+  { id: "gateway", name: "Kong AI Gateway" },
 ];
 
 /**

--- a/src/app/features/settings/sections/ai/ai-defaults-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-defaults-block.component.ts
@@ -35,7 +35,7 @@ import { AiRoleRowsComponent } from "./ai-role-rows.component";
           <option value="claude_code">Claude Code (default)</option>
           <option value="anthropic">Anthropic API</option>
           <option value="ollama">Ollama</option>
-          <option value="gateway">AI Gateway (OpenAI-compatible)</option>
+          <option value="gateway">Kong AI Gateway (OpenAI-compatible)</option>
         </select>
         <span class="field-help text-muted">
           Used for everything Murmur writes: notes, answers, digests, briefs.
@@ -55,7 +55,7 @@ import { AiRoleRowsComponent } from "./ai-role-rows.component";
         @switch (form.controls.providerId.value) {
           @case ("gateway") {
             <p class="brain-note text-muted">
-              The model for AI Gateway is set in its connection card above.
+              The model for Kong AI Gateway is set in its connection card above.
             </p>
           }
           @case ("ollama") {

--- a/src/app/features/settings/sections/ai/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows.component.ts
@@ -105,7 +105,7 @@ interface RoleRowVm {
                 <option value="claude_code">Claude Code</option>
                 <option value="anthropic">Anthropic API</option>
                 <option value="ollama">Ollama</option>
-                <option value="gateway">AI Gateway (OpenAI-compatible)</option>
+                <option value="gateway">Kong AI Gateway (OpenAI-compatible)</option>
                 @if (row.offersReasonerTargets) {
                   <option value="local">Local model — on-device</option>
                   <option value="off">Off — retrieval only</option>

--- a/src/app/features/settings/sections/settings-privacy-section.component.ts
+++ b/src/app/features/settings/sections/settings-privacy-section.component.ts
@@ -57,7 +57,7 @@ import { SettingsStore } from "../settings.store";
                     Emails, card numbers and phone numbers are automatically
                     scrubbed before any text leaves this Mac — that covers the Anthropic
                     API, Claude Code (the <code>claude</code> CLI uploads your
-                    transcript to Anthropic too), an AI Gateway, and a remote Ollama
+                    transcript to Anthropic too), a Kong AI Gateway, and a remote Ollama
                     server — then restored in your notes. Only Ollama running on this
                     Mac keeps everything on-device.
                   </p>
@@ -74,7 +74,7 @@ import { SettingsStore } from "../settings.store";
                 <div class="privacy-section">
                   <span class="privacy-section-label text-muted">Cloud processing</span>
                   <p class="text-secondary privacy-note">
-                    Cloud providers — Claude Code, the Anthropic API, an AI Gateway, or
+                    Cloud providers — Claude Code, the Anthropic API, a Kong AI Gateway, or
                     a remote Ollama server — send your (redacted) transcript off this
                     Mac to write each summary. Only Ollama running on this Mac stays
                     fully on-device. Until you allow this once, cloud summaries are

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -55,7 +55,7 @@ const CONNECTION_LABELS: Readonly<Record<string, string>> = {
   claude_code: "Claude Code",
   anthropic: "Anthropic API",
   ollama: "Ollama",
-  gateway: "AI Gateway",
+  gateway: "Kong AI Gateway",
 };
 
 /**
@@ -451,7 +451,7 @@ export class SettingsStore {
         case "gateway": {
           const dest = this.gatewayDestination();
           return {
-            connection: "AI Gateway",
+            connection: "Kong AI Gateway",
             destination: dest ? dest.host : "your gateway (base URL not set)",
           };
         }


### PR DESCRIPTION
## v0.6.4

Two robustness fixes + a UI cleanup, verified by the adversarial-verifier and lock-security-reviewer (both PASS), on a clean rebase onto the current trunk.

### Fixes
- **fix(audio): reap orphaned capture helpers at startup.** A capture sidecar (`meetnotes-sysaudio`/`audiocap`/`aeccap`) orphaned to launchd by a session that died without a clean Stop (crash, force-quit, or a `tauri dev` hot-rebuild SIGKILLing the app mid-record) keeps capturing to a temp WAV for up to 4h — gigabytes the file-age sweep can't reclaim. `reap_orphaned_capture_helpers()` SIGTERMs **only** `ppid==1` orphans (a live helper of this or a concurrent Murmur is a child of its app pid, never launchd) and deletes the scratch WAV. Lock-security confirmed it can only ever touch a `meetnotes-sys-`/`meetnotes-aec-` temp scratch WAV — never a sealed `.enc` blob or a persisted recording.
- **fix(timeline): repair under-coverage.** A 0:45 recording could show a 0:14 timeline when the provider clustered topics early. `repair_coverage()` deterministically clamps/extends to the last segment's end, applied on read (`get_timeline`) and export (`export_canvas`) so legacy caches heal too. Both new segment reads stay behind the existing `meeting_is_unlocked` gate (verified — `export_canvas` returns `Locked` before reading).

### UI
- **feat(ui): rebrand "AI Gateway" → "Kong AI Gateway"** across the connection card, onboarding, role/default pickers and privacy copy. Backend id `gateway` and its OpenAI-compatible support unchanged — label only.
- **fix(ui): human-readable summarizing status.** It showed `Summarizing With Provider 'Claude_code'…` (raw id, Title-cased by CSS). Now emits `Summarizing with Claude Code…` via `connection_display_name()`; the record strip renders the message verbatim (a `procLabel` computed replaces the `text-transform: capitalize` that mangled it).

### Gates
`cargo test --lib` (736 passed) · `clippy --lib -D warnings` clean · `ng lint` · `ng build` — all green. Adversarial-verifier + lock-security-reviewer: **PASS** (RED-before-GREEN proven for the reaper `ppid==1` filter and `repair_coverage`). Real-Mac-only items (orphan reaping, cached-DB heal, live render) flagged honestly.