### PR TITLE
feat(brain): Privacy Receipt — per-note egress self-report (Tier 4c)

### DIFF
--- a/src-tauri/src/export/obsidian.rs
+++ b/src-tauri/src/export/obsidian.rs
@@ -560,6 +560,109 @@ pub fn inject_provenance_frontmatter(
     format!("---\n{new_fm}{after_close}")
 }
 
+/// Stamp a content-free **PRIVACY RECEIPT** into a note's YAML front-matter — an HONEST
+/// self-report of what left the device to produce this note.
+///
+/// This is a plain self-declared record, **not** a cryptographic attestation and **not** a
+/// verifiable/provable claim: it is exactly as trustworthy as the app that wrote it. Its value is
+/// that a local-only summary can state, in one screenshot-able line, that nothing egressed.
+///
+/// Mirrors [`inject_provenance_frontmatter`] byte-for-byte in structure (strip the opening
+/// `---\n`, find the closing fence, skip keys already present, append the missing keys before the
+/// closing fence, reconstruct). Pure — no I/O, no state — and byte-identical to the input when
+/// there is nothing to inject or the note has no front-matter block.
+///
+/// Keys (all content-FREE — booleans / integer counts / non-PII host labels, NEVER note text,
+/// transcript, attendee names, titles, keys, or DEK/KEK/CK material):
+/// - `privacy-cloud-calls: 0` — stamped **only** when `local_only` (nothing left the device: a
+///   loopback-ollama / on-device-reasoner summary). This is the strong local headline; `0` is
+///   truthful exactly because [`egress_is_cloud`](crate::summarize::egress_is_cloud) — the SAME
+///   classifier the consent gate uses — reports local.
+/// - `privacy-egress-host: <host>` — for a cloud summary, the non-PII destination label
+///   (`api.anthropic.com`, `claude_code (Anthropic CLI)`, a gateway `host:port`, …). Its presence
+///   is the honest signal that the summary DID leave the device, and where.
+/// - `privacy-pii-redacted: <n>` — for a cloud summary with a known count, how many PII items the
+///   redaction firewall scrubbed before egress. Omitted when the count is unknown.
+///
+/// A numeric cloud-CALL count `> 0` is deliberately NOT stamped. The egress ledger is a global
+/// rolling log (per-entry `meeting_id` is `None`), so a call count is not per-note attributable,
+/// and stamping `1` would UNDER-count total cloud activity (entity-extraction / auto-organize also
+/// call the cloud) — the dangerous direction for a privacy claim. The local-vs-host signal is the
+/// honest headline; the numeric receipt for the cloud case is the redaction count, not a call
+/// count. Values need no YAML quoting (host labels carry no `": "` colon-space; unquoted style
+/// matches `inject_provenance_frontmatter`).
+pub fn inject_privacy_receipt_frontmatter(
+    markdown: &str,
+    local_only: bool,
+    egress_host: Option<&str>,
+    redacted_pii: Option<u32>,
+) -> String {
+    // The content-free receipt key(s) to (potentially) inject, in stable order.
+    let mut wanted: Vec<(&str, String)> = Vec::new();
+    if local_only {
+        // Strong local headline: nothing left the device to produce this note.
+        wanted.push(("privacy-cloud-calls", "0".to_string()));
+    } else {
+        // Cloud summary: declare WHERE it went + how much PII the firewall scrubbed. No call COUNT
+        // (not per-note attributable + would under-count — see the doc comment).
+        if let Some(host) = egress_host.map(str::trim).filter(|h| !h.is_empty()) {
+            wanted.push(("privacy-egress-host", host.to_string()));
+        }
+        if let Some(n) = redacted_pii {
+            wanted.push(("privacy-pii-redacted", n.to_string()));
+        }
+    }
+
+    // Nothing to inject — preserve byte identity.
+    if wanted.is_empty() {
+        return markdown.to_string();
+    }
+
+    // The note must start with `---\n` to have a frontmatter block.
+    let Some(rest_after_open) = markdown.strip_prefix("---\n") else {
+        return markdown.to_string();
+    };
+
+    // Find the closing `---` line (same logic as `inject_provenance_frontmatter`).
+    let Some(close_pos) = rest_after_open.find("\n---\n").or_else(|| {
+        if rest_after_open.ends_with("\n---") {
+            Some(rest_after_open.len() - 4)
+        } else {
+            None
+        }
+    }) else {
+        return markdown.to_string();
+    };
+
+    let fm_content = &rest_after_open[..close_pos]; // the YAML lines between the fences
+
+    // Idempotent: keep only keys NOT already present (a defensive double-call within one export is
+    // a no-op; a fresh (re)summarize always builds new markdown, so keys are stamped each time).
+    let missing: Vec<(&str, String)> = wanted
+        .into_iter()
+        .filter(|(k, _)| {
+            let prefix = format!("{k}:");
+            !fm_content.lines().any(|l| l.starts_with(&prefix))
+        })
+        .collect();
+    if missing.is_empty() {
+        return markdown.to_string();
+    }
+
+    // Append the missing keys before the closing fence.
+    let mut new_fm = fm_content.to_string();
+    if !new_fm.ends_with('\n') && !new_fm.is_empty() {
+        new_fm.push('\n');
+    }
+    for (k, v) in &missing {
+        new_fm.push_str(&format!("{k}: {v}\n"));
+    }
+
+    // Reconstruct the full note.
+    let after_close = &rest_after_open[close_pos..]; // starts with `\n---`
+    format!("---\n{new_fm}{after_close}")
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -816,5 +919,108 @@ mod tests {
         assert!(fm.contains("ai-model: claude-opus-4-8"), "model key inside fm: {fm}");
         // Body untouched.
         assert!(out.ends_with("# Body\n"), "body unchanged: {out}");
+    }
+
+    // ── Tier 4c: inject_privacy_receipt_frontmatter (per-note egress self-report) ────────────
+
+    /// LOCAL summary ⇒ only the honest `privacy-cloud-calls: 0` headline is stamped. Even if a
+    /// host / count are (defensively) passed, a local note NEVER stamps a host or pii key.
+    #[test]
+    fn privacy_receipt_local_stamps_zero_cloud_calls_only() {
+        let md = "---\ntitle: T\ndate: 2026-07-03\n---\n# T\n\nBody.\n";
+        let out = inject_privacy_receipt_frontmatter(md, true, Some("api.anthropic.com"), Some(9));
+        assert!(out.contains("privacy-cloud-calls: 0"), "local headline present: {out}");
+        assert!(!out.contains("privacy-egress-host"), "no host for a local note: {out}");
+        assert!(!out.contains("privacy-pii-redacted"), "no pii key for a local note: {out}");
+    }
+
+    /// CLOUD summary ⇒ the non-PII destination host + the real redaction count are stamped, and no
+    /// `privacy-cloud-calls` integer is claimed (not per-note attributable — see the fn doc).
+    #[test]
+    fn privacy_receipt_cloud_stamps_host_and_pii_count() {
+        let md = "---\ntitle: T\n---\nBody.";
+        let out = inject_privacy_receipt_frontmatter(md, false, Some("api.anthropic.com"), Some(14));
+        assert!(out.contains("privacy-egress-host: api.anthropic.com"), "host: {out}");
+        assert!(out.contains("privacy-pii-redacted: 14"), "pii count: {out}");
+        assert!(
+            !out.contains("privacy-cloud-calls"),
+            "no cloud-call count is claimed for a cloud note (would under-count): {out}"
+        );
+    }
+
+    /// CONTENT-FREE & NON-NO-OP: a note whose BODY carries PII must have that PII preserved as
+    /// opaque passthrough, and the injector must NEVER copy any body text into a `privacy-*` key.
+    /// The ONLY new lines vs the input are `privacy-*` keys.
+    #[test]
+    fn privacy_receipt_is_content_free_and_non_noop() {
+        let md = "---\ntitle: Board Sync\n---\n# Board Sync\n\nContact bob@example.com or call +1 415 555 0199.\n";
+        let out = inject_privacy_receipt_frontmatter(md, false, Some("api.anthropic.com"), Some(3));
+        // It actually stamped something (not a no-op).
+        assert_ne!(out, md, "the receipt was injected");
+        assert!(out.contains("privacy-egress-host: api.anthropic.com"), "host stamped: {out}");
+        assert!(out.contains("privacy-pii-redacted: 3"), "count stamped: {out}");
+        // The body PII survives untouched (passthrough) — but NEVER inside an injected key.
+        assert!(out.contains("bob@example.com"), "body PII preserved as passthrough");
+        for line in out.lines().filter(|l| l.starts_with("privacy-")) {
+            assert!(!line.contains("bob@example.com"), "no email in a privacy key: {line}");
+            assert!(!line.contains("555 0199"), "no phone in a privacy key: {line}");
+            assert!(!line.contains("Board Sync"), "no title/body text in a privacy key: {line}");
+        }
+        // The ONLY lines present in the output but not the input are `privacy-*` keys.
+        let input_lines: std::collections::HashSet<&str> = md.lines().collect();
+        for line in out.lines() {
+            if !input_lines.contains(line) {
+                assert!(
+                    line.starts_with("privacy-"),
+                    "the only injected lines are privacy-* keys, got: {line}"
+                );
+            }
+        }
+    }
+
+    /// The injected keys appear INSIDE the frontmatter fence (before the closing `---`), body
+    /// untouched. Also exercises a host label containing spaces/parens (needs no YAML quoting).
+    #[test]
+    fn privacy_receipt_keys_are_inside_the_frontmatter_block() {
+        let md = "---\ntitle: T\ndate: 2026-07-03\n---\n# Body\n";
+        let out =
+            inject_privacy_receipt_frontmatter(md, false, Some("claude_code (Anthropic CLI)"), Some(2));
+        let close = out.find("\n---\n").expect("closing fence present");
+        let fm = &out[..close];
+        assert!(
+            fm.contains("privacy-egress-host: claude_code (Anthropic CLI)"),
+            "host key inside fm: {fm}"
+        );
+        assert!(fm.contains("privacy-pii-redacted: 2"), "pii key inside fm: {fm}");
+        assert!(out.ends_with("# Body\n"), "body unchanged: {out}");
+    }
+
+    /// Idempotent: injecting twice equals injecting once — a re-export never duplicates the keys.
+    #[test]
+    fn privacy_receipt_is_idempotent() {
+        let md = "---\ntitle: T\n---\nBody.";
+        let once = inject_privacy_receipt_frontmatter(md, false, Some("api.anthropic.com"), Some(7));
+        let twice =
+            inject_privacy_receipt_frontmatter(&once, false, Some("api.anthropic.com"), Some(7));
+        assert_eq!(once, twice, "second inject is a no-op");
+        assert_eq!(once.matches("privacy-egress-host:").count(), 1, "no duplicate host key");
+        assert_eq!(once.matches("privacy-pii-redacted:").count(), 1, "no duplicate pii key");
+    }
+
+    /// Notes WITHOUT a `---` frontmatter block are returned byte-identical (even with PII in body).
+    #[test]
+    fn privacy_receipt_leaves_notes_without_frontmatter_unchanged() {
+        let md = "# Just a heading\n\nNo frontmatter, mentions bob@example.com.";
+        let out = inject_privacy_receipt_frontmatter(md, true, None, None);
+        assert_eq!(out, md, "no frontmatter → byte-identical");
+    }
+
+    /// A cloud note with an UNKNOWN host and count is a no-op (byte-identical) — never a bogus
+    /// empty stamp. Guards the `wanted.is_empty()` early return.
+    #[test]
+    fn privacy_receipt_cloud_without_facts_is_noop() {
+        let md = "---\ntitle: T\n---\nBody.";
+        let out = inject_privacy_receipt_frontmatter(md, false, None, None);
+        assert_eq!(out, md, "cloud with no host/count → nothing to honestly stamp");
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -744,6 +744,68 @@ fn resolve_summarize_egress(
     Ok((config, provider))
 }
 
+/// Content-FREE per-note PRIVACY RECEIPT facts (Tier 4c), derived purely from in-hand egress
+/// metadata at note-generation time. All fields are booleans / non-PII destination labels /
+/// integer counts — NEVER note text, transcript, attendee names, titles, keys, or DEK/KEK/CK.
+///
+/// This is a plain self-declared record, NOT a cryptographic attestation and NOT a
+/// verifiable/provable claim — it is exactly as trustworthy as the app that wrote it. Its value is
+/// that a local-only summary can state, in one screenshot-able front-matter line, that nothing left
+/// the device.
+pub(crate) struct PrivacyReceiptFacts {
+    /// `true` when nothing left the device to produce this note (a loopback-ollama / on-device
+    /// summary) — the honest `privacy-cloud-calls: 0` headline. Reuses [`egress_is_cloud`], the
+    /// SAME classifier the consent gate enforces, so it can never under-claim "local" (a REMOTE
+    /// `ollama_base_url` correctly classifies as cloud).
+    ///
+    /// [`egress_is_cloud`]: crate::summarize::egress_is_cloud
+    pub local_only: bool,
+    /// Non-PII destination LABEL for a cloud summary (`api.anthropic.com`, a gateway `host:port`,
+    /// …); `None` for a local summary (nothing left the device to declare).
+    pub egress_host: Option<String>,
+    /// The redaction firewall's REAL scrub total for THIS summary call. `None` for a local provider
+    /// (it returns unwrapped — no firewall ran), so no `privacy-pii-redacted` key is stamped.
+    pub redacted_pii: Option<u32>,
+}
+
+/// Compute the [`PrivacyReceiptFacts`] for a just-generated note. Pure: no I/O, no state, no
+/// egress-ledger query (the ledger's `meeting_id` is always `None` → not per-note attributable).
+///
+/// The `egress_host` labels MIRROR `make_provider_resolved`'s own `destination` match (literal
+/// constants, no drift risk); a numeric cloud-CALL count is deliberately NOT reported (would
+/// under-count, since entity-extraction / auto-organize also call the cloud — the dangerous
+/// direction for a privacy claim), so the honest cloud receipt is the host + the PII count.
+pub(crate) fn privacy_receipt_facts(
+    connection: &str,
+    config: &AppConfig,
+    gateway_host: Option<&str>,
+    call_meta: &crate::summarize::meta::CallMeta,
+) -> PrivacyReceiptFacts {
+    let local_only = !crate::summarize::egress_is_cloud(connection, config);
+    let egress_host: Option<String> = if local_only {
+        None
+    } else {
+        match connection {
+            crate::summarize::PROVIDER_CLAUDE_CODE => Some("claude_code (Anthropic CLI)".to_string()),
+            crate::summarize::PROVIDER_ANTHROPIC => Some("api.anthropic.com".to_string()),
+            crate::summarize::PROVIDER_GATEWAY => gateway_host.map(str::to_string),
+            crate::summarize::PROVIDER_OLLAMA => reqwest::Url::parse(&config.ollama_base_url)
+                .ok()
+                .and_then(|u| u.host_str().map(str::to_string)),
+            other => Some(other.to_string()),
+        }
+    };
+    let redacted_pii = call_meta
+        .redactions
+        .as_ref()
+        .map(|r| r.email + r.card + r.phone + r.name);
+    PrivacyReceiptFacts {
+        local_only,
+        egress_host,
+        redacted_pii,
+    }
+}
+
 /// Summarize a transcript with the configured provider, persist the note to the canonical
 /// DB, and — when a vault folder is configured — export it to the Obsidian vault and update
 /// the meeting status/title. When NO vault is configured the note is still fully saved
@@ -920,6 +982,15 @@ async fn summarize_and_export(
     // Provenance names the RESOLVED connection that actually served the note (identical to
     // `provider_id` while role keys are absent).
     let provider_id_for_fm = notes_target.connection.clone();
+    // Tier 4c — compute the content-FREE per-note PRIVACY RECEIPT facts HERE, from in-hand egress
+    // metadata, BEFORE `gateway_host` is moved into the `NoteRecord` below (the helper only borrows
+    // it). See `privacy_receipt_facts` for the honest-self-report rationale.
+    let privacy = privacy_receipt_facts(
+        &notes_target.connection,
+        config,
+        gateway_host.as_deref(),
+        &call_meta,
+    );
     state.db.upsert_note(&NoteRecord {
         meeting_id: meeting_id.to_string(),
         provider_id: notes_target.connection.clone(),
@@ -1012,6 +1083,19 @@ async fn summarize_and_export(
         &provider_id_for_fm,
         model_requested_for_fm.as_deref(),
         model_served_for_fm.as_deref(),
+    );
+    // Tier 4c — stamp the content-free per-note PRIVACY RECEIPT (facts computed in the prep block
+    // above). Local/on-device summary ⇒ `privacy-cloud-calls: 0` (nothing left the device — the
+    // honest local headline). Cloud summary ⇒ `privacy-egress-host: <label>` + `privacy-pii-redacted:
+    // <n>` (no cloud-CALL count is claimed — not per-note attributable and would under-count).
+    // Pure + idempotent, same contract as the provenance injector above; a (re)summarize rebuilds
+    // `markdown` fresh so the keys REFRESH rather than duplicate. Vault-write-only (like the
+    // provenance keys): no new content read, no DB write, no egress-ledger query.
+    let markdown = export::inject_privacy_receipt_frontmatter(
+        &markdown,
+        privacy.local_only,
+        privacy.egress_host.as_deref(),
+        privacy.redacted_pii,
     );
     let exported_path = export::write_note(
         Path::new(vault_path),
@@ -1344,6 +1428,143 @@ fn should_auto_index(semantic_enabled: bool, embed_model_present: bool) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Tier 4c: privacy_receipt_facts (per-note egress self-report wiring) ────────────────────
+    //
+    // These guard the WIRING the pure `inject_privacy_receipt_frontmatter` tests (in
+    // export/obsidian.rs) cannot: that `summarize_and_export` derives the right facts from a
+    // provider connection + config + `CallMeta` and feeds them to the injector. The injector was
+    // defined + tested but UN-CALLED before this change; without a facts test the vault note would
+    // silently carry no `privacy-*` key at all (the "compiles but inert" gap).
+    use crate::summarize::meta::{CallMeta, RedactionCounts};
+
+    /// LOCAL provider (loopback ollama) ⇒ `local_only`, no host, no PII count — and the injector
+    /// stamps ONLY the honest `privacy-cloud-calls: 0` headline. The task's explicit requirement.
+    #[test]
+    fn privacy_receipt_facts_local_ollama_stamps_zero_cloud_calls() {
+        let cfg = AppConfig {
+            ollama_base_url: "http://localhost:11434".into(),
+            ..AppConfig::default()
+        };
+        // A local provider returns UNWRAPPED (no RedactingProvider), so no firewall ran → None.
+        let meta = CallMeta::default();
+        let facts = privacy_receipt_facts(crate::summarize::PROVIDER_OLLAMA, &cfg, None, &meta);
+        assert!(facts.local_only, "loopback ollama = nothing left the device");
+        assert_eq!(facts.egress_host, None);
+        assert_eq!(facts.redacted_pii, None);
+        // End-to-end through the SAME injector the pipeline calls.
+        let out = crate::export::inject_privacy_receipt_frontmatter(
+            "---\ntitle: T\n---\n# T\n\nBody.\n",
+            facts.local_only,
+            facts.egress_host.as_deref(),
+            facts.redacted_pii,
+        );
+        assert!(out.contains("privacy-cloud-calls: 0"), "local headline stamped: {out}");
+        assert!(!out.contains("privacy-egress-host"), "no host for a local note: {out}");
+        assert!(!out.contains("privacy-pii-redacted"), "no pii key for a local note: {out}");
+    }
+
+    /// ANTHROPIC (cloud) ⇒ the non-PII host label + the firewall's REAL scrub total (summed across
+    /// buckets) reach the receipt; NO cloud-CALL integer is claimed (would under-count).
+    #[test]
+    fn privacy_receipt_facts_anthropic_stamps_host_and_real_pii_count() {
+        let cfg = AppConfig::default();
+        let meta = CallMeta {
+            redactions: Some(RedactionCounts { email: 2, card: 0, phone: 1, name: 3 }),
+            ..Default::default()
+        };
+        let facts = privacy_receipt_facts(crate::summarize::PROVIDER_ANTHROPIC, &cfg, None, &meta);
+        assert!(!facts.local_only, "anthropic is cloud egress");
+        assert_eq!(facts.egress_host.as_deref(), Some("api.anthropic.com"));
+        assert_eq!(facts.redacted_pii, Some(6), "2+0+1+3 = the real firewall total");
+        let out = crate::export::inject_privacy_receipt_frontmatter(
+            "---\ntitle: T\n---\nBody.",
+            facts.local_only,
+            facts.egress_host.as_deref(),
+            facts.redacted_pii,
+        );
+        assert!(out.contains("privacy-egress-host: api.anthropic.com"), "host: {out}");
+        assert!(out.contains("privacy-pii-redacted: 6"), "real count: {out}");
+        assert!(!out.contains("privacy-cloud-calls"), "no cloud-call count claimed: {out}");
+    }
+
+    /// GATEWAY ⇒ the receipt reuses the already-computed non-PII endpoint `host:port` label.
+    #[test]
+    fn privacy_receipt_facts_gateway_uses_endpoint_host() {
+        let facts = privacy_receipt_facts(
+            crate::summarize::PROVIDER_GATEWAY,
+            &AppConfig::default(),
+            Some("127.0.0.1:4000"),
+            &CallMeta::default(),
+        );
+        assert!(!facts.local_only, "gateway is always cloud (a localhost gateway may forward)");
+        assert_eq!(facts.egress_host.as_deref(), Some("127.0.0.1:4000"));
+    }
+
+    /// A REMOTE `ollama_base_url` classifies as CLOUD — the receipt can NEVER under-claim "local".
+    #[test]
+    fn privacy_receipt_facts_remote_ollama_is_cloud_not_local() {
+        let cfg = AppConfig {
+            ollama_base_url: "https://ollama.remote.example/api".into(),
+            ..AppConfig::default()
+        };
+        let meta = CallMeta {
+            redactions: Some(RedactionCounts::default()),
+            ..Default::default()
+        };
+        let facts = privacy_receipt_facts(crate::summarize::PROVIDER_OLLAMA, &cfg, None, &meta);
+        assert!(!facts.local_only, "a remote ollama endpoint is cloud egress, not local");
+        assert_eq!(facts.egress_host.as_deref(), Some("ollama.remote.example"));
+        assert_eq!(facts.redacted_pii, Some(0), "wrapped-but-zero scrubs = an honest 0");
+    }
+
+    /// REFRESH-on-resummarize: each (re)summarize hands the injector a FRESH markdown (the LLM
+    /// regenerates the note carrying no `privacy-*` key), so switching provider between runs
+    /// REFRESHES the receipt — a run-2 cloud note does NOT retain run-1's `privacy-cloud-calls: 0`.
+    #[test]
+    fn privacy_receipt_refreshes_when_provider_changes_between_summaries() {
+        // Run 1: local ollama.
+        let local_cfg = AppConfig {
+            ollama_base_url: "http://localhost:11434".into(),
+            ..AppConfig::default()
+        };
+        let f1 = privacy_receipt_facts(
+            crate::summarize::PROVIDER_OLLAMA,
+            &local_cfg,
+            None,
+            &CallMeta::default(),
+        );
+        let run1 = crate::export::inject_privacy_receipt_frontmatter(
+            "---\ntitle: T\n---\nBody.",
+            f1.local_only,
+            f1.egress_host.as_deref(),
+            f1.redacted_pii,
+        );
+        assert!(run1.contains("privacy-cloud-calls: 0"), "run 1 = local: {run1}");
+
+        // Run 2 (resummarize): provider switched to anthropic; the model produced a FRESH note.
+        let f2 = privacy_receipt_facts(
+            crate::summarize::PROVIDER_ANTHROPIC,
+            &AppConfig::default(),
+            None,
+            &CallMeta {
+                redactions: Some(RedactionCounts { email: 1, card: 0, phone: 0, name: 0 }),
+                ..Default::default()
+            },
+        );
+        let run2 = crate::export::inject_privacy_receipt_frontmatter(
+            "---\ntitle: T\n---\nBody.", // fresh markdown, no stale privacy keys
+            f2.local_only,
+            f2.egress_host.as_deref(),
+            f2.redacted_pii,
+        );
+        assert!(run2.contains("privacy-egress-host: api.anthropic.com"), "run 2 = cloud host: {run2}");
+        assert!(run2.contains("privacy-pii-redacted: 1"), "run 2 real count: {run2}");
+        assert!(
+            !run2.contains("privacy-cloud-calls: 0"),
+            "the local headline did NOT bleed into the cloud re-summary: {run2}"
+        );
+    }
 
     /// LEAK regression (lock-security review 2026-07-02): a cloud-egress consent REVOKE landing
     /// DURING transcription — between `run_inner`'s Stop-time config snapshot and the summarize

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5458,6 +5458,7 @@ mod tests {
                 completion_tokens: Some(50),
                 total_tokens: Some(150),
                 cached_tokens: None,
+                redactions: None,
             },
             redactions: RedactionCounts { email: 1, card: 0, phone: 1, name: 2 },
             system_bytes: 512,
@@ -5536,6 +5537,7 @@ mod tests {
                 completion_tokens: None,
                 total_tokens: Some(total_tokens),
                 cached_tokens: None,
+                redactions: None,
             },
             redactions: RedactionCounts {
                 email: redaction_email,
@@ -5686,6 +5688,7 @@ mod tests {
                 completion_tokens: Some(5),
                 total_tokens: Some(15),
                 cached_tokens: None,
+                redactions: None,
             },
             redactions: RedactionCounts::default(),
             system_bytes: 0,

--- a/src-tauri/src/summarize/anthropic.rs
+++ b/src-tauri/src/summarize/anthropic.rs
@@ -173,6 +173,9 @@ pub(crate) fn parse_messages_response(body: &str) -> crate::error::Result<(Strin
                 .usage
                 .as_ref()
                 .and_then(|u| u.cache_read_input_tokens),
+            // The raw provider never redacts (the RedactingProvider wrapper does + overwrites this
+            // with the real scrub count for cloud egress).
+            redactions: None,
         }
     };
 

--- a/src-tauri/src/summarize/egress_log.rs
+++ b/src-tauri/src/summarize/egress_log.rs
@@ -122,6 +122,7 @@ mod tests {
                 completion_tokens: Some(50),
                 total_tokens: Some(150),
                 cached_tokens: None,
+                redactions: None,
             },
             redactions: RedactionCounts {
                 email: 1,

--- a/src-tauri/src/summarize/gateway.rs
+++ b/src-tauri/src/summarize/gateway.rs
@@ -173,6 +173,9 @@ pub(crate) fn parse_chat_response(body: &str) -> Result<(String, CallMeta)> {
             .as_ref()
             .and_then(|u| u.prompt_tokens_details.as_ref())
             .and_then(|d| d.cached_tokens),
+        // The raw provider never redacts (the RedactingProvider wrapper does + overwrites this
+        // with the real scrub count for cloud egress).
+        redactions: None,
     };
 
     Ok((note.to_string(), meta))

--- a/src-tauri/src/summarize/meta.rs
+++ b/src-tauri/src/summarize/meta.rs
@@ -23,6 +23,12 @@ pub struct CallMeta {
     /// Prompt tokens served from the provider's prompt cache (KV-cache or equivalent). `None`
     /// means the provider did not report a cache hit count — not that there were zero.
     pub cached_tokens: Option<u32>,
+    /// PII the redaction firewall scrubbed from THIS call's content before egress, bucketed by
+    /// kind. `Some(..)` ONLY when a [`RedactingProvider`](crate::summarize::redact::RedactingProvider)
+    /// wrapped the call — i.e. a cloud provider. A LOCAL provider (loopback ollama / on-device
+    /// reasoner) returns unwrapped, so its `redactions` stays `None` (no firewall ran). Counts
+    /// only, never the scrubbed values. Read by the per-note privacy-receipt self-report.
+    pub redactions: Option<RedactionCounts>,
 }
 
 /// Counts of PII placeholders injected by the redaction firewall for a single cloud call.
@@ -50,6 +56,7 @@ mod tests {
         assert_eq!(m.completion_tokens, None);
         assert_eq!(m.total_tokens, None);
         assert_eq!(m.cached_tokens, None);
+        assert_eq!(m.redactions, None);
     }
 
     #[test]
@@ -69,6 +76,7 @@ mod tests {
             completion_tokens: Some(22),
             total_tokens: Some(33),
             cached_tokens: None,
+            redactions: None,
         };
         let b = a.clone();
         assert_eq!(a, b);

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -445,11 +445,17 @@ impl SummarizerProvider for RedactingProvider {
             model_requested: self.model_requested.clone(),
             call_kind: "summarize",
             meta: meta.clone(),
-            redactions,
+            redactions: redactions.clone(),
             system_bytes: 0, // summarize has no separate system prompt
             user_bytes,
             meeting_id: None,
         });
+        // Tier 4c — surface the SAME scrub count to the CALLER so the per-note privacy receipt can
+        // report how many PII items the firewall removed before this cloud call. A LOCAL provider
+        // returns unwrapped upstream and never reaches this wrapper, so a local note's
+        // `CallMeta.redactions` stays `None` (no firewall ran) — correctly, no PII key is stamped.
+        let mut meta = meta;
+        meta.redactions = Some(redactions);
         Ok((out, meta))
     }
 
@@ -483,11 +489,14 @@ impl SummarizerProvider for RedactingProvider {
             model_requested: self.model_requested.clone(),
             call_kind: "complete",
             meta: meta.clone(),
-            redactions,
+            redactions: redactions.clone(),
             system_bytes,
             user_bytes,
             meeting_id: None,
         });
+        // Tier 4c — surface the scrub count to the caller (see `summarize_with_meta`).
+        let mut meta = meta;
+        meta.redactions = Some(redactions);
         Ok((out, meta))
     }
 
@@ -545,11 +554,14 @@ impl SummarizerProvider for RedactingProvider {
             model_requested: self.model_requested.clone(),
             call_kind: "complete_json",
             meta: meta.clone(),
-            redactions,
+            redactions: redactions.clone(),
             system_bytes,
             user_bytes,
             meeting_id: None,
         });
+        // Tier 4c — surface the scrub count to the caller (see `summarize_with_meta`).
+        let mut meta = meta;
+        meta.redactions = Some(redactions);
         Ok((out, meta))
     }
     // `complete_json` inherits the delegating default: calls `complete_json_with_meta` and
@@ -924,6 +936,7 @@ mod tests {
                 completion_tokens: Some(13),
                 total_tokens: Some(55),
                 cached_tokens: None,
+                redactions: None,
             }))
         }
         async fn complete_with_meta(&self, system: &str, user: &str) -> Result<(String, crate::summarize::meta::CallMeta)> {
@@ -934,6 +947,7 @@ mod tests {
                 completion_tokens: Some(5),
                 total_tokens: Some(15),
                 cached_tokens: None,
+                redactions: None,
             }))
         }
     }
