### PR TITLE
fix(brain): don't surface StubReasoner echo as an @brain answer

### DIFF
--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -1442,7 +1442,10 @@ mod tests {
         let r = crate::voice_action::VoiceActionResult::nothing_heard();
         assert_eq!(r.status, "nothing_heard");
         assert!(r.command.is_empty(), "nothing was heard ⇒ no command surfaced");
-        assert!(r.summary.contains("Nie usłyszałem"), "friendly PL nudge, not 'didn't catch an action'");
+        assert!(
+            r.summary.contains("didn't hear"),
+            "friendly nudge to click + speak again, not 'didn't catch an action'"
+        );
     }
 
     #[test]

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -140,10 +140,19 @@ impl VoiceActionResult {
         VoiceActionResult::new(
             "unknown",
             "nothing_heard",
-            "Nie usłyszałem polecenia — kliknij i powiedz jeszcze raz.",
+            "I didn't hear a command — click and say it again.",
         )
     }
 }
+
+/// The honest notice surfaced when a RAG floor request found VISIBLE vault matches but NO AI model
+/// is available to SYNTHESIZE an answer — i.e. the active reasoner is the deterministic
+/// [`crate::reason::StubReasoner`] (`id() == "stub"`: brain backend Off, or Local with no GGUF
+/// downloaded yet). The stub's `reason()` returns a DIAGNOSTIC ECHO, never an answer; surfacing that
+/// echo as the assistant's reply is a bug, so the floor returns THIS message + keeps the gated
+/// citations (still useful) under a non-"ok" status the FE renders as a non-answer notice.
+const NO_MODEL_ANSWER_NOTICE: &str = "No AI model is available to answer — showing matching notes \
+    instead. Pick a provider or download an on-device model in Settings.";
 
 /// Dispatch one parsed [`VoiceIntent`] over the GATED vault + consent-gated brain. Synchronous (the
 /// live loop spawns it off-thread) and PANIC-FREE: every fallible step degrades to a graceful
@@ -511,6 +520,26 @@ fn rag_answer(
             "ok",
             format!("I couldn't find anything in your vault about \"{display_query}\"."),
         );
+    }
+
+    // STUB-SHIM (the floor): no real brain is available to SYNTHESIZE an answer. The active reasoner
+    // is the deterministic `StubReasoner` (`id() == "stub"`: backend Off, or Local with no GGUF
+    // downloaded), whose `reason()` returns a DIAGNOSTIC ECHO ("[stub-reason] system=… user=…"),
+    // NEVER an answer — surfacing that echo as the reply reads like a broken answer. Mirror the exact
+    // `reasoner.id() == "stub"` guard the note-context floor uses (`orchestrate.rs`): do NOT call
+    // `reason()`, return an HONEST notice + KEEP the gated citations (still useful), under a non-"ok"
+    // status the FE already renders as a non-answer notice. Placed AFTER grounding so the useful
+    // citations are still surfaced; the visible-only citation set was built above.
+    if reasoner.id() == "stub" {
+        return VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "unavailable".to_string(),
+            summary: NO_MODEL_ANSWER_NOTICE.to_string(),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+        };
     }
 
     // The brain may now ground its answer on BOTH the user's vault notes AND any web results. The
