### PR TITLE
feat(brain): structured Person dossier command (Tier 4b, backend)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2225,6 +2225,34 @@ pub fn get_entity_detail(
         .ok_or_else(|| AppError::InvalidArg(format!("no entity with id {entity_id}")))
 }
 
+/// Structured, GATED, egress-free person dossier for the `/people` detail pane. Unlike
+/// [`entity_dossier`] (which CLOUD-synthesizes a markdown String via the provider and discards the
+/// struct), this returns the STRUCTURED [`DossierData`](crate::summarize::dossier::DossierData) with
+/// NO provider/cloud call — deterministic DB assembly, strictly MORE local-first. Gated exactly like
+/// [`get_entity_detail`]/[`list_people`]: it snapshots the LIVE session unlock set and reuses
+/// `build_dossier_data` VERBATIM, so a sealed-and-not-session-unlocked meeting contributes NOTHING
+/// (its title, note body, commitments, and facts all stay invisible until the folder is
+/// session-unlocked). `corpus` is `#[serde(skip)]`, so meeting note bodies never reach the FE.
+#[tauri::command]
+pub fn get_person_dossier(
+    state: State<'_, AppState>,
+    entity_id: String,
+) -> Result<crate::summarize::dossier::DossierData, AppError> {
+    get_person_dossier_inner(state.inner(), &entity_id)
+}
+
+/// Inner of [`get_person_dossier`] taking `&AppState` (unit-testable gate). `None` — an unknown id
+/// OR an entity visible only through sealed-not-unlocked meetings — maps to `InvalidArg`, mirroring
+/// [`get_entity_detail`] so unknown-vs-sealed-only stays indistinguishable (no existence leak).
+pub(crate) fn get_person_dossier_inner(
+    state: &AppState,
+    entity_id: &str,
+) -> Result<crate::summarize::dossier::DossierData, AppError> {
+    let unlocked = unlocked_snapshot(state)?;
+    crate::summarize::dossier::build_dossier_data(&state.db, entity_id, &unlocked)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no visible entity with id {entity_id}")))
+}
+
 /// Ask-My-Vault: answer a question across ALL past meetings' notes (grounded, with sources).
 ///
 /// PR G (ask-unify): on the CLOUD brain backend this routes through the SAME model-driven agentic
@@ -7252,6 +7280,102 @@ mod lifecycle_tests {
             created_at: "2026-06-27T08:00:00Z".to_string(),
         })
         .unwrap();
+    }
+
+    /// WS6 (Tier 4b) — the NEW structured, egress-free `get_person_dossier` command inherits the
+    /// dossier visibility gate through `get_person_dossier_inner`: with a folder sealed and NOT
+    /// session-unlocked, its meeting + commitment contribute NOTHING to the dossier, and both reappear
+    /// only once the folder id is inserted into the live `unlocked_folders` set. An unknown entity id
+    /// → `AppError::InvalidArg` (unknown vs sealed-only indistinguishable — no existence leak). This
+    /// is the command-seam mirror of `dossier::build_dossier_gates_sealed_and_filters_commitments`.
+    #[test]
+    fn get_person_dossier_gates_sealed() {
+        let state = build_state("person-dossier");
+        let db = &state.db;
+        make_open_folder(db, "f-lock", "Locked");
+        seed_meeting(db, "open1", "## Action items\n- [ ] Anna — draft Atlas spec 2026-07-01\n", None);
+        seed_meeting(
+            db,
+            "sealedX",
+            "LOCKED Atlas price\n## Action items\n- [ ] Carol — sign 2026-07-09\n",
+            Some("f-lock"),
+        );
+        let atlas = db
+            .upsert_entity("Atlas", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&atlas, "open1").unwrap();
+        db.add_mention(&atlas, "sealedX").unwrap();
+        db.set_folder_locked("f-lock", true, Some(&b"wrapped"[..])).unwrap();
+
+        // Sealed + not session-unlocked: the sealed meeting + its commitment MUST be invisible.
+        let data = get_person_dossier_inner(&state, &atlas).unwrap();
+        assert!(
+            data.meetings.iter().any(|m| m.meeting_id == "open1"),
+            "the visible mentioning meeting must be present"
+        );
+        assert!(
+            data.meetings.iter().all(|m| m.meeting_id != "sealedX"),
+            "sealed-not-unlocked meeting leaked into the dossier (gate violation)"
+        );
+        assert!(
+            data.commitments.iter().any(|c| c.text.contains("draft Atlas spec")),
+            "the visible commitment must be present"
+        );
+        assert!(
+            data.commitments.iter().all(|c| !c.text.contains("sign")),
+            "sealed-not-unlocked commitment leaked (gate violation)"
+        );
+
+        // Session-unlock the folder → the sealed meeting + its commitment reappear (reversible gate).
+        state.unlocked_folders.lock().unwrap().insert("f-lock".to_string());
+        let data2 = get_person_dossier_inner(&state, &atlas).unwrap();
+        assert!(
+            data2.meetings.iter().any(|m| m.meeting_id == "sealedX"),
+            "session-unlock must reveal the sealed meeting"
+        );
+        assert!(
+            data2.commitments.iter().any(|c| c.text.contains("sign")),
+            "session-unlock must reveal the sealed commitment"
+        );
+
+        // Unknown id → InvalidArg (unknown vs sealed-only indistinguishable; no existence leak).
+        match get_person_dossier_inner(&state, "no-such-entity") {
+            Err(AppError::InvalidArg(_)) => {}
+            other => panic!("unknown entity must be InvalidArg, got {other:?}"),
+        }
+    }
+
+    /// WS6 (Tier 4b) DTO contract lock: the serialized `DossierData` the FE receives exposes
+    /// `entity`/`meetings`/`commitments`/`neighbors`/`facts` in camelCase and OMITS `corpus`
+    /// (`#[serde(skip)]`) — so meeting note bodies never cross IPC. Guards both the FE field contract
+    /// and the leak invariant.
+    #[test]
+    fn get_person_dossier_dto_omits_corpus_and_is_camelcase() {
+        let state = build_state("person-dossier-dto");
+        let db = &state.db;
+        seed_meeting(db, "m-open", "## Action items\n- [ ] Anna — draft Atlas spec 2026-07-01\n", None);
+        let atlas = db
+            .upsert_entity("Atlas", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&atlas, "m-open").unwrap();
+
+        let data = get_person_dossier_inner(&state, &atlas).unwrap();
+        let v = serde_json::to_value(&data).unwrap();
+        let obj = v.as_object().expect("dossier serializes to a JSON object");
+        for key in ["entity", "meetings", "commitments", "neighbors", "facts"] {
+            assert!(obj.contains_key(key), "DTO must expose `{key}`");
+        }
+        assert!(
+            !obj.contains_key("corpus"),
+            "corpus must be serde-skipped — note bodies must never cross IPC to the FE"
+        );
+        // Nested camelCase the FE consumes (a commitment carries meetingId/meetingTitle/dueDate).
+        let commit = v["commitments"].get(0).expect("the visible commitment must serialize");
+        assert!(commit.get("meetingId").is_some(), "commitment.meetingId must be camelCase");
+        assert!(
+            commit.get("meeting_id").is_none(),
+            "snake_case commitment.meeting_id must not appear"
+        );
     }
 
     /// Add a user-memory fact sourced from `meeting_id` (the gating + purge anchor) for the injection

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             commands::link_meeting_entities,
             commands::get_graph,
             commands::get_entity_detail,
