### PR TITLE
feat(brain): cross-meeting user memory + configurable embedder + bake-off harness + default hardening

### DIFF
--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -38,6 +38,21 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-07-03] Phase 3 cross-meeting user memory (lock-touching)
+- **Pattern:** reused the bitemporal `facts` substrate (pure `reconcile_facts`) for a NEW user-scoped
+  `user_facts` table (separate table, NO entity FK, `USER_SCOPE` sentinel in the `entity_id` reconcile
+  slot only — never persisted). Purge-on-seal wired into BOTH the seal tx (`purge_user_facts_tx`) AND
+  the at-rest reconcile; gated read `list_user_facts_visible` mirrors `list_facts_visible`'s
+  meetings-JOIN `visibility_clause`. Injected the brief into `assistant_system_prompt` exactly like
+  `live_transcript` (rides the existing RedactingProvider + consent gate — no new egress class).
+- **Trap hit:** a SQL string comment containing `"double quotes"` TERMINATES the Rust string literal →
+  21 spurious compile errors. Use single-quotes / plain words in SQL-string comments.
+- **Caught by:** `cargo test --lib` (12 new tests). RED-before-GREEN proven by deleting the
+  visibility predicate → both the DB gate test AND the brief-injection test failed (sealed fact leaks).
+- **Lesson:** when adding an `fn(a, b)` arg, grep ALL call sites incl. test modules — 13 test sites
+  needed the 3rd arg; a `perl -0pi` batch is faster than 13 Edits. Flag for lock-security-reviewer.
+- **Status:** GREEN (771 lib tests pass; migration still idempotent).
+
 ### [2026-07-02 seed] Distilled from rust-tauri.md + lock-model.md
 - **Pattern:** errors/commands/SQLCipher/additive-migrations/seal-verify/gate-reads/crash-safe-FFI.
 - **Caught by:** operator (seeding the loop).