@@ -1037,6 +1066,62 @@ mod tests {
         assert!(
             !res.citations.iter().any(|c| c.contains("Secret")),
             "SEALED meeting must NOT be cited"
+        );
+    }
+
+    /// RED-before-GREEN (adversarial bug 2026-07-04): on the DETERMINISTIC FLOOR (brain backend Off,
+    /// or Local with no GGUF downloaded), `ReasonerCell` dispatches the `StubReasoner`, whose
+    /// `reason()` returns a DIAGNOSTIC ECHO ("[stub-reason] system=… user=…"). Before the fix, with
+    /// non-empty vault grounding this echo became the `summary` under status "ok" and rendered in the
+    /// FE thread as the assistant's ANSWER — a broken-looking reply. The floor MUST NOT surface the
+    /// stub echo: it returns an honest "no model available" notice (non-"ok" status) while KEEPING
+    /// the gated citations. RED on the old code (summary == the "[stub-reason] …" echo, status "ok").
+    #[test]
+    fn floor_with_stub_reasoner_never_surfaces_stub_echo() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // gives a VISIBLE "Atlas Kickoff" note ⇒ non-empty grounding.
+        let stub = crate::reason::StubReasoner;
+        let res = handle_voice_action(
+            &VoiceIntent::Research { topic: "Atlas".into() },
+            &stub,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            None,
+        );
+
+        // THE BUG: the stub's diagnostic echo must NEVER become the assistant's answer.
+        assert!(
+            !res.summary.contains("[stub-reason]"),
+            "stub echo leaked as the answer: {}",
+            res.summary
+        );
+        assert!(
+            !res.summary.contains("stub-reason"),
+            "no stub-echo shape may surface: {}",
+            res.summary
+        );
+        // Honest, non-"ok" status the FE renders as a non-answer notice (reused: the SlackSearch arm's
+        // "unavailable" — an existing VoiceActionStatus already rendered on the FE).
+        assert_eq!(res.status, "unavailable", "stub floor must be a non-'ok' notice, not an answer");
+        assert!(
+            res.summary.contains("No AI model is available"),
+            "the honest notice must be surfaced: {}",
+            res.summary
+        );
+        // The gated citations are still useful and MUST be kept (VISIBLE meeting only).
+        assert!(
+            res.citations.contains(&"[[Atlas Kickoff]]".to_string()),
+            "the visible-only citations must be preserved: {:?}",
+            res.citations
+        );
+        // ...and the SEALED meeting stays out of the citations even on the stub floor.
+        assert!(
+            !res.citations.iter().any(|c| c.contains("Secret")),
+            "SEALED meeting must NOT be cited on the stub floor: {:?}",
+            res.citations
         );
     }
 


### PR DESCRIPTION
## The bug
On the deterministic voice/`@brain` floor, with brain backend **Off** or **Local without a downloaded GGUF** (a plausible mid-download state), `rag_answer` called `reasoner.reason()` and `StubReasoner`'s diagnostic echo — `[stub-reason] system=N chars user=M chars` — became the assistant's answer under status `"ok"`, rendered as a normal thread bubble. No `id()=="stub"` guard existed on the floor (while `orchestrate.rs` has one).

## The fix
Guard `rag_answer` on `reasoner.id()=="stub"` (after grounding is built, before synthesis): return an honest notice — *"No AI model is available to answer — showing matching notes instead. Pick a provider or download an on-device model in Settings."* — under the existing `"unavailable"` `VoiceActionStatus`, **keeping the already-gated (visible-only) citations**. The `nothing_heard()` message moved PL→EN.

**No FE change needed:** `"unavailable"` is already a rendered status; the non-empty notice renders as the bubble text.

**Honest deviation (task premise corrected):** `ask_vault_floor` needs **no** guard — it routes through the `SummarizerProvider` seam (`provider_for(Role::Ask)`), not a reasoner, so a stub echo is architecturally unreachable there (and the Ask *agentic* path breaks to `Ok(None)` → provider floor on a stub). Adding a guard there would be untestable dead code that risks the floor-equivalence tests, so none was added. Verified by grounding, not docs.

## Verification
- **RED-before-GREEN:** neutralizing the guard re-surfaces `[stub-reason]…` as the answer (independently reproduced by the verifier).
- **`cargo test --lib`: 881 passed, 0 failed** — incl. the new `floor_with_stub_reasoner_never_surfaces_stub_echo` and the untouched byte-identity / floor-equivalence tests.
- **adversarial-verifier: PASS** — enumerated every production `reason()` surface (only `rag_answer`), confirmed the guard fires for Off *and* Local-without-model, a real reasoner still answers normally, and sealed content stays uncited on the stub floor.

Gate-neutral for the lock model (it strictly *reduces* what is surfaced; citations reuse the existing `visibility_clause`-gated set). Rust-only, no new deps.