### PR TITLE
feat(brain): structured Person page render (Tier 4b, frontend)

### DIFF
--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -25,6 +25,7 @@ import type {
   ChatTurn,
   DigestResult,
   DocumentInfo,
+  DossierData,
   EntityDetail,
   Folder,
   FolderNode,
@@ -416,6 +417,21 @@ export class IpcService {
    */
   listPeople(): Promise<PersonCard[]> {
     return invoke<PersonCard[]>("list_people");
+  }
+
+  /**
+   * The STRUCTURED, egress-free person dossier for the `/people` detail pane: the
+   * entity + its mentioning-meeting TIMELINE + open COMMITMENTS (who-owes-what) +
+   * bitemporal FACTS (open + recently-closed) + co-occurring NEIGHBOURS, assembled
+   * DETERMINISTICALLY from the gated DB with NO cloud call (unlike the cloud-
+   * synthesizing `entity_dossier`). GATED server-side exactly like
+   * {@link getEntityDetail}: a sealed-and-not-session-unlocked meeting contributes
+   * nothing, and an unknown / sealed-only id REJECTS (InvalidArg) — so re-fetch on
+   * the entity id change (and, upstream, on a FoldersService lock-state change) to
+   * shift content live. The note-body `corpus` is serde-skipped and never crosses IPC.
+   */
+  getPersonDossier(entityId: string): Promise<DossierData> {
+    return invoke<DossierData>("get_person_dossier", { entityId });
   }
 
   // ── brain2 — the Brain page "what's in my brain" overview ──────────────

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -944,6 +944,70 @@ export interface PersonCard {
   currentFactCount: number;
 }
 
+/**
+ * One OPEN action-item "commitment" rolled up across the library, with its meeting
+ * context. Mirrors the Rust `Commitment` (camelCase via `#[serde(rename_all)]`).
+ * Produced by the deterministic gated aggregation — only OPEN (`- [ ]`) items from
+ * VISIBLE meetings contribute, so a sealed-not-unlocked meeting yields nothing.
+ */
+export interface Commitment {
+  meetingId: string;
+  meetingTitle: string;
+  /** ISO 8601 meeting start (recency ordering + the [[Title]] context). */
+  startedAt: string;
+  /** The item owner (name), or null when unattributed. */
+  owner: string | null;
+  /** The due date (as written in the note), or null. */
+  dueDate: string | null;
+  text: string;
+}
+
+/**
+ * One persisted bitemporal FACT row about an entity. Mirrors the Rust `Fact`
+ * (camelCase via `#[serde(rename_all)]`). `validTo == null` ⇒ CURRENTLY valid (the
+ * present state); a non-null `validTo` ⇒ CLOSED/superseded at that instant (history —
+ * the fact is never deleted, only closed). GATED like the rest of the dossier: a
+ * sealed-not-unlocked source meeting's facts never surface.
+ */
+export interface Fact {
+  id: string;
+  entityId: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  /** Valid-time start — when the fact became true (the source meeting's time). */
+  validFrom: string;
+  /** Valid-time end — null while currently valid, set when superseded. */
+  validTo: string | null;
+  /** Transaction time — when the reconcile run recorded it. */
+  recordedAt: string;
+  /** The meeting the fact was derived from (gating + purge anchor); null for legacy rows. */
+  meetingId: string | null;
+  confidence: number;
+}
+
+/**
+ * The structured, GATED, egress-free person dossier for the `/people` detail pane
+ * (`getPersonDossier`). Mirrors the Rust `DossierData` (camelCase) field-for-field
+ * EXCEPT `corpus`: that field is `#[serde(skip)]` on the backend (the full note
+ * bodies are a synthesis-only input that NEVER crosses IPC), so there is deliberately
+ * NO `corpus` field here. Assembled DETERMINISTICALLY from the encrypted DB with NO
+ * provider/cloud call. Every list is visibility-gated — a sealed-and-not-session-
+ * unlocked meeting contributes nothing (its meeting, commitments, and facts stay
+ * invisible) until the folder is session-unlocked.
+ */
+export interface DossierData {
+  entity: GraphEntity;
+  /** Visible meetings mentioning this entity, newest first (the mention timeline). */
+  meetings: VaultSource[];
+  /** Open commitments tied to this entity (a mentioning meeting's item OR owner-name match). */
+  commitments: Commitment[];
+  /** Top co-occurring neighbour entities (shared visible meetings). */
+  neighbors: EntityNeighbor[];
+  /** Visible bitemporal facts (open + recently-closed), newest first. */
+  facts: Fact[];
+}
+
 export interface AskVaultResult {
   answer: string;
   sources: VaultSource[];

--- a/src/app/features/people/people.component.ts
+++ b/src/app/features/people/people.component.ts
@@ -9,16 +9,16 @@ import {
 import { IpcService } from "../../core/ipc.service";
 import type { PersonCard } from "../../core/models";
 import { FoldersService } from "../../services/folders.service";
-import { EntityDetailComponent } from "../graph/entity-detail.component";
+import { PersonDossierComponent } from "./person-dossier.component";
 
 /**
  * The `/people` page — a personal CRM over the people across your meetings.
  *
  * A directory of {@link PersonCard}s (name + when you last talked + how many open
- * commitments and known facts) is the spine; picking a card opens the SAME
- * self-contained {@link EntityDetailComponent} panel the /graph page uses (its
- * neighborhood + backlinked meetings + connected entities) — no graph is rebuilt
- * here, the detail component is reused verbatim.
+ * commitments and known facts) is the spine; picking a card opens the structured
+ * {@link PersonDossierComponent} pane — a glanceable, deterministic, egress-free
+ * dossier (mentioning-meeting timeline + who-owes-what commitments + bitemporal
+ * facts + co-occurring neighbours) assembled from the gated DB, no cloud call.
  *
  * Lock-awareness (mirrors GraphComponent): `listPeople()` returns ONLY visible
  * people with visible-only counts, so we re-fetch whenever {@link FoldersService}'s
@@ -31,7 +31,7 @@ import { EntityDetailComponent } from "../graph/entity-detail.component";
   selector: "app-people",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [EntityDetailComponent],
+  imports: [PersonDossierComponent],
   template: `
     <section class="people">
       <header class="p-head">
@@ -150,7 +150,7 @@ import { EntityDetailComponent } from "../graph/entity-detail.component";
           </ul>
 
           @if (selectedId(); as id) {
-            <app-entity-detail
+            <app-person-dossier
               class="p-detail"
               [entityId]="id"
               (select)="onSelect($event)"
@@ -332,7 +332,7 @@ export class PeopleComponent {
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
 
-  /** The selected person id — opens the reused entity-detail panel. */
+  /** The selected person id — opens the structured person-dossier pane. */
   readonly selectedId = signal<string | null>(null);
 
   protected readonly total = computed(() => this.people().length);

--- a/src/app/features/people/person-dossier.component.ts
+++ b/src/app/features/people/person-dossier.component.ts
@@ -1,0 +1,671 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+
+import { IpcService } from "../../core/ipc.service";
+import type {
+  Commitment,
+  DossierData,
+  EntityNeighbor,
+} from "../../core/models";
+
+/**
+ * The `/people` detail pane — a STRUCTURED, glanceable dossier for one person
+ * (Tier 4b). Loads the gated {@link DossierData} via {@link IpcService.getPersonDossier}
+ * (re-loading whenever the `entityId` input changes) and renders four native
+ * sections over it:
+ *   • 🕑 a TIMELINE of the meetings that mention this person (newest first → /meeting),
+ *   • ⏳ WHO OWES WHAT — the open commitments tied to them (owner · due · item · source),
+ *   • 🔵 FACTS — the current bitemporal state (open facts) plus WHAT CHANGED (closed),
+ *   • 🧭 co-occurring NEIGHBOURS — click to pivot the pane to that entity.
+ *
+ * This replaces the reused graph {@link EntityDetailComponent} in the pane: strictly
+ * richer, deterministic, and egress-free (no cloud synthesis). The component contract
+ * (`entityId` input + `select`/`close` outputs) matches the panel it supersedes, so
+ * the container wiring is unchanged.
+ *
+ * The IPC call is a one-shot awaited promise (not a data stream), loaded imperatively
+ * inside an `effect()` that tracks the input signal — a stale-result guard drops a
+ * response that resolves after the id moved on (fast neighbour-to-neighbour pivots),
+ * and `allowSignalWrites` is required because loading/error are written synchronously
+ * inside that tracked effect (NG0600 guard). Mirrors `entity-detail.component.ts`.
+ */
+@Component({
+  selector: "app-person-dossier",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  template: `
+    <aside class="dossier card" aria-label="Person dossier">
+      <button
+        type="button"
+        class="dossier-close btn btn-ghost"
+        aria-label="Close dossier"
+        (click)="close.emit()"
+      >
+        <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+          <path
+            d="M4 4l8 8M12 4l-8 8"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+
+      @if (loading()) {
+        <div class="dossier-state">
+          <p class="empty">Loading…</p>
+        </div>
+      } @else if (error()) {
+        <div class="dossier-state">
+          <p class="empty-title">Couldn’t load this dossier</p>
+          <p class="empty">{{ error() }}</p>
+        </div>
+      } @else if (dossier()) {
+        @if (dossier(); as d) {
+          <header class="dossier-head">
+            <span
+              class="dossier-dot"
+              [class.is-project]="d.entity.kind === 'project'"
+              aria-hidden="true"
+            ></span>
+            <div class="dossier-head-text">
+              <h3 class="dossier-name">{{ d.entity.name }}</h3>
+              <span class="dossier-sub">
+                {{ d.entity.kind === "project" ? "Project" : "Person" }}
+                · {{ summaryLabel() }}
+              </span>
+            </div>
+          </header>
+
+          <!-- 🕑 Timeline of mentioning meetings (newest first). -->
+          <section class="dossier-section">
+            <h4 class="dossier-section-title">
+              <span class="dossier-section-emoji" aria-hidden="true">🕑</span>
+              Timeline
+            </h4>
+            <ol class="tl">
+              @for (m of d.meetings; track m.meetingId) {
+                <li class="tl-row">
+                  <a class="tl-link" [routerLink]="['/meeting', m.meetingId]">
+                    <span class="tl-node" aria-hidden="true"></span>
+                    <span class="tl-date">{{ fmtDate(m.startedAt) }}</span>
+                    <span class="tl-title">{{ m.title || "(untitled)" }}</span>
+                  </a>
+                </li>
+              } @empty {
+                <li class="dossier-empty-row">
+                  <p class="empty">
+                    No visible meetings mention this person yet.
+                  </p>
+                </li>
+              }
+            </ol>
+          </section>
+
+          <!-- ⏳ Who owes what — open commitments tied to this person. -->
+          <section class="dossier-section">
+            <h4 class="dossier-section-title">
+              <span class="dossier-section-emoji" aria-hidden="true">⏳</span>
+              Who owes what
+              @if (d.commitments.length) {
+                <span class="count dossier-count">{{
+                  d.commitments.length
+                }}</span>
+              }
+            </h4>
+            <ul class="ci-list">
+              @for (c of d.commitments; track c.meetingId + "|" + c.text) {
+                <li class="ci">
+                  <div class="ci-main">
+                    @if (ownerLabel(c); as o) {
+                      <span class="ci-owner">{{ o }}</span>
+                    }
+                    <span class="ci-text">{{ c.text }}</span>
+                  </div>
+                  <div class="ci-meta">
+                    @if (c.dueDate) {
+                      <span class="pill is-warning ci-due"
+                        >due {{ c.dueDate }}</span
+                      >
+                    }
+                    <a class="ci-src" [routerLink]="['/meeting', c.meetingId]">
+                      {{ c.meetingTitle || "(untitled)" }}
+                    </a>
+                  </div>
+                </li>
+              } @empty {
+                <li class="dossier-empty-row">
+                  <p class="empty">All caught up — no open commitments.</p>
+                </li>
+              }
+            </ul>
+          </section>
+
+          <!-- 🔵 Facts — current state (open) + what changed (closed history). -->
+          @if (d.facts.length) {
+            <section class="dossier-section">
+              <h4 class="dossier-section-title">
+                <span class="dossier-section-emoji" aria-hidden="true">🔵</span>
+                Facts
+              </h4>
+
+              @if (currentFacts().length) {
+                <p class="dossier-sub-label">Current</p>
+                <ul class="fact-list">
+                  @for (f of currentFacts(); track f.id) {
+                    <li class="fact fact-current">
+                      <span class="fact-pred">{{ f.predicate }}</span>
+                      <span class="fact-obj">{{ f.object }}</span>
+                      <span class="fact-since"
+                        >since {{ fmtDate(f.validFrom) }}</span
+                      >
+                    </li>
+                  }
+                </ul>
+              }
+
+              @if (changedFacts().length) {
+                <p class="dossier-sub-label">What changed</p>
+                <ul class="fact-list">
+                  @for (f of changedFacts(); track f.id) {
+                    <li class="fact fact-changed">
+                      <span class="fact-pred">{{ f.predicate }}</span>
+                      <span class="fact-obj">was “{{ f.object }}”</span>
+                      <span class="fact-since">
+                        {{ fmtDate(f.validFrom) }} → {{ fmtDate(f.validTo) }}
+                      </span>
+                    </li>
+                  }
+                </ul>
+              }
+            </section>
+          }
+
+          <!-- 🧭 Co-occurring neighbours — click to pivot the pane. -->
+          @if (d.neighbors.length) {
+            <section class="dossier-section">
+              <h4 class="dossier-section-title">
+                <span class="dossier-section-emoji" aria-hidden="true">🧭</span>
+                Also appears with
+              </h4>
+              <ul class="nb-list">
+                @for (nb of d.neighbors; track nb.id) {
+                  <li>
+                    <button
+                      type="button"
+                      class="nb"
+                      [class.is-project]="nb.kind === 'project'"
+                      (click)="select.emit(nb.id)"
+                    >
+                      <span class="nb-dot" aria-hidden="true"></span>
+                      <span class="nb-name">{{ nb.name }}</span>
+                      <span
+                        class="count nb-count"
+                        [attr.title]="sharedLabel(nb)"
+                      >
+                        {{ nb.sharedMeetings }}
+                      </span>
+                    </button>
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+        }
+      }
+    </aside>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .dossier {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+        padding: var(--space-5);
+        animation: rise 360ms var(--transition) both;
+      }
+      .dossier-close {
+        position: absolute;
+        top: var(--space-3);
+        right: var(--space-3);
+        width: 32px;
+        height: 32px;
+        padding: 0;
+      }
+      .dossier-state {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        padding: var(--space-6) var(--space-2);
+        text-align: center;
+      }
+
+      /* --- Header --- */
+      .dossier-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding-right: var(--space-6);
+      }
+      .dossier-dot {
+        flex: none;
+        width: 12px;
+        height: 12px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+      .dossier-dot.is-project {
+        background: #9d7bff;
+        box-shadow: 0 0 0 4px rgba(157, 123, 255, 0.18);
+      }
+      .dossier-head-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+      }
+      .dossier-name {
+        margin: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .dossier-sub {
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* --- Sections --- */
+      .dossier-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .dossier-section-title {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .dossier-section-emoji {
+        font-size: 0.8125rem;
+        line-height: 1;
+      }
+      .dossier-count {
+        margin-left: auto;
+      }
+      .dossier-sub-label {
+        margin: var(--space-1) 0 0;
+        color: var(--text-muted);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .dossier-empty-row {
+        list-style: none;
+      }
+      .dossier-empty-row .empty {
+        font-size: 0.875rem;
+      }
+
+      /* --- Timeline --- */
+      .tl {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .tl-link {
+        display: grid;
+        grid-template-columns: auto auto 1fr;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        color: var(--text-primary);
+        text-decoration: none;
+        transition: background var(--transition-fast);
+      }
+      .tl-link:hover {
+        background: var(--surface-hover);
+      }
+      .tl-link:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .tl-node {
+        flex: none;
+        width: 7px;
+        height: 7px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+      }
+      .tl-date {
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .tl-title {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 0.875rem;
+        font-weight: 550;
+      }
+
+      /* --- Commitments (who owes what) --- */
+      .ci-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .ci {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+      }
+      .ci-main {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: var(--space-2);
+      }
+      .ci-owner {
+        flex: none;
+        padding: 1px var(--space-2);
+        border-radius: var(--radius-pill);
+        background: var(--accent-soft);
+        color: var(--accent-hover);
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .ci-text {
+        min-width: 0;
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        line-height: 1.4;
+      }
+      .ci-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .ci-due {
+        height: 22px;
+        padding: 0 var(--space-2);
+        font-size: 0.6875rem;
+      }
+      .ci-src {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-decoration: none;
+      }
+      .ci-src:hover {
+        color: var(--accent-hover);
+        text-decoration: underline;
+      }
+
+      /* --- Facts --- */
+      .fact-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .fact {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-sm);
+        background: var(--surface-input);
+        font-size: 0.8125rem;
+      }
+      .fact-changed {
+        opacity: 0.7;
+      }
+      .fact-pred {
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 0.6875rem;
+        font-weight: 600;
+      }
+      .fact-obj {
+        color: var(--text-primary);
+        font-weight: 550;
+      }
+      .fact-changed .fact-obj {
+        font-weight: 400;
+      }
+      .fact-since {
+        margin-left: auto;
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+
+      /* --- Neighbours --- */
+      .nb-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .nb {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: var(--space-3);
+        width: 100%;
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--border-subtle);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font-family: inherit;
+        font-size: 0.875rem;
+        text-align: left;
+        cursor: pointer;
+        transition:
+          background var(--transition),
+          border-color var(--transition);
+      }
+      .nb:hover {
+        background: var(--surface-hover);
+        border-color: var(--border-strong);
+      }
+      .nb:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .nb-dot {
+        flex: none;
+        width: 7px;
+        height: 7px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+      }
+      .nb.is-project .nb-dot {
+        background: #9d7bff;
+      }
+      .nb-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 550;
+      }
+      .nb-count {
+        flex: none;
+        min-width: 22px;
+        height: 22px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .dossier {
+          animation: none;
+        }
+      }
+    `,
+  ],
+})
+export class PersonDossierComponent {
+  private readonly ipc = inject(IpcService);
+
+  /** The person/entity to build the dossier for; changing it re-loads the pane. */
+  readonly entityId = input.required<string>();
+  /** Emits when the user picks a neighbour — the container re-selects it. */
+  readonly select = output<string>();
+  /** Emits when the user dismisses the pane. */
+  readonly close = output<void>();
+
+  readonly dossier = signal<DossierData | null>(null);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  /** Currently-valid facts (open — `validTo == null`): the present state. */
+  protected readonly currentFacts = computed(() =>
+    (this.dossier()?.facts ?? []).filter((f) => f.validTo == null),
+  );
+  /** Superseded facts (closed — `validTo` set): the history / what changed. */
+  protected readonly changedFacts = computed(() =>
+    (this.dossier()?.facts ?? []).filter((f) => f.validTo != null),
+  );
+
+  /** A compact "3 meetings · 2 open · 4 facts" summary for the header. */
+  protected readonly summaryLabel = computed(() => {
+    const d = this.dossier();
+    if (!d) {
+      return "";
+    }
+    const parts: string[] = [
+      d.meetings.length === 1 ? "1 meeting" : `${d.meetings.length} meetings`,
+    ];
+    if (d.commitments.length) {
+      parts.push(`${d.commitments.length} open`);
+    }
+    const facts = this.currentFacts().length;
+    if (facts) {
+      parts.push(facts === 1 ? "1 fact" : `${facts} facts`);
+    }
+    return parts.join(" · ");
+  });
+
+  /**
+   * Re-load the dossier whenever `entityId` changes. The IPC call is a one-shot
+   * promise, so we await it inside an effect that tracks the input signal — a
+   * stale-result guard drops responses that resolve after the id moved on (fast
+   * neighbour-to-neighbour pivots), so the pane never shows mismatched data.
+   * `allowSignalWrites` because loading/error are set synchronously here (NG0600).
+   */
+  private readonly _load = effect(
+    () => {
+      const id = this.entityId();
+      this.loading.set(true);
+      this.error.set(null);
+      void this.fetch(id);
+    },
+    { allowSignalWrites: true },
+  );
+
+  private async fetch(id: string): Promise<void> {
+    try {
+      const result = await this.ipc.getPersonDossier(id);
+      // Guard against an out-of-order resolution (the selection moved on).
+      if (this.entityId() !== id) {
+        return;
+      }
+      this.dossier.set(result);
+    } catch (e) {
+      if (this.entityId() !== id) {
+        return;
+      }
+      this.dossier.set(null);
+      this.error.set(String(e));
+    } finally {
+      if (this.entityId() === id) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  /** The trimmed owner name, or null when unattributed (so the chip is skipped). */
+  protected ownerLabel(c: Commitment): string | null {
+    const o = c.owner?.trim();
+    return o ? o : null;
+  }
+
+  protected sharedLabel(nb: EntityNeighbor): string {
+    return nb.sharedMeetings === 1
+      ? "1 shared meeting"
+      : `${nb.sharedMeetings} shared meetings`;
+  }
+
+  /** Short, locale-aware date for timeline rows + fact validity (year only when it differs). */
+  protected fmtDate(iso: string | null): string {
+    if (!iso) {
+      return "";
+    }
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) {
+      // Fall back to the raw date portion (facts/meetings always carry ISO strings).
+      return iso.split(/[T ]/)[0] ?? "";
+    }
+    const now = new Date();
+    const opts: Intl.DateTimeFormatOptions =
+      d.getFullYear() === now.getFullYear()
+        ? { month: "short", day: "numeric" }
+        : { month: "short", day: "numeric", year: "numeric" };
+    return d.toLocaleDateString(undefined, opts);
+  }
+}


### PR DESCRIPTION
## Tier 4b (frontend) — the relationship-OS Person page

Renders the gated `get_person_dossier` `DossierData` (merged in the backend PR) as a native `/people` card: **Timeline** (mentioning meetings) · **Who owes what** (open commitments) · **Facts** (current + what-changed, bitemporal) · **Also appears with** (neighbors). Replaces the graph entity-detail on this pane — a glanceable relationship dossier no competitor builds from your own on-device meetings (the graph SVG stays on `/graph`).

- `models.ts`: `DossierData`/`Commitment`/`Fact` mirror the Rust DTO camelCase field-for-field (**no `corpus`** — note bodies never cross IPC).
- `ipc.service.ts`: one typed `getPersonDossier(entityId)`.
- `person-dossier.component.ts` (new): standalone OnPush signal component; fetch in an `effect()` with `allowSignalWrites` + a **stale-result guard**; `@if`/`@for` track-by-id; `@empty` states; `var(--token)` throughout.

### Verification (adversarial PASS)
- `ng lint` + `ng build` green (per-component 16 kB style budget clean; the `library`/`detail` budget warnings are pre-existing on trunk, untouched here).
- Drove a fresh `ng serve` (dev-mode NG0600 assertions active) with a mocked `invoke` returning a sample dossier: all four sections render, correct counts, neighbor-pivot re-fetches, `(close)` works, **zero console errors, no NG0600**.
- **RED-before-GREEN** on the stale-result guard: forcing an out-of-order late response renders the *new* entity (guard present) vs the stale one (guard removed).

Pure FE render over the already-lock-reviewed gated command — no new content path.