### PR TITLE
feat(capture): capture_system_audio default-ON (ws8)

### DIFF
--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -442,6 +442,47 @@ mod tests {
         assert!(merge_streams(Vec::new()).is_empty());
     }
 
+    /// WS8 DEGRADATION (crash-safe default-on guard). With `capture_system_audio` ON, if system
+    /// capture yields NOTHING — Screen-Recording (TCC) permission denied (the fresh-install state),
+    /// or the sidecar spawned but captured no audio → an EMPTY "others" stream — the merge must still
+    /// produce the COMPLETE mic transcript, every segment attributed "me", with no panic and no lost
+    /// content. This is the "degrade to mic-only, never fail the recording" contract the default-on
+    /// flip depends on, proven at the merge layer: the `audio::system` spawn/stop layer returns
+    /// `Ok(None)` on capture failure and the pipeline then feeds only the mic StreamInput (see
+    /// `pipeline::run_inner`). Complements `single_stream_passthrough_is_mic_only_me` (stream ABSENT)
+    /// with the stream-PRESENT-but-EMPTY case.
+    #[test]
+    fn empty_system_stream_degrades_to_full_mic_only() {
+        let origin = Instant::now();
+        let mic = StreamInput {
+            segments: vec![
+                seg(0, 0.0, 2.0, "the whole call recorded on my mic"),
+                seg(1, 2.0, 4.0, "second line survives too"),
+            ],
+            started_at: origin,
+            speaker: SPEAKER_ME,
+        };
+        // System capture failed/denied → an EMPTY stream (zero segments), same start instant.
+        let system = StreamInput {
+            segments: Vec::new(),
+            started_at: origin,
+            speaker: SPEAKER_OTHERS,
+        };
+        let out = merge_streams(vec![mic, system]);
+        // No content lost: both mic segments survive, in order, re-indexed.
+        assert_eq!(out.len(), 2, "mic transcript is complete despite the absent far side");
+        assert!(
+            out.iter().all(|s| s.speaker.as_deref() == Some("me")),
+            "with no system stream every segment is attributed to me"
+        );
+        assert_eq!(
+            out.iter().map(|s| s.text.as_str()).collect::<Vec<_>>(),
+            vec!["the whole call recorded on my mic", "second line survives too"]
+        );
+        assert_eq!(out.iter().map(|s| s.idx).collect::<Vec<_>>(), vec![0, 1]);
+        assert_eq!(out[0].start_s, 0.0, "no spurious time shift from the empty system stream");
+    }
+
     /// REGRESSION (mute × wall-clock alignment — the load-bearing Phase-B invariant).
     ///
     /// A muted-mic span writes SILENCE that keeps the mic buffer full-length (see

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -98,7 +98,23 @@ pub struct AppConfig {
     /// Preferred microphone input device by NAME (cpal exposes no stable id). None = system
     /// default. A saved device that is no longer present falls back to default at capture time.
     pub input_device: Option<String>,
-    /// Capture system audio (the other side of the call) via ScreenCaptureKit. Default off.
+    /// Capture system audio (the other side of the call) via the Core Audio process tap (macOS
+    /// 14.4+) or the ScreenCaptureKit sidecar (13–14.3). Default ON (WS8) — a fresh user's first
+    /// Zoom/Meet/Teams call captures BOTH sides, which is the differentiated edge and the
+    /// diarization/voiceprint keystone. SAFE to default on because capture degrades GRACEFULLY to
+    /// mic-only, crash-free, whenever it can't run: no helper bundled/available
+    /// (`audio::system::is_available` false ⇒ never attempted), a spawn failure (the start call's
+    /// `Err` arm logs + records mic-only), or Screen-Recording (TCC) permission denied — the
+    /// fresh-install state — where the helper exits non-zero and `SystemAudioRecorder::stop` returns
+    /// `Ok(None)`, so the pipeline runs the mic-only single pass (everything attributed `me`). It
+    /// NEVER panics/aborts/fails the recording. The settings-table load treats an absent key as this
+    /// new default (`K_CAPTURE_SYSTEM_AUDIO`), so BOTH fresh and existing key-less installs pick it
+    /// up; an explicit stored opt-out (`false`) is still honored across reload.
+    ///
+    /// NOT verifiable headless — SIGNED-MAC ONLY (per the honesty bar): the real macOS
+    /// Screen-Recording TCC prompt appearing, that a grant-then-restart actually lights up SCK/tap
+    /// capture, genuine dual-stream both-sides capture, and whether capture survives Bluetooth
+    /// headphones — all FFI/permission/live-audio, unprovable by `cargo test`.
     pub capture_system_audio: bool,
     /// Voice-activity-detection pre-segmentation + ASR-feed loudness normalisation for the
     /// Accurate batch transcription. Default ON; off = transcribe the whole buffer (legacy).
@@ -358,7 +374,7 @@ impl Default for AppConfig {
             ollama_model: "llama3.1".to_string(),
             claude_binary: "claude".to_string(),
             input_device: None,
-            capture_system_audio: false,
+            capture_system_audio: true,
             vad_enabled: true,
             keep_hires_masters: false,
             diarize_others: false,
@@ -878,6 +894,30 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(AppConfig::load(&db).unwrap().post_aec_enabled);
+    }
+
+    /// WS8 — system-audio capture defaults ON so a fresh user's first Zoom/Meet/Teams call captures
+    /// BOTH sides (the differentiated edge + the diarization/voiceprint keystone). Default-on is safe
+    /// because capture degrades GRACEFULLY to mic-only when Screen-Recording (TCC) permission is
+    /// absent or no helper is bundled — never panics/aborts/fails the recording (see the field doc +
+    /// `audio::system` spawn/stop + `audio::merge::merge_streams` single-stream passthrough). Assert
+    /// the in-memory struct default AND the settings-table load (empty DB / absent key) resolve to
+    /// `true`, and that an explicit opt-out still persists + reloads OFF (not a one-way latch — the
+    /// existing user who deliberately turned it off stays off). RED on the pre-flip default (`false`).
+    #[test]
+    fn capture_system_audio_defaults_on() {
+        // In-memory struct default.
+        assert!(AppConfig::default().capture_system_audio);
+        // Settings-table path: empty DB (no key written) loads the ON default.
+        let db = temp_db();
+        assert!(AppConfig::load(&db).unwrap().capture_system_audio);
+        // But an explicit opt-out still persists + reloads OFF.
+        let cfg = AppConfig {
+            capture_system_audio: false,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert!(!AppConfig::load(&db).unwrap().capture_system_audio);
     }
 
     /// A2 — the app default whisper model is `small` (RAM-safe; `large-v3` is ~3 GB and swaps on


### PR DESCRIPTION
## Flip the single most damaging default

A new user's first Zoom/Meet/Teams call now captures **both sides** — the far side is Murmur's differentiated edge (ScreenCaptureKit, no bot) and the voiceprint/diarization keystone — instead of only their own mic.

**Graceful degradation is already crash-safe at every layer** (verified across the whole path, no hardening needed): availability gate skips capture with no sidecar → spawn `Err` → mic-only warn → permission-denied `stop()` returns `Ok(None)` → pipeline treats `system_wav` None/unreadable as `sys_16k` None → `merge_streams` with only the mic yields the full transcript. **A fresh install without Screen-Recording permission records mic-only and never aborts the recording** (the crash-safe-FFI rule — the whole risk of this flip).

- `config.rs`: default `false → true` + doc + test (defaults-on, opt-out persists OFF).
- `merge.rs`: degradation proof test (present-but-empty "others" stream → full mic-only).

### Safety (both gates PASS)
- adversarial **PASS** — RED-before-GREEN on both tests (SUT mutants); all 5 degradation layers traced crash-safe (zero `msg_send`, subprocess/Option-based); no other default flipped.
- lock-security **PASS** — the now-universal far-side scratch WAV is delete-on-drop + reclaimed by the startup sweep, never enters DB `audio_path` (unservable via `convertFileSrc`); the only persisted audio is the merged archive, sealed verify-before-destroy; `audio_path:None` masking on locked meetings intact; **no new egress** (system audio is local capture; only the transcript egresses, through the existing redaction+consent gate).

### Deferred follow-up
The onboarding "capture the whole call" step (primes the TCC prompt at setup + a recording-consent disclosure = the BIPA/wiretap surface), plus the real TCC prompt / dual-stream / Bluetooth-headphone verification (signed Mac).

`cargo test --lib` **876 passed / 0 failed**.