@@ -989,6 +1003,31 @@ mod tests {
         );
         // Only non-PII metadata present:
         assert!(debug.contains("api.anthropic.com"), "destination label is non-PII");
+    }
+
+    /// Tier 4c (v1.1) — RED-before-GREEN: `summarize_with_meta` must SURFACE the firewall's scrub
+    /// count to the CALLER via `CallMeta.redactions`, so the per-note privacy receipt reports a
+    /// REAL number equal to what actually left the device redacted. RED on the pre-change code
+    /// (the field did not exist / stayed `None`); GREEN once `RedactingProvider` sets
+    /// `meta.redactions = Some(count)` before returning.
+    #[test]
+    fn summarize_with_meta_surfaces_redaction_count_to_caller() {
+        let prov = RedactingProvider::with_name_redactor(
+            Arc::new(EchoMetaProvider),
+            Arc::new(NoopNameRedactor),
+        );
+        // One email in the transcript → the firewall scrubs exactly one EMAIL placeholder.
+        let (_out, meta) = block_on(
+            prov.summarize_with_meta(&sample_req("Ping alice@corp.example about the roadmap.")),
+        )
+        .unwrap();
+        let counts = meta
+            .redactions
+            .expect("scrub count surfaced to the caller (Some), not dropped");
+        assert_eq!(counts.email, 1, "one email scrubbed");
+        assert_eq!(counts.card, 0);
+        assert_eq!(counts.phone, 0);
+        assert_eq!(counts.name, 0, "no-op name redactor → zero names");
     }
 
     /// The default `with_name_redactor` path records to a NoopEgressSink — no panic, no row.
