### PR TITLE
feat(brain): Apple Foundation Models reasoner seam (Tier 2, experimental)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -37,6 +37,21 @@ fn main() {
         "13.4",
         &["EventKit", "Foundation"],
     );
+    // WS2 (DEFERRED) — Apple Foundation Models reasoner sidecar. `afm/afm.swift` does NOT exist yet:
+    // it needs the macOS 26 SDK (`import FoundationModels`, `@Generable`/`DynamicGenerationSchema`),
+    // which this CLT-only Mac lacks. `build_swift_helper` EARLY-RETURNS when the source is absent
+    // (see the `!src.exists()` guard), so this line is a HARMLESS NO-OP today and compiles nothing.
+    // Once `afm/afm.swift` is written on a signed macOS-26 machine this stages `binaries/meetnotes-afm`
+    // (arm64; the x86_64 slice fails FoundationModels → the single-arch fallback), and ONLY THEN may a
+    // `bundle.resources` entry be added to `tauri.conf.json` (tauri_build validates the binary exists,
+    // so that entry cannot land before the compile).
+    build_swift_helper(
+        "afm/afm.swift",
+        "meetnotes-afm",
+        "AFM_BIN",
+        "26.0",
+        &["FoundationModels"],
+    );
     tauri_build::build();
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4557,6 +4557,21 @@ pub async fn download_brain_model(
     Ok(dest.to_string_lossy().to_string())
 }
 
+/// WS2 (EXPERIMENTAL) — availability of the on-device Apple Foundation Models sidecar
+/// (`meetnotes-afm`): is it bundled, and (if so) does its on-device model report available? Lets the
+/// FE offer the "Apple Intelligence (on-device)" brain option ONLY on macOS-26 Apple-Silicon
+/// hardware where the native sidecar is present — never advertise it elsewhere. On every current
+/// (non-macOS-26) build the sidecar is ABSENT, so this returns
+/// `{sidecar_present:false, model_available:None}`.
+///
+/// Opens NO content-read path (a device-capability probe only, like [`brain_model_present`]), so no
+/// `meeting_is_unlocked` / `visibility_clause` gate applies. NEVER panics, NEVER egresses (the probe
+/// is a local `--probe` spawn; a missing/wedged sidecar degrades gracefully).
+#[tauri::command]
+pub fn afm_available(app: AppHandle) -> Result<crate::reason::afm::AfmStatus, AppError> {
+    Ok(crate::reason::afm::probe(Some(&app)))
+}
+
 /// `true` when all three multilingual-e5-small files are present in the shared models dir's embed
 /// sub-dir — i.e. the REAL embedder would load (candle is always compiled; it activates on model
 /// presence). Cheap existence probe; NEVER errors on a missing models dir (treats it as "not present").

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,6 +169,7 @@ pub fn run() {
             commands::list_brain_models,
             commands::select_brain_model,
             commands::download_brain_model,
+            commands::afm_available,
             commands::embed_model_present,
             commands::list_embed_models,
             commands::select_embed_model,

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -26,6 +26,12 @@ use crate::summarize::roles::{self, Role};
 /// runtime by [`local_reasoner`] when a GGUF resolves on disk, else the dependency-free stub.
 pub mod mistral;
 
+/// WS2 — the EXPERIMENTAL on-device Apple Foundation Models reasoner ([`afm::AfmReasoner`]), driven
+/// by the `meetnotes-afm` Swift sidecar (macOS 26+). Selected at runtime for
+/// [`BrainBackend::AppleFoundation`]; falls back to the [`StubReasoner`] when the sidecar is absent
+/// (the current state on every non-macOS-26 machine).
+pub mod afm;
+
 /// A curated, mistral.rs-arch-SAFE on-device reasoning model the user can pick from. The app must
 /// serve BOTH English and Polish, so the brain offers a CHOICE — not one hardcoded GGUF. Every entry
 /// here is a `Q4_K_M` GGUF whose architecture mistral.rs parses today (`llama` / `qwen2` / `qwen3`,
@@ -270,6 +276,10 @@ pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
             tracing::info!(target: "reason", "brain backend = off; using stub reasoner");
             Box::new(StubReasoner)
         }
+        BrainBackend::AppleFoundation => {
+            tracing::info!(target: "reason", "brain backend = apple foundation (on-device sidecar)");
+            afm::afm_reasoner(config)
+        }
     }
 }
 
