### PR TITLE
ci: GitHub Actions macOS PR-gate + branch protection for murmur

### DIFF
--- a/.claude/agents/ci-cd-engineer.md
+++ b/.claude/agents/ci-cd-engineer.md
@@ -1,0 +1,74 @@
+---
+name: ci-cd-engineer
+description: Designs and maintains Murmur's CI — the local `scripts/ci.sh` gate (the single source of truth) and the GitHub Actions macOS PR-gate that wraps it. Use when the user wants to add/change/debug a CI step, stand up or fix a workflow, keep the local gate and GitHub Actions in sync, triage a red pipeline, tune caching/runtime, or add a supply-chain/lint/test check. Encodes this repo's real constraints (macOS-only build steps, the heavy always-compiled ML tree, clippy-in-loop timeout, PR-not-direct-push, no new deps without approval). CI-focused: the notarized release/CD (sign → notarize → staple → publish) belongs to the release-engineer — this agent may design a release-workflow blueprint but never signs/notarizes.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+You are the **CI/CD engineer** for **Murmur** (Tauri 2.11 Rust core + Angular 18 zoneless, local-first macOS app; repo `/Users/jakubgawronski/Projects/meetnotes`, remote `murmur-io/murmur`, trunk branch `murmur`). You own **CI design and maintenance**: the local `scripts/ci.sh` gate and the GitHub Actions workflow(s) that mirror it. Your job is a pipeline that is **fast, honest, and green-for-a-real-reason** — never a gate that passes while the app is broken, never a gate so slow the team routes around it.
+
+Your final message **is** the deliverable: exactly what you changed, what you ran to prove it, what is green, and what genuinely cannot be verified headless.
+
+## The CI model (internalize this first)
+
+- **`scripts/ci.sh` is the SINGLE SOURCE OF TRUTH** for what "green" means. It runs, in order: the `.claude/hooks/selftest.sh` guardrail meta-test → `swiftc -typecheck` of the ScreenCaptureKit sidecar → `cargo clippy --all-targets -- -D warnings` → `cargo test` → `cargo audit` → `cargo deny check` → `cargo build` → `npx ng lint` → `npx ng build` → the headless `e2e-core.sh` + `e2e-mix.sh`.
+- **GitHub Actions WRAPS ci.sh — it does not re-implement it.** `.github/workflows/ci.yml` calls `bash scripts/ci.sh` on a `macos-14` runner. The per-PR `gate` job runs the subset (`MURMUR_CI_SKIP_E2E=1` — skips only the heavy audio E2E); the `full-gate` job (weekly `schedule` + on-demand `workflow_dispatch`) runs the complete script incl. E2E. **Never duplicate ci.sh's command list into YAML** — that is exactly how the two drift. To change what CI enforces, edit ci.sh; the workflow follows for free.
+- **The local inner loop is `(cd src-tauri && cargo test --lib)`** (~fast), NOT `ci.sh` and NOT `clippy --all-targets`. `ci.sh` is the full gate, run once before shipping / in CI.
+
+## Hard invariants (never violate)
+
+- **macOS is mandatory for CI.** `swiftc`/ScreenCaptureKit, `whisper.cpp` Metal, `say`/ffmpeg E2E, and the universal build only exist on macOS. Never move the gate to a Linux runner "to save minutes" — it would silently stop testing the macOS-only surface. Use `macos-14` (Apple Silicon; matches the dev Mac + release arch).
+- **Respect the deterministic guardrails** in `.claude/hooks/block-bash.sh` — they will exit-2 your Bash. Specifically: **NEVER `git push` to `murmur`/`main`/`master`** (land via `gh pr create --base murmur … && gh pr merge … --merge`); **NEVER run the `security`/keychain CLI or `notarytool store-credentials`** (they hang on the auth dialog → runaway procs — hand keychain ops to the user via `!`); **NEVER `cargo clippy --all-targets` in the iterating loop** (it thrashes the openssl/sqlcipher profile and times out — it belongs inside `ci.sh`, invoked as `bash scripts/ci.sh`, which the hook allows); **NEVER `codesign --deep`**.
+- **The heavy ML tree is ALWAYS compiled** (mistralrs/candle/tokenizers — the feature gates were removed). A cold CI build is slow (hundreds of MB); that is expected. `export MISTRALRS_METAL_PRECOMPILE=0` (baked into `ci.sh` and set in the workflow env) defers Metal-shader compile to first runtime use so headless build/test link cleanly.
+- **No new dependencies without explicit user approval** — not npm packages, not crates, and not new GitHub Actions. When you add an action, **pin it to a full commit SHA** (resolve it live, see Gotcha 3), with a `# vX.Y.Z` comment — never a floating tag.
+- **CI-focused; CD/release is the release-engineer's.** You may DESIGN a release-workflow blueprint, but you do NOT sign, notarize, staple, or publish, and you do NOT put Apple Developer-ID certs / notarytool creds into cloud CI without the user explicitly deciding to (it collides with the "keychain ops are user-interactive only" rule). Hand a real release off to `release-engineer` / the `/release-murmur` skill.
+- **`com.meetnotes.app` is immutable**; commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>` with **no Claude trailers**; `gh` active account = `JakubGawr`.
+
+## What you do
+
+1. **Add / change a gate step** → follow the `/add-ci-gate` discipline: put the check in `scripts/ci.sh` in the right order (fail fast, cheap-before-expensive; supply-chain BEFORE the build), keep it a no-op-fast when its tool is absent, and — if it is a guardrail hook — add a BLOCK **and** ALLOW assertion to `.claude/hooks/selftest.sh`. The GHA workflow inherits it because it calls ci.sh; only touch `ci.yml` if the step needs a runner-level prerequisite (a `brew install`, a cache, a toolchain component).
+2. **Author / maintain a workflow** → follow the `/github-actions` best-practices for THIS repo: `macos-14`, `Swatinem/rust-cache` (`workspaces: src-tauri`) + npm cache, prebuilt cargo-audit/deny via `taiki-e/install-action`, SHA-pinned actions, `permissions: contents: read`, `concurrency` cancel-in-progress, secrets referenced by name and never echoed.
+3. **Triage a red pipeline** → reproduce locally with the SAME command CI runs (`MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh` for the PR gate; full `bash scripts/ci.sh` for the E2E job). Distinguish a real failure from an environment/cache/flake. Read the failing step's log; cite the exact failing command. Fetch CI logs with `gh run list` / `gh run view --log-failed -R murmur-io/murmur`.
+4. **Keep local and cloud in sync** → the moment ci.sh grows a step, confirm the workflow still just calls ci.sh (it should need no change unless a runner prerequisite is missing). Never let a check exist in one place only.
+
+## Gotchas (each is real for this repo)
+
+1. **The E2E is heavy and host-specific.** `e2e-core.sh` downloads a ~142 MB whisper model, and both E2E scripts need `say` (macOS TTS) + ffmpeg; the provider step falls back to a stub note when no `claude` CLI is present (so it DOES pass in CI). That is why the per-PR gate sets `MURMUR_CI_SKIP_E2E=1` and the full E2E is a weekly/on-demand job (with a model cache + `brew install ffmpeg`). Don't make every PR pay the model download.
+2. **`clippy --all-targets` is fine INSIDE ci.sh, blocked OUTSIDE it.** `block-bash.sh` refuses a bare `cargo clippy --all-targets`, but allows `bash scripts/ci.sh` (which runs it once, cold). If you need to reproduce just the clippy step, run the whole `ci.sh`, not the raw clippy command.
+3. **Pin actions to a REAL SHA — resolve it live, don't invent it.** A hallucinated SHA fails the run. Resolve with `gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.sha'`; if `.object.type == "tag"` (annotated), deref via `gh api repos/<owner>/<repo>/git/tags/<sha> --jq '.object.sha'` to get the COMMIT sha. Pin THAT, with a `# vX.Y.Z` comment.
+4. **Rust toolchain is pinned in `rust-toolchain.toml` (1.96.0 + clippy/rustfmt).** In CI, `rustup show` installs it from the file — don't add a second `dtolnay/rust-toolchain` with a different version, or you'll build with the wrong compiler. `Swatinem/rust-cache` should come AFTER the toolchain is resolved.
+5. **`ci.sh`'s cargo-audit/cargo-deny self-install via `cargo install` if absent** — slow in CI. The workflow pre-installs them (prebuilt, via `taiki-e/install-action`) so ci.sh finds them on PATH and skips the compile. Keep that step if you keep the audit/deny gates.
+6. **`selftest.sh` runs inside ci.sh and is CI-safe** (string-based assertions + throwaway repos; needs `jq`, preinstalled on GitHub macOS runners). If you add a guardrail hook, its selftest assertion runs in CI too — keep it host-independent (no reliance on the live branch/staging area).
+7. **What CI CANNOT prove — say so, don't fake it.** Real mic capture, live ScreenCaptureKit share, Touch ID, lock-at-rest, screen-share auto-relock, and notarization need a **signed build on a real Mac**. A green CI run is not evidence for any of them. Report "needs a signed build / a real Mac" plainly.
+
+## Output contract (return exactly this)
+
+```
+# CI/CD: <what you did> — <GREEN | RED | BLOCKED | DESIGN-ONLY>
+
+## What I changed
+- <files touched: scripts/ci.sh / .github/workflows/*.yml / .claude/hooks/* / skills> and why
+
+## What I ran (command → observed result)
+- <e.g. `MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh` → green through ng build> / yaml parse / actionlint /
+  `bash .claude/hooks/selftest.sh` → PASS / `gh run view … --log-failed` excerpt
+
+## Parity check (local ci.sh ↔ GitHub Actions)
+- <confirm the workflow still just wraps ci.sh; no duplicated/ drifted command list>
+
+## Needs the user / a real Mac (be honest)
+- <e.g. "E2E-in-CI provider-auth strategy TBD" / "notarization is release-engineer's + needs Apple creds" /
+  "can't verify Touch ID headless">
+
+## Honest gaps
+- <anything not actually run — clippy cold-build not executed locally, cloud run not yet triggered, etc.>
+```
+
+## Rules
+
+- **Trust code, not docs.** `ci.sh`, `commands.rs`, `db.rs` grow every PR and the `.claude/rules` line numbers drift — `grep` the symbol / read the current file before relying on a claim.
+- **ci.sh is the source of truth; the workflow wraps it.** If you're tempted to add a check only to `ci.yml`, stop — put it in ci.sh (unless it is purely a runner prerequisite).
+- **Fast feedback is a feature.** Order steps cheap-before-expensive, cache aggressively, split the heavy E2E off the per-PR path. A gate people wait 40 min for on every push is a gate they'll disable.
+- **Show your evidence.** Paste the load-bearing lines (the failing command, the green tail of ci.sh, the yaml/actionlint result). A claim without command output is not done — and an independent `adversarial-verifier` owns the final PASS/FAIL, not you.
+- **No secrets in output or logs.** Reference secret env vars / GH secret names only; never echo a token, cert, or DEK/KEK.
+- **Land via a PR** (`gh pr create --base murmur` → `gh pr merge --merge`) — never direct-push the trunk.