--- a/docs/RAG-BAKEOFF.md
+++ b/docs/RAG-BAKEOFF.md
@@ -89,7 +89,76 @@ Once 2c wires a real on-device embedder (BGE-M3 via mistral.rs/llama.cpp or fast
 
 ---
 
+## Stage 2b — AUTOMATED metric harness (`eval::bakeoff`) — recall@k / nDCG@k / MRR
+
+The human 0–2 scoring above is the gold signal, but it's slow and subjective. The `eval::bakeoff` module (`src-tauri/src/eval/`) automates the comparison: give it a **labeled set** (queries + the meeting ids that *should* be retrieved) and it runs all three legs — **FTS-only**, **semantic-only** (vector KNN), and **hybrid** (RRF fusion) — and prints **recall@k**, **nDCG@k**, and **MRR** per mode. Same visibility gating as the app (sealed-not-unlocked meetings are invisible to the eval).
+
+### 1. Build a labeled set (JSON)
+Format = a top-level array of `{ query, lang, expected_meeting_ids }`. A sample lives at `src-tauri/src/eval/fixtures/rag-bakeoff-sample.json` — copy it and fill the `expected_meeting_ids` with **real meeting ids from your DB**.
+
+To find meeting ids, read your dev DB (see the "inspect the dev DB" recipe): the ids are `meetings.id`. Reuse the Stage-1 question set — you already know which meetings each question *should* pull. Example:
+```json
+[
+  { "query": "kiedy ustaliliśmy deadline na integrację API", "lang": "pl",
+    "expected_meeting_ids": ["mtg_abc123"] },
+  { "query": "what did we decide about the Q3 budget", "lang": "en",
+    "expected_meeting_ids": ["mtg_def456", "mtg_ghi789"] }
+]
+```
+
+### 2. Point the harness at a real DB + set and run it (on your Mac)
+The end-to-end run is an `#[ignore]`d test driven by env vars (no recompile needed to change the set):
+
+```bash
+source ~/.cargo/env
+# Copy your dev DB first (WAL-safe): the dev app writes MeetNotes-dev/meetnotes.sqlite with the dev DEK.
+cp ~/Library/Application\ Support/MeetNotes-dev/meetnotes.sqlite* /tmp/   # copy the .sqlite + -wal + -shm
+
+cd src-tauri
+MURMUR_BAKEOFF_DB=/tmp/meetnotes.sqlite \
+MURMUR_BAKEOFF_DEK=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+MURMUR_BAKEOFF_SET=/path/to/your-labeled-set.json \
+MURMUR_BAKEOFF_K=5 \
+cargo test --lib eval::bakeoff::tests::run_bakeoff_over_real_db_from_env -- --ignored --nocapture
+```
+- `MURMUR_BAKEOFF_DEK` = the dev DEK (above) for a dev DB; the real Keychain DEK for a release DB.
+- The embedder is `active_embedder()` — the **real model when its files are on disk**, else the stub (it prints a WARNING; stub numbers are NOT a quality signal, so download the model first).
+- To include a sealed folder, unlock it in the app, then copy the DB (its chunks are only present while unlocked).
+
+### 3. Read the output
+A table like:
+```
+RAG bake-off — 18 queries, k=5
+mode          recall@5     ndcg@5        mrr
+--------------------------------------------
+fts             0.6111     0.5487     0.6389
+semantic        0.7222     0.6841     0.7500
+hybrid          0.7778     0.7213     0.7917
+```
+- **recall@k** — did the right meetings show up in the top-k at all (coverage).
+- **nDCG@k** — were they ranked *high* (position-weighted).
+- **MRR** — how high was the *first* correct hit.
+Higher is better on all three (0–1). If **hybrid** beats **fts** on your PL + paraphrase queries, the vector layer earns its keep; if **fts ≈ hybrid**, it doesn't at your scale. Compare **semantic** vs **hybrid** to see whether fusion helps or the raw vectors are enough.
+
+### 4. Comparing embedding MODELS (e5 vs mmlw-e5-small)
+Two embedders ship as first-class selectable options (both BERT / 384-dim, so switching needs **no** DB migration — only a re-index):
+- `multilingual-e5-small` (default, intfloat) — general multilingual.
+- `mmlw-e5-small` (sdadas) — a **Polish-first** distilled e5, strong PL-MTEB retrieval.
+
+To bake them off against each other on your Polish queries:
+1. In the app, pick the model (or call the `select_embed_model` command with `"multilingual-e5-small"` / `"mmlw-e5-small"`) → download it (`download_embed_model`) → **re-index** (`reindex_embeddings`, required because a different model's vectors aren't comparable).
+2. Copy the DB and run the harness above → record the table.
+3. Switch the model, re-index, re-run → compare the `semantic`/`hybrid` rows. The model with the higher PL recall@k / nDCG@k wins for your vault.
+
+*mmlw config verified: BERT architecture (`model_type: bert`, loadable by candle's `BertModel`), `hidden_size == 384` (matches `EMBED_DIM`, zero schema change), and the same `"query: "`/`"passage: "` asymmetric prefix convention as e5 (per its HF card).*
+
+### Metric math is unit-tested (no model needed)
+The recall@k / nDCG@k / MRR implementations are pure and covered by deterministic unit tests over synthetic rankings (`cargo test --lib eval::` — runs in the normal loop). The *real* run above is the only part that needs a Mac + the model.
+
+---
+
 ## Honesty notes
 - Stage 1 is fully doable **today** (FTS5 is live) and is the cheaper, decision-first gate — do it first.
-- Stage 2 needs the real embedder (Phase 2c) + your signed/dev build on a real Mac; headless tests can't measure retrieval *quality* or Polish recall.
+- Stage 2 needs the real embedder + your signed/dev build on a real Mac; headless tests can't measure retrieval *quality* or Polish recall.
+- Stage 2b (`eval::bakeoff`) gives OBJECTIVE recall@k/nDCG@k/MRR numbers, but they're only as good as your labeled set — label from real questions where you *know* the right meetings, and keep the set stable across runs so model/mode comparisons are apples-to-apples.
 - Keep the question set stable across runs so scores are comparable. Real questions from your actual work give far better signal than synthetic ones.

--- a/docs/research/2026-07-03-murmur-full-analysis-strengths-gaps-killer-features.md
+++ b/docs/research/2026-07-03-murmur-full-analysis-strengths-gaps-killer-features.md
@@ -1,0 +1,198 @@
+<!-- Generated 2026-07-03 via /research (Workflow: 8 murmur-researcher agents + 1 completeness critic; ~954k subagent tokens, 187 web/code tool calls). Pricing/funding/versions/lawsuits = point-in-time mid-2026. Trust code over docs; symbols grep-confirmed where cited. -->
+# Research: Murmur — full-app analysis (strengths, weaknesses), competitive gaps, killer features, and "is it breakthrough?"
+
+## TL;DR / Verdict
+
+**On the cusp of breakthrough — not there yet, and the reason is not the build, it's three things: the defaults hide the moat, the "brain" is unproven, and distribution is ~0.**
+
+Murmur (v0.6.4, macOS) has the **deepest private-AI architecture in its entire category** — no surveyed competitor, cloud *or* local, combines all five of: per-folder biometric encryption-at-rest (Touch-ID KEK → AES-256-GCM content key, verify-before-destroy), a redaction firewall that lets you run a **frontier cloud model on scrubbed text**, Obsidian-owned `.md` files, a local lock-gated MCP server, and a **live in-meeting agentic brain**. That bundle is architecture, not policy, so a $192M-funded incumbent structurally cannot copy it without cannibalizing its own business.
+
+But "breakthrough" is a **market** verdict, and by that measure Murmur is a category-leading *build* with three gaps:
+
+1. **Its own defaults read as a cloud notetaker.** Out of the box the brain runs on cloud `claude_code`, diarization is OFF, semantic vectors are OFF, NER name-redaction is OFF. Every architectural moat is opt-in configuration. *The single cheapest strategic win is flipping/spotlighting defaults, not building features.*
+2. **The "ClickUp-Brain-class local knowledge manager" ambition rests on an unproven core.** The semantic-retrieval leg (e5 vectors) is dormant-by-default, the embedder is mis-chosen for Polish (55.2 vs 67.5 PL-MTEB), the RAG bake-off is unrun, and *there is no eval harness to run it with*. Cross-meeting persistent memory doesn't exist yet (per-meeting threads DO now persist — see corrections). Until "ask my last 6 months, get a cited correct answer, fully on-device" provably beats the cloud incumbents on the user's own data, "second brain" is aspirational.
+3. **Distribution ≈ 0 in a suddenly-crowded lane.** anarlog/Hyprnote (YC S25, 8.8k★), Meetily (13.5k★), Screenpipe (YC S26, 19.6k★), Talat (local-by-default), and Basil (on-device, already selling to lawyers/therapists) all exist. "Local + owned markdown + an MCP" is now **table-stakes**, not a moat.
+
+Two structural forces the roadmap must respect: **the OS is commoditizing the core loop from below** (Apple Intelligence/Notes ships free on-device record→transcribe→summarize on M1+/8GB; Microsoft Recall does Windows ambient memory) — so stop selling transcription/summary as the value. And **the ambient/always-on frontier is a graveyard** (Rewind→Meta, Bee→Amazon, live wiretap litigation) — don't go there.
+
+**The one feature everyone converges on** as the differentiated, half-built, legally-defensible move: **on-device cross-meeting speaker voiceprint identity** ("this is Anna again," across your whole history). It is the category's #1 unmet demand; Otter/Fireflies ship it in the cloud and are being **sued under BIPA** for exactly that; Murmur already computes the CAM++ embeddings and can persist them sealed-at-rest — the one way the market legally can't.
+
+**Verdict in one line:** *Murmur is what people wish Granola were, engineered better than anyone in the lane — but it's a superb instrument nobody's holding yet. It becomes breakthrough when it (a) makes the local moat the default and visible, (b) proves the brain, and (c) ships voiceprint identity — then picks ONE wedge: a regulated vertical, or E2EE multi-device sync.*
+
+---
+
+## Corrections to the standing record (trust code, not docs)
+
+The sweep grep-confirmed several facts that older docs/memory got wrong. Fix these before they misdirect the roadmap:
+
+| Claim in old docs/memory | Reality (code-confirmed 2026-07-03) |
+|---|---|
+| "shipped 0.6.3" | **0.6.4** in `src-tauri/Cargo.toml` + `package.json` on trunk. |
+| "@brain threads are FE RAM-only, no `thread_id`, no cross-session memory" | **Per-meeting thread persistence is SHIPPED**: `thread_id` on `assistant_interactions` (`db.rs:436`), backend UUIDv4 when FE omits it (`commands.rs:759`), gated `list_assistant_threads_visible` (`db.rs:3770`), purge-on-seal + round-trip tests (`db.rs:5538/5591`). The **real** remaining gap is *cross-meeting* memory and *whole-vault Ask* (still RAM-only). |
+| "no on-device diarization; me/others only" | **N-way on-device diarization IS shipped** (sherpa-onnx pyannote-3.0 + WeSpeaker CAM++, `diarize.rs`, wired `pipeline.rs:424`) — but **default OFF** (`config.rs:302`), **system-stream only** (mic never diarized), **per-meeting only** (no cross-meeting identity), and **quality unverified**. |
+| "redaction is regex-only; names not redacted" | A real **multilingual mDeBERTa-v3 NER name-redactor exists** (`redact.rs`, `ner-mdeberta-v3-multilingual`) — but **downloaded-not-bundled, presence-gated, no-op fallback**. Default installs redact only emails/cards/phones by regex. Selling it as "compliance-grade name scrubbing" without the model present is a **false-safety liability**. |
+| "STATUS.md is current" | `docs/STATUS.md` is **stale** (dated 2026-06-24: base.en model, 31 tests, "Phase 2 unverified"). Rules still cite `biometric.rs`, which **no longer exists** (Touch-ID/LAContext folded into `secrets/keychain.rs`). Regenerate or delete it. |
+| "proactive brain is a spec" | **In-meeting proactive recall is SHIPPED** (`proactive.rs`, zero-egress matcher → dismissible cards, `EVENT_PROACTIVE_HINT`). Post-meeting fact-deltas deferred (spec P3). |
+
+---
+
+## Co już mamy — current state, code-cited (v0.6.4)
+
+Murmur is far past "record → summarize → note." Verified substrates:
+
+- **Privacy/lock engineering (strongest in category):** whole-DB SQLCipher (DEK) + a *second* per-folder AES-256-GCM content-key wrapped by a Touch-ID-released master KEK; **verify-before-destroy** on every seal; **every content read gated** by `meeting_is_unlocked`/`visibility_clause`; screen-share auto-relock; the `convertFileSrc`/`asset:` leak closed by nulling `audio_path` in the masked DTO. (`.claude/rules/lock-model.md`; `commands.rs:4780,6125`; `db.rs:4555`.)
+- **Redaction firewall + egress ledger + revocable fail-closed consent:** `RedactingProvider` wraps *every* cloud provider across pipeline/orchestrate/reason/voice_action, scrubbing PII before egress and restoring in the reply; content-free egress ledger; ollama path = zero egress. (`redact.rs`; `tools.rs:375-424`; `lib.rs:100-111`.)
+- **Live in-meeting agentic brain:** `run_agentic_loop` (`agent.rs:72`) answers `@brain` threads against the rolling live transcript; **read-only by construction** (`allow_writes:false`), propose-accept, gated tools re-read the unlock set every call. (`voice_action.rs`, `tools.rs`.)
+- **The "brain" data layer (all derived indexes over the one SQLCipher DB):** FTS5 (always-on) + e5 vectors via sqlite-vec/RRF (**dormant by default**) + entity Person/Project graph + **bitemporal facts** (Graphiti-lite, invalidate-not-delete) + document ingestion + a `/brain` page. (`db.rs`, `facts.rs`, `embed.rs`.)
+- **Crash-safety, incident-driven:** Metal residency abort-guard at process entry (aborts in RELEASE too), graceful native dialog + clean exit on DB/keychain failure, startup reaping of capture helpers orphaned to launchd, lifecycle relock+KEK-zeroize+WAL-checkpoint. Crash-safe FFI (CoreGraphics C-funcs only, zero `msg_send`). (`lib.rs:54,189-352`; `screenshare.rs:16-41`.)
+- **On-device N-way diarization** (opt-in), a **two-profile tuned Whisper** (Fast greedy / Accurate beam-5 + temperature ladder + anti-hallucination, tuned for inflected Polish; default large-v3), **~733 in-tree tests** + a supply-chain CI gate (clippy `-D warnings` + cargo audit + cargo deny + E2E). (`whisper.rs`, `diarize.rs`, `scripts/ci.sh`.)
+- **Owned output + no-per-seat economics:** Obsidian `.md` + front-matter + `[[wikilinks]]` + `obsidian://` block-refs + `.canvas`; **zero payment code**, AGPL-3.0, BYO-key or local Ollama.
+- **Local read-only MCP** (6 gated tools on `127.0.0.1:8765`, fail-closed token). (`mcp.rs`.)
+- **Polished non-brain surfaces** (detail 3.3k-line view + timeline scrubber, library, analytics with egress-ledger/digest/threads, graph, 10-section settings + 5-component AI hub); a calm 5-step onboarding wizard; the standout **`@brain` grammar** (one token splits verbatim-note vs thread) and **propose→accept** trust identity.
+
+---
+
+## Findings — the honest picture
+
+### Strengths (defensible vs table-stakes)
+
+**Genuinely differentiated / architecture-level (hard to copy):**
+- **Content-level encryption-at-rest with biometric unlock.** *No surveyed competitor has it* — cloud tools store plaintext transcripts on their servers; local tools (Talat/Meetily/Screenpipe/anarlog) store a plaintext local SQLite. Murmur's single most differentiated axis. (C1, C2, K2 — high.)
+- **The redaction firewall.** A category no one occupies: cloud tools send everything; local tools avoid cloud (worse models). Murmur uniquely runs a *frontier* model on *redacted* text. (C1, C2, K2 — high.)
+- **The integrated bundle + brain depth.** Every cohort member has 1–2 of {local capture, vault-native Obsidian, local MCP, graph/facts, lock, redaction, live agentic}; none has 5+. The moat is the *integration*, not any single feature. (C2 — high.)
+- **Live agentic in-meeting AI** — ahead of the cohort's post-meeting-only AI (though narrow and being crept on). (C1, C2 — high.)
+- **Crash-safety + crash-safe FFI maturity** — incident-driven, above category norm. (A1 — high.)
+
+**Commodity / table-stakes (be candid):** on-device Whisper, local Ollama summaries, "an Ask," "has an MCP" (Fellow/Fireflies/Otter/Granola/Screenpipe all ship one now), local + owned-markdown output. These are cost-of-entry, not the pitch.
+
+### Weaknesses & risks (ranked by strategic weight)
+
+1. **The defaults bury the moat.** Cloud `claude_code` brain by default; diarization/vectors/NER all OFF. Out-of-box Murmur reads as a cloud notetaker; the whole local-first story is opt-in. Talat/Meetily default to a *local* reasoner and thus *out-privacy* Murmur's default config. (Critique headline; A1, C1 — high.)
+2. **The brain is unproven, and the proof is blocked on unbuilt infrastructure.** No bake-off harness, no labeled PL+EN dataset, no retrieval metric, no diarization-DER harness — *and* the embedder is mis-chosen for Polish. Proving the brain is a build, not a weekend spike. This gates the entire ClickUp-Brain-class ambition. (Critique; T1, K2 — high.)
+3. **Distribution ≈ 0; AGPL is a double-edge.** Solo/small team vs YC-funded, high-star, multi-platform competitors. AGPL-3.0 (a) lets a funded competitor *fork* the lock/redaction/facts code that is the moat, and (b) is *banned by many enterprise/regulated IT departments* — directly undercutting the regulated-vertical GTM. Dual-licensing is unaddressed. (Critique; C2, K2 — high.)
+4. **Single-device / macOS-only / no team/mobile/sync** — a hard ceiling that directly caps the "knowledge-manager" ambition and loses to *every* competitor on reach. Closing it means either breaking local-first or building E2EE sync of the SQLCipher store (large effort). (A1, C1, K2 — high.)
+5. **Default-ON offline AEC3 rides a 5-month-old v0.1.0 crate** (`sonora`, Feb-2026, 55★) on every recording with a system stream, and its real efficacy (ERLE on genuine speaker→mic echo) is unverifiable headless. For a compliance pitch, shipping a transcript-corrupting-if-wrong, real-Mac-unverified default-ON dependency into a lawyer's privileged record is a trust risk. **Consider default-OFF until real-Mac-proven.** (A1 — high code / medium efficacy.)
+6. **Diarization solves the easier half** — system-stream only, no in-room mic split, **no cross-meeting voiceprint identity** (the actual #1 ask). (A1, T1 — high.)
+7. **First-run friction & weak-Mac risk:** the default provider needs the `claude` CLI in PATH; the backend default model is large-v3 (~3GB/3–4GB RAM, swaps on 8GB Macs) while onboarding preselects "small" — any path bypassing onboarding hits the 3GB surprise; the model-download step is a blocking gate. (A1, K3 — high.)
+8. **The regulated-vertical GTM is more fragile than it reads:** single-user Touch-ID-local KEK vs multi-seat/MDM/audit; AGPL IT bans; dormant NER = false-compliance; bus-factor/SLA credibility for a solo project. Promising wedge, needs real de-risking. (Critique — high.)
+9. **Surface sprawl** — 7 nav tabs, THREE chat surfaces sharing one grammar, `/graph` duplicated inside `/brain`: the exact "AI sprawl" 77.5% of workers say they'd be relieved to lose, *inside a tool that sells consolidation*. (K3 — high.)
+10. **Maintainability tax:** `commands.rs`/`db.rs` are 8k-line monoliths; STATUS.md drift. Review-surface + merge-conflict risk, not a correctness bug. (A1 — high.)
+
+### The competitive landscape, mid-2026 (fresh)
+
+**Cloud/mainstream has caught up to the "knowledge engine" framing.** Otter's **Conversational Knowledge Engine** (28 Apr 2026): longitudinal knowledge graph + agentic workflows + **bidirectional MCP** (Otter as both client and server). Read.ai cross-channel personal knowledge graph; Granola Chat + cloud MCP + public REST API ($1.5B, $192M raised, pivoting to "enterprise memory layer"); Sembly multi-meeting chat + AI Artifacts; Notion AI native meeting notes + Enterprise connectors; Zoom AI Companion 3.0 cross-platform (81.35% in independent benchmarking, ahead of Copilot). **Cross-meeting "ask your history" and MCP are now commodity** in this tier. All are cloud, none Obsidian-native, none on-device.
+
+**The local-first cohort is crowded and moving fast:**
+- **fastrepl/anarlog** (ex-Hyprnote, YC S25, MIT, 8.8k★, near-daily releases) — *Murmur's exact stack twin* (Tauri+Rust+local Whisper+Ollama). Already shipped **persistent cross-meeting chat**, dual calendar sync, assisted speaker assignment. Missing only: MCP, Obsidian export, graph/facts, the lock model. **The single most dangerous "could become Murmur."**
+- **Meetily** (Zackriya, MIT, 13.5k★, mac/Win/Linux) — system-audio capture, Parakeet/Whisper, Ollama; diarization + Obsidian + chat all "coming soon."
+- **Screenpipe** (YC S26, 19.6k★) — 24/7 local screen+audio → SQLite + MCP; structurally closest to a "multi-source local context store," but surveillance-DNA, not vault/meeting-native, no lock.
+- **Talat** ($49→$99, TechCrunch Mar-2026) — local Mac (ANE/Parakeet or Ollama) + Obsidian + MCP + dual-side capture, **local reasoner by default**. The near-exact positional clone; lacks lock/redaction/facts/live-AI.
+- **Basil** — fully on-device Mac/iPhone, **already selling to lawyers/therapists** — proves the regulated wedge, at shallower feature depth.
+- **MegaMem** (54★) — Obsidian→Graphiti graph + MCP, but no capture; the cheap "assemble ~80% of Murmur's brain" supplier.
+
+**The Obsidian community-plugin channel is empty** — no meeting-brain has taken it (top hits <25★), yet Murmur already writes owned `.md`/`.canvas`/block-refs. A real distribution wedge into Obsidian's ~1.5M MAU.
+
+**Trust wounds to weaponize (fresh, citable):** Otter faces an Aug-2025 federal **wiretapping/consent class action** (Brewer v. Otter, N.D. Cal., MTD hearing 20 May 2026); Fireflies faces two BIPA voiceprint suits (Cruz Dec-2025, Fricker Jan-2026). Murmur *structurally cannot* train on you (on-device / redacted-only egress) vs incumbents that merely *promise* not to.
+
+### The un-modeled structural threat: OS commoditization from below
+
+Only surfaced by the critic. **Apple Notes on Mac** (M1+, 8GB+, macOS 15.1+) *already* records audio → on-device Apple-Intelligence transcript **summary**, free; the Phone app does on-device call transcription; **Microsoft Recall** does Windows ambient memory. The `record→transcribe→summarize` loop is being eaten from below. Murmur's durable value is precisely what the OS does *not* do: **system-audio capture from Zoom/Meet/Teams, a cross-meeting brain, the lock model, Obsidian-owned files, MCP.** Stop selling transcription/summary as the value.
+
+### The ambient/always-on frontier: a trap with a graveyard (do NOT enter)
+
+Rewind (the local-first pioneer) abandoned local-first ("turned MacBooks into a toaster," ~11GB/mo), pivoted to a cloud pendant, and was **absorbed by Meta (Dec 2025), deleting EU users' data**. **Bee → Amazon (Jul 2025).** The one profitable winner, **Plaud** (~$250M annualized, 2M+ users), is **intentful** press-to-record — essentially Murmur's meeting-scoped model with hardware, not always-on. The legal third rail (Brewer v. Otter, all-party consent) *worsens* with bystander capture, and local encryption fixes data-at-rest but does nothing for *other-party consent*. **Keep meeting/session-scoped capture as the trust boundary** — but **claim the narrative the incumbents vacated**: a "bring your life-log home" import adapter (Limitless/Plaud/Bee/Otter/Rewind exports → owned SQLCipher markdown) and a **companion posture** ("your pendant records, Murmur remembers, on *your* Mac"), zero hardware, zero ambient liability.
+
+### The on-device model frontier (what's now feasible)
+
+- **Cross-meeting voiceprint identity is now shippable and half-built.** CAM++/WeSpeaker embeddings already compute for opt-in per-meeting diarization; FluidAudio (Apache-2.0, ANE, pyannote-3.1, speaker-enrollment + speaker database, 10.6% DER on AMI-SDM) is the reference design. Persist a CK-sealed embedding table + cosine-match = "who said what" across every future meeting, on-device.
+- **The embedder is the wrong choice for Polish** — multilingual-e5-small scores 55.21 PL-MTEB vs 67.50 for a Polish-native 124M (mmlw-roberta-base). Running the bake-off on e5-small would make the semantic leg lose to BM25 *for the wrong reason*. **Fix the embedder first** (mmlw-e5-small is a zero-migration 384-dim drop-in), *then* run the bake-off.
+- **Whisper large-v3 is already near-SOTA for Polish** (~7.3% FLEURS, comparable to Parakeet-v3's 7.31%). An ASR migration is a **speed/battery** play (Parakeet on ANE ~10x RTF, frees the GPU), *not* an accuracy upgrade — keep large-v3 as the accurate PL + code-switch default.
+- **A fully-local *reasoner* is close-but-not-there.** The seam exists (Qwen3-14B/Bielik-11B/Qwen2.5-3B GGUF registry), but it runs *prompt-instructed* JSON with **no constrained decoding** (JsonSchema overflowed Bielik's 32K context, `reason/mistral.rs:133`), open models top ~75% on *single-turn* BFCL with a steep unmeasured multi-turn drop, and a 14B on Metal competes with Whisper for the GPU (seconds-to-tens-of-seconds/turn). Ship it as an opt-in **"airplane-mode brain,"** not the default; the cheap reliability win is re-enabling constrained decoding.
+- **Architectural unlock:** a FluidAudio-style CoreML/ANE sidecar for ASR+diarization would move that workload off the Metal GPU onto the Neural Engine, freeing the GPU for a local reasoner — the integration edge that makes "fully-local transcription + diarization + reasoning at once" tractable on one M-chip.
+
+---
+
+## Killer features — ranked (novel × moat-fit × feasibility)
+
+| # | Feature | Why it's a breakthrough lever | Fit / effort | Verdict |
+|---|---|---|---|---|
+| **1** | **On-device cross-meeting speaker voiceprint identity** | Category's #1 unmet demand; Otter/Fireflies do it in cloud and are **sued (BIPA)** for it; Granola deletes audio. Half-built (CAM++ already computes embeddings). | Persist CK-sealed embedding table + cosine-match; **M**, risk = sherpa binding exposes the vector + cross-mic accuracy + *untested* on-device biometric-consent law. | **BUILD FIRST.** The differentiated, legally-defensible, half-built moat. |
+| **2** | **Cross-session persistent memory ("memory of you")** | ClickUp Brain²'s entire pitch is persistent context (we scored 3 vs 8). Parity-critical for *class membership*. Spec-ready; reuses `facts.rs` with a user scope. | **M**, risk = does synthesized memory help or pollute (needs the same eval). Ship behind flag + forget/audit control. | **BUILD SECOND.** The foundation #1/#3 lean on. |
+| **3** | **Auto-built Personal CRM / relationship graph** | Genuine whitespace — Monica is manual, Dex is cloud/LinkedIn; *no* meeting-AI auto-builds a relationship graph from transcripts. Primitives all exist (entities + facts + `get_entity_dossier` + `list_open_commitments`). | A `/people` synthesis surface + a couple gated readers; **S–M**. | **BUILD THIRD.** The most demo-able payoff of #1+#2. |
+| **4** | **Provenance-linked notes** ("Anna said this, at 12:04") | Kills the #1 AI-notes trust objection (hallucinated summaries); Granola's enhance is *not* provenance-linked. Enabled uniquely by SQLite-canonical + block-refs + timeline. | **M**; supercharged by #1's real names. | **ADD.** Differentiated trust feature, cheap. |
+| **5** | **⌘K "talk to your brain" global command bar** | The single highest *perceived-magic* lever (K3): summon anywhere (even over Zoom), cited answer across the vault, one keystroke to save-as-note/open-thread. Collapses the 7-tab sprawl; reuses the floating-bar window + `ask_vault` + agentic loop. | **M** (window+composer+hotkey; intelligence exists). Keep BOTH fuzzy-jump AND chat (Dia's cautionary tale). | **SHIP.** Makes the second-brain omnipresent, not a destination. |
+| **6** | **Murmur as the local private-memory MCP for your whole AI stack** | Positioning/platform play — *but the MCP substrate is now commodity* (ai-memory-mcp, MemPalace, Granola cloud MCP). Differentiated only as **local + lock-gated + voice-sourced**. | One-click installer registering Murmur into Claude Desktop/Cursor config + expose the dormant propose-accept *write* tool under an approval gate (lock-security required); **S–M**. | **SHIP, don't lead with it.** |
+| **7** | **Proactive post-meeting fact-deltas** ("this updates a fact from 2 weeks ago") | In-meeting recall already ships; this finishes it. Zero-egress proactive is uncontested. | **S–M**; compounds with #1/#2. | **FINISH** after #1/#2. |
+| **8** | **"Bring your life-log home" import adapter** (Limitless/Plaud/Bee/Otter/Rewind exports → owned SQLCipher `.md`) | Rides the wearable wave with **zero** capture/consent/thermal risk; monetizes acquisition anxiety + Granola 30-day-paywall churn; fits the pluggable-ingest thesis. | **S–M**. | **STRONG cheap wedge.** |
+| — | Prove + default the **semantic RAG** (fix embedder → bake-off) | *Enabler, not a headline.* Gates ask-anything quality that #2/#3/#6 depend on. | **S** (embedder swap) + a real-Mac eval build. | **UNBLOCK as a dependency.** |
+| **↓** | Agentic **write-back to Slack/Linear/Jira** | *Contested* — ClickUp Super Agents already ship approval-gated write-back; means new egress + per-connector OAuth (strains local-first). | — | **DEFER.** |
+| **↓** | **Multi-device DB sync** | Real demand, but collides with the Touch-ID-local KEK + whole-DB SQLCipher. Interim: notes are *already* owned `.md` → Obsidian Sync/iCloud/Syncthing over the vault gives multi-device read today. | E2EE zero-knowledge sync = **L** | **DEFER true DB sync;** document the vault-sync interim. |
+| ✗ | "Redaction-firewall-as-a-service" | Off-mission; firewall is best-effort → reselling invites a false-safety claim. | — | **SKIP.** |
+
+---
+
+## Fit with Murmur's constraints
+
+- **Local-first / redaction:** #1 (voiceprints), #2 (memory), #3 (CRM), #7 (deltas) are **zero new egress** (local reads only). #5 (⌘K) and #6 (MCP write) route any cloud text through the existing firewall. #8 (import) is pure local ingest. All on-thesis.
+- **Lock model:** #1 (voiceprints are PII-at-rest), #2 (memory), #8 (imported content), and any new FTS-over-documents / cross-meeting memory table are **mandatory `lock-security-reviewer` gates** — seal + purge-on-lock + gate-every-read, copying the `assistant_interactions`/facts purge pattern.
+- **SQLite-canonical:** every proposed substrate is an additive gated table over the one DB — no second copy of content.
+- **Provider seam:** memory-brief injection mirrors the shipped `live_transcript` pattern; the local-reasoner and ANE-ASR sidecar both slot behind existing seams.
+- **CI honesty (needs a real Mac):** voiceprint re-ID accuracy, diarization DER, AEC3 ERLE, the RAG bake-off, local tool-calling reliability + latency, live diarization, Touch-ID/screen-share-relock. Headless proves plumbing + gating only.
+
+---
+
+## Options & trade-offs — the strategic fork
+
+The critic frames the real decision, and it's a fork a solo team must pick, not drift through:
+
+**A) Double down as the single-user privacy-sovereign "meeting brain" for Mac power-users.** Win the Obsidian/LocalLLaMA niche; monetize the **proven Obsidian model** (app free + owned files; one-time Pro license $49–99 — proven by Superwhisper $249/MacWhisper €59/VoiceInk; a voluntary $50/user/yr commercial license; later an optional E2EE sync $4–8/mo). Lower risk, defensible niche, near-zero marginal cost. Distribution via HN Launch (Hyprnote hit 270 pts), the empty Obsidian plugin channel, r/LocalLLaMA (764k) + r/ObsidianMD (339k), MCP directory.
+
+**B) Make the harder bet: a defensible multi-seat compliance product for ONE regulated vertical** (lawyers via ABA Op 512 / therapists via HIPAA — highest WTP, Granola architecturally cannot enter). *But* this collides with the single-user Touch-ID-local KEK (no multi-seat/MDM), AGPL (IT bans + fork risk on the very moat), and the dormant NER (false-compliance). It needs multi-seat provisioning, audit logs, a support SLA, and dual-licensing — real de-risking, not the frictionless path K2 implied. Validate WTP with a landing page + a compliance one-pager + one bar/therapy-community beta *before* building vertical features.
+
+Both paths share the same **first three builds** (voiceprint, memory, brain-proof) and the same **default-flip**. The fork is really about the *fourth* investment: **Pro-license + E2EE sync (A)** vs **multi-seat + compliance packaging (B)**. Recommendation below leans A-first because it's lower-risk, funds the team, and keeps B open — but the founder's ClickUp-Brain-class ambition points at B, so treat it as an explicit choice, not a default.
+
+---
+
+## Recommendation & first step
+
+**Sequence (each independently shippable, RED-before-GREEN, lock-reviewed where it touches content):**
+
+1. **Flip/spotlight the defaults so the moat is visible out-of-box** (S, this week). Make the fully-local path (Ollama + local brain) a first-class, prominent onboarding choice; align the backend default Whisper model with onboarding's "small"; **default `post_aec` OFF** until real-Mac-proven; regenerate/delete stale `docs/STATUS.md`. *The cheapest strategic win — it converts "reads as a cloud notetaker" into "local-first by default."*
+2. **Fix the embedder, then run the RAG bake-off** (S + a real-Mac eval). Swap multilingual-e5-small → **mmlw-e5-small** (zero-migration 384-dim). Build the missing eval harness + a labeled PL+EN dataset + a retrieval metric. *This unblocks the entire knowledge-manager ambition; without it "second brain" stays aspirational.*
+3. **Ship on-device cross-meeting voiceprint identity** (M) — **the differentiated, half-built moat.** *De-risk with a 1-day spike first:* does the sherpa-onnx Rust binding expose the per-span CAM++ embedding **vector** standalone (not just internal clustering)? + a small real-Mac accuracy eval on 2–3 speakers across mics. Then: enroll-on-rename → CK-sealed embedding row → "This looks like Anna?" suggestion next meeting. Get counsel on the on-device-biometric-consent UX before default-on.
+4. **Ship cross-session user memory** (M, spec-ready) behind a flag with a forget/audit view, then **the `/people` Personal CRM** (S–M) over the existing dossier/commitments/facts. Class membership + the most demo-able payoff.
+5. **Ship the ⌘K "talk to your brain" bar + de-sprawl** (M) — merge `/graph` into `/brain`, unify the three chat surfaces under one store, background-prefetch the model + a canned demo meeting for onboarding-to-first-value. The felt "magic" lever.
+6. **In parallel, validate ONE wedge with zero code** — either a Pro-license page (path A) or a compliance one-pager + one regulated-community beta (path B) — to learn WTP before committing the fourth investment.
+
+**Smallest verifiable first slice (do this next):** the **default-flip + embedder swap** (steps 1–2 up to the eval), because they're headless-shippable, unblock everything downstream, and turn the biggest self-inflicted weakness (defaults hide the moat; brain unproven for the wrong reason) into momentum — while the voiceprint spike de-risks the flagship build in a day.
+
+---
+
+## Open questions / couldn't verify (needs a real Mac or is point-in-time)
+
+- **Legal:** does an on-device, never-egressed, single-user voiceprint capturing a non-consenting remote participant still trigger BIPA/CIPA? Almost certainly far safer than the cloud-collection theory the Otter/Fireflies suits turn on, but **untested law** — needs counsel + a consent-UX decision before default-on. ("Granola *structurally cannot* match voiceprint" is slightly overstated — they *could* store an embedding without audio; they won't because their model is cloud.)
+- **Voiceprint feasibility spike:** does the sherpa binding expose the standalone CAM++ vector, or only cluster internally? Bounds M-vs-L effort.
+- **RAG quality (PL, names, paraphrase)** is unmeasured — only the (embedder-fixed) bake-off answers whether the semantic leg earns default-on.
+- **AEC3 ERLE / diarization DER / voiceprint re-ID accuracy / local-reasoner latency & multi-turn reliability / live-caption cadence** — all real-Mac + recorded-evidence bars; green `cargo test` is not proof.
+- **Regulated-vertical WTP & IT-procurement reality** (MDM/notarization/multi-seat for a free AGPL indie app) — inferred, not measured. Basil's actual depth/pricing came from snippets, not a fetched product page.
+- **Competitor velocity** (anarlog star-growth, managed-cloud pricing; whether Meetily's diarization shipped post-v0.4.0; whether Talat's Obsidian/MCP is shipped vs "planned") — point-in-time snapshots; the real threat is their *rate*, under-measured here.
+- **Market-size TAM ($3.5B→$21–29B)** — analyst estimates that habitually inflate; directional only. **Plaud "~$250M ARR, profitable"** — single-source press; directional.
+- **E2EE zero-knowledge sync feasibility** on the owned-`.md` + SQLCipher + Touch-ID-KEK model — un-spiked; the recurring-revenue thesis depends on it being tractable.
+
+## Sources
+
+**Internal (key symbols — grep-confirmed):** `src-tauri/Cargo.toml` (v0.6.4); `src/lib.rs:34,54,100-111,189-352`; `commands.rs:759,781,4780,6125` + `db.rs:436,3770,4555,5538`; `redact.rs` (NER `ner-mdeberta-v3-multilingual`); `tools.rs:375-424`; `agent.rs:72`, `voice_action.rs`, `proactive.rs`; `transcribe/diarize.rs`, `pipeline.rs:424-495`, `transcribe/model.rs:25-26`, `whisper.rs:16-57`; `reason/mistral.rs:133-142`, `reason.rs:56-84`; `embed.rs:26-104`, `embed/candle_bert.rs`; `settings/config.rs:302,316`; `mcp.rs`; `.claude/rules/lock-model.md`; `docs/STATUS.md` (stale). Prior briefs: `docs/research/2026-07-02-{murmur-vs-granola,clickup-brain-gap-analysis,brain-full-analysis,audio-echo-full-remediation}.md`, `docs/COMPETITIVE-LANDSCAPE.md`, `docs/RAG-BAKEOFF.md`.
+
+**External (fetched, point-in-time mid-2026):**
+- Otter Conversational Knowledge Engine + bidirectional MCP (28 Apr 2026): otter.ai/blog/otter-ai-evolves-from-ai-notetaker...
+- Talat local Mac + Obsidian + MCP, local-by-default: techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine...
+- MCP landscape (Fellow Anthropic-verified, Fireflies, Otter, Screenpipe): meetingnotes.com/blog/ai-meeting-notes-with-mcp...
+- anarlog changelog (persistent cross-meeting chat, calendar, speaker assignment): anarlog.so/changelog · github.com/fastrepl/anarlog (8.8k★) · Hyprnote Launch HN (270 pts): news.ycombinator.com/item?id=44725306
+- Meetily: github.com/Zackriya-Solutions/meetily (13.5k★) · Screenpipe: github.com/screenpipe/screenpipe (19.6k★) · MegaMem: github.com/C-Bjorn/MegaMem (54★)
+- Otter wiretapping class action: npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit · BIPA voiceprint suits (Cruz/Fricker v. Fireflies, Brewer v. Otter): topreviewed.ai/blog/voiceprint-lawsuit-reprice-meeting-ai
+- Otter/Fireflies cross-meeting speaker ID: help.otter.ai/hc/en-us/articles/21665587209367 · summarizemeeting.com/en/faq/does-fireflies-have-speaker-identification
+- Apple Intelligence on Mac (on-device Notes record+summary): support.apple.com/guide/mac-help/...mchl2102c2ae · shadow.do/blog/apple-intelligence-on-mac-2026
+- Ambient graveyard: Meta acquires Limitless (Dec 2025): mlq.ai/news/meta-acquires-ai-wearables-startup-limitless... · Amazon acquires Bee (Jul 2025): techcrunch.com/2025/07/22/amazon-acquires-bee... · Rewind local-first post-mortem: andrewschreiber.substack.com/p/an-early-adopters-thoughts-on-rewindais · Plaud profitable ~$250M: forbes.com/sites/iainmartin/2025/09/02/...
+- On-device models: BFCL V4: gorilla.cs.berkeley.edu/leaderboard.html · FluidAudio (ANE diarization + enrollment, 10.6% DER): github.com/FluidInference/FluidAudio + Benchmarks.md · Parakeet-v3 Polish 7.31% FLEURS: huggingface.co/nvidia/parakeet-tdt-0.6b-v3 · PL-MTEB embeddings (e5-small 55.21 vs mmlw-roberta-base 67.50): arxiv.org/html/2405.10138v2 · Bielik v3: arxiv.org/pdf/2505.02550
+- Market/moat/monetization: Granola $125M/$1.5B: techcrunch.com/2026/03/25/granola-raises-125m... · Obsidian $25M ARR/7-ppl/zero-VC + pricing: finance.biggo.com/news/iVboYp0Bga3fZL9MJEv_ + obsidian.md/pricing · ABA Op 512 / on-device lawyers: basilai.app/articles/2026-06-10-ai-notetaker-lawyers... · therapists+AI: npr.org/2026/05/26/nx-s1-5826943 · Mac transcription one-time licenses: getvoibe.com/resources/macwhisper-pricing, spokenly.app/blog/superwhisper-pricing
+- UX: ClickUp AI-sprawl survey (77.5%/46.5%/2.78x): clickup.com/blog/ai-sprawl-survey · notification budget (3–5/day): tianpan.co/blog/2026-05-13-background-agents-notification-budget... · Dia chat-vs-launcher: supasidebar.com/blog/dia-browser-mac-review-2026 · Superhuman 60-sec wow: flowjam.com/blog/superhuman-onboarding-teardown... · Cursor accept/reject diff: dev.to/vikram_ray/i-reverse-engineered-cursors-ai-agent...

--- a/docs/research/2026-07-03-voiceprint-feasibility-spike.md
+++ b/docs/research/2026-07-03-voiceprint-feasibility-spike.md
@@ -1,0 +1,32 @@
+<!-- Generated 2026-07-03 during the goal-loop follow-up (after the brain-hardening program). Point-in-time. -->
+# Spike: on-device cross-meeting speaker voiceprint identity — is it buildable on our stack?
+
+## Verdict: YES — buildable with the EXISTING dependency, no new crate. Accuracy is @Mac-gated.
+
+The single gating unknown from the analysis ("does the sherpa-onnx Rust binding expose the per-span CAM++ embedding VECTOR standalone, or only run clustering internally?") is resolved.
+
+## Findings
+
+- Today's diarizer (`src-tauri/src/transcribe/diarize.rs`) uses `sherpa_onnx::OfflineSpeakerDiarization`, which runs the full pipeline (pyannote segmentation → CAM++ embedding → fast clustering) and returns only per-meeting cluster **labels** (`SpeakerSpan { speaker: usize }`) — NOT the embedding vectors. So cross-meeting identity is impossible with the current call alone.
+- The **same crate** (`sherpa-onnx = "1.13"`, already compiled) exposes, separately from diarization:
+  - **`SpeakerEmbeddingExtractor`** — computes a speaker embedding vector (`Vec<f32>`) from audio (consumed via an `OnlineStream`). This is the standalone extractor we need.
+  - **`SpeakerEmbeddingManager`** — an in-memory index of named speaker embeddings with `register` + `get_best_matches` (cosine search) + `SpeakerEmbeddingMatch`.
+  - `SpeakerEmbeddingExtractorConfig` — already imported by `diarize.rs` (it configures the embedding leg of the diarizer), so the CAM++ model (`wespeaker_en_voxceleb_CAM++.onnx`) is already downloaded + wired.
+- Sources: docs.rs/sherpa-onnx, github.com/thewh1teagle/sherpa-rs, github.com/k2-fsa/sherpa-onnx (C-API `SpeakerEmbeddingExtractor` + `SpeakerEmbeddingManager`, mirrored across Go/C#/Rust bindings).
+
+## Implementation shape (prod-ready plumbing; accuracy @Mac-gated)
+
+1. **Extract** — after diarization relabels `others-N`, run `SpeakerEmbeddingExtractor::compute` over each span's system-stream samples → one CAM++ vector per per-meeting speaker cluster. (No new model download — the CAM++ file is already present when diarization is enabled.)
+2. **Persist (CK-sealed + gated)** — additive `speaker_voiceprints` table: `{ id, label (e.g. [[Anna]]), embedding BLOB, source_meeting_id, valid_from/valid_to }`. Voiceprints are PII-at-rest → gate reads by visibility + purge-on-seal like `user_facts`/`facts`; lock-security review mandatory.
+3. **Match** — on a new meeting, cosine-match each `others-N` cluster embedding against enrolled voiceprints (`SpeakerEmbeddingManager` or a manual cosine over the gated table) → surface a "This looks like Anna?" suggestion (confirm-to-bind).
+4. **Enroll-on-rename** — when the user renames a speaker (`rename_speaker`), store that span's embedding as the enrolled voiceprint bound to the [[Person]] entity. This feeds the self-assembling Person graph + fact/commitment attribution.
+5. **Flag** — default OFF (like `diarize_others` / `semantic_search_enabled`); depends on `diarize_others` being on.
+
+## Honesty bar (why "prod-ready plumbing" ≠ "proven")
+
+- **Re-identification accuracy** across different mics/meetings, cluster purity, and the cosine threshold can ONLY be validated on a signed build on a real Mac with real multi-speaker audio + the models downloaded. Headless `cargo test` proves the extract→persist→match→gate plumbing + lock invariants, NOT the biometric accuracy. Same pattern as the e5 embedder / AEC / diarization already in the tree.
+- **Legal:** capturing a non-consenting remote participant's voice biometric — even on-device, never-egressed, encrypted-at-rest — is UNTESTED under BIPA/CIPA (the theory the Otter/Fireflies cloud suits turn on is *collection*, largely regardless of storage location). Almost certainly far safer than cloud retention, but not "immune." Ship behind an explicit opt-in + a consent/disclosure note; get counsel before any default-on.
+
+## Recommendation
+
+Implementable as a focused, lock-reviewed increment (M) once the brain-completion increment (thread-turn memory extraction + Ask injection + /people CRM) lands. Plumbing is prod-ready-verifiable headless; the accuracy + legal posture are the honest @Mac / counsel gates — flag them, don't hide them.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1191,6 +1191,70 @@ pub(crate) fn delete_document_inner(state: &AppState, id: &str) -> Result<(), Ap
     Ok(())
 }
 
+// ── CROSS-MEETING USER MEMORY (Phase 3) ────────────────────────────────────────
+//
+// The auditable "what the brain knows about you" surface: list the current user-scoped memory facts
+// (with provenance), forget one, or clear all. Every read is VISIBILITY-GATED — a user fact whose
+// SOURCE meeting is sealed-and-not-session-unlocked is INVISIBLE here (and injected into no prompt),
+// because `list_user_facts_visible` filters by source-meeting `visibility_clause` on the live
+// unlocked snapshot. Forget/clear are bitemporal INVALIDATE (close valid_to), never a silent delete.
+
+/// List the current user-memory facts (open + visible) with provenance, plus the synthesized brief
+/// that is injected into grounding. GATED: only facts whose SOURCE meeting is visible under the live
+/// unlocked snapshot are returned — a sealed-not-unlocked meeting's user memory surfaces NOTHING.
+#[tauri::command]
+pub fn get_user_memory(state: State<'_, AppState>) -> Result<crate::user_memory::UserMemory, AppError> {
+    get_user_memory_inner(state.inner())
+}
+
+/// Inner of [`get_user_memory`] taking `&AppState` (unit-testable gate).
+pub(crate) fn get_user_memory_inner(
+    state: &AppState,
+) -> Result<crate::user_memory::UserMemory, AppError> {
+    let unlocked = unlocked_snapshot(state)?;
+    let facts = state.db.list_user_facts_visible(&unlocked)?;
+    // The audit view and the injected brief are derived from EXACTLY the same visible set, so the UI
+    // faithfully mirrors what the brain actually injects.
+    let brief = crate::user_memory::synthesize_brief(&facts);
+    let dtos = facts
+        .iter()
+        .map(crate::user_memory::UserMemoryFact::from_fact)
+        .collect();
+    Ok(crate::user_memory::UserMemory { facts: dtos, brief })
+}
+
+/// Forget ONE user-memory fact (bitemporal invalidate — the row is CLOSED, never silently deleted,
+/// so history is preserved). After this the fact drops out of `get_user_memory` and the regenerated
+/// brief. Idempotent. Content-free logging (the fact id only, never its text).
+#[tauri::command]
+pub fn forget_user_fact(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
+    forget_user_fact_inner(state.inner(), &id)
+}
+
+/// Inner of [`forget_user_fact`] taking `&AppState` (unit-testable).
+pub(crate) fn forget_user_fact_inner(state: &AppState, id: &str) -> Result<(), AppError> {
+    let at = chrono::Utc::now().to_rfc3339();
+    let closed = state.db.forget_user_fact(id, &at)?;
+    tracing::info!(target: "user_memory", fact_id = %id, closed, "user fact forgotten (invalidated)");
+    Ok(())
+}
+
+/// Clear ALL user memory: bitemporal-close every currently-open user fact (invalidate, never delete —
+/// closed history stays). After this `get_user_memory` and the brief are empty. Content-free logging
+/// (a count only).
+#[tauri::command]
+pub fn clear_user_memory(state: State<'_, AppState>) -> Result<(), AppError> {
+    clear_user_memory_inner(state.inner())
+}
+
+/// Inner of [`clear_user_memory`] taking `&AppState` (unit-testable).
+pub(crate) fn clear_user_memory_inner(state: &AppState) -> Result<(), AppError> {
+    let at = chrono::Utc::now().to_rfc3339();
+    let n = state.db.clear_user_facts(&at)?;
+    tracing::info!(target: "user_memory", count = n, "user memory cleared (all facts invalidated)");
+    Ok(())
+}
+
 /// Full-text-ish search across meeting titles, transcripts, and notes (Library search).
 #[tauri::command]
 pub fn search_meetings(
@@ -1840,6 +1904,15 @@ pub async fn build_and_persist_entities(
         tracing::warn!(target: "facts", error = %e, "fact reconcile failed (note unaffected)");
     }
 
+    // Phase 3 CROSS-MEETING USER MEMORY — extract → reconcile → apply USER-SCOPED facts (preferences,
+    // ongoing work, commitments about the USER) from the note + the user's own typed notes. Same
+    // BEST-EFFORT + NEVER-fails-the-note contract as the entity facts above: empty with the stub / no
+    // model, a hiccup is logged (non-PII) and swallowed. Runs even with zero entities (user memory is
+    // not entity-scoped).
+    if let Err(e) = persist_user_facts_for_meeting(state, meeting_id, title, markdown) {
+        tracing::warn!(target: "user_memory", error = %e, "user-fact reconcile failed (note unaffected)");
+    }
+
     // Sink B — vault [[ ]] stubs, ONLY when a vault is configured AND the meeting's folder is
     // NOT sealed on disk. Disk-truth `locked` (not session `unlocked`): a session-unlock must
     // never re-write encrypted-content stubs back to plaintext on disk.
@@ -1913,6 +1986,51 @@ fn persist_facts_for_meeting(
     // 4) Stamp the source meeting (gating + purge anchor) and apply atomically.
     crate::facts::set_meeting_id(&mut ops, meeting_id);
     state.db.apply_fact_ops(&ops)?;
+    Ok(())
+}
+
+/// Phase 3 CROSS-MEETING USER MEMORY — extract → reconcile → apply USER-SCOPED facts for one
+/// summarized meeting. Mirrors [`persist_facts_for_meeting`] but for the user, not entities:
+///   1. BEST-EFFORT extract user·predicate·object candidates from the note + the user's own typed
+///      notes (empty with the stub / no model — the deterministic core is what carries the value),
+///   2. load the EXISTING user facts (un-gated lifecycle read — reconcile runs before any seal),
+///   3. run the PURE deterministic [`crate::facts::reconcile_facts`] at the meeting's time (the
+///      user-scope sentinel in `entity_id` keys the reconcile),
+///   4. stamp the source meeting onto the Add ops and apply them to `user_facts` in ONE atomic tx.
+///
+/// The (derived) memory brief is regenerated lazily on the next read/turn — no cache to invalidate.
+fn persist_user_facts_for_meeting(
+    state: &AppState,
+    meeting_id: &str,
+    title: &str,
+    markdown: &str,
+) -> Result<(), AppError> {
+    // The user's OWN typed notes for this meeting are the highest-signal memory source (an explicit
+    // "remember that…"). Empty when none (best-effort read).
+    let typed_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
+    // 1) Best-effort extraction (panic-free, empty on stub/no model/decode failure). The reasoner is
+    //    re-resolved from the LIVE config so a consent/backend change applies without restart.
+    let candidates = crate::user_memory::extract_user_fact_candidates(
+        &*state.reasoner.current_for(crate::summarize::roles::Role::Notes),
+        title,
+        markdown,
+        &typed_notes,
+    );
+    if candidates.is_empty() {
+        return Ok(()); // nothing to reconcile — common in the default (no-model) build.
+    }
+    // 2) Existing user facts (all of them — the reconcile input).
+    let existing = state.db.user_facts_all()?;
+    // 3) Deterministic reconcile at the meeting's time (valid-time origin).
+    let at = state
+        .db
+        .get_meeting(meeting_id)?
+        .map(|m| m.started_at)
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    let mut ops = crate::facts::reconcile_facts(&existing, &candidates, &at);
+    // 4) Stamp the source meeting (gating + purge anchor) and apply atomically.
+    crate::facts::set_meeting_id(&mut ops, meeting_id);
+    state.db.apply_user_fact_ops(&ops)?;
     Ok(())
 }
 
@@ -3209,6 +3327,12 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // (`#[serde(default)]`), so a partial/older save can never silently enable it. Unlike
         // `cloud_egress_consented` (preserved-only), this one is settable.
         semantic_search_enabled: d.semantic_search_enabled,
+        // brain2 RAG Phase 2: the SELECTED embedder id is NOT carried on the settings DTO — it is
+        // owned exclusively by the dedicated `select_embed_model` command (which validates the id and
+        // reports whether a re-index is needed). Preserve the live value, so a generic settings save
+        // can never change (or clear) the embedder. Mirrors the `cloud_egress_consented` preserve-only
+        // discipline.
+        embed_model_id: current.embed_model_id.clone(),
         // Phase H (custom GGUF): a CUSTOM brain model file path IS carried on the settings DTO (the
         // "Custom GGUF model" input, camelCase `brainModelPath`). Unlike `brain_model_id` there is NO
         // registry validation — it is a local file path, stored VERBATIM. An empty/absent value clears
@@ -4094,6 +4218,88 @@ pub async fn download_brain_model(
 #[tauri::command]
 pub fn embed_model_present() -> Result<bool, AppError> {
     Ok(crate::embed::embed_model_present())
+}
+
+/// The bundled selectable embedders (multilingual-e5-small default + mmlw-e5-small), each with
+/// `downloaded` (files present in its own subdir) and `selected` (mirrors the persisted
+/// `embed_model_id`). Feeds the embedder picker. No content read / no egress — static metadata +
+/// on-disk existence only.
+#[tauri::command]
+pub fn list_embed_models(
+    state: State<'_, AppState>,
+) -> Result<Vec<crate::embed::EmbedModelDto>, AppError> {
+    let selected = {
+        let c = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        c.embed_model_id.clone()
+    };
+    Ok(crate::embed::embed_model_dtos(selected.as_deref()))
+}
+
+/// Result of [`select_embed_model`]. `reindex_needed` is `true` when the selection actually CHANGED
+/// the resolved model (so its old vectors are stale — a different model's embeddings are not
+/// comparable): the FE should prompt the user to run `reindex_embeddings` (and download the new
+/// model first via `download_embed_model` if `!embed_model_present()`). Counts/flags only — no PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectEmbedModelResult {
+    pub selected: String,
+    pub reindex_needed: bool,
+    pub model_present: bool,
+}
+
+/// Persist the user's SELECTED on-device embedding model id. Validates `model_id` against the
+/// registry (unknown ⇒ `AppError::InvalidArg`) and saves it to config; `AppConfig::save` republishes
+/// the process-global selection so `embed::active_embedder`/`embed_model_present`/`download_embed_model`
+/// pick up the new model with NO restart. Switching the model INVALIDATES existing vectors (a
+/// different model's embeddings are not comparable), so `reindex_needed` is `true` when the resolved
+/// model actually changed — the FE then prompts the user to download (if missing) + re-index. All
+/// bundled options are BERT/384 ⇒ NO `vec0` schema migration. Does NOT download and does NOT auto-
+/// reindex (both are explicit user actions).
+#[tauri::command]
+pub fn select_embed_model(
+    state: State<'_, AppState>,
+    model_id: String,
+) -> Result<SelectEmbedModelResult, AppError> {
+    select_embed_model_inner(&state, model_id)
+}
+
+/// Testable core of [`select_embed_model`]: validate the id, compute whether the resolved model
+/// changed, persist it. No `AppHandle`, so it runs headless.
+fn select_embed_model_inner(
+    state: &AppState,
+    model_id: String,
+) -> Result<SelectEmbedModelResult, AppError> {
+    let model = crate::embed::embed_model_by_id(&model_id)
+        .ok_or_else(|| AppError::InvalidArg(format!("unknown embed model id: {model_id}")))?;
+
+    let mut c = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+
+    // The PREVIOUS resolved model id (None/empty/unknown ⇒ the default) — the re-index trigger keys
+    // on a real change of the resolved model, not merely a config-string write.
+    let prev_resolved = c
+        .embed_model_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(crate::embed::embed_model_by_id)
+        .map(|m| m.id)
+        .unwrap_or(crate::embed::DEFAULT_EMBED_MODEL_ID);
+    let reindex_needed = prev_resolved != model.id;
+
+    c.embed_model_id = Some(model.id.to_string());
+    c.save(&state.db)?; // republishes the process-global selection.
+    drop(c);
+
+    Ok(SelectEmbedModelResult {
+        selected: model.id.to_string(),
+        reindex_needed,
+        model_present: crate::embed::embed_model_present(),
+    })
 }
 
 /// Download the multilingual-e5-small model (3 HF files) into the shared models dir, INBOUND-ONLY,
@@ -7912,6 +8118,47 @@ mod lifecycle_tests {
             state.config.lock().unwrap().brain_model_id.as_deref(),
             Some("bielik-11b-v3")
         );
+    }
+
+    /// `select_embed_model` validates the id, PERSISTS it, and reports `reindex_needed` only when the
+    /// resolved model actually CHANGED (a different model's vectors are stale). Unknown id ⇒
+    /// `InvalidArg` with the selection untouched. Serialized on the embedder-selection global lock;
+    /// restores the default (`None`) at the end so it cannot leak state into parallel tests.
+    #[test]
+    fn select_embed_model_persists_and_flags_reindex() {
+        let _g = crate::embed::EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let state = build_state("embed-select");
+
+        // Selecting the SAME (default) model as the effective one ⇒ no re-index needed.
+        let res = select_embed_model_inner(&state, "multilingual-e5-small".to_string()).unwrap();
+        assert_eq!(res.selected, "multilingual-e5-small");
+        assert!(!res.reindex_needed, "re-selecting the default must not force a re-index");
+
+        // Switching to mmlw CHANGES the resolved model ⇒ re-index needed; persists + reloads.
+        let res = select_embed_model_inner(&state, "mmlw-e5-small".to_string()).unwrap();
+        assert_eq!(res.selected, "mmlw-e5-small");
+        assert!(res.reindex_needed, "changing the embed model must flag a re-index");
+        assert_eq!(
+            state.config.lock().unwrap().embed_model_id.as_deref(),
+            Some("mmlw-e5-small")
+        );
+        assert_eq!(
+            AppConfig::load(&state.db).unwrap().embed_model_id.as_deref(),
+            Some("mmlw-e5-small")
+        );
+
+        // Unknown id ⇒ InvalidArg, selection unchanged.
+        let err = select_embed_model_inner(&state, "not-a-real-embedder".to_string()).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+        assert_eq!(
+            state.config.lock().unwrap().embed_model_id.as_deref(),
+            Some("mmlw-e5-small")
+        );
+
+        // Restore the default so the shared process-global doesn't leak mmlw into other tests.
+        crate::embed::set_selected_embed_model_id(None);
     }
 
     /// The download-target resolver rejects an unknown id (the exact guard `download_brain_model`

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -18,6 +18,7 @@
 use crate::error::Result;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::RwLock;
 
 /// The REAL on-device embedder (multilingual-e5-small via candle). ALWAYS compiled; the real impl is
 /// selected at runtime by [`active_embedder`] when the e5 model dir is present, else the stub.
@@ -72,35 +73,179 @@ pub trait Embedder {
 /// documents and `"query: "` on queries; using the right prefix is load-bearing for retrieval recall
 /// (incl. Polish). This is a Mac-eval TUNABLE — the exact prefix string and whether the bake-off
 /// prefers symmetric encoding is validated @Mac, not by `cargo test`.
+///
+/// NOTE: this is the DEFAULT (multilingual-e5-small) passage prefix; a selected [`EmbedModel`]
+/// carries its own — resolved via [`selected_embed_model`]. `mmlw-e5-small` happens to share the
+/// same `"query: "`/`"passage: "` convention (verified against its HF card), so the effective prefix
+/// is identical for both bundled options.
 pub const PASSAGE_PREFIX: &str = "passage: ";
 
 /// e5 ASYMMETRIC PREFIX (query side). See [`PASSAGE_PREFIX`].
 pub const QUERY_PREFIX: &str = "query: ";
 
-/// Sub-directory under the shared models dir holding the multilingual-e5-small files
+/// Sub-directory under the shared models dir holding the DEFAULT (multilingual-e5-small) files
 /// (`model.safetensors` + `tokenizer.json` + `config.json`). 384-dim ⇒ [`EMBED_DIM`] is unchanged,
-/// so swapping the real model in costs ZERO vec0 schema migration.
+/// so swapping the real model in costs ZERO vec0 schema migration. A selected [`EmbedModel`] carries
+/// its own subdir — resolved via [`selected_embed_model`].
 pub const EMBED_MODEL_SUBDIR: &str = "embed-multilingual-e5-small";
 
-/// The three Hugging Face files the real e5 embedder needs, fetched INBOUND-ONLY by
-/// `download_embed_model`. Order is irrelevant; each is downloaded into [`EMBED_MODEL_SUBDIR`].
+/// The three Hugging Face files the real embedder needs, fetched INBOUND-ONLY by
+/// `download_embed_model`. Order is irrelevant; each is downloaded into the selected model's subdir.
+/// Every bundled [`EmbedModel`] uses this same three-file set (BERT safetensors + tokenizer + config).
 pub const EMBED_MODEL_FILES: &[&str] = &["model.safetensors", "tokenizer.json", "config.json"];
 
-/// Hugging Face `resolve/main` base for intfloat/multilingual-e5-small. INBOUND ONLY — fetched,
-/// never sent meeting content.
+/// Hugging Face `resolve/main` base for the DEFAULT (intfloat/multilingual-e5-small). INBOUND ONLY —
+/// fetched, never sent meeting content. A selected [`EmbedModel`] carries its own base.
 pub const EMBED_MODEL_HF_BASE: &str =
     "https://huggingface.co/intfloat/multilingual-e5-small/resolve/main";
 
-/// Resolve the on-disk dir the real e5 embedder loads from: `<models_dir>/embed-multilingual-e5-small/`.
+/// The stable id of the DEFAULT embedder. `None`/unknown selection resolves here → BYTE-IDENTICAL to
+/// the historical hardcoded-const behavior.
+pub const DEFAULT_EMBED_MODEL_ID: &str = "multilingual-e5-small";
+
+/// A selectable on-device embedder. All bundled options MUST be BERT / 384-hidden so the `vec0`
+/// column width ([`EMBED_DIM`]) never changes — a differently-dimensioned model would be a `vec0`
+/// SCHEMA migration, which we explicitly do NOT do (the loader guards `hidden_size == EMBED_DIM` and
+/// fails loud otherwise). Fields are `&'static str` (a compile-time registry, like `BRAIN_MODELS`).
+#[derive(Debug, Clone, Copy)]
+pub struct EmbedModel {
+    /// Stable id persisted in `AppConfig::embed_model_id` (e.g. `"multilingual-e5-small"`).
+    pub id: &'static str,
+    /// Human label for the picker.
+    pub name: &'static str,
+    /// Sub-directory under the shared models dir holding this model's three files.
+    pub subdir: &'static str,
+    /// Hugging Face `resolve/main` base the three files are fetched from (INBOUND ONLY).
+    pub hf_base: &'static str,
+    /// Asymmetric QUERY prefix for this model (the search side).
+    pub query_prefix: &'static str,
+    /// Asymmetric PASSAGE prefix for this model (the index side).
+    pub passage_prefix: &'static str,
+}
+
+/// The bundled, selectable embedders. ALL are BERT / hidden_size 384 (verified against their HF
+/// `config.json`), so switching between them needs NO `vec0` schema migration — only a re-index
+/// (`reindex_embeddings`) because the vectors from a different model are not comparable.
+///
+/// - `multilingual-e5-small` (intfloat) — the DEFAULT; the historical values, so a fresh/unset
+///   config behaves BYTE-IDENTICALLY to before this registry existed.
+/// - `mmlw-e5-small` (sdadas) — a Polish-first distilled e5 (BERT, hidden_size 384, XLM-R tokenizer),
+///   initialized from the multilingual-e5-small checkpoint. Its HF card documents the SAME
+///   `"query: "`/`"passage: "` asymmetric prefix convention as e5. Strong PL-MTEB retrieval scores;
+///   the real recall win is a Mac-eval (the `eval::bakeoff` harness), not a `cargo test` claim.
+pub static EMBED_MODELS: &[EmbedModel] = &[
+    EmbedModel {
+        id: DEFAULT_EMBED_MODEL_ID,
+        name: "Multilingual E5 Small (default)",
+        subdir: EMBED_MODEL_SUBDIR,
+        hf_base: EMBED_MODEL_HF_BASE,
+        query_prefix: QUERY_PREFIX,
+        passage_prefix: PASSAGE_PREFIX,
+    },
+    EmbedModel {
+        id: "mmlw-e5-small",
+        name: "MMLW E5 Small (Polish-first)",
+        subdir: "embed-mmlw-e5-small",
+        hf_base: "https://huggingface.co/sdadas/mmlw-e5-small/resolve/main",
+        // mmlw's HF card: "queries should be prefixed with \"query: \" and passages with \"passage: \"".
+        query_prefix: "query: ",
+        passage_prefix: "passage: ",
+    },
+];
+
+/// Look up a bundled embedder by id; `None` for an unknown id.
+pub fn embed_model_by_id(id: &str) -> Option<&'static EmbedModel> {
+    EMBED_MODELS.iter().find(|m| m.id == id)
+}
+
+/// IPC view of an [`EmbedModel`] for the picker: the static metadata plus the two runtime flags the
+/// FE needs — `downloaded` (all three files present in this model's subdir) and `selected` (mirrors
+/// the persisted `embed_model_id`, with `None`/unknown resolving to the default). No content read /
+/// no egress — static metadata + on-disk existence only.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedModelDto {
+    pub id: String,
+    pub name: String,
+    pub downloaded: bool,
+    pub selected: bool,
+}
+
+/// Build the picker DTOs for all bundled embedders. `selected_id` is the persisted config value
+/// (`None`/empty ⇒ the default is the selected one). `downloaded` probes each model's own subdir
+/// under `models_dir` (an unresolvable models dir ⇒ all `false`, graceful). NEVER panics.
+pub fn embed_model_dtos(selected_id: Option<&str>) -> Vec<EmbedModelDto> {
+    let base = crate::transcribe::models_dir().ok();
+    let effective = selected_id
+        .filter(|s| !s.is_empty())
+        .and_then(embed_model_by_id)
+        .map(|m| m.id)
+        .unwrap_or(DEFAULT_EMBED_MODEL_ID);
+    EMBED_MODELS
+        .iter()
+        .map(|m| {
+            let downloaded = base
+                .as_ref()
+                .map(|b| {
+                    let dir = b.join(m.subdir);
+                    EMBED_MODEL_FILES.iter().all(|f| dir.join(f).is_file())
+                })
+                .unwrap_or(false);
+            EmbedModelDto {
+                id: m.id.to_string(),
+                name: m.name.to_string(),
+                downloaded,
+                selected: m.id == effective,
+            }
+        })
+        .collect()
+}
+
+/// The DEFAULT embedder descriptor (the first registry entry). Infallible.
+pub fn default_embed_model() -> &'static EmbedModel {
+    &EMBED_MODELS[0]
+}
+
+/// Process-global "which embedder is selected" — the SEAM that lets the existing zero-arg
+/// `active_embedder`/`embed_model_present`/`embed_model_dir`/`download_embed_model` resolve the
+/// user's configured model WITHOUT threading `&AppConfig` through every call site. `None` (never set,
+/// or set to `None`) means "use the default" → byte-identical to the historical behavior. Written
+/// once by `AppConfig::load` at startup and again by `AppConfig::save` when the selection changes;
+/// read on every embedder construction. A poisoned lock degrades to the default (never panics).
+static SELECTED_EMBED_MODEL_ID: RwLock<Option<String>> = RwLock::new(None);
+
+/// Set the process-global selected embedder id (called by `AppConfig::load`/`save`). `None` clears
+/// back to the default. NEVER panics — a poisoned lock is silently ignored (the default stands).
+pub fn set_selected_embed_model_id(id: Option<String>) {
+    if let Ok(mut g) = SELECTED_EMBED_MODEL_ID.write() {
+        *g = id.filter(|s| !s.is_empty());
+    }
+}
+
+/// Resolve the currently-selected [`EmbedModel`]: the process-global id if it names a known model,
+/// else the DEFAULT. NEVER panics (a poisoned lock or an unknown id both fall back to the default),
+/// so this is safe on any hot path.
+pub fn selected_embed_model() -> &'static EmbedModel {
+    let id = SELECTED_EMBED_MODEL_ID
+        .read()
+        .ok()
+        .and_then(|g| g.clone());
+    match id.as_deref().and_then(embed_model_by_id) {
+        Some(m) => m,
+        None => default_embed_model(),
+    }
+}
+
+/// Resolve the on-disk dir the SELECTED embedder loads from: `<models_dir>/<selected.subdir>/`.
 /// Creating the models dir can fail (returns `Err`); the dir itself may not yet exist (that is fine —
 /// the caller checks [`embed_model_present`]). NEVER panics.
 pub fn embed_model_dir() -> Result<PathBuf> {
-    Ok(crate::transcribe::models_dir()?.join(EMBED_MODEL_SUBDIR))
+    Ok(crate::transcribe::models_dir()?.join(selected_embed_model().subdir))
 }
 
-/// `true` when all three e5 model files exist in [`embed_model_dir`]. Pure existence probe (the only
-/// I/O is `is_file`); a models-dir resolution error is treated as "not present" (graceful — falls
-/// back to the stub), never propagated as a hard error.
+/// `true` when all three model files exist in the SELECTED model's [`embed_model_dir`]. Pure
+/// existence probe (the only I/O is `is_file`); a models-dir resolution error is treated as "not
+/// present" (graceful — falls back to the stub), never propagated as a hard error.
 pub fn embed_model_present() -> bool {
     match embed_model_dir() {
         Ok(dir) => EMBED_MODEL_FILES.iter().all(|f| dir.join(f).is_file()),
@@ -144,18 +289,22 @@ impl Embedder for StubEmbedder {
 /// so callers build one per operation. NEVER invoked when `semantic_search_enabled` is off (the gate
 /// short-circuits before this is called) — building the real embedder does NOT flip that flag.
 pub fn active_embedder() -> Box<dyn Embedder> {
+    let model = selected_embed_model();
     if embed_model_present() {
-        match embed_model_dir().and_then(candle_bert::CandleBertEmbedder::new) {
+        let built = embed_model_dir().and_then(|dir| {
+            candle_bert::CandleBertEmbedder::new(dir, model.query_prefix, model.passage_prefix)
+        });
+        match built {
             Ok(e) => {
-                tracing::info!(target: "embed", "local embed model ready (lazy load)");
+                tracing::info!(target: "embed", model_id = %model.id, "local embed model ready (lazy load)");
                 return Box::new(e);
             }
             Err(e) => {
-                tracing::warn!(target: "embed", error = %e, "local embed init failed; using stub embedder");
+                tracing::warn!(target: "embed", model_id = %model.id, error = %e, "local embed init failed; using stub embedder");
             }
         }
     } else {
-        tracing::info!(target: "embed", "no local embed model present; using stub embedder");
+        tracing::info!(target: "embed", model_id = %model.id, "no local embed model present; using stub embedder");
     }
     Box::new(StubEmbedder)
 }
@@ -282,13 +431,15 @@ pub fn fuse_doc_hits(
         .collect()
 }
 
-/// Download the three e5 model files into [`embed_model_dir`], INBOUND-ONLY, with progress.
+/// Download the three model files for the SELECTED embedder into [`embed_model_dir`], INBOUND-ONLY,
+/// with progress.
 ///
 /// Mirrors [`crate::reason::download_brain_model`]: each file streams to `<file>.part` then renames
 /// atomically; `on_progress(file_index, downloaded, total)` fires as bytes arrive (`total` is `None`
 /// when the server omits `Content-Length`). A file already present on disk is SKIPPED. INBOUND ONLY:
 /// fetches model files and sends NO request body / NO meeting content (no egress). NO PII logged —
-/// filenames + byte counts only.
+/// filenames + byte counts only. The HF base + destination subdir come from [`selected_embed_model`],
+/// so `mmlw-e5-small` is fetched from its own repo into its own dir.
 pub async fn download_embed_model<F>(mut on_progress: F) -> Result<PathBuf>
 where
     F: FnMut(usize, u64, Option<u64>),
@@ -296,6 +447,7 @@ where
     use crate::error::AppError;
     use tokio::io::AsyncWriteExt;
 
+    let model = selected_embed_model();
     let dir = embed_model_dir()?;
     std::fs::create_dir_all(&dir)
         .map_err(|e| AppError::Storage(format!("create embed model dir: {e}")))?;
@@ -305,7 +457,7 @@ where
         if dest.is_file() {
             continue;
         }
-        let url = format!("{EMBED_MODEL_HF_BASE}/{file}");
+        let url = format!("{}/{file}", model.hf_base);
         tracing::info!(target: "embed", file = %file, "downloading embed model file");
 
         let mut resp = reqwest::get(&url)
@@ -354,6 +506,14 @@ where
 
     Ok(dir)
 }
+
+/// A process-wide lock serializing every test that mutates the [`SELECTED_EMBED_MODEL_ID`] global
+/// (in THIS module and in `config`/`commands` tests). `cargo test` runs tests in parallel, so without
+/// this a test that sets the selection could race a test that reads `embed_model_dir`/`active_embedder`
+/// under the default. Callers lock it for the whole set→act→restore span, and MUST restore the
+/// selection to `None` (the default) before dropping the guard.
+#[cfg(test)]
+pub(crate) static EMBED_SELECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 mod tests {
@@ -439,6 +599,9 @@ mod tests {
 
     #[test]
     fn embed_model_dir_is_under_models_dir() {
+        let _g = EMBED_SELECTION_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // With no selection set, the resolver falls back to the default (e5) subdir.
+        set_selected_embed_model_id(None);
         let dir = embed_model_dir().unwrap();
         assert!(dir.ends_with(EMBED_MODEL_SUBDIR));
         // The three e5 files are the documented set.
@@ -446,8 +609,74 @@ mod tests {
         assert!(EMBED_MODEL_HF_BASE.contains("intfloat/multilingual-e5-small"));
     }
 
+    /// The registry is well-formed: the DEFAULT is first, ids are unique, mmlw is present, and EVERY
+    /// bundled option is 384-safe by construction (they all share EMBED_MODEL_FILES; the loader guards
+    /// hidden_size == EMBED_DIM at load, so a wrong-width model would fail loud — never silently).
+    #[test]
+    fn embed_registry_is_wellformed_and_has_mmlw() {
+        assert_eq!(default_embed_model().id, DEFAULT_EMBED_MODEL_ID);
+        assert_eq!(EMBED_MODELS[0].id, DEFAULT_EMBED_MODEL_ID, "default must be first");
+        // Unique ids.
+        let mut ids: Vec<&str> = EMBED_MODELS.iter().map(|m| m.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), EMBED_MODELS.len(), "embed model ids must be unique");
+        // mmlw is a first-class selectable option with the documented e5-compatible prefixes.
+        let mmlw = embed_model_by_id("mmlw-e5-small").expect("mmlw-e5-small must be registered");
+        assert_eq!(mmlw.query_prefix, "query: ");
+        assert_eq!(mmlw.passage_prefix, "passage: ");
+        assert!(mmlw.hf_base.contains("sdadas/mmlw-e5-small"));
+        assert_ne!(mmlw.subdir, EMBED_MODEL_SUBDIR, "each model needs its own subdir");
+        // The default carries the historical values verbatim (byte-identical default behavior).
+        let def = default_embed_model();
+        assert_eq!(def.subdir, EMBED_MODEL_SUBDIR);
+        assert_eq!(def.hf_base, EMBED_MODEL_HF_BASE);
+        assert_eq!(def.query_prefix, QUERY_PREFIX);
+        assert_eq!(def.passage_prefix, PASSAGE_PREFIX);
+    }
+
+    /// The process-global selection seam: setting a known id resolves to it; unknown/None fall back
+    /// to the default. `embed_model_dir` tracks the selection's subdir. Restore the default after so
+    /// this test cannot leak state into others that share the process global.
+    #[test]
+    fn selected_embed_model_resolves_and_falls_back() {
+        let _g = EMBED_SELECTION_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_selected_embed_model_id(Some("mmlw-e5-small".to_string()));
+        assert_eq!(selected_embed_model().id, "mmlw-e5-small");
+        assert!(embed_model_dir().unwrap().ends_with("embed-mmlw-e5-small"));
+
+        // Unknown id ⇒ default. Empty ⇒ default. None ⇒ default.
+        set_selected_embed_model_id(Some("does-not-exist".to_string()));
+        assert_eq!(selected_embed_model().id, DEFAULT_EMBED_MODEL_ID);
+        set_selected_embed_model_id(Some(String::new()));
+        assert_eq!(selected_embed_model().id, DEFAULT_EMBED_MODEL_ID);
+        set_selected_embed_model_id(None);
+        assert_eq!(selected_embed_model().id, DEFAULT_EMBED_MODEL_ID);
+    }
+
+    /// The picker DTOs cover every registry entry, mark exactly one as `selected` (the resolved one),
+    /// and default (None) selects the default model.
+    #[test]
+    fn embed_model_dtos_mark_selected() {
+        let dtos = embed_model_dtos(None);
+        assert_eq!(dtos.len(), EMBED_MODELS.len());
+        let selected: Vec<&str> = dtos.iter().filter(|d| d.selected).map(|d| d.id.as_str()).collect();
+        assert_eq!(selected, vec![DEFAULT_EMBED_MODEL_ID], "None ⇒ default is selected");
+
+        let dtos = embed_model_dtos(Some("mmlw-e5-small"));
+        let selected: Vec<&str> = dtos.iter().filter(|d| d.selected).map(|d| d.id.as_str()).collect();
+        assert_eq!(selected, vec!["mmlw-e5-small"]);
+
+        // Unknown id ⇒ the default is marked selected (never zero-selected).
+        let dtos = embed_model_dtos(Some("bogus"));
+        assert!(dtos.iter().filter(|d| d.selected).count() == 1);
+        assert!(dtos.iter().find(|d| d.selected).map(|d| d.id.as_str()) == Some(DEFAULT_EMBED_MODEL_ID));
+    }
+
     #[test]
     fn embed_model_present_false_when_any_file_missing() {
+        let _g = EMBED_SELECTION_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_selected_embed_model_id(None);
         // On a clean machine the e5 dir is absent ⇒ not present. Even with a partial dir (only one of
         // the three files), `present` must be false — the loader needs all three.
         let dir = embed_model_dir().unwrap();
@@ -466,6 +695,8 @@ mod tests {
     /// `active_reasoner_falls_back_to_stub_without_model`).
     #[test]
     fn active_embedder_falls_back_to_stub_without_model() {
+        let _g = EMBED_SELECTION_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_selected_embed_model_id(None);
         // Only meaningful as a fallback assertion when no real model is installed; on a clean
         // machine/CI the e5 dir is absent, so the always-compiled candle backend still yields the stub.
         if !embed_model_present() {

--- a/src-tauri/src/embed/candle_bert.rs
+++ b/src-tauri/src/embed/candle_bert.rs
@@ -43,6 +43,12 @@ use crate::error::{AppError, Result};
 pub struct CandleBertEmbedder {
     /// Directory holding `model.safetensors` + `tokenizer.json` + `config.json`.
     model_dir: PathBuf,
+    /// Asymmetric QUERY prefix for the selected model (e.g. `"query: "`). Applied by
+    /// [`Embedder::embed_query`]'s default impl via [`Self::query_prefix`].
+    query_prefix: String,
+    /// Asymmetric PASSAGE prefix for the selected model (e.g. `"passage: "`). Applied by
+    /// [`Embedder::embed_passage`]'s default impl via [`Self::passage_prefix`].
+    passage_prefix: String,
     /// Lazily-built, cached `(model, tokenizer, device)`. `None` until the first `embed` call.
     inner: Mutex<Option<Arc<Loaded>>>,
 }
@@ -55,11 +61,16 @@ struct Loaded {
 }
 
 impl CandleBertEmbedder {
-    /// Build an embedder for the e5 files in `model_dir`. CHEAP + non-blocking: it only validates the
-    /// three files exist and stores the dir — the safetensors/tokenizer load is deferred to first use,
-    /// so this is safe to call from `active_embedder` on the startup path. Returns `Err` (never panics)
-    /// if a required file is missing.
-    pub fn new(model_dir: PathBuf) -> Result<Self> {
+    /// Build an embedder for the BERT files in `model_dir`, applying the selected model's asymmetric
+    /// `query_prefix`/`passage_prefix` (e5 and mmlw both use `"query: "`/`"passage: "`). CHEAP +
+    /// non-blocking: it only validates the three files exist and stores the dir/prefixes — the
+    /// safetensors/tokenizer load is deferred to first use, so this is safe to call from
+    /// `active_embedder` on the startup path. Returns `Err` (never panics) if a required file is missing.
+    pub fn new(
+        model_dir: PathBuf,
+        query_prefix: impl Into<String>,
+        passage_prefix: impl Into<String>,
+    ) -> Result<Self> {
         for f in EMBED_MODEL_FILES {
             let p = model_dir.join(f);
             if !p.is_file() {
@@ -70,6 +81,8 @@ impl CandleBertEmbedder {
         }
         Ok(Self {
             model_dir,
+            query_prefix: query_prefix.into(),
+            passage_prefix: passage_prefix.into(),
             inner: Mutex::new(None),
         })
     }
@@ -143,6 +156,23 @@ impl CandleBertEmbedder {
 impl Embedder for CandleBertEmbedder {
     fn dim(&self) -> usize {
         EMBED_DIM
+    }
+
+    /// Override the trait default so the SELECTED model's passage prefix is applied (not the module
+    /// const). e5 and mmlw share `"passage: "`, so this is behavior-identical for both bundled models
+    /// while correctly generalizing to any future model whose convention differs.
+    fn embed_passage(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{}{t}", self.passage_prefix)).collect();
+        self.embed(&prefixed)
+    }
+
+    /// Override the trait default so the SELECTED model's query prefix is applied. See
+    /// [`Self::embed_passage`].
+    fn embed_query(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{}{t}", self.query_prefix)).collect();
+        self.embed(&prefixed)
     }
 
     fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
@@ -257,7 +287,8 @@ mod smoke {
             dir.join("model.safetensors").is_file(),
             "e5 model not found at {dir:?}"
         );
-        let e = CandleBertEmbedder::new(dir).expect("construct CandleBertEmbedder");
+        let e = CandleBertEmbedder::new(dir, "query: ", "passage: ")
+            .expect("construct CandleBertEmbedder");
 
         let passages = vec![
             "Notatki ze spotkania o projekcie Atlas i terminie integracji API.".to_string(),

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -1,0 +1,238 @@
+//! The bake-off RUNNER: over a real `Db` vault + an [`crate::embed::Embedder`], run all three
+//! retrieval legs for each labeled query and compute the per-mode metrics.
+//!
+//! ## Modes
+//!
+//! - **FTS** — `Db::search_visible(query)` → the meeting ids in BM25 order.
+//! - **Semantic** — embed the query (asymmetric `embed_query`), then
+//!   `Db::search_semantic_visible(query_vec)` → the meeting ids in vector-distance order.
+//! - **Hybrid** — RRF-fuse the FTS and semantic id lists via [`crate::embed::rrf_fuse`] (the same
+//!   fusion the app uses for documents) → the fused meeting-id order.
+//!
+//! ## Gating (read the lock-model note in `mod.rs`)
+//!
+//! Both `search_visible` and `search_semantic_visible` apply `visibility_clause`, so a sealed-not-
+//! session-unlocked meeting is invisible to the eval — identical to the app. The harness opens NO
+//! raw connection and adds NO ungated read. `unlocked` is the session unlock set (pass an empty set
+//! to eval only OPEN content).
+//!
+//! ## Headless honesty
+//!
+//! This file typechecks against the retrieval APIs in `cargo test --lib`, but a MEANINGFUL run needs
+//! the embedding model on disk (else the semantic leg uses the deterministic `StubEmbedder`, whose
+//! vectors are not semantic) and a populated vault. The end-to-end test is `#[ignore]`d; run it on a
+//! Mac per `docs/RAG-BAKEOFF.md`. A green build is NOT a retrieval-quality claim.
+
+use std::collections::HashSet;
+
+use crate::embed::{rrf_fuse, Embedder, RRF_K};
+use crate::error::{AppError, Result};
+use crate::eval::{
+    aggregate_metrics, BakeoffReport, LabeledSet, ModeMetrics, RetrievalMode,
+};
+use crate::storage::Db;
+
+/// Retrieve the FTS meeting-id ranking for one query (BM25 order, deduped, visibility-gated).
+fn fts_ranked(db: &Db, query: &str, k: usize, unlocked: &HashSet<String>) -> Result<Vec<String>> {
+    // Fetch a few extra candidates so the top-k cutoff is applied to a full list, not a truncated one.
+    let limit = (k.max(1) * 4) as i64;
+    let hits = db.search_visible(query, limit, unlocked)?;
+    Ok(hits.into_iter().map(|h| h.meeting.id).collect())
+}
+
+/// Retrieve the SEMANTIC meeting-id ranking for one query (vector KNN order, visibility-gated). The
+/// query is embedded with the asymmetric `embed_query` convention (the same as index-side
+/// `embed_passage` — see `Db::index_meeting_chunks`). Returns an empty ranking if the embedder yields
+/// no vector (e.g. an all-punctuation query).
+fn semantic_ranked(
+    db: &Db,
+    embedder: &dyn Embedder,
+    query: &str,
+    k: usize,
+    unlocked: &HashSet<String>,
+) -> Result<Vec<String>> {
+    let query_vec = embedder
+        .embed_query(&[query.to_string()])?
+        .into_iter()
+        .next()
+        .unwrap_or_default();
+    if query_vec.is_empty() {
+        return Ok(Vec::new());
+    }
+    // KNN returns one hit per meeting (nearest chunk) already deduped by `search_semantic_visible`.
+    let hits = db.search_semantic_visible(&query_vec, (k.max(1) * 4) as i64, unlocked)?;
+    Ok(hits.into_iter().map(|h| h.meeting.id).collect())
+}
+
+/// RRF-fuse the FTS and semantic rankings into one meeting-id order (the hybrid leg). Either list may
+/// be empty; RRF over the remaining one preserves its order. Uses the app's [`RRF_K`].
+fn hybrid_ranked(fts: &[String], semantic: &[String]) -> Vec<String> {
+    let fused = rrf_fuse(&[fts.to_vec(), semantic.to_vec()], RRF_K);
+    fused.into_iter().map(|(id, _score)| id).collect()
+}
+
+/// Run the full bake-off over `set` at cutoff `k`, returning per-mode averaged metrics.
+///
+/// For each labeled query we compute the three rankings, then average recall@k / nDCG@k / MRR across
+/// the set per mode. READ-ONLY + visibility-gated (see the module note). `k` is clamped to `>= 1`.
+/// A meaningful semantic/hybrid result requires a REAL embedder + an indexed vault; with the stub or
+/// an empty index the semantic leg is uninformative (documented, not an error).
+pub fn run_bakeoff(
+    db: &Db,
+    embedder: &dyn Embedder,
+    set: &LabeledSet,
+    k: usize,
+    unlocked: &HashSet<String>,
+) -> Result<BakeoffReport> {
+    let k = k.max(1);
+    if set.is_empty() {
+        return Err(AppError::InvalidArg(
+            "bake-off labeled set is empty".to_string(),
+        ));
+    }
+
+    let mut fts_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
+    let mut sem_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
+    let mut hyb_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
+
+    for q in &set.0 {
+        let fts = fts_ranked(db, &q.query, k, unlocked)?;
+        let sem = semantic_ranked(db, embedder, &q.query, k, unlocked)?;
+        let hyb = hybrid_ranked(&fts, &sem);
+        fts_rankings.push(fts);
+        sem_rankings.push(sem);
+        hyb_rankings.push(hyb);
+    }
+
+    let modes: Vec<ModeMetrics> = vec![
+        aggregate_metrics(RetrievalMode::Fts, set, &fts_rankings, k),
+        aggregate_metrics(RetrievalMode::Semantic, set, &sem_rankings, k),
+        aggregate_metrics(RetrievalMode::Hybrid, set, &hyb_rankings, k),
+    ];
+
+    Ok(BakeoffReport {
+        k,
+        queries: set.len(),
+        modes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hybrid_ranked_fuses_both_legs() {
+        // m2 appears in both legs (high in each) → should outrank m1/m3 (each in only one leg).
+        let fts = vec!["m1".to_string(), "m2".to_string()];
+        let sem = vec!["m3".to_string(), "m2".to_string(), "m1".to_string()];
+        let fused = hybrid_ranked(&fts, &sem);
+        let pos = |id: &str| fused.iter().position(|x| x == id).unwrap();
+        assert!(pos("m2") < pos("m3"), "m2 (both legs) must outrank m3 (one leg)");
+        assert!(pos("m1") < pos("m3"), "m1 (both legs) must outrank m3 (one leg)");
+        // Dedup: every id appears once.
+        assert_eq!(fused.len(), 3);
+    }
+
+    #[test]
+    fn hybrid_ranked_handles_empty_leg() {
+        // Semantic leg empty (e.g. no model / punctuation query) → hybrid preserves the FTS order.
+        let fts = vec!["a".to_string(), "b".to_string()];
+        let fused = hybrid_ranked(&fts, &[]);
+        assert_eq!(fused, vec!["a".to_string(), "b".to_string()]);
+        // FTS leg empty → hybrid preserves the semantic order.
+        let sem = vec!["x".to_string(), "y".to_string()];
+        assert_eq!(hybrid_ranked(&[], &sem), vec!["x".to_string(), "y".to_string()]);
+        // Both empty → empty.
+        assert!(hybrid_ranked(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn run_bakeoff_rejects_empty_set() {
+        // The empty-set guard fires before any retrieval. A migrated throwaway Db satisfies the
+        // signature; the guard returns before it is touched.
+        let set = LabeledSet(vec![]);
+        let db = throwaway_db("bakeoff-empty");
+        let stub = crate::embed::StubEmbedder;
+        let err = run_bakeoff(&db, &stub, &set, 5, &HashSet::new()).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+    }
+
+    #[test]
+    fn run_bakeoff_runs_over_empty_vault_and_reports_three_modes() {
+        // With an empty (migrated) vault every retrieval returns nothing, so recall/ndcg/mrr are 0
+        // for the gold-bearing query — but the WIRING is exercised: three modes reported, table
+        // renders, no panic. This is a pure headless proof that `run_bakeoff` threads FTS + semantic
+        // + hybrid through the gated readers without a model.
+        let db = throwaway_db("bakeoff-empty-vault");
+        let stub = crate::embed::StubEmbedder;
+        let set = LabeledSet(vec![crate::eval::LabeledQuery {
+            query: "budget planning".to_string(),
+            lang: "en".to_string(),
+            expected_meeting_ids: vec!["m-nonexistent".to_string()],
+        }]);
+        let report = run_bakeoff(&db, &stub, &set, 5, &HashSet::new()).unwrap();
+        assert_eq!(report.modes.len(), 3, "all three modes must be reported");
+        assert_eq!(report.k, 5);
+        assert_eq!(report.queries, 1);
+        for m in &report.modes {
+            assert_eq!(m.recall_at_k, 0.0, "empty vault ⇒ nothing retrieved ⇒ recall 0");
+            assert_eq!(m.mrr, 0.0);
+        }
+        let table = crate::eval::format_report_table(&report);
+        assert!(table.contains("fts") && table.contains("semantic") && table.contains("hybrid"));
+    }
+
+    /// END-TO-END real run — points at a REAL DB + a labeled-set JSON via env vars, so a human can run
+    /// the actual quality bake-off on a Mac WITHOUT recompiling. `#[ignore]`d so it never runs in the
+    /// normal loop. Set:
+    ///   `MURMUR_BAKEOFF_DB`  — path to a SQLCipher murmur DB (a copy of the dev DB is fine),
+    ///   `MURMUR_BAKEOFF_DEK` — the 64-hex DEK for that DB (the dev DEK for a dev DB),
+    ///   `MURMUR_BAKEOFF_SET` — path to a labeled-set JSON (the `LabeledSet` array format),
+    ///   `MURMUR_BAKEOFF_K`   — (optional) cutoff k, default 5.
+    /// The embedder is `active_embedder()` — the REAL model when its files are on disk, else the stub
+    /// (a warning is printed). See `docs/RAG-BAKEOFF.md`.
+    #[test]
+    #[ignore = "real bake-off: needs MURMUR_BAKEOFF_DB/DEK/SET env + the embed model on a Mac"]
+    fn run_bakeoff_over_real_db_from_env() {
+        let db_path = std::env::var("MURMUR_BAKEOFF_DB")
+            .expect("set MURMUR_BAKEOFF_DB to a murmur SQLCipher DB path");
+        let dek = std::env::var("MURMUR_BAKEOFF_DEK")
+            .expect("set MURMUR_BAKEOFF_DEK to that DB's 64-hex DEK");
+        let set_path = std::env::var("MURMUR_BAKEOFF_SET")
+            .expect("set MURMUR_BAKEOFF_SET to a labeled-set JSON path");
+        let k: usize = std::env::var("MURMUR_BAKEOFF_K")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+
+        let db = Db::open_with_key(std::path::Path::new(&db_path), &dek)
+            .expect("open bake-off DB (check the DEK)");
+        let set = LabeledSet::from_json(
+            &std::fs::read_to_string(&set_path).expect("read labeled-set JSON"),
+        )
+        .expect("parse labeled-set JSON");
+
+        if !crate::embed::embed_model_present() {
+            eprintln!(
+                "WARNING: no embedding model on disk — the semantic/hybrid legs use the STUB \
+                 embedder and their numbers are NOT a quality signal. Download the model first."
+            );
+        }
+        let embedder = crate::embed::active_embedder();
+        // Empty unlocked set = eval OPEN content only. To include a sealed folder, unlock it in the
+        // app and copy the WAL'd DB, or extend this to accept a folder-id list.
+        let report = run_bakeoff(&db, embedder.as_ref(), &set, k, &HashSet::new()).unwrap();
+        println!("\n{}", crate::eval::format_report_table(&report));
+    }
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// A migrated, empty SQLCipher Db under the fixed test DEK (headless-safe temp file).
+    fn throwaway_db(label: &str) -> Db {
+        let mut p = std::env::temp_dir();
+        p.push(format!("murmur-bakeoff-{label}-{}.sqlite", std::process::id()));
+        let _ = std::fs::remove_file(&p);
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+}

--- a/src-tauri/src/eval/fixtures/rag-bakeoff-sample.json
+++ b/src-tauri/src/eval/fixtures/rag-bakeoff-sample.json
@@ -1,0 +1,27 @@
+[
+  {
+    "query": "budget planning for the next quarter",
+    "lang": "en",
+    "expected_meeting_ids": ["REPLACE-with-a-real-meeting-id"]
+  },
+  {
+    "query": "planowanie budżetu na następny kwartał",
+    "lang": "pl",
+    "expected_meeting_ids": ["REPLACE-with-a-real-meeting-id"]
+  },
+  {
+    "query": "who owns the API integration deadline",
+    "lang": "en",
+    "expected_meeting_ids": ["REPLACE-with-a-real-meeting-id"]
+  },
+  {
+    "query": "kto odpowiada za termin integracji API",
+    "lang": "pl",
+    "expected_meeting_ids": ["REPLACE-with-a-real-meeting-id", "REPLACE-with-another-id"]
+  },
+  {
+    "query": "decisions from the roadmap review",
+    "lang": "en",
+    "expected_meeting_ids": ["REPLACE-with-a-real-meeting-id"]
+  }
+]

--- a/src-tauri/src/eval/mod.rs
+++ b/src-tauri/src/eval/mod.rs
@@ -1,0 +1,436 @@
+//! RAG BAKE-OFF eval harness — the missing retrieval-quality infra for brain2's semantic layer.
+//!
+//! ## Why this exists
+//!
+//! Murmur ships THREE retrieval legs over one vault: keyword **FTS** (`Db::search_visible`),
+//! on-device **semantic** vector KNN (`Db::search_semantic_visible`), and their **hybrid** RRF fusion
+//! (`embed::rrf_fuse`). Which one — and which embedding model ([`crate::embed::EMBED_MODELS`]:
+//! multilingual-e5-small vs mmlw-e5-small) — actually retrieves the right meetings for a real (often
+//! Polish) query can ONLY be answered empirically. This module is that measurement: given a labeled
+//! set and a [`crate::embed::Embedder`], it runs all three modes and reports **recall@k**, **nDCG@k**,
+//! and **MRR** per mode so a human can pick the winner on a Mac.
+//!
+//! ## What is / isn't testable headless
+//!
+//! - The METRIC MATH (this file) is pure and unit-tested with synthetic rankings — NO model, runs in
+//!   `cargo test --lib`.
+//! - The REAL RUN ([`bakeoff::run_bakeoff`]) needs a real `Db` vault + the embedding model on disk +
+//!   Metal, so its end-to-end test is `#[ignore]`d and driven manually on a Mac (see
+//!   `docs/RAG-BAKEOFF.md`). A green build proves the harness typechecks against the retrieval APIs,
+//!   NOT that any model retrieves well.
+//!
+//! ## Gating
+//!
+//! The harness is READ-ONLY and routes EVERY retrieval through the SAME visibility-gated Db readers
+//! the app uses (`search_visible` / `search_semantic_visible`), so a sealed-and-not-session-unlocked
+//! meeting is invisible to the eval exactly as it is to the app. It never opens a raw connection,
+//! never bypasses `visibility_clause`, and reads no plaintext outside those gated readers. Not
+//! lock-touching: it adds no seal, no new read path, no new export.
+
+pub mod bakeoff;
+
+use serde::{Deserialize, Serialize};
+
+/// One labeled evaluation example: a `query` (optionally tagged with a `lang` for readability /
+/// per-language slicing) and the set of `expected_meeting_ids` that a good retriever SHOULD surface.
+/// Serde-friendly so a set lives in a small JSON fixture (see `fixtures/rag-bakeoff-sample.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabeledQuery {
+    /// The natural-language query as a user would type it (any language; PL + EN are the priorities).
+    pub query: String,
+    /// A free-form language tag (`"pl"`, `"en"`, …) — informational, used only for a per-language
+    /// breakdown in the printed table. `#[serde(default)]` so it may be omitted.
+    #[serde(default)]
+    pub lang: String,
+    /// The meeting ids that count as RELEVANT for this query (the gold set). Order does not matter.
+    pub expected_meeting_ids: Vec<String>,
+}
+
+/// A labeled set = a list of [`LabeledQuery`]. Thin newtype so the on-disk JSON is just an array.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabeledSet(pub Vec<LabeledQuery>);
+
+impl LabeledSet {
+    /// Parse a labeled set from a JSON string (the fixture format: a top-level array of queries).
+    pub fn from_json(s: &str) -> crate::error::Result<Self> {
+        let queries: Vec<LabeledQuery> = serde_json::from_str(s)
+            .map_err(|e| crate::error::AppError::InvalidArg(format!("parse labeled set: {e}")))?;
+        Ok(LabeledSet(queries))
+    }
+
+    /// Number of labeled queries.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// True when the set has no queries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Which retrieval leg a metric row describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalMode {
+    /// Keyword FTS/BM25 only (`Db::search_visible`).
+    Fts,
+    /// On-device semantic vector KNN only (`Db::search_semantic_visible`).
+    Semantic,
+    /// RRF fusion of FTS ∪ semantic (`embed::rrf_fuse`).
+    Hybrid,
+}
+
+impl RetrievalMode {
+    /// Stable label for the printed table.
+    pub fn label(self) -> &'static str {
+        match self {
+            RetrievalMode::Fts => "fts",
+            RetrievalMode::Semantic => "semantic",
+            RetrievalMode::Hybrid => "hybrid",
+        }
+    }
+}
+
+/// Averaged metrics for ONE mode over a whole labeled set. All three are in `[0, 1]`, higher = better.
+#[derive(Debug, Clone, Copy)]
+pub struct ModeMetrics {
+    pub mode: RetrievalMode,
+    /// Mean recall@k: fraction of a query's expected ids found in its top-k, averaged over queries.
+    pub recall_at_k: f64,
+    /// Mean nDCG@k: discounted cumulative gain (binary relevance) normalized by the ideal, averaged.
+    pub ndcg_at_k: f64,
+    /// Mean reciprocal rank: `1 / rank-of-first-relevant`, averaged over queries (0 when none found).
+    pub mrr: f64,
+    /// The `k` these metrics were computed at (the cutoff).
+    pub k: usize,
+    /// How many queries were averaged (the set size).
+    pub queries: usize,
+}
+
+/// The full bake-off result: one [`ModeMetrics`] per mode, plus the cutoff and set size, ready to
+/// print with [`format_report_table`].
+#[derive(Debug, Clone)]
+pub struct BakeoffReport {
+    pub k: usize,
+    pub queries: usize,
+    pub modes: Vec<ModeMetrics>,
+}
+
+/// **recall@k** for ONE query: fraction of `expected` ids present in the first `k` of `ranked`.
+/// `expected` empty ⇒ 1.0 (nothing to find is trivially fully found — a query with no gold set is
+/// vacuous, not a miss). `k == 0` ⇒ 0.0 (no cutoff, no hits). Duplicates in `ranked` are ignored for
+/// counting distinct expected ids. Pure — no DB, no model.
+pub fn recall_at_k(ranked: &[String], expected: &[String], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    if k == 0 {
+        return 0.0;
+    }
+    let topk: std::collections::HashSet<&String> = ranked.iter().take(k).collect();
+    let hits = expected.iter().filter(|e| topk.contains(e)).count();
+    hits as f64 / expected.len() as f64
+}
+
+/// **nDCG@k** for ONE query with BINARY relevance (an id is relevant iff it is in `expected`).
+/// DCG sums `1 / log2(rank + 1)` (rank 1-based) over the first `k` ranked ids that are relevant; the
+/// ideal DCG (IDCG) places `min(k, |expected|)` relevant ids first. `nDCG = DCG / IDCG`.
+/// `expected` empty ⇒ 1.0 (vacuous); `k == 0` or `IDCG == 0` ⇒ 0.0. Pure.
+pub fn ndcg_at_k(ranked: &[String], expected: &[String], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    if k == 0 {
+        return 0.0;
+    }
+    let gold: std::collections::HashSet<&String> = expected.iter().collect();
+    let mut dcg = 0.0;
+    // Guard against duplicate ids in `ranked` double-counting a single relevant meeting.
+    let mut counted: std::collections::HashSet<&String> = std::collections::HashSet::new();
+    for (rank0, id) in ranked.iter().take(k).enumerate() {
+        if gold.contains(id) && counted.insert(id) {
+            dcg += 1.0 / ((rank0 as f64 + 2.0).log2()); // log2(rank+1), rank = rank0+1.
+        }
+    }
+    let ideal_hits = expected.len().min(k);
+    let mut idcg = 0.0;
+    for rank0 in 0..ideal_hits {
+        idcg += 1.0 / ((rank0 as f64 + 2.0).log2());
+    }
+    if idcg == 0.0 {
+        return 0.0;
+    }
+    dcg / idcg
+}
+
+/// **reciprocal rank** for ONE query: `1 / (position-of-first-relevant)` (1-based), or `0.0` when no
+/// relevant id appears in `ranked`. `expected` empty ⇒ 1.0 (vacuous). Pure — averaged across queries
+/// this is MRR.
+pub fn reciprocal_rank(ranked: &[String], expected: &[String]) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    let gold: std::collections::HashSet<&String> = expected.iter().collect();
+    for (rank0, id) in ranked.iter().enumerate() {
+        if gold.contains(id) {
+            return 1.0 / (rank0 as f64 + 1.0);
+        }
+    }
+    0.0
+}
+
+/// Average [`recall_at_k`] / [`ndcg_at_k`] / [`reciprocal_rank`] over a whole labeled set for ONE
+/// mode, given each query's ranked id list (`per_query_ranked[i]` is the mode's ranking for
+/// `set.0[i]`). Panics-free: an empty set yields all-zero metrics. `per_query_ranked` MUST be the
+/// same length/order as `set.0` (the bake-off runner guarantees this).
+pub fn aggregate_metrics(
+    mode: RetrievalMode,
+    set: &LabeledSet,
+    per_query_ranked: &[Vec<String>],
+    k: usize,
+) -> ModeMetrics {
+    let n = set.0.len();
+    if n == 0 {
+        return ModeMetrics {
+            mode,
+            recall_at_k: 0.0,
+            ndcg_at_k: 0.0,
+            mrr: 0.0,
+            k,
+            queries: 0,
+        };
+    }
+    let mut sum_recall = 0.0;
+    let mut sum_ndcg = 0.0;
+    let mut sum_rr = 0.0;
+    for (q, ranked) in set.0.iter().zip(per_query_ranked.iter()) {
+        sum_recall += recall_at_k(ranked, &q.expected_meeting_ids, k);
+        sum_ndcg += ndcg_at_k(ranked, &q.expected_meeting_ids, k);
+        sum_rr += reciprocal_rank(ranked, &q.expected_meeting_ids);
+    }
+    let denom = n as f64;
+    ModeMetrics {
+        mode,
+        recall_at_k: sum_recall / denom,
+        ndcg_at_k: sum_ndcg / denom,
+        mrr: sum_rr / denom,
+        k,
+        queries: n,
+    }
+}
+
+/// Render a [`BakeoffReport`] as a fixed-width comparison table (stdout-friendly; no color, no deps).
+/// One row per mode, columns recall@k / nDCG@k / MRR. Deterministic — pure string formatting.
+pub fn format_report_table(report: &BakeoffReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "RAG bake-off — {} queries, k={}\n",
+        report.queries, report.k
+    ));
+    out.push_str(&format!(
+        "{:<10} {:>10} {:>10} {:>10}\n",
+        "mode",
+        format!("recall@{}", report.k),
+        format!("ndcg@{}", report.k),
+        "mrr"
+    ));
+    out.push_str(&format!("{}\n", "-".repeat(44)));
+    for m in &report.modes {
+        out.push_str(&format!(
+            "{:<10} {:>10.4} {:>10.4} {:>10.4}\n",
+            m.mode.label(),
+            m.recall_at_k,
+            m.ndcg_at_k,
+            m.mrr
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── recall@k ────────────────────────────────────────────────────────────────────────────────
+    #[test]
+    fn recall_at_k_counts_expected_in_topk() {
+        // ranked: a, b, c, d ; expected: b, d ; k=3 → b in top3, d NOT (rank 4) → 1/2.
+        let ranked = ids(&["a", "b", "c", "d"]);
+        let expected = ids(&["b", "d"]);
+        assert!((recall_at_k(&ranked, &expected, 3) - 0.5).abs() < 1e-9);
+        // k=4 → both found → 1.0.
+        assert!((recall_at_k(&ranked, &expected, 4) - 1.0).abs() < 1e-9);
+        // k=1 → only `a` seen, neither expected → 0.0.
+        assert!((recall_at_k(&ranked, &expected, 1) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_edge_cases() {
+        // Empty expected ⇒ 1.0 (vacuous).
+        assert!((recall_at_k(&ids(&["a"]), &[], 5) - 1.0).abs() < 1e-9);
+        // k = 0 ⇒ 0.0.
+        assert!((recall_at_k(&ids(&["a", "b"]), &ids(&["a"]), 0) - 0.0).abs() < 1e-9);
+        // Nothing retrieved ⇒ 0.0.
+        assert!((recall_at_k(&[], &ids(&["a"]), 5) - 0.0).abs() < 1e-9);
+        // Duplicate in ranked doesn't inflate — one distinct expected still counts once.
+        assert!((recall_at_k(&ids(&["a", "a", "b"]), &ids(&["a"]), 5) - 1.0).abs() < 1e-9);
+    }
+
+    // ── nDCG@k ──────────────────────────────────────────────────────────────────────────────────
+    #[test]
+    fn ndcg_at_k_perfect_ranking_is_one() {
+        // Expected {a,b} at ranks 1,2 → DCG == IDCG → 1.0.
+        let ranked = ids(&["a", "b", "c"]);
+        let expected = ids(&["a", "b"]);
+        assert!((ndcg_at_k(&ranked, &expected, 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ndcg_at_k_single_relevant_at_known_rank() {
+        // One relevant id at rank 2 (0-based idx 1): DCG = 1/log2(3); IDCG (1 ideal hit) = 1/log2(2)=1.
+        // nDCG = 1/log2(3) ≈ 0.6309.
+        let ranked = ids(&["x", "a", "y"]);
+        let expected = ids(&["a"]);
+        let want = 1.0 / (3f64.log2());
+        assert!((ndcg_at_k(&ranked, &expected, 3) - want).abs() < 1e-9);
+        // Same id at rank 1 → nDCG 1.0.
+        let ranked2 = ids(&["a", "x", "y"]);
+        assert!((ndcg_at_k(&ranked2, &expected, 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ndcg_at_k_two_relevant_out_of_order_lt_one() {
+        // Relevant {a,b} at ranks 1 and 3 → DCG = 1/log2(2) + 1/log2(4) = 1 + 0.5 = 1.5;
+        // IDCG (2 hits) = 1/log2(2) + 1/log2(3) = 1 + 0.6309 = 1.6309 → nDCG ≈ 0.9197 (< 1).
+        let ranked = ids(&["a", "z", "b", "q"]);
+        let expected = ids(&["a", "b"]);
+        let dcg = 1.0 + 1.0 / (4f64.log2());
+        let idcg = 1.0 + 1.0 / (3f64.log2());
+        assert!((ndcg_at_k(&ranked, &expected, 4) - dcg / idcg).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ndcg_at_k_edge_cases() {
+        assert!((ndcg_at_k(&ids(&["a"]), &[], 5) - 1.0).abs() < 1e-9); // vacuous
+        assert!((ndcg_at_k(&ids(&["a"]), &ids(&["a"]), 0) - 0.0).abs() < 1e-9); // k=0
+        assert!((ndcg_at_k(&[], &ids(&["a"]), 5) - 0.0).abs() < 1e-9); // nothing retrieved
+        // No relevant in top-k → 0 (relevant is beyond the cutoff).
+        assert!((ndcg_at_k(&ids(&["x", "y", "a"]), &ids(&["a"]), 2) - 0.0).abs() < 1e-9);
+    }
+
+    // ── MRR / reciprocal rank ─────────────────────────────────────────────────────────────────────
+    #[test]
+    fn reciprocal_rank_uses_first_relevant() {
+        // First relevant at rank 3 → 1/3.
+        let ranked = ids(&["x", "y", "a", "b"]);
+        let expected = ids(&["a", "b"]);
+        assert!((reciprocal_rank(&ranked, &expected) - 1.0 / 3.0).abs() < 1e-9);
+        // First relevant at rank 1 → 1.0.
+        assert!((reciprocal_rank(&ids(&["b", "x"]), &expected) - 1.0).abs() < 1e-9);
+        // None relevant → 0.0.
+        assert!((reciprocal_rank(&ids(&["x", "y"]), &expected) - 0.0).abs() < 1e-9);
+        // Empty expected ⇒ 1.0 (vacuous).
+        assert!((reciprocal_rank(&ids(&["x"]), &[]) - 1.0).abs() < 1e-9);
+    }
+
+    // ── aggregate + table ─────────────────────────────────────────────────────────────────────────
+    #[test]
+    fn aggregate_metrics_averages_over_queries() {
+        let set = LabeledSet(vec![
+            LabeledQuery {
+                query: "q1".into(),
+                lang: "en".into(),
+                expected_meeting_ids: ids(&["a"]),
+            },
+            LabeledQuery {
+                query: "q2".into(),
+                lang: "pl".into(),
+                expected_meeting_ids: ids(&["b"]),
+            },
+        ]);
+        // q1: perfect (a at rank1). q2: b at rank2 → recall@2=1, ndcg@2=1/log2(3), rr=1/2.
+        let per_query = vec![ids(&["a", "z"]), ids(&["z", "b"])];
+        let m = aggregate_metrics(RetrievalMode::Hybrid, &set, &per_query, 2);
+        assert_eq!(m.queries, 2);
+        assert_eq!(m.k, 2);
+        // recall: (1.0 + 1.0)/2 = 1.0.
+        assert!((m.recall_at_k - 1.0).abs() < 1e-9);
+        // ndcg: (1.0 + 1/log2(3)) / 2.
+        let want_ndcg = (1.0 + 1.0 / 3f64.log2()) / 2.0;
+        assert!((m.ndcg_at_k - want_ndcg).abs() < 1e-9);
+        // mrr: (1.0 + 0.5)/2 = 0.75.
+        assert!((m.mrr - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_metrics_empty_set_is_zero() {
+        let set = LabeledSet(vec![]);
+        let m = aggregate_metrics(RetrievalMode::Fts, &set, &[], 5);
+        assert_eq!(m.queries, 0);
+        assert_eq!(m.recall_at_k, 0.0);
+        assert_eq!(m.ndcg_at_k, 0.0);
+        assert_eq!(m.mrr, 0.0);
+    }
+
+    #[test]
+    fn labeled_set_parses_sample_json() {
+        let json = r#"[
+            {"query":"budget planning","lang":"en","expected_meeting_ids":["m-1","m-2"]},
+            {"query":"planowanie budżetu","lang":"pl","expected_meeting_ids":["m-1"]}
+        ]"#;
+        let set = LabeledSet::from_json(json).unwrap();
+        assert_eq!(set.len(), 2);
+        assert_eq!(set.0[0].expected_meeting_ids, ids(&["m-1", "m-2"]));
+        assert_eq!(set.0[1].lang, "pl");
+        // lang may be omitted → defaults to "".
+        let set2 = LabeledSet::from_json(r#"[{"query":"q","expected_meeting_ids":[]}]"#).unwrap();
+        assert_eq!(set2.0[0].lang, "");
+    }
+
+    #[test]
+    fn format_report_table_has_a_row_per_mode() {
+        let report = BakeoffReport {
+            k: 5,
+            queries: 3,
+            modes: vec![
+                ModeMetrics {
+                    mode: RetrievalMode::Fts,
+                    recall_at_k: 0.5,
+                    ndcg_at_k: 0.4,
+                    mrr: 0.6,
+                    k: 5,
+                    queries: 3,
+                },
+                ModeMetrics {
+                    mode: RetrievalMode::Semantic,
+                    recall_at_k: 0.7,
+                    ndcg_at_k: 0.65,
+                    mrr: 0.72,
+                    k: 5,
+                    queries: 3,
+                },
+                ModeMetrics {
+                    mode: RetrievalMode::Hybrid,
+                    recall_at_k: 0.8,
+                    ndcg_at_k: 0.75,
+                    mrr: 0.81,
+                    k: 5,
+                    queries: 3,
+                },
+            ],
+        };
+        let table = format_report_table(&report);
+        assert!(table.contains("fts"));
+        assert!(table.contains("semantic"));
+        assert!(table.contains("hybrid"));
+        assert!(table.contains("recall@5"));
+        assert!(table.contains("ndcg@5"));
+        assert!(table.contains("mrr"));
+        // The hybrid recall value is rendered to 4dp.
+        assert!(table.contains("0.8000"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod connectors;
 pub mod crypto;
 pub mod embed;
 pub mod error;
+pub mod eval;
 pub mod events;
 pub mod export;
 pub mod facts;
@@ -23,6 +24,7 @@ pub mod summarize;
 pub mod tools;
 pub mod transcribe;
 pub mod update;
+pub mod user_memory;
 pub mod voice_action;
 
 use tauri::window::{Effect, EffectsBuilder};
@@ -95,6 +97,9 @@ pub fn run() {
             commands::list_documents,
             commands::get_document,
             commands::delete_document,
+            commands::get_user_memory,
+            commands::forget_user_fact,
+            commands::clear_user_memory,
             commands::get_config,
             commands::save_config,
             commands::consent_to_cloud_egress,
@@ -160,6 +165,8 @@ pub fn run() {
             commands::select_brain_model,
             commands::download_brain_model,
             commands::embed_model_present,
+            commands::list_embed_models,
+            commands::select_embed_model,
             commands::download_embed_model,
             commands::reindex_embeddings,
             commands::related_meetings,

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -98,15 +98,18 @@ pub struct AppConfig {
     pub aec_enabled: bool,
     /// Post-hoc on-device echo cancellation (WebRTC AEC3): after Stop, cancel the captured
     /// system-audio out of the mic track (ASR feed AND playback mix) when a speaker leak is
-    /// detected. Default ON — pure offline DSP, no live-call impact; falls back to the raw mic
-    /// on any anomaly. Fixes the doubled voice when recording on speakers.
-    /// `#[serde(default = "default_true")]` ⇒ a config persisted before this field existed loads
-    /// as `true` (existing users get the fix) instead of resetting the whole config.
-    #[serde(default = "default_true")]
+    /// detected. Pure offline DSP, no live-call impact; falls back to the raw mic on any anomaly.
+    /// Fixes the doubled voice when recording on speakers — but rides an UNPROVEN v0.1 AEC3 crate
+    /// on every system-audio recording, so it is DEFAULT-OFF until real-Mac-verified. Users can
+    /// opt in from Settings.
+    /// `#[serde(default)]` ⇒ a config persisted before this field existed loads as `false`
+    /// (the safe default) instead of resetting the whole config.
+    #[serde(default)]
     pub post_aec_enabled: bool,
     /// Whisper model size: "tiny" | "base" | "small" | "medium" | "large-v3-turbo" |
-    /// "large-v3". Default "large-v3" (~3 GB, multilingual) — best transcription quality,
-    /// notably for Polish; downloaded on demand via `download_model`.
+    /// "large-v3". Default "small" (~466 MB) — a RAM-safe default: `large-v3` is ~3 GB and swaps
+    /// on 8 GB Macs, and onboarding already preselects `small`. All sizes (incl. `large-v3`, best
+    /// for Polish) stay selectable; the chosen model is downloaded on demand via `download_model`.
     pub model_size: String,
     /// Voice trigger: start recording when a wake phrase is heard. Default off.
     pub voice_trigger: bool,
@@ -158,6 +161,15 @@ pub struct AppConfig {
     /// (Phase 2c) replaces the stub; until then the only embedder is the deterministic `StubEmbedder`.
     #[serde(default)]
     pub semantic_search_enabled: bool,
+    /// brain2 RAG Phase 2 — the SELECTED on-device embedding model id (from
+    /// [`crate::embed::EMBED_MODELS`], e.g. `"multilingual-e5-small"` (default) / `"mmlw-e5-small"`).
+    /// `None`/empty (the default) resolves to `multilingual-e5-small` ⇒ BYTE-IDENTICAL to the
+    /// historical hardcoded behavior. Set via the `select_embed_model` command, which also triggers a
+    /// re-index (a different model's vectors are not comparable). `#[serde(default)]` ⇒ a config
+    /// persisted before this field existed loads as `None`. All bundled options are BERT/384 so
+    /// switching costs NO `vec0` schema migration (only a re-embed).
+    #[serde(default)]
+    pub embed_model_id: Option<String>,
     /// Phase B — optional explicit path to a local reasoning GGUF for the on-device brain
     /// (`MistralReasoner`). `None` (the default) means the resolver falls back to the default model
     /// filename inside the shared models dir. Consulted at runtime when `brain_backend == Local`;
@@ -301,8 +313,8 @@ impl Default for AppConfig {
             keep_hires_masters: false,
             diarize_others: false,
             aec_enabled: false,
-            post_aec_enabled: true,
-            model_size: "large-v3".to_string(),
+            post_aec_enabled: false,
+            model_size: "small".to_string(),
             voice_trigger: false,
             onboarded: false,
             note_style: "standard".to_string(),
@@ -314,6 +326,7 @@ impl Default for AppConfig {
             relock_on_screenshare: true,
             cloud_egress_consented: false,
             semantic_search_enabled: false,
+            embed_model_id: None,
             brain_model_path: None,
             brain_model_id: None,
             brain_backend: BrainBackend::default(),
@@ -368,6 +381,7 @@ const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 const K_CLOUD_EGRESS_CONSENTED: &str = "cloud_egress_consented";
 const K_SEMANTIC_SEARCH_ENABLED: &str = "semantic_search_enabled";
+const K_EMBED_MODEL_ID: &str = "embed_model_id";
 const K_BRAIN_MODEL_PATH: &str = "brain_model_path";
 const K_BRAIN_MODEL_ID: &str = "brain_model_id";
 const K_BRAIN_BACKEND: &str = "brain_backend";
@@ -495,6 +509,11 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_SEMANTIC_SEARCH_ENABLED)? {
             cfg.semantic_search_enabled = v == "true";
         }
+        cfg.embed_model_id = opt(db.get_setting(K_EMBED_MODEL_ID)?);
+        // Publish the selection to the process-global seam the zero-arg embedder resolvers read
+        // (`embed::active_embedder`/`embed_model_present`/`embed_model_dir`/`download_embed_model`).
+        // `None`/empty ⇒ the default model ⇒ byte-identical to the historical behavior.
+        crate::embed::set_selected_embed_model_id(cfg.embed_model_id.clone());
         cfg.brain_model_path = opt(db.get_setting(K_BRAIN_MODEL_PATH)?);
         cfg.brain_model_id = opt(db.get_setting(K_BRAIN_MODEL_ID)?);
         if let Some(v) = db.get_setting(K_BRAIN_BACKEND)? {
@@ -637,6 +656,12 @@ impl AppConfig {
             if self.semantic_search_enabled { "true" } else { "false" },
         )?;
         db.set_setting(
+            K_EMBED_MODEL_ID,
+            self.embed_model_id.as_deref().unwrap_or(""),
+        )?;
+        // Keep the process-global embedder selection in sync with the persisted value on every save.
+        crate::embed::set_selected_embed_model_id(self.embed_model_id.clone());
+        db.set_setting(
             K_BRAIN_MODEL_PATH,
             self.brain_model_path.as_deref().unwrap_or(""),
         )?;
@@ -756,6 +781,37 @@ mod tests {
     #[test]
     fn notes_mode_defaults_to_enhance() {
         assert_eq!(AppConfig::default().notes_mode, "enhance");
+    }
+
+    /// A1 — offline AEC3 rides an UNPROVEN v0.1 crate on every system-audio recording, so it is
+    /// DEFAULT-OFF until real-Mac-verified. Assert both the in-memory struct default AND the
+    /// settings-table load path (empty DB / key absent) resolve to `false`. `#[serde(default)]`
+    /// (bool default = false) covers a config persisted before the field flip.
+    #[test]
+    fn post_aec_defaults_off() {
+        // In-memory struct default.
+        assert!(!AppConfig::default().post_aec_enabled);
+        // Settings-table path: empty DB (no key written) loads false.
+        let db = temp_db();
+        assert!(!AppConfig::load(&db).unwrap().post_aec_enabled);
+        // But an explicit opt-in still persists + reloads ON (not a one-way latch).
+        let cfg = AppConfig {
+            post_aec_enabled: true,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert!(AppConfig::load(&db).unwrap().post_aec_enabled);
+    }
+
+    /// A2 — the app default whisper model is `small` (RAM-safe; `large-v3` is ~3 GB and swaps on
+    /// 8 GB Macs). Must match `transcribe::model_filename("", _)`'s empty-size fallback so a config
+    /// that bypasses onboarding no longer lands on `large-v3`. All sizes stay selectable.
+    #[test]
+    fn model_size_defaults_to_small() {
+        assert_eq!(AppConfig::default().model_size, "small");
+        // Empty settings table loads the same default.
+        let db = temp_db();
+        assert_eq!(AppConfig::load(&db).unwrap().model_size, "small");
     }
 
     #[test]
@@ -921,6 +977,35 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(AppConfig::load(&db).unwrap().semantic_search_enabled);
+    }
+
+    #[test]
+    fn embed_model_id_defaults_none_and_round_trips() {
+        // Serialize with other tests that touch the process-global embedder selection.
+        let _g = crate::embed::EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let db = temp_db();
+        // Absent key ⇒ None (⇒ the default embedder ⇒ byte-identical to historical behavior).
+        assert!(AppConfig::load(&db).unwrap().embed_model_id.is_none());
+
+        let cfg = AppConfig {
+            embed_model_id: Some("mmlw-e5-small".to_string()),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert_eq!(
+            AppConfig::load(&db).unwrap().embed_model_id.as_deref(),
+            Some("mmlw-e5-small")
+        );
+
+        // Clearing back to None (default model) also round-trips — not a one-way latch.
+        let cleared = AppConfig {
+            embed_model_id: None,
+            ..Default::default()
+        };
+        cleared.save(&db).unwrap();
+        assert!(AppConfig::load(&db).unwrap().embed_model_id.is_none());
     }
 
     #[test]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -373,7 +373,33 @@ impl Db {
                FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
              );
              CREATE INDEX IF NOT EXISTS idx_facts_entity ON facts(entity_id);
-             CREATE INDEX IF NOT EXISTS idx_facts_meeting ON facts(meeting_id);",
+             CREATE INDEX IF NOT EXISTS idx_facts_meeting ON facts(meeting_id);
+             -- CROSS-MEETING USER MEMORY (Phase 3). The SAME bitemporal shape as `facts`
+             -- (subject·predicate·object with valid_from/valid_to — invalidate-not-delete via
+             -- reconcile) but USER-SCOPED, not entity-scoped: these are durable facts/preferences/
+             -- commitments about the USER accumulated across ALL meetings (prefers Polish replies,
+             -- works on Project Atlas, deadline Q3 = 15.09). Deliberately a SEPARATE table (no
+             -- entity FK) so the entity-graph fact reads (`list_facts_visible`) can NEVER surface a
+             -- user fact and vice-versa. `meeting_id` is the provenance + gating + purge anchor:
+             -- user facts are DERIVED content tied to the meeting they were learned from, so — exactly
+             -- like `facts` / `note_chunks` / `correction_log` — they are PURGED on seal in the same
+             -- atomic tx (`purge_user_facts_tx`) and every USER-FACING read is visibility-gated
+             -- (`list_user_facts_visible`). FK CASCADE on meeting_id so a deleted meeting drops its
+             -- user facts too. NULL meeting_id (legacy/imperative-without-source) reads back as NOT
+             -- visible (fail-closed via the INNER JOIN in the gated reader).
+             CREATE TABLE IF NOT EXISTS user_facts (
+               id TEXT PRIMARY KEY,
+               subject TEXT NOT NULL,
+               predicate TEXT NOT NULL,
+               object TEXT NOT NULL,
+               valid_from TEXT NOT NULL,
+               valid_to TEXT,
+               recorded_at TEXT NOT NULL,
+               meeting_id TEXT,
+               confidence REAL NOT NULL DEFAULT 1.0,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_user_facts_meeting ON user_facts(meeting_id);",
         )
         .map_err(map_err)?;
         // Guarded ALTERs — notes gain a folder association + a sealed-content blob (AES-GCM
@@ -1445,6 +1471,12 @@ impl Db {
         // drop them in the SAME seal tx so a sealed meeting contributes no fact — same purge-on-seal
         // contract as corrections / chunks / assistant interactions.
         Self::purge_facts_tx(&tx, meeting_ids)?;
+        // Phase 3 CROSS-MEETING USER MEMORY: user-scoped facts are DERIVED content tied to the source
+        // meeting (plaintext at rest); drop them in the SAME seal tx so a sealed meeting contributes
+        // no user memory — identical purge-on-seal contract as `facts` above. The injected brief is
+        // derived data (never sealed) → the next read regenerates it from the remaining VISIBLE
+        // sources only (design spec D3).
+        Self::purge_user_facts_tx(&tx, meeting_ids)?;
         tx.commit().map_err(map_err)?;
         Ok(())
     }
@@ -1460,6 +1492,26 @@ impl Db {
         for mid in meeting_ids {
             tx.execute(
                 "DELETE FROM facts WHERE meeting_id = ?1",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
+    /// Phase 3 CROSS-MEETING USER MEMORY LOCK-SAFETY: delete every `user_facts` row derived from
+    /// `meeting_ids` within an EXISTING transaction, so the purge lands in the SAME atomic unit as
+    /// the plaintext blanking on a seal (and on `delete_meeting` / the startup reconcile). User facts
+    /// are plaintext-derived (subject · predicate · object) memory that mirrors a meeting; a sealed
+    /// meeting must surface NOTHING and inject NOTHING, so — exactly like `facts` / `correction_log`
+    /// / `note_chunks` / `assistant_interactions` — we DELETE rather than key-seal. Dropped by design
+    /// and not recoverable (never keyed); the underlying transcript is still sealed + restorable, and a
+    /// later re-summarize re-derives user facts. The (derived) memory brief is regenerated on the
+    /// next read from the remaining VISIBLE user facts only.
+    fn purge_user_facts_tx(tx: &rusqlite::Transaction<'_>, meeting_ids: &[String]) -> Result<()> {
+        for mid in meeting_ids {
+            tx.execute(
+                "DELETE FROM user_facts WHERE meeting_id = ?1",
                 rusqlite::params![mid],
             )
             .map_err(map_err)?;
@@ -3126,6 +3178,15 @@ impl Db {
             [],
         )
         .map_err(map_err)?;
+        // Phase 3 CROSS-MEETING USER MEMORY LOCK-SAFETY: purge user-scoped facts for every meeting in
+        // a locked folder, in this same reconciliation transaction — so a crash-while-unlocked (which
+        // may have re-derived user memory against a since-sealed meeting) cannot leave plaintext user
+        // facts at rest after a restart. Same purge-on-seal contract as `facts` above.
+        tx.execute(
+            &format!("DELETE FROM user_facts WHERE meeting_id IN ({LOCKED_MEETINGS})"),
+            [],
+        )
+        .map_err(map_err)?;
         // brain2 realtime notes LOCK-SAFETY: re-blank the typed-notes plaintext of every meeting in a
         // locked folder ONLY WHERE its `manual_notes_blob` exists (the sealed copy is present) — so a
         // crash-while-unlocked (which restored the plaintext) cannot leave typed plaintext at rest
@@ -4480,6 +4541,154 @@ impl Db {
         }
         Ok(out)
     }
+
+    // ── CROSS-MEETING USER MEMORY (Phase 3) ────────────────────────────────────
+    //
+    // User facts reuse the bitemporal `crate::facts::{Fact, FactOp}` shape and the PURE deterministic
+    // `reconcile_facts` core, but persist to the SEPARATE `user_facts` table (no entity FK). In the
+    // in-memory `Fact`/`NewFact` the `entity_id` field carries the USER-SCOPE SENTINEL
+    // (`crate::user_memory::USER_SCOPE`) so `reconcile_facts` keys on `(sentinel, subject, predicate)`
+    // — it is the reconcile key only, NOT a stored column. LOCK MODEL: `user_facts_all` is the
+    // INTERNAL un-gated reconcile input (pipeline-only, before any seal can hide rows, like
+    // `facts_for_entities`); every USER-FACING read goes through `list_user_facts_visible`, and a
+    // sealed meeting's user facts are PURGED on seal (`purge_user_facts_tx`).
+
+    /// ALL user facts (open + closed) — the reconcile input. INTERNAL: the un-gated lifecycle read
+    /// (the pipeline reconciles before any seal can hide rows), NOT a user-facing surface. Rows are
+    /// hydrated into `crate::facts::Fact` with `entity_id` set to the user-scope sentinel so the pure
+    /// `reconcile_facts` keys them correctly. Newest-recorded last (stable reconcile order).
+    pub fn user_facts_all(&self) -> Result<Vec<crate::facts::Fact>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, subject, predicate, object, valid_from, valid_to, recorded_at, \
+                        meeting_id, confidence \
+                   FROM user_facts ORDER BY recorded_at ASC, id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt.query_map([], row_to_user_fact).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Apply a batch of reconcile [`crate::facts::FactOp`]s to `user_facts` in ONE atomic transaction:
+    /// INSERT each `Add`, set `valid_to` on each `Invalidate` (only if still open — idempotent), skip
+    /// `NoOp`. A fresh UUID is minted per Add. The `entity_id` on an Add op is the user-scope sentinel
+    /// and is NOT persisted (there is no entity column). The whole batch commits or rolls back
+    /// together, so a crash mid-apply never leaves a half-reconciled store.
+    pub fn apply_user_fact_ops(&self, ops: &[crate::facts::FactOp]) -> Result<()> {
+        use crate::facts::FactOp;
+        if ops.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        for op in ops {
+            match op {
+                FactOp::Add(nf) => {
+                    let id = uuid::Uuid::new_v4().to_string();
+                    tx.execute(
+                        "INSERT INTO user_facts \
+                           (id, subject, predicate, object, valid_from, valid_to, \
+                            recorded_at, meeting_id, confidence) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8)",
+                        rusqlite::params![
+                            id,
+                            nf.subject,
+                            nf.predicate,
+                            nf.object,
+                            nf.valid_from,
+                            nf.recorded_at,
+                            nf.meeting_id,
+                            nf.confidence,
+                        ],
+                    )
+                    .map_err(map_err)?;
+                }
+                FactOp::Invalidate { id, valid_to } => {
+                    tx.execute(
+                        "UPDATE user_facts SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
+                        rusqlite::params![id, valid_to],
+                    )
+                    .map_err(map_err)?;
+                }
+                FactOp::NoOp => {}
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// GATED read: the CURRENTLY-VALID (open) user facts whose SOURCE meeting is VISIBLE, newest
+    /// valid_from first. Visibility uses the SAME predicate as every other graph/MCP read
+    /// (`visibility_clause`): a user fact is visible iff its source meeting has a visible note (or no
+    /// note yet). A row with a NULL `meeting_id` is NOT visible — the INNER JOIN to `meetings` drops
+    /// it (fail-closed). This is the single user-facing user-fact read: it feeds BOTH the audit view
+    /// (`get_user_memory`) AND the injected memory brief, so a sealed-and-not-session-unlocked
+    /// meeting's user facts surface NOTHING and are injected into NO prompt. Only OPEN facts
+    /// (`valid_to IS NULL`) are returned — a forgotten/superseded fact is closed and excluded.
+    pub fn list_user_facts_visible(
+        &self,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<crate::facts::Fact>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT uf.id, uf.subject, uf.predicate, uf.object, uf.valid_from, \
+                    uf.valid_to, uf.recorded_at, uf.meeting_id, uf.confidence \
+               FROM user_facts uf \
+               JOIN meetings m ON m.id = uf.meeting_id \
+              WHERE uf.valid_to IS NULL \
+                AND ( \
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id) \
+                   OR EXISTS ( \
+                        SELECT 1 FROM notes n \
+                         LEFT JOIN folders f ON f.id = n.folder_id \
+                         WHERE n.meeting_id = m.id AND {visible} \
+                      ) \
+                    ) \
+              ORDER BY uf.valid_from DESC, uf.id DESC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt.query_map([], row_to_user_fact).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// FORGET one user fact by id (bitemporal INVALIDATE, never a silent delete): close the row at
+    /// `at` if it is still open. Idempotent (a already-closed row is untouched). History is preserved
+    /// — the fact simply stops being current, so it drops out of `list_user_facts_visible` and the
+    /// regenerated brief. Returns `true` iff a row was closed by this call.
+    pub fn forget_user_fact(&self, id: &str, at: &str) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE user_facts SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
+                rusqlite::params![id, at],
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
+    }
+
+    /// CLEAR all user memory: bitemporal-close EVERY currently-open user fact at `at` (invalidate,
+    /// never delete — closed history stays for the record). After this the brief regenerates empty and
+    /// the audit view is empty. Returns the number of facts closed.
+    pub fn clear_user_facts(&self, at: &str) -> Result<usize> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE user_facts SET valid_to = ?1 WHERE valid_to IS NULL",
+                rusqlite::params![at],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
 }
 
 /// Collision-proof unique temp path for file-backed tests.
@@ -4642,6 +4851,25 @@ fn row_to_fact(row: &Row<'_>) -> rusqlite::Result<crate::facts::Fact> {
         recorded_at: row.get(7)?,
         meeting_id: row.get(8)?,
         confidence: row.get(9)?,
+    })
+}
+
+/// Map a `user_facts` row (column order: id, subject, predicate, object, valid_from, valid_to,
+/// recorded_at, meeting_id, confidence — NO entity column) to a [`crate::facts::Fact`], stamping the
+/// user-scope sentinel into `entity_id` so the pure `reconcile_facts` keys the row correctly. The
+/// sentinel is a reconcile key only, never persisted.
+fn row_to_user_fact(row: &Row<'_>) -> rusqlite::Result<crate::facts::Fact> {
+    Ok(crate::facts::Fact {
+        id: row.get(0)?,
+        entity_id: crate::user_memory::USER_SCOPE.to_string(),
+        subject: row.get(1)?,
+        predicate: row.get(2)?,
+        object: row.get(3)?,
+        valid_from: row.get(4)?,
+        valid_to: row.get(5)?,
+        recorded_at: row.get(6)?,
+        meeting_id: row.get(7)?,
+        confidence: row.get(8)?,
     })
 }
 
@@ -7816,6 +8044,148 @@ mod lock_tests {
             .unwrap();
         db.delete_meeting("m1").unwrap();
         assert!(db.facts_for_entities(&[atlas]).unwrap().is_empty(), "FK CASCADE drops facts");
+    }
+
+    // ── Phase 3 CROSS-MEETING USER MEMORY: persistence + reconcile + gating + forget + purge ──
+
+    fn user_add_op(predicate: &str, object: &str, valid_from: &str, meeting_id: &str) -> FactOp {
+        FactOp::Add(NewFact {
+            entity_id: crate::user_memory::USER_SCOPE.to_string(),
+            subject: "You".to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: valid_from.to_string(),
+            recorded_at: valid_from.to_string(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })
+    }
+
+    /// ROUND-TRIP persist/reconcile (task C5.ii): apply an open user fact; a later reconcile of a
+    /// CHANGED object for the SAME predicate closes the old (valid_to set) and opens the new — both
+    /// rows survive (bitemporal history), and only the current one is visible. RED-before-GREEN:
+    /// without the Invalidate UPDATE two open rows survive, failing the single-open assertion.
+    #[test]
+    fn user_facts_apply_and_reconcile_round_trips() {
+        let db = file_db("user-facts-roundtrip");
+        seed_note(&db, "m1", "note", None);
+        db.apply_user_fact_ops(&[user_add_op("prefer", "English replies", "2026-06-01T00:00:00Z", "m1")])
+            .unwrap();
+
+        // A later meeting supersedes the preference: prefer = Polish replies.
+        seed_note(&db, "m2", "note2", None);
+        let existing = db.user_facts_all().unwrap();
+        assert_eq!(existing.len(), 1);
+        let cands = vec![FactCandidate {
+            entity_id: crate::user_memory::USER_SCOPE.to_string(),
+            subject: "You".to_string(),
+            predicate: "prefer".to_string(),
+            object: "Polish replies".to_string(),
+            confidence: 1.0,
+        }];
+        let at = "2026-06-20T00:00:00Z";
+        let mut ops = crate::facts::reconcile_facts(&existing, &cands, at);
+        crate::facts::set_meeting_id(&mut ops, "m2");
+        db.apply_user_fact_ops(&ops).unwrap();
+
+        let all = db.user_facts_all().unwrap();
+        assert_eq!(all.len(), 2, "history preserved — old user fact kept, not overwritten");
+        let open: Vec<_> = all.iter().filter(|f| f.valid_to.is_none()).collect();
+        assert_eq!(open.len(), 1, "exactly one currently-valid user fact");
+        assert_eq!(open[0].object, "Polish replies");
+
+        // The gated read returns only the OPEN, VISIBLE fact.
+        let visible = db.list_user_facts_visible(&HashSet::new()).unwrap();
+        assert_eq!(visible.len(), 1, "only the current preference is visible");
+        assert_eq!(visible[0].object, "Polish replies");
+        assert_eq!(visible[0].meeting_id.as_deref(), Some("m2"), "provenance = the source meeting");
+    }
+
+    /// GATE (task C5.i, DB layer): a user fact whose source meeting is sealed-and-not-unlocked is
+    /// INVISIBLE and reappears once the folder is session-unlocked. Uses set_folder_locked directly
+    /// (NOT lock_folder) so the row survives at rest — this proves the READ GATE, independent of the
+    /// purge-on-seal. RED-before-GREEN: drop the meetings-JOIN visibility predicate → the sealed user
+    /// fact leaks into the audit view AND the brief.
+    #[test]
+    fn list_user_facts_visible_excludes_sealed_meeting() {
+        let db = file_db("user-facts-gate");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "secret1", "private", Some("f-lock"));
+        db.apply_user_fact_ops(&[user_add_op("salary", "confidential", "2026-06-01T00:00:00Z", "secret1")])
+            .unwrap();
+
+        assert_eq!(db.list_user_facts_visible(&HashSet::new()).unwrap().len(), 1);
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        assert!(
+            db.list_user_facts_visible(&HashSet::new()).unwrap().is_empty(),
+            "a sealed-not-unlocked meeting's user facts must not surface (gate violation)"
+        );
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        assert_eq!(
+            db.list_user_facts_visible(&unlocked).unwrap().len(),
+            1,
+            "user facts reappear once the folder is session-unlocked"
+        );
+    }
+
+    /// FORGET (task C5.iii): forget_user_fact bitemporally CLOSES the row (never deletes) so it drops
+    /// out of the gated read; a second forget is a no-op. clear_user_facts closes ALL open facts.
+    #[test]
+    fn forget_and_clear_user_facts() {
+        let db = file_db("user-facts-forget");
+        seed_note(&db, "m1", "note", None);
+        db.apply_user_fact_ops(&[
+            user_add_op("prefer", "Polish", "2026-06-01T00:00:00Z", "m1"),
+            user_add_op("role", "PM", "2026-06-01T00:00:00Z", "m1"),
+        ])
+        .unwrap();
+        let visible = db.list_user_facts_visible(&HashSet::new()).unwrap();
+        assert_eq!(visible.len(), 2);
+        let target = visible[0].id.clone();
+
+        // Forget one → it is closed and drops out.
+        assert!(db.forget_user_fact(&target, "2026-06-02T00:00:00Z").unwrap(), "closed one open fact");
+        assert!(!db.forget_user_fact(&target, "2026-06-02T00:00:00Z").unwrap(), "re-forget is a no-op");
+        let after = db.list_user_facts_visible(&HashSet::new()).unwrap();
+        assert_eq!(after.len(), 1, "the forgotten fact drops out of the gated read");
+        assert!(after.iter().all(|f| f.id != target));
+        // The row still EXISTS (closed, not deleted) — history preserved.
+        assert_eq!(db.user_facts_all().unwrap().len(), 2, "forget is an invalidate, not a delete");
+
+        // Clear all → nothing visible; every open fact closed.
+        let n = db.clear_user_facts("2026-06-03T00:00:00Z").unwrap();
+        assert_eq!(n, 1, "one remaining open fact closed");
+        assert!(db.list_user_facts_visible(&HashSet::new()).unwrap().is_empty(), "no user memory after clear");
+    }
+
+    /// PURGE-ON-SEAL (task C2.a, DB layer): the same atomic seal tx that purges facts also DELETES the
+    /// meeting's user facts (purge_user_facts_tx). RED-before-GREEN: without the purge_user_facts_tx
+    /// call the user-fact row survives the seal at rest.
+    #[test]
+    fn seal_purges_user_facts() {
+        let db = file_db("user-facts-purge");
+        seed_note(&db, "m1", "note", None);
+        db.apply_user_fact_ops(&[user_add_op("prefer", "Polish", "2026-06-01T00:00:00Z", "m1")])
+            .unwrap();
+        assert_eq!(db.user_facts_all().unwrap().len(), 1);
+        // The seal purge (chunks + corrections + assistant interactions + facts + USER facts) in one tx.
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert!(
+            db.user_facts_all().unwrap().is_empty(),
+            "user facts must be purged on seal (drop-on-seal, like facts / note_chunks)"
+        );
+    }
+
+    /// delete_meeting cascades to user_facts (FK ON DELETE CASCADE).
+    #[test]
+    fn delete_meeting_cascades_to_user_facts() {
+        let db = file_db("user-facts-cascade");
+        seed_note(&db, "m1", "note", None);
+        db.apply_user_fact_ops(&[user_add_op("prefer", "Polish", "2026-06-01T00:00:00Z", "m1")])
+            .unwrap();
+        db.delete_meeting("m1").unwrap();
+        assert!(db.user_facts_all().unwrap().is_empty(), "FK CASCADE drops user facts");
     }
 }
 

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -509,7 +509,12 @@ fn run_informational(
         // Cloud-only). NO new egress class.
         let (live, typed_notes) =
             gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
-        let system = assistant_system_prompt(&live, &typed_notes);
+        // Phase 3 CROSS-MEETING USER MEMORY: synthesize the memory brief from the currently-VISIBLE
+        // user facts only (sealed-source facts are excluded by `list_user_facts_visible`), and inject
+        // it next to the live-transcript section. It rides the SAME redaction firewall + cloud-consent
+        // gate as every other prompt segment — NO new egress class (design spec C3).
+        let memory_brief = gated_user_memory_brief(&state.db, unlocked);
+        let system = assistant_system_prompt(&live, &typed_notes, &memory_brief);
         match crate::agent::run_agentic_loop(
             &*reasoner,
             &system,
@@ -1048,6 +1053,20 @@ fn gated_live_context(
     (live, typed)
 }
 
+/// Phase 3 CROSS-MEETING USER MEMORY: synthesize the injectable memory brief from the CURRENTLY-
+/// VISIBLE user facts (design spec C3/D3). The visibility gate lives in `list_user_facts_visible`
+/// (source-meeting `visibility_clause`), so a sealed-and-not-session-unlocked meeting's user facts
+/// are NEVER read here and NEVER injected — the brief is regenerated from the remaining visible
+/// sources on every turn. Best-effort: a read error degrades to an EMPTY brief (no injection), never
+/// a failure. The brief egresses only inside the already-redacted, consent-gated system prompt.
+fn gated_user_memory_brief(
+    db: &crate::storage::Db,
+    unlocked: &std::collections::HashSet<String>,
+) -> String {
+    let facts = db.list_user_facts_visible(unlocked).unwrap_or_default();
+    crate::user_memory::synthesize_brief(&facts)
+}
+
 /// Clear the accumulated live-transcript buffer. Called when a recording STOPS
 /// (`commands::stop_recording`) so a stale tail can never be injected into assistant prompts after
 /// Stop — nor keep egressing once the just-recorded folder is sealed — and by the lock-surface
@@ -1096,7 +1115,7 @@ fn tail_chars(s: &str, n: usize) -> String {
 /// to the pre-feature output (the section is simply absent). Both the injected transcript AND the typed
 /// notes egress through the SAME redaction firewall as every other prompt
 /// (`RedactingProvider::complete` scrubs `system` + `user`) — they are NOT a new egress class.
-fn assistant_system_prompt(live_transcript: &str, typed_notes: &str) -> String {
+fn assistant_system_prompt(live_transcript: &str, typed_notes: &str, memory_brief: &str) -> String {
     let base = "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 \
                 sentences). Do not invent facts; if you cannot find the answer, say so plainly. \
                 Decide what the user wants: for a plain QUESTION or conversation, just ANSWER it. \
@@ -1130,6 +1149,19 @@ fn assistant_system_prompt(live_transcript: &str, typed_notes: &str) -> String {
         let notes_tail = tail_chars(notes, LIVE_TRANSCRIPT_INJECT_CHARS);
         prompt.push_str(&format!(
             "\n\nUSER'S OWN TYPED NOTES for this meeting (their emphasis — weight these):\n{notes_tail}"
+        ));
+    }
+    // Phase 3 CROSS-MEETING USER MEMORY: the synthesized brief of what the brain durably knows about
+    // the USER across all meetings (preferences, ongoing work, commitments), regenerated from
+    // currently-VISIBLE user facts only. Appended as a distinct bounded section; ABSENT when empty
+    // (so the prompt is BYTE-IDENTICAL to the pre-feature output when there is no memory). It rides
+    // the SAME redaction firewall + cloud-consent gate as the rest of the prompt — NOT a new egress
+    // class.
+    let brief = memory_brief.trim();
+    if !brief.is_empty() {
+        prompt.push_str(&format!(
+            "\n\nWHAT YOU KNOW ABOUT THE USER (durable memory across meetings — use it to ground and \
+             personalize your answers; it may be stale, so defer to anything the user says now):\n{brief}"
         ));
     }
     prompt
@@ -1644,7 +1676,7 @@ mod tests {
     /// attribution from it would be hallucinated).
     #[test]
     fn assistant_system_prompt_is_honest_about_attribution() {
-        let p = assistant_system_prompt("we shipped the beta", "");
+        let p = assistant_system_prompt("we shipped the beta", "", "");
         let lower = p.to_lowercase();
         assert!(lower.contains("unattributed"), "must state the transcript is unattributed: {p}");
         assert!(lower.contains("microphone"), "must state the mic-side capture origin: {p}");
@@ -1714,7 +1746,7 @@ mod tests {
         let (tail, notes) = gated_live_context(&db, &live, "m1", &unlocked);
         assert!(tail.is_empty(), "sealed-not-unlocked meeting must inject NO live tail");
         assert!(notes.is_empty(), "sealed-not-unlocked meeting must inject NO typed notes");
-        let prompt = assistant_system_prompt(&tail, &notes);
+        let prompt = assistant_system_prompt(&tail, &notes, "");
         assert!(!prompt.contains("LIVE TRANSCRIPT"), "no live section for a sealed meeting: {prompt}");
         assert!(!prompt.contains("sealed meeting tail"), "the RAM buffer must not reach the prompt");
         // The in-flight buffer itself is NOT wiped — a session re-unlock re-injects it.
@@ -1800,11 +1832,11 @@ mod tests {
     #[test]
     fn assistant_system_prompt_injects_transcript_only_when_present() {
         // No live transcript (not recording / no captions yet) ⇒ the base prompt, no transcript section.
-        let base = assistant_system_prompt("", "");
+        let base = assistant_system_prompt("", "", "");
         assert!(!base.contains("LIVE TRANSCRIPT"), "no transcript section when empty: {base}");
         assert!(base.contains("in-meeting assistant"));
         // With a transcript ⇒ it is embedded + the brain is told to use it for the current meeting.
-        let with = assistant_system_prompt("we shipped the beta and assigned the deck to Anna", "");
+        let with = assistant_system_prompt("we shipped the beta and assigned the deck to Anna", "", "");
         assert!(with.contains("LIVE TRANSCRIPT"), "names the transcript section: {with}");
         assert!(with.contains("assigned the deck to Anna"), "embeds the transcript text");
         assert!(with.to_lowercase().contains("current"), "tells the brain it's the current meeting");
@@ -1816,8 +1848,8 @@ mod tests {
     #[test]
     fn assistant_system_prompt_instructs_propose_note_decision() {
         for prompt in [
-            assistant_system_prompt("", ""),
-            assistant_system_prompt("we shipped the beta", ""),
+            assistant_system_prompt("", "", ""),
+            assistant_system_prompt("we shipped the beta", "", ""),
         ] {
             assert!(prompt.contains("propose_note"), "names the propose_note tool: {prompt}");
             assert!(
@@ -1834,7 +1866,7 @@ mod tests {
         // A very long transcript is truncated to the RECENT tail (so a 2-hour meeting can't blow the
         // context) and marked elided.
         let long = "x ".repeat(LIVE_TRANSCRIPT_INJECT_CHARS); // way over the inject budget
-        let p = assistant_system_prompt(&long, "");
+        let p = assistant_system_prompt(&long, "", "");
         assert!(p.contains('…'), "elision marker present when truncated");
         assert!(p.chars().count() < long.chars().count(), "shorter than the raw transcript");
     }
@@ -1845,30 +1877,122 @@ mod tests {
     fn assistant_system_prompt_injects_typed_notes_and_empty_is_byte_identical() {
         // Empty typed notes ⇒ no typed-notes section, AND byte-identical to the no-notes prompt for
         // BOTH the no-transcript and with-transcript branches.
-        let no_tx = assistant_system_prompt("", "");
+        let no_tx = assistant_system_prompt("", "", "");
         assert!(!no_tx.contains("TYPED NOTES"), "no typed-notes section when empty: {no_tx}");
         let tx = "we shipped the beta and assigned the deck to Anna";
         assert_eq!(
-            assistant_system_prompt(tx, ""),
-            assistant_system_prompt(tx, "   "),
+            assistant_system_prompt(tx, "", ""),
+            assistant_system_prompt(tx, "   ", ""),
             "whitespace-only typed notes must be byte-identical to none (no regression)"
         );
 
         // Present typed notes ⇒ embedded under the labeled section, alongside the transcript.
-        let with = assistant_system_prompt(tx, "DECISION: ship Friday. Anna owns QA sign-off.");
+        let with = assistant_system_prompt(tx, "DECISION: ship Friday. Anna owns QA sign-off.", "");
         assert!(with.contains("TYPED NOTES"), "names the typed-notes section: {with}");
         assert!(with.contains("Anna owns QA sign-off"), "embeds the typed-notes text");
         assert!(with.contains("LIVE TRANSCRIPT"), "still injects the transcript too");
 
         // Typed notes inject even with NO transcript (the user can type before any caption lands).
-        let notes_only = assistant_system_prompt("", "remember: budget cap is the blocker");
+        let notes_only = assistant_system_prompt("", "remember: budget cap is the blocker", "");
         assert!(notes_only.contains("TYPED NOTES"), "typed notes inject without a transcript");
         assert!(notes_only.contains("budget cap is the blocker"));
         assert!(!notes_only.contains("LIVE TRANSCRIPT"), "no transcript section when transcript empty");
 
         // A very long typed-notes buffer is truncated to the recent tail (bounded like the transcript).
         let long = "y ".repeat(LIVE_TRANSCRIPT_INJECT_CHARS);
-        let p = assistant_system_prompt("", &long);
+        let p = assistant_system_prompt("", &long, "");
         assert!(p.contains('…'), "elision marker present when typed notes truncated");
+    }
+
+    // ── Phase 3 CROSS-MEETING USER MEMORY: brief injection + the seal invariant ───────────────────
+
+    /// The memory brief is injected as its own labeled section when present, and the EMPTY-brief
+    /// prompt is BYTE-IDENTICAL to the no-brief output (no regression). This is the "included when
+    /// present, empty when memory is empty" contract from the task.
+    #[test]
+    fn assistant_system_prompt_injects_memory_brief_and_empty_is_byte_identical() {
+        // Empty brief ⇒ no memory section, AND byte-identical to the no-brief prompt for BOTH the
+        // no-transcript and with-transcript branches.
+        let no_brief = assistant_system_prompt("", "", "");
+        assert!(!no_brief.to_uppercase().contains("KNOW ABOUT THE USER"), "no memory section when empty");
+        assert_eq!(
+            assistant_system_prompt("we shipped the beta", "", ""),
+            assistant_system_prompt("we shipped the beta", "", "   "),
+            "whitespace-only brief must be byte-identical to none (no regression)"
+        );
+
+        // Present brief ⇒ embedded under the labeled memory section, alongside transcript + notes.
+        let brief = "- You prefer: Polish replies\n- You work on: Project Atlas";
+        let with = assistant_system_prompt("we shipped the beta", "ship Friday", brief);
+        assert!(with.to_uppercase().contains("KNOW ABOUT THE USER"), "names the memory section: {with}");
+        assert!(with.contains("Project Atlas"), "embeds the brief text");
+        assert!(with.contains("LIVE TRANSCRIPT"), "still injects the transcript too");
+        assert!(with.contains("TYPED NOTES"), "still injects the typed notes too");
+
+        // The brief injects even with NO transcript and NO notes.
+        let brief_only = assistant_system_prompt("", "", brief);
+        assert!(brief_only.to_uppercase().contains("KNOW ABOUT THE USER"), "brief injects standalone");
+        assert!(brief_only.contains("Polish replies"));
+    }
+
+    /// THE WHOLE-FEATURE SEAL INVARIANT (RED-before-GREEN, design spec D3 / task C5.i): a user-memory
+    /// fact whose SOURCE meeting is sealed-and-not-session-unlocked is NEITHER returned by
+    /// `list_user_facts_visible` NOR present in the injected brief. Before the visibility gate on
+    /// `list_user_facts_visible` this test FAILS (the sealed fact leaks into the brief); after the
+    /// gate it passes. Session re-unlock re-admits it (the gate is reversible, not a wipe).
+    #[test]
+    fn user_memory_brief_excludes_sealed_source_and_reinjects_after_unlock() {
+        let db = tmp_db("user-mem-seal");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        // A summarized, foldered meeting is the SOURCE of a user fact.
+        seed_meeting(&db, "m1", Some("f1"));
+        db.apply_user_fact_ops(&[crate::facts::FactOp::Add(crate::facts::NewFact {
+            entity_id: crate::user_memory::USER_SCOPE.to_string(),
+            subject: "You".into(),
+            predicate: "prefer".into(),
+            object: "Polish replies".into(),
+            valid_from: "2026-07-01T00:00:00Z".into(),
+            recorded_at: "2026-07-01T00:00:00Z".into(),
+            confidence: 1.0,
+            meeting_id: Some("m1".into()),
+        })])
+        .unwrap();
+
+        // While the folder is OPEN the fact is visible → the brief contains it.
+        let mut unlocked = std::collections::HashSet::new();
+        let brief_open = gated_user_memory_brief(&db, &unlocked);
+        assert!(brief_open.contains("Polish replies"), "an open-folder user fact must be in the brief");
+        let prompt_open = assistant_system_prompt("", "", &brief_open);
+        assert!(prompt_open.contains("Polish replies"), "and injected into the prompt");
+
+        // SEAL the folder (session NOT unlocked). NOTE: `set_folder_locked` only flips the flag — the
+        // real seal path PURGES the fact (`purge_user_facts_tx`); here we assert the READ GATE alone,
+        // so we don't purge, proving the gate hides a fact whose row still exists at rest.
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..])).unwrap();
+        let visible_sealed = db.list_user_facts_visible(&unlocked).unwrap();
+        assert!(
+            visible_sealed.is_empty(),
+            "a sealed-not-unlocked meeting's user fact must be INVISIBLE to the gated reader"
+        );
+        let brief_sealed = gated_user_memory_brief(&db, &unlocked);
+        assert!(brief_sealed.is_empty(), "sealed-source fact must NOT appear in the injected brief");
+        let prompt_sealed = assistant_system_prompt("", "", &brief_sealed);
+        assert!(!prompt_sealed.contains("Polish replies"), "the sealed fact must not reach the prompt");
+        assert!(!prompt_sealed.to_uppercase().contains("KNOW ABOUT THE USER"), "no memory section at all");
+
+        // A SESSION UNLOCK re-admits it (reversible gate).
+        unlocked.insert("f1".to_string());
+        assert!(
+            gated_user_memory_brief(&db, &unlocked).contains("Polish replies"),
+            "a session unlock must re-inject the user fact"
+        );
     }
 }

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -36,11 +36,12 @@ pub const DIARIZE_EMB_MODEL_FILE: &str = "wespeaker_en_voxceleb_CAM++.onnx";
 /// are multilingual-only (no `.en` variant), so Polish always resolves the full
 /// multilingual `ggml-large-v3.bin`.
 ///
-/// An empty size falls back to the app default (`large-v3`), matching
-/// `AppConfig::default().model_size`.
+/// An empty size falls back to the app default (`small`), matching
+/// `AppConfig::default().model_size` — a RAM-safe default so a config that bypasses onboarding
+/// no longer lands on the ~3 GB `large-v3`. All sizes (incl. `large-v3`) stay selectable.
 pub fn model_filename(size: &str, language: &str) -> String {
     let size = match size.trim() {
-        "" => "large-v3",
+        "" => "small",
         s => s,
     };
     let en_only = language == "en" && matches!(size, "tiny" | "base" | "small" | "medium");
@@ -284,10 +285,13 @@ mod tests {
     }
 
     #[test]
-    fn empty_size_falls_back_to_large_v3_default() {
-        // Mirrors AppConfig::default().model_size.
-        assert_eq!(model_filename("", ""), "ggml-large-v3.bin");
-        assert_eq!(model_filename("   ", "pl"), "ggml-large-v3.bin");
+    fn empty_size_falls_back_to_small_default() {
+        // Mirrors AppConfig::default().model_size — a RAM-safe default (was large-v3, ~3 GB).
+        // For English, the empty-size fallback resolves the multilingual build (no explicit "en").
+        assert_eq!(model_filename("", ""), "ggml-small.bin");
+        assert_eq!(model_filename("   ", "pl"), "ggml-small.bin");
+        // large-v3 stays selectable when explicitly chosen.
+        assert_eq!(model_filename("large-v3", ""), "ggml-large-v3.bin");
     }
 
     #[test]

--- a/src-tauri/src/user_memory.rs
+++ b/src-tauri/src/user_memory.rs
@@ -1,0 +1,316 @@
+//! Cross-meeting USER MEMORY (Phase 3) — a durable, user-scoped "what the brain knows about you"
+//! layer that persists facts/preferences/commitments across ALL meetings and injects an auditable
+//! brief into the agentic loop. It REUSES the bitemporal facts substrate (`crate::facts`) — the same
+//! valid_from/valid_to, invalidate-not-delete, deterministic reconcile — but scoped to the USER
+//! rather than a graph entity.
+//!
+//! ## Why a separate table, not `facts` rows
+//! Entity facts are keyed on `(entity_id, subject, predicate)` and carry an FK to `entities`. User
+//! facts are about "me" — there is no entity — so they live in a PARALLEL `user_facts` table with no
+//! entity FK. Reusing the pure `crate::facts::reconcile_facts` needs SOME key in the `entity_id`
+//! slot, so every user-fact op/row carries the fixed [`USER_SCOPE`] sentinel there — a reconcile key
+//! ONLY, never a persisted column. Keeping the tables separate means the entity-graph reads
+//! (`list_facts_visible`, MCP dossier) can NEVER surface a user fact and vice-versa.
+//!
+//! ## Lock model (see `.claude/rules/lock-model.md`, design spec D3)
+//! A user fact carries the SOURCE `meeting_id` it was derived from (the gating + purge anchor). Like
+//! `facts` / `note_chunks` / `correction_log`, user facts are DERIVED content: PURGED on seal in the
+//! same atomic tx (`Db::purge_user_facts_tx`) and every USER-FACING read is visibility-gated
+//! (`Db::list_user_facts_visible`). The memory brief is DERIVED data — never sealed, always
+//! REGENERATED from the currently-VISIBLE user facts — so a sealed-and-not-session-unlocked meeting's
+//! user facts surface NOTHING in the audit view AND are injected into NO prompt.
+//!
+//! ## Determinism
+//! [`synthesize_brief`] is a PURE function (no LLM, no DB, no clock) — the headless-testable heart.
+//! The only non-deterministic part is [`extract_user_fact_candidates`], which is BEST-EFFORT: it
+//! asks the on-device reasoner for user·predicate·object preferences and degrades to an EMPTY result
+//! (never an error, never a panic, never a block) when the brain/model is unavailable.
+
+use serde::{Deserialize, Serialize};
+
+use crate::facts::{Fact, FactCandidate};
+use crate::reason::LocalReasoner;
+
+/// The reserved `entity_id` sentinel that scopes a fact to the USER (not a graph entity). It is a
+/// reconcile-key placeholder ONLY — it is never written to the `user_facts` table (which has no
+/// entity column) and never surfaces to the FE. Chosen to be impossible as a real UUID entity id.
+pub const USER_SCOPE: &str = "__user__";
+
+/// Max chars of the synthesized memory brief injected into the agentic system prompt. Small on
+/// purpose (design spec D2): the brief is always-injected, so it must stay a tight budget.
+pub const MEMORY_BRIEF_MAX_CHARS: usize = 2_000;
+
+/// Max user facts fed into a single brief (belt-and-braces bound alongside the char budget).
+const MAX_BRIEF_FACTS: usize = 40;
+
+/// Max note chars fed to the user-fact extractor (bounds the prompt / leak surface, like facts.rs).
+const EXTRACT_EXCERPT_CHARS: usize = 8_000;
+
+/// One current user-memory fact, as surfaced to the FE audit view. Content-bearing (subject /
+/// predicate / object) BUT only ever built from VISIBLE facts (`Db::list_user_facts_visible`), so a
+/// sealed source never reaches here. `sourceMeetingId` is the provenance link (the audit "where did
+/// the brain learn this" affordance).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserMemoryFact {
+    pub id: String,
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    /// Valid-time origin (the source meeting's time) — when the brain learned it was true.
+    pub valid_from: String,
+    /// The meeting this was derived from (the provenance link + purge anchor). Always `Some` for a
+    /// visible fact (the gated reader drops NULL-source rows fail-closed).
+    pub source_meeting_id: Option<String>,
+    pub confidence: f64,
+}
+
+impl UserMemoryFact {
+    /// Project a persisted [`Fact`] (already visibility-filtered) into the FE audit DTO.
+    pub fn from_fact(f: &Fact) -> Self {
+        Self {
+            id: f.id.clone(),
+            subject: f.subject.clone(),
+            predicate: f.predicate.clone(),
+            object: f.object.clone(),
+            valid_from: f.valid_from.clone(),
+            source_meeting_id: f.meeting_id.clone(),
+            confidence: f.confidence,
+        }
+    }
+}
+
+/// The full audit payload for the Brain-page Memory section: the current (visible, open) user facts
+/// plus the synthesized brief that is injected into grounding. Both are derived from EXACTLY the same
+/// visible-facts set, so the audit view is a faithful mirror of what the brain actually injects.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserMemory {
+    pub facts: Vec<UserMemoryFact>,
+    /// The injected brief (same text the agentic loop receives), or empty when memory is empty.
+    pub brief: String,
+}
+
+/// DETERMINISTIC brief synthesis (no LLM, no DB, no clock) — the headless-testable core. Assemble the
+/// currently-valid `facts` (already visibility-filtered by the caller) into a compact markdown brief:
+/// one `- <subject> <predicate>: <object>` bullet per fact, newest valid_from first (the caller's
+/// order is preserved), bounded by [`MAX_BRIEF_FACTS`] and hard-truncated to [`MEMORY_BRIEF_MAX_CHARS`]
+/// on a char boundary. EMPTY facts ⇒ EMPTY string (no header) so injection is a pure no-op when there
+/// is no memory. NEVER panics; skips malformed (empty subject/predicate/object) rows defensively.
+pub fn synthesize_brief(facts: &[Fact]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for f in facts.iter().take(MAX_BRIEF_FACTS) {
+        let subject = f.subject.trim();
+        let predicate = f.predicate.trim();
+        let object = f.object.trim();
+        if subject.is_empty() || predicate.is_empty() || object.is_empty() {
+            continue; // never emit a junk bullet.
+        }
+        lines.push(format!("- {subject} {predicate}: {object}"));
+    }
+    if lines.is_empty() {
+        return String::new();
+    }
+    let body = lines.join("\n");
+    // Hard char budget (on a char boundary) — the brief is always-injected.
+    let brief: String = body.chars().take(MEMORY_BRIEF_MAX_CHARS).collect();
+    brief
+}
+
+/// The shape the reasoner must emit. Best-effort: parse failures degrade to no facts.
+#[derive(Debug, Deserialize)]
+struct UserFactsReply {
+    #[serde(default)]
+    facts: Vec<RawUserFact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUserFact {
+    #[serde(default)]
+    predicate: String,
+    #[serde(default)]
+    object: String,
+}
+
+const EXTRACT_SYSTEM: &str = "You extract durable facts, preferences and commitments ABOUT THE \
+USER (the person whose notes these are — first person \"I / me / my\") from a meeting note and the \
+user's own typed notes. Output STRICT JSON ONLY (no prose, no code fences): \
+{\"facts\":[{\"predicate\":\"short attribute\",\"object\":\"value\"}]}.\n\
+- Extract ONLY durable, user-scoped state worth remembering across meetings: the user's own \
+preferences (\"prefers replies in Polish\"), ongoing work (\"works on Project Atlas\"), commitments \
+and recurring context (\"deadline Q3 = 2026-09-15\"). Prefer things the user explicitly asks to \
+remember (\"remember that…\", \"zapamiętaj, że…\").\n\
+- predicate is a short, stable attribute (e.g. \"prefers\", \"works on\", \"role\", \"deadline\").\n\
+- object is the current value (e.g. \"Polish replies\", \"Project Atlas\", \"2026-09-15\").\n\
+- Do NOT extract facts about OTHER people or projects (those are entity facts, handled elsewhere), \
+one-off remarks, or anything not clearly about the USER. Precision over recall — a wrong memory is \
+worse than a missing one. Empty array if none.\n\
+Output ONLY the JSON.";
+
+/// The stable subject stored on every user fact (the memory is about "you"). A single constant
+/// subject keeps the reconcile key `(USER_SCOPE, subject, predicate)` effectively
+/// `(predicate)`-keyed — so a later note that changes the user's answer to the SAME predicate
+/// supersedes it, exactly like entity facts.
+const USER_SUBJECT: &str = "You";
+
+/// BEST-EFFORT extraction of user-scoped fact candidates from a meeting's note markdown + the user's
+/// own typed notes. Uses the on-device reasoner's `structured` decode; on ANY failure (stub reasoner
+/// / no model / decode error / parse error) returns an EMPTY vec — never an error, never a panic,
+/// never a block beyond the reasoner call itself. The RECONCILE is the load-bearing deterministic
+/// core; this is the soft front-end that feeds it. Every candidate carries the [`USER_SCOPE`]
+/// sentinel + the [`USER_SUBJECT`] so `reconcile_facts` keys them on the predicate.
+pub fn extract_user_fact_candidates(
+    reasoner: &dyn LocalReasoner,
+    title: &str,
+    note_markdown: &str,
+    typed_notes: &str,
+) -> Vec<FactCandidate> {
+    // No real brain (the default build / no model) → no extraction. The deterministic reconcile +
+    // synthesis are still exercised on whatever candidates a real brain would produce.
+    if reasoner.id() == "stub" {
+        return Vec::new();
+    }
+    let excerpt: String = note_markdown.chars().take(EXTRACT_EXCERPT_CHARS).collect();
+    let notes_excerpt: String = typed_notes.chars().take(EXTRACT_EXCERPT_CHARS).collect();
+    let user = if notes_excerpt.trim().is_empty() {
+        format!("MEETING: {title}\n\nNOTE:\n{excerpt}")
+    } else {
+        format!("MEETING: {title}\n\nUSER'S OWN TYPED NOTES:\n{notes_excerpt}\n\nNOTE:\n{excerpt}")
+    };
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "facts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "predicate": { "type": "string" },
+                        "object": { "type": "string" }
+                    },
+                    "required": ["predicate", "object"]
+                }
+            }
+        },
+        "required": ["facts"]
+    });
+
+    let value = match reasoner.structured(EXTRACT_SYSTEM, &user, &schema) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(target: "user_memory", error = %e, "user-fact extraction failed; no candidates (best-effort)");
+            return Vec::new();
+        }
+    };
+    let reply: UserFactsReply = match serde_json::from_value(value) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(target: "user_memory", error = %e, "user-fact extraction reply unparseable; no candidates");
+            return Vec::new();
+        }
+    };
+    candidates_from_raw(reply.facts)
+}
+
+/// Map raw extracted (predicate, object) pairs to [`FactCandidate`]s scoped to the user. Pure +
+/// headless-testable (no reasoner needed). Drops empty predicate/object pairs (never invent).
+fn candidates_from_raw(raw: Vec<RawUserFact>) -> Vec<FactCandidate> {
+    let mut out = Vec::new();
+    for r in raw {
+        let predicate = r.predicate.trim();
+        let object = r.object.trim();
+        if predicate.is_empty() || object.is_empty() {
+            continue;
+        }
+        out.push(FactCandidate {
+            entity_id: USER_SCOPE.to_string(),
+            subject: USER_SUBJECT.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            confidence: 1.0,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ufact(subject: &str, predicate: &str, object: &str) -> Fact {
+        Fact {
+            id: format!("uf-{predicate}-{object}"),
+            entity_id: USER_SCOPE.to_string(),
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: "2026-07-01T00:00:00Z".to_string(),
+            valid_to: None,
+            recorded_at: "2026-07-01T00:00:00Z".to_string(),
+            meeting_id: Some("m1".to_string()),
+            confidence: 1.0,
+        }
+    }
+
+    /// EMPTY memory ⇒ EMPTY brief (no header) — so injection is a byte-for-byte no-op when the user
+    /// has no memory yet. This is the "empty when memory is empty" contract.
+    #[test]
+    fn synthesize_brief_is_empty_when_no_facts() {
+        assert_eq!(synthesize_brief(&[]), "");
+    }
+
+    /// A present fact becomes a bullet with subject/predicate/object; order is the caller's order.
+    #[test]
+    fn synthesize_brief_lists_facts_as_bullets() {
+        let facts = vec![
+            ufact("You", "prefer", "Polish replies"),
+            ufact("You", "work on", "Project Atlas"),
+        ];
+        let brief = synthesize_brief(&facts);
+        assert!(brief.contains("- You prefer: Polish replies"));
+        assert!(brief.contains("- You work on: Project Atlas"));
+    }
+
+    /// Malformed (empty field) facts never emit a junk bullet; if ALL are junk the brief is empty.
+    #[test]
+    fn synthesize_brief_skips_malformed_and_can_be_empty() {
+        let facts = vec![ufact("You", "", "x"), ufact("You", "prefer", "  ")];
+        assert_eq!(synthesize_brief(&facts), "");
+    }
+
+    /// The brief is hard-bounded to the char budget (always-injected → must stay small).
+    #[test]
+    fn synthesize_brief_enforces_char_budget() {
+        let big_object = "x".repeat(MEMORY_BRIEF_MAX_CHARS * 2);
+        let facts = vec![ufact("You", "note", &big_object)];
+        let brief = synthesize_brief(&facts);
+        assert!(brief.chars().count() <= MEMORY_BRIEF_MAX_CHARS);
+    }
+
+    /// The audit DTO carries the provenance link (source meeting id) so "where did the brain learn
+    /// this" is answerable in the UI.
+    #[test]
+    fn user_memory_fact_carries_provenance() {
+        let f = ufact("You", "prefer", "Polish replies");
+        let dto = UserMemoryFact::from_fact(&f);
+        assert_eq!(dto.source_meeting_id.as_deref(), Some("m1"));
+        assert_eq!(dto.predicate, "prefer");
+        assert_eq!(dto.object, "Polish replies");
+    }
+
+    /// candidates_from_raw scopes every candidate to the user + drops empty pairs.
+    #[test]
+    fn candidates_from_raw_scopes_to_user_and_drops_empties() {
+        let raw = vec![
+            RawUserFact { predicate: "prefers".into(), object: "Polish replies".into() },
+            RawUserFact { predicate: "".into(), object: "x".into() },
+            RawUserFact { predicate: "role".into(), object: "".into() },
+        ];
+        let cands = candidates_from_raw(raw);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].entity_id, USER_SCOPE);
+        assert_eq!(cands[0].subject, USER_SUBJECT);
+        assert_eq!(cands[0].predicate, "prefers");
+        assert_eq!(cands[0].object, "Polish replies");
+    }
+}

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -34,8 +34,10 @@ import type {
   MeetingDetail,
   MeetingTimeline,
   ModelDownloadProgress,
+  NerDownloadProgress,
   NoteDto,
   PinResult,
+  UserMemory,
   ProviderStatus,
   SavedRecipe,
   SearchHit,
@@ -80,6 +82,8 @@ export const EVENT_BRAIN_DOWNLOAD = "murmur://brain-download";
 // brain2 RAG — semantic-search model download + reindex backfill event streams.
 export const EVENT_EMBED_DOWNLOAD = "murmur://embed-download";
 export const EVENT_REINDEX = "murmur://reindex-embeddings";
+// Phase D — on-device PERSON-name NER (redaction) model download progress stream.
+export const EVENT_NER_DOWNLOAD = "murmur://ner-download";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -412,6 +416,39 @@ export class IpcService {
     return invoke<BrainOverview>("brain_overview");
   }
 
+  // ── user memory — "what the brain knows about you" ─────────────────────
+
+  /**
+   * The current user-memory facts (subject/predicate/object + provenance) plus
+   * the synthesized brief that is injected into grounding. GATED server-side:
+   * only facts whose SOURCE meeting is visible under the live unlocked snapshot
+   * are returned — a sealed-not-unlocked meeting's user memory surfaces NOTHING,
+   * so re-fetch on a FoldersService lock-state change to shift the list live
+   * (mirrors {@link brainOverview}).
+   */
+  getUserMemory(): Promise<UserMemory> {
+    return invoke<UserMemory>("get_user_memory");
+  }
+
+  /**
+   * Forget ONE user-memory fact by id (a bitemporal INVALIDATE — the row is
+   * CLOSED, never silently deleted, so history is preserved). After this the
+   * fact drops out of {@link getUserMemory} and the regenerated brief.
+   * Idempotent (an already-closed / unknown id is a no-op).
+   */
+  forgetUserFact(id: string): Promise<void> {
+    return invoke<void>("forget_user_fact", { id });
+  }
+
+  /**
+   * Clear ALL user memory: bitemporally close every currently-open user fact
+   * (invalidate, never delete — closed history stays). After this
+   * {@link getUserMemory} and the brief are empty.
+   */
+  clearUserMemory(): Promise<void> {
+    return invoke<void>("clear_user_memory");
+  }
+
   // ── brain2 documents — expand the brain with imported .md/.txt files ────
 
   /**
@@ -686,6 +723,32 @@ export class IpcService {
    */
   reindexEmbeddings(): Promise<ReindexResult> {
     return invoke<ReindexResult>("reindex_embeddings");
+  }
+
+  // ── Phase D — on-device PERSON-name redaction (NER) model ──────────────
+
+  /**
+   * Whether the on-device PERSON-name NER model (mDeBERTa-v3) is present — i.e.
+   * the redaction firewall additionally masks people's NAMES before any cloud
+   * egress. Cheap existence probe; NEVER errors on a missing models dir. When
+   * false, only emails / card numbers / phone numbers are redacted by default —
+   * names can leave alongside the transcript on a cloud provider. Mirrors
+   * {@link embedModelPresent}.
+   */
+  nerModelPresent(): Promise<boolean> {
+    return invoke<boolean>("ner_model_present");
+  }
+
+  /**
+   * Download the on-device PERSON-name NER model (mDeBERTa-v3, 3 files) into the
+   * shared models dir. Progress streams over {@link onNerDownload}
+   * (EVENT_NER_DOWNLOAD); the promise resolves with the model dir when the
+   * download finishes. INBOUND-ONLY — sends NO meeting content (no egress). The
+   * model is picked up lazily on the next cloud summarization. Mirrors
+   * {@link downloadEmbedModel}.
+   */
+  downloadNerModel(): Promise<string> {
+    return invoke<string>("download_ner_model");
   }
 
   /** Show/hide the floating always-on-top recorder bar window. */
@@ -1023,5 +1086,12 @@ export class IpcService {
   /** Fires with COUNT-only progress for the in-flight semantic reindex backfill. */
   onReindex(cb: (p: ReindexProgress) => void): Promise<UnlistenFn> {
     return listen<ReindexProgress>(EVENT_REINDEX, (e) => cb(e.payload));
+  }
+
+  /** Fires with per-file progress for the in-flight PERSON-name NER model download. */
+  onNerDownload(cb: (p: NerDownloadProgress) => void): Promise<UnlistenFn> {
+    return listen<NerDownloadProgress>(EVENT_NER_DOWNLOAD, (e) =>
+      cb(e.payload),
+    );
   }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -704,6 +704,57 @@ export interface BrainOverview {
   embedModelPresent: boolean;
 }
 
+/**
+ * ONE user-memory fact — "what the brain knows about you". Mirrors the backend
+ * `crate::user_memory::UserMemoryFact` (camelCase via `#[serde(rename_all)]`).
+ * The visible facts are the same set synthesized into the grounding brief, so the
+ * Memory view is a faithful mirror of what the brain actually injects. `subject`
+ * is the person/topic the fact is about, `predicate` the relationship, `object`
+ * the value (e.g. "you" / "prefers" / "async standups"). `sourceMeetingId` is the
+ * provenance link (always set for a visible fact — the gated reader drops
+ * NULL-source rows fail-closed). Forgetting one bitemporally CLOSES it (never a
+ * silent delete), so it drops out of `getUserMemory()` and the regenerated brief.
+ */
+export interface UserMemoryFact {
+  id: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  /** Valid-time origin (the source meeting's time — when the brain learned it). */
+  validFrom: string;
+  /** The meeting this was derived from (provenance + purge anchor). */
+  sourceMeetingId: string | null;
+  confidence: number;
+}
+
+/**
+ * The full user-memory audit payload for the Memory view (`get_user_memory`).
+ * Mirrors the backend `crate::user_memory::UserMemory`. GATED server-side: only
+ * facts whose SOURCE meeting is visible under the live unlocked snapshot are
+ * returned — a sealed-not-unlocked meeting's user memory surfaces NOTHING, so
+ * re-fetch on a FoldersService lock-state change to shift the list live. `brief`
+ * is the exact injected grounding text (empty when memory is empty).
+ */
+export interface UserMemory {
+  facts: UserMemoryFact[];
+  brief: string;
+}
+
+/**
+ * Phase D — progress for the on-device PERSON-name NER model (mDeBERTa-v3)
+ * download (`EVENT_NER_DOWNLOAD`). Mirrors the backend `NerDownloadPayload`: the
+ * model is 3 files, so progress is reported per-file (`fileIndex` / `fileCount`).
+ * `total` is null when the server omits Content-Length; `done` fires once all
+ * files are written + renamed into place. Sends NO meeting content (inbound-only).
+ */
+export interface NerDownloadProgress {
+  fileIndex: number;
+  fileCount: number;
+  downloaded: number;
+  total: number | null;
+  done: boolean;
+}
+
 export interface ChatTurn {
   role: "user" | "assistant";
   content: string;

--- a/src/app/features/brain/brain-memory.component.ts
+++ b/src/app/features/brain/brain-memory.component.ts
@@ -1,0 +1,395 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { IpcService } from "../../core/ipc.service";
+import type { UserMemory, UserMemoryFact } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
+
+/**
+ * "What the brain knows about you" — the user-memory audit section on the Brain
+ * page. Lists the persisted user-memory FACTS (subject/predicate/object +
+ * provenance) that the brain injects into grounding, each with a per-fact
+ * "Forget", plus a "Clear all". Data + mutations go through the Phase-3 memory
+ * commands ({@link IpcService.getUserMemory} / `forgetUserFact` / `clearUserMemory`).
+ *
+ * Signals-first + OnPush. GATED server-side: `get_user_memory` only returns facts
+ * whose SOURCE meeting is visible under the live unlocked snapshot, so a
+ * lock-state change (`folders.tree()`) re-fetches — a sealed-not-unlocked
+ * meeting's memory disappears from this list live (mirrors the overview/graph
+ * refetch shape in `BrainComponent`). Forget / Clear are bitemporal INVALIDATEs
+ * in the backend (history preserved) — the copy says "Forget", not "Delete".
+ */
+@Component({
+  selector: "app-brain-memory",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  template: `
+    <section class="mem">
+      <button
+        type="button"
+        class="mem-toggle"
+        [attr.aria-expanded]="open()"
+        (click)="open.set(!open())"
+      >
+        <svg
+          class="mem-chevron"
+          [class.is-open]="open()"
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M5.5 4l5 4-5 4"
+            stroke="currentColor"
+            stroke-width="1.7"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span class="mem-title">What the brain knows about you</span>
+        @if (facts().length > 0) {
+          <span class="count mem-count">{{ facts().length }}</span>
+        }
+        <span class="mem-sub">
+          Facts the brain remembers about you and injects into its answers.
+        </span>
+      </button>
+
+      @if (open()) {
+        @if (loading()) {
+          <div class="card state-card">
+            <p class="empty">Loading what the brain remembers…</p>
+          </div>
+        } @else if (error()) {
+          <div class="card empty-state">
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">Couldn’t load your memory</p>
+            <p class="empty">{{ error() }}</p>
+          </div>
+        } @else if (facts().length === 0) {
+          <div class="card empty-state">
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">The brain hasn’t learned anything yet</p>
+            <p class="empty">
+              As you record meetings, the brain notes durable facts about you —
+              how you like to work, who you work with, what you own — so it can
+              answer with context. They’ll appear here for you to review or
+              forget. Nothing leaves this Mac unredacted.
+            </p>
+          </div>
+        } @else {
+          <div class="card mem-card">
+            <ul class="mem-list">
+              @for (f of facts(); track f.id) {
+                <li class="mem-item">
+                  <div class="mem-fact">
+                    <span class="mem-fact-text">{{ factLine(f) }}</span>
+                    @if (f.sourceMeetingId; as mid) {
+                      <a
+                        class="mem-source"
+                        [routerLink]="['/meeting', mid]"
+                        title="Where the brain learned this"
+                      >
+                        <svg
+                          viewBox="0 0 16 16"
+                          width="11"
+                          height="11"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M4 2.5h5l3 3v8H4z"
+                            stroke="currentColor"
+                            stroke-width="1.3"
+                            stroke-linejoin="round"
+                          />
+                          <path
+                            d="M9 2.5v3h3"
+                            stroke="currentColor"
+                            stroke-width="1.3"
+                            stroke-linejoin="round"
+                          />
+                        </svg>
+                        Source
+                      </a>
+                    }
+                  </div>
+                  <button
+                    type="button"
+                    class="btn btn-ghost mem-forget"
+                    (click)="forget(f.id)"
+                    [disabled]="forgettingId() === f.id"
+                    [attr.aria-label]="'Forget: ' + factLine(f)"
+                  >
+                    {{ forgettingId() === f.id ? "Forgetting…" : "Forget" }}
+                  </button>
+                </li>
+              }
+            </ul>
+
+            <footer class="mem-footer">
+              @if (confirmingClear()) {
+                <span class="mem-confirm-copy text-secondary">
+                  Forget everything the brain has learned about you?
+                </span>
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  (click)="confirmingClear.set(false)"
+                  [disabled]="clearing()"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-danger"
+                  (click)="clearAll()"
+                  [disabled]="clearing()"
+                >
+                  {{ clearing() ? "Clearing…" : "Forget all" }}
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  class="btn btn-ghost mem-clear"
+                  (click)="confirmingClear.set(true)"
+                >
+                  Clear all
+                </button>
+              }
+            </footer>
+          </div>
+        }
+      }
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .mem {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+
+      /* Collapsible header — mirrors the Connections section on the Brain page. */
+      .mem-toggle {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        width: 100%;
+        padding: var(--space-2) 0;
+        border: 0;
+        background: transparent;
+        color: var(--text-primary);
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+      }
+      .mem-toggle:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+        border-radius: var(--radius-sm);
+      }
+      .mem-chevron {
+        flex: none;
+        color: var(--text-muted);
+        transition: transform var(--transition);
+      }
+      .mem-chevron.is-open {
+        transform: rotate(90deg);
+      }
+      .mem-title {
+        font-size: 1rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .mem-count {
+        flex: none;
+      }
+      .mem-sub {
+        color: var(--text-muted);
+        font-size: 0.85rem;
+        margin-left: var(--space-2);
+      }
+      @media (max-width: 560px) {
+        .mem-sub {
+          display: none;
+        }
+      }
+
+      .mem-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+
+      /* Fact rows: the fact line + a source chip, and a right-aligned Forget. */
+      .mem-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .mem-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .mem-fact {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .mem-fact-text {
+        font-size: 0.925rem;
+        line-height: 1.45;
+        color: var(--text-primary);
+      }
+      .mem-source {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        align-self: flex-start;
+        color: var(--text-muted);
+        font-size: 0.78rem;
+        text-decoration: none;
+      }
+      .mem-source:hover {
+        color: var(--accent-hover);
+      }
+      .mem-forget {
+        flex: none;
+        height: 32px;
+        padding: 0 var(--space-3);
+        font-size: 0.85rem;
+      }
+
+      .mem-footer {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        padding-top: var(--space-2);
+        border-top: 1px solid var(--border-subtle);
+      }
+      .mem-confirm-copy {
+        flex: 1 1 auto;
+        min-width: 0;
+        font-size: 0.875rem;
+        line-height: 1.4;
+      }
+      .mem-clear {
+        color: var(--text-muted);
+      }
+    `,
+  ],
+})
+export class BrainMemoryComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+
+  /** Collapsed by default — the Brain page leads with sources, not memory. */
+  readonly open = signal(false);
+
+  private readonly memory = signal<UserMemory | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  readonly facts = computed<UserMemoryFact[]>(
+    () => this.memory()?.facts ?? [],
+  );
+
+  /** The id of the fact currently being forgotten (disables just that row). */
+  readonly forgettingId = signal<string | null>(null);
+  /** Clear-all confirm gate + in-flight flag (inline confirm, no floating menu). */
+  readonly confirmingClear = signal(false);
+  readonly clearing = signal(false);
+
+  constructor() {
+    // (Re)load memory whenever the folder lock-state changes — a session
+    // unlock/relock shifts which facts are visible (gated by source-meeting
+    // visibility server-side). Reading `tree()` registers the dependency; the
+    // fetch writes signals synchronously before its first await, so writes must
+    // be allowed (NG0600 guard — mirrors BrainComponent's overview effect).
+    effect(
+      () => {
+        this.folders.tree();
+        void this.fetch();
+      },
+      { allowSignalWrites: true },
+    );
+  }
+
+  /** Render one fact as a plain sentence: "<subject> <predicate> <object>". */
+  factLine(f: UserMemoryFact): string {
+    return [f.subject, f.predicate, f.object]
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .join(" ");
+  }
+
+  private async fetch(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.memory.set(await this.ipc.getUserMemory());
+    } catch (e) {
+      this.memory.set(null);
+      this.error.set(String(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async forget(id: string): Promise<void> {
+    if (this.forgettingId()) return;
+    this.forgettingId.set(id);
+    try {
+      await this.ipc.forgetUserFact(id);
+      await this.fetch();
+      this.toast.info("Forgotten.");
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.forgettingId.set(null);
+    }
+  }
+
+  async clearAll(): Promise<void> {
+    if (this.clearing()) return;
+    this.clearing.set(true);
+    try {
+      await this.ipc.clearUserMemory();
+      await this.fetch();
+      this.confirmingClear.set(false);
+      this.toast.info("Memory cleared.");
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.clearing.set(false);
+    }
+  }
+}

--- a/src/app/features/brain/brain.component.ts
+++ b/src/app/features/brain/brain.component.ts
@@ -18,6 +18,7 @@ import type {
 import { FoldersService } from "../../services/folders.service";
 import { ToastService } from "../../services/toast.service";
 import { BrainMapComponent } from "./brain-map.component";
+import { BrainMemoryComponent } from "./brain-memory.component";
 import { BrainNoteEditorComponent } from "./brain-note-editor.component";
 import { BrainSourceCardComponent } from "./brain-source-card.component";
 
@@ -76,6 +77,7 @@ interface FolderOption {
     BrainSourceCardComponent,
     BrainNoteEditorComponent,
     BrainMapComponent,
+    BrainMemoryComponent,
   ],
   template: `
     <section class="brain">
@@ -317,6 +319,9 @@ interface FolderOption {
           }
         }
       </section>
+
+      <!-- 4 — MEMORY: "what the brain knows about you" (collapsible) --------- -->
+      <app-brain-memory />
 
       @if (noteEditorOpen()) {
         <app-brain-note-editor

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -33,16 +33,28 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 /**
- * The four selectable providers, in display order. The tile list is FE-pinned
- * because `provider_statuses` omits the gateway until a base URL is
+ * The privacy posture the user consciously chooses at the provider step:
+ *  - `"local"` — fully on-device (Ollama on this Mac + local brain); NOTHING
+ *    leaves the Mac.
+ *  - `"cloud"` — a cloud provider behind the redaction firewall; only REDACTED
+ *    text ever leaves. Cloud is the DEFAULT (product decision) but the choice is
+ *    explicit + visible, never silent.
+ */
+type Posture = "local" | "cloud";
+
+/**
+ * The cloud-posture providers (behind the redaction firewall), in display order.
+ * FE-pinned because `provider_statuses` omits the gateway until a base URL is
  * configured — the wizard must still offer it (with a setup well below).
  */
-const PROVIDER_IDS: readonly string[] = [
+const CLOUD_PROVIDER_IDS: readonly string[] = [
   "claude_code",
   "anthropic",
-  "ollama",
   "gateway",
 ];
+
+/** The local-posture provider — Ollama running on THIS Mac (loopback). */
+const LOCAL_PROVIDER_ID = "ollama";
 
 /** Approx download size per Whisper quality (mirrors Settings). */
 const SIZE_HINTS: Record<string, string> = {
@@ -225,12 +237,93 @@ const SIZE_HINTS: Record<string, string> = {
             <!-- ───────────────────────── AI PROVIDER ────────────────────── -->
             @case ("provider") {
               <div class="ob-head">
-                <span class="ob-eyebrow">Summaries</span>
-                <h2 class="ob-title">Pick how notes get written</h2>
+                <span class="ob-eyebrow">Privacy &amp; summaries</span>
+                <h2 class="ob-title">How should your notes get written?</h2>
                 <p class="ob-sub text-secondary">
                   After transcription, an AI turns the transcript into a clean
-                  summary. You just need one of these working.
+                  summary. First, choose where that happens — this is a conscious
+                  privacy choice.
                 </p>
+              </div>
+
+              <!-- A3 — the explicit two-posture choice. Cloud is the default. -->
+              <div
+                class="postures"
+                role="radiogroup"
+                aria-label="Where notes get written"
+              >
+                <button
+                  type="button"
+                  class="posture"
+                  [class.is-selected]="posture() === 'local'"
+                  (click)="selectPosture('local')"
+                  role="radio"
+                  [attr.aria-checked]="posture() === 'local'"
+                >
+                  <span class="posture-icon" aria-hidden="true">
+                    <svg viewBox="0 0 20 20" width="20" height="20" fill="none">
+                      <rect
+                        x="3"
+                        y="4"
+                        width="14"
+                        height="9"
+                        rx="1.6"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M7 16.5h6M10 13.5v3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                  <span class="posture-name">Fully local</span>
+                  <span class="posture-sub text-secondary">
+                    Ollama on this Mac. Nothing leaves your Mac.
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  class="posture"
+                  [class.is-selected]="posture() === 'cloud'"
+                  (click)="selectPosture('cloud')"
+                  role="radio"
+                  [attr.aria-checked]="posture() === 'cloud'"
+                >
+                  <span class="posture-recommended">Default</span>
+                  <span class="posture-icon" aria-hidden="true">
+                    <svg viewBox="0 0 20 20" width="20" height="20" fill="none">
+                      <path
+                        d="M6 14.5a3.5 3.5 0 0 1-.3-6.98A4.5 4.5 0 0 1 14.4 8.2 3 3 0 0 1 14 14.5H6Z"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </span>
+                  <span class="posture-name">Cloud via redaction firewall</span>
+                  <span class="posture-sub text-secondary">
+                    A cloud AI. Only redacted text ever leaves.
+                  </span>
+                </button>
+              </div>
+
+              <!-- Persistent, visible privacy-posture badge (A3). -->
+              <div
+                class="privacy-badge"
+                [class.is-local]="posture() === 'local'"
+                role="status"
+              >
+                <span class="privacy-badge-dot" aria-hidden="true"></span>
+                <span class="privacy-badge-label">{{
+                  privacyBadge().label
+                }}</span>
+                <span class="privacy-badge-detail text-muted">
+                  {{ privacyBadge().detail }}
+                </span>
               </div>
 
               <div class="providers">
@@ -874,6 +967,115 @@ const SIZE_HINTS: Record<string, string> = {
         display: inline-flex;
       }
 
+      /* ── A3 privacy-posture chooser (two big cards) ───────────────────── */
+      .postures {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-3);
+      }
+      @media (max-width: 520px) {
+        .postures {
+          grid-template-columns: 1fr;
+        }
+      }
+      .posture {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        text-align: left;
+        padding: var(--space-4);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font-family: inherit;
+        cursor: pointer;
+        transition:
+          border-color var(--transition),
+          background var(--transition),
+          box-shadow var(--transition),
+          transform var(--transition-fast);
+      }
+      .posture:hover {
+        border-color: var(--border-strong);
+        background: var(--surface-hover);
+      }
+      .posture:active {
+        transform: translateY(1px);
+      }
+      .posture:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .posture.is-selected {
+        border-color: transparent;
+        background: var(--accent-soft);
+        box-shadow:
+          0 0 0 1px var(--accent),
+          var(--glass-highlight);
+      }
+      .posture-icon {
+        display: inline-flex;
+        color: var(--accent-hover);
+      }
+      .posture-name {
+        font-size: 0.95rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .posture-sub {
+        font-size: 0.8125rem;
+        line-height: 1.45;
+      }
+      .posture-recommended {
+        position: absolute;
+        top: var(--space-3);
+        right: var(--space-3);
+        padding: 2px 8px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+
+      /* Persistent, visible privacy-posture badge. */
+      .privacy-badge {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--accent-soft);
+        border: 1px solid var(--glass-border);
+      }
+      .privacy-badge.is-local {
+        background: var(--success-soft);
+      }
+      .privacy-badge-dot {
+        align-self: center;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent);
+        flex: none;
+      }
+      .privacy-badge.is-local .privacy-badge-dot {
+        background: var(--success);
+      }
+      .privacy-badge-label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .privacy-badge-detail {
+        font-size: 0.8125rem;
+      }
+
       /* ── Provider chooser ─────────────────────────────────────────────── */
       .providers {
         display: flex;
@@ -1206,6 +1408,13 @@ export class OnboardingComponent implements OnInit {
   /** Provider step. */
   readonly providers = signal<ProviderStatus[]>([]);
   readonly provider = signal("claude_code");
+  /**
+   * The consciously-chosen privacy POSTURE (A3). Cloud is the DEFAULT (product
+   * decision) but the two-way choice is explicit + visible — never silent. It is
+   * seeded from the loaded provider on mount (ollama → local, else cloud) so
+   * re-running setup reflects the real state.
+   */
+  readonly posture = signal<Posture>("cloud");
   readonly checking = signal(false);
   readonly apiKey = signal("");
   readonly savingKey = signal(false);
@@ -1225,13 +1434,17 @@ export class OnboardingComponent implements OnInit {
   readonly skippedProvider = signal(false);
 
   /**
-   * The 4 selectable tiles, FE-pinned (see PROVIDER_IDS) and merged with the
-   * availability fan-out — an unconfigured gateway has NO status row, so it
-   * renders as needing setup instead of vanishing.
+   * The provider tiles for the CHOSEN posture, FE-pinned (CLOUD_PROVIDER_IDS /
+   * LOCAL_PROVIDER_ID) and merged with the availability fan-out — an unconfigured
+   * gateway has NO status row, so it renders as needing setup instead of
+   * vanishing. The local posture shows only Ollama; the cloud posture shows the
+   * redaction-firewall providers.
    */
   readonly providerTiles = computed<ProviderStatus[]>(() => {
     const statuses = this.providers();
-    return PROVIDER_IDS.map(
+    const ids =
+      this.posture() === "local" ? [LOCAL_PROVIDER_ID] : CLOUD_PROVIDER_IDS;
+    return ids.map(
       (id) =>
         statuses.find((p) => p.id === id) ?? {
           id,
@@ -1241,6 +1454,23 @@ export class OnboardingComponent implements OnInit {
         },
     );
   });
+
+  /**
+   * The visible privacy-posture badge (A3): a short, honest one-liner of what
+   * leaves the Mac under the current choice. Derived, not stored — always mirrors
+   * `posture()`.
+   */
+  readonly privacyBadge = computed(() =>
+    this.posture() === "local"
+      ? {
+          label: "Fully local",
+          detail: "Nothing leaves your Mac",
+        }
+      : {
+          label: "Cloud via redaction firewall",
+          detail: "Only redacted text ever leaves",
+        },
+  );
 
   /**
    * FE mirror of the backend's egress classification for the picked provider
@@ -1306,6 +1536,14 @@ export class OnboardingComponent implements OnInit {
       this.language.set(cfg.language ?? "");
       this.modelSize.set(cfg.modelSize ?? "small");
       this.provider.set(cfg.providerId ?? "claude_code");
+      // Seed the posture from the loaded provider so re-running setup reflects
+      // reality: only the local provider (Ollama) implies the local posture;
+      // everything else (incl. a fresh install's claude_code default) is cloud.
+      this.posture.set(
+        (cfg.providerId ?? "claude_code") === LOCAL_PROVIDER_ID
+          ? "local"
+          : "cloud",
+      );
       this.vaultPath.set(cfg.vaultPath ?? null);
       this.gatewayBaseUrl.set(cfg.gatewayBaseUrl ?? "");
       this.ollamaBaseUrl.set(cfg.ollamaBaseUrl ?? "http://localhost:11434");
@@ -1387,6 +1625,27 @@ export class OnboardingComponent implements OnInit {
   }
 
   // ── Provider step ───────────────────────────────────────────────────────
+
+  /**
+   * A3 — the conscious privacy-posture choice. Switching posture also picks a
+   * sensible provider so the choice is never left in an inconsistent state:
+   *  - local  → Ollama on this Mac (fully on-device).
+   *  - cloud  → keep the current cloud pick, or default to claude_code if the
+   *    current selection is the local provider.
+   * An explicit posture pick supersedes an earlier "set this up later".
+   */
+  selectPosture(p: Posture): void {
+    if (this.posture() === p) return;
+    this.skippedProvider.set(false);
+    this.posture.set(p);
+    this.keyError.set(null);
+    if (p === "local") {
+      this.provider.set(LOCAL_PROVIDER_ID);
+    } else if (this.provider() === LOCAL_PROVIDER_ID) {
+      this.provider.set("claude_code");
+    }
+    void this.persistConfig();
+  }
 
   selectProvider(id: string): void {
     // An explicit pick supersedes an earlier "set this up later" — consent

--- a/src/app/features/settings/sections/settings-audio-section.component.ts
+++ b/src/app/features/settings/sections/settings-audio-section.component.ts
@@ -39,8 +39,8 @@ import { SettingsStore } from "../settings.store";
                   <span class="toggle-copy">
                     <span class="toggle-title">Capture system audio</span>
                     <span class="text-secondary toggle-sub">
-                      Records the other side of the call — needs the Screen Recording
-                      permission on first use.
+                      Capture the other side of a Zoom / Meet / Teams call, not just
+                      your mic — needs the Screen Recording permission on first use.
                     </span>
                   </span>
                   <input type="checkbox" formControlName="captureSystemAudio" />
@@ -80,11 +80,12 @@ import { SettingsStore } from "../settings.store";
               <div class="card">
                 <label class="toggle-row">
                   <span class="toggle-copy">
-                    <span class="toggle-title">Identify remote speakers</span>
+                    <span class="toggle-title">Split “Others” into individual speakers</span>
                     <span class="text-secondary toggle-sub">
                       Label individual people on the other side of the call (Speaker
-                      1/2/3) instead of one “Others”. Needs system-audio capture;
-                      downloads ~40 MB of models on first use.
+                      1/2/3) instead of one “Others”. Experimental — verify the
+                      quality on your calls. Needs system-audio capture; downloads
+                      ~40 MB of models on first use.
                     </span>
                   </span>
                   <input type="checkbox" formControlName="diarizeOthers" />

--- a/src/app/features/settings/sections/settings-privacy-section.component.ts
+++ b/src/app/features/settings/sections/settings-privacy-section.component.ts
@@ -61,13 +61,68 @@ import { SettingsStore } from "../settings.store";
                     server — then restored in your notes. Only Ollama running on this
                     Mac keeps everything on-device.
                   </p>
-                  <p class="text-secondary privacy-note">
-                    Names: the pattern firewall alone does not catch them, but an
-                    on-device name-redaction layer additionally masks people's names
-                    when its local model is present. Without that model, names can
-                    leave your device alongside the transcript when you use a cloud
-                    provider.
-                  </p>
+                </div>
+
+                <!-- (1a) On-device name redaction (Phase D — NER model) -->
+                <div class="privacy-section">
+                  <span class="privacy-section-label text-muted"
+                    >Name redaction</span
+                  >
+                  @if (nerModelPresent() === true) {
+                    <p class="text-secondary privacy-note">
+                      An on-device name-redaction model is installed, so people's
+                      NAMES are additionally masked before any redacted text leaves
+                      this Mac (Polish + English), then restored in your notes.
+                    </p>
+                    <span class="pill is-success ner-pill">
+                      <span class="pill-dot"></span>
+                      Name redaction on
+                    </span>
+                  } @else {
+                    <!-- HONEST copy: without the model, do NOT claim names are
+                         redacted — only emails / cards / phones are by default. -->
+                    <p class="text-secondary privacy-note">
+                      By default only emails, card numbers and phone numbers are
+                      redacted — people's NAMES are not. The pattern firewall alone
+                      can't catch names, so they can leave your device alongside the
+                      transcript when you use a cloud provider. Download the optional
+                      on-device name-redaction model to additionally mask names
+                      (Polish + English) before any text leaves this Mac.
+                    </p>
+                    @if (downloadingNerModel()) {
+                      <div class="dl-progress" role="status">
+                        <div class="dl-progress-track" aria-hidden="true">
+                          <div
+                            class="dl-progress-fill"
+                            [style.width.%]="nerDownloadFrac() * 100"
+                          ></div>
+                        </div>
+                        <span class="dl-progress-label text-muted">
+                          @if (nerDownloadFrac() > 0) {
+                            Downloading… {{ nerPct() }}
+                          } @else {
+                            <span class="spin-ring" aria-hidden="true"></span>
+                            Downloading…
+                          }
+                        </span>
+                      </div>
+                    } @else {
+                      <button
+                        type="button"
+                        class="btn"
+                        (click)="downloadNerModel()"
+                        [disabled]="nerModelPresent() === null"
+                      >
+                        Enable name redaction (download model)
+                      </button>
+                      <span class="text-muted ner-hint">
+                        One time, on-device, no meeting content is sent.
+                      </span>
+                    }
+                    @if (nerDownloadError(); as nerr) {
+                      <p class="text-danger privacy-note">{{ nerr }}</p>
+                    }
+                  }
                 </div>
 
                 <!-- (1b) Cloud processing consent (E10) -->
@@ -357,6 +412,42 @@ import { SettingsStore } from "../settings.store";
         line-height: 1.5;
       }
 
+      /* Name-redaction status pill + one-line hint. */
+      .ner-pill {
+        align-self: flex-start;
+      }
+      .ner-hint {
+        display: block;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+
+      /* NER model-download progress bar (mirrors the onboarding wizard). */
+      .dl-progress {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        max-width: 320px;
+      }
+      .dl-progress-track {
+        height: 8px;
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        overflow: hidden;
+      }
+      .dl-progress-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: var(--radius-sm);
+        transition: width var(--transition);
+      }
+      .dl-progress-label {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: 0.85rem;
+      }
+
       /* Inline spinner on the Download button (matches the onboarding wizard). */
       .spin-ring {
         width: 15px;
@@ -392,8 +483,19 @@ export class SettingsPrivacySectionComponent {
   readonly mcpUrl = this.store.mcpUrl;
   readonly mcpConfig = this.store.mcpConfig;
 
+  // Phase D — on-device name-redaction (NER) model affordance.
+  readonly nerModelPresent = this.store.nerModelPresent;
+  readonly downloadingNerModel = this.store.downloadingNerModel;
+  readonly nerDownloadFrac = this.store.nerDownloadFrac;
+  readonly nerPct = this.store.nerPct;
+  readonly nerDownloadError = this.store.nerDownloadError;
+
   allowCloudProcessing(): void {
     void this.store.allowCloudProcessing();
+  }
+
+  downloadNerModel(): void {
+    void this.store.downloadNerModel();
   }
 
   copyMcpConfig(): void {

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -810,6 +810,32 @@ export class SettingsStore {
   private unlistenEmbedDownload: UnlistenFn | null = null;
   private unlistenReindex: UnlistenFn | null = null;
 
+  // ── Phase D — on-device PERSON-name redaction (NER) model ──────────────
+
+  /**
+   * Whether the on-device PERSON-name NER model is present (the redaction
+   * firewall additionally masks NAMES before cloud egress). `null` = not yet
+   * checked. Drives the honest Privacy copy: when false the copy must NOT claim
+   * names are redacted — only emails/cards/phones are by default.
+   */
+  private readonly _nerModelPresent = signal<boolean | null>(null);
+  readonly nerModelPresent = this._nerModelPresent.asReadonly();
+  /** True while the NER model is downloading — disables its button. */
+  private readonly _downloadingNerModel = signal(false);
+  readonly downloadingNerModel = this._downloadingNerModel.asReadonly();
+  /** 0..1 download progress for the in-flight NER-model download. */
+  private readonly _nerDownloadFrac = signal(0);
+  readonly nerDownloadFrac = this._nerDownloadFrac.asReadonly();
+  /** Whole-percent label for the in-flight NER-model download. */
+  readonly nerPct = computed(
+    () => Math.round(this.nerDownloadFrac() * 100) + "%",
+  );
+  /** Surfaced if ipc.downloadNerModel() rejects. */
+  private readonly _nerDownloadError = signal<string | null>(null);
+  readonly nerDownloadError = this._nerDownloadError.asReadonly();
+  /** Release handle for the NER-download event stream. */
+  private unlistenNerDownload: UnlistenFn | null = null;
+
   async load(): Promise<void> {
     try {
       const cfg = await this.ipc.getConfig();
@@ -912,6 +938,11 @@ export class SettingsStore {
       await this.subscribeSemanticStreams();
       this._embedModelPresent.set(
         await this.ipc.embedModelPresent().catch(() => false),
+      );
+      // Phase D — PERSON-name NER (redaction) model presence + download stream.
+      await this.subscribeNerDownload();
+      this._nerModelPresent.set(
+        await this.ipc.nerModelPresent().catch(() => false),
       );
       // About section — product identity (best-effort; null leaves a "loading" line).
       this._appInfo.set(await this.ipc.appInfo().catch(() => null));
@@ -1060,6 +1091,48 @@ export class SettingsStore {
       this._embedDownloadError.set(String(e));
     } finally {
       this._downloadingEmbedModel.set(false);
+    }
+  }
+
+  // ── Phase D — PERSON-name NER (redaction) model ────────────────────────
+
+  /**
+   * Subscribe ONCE to the NER-download progress stream and store the unlisten so
+   * DestroyRef can release it (no leaked listener). Best-effort: a missing
+   * backend stream just leaves the progress bar inert (the download still
+   * resolves via the command promise). Mirrors {@link subscribeSemanticStreams}.
+   */
+  private async subscribeNerDownload(): Promise<void> {
+    try {
+      this.unlistenNerDownload = await this.ipc.onNerDownload((p) => {
+        // Per-file progress: blend the completed files + the current file's
+        // fraction across the whole set so the single bar advances smoothly.
+        if (p.fileCount > 0) {
+          const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
+          this._nerDownloadFrac.set(
+            Math.min(1, (p.fileIndex + cur) / p.fileCount),
+          );
+        }
+        if (p.done) this._nerDownloadFrac.set(1);
+      });
+      this.destroyRef.onDestroy(() => this.unlistenNerDownload?.());
+    } catch {
+      // No stream available — progress bar stays inert; the command still resolves.
+    }
+  }
+
+  /** Download the on-device PERSON-name NER model, then re-check presence. */
+  async downloadNerModel(): Promise<void> {
+    this._nerDownloadError.set(null);
+    this._nerDownloadFrac.set(0);
+    this._downloadingNerModel.set(true);
+    try {
+      await this.ipc.downloadNerModel();
+      this._nerModelPresent.set(await this.ipc.nerModelPresent());
+    } catch (e) {
+      this._nerDownloadError.set(String(e));
+    } finally {
+      this._downloadingNerModel.set(false);
     }
   }
 


### PR DESCRIPTION
## What

Brain-hardening + default-flip program in three parts, landed as one verified unit (the three phases share `config.rs` / `commands.rs` / `lib.rs`, and interactive per-hunk staging isn't available here, so a clean 3-way split was impractical — sectioned below instead).

### A — defaults (make the local-first moat visible; drop an unproven default-ON path)
- `post_aec_enabled` default **ON→OFF** — the offline AEC3 rides an unproven v0.1 crate on every system-audio recording; opt-in until real-Mac-verified.
- whisper `model_size` default **large-v3→small** — RAM-safe (large-v3 swaps on 8 GB Macs), matches onboarding; every size stays selectable.
- NER name-redaction: optional-download plumbing verified (presence probe + download command); redaction path unchanged.
- Onboarding: explicit **"Fully local / Cloud via redaction firewall"** posture choice (Cloud stays default) + privacy indicator; expose system-audio + diarization.

### B — semantic RAG (configurable + measurable, still default-OFF)
- Configurable embedder registry (`EMBED_MODELS`); **mmlw-e5-small** added as a verified BERT/384 **zero-migration** option (same `query:`/`passage:` prefixes as e5), `select_embed_model` + reindex trigger.
- **Bake-off harness** (`src/eval`): recall@k / nDCG@k / MRR over FTS vs semantic vs hybrid, deterministic metric unit tests + `#[ignore]` real run + sample fixture + `RAG-BAKEOFF.md`.
- Semantic search stays **default-OFF** (unchanged).

### C — cross-meeting user memory (lock-touching)
- Additive `user_facts` table (bitemporal, provenance-anchored); gated `list_user_facts_visible`; **purge-on-seal** in the seal tx + at-rest reconcile.
- Deterministic memory brief injected into the agentic loop **exactly like `live_transcript`** — rides the existing `RedactingProvider` + consent gate, **no new egress class**.
- `get_user_memory` / `forget_user_fact` / `clear_user_memory`; Brain-page **Memory** view (audit + forget/clear).
- **RED-before-GREEN**: sealed-source facts excluded from the audit view AND the injected brief; re-admitted on session unlock.

## How verified
- `bash scripts/ci.sh` **GREEN** — clippy `-D warnings` + `cargo test --lib` (771) + cargo audit + cargo deny + build + ng lint + ng build + headless E2E (incl. mic+system mixing).
- **adversarial-verifier: PASS** — RED-before-GREEN proven for the memory seal-gating and the default flips.
- **lock-security-reviewer: PASS** — every user-memory read + the injected brief route through the gated reader; purge-on-seal in the seal tx (+ startup reconcile + FK cascade); no new egress; no PII in logs; MCP does not expose memory; migration additive+guarded.

## Real-Mac gates (cannot be proven headless — flagged honestly)
AEC efficacy, small-vs-large ASR quality on 8 GB Macs, **mmlw retrieval quality (the bake-off run on a real vault)**, NER masking on cloud egress, and whether synthesized memory helps vs pollutes. Touch-ID / lock-at-rest are unaffected by this change but, as always, only truly verify on a signed build.