+            commands::get_person_dossier,
             commands::list_people,
             commands::ask_vault,
             commands::entity_dossier,

--- a/src-tauri/src/summarize/dossier.rs
+++ b/src-tauri/src/summarize/dossier.rs
@@ -19,6 +19,8 @@
 
 use std::collections::HashSet;
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::Result;
 use crate::facts::Fact;
 use crate::storage::models::{Commitment, EntityNeighbor, GraphEntity, VaultSource};
@@ -43,7 +45,8 @@ fn budget_for(provider_id: &str) -> usize {
 /// Db reads — a sealed-not-unlocked meeting contributes nothing. The `corpus` is the
 /// citation-tagged note material (each meeting headed `### [[Title]] · date · id:`), ready to feed
 /// a provider (cloud command) or hand to an MCP client (egress-free) for synthesis.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DossierData {
     pub entity: GraphEntity,
     /// Visible meetings mentioning this entity (newest first), as `[[Title]]` citation chips.
@@ -58,6 +61,11 @@ pub struct DossierData {
     /// by `list_facts_visible` — a sealed-not-unlocked meeting's facts are absent.
     pub facts: Vec<Fact>,
     /// Citation-tagged note corpus, each meeting headed `### [[Title]] · date · id:`.
+    /// `#[serde(skip)]`: an internal synthesis input (the largest field — full visible note bodies)
+    /// consumed only by `render_dossier_user`/`format_dossier_client` via direct field access. It
+    /// NEVER crosses IPC — the structured FE render (`get_person_dossier`) needs only
+    /// entity/meetings/commitments/neighbors/facts. `String: Default` satisfies the skip on deser.
+    #[serde(skip)]
     pub corpus: String,
 }
 


### PR DESCRIPTION
## Tier 4b (backend) — the relationship-OS substrate, surfaced

Exposes the already-built structured `DossierData` (per-person **timeline** / **who-owes-what** open commitments / **bitemporal facts** open+closed / co-occurring **neighbors**) to the FE via a NEW gated `get_person_dossier` command — **deterministic DB assembly, no provider/cloud call** (strictly more local-first than the existing cloud-synthesizing `entity_dossier`, which is left untouched). This is the substrate for a native /people Person page; the FE render is the follow-up.

- `DossierData` gains `Serialize/Deserialize` + camelCase; **`corpus`** (the full note-body synthesis input, the largest surface) is `#[serde(skip)]` so note bodies never cross IPC.
- `get_person_dossier` reuses `build_dossier_data` **verbatim** with the **live** unlock snapshot.

### Safety (both gates PASS)
- lock-security **PASS** — every sub-read (`entity_is_visible`/`entity_mentions_visible`/`list_open_commitments`/`entity_neighbors_visible`/`list_facts_visible`/`get_note_if_visible`) re-applies `visibility_clause`, so an entity visible through one open meeting still contributes **nothing** from its sealed mentioning meetings; `corpus` serde-skipped; `None → InvalidArg` (no existence leak); no egress/asset/seal/logs.
- adversarial **PASS** — RED-before-GREEN: replacing the live unlock snapshot with a hardcoded empty set makes the sealed→reappear-on-unlock test fail, proving the gate binds to the session set.

`cargo test --lib` **855 passed / 0 failed** (+2 tests).