### PR TITLE
chore(truth-up): align README/comments/FE defaults with code + capture_default_v1 migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The four rule files below are **imported into context automatically** via the `@
 A **local-first macOS desktop app** that records meetings, transcribes on-device, turns the transcript into a clean note via a pluggable LLM provider, and lives inside the user's **Obsidian vault**. Currently shipped at **0.5.0**.
 
 - **Stack:** Tauri 2.11 (Rust crate `murmur`, lib `meetnotes_lib`, bin `Murmur`) + Angular 18 **zoneless** (standalone, signals). IPC = Tauri commands (registered in `src-tauri/src/lib.rs` `generate_handler!`) + events. The FE talks to the backend through `src/app/core/ipc.service.ts` — **there is no NgRx**.
-- **Pipeline:** capture (mic via `cpal` + system audio via a Swift **ScreenCaptureKit** sidecar) → **dual-stream** (transcribed separately, merged by wall-clock → `Me`/`Others`) → **whisper.cpp** (`whisper-rs`, Metal; default model **large-v3**) → segments → **SQLite (canonical source of truth, SQLCipher-encrypted)** → `SummarizerProvider` → note markdown → atomic **Obsidian `.md`** export.
+- **Pipeline:** capture (mic via `cpal` + system audio via a Swift **ScreenCaptureKit** sidecar) → **dual-stream** (transcribed separately, merged by wall-clock → `Me`/`Others`) → **whisper.cpp** (`whisper-rs`, Metal; default model **small**, ~470 MB — `tiny`…`large-v3` selectable) → segments → **SQLite (canonical source of truth, SQLCipher-encrypted)** → `SummarizerProvider` → note markdown → atomic **Obsidian `.md`** export.
 - **Providers (one trait, swappable):** `claude_code` (default), `anthropic` (BYO key in Keychain), `ollama` (local). Cloud-bound text passes the **redaction firewall**.
 - **Three consumption surfaces over one store:** the app UI, a local read-only **MCP server** (`127.0.0.1:8765`), and the Obsidian vault.
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ an AI provider, and (optionally) an Obsidian vault.
   <img src="docs/screenshots/onboarding.png" alt="First-run onboarding wizard" width="720">
 </p>
 
-To unlock the in-meeting brain, download an on-device model (Bielik / Qwen) and turn on **realtime
-reactions** in Settings — see [Providers & the on-device brain](#-providers--the-on-device-brain).
+To run the in-meeting brain fully offline, download an on-device model (Bielik / Qwen) and turn on
+**realtime reactions** in Settings — it gives grounded, cited answers on device. The full model-driven
+**agentic loop** (the brain chooses which tools to call) runs with a **provider connection** — including
+local **Ollama** — while a downloaded on-device model uses a grounded retrieval floor. See
+[Providers & the on-device brain](#-providers--the-on-device-brain).
 Building from source? Jump to [Development](#-development).
 
 ---
@@ -102,9 +105,10 @@ your whole history, and browse what it knows — all over the same store.
   standalone **`@brain`** to open an anchored, multi-turn **thread** where the assistant answers — the
   recording bar stays out of the way at the top.
 - **Voice *or* text, one loop.** Ask by voice (wake phrase or a single **Ask AI** click, click-to-stop
-  so it catches your whole question) or by typing `@brain` — both funnel through the **same model-driven
-  agentic loop** that decides which gated tools to call. A live tool-trace ("Searching notes… ✓") shows
-  its work.
+  so it catches your whole question) or by typing `@brain` — both funnel through the **same brain**. With a
+  **provider connection** (including local **Ollama**) it's a model-driven **agentic loop** that decides
+  which gated tools to call, with a live tool-trace ("Searching notes… ✓"); a downloaded on-device model
+  answers from a grounded retrieval floor instead.
 - **Grounded, not hallucinated.** Every answer is retrieved from your own transcripts and notes first,
   then summarized — with the source meetings cited as chips you can open.
 - **✨ Ask brain on any note.** Hover a note and hit **✨ ask brain** to open a thread seeded from that
@@ -135,8 +139,9 @@ your whole history, and browse what it knows — all over the same store.
   agentic loop, every answer linked back to the meetings it came from. Single-meeting chat cites
   time-indexed transcript segments.
 - **Hybrid retrieval** — keyword search (FTS) fused with on-device **semantic vectors**
-  (`multilingual-e5-small`, 384-dim, `sqlite-vec` KNN, Reciprocal Rank Fusion). On-device, off by default,
-  one-time backfill to enable.
+  (`multilingual-e5-small`, 384-dim, `sqlite-vec` KNN, Reciprocal Rank Fusion). On device and **on by
+  default**; it downloads a ~470 MB on-device embedding model from Settings to activate, and falls back to
+  keyword search until then.
 - **Related meetings** (semantic neighbors) and **entity dossiers** that synthesize a person or project
   across everything they touched.
 
@@ -160,12 +165,15 @@ your whole history, and browse what it knows — all over the same store.
   and merged by host wall-clock into **Me / Others**.
 - **On-device Whisper** (`whisper.cpp` via `whisper-rs`, **Metal**). A *Fast* pass drives ~3-second live
   captions while you record; an *Accurate* beam-search pass (anti-hallucination gates) runs once after you stop.
+- **Live captions are mic-only until you stop.** During the call, the live captions (and the live `@brain`
+  context) transcribe *your* microphone; the other side's system audio is captured in parallel and folded
+  into the full **Me / Others** transcript only after you stop.
 - **Best-effort extras, graceful by default** — Silero **VAD**, optional **speaker diarization** of the
   others stream, **offline echo cancellation**, and opt-in hi-fidelity native-rate masters; each degrades
   cleanly when its model is absent.
 - **Guardrails** — a 4-hour cap, live mic-mute that preserves sync, an input-device picker, and detection
-  of a running meeting app (Zoom / Teams / Webex). Whisper sizes `tiny`…`large-v3` (default **large-v3**)
-  download once from Settings.
+  of a running meeting app (Zoom / Teams / Webex). Whisper sizes `tiny`…`large-v3` (**default `small`**,
+  ~470 MB — a RAM-safe default; all sizes stay selectable) download once from Settings.
 
 <p align="center">
   <img src="docs/screenshots/bar.png" alt="Floating always-on-top recorder bar" width="560">
@@ -189,8 +197,9 @@ your whole history, and browse what it knows — all over the same store.
   re-summarize any meeting with a different model.
 - **Recipes** turn a transcript into emails, decision logs, or action lists; action items can push to **Apple Reminders**.
 - **Timeline & more** — an interactive **speaker + topic timeline**, pin-a-moment block refs, weekly
-  **digests**, deterministic cross-meeting **Topic Threads**, and a calendar-aware **pre-meeting brief**
-  (on-device EventKit, zero-OAuth).
+  **digests**, and deterministic cross-meeting **Topic Threads**. Your on-device macOS **calendar**
+  (EventKit, zero-OAuth) is reachable on demand as the brain's `calendar_lookup` tool when you ask in
+  Ask / `@brain` (e.g. "who's in my next meeting?") — there is no standalone proactive brief screen.
 
 <p align="center">
   <img src="docs/screenshots/detail-timeline.png" alt="Interactive speaker + topic timeline" width="860">
@@ -222,8 +231,10 @@ Murmur is a **Tauri 2.11** desktop app: a **Rust** core (crate `murmur`, lib `me
 talks to an **Angular 18 zoneless** frontend over Tauri IPC. There's no NgRx — every screen is a standalone
 *signals* component calling a single `IpcService`. The Rust side captures, transcribes, summarizes, and
 persists everything to **one SQLCipher-encrypted SQLite database** — the canonical store. Over it sit the
