### PR TITLE
feat(brain): Trust Layer — ASR confidence + deterministic grounding (Tier 3b)

### DIFF
--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -88,6 +88,8 @@ pub fn merge_streams(streams: Vec<StreamInput>) -> Vec<Segment> {
                         .clone()
                         .unwrap_or_else(|| stream.speaker.to_string()),
                 ),
+                // Carry the ASR confidence through the wall-clock merge unchanged (metadata).
+                confidence: seg.confidence,
             });
         }
     }
@@ -298,6 +300,7 @@ mod tests {
             end_s,
             text: text.into(),
             speaker: None,
+            confidence: None,
         }
     }
 
@@ -490,7 +493,7 @@ mod tests {
     use crate::audio::align::EchoLeak;
 
     fn seg_sp(start_s: f64, end_s: f64, text: &str, speaker: &str) -> Segment {
-        Segment { idx: 0, start_s, end_s, text: text.into(), speaker: Some(speaker.into()) }
+        Segment { idx: 0, start_s, end_s, text: text.into(), speaker: Some(speaker.into()), confidence: None }
     }
     fn leak(corr: f32) -> EchoLeak {
         EchoLeak { offset_s: 0.3, correlation: corr }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3547,6 +3547,11 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default — an
         // older FE payload can never silently turn memory off.
         user_memory_enabled: d.user_memory_enabled,
+        // Tier 3b (B) grounding: NOT yet carried on the settings DTO (the FE toggle is a follow-up),
+        // so PRESERVE the live value here — a normal settings save can neither enable nor clear it,
+        // and it round-trips through the dedicated K_GROUND_SUMMARY load/save keys. Mirrors the
+        // preserve-only discipline used for consent + embedder id.
+        ground_summary: current.ground_summary,
         // Model-role keys ARE settable from the DTO (a future Settings UI owns the rows), like
         // `gateway_model` — plain strings, `""` = inherit legacy. An omitted key deserializes to
         // `""` (`#[serde(default)]`), so an older FE payload can never flip a role.
@@ -7228,8 +7233,8 @@ mod lifecycle_tests {
         db.insert_segments(
             mid,
             &[
-                Segment { idx: 0, start_s: 0.0, end_s: 2.0, text: "alpha bravo".to_string(), speaker: None },
-                Segment { idx: 1, start_s: 2.0, end_s: 4.0, text: "charlie delta".to_string(), speaker: None },
+                Segment { idx: 0, start_s: 0.0, end_s: 2.0, text: "alpha bravo".to_string(), speaker: None, confidence: None },
+                Segment { idx: 1, start_s: 2.0, end_s: 4.0, text: "charlie delta".to_string(), speaker: None, confidence: None },
             ],
         )
         .unwrap();

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -670,22 +670,47 @@ pub(crate) fn build_transcript_feed(
         .collect();
     let labeled = distinct.len() >= 2;
 
+    // Tier 3b/A3 — PREVENTIVE [UNCLEAR] MARKING. Prefix an acoustically-shaky segment (ASR
+    // `confidence < LOW_CONFIDENCE_P`) so the summarizer is TOLD which spans are garbled and does not
+    // confidently mint an action item from bad audio. NON-ACTIVATING BY DEFAULT: `confidence` is only
+    // computed on the Accurate batch path with a real model — on CI / model-less installs every
+    // segment is `None` ⇒ no prefix ⇒ `summary_text` is BYTE-IDENTICAL to before (the mono-`me`
+    // default egress is unchanged). The marker is a fixed on-device token (no PII) and rides
+    // `req.transcript` through the SAME RedactingProvider firewall as the rest of the feed — no new
+    // egress class, no side channel. `retrieval_text` is NEVER prefixed (retrieval stays flat).
+    let unclear = |s: &crate::transcribe::types::Segment| -> &'static str {
+        if s.confidence
+            .map(|c| c < crate::summarize::grounding::LOW_CONFIDENCE_P)
+            .unwrap_or(false)
+        {
+            "[UNCLEAR] "
+        } else {
+            ""
+        }
+    };
+
     let summary_text = if labeled {
         // The line shape is IDENTICAL to summarize::timeline's feed so the model reads one convention.
         kept.iter()
             .map(|s| {
                 format!(
-                    "[{:.1}-{:.1}] ({}) {}",
+                    "[{:.1}-{:.1}] ({}) {}{}",
                     s.start_s,
                     s.end_s,
                     s.speaker.as_deref().unwrap_or(SPEAKER_ME),
+                    unclear(s),
                     s.text.trim()
                 )
             })
             .collect::<Vec<_>>()
             .join("\n")
     } else {
-        retrieval_text.clone()
+        // Flat join, but with the [UNCLEAR] prefix on shaky segments. All-`None` ⇒ every prefix is
+        // "" ⇒ this equals `retrieval_text` exactly (the single-speaker byte-identical guarantee).
+        kept.iter()
+            .map(|s| format!("{}{}", unclear(s), s.text.trim()))
+            .collect::<Vec<_>>()
+            .join(" ")
     };
 
     TranscriptFeed {
@@ -837,6 +862,25 @@ async fn summarize_and_export(
     // The `manual_notes` buffer stays the DURABLE CANONICAL store — never blanked here, so
     // every (re)summarize re-reads it fresh in EITHER mode; empty buffer ⇒ byte-identical.
     let markdown = finalize_note_markdown(&generated, &manual_notes, &config.notes_mode);
+
+    // Tier 3b (B) — DETERMINISTIC GROUNDING (anti-hallucination). Annotate summary units this
+    // meeting's OWN transcript does not support with a non-destructive `> unverified` line (or
+    // `(low audio confidence)` when the overlap was acoustically shaky). Gated by `ground_summary`
+    // (default OFF / opt-in until the overlap thresholds are calibrated on real data — an over-flag
+    // would `> unverified` a legitimately-abstractive sentence in the note 100% of users read).
+    // GATE/EGRESS posture: reads ONLY `get_segments(meeting_id)` — this meeting's own
+    // segments, the SAME plaintext the pipeline just summarized — so it adds NO new read path, NO
+    // cross-meeting read, and NO egress (pure local string ops). The markers become part of the note
+    // markdown and are sealed WITH it. Best-effort: a `get_segments` failure degrades to no segments
+    // ⇒ `annotate_unverified` returns the note byte-identical; it NEVER fails the pipeline. Runs
+    // BEFORE `upsert_note` + the vault write so the DB copy and the exported `.md` carry the same
+    // grounded body.
+    let markdown = if config.ground_summary {
+        let segments = state.db.get_segments(meeting_id).unwrap_or_default();
+        crate::summarize::grounding::annotate_unverified(&markdown, &segments)
+    } else {
+        markdown
+    };
 
     state
         .db
@@ -1383,6 +1427,7 @@ mod tests {
             end_s: end,
             text: text.to_string(),
             speaker: speaker.map(str::to_string),
+            confidence: None,
         }
     }
 
@@ -1435,6 +1480,48 @@ mod tests {
         assert!(!feed.summary_text.contains("Klaudku") && !feed.summary_text.contains("pogodę"));
         assert!(feed.summary_text.contains("(me) let's plan the launch"));
         assert!(feed.summary_text.contains("(others) sounds good"));
+    }
+
+    /// Tier 3b/A3: a shaky segment (`confidence < LOW_CONFIDENCE_P`) is prefixed `[UNCLEAR]` in the
+    /// summarizer feed; high-confidence + `None` segments are NOT; `retrieval_text` NEVER carries the
+    /// marker; and a feed with ALL-`None` confidence is byte-identical to today (no-regression proof
+    /// for the model-less / CI default).
+    #[test]
+    fn feed_marks_low_confidence_segments_unclear() {
+        let mut low = seg(0, 0.0, 2.0, Some("me"), "the garbled acoustic span");
+        low.confidence = Some(0.30);
+        let mut hi = seg(1, 2.0, 5.0, Some("others"), "the clear response here");
+        hi.confidence = Some(0.95);
+        let feed = build_transcript_feed(&[low, hi]);
+        assert!(feed.labeled);
+        // The low-confidence line is marked; the confident one is not.
+        assert!(
+            feed.summary_text.contains("(me) [UNCLEAR] the garbled acoustic span"),
+            "low-confidence span must be prefixed [UNCLEAR]; got: {}",
+            feed.summary_text
+        );
+        assert!(feed.summary_text.contains("(others) the clear response here"));
+        assert!(!feed.summary_text.contains("[UNCLEAR] the clear"));
+        // Retrieval text is never perturbed by the marker.
+        assert!(!feed.retrieval_text.contains("[UNCLEAR]"));
+
+        // No-regression: ALL-None confidence ⇒ summary_text is byte-identical to the pre-A3 output
+        // (both the labeled and the flat single-speaker paths).
+        let none_multi = vec![
+            seg(0, 0.0, 2.0, Some("me"), "hi there"),
+            seg(1, 2.0, 6.0, Some("others"), "great to meet you"),
+        ];
+        assert_eq!(
+            build_transcript_feed(&none_multi).summary_text,
+            "[0.0-2.0] (me) hi there\n[2.0-6.0] (others) great to meet you"
+        );
+        let none_solo = vec![
+            seg(0, 0.0, 2.0, Some("me"), "hello everyone"),
+            seg(1, 2.0, 5.0, None, "let's begin"),
+        ];
+        let solo = build_transcript_feed(&none_solo);
+        assert_eq!(solo.summary_text, "hello everyone let's begin");
+        assert_eq!(solo.summary_text, solo.retrieval_text);
     }
 
     const HZ: usize = crate::audio::TARGET_RATE_HZ as usize;

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -285,6 +285,20 @@ pub struct AppConfig {
     /// this field existed loads as `true` (memory stays on for existing installs).
     #[serde(default = "default_true")]
     pub user_memory_enabled: bool,
+    /// Tier 3b (B) anti-hallucination — DETERMINISTIC GROUNDING of the generated note. When ON, a
+    /// pure, on-device, ZERO-EGRESS pass (`crate::summarize::grounding`) runs after summarization and
+    /// annotates any summary bullet / action item / prose line whose content words are NOT supported
+    /// by this meeting's OWN transcript segments with a non-destructive `> unverified` blockquote
+    /// (`> unverified (low audio confidence)` when the best-overlapping segments were acoustically
+    /// shaky). NON-DESTRUCTIVE: the original line stays byte-identical (action-item parsing is
+    /// unaffected); it only APPENDS a marker. Default OFF / OPT-IN (`#[serde(default)]` ⇒ `false`):
+    /// the overlap thresholds are UNCALIBRATED placeholders, so an over-flag would `> unverified` a
+    /// legitimately-abstractive sentence and degrade the note 100% of users read — it must stay opt-in
+    /// until a gold-label precision/recall pass on real data justifies flipping the default. PRESERVE-
+    /// ONLY on the settings DTO for now (the FE toggle is a follow-up) — a normal settings save neither
+    /// grants nor clears it; it round-trips through the load/save keys.
+    #[serde(default)]
+    pub ground_summary: bool,
     /// Model-role override — the CONNECTION serving the **Notes** role (everything Murmur writes).
     /// `""` (the default, and every pre-role install) = inherit the legacy mapping EXACTLY — see
     /// [`crate::summarize::roles::resolve`]. Values: `claude_code`/`anthropic`/`ollama`/`gateway`
@@ -375,6 +389,7 @@ impl Default for AppConfig {
             gateway_model: String::new(),
             proactive_hints_enabled: true,
             user_memory_enabled: true,
+            ground_summary: false,
             role_notes_connection: String::new(),
             role_notes_model: String::new(),
             role_notes_effort: String::new(),
@@ -432,6 +447,7 @@ const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
 const K_PROACTIVE_HINTS_ENABLED: &str = "proactive_hints_enabled";
 const K_USER_MEMORY_ENABLED: &str = "user_memory_enabled";
+const K_GROUND_SUMMARY: &str = "ground_summary";
 const K_ROLE_NOTES_CONNECTION: &str = "role_notes_connection";
 const K_ROLE_NOTES_MODEL: &str = "role_notes_model";
 const K_ROLE_NOTES_EFFORT: &str = "role_notes_effort";
@@ -590,6 +606,9 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_USER_MEMORY_ENABLED)? {
             cfg.user_memory_enabled = v == "true";
         }
+        if let Some(v) = db.get_setting(K_GROUND_SUMMARY)? {
+            cfg.ground_summary = v == "true";
+        }
         // Model-role keys: `""` is a VALID value (= inherit legacy) and also the default, so the
         // stored value is taken verbatim (mirrors `provider_model`, not `anthropic_model`).
         if let Some(v) = db.get_setting(K_ROLE_NOTES_CONNECTION)? {
@@ -745,6 +764,10 @@ impl AppConfig {
         db.set_setting(
             K_USER_MEMORY_ENABLED,
             if self.user_memory_enabled { "true" } else { "false" },
+        )?;
+        db.set_setting(
+            K_GROUND_SUMMARY,
+            if self.ground_summary { "true" } else { "false" },
         )?;
         db.set_setting(K_ROLE_NOTES_CONNECTION, &self.role_notes_connection)?;
         db.set_setting(K_ROLE_NOTES_MODEL, &self.role_notes_model)?;
@@ -1075,6 +1098,53 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(!AppConfig::load(&db).unwrap().semantic_search_enabled);
+    }
+
+    /// Tier 3b (B): `ground_summary` defaults OFF / opt-in (empty DB ⇒ false, thresholds uncalibrated),
+    /// and both an explicit ON and an explicit OFF round-trip through save/load — so an opt-IN persists
+    /// across reload despite the default-false.
+    #[test]
+    fn ground_summary_defaults_off_and_round_trips_both_ways() {
+        let db = temp_db();
+        // Empty DB (no stored key) ⇒ the default (OFF / opt-in until calibrated).
+        assert!(
+            !AppConfig::load(&db).unwrap().ground_summary,
+            "ground_summary must default OFF on a fresh DB (opt-in until calibrated)"
+        );
+
+        // Explicit ON persists (a maintainer/user opt-in).
+        AppConfig { ground_summary: true, ..Default::default() }
+            .save(&db)
+            .unwrap();
+        assert!(
+            AppConfig::load(&db).unwrap().ground_summary,
+            "an explicit ground_summary opt-in must persist"
+        );
+
+        // Explicit OFF persists.
+        AppConfig { ground_summary: false, ..Default::default() }
+            .save(&db)
+            .unwrap();
+        assert!(!AppConfig::load(&db).unwrap().ground_summary);
+    }
+
+    /// A config payload that OMITS `ground_summary` (persisted before the field existed) deserializes
+    /// it as `false` via `#[serde(default)]` — matching `AppConfig::default` (opt-in until calibrated).
+    #[test]
+    fn missing_ground_summary_deserializes_off() {
+        // A minimal payload carrying only the no-serde-default fields; `ground_summary` is omitted.
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"postAecEnabled":true,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+        assert!(!cfg.ground_summary, "serde default for ground_summary must be false (opt-in)");
     }
 
     #[test]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -446,6 +446,12 @@ impl Db {
         // Guarded ALTER (idempotent); NULL for every row in an open folder.
         Self::add_column_if_missing(&conn, "segments", "text_blob", "BLOB")?;
         Self::add_column_if_missing(&conn, "timelines", "data_blob", "BLOB")?;
+        // Tier 3b/A — per-segment ASR confidence (mean token probability × (1−no_speech), computed on
+        // the Accurate batch path). Guarded ALTER (idempotent, ADDITIVE); NULL for every legacy row
+        // and for `Fast`-path rows → reads back as `confidence: None`. NON-CONTENT metadata (a
+        // probability, never words): seal-blanking (`UPDATE segments SET text=''`) leaves it, exactly
+        // like `start_s`/`end_s`/`speaker`, so it never survives as leaked content.
+        Self::add_column_if_missing(&conn, "segments", "confidence", "REAL")?;
         // Rec #3: faithful per-stream float32 MASTER archives (mic native + system 48k), opt-in.
         // Each is sealed at rest exactly like `audio_path` (→ `<file>.enc`). NULL for every meeting
         // recorded without `keep_hires_masters` → zero change for existing / non-opted users. These
@@ -2357,8 +2363,8 @@ impl Db {
             let mut stmt = tx
                 .prepare(
                     "INSERT OR REPLACE INTO segments
-                       (meeting_id, idx, start_s, end_s, text, speaker)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                       (meeting_id, idx, start_s, end_s, text, speaker, confidence)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 )
                 .map_err(map_err)?;
             for seg in segments {
@@ -2369,6 +2375,7 @@ impl Db {
                     seg.end_s,
                     seg.text,
                     seg.speaker,
+                    seg.confidence,
                 ])
                 .map_err(map_err)?;
             }
@@ -2382,7 +2389,7 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT idx, start_s, end_s, text, speaker
+                "SELECT idx, start_s, end_s, text, speaker, confidence
                    FROM segments WHERE meeting_id = ?1 ORDER BY idx",
             )
             .map_err(map_err)?;
@@ -2395,6 +2402,8 @@ impl Db {
                     text: row.get(3)?,
                     // NULL (legacy / unattributed rows) → None.
                     speaker: row.get(4)?,
+                    // NULL (legacy / Fast-path rows) → None; a stored REAL → Some(f32).
+                    confidence: row.get(5)?,
                 })
             })
             .map_err(map_err)?;
@@ -6309,6 +6318,7 @@ mod tests {
                 end_s: 1.5,
                 text: "hello".into(),
                 speaker: Some("me".into()),
+                confidence: None,
             },
             Segment {
                 idx: 1,
@@ -6316,6 +6326,7 @@ mod tests {
                 end_s: 3.0,
                 text: "world".into(),
                 speaker: None,
+                confidence: None,
             },
         ];
         db.insert_segments("m1", &segs).unwrap();
@@ -6347,6 +6358,43 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM segments", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// Tier 3b/A: `segments.confidence` persists through `insert_segments` → `get_segments`. A stored
+    /// `Some(0.42)` round-trips (within f32 epsilon), a `None` writes NULL and reads back `None`, and
+    /// the additive column never disturbs the other fields.
+    #[test]
+    fn segments_confidence_round_trips() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("mc", "2026-07-03T10:00:00Z"))
+            .unwrap();
+        let segs = vec![
+            Segment {
+                idx: 0,
+                start_s: 0.0,
+                end_s: 1.0,
+                text: "clear speech".into(),
+                speaker: Some("me".into()),
+                confidence: Some(0.42),
+            },
+            Segment {
+                idx: 1,
+                start_s: 1.0,
+                end_s: 2.0,
+                text: "unknown".into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            },
+        ];
+        db.insert_segments("mc", &segs).unwrap();
+        let read = db.get_segments("mc").unwrap();
+        assert_eq!(read.len(), 2);
+        let c0 = read[0].confidence.expect("Some(0.42) must round-trip");
+        assert!((c0 - 0.42).abs() < 1e-6, "confidence drifted: {c0}");
+        assert_eq!(read[1].confidence, None, "NULL confidence must read back as None");
+        // The additive column did not perturb the other fields.
+        assert_eq!(read[0].text, "clear speech");
+        assert_eq!(read[1].speaker.as_deref(), Some("others"));
     }
 
     #[test]