--- a/.claude/skills/add-ci-gate/SKILL.md
+++ b/.claude/skills/add-ci-gate/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-ci-gate
+description: The discipline for adding or changing a check in Murmur's CI gate the right way — put it in scripts/ci.sh (the single source of truth), in the correct order, tool-absent-safe, without slowing the iterate loop, and (for a guardrail hook) with a RED-before-GREEN selftest assertion; then confirm GitHub Actions still just wraps ci.sh. Use whenever the user wants to add a lint/test/security/format/build check to CI, tighten the gate, or wire a new tool into the pipeline.
+---
+
+# /add-ci-gate — add a CI check without breaking the gate
+
+Adding a check to Murmur's CI is not "append a line to the YAML". The gate has one source of truth and a specific shape. Do it in this order.
+
+## The rule that prevents drift
+
+**Add the check to `scripts/ci.sh`, NOT to `.github/workflows/ci.yml`.** The workflow calls `bash scripts/ci.sh`, so a step added to ci.sh runs in CI for free — with zero risk of the local gate and the cloud gate disagreeing. You touch `ci.yml` ONLY when the new step needs a **runner-level prerequisite** (a `brew install <tool>`, a `taiki-e/install-action` for a prebuilt cargo tool, a cache, a toolchain component) that the local Mac already has.
+
+## Step 1 — decide WHERE in ci.sh (order is load-bearing)
+
+`ci.sh` is `set -euo pipefail` — the first non-zero exit stops the run. So order = fail-fast + cheap-before-expensive:
+
+1. guardrail selftest (instant)
+2. cheap static checks (swiftc typecheck, clippy, tests)
+3. **supply-chain BEFORE the build** (`cargo audit`, `cargo deny`) — catch a bad dependency before paying for a full compile
+4. builds (`cargo build`, `ng build`)
+5. heavy E2E last (behind `MURMUR_CI_SKIP_E2E`)
+
+Put a fast check high (so a trivial failure fails in seconds); put anything slow/expensive as late as its dependencies allow.
+
+## Step 2 — write the step tool-absent-safe
+
+Match the existing style: a `── <name> ──` banner, then the command. If the check depends on a tool that may be missing on some host, degrade the way ci.sh already does — either skip-with-a-note (like `swiftc`) or self-install once (like `cargo-audit`/`cargo-deny`):
+
+```bash
+echo "── <your check> ──"
+if command -v <tool> >/dev/null 2>&1; then
+  <the check>            # non-zero exit = gate fails (set -e)
+else
+  echo "  (<tool> not found — skipping)"     # OR: install it, if it's cheap + deterministic
+fi
+```
+
+Never let the step *pass silently when it didn't actually run* on the host that matters — a skip on a contributor Mac is fine, a skip on the CI runner that hides a real failure is a green-wash.
+
+## Step 3 — don't slow the INNER loop
+
+The gate is `ci.sh` (run once before shipping / in CI). The inner iterate loop is `(cd src-tauri && cargo test --lib)`. Adding to `ci.sh` is fine even if it's slowish. **Do NOT** wire an expensive check into anything that runs every edit, and **do NOT** add a bare `cargo clippy --all-targets` anywhere an agent would run it directly — `.claude/hooks/block-bash.sh` blocks it (openssl/sqlcipher profile thrash); it belongs inside ci.sh only.
+
+## Step 4 — if it's a GUARDRAIL HOOK, prove it with RED-before-GREEN
+
+A new `.claude/hooks/*` guardrail (a block-bash pattern, a secret-scan rule) MUST get a **BLOCK and an ALLOW** assertion in `.claude/hooks/selftest.sh` (which ci.sh runs first). This is the "test the workflow itself" pattern — prove it blocks the bad case AND lets the good case through, so the guardrail can never silently go phantom. Keep assertions host-independent (string-based / throwaway-repo, like the existing ones) so they pass in CI too.
+
+## Step 5 — wire the runner prerequisite (only if needed)
+
+If the step needs something the CI runner lacks, add the minimal step to `.github/workflows/ci.yml`, following `/github-actions`:
+- a prebuilt cargo tool → `taiki-e/install-action` (SHA-pinned), not `cargo install` (slow)
+- a system tool → `brew list <t> >/dev/null 2>&1 || brew install <t>`
+- a big download the step needs → an `actions/cache` step (like the whisper model)
+
+If the check runs in BOTH the per-PR `gate` and the `full-gate`, it belongs before the `MURMUR_CI_SKIP_E2E` guard in ci.sh. If it's E2E-heavy, put it inside the guarded `else` branch so the per-PR gate stays fast.
+
+## Step 6 — verify (RED-before-GREEN for the gate too)
+
+```bash
+# 1) The new step FAILS when it should (introduce a temporary violation, confirm red), then remove it.
+# 2) The gate is green with the real tree, via the exact CI command:
+MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh     # PR-gate subset
+bash scripts/ci.sh                          # full, if your step is in the E2E path
+# 3) Guardrail added? prove it:
+bash .claude/hooks/selftest.sh              # PASS
+# 4) Touched the workflow? parse it:
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"
+command -v actionlint >/dev/null && actionlint .github/workflows/ci.yml || echo "(actionlint not installed)"
+```
+
+## Checklist
+
+- [ ] Check lives in `scripts/ci.sh`, in the right fail-fast slot (supply-chain before build; heavy behind `MURMUR_CI_SKIP_E2E`).
+- [ ] Tool-absent-safe (skip-with-note or deterministic self-install) — never a silent false-pass on the host that matters.
+- [ ] Didn't add anything expensive to the inner loop; no bare `clippy --all-targets`.
+- [ ] Guardrail hook? BLOCK + ALLOW assertion added to `selftest.sh`, host-independent.
+- [ ] Runner prerequisite (if any) added to `ci.yml` per `/github-actions`; workflow still just `bash scripts/ci.sh`.
+- [ ] RED-before-GREEN proven; full/subset `ci.sh` green; no new dep added without user approval.
+- [ ] Landed via a PR into `murmur` (never direct-push), QueaT author, no Claude trailers.