@@ -362,6 +372,12 @@ impl ReasonerCell {
         match target.connection.as_str() {
             roles::CONN_OFF => Arc::new(StubReasoner),
             roles::CONN_LOCAL => self.local_cached(&cfg, &target),
+            // WS2 anti-egress ORDERING (load-bearing): the on-device AFM arm MUST come BEFORE the
+            // catch-all cloud arm below. The `_` sends anything non-off/non-local/non-apple to the
+            // cloud (egress); without this explicit arm an `apple` target would silently
+            // cloud-dispatch. AfmReasoner holds only a PathBuf, so build per call like CloudReasoner
+            // (no cache slot); a missing sidecar falls back to the stub inside `afm_reasoner_arc`.
+            roles::CONN_AFM => afm::afm_reasoner_arc(&cfg),
             // Cheap per call: the provider (+ consent gate) is built lazily inside, from a fresh
             // config read, so this instance can never pin a stale provider/consent state.
             _ => Arc::new(CloudReasoner::for_role(Arc::clone(&self.config), role)),
@@ -1358,5 +1374,61 @@ mod tests {
     fn active_reasoner_default_is_cloud() {
         let id = active_reasoner(&AppConfig::default()).id().to_string();
         assert!(id.starts_with("cloud:"), "default brain must be cloud, got {id}");
+    }
+
+    // ---- WS2: AppleFoundation dispatch + anti-egress ordering --------------------------------
+
+    /// GRACEFUL FALLBACK: the AppleFoundation backend with NO sidecar (this CLT-only machine)
+    /// resolves to the deterministic stub — byte-identical to Off, zero egress, no panic. Mirrors
+    /// `active_reasoner_local_backend_without_model_yields_stub`. The env override is force-unset
+    /// under the shared lock so a concurrent spawn test can't leak a fixture sidecar into this probe.
+    #[test]
+    fn active_reasoner_apple_backend_without_sidecar_yields_stub() {
+        let _g = crate::reason::afm::AFM_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("MURMUR_AFM_SIDECAR");
+        let cfg = AppConfig {
+            brain_backend: BrainBackend::AppleFoundation,
+            ..Default::default()
+        };
+        assert_eq!(active_reasoner(&cfg).id(), "stub");
+    }
+
+    /// ANTI-EGRESS ORDERING regression (the load-bearing `CONN_AFM`-before-`_` arm): a mid-session
+    /// flip to AppleFoundation must dispatch the on-device path — which, with the sidecar absent,
+    /// is the stub — and must NEVER fall through to the catch-all CloudReasoner (a `cloud:` id would
+    /// mean an on-device backend silently egressed). RED if the `CONN_AFM` arm is removed: the
+    /// `apple` target would hit `_ => CloudReasoner` and this assertion would see `cloud:`.
+    #[test]
+    fn reasoner_cell_apple_backend_dispatches_stub_never_cloud() {
+        use crate::summarize::roles::Role;
+        let _g = crate::reason::afm::AFM_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("MURMUR_AFM_SIDECAR");
+        let cfg = shared(AppConfig {
+            brain_backend: BrainBackend::Off,
+            ..Default::default()
+        });
+        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        assert_eq!(cell.current().id(), "stub", "Off dispatches the stub");
+
+        cfg.lock().unwrap().brain_backend = BrainBackend::AppleFoundation;
+        let id = cell.current().id().to_string();
+        assert_eq!(id, "stub", "AFM without a sidecar dispatches the stub, got {id}");
+        assert!(
+            !id.starts_with("cloud:"),
+            "AFM (on-device) must NEVER fall through to the cloud reasoner (anti-egress), got {id}"
+        );
+
+        // Per-role explicit `apple` key routes the same on-device path (also stub-when-absent),
+        // never cloud — proving the CONN_AFM arm covers the explicit-target path too.
+        cfg.lock().unwrap().brain_backend = BrainBackend::Cloud;
+        cfg.lock().unwrap().role_ask_connection = "apple".to_string();
+        let ask_id = cell.current_for(Role::Ask).id().to_string();
+        assert_eq!(ask_id, "stub", "explicit Ask→apple dispatches on-device (stub when absent)");
+        // Notes (no key) keeps the legacy Cloud dispatch — the AFM arm didn't hijack other roles.
+        assert!(cell.current_for(Role::Notes).id().starts_with("cloud:"));
     }
 }

--- a/src-tauri/src/reason/afm.rs
+++ b/src-tauri/src/reason/afm.rs
@@ -1,0 +1,643 @@
+//! WS2 — Tier 2: the Apple Foundation Models (AFM) on-device reasoner seam (EXPERIMENTAL).
+//!
+//! [`AfmReasoner`] implements [`LocalReasoner`] by shelling out to a bundled `meetnotes-afm` Swift
+//! sidecar over stdio (mirroring the `meetnotes-calendar` / `meetnotes-sysaudio` pattern): the Rust
+//! side sends a `{mode, system, user, schema}` JSON request on the child's STDIN and reads a
+//! validated `{status, text?, json?, reason?, error?}` envelope from STDOUT. On macOS 26+ Apple
+//! Silicon the sidecar drives `SystemLanguageModel.default` (the ~3B on-device model) for a
+//! zero-download, zero-egress, Polish-capable, guaranteed-structured reasoner.
+//!
+//! ## Status: the native sidecar is DEFERRED to a signed macOS-26 Mac
+//! This machine is CLT-only (no macOS 26 SDK), so `afm/afm.swift` is intentionally NOT written and
+//! NOT bundled — [`build.rs`] early-returns when the source is absent, and there is no
+//! `tauri.conf.json` `bundle.resources` entry (tauri_build validates the binary exists). Everything
+//! HERE is headless-green NOW: sidecar resolution, the pure `{build,parse}_afm_request/response`
+//! contract, the bounded/hardened spawn, availability probing, and — critically — GRACEFUL
+//! DEGRADATION: with the sidecar ABSENT (every current machine) [`afm_reasoner`] returns the
+//! deterministic [`StubReasoner`], byte-identical to `BrainBackend::Off`. It NEVER panics/aborts.
+//!
+//! ## Privacy posture (audited by the lock-security reviewer)
+//! AFM is classified ON-DEVICE like the `Local` GGUF reasoner: it is intentionally NOT behind the
+//! `cloud_egress_consented` gate and NOT `RedactingProvider`-wrapped — the transcript excerpt stays
+//! on the Mac. [`AfmReasoner`] holds no HTTP client and opens no network path; the request rides the
+//! child's STDIN PIPE only (never a temp file), and the child is spawned with `env_clear()` + a
+//! fixed `PATH` so no DEK/KEK/token/`MURMUR_DEV_*` can leak into it. The zero-egress claim ultimately
+//! rests on the native sidecar pinning `SystemLanguageModel.default` (NOT Apple Private Cloud
+//! Compute) — that MUST be verified on-Mac with a network capture before the experimental flag comes
+//! off (see LOCKSEC in the spec). Logs carry `target: "reason"` + stages/errors only, never content.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::error::{AppError, Result};
+use crate::settings::AppConfig;
+
+use super::{parse_first_json, LocalReasoner, StubReasoner};
+
+/// Filename of the sidecar — both inside `Contents/Resources` of a shipped `.app` and at the dev
+/// `OUT_DIR`.
+const SIDECAR_NAME: &str = "meetnotes-afm";
+
+/// DEV/TEST-ONLY runtime override: an absolute path to a `meetnotes-afm`-compatible executable. NOT a
+/// secret (just a path) — it lets the headless spawn round-trip point at a fixture script on any OS,
+/// and lets a developer swap the sidecar without a rebuild. Checked FIRST in [`sidecar_path`], but
+/// ONLY under `test`/`debug_assertions` — a signed RELEASE never reads it (mirrors the
+/// `MURMUR_DEV_DEK`/`MURMUR_DEV_KEK` precedent), so a release build can't be pointed at a
+/// bring-your-own sidecar via the process env.
+#[cfg(any(test, debug_assertions))]
+const ENV_OVERRIDE: &str = "MURMUR_AFM_SIDECAR";
+
+/// Hard wall-clock cap on a sidecar invocation from the Rust side. A forward pass is slower than the
+/// calendar lookup (10s), so this is generous; a wedged child is hard-killed at the deadline so it
+/// can never block the reasoner call.
+const SIDECAR_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// TEST-ONLY process-wide lock serializing every test that reads/writes the [`ENV_OVERRIDE`] env var
+/// (in THIS module AND in `reason` / `commands` tests). `cargo test` runs in parallel, so without it
+/// the spawn round-trip (which SETS `MURMUR_AFM_SIDECAR`) could race the stub-fallback tests (which
+/// require it UNSET) and flip an "absent sidecar → stub" assertion into an "afm" id. Mirrors
+/// `crate::embed::EMBED_SELECTION_TEST_LOCK`. Hold it for the whole set→act→restore span.
+#[cfg(test)]
+pub(crate) static AFM_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Availability status of the on-device AFM sidecar, for the FE capability probe (`afm_available`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AfmStatus {
+    /// The `meetnotes-afm` binary is bundled/resolvable on this machine.
+    pub sidecar_present: bool,
+    /// When the sidecar is present, whether its on-device model reports available (`--probe`);
+    /// `None` when the sidecar is absent (nothing to ask). `Some(false)` = present but the model is
+    /// unavailable (wrong OS / not yet downloaded / probe error).
+    pub model_available: Option<bool>,
+    /// A short, non-PII human explanation for the status (e.g. "sidecar not bundled (needs a
+    /// macOS 26 build)").
+    pub reason: String,
+}
+
+/// The two success shapes a sidecar reply can carry: free-form `Text` (the `reason` mode) or a
+/// native-validated `Json` value (the `structured` mode). Public because it is the return type of
+/// the pure [`parse_afm_response`] contract.
+#[derive(Debug)]
+pub enum AfmReply {
+    Text(String),
+    Json(Value),
+}
+
+/// The generation-reply envelope the sidecar prints for `reason` / `structured`.
+#[derive(Deserialize)]
+struct AfmEnvelope {
+    status: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    json: Option<Value>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// The `--probe` envelope: `{"status":"available"|"unavailable","reason":..}`.
+#[derive(Deserialize)]
+struct AfmProbeEnvelope {
+    status: String,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Resolve the AFM sidecar binary, or `None` when it is not present on this machine. Resolution
+/// order (each candidate filtered by `.exists()`):
+/// 1. `MURMUR_AFM_SIDECAR` runtime override (dev/test — enables the headless spawn round-trip);
+/// 2. the bundled resource inside a shipped `.app` (`Contents/Resources/<name>`) when an
+///    [`AppHandle`] is available (the command path);
+/// 3. `<current_exe dir>/../Resources/<name>` — the same `.app` layout when NO `AppHandle` is
+///    available (the reasoner-dispatch path builds no handle);
+/// 4. the compile-time `AFM_BIN` (`OUT_DIR`) DEV fallback (unset until `afm/afm.swift` compiles on a
+///    macOS-26 SDK machine, so `option_env!` is `None` today).
+///
+/// NEVER panics; a missing binary is `None`, which the callers treat as "use the stub".
+pub fn sidecar_path(app: Option<&AppHandle>) -> Option<PathBuf> {
+    // 1. DEV/TEST runtime override — debug/test builds ONLY (matches the MURMUR_DEV_* precedent), so a
+    //    signed release can never be pointed at a bring-your-own sidecar via the process env.
+    #[cfg(any(test, debug_assertions))]
+    if let Ok(p) = std::env::var(ENV_OVERRIDE) {
+        let path = PathBuf::from(p);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    // 2. Bundled resource via the AppHandle (prod, command path).
+    if let Some(app) = app {
+        if let Ok(p) = app
+            .path()
+            .resolve(SIDECAR_NAME, tauri::path::BaseDirectory::Resource)
+        {
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    // 3. Sibling Resources dir via current_exe (prod, reasoner path with no AppHandle). Tauri .app
+    //    layout is Contents/MacOS/<exe> + Contents/Resources/<sidecar>.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("..").join("Resources").join(SIDECAR_NAME);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    // 4. Dev OUT_DIR fallback (compile-time; None until the swift sidecar exists).
+    option_env!("AFM_BIN")
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Serialize the `{mode, system, user, schema}` stdin request. `schema` is `null` for the free-form
+/// `reason` mode and the JSON schema for the `structured` mode. Pure + infallible
+/// ([`Value::to_string`] cannot fail for this in-memory value) so it is trivially unit-testable.
+pub fn build_afm_request(mode: &str, system: &str, user: &str, schema: Option<&Value>) -> String {
+    serde_json::json!({
+        "mode": mode,
+        "system": system,
+        "user": user,
+        "schema": schema,
+    })
+    .to_string()
+}
+
+/// Parse the sidecar's generation stdout into an [`AfmReply`]. Contract (NEVER panics):
+/// - `status:"ok"` + `json` present ⇒ [`AfmReply::Json`] (prefer the native-validated object);
+/// - `status:"ok"` + `text` present ⇒ [`AfmReply::Text`];
+/// - `status:"unavailable"` ⇒ `Err(AppError::Unavailable(reason))`;
+/// - `status:"error"` ⇒ `Err(AppError::Summarize(error))`;
+/// - malformed / empty / unknown status ⇒ `Err(AppError::Summarize("afm: unparseable …"))`.
+///
+/// Every `Err` floors the reasoner to the deterministic path in `orchestrate.rs`.
+pub fn parse_afm_response(stdout: &str) -> Result<AfmReply> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Summarize(
+            "afm: unparseable sidecar output".to_string(),
+        ));
+    }
+    let env: AfmEnvelope = serde_json::from_str(trimmed)
+        .map_err(|_| AppError::Summarize("afm: unparseable sidecar output".to_string()))?;
+    match env.status.as_str() {
+        "ok" => {
+            if let Some(json) = env.json {
+                Ok(AfmReply::Json(json))
+            } else if let Some(text) = env.text {
+                Ok(AfmReply::Text(text))
+            } else {
+                Err(AppError::Summarize(
+                    "afm: ok envelope carried neither json nor text".to_string(),
+                ))
+            }
+        }
+        "unavailable" => Err(AppError::Unavailable(
+            env.reason
+                .unwrap_or_else(|| "afm model unavailable".to_string()),
+        )),
+        "error" => Err(AppError::Summarize(
+            env.error.unwrap_or_else(|| "afm sidecar error".to_string()),
+        )),
+        _ => Err(AppError::Summarize(
+            "afm: unparseable sidecar output".to_string(),
+        )),
+    }
+}
+
+/// Parse the `--probe` stdout into `(model_available, reason)`. `available` ⇒ `true`; any other
+/// status ⇒ `false`; malformed/empty ⇒ `Err`. NEVER panics.
+fn parse_probe_output(stdout: &str) -> Result<(bool, String)> {
+    let trimmed = stdout.trim();
+    let env: AfmProbeEnvelope = serde_json::from_str(trimmed)
+        .map_err(|_| AppError::Summarize("afm: unparseable probe output".to_string()))?;
+    Ok((env.status == "available", env.reason.unwrap_or_default()))
+}
+
+/// Build a hardened [`std::process::Command`] for the sidecar: `env_clear()` + a fixed `PATH`, with
+/// only `HOME`/`USER`/`LOGNAME`/`TMPDIR` passed through (the on-device model container is per-user).
+/// Mirrors `calendar::run_sidecar` so no DEK/KEK/token/`MURMUR_DEV_*` can be inherited by the child.
+fn hardened_command(bin: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new(bin);
+    cmd.env_clear().env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+    for key in ["HOME", "USER", "LOGNAME", "TMPDIR"] {
+        if let Ok(val) = std::env::var(key) {
+            cmd.env(key, val);
+        }
+    }
+    cmd
+}
+
+/// Poll a spawned child to exit under a hard [`SIDECAR_TIMEOUT`] wall-clock cap, hard-killing a
+/// wedged child at the deadline so it can never block the caller. `Ok(())` once the child has exited
+/// (any status); `Err` on timeout or a wait error. NEVER panics.
+fn wait_bounded(child: &mut std::process::Child) -> Result<()> {
+    let deadline = std::time::Instant::now() + SIDECAR_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return Ok(()),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    tracing::warn!(target: "reason", "afm sidecar timed out; killing");
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(AppError::Summarize("afm: sidecar timed out".to_string()));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                let _ = child.kill();
+                return Err(AppError::Summarize(format!("afm: sidecar wait failed: {e}")));
+            }
+        }
+    }
+}
+
+/// Spawn the sidecar, stream `request` to its STDIN, bound its runtime, and return its STDOUT.
+///
+/// DEADLOCK AVOIDANCE: the request is written on a SCOPED writer thread that drops stdin (EOF) when
+/// done, WHILE the main thread runs the bounded try_wait loop — so neither side blocks on a full OS
+/// pipe buffer. Every failure (spawn / timeout / non-zero exit / read) is an `Err` (which floors the
+/// reasoner). NO transcript ever touches disk — stdin pipe only. NEVER panics.
+fn run_afm(bin: &Path, request: &str) -> Result<String> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut cmd = hardened_command(bin);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| AppError::Summarize(format!("afm: spawn failed: {e}")))?;
+    let stdin = child.stdin.take();
+
+    std::thread::scope(|scope| -> Result<String> {
+        // Writer thread: stream the request, then drop stdin (EOF). A BrokenPipe (child already
+        // exited / didn't read stdin) is ignored — the bounded wait below owns the outcome.
+        if let Some(mut stdin) = stdin {
+            scope.spawn(move || {
+                let _ = stdin.write_all(request.as_bytes());
+                // `stdin` dropped here → the child's stdin read sees EOF.
+            });
+        }
+        wait_bounded(&mut child)?;
+        let out = child
+            .wait_with_output()
+            .map_err(|e| AppError::Summarize(format!("afm: read output failed: {e}")))?;
+        if !out.status.success() {
+            return Err(AppError::Summarize(format!(
+                "afm: sidecar exited with {}",
+                out.status
+            )));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    })
+}
+
+/// Spawn the sidecar with a single `--probe` arg (a fast availability check, NOT a generation) and
+/// return its STDOUT. No stdin. Same hardening + bounded wait as [`run_afm`]. NEVER panics.
+fn run_probe(bin: &Path) -> Result<String> {
+    use std::process::Stdio;
+
+    let mut cmd = hardened_command(bin);
+    cmd.arg("--probe")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| AppError::Summarize(format!("afm: probe spawn failed: {e}")))?;
+    wait_bounded(&mut child)?;
+    let out = child
+        .wait_with_output()
+        .map_err(|e| AppError::Summarize(format!("afm: probe read failed: {e}")))?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Availability probe for the FE (`afm_available`). GRACEFUL on every path:
+/// - sidecar absent ⇒ `{sidecar_present:false, model_available:None}` (the current state on every
+///   non-macOS-26 machine);
+/// - sidecar present + probe ok ⇒ `{sidecar_present:true, model_available:Some(available)}`;
+/// - sidecar present + probe error ⇒ `{sidecar_present:true, model_available:Some(false)}` + reason.
+///
+/// NEVER panics, NEVER egresses (a local availability check only).
+pub fn probe(app: Option<&AppHandle>) -> AfmStatus {
+    let Some(bin) = sidecar_path(app) else {
+        return AfmStatus {
+            sidecar_present: false,
+            model_available: None,
+            reason: "sidecar not bundled (needs a macOS 26 build)".to_string(),
+        };
+    };
+    match run_probe(&bin).and_then(|out| parse_probe_output(&out)) {
+        Ok((available, reason)) => AfmStatus {
+            sidecar_present: true,
+            model_available: Some(available),
+            reason: if reason.is_empty() {
+                if available {
+                    "on-device model available".to_string()
+                } else {
+                    "on-device model unavailable".to_string()
+                }
+            } else {
+                reason
+            },
+        },
+        Err(e) => AfmStatus {
+            sidecar_present: true,
+            model_available: Some(false),
+            reason: format!("afm probe failed: {e}"),
+        },
+    }
+}
+
+/// The EXPERIMENTAL on-device Apple Foundation Models reasoner. Holds only the resolved sidecar
+/// path (the ~3B model lives OS-resident in the sidecar process, not loaded by us), so it is cheap
+/// to build per call — no cache slot, like [`super::CloudReasoner`].
+pub struct AfmReasoner {
+    /// Stable id (`"afm"`) so [`LocalReasoner::id`] can return a borrow.
+    id: String,
+    /// The resolved `meetnotes-afm` binary.
+    bin: PathBuf,
+}
+
+impl AfmReasoner {
+    /// Build over a resolved sidecar path. `id()` is `"afm"`.
+    pub fn new(bin: PathBuf) -> Self {
+        Self {
+            id: "afm".to_string(),
+            bin,
+        }
+    }
+}
+
+impl LocalReasoner for AfmReasoner {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn reason(&self, system: &str, user: &str) -> Result<String> {
+        let req = build_afm_request("reason", system, user, None);
+        let out = run_afm(&self.bin, &req)?;
+        match parse_afm_response(&out)? {
+            AfmReply::Text(t) => Ok(t),
+            // A JSON reply to a free-form ask is unusual but valid — surface it as text.
+            AfmReply::Json(v) => Ok(v.to_string()),
+        }
+    }
+
+    fn structured(&self, system: &str, user: &str, json_schema: &Value) -> Result<Value> {
+        let req = build_afm_request("structured", system, user, Some(json_schema));
+        let out = run_afm(&self.bin, &req)?;
+        match parse_afm_response(&out)? {
+            // Prefer the native-validated JSON.
+            AfmReply::Json(v) => Ok(v),
+            // Fall back to the robust extractor (like MistralReasoner / CloudReasoner) when the
+            // sidecar returned prose/fenced text instead of a validated object.
+            AfmReply::Text(t) => parse_first_json(&t),
+        }
+    }
+}
+
+/// Resolve the AFM reasoner for a one-shot [`super::active_reasoner`] dispatch: the real
+/// [`AfmReasoner`] when the sidecar resolves, else the dependency-free [`StubReasoner`]. Keeps the
+/// fallback IDENTICAL to `Local`-without-a-GGUF (id `"stub"`, zero egress). NEVER panics.
+pub fn afm_reasoner(_config: &AppConfig) -> Box<dyn LocalReasoner> {
+    match sidecar_path(None) {
+        Some(bin) => {
+            tracing::info!(target: "reason", "afm sidecar resolved; using on-device apple foundation reasoner");
+            Box::new(AfmReasoner::new(bin))
+        }
+        None => {
+            tracing::info!(target: "reason", "no afm sidecar; using stub reasoner");
+            Box::new(StubReasoner)
+        }
+    }
+}
+
+/// `Arc` variant for the live [`super::ReasonerCell::current_for`] dispatch — same fallback as
+/// [`afm_reasoner`]. Built per call (the reasoner holds only a `PathBuf`, so there is nothing
+/// expensive to cache). NEVER panics.
+pub fn afm_reasoner_arc(_cfg: &AppConfig) -> Arc<dyn LocalReasoner> {
+    match sidecar_path(None) {
+        Some(bin) => Arc::new(AfmReasoner::new(bin)),
+        None => Arc::new(StubReasoner),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- pure protocol: build_afm_request / parse_afm_response ---------------------------------
+
+    #[test]
+    fn build_request_round_trips_mode_system_user_schema() {
+        // reason mode: schema is null.
+        let req = build_afm_request("reason", "sys", "usr", None);
+        let v: Value = serde_json::from_str(&req).unwrap();
+        assert_eq!(v["mode"], serde_json::json!("reason"));
+        assert_eq!(v["system"], serde_json::json!("sys"));
+        assert_eq!(v["user"], serde_json::json!("usr"));
+        assert_eq!(v["schema"], serde_json::json!(null));
+
+        // structured mode: the schema is carried verbatim.
+        let schema = serde_json::json!({ "type": "object", "properties": { "n": { "type": "number" } } });
+        let req = build_afm_request("structured", "s", "u", Some(&schema));
+        let v: Value = serde_json::from_str(&req).unwrap();
+        assert_eq!(v["mode"], serde_json::json!("structured"));
+        assert_eq!(v["schema"], schema);
+    }
+
+    #[test]
+    fn parse_ok_text_is_text() {
+        match parse_afm_response(r#"{"status":"ok","text":"hello world"}"#).unwrap() {
+            AfmReply::Text(t) => assert_eq!(t, "hello world"),
+            AfmReply::Json(_) => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn parse_ok_json_is_json_and_wins_over_text() {
+        // When both json and text are present, the native-validated json is preferred.
+        let s = r#"{"status":"ok","json":{"entities":["Atlas"]},"text":"ignored"}"#;
+        match parse_afm_response(s).unwrap() {
+            AfmReply::Json(v) => assert_eq!(v["entities"], serde_json::json!(["Atlas"])),
+            AfmReply::Text(_) => panic!("expected Json to win"),
+        }
+    }
+
+    #[test]
+    fn parse_unavailable_is_unavailable_err() {
+        match parse_afm_response(r#"{"status":"unavailable","reason":"needs macOS 26"}"#) {
+            Err(AppError::Unavailable(r)) => assert_eq!(r, "needs macOS 26"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_is_summarize_err() {
+        match parse_afm_response(r#"{"status":"error","error":"model load failed"}"#) {
+            Err(AppError::Summarize(e)) => assert_eq!(e, "model load failed"),
+            other => panic!("expected Summarize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_malformed_and_empty_are_err_never_panic() {
+        assert!(parse_afm_response("not json at all").is_err());
+        assert!(parse_afm_response(r#"{"status":"#).is_err());
+        assert!(parse_afm_response("").is_err());
+        assert!(parse_afm_response("   \n  ").is_err());
+        // ok with neither text nor json is an error, not a panic.
+        assert!(parse_afm_response(r#"{"status":"ok"}"#).is_err());
+        // an unknown status is treated as unparseable.
+        assert!(parse_afm_response(r#"{"status":"weird"}"#).is_err());
+    }
+
+    #[test]
+    fn parse_probe_output_maps_status_to_bool() {
+        assert_eq!(
+            parse_probe_output(r#"{"status":"available","reason":"ready"}"#).unwrap(),
+            (true, "ready".to_string())
+        );
+        let (avail, _) = parse_probe_output(r#"{"status":"unavailable","reason":"no os26"}"#).unwrap();
+        assert!(!avail);
+        assert!(parse_probe_output("garbage").is_err());
+    }
+
+    // ---- availability probe: the sidecar-ABSENT path (this CLT-only machine) -------------------
+
+    /// On every non-macOS-26 machine the sidecar is absent, so `probe(None)` reports
+    /// `sidecar_present:false, model_available:None` and NEVER panics — the graceful capability
+    /// floor `afm_available` returns.
+    #[test]
+    fn probe_reports_absent_when_no_sidecar() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(ENV_OVERRIDE);
+        let status = probe(None);
+        assert!(!status.sidecar_present);
+        assert_eq!(status.model_available, None);
+        assert!(!status.reason.is_empty());
+    }
+
+    /// With no sidecar resolvable, both constructors degrade to the deterministic stub (id `"stub"`)
+    /// — byte-identical to `BrainBackend::Off`, zero egress, no panic.
+    #[test]
+    fn constructors_fall_back_to_stub_without_sidecar() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(ENV_OVERRIDE);
+        let cfg = AppConfig::default();
+        assert_eq!(afm_reasoner(&cfg).id(), "stub");
+        assert_eq!(afm_reasoner_arc(&cfg).id(), "stub");
+    }
+
+    // ---- spawn round-trip via the MURMUR_AFM_SIDECAR fixture (headless, any OS) ----------------
+
+    /// Write an executable fixture script that drains stdin then echoes `envelope` on stdout, so the
+    /// full spawn + stdin-write + stdout-parse path can be exercised WITHOUT a real macOS-26 sidecar.
+    #[cfg(unix)]
+    fn write_fixture(tag: &str, envelope: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-afm-fixture-{tag}-{}-{}.sh",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        // Drain stdin (so the parent's write never SIGPIPEs / blocks), then print the canned reply.
+        // Single-quote the envelope for the shell; our envelopes contain no single quotes.
+        let script = format!("#!/bin/sh\ncat >/dev/null\nprintf '%s' '{envelope}'\n");
+        std::fs::write(&p, script).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        p
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reason_round_trips_through_a_fixture_sidecar() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fixture = write_fixture("reason", r#"{"status":"ok","text":"canned answer"}"#);
+        std::env::set_var(ENV_OVERRIDE, &fixture);
+
+        // Resolve via sidecar_path(None) → the env-override branch → the fixture.
+        let bin = sidecar_path(None).expect("fixture must resolve via MURMUR_AFM_SIDECAR");
+        let r = AfmReasoner::new(bin);
+        assert_eq!(r.id(), "afm");
+        let got = r.reason("system prompt", "user prompt").unwrap();
+        assert_eq!(got, "canned answer");
+
+        std::env::remove_var(ENV_OVERRIDE);
+        let _ = std::fs::remove_file(&fixture);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn structured_round_trips_native_json_through_a_fixture_sidecar() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fixture = write_fixture("structured", r#"{"status":"ok","json":{"n":2,"ok":true}}"#);
+        std::env::set_var(ENV_OVERRIDE, &fixture);
+
+        let bin = sidecar_path(None).expect("fixture must resolve via MURMUR_AFM_SIDECAR");
+        let r = AfmReasoner::new(bin);
+        let schema = serde_json::json!({ "type": "object" });
+        let v = r.structured("sys", "user", &schema).unwrap();
+        assert_eq!(v["n"], serde_json::json!(2));
+        assert_eq!(v["ok"], serde_json::json!(true));
+
+        std::env::remove_var(ENV_OVERRIDE);
+        let _ = std::fs::remove_file(&fixture);
+    }
+
+    /// An `unavailable` envelope from the sidecar surfaces as `Err(Unavailable)` end-to-end (the
+    /// reasoner then floors) — proving the spawn path propagates the sidecar's own status.
+    #[cfg(unix)]
+    #[test]
+    fn unavailable_envelope_propagates_as_err_through_the_spawn_path() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fixture = write_fixture("unavail", r#"{"status":"unavailable","reason":"no model"}"#);
+        std::env::set_var(ENV_OVERRIDE, &fixture);
+
+        let bin = sidecar_path(None).unwrap();
+        let r = AfmReasoner::new(bin);
+        match r.reason("s", "u") {
+            Err(AppError::Unavailable(reason)) => assert_eq!(reason, "no model"),
+            other => panic!("expected Unavailable from the sidecar, got {other:?}"),
+        }
+
+        std::env::remove_var(ENV_OVERRIDE);
+        let _ = std::fs::remove_file(&fixture);
+    }
+
+    /// The probe path over a fixture: a `--probe` reply of `available` is reported as
+    /// `sidecar_present:true, model_available:Some(true)`.
+    #[cfg(unix)]
+    #[test]
+    fn probe_reports_available_through_a_fixture_sidecar() {
+        let _g = AFM_ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fixture = write_fixture("probe", r#"{"status":"available","reason":"ready"}"#);
+        std::env::set_var(ENV_OVERRIDE, &fixture);
+
+        let status = probe(None);
+        assert!(status.sidecar_present);
+        assert_eq!(status.model_available, Some(true));
+
+        std::env::remove_var(ENV_OVERRIDE);
+        let _ = std::fs::remove_file(&fixture);
+    }
+}

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -13,6 +13,12 @@ use crate::storage::Db;
 /// - **`Local`**: the on-device GGUF (`MistralReasoner`, e.g. Bielik) when the selected model file
 ///   is present on disk (mistralrs is always compiled); otherwise the `StubReasoner`.
 /// - **`Off`**: the dependency-free `StubReasoner` (the deterministic floor — zero brain).
+/// - **`AppleFoundation`** (EXPERIMENTAL, opt-in — the default stays `Cloud`): the on-device Apple
+///   Foundation Models reasoner ([`crate::reason::afm`]) via the `meetnotes-afm` Swift sidecar
+///   (macOS 26+, Apple Silicon). ON-DEVICE like `Local`: no cloud egress, no consent gate, no
+///   redaction wrap. Until a signed macOS-26 build bundles the native sidecar it is ABSENT on every
+///   machine, so `AppleFoundation` degrades to the deterministic `StubReasoner` — byte-identical to
+///   `Off`/`Local`-without-a-model. Do NOT flip the default to this until on-Mac-verified.
 ///
 /// `#[serde(default)]` on the field ⇒ a config persisted before this field existed loads as
 /// `Cloud` (the chosen default). NEVER changes the egress envelope: a Cloud brain that lacks
@@ -27,23 +33,33 @@ pub enum BrainBackend {
     Local,
     /// No brain — the deterministic floor.
     Off,
+    /// EXPERIMENTAL — on-device Apple Foundation Models via the `meetnotes-afm` sidecar (macOS 26+
+    /// Apple Silicon); falls back to the stub when the sidecar/model is absent. Explicit
+    /// `#[serde(rename = "apple")]` so the persisted token is the single word `apple` (the container
+    /// `rename_all = "lowercase"` would otherwise emit `applefoundation`).
+    #[serde(rename = "apple")]
+    AppleFoundation,
 }
 
 impl BrainBackend {
-    /// Stable lowercase token persisted in the settings table (`cloud` | `local` | `off`).
+    /// Stable lowercase token persisted in the settings table (`cloud` | `local` | `off` | `apple`).
     pub fn as_str(self) -> &'static str {
         match self {
             BrainBackend::Cloud => "cloud",
             BrainBackend::Local => "local",
             BrainBackend::Off => "off",
+            BrainBackend::AppleFoundation => "apple",
         }
     }
 
-    /// Parse the persisted token; an unknown/empty value falls back to the default (`Cloud`).
+    /// Parse the persisted token; an unknown/empty value falls back to the default (`Cloud`) — so an
+    /// OLD build reading a config written by a NEW build (e.g. an `apple` token it doesn't know)
+    /// downgrades gracefully to `Cloud`, never crashes.
     pub fn from_str_or_default(s: &str) -> Self {
         match s {
             "local" => BrainBackend::Local,
             "off" => BrainBackend::Off,
+            "apple" => BrainBackend::AppleFoundation,
             _ => BrainBackend::Cloud,
         }
     }
@@ -917,7 +933,14 @@ mod tests {
         // Absent key ⇒ Cloud (the chosen default for fresh + pre-existing installs).
         assert_eq!(AppConfig::load(&db).unwrap().brain_backend, BrainBackend::Cloud);
 
-        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+        // AppleFoundation (WS2) joins the DB save/load round-trip loop — a persisted `apple` token
+        // reloads as AppleFoundation, never the Cloud default.
+        for backend in [
+            BrainBackend::Cloud,
+            BrainBackend::Local,
+            BrainBackend::Off,
+            BrainBackend::AppleFoundation,
+        ] {
             let cfg = AppConfig {
                 brain_backend: backend,
                 ..Default::default()
@@ -933,11 +956,32 @@ mod tests {
         assert_eq!(BrainBackend::Cloud.as_str(), "cloud");
         assert_eq!(BrainBackend::Local.as_str(), "local");
         assert_eq!(BrainBackend::Off.as_str(), "off");
+        // WS2 — AppleFoundation persists as the single token `apple`.
+        assert_eq!(BrainBackend::AppleFoundation.as_str(), "apple");
         assert_eq!(BrainBackend::from_str_or_default("local"), BrainBackend::Local);
         assert_eq!(BrainBackend::from_str_or_default("off"), BrainBackend::Off);
-        // Unknown / empty falls back to the default brain.
+        assert_eq!(
+            BrainBackend::from_str_or_default("apple"),
+            BrainBackend::AppleFoundation
+        );
+        // Unknown / empty falls back to the default brain — INCLUDING the un-renamed
+        // `applefoundation` spelling, which an OLD build must NOT accidentally accept.
         assert_eq!(BrainBackend::from_str_or_default("bogus"), BrainBackend::Cloud);
         assert_eq!(BrainBackend::from_str_or_default(""), BrainBackend::Cloud);
+        assert_eq!(
+            BrainBackend::from_str_or_default("applefoundation"),
+            BrainBackend::Cloud
+        );
+
+        // serde: AppleFoundation serializes to the QUOTED token `"apple"` and round-trips back.
+        assert_eq!(
+            serde_json::to_string(&BrainBackend::AppleFoundation).unwrap(),
+            "\"apple\""
+        );
+        assert_eq!(
+            serde_json::from_str::<BrainBackend>("\"apple\"").unwrap(),
+            BrainBackend::AppleFoundation
+        );
 
         // JSON DTO: a payload omitting brainBackend loads as Cloud (#[serde(default)]).
         let json = r#"{

--- a/src-tauri/src/summarize/roles.rs
+++ b/src-tauri/src/summarize/roles.rs
@@ -44,6 +44,11 @@ use crate::settings::{AppConfig, BrainBackend};
 pub const CONN_LOCAL: &str = "local";
 /// Reasoner-only connection id: no model — the deterministic [`crate::reason::StubReasoner`] floor.
 pub const CONN_OFF: &str = "off";
+/// Reasoner-only connection id (WS2, EXPERIMENTAL): the on-device Apple Foundation Models brain
+/// ([`crate::reason::afm`]) via the `meetnotes-afm` sidecar. ON-DEVICE like [`CONN_LOCAL`] — it
+/// builds no `SummarizerProvider` and is auto-excluded from the cloud agentic loop (see
+/// [`RoleTarget::is_reasoner_only`]); falls back to the stub when the sidecar is absent.
+pub const CONN_AFM: &str = "apple";
 
 /// Human-facing display name for a connection id — for USER-VISIBLE status lines
 /// (e.g. the pipeline's "Summarizing with …" line). Mirrors the FE connection
@@ -56,6 +61,7 @@ pub fn connection_display_name(connection: &str) -> &str {
         "ollama" => "Ollama",
         "gateway" => "Kong AI Gateway",
         CONN_LOCAL => "the on-device model",
+        CONN_AFM => "Apple Intelligence (on-device)",
         other => other,
     }
 }
@@ -95,10 +101,15 @@ pub struct RoleTarget {
 }
 
 impl RoleTarget {
-    /// `true` when this target is served by a [`crate::reason::LocalReasoner`] only (`local`/
-    /// `off`) — it can never build a `SummarizerProvider`, and the agentic loops don't run on it.
+    /// `true` when this target is served by a [`crate::reason::LocalReasoner`] only (`local`/`off`/
+    /// `apple`) — it can never build a `SummarizerProvider`, and the cloud agentic loops don't run
+    /// on it. Including `apple` here is what auto-excludes the on-device Apple Foundation Models
+    /// backend from the cloud agentic-eligibility gate AND makes `provider_for` refuse to build a
+    /// cloud provider for an explicit `apple` role key — both correct, both free.
     pub fn is_reasoner_only(&self) -> bool {
-        self.connection == CONN_LOCAL || self.connection == CONN_OFF
+        self.connection == CONN_LOCAL
+            || self.connection == CONN_OFF
+            || self.connection == CONN_AFM
     }
 }
 
@@ -176,6 +187,14 @@ fn legacy_brain_target(cfg: &AppConfig) -> RoleTarget {
         },
         BrainBackend::Off => RoleTarget {
             connection: CONN_OFF.to_string(),
+            model: String::new(),
+            effort: String::new(),
+        },
+        // WS2 — the on-device Apple Foundation Models reasoner. Model/effort are empty (the sidecar
+        // pins `SystemLanguageModel.default`), so a `role_*_connection = "apple"` key ALSO routes to
+        // AFM automatically via the explicit_target path — per-role AFM steering falls out for free.
+        BrainBackend::AppleFoundation => RoleTarget {
+            connection: CONN_AFM.to_string(),
             model: String::new(),
             effort: String::new(),
         },
@@ -284,7 +303,12 @@ mod tests {
                 _ => "",
             };
             let notes_want = target(provider_id, legacy_model, "high");
-            for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            for backend in [
+                BrainBackend::Cloud,
+                BrainBackend::Local,
+                BrainBackend::Off,
+                BrainBackend::AppleFoundation,
+            ] {
                 let cfg = legacy_cfg(provider_id, backend);
                 // Notes ignores brain_backend entirely.
                 assert_eq!(resolve(Role::Notes, &cfg), notes_want, "{provider_id}/{backend:?}");
@@ -293,6 +317,7 @@ mod tests {
                     BrainBackend::Cloud => notes_want.clone(),
                     BrainBackend::Local => target(CONN_LOCAL, "bielik-11b-v3", ""),
                     BrainBackend::Off => target(CONN_OFF, "", ""),
+                    BrainBackend::AppleFoundation => target(CONN_AFM, "", ""),
                 };
                 for role in [Role::Ask, Role::Live] {
                     assert_eq!(
@@ -352,7 +377,13 @@ mod tests {
     /// identical for every backend (the RED/GREEN proof for the gate swap).
     #[test]
     fn reasoner_only_matches_legacy_cloud_gate_under_fallback() {
-        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+        // AppleFoundation is reasoner-only ⇒ the cloud agentic gate is CLOSED for it (like Local/Off).
+        for backend in [
+            BrainBackend::Cloud,
+            BrainBackend::Local,
+            BrainBackend::Off,
+            BrainBackend::AppleFoundation,
+        ] {
             let cfg = legacy_cfg("claude_code", backend);
             let legacy_gate_open = backend == BrainBackend::Cloud;
             for role in [Role::Ask, Role::Live] {
@@ -371,7 +402,12 @@ mod tests {
     #[test]
     fn provider_target_is_default_triple_under_fallback_for_all_backends() {
         for provider_id in ["claude_code", "anthropic", "ollama", "gateway"] {
-            for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+            for backend in [
+                BrainBackend::Cloud,
+                BrainBackend::Local,
+                BrainBackend::Off,
+                BrainBackend::AppleFoundation,
+            ] {
                 let cfg = legacy_cfg(provider_id, backend);
                 let want = legacy_default_target(&cfg);
                 for role in [Role::Notes, Role::Ask, Role::Live] {
@@ -405,7 +441,12 @@ mod tests {
     /// from `provider_id` instead would cloud-dispatch an Off/Local install's pre-analysis.
     #[test]
     fn reasoner_target_maps_brain_backend_for_all_roles_under_fallback() {
-        for backend in [BrainBackend::Cloud, BrainBackend::Local, BrainBackend::Off] {
+        for backend in [
+            BrainBackend::Cloud,
+            BrainBackend::Local,
+            BrainBackend::Off,
+            BrainBackend::AppleFoundation,
+        ] {
             let cfg = legacy_cfg("claude_code", backend);
             let want = legacy_brain_target(&cfg);
             for role in [Role::Notes, Role::Ask, Role::Live] {
@@ -436,6 +477,44 @@ mod tests {
         assert_eq!(Role::Live.as_str(), "live");
         assert!(target(CONN_LOCAL, "", "").is_reasoner_only());
         assert!(target(CONN_OFF, "", "").is_reasoner_only());
+        assert!(target(CONN_AFM, "", "").is_reasoner_only());
         assert!(!target("claude_code", "", "").is_reasoner_only());
+    }
+
+    /// WS2 — the AppleFoundation backend maps to the on-device AFM reasoner-only target across all
+    /// three resolution views, is auto-excluded from the cloud agentic gate, renders a human display
+    /// name, and is reachable BOTH via `brain_backend = AppleFoundation` (legacy path) AND via an
+    /// explicit `role_*_connection = "apple"` key (explicit path).
+    #[test]
+    fn apple_foundation_maps_to_afm_reasoner_only() {
+        let want = target(CONN_AFM, "", "");
+
+        // (a) brain_backend = AppleFoundation → CONN_AFM for the reasoner + resolve views (Ask/Live).
+        let cfg = AppConfig {
+            brain_backend: BrainBackend::AppleFoundation,
+            ..AppConfig::default()
+        };
+        assert_eq!(legacy_brain_target(&cfg), want);
+        for role in [Role::Ask, Role::Live] {
+            assert_eq!(resolve(role, &cfg), want, "{role:?}");
+            assert_eq!(reasoner_target(role, &cfg), want, "{role:?}");
+            // The cloud agentic-eligibility gate (commands.rs) auto-excludes AFM like Local/Off.
+            assert!(resolve(role, &cfg).is_reasoner_only(), "{role:?} must be reasoner-only");
+        }
+
+        // (b) A human-facing display name (never the raw token) — mirrors the FE label.
+        assert_eq!(connection_display_name(CONN_AFM), "Apple Intelligence (on-device)");
+        assert_ne!(connection_display_name(CONN_AFM), CONN_AFM);
+
+        // (c) An EXPLICIT per-role `apple` key also routes to AFM and stays reasoner-only (the
+        // provider factory then refuses to build a cloud provider for it — is_reasoner_only == true).
+        let explicit = AppConfig {
+            role_ask_connection: "apple".to_string(),
+            ..AppConfig::default()
+        };
+        assert_eq!(resolve(Role::Ask, &explicit), want);
+        assert_eq!(reasoner_target(Role::Ask, &explicit), want);
+        assert!(provider_target(Role::Ask, &explicit).is_reasoner_only());
+        assert_eq!(provider_target(Role::Ask, &explicit).connection, CONN_AFM);
     }
 }


### PR DESCRIPTION
## Tier 2 — the on-device reasoner unlock (seam; native sidecar deferred)

Adds `BrainBackend::AppleFoundation` as a first-class **on-device** `LocalReasoner`. Today a zero-egress reasoner needs a 2–9 GB GGUF download nobody performs (so `brain_backend` defaults to Cloud); Apple Foundation Models (macOS 26+, ~1 GB, OS-resident, Polish-capable, guaranteed-structured `@Generable`) removes that barrier. This ships the **Rust seam + graceful fallback**; the native `@Generable` Swift sidecar needs a macOS-26 SDK (this Mac is CLT-only) and is **deferred to a signed Mac**.

- `reason/afm.rs`: `AfmReasoner` shells to a `meetnotes-afm` sidecar over stdio; absent → `StubReasoner` (never a panic). Hardened spawn (`env_clear` → no DEK/KEK reaches the child; request on stdin only, never disk). Pure `build_afm_request`/`parse_afm_response` with fixture round-trip tests.
- **Anti-egress ordering (load-bearing):** AFM is on-device, so it is intentionally *not* `cloud_egress_consented`-gated and *not* `RedactingProvider`-wrapped. The `CONN_AFM` arm is inserted **before** the `CloudReasoner` catch-all in `ReasonerCell::current_for`, so an AFM role can never silently cloud-dispatch (ordering test is RED-proven), and `provider_for` refuses the reasoner-only `apple` target so no cloud provider can be built for it.
- `afm_available()` device-capability probe (commands.rs + lib.rs).

### Safety (both gates PASS)
- lock-security **PASS** — no HTTP client, local sidecar only, `env_clear`'d child, no new content read/egress path, `afm_available` reads no content. Review flagged a release-reachable `MURMUR_AFM_SIDECAR` override → **hardened to `#[cfg(any(test, debug_assertions))]`** (matches the `MURMUR_DEV_*` precedent) so a signed release can't be pointed at a bring-your-own sidecar.
- adversarial **PASS** — RED-before-GREEN on both the anti-egress ordering and the `env_clear` child isolation; crash-safe (absent sidecar → stub, no abort); no new dep.

### Deferred to a signed macOS-26 Mac
The native `afm/afm.swift` (`@Generable` FoundationModels), the real forward pass, and the **zero-egress network capture** proving it pins `SystemLanguageModel.default` (not Private Cloud Compute) before the experimental flag comes off. `brain_backend` default stays `Cloud`.

`cargo test --lib` **828 passed / 0 failed** (+16 tests).