@@ -1066,6 +1105,7 @@ mod tests {
                         completion_tokens: Some(7),
                         total_tokens: Some(49),
                         cached_tokens: None,
+                        redactions: None,
                     },
                 ))
             }


### PR DESCRIPTION
## Tier 4c — make local-first legible in owned files

Stamps the already-computed egress facts into each note's Obsidian front-matter as an **honest self-report** a cloud tool physically cannot answer:
- local / on-device summary → `privacy-cloud-calls: 0`
- cloud summary → `privacy-egress-host: <label>` + `privacy-pii-redacted: <n>`

`local_only` reuses the **same `egress_is_cloud` classifier as the fail-closed consent gate** (a remote ollama/gateway can never falsely claim "local" — the classifier errs toward cloud), and `privacy-pii-redacted` is the redaction firewall's **real** scrub count from `CallMeta.redactions` (not a stub). Reads in-hand egress metadata only — **no new column/migration, no new command, no new egress**.

### Safety (both gates PASS)
- lock-security **PASS** — content-free values (booleans/counts/host-labels, never note content — proven by feeding an email+phone into the body and asserting they're absent from every key); **vault-write-only** (injected AFTER `upsert_note` stores the clean DB markdown, so the keys never enter the sealed `content_blob`); no new read/command/egress; not `Serialize` so it can't cross IPC.
- adversarial **PASS** — RED-before-GREEN on all three worst outcomes (false "0 cloud calls", stub PII count, duplicated front-matter block); idempotent refresh confirmed in the real resummarize path.

### Honesty
No "hashable/attestation/verifiable/provable" framing — it's a plain self-declared record. `privacy-cloud-calls: 0` is only stamped when the classifier says local (scoped to this note's production, honestly documented).

`cargo test --lib` **853 passed / 0 failed** (+13 tests).