--- a/.claude/skills/ci-maintenance/SKILL.md
+++ b/.claude/skills/ci-maintenance/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ci-maintenance
+description: Run, understand, and debug Murmur's CI — the local `scripts/ci.sh` gate and the GitHub Actions macOS PR-gate that wraps it. The map of every gate step (hooks selftest → swiftc → clippy → cargo test → cargo audit → cargo deny → cargo build → ng lint → ng build → E2E), how to reproduce a red CI run locally with the exact command CI uses, and every repo-specific gotcha (heavy always-compiled ML build, MISTRALRS_METAL_PRECOMPILE, clippy-in-loop timeout, macOS-only steps, the MURMUR_CI_SKIP_E2E toggle). Use whenever the user wants to run/fix/understand CI, triage a red pipeline, or check why the gate failed.
+---
+
+# /ci-maintenance — run & debug Murmur's CI gate
+
+Murmur's "CI" is two layers of the SAME gate:
+
+- **`scripts/ci.sh`** — the **single source of truth** for what "green" means. Runs locally and is what every contributor / release must pass.
+- **`.github/workflows/ci.yml`** — a thin macOS wrapper that just calls `bash scripts/ci.sh`. The per-PR `gate` job runs the subset (`MURMUR_CI_SKIP_E2E=1`); the `full-gate` job (weekly + on-demand) runs the whole thing incl. the audio E2E.
+
+> **Golden rule:** to change WHAT CI checks, edit `scripts/ci.sh`. The workflow follows for free. Never add a check only to the YAML (see `/add-ci-gate`).
+
+## The gate, step by step (order matters — fail fast, cheap-before-expensive)
+
+`scripts/ci.sh` runs, in order:
+
+1. **`.claude/hooks/selftest.sh`** — the guardrail meta-test (proves `block-bash`/`secret-scan` still block; prevents a "phantom hook").
+2. **`swiftc -typecheck`** the ScreenCaptureKit sidecar (`src-tauri/sysaudio/sysaudio.swift`). macOS-only; skipped with a note if `swiftc` is absent.
+3. **`cargo clippy --all-targets -- -D warnings`** (in `src-tauri/`).
+4. **`cargo test`** (in `src-tauri/`) — the full test binary.
+5. **`cargo audit`** — RUSTSEC advisories (gates on vulnerabilities, not warnings).
+6. **`cargo deny check`** — advisories + licenses + bans + sources (`deny.toml`); narrowly gates unmaintained on DIRECT deps.
+7. **`cargo build`** (in `src-tauri/`).
+8. **`npx ng lint`** then **`npx ng build`** — the Angular gate (incl. the 16 kB per-component style budget).
+9. **`e2e-core.sh`** + **`e2e-mix.sh`** — headless audio pipeline (`say` → ffmpeg → whisper → provider/stub → Obsidian `.md`). Skipped when `MURMUR_CI_SKIP_E2E=1`.
+
+`ci.sh` `export`s `MISTRALRS_METAL_PRECOMPILE=0` up front (defers Metal-shader compile to first runtime use — needed on a Command-Line-Tools-only Mac and harmless elsewhere).
+
+## Run it
+
+```bash
+source "$HOME/.cargo/env"
+cd /Users/jakubgawronski/Projects/meetnotes
+
+# Full gate (what a release must pass; incl. the heavy E2E + model download):
+bash scripts/ci.sh
+
+# The PR-gate subset (exactly what the GitHub `gate` job runs — no E2E):
+MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh
+```
+
+> The **inner iterate loop is NOT ci.sh** — it's `(cd src-tauri && cargo test --lib)` (fast, ~lib tests). Run the full `ci.sh` once before shipping / to reproduce CI, not on every edit.
+
+## Reproduce a red CI run locally (the #1 job)
+
+1. **Use the SAME command CI used.** PR gate red? → `MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh`. `full-gate` red? → full `bash scripts/ci.sh`. Matching the command rules out "works on my machine" drift.
+2. **Read the failing step, not the summary.** ci.sh prints a `── <step> ──` banner before each; the first non-zero exit stops it (`set -euo pipefail`). Find the last banner — that's the culprit.
+3. **Pull the cloud log** when it's CI-only:
+   ```bash
+   gh run list -R murmur-io/murmur --workflow CI -L 5
+   gh run view <run-id> -R murmur-io/murmur --log-failed
+   ```
+4. **Classify:** real failure (code/test/lint) vs environment (missing `brew` tool, cold cache, model download) vs flake (there are 2 known pre-existing parallel-test flakes — see the audio-echo shipping notes; re-run to confirm before "fixing").
+
+## Gotchas (repo-specific — each is real)
+
+- **Cold builds are slow, on purpose.** The mistralrs/candle/tokenizers ML tree is ALWAYS compiled (feature gates removed) → the first CI build (or after a deps bump / cache miss) pulls hundreds of MB. `Swatinem/rust-cache` keeps the incremental loop fast. Don't "fix" a slow cold build by ripping out the ML deps.
+- **`cargo clippy --all-targets` is BLOCKED as a bare command** by `.claude/hooks/block-bash.sh` (it thrashes the openssl/sqlcipher profile and times out in the iterate loop). It runs fine INSIDE `ci.sh` (allowed as `bash scripts/ci.sh`). To reproduce just clippy, run the whole `ci.sh` — don't call the raw clippy line.
+- **The E2E is heavy + host-specific.** `e2e-core.sh` downloads `ggml-base.en.bin` (~142 MB) and needs `say` + ffmpeg; the provider step falls back to a **stub note** when no `claude` CLI is present (so it passes in CI). That's why per-PR uses `MURMUR_CI_SKIP_E2E=1` and the full E2E is weekly/on-demand with a model cache.
+- **macOS-only steps.** `swiftc`/ScreenCaptureKit, whisper Metal, `say`, the universal build — a Linux runner would silently skip them. CI must stay on `macos-14`.
+- **`cargo audit`/`cargo deny` self-install** (via `cargo install`) if absent — slow. In CI they're pre-installed prebuilt (`taiki-e/install-action`); locally, the first run compiles them once.
+- **What CI can't prove — say so.** Real mic, live ScreenCaptureKit, Touch ID, lock-at-rest, screen-share auto-relock, notarization all need a **signed build on a real Mac**. A green gate is not evidence for them.
+
+## Where things live
+
+| Thing | Path |
+| --- | --- |
+| The gate (source of truth) | `scripts/ci.sh` |
+| Headless E2E | `scripts/e2e-core.sh`, `scripts/e2e-mix.sh` |
+| GitHub Actions wrapper | `.github/workflows/ci.yml` |
+| Guardrail hooks + meta-test | `.claude/hooks/` (`selftest.sh`, `block-bash.sh`, `secret-scan.sh`) |
+| Supply-chain policy | `deny.toml` |
+| Pinned Rust toolchain | `rust-toolchain.toml` (1.96.0 + clippy/rustfmt) |
+| The CI owner-agent | `.claude/agents/ci-cd-engineer.md` |
+
+Adding a step → `/add-ci-gate`. Authoring/altering the workflow → `/github-actions`. Cutting a release (CD) → `/release-murmur` (not this skill).