@@ -7972,6 +8020,7 @@ mod lock_tests {
                 end_s: (i + 1) as f64,
                 text: t.to_string(),
                 speaker: if i % 2 == 0 { Some("me".into()) } else { Some("others".into()) },
+                confidence: None,
             })
             .collect();
         db.insert_segments(meeting_id, &segs).unwrap();

--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -1,0 +1,430 @@
+//! Tier 3b (B) — DETERMINISTIC GROUNDING: flag summary units the transcript does not support.
+//!
+//! The #1 category complaint about AI notes is confident fabrication — a hallucinated action item
+//! ("Anna owns the rollout by Friday") that nobody actually said. This pass attacks it with a pure,
+//! on-device, ZERO-EGRESS check: after the model writes the note, every candidate unit (an action
+//! item, a bullet, a prose line) is scored against the meeting's OWN transcript segments. A unit
+//! whose content words are largely ABSENT from the transcript is annotated with a NON-DESTRUCTIVE
+//! `> unverified` blockquote line immediately after it.
+//!
+//! It is modeled on [`crate::summarize::timeline::repair_coverage`]: deterministic, idempotent, and
+//! pure over `(note_markdown, segments)`. Crucially it NEVER rewrites or deletes a line — the
+//! original bullet/checklist stays BYTE-IDENTICAL, so `action_items::parse_action_items` /
+//! `patch_tasks_markdown` still parse it exactly as before; grounding only APPENDS a marker.
+//!
+//! LOCK / EGRESS posture (see `.claude/rules/lock-model.md`): this runs INSIDE the pipeline that
+//! just produced the plaintext note, over that meeting's OWN segments (`Db::get_segments`) — it adds
+//! NO new read path, NO cross-meeting read, and NO egress (100% local string ops). The `> unverified`
+//! lines become part of the note markdown, so they are sealed WITH the note by `seal_note` (no
+//! plaintext survives a lock). `segments.confidence` is non-content metadata (a probability).
+//!
+//! ASR-CONFIDENCE SURFACE (Tier 3b/A → B): the note is an LLM summary with no raw transcript, so the
+//! only honest, guaranteed way to render whisper's per-segment confidence "in the exported note" is
+//! here — when a flagged unit's best-overlapping transcript segments were ALL acoustically shaky
+//! (`Segment.confidence < LOW_CONFIDENCE_P`), the marker becomes `> unverified (low audio confidence)`
+//! so the reader learns the ASR itself was unsure, not that the model invented the claim.
+//!
+//! CALIBRATION HONESTY: the thresholds below are conservative defaults chosen to minimize false
+//! `> unverified`; the RIGHT operating point (precision/recall of the flag vs a human's judgment of
+//! which sentences are truly hallucinated) needs the maintainer's gold labels — a documented
+//! follow-up, NOT provable by `cargo test --lib`. The grounding LOGIC is what these tests lock.
+
+use std::collections::HashSet;
+
+use crate::summarize::related_context::{is_stopword, tokenize};
+use crate::transcribe::types::Segment;
+
+/// Min DISTINCT content tokens a unit needs before we judge it. Shorter units (a bare title, a
+/// two-word bullet, a bold label) carry too little signal to call "unsupported" without false
+/// positives, so they are never flagged.
+const GROUND_MIN_CONTENT_TOKENS: usize = 3;
+
+/// A unit is UNVERIFIED when fewer than this fraction of its distinct content tokens appear anywhere
+/// in the transcript. Conservative on purpose (flag only clearly-unsupported units). The exact
+/// operating point is a maintainer-calibration follow-up (needs gold labels).
+const GROUND_MIN_COVERAGE: f64 = 0.5;
+
+/// Per-segment ASR confidence below this reads as "acoustically shaky". When a flagged unit's
+/// best-overlapping segments are ALL this low, the annotation names the likely cause ("low audio
+/// confidence") instead of a plain "unverified". Aligns with the whisper compute (higher = more
+/// certain); the value is a placeholder pending signed-Mac calibration. `pub(crate)` because the
+/// summarizer-feed `[UNCLEAR]` prefix (A3, `pipeline::build_transcript_feed`) uses the SAME
+/// threshold — one operating point to calibrate, not two.
+pub(crate) const LOW_CONFIDENCE_P: f32 = 0.55;
+
+/// The non-destructive markers appended after an unsupported unit. Both start with `> unverified`,
+/// so the idempotency check (`next line is already a marker`) covers either variant.
+const UNVERIFIED: &str = "> unverified";
+const UNVERIFIED_LOW_AUDIO: &str = "> unverified (low audio confidence)";
+
+/// Annotate `note_markdown`, appending a `> unverified` line after every candidate unit whose content
+/// is not supported by `segments`. Deterministic, idempotent, and pure. The YAML front-matter, the
+/// `## My notes` / `## Related prior notes` sections (which legitimately hold content NOT in THIS
+/// transcript), headings, code fences, existing blockquotes, and wikilink-only lines are all left
+/// untouched. With no usable transcript, the note is returned BYTE-IDENTICAL (nothing to verify
+/// against — never guess a leak or a false flag).
+pub fn annotate_unverified(note_markdown: &str, segments: &[Segment]) -> String {
+    // Build the per-segment content-token sets ONCE, dropping empty + assistant-directed spans with
+    // the IDENTICAL predicate the summarizer feed uses (`pipeline::build_transcript_feed`) — an
+    // assistant command ("Klaudku, …") is not transcript evidence.
+    let seg_tokens: Vec<(HashSet<String>, Option<f32>)> = segments
+        .iter()
+        .filter(|s| {
+            let t = s.text.trim();
+            !t.is_empty() && !crate::audio::wake::is_assistant_directed(t)
+        })
+        .map(|s| (content_tokens(&s.text), s.confidence))
+        .collect();
+
+    // The global support set: every content token spoken anywhere in the (filtered) transcript.
+    let transcript: HashSet<String> = seg_tokens
+        .iter()
+        .flat_map(|(set, _)| set.iter().cloned())
+        .collect();
+
+    // Nothing to ground against ⇒ return byte-identical (can't verify against an empty transcript).
+    if transcript.is_empty() {
+        return note_markdown.to_string();
+    }
+
+    // Split off the YAML front-matter (never annotated); `body` is what we walk.
+    let (front, body) = split_frontmatter(note_markdown);
+
+    let lines: Vec<&str> = body.split('\n').collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 8);
+    let mut in_code_fence = false;
+    let mut in_skipped_section = false;
+
+    for (i, &line) in lines.iter().enumerate() {
+        // Always keep the original line verbatim (non-destructive).
+        out.push(line.to_string());
+        let trimmed = line.trim();
+
+        // Code fences: toggle state; never annotate the fence line or anything inside a fence.
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+
+        // Headings: re-evaluate the skip-section state from THIS heading's own title, then move on
+        // (a heading is never a candidate unit). A `## My notes` / `## Related prior notes` heading
+        // enters a skipped section; any other heading leaves it.
+        if trimmed.starts_with('#') {
+            in_skipped_section = is_skipped_heading(trimmed);
+            continue;
+        }
+        if in_skipped_section {
+            continue;
+        }
+
+        // Non-candidate lines: blanks, existing blockquotes (incl. our own markers → idempotency).
+        if trimmed.is_empty() || trimmed.starts_with('>') {
+            continue;
+        }
+
+        // Strip the list/checkbox marker so it doesn't pollute tokens; skip wikilink-only citations.
+        let unit = unit_content(trimmed);
+        if is_wikilink_only(unit) {
+            continue;
+        }
+
+        let toks = content_tokens(unit);
+        if toks.len() < GROUND_MIN_CONTENT_TOKENS {
+            continue;
+        }
+        let covered = toks.iter().filter(|t| transcript.contains(*t)).count();
+        let coverage = covered as f64 / toks.len() as f64;
+        if coverage >= GROUND_MIN_COVERAGE {
+            continue;
+        }
+
+        // Idempotency: if the next non-empty ORIGINAL line is already a `> unverified` marker, skip
+        // (mirrors `repair_is_idempotent` — running the pass twice is a no-op).
+        if next_nonempty_is_marker(&lines, i + 1) {
+            continue;
+        }
+
+        // ASR-confidence surface: when the unit's best-overlapping segments are ALL known-low
+        // confidence, name the likely cause; otherwise a plain "unverified".
+        let marker = if best_overlap_all_low_confidence(&toks, &seg_tokens) {
+            UNVERIFIED_LOW_AUDIO
+        } else {
+            UNVERIFIED
+        };
+        out.push(marker.to_string());
+    }
+
+    let annotated_body = out.join("\n");
+    match front {
+        Some(fm) => format!("{fm}{annotated_body}"),
+        None => annotated_body,
+    }
+}
+
+/// Distinct, lowercased, stopword-stripped content tokens (reusing the retrieval tokenizer +
+/// stopword list — one source of truth, PL-aware).
+fn content_tokens(s: &str) -> HashSet<String> {
+    tokenize(s).into_iter().filter(|t| !is_stopword(t)).collect()
+}
+
+/// Strip a leading list / checklist / numbered marker from a trimmed line so the marker glyphs
+/// (`- [ ]`, `* `, `1. `) never count as content tokens. Returns the remainder verbatim.
+fn unit_content(trimmed: &str) -> &str {
+    for cb in [
+        "- [ ] ", "- [x] ", "- [X] ", "* [ ] ", "* [x] ", "* [X] ", "+ [ ] ", "+ [x] ", "+ [X] ",
+    ] {
+        if let Some(r) = trimmed.strip_prefix(cb) {
+            return r;
+        }
+    }
+    for b in ["- ", "* ", "+ "] {
+        if let Some(r) = trimmed.strip_prefix(b) {
+            return r;
+        }
+    }
+    // Numbered list marker: leading ASCII digits then ". " or ") ".
+    let digits = trimmed.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0 {
+        let after = &trimmed[digits..];
+        if let Some(r) = after.strip_prefix(". ").or_else(|| after.strip_prefix(") ")) {
+            return r;
+        }
+    }
+    trimmed
+}
+
+/// True when `content` is ONLY `[[wikilink]]` citations (plus punctuation/whitespace) — a link line
+/// legitimately references another note's title, which is not spoken in THIS transcript, so it must
+/// never be flagged. Detected by removing every `[[…]]` span and checking the remainder for any
+/// alphanumeric content.
+fn is_wikilink_only(content: &str) -> bool {
+    let mut remainder = String::new();
+    let mut rest = content;
+    while let Some(open) = rest.find("[[") {
+        remainder.push_str(&rest[..open]);
+        match rest[open + 2..].find("]]") {
+            Some(close_rel) => rest = &rest[open + 2 + close_rel + 2..],
+            None => {
+                // Unbalanced `[[` — keep the tail so a stray bracket alone isn't treated as a link.
+                remainder.push_str(&rest[open..]);
+                rest = "";
+                break;
+            }
+        }
+    }
+    remainder.push_str(rest);
+    !remainder.chars().any(|c| c.is_alphanumeric())
+}
+
+/// Whether a heading opens a section that legitimately carries content NOT in the transcript (the
+/// user's typed `## My notes`, the `## Related prior notes` grounding corpus) — those must never be
+/// flagged as unverified. Case-insensitive, tolerant of a title suffix.
+fn is_skipped_heading(trimmed_heading: &str) -> bool {
+    let title = trimmed_heading
+        .trim_start_matches('#')
+        .trim()
+        .to_lowercase();
+    title.starts_with("my notes") || title.starts_with("related prior notes")
+}
+
+/// Whether the first non-empty line at/after `start` is already a `> unverified` marker (either
+/// variant). Guards idempotency.
+fn next_nonempty_is_marker(lines: &[&str], start: usize) -> bool {
+    lines
+        .get(start..)
+        .and_then(|rest| rest.iter().find(|l| !l.trim().is_empty()))
+        .map(|l| l.trim().starts_with(UNVERIFIED))
+        .unwrap_or(false)
+}
+
+/// Whether the segments that OVERLAP a unit the most were all acoustically shaky. Returns true only
+/// when there IS overlapping support AND every max-overlap segment has a KNOWN confidence below
+/// [`LOW_CONFIDENCE_P`] (a `None` confidence is UNKNOWN, not low — we never over-claim "low audio").
+fn best_overlap_all_low_confidence(
+    unit_tokens: &HashSet<String>,
+    seg_tokens: &[(HashSet<String>, Option<f32>)],
+) -> bool {
+    let mut best = 0usize;
+    let mut best_confs: Vec<Option<f32>> = Vec::new();
+    for (toks, conf) in seg_tokens {
+        let overlap = unit_tokens.iter().filter(|t| toks.contains(*t)).count();
+        if overlap == 0 {
+            continue;
+        }
+        if overlap > best {
+            best = overlap;
+            best_confs.clear();
+            best_confs.push(*conf);
+        } else if overlap == best {
+            best_confs.push(*conf);
+        }
+    }
+    !best_confs.is_empty()
+        && best_confs
+            .iter()
+            .all(|c| c.map(|v| v < LOW_CONFIDENCE_P).unwrap_or(false))
+}
+
+/// Split a note into `(front_matter, body)`. The front-matter is a leading `---\n … \n---\n` block
+/// (mirrors `export::inject_provenance_frontmatter`'s split); it is returned whole so a re-join is
+/// byte-exact and is NEVER annotated. A note without front-matter is all body. A note that is ONLY
+/// front-matter (or a malformed unterminated block) yields an empty body ⇒ no annotation.
+fn split_frontmatter(md: &str) -> (Option<&str>, &str) {
+    let Some(rest) = md.strip_prefix("---\n") else {
+        return (None, md);
+    };
+    let open = "---\n".len();
+    if let Some(pos) = rest.find("\n---\n") {
+        let end = open + pos + "\n---\n".len();
+        (Some(&md[..end]), &md[end..])
+    } else {
+        // Opened but never closed with content after it (whole-note front-matter or malformed) — be
+        // conservative: treat all of it as front-matter, leaving an empty body (nothing annotated).
+        (Some(md), "")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(text: &str, confidence: Option<f32>) -> Segment {
+        Segment {
+            idx: 0,
+            start_s: 0.0,
+            end_s: 1.0,
+            text: text.into(),
+            speaker: Some("others".into()),
+            confidence,
+        }
+    }
+
+    /// RED-before-GREEN: an action item the transcript never supports gets a following `> unverified`
+    /// line, while a SUPPORTED summary sentence stays clean. Reverting `annotate_unverified` to a
+    /// no-op drops the marker (RED). The marker here is the PLAIN variant (no overlapping segment).
+    #[test]
+    fn unsupported_action_item_gets_unverified() {
+        let segments = vec![
+            seg("we shipped the login page and the payment flow this week", None),
+            seg("the database migration is done", None),
+        ];
+        let note = "## Summary\n\nThe team shipped the login page.\n\n## Action items\n\n- [ ] Anna own the rollout by Friday\n";
+        let out = annotate_unverified(note, &segments);
+
+        // The fabricated action item (anna/own/rollout/friday absent from the transcript) is flagged.
+        assert!(
+            out.contains("- [ ] Anna own the rollout by Friday\n> unverified\n"),
+            "unsupported action item must gain a plain `> unverified` line; got:\n{out}"
+        );
+        // No overlapping segment ⇒ NOT the low-audio variant.
+        assert!(!out.contains("low audio confidence"), "no segment overlaps ⇒ plain marker");
+        // The supported summary sentence (login/page/shipped are in the transcript) stays clean.
+        assert!(
+            out.contains("The team shipped the login page.\n\n## Action items"),
+            "a supported sentence must not be annotated; got:\n{out}"
+        );
+    }
+
+    /// Running the pass twice is byte-identical to running it once (mirrors `repair_is_idempotent`).
+    #[test]
+    fn annotate_is_idempotent() {
+        let segments = vec![seg("we shipped the login page this week", None)];
+        let note = "## Action items\n\n- [ ] Zenon rebuild the reactor core tomorrow\n";
+        let once = annotate_unverified(note, &segments);
+        let twice = annotate_unverified(&once, &segments);
+        assert_eq!(once, twice, "annotate must be idempotent");
+        // And it actually annotated on the first pass (guards a vacuous idempotency).
+        assert!(once.contains("> unverified"));
+    }
+
+    /// No false positives: front-matter, headings, wikilink-only lines, pre-existing blockquotes, and
+    /// the `## My notes` section are all left byte-identical even though their words are NOT in the
+    /// transcript. RED if the wikilink-only skip or the section skip regresses.
+    #[test]
+    fn frontmatter_headings_wikilinks_and_user_sections_untouched() {
+        let segments = vec![seg("completely different words were spoken aloud", None)];
+        let note = "---\ntitle: Test\ntags: [a]\n---\n\n# Summary\n\n[[Some Wikilink Page Reference Title Here]]\n\n> a pre-existing quote with several unsupported words indeed present\n\n## My notes\n\nmy typed personal reminder that never appears in the transcript whatsoever\n";
+        let out = annotate_unverified(note, &segments);
+        assert_eq!(
+            out, note,
+            "front-matter / headings / wikilink-only / blockquote / `## My notes` must be untouched"
+        );
+    }
+
+    /// With no usable transcript (empty slice, or only assistant-directed spans), the note is
+    /// returned byte-identical — grounding never invents a flag when it has nothing to verify against.
+    #[test]
+    fn empty_or_assistant_only_transcript_yields_no_annotations() {
+        let note = "## Summary\n\n- [ ] some unsupported action item written here today\n";
+        // Empty segments.
+        assert_eq!(annotate_unverified(note, &[]), note);
+        // Only an assistant-directed command → excluded → transcript empty → unchanged.
+        let cmd = vec![seg("Klaudku, sprawdź pogodę w Warszawie na jutro", None)];
+        assert_eq!(annotate_unverified(note, &cmd), note);
+    }
+
+    /// Parse safety: after annotation, `action_items::parse_action_items` returns the SAME count and
+    /// owners — the `- [ ]` lines stay byte-identical and the appended `> unverified` line is not a
+    /// checklist item, so task parsing/patching is unaffected.
+    #[test]
+    fn action_item_parsing_unchanged_after_annotation() {
+        use crate::summarize::action_items::parse_action_items;
+        let segments = vec![seg("we agreed to ship the invoice export next sprint", None)];
+        let note = "## Action items\n\n- [ ] Bob — ship the invoice export next sprint\n- [ ] Zoltan — colonize the moon by Q3\n";
+        let before = parse_action_items(note);
+        let out = annotate_unverified(note, &segments);
+
+        // The supported item stays clean; the fabricated one is flagged.
+        assert!(out.contains("Zoltan — colonize the moon by Q3\n> unverified"));
+        assert!(!out.contains("invoice export next sprint\n> unverified"));
+
+        let after = parse_action_items(&out);
+        assert_eq!(before.len(), after.len(), "task count must be unchanged");
+        let owners_before: Vec<_> = before.iter().map(|a| a.owner.clone()).collect();
+        let owners_after: Vec<_> = after.iter().map(|a| a.owner.clone()).collect();
+        assert_eq!(owners_before, owners_after, "task owners must be unchanged");
+    }
+
+    /// ASR-confidence surface (A → B): a flagged unit whose best-overlapping segment was acoustically
+    /// shaky (`confidence < LOW_CONFIDENCE_P`) gets the `(low audio confidence)` variant, landing
+    /// whisper's confidence signal verbatim in the exported note.
+    #[test]
+    fn low_confidence_best_overlap_names_the_cause() {
+        // The one segment overlaps the unit on "quarterly" but was decoded at low confidence.
+        let segments = vec![seg("mumbling something about the quarterly figures", Some(0.30))];
+        let note = "## Summary\n\nThe quarterly revenue tripled after the acquisition finally closed.\n";
+        let out = annotate_unverified(note, &segments);
+        assert!(
+            out.contains("> unverified (low audio confidence)"),
+            "a flagged unit whose overlap is all-low-confidence must name the cause; got:\n{out}"
+        );
+    }
+
+    /// A high-confidence overlapping segment on an otherwise-unsupported unit yields the PLAIN marker
+    /// (the ASR was sure; the model still over-reached) — proves the low-audio branch is confidence-
+    /// gated, not just overlap-gated.
+    #[test]
+    fn high_confidence_overlap_stays_plain() {
+        let segments = vec![seg("something about the quarterly figures", Some(0.95))];
+        let note = "## Summary\n\nThe quarterly revenue tripled after the acquisition finally closed.\n";
+        let out = annotate_unverified(note, &segments);
+        assert!(out.contains("> unverified"));
+        assert!(
+            !out.contains("low audio confidence"),
+            "a confident overlap must not be blamed on audio; got:\n{out}"
+        );
+    }
+
+    /// A too-short unit (below `GROUND_MIN_CONTENT_TOKENS` distinct content tokens) is never flagged,
+    /// even if unsupported — avoids annotating bare labels / two-word bullets.
+    #[test]
+    fn short_unit_is_not_flagged() {
+        let segments = vec![seg("we discussed the budget and the roadmap at length", None)];
+        let note = "## Summary\n\n- Xanadu teleporter\n";
+        let out = annotate_unverified(note, &segments);
+        assert_eq!(out, note, "a 2-token unsupported bullet is below the min and stays clean");
+    }
+}

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -17,6 +17,10 @@ pub mod claude_code;
 pub mod digest;
 pub mod dossier;
 pub mod graph;
+/// Tier 3b (B) anti-hallucination — DETERMINISTIC GROUNDING of the generated note against its own
+/// transcript segments. Pure, on-device, zero-egress; annotates unsupported summary units with a
+/// non-destructive `> unverified` marker.
+pub mod grounding;
 /// The REAL on-device PERSON-name NER redactor (Phase D). ALWAYS compiled; the real impl is selected
 /// at runtime by `redact::active_name_redactor` when the NER model dir is present, else the
 /// byte-identical `NoopNameRedactor` (so a no-model build's name egress is unchanged).

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -755,6 +755,7 @@ mod tests {
                 end_s: 2.0,
                 text: "let's begin".into(),
                 speaker: Some("Anna Kowalska".into()),
+                confidence: None,
             },
             Segment {
                 idx: 1,
@@ -762,6 +763,7 @@ mod tests {
                 end_s: 6.0,
                 text: "sounds good".into(),
                 speaker: Some("me".into()),
+                confidence: None,
             },
         ];
         let feed = crate::pipeline::build_transcript_feed(&segs);

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -44,7 +44,9 @@ pub(crate) fn budget_for(provider_id: &str) -> usize {
 
 /// Basic EN + PL stopword set. Deliberately small + deterministic (no external word-list dep); it
 /// strips the highest-frequency function words so the salient query keys off content terms.
-fn is_stopword(t: &str) -> bool {
+/// `pub(crate)` so the grounding pass (`summarize::grounding`) reuses the SAME word list — one
+/// source of truth, no second stopword set to drift.
+pub(crate) fn is_stopword(t: &str) -> bool {
     const STOP: &[&str] = &[
         // English
         "the", "and", "for", "are", "but", "not", "you", "your", "all", "can", "had", "her", "was",
@@ -70,8 +72,10 @@ fn is_stopword(t: &str) -> bool {
     STOP.contains(&t)
 }
 
-/// Tokenize to lowercased alphanumeric tokens (Unicode-aware; handles PL diacritics).
-fn tokenize(s: &str) -> Vec<String> {
+/// Tokenize to lowercased alphanumeric tokens (Unicode-aware; handles PL diacritics). `pub(crate)`
+/// so the grounding pass (`summarize::grounding`) tokenizes summary units + transcript segments the
+/// SAME way the retrieval query does — no divergent tokenizer.
+pub(crate) fn tokenize(s: &str) -> Vec<String> {
     s.split(|c: char| !c.is_alphanumeric())
         .filter(|t| !t.is_empty())
         .map(|t| t.to_lowercase())

--- a/src-tauri/src/summarize/timeline.rs
+++ b/src-tauri/src/summarize/timeline.rs
@@ -241,6 +241,7 @@ mod tests {
             end_s,
             text: "x".into(),
             speaker: Some("me".into()),
+            confidence: None,
         }
     }
     fn turn(start_s: f64, end_s: f64) -> SpeakerTurn {

--- a/src-tauri/src/transcribe/diarize.rs
+++ b/src-tauri/src/transcribe/diarize.rs
@@ -364,6 +364,7 @@ mod tests {
             end_s,
             text: "x".into(),
             speaker: None,
+            confidence: None,
         }
     }
 

--- a/src-tauri/src/transcribe/types.rs
+++ b/src-tauri/src/transcribe/types.rs
@@ -15,6 +15,16 @@ pub struct Segment {
     /// purely by WHICH capture stream produced the segment, not by voice fingerprinting.
     #[serde(default)]
     pub speaker: Option<String>,
+    /// Per-segment ASR confidence in `[0.0, 1.0]` (higher = the decoder was more certain). Computed
+    /// ONLY on the `Accurate` batch path from whisper's per-token linear probabilities, discounted by
+    /// the segment's no-speech probability (a confident-but-likely-silence decode — the classic
+    /// hallucination — scores low). `None` when not computed: the low-latency live/voice-trigger
+    /// (`Fast`) captions, a legacy row transcribed before this field existed, or a token read that
+    /// yielded nothing. NON-CONTENT METADATA (a probability, never the words), so it survives
+    /// seal-blanking exactly like `start_s`/`end_s`/`speaker`. The grounding pass surfaces a low value
+    /// as `> unverified (low audio confidence)` in the exported note (see `summarize::grounding`).
+    #[serde(default)]
+    pub confidence: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -170,6 +170,41 @@ impl Transcriber {
             let t0 = segment.start_timestamp();
             let t1 = segment.end_timestamp();
 
+            // ASR CONFIDENCE (Tier 3b/A) — ONLY on the `Accurate` batch path (the authoritative,
+            // persisted transcript). The `Fast` live/voice-trigger captions are throwaway (greedy
+            // best_of:1) so they leave `confidence = None`. Confidence = the mean of whisper's
+            // per-token LINEAR probabilities (`token_probability` = `whisper_full_get_token_p`),
+            // DISCOUNTED by the segment's no-speech probability so a confident-but-likely-silence
+            // decode scores low. All getters return plain `f32` / `Option` (`get_token`) — no
+            // fallible call, no `unwrap`, no panic; a segment with no readable tokens yields `None`
+            // rather than a wrong-but-confident value. HONEST SCOPE: the wiring ships here, but the
+            // real confidence VALUES + the `LOW_CONFIDENCE_P` threshold calibration need a loaded
+            // GGUF + Metal on a signed Mac — `cargo test --lib` cannot exercise a real decode.
+            let confidence = if quality == TranscribeQuality::Accurate {
+                let n_tok = segment.n_tokens();
+                if n_tok > 0 {
+                    let mut sum = 0.0_f32;
+                    let mut count = 0_u32;
+                    for tk in 0..n_tok {
+                        if let Some(token) = segment.get_token(tk) {
+                            sum += token.token_probability();
+                            count += 1;
+                        }
+                    }
+                    if count > 0 {
+                        let mean_p = sum / count as f32;
+                        let no_speech = segment.no_speech_probability().clamp(0.0, 1.0);
+                        Some((mean_p * (1.0 - no_speech)).clamp(0.0, 1.0))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
             let trimmed = text.trim();
             if !full_text.is_empty() && !trimmed.is_empty() {
                 full_text.push(' ');
@@ -185,6 +220,7 @@ impl Transcriber {
                 // assigned by the wall-clock merge in `audio::merge` from which stream produced
                 // these segments, not here. Live/voice-trigger callers leave it as `None`.
                 speaker: None,
+                confidence,
             });
         }
 


### PR DESCRIPTION
## Tier 3b — attack the #1 category complaint (hallucinated notes), from signals we already compute

**(A) ASR confidence.** `Segment` gains `confidence: Option<f32>` from whisper-rs's per-segment token/no-speech probabilities (Accurate path, safe getters), persisted via an **additive** `segments.confidence` migration. Low-confidence spans get an `[UNCLEAR]` prefix in the summarizer **feed** so the model doesn't confidently mint action items from garbled audio. **Dormant on model-less installs** (confidence `None` → feed byte-identical); the marker rides `req.transcript` through the same RedactingProvider firewall.

**(B) Deterministic grounding** (`summarize/grounding.rs`). A pure, on-device, zero-egress pass annotates summary lines **unsupported by the meeting's own transcript** with a non-destructive `> unverified` blockquote (original line byte-identical, action-item parsing unaffected, idempotent). Reads only `get_segments(meeting_id)`; markers seal with the note.

### Judgment call — grounding ships OPT-IN
The design spec recommended default-ON, but the overlap thresholds are **uncalibrated placeholders**, so an over-flag would `> unverified` a legitimately-abstractive sentence and degrade the note 100% of users read. Unlike semantic/capture (safe default-ons), this can produce *wrong* output — so `ground_summary` defaults **OFF / opt-in** until a gold-label precision/recall pass justifies flipping it. (`[UNCLEAR]` is a lower-stakes internal summarizer hint, so it stays model-presence-activated.)

### Safety (both gates PASS)
- lock-security **PASS** — additive/idempotent/seal-safe migration (`confidence` survives seal-blanking like `speaker`); `[UNCLEAR]` is a fixed non-PII token through the existing firewall, byte-identical when `None`; grounding reads only the meeting's own segments (no `visibility_clause` bypass), markers seal with the note; no PII in logs; safe whisper getters (no `msg_send`).
- adversarial **PASS** — RED-before-GREEN on both mechanisms; all-`None` default note proven byte-identical; migration non-destructive + idempotent.

### Deferred to a signed Mac
Real confidence **values** + threshold **calibration** (0.55 / 0.5-coverage) need a loaded GGUF + Metal decode + gold labels.

`cargo test --lib` **840 passed / 0 failed** (+12 tests).