### PR TITLE
feat(brain): semantic retrieval default-ON (Tier 1)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -190,6 +190,11 @@ pub struct AppConfigDto {
     /// toggle), unlike `cloud_egress_consented` which is preserved-only. Plain bool; an omitted value
     /// deserializes to `false` (`#[serde(default)]`), so a partial/older save can never silently
     /// enable it. Flipping it on does NOT auto-index — the user runs `reindex_embeddings` to backfill.
+    /// TIER 1 ASYMMETRY (intentional): the INTERNAL `AppConfig` now defaults this ON (the fresh-install
+    /// default), but this DTO stays fail-safe-`false` so a partial/malformed FE save can never SILENTLY
+    /// turn it ON (a field-omitting save resolves to `false` = the fail-safe OFF direction). `config_to_dto`
+    /// carries the real stored value OUT and the FE echoes it back, so the true value still round-trips
+    /// (see `dto_round_trips_semantic_search_enabled_both_ways`).
     #[serde(default)]
     pub semantic_search_enabled: bool,
     /// brain2 connector framework — the WEB SEARCH master toggle. Settable from the DTO (the Settings
@@ -2645,7 +2650,14 @@ mod ask_vault_tests {
         let db = tmp_db();
         seed_note(&db, "m1", "Atlas Kickoff", "We decided to ship atlas on Friday.", None);
         seed_note(&db, "m2", "Weekly Sync", "Anna owns QA for atlas.", None);
-        let cfg = AppConfig::default(); // semantic_search_enabled = false → the FTS floor branch
+        // Tier 1 flipped the semantic default ON; PIN it false so this test keeps EXPLICITLY exercising
+        // the FTS-floor branch (its stated purpose) rather than the hybrid branch — which, on an empty
+        // vec_chunks, happens to degenerate to the same bytes. Defensive/self-documenting, not a strict
+        // regression guard (the hybrid path is byte-identical here even without the pin).
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
         let unlocked = HashSet::new();
         let history = vec![
             ChatTurn { role: "user".into(), content: "earlier question".into() },
@@ -7945,9 +7957,13 @@ mod lifecycle_tests {
             "flag-off Ask corpus must surface ingested document/note content; got: {corpus:?}"
         );
 
-        // 3. The tool seam (default config: semantic OFF) surfaces the token through BOTH advertised
-        //    search tools — the same seam MCP and the agentic loop dispatch through.
-        let cfg = AppConfig::default();
+        // 3. The tool seam (PIN semantic OFF — this test asserts the flag-OFF keyword-fallback path)
+        //    surfaces the token through BOTH advertised search tools — the same seam MCP and the
+        //    agentic loop dispatch through.
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
         let out = crate::tools::execute_tool(
             &crate::tools::ToolCall::SearchMeetings { query: "fioletowoszary".into() },
             &state.db,
@@ -7971,6 +7987,41 @@ mod lifecycle_tests {
             out2.contains("Ulubiony"),
             "search_semantic (flag OFF) must fall back to gated keyword doc search and surface \
              document CONTENT; got: {out2:?}"
+        );
+    }
+
+    /// TIER 1 default-on graceful degradation: with `semantic_search_enabled = true` but NO e5 model
+    /// (CI / the common fresh-install state), `search_semantic` must DEGRADE to gated keyword doc
+    /// search and still surface document CONTENT — not panic, not go empty. Proves the NEW default is
+    /// safe when the model is absent (which it is until the user downloads e5).
+    #[test]
+    fn semantic_on_without_model_surfaces_keyword_results() {
+        let state = build_state("docs-semantic-on-nomodel");
+        make_open_folder(&state.db, "f-open", "Project");
+        import_text_inner(
+            &state,
+            "Preferencje",
+            "Ulubiony kolor użytkownika to fioletowoszary.",
+            "f-open",
+        )
+        .unwrap();
+        let nothing = HashSet::new();
+        // The NEW default: semantic ON. With no e5 model on disk the hybrid leg degenerates to FTS.
+        let cfg = AppConfig {
+            semantic_search_enabled: true,
+            ..AppConfig::default()
+        };
+        let out = crate::tools::execute_tool(
+            &crate::tools::ToolCall::SearchSemantic { query: "fioletowoszary".into() },
+            &state.db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("Ulubiony"),
+            "semantic ON + no model must degrade to gated keyword doc search and surface CONTENT; \
+             got: {out:?}"
         );
     }
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -339,8 +339,9 @@ fn dispatch_tool(
         other => return Err((-32602, format!("unknown tool: {other}"))),
     };
     // The `semantic_search_enabled` flag lives in the whole-DB-encrypted settings table; load it from
-    // the SAME DB the MCP reader opened. A load failure degrades to the default (flag OFF), matching
-    // the pre-refactor `unwrap_or(false)` behaviour.
+    // the SAME DB the MCP reader opened. On a load failure this degrades to `AppConfig::default()`,
+    // whose Tier 1 default is now flag ON — harmless: with no e5 model the hybrid `search_semantic`
+    // leg degenerates to the SAME gated FTS (no leak, no crash), and every leg stays visibility-gated.
     let config = crate::settings::AppConfig::load(db).unwrap_or_default();
     crate::tools::execute_tool(&call, db, unlocked_set, &config).map_err(|e| (-32000, e.to_string()))
 }
@@ -517,7 +518,9 @@ mod tests {
     fn search_semantic_flag_off_degrades_to_labelled_keyword_match() {
         let (db, p) = temp_db();
         seed(&db, "m1", "Budget", "budget planning hiring quarter", None);
-        // Flag defaults OFF (never written).
+        // Tier 1 flipped the semantic default ON; this test covers the flag-OFF keyword-degradation
+        // labelling, so pin the flag it asserts about explicitly (it used to rely on the old default).
+        db.set_setting("semantic_search_enabled", "false").unwrap();
         let out = dispatch_tool(
             &db,
             "search_semantic",

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -161,13 +161,15 @@ pub struct AppConfig {
     /// by the purpose-built `consent_to_cloud_egress` / `revoke_cloud_egress` commands, so flipping
     /// it either way is an explicit, auditable user act.
     pub cloud_egress_consented: bool,
-    /// brain2 RAG Phase 2b — master gate for the on-device semantic (vector) retrieval layer.
-    /// Default OFF (`#[serde(default)]` ⇒ a config persisted before this field existed loads as
-    /// `false`). When OFF, NOTHING in the vector path runs: no chunk indexing on note creation, the
-    /// Ask-My-Vault corpus stays pure FTS, and the MCP `search_semantic` tool reports "disabled" —
-    /// so shipping this changes NOTHING vs today. It is wired ON only once a real embedding model
-    /// (Phase 2c) replaces the stub; until then the only embedder is the deterministic `StubEmbedder`.
-    #[serde(default)]
+    /// brain2 RAG Tier 1 — master gate for the on-device semantic (vector) retrieval layer.
+    /// Default ON (`#[serde(default = "default_true")]` ⇒ a config persisted before this field existed
+    /// loads as `true`). SAFE to default on: when the e5 model is PRESENT, note chunks auto-index on
+    /// creation and Ask / MCP `search_semantic` / related-meetings use hybrid FTS+vector retrieval;
+    /// when the model is ABSENT (the common fresh-install state) `should_auto_index` stays false and
+    /// every retrieval leg DEGENERATES to the same gated FTS as before — so default-on changes NOTHING
+    /// for a model-less install and only lights up once the user downloads e5. The Settings opt-out
+    /// persists (a stored `false` is honored across reload; see `semantic_flag_off_round_trips`).
+    #[serde(default = "default_true")]
     pub semantic_search_enabled: bool,
     /// brain2 RAG Phase 2 — the SELECTED on-device embedding model id (from
     /// [`crate::embed::EMBED_MODELS`], e.g. `"multilingual-e5-small"` (default) / `"mmlw-retrieval-e5-small"`).
@@ -344,7 +346,7 @@ impl Default for AppConfig {
             lock_require_biometric: true,
             relock_on_screenshare: true,
             cloud_egress_consented: false,
-            semantic_search_enabled: false,
+            semantic_search_enabled: true,
             embed_model_id: None,
             brain_model_path: None,
             brain_model_id: None,
@@ -862,16 +864,18 @@ mod tests {
         assert!(cfg.relock_on_screenshare);
         // E10 cloud-egress consent is fail-closed (OFF) until explicitly granted.
         assert!(!cfg.cloud_egress_consented);
-        // Phase 2b semantic search is OFF by default — shipping it changes nothing.
-        assert!(!cfg.semantic_search_enabled);
+        // Tier 1: semantic search defaults ON; graceful FTS fallback until the e5 model is downloaded.
+        assert!(cfg.semantic_search_enabled);
     }
 
-    /// A config persisted before `semantic_search_enabled` existed (key absent from both the JSON
-    /// DTO and the settings table) must load with the flag defaulting to `false` — `#[serde(default)]`
-    /// for the JSON path, the missing-key fallthrough for the settings-table path. Proves the
-    /// prod-safe default for existing installs.
+    /// TIER 1: a config whose JSON omits `semantic_search_enabled` now loads it as `true`
+    /// (`#[serde(default = "default_true")]` for the JSON path), and an empty settings DB loads the ON
+    /// struct default. The forward-compat path matches the struct default so old payloads pick up the
+    /// new default. NOTE: an existing install that already PERSISTED `false` (any prior Settings save
+    /// wrote the key) keeps FTS-only until re-enabled — reaching that installed base is a deliberate,
+    /// reversible follow-up (a guarded one-time settings flip), intentionally NOT shipped in this change.
     #[test]
-    fn missing_semantic_flag_defaults_off() {
+    fn missing_semantic_flag_defaults_on() {
         // JSON path: deserialize a payload that omits the field entirely.
         let json = r#"{
             "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
@@ -884,11 +888,11 @@ mod tests {
             "cloudEgressConsented":false
         }"#;
         let cfg: AppConfig = serde_json::from_str(json).unwrap();
-        assert!(!cfg.semantic_search_enabled, "serde default must be false");
+        assert!(cfg.semantic_search_enabled, "serde default must be true");
 
-        // Settings-table path: an empty DB (no key written) loads false.
+        // Settings-table path: an empty DB (no key written) loads the ON struct default.
         let db = temp_db();
-        assert!(!AppConfig::load(&db).unwrap().semantic_search_enabled);
+        assert!(AppConfig::load(&db).unwrap().semantic_search_enabled);
     }
 
     #[test]
@@ -1013,6 +1017,20 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(AppConfig::load(&db).unwrap().semantic_search_enabled);
+    }
+
+    /// TIER 1 default-on: an EXPLICIT opt-out (a stored `false`) must PERSIST across reload — a user
+    /// who turns semantic search off stays off despite the new default-true. The critical new
+    /// regression that keeps default-on from being a footgun.
+    #[test]
+    fn semantic_flag_off_round_trips() {
+        let db = temp_db();
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert!(!AppConfig::load(&db).unwrap().semantic_search_enabled);
     }
 
     #[test]


### PR DESCRIPTION
## Tier 1 — semantic retrieval on by default

Flips `semantic_search_enabled` to **default true** so hybrid FTS+vector retrieval (Ask, MCP `search_semantic`, related-meetings) activates automatically **wherever the e5 model is present**, and **degrades gracefully to gated FTS when it is absent** (the common fresh-install state — proven by running the degradation test under a fake `$HOME` with no model on disk). An explicit opt-out (`false`) persists across reload.

Backend-only default-flip — **no new read/index code**; every retrieval leg already exists and is `visibility_clause`-gated. `should_auto_index` still requires `embed_model_present()`, so a default-on **model-less install writes ZERO vectors** (no stub-vector pollution).

### Safety (lock-security PASS)
- Every semantic/hybrid leg the default now routes through is already visibility-gated; the flip only swaps one gated branch for another. `sealed_folder_docs_invisible_through_every_leg_until_unlock` now exercises the flag-ON hybrid branch and stays green (sealed → invisible, unlock → visible).
- No new egress: embeddings are on-device and never cross IPC/network; the Ask corpus egress is the same redacted + `cloud_egress_consented`-gated provider path.
- DTO stays fail-safe-`false` (a partial FE save can never silently turn it ON).

### Scope note
The **installed-base flip** (existing DBs — including the maintainer's — that persisted `false` from the old default) is a deliberate, reversible follow-up decision (a guarded one-time settings flip), **intentionally not in this PR**. Fresh installs get default-on here.

### Verification
- `cargo test --lib` **811 passed / 0 failed** (+2 new tests; the flip surfaced and fixed one hidden default-dependency in an MCP test).
- `adversarial-verifier` **PASS** (ran the model-absent degradation path under a fake `$HOME`; verified the no-stub-vector guard is env-independent) + `lock-security-reviewer` **PASS**.