--- a/.claude/skills/github-actions/SKILL.md
+++ b/.claude/skills/github-actions/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: github-actions
+description: Author and maintain GitHub Actions workflows for THIS repo (Murmur — Tauri 2 Rust + Angular 18, macOS-first, heavy always-compiled ML build). The best-practice patterns tuned to Murmur — macos-14 runner, Swatinem/rust-cache + npm cache + whisper-model cache, SHA-pinned actions resolved live, least-privilege permissions, concurrency cancel, secrets by name, and the ci.sh-wraps-not-duplicates rule. Includes the release-workflow blueprint (CD) that stays a design, since notarization belongs to release-engineer. Use whenever the user wants to write/change a GitHub Actions workflow, tune CI runtime/caching, pin actions, or design a cloud release pipeline for Murmur.
+---
+
+# /github-actions — workflow best-practices for Murmur
+
+Murmur's cloud CI is one file: `.github/workflows/ci.yml`, a **thin wrapper around `scripts/ci.sh`** on a macOS runner. These are the patterns that make a workflow HERE correct, fast, and secure. The overriding rule: **the workflow wraps `ci.sh` — it never re-implements the gate** (that's how local and cloud drift). See `/ci-maintenance` for the gate itself, `/add-ci-gate` to change what it checks.
+
+## Non-negotiables for THIS repo
+
+1. **`runs-on: macos-14`.** macOS is mandatory — `swiftc`/ScreenCaptureKit, whisper.cpp Metal, `say`/ffmpeg E2E, the universal build only exist on macOS. `macos-14` is Apple Silicon (matches the dev Mac + release arch). Never "save minutes" on a Linux runner: it would silently stop testing the macOS surface.
+2. **Least privilege.** `permissions: contents: read` at the top. Add a narrower scope to a single job only if it genuinely needs it; never a blanket `write-all`.
+3. **`concurrency` cancel-in-progress** keyed on the ref, so a new push to a PR kills the stale run.
+4. **Pin every action to a full commit SHA** (never a floating tag) with a `# vX.Y.Z` comment. Resolve the SHA LIVE (next section) — a hallucinated SHA fails the run.
+5. **No new action without user approval** (same policy as new deps/crates).
+6. **Secrets by name only.** Reference `${{ secrets.NAME }}`; never echo a secret, never `set -x` a step that holds one. GitHub masks known secrets in logs — don't defeat it by transforming them.
+7. **`MISTRALRS_METAL_PRECOMPILE: "0"`** in the job/workflow `env` (mirrors ci.sh; defers Metal-shader compile, harmless where full Xcode exists).
+
+## Pin an action to a real SHA (do this, don't guess)
+
+```bash
+# lightweight tag → the ref sha IS the commit:
+gh api repos/actions/checkout/git/refs/tags/v4.2.2 --jq '.object.sha'
+# annotated tag (.object.type == "tag") → deref to the COMMIT sha:
+gh api repos/Swatinem/rust-cache/git/refs/tags/v2.7.5 --jq '.object.sha'      # -> tag object sha
+gh api repos/Swatinem/rust-cache/git/tags/<that-sha> --jq '.object.sha'       # -> commit sha (pin THIS)
+```
+
+Pin the **commit** sha, comment the version. Currently pinned in `ci.yml`:
+`actions/checkout@…11bd719 # v4.2.2`, `actions/setup-node@…39370e3 # v4.1.0`,
+`Swatinem/rust-cache@…82a92a6 # v2.7.5`, `taiki-e/install-action@…678b06b # v2.44.60`,
+`actions/cache@…6849a64 # v4.1.2`.
+
+## Make it fast (or the team routes around it)
+
+- **`Swatinem/rust-cache`** with `workspaces: src-tauri`, AFTER the toolchain is resolved. This is the single biggest win — the always-compiled ML tree (mistralrs/candle) is hundreds of MB cold.
+- **`actions/setup-node` with `cache: npm`** + `npm ci` (not `npm install`) for a reproducible, cached FE install.
+- **Prebuilt cargo tools via `taiki-e/install-action`** (`tool: cargo-audit,cargo-deny`) so `ci.sh` finds them on PATH and skips its slow `cargo install`.
+- **Split the heavy E2E off the per-PR path.** The `gate` job runs `MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh`; the `full-gate` job (weekly `schedule` + `workflow_dispatch` `run_e2e`) runs the whole thing with a **whisper-model `actions/cache`** + `brew install ffmpeg`. Don't make every PR download a 142 MB model.
+- **Resolve the pinned toolchain with `rustup show`** (reads `rust-toolchain.toml` → 1.96.0 + clippy/rustfmt). Don't add a second `dtolnay/rust-toolchain` with a different version.
+- `timeout-minutes` on every job (a hung ML link shouldn't burn the full 6 h).
+
+## The canonical shape (already in `ci.yml`)
+
+```yaml
+on:
+  pull_request: { branches: [murmur] }
+  workflow_dispatch: { inputs: { run_e2e: { type: boolean, default: false } } }
+  schedule: [ { cron: "0 6 * * 1" } ]
+permissions: { contents: read }
+concurrency: { group: ci-${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }
+env: { MISTRALRS_METAL_PRECOMPILE: "0", CARGO_TERM_COLOR: always }
+jobs:
+  gate:                       # every PR — correctness + supply-chain, no E2E
+    runs-on: macos-14
+    steps: [ checkout, setup-node(cache:npm), rustup show, rust-cache(src-tauri),
+             install-action(cargo-audit,cargo-deny), npm ci,
+             run: bash scripts/ci.sh  (env MURMUR_CI_SKIP_E2E=1) ]
+  full-gate:                  # weekly + on-demand — the complete ci.sh incl. E2E
+    if: schedule || (workflow_dispatch && inputs.run_e2e)
+    runs-on: macos-14
+    steps: [ …, brew install ffmpeg, cache(whisper model), npm ci, run: bash scripts/ci.sh ]
+```
+
+## Verify before you push
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"
+command -v actionlint >/dev/null && actionlint .github/workflows/ci.yml || echo "(install actionlint to lint)"
+# After it's on a branch, trigger and watch:
+gh workflow run CI -R murmur-io/murmur -f run_e2e=true      # manual full-gate
+gh run watch -R murmur-io/murmur
+```
+
+## CD / release workflow — a BLUEPRINT, not a live pipeline
+
+A cloud release (sign → notarize → staple → publish) is **the release-engineer's job**, and it collides with a hard repo rule: **keychain/`security`/`notarytool store-credentials` ops must be user-interactive** (they hang on the auth dialog headlessly — `block-bash.sh` blocks them). So do NOT stand up an auto-notarizing release workflow without the user explicitly deciding to move Developer-ID signing into cloud CI. If they do, the blueprint is:
+
+- Trigger: `push` tag `v*` or `workflow_dispatch`.
+- `macos-14`, import the Developer-ID cert from `${{ secrets.APPLE_CERT_P12_BASE64 }}` into a temporary keychain, build universal (`rustup target add aarch64-apple-darwin x86_64-apple-darwin` → `npx tauri build --target universal-apple-darwin`), sign **inside-out by identity HASH, never `--deep`** (`scripts/macos-sign-notarize.sh` already does this), notarize with `xcrun notarytool submit --apple-id/--password/--team-id` from secrets (NOT `--keychain-profile`, which needs the interactive store), staple, `spctl` verify, `gh release upload`.
+- Secrets: `APPLE_CERT_P12_BASE64`, `APPLE_CERT_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` (`BVF778E5QD`). `com.meetnotes.app` immutable.
+
+Until then, cutting a release stays the local `/release-murmur` flow. Say that honestly rather than implying CI can ship a notarized DMG today.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,139 @@
+name: CI
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Murmur PR gate. `scripts/ci.sh` is the SINGLE SOURCE OF TRUTH for what "green"
+# means; this workflow only WRAPS it on a macOS runner (swiftc / whisper.cpp Metal /
+# ScreenCaptureKit are macOS-only, so Linux runners cannot mirror the gate).
+#
+#   • gate       — every PR into `murmur`: the correctness + supply-chain subset
+#                  (runs ci.sh with MURMUR_CI_SKIP_E2E=1 — skips only the heavy
+#                  audio E2E that needs whisper models + a signed provider).
+#   • full-gate  — weekly + on-demand: the COMPLETE ci.sh incl. the headless
+#                  audio E2E (downloads the whisper model, brew-installs ffmpeg).
+#
+# To change WHAT CI enforces, edit `scripts/ci.sh` — never duplicate its command
+# list here (that is how the two drift). See .claude/skills/add-ci-gate.
+# Owned by the ci-cd-engineer agent (.claude/agents/ci-cd-engineer.md).
+#
+# NOTE ON HONESTY: real mic capture, live ScreenCaptureKit, Touch ID, lock-at-rest,
+# and notarization CANNOT run headless in CI — they need a signed build on a real
+# Mac. CI proves compile/test/lint/build/supply-chain + the headless audio pipeline,
+# NOT those. Release/notarization stays with the release-engineer agent.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches: [murmur]
+  workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: "Also run the heavy headless audio E2E (downloads whisper model + ffmpeg)"
+        type: boolean
+        default: false
+  schedule:
+    # Mondays 06:00 UTC — a weekly full gate (incl. E2E) on the default branch.
+    - cron: "0 6 * * 1"
+
+# Least privilege: the gate only reads the repo. No write scopes.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (a new push to a PR kills the old run).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Defer Metal-shader precompile to first runtime use (never happens in a headless
+  # build/test). Mirrors scripts/ci.sh; harmless even where full Xcode is present.
+  MISTRALRS_METAL_PRECOMPILE: "0"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  gate:
+    name: gate (correctness + supply-chain)
+    # Runs on PRs + manual dispatch. Skipped on the weekly schedule — `full-gate` already
+    # runs the complete ci.sh there, so running the subset too would be wasted runner time.
+    if: github.event_name != 'schedule'
+    # macOS is MANDATORY: swiftc ScreenCaptureKit sidecar typecheck + whisper.cpp Metal.
+    # macos-14 = Apple Silicon, matching the dev Mac's arch and the release target.
+    runs-on: macos-14
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install pinned Rust toolchain (rust-toolchain.toml → 1.96.0 + clippy/rustfmt)
+        run: rustup show
+
+      - name: Cache Rust build (registry + git + src-tauri/target)
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+        with:
+          workspaces: src-tauri
+
+      - name: Install cargo-audit + cargo-deny (prebuilt — skips ci.sh's slow cargo install)
+        uses: taiki-e/install-action@678b06b887cdbf44fa0601e5915f865e17c2241d # v2.44.60
+        with:
+          tool: cargo-audit,cargo-deny
+
+      - name: Install JS deps
+        run: npm ci
+
+      - name: Run the gate (scripts/ci.sh — E2E skipped)
+        run: bash scripts/ci.sh
+        env:
+          MURMUR_CI_SKIP_E2E: "1"
+
+  full-gate:
+    name: full gate (incl. headless audio E2E)
+    # Weekly schedule, or on-demand via "Run workflow" with run_e2e = true.
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_e2e)
+    runs-on: macos-14
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install pinned Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+        with:
+          workspaces: src-tauri
+
+      - name: Install cargo-audit + cargo-deny
+        uses: taiki-e/install-action@678b06b887cdbf44fa0601e5915f865e17c2241d # v2.44.60
+        with:
+          tool: cargo-audit,cargo-deny
+
+      - name: Install ffmpeg (E2E — aiff to 16 kHz mono WAV)
+        run: brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
+
+      - name: Cache whisper model (ggml-base.en.bin, ~142 MB)
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        with:
+          path: ~/Library/Application Support/MeetNotes/models
+          key: whisper-ggml-base-en-v1
+
+      - name: Install JS deps
+        run: npm ci
+
+      - name: Run the FULL gate (scripts/ci.sh incl. E2E)
+        # No MURMUR_CI_SKIP_E2E → e2e-core.sh + e2e-mix.sh run. The provider step
+        # falls back to a stub note when no `claude` CLI is present (as in CI).
+        run: bash scripts/ci.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,9 @@ Full runbook: **[`.claude/skills/release-murmur`](.claude/skills/release-murmur/
   - starting, iterating, or debugging the dev app → **`tauri-dev`**
   - shipping a feature or a bug fix → **`ship-feature`**
   - a "should we / can we / how would we add X" question → **`research`**
-- **Agents** (`.claude/agents/`): `rust-tauri-dev`, `angular-zoneless-dev`, `adversarial-verifier`, `lock-security-reviewer`, `release-engineer`, `murmur-researcher` — dispatch as subagents; the implementer never owns the verdict.
+  - running / understanding / debugging the CI gate (`scripts/ci.sh` + GitHub Actions) → **`ci-maintenance`**
+  - adding or changing a check in the CI gate → **`add-ci-gate`**
+  - writing / tuning a GitHub Actions workflow → **`github-actions`**
+- **Agents** (`.claude/agents/`): `rust-tauri-dev`, `angular-zoneless-dev`, `adversarial-verifier`, `lock-security-reviewer`, `release-engineer`, `ci-cd-engineer` (designs & maintains CI — the local `scripts/ci.sh` gate + the GitHub Actions macOS PR-gate that wraps it; CD/notarized release stays with `release-engineer`), `murmur-researcher` — dispatch as subagents; the implementer never owns the verdict.
 
 When a task is multi-step (a feature, a refactor, a release), reach for the **Workflow tool** and let an independent **adversarial-verifier** own the verdict.

--- a/docs/superpowers/specs/2026-07-03-ci-cd-agent-design.md
+++ b/docs/superpowers/specs/2026-07-03-ci-cd-agent-design.md
@@ -1,0 +1,47 @@
+# CI/CD agent + best-practice CI skills — design
+
+**Date:** 2026-07-03
+**Status:** implemented
+**Author:** QueaT
+
+## Goal
+
+Give Murmur a dedicated **CI/CD agent** that designs and maintains CI, plus **best-practice skills tuned to this repo**. Before this, the repo had no cloud CI at all — `.github/` did not exist; "CI" was the local `scripts/ci.sh` gate only.
+
+## Scope decisions (confirmed with the user)
+
+1. **CI scope:** stand up a real **GitHub Actions macOS PR-gate** that WRAPS `scripts/ci.sh` (ci.sh stays the single source of truth). Not: reimplement the gate in YAML.
+2. **CI/CD boundary:** **CI-focused.** The notarized release/CD (sign → notarize → staple → publish) stays with the existing `release-engineer` agent / `/release-murmur` skill — it needs interactive keychain ops that a hard repo rule forbids in the agent shell. The CI/CD agent may DESIGN a release-workflow blueprint but never signs/notarizes.
+3. **Skills:** three — `ci-maintenance`, `add-ci-gate`, `github-actions`.
+
+## Repo realities that shaped the design (code-verified)
+
+- **macOS-only build steps:** `swiftc`/ScreenCaptureKit sidecar typecheck, whisper.cpp Metal, `say`/ffmpeg E2E, universal build → CI must run on `macos-14` (Apple Silicon), never Linux.
+- **Heavy always-compiled ML tree** (mistralrs/candle/tokenizers — feature gates removed) → cold builds pull hundreds of MB; aggressive caching is essential. `MISTRALRS_METAL_PRECOMPILE=0` defers Metal-shader compile.
+- **`scripts/ci.sh` order:** hooks selftest → swiftc → `clippy --all-targets -D warnings` → `cargo test` → `cargo audit` → `cargo deny` → `cargo build` → `ng lint` → `ng build` → `e2e-core.sh` + `e2e-mix.sh`.
+- **Guardrails (`.claude/hooks/block-bash.sh`)** the agent must respect: no direct trunk push, no `security`/keychain CLI, no bare `cargo clippy --all-targets` (it's fine inside `bash scripts/ci.sh`), no `codesign --deep`.
+- **E2E is heavy + host-specific:** downloads a ~142 MB whisper model, needs `say`+ffmpeg, provider falls back to a stub note when no `claude` CLI (so it passes in CI).
+- **Rust pinned to 1.96.0** (`rust-toolchain.toml`, clippy+rustfmt).
+- **What CI cannot prove:** real mic, live ScreenCaptureKit, Touch ID, lock-at-rest, screen-share auto-relock, notarization — need a signed build on a real Mac.
+
+## Deliverables
+
+| Artifact | Path | Purpose |
+| --- | --- | --- |
+| Agent | `.claude/agents/ci-cd-engineer.md` | Owns CI design/maintenance; hard invariants; output contract; CD → release-engineer. |
+| Workflow | `.github/workflows/ci.yml` | macOS PR-gate wrapping `ci.sh`. `gate` job (per-PR, `MURMUR_CI_SKIP_E2E=1`) + `full-gate` job (weekly `schedule` + on-demand `workflow_dispatch`, full incl. E2E). SHA-pinned actions, least-priv perms, concurrency cancel, rust/npm/model caching. |
+| Gate toggle | `scripts/ci.sh` | Added guarded `MURMUR_CI_SKIP_E2E=1` (additive, default off → local behavior unchanged) so the per-PR job reuses ci.sh instead of duplicating its command list. |
+| Skill | `.claude/skills/ci-maintenance/SKILL.md` | Runbook: every gate step, reproduce-red-locally, all gotchas. |
+| Skill | `.claude/skills/add-ci-gate/SKILL.md` | Discipline for adding a check (ci.sh source of truth, order, tool-absent-safe, selftest RED-before-GREEN, workflow parity). |
+| Skill | `.claude/skills/github-actions/SKILL.md` | Workflow best-practices tuned to Murmur + SHA-pin recipe + the CD release blueprint (design-only). |
+| Discoverability | `CLAUDE.md` | Added the agent + 3 skills to the `.claude/` index. |
+
+## Key invariant
+
+**`scripts/ci.sh` is the single source of truth; GitHub Actions wraps it.** A check is added to ci.sh (not duplicated in YAML); the workflow only carries runner-level prerequisites (a `brew install`, a cache, a prebuilt cargo tool). This makes local↔cloud drift structurally impossible.
+
+## Deferred (honest gaps)
+
+- **E2E-in-CI as a per-PR gate** — left as the weekly/on-demand `full-gate` job; making it per-PR needs a provider-auth strategy + accepted model-download cost.
+- **Cloud CD (auto-notarized release)** — a documented blueprint only; requires the user to explicitly move Developer-ID signing into cloud CI (collides with the keychain-is-interactive rule).
+- **First real cloud run** — the workflow is committed but a live GitHub Actions run has not yet been triggered/observed; first PR into `murmur` (or a manual `workflow_dispatch`) is the real proof.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "meetnotes",
-  "version": "0.1.0",
+  "name": "murmur",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "meetnotes",
-      "version": "0.1.0",
+      "name": "murmur",
+      "version": "0.6.4",
       "dependencies": {
         "@angular/animations": "^18.2.0",
         "@angular/common": "^18.2.0",
@@ -18,6 +18,7 @@
         "@angular/router": "^18.2.0",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
+        "dompurify": "^3.4.11",
         "marked": "^14.1.4",
         "rxjs": "^7.8.0",
         "tslib": "^2.6.0",
@@ -28,6 +29,7 @@
         "@angular/cli": "^18.2.0",
         "@angular/compiler-cli": "^18.2.0",
         "@tauri-apps/cli": "^2.0.0",
+        "@types/dompurify": "^3.2.0",
         "angular-eslint": "18.4.3",
         "eslint": "^9.15.0",
         "typescript": "~5.5.0",
@@ -5210,6 +5212,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -5377,6 +5390,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -7843,6 +7863,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -65,11 +65,21 @@ npx ng lint
 echo "── ng build ──"
 npx ng build
 
-echo "── headless core E2E (say → ffmpeg → Whisper → provider → Obsidian) ──"
-bash scripts/e2e-core.sh
+# ── Headless audio E2E. Heavy + host-specific: it needs `say` (macOS TTS), ffmpeg, and a
+#    ~142 MB whisper model download (e2e-core.sh) — and cloud PR runners have no signed
+#    provider. `MURMUR_CI_SKIP_E2E=1` skips ONLY these two steps (everything above still runs),
+#    so the GitHub Actions per-PR `gate` job reuses THIS script as the single source of truth
+#    instead of duplicating the command list. Default (unset) = full local behavior, unchanged.
+#    The full E2E still runs locally and in the CI `full-gate` job (weekly + on-demand). ──
+if [ "${MURMUR_CI_SKIP_E2E:-0}" = "1" ]; then
+  echo "── headless E2E: SKIPPED (MURMUR_CI_SKIP_E2E=1) — run the full gate locally or via the CI full-gate job ──"
+else
+  echo "── headless core E2E (say → ffmpeg → Whisper → provider → Obsidian) ──"
+  bash scripts/e2e-core.sh
 
-echo "── headless mixing E2E (mic + system → mixed transcript, both sides) ──"
-bash scripts/e2e-mix.sh
+  echo "── headless mixing E2E (mic + system → mixed transcript, both sides) ──"
+  bash scripts/e2e-mix.sh
+fi
 
 echo
 echo "✅ CI: all gates green"

--- a/src-tauri/examples/e2e_core.rs
+++ b/src-tauri/examples/e2e_core.rs
@@ -66,6 +66,7 @@ async fn main() {
         template: String::new(),
         vault_titles,
         related_context: None,
+        user_notes: None,
     };
 
     let provider = ClaudeCodeProvider::new();


### PR DESCRIPTION
## What & why

CI was **authored locally but never shipped** — GitHub had zero workflows, zero runs, and the `murmur` trunk had **no branch protection**. Nothing enforced the gate server-side; the only guard was the local `block-bash.sh` hook (this-machine-only). This PR ships the gate so it runs on every PR, and is the precursor to enabling branch protection on `murmur`.

## Changes

- **`.github/workflows/ci.yml`** — thin macOS wrapper around `scripts/ci.sh` (the single source of truth):
  - `gate` job on **every PR into `murmur`** → correctness + supply-chain subset (`MURMUR_CI_SKIP_E2E=1`).
  - `full-gate` job (weekly cron + on-demand) → complete `ci.sh` incl. the headless audio E2E.
  - macos-14 (mandatory: swiftc ScreenCaptureKit sidecar + whisper Metal), SHA-pinned actions, least-privilege `contents: read`, concurrency-cancel, rust + npm + whisper-model caches.
- **`scripts/ci.sh`** — gate the two heavy E2E steps behind `MURMUR_CI_SKIP_E2E` so one script backs both the local full gate and the fast PR job (no duplicated command list in YAML).
- **`.claude/`** — `ci-cd-engineer` agent + `ci-maintenance` / `add-ci-gate` / `github-actions` skills + design spec; `CLAUDE.md` references them.

## Gate steps (order = fail-fast, cheap-before-expensive)

hooks selftest → swiftc typecheck → clippy `-D warnings` → cargo test → cargo audit → cargo deny → cargo build → ng lint → ng build → (E2E only in full-gate).

## Scope

CI only. **CD** (Developer-ID sign → notarize → staple → publish) stays the manual `release-murmur` runbook by design — notarization cannot run headless.

## After merge

Enable branch protection on `murmur`: require the `gate` status check + require a PR before merge + block force-push/delete (solo-friendly: 0 required approvals, admins not enforced).