-**on-device brain** (an agentic reasoning + RAG loop that powers the in-meeting assistant and Ask), plus
-three read surfaces: the app UI, a read-only **MCP server**, and your Obsidian vault.
+**brain** (a grounded RAG + reasoning layer powering the in-meeting assistant and Ask — full model-driven
+agentic tool-choice with a provider connection incl. local Ollama, a grounded retrieval floor on a
+downloaded on-device model), plus three read surfaces: the app UI, a read-only **MCP server**, and your
+Obsidian vault.
 
 ```mermaid
 flowchart LR
@@ -235,7 +246,7 @@ flowchart LR
   redact["🛡️ Redaction firewall"] --> prov
   prov["✍️ Summarizer<br/>claude_code · anthropic · ollama · gateway"] --> db
   db[("🗄️ SQLite + SQLCipher<br/>per-folder AES-256-GCM lock")]
-  db --> brain["🧠 On-device brain<br/>agentic loop · GGUF reasoner · e5 vectors"]
+  db --> brain["🧠 Brain (grounded RAG + reasoning)<br/>GGUF/cloud reasoner · e5 vectors"]
   brain --> live["💬 In-meeting @brain threads"]
   brain --> ask["🔎 Ask across all meetings"]
   db --> mcp["🧩 MCP server · 127.0.0.1:8765"]
@@ -288,7 +299,7 @@ to run **without a network**.
 
 | Brain / provider | Where it runs | Does meeting text leave your Mac? |
 | --- | --- | --- |
-| **On-device brain** (Bielik / Qwen GGUF) | Fully local | **No.** Reasoning + the in-meeting assistant, on-device. |
+| **On-device brain** (Bielik / Qwen GGUF) | Fully local | **No.** Grounded reasoning + the in-meeting assistant, on-device. |
 | **Ollama** | Fully local | **No.** Nothing leaves the device. |
 | **Claude Code** (default summarizer) | Local CLI → Anthropic's cloud | **Yes** — the *redacted* transcript is sent to Anthropic. |
 | **Anthropic API** (BYO key) | Direct HTTPS → Anthropic | **Yes** — the *redacted* transcript is sent to Anthropic. |
@@ -337,7 +348,9 @@ and the **candle** DeBERTa NER redactor — is **always compiled in** (no cargo 
 runtime **only when its model files are present**, otherwise degrading to a clean no-op.
 
 - 🧠 **On-device reasoners.** A curated GGUF registry — **Bielik-11B**, **Qwen3-14B**, **Qwen2.5-3B** — runs
-  locally via `mistralrs` (Metal). Download one and the brain activates; nothing leaves your Mac.
+  locally via `mistralrs` (Metal). Download one and the on-device brain activates with grounded, cited
+  answers; nothing leaves your Mac. The full model-driven agentic tool-choice runs with a provider
+  connection (including local **Ollama**).
 - 🌐 **Optional live web** (off by default). A consent-gated **Brave** connector (BYO key) lets the brain
   reach the web when you ask it to; web hits are shown distinctly as "via web", and queries are redacted
   before they leave.

--- a/docs/RAG-BAKEOFF.md
+++ b/docs/RAG-BAKEOFF.md
@@ -1,7 +1,7 @@
 <!-- Turnkey protocol for validating retrieval quality on YOUR real Mac + vault. Decides whether the vector/brain stack earns its keep, or FTS5 (already shipped) is enough. -->
 # RAG bake-off — does the vector layer earn its keep? (run on your Mac)
 
-The lock-safe vector + GraphRAG-lite stack is merged but **dormant in prod** (behind the default-off `semantic_search_enabled` flag, with a stub embedder). Before we invest in the real embedder + the local reasoning brain, this protocol answers — **on your real vault** — the one question headless tests can't:
+The lock-safe vector + GraphRAG-lite stack ships and is **on by default** (`semantic_search_enabled` defaults ON since #159/#160). The real on-device embedder (multilingual-e5-small, ~470 MB) is downloaded from Settings and activates on model-presence; until it's downloaded, retrieval falls back to keyword (FTS) search backed by a deterministic stub embedder. This protocol answers — **on your real vault** — the one question headless tests can't:
 
 > **Is the shipped FTS5 search already "a brain", or do paraphrase / cross-lingual / entity-spread questions genuinely need the vector + graph layer?**
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -414,7 +414,8 @@ pub async fn start_recording(
     }
 
     // NOTE: the live VPIO echo-cancel helper (aeccap) is intentionally NEVER spawned anymore.
-    // It is superseded by the OFFLINE AEC pass (`post_aec_enabled`, default on) which cancels
+    // It is superseded by the OFFLINE AEC pass (`post_aec_enabled`, default OFF — opt-in in
+    // Settings → Audio) which cancels
     // echo after Stop using the captured system track as a perfect far-end reference — with zero
     // effect on the live call. On a real Mac VPIO (a) cancelled ~nothing (macOS gives an input-
     // only voice-processing unit no downlink reference) and (b) DUCKED all other apps' audio

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -55,7 +55,9 @@ pub type UnlockedSet = Arc<Mutex<HashSet<String>>>;
 
 /// Spawn the MCP server on a background thread. Best-effort: a bind failure is logged; the app
 /// continues normally. `unlocked` is shared with the command surface so visibility tracks the
-/// live session state. `require_token` gates `tools/call` behind a bearer token (default off).
+/// live session state. `require_token` gates `tools/call` behind a bearer token (default ON —
+/// `AppConfig::mcp_require_token` defaults `true`, and `lib.rs` fails CLOSED to `true` on a
+/// poisoned/unreadable config).
 pub fn spawn(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
     let _ = std::thread::Builder::new()
         .name("murmur-mcp".into())

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -1,15 +1,24 @@
-//! Local on-device reasoning seam (Phase 3a — PROD-INERT).
+//! Local on-device reasoning seam — WIRED into production.
 //!
-//! [`LocalReasoner`] is the trait the heavy local reasoner (mistral.rs with grammar-constrained
-//! decoding, Phase 3b) will implement. This increment ships ONLY the seam plus a deterministic
-//! [`StubReasoner`] and a robust JSON extractor — NO ML crate, NO model download. The real impl is
-//! a one-line swap at the construction site; nothing here is wired into a production path yet
-//! (`graph.rs`/`timeline.rs` keep their existing brittle parse until a later increment).
+//! [`LocalReasoner`] is the trait the whole brain reasons through. It is NO longer inert: the live
+//! dispatch runs through [`ReasonerCell`] (held on `AppState.reasoner`) and drives the shipped
+//! reasoning paths — the agentic tool-choice loop ([`crate::agent`]), the retrieval planner
+//! ([`crate::orchestrate`]), fact/user-memory extraction ([`crate::facts`] / [`crate::user_memory`]),
+//! voice-intent interpretation ([`crate::voice_action`]), and the note/Ask commands
+//! (`ask_vault`, note synthesis in `commands.rs` / `pipeline.rs`). [`active_reasoner`] selects the
+//! concrete impl at runtime from the configured [`BrainBackend`]: the cloud provider
+//! ([`CloudReasoner`], claude_code / anthropic / gateway / local Ollama), the on-device GGUF
+//! ([`mistral::MistralReasoner`], selected when a model resolves on disk), the experimental Apple
+//! Foundation sidecar ([`afm::AfmReasoner`]), or the dependency-free [`StubReasoner`] fallback.
 //!
 //! The [`LocalReasoner::structured`] method is the load-bearing seam: it is where reliable
-//! tool-call / NER-classification JSON comes from. A real impl constrains decoding to the schema;
-//! the stub fakes it but still routes its output through [`extract_first_json`] so the
-//! recover-JSON-from-noisy-text path is exercised and testable.
+//! tool-call / NER-classification / retrieval-plan JSON comes from. NONE of the shipped reasoners
+//! grammar-constrain the decode — the on-device GGUF path DELIBERATELY abandoned
+//! `Constraint::JsonSchema` (it overflowed the model context on Bielik-11B; see
+//! [`mistral::MistralReasoner::structured`]) and instead INSTRUCTS the JSON schema in the prompt,
+//! recovering the object with [`extract_first_json`], the SAME schema-in-prompt approach
+//! [`CloudReasoner`] uses. The robust recover-JSON-from-noisy-text path is therefore load-bearing
+//! for every backend, and every reasoner (stub included) routes through it.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -467,8 +476,11 @@ pub trait LocalReasoner: Send + Sync {
     fn reason(&self, system: &str, user: &str) -> Result<String>;
 
     /// Structured reasoning: run `system` + `user` and return a JSON value. `json_schema` is the
-    /// shape the output must conform to — a real impl constrains decoding to it; the stub ignores
-    /// the constraint but still returns valid JSON recovered via [`extract_first_json`].
+    /// shape the output must conform to. NONE of the shipped impls hard-constrain the decode: the
+    /// GGUF path (`MistralReasoner`) and the cloud path (`CloudReasoner`) both INSTRUCT the schema in
+    /// the prompt and recover the object via [`extract_first_json`] (mistral.rs abandoned
+    /// `Constraint::JsonSchema` — it overflowed the context on Bielik-11B); the stub likewise ignores
+    /// the schema but still returns valid JSON through the same extractor.
     fn structured(&self, system: &str, user: &str, json_schema: &Value) -> Result<Value>;
 }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -574,6 +574,38 @@ impl Db {
             )
             .map_err(map_err)?;
         }
+
+        // WS8 / capture-default: one-time flip of the SYSTEM-AUDIO-CAPTURE default to ON for the
+        // INSTALLED base (fresh installs already default ON via `AppConfig::default().capture_system_audio`
+        // — the default flipped OFF→ON in #167). This reaches DBs that persisted the historical 'false'.
+        // RATIONALE: that stored 'false' comes from onboarding round-tripping the OLD (pre-#167) default,
+        // NOT a deliberate opt-out — so, exactly as the `semantic_default_v1` precedent did for a
+        // historical default, we flip it ON once. Sentinel-guarded (`capture_default_v1`) so it runs
+        // EXACTLY once and never re-fires: a user who turns capture OFF *after* this migration stays off.
+        // Uses the HELD `conn` directly (self.get_setting/set_setting would re-lock `self.lock()` and
+        // DEADLOCK). Config-only settings key, additive, idempotent, and reversible via Settings → Audio
+        // — it touches NO meeting content, crypto, or seal state.
+        let capture_default_applied: Option<String> = conn
+            .query_row(
+                "SELECT value FROM settings WHERE key = 'capture_default_v1'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        if capture_default_applied.is_none() {
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('capture_system_audio', 'true')
+                 ON CONFLICT(key) DO UPDATE SET value = 'true'",
+                [],
+            )
+            .map_err(map_err)?;
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('capture_default_v1', '1')",
+                [],
+            )
+            .map_err(map_err)?;
+        }
         Ok(())
     }
 
@@ -5571,6 +5603,35 @@ mod tests {
         db.migrate().unwrap();
         assert_eq!(
             db.get_setting("semantic_search_enabled").unwrap().as_deref(),
+            Some("false"),
+            "sentinel-guarded: a post-migration opt-out persists across re-migrate"
+        );
+    }
+
+    /// WS8 installed-base flip (mirrors the `semantic_default_v1` precedent): `migrate()` sets
+    /// `capture_system_audio='true'` + the `capture_default_v1` sentinel exactly ONCE; a later opt-out
+    /// (`false`) survives a re-migrate (the sentinel guards the block so it never re-fires). Config-only,
+    /// idempotent, reversible.
+    #[test]
+    fn capture_default_migration_runs_once_and_opt_out_persists() {
+        let db = mem_db();
+        db.migrate().unwrap();
+        assert_eq!(
+            db.get_setting("capture_default_v1").unwrap().as_deref(),
+            Some("1"),
+            "sentinel is set after the migration"
+        );
+        assert_eq!(
+            db.get_setting("capture_system_audio").unwrap().as_deref(),
+            Some("true"),
+            "installed base is flipped ON once"
+        );
+        // A user turns system-audio capture OFF after the migration; re-running migrate() must NOT
+        // flip it back.
+        db.set_setting("capture_system_audio", "false").unwrap();
+        db.migrate().unwrap();
+        assert_eq!(
+            db.get_setting("capture_system_audio").unwrap().as_deref(),
             Some("false"),
             "sentinel-guarded: a post-migration opt-out persists across re-migrate"
         );

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -32,13 +32,16 @@ use crate::error::{AppError, Result};
 use crate::settings::AppConfig;
 use crate::storage::Db;
 
-/// A single read-only tool invocation. The six MCP tools are implemented today; the commented
-/// variants below are the Phase-E extension points (voice-intent-driven WRITE actions) — they are
-/// deliberately NOT yet part of the enum so no surface can dispatch them before the brain lands.
+/// A single read-only tool INVOCATION. This enum holds the 8 read-only calls the brain can run
+/// against the vault: the 6 the MCP surface advertises (`mcp.rs::tools_spec`) — `search_meetings`,
+/// `get_meeting`, `list_recent_meetings`, `search_semantic`, `get_open_commitments`,
+/// `get_entity_dossier` — plus the 2 consent-gated CONNECTOR tools (`WebSearch`, `CalendarLookup`),
+/// which dispatch through the async connector executors rather than the synchronous `execute_tool`.
 ///
-/// Room for future (Phase E, NOT implemented here):
-///   - `NoteAside { text: String }`        — append an aside to the live note.
-///   - `CreateReminder { text, due }`       — create a reminder.
+/// The FULL model-facing catalog is [`tool_specs`] — 11 entries: these 8 read tools, the DB-free
+/// `propose_note` draft tool, and the 2 gated WRITE tools (`save_note`, `create_reminder`). The
+/// writes live on [`GatedToolExecutor`] (dispatched ONLY when it was built with `allow_writes`), NOT
+/// on this enum — so no read-only surface (e.g. MCP) can ever dispatch a write.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolCall {
     /// Full-text search across titles/transcripts/notes.

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -10,6 +10,10 @@
 //!   and the authoritative final transcript produced at stop are unaffected.
 //! - Live quality/latency depends on the chosen model (use a small model for snappy
 //!   captions); a slow tick just means less frequent captions, never a broken recording.
+//! - MIC-ONLY until Stop: this loop transcribes the LOCAL MIC tail alone. The system-audio
+//!   (far-side / other participants) stream is captured separately and is batch-transcribed only
+//!   in the post-Stop `pipeline.rs` dual-stream merge — so the live captions AND the live `@brain`
+//!   context reflect what YOU say during the call; the other side is folded in only after Stop.
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1784,7 +1784,8 @@ export class OnboardingComponent implements OnInit {
       ollamaModel: base?.ollamaModel ?? "llama3.1",
       claudeBinary: base?.claudeBinary ?? "claude",
       inputDevice: base?.inputDevice ?? null,
-      captureSystemAudio: base?.captureSystemAudio ?? false,
+      // Mirrors backend default capture_system_audio = true (settings/config.rs; #167).
+      captureSystemAudio: base?.captureSystemAudio ?? true,
       vadEnabled: base?.vadEnabled ?? true,
       keepHiresMasters: base?.keepHiresMasters ?? false,
       diarizeOthers: base?.diarizeOthers ?? false,
@@ -1824,8 +1825,9 @@ export class OnboardingComponent implements OnInit {
       proactiveHintsEnabled: base?.proactiveHintsEnabled ?? true,
       // Cross-meeting user memory — round-trip the snapshot, default ON (fresh install).
       userMemoryEnabled: base?.userMemoryEnabled ?? true,
-      // brain2 RAG — semantic-search master flag; round-trip the snapshot, default off.
-      semanticSearchEnabled: base?.semanticSearchEnabled ?? false,
+      // brain2 RAG — semantic-search master flag; round-trip the snapshot.
+      // Mirrors backend default semantic_search_enabled = true (settings/config.rs; #159/#160).
+      semanticSearchEnabled: base?.semanticSearchEnabled ?? true,
       // brain2 connectors — web-search toggle + its preserve-only consent; round-trip
       // the snapshot so onboarding never resets them, both default off (no egress).
       webSearchEnabled: base?.webSearchEnabled ?? false,

--- a/src/app/features/record/record.component.ts
+++ b/src/app/features/record/record.component.ts
@@ -109,6 +109,42 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
             }
           </p>
 
+          <!-- Honesty hint: live captions are mic-only until Stop (matches the
+               README "Live captions are mic-only until you stop"). The other
+               side's system audio is captured in parallel and folded into the
+               full Me / Others transcript only after you stop. Compact + muted +
+               flex:none so it never crowds the ticker (which absorbs the flex). -->
+          <span
+            class="cc-scope"
+            role="note"
+            title="Live captions show your side (your microphone) during the meeting. The other participants are captured now and added to the full Me / Others transcript after you stop."
+          >
+            <svg
+              class="cc-scope-ico"
+              viewBox="0 0 16 16"
+              width="12"
+              height="12"
+              aria-hidden="true"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6.5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.3"
+              />
+              <path
+                d="M8 7.2v4"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-linecap="round"
+              />
+              <circle cx="8" cy="4.6" r="0.9" fill="currentColor" />
+            </svg>
+            <span class="cc-scope-text">Your side · full transcript after Stop</span>
+          </span>
+
           <!-- Mic-mute: silences only the local mic; system audio keeps recording.
                Compact (icon-only) so the strip stays uncrowded. -->
           <app-mic-mute-toggle [compact]="true" #micToggle />
@@ -857,6 +893,28 @@ import { MeetingConversationStore } from "../../core/meeting-conversation.store"
       .cc-idle {
         color: var(--text-muted);
         font-style: italic;
+      }
+      /* Live-captions honesty hint — muted, non-shrinking (flex:none) so the
+         ticker keeps absorbing the free space. Not part of the ticker itself. */
+      .cc-scope {
+        flex: none;
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        white-space: nowrap;
+        cursor: default;
+      }
+      .cc-scope-ico {
+        flex: none;
+        opacity: 0.8;
+      }
+      /* On tighter widths drop the label; the ⓘ icon + tooltip still carry it. */
+      @media (max-width: 720px) {
+        .cc-scope-text {
+          display: none;
+        }
       }
       @keyframes cc-in {
         from {

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -920,17 +920,20 @@ export class SettingsStore {
         claudeBinary: cfg.claudeBinary,
         claudeCodeInheritEnv: cfg.claudeCodeInheritEnv ?? false,
         inputDevice: cfg.inputDevice ?? "",
-        captureSystemAudio: cfg.captureSystemAudio ?? false,
+        // Mirrors backend default capture_system_audio = true (settings/config.rs, AppConfig::default; #167).
+        captureSystemAudio: cfg.captureSystemAudio ?? true,
         vadEnabled: cfg.vadEnabled ?? true,
         keepHiresMasters: cfg.keepHiresMasters ?? false,
         diarizeOthers: cfg.diarizeOthers ?? false,
         voiceprintEnabled: cfg.voiceprintEnabled ?? false,
         aecEnabled: cfg.aecEnabled ?? false,
-        postAecEnabled: cfg.postAecEnabled ?? true,
+        // Mirrors backend default post_aec_enabled = false (settings/config.rs, AppConfig::default).
+        postAecEnabled: cfg.postAecEnabled ?? false,
         audioStorageLimitGb:
           cfg.audioStorageLimitGb != null ? String(cfg.audioStorageLimitGb) : "",
         audioAutoPrune: cfg.audioAutoPrune ?? false,
-        modelSize: cfg.modelSize ?? "large-v3",
+        // Mirrors backend default model_size = "small" (settings/config.rs, AppConfig::default).
+        modelSize: cfg.modelSize ?? "small",
         voiceTrigger: cfg.voiceTrigger ?? false,
         noteStyle: cfg.noteStyle ?? "standard",
         notesMode: cfg.notesMode ?? "enhance",
@@ -942,7 +945,8 @@ export class SettingsStore {
         userMemoryEnabled: cfg.userMemoryEnabled ?? true,
         brainModelId: cfg.brainModelId ?? "",
         brainModelPath: cfg.brainModelPath ?? "",
-        semanticSearchEnabled: cfg.semanticSearchEnabled ?? false,
+        // Mirrors backend default semantic_search_enabled = true (settings/config.rs; #159/#160).
+        semanticSearchEnabled: cfg.semanticSearchEnabled ?? true,
         webSearchEnabled: cfg.webSearchEnabled ?? false,
         // AI Gateway (Phase 1) — base URL + model, default "" for pre-existing configs.
         gatewayBaseUrl: cfg.gatewayBaseUrl ?? "",


### PR DESCRIPTION
Fixes documentation/comment/FE-default drift surfaced by the 2026-07-04 truth-audit — **every edited claim was verified against the current code** (a truth-up that introduced a new false claim would be a fail; the adversarial-verifier checked all 14+).

## Stale claims → code truth
- **Default Whisper model** is `small` (~470 MB), not `large-v3` (README + CLAUDE.md).
- **Pre-meeting brief**: the UI was removed in PR #108 and never re-homed; calendar survives only as the brain's `calendar_lookup` tool in Ask/`@brain` — bullet reworded (no proactive-brief promise).
- **Semantic search** is **on by default** (#159/#160); the model downloads from Settings and it falls back to keyword search until then — not "off by default" (README + `docs/RAG-BAKEOFF.md`).
- **Agentic loop**: the model-driven tool-choice loop runs on provider connections (**including local Ollama**); the downloaded GGUF / AFM / Off use a grounded retrieval **floor** — reworded from the on-device-agentic claim (quick-start, bullets, architecture prose, mermaid node, comparison row).
- **Live captions are mic-only until Stop** — one README line + a record-screen hint + a `live.rs` comment.
- Comments: `post_aec` default **OFF** (said "default on"); MCP token gate default **ON** (said "default off"); `reason.rs` drop the stale "PROD-INERT" header for the real wiring; `tools.rs` **11-entry** `tool_specs` catalog (said "six MCP tools"); `LocalReasoner::structured` doc aligned with the schema-in-prompt reality.

## FE default-fallback drift
The `??` fallbacks (fired when a loaded config lacks a field) now mirror the backend defaults: `postAecEnabled` false, `captureSystemAudio` true, `semanticSearchEnabled` true, `modelSize` small — each with a comment naming the backend source of truth. The `captureSystemAudio ?? false` one was a real bug (a fresh-install onboarding persisted `false`, defeating the #167 default-ON).

## `capture_default_v1` installed-base migration
A one-time sentinel migration flipping a stored `capture_system_audio='false'` → `'true'`, mirroring `semantic_default_v1` exactly. Rationale: the pre-#167 stored `false` came from onboarding round-tripping the old default, not a deliberate opt-out; the semantic flip set the precedent. **Additive, idempotent, sentinel-guarded** — an explicit opt-out *after* the migration persists across restarts.

## Verification
- **cargo test --lib: 883 passed** — incl. `capture_default_migration_runs_once_and_opt_out_persists`, `migrate_is_idempotent`, `tier1_semantic_default_migration_runs_once_and_opt_out_persists`.
- **ng lint + ng build green.**
- **adversarial-verifier: PASS** — confirmed every edited claim is now TRUE against the code (default model / brief-gone / semantic-on / agentic-gating / live-captions-mic-only / mcp-token-on / post_aec-off / tools-count-11), the migration is additive+idempotent+opt-out-persists, and each FE fallback mirrors the real backend default.

No new deps.