### PR TITLE
feat(notes): speaker-aware default note (Tier 0)

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -583,23 +583,17 @@ async fn run_inner(
         .db
         .update_meeting_status(meeting_id, MeetingStatus::Transcribed)?;
 
-    // Rebuild the full transcript text from the merged, time-ordered segments — EXCLUDING segments
-    // the user spoke TO the assistant ("Klaudku, sprawdź pogodę"). Those are assistant commands, not
-    // meeting content: fed to the summarizer they get mangled into owner-less action items. The
-    // assistant's ANSWER lives in the persisted Q&A log (assistant_interactions), not the note.
-    let mut full_text = String::new();
-    for seg in &merged_segments {
-        let t = seg.text.trim();
-        if t.is_empty() || crate::audio::wake::is_assistant_directed(t) {
-            continue;
-        }
-        if !full_text.is_empty() {
-            full_text.push(' ');
-        }
-        full_text.push_str(t);
-    }
+    // Rebuild the transcript from the merged, time-ordered segments — EXCLUDING segments the user
+    // spoke TO the assistant ("Klaudku, sprawdź pogodę"). Those are assistant commands, not meeting
+    // content: fed to the summarizer they get mangled into owner-less action items. The assistant's
+    // ANSWER lives in the persisted Q&A log (assistant_interactions), not the note.
+    // TIER 0: `build_transcript_feed` yields a SPEAKER-LABELED `summary_text` (`[start-end] (speaker)
+    // text`, the exact shape the timeline already consumes) when the meeting has ≥2 distinct speakers
+    // — so the note can attribute owners/decisions — and stays byte-identical flat text for the
+    // default solo-`me` meeting. `retrieval_text` is always the flat join (RAG query unchanged).
+    let feed = build_transcript_feed(&merged_segments);
 
-    if full_text.trim().is_empty() {
+    if feed.summary_text.trim().is_empty() {
         return Err(AppError::Transcribe(
             "No speech detected in the recording — nothing to transcribe. \
              Check your microphone input and try recording again."
@@ -614,13 +608,91 @@ async fn run_inner(
         app,
         state,
         meeting_id,
-        &full_text,
+        &feed,
         lang.map(str::to_string),
         duration_s,
         &date_iso,
         &ended_at,
     )
     .await
+}
+
+/// TIER 0 — the summarizer's transcript, in two forms.
+///
+/// The pipeline computes diarized, timestamped segments but historically fed the summarizer a flat,
+/// speaker-stripped wall of text — so the note (the one artifact every user reads) could never
+/// attribute owners/decisions even when system-audio capture labeled the far side. `summary_text`
+/// fixes that: for a meeting with ≥2 DISTINCT speakers it is the `[start-end] (speaker) text` shape
+/// the timeline already uses ([`crate::summarize::timeline`]), so the model can attribute. For the
+/// default solo-`me` meeting (one distinct speaker) it stays the flat join — BYTE-IDENTICAL to the
+/// old note input. `retrieval_text` is ALWAYS the flat join: it feeds only the RAG salient-query
+/// path (`orchestrate_context`), which must not be perturbed by tag tokens.
+///
+/// The labeled `summary_text` becomes `SummarizeRequest.transcript`, so any real NAME that ever
+/// occupies a `(speaker)` tag is scrubbed by the SAME RedactingProvider/DebertaNameRedactor firewall
+/// as the rest of the transcript before any cloud egress — it rides no side channel.
+pub(crate) struct TranscriptFeed {
+    /// Flat text (assistant-directed segments dropped) for retrieval — byte-identical to the legacy join.
+    pub retrieval_text: String,
+    /// What the model summarizes: speaker-labeled when `labeled`, else identical to `retrieval_text`.
+    pub summary_text: String,
+    /// Whether `summary_text` carries `(speaker)` tags (i.e. ≥2 distinct speakers).
+    pub labeled: bool,
+}
+
+/// Build the [`TranscriptFeed`] from the merged, time-ordered segments. Drops empty and
+/// assistant-directed ("Klaudku, …") segments with the IDENTICAL predicate the flat loops used.
+pub(crate) fn build_transcript_feed(
+    segments: &[crate::transcribe::types::Segment],
+) -> TranscriptFeed {
+    use crate::audio::merge::SPEAKER_ME;
+    let kept: Vec<&crate::transcribe::types::Segment> = segments
+        .iter()
+        .filter(|s| {
+            let t = s.text.trim();
+            !t.is_empty() && !crate::audio::wake::is_assistant_directed(t)
+        })
+        .collect();
+
+    let mut retrieval_text = String::new();
+    for s in &kept {
+        if !retrieval_text.is_empty() {
+            retrieval_text.push(' ');
+        }
+        retrieval_text.push_str(s.text.trim());
+    }
+
+    // ≥2 distinct speaker labels (None counts as `me`, the mic stream) ⇒ worth tagging. A default
+    // mono-`me` meeting has exactly one distinct label ⇒ stays flat (byte-identical to before).
+    let distinct: std::collections::HashSet<&str> = kept
+        .iter()
+        .map(|s| s.speaker.as_deref().unwrap_or(SPEAKER_ME))
+        .collect();
+    let labeled = distinct.len() >= 2;
+
+    let summary_text = if labeled {
+        // The line shape is IDENTICAL to summarize::timeline's feed so the model reads one convention.
+        kept.iter()
+            .map(|s| {
+                format!(
+                    "[{:.1}-{:.1}] ({}) {}",
+                    s.start_s,
+                    s.end_s,
+                    s.speaker.as_deref().unwrap_or(SPEAKER_ME),
+                    s.text.trim()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        retrieval_text.clone()
+    };
+
+    TranscriptFeed {
+        retrieval_text,
+        summary_text,
+        labeled,
+    }
 }
 
 /// Resolve the summarize step's (config, NOTES provider) from the LIVE state — the egress
@@ -659,7 +731,7 @@ async fn summarize_and_export(
     app: &AppHandle,
     state: &AppState,
     meeting_id: &str,
-    transcript_text: &str,
+    feed: &TranscriptFeed,
     language: Option<String>,
     duration_s: i64,
     date_iso: &str,
@@ -724,7 +796,8 @@ async fn summarize_and_export(
         &state.db,
         meeting_id,
         related_title.as_deref(),
-        transcript_text,
+        // Retrieval query planning reads the FLAT text — unperturbed by `(speaker)` tag tokens.
+        &feed.retrieval_text,
         &unlocked,
         config,
     );
@@ -738,14 +811,16 @@ async fn summarize_and_export(
     let manual_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
 
     let request = SummarizeRequest {
-        transcript: transcript_text.to_string(),
+        // TIER 0: the SPEAKER-LABELED transcript (or the flat one for a solo-`me` meeting). It rides
+        // `req.transcript`, so the RedactingProvider firewall scrubs any name in a `(speaker)` tag.
+        transcript: feed.summary_text.clone(),
         meta: MeetingMeta {
             date_iso: date_iso.to_string(),
             title_hint: None,
             duration_s,
             language,
         },
-        template: template::build_template(&config.note_style, &config.note_language),
+        template: template::build_template(&config.note_style, &config.note_language, feed.labeled),
         vault_titles,
         related_context,
         user_notes: if config.notes_mode == "enhance" && !manual_notes.trim().is_empty() {
@@ -1136,19 +1211,10 @@ pub async fn resummarize_existing(
         ));
     }
 
-    // Rebuild full text from segments (same joining as the transcriber), EXCLUDING assistant-
-    // directed utterances ("Klaudku, …") so they never reach the action-items extraction.
-    let mut full_text = String::new();
-    for seg in &segments {
-        let t = seg.text.trim();
-        if t.is_empty() || crate::audio::wake::is_assistant_directed(t) {
-            continue;
-        }
-        if !full_text.is_empty() {
-            full_text.push(' ');
-        }
-        full_text.push_str(t);
-    }
+    // Rebuild the transcript from segments — EXCLUDING assistant-directed utterances ("Klaudku, …")
+    // so they never reach action-item extraction. TIER 0: `build_transcript_feed` speaker-labels the
+    // summary input when ≥2 distinct speakers, else stays byte-identical flat text.
+    let feed = build_transcript_feed(&segments);
 
     let date_iso = meeting
         .started_at
@@ -1162,7 +1228,7 @@ pub async fn resummarize_existing(
         app,
         state,
         meeting_id,
-        &full_text,
+        &feed,
         config.language.clone(),
         meeting.duration_s,
         &date_iso,
@@ -1301,6 +1367,74 @@ mod tests {
     fn derive_title_prefers_frontmatter() {
         let md = "---\ntitle: Q3 Planning\ndate: 2026-06-24\n---\n# Heading\n";
         assert_eq!(derive_title(md, "2026-06-24"), "Q3 Planning");
+    }
+
+    // ── TIER 0: speaker-aware transcript feed ────────────────────────────────
+    fn seg(
+        idx: i64,
+        start: f64,
+        end: f64,
+        speaker: Option<&str>,
+        text: &str,
+    ) -> crate::transcribe::types::Segment {
+        crate::transcribe::types::Segment {
+            idx,
+            start_s: start,
+            end_s: end,
+            text: text.to_string(),
+            speaker: speaker.map(str::to_string),
+        }
+    }
+
+    /// The default mono-`me` meeting (one distinct label, incl. `None`→`me`): NOT labeled;
+    /// `summary_text` == `retrieval_text` == the exact legacy flat join. Guards no-regression on the
+    /// artifact 100% of users read. RED on any change that tags a single-speaker meeting.
+    #[test]
+    fn feed_single_speaker_is_flat_and_byte_identical() {
+        let segs = vec![
+            seg(0, 0.0, 2.0, Some("me"), "  hello everyone  "),
+            seg(1, 2.0, 5.0, None, "let's begin"),
+        ];
+        let feed = build_transcript_feed(&segs);
+        assert!(!feed.labeled, "one distinct speaker ⇒ not labeled");
+        assert_eq!(feed.summary_text, "hello everyone let's begin");
+        assert_eq!(feed.summary_text, feed.retrieval_text, "flat == retrieval");
+        assert!(!feed.summary_text.contains('(') && !feed.summary_text.contains('['));
+    }
+
+    /// ≥2 distinct speakers ⇒ labeled with the EXACT `[start-end] (speaker) text` timeline shape,
+    /// while `retrieval_text` stays FLAT (no tag/timestamp tokens perturb the RAG query).
+    #[test]
+    fn feed_multi_speaker_is_labeled_timeline_format() {
+        let segs = vec![
+            seg(0, 0.0, 2.0, Some("me"), "hi there"),
+            seg(1, 2.0, 6.0, Some("others"), "great to meet you"),
+        ];
+        let feed = build_transcript_feed(&segs);
+        assert!(feed.labeled);
+        assert_eq!(
+            feed.summary_text,
+            "[0.0-2.0] (me) hi there\n[2.0-6.0] (others) great to meet you"
+        );
+        assert_eq!(feed.retrieval_text, "hi there great to meet you");
+        assert!(!feed.retrieval_text.contains('[') && !feed.retrieval_text.contains("(me)"));
+    }
+
+    /// Empty + assistant-directed ("Klaudku, …") segments are dropped identically to the old flat
+    /// loop; the surviving multi-speaker lines are labeled and carry no assistant command.
+    #[test]
+    fn feed_filters_empty_and_assistant_directed() {
+        let segs = vec![
+            seg(0, 0.0, 1.0, Some("me"), "   "),
+            seg(1, 1.0, 3.0, Some("me"), "Klaudku, sprawdź pogodę"),
+            seg(2, 3.0, 5.0, Some("me"), "let's plan the launch"),
+            seg(3, 5.0, 8.0, Some("others"), "sounds good"),
+        ];
+        let feed = build_transcript_feed(&segs);
+        assert!(feed.labeled);
+        assert!(!feed.summary_text.contains("Klaudku") && !feed.summary_text.contains("pogodę"));
+        assert!(feed.summary_text.contains("(me) let's plan the launch"));
+        assert!(feed.summary_text.contains("(others) sounds good"));
     }
 
     const HZ: usize = crate::audio::TARGET_RATE_HZ as usize;

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -740,6 +740,68 @@ mod tests {
         assert!(out.contains("Anna Kowalska") && out.contains("Bob Smith"));
     }
 
+    /// TIER 0 PII (lock-security): a real NAME that occupies a `(speaker)` tag rides `req.transcript`
+    /// (via `pipeline::build_transcript_feed` → `summary_text`), so the SAME NameRedactor firewall
+    /// that scrubs the body scrubs the tag before egress — the speaker labels use NO side channel
+    /// (the analogue of the old un-scrubbed `user_notes` leak). RED-before-GREEN: the pre-redaction
+    /// feed CONTAINS the raw name; what egresses must NOT.
+    #[test]
+    fn tier0_named_speaker_tag_is_scrubbed_before_egress() {
+        use crate::transcribe::types::Segment;
+        let segs = vec![
+            Segment {
+                idx: 0,
+                start_s: 0.0,
+                end_s: 2.0,
+                text: "let's begin".into(),
+                speaker: Some("Anna Kowalska".into()),
+            },
+            Segment {
+                idx: 1,
+                start_s: 2.0,
+                end_s: 6.0,
+                text: "sounds good".into(),
+                speaker: Some("me".into()),
+            },
+        ];
+        let feed = crate::pipeline::build_transcript_feed(&segs);
+        // Two distinct speakers ⇒ labeled ⇒ the raw name occupies a `(speaker)` tag pre-redaction.
+        assert!(feed.labeled);
+        assert!(
+            feed.summary_text.contains("(Anna Kowalska)"),
+            "raw name sits in the tag before redaction"
+        );
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        struct CaptureProvider(std::sync::Arc<std::sync::Mutex<String>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureProvider {
+            fn id(&self) -> &str {
+                "capture"
+            }
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                *self.0.lock().unwrap() = req.transcript.clone();
+                Ok(req.transcript.clone())
+            }
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+        let prov = RedactingProvider::with_name_redactor(
+            Arc::new(CaptureProvider(captured.clone())),
+            Arc::new(FixtureNameRedactor),
+        );
+        block_on(prov.summarize(&sample_req(&feed.summary_text))).unwrap();
+        let sent = captured.lock().unwrap().clone();
+        // The name in the speaker tag was scrubbed to a token before egress; the labeled line survives.
+        assert!(!sent.contains("Anna Kowalska"), "name must NOT egress");
+        assert!(sent.contains("\u{27ea}NAME_1\u{27eb}"), "name replaced by the stable token");
+        assert!(sent.contains("[0.0-2.0] ("), "the labeled line shape survives redaction");
+    }
+
     // ── Phase D model plumbing + active factory ──────────────────────────────
 
     #[test]

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -146,13 +146,42 @@ never the keys."
     )
 }
 
-/// The full summary system prompt: the style template + the output-language directive.
-pub fn build_template(style: &str, note_language: &str) -> String {
-    format!(
+/// The full summary system prompt: the style template + the output-language directive, and — when
+/// the transcript is SPEAKER-LABELED (`labeled`, i.e. the meeting had ≥2 distinct diarized speakers)
+/// — the speaker-attribution directive so the model attributes decisions / key points / action-item
+/// OWNERS to who actually said them. `labeled == false` (the default solo-`me` meeting) is
+/// byte-identical to the pre-Tier-0 prompt.
+pub fn build_template(style: &str, note_language: &str, labeled: bool) -> String {
+    let mut t = format!(
         "{}\n\n{}",
         template_for_style(style),
         language_directive(note_language)
-    )
+    );
+    if labeled {
+        t.push_str("\n\n");
+        t.push_str(speaker_attribution_directive());
+    }
+    t
+}
+
+/// Appended to the system prompt ONLY when the transcript is speaker-labeled (`[start-end] (speaker)
+/// text`, the same shape the timeline consumes — see [`crate::summarize::timeline`]). Tells the model
+/// to attribute content to the speaker who said it (`me` = the person recording; `others` /
+/// `others-0` / `others-1` … = the DISTINCT other participants) so action-item OWNERS and decisions
+/// are correctly assigned instead of guessed from speaker-blind text. Mirrors `timeline::SYSTEM`.
+pub(crate) fn speaker_attribution_directive() -> &'static str {
+    "SPEAKER ATTRIBUTION: the transcript below is diarized — each line is `[start-end] (speaker) \
+text` (seconds). The `(speaker)` tag is the source of truth for who is talking: `me` is the person \
+recording the meeting; `others`, `others-0`, `others-1`, … are the DISTINCT people on the other \
+side of the call. Use it to:\n\
+- Attribute every DECISION and KEY POINT to the speaker who made it.\n\
+- Assign each action item to its real OWNER — write items as `Owner — action`, where Owner is the \
+speaker responsible (map `me` to the recording user; use a participant's real NAME when it is \
+clearly stated in the conversation, otherwise keep the tag label).\n\
+- List the distinct speakers under the `participants` front-matter (real names when clearly stated, \
+else the tag labels).\n\
+Never attribute to `me` something another participant said or owns, and never invent a speaker the \
+tags do not support."
 }
 
 /// Render the full prompt text a provider sends (template + meta + vault titles + transcript).
@@ -338,5 +367,27 @@ mod tests {
         assert!(notes_at < transcript_at, "skeleton before transcript");
         assert!(s.contains("## Also discussed"), "instructs the Also discussed section");
         assert!(s.contains("Never output a section titled"), "forbids a My notes section");
+    }
+
+    /// TIER 0: the speaker-attribution directive is appended ONLY when `labeled`, and the
+    /// `labeled == false` prompt is byte-identical to the legacy `template + language` prompt.
+    /// RED on the old 2-arg `build_template` (no `labeled` param, never appends the directive).
+    #[test]
+    fn build_template_adds_attribution_only_when_labeled() {
+        let base = format!(
+            "{}\n\n{}",
+            template_for_style("standard"),
+            language_directive("auto")
+        );
+        // Unlabeled (the default solo-`me` meeting): byte-identical to the legacy prompt.
+        let unlabeled = build_template("standard", "auto", false);
+        assert_eq!(unlabeled, base, "unlabeled must be byte-identical to the pre-Tier-0 prompt");
+        assert!(!unlabeled.contains("SPEAKER ATTRIBUTION"));
+        // Labeled: the unlabeled prompt PLUS the attribution directive instructing owner/speaker.
+        let labeled = build_template("standard", "auto", true);
+        assert!(labeled.starts_with(&base), "labeled prompt extends the base prompt");
+        assert!(labeled.contains("SPEAKER ATTRIBUTION"));
+        assert!(labeled.contains("OWNER"), "instructs action-item OWNER attribution");
+        assert!(labeled.contains("(speaker)") && labeled.contains("others"));
     }
 }


### PR DESCRIPTION
## Tier 0 — the cheapest high-leverage brain fix

The default note is the one artifact 100% of users read, yet the summarizer was fed a **speaker- and timestamp-stripped** wall of text via a one-line flatten in `pipeline.rs::run_inner` — even though the timeline already consumes the labeled `[start-end] (speaker) text` shape. So owners/decisions were guessed from speaker-blind text, and enabling system-audio (the differentiated far-side capture) still attributed nothing.

This threads a `TranscriptFeed` through the pipeline: for a meeting with **≥2 distinct speakers** the summarizer input becomes the labeled timeline shape + a speaker-attribution directive (attribute decisions / key points / action-item **owners** to who said them); the default **solo-`me` meeting stays byte-identical**.

### Safety
- The labeled transcript rides `SummarizeRequest.transcript`, so any real name in a `(speaker)` tag is scrubbed by the **same RedactingProvider/DebertaNameRedactor firewall** as the body before egress — **no side channel** (test `tier0_named_speaker_tag_is_scrubbed_before_egress`).
- The RAG retrieval query is fed the **flat** `feed.retrieval_text` (unperturbed by tag tokens).
- `lock-security-reviewer` **PASS** — no new egress class, no new read, gating untouched, no PII in logs. (Noted: today a real name can't even reach `segments.speaker`, so the scrub is defense-in-depth for the voiceprint-naming path.)

### Verification
- `cargo test --lib` **809 passed / 0 failed** (+5 new tests).
- `adversarial-verifier` **PASS** (mutation-tested the single-speaker no-regression claim; `ng lint` + `ng build` green — no FE change).

First of the Tier 0–4 brain program; it reshapes `summarize_and_export(feed)` that the later pipeline workstreams rebase on.