### PR TITLE
feat(brain): complete cross-meeting memory (thread turns + Ask/detail injection + flag) + /people CRM

### DIFF
--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -38,6 +38,31 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-07-03] Phase 1 COMPLETE user memory (D5 thread-turns + Ask/detail inject + flag) — lock-touching
+- **Pattern:** three seams. (1) D5: `extract_user_fact_candidates` grew a `thread_turns` arg + a PURE
+  testable `build_extraction_user_prompt` seam (thread turns section, bounded, omitted-when-empty);
+  fed from `list_assistant_interactions_visible` (GATED — the just-finished meeting is its own unlocked
+  meeting, USER command text only). (2) Inject the gated brief into the 2 non-agentic surfaces:
+  `vault_chat::build`/`agentic_system` + `chat::build` each took a `memory_brief` arg with an
+  EMPTY⇒byte-identical contract (a `memory_block` helper). Brief computed by a new commands-level
+  `gated_memory_brief_for_injection(&AppState, &unlocked)` → `list_user_facts_visible` (same gate as the
+  @brain loop). (3) `user_memory_enabled` flag (default TRUE, `default_true`) threaded EVERYWHERE:
+  extraction skip, all 3 inject paths (incl. live.rs `gated_user_memory_brief(.., enabled)`),
+  `get_user_memory` → `UserMemory::disabled()` marker. Full DTO wiring BE (AppConfigDto/dto_to_config/
+  config_to_dto) + FE (models.ts UserMemory.disabled?/AppConfigDto.userMemoryEnabled + settings.store 3
+  sites + onboarding literal).
+- **Trap hit:** an `fn(a,b,c)`→`fn(a,b,c,d)` arg change hit ~8 test call sites (ask_vault_loop ×4,
+  build_ask_vault_floor_prompt ×2, ask_vault_floor ×1, vault_chat::build ×1) — grep the symbol, fix them
+  all in the same pass. FE: a full-DTO `AppConfigDto` literal in onboarding.component.ts (NOT just the
+  store) needed the new field or `ng build` TS2741'd — grep every literal, not just the store.
+- **Caught by:** `cargo test --lib` (781 pass, +13 new); `cargo clippy --lib` clean; `ng lint`+`ng build`
+  green. RED proven by swapping `list_user_facts_visible`→`user_facts_all()` in the inject helper: the
+  ask-gate test FAILED ("sealed-source user fact must NOT be in the injected brief"); reverted → GREEN.
+- **Lesson:** the byte-identical-when-empty contract is the safe way to add a prompt segment behind a
+  flag — test it explicitly (`assert_eq!(with_empty, pre_change)`) on EVERY surface, so a disabled/empty
+  brief can never drift the prompt. FLAG for lock-security-reviewer (new gated read + new inject path).
+- **Status:** GREEN (781 lib tests; FE lint+build clean).
+
 ### [2026-07-03] Phase 3 cross-meeting user memory (lock-touching)
 - **Pattern:** reused the bitemporal `facts` substrate (pure `reconcile_facts`) for a NEW user-scoped
   `user_facts` table (separate table, NO entity FK, `USER_SCOPE` sentinel in the `entity_id` reconcile

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use crate::storage::models::{
     CalendarContext,
     CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, DocumentInfo,
     EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus, MeetingTimeline,
-    NoteRecord, PinResult, RecipeRecord, SearchHit, TopicThread,
+    NoteRecord, PersonCard, PinResult, RecipeRecord, SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -193,6 +193,11 @@ pub struct AppConfigDto {
     /// `AppConfig::default` — an older FE payload must not silently flip the backend mute.
     #[serde(default = "default_true")]
     pub proactive_hints_enabled: bool,
+    /// Cross-meeting USER MEMORY master gate (`crate::user_memory`). Settable from the DTO (the
+    /// Settings UI owns the toggle). Defaults ON when omitted (`default_true`), matching
+    /// `AppConfig::default` — an older FE payload must not silently turn memory off.
+    #[serde(default = "default_true")]
+    pub user_memory_enabled: bool,
     /// Model-role override — the connection serving the NOTES role (see
     /// `crate::summarize::roles`). Settable from the DTO (a future Settings UI owns the rows).
     /// `""` (and an omitted key, `#[serde(default)]`) = inherit the legacy mapping — so an older
@@ -1211,6 +1216,13 @@ pub fn get_user_memory(state: State<'_, AppState>) -> Result<crate::user_memory:
 pub(crate) fn get_user_memory_inner(
     state: &AppState,
 ) -> Result<crate::user_memory::UserMemory, AppError> {
+    // FLAG: memory turned OFF entirely ⇒ the explicit disabled marker (empty facts + empty brief +
+    // `disabled: true`), so the FE shows a "memory is off" affordance and NOTHING is surfaced. This
+    // mirrors the injection paths, which are also flag-suppressed — the audit view can never show
+    // facts the brain would not inject.
+    if !user_memory_enabled(state) {
+        return Ok(crate::user_memory::UserMemory::disabled());
+    }
     let unlocked = unlocked_snapshot(state)?;
     let facts = state.db.list_user_facts_visible(&unlocked)?;
     // The audit view and the injected brief are derived from EXACTLY the same visible set, so the UI
@@ -1220,7 +1232,7 @@ pub(crate) fn get_user_memory_inner(
         .iter()
         .map(crate::user_memory::UserMemoryFact::from_fact)
         .collect();
-    Ok(crate::user_memory::UserMemory { facts: dtos, brief })
+    Ok(crate::user_memory::UserMemory { facts: dtos, brief, disabled: false })
 }
 
 /// Forget ONE user-memory fact (bitemporal invalidate — the row is CLOSED, never silently deleted,
@@ -1347,7 +1359,13 @@ pub async fn chat_meeting(
     // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
     // default provider as before (the legacy chat path always ignored `brain_backend`).
     let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Ask, &config)?;
-    let (system, user) = crate::summarize::chat::build(&transcript, &history, &question);
+    // Inject the gated cross-meeting USER MEMORY brief (parity with the @brain agentic loop): derived
+    // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
+    // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
+    let unlocked = unlocked_snapshot(state.inner())?;
+    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked);
+    let (system, user) =
+        crate::summarize::chat::build(&transcript, &history, &question, &memory_brief);
     provider.complete(&system, &user).await
 }
 
@@ -2005,9 +2023,21 @@ fn persist_user_facts_for_meeting(
     title: &str,
     markdown: &str,
 ) -> Result<(), AppError> {
-    // The user's OWN typed notes for this meeting are the highest-signal memory source (an explicit
+    // FLAG: when the user has turned cross-meeting memory OFF, skip extraction ENTIRELY — no
+    // reasoner call, no candidates, nothing new persisted. (Existing facts stay; the user can
+    // forget/clear them, and the gated reads/injection are separately flag-suppressed.)
+    if !user_memory_enabled(state) {
+        return Ok(());
+    }
+    // The user's OWN typed notes for this meeting are a high-signal memory source (an explicit
     // "remember that…"). Empty when none (best-effort read).
     let typed_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
+    // D5 — the meeting's own @brain THREAD TURNS are the HIGHEST-signal source (an explicit
+    // "zapamiętaj, że…" in a thread). GATED like every content read: the just-finished meeting is
+    // its own unlocked meeting, so `list_assistant_interactions_visible` under the live unlock
+    // snapshot returns its turns (and NOTHING for a sealed-not-unlocked meeting — fail-closed). We
+    // feed the USER COMMAND text (the high-signal part), never the assistant's answer.
+    let thread_turns = gated_meeting_thread_turns(state, meeting_id);
     // 1) Best-effort extraction (panic-free, empty on stub/no model/decode failure). The reasoner is
     //    re-resolved from the LIVE config so a consent/backend change applies without restart.
     let candidates = crate::user_memory::extract_user_fact_candidates(
@@ -2015,6 +2045,7 @@ fn persist_user_facts_for_meeting(
         title,
         markdown,
         &typed_notes,
+        &thread_turns,
     );
     if candidates.is_empty() {
         return Ok(()); // nothing to reconcile — common in the default (no-model) build.
@@ -2032,6 +2063,61 @@ fn persist_user_facts_for_meeting(
     crate::facts::set_meeting_id(&mut ops, meeting_id);
     state.db.apply_user_fact_ops(&ops)?;
     Ok(())
+}
+
+/// Whether cross-meeting USER MEMORY is enabled (config `user_memory_enabled`, default TRUE). When
+/// OFF: no extraction runs, no brief is injected into ANY surface, and `get_user_memory` reports the
+/// disabled marker. Fail-safe: a poisoned config mutex reports ENABLED (the default) so a transient
+/// lock error never silently disables the feature.
+fn user_memory_enabled(state: &AppState) -> bool {
+    state
+        .config
+        .lock()
+        .map(|c| c.user_memory_enabled)
+        .unwrap_or(true)
+}
+
+/// Read the meeting's OWN @brain THREAD TURNS for user-fact extraction (design spec D5), GATED by the
+/// live session unlock snapshot: `list_assistant_interactions_visible` returns the meeting's turns
+/// only when the meeting is VISIBLE (a sealed-not-unlocked meeting returns EMPTY — fail-closed). Only
+/// the USER COMMAND text is included (the high-signal part — an explicit "zapamiętaj, że…"); the
+/// assistant's answer is never fed back into extraction. Best-effort: any read error ⇒ empty string
+/// (extraction degrades to note+notes). Content-free on error.
+fn gated_meeting_thread_turns(state: &AppState, meeting_id: &str) -> String {
+    let unlocked = match unlocked_snapshot(state) {
+        Ok(u) => u,
+        Err(_) => return String::new(),
+    };
+    let turns = match state
+        .db
+        .list_assistant_interactions_visible(meeting_id, &unlocked)
+    {
+        Ok(t) => t,
+        Err(_) => return String::new(),
+    };
+    turns
+        .iter()
+        .map(|i| format!("User: {}", i.command.trim()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The gated cross-meeting USER MEMORY brief for injection into the non-agentic Ask / meeting-chat
+/// surfaces (design spec: parity with the @brain agentic loop, which already injects it). It is
+/// DERIVED data — never sealed, always REGENERATED from the currently-VISIBLE user facts under the
+/// passed `unlocked` snapshot — so a sealed-not-unlocked meeting's user facts inject NOTHING. When
+/// memory is disabled (config `user_memory_enabled == false`) it returns EMPTY, so the prompt is
+/// byte-identical to the pre-memory prompt. Rides the EXISTING redaction + consent egress of the
+/// surface it is injected into — no new egress class.
+fn gated_memory_brief_for_injection(
+    state: &AppState,
+    unlocked: &std::collections::HashSet<String>,
+) -> String {
+    if !user_memory_enabled(state) {
+        return String::new();
+    }
+    let facts = state.db.list_user_facts_visible(unlocked).unwrap_or_default();
+    crate::user_memory::synthesize_brief(&facts)
 }
 
 /// Resolve the people + projects in a meeting note → persist them to the encrypted DB graph
@@ -2073,6 +2159,18 @@ const ENTITY_NEIGHBOR_LIMIT: i64 = 12;
 pub fn get_graph(state: State<'_, AppState>) -> Result<GraphData, AppError> {
     let unlocked = unlocked_snapshot(state.inner())?;
     state.db.build_graph(&unlocked)
+}
+
+/// `/people` personal CRM: one card per VISIBLE Person entity, rolled up over the SAME gated
+/// graph/facts/commitment readers as the graph + rollup views (`list_entities_visible` filtered to
+/// people, `entity_mentions_visible`, `list_facts_visible`, `list_open_commitments`). Snapshots the
+/// live session `unlocked` set like `get_graph`, so a person whose only mentions are in
+/// sealed-and-not-session-unlocked meetings never appears and every count reflects visible sources
+/// only. Read-only, no model, no new egress.
+#[tauri::command]
+pub fn list_people(state: State<'_, AppState>) -> Result<Vec<PersonCard>, AppError> {
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.list_people(&unlocked)
 }
 
 /// Detail for one entity: the entity, its VISIBLE backlinked meetings (as `VaultSource` chips),
@@ -2149,7 +2247,10 @@ pub async fn ask_vault(
     // Pass the LIVE session unlock set (E9): a folder the user has session-unlocked is included
     // again, while sealed-and-NOT-unlocked content stays excluded by the same visibility predicate.
     let unlocked = unlocked_snapshot(state.inner())?;
-    ask_vault_floor(&state.db, &config, &unlocked, &question, &history).await
+    // Gated cross-meeting USER MEMORY brief (parity with the @brain loop): VISIBLE facts only under
+    // this same unlock snapshot, empty when memory is disabled ⇒ the floor prompt is byte-identical.
+    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked);
+    ask_vault_floor(&state.db, &config, &unlocked, &question, &history, &memory_brief).await
 }
 
 /// Max agentic rounds for the Ask surface. Not live-latency-bound like the in-meeting loop
@@ -2201,6 +2302,15 @@ fn ask_vault_agentic_attempt(
         event: crate::events::EVENT_ASK_TOOL,
         thread_id: thread_id.to_string(),
     };
+    // Gated cross-meeting USER MEMORY brief for the agentic persona (parity with the @brain loop):
+    // VISIBLE facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒ the persona
+    // is byte-identical. Rides the loop's existing redaction + consent egress (no new class).
+    let unlocked_now = state
+        .unlocked_folders
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+    let memory_brief = gated_memory_brief_for_injection(&state, &unlocked_now);
     match ask_vault_loop(
         &*reasoner,
         &executor,
@@ -2208,6 +2318,7 @@ fn ask_vault_agentic_attempt(
         &state.unlocked_folders,
         question,
         history,
+        &memory_brief,
         Some(&sink as &dyn crate::agent::DeltaSink),
     ) {
         Ok(converged) => converged,
@@ -2227,6 +2338,7 @@ fn ask_vault_agentic_attempt(
 /// vault-QA persona over the rendered conversation, then map a converged outcome onto the Ask DTO.
 /// `Ok(None)` = non-convergence (caller floors); `Err` propagates (caller floors) — the loop
 /// contract of `run_informational`, applied to the Ask surface.
+#[allow(clippy::too_many_arguments)]
 fn ask_vault_loop(
     reasoner: &dyn crate::reason::LocalReasoner,
     executor: &dyn crate::agent::ToolExecutor,
@@ -2234,9 +2346,10 @@ fn ask_vault_loop(
     unlocked: &std::sync::Mutex<std::collections::HashSet<String>>,
     question: &str,
     history: &[ChatTurn],
+    memory_brief: &str,
     sink: Option<&dyn crate::agent::DeltaSink>,
 ) -> Result<Option<AskVaultResult>, AppError> {
-    let system = crate::summarize::vault_chat::agentic_system();
+    let system = crate::summarize::vault_chat::agentic_system(memory_brief);
     let user = crate::summarize::vault_chat::render_conversation(history, question);
     let Some(outcome) =
         crate::agent::run_agentic_loop(reasoner, &system, &user, executor, ASK_MAX_STEPS, sink)?
@@ -2301,6 +2414,7 @@ fn build_ask_vault_floor_prompt(
     unlocked: &std::collections::HashSet<String>,
     question: &str,
     history: &[ChatTurn],
+    memory_brief: &str,
 ) -> Result<AskFloorPrompt, AppError> {
     // Phase 2b (gated): when semantic search is ON, pick candidates by HYBRID retrieval (FTS ∪
     // vector KNN, RRF-fused) — embedding the query with the active embedder — then pack with the
@@ -2345,7 +2459,8 @@ fn build_ask_vault_floor_prompt(
             citations: Vec::new(),
         }));
     }
-    let (system, user) = crate::summarize::vault_chat::build(&corpus, history, question);
+    let (system, user) =
+        crate::summarize::vault_chat::build(&corpus, history, question, memory_brief);
     Ok(AskFloorPrompt::Ready { system, user, sources })
 }
 
@@ -2359,8 +2474,9 @@ async fn ask_vault_floor(
     unlocked: &std::collections::HashSet<String>,
     question: &str,
     history: &[ChatTurn],
+    memory_brief: &str,
 ) -> Result<AskVaultResult, AppError> {
-    match build_ask_vault_floor_prompt(db, config, unlocked, question, history)? {
+    match build_ask_vault_floor_prompt(db, config, unlocked, question, history, memory_brief)? {
         AskFloorPrompt::Empty(result) => Ok(result),
         AskFloorPrompt::Ready { system, user, sources } => {
             // ASK role. With role keys absent this builds the legacy default provider for EVERY
@@ -2514,9 +2630,11 @@ mod ask_vault_tests {
         )
         .unwrap();
         assert!(!corpus.trim().is_empty(), "fixture must produce a non-empty corpus");
-        let (want_system, want_user) = crate::summarize::vault_chat::build(&corpus, &history, q);
+        // Empty memory brief ⇒ the floor prompt must stay BYTE-IDENTICAL to the pre-memory build.
+        let (want_system, want_user) =
+            crate::summarize::vault_chat::build(&corpus, &history, q, "");
 
-        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history).unwrap() {
+        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "").unwrap() {
             AskFloorPrompt::Ready { system, user, sources } => {
                 assert_eq!(system, want_system, "floor system prompt diverged from pre-change");
                 assert_eq!(user, want_user, "floor user prompt diverged from pre-change");
@@ -2531,7 +2649,7 @@ mod ask_vault_tests {
 
         // The empty-vault early return keeps the EXACT pre-change canned answer.
         let empty = tmp_db();
-        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[]).unwrap() {
+        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "").unwrap() {
             AskFloorPrompt::Empty(r) => {
                 assert_eq!(
                     r.answer,
@@ -2555,7 +2673,7 @@ mod ask_vault_tests {
             ..AppConfig::default()
         };
         assert!(!cfg.cloud_egress_consented, "fresh config defaults to consent OFF");
-        let res = block_on(ask_vault_floor(&db, &cfg, &HashSet::new(), "atlas?", &[]));
+        let res = block_on(ask_vault_floor(&db, &cfg, &HashSet::new(), "atlas?", &[], ""));
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),
             "no-consent floor must keep the Unavailable refusal: {res:?}"
@@ -2582,7 +2700,7 @@ mod ask_vault_tests {
             serde_json::json!({ "tool": "get_open_commitments", "args": {} }),
             serde_json::json!({ "answer": "Anna ships the deck by 2026-07-10 [[Atlas Kickoff]]." }),
         ]);
-        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "who owns the deck?", &[], None)
+        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "who owns the deck?", &[], "", None)
             .unwrap()
             .expect("scripted brain converged");
         assert_eq!(out.answer, "Anna ships the deck by 2026-07-10 [[Atlas Kickoff]].");
@@ -2612,7 +2730,7 @@ mod ask_vault_tests {
         let stuck = ScriptReasoner::ok(vec![
             serde_json::json!({ "tool": "search_meetings", "args": { "query": "a" } }),
         ]);
-        let out = ask_vault_loop(&stuck, &exec, &db, &unlocked, "q", &[], None).unwrap();
+        let out = ask_vault_loop(&stuck, &exec, &db, &unlocked, "q", &[], "", None).unwrap();
         assert!(out.is_none(), "non-convergence must return Ok(None) for the command to floor");
 
         struct Refuses;
@@ -2632,7 +2750,7 @@ mod ask_vault_tests {
                 Err(AppError::Unavailable("no consent".into()))
             }
         }
-        let res = ask_vault_loop(&Refuses, &exec, &db, &unlocked, "q", &[], None);
+        let res = ask_vault_loop(&Refuses, &exec, &db, &unlocked, "q", &[], "", None);
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),
             "a loop error must propagate so the attempt wrapper can floor: {res:?}"
@@ -2730,7 +2848,7 @@ mod ask_vault_tests {
             serde_json::json!({ "tool": "search_meetings", "args": { "query": "Atlas Secret Terms" } }),
             serde_json::json!({ "answer": "Here is what I found." }),
         ]);
-        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "the secret terms?", &[], None)
+        let out = ask_vault_loop(&brain, &exec, &db, &unlocked, "the secret terms?", &[], "", None)
             .unwrap()
             .expect("converged");
         assert!(
@@ -3246,6 +3364,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         gateway_base_url: c.gateway_base_url.clone(),
         gateway_model: c.gateway_model.clone(),
         proactive_hints_enabled: c.proactive_hints_enabled,
+        user_memory_enabled: c.user_memory_enabled,
         role_notes_connection: c.role_notes_connection.clone(),
         role_notes_model: c.role_notes_model.clone(),
         role_notes_effort: c.role_notes_effort.clone(),
@@ -3378,6 +3497,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default —
         // the backend mute is an explicit user choice, never a partial-save side effect.
         proactive_hints_enabled: d.proactive_hints_enabled,
+        // Cross-meeting USER MEMORY: the master gate IS settable from the DTO (Settings owns the
+        // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default — an
+        // older FE payload can never silently turn memory off.
+        user_memory_enabled: d.user_memory_enabled,
         // Model-role keys ARE settable from the DTO (a future Settings UI owns the rows), like
         // `gateway_model` — plain strings, `""` = inherit legacy. An omitted key deserializes to
         // `""` (`#[serde(default)]`), so an older FE payload can never flip a role.
@@ -6889,6 +7012,81 @@ mod lifecycle_tests {
         .unwrap();
     }
 
+    /// Add a user-memory fact sourced from `meeting_id` (the gating + purge anchor) for the injection
+    /// tests below.
+    fn add_user_fact(db: &Db, meeting_id: &str, object: &str) {
+        db.apply_user_fact_ops(&[crate::facts::FactOp::Add(crate::facts::NewFact {
+            entity_id: crate::user_memory::USER_SCOPE.to_string(),
+            subject: "You".into(),
+            predicate: "prefer".into(),
+            object: object.into(),
+            valid_from: "2026-06-27T09:00:00Z".into(),
+            recorded_at: "2026-06-27T09:00:00Z".into(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })])
+        .unwrap();
+    }
+
+    /// LOCK INVARIANT for the Ask surface's memory injection (RED-before-GREEN, task Phase-1 Ask):
+    /// a user-memory fact whose SOURCE meeting is sealed-and-not-session-unlocked does NOT appear in
+    /// the `ask_vault` system prompt, and an EMPTY memory brief yields a BYTE-IDENTICAL prompt. Before
+    /// the visibility gate on `gated_memory_brief_for_injection` (deleting the
+    /// `list_user_facts_visible` predicate) this FAILS — the sealed fact leaks into the Ask prompt.
+    #[test]
+    fn ask_vault_memory_brief_is_gated_and_empty_is_byte_identical() {
+        let state = build_state("ask-mem-gate");
+        make_open_folder(&state.db, "f1", "Secret");
+        seed_meeting(&state.db, "m1", "We shipped the beta.", None);
+        state.db.set_meeting_folder("m1", Some("f1")).unwrap();
+        add_user_fact(&state.db, "m1", "Polish replies");
+
+        // A grounding corpus + the (byte-identical) EMPTY-brief prompt to compare against.
+        let corpus = "### [[Sync]] · 2026-07-01 · id:m1\nWe shipped the beta.";
+        let (want_empty_system, _) =
+            crate::summarize::vault_chat::build(corpus, &[], "what did we ship?", "");
+
+        // OPEN folder: the fact is VISIBLE → the gated brief carries it → it reaches the Ask prompt.
+        let open = unlocked_snapshot(&state).unwrap();
+        let brief_open = gated_memory_brief_for_injection(&state, &open);
+        assert!(brief_open.contains("Polish replies"), "an open-folder user fact must be in the brief");
+        let (sys_open, _) =
+            crate::summarize::vault_chat::build(corpus, &[], "what did we ship?", &brief_open);
+        assert!(sys_open.contains("Polish replies"), "and reach the Ask system prompt when open");
+        assert_ne!(sys_open, want_empty_system, "a present brief changes the prompt");
+
+        // SEAL the folder (session NOT unlocked). Flip the flag only (the real seal purges the fact);
+        // here we prove the READ GATE hides a fact whose row still exists at rest.
+        state.db.set_folder_locked("f1", true, Some(&b"wrapped"[..])).unwrap();
+        let sealed = unlocked_snapshot(&state).unwrap();
+        let brief_sealed = gated_memory_brief_for_injection(&state, &sealed);
+        assert!(brief_sealed.is_empty(), "a sealed-source user fact must NOT be in the injected brief");
+        let (sys_sealed, _) =
+            crate::summarize::vault_chat::build(corpus, &[], "what did we ship?", &brief_sealed);
+        assert!(!sys_sealed.contains("Polish replies"), "the sealed fact must not reach the Ask prompt");
+        // Empty brief ⇒ the prompt is BYTE-IDENTICAL to the pre-memory prompt.
+        assert_eq!(sys_sealed, want_empty_system, "empty memory ⇒ byte-identical Ask prompt");
+
+        // A SESSION UNLOCK re-admits it (reversible gate).
+        state.unlocked_folders.lock().unwrap().insert("f1".to_string());
+        let unlocked = unlocked_snapshot(&state).unwrap();
+        assert!(
+            gated_memory_brief_for_injection(&state, &unlocked).contains("Polish replies"),
+            "a session unlock must re-admit the user fact to the Ask brief"
+        );
+
+        // FLAG OFF: even the visible fact must NOT be injected when memory is disabled.
+        state.config.lock().unwrap().user_memory_enabled = false;
+        assert!(
+            gated_memory_brief_for_injection(&state, &unlocked).is_empty(),
+            "memory disabled must suppress the Ask brief even for a visible fact"
+        );
+        // And get_user_memory reports the explicit disabled marker (empty + disabled:true).
+        let mem = get_user_memory_inner(&state).unwrap();
+        assert!(mem.disabled, "disabled flag ⇒ the audit payload reports disabled");
+        assert!(mem.facts.is_empty() && mem.brief.is_empty(), "disabled ⇒ nothing surfaced");
+    }
+
     /// PR-A #3 belt-and-braces: sealing a folder while NO recording is active clears any stale
     /// live-transcript buffer (post clear-on-Stop it is normally already empty — idempotent
     /// hygiene so a stale tail can never outlive the folder it belongs to).
@@ -7741,6 +7939,10 @@ mod lifecycle_tests {
             dto.proactive_hints_enabled,
             "omitted proactiveHintsEnabled defaults ON (matches AppConfig::default)"
         );
+        assert!(
+            dto.user_memory_enabled,
+            "omitted userMemoryEnabled defaults ON (matches AppConfig::default)"
+        );
     }
 
     /// Proactive brain P1 — the mute toggle round-trips through the settings DTO: `config_to_dto`
@@ -7759,6 +7961,25 @@ mod lifecycle_tests {
         assert!(
             !dto_to_config(dto, &current).proactive_hints_enabled,
             "a settings save must be able to mute the backend scanner"
+        );
+    }
+
+    /// Cross-meeting USER MEMORY — the master gate round-trips through the settings DTO:
+    /// `config_to_dto` carries it OUT (the FE reads `userMemoryEnabled`) and `dto_to_config` takes it
+    /// IN (the FE sets it), so Settings can actually turn memory off in the backend.
+    #[test]
+    fn dto_round_trips_user_memory_toggle() {
+        // OUT: the DTO reflects the live value.
+        let cfg = AppConfig { user_memory_enabled: false, ..Default::default() };
+        assert!(!config_to_dto(&cfg).user_memory_enabled);
+
+        // IN: the DTO value lands in the merged config (proven from a differing `current`).
+        let mut dto = config_to_dto(&AppConfig::default());
+        dto.user_memory_enabled = false;
+        let current = AppConfig::default(); // ON
+        assert!(
+            !dto_to_config(dto, &current).user_memory_enabled,
+            "a settings save must be able to turn cross-meeting memory off"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             commands::link_meeting_entities,
             commands::get_graph,
             commands::get_entity_detail,
+            commands::list_people,
             commands::ask_vault,
             commands::entity_dossier,
             commands::generate_digest,

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -249,6 +249,16 @@ pub struct AppConfig {
     /// as `true`.
     #[serde(default = "default_true")]
     pub proactive_hints_enabled: bool,
+    /// Cross-meeting USER MEMORY master gate (Phase 3, `crate::user_memory`). Default ON (spec: memory
+    /// is a headline capability). When OFF, memory is turned off ENTIRELY in the BACKEND: no user-fact
+    /// extraction runs after a meeting (`persist_user_facts_for_meeting` early-returns), NO memory
+    /// brief is injected into ANY surface (the @brain agentic loop, Ask, per-meeting chat), and
+    /// `get_user_memory` reports the disabled marker — not just UI hiding. Existing facts are NOT
+    /// deleted by flipping it (the user can forget/clear them); flipping it back ON resumes injection
+    /// from the still-present facts. `#[serde(default = "default_true")]` ⇒ a config persisted before
+    /// this field existed loads as `true` (memory stays on for existing installs).
+    #[serde(default = "default_true")]
+    pub user_memory_enabled: bool,
     /// Model-role override — the CONNECTION serving the **Notes** role (everything Murmur writes).
     /// `""` (the default, and every pre-role install) = inherit the legacy mapping EXACTLY — see
     /// [`crate::summarize::roles::resolve`]. Values: `claude_code`/`anthropic`/`ollama`/`gateway`
@@ -337,6 +347,7 @@ impl Default for AppConfig {
             gateway_base_url: String::new(),
             gateway_model: String::new(),
             proactive_hints_enabled: true,
+            user_memory_enabled: true,
             role_notes_connection: String::new(),
             role_notes_model: String::new(),
             role_notes_effort: String::new(),
@@ -392,6 +403,7 @@ const K_CLAUDE_CODE_INHERIT_ENV: &str = "claude_code_inherit_env";
 const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
 const K_PROACTIVE_HINTS_ENABLED: &str = "proactive_hints_enabled";
+const K_USER_MEMORY_ENABLED: &str = "user_memory_enabled";
 const K_ROLE_NOTES_CONNECTION: &str = "role_notes_connection";
 const K_ROLE_NOTES_MODEL: &str = "role_notes_model";
 const K_ROLE_NOTES_EFFORT: &str = "role_notes_effort";
@@ -544,6 +556,9 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_PROACTIVE_HINTS_ENABLED)? {
             cfg.proactive_hints_enabled = v == "true";
         }
+        if let Some(v) = db.get_setting(K_USER_MEMORY_ENABLED)? {
+            cfg.user_memory_enabled = v == "true";
+        }
         // Model-role keys: `""` is a VALID value (= inherit legacy) and also the default, so the
         // stored value is taken verbatim (mirrors `provider_model`, not `anthropic_model`).
         if let Some(v) = db.get_setting(K_ROLE_NOTES_CONNECTION)? {
@@ -691,6 +706,10 @@ impl AppConfig {
         db.set_setting(
             K_PROACTIVE_HINTS_ENABLED,
             if self.proactive_hints_enabled { "true" } else { "false" },
+        )?;
+        db.set_setting(
+            K_USER_MEMORY_ENABLED,
+            if self.user_memory_enabled { "true" } else { "false" },
         )?;
         db.set_setting(K_ROLE_NOTES_CONNECTION, &self.role_notes_connection)?;
         db.set_setting(K_ROLE_NOTES_MODEL, &self.role_notes_model)?;
@@ -1212,6 +1231,37 @@ mod tests {
         let cfg = AppConfig { proactive_hints_enabled: false, ..Default::default() };
         cfg.save(&db).unwrap();
         assert!(!AppConfig::load(&db).unwrap().proactive_hints_enabled);
+    }
+
+    /// Cross-meeting USER MEMORY — the master gate defaults ON for fresh installs AND for configs
+    /// persisted before the field existed (both the settings-table path and the serde path), and an
+    /// explicit OFF round-trips (turning memory off is a real, persistable choice — not a one-way
+    /// latch). ON-on-absent is the "memory stays on for existing installs" guarantee.
+    #[test]
+    fn user_memory_enabled_defaults_on_and_round_trips() {
+        // In-memory default + empty settings table (key never written) ⇒ ON.
+        assert!(AppConfig::default().user_memory_enabled);
+        let db = temp_db();
+        assert!(AppConfig::load(&db).unwrap().user_memory_enabled);
+
+        // serde path: a JSON payload omitting the field entirely loads ON (default_true).
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"postAecEnabled":true,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.user_memory_enabled, "an omitted key must default ON");
+
+        // Explicit OFF persists + reloads OFF (the backend-side memory kill switch).
+        let cfg = AppConfig { user_memory_enabled: false, ..Default::default() };
+        cfg.save(&db).unwrap();
+        assert!(!AppConfig::load(&db).unwrap().user_memory_enabled);
     }
 
     /// Model roles — the 9 role keys default `""` (inherit-legacy) for fresh installs AND for

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -10,8 +10,8 @@ use std::collections::HashSet;
 use crate::storage::models::{
     Analytics, AssistantInteraction, AssistantThreadRow, Commitment, CorrectionRecord, DayCount,
     DocChunkHit, DocumentInfo, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData,
-    GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, RecipeRecord, SearchHit,
-    StatusCount, VaultSource,
+    GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteRecord, PersonCard, RecipeRecord,
+    SearchHit, StatusCount, VaultSource,
 };
 use crate::embed::Embedder;
 use crate::transcribe::types::Segment;
@@ -4542,6 +4542,70 @@ impl Db {
         Ok(out)
     }
 
+    /// GATED `/people` personal-CRM rollup: one [`PersonCard`] per VISIBLE Person entity, built
+    /// ENTIRELY from the existing gated graph/facts/commitment readers — NO new or ungated query.
+    ///
+    /// LOCK MODEL: the candidate set is `list_entities_visible` filtered to `EntityKind::Person`,
+    /// so a person mentioned ONLY in sealed-and-not-session-unlocked meetings is already dropped
+    /// (its `HAVING cnt > 0` count is 0 while sealed) and never surfaces here. Each per-person count
+    /// then reuses a gate that pushes the SAME `unlocked` set through `visibility_clause`:
+    /// `entity_mentions_visible` (meeting_count + last_talked), `list_facts_visible` (current facts),
+    /// and `list_open_commitments` (owner-scoped, name match) — so every count reflects VISIBLE
+    /// sources only; a sealed source contributes nothing to any of them. Ordered by most-recent
+    /// contact (last_talked DESC), then name.
+    pub fn list_people(&self, unlocked: &HashSet<String>) -> Result<Vec<PersonCard>> {
+        // GATE: the visible-only entity set, Persons only. A sealed-only person is absent here.
+        let people: Vec<GraphNode> = self
+            .list_entities_visible(unlocked)?
+            .into_iter()
+            .filter(|n| n.kind == EntityKind::Person)
+            .collect();
+        // Owner-scoped commitments are cheap to compute ONCE (the full visible rollup) and bucket
+        // by lowercased owner name, rather than re-scanning every note per person.
+        let mut commitments_by_owner: std::collections::HashMap<String, i64> =
+            std::collections::HashMap::new();
+        for c in self.list_open_commitments(unlocked, None)? {
+            if let Some(owner) = c.owner.as_deref() {
+                let key = owner.trim().to_lowercase();
+                if !key.is_empty() {
+                    *commitments_by_owner.entry(key).or_insert(0) += 1;
+                }
+            }
+        }
+        let mut out: Vec<PersonCard> = Vec::with_capacity(people.len());
+        for p in people {
+            // meeting_count + last_talked: VISIBLE mentions only, newest first.
+            let mentions = self.entity_mentions_visible(&p.id, unlocked)?;
+            let meeting_count = mentions.len() as i64;
+            let last_talked = mentions.first().map(|m| m.started_at.clone());
+            // current_fact_count: currently-valid facts about this person from VISIBLE meetings.
+            let current_fact_count = self.list_facts_visible(&p.id, unlocked)?.len() as i64;
+            // open_commitment_count: open action items owned by this person (case-insensitive name).
+            let open_commitment_count = commitments_by_owner
+                .get(&p.name.trim().to_lowercase())
+                .copied()
+                .unwrap_or(0);
+            out.push(PersonCard {
+                id: p.id,
+                name: p.name,
+                meeting_count,
+                last_talked,
+                open_commitment_count,
+                current_fact_count,
+            });
+        }
+        // Most-recent contact first (None last), ties broken by name.
+        out.sort_by(|a, b| match (a.last_talked.as_deref(), b.last_talked.as_deref()) {
+            (Some(x), Some(y)) => y
+                .cmp(x)
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase())),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        });
+        Ok(out)
+    }
+
     // ── CROSS-MEETING USER MEMORY (Phase 3) ────────────────────────────────────
     //
     // User facts reuse the bitemporal `crate::facts::{Fact, FactOp}` shape and the PURE deterministic
@@ -8415,6 +8479,113 @@ mod graph_tests {
             db.entity_mentions_visible(&secret_p, &unlocked).unwrap().len(),
             1
         );
+    }
+
+    /// `/people` CRM GATE: a Person mentioned ONLY in a sealed-and-not-session-unlocked meeting is
+    /// ABSENT from `list_people`, and every count on a visible Person reflects VISIBLE sources only.
+    /// A Person seen in BOTH an open and a sealed meeting keeps only the open-source counts while the
+    /// folder is sealed, and the sealed source's meeting/fact/commitment all reappear once the folder
+    /// id is session-unlocked. RED-before-GREEN: drop the `list_entities_visible` filter (or the
+    /// per-count gated readers) and the secret person / sealed counts leak.
+    #[test]
+    fn list_people_excludes_sealed_person_and_counts_visible_only() {
+        use crate::facts::{FactOp, NewFact};
+        let db = file_db("people-gate");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "secret", "Secret");
+
+        // OPEN meeting: mentions Bob, has an open commitment Bob owns, no facts here.
+        seed_note(&db, "open1", "## Action items\n- [ ] Bob — ship the deck 2026-07-01\n", None);
+        // SEALED meeting: mentions Bob AGAIN + a Secret-Person-only mention, plus Bob's sealed
+        // commitment and a sealed fact about Bob.
+        seed_note(
+            &db,
+            "sealed1",
+            "## Action items\n- [ ] Bob — secret task 2026-07-05\n",
+            Some("secret"),
+        );
+
+        let bob = db.upsert_entity("Bob", EntityKind::Person).unwrap();
+        db.add_mention(&bob, "open1").unwrap();
+        db.add_mention(&bob, "sealed1").unwrap();
+        let secret_p = db.upsert_entity("Secret Person", EntityKind::Person).unwrap();
+        db.add_mention(&secret_p, "sealed1").unwrap();
+
+        // One VISIBLE-source fact about Bob (open meeting) + one SEALED-source fact (sealed meeting).
+        let add = |predicate: &str, object: &str, meeting_id: &str| {
+            FactOp::Add(NewFact {
+                entity_id: bob.clone(),
+                subject: "Bob".to_string(),
+                predicate: predicate.to_string(),
+                object: object.to_string(),
+                valid_from: "2026-06-01T00:00:00Z".to_string(),
+                recorded_at: "2026-06-01T00:00:00Z".to_string(),
+                confidence: 1.0,
+                meeting_id: Some(meeting_id.to_string()),
+            })
+        };
+        db.apply_fact_ops(&[add("role", "PM", "open1"), add("team", "Growth", "sealed1")])
+            .unwrap();
+
+        // SEAL the folder; session NOT unlocked.
+        seal_folder(&db, "secret", &kek);
+
+        let empty: HashSet<String> = HashSet::new();
+        let sealed_view = db.list_people(&empty).unwrap();
+
+        // (1) A person known only through the sealed meeting must NOT surface.
+        assert!(
+            !sealed_view.iter().any(|p| p.id == secret_p),
+            "a person mentioned only in a sealed-not-unlocked meeting leaked into /people"
+        );
+
+        // (2) Bob surfaces via his OPEN meeting, but every count reflects VISIBLE sources only.
+        let bob_card = sealed_view
+            .iter()
+            .find(|p| p.id == bob)
+            .expect("Bob is visible via his open meeting");
+        assert_eq!(bob_card.name, "Bob");
+        assert_eq!(bob_card.meeting_count, 1, "only the open meeting counts while sealed");
+        assert_eq!(
+            bob_card.last_talked.as_deref(),
+            Some("2026-06-26T09:00:00Z+open1"),
+            "last_talked = the open meeting's start (the sealed one is invisible)"
+        );
+        assert_eq!(
+            bob_card.open_commitment_count, 1,
+            "only the open-meeting commitment counts; the sealed task is hidden"
+        );
+        assert_eq!(
+            bob_card.current_fact_count, 1,
+            "only the open-source fact counts; the sealed fact is hidden"
+        );
+
+        // (3) Session-unlock the folder → the sealed contributions reappear. A real `unlock_folder`
+        // decrypts the sealed note markdown back into the plaintext column for the session; the
+        // `seal_folder` test helper only seals, so mirror that restore here (the CK->markdown decrypt
+        // is exercised by the lock round-trip tests) before asserting the note-derived commitment
+        // count. Mentions + facts need no restore — their rows persist through sealing.
+        db.restore_note_markdown(
+            "sealed1",
+            "claude_code",
+            "## Action items\n- [ ] Bob — secret task 2026-07-05\n",
+        )
+        .unwrap();
+        let unlocked = unlocked_set(&["secret"]);
+        let unlocked_view = db.list_people(&unlocked).unwrap();
+        assert!(
+            unlocked_view.iter().any(|p| p.id == secret_p),
+            "the secret person reappears once its folder id is in the unlocked set"
+        );
+        let bob_u = unlocked_view.iter().find(|p| p.id == bob).unwrap();
+        assert_eq!(bob_u.meeting_count, 2, "both meetings visible when unlocked");
+        assert_eq!(
+            bob_u.last_talked.as_deref(),
+            Some("2026-06-26T09:00:00Z+sealed1"),
+            "last_talked advances to the now-visible sealed meeting (later suffix sorts last)"
+        );
+        assert_eq!(bob_u.open_commitment_count, 2, "both commitments visible when unlocked");
+        assert_eq!(bob_u.current_fact_count, 2, "both facts visible when unlocked");
     }
 
     #[test]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -86,6 +86,28 @@ pub struct EntityDetail {
     pub neighbors: Vec<EntityNeighbor>,
 }
 
+/// One row of the `/people` personal-CRM list (`list_people`): a Person entity rolled up over
+/// the EXISTING gated graph + facts + commitments readers. EVERY count here is VISIBLE-only —
+/// a Person whose mentions/facts/commitments live solely in sealed-and-not-session-unlocked
+/// meetings never surfaces (dropped by `list_entities_visible`'s `HAVING`), and its counts
+/// reflect only visible sources. No new/ungated query feeds this DTO.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonCard {
+    pub id: String,
+    pub name: String,
+    /// Number of VISIBLE meetings mentioning this person (sealed meetings drop out).
+    pub meeting_count: i64,
+    /// ISO 8601 start of the most-recent VISIBLE meeting that mentioned this person, or `None`
+    /// when there is no visible mention (should not happen — a card is only built for a visible
+    /// person, but kept fail-soft).
+    pub last_talked: Option<String>,
+    /// Open (`- [ ]`) action items across VISIBLE meetings owned by this person (name match).
+    pub open_commitment_count: i64,
+    /// Currently-valid (open) facts about this person from VISIBLE meetings.
+    pub current_fact_count: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Meeting {

--- a/src-tauri/src/summarize/chat.rs
+++ b/src-tauri/src/summarize/chat.rs
@@ -8,7 +8,19 @@ use crate::storage::models::ChatTurn;
 const MAX_TRANSCRIPT_CHARS: usize = 40_000;
 
 /// Build the (system, user) prompt pair for a meeting chat turn. Pure + testable.
-pub fn build(transcript: &str, history: &[ChatTurn], question: &str) -> (String, String) {
+///
+/// `memory_brief` is the gated cross-meeting USER MEMORY brief (durable preferences/commitments
+/// about the user). When non-empty it is injected as a small "WHAT YOU KNOW ABOUT THE USER" block so
+/// the meeting answer honors the user's standing preferences (e.g. "prefers replies in Polish");
+/// EMPTY ⇒ the block is omitted entirely, so the prompt is BYTE-IDENTICAL to the pre-memory prompt
+/// (the caller passes `""` when memory is empty or disabled). The brief is DERIVED from VISIBLE facts
+/// only (gated by the caller) and rides this surface's existing redaction + consent egress.
+pub fn build(
+    transcript: &str,
+    history: &[ChatTurn],
+    question: &str,
+    memory_brief: &str,
+) -> (String, String) {
     let t = if transcript.chars().count() > MAX_TRANSCRIPT_CHARS {
         let head: String = transcript.chars().take(MAX_TRANSCRIPT_CHARS).collect();
         format!("{head}\n[transcript truncated]")
@@ -16,11 +28,21 @@ pub fn build(transcript: &str, history: &[ChatTurn], question: &str) -> (String,
         transcript.to_string()
     };
 
+    // Present brief ⇒ a labelled block BEFORE the transcript; empty ⇒ byte-identical to before.
+    let memory = if memory_brief.trim().is_empty() {
+        String::new()
+    } else {
+        format!(
+            "WHAT YOU KNOW ABOUT THE USER (their durable preferences / commitments — honor them):\n\
+{memory_brief}\n\n"
+        )
+    };
+
     let system = format!(
         "You are a helpful assistant answering questions about ONE meeting. Base your answers \
 strictly on the transcript below. If the answer is not in the transcript, say you don't know \
 — do not invent facts, decisions, or attributions. Be concise and concrete, and reference \
-what was said (and roughly when) when useful.\n\nTRANSCRIPT:\n{t}"
+what was said (and roughly when) when useful.\n\n{memory}TRANSCRIPT:\n{t}"
     );
 
     let mut user = String::new();
@@ -50,7 +72,7 @@ mod tests {
 
     #[test]
     fn includes_transcript_and_question() {
-        let (system, user) = build("Alice: hi\nBob: bye", &[], "Who said hi?");
+        let (system, user) = build("Alice: hi\nBob: bye", &[], "Who said hi?", "");
         assert!(system.contains("Alice: hi"));
         assert!(user.contains("User: Who said hi?"));
         assert!(user.trim_end().ends_with("Assistant:"));
@@ -59,7 +81,7 @@ mod tests {
     #[test]
     fn renders_prior_history() {
         let history = [turn("user", "What was decided?"), turn("assistant", "To ship Friday.")];
-        let (_s, user) = build("t", &history, "By whom?");
+        let (_s, user) = build("t", &history, "By whom?", "");
         assert!(user.contains("User: What was decided?"));
         assert!(user.contains("Assistant: To ship Friday."));
         assert!(user.contains("User: By whom?"));
@@ -68,7 +90,24 @@ mod tests {
     #[test]
     fn truncates_very_long_transcript() {
         let long = "x".repeat(MAX_TRANSCRIPT_CHARS + 5_000);
-        let (system, _u) = build(&long, &[], "q");
+        let (system, _u) = build(&long, &[], "q", "");
         assert!(system.contains("[transcript truncated]"));
+    }
+
+    /// EMPTY memory brief ⇒ byte-identical to the pre-memory prompt (no block); a present brief ⇒
+    /// the labelled block appears BEFORE the transcript.
+    #[test]
+    fn memory_brief_injects_and_empty_is_byte_identical() {
+        let (s_empty, _) = build("t", &[], "q", "");
+        let (s_blank, _) = build("t", &[], "q", "   ");
+        assert_eq!(s_empty, s_blank);
+        assert!(!s_empty.contains("WHAT YOU KNOW ABOUT THE USER"));
+
+        let (s_mem, _) = build("transcript body", &[], "q", "- You prefer: Polish replies");
+        assert!(s_mem.contains("WHAT YOU KNOW ABOUT THE USER"));
+        assert!(s_mem.contains("Polish replies"));
+        let mem_at = s_mem.find("Polish replies").unwrap();
+        let tx_at = s_mem.find("transcript body").unwrap();
+        assert!(mem_at < tx_at, "memory must precede the transcript");
     }
 }

--- a/src-tauri/src/summarize/vault_chat.rs
+++ b/src-tauri/src/summarize/vault_chat.rs
@@ -5,7 +5,19 @@ use crate::storage::models::ChatTurn;
 
 /// Build the (system, user) prompt pair: the meeting-notes corpus as system context, the
 /// running conversation + question as the user message.
-pub fn build(corpus: &str, history: &[ChatTurn], question: &str) -> (String, String) {
+///
+/// `memory_brief` is the gated cross-meeting USER MEMORY brief (durable preferences/commitments
+/// about the user). When non-empty it is injected as a small "WHAT YOU KNOW ABOUT THE USER" block so
+/// the vault answer honors the user's standing preferences (e.g. "prefers replies in Polish");
+/// EMPTY ⇒ the block is omitted entirely, so the prompt is BYTE-IDENTICAL to the pre-memory prompt
+/// (the caller passes `""` when memory is empty or disabled). The brief is DERIVED from VISIBLE facts
+/// only (gated by the caller) and rides this surface's existing redaction + consent egress.
+pub fn build(
+    corpus: &str,
+    history: &[ChatTurn],
+    question: &str,
+    memory_brief: &str,
+) -> (String, String) {
     let system = format!(
         "You answer questions across a user's PAST MEETINGS, using ONLY the meeting notes \
 provided below. Each note is headed by `### [[Title]] · date · id:...`. \n\
@@ -18,10 +30,25 @@ invent facts, decisions, or attributions.\n\
 - Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight bullets \
 or short `##` sections. A tasteful emoji in a section header is welcome (e.g. ## ✅ Decisions). \
 Never output YAML or front-matter.\n\n\
-MEETING NOTES:\n{corpus}"
+{memory}MEETING NOTES:\n{corpus}",
+        memory = memory_block(memory_brief),
     );
 
     (system, render_conversation(history, question))
+}
+
+/// Render the optional USER MEMORY block. EMPTY brief ⇒ EMPTY string (byte-identical prompt); a
+/// present brief ⇒ a small labelled block terminated by a blank line so the following section header
+/// stays on its own line. Shared by the corpus floor ([`build`]) and the agentic persona
+/// ([`agentic_system`]) so both surfaces inject the brief identically.
+fn memory_block(memory_brief: &str) -> String {
+    if memory_brief.trim().is_empty() {
+        return String::new();
+    }
+    format!(
+        "WHAT YOU KNOW ABOUT THE USER (their durable preferences / commitments — honor them):\n\
+{memory_brief}\n\n"
+    )
 }
 
 /// Render the running conversation + latest question into the user message. Shared VERBATIM by the
@@ -45,8 +72,13 @@ pub fn render_conversation(history: &[ChatTurn], question: &str) -> String {
 /// concise rules as the corpus prompt, but the grounding arrives through GATED TOOLS instead of a
 /// pre-packed corpus (the agentic loop appends the tool catalog + JSON protocol itself). Deliberately
 /// NO live-transcript / typed-notes injection — the Ask page is not a recording surface.
-pub fn agentic_system() -> String {
-    "You answer questions across a user's PAST MEETINGS, imported documents, and brain notes \
+///
+/// `memory_brief` is the gated cross-meeting USER MEMORY brief, injected identically to [`build`]:
+/// non-empty ⇒ a "WHAT YOU KNOW ABOUT THE USER" block; EMPTY ⇒ byte-identical to the pre-memory
+/// persona. Gated by the caller (VISIBLE facts only), rides the surface's existing egress.
+pub fn agentic_system(memory_brief: &str) -> String {
+    format!(
+        "You answer questions across a user's PAST MEETINGS, imported documents, and brain notes \
      (their private, on-device vault).\n\
      Rules:\n\
      - Ground every claim in tool results — search before answering unless you already have \
@@ -58,8 +90,21 @@ pub fn agentic_system() -> String {
      - Be concise and concrete.\n\
      - Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight \
      bullets or short `##` sections. A tasteful emoji in a section header is welcome (e.g. \
-     ## ✅ Decisions). Never output YAML or front-matter."
-        .to_string()
+     ## ✅ Decisions). Never output YAML or front-matter.{memory}",
+        memory = agentic_memory_suffix(memory_brief),
+    )
+}
+
+/// The agentic persona's optional USER MEMORY suffix. EMPTY brief ⇒ EMPTY string (byte-identical to
+/// the pre-memory persona); a present brief ⇒ a leading-newline-separated labelled block.
+fn agentic_memory_suffix(memory_brief: &str) -> String {
+    if memory_brief.trim().is_empty() {
+        return String::new();
+    }
+    format!(
+        "\n\nWHAT YOU KNOW ABOUT THE USER (their durable preferences / commitments — honor them):\n\
+{memory_brief}"
+    )
 }
 
 #[cfg(test)]
@@ -68,9 +113,49 @@ mod tests {
 
     #[test]
     fn includes_corpus_and_question() {
-        let (s, u) = build("### [[Sync]] · 2026-07-01 · id:1\nWe shipped.", &[], "What shipped?");
+        let (s, u) =
+            build("### [[Sync]] · 2026-07-01 · id:1\nWe shipped.", &[], "What shipped?", "");
         assert!(s.contains("[[Sync]]"));
         assert!(u.contains("User: What shipped?"));
         assert!(u.trim_end().ends_with("Assistant:"));
+    }
+
+    /// EMPTY memory brief ⇒ the floor prompt is BYTE-IDENTICAL to the pre-memory prompt (no block,
+    /// no stray whitespace difference). This is the "empty memory => byte-identical prompt" contract
+    /// that keeps the floor faithful to the pre-memory behavior.
+    #[test]
+    fn empty_memory_brief_is_byte_identical() {
+        let corpus = "### [[Sync]] · 2026-07-01 · id:1\nWe shipped.";
+        let (s_empty, _) = build(corpus, &[], "q", "");
+        let (s_blank, _) = build(corpus, &[], "q", "   ");
+        assert_eq!(s_empty, s_blank);
+        // And it is EXACTLY the historical prompt (no memory block spliced in).
+        assert!(!s_empty.contains("WHAT YOU KNOW ABOUT THE USER"));
+        assert!(s_empty.contains("MEETING NOTES:"));
+    }
+
+    /// A present memory brief is injected as a labelled block, BEFORE the meeting-notes corpus, so
+    /// the model honors the user's standing preferences while still grounding in the notes.
+    #[test]
+    fn present_memory_brief_is_injected_before_corpus() {
+        let (s, _) = build("corpus text", &[], "q", "- You prefer: Polish replies");
+        assert!(s.contains("WHAT YOU KNOW ABOUT THE USER"));
+        assert!(s.contains("Polish replies"));
+        let mem_at = s.find("Polish replies").unwrap();
+        let corpus_at = s.find("corpus text").unwrap();
+        assert!(mem_at < corpus_at, "memory must precede the corpus");
+    }
+
+    /// The agentic persona injects the SAME brief the same way: empty ⇒ byte-identical, present ⇒
+    /// the labelled block appears.
+    #[test]
+    fn agentic_system_injects_memory_brief_and_empty_is_byte_identical() {
+        let base = agentic_system("");
+        assert_eq!(base, agentic_system("   "));
+        assert!(!base.contains("WHAT YOU KNOW ABOUT THE USER"));
+        let with = agentic_system("- You prefer: Polish replies");
+        assert!(with.contains("WHAT YOU KNOW ABOUT THE USER"));
+        assert!(with.contains("Polish replies"));
+        assert!(with.starts_with(&base), "the persona prefix is unchanged");
     }
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -512,8 +512,10 @@ fn run_informational(
         // Phase 3 CROSS-MEETING USER MEMORY: synthesize the memory brief from the currently-VISIBLE
         // user facts only (sealed-source facts are excluded by `list_user_facts_visible`), and inject
         // it next to the live-transcript section. It rides the SAME redaction firewall + cloud-consent
-        // gate as every other prompt segment — NO new egress class (design spec C3).
-        let memory_brief = gated_user_memory_brief(&state.db, unlocked);
+        // gate as every other prompt segment — NO new egress class (design spec C3). Suppressed
+        // entirely when memory is turned off (`user_memory_enabled == false`).
+        let memory_brief =
+            gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled);
         let system = assistant_system_prompt(&live, &typed_notes, &memory_brief);
         match crate::agent::run_agentic_loop(
             &*reasoner,
@@ -1059,10 +1061,18 @@ fn gated_live_context(
 /// are NEVER read here and NEVER injected — the brief is regenerated from the remaining visible
 /// sources on every turn. Best-effort: a read error degrades to an EMPTY brief (no injection), never
 /// a failure. The brief egresses only inside the already-redacted, consent-gated system prompt.
+///
+/// `enabled` is the config `user_memory_enabled` master gate: when FALSE the brief is EMPTY (no read,
+/// no injection) — so turning memory off suppresses injection into the @brain loop too, identically
+/// to Ask / per-meeting chat.
 fn gated_user_memory_brief(
     db: &crate::storage::Db,
     unlocked: &std::collections::HashSet<String>,
+    enabled: bool,
 ) -> String {
+    if !enabled {
+        return String::new();
+    }
     let facts = db.list_user_facts_visible(unlocked).unwrap_or_default();
     crate::user_memory::synthesize_brief(&facts)
 }
@@ -1968,7 +1978,7 @@ mod tests {
 
         // While the folder is OPEN the fact is visible → the brief contains it.
         let mut unlocked = std::collections::HashSet::new();
-        let brief_open = gated_user_memory_brief(&db, &unlocked);
+        let brief_open = gated_user_memory_brief(&db, &unlocked, true);
         assert!(brief_open.contains("Polish replies"), "an open-folder user fact must be in the brief");
         let prompt_open = assistant_system_prompt("", "", &brief_open);
         assert!(prompt_open.contains("Polish replies"), "and injected into the prompt");
@@ -1982,7 +1992,7 @@ mod tests {
             visible_sealed.is_empty(),
             "a sealed-not-unlocked meeting's user fact must be INVISIBLE to the gated reader"
         );
-        let brief_sealed = gated_user_memory_brief(&db, &unlocked);
+        let brief_sealed = gated_user_memory_brief(&db, &unlocked, true);
         assert!(brief_sealed.is_empty(), "sealed-source fact must NOT appear in the injected brief");
         let prompt_sealed = assistant_system_prompt("", "", &brief_sealed);
         assert!(!prompt_sealed.contains("Polish replies"), "the sealed fact must not reach the prompt");
@@ -1991,8 +2001,15 @@ mod tests {
         // A SESSION UNLOCK re-admits it (reversible gate).
         unlocked.insert("f1".to_string());
         assert!(
-            gated_user_memory_brief(&db, &unlocked).contains("Polish replies"),
+            gated_user_memory_brief(&db, &unlocked, true).contains("Polish replies"),
             "a session unlock must re-inject the user fact"
+        );
+
+        // FLAG OFF: even a VISIBLE, open-folder fact must NOT be injected when memory is disabled —
+        // the brief is empty regardless of visibility, so the @brain loop injects nothing.
+        assert!(
+            gated_user_memory_brief(&db, &unlocked, false).is_empty(),
+            "memory disabled must suppress the brief even for a visible fact"
         );
     }
 }

--- a/src-tauri/src/user_memory.rs
+++ b/src-tauri/src/user_memory.rs
@@ -46,6 +46,11 @@ const MAX_BRIEF_FACTS: usize = 40;
 /// Max note chars fed to the user-fact extractor (bounds the prompt / leak surface, like facts.rs).
 const EXTRACT_EXCERPT_CHARS: usize = 8_000;
 
+/// Max chars of the meeting's @brain THREAD TURNS fed to the extractor. Bounded like the note/notes
+/// excerpts (design spec D5): thread turns are the HIGHEST-signal source (an explicit "zapamiętaj,
+/// że…"), but the section must still stay a tight, leak-bounded budget.
+const THREAD_TURNS_MAX_CHARS: usize = 4_000;
+
 /// One current user-memory fact, as surfaced to the FE audit view. Content-bearing (subject /
 /// predicate / object) BUT only ever built from VISIBLE facts (`Db::list_user_facts_visible`), so a
 /// sealed source never reaches here. `sourceMeetingId` is the provenance link (the audit "where did
@@ -89,6 +94,21 @@ pub struct UserMemory {
     pub facts: Vec<UserMemoryFact>,
     /// The injected brief (same text the agentic loop receives), or empty when memory is empty.
     pub brief: String,
+    /// TRUE when cross-meeting memory is turned OFF entirely (config `user_memory_enabled == false`).
+    /// In that state `facts`/`brief` are EMPTY and NOTHING is injected into any prompt — the FE shows
+    /// a "memory is off" affordance rather than an empty list. Default FALSE (memory on) so a payload
+    /// that omits it (older FE) reads as enabled.
+    #[serde(default)]
+    pub disabled: bool,
+}
+
+impl UserMemory {
+    /// The explicit "memory is turned OFF" payload: empty facts, empty brief, `disabled: true`. Used
+    /// by `get_user_memory` when the config gate is off so the FE can render a distinct "memory is
+    /// off" affordance instead of an "empty memory" one — and NOTHING content-bearing is surfaced.
+    pub fn disabled() -> Self {
+        Self { facts: Vec::new(), brief: String::new(), disabled: true }
+    }
 }
 
 /// DETERMINISTIC brief synthesis (no LLM, no DB, no clock) — the headless-testable core. Assemble the
@@ -133,13 +153,14 @@ struct RawUserFact {
 }
 
 const EXTRACT_SYSTEM: &str = "You extract durable facts, preferences and commitments ABOUT THE \
-USER (the person whose notes these are — first person \"I / me / my\") from a meeting note and the \
-user's own typed notes. Output STRICT JSON ONLY (no prose, no code fences): \
-{\"facts\":[{\"predicate\":\"short attribute\",\"object\":\"value\"}]}.\n\
+USER (the person whose notes these are — first person \"I / me / my\") from a meeting note, the \
+user's own typed notes, and the user's own messages to the brain assistant. Output STRICT JSON \
+ONLY (no prose, no code fences): {\"facts\":[{\"predicate\":\"short attribute\",\"object\":\"value\"}]}.\n\
 - Extract ONLY durable, user-scoped state worth remembering across meetings: the user's own \
 preferences (\"prefers replies in Polish\"), ongoing work (\"works on Project Atlas\"), commitments \
 and recurring context (\"deadline Q3 = 2026-09-15\"). Prefer things the user explicitly asks to \
-remember (\"remember that…\", \"zapamiętaj, że…\").\n\
+remember (\"remember that…\", \"zapamiętaj, że…\") — an explicit ask in a THREAD TURN is the \
+highest-signal source.\n\
 - predicate is a short, stable attribute (e.g. \"prefers\", \"works on\", \"role\", \"deadline\").\n\
 - object is the current value (e.g. \"Polish replies\", \"Project Atlas\", \"2026-09-15\").\n\
 - Do NOT extract facts about OTHER people or projects (those are entity facts, handled elsewhere), \
@@ -153,30 +174,55 @@ Output ONLY the JSON.";
 /// supersedes it, exactly like entity facts.
 const USER_SUBJECT: &str = "You";
 
-/// BEST-EFFORT extraction of user-scoped fact candidates from a meeting's note markdown + the user's
-/// own typed notes. Uses the on-device reasoner's `structured` decode; on ANY failure (stub reasoner
-/// / no model / decode error / parse error) returns an EMPTY vec — never an error, never a panic,
-/// never a block beyond the reasoner call itself. The RECONCILE is the load-bearing deterministic
-/// core; this is the soft front-end that feeds it. Every candidate carries the [`USER_SCOPE`]
-/// sentinel + the [`USER_SUBJECT`] so `reconcile_facts` keys them on the predicate.
+/// PURE + headless-testable assembly of the extraction USER prompt from the meeting's title, note
+/// markdown, the user's own typed notes, and the meeting's own @brain THREAD TURNS (design spec D5 —
+/// an explicit "zapamiętaj, że…" in a thread is the highest-signal source). Each free-text source is
+/// bounded (note/notes → [`EXTRACT_EXCERPT_CHARS`], thread turns → [`THREAD_TURNS_MAX_CHARS`]) and an
+/// empty source is omitted entirely so an all-empty payload stays minimal. Split out so the
+/// prompt-assembly + the source ordering can be unit-tested without a live model.
+fn build_extraction_user_prompt(
+    title: &str,
+    note_markdown: &str,
+    typed_notes: &str,
+    thread_turns: &str,
+) -> String {
+    let excerpt: String = note_markdown.chars().take(EXTRACT_EXCERPT_CHARS).collect();
+    let notes_excerpt: String = typed_notes.chars().take(EXTRACT_EXCERPT_CHARS).collect();
+    let thread_excerpt: String = thread_turns.chars().take(THREAD_TURNS_MAX_CHARS).collect();
+    let mut user = format!("MEETING: {title}");
+    // THREAD TURNS first after the title: the highest-signal, most explicit source.
+    if !thread_excerpt.trim().is_empty() {
+        user.push_str(&format!(
+            "\n\nUSER'S OWN MESSAGES TO THE BRAIN (THREAD TURNS):\n{thread_excerpt}"
+        ));
+    }
+    if !notes_excerpt.trim().is_empty() {
+        user.push_str(&format!("\n\nUSER'S OWN TYPED NOTES:\n{notes_excerpt}"));
+    }
+    user.push_str(&format!("\n\nNOTE:\n{excerpt}"));
+    user
+}
+
+/// BEST-EFFORT extraction of user-scoped fact candidates from a meeting's note markdown, the user's
+/// own typed notes, and the meeting's own @brain THREAD TURNS (design spec D5 — the highest-signal
+/// source). Uses the on-device reasoner's `structured` decode; on ANY failure (stub reasoner / no
+/// model / decode error / parse error) returns an EMPTY vec — never an error, never a panic, never a
+/// block beyond the reasoner call itself. The RECONCILE is the load-bearing deterministic core; this
+/// is the soft front-end that feeds it. Every candidate carries the [`USER_SCOPE`] sentinel + the
+/// [`USER_SUBJECT`] so `reconcile_facts` keys them on the predicate.
 pub fn extract_user_fact_candidates(
     reasoner: &dyn LocalReasoner,
     title: &str,
     note_markdown: &str,
     typed_notes: &str,
+    thread_turns: &str,
 ) -> Vec<FactCandidate> {
     // No real brain (the default build / no model) → no extraction. The deterministic reconcile +
     // synthesis are still exercised on whatever candidates a real brain would produce.
     if reasoner.id() == "stub" {
         return Vec::new();
     }
-    let excerpt: String = note_markdown.chars().take(EXTRACT_EXCERPT_CHARS).collect();
-    let notes_excerpt: String = typed_notes.chars().take(EXTRACT_EXCERPT_CHARS).collect();
-    let user = if notes_excerpt.trim().is_empty() {
-        format!("MEETING: {title}\n\nNOTE:\n{excerpt}")
-    } else {
-        format!("MEETING: {title}\n\nUSER'S OWN TYPED NOTES:\n{notes_excerpt}\n\nNOTE:\n{excerpt}")
-    };
+    let user = build_extraction_user_prompt(title, note_markdown, typed_notes, thread_turns);
     let schema = serde_json::json!({
         "type": "object",
         "properties": {
@@ -296,6 +342,42 @@ mod tests {
         assert_eq!(dto.source_meeting_id.as_deref(), Some("m1"));
         assert_eq!(dto.predicate, "prefer");
         assert_eq!(dto.object, "Polish replies");
+    }
+
+    /// D5 — the meeting's own @brain THREAD TURNS are appended to the extraction prompt as a
+    /// dedicated, clearly-labelled section (the highest-signal source). This binds the seam a real
+    /// model would see: an explicit "zapamiętaj że wolę odpowiedzi po polsku" reaches the extractor.
+    /// RED before D5: `build_extraction_user_prompt` did not take/emit thread turns at all.
+    #[test]
+    fn extraction_prompt_includes_thread_turns_section() {
+        let prompt = build_extraction_user_prompt(
+            "Sync",
+            "note body",
+            "",
+            "User: zapamiętaj że wolę odpowiedzi po polsku",
+        );
+        assert!(prompt.contains("THREAD TURNS"));
+        assert!(prompt.contains("zapamiętaj że wolę odpowiedzi po polsku"));
+        // The note body is still present (thread turns AUGMENT, never replace, the note source).
+        assert!(prompt.contains("note body"));
+    }
+
+    /// Empty thread turns ⇒ NO thread-turns section at all (an all-note payload stays minimal, and
+    /// the extractor never sees a bare empty header). Note is always present.
+    #[test]
+    fn extraction_prompt_omits_empty_thread_turns() {
+        let prompt = build_extraction_user_prompt("Sync", "note body", "", "   ");
+        assert!(!prompt.contains("THREAD TURNS"));
+        assert!(prompt.contains("note body"));
+    }
+
+    /// The thread-turns section is hard-bounded to its char budget (bounds prompt / leak surface).
+    #[test]
+    fn extraction_prompt_bounds_thread_turns() {
+        let huge = "z".repeat(THREAD_TURNS_MAX_CHARS * 3);
+        let prompt = build_extraction_user_prompt("Sync", "n", "", &huge);
+        let z_count = prompt.chars().filter(|c| *c == 'z').count();
+        assert!(z_count <= THREAD_TURNS_MAX_CHARS);
     }
 
     /// candidates_from_raw scopes every candidate to the user + drops empty pairs.

--- a/src/app/app-shell.component.ts
+++ b/src/app/app-shell.component.ts
@@ -26,7 +26,14 @@ const SIDEBAR_KEY = "murmur-sidebar-collapsed";
 interface NavItem {
   readonly path: string;
   readonly label: string;
-  readonly icon: "record" | "meetings" | "analytics" | "graph" | "brain" | "ask";
+  readonly icon:
+    | "record"
+    | "meetings"
+    | "analytics"
+    | "graph"
+    | "people"
+    | "brain"
+    | "ask";
 }
 
 /**
@@ -116,6 +123,13 @@ interface NavItem {
                     <circle cx="15" cy="7.5" r="2.1" stroke="currentColor" stroke-width="1.4" />
                     <circle cx="9" cy="15" r="2.1" stroke="currentColor" stroke-width="1.4" />
                     <path d="M6.7 7.3l5.2 6.2M6.9 6.6l6-.8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                  </svg>
+                }
+                @case ("people") {
+                  <svg viewBox="0 0 20 20" fill="none">
+                    <circle cx="7.3" cy="7.5" r="2.6" stroke="currentColor" stroke-width="1.4" />
+                    <path d="M2.8 15.5c.4-2.4 2.3-3.9 4.5-3.9s4.1 1.5 4.5 3.9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+                    <path d="M13 5.2a2.3 2.3 0 0 1 0 4.4M14.4 11.9c1.6.4 2.7 1.7 3 3.4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
                   </svg>
                 }
                 @case ("brain") {
@@ -304,6 +318,7 @@ export class AppShellComponent {
     { path: "/library", label: "Meetings", icon: "meetings" },
     { path: "/analytics", label: "Analytics", icon: "analytics" },
     { path: "/graph", label: "Graph", icon: "graph" },
+    { path: "/people", label: "People", icon: "people" },
     { path: "/brain", label: "Brain", icon: "brain" },
     { path: "/ask", label: "Ask", icon: "ask" },
   ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -68,6 +68,13 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "people",
+        loadComponent: () =>
+          import("./features/people/people.component").then(
+            (m) => m.PeopleComponent,
+          ),
+      },
+      {
         path: "brain",
         loadComponent: () =>
           import("./features/brain/brain.component").then(

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -36,6 +36,7 @@ import type {
   ModelDownloadProgress,
   NerDownloadProgress,
   NoteDto,
+  PersonCard,
   PinResult,
   UserMemory,
   ProviderStatus,
@@ -400,6 +401,19 @@ export class IpcService {
   /** Detail for one entity: the entity + its visible backlinked meetings + top neighbors. */
   getEntityDetail(entityId: string): Promise<EntityDetail> {
     return invoke<EntityDetail>("get_entity_detail", { entityId });
+  }
+
+  /**
+   * The `/people` personal-CRM list: one {@link PersonCard} per VISIBLE Person
+   * entity (name + last-talked + open-commitment / fact counts), rolled up over
+   * the SAME gated graph/facts/commitment readers as {@link getGraph}. GATED
+   * server-side — a person whose mentions/facts/commitments live solely in
+   * sealed-not-unlocked meetings never appears, and every count reflects visible
+   * sources only — so re-fetch on a FoldersService lock-state change to shift the
+   * list live (mirrors {@link getGraph}). Each `id` links to the entity detail.
+   */
+  listPeople(): Promise<PersonCard[]> {
+    return invoke<PersonCard[]>("list_people");
   }
 
   // ── brain2 — the Brain page "what's in my brain" overview ──────────────

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -198,6 +198,16 @@ export interface AppConfigDto {
    */
   proactiveHintsEnabled: boolean;
   /**
+   * Cross-meeting USER MEMORY master gate. Off turns memory off ENTIRELY in the
+   * BACKEND: no user-fact extraction after a meeting, no memory brief injected
+   * into any surface (the @brain loop, Ask, per-meeting chat), and
+   * `getUserMemory()` reports `disabled`. Existing facts are NOT deleted by
+   * flipping it off (the user forgets/clears them). Settable flag, round-tripped
+   * on every `save_config`. Default TRUE. Mirrors Rust
+   * `AppConfigDto.user_memory_enabled`.
+   */
+  userMemoryEnabled: boolean;
+  /**
    * Stage 4 — per-feature model-role overrides (Notes / Ask / Live), mirroring
    * Rust `AppConfigDto.role_*` (camelCase). `""` = inherit: the role follows
    * the legacy mapping (Notes → the Default AI triple; Ask/Live → the
@@ -738,6 +748,13 @@ export interface UserMemoryFact {
 export interface UserMemory {
   facts: UserMemoryFact[];
   brief: string;
+  /**
+   * TRUE when cross-meeting memory is turned OFF entirely (`userMemoryEnabled`
+   * is false). In that state `facts`/`brief` are empty and nothing is injected
+   * into any prompt — the FE shows a "memory is off" affordance rather than an
+   * empty list. Optional (older payloads omit it) ⇒ treat absent as `false`.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -851,6 +868,31 @@ export interface EntityDetail {
   /** Visible meetings mentioning this entity (reuses the `VaultSource` backlink chip shape). */
   meetings: VaultSource[];
   neighbors: EntityNeighbor[];
+}
+
+/**
+ * One card in the `/people` personal-CRM list (`listPeople()`). Mirrors the Rust
+ * `PersonCard` (camelCase via `#[serde(rename_all)]`) — a Person entity rolled up
+ * over the SAME gated graph/facts/commitment readers as the graph. GATED
+ * server-side: every count reflects VISIBLE sources only, and a person whose
+ * mentions/facts/commitments live solely in sealed-not-unlocked meetings never
+ * appears — so re-fetch on a FoldersService lock-state change to shift the list
+ * live (mirrors {@link GraphData}). The `id` links to the existing entity detail.
+ */
+export interface PersonCard {
+  id: string;
+  name: string;
+  /** VISIBLE meetings mentioning this person (sealed-not-unlocked meetings drop out). */
+  meetingCount: number;
+  /**
+   * ISO 8601 start of the most-recent VISIBLE meeting that mentioned this person,
+   * or null when there is no visible mention.
+   */
+  lastTalked: string | null;
+  /** Open (`- [ ]`) action items across VISIBLE meetings owned by this person. */
+  openCommitmentCount: number;
+  /** Currently-valid (open) facts about this person from VISIBLE meetings. */
+  currentFactCount: number;
 }
 
 export interface AskVaultResult {

--- a/src/app/features/brain/brain-memory.component.ts
+++ b/src/app/features/brain/brain-memory.component.ts
@@ -76,6 +76,18 @@ import { ToastService } from "../../services/toast.service";
             <p class="empty-title">Couldn’t load your memory</p>
             <p class="empty">{{ error() }}</p>
           </div>
+        } @else if (disabled()) {
+          <div class="card empty-state">
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">Cross-meeting memory is off</p>
+            <p class="empty">
+              The brain isn’t learning or remembering durable facts about you, and
+              injects nothing into its answers. Turn it back on in
+              <a routerLink="/settings">Settings → Privacy</a> to let it build
+              context across your meetings — stored locally, gated, and
+              forgettable.
+            </p>
+          </div>
         } @else if (facts().length === 0) {
           <div class="card empty-state">
             <span class="empty-mark" aria-hidden="true"></span>
@@ -321,6 +333,14 @@ export class BrainMemoryComponent {
   readonly facts = computed<UserMemoryFact[]>(
     () => this.memory()?.facts ?? [],
   );
+
+  /**
+   * TRUE when cross-meeting memory is turned OFF entirely (`get_user_memory`
+   * returns the `disabled` marker with empty facts/brief). Renders a distinct
+   * "memory is off" affordance rather than an "empty memory" one — mirrors the
+   * backend, which suppresses ALL injection in this state.
+   */
+  readonly disabled = computed<boolean>(() => this.memory()?.disabled ?? false);
 
   /** The id of the fact currently being forgotten (disables just that row). */
   readonly forgettingId = signal<string | null>(null);

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1817,6 +1817,8 @@ export class OnboardingComponent implements OnInit {
       brainModelPath: base?.brainModelPath ?? null,
       // Proactive brain hints — round-trip the snapshot, default ON (fresh install).
       proactiveHintsEnabled: base?.proactiveHintsEnabled ?? true,
+      // Cross-meeting user memory — round-trip the snapshot, default ON (fresh install).
+      userMemoryEnabled: base?.userMemoryEnabled ?? true,
       // brain2 RAG — semantic-search master flag; round-trip the snapshot, default off.
       semanticSearchEnabled: base?.semanticSearchEnabled ?? false,
       // brain2 connectors — web-search toggle + its preserve-only consent; round-trip

--- a/src/app/features/people/people.component.ts
+++ b/src/app/features/people/people.component.ts
@@ -1,0 +1,434 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { PersonCard } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+import { EntityDetailComponent } from "../graph/entity-detail.component";
+
+/**
+ * The `/people` page — a personal CRM over the people across your meetings.
+ *
+ * A directory of {@link PersonCard}s (name + when you last talked + how many open
+ * commitments and known facts) is the spine; picking a card opens the SAME
+ * self-contained {@link EntityDetailComponent} panel the /graph page uses (its
+ * neighborhood + backlinked meetings + connected entities) — no graph is rebuilt
+ * here, the detail component is reused verbatim.
+ *
+ * Lock-awareness (mirrors GraphComponent): `listPeople()` returns ONLY visible
+ * people with visible-only counts, so we re-fetch whenever {@link FoldersService}'s
+ * tree signal changes (a session unlock/relock or screen-share re-lock shifts
+ * visibility) — sealed people drop out, or reappear, live, with no client-side
+ * security decision. The IPC call is a one-shot awaited promise written into a
+ * signal (never subscribed-into a field).
+ */
+@Component({
+  selector: "app-people",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [EntityDetailComponent],
+  template: `
+    <section class="people">
+      <header class="p-head">
+        <div class="p-head-text">
+          <h2 class="p-title">People</h2>
+          <p class="p-intro">
+            Everyone across your meetings — how recently you talked, what they
+            still owe, and what Murmur knows about them.
+          </p>
+        </div>
+        @if (!loading() && total() > 0) {
+          <span class="count p-total" [attr.title]="total() + ' people'">
+            {{ total() }}
+          </span>
+        }
+      </header>
+
+      @if (loading()) {
+        <div class="card state-card">
+          <p class="empty">Loading…</p>
+        </div>
+      } @else if (error()) {
+        <div class="card empty-state">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">Couldn’t load your people</p>
+          <p class="empty">{{ error() }}</p>
+        </div>
+      } @else if (total() === 0) {
+        <div class="card empty-state">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">Your people appear as you record</p>
+          <p class="empty">
+            As Murmur recognises the people you talk about, they’ll show up here —
+            with when you last talked and what they still owe.
+          </p>
+        </div>
+      } @else {
+        <div class="p-layout" [class.has-detail]="selectedId() !== null">
+          <ul class="p-cards" role="list">
+            @for (p of people(); track p.id) {
+              <li>
+                <button
+                  type="button"
+                  class="p-card card"
+                  [class.is-selected]="selectedId() === p.id"
+                  [attr.aria-pressed]="selectedId() === p.id"
+                  (click)="onSelect(p.id)"
+                >
+                  <span class="p-avatar" aria-hidden="true">
+                    {{ initial(p.name) }}
+                  </span>
+                  <span class="p-body">
+                    <span class="p-name">{{ p.name }}</span>
+                    <span class="p-last">{{ lastTalkedLabel(p) }}</span>
+                    <span class="p-meta">
+                      <span
+                        class="p-chip"
+                        [class.is-active]="p.openCommitmentCount > 0"
+                        [attr.title]="commitmentTitle(p)"
+                      >
+                        <svg
+                          viewBox="0 0 16 16"
+                          width="12"
+                          height="12"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <rect
+                            x="2.5"
+                            y="3"
+                            width="11"
+                            height="10.5"
+                            rx="1.6"
+                            stroke="currentColor"
+                            stroke-width="1.3"
+                          />
+                          <path
+                            d="M5 6.7 6.6 8.3 11 4.9"
+                            stroke="currentColor"
+                            stroke-width="1.3"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </svg>
+                        {{ p.openCommitmentCount }} open
+                      </span>
+                      <span class="p-chip" [attr.title]="factTitle(p)">
+                        <svg
+                          viewBox="0 0 16 16"
+                          width="12"
+                          height="12"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M8 2.5a3.2 3.2 0 0 0-2 5.7c.5.4.8 1 .8 1.6v.4h2.4v-.4c0-.6.3-1.2.8-1.6A3.2 3.2 0 0 0 8 2.5Z"
+                            stroke="currentColor"
+                            stroke-width="1.2"
+                            stroke-linejoin="round"
+                          />
+                          <path
+                            d="M6.6 12.4h2.8"
+                            stroke="currentColor"
+                            stroke-width="1.2"
+                            stroke-linecap="round"
+                          />
+                        </svg>
+                        {{ p.currentFactCount }}
+                        {{ p.currentFactCount === 1 ? "fact" : "facts" }}
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </li>
+            }
+          </ul>
+
+          @if (selectedId(); as id) {
+            <app-entity-detail
+              class="p-detail"
+              [entityId]="id"
+              (select)="onSelect($event)"
+              (close)="clearSelection()"
+            />
+          }
+        </div>
+      }
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .people {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+      }
+
+      /* --- Head --- */
+      .p-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+      .p-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .p-title {
+        margin: 0;
+      }
+      .p-intro {
+        margin: 0;
+        max-width: 60ch;
+        color: var(--text-secondary);
+        font-size: 0.9375rem;
+      }
+      .p-total {
+        flex: none;
+        margin-top: 6px;
+      }
+
+      /* --- Two-pane layout (directory | sticky detail) --- */
+      .p-layout {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--space-5);
+        align-items: start;
+      }
+      .p-layout.has-detail {
+        grid-template-columns: minmax(0, 1.5fr) minmax(300px, 1fr);
+      }
+      .p-detail {
+        position: sticky;
+        top: 84px;
+      }
+
+      /* --- Cards --- */
+      .p-cards {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+        gap: var(--space-3);
+        min-width: 0;
+      }
+      .p-card {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-3);
+        width: 100%;
+        padding: var(--space-4);
+        text-align: left;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        transition:
+          border-color var(--transition),
+          transform var(--transition-fast);
+      }
+      .p-card:hover {
+        border-color: var(--border-strong);
+        transform: translateY(-1px);
+      }
+      .p-card:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .p-card.is-selected {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 1px var(--accent);
+      }
+      .p-avatar {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        width: 38px;
+        height: 38px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        border: 1px solid var(--accent-ring);
+        color: var(--accent-hover);
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+      .p-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 0;
+      }
+      .p-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        font-weight: 600;
+      }
+      .p-last {
+        color: var(--text-muted);
+        font-size: 0.8125rem;
+      }
+      .p-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin-top: var(--space-1);
+      }
+      .p-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-pill);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+        font-weight: 550;
+        font-variant-numeric: tabular-nums;
+      }
+      .p-chip.is-active {
+        color: var(--accent-hover);
+        background: var(--accent-soft);
+        border-color: var(--accent-ring);
+      }
+
+      /* --- Responsive: one column, detach the sticky panel. --- */
+      @media (max-width: 760px) {
+        .p-layout.has-detail {
+          grid-template-columns: 1fr;
+        }
+        .p-detail {
+          position: static;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .p-card {
+          transition: none;
+        }
+      }
+    `,
+  ],
+})
+export class PeopleComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+
+  readonly people = signal<PersonCard[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  /** The selected person id — opens the reused entity-detail panel. */
+  readonly selectedId = signal<string | null>(null);
+
+  protected readonly total = computed(() => this.people().length);
+
+  /**
+   * Load the people list, and re-load whenever the folder lock-state changes.
+   * Reading the folders `tree` signal registers this effect as its dependent, so
+   * its initial value drives the first fetch (no separate `ngOnInit`), and a
+   * later session unlock/relock — or a screen-share-triggered relock-all —
+   * re-runs the fetch so sealed people drop out, or reappear, live (mirrors
+   * GraphComponent). `fetch()` writes loading/error/data synchronously before its
+   * first await, so this tracked effect must be allowed to write (NG0600 guard).
+   */
+  private readonly _refetchOnLock = effect(
+    () => {
+      this.folders.tree();
+      void this.fetch();
+    },
+    { allowSignalWrites: true },
+  );
+
+  private async fetch(): Promise<void> {
+    this.error.set(null);
+    try {
+      const rows = await this.ipc.listPeople();
+      this.people.set(rows);
+      // If the selected person is no longer visible (e.g. their folder re-sealed),
+      // close the detail panel so we never point at a vanished person.
+      const sel = this.selectedId();
+      if (sel && !rows.some((p) => p.id === sel)) {
+        this.selectedId.set(null);
+      }
+    } catch (e) {
+      this.people.set([]);
+      this.error.set(String(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /** Open (or toggle closed) the detail panel for a person. */
+  onSelect(id: string): void {
+    this.selectedId.update((cur) => (cur === id ? null : id));
+  }
+
+  clearSelection(): void {
+    this.selectedId.set(null);
+  }
+
+  /** The uppercase leading letter for the avatar (fallback "?" for empty names). */
+  protected initial(name: string): string {
+    const c = name.trim().charAt(0);
+    return c ? c.toUpperCase() : "?";
+  }
+
+  /** Human "last talked" label: Today / Yesterday / N days ago / a short date. */
+  protected lastTalkedLabel(p: PersonCard): string {
+    const iso = p.lastTalked;
+    if (!iso) {
+      return "No recent meetings";
+    }
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) {
+      return "";
+    }
+    const now = new Date();
+    const startOfDay = (x: Date): number =>
+      new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+    const days = Math.round(
+      (startOfDay(now) - startOfDay(d)) / 86_400_000,
+    );
+    if (days <= 0) {
+      return "Talked today";
+    }
+    if (days === 1) {
+      return "Talked yesterday";
+    }
+    if (days < 7) {
+      return `Talked ${days} days ago`;
+    }
+    const opts: Intl.DateTimeFormatOptions =
+      d.getFullYear() === now.getFullYear()
+        ? { month: "short", day: "numeric" }
+        : { month: "short", day: "numeric", year: "numeric" };
+    return `Last talked ${d.toLocaleDateString(undefined, opts)}`;
+  }
+
+  protected commitmentTitle(p: PersonCard): string {
+    return p.openCommitmentCount === 1
+      ? "1 open commitment"
+      : `${p.openCommitmentCount} open commitments`;
+  }
+
+  protected factTitle(p: PersonCard): string {
+    return p.currentFactCount === 1
+      ? "1 known fact"
+      : `${p.currentFactCount} known facts`;
+  }
+}

--- a/src/app/features/settings/sections/settings-privacy-section.component.ts
+++ b/src/app/features/settings/sections/settings-privacy-section.component.ts
@@ -1,4 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { RouterLink } from "@angular/router";
 import { SettingsStore } from "../settings.store";
 
 /**
@@ -10,9 +12,10 @@ import { SettingsStore } from "../settings.store";
   selector: "app-settings-privacy-section",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, RouterLink],
   template: `
     <div class="section-stack">
-              <div class="card privacy-card">
+              <div class="card privacy-card" [formGroup]="form">
                 <div class="privacy-head">
                   <span class="privacy-mark" aria-hidden="true">
                     <svg
@@ -163,6 +166,28 @@ import { SettingsStore } from "../settings.store";
                   @if (consentError(); as cerr) {
                     <p class="text-danger privacy-note">{{ cerr }}</p>
                   }
+                </div>
+
+                <!-- (1c) Cross-meeting user memory -->
+                <div class="privacy-section">
+                  <span class="privacy-section-label text-muted"
+                    >Cross-meeting memory</span
+                  >
+                  <label class="toggle-row">
+                    <span class="toggle-copy">
+                      <span class="toggle-title">Remember facts about you</span>
+                      <span class="text-secondary toggle-sub">
+                        The brain remembers durable facts about you across
+                        meetings — how you like to work, what you own, your
+                        commitments — so it can answer with context. Everything
+                        is stored locally on this Mac, gated behind your locked
+                        folders, and forgettable: review or clear it any time on
+                        the <a routerLink="/brain">Brain page</a>. Turn this off
+                        to stop learning and inject nothing.
+                      </span>
+                    </span>
+                    <input type="checkbox" formControlName="userMemoryEnabled" />
+                  </label>
                 </div>
 
                 <!-- (2) Locked folders (honest encryption boundary) -->
@@ -335,6 +360,29 @@ import { SettingsStore } from "../settings.store";
         letter-spacing: -0.01em;
       }
 
+      /* Cross-meeting-memory toggle (mirrors the AI-section toggle rows). */
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        cursor: pointer;
+      }
+      .toggle-copy {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .toggle-title {
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        font-weight: 550;
+      }
+      .toggle-sub {
+        font-size: 0.85rem;
+        line-height: 1.55;
+      }
+
       /* Cloud-processing consent — button + reassurance, or the granted pill. */
       .cloud-consent-row {
         display: flex;
@@ -475,6 +523,9 @@ import { SettingsStore } from "../settings.store";
 })
 export class SettingsPrivacySectionComponent {
   private readonly store = inject(SettingsStore);
+
+  /** The shared settings form — the `userMemoryEnabled` toggle round-trips here. */
+  readonly form = this.store.form;
 
   readonly cloudConsented = this.store.cloudConsented;
   readonly consenting = this.store.consenting;

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -42,7 +42,7 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   // Stage-2 hub: Brain & AI + Providers collapsed into ONE section (keywords merged).
   { id: "ai", label: "AI & Models", keywords: "provider assistant backend cloud local gguf model reasoning effort semantic search embedding reindex in-meeting voice assistant wake anthropic ollama claude code gateway openai api key availability binary default consent revoke privacy egress" },
   { id: "connectors", label: "Connectors", keywords: "web search brave egress api key internet" },
-  { id: "privacy", label: "Privacy & Integrations", keywords: "redaction firewall cloud processing consent locked folders mcp server claude desktop" },
+  { id: "privacy", label: "Privacy & Integrations", keywords: "redaction firewall cloud processing consent locked folders mcp server claude desktop memory remember facts user memory cross-meeting forget" },
   { id: "obsidian", label: "Obsidian", keywords: "vault markdown notes companion export wikilinks" },
   { id: "about", label: "About", keywords: "about version update check for updates release changelog product info" },
 ];

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -136,6 +136,8 @@ export class SettingsStore {
     realtimeReactions: false,
     // Proactive brain (P2) — zero-egress recall cards while recording; default ON.
     proactiveHintsEnabled: true,
+    // Cross-meeting USER MEMORY master gate; default ON. Off turns memory off entirely (backend).
+    userMemoryEnabled: true,
     /** Selected registry brain-model id. Empty → null on save. */
     brainModelId: "",
     /** Explicit custom GGUF file PATH (wins over brainModelId). Empty → null on save. */
@@ -879,6 +881,7 @@ export class SettingsStore {
         brainBackend: cfg.brainBackend ?? "cloud",
         realtimeReactions: cfg.realtimeReactions ?? false,
         proactiveHintsEnabled: cfg.proactiveHintsEnabled ?? true,
+        userMemoryEnabled: cfg.userMemoryEnabled ?? true,
         brainModelId: cfg.brainModelId ?? "",
         brainModelPath: cfg.brainModelPath ?? "",
         semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
@@ -1202,6 +1205,8 @@ export class SettingsStore {
       realtimeReactions: v.realtimeReactions,
       // Proactive brain hints — round-tripped so a save preserves the mute.
       proactiveHintsEnabled: v.proactiveHintsEnabled,
+      // Cross-meeting user memory — round-tripped so a save preserves the choice.
+      userMemoryEnabled: v.userMemoryEnabled,
       brainModelId: v.brainModelId || null,
       // A custom GGUF file path (settable; wins over brainModelId in the resolver).
       brainModelPath: v.brainModelPath || null,


### PR DESCRIPTION
> Re-opened: the original #154 was auto-closed when its base branch `feat/brain-hardening` (#153, now merged) was deleted. Same diff, base now `murmur`.

## What
Increment D — **completes** the cross-meeting user memory from #153, plus a **/people CRM**.

- **D5** — user facts also extracted from the meeting's persisted `@brain` **thread turns** (highest-signal "zapamiętaj, że…"), gated to the meeting's own visible interactions.
- **Ask/detail injection** — memory brief injected into `ask_vault` + `chat_meeting` (parity with the loop), same gate; **empty brief ⇒ byte-identical prompt**.
- **`user_memory_enabled` flag** (default true) — OFF fully suppresses extraction + injection + audit read.
- **/people CRM** — gated `list_people` reader (name, last-talked, open-commitment + fact counts) from existing visibility-gated readers; People FE view + route.

## How verified
`bash scripts/ci.sh` **GREEN**; **adversarial PASS**; **lock-security PASS**. 782 `cargo test --lib`, clippy `-D warnings` clean. RED-before-GREEN: sealed-source facts excluded from `ask_vault`/`chat_meeting`; sealed-only people excluded from `/people`.
