### PR TITLE
fix(recording): reconcile crash-abandoned RECORDING rows at startup

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -342,8 +342,12 @@ pub async fn start_recording(
     let meeting_id = meeting_uuid.to_string();
     let started_at = chrono::Utc::now().to_rfc3339();
 
-    // Persist the meeting in RECORDING state up-front so a crash mid-capture leaves a
-    // recoverable row.
+    // Persist the meeting in RECORDING state up-front so a crash mid-capture leaves a row behind
+    // rather than losing the meeting silently. If this process dies before `stop_recording`, that
+    // row is reconciled to the terminal ERROR state at the next launch
+    // (`Db::reconcile_stuck_recordings`, called from `lib.rs` setup) so it never lingers as a
+    // "still recording" ghost. Full audio salvage of the abandoned capture is tracked separately
+    // (mic-spill task).
     state.db.insert_meeting(&Meeting {
         id: meeting_id.clone(),
         started_at,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -222,6 +222,21 @@ pub fn run() {
                 ));
             }
 
+            // Crash-recovery: a session that died mid-record (crash / SIGKILL / `tauri dev`
+            // hot-rebuild) never ran `stop_recording`, so the meeting row `start_recording` inserted
+            // up-front sits in the library forever as a `RECORDING` "ghost". Flip every such stuck row
+            // to the terminal `ERROR` state so it renders honestly (no spinner, no phantom live row).
+            // ORDERING IS LOAD-BEARING: a future crash-salvage stage (task: mic spill) must claim the
+            // far-side scratch WAV BEFORE the reaper below deletes it, so the launch order is
+            // salvage → reconcile → reap. Reconcile therefore stays ABOVE the reaper/sweep; when
+            // salvage lands it goes ABOVE this reconcile.
+            {
+                let state = app.state::<AppState>();
+                if let Err(e) = state.db.reconcile_stuck_recordings() {
+                    tracing::warn!(target: "startup", error = %e, "could not reconcile stuck recordings");
+                }
+            }
+
             // Reap any capture helper ORPHANED by a previous session that died without a clean Stop
             // (crash / force-quit / a `tauri dev` hot-rebuild SIGKILLing the app mid-record). Such a
             // helper reparents to launchd and keeps capturing to a temp WAV for up to 4h — GBs of

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1178,6 +1178,57 @@ impl Db {
         Ok(())
     }
 
+    /// Crash-recovery reconcile: flip every meeting still stuck in `RECORDING` to the terminal
+    /// `ERROR` state. Returns the number of rows reconciled.
+    ///
+    /// `start_recording` (`commands.rs`) inserts a meeting row in `RECORDING` up-front so a crash /
+    /// SIGKILL mid-capture leaves a recoverable row instead of losing the meeting outright. A process
+    /// that dies before `stop_recording`, though, never transitions that row out of `RECORDING`, so
+    /// it lingers in the library as a "ghost" that still looks live forever. Run this once at launch
+    /// (from `lib.rs` setup, after the DB is open + migrated) to make each ghost HONEST: it becomes a
+    /// plain terminal `ERROR` row (which the library already renders as "Error" — no audio, no note,
+    /// no spinner).
+    ///
+    /// ADDITIVE + non-destructive: no row is deleted and no other column is touched. Full audio
+    /// salvage of an abandoned recording (mic spill) is a SEPARATE, later task. Idempotent — with no
+    /// live recording a second call reconciles 0. Non-`RECORDING` rows (Complete/Error/…) are left
+    /// untouched by the `WHERE status = 'RECORDING'` guard. Logs only meeting UUIDs + a count (no PII).
+    pub fn reconcile_stuck_recordings(&self) -> Result<usize> {
+        let conn = self.lock();
+        // Collect the ghost ids first (UUIDs — not PII) so the reconcile is auditable in the log.
+        let ids: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT id FROM meetings WHERE status = ?1")
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::params![MeetingStatus::Recording.as_str()],
+                    |r| r.get::<_, String>(0),
+                )
+                .map_err(map_err)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)?
+        };
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let n = conn
+            .execute(
+                "UPDATE meetings SET status = ?2 WHERE status = ?1",
+                rusqlite::params![
+                    MeetingStatus::Recording.as_str(),
+                    MeetingStatus::Error.as_str()
+                ],
+            )
+            .map_err(map_err)?;
+        tracing::info!(
+            target: "startup",
+            reconciled = n,
+            ids = ?ids,
+            "reconciled stuck RECORDING meetings to ERROR (crash recovery)"
+        );
+        Ok(n)
+    }
+
     pub fn finalize_meeting(
         &self,
         id: &str,
@@ -6296,6 +6347,52 @@ mod tests {
         assert_eq!(fin.audio_path.as_deref(), Some("/tmp/m1.wav"));
 
         assert!(db.get_meeting("nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn reconcile_stuck_recordings_flips_recording_to_error_and_is_idempotent() {
+        let db = mem_db();
+
+        // A ghost: inserted RECORDING and never stopped (crash mid-capture).
+        db.insert_meeting(&sample_meeting("ghost", "2026-07-04T09:00:00Z"))
+            .unwrap();
+        db.update_meeting_status("ghost", MeetingStatus::Recording)
+            .unwrap();
+
+        // A healthy, finished meeting that must be left alone.
+        db.insert_meeting(&sample_meeting("done", "2026-07-04T10:00:00Z"))
+            .unwrap();
+        db.update_meeting_status("done", MeetingStatus::Summarized)
+            .unwrap();
+
+        // An already-terminal ERROR row must NOT be re-counted (guards against a broad WHERE).
+        db.insert_meeting(&sample_meeting("failed", "2026-07-04T11:00:00Z"))
+            .unwrap();
+        db.update_meeting_status("failed", MeetingStatus::Error)
+            .unwrap();
+
+        // First reconcile flips exactly the one stuck RECORDING row to ERROR.
+        assert_eq!(db.reconcile_stuck_recordings().unwrap(), 1);
+        assert_eq!(
+            db.get_meeting("ghost").unwrap().unwrap().status,
+            MeetingStatus::Error
+        );
+        // Non-recording rows are untouched.
+        assert_eq!(
+            db.get_meeting("done").unwrap().unwrap().status,
+            MeetingStatus::Summarized
+        );
+        assert_eq!(
+            db.get_meeting("failed").unwrap().unwrap().status,
+            MeetingStatus::Error
+        );
+
+        // Idempotent: with no live recording a second call reconciles nothing.
+        assert_eq!(db.reconcile_stuck_recordings().unwrap(), 0);
+        assert_eq!(
+            db.get_meeting("ghost").unwrap().unwrap().status,
+            MeetingStatus::Error
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The gap
`start_recording` inserts the meeting row in `RECORDING` state with the comment *"so a crash mid-capture leaves a recoverable row"* — but nothing ever reconciled it. After a crash / force-quit / dev-rebuild SIGKILL, the dead meeting sat in the library as a permanently-`recording` ghost.

## The fix (stage 1 of 2)
`Db::reconcile_stuck_recordings` — a runtime `UPDATE meetings SET status='ERROR' WHERE status='RECORDING'` — called once at `setup()` **after** migrate and **before** the orphan reaper / scratch sweep. The ordering is commented as **load-bearing**: a future crash-salvage stage (mic spill, separate task) must be able to claim the far-side scratch WAV before the reaper deletes it → `salvage → reconcile → reap`.

- **Reused `MeetingStatus::Error`** (pre-existing) — renders honestly as an "Error" pill with no note / no audio / no spinner. No new variant, **no schema migration**, no `models.ts` change.
- Truth-up the misleading `start_recording` comment.

**Scope:** stage 1 makes the ghost *honest*; it does **not** salvage the abandoned audio (the reaper still deletes the scratch) — that's the stage-2 mic-spill task, and the ordering slot is reserved for it.

## Verification
- **cargo test --lib: 882 passed, 0 failed** — new `reconcile_stuck_recordings_flips_recording_to_error_and_is_idempotent` (flip+count, non-recording rows untouched, idempotent).
- **RED-before-GREEN:** compile-time — the fn didn't exist on trunk; ghosts persisted forever.
- **adversarial-verifier: PASS** — additive (no DROP/DELETE/ALTER; Complete/Draft/already-Error untouched), idempotent, ordered before the reaper, cannot clobber a live recording (runs at setup before any `start_recording` can fire), FE renders `ERROR` honestly, no PII in logs, startup stays panic-free (warn-and-continue).

**Honest bar:** SQL correctness + ordering are proven headless; the end-to-end "ghost flips to Error in the live UI after a real crash" render is inferred from `library.component.ts` and needs a live crash-and-relaunch on a signed build to visually confirm. Rust-only, no new deps.