### PR TITLE
feat(brain): embed meeting transcripts into the semantic index

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5037,9 +5037,19 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
         // Defense-in-depth: only index a meeting whose latest note is currently visible.
         match db.get_note_if_visible(&m.id, unlocked) {
             Ok(Some(_note)) => {
-                if let Err(e) = db.index_meeting_chunks(&m.id, embedder) {
-                    // Never abort the whole backfill on one bad note — log (no PII) and continue.
-                    tracing::warn!(target: "rag", error = %e, "reindex: indexing one meeting failed (skipped)");
+                // The meeting is visible ⇒ its segments are restored plaintext; index BOTH the note-
+                // summary and the transcript chunks. A read failure on segments is logged + skipped
+                // (never aborts the whole backfill).
+                match db.get_segments(&m.id) {
+                    Ok(segments) => {
+                        if let Err(e) = db.index_meeting_chunks(&m.id, &segments, embedder) {
+                            // Never abort the whole backfill on one bad note — log (no PII) and continue.
+                            tracing::warn!(target: "rag", error = %e, "reindex: indexing one meeting failed (skipped)");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(target: "rag", error = %e, "reindex: reading segments failed (skipped)");
+                    }
                 }
             }
             Ok(None) => {
@@ -6662,7 +6672,17 @@ fn reindex_meetings_after_unseal(
         return;
     };
     for mid in meeting_ids {
-        if let Err(e) = state.db.index_meeting_chunks(mid, embedder) {
+        // The caller (`unseal_folder_extras`) has ALREADY restored each meeting's segment plaintext
+        // (`restore_segment_text`) and note markdown BEFORE this runs, so the transcript chunks re-derive
+        // from restored plaintext. A segments read failure is logged + skipped (never fails the unlock).
+        let segments = match state.db.get_segments(mid) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(target: "rag", error = %e, "meeting re-index on unlock: reading segments failed (skipped)");
+                continue;
+            }
+        };
+        if let Err(e) = state.db.index_meeting_chunks(mid, &segments, embedder) {
             tracing::warn!(target: "rag", error = %e, "meeting re-index on unlock failed (note plaintext already restored)");
         }
     }
@@ -8498,7 +8518,7 @@ mod lifecycle_tests {
         );
         // Index while the folder is OPEN (the stub stands in for a present model, as every other
         // meeting-chunk test does) → chunks + vectors present.
-        state.db.index_meeting_chunks("m1", &crate::embed::StubEmbedder).unwrap();
+        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
         assert!(state.db.note_chunk_count("m1").unwrap() > 0, "precondition: chunked while open");
         assert!(state.db.note_vec_count("m1").unwrap() > 0, "precondition: vectored while open");
 
@@ -8552,7 +8572,7 @@ mod lifecycle_tests {
             "# Roadmap\n\nrevisit auth and the billing migration next sprint",
             Some("f-lock"),
         );
-        state.db.index_meeting_chunks("m1", &crate::embed::StubEmbedder).unwrap();
+        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
         assert!(state.db.note_chunk_count("m1").unwrap() > 0, "precondition: chunked while open");
 
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();
@@ -8598,7 +8618,7 @@ mod lifecycle_tests {
             "# Notes\n\nlaunch on the 14th; hire two engineers",
             Some("f-lock"),
         );
-        state.db.index_meeting_chunks("m1", &crate::embed::StubEmbedder).unwrap();
+        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
 
         // Lock → purge.
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -33,6 +33,17 @@ pub const EMBED_DIM: usize = 384;
 /// Target character size for one note chunk (paragraphs are merged up to roughly this width).
 const CHUNK_CHAR_TARGET: usize = 800;
 
+/// Target character size for one TRANSCRIPT chunk. Speaker-turn / sliding-window chunking follows the
+/// 2026 meeting-RAG convention (~800-1200 chars): big enough to hold a coherent exchange, small
+/// enough to embed with focus. Turns are accumulated until adding the next one would exceed this.
+const TRANSCRIPT_CHUNK_CHAR_TARGET: usize = 1000;
+
+/// Sliding-window OVERLAP (~15% of [`TRANSCRIPT_CHUNK_CHAR_TARGET`]) carried from the end of one
+/// transcript chunk into the start of the next, so a fact spanning a chunk boundary is embedded in
+/// both windows and stays retrievable. Whole trailing TURNS are carried (never a mid-turn cut) up to
+/// this many characters — this preserves the `[mm:ss-mm:ss] (speaker)` provenance on every line.
+const TRANSCRIPT_CHUNK_OVERLAP_CHARS: usize = 150;
+
 /// Reciprocal Rank Fusion constant (the standard k=60). Larger k flattens the contribution of
 /// rank position; 60 is the widely-used default from the original RRF paper.
 pub const RRF_K: f64 = 60.0;
@@ -390,6 +401,149 @@ pub fn chunk_note(title: &str, date: &str, markdown: &str) -> Vec<String> {
     chunks
 }
 
+/// Render `seconds` as `mm:ss` (minutes uncapped past 60 — a 75-minute meeting reads `75:xx`, not
+/// `01:15:xx`; provenance, not a clock). Negative/NaN clamp to `0`.
+fn mmss(seconds: f64) -> String {
+    let s = if seconds.is_finite() && seconds > 0.0 {
+        seconds as u64
+    } else {
+        0
+    };
+    format!("{:02}:{:02}", s / 60, s % 60)
+}
+
+/// One speaker-turn: consecutive same-speaker segments merged, carrying the turn's overall time span
+/// and the (already-rendered) `[mm:ss-mm:ss] (speaker)\n<text>` line used inside a chunk.
+struct Turn {
+    line: String,
+}
+
+/// Group `segments` into speaker TURNS: runs of consecutive segments with the SAME `speaker` label are
+/// merged into one turn (their texts joined by a space). The speaker tag is the segment's `speaker`
+/// (`me`/`others`, or any Unicode label); `None`/empty renders as `unknown`. Each turn becomes a
+/// single line `[mm:ss-mm:ss] (speaker)\n<merged text>` — the time span runs from the first segment's
+/// `start_s` to the last's `end_s`. Blank-text segments are skipped (they carry no content, only a
+/// gap); a turn made entirely of blank segments is dropped.
+fn group_turns(segments: &[crate::transcribe::types::Segment]) -> Vec<Turn> {
+    let mut turns: Vec<Turn> = Vec::new();
+    let mut cur_speaker: Option<Option<String>> = None; // None = no open turn yet
+    let mut cur_text = String::new();
+    let mut cur_start = 0.0f64;
+    let mut cur_end = 0.0f64;
+
+    let flush = |turns: &mut Vec<Turn>, speaker: &Option<String>, text: &str, start: f64, end: f64| {
+        let text = text.trim();
+        if text.is_empty() {
+            return;
+        }
+        let label = match speaker {
+            Some(s) if !s.trim().is_empty() => s.trim(),
+            _ => "unknown",
+        };
+        turns.push(Turn {
+            line: format!("[{}-{}] ({label})\n{text}", mmss(start), mmss(end)),
+        });
+    };
+
+    for seg in segments {
+        let text = seg.text.trim();
+        if text.is_empty() {
+            continue; // pure-gap segment — no content to attribute.
+        }
+        let same = cur_speaker.as_ref().map(|s| s == &seg.speaker).unwrap_or(false);
+        if same {
+            if !cur_text.is_empty() {
+                cur_text.push(' ');
+            }
+            cur_text.push_str(text);
+            cur_end = seg.end_s;
+        } else {
+            if cur_speaker.is_some() {
+                flush(&mut turns, cur_speaker.as_ref().unwrap(), &cur_text, cur_start, cur_end);
+            }
+            cur_speaker = Some(seg.speaker.clone());
+            cur_text = text.to_string();
+            cur_start = seg.start_s;
+            cur_end = seg.end_s;
+        }
+    }
+    if let Some(sp) = &cur_speaker {
+        flush(&mut turns, sp, &cur_text, cur_start, cur_end);
+    }
+    turns
+}
+
+/// Split a meeting's TRANSCRIPT segments into deterministic, provenance-carrying chunks for the
+/// semantic layer — the SAID-but-not-summarized substrate that note-summary chunks miss.
+///
+/// Pipeline: consecutive same-speaker segments merge into speaker TURNS (`group_turns`); turns are
+/// then packed into sliding windows of ~[`TRANSCRIPT_CHUNK_CHAR_TARGET`] chars with a ~15% overlap
+/// ([`TRANSCRIPT_CHUNK_OVERLAP_CHARS`]) — the trailing whole turn(s) of one window are re-emitted at
+/// the head of the next so a fact spanning a boundary is embedded in both. Each chunk is PREFIXED with
+/// the same `<title> · <date>` header as [`chunk_note`] (so provenance is identical across the two
+/// chunk classes), and every turn line inside carries `[mm:ss-mm:ss] (speaker)` — retrieval therefore
+/// surfaces WHO said it and WHEN.
+///
+/// Pure + deterministic: identical segments always yield identical chunk text (unit-tested), which is
+/// what keeps `content_hash`-based dedup and re-index stable. Empty/blank input yields no chunks. A
+/// single oversized turn becomes its own chunk (never split mid-turn — provenance is kept intact).
+pub fn chunk_transcript(
+    title: &str,
+    date: &str,
+    segments: &[crate::transcribe::types::Segment],
+) -> Vec<String> {
+    let header = format!("{title} · {date}");
+    let turns = group_turns(segments);
+    if turns.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks: Vec<String> = Vec::new();
+    // The turns (as body lines) currently accumulated for the in-progress window.
+    let mut window: Vec<&str> = Vec::new();
+    let mut window_len = 0usize; // char length of the body (lines joined by '\n')
+
+    let emit = |chunks: &mut Vec<String>, window: &[&str]| {
+        if window.is_empty() {
+            return;
+        }
+        chunks.push(format!("{header}\n{}", window.join("\n")));
+    };
+
+    for turn in &turns {
+        let line = turn.line.as_str();
+        let add = if window.is_empty() { line.len() } else { line.len() + 1 };
+        // Close the current window before it overflows (but never emit an empty one).
+        if !window.is_empty() && window_len + add > TRANSCRIPT_CHUNK_CHAR_TARGET {
+            emit(&mut chunks, &window);
+            // OVERLAP: carry the trailing whole turn(s), newest-first up to the overlap budget, into
+            // the next window so a boundary-spanning fact is embedded in both chunks.
+            let mut carry: Vec<&str> = Vec::new();
+            let mut carry_len = 0usize;
+            for &prev in window.iter().rev() {
+                let plen = if carry.is_empty() { prev.len() } else { prev.len() + 1 };
+                if carry_len + plen > TRANSCRIPT_CHUNK_OVERLAP_CHARS && !carry.is_empty() {
+                    break;
+                }
+                carry.push(prev);
+                carry_len += plen;
+            }
+            carry.reverse();
+            window = carry;
+            window_len = window
+                .iter()
+                .map(|l| l.len())
+                .sum::<usize>()
+                + window.len().saturating_sub(1);
+        }
+        let add = if window.is_empty() { line.len() } else { line.len() + 1 };
+        window.push(line);
+        window_len += add;
+    }
+    emit(&mut chunks, &window);
+    chunks
+}
+
 /// Reciprocal Rank Fusion over any number of ranked id-lists (each already ordered best-first).
 /// Each list contributes `1 / (RRF_K + rank)` (rank 1-based) to an id's fused score; scores sum
 /// across lists. Returns `(id, score)` sorted by score DESC, ties broken by id ASC for a stable,
@@ -562,6 +716,128 @@ mod tests {
         let big = format!("{}\n\n{}", "x".repeat(900), "y".repeat(50));
         // 900-char para exceeds target → its own chunk; the 50-char para is a second chunk.
         assert_eq!(chunk_note("T", "D", &big).len(), 2);
+    }
+
+    fn seg(idx: i64, start: f64, end: f64, speaker: Option<&str>, text: &str) -> crate::transcribe::types::Segment {
+        crate::transcribe::types::Segment {
+            idx,
+            start_s: start,
+            end_s: end,
+            text: text.to_string(),
+            speaker: speaker.map(str::to_string),
+            confidence: None,
+        }
+    }
+
+    #[test]
+    fn chunk_transcript_empty_and_blank_yield_no_chunks() {
+        assert!(chunk_transcript("T", "D", &[]).is_empty(), "no segments → no chunks");
+        // Segments with only whitespace text carry no content → no chunks.
+        let blanks = [seg(0, 0.0, 1.0, Some("me"), "   "), seg(1, 1.0, 2.0, Some("others"), "")];
+        assert!(chunk_transcript("T", "D", &blanks).is_empty(), "all-blank transcript → no chunks");
+    }
+
+    #[test]
+    fn chunk_transcript_single_segment_carries_header_time_and_speaker() {
+        let segs = [seg(0, 5.0, 12.0, Some("me"), "let us discuss the budget")];
+        let chunks = chunk_transcript("Quarterly Sync", "2026-06-28", &segs);
+        assert_eq!(chunks.len(), 1);
+        let c = &chunks[0];
+        assert!(c.starts_with("Quarterly Sync · 2026-06-28\n"), "must carry the <title> · <date> header, got: {c:?}");
+        assert!(c.contains("[00:05-00:12] (me)"), "must carry [mm:ss-mm:ss] (speaker) provenance, got: {c:?}");
+        assert!(c.contains("let us discuss the budget"));
+    }
+
+    #[test]
+    fn chunk_transcript_groups_consecutive_same_speaker_into_one_turn() {
+        // Two consecutive "me" segments merge into ONE turn line (one time span, one speaker tag);
+        // then "others" opens a new turn.
+        let segs = [
+            seg(0, 0.0, 3.0, Some("me"), "hello there"),
+            seg(1, 3.0, 6.0, Some("me"), "and welcome"),
+            seg(2, 6.0, 9.0, Some("others"), "thanks glad to be here"),
+        ];
+        let chunks = chunk_transcript("T", "D", &segs);
+        assert_eq!(chunks.len(), 1, "short transcript fits one chunk");
+        let body = &chunks[0];
+        // Exactly two turn headers (me merged, others separate).
+        assert_eq!(body.matches("(me)").count(), 1, "consecutive me segments must merge into one turn");
+        assert_eq!(body.matches("(others)").count(), 1);
+        // The merged me turn spans 0:00-0:06 and joins both texts.
+        assert!(body.contains("[00:00-00:06] (me)\nhello there and welcome"), "got: {body:?}");
+        assert!(body.contains("[00:06-00:09] (others)"));
+    }
+
+    #[test]
+    fn chunk_transcript_solo_me_only() {
+        // A solo (mic-only) recording: every segment is "me" → one turn, one chunk, no "others".
+        let segs = [
+            seg(0, 0.0, 2.0, Some("me"), "note to self one"),
+            seg(1, 2.0, 4.0, Some("me"), "note to self two"),
+        ];
+        let chunks = chunk_transcript("Solo", "2026-06-28", &segs);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].contains("(me)"));
+        assert!(!chunks[0].contains("(others)"));
+    }
+
+    #[test]
+    fn chunk_transcript_unicode_polish_speaker_tag_preserved() {
+        // A non-me/others Unicode speaker label (Polish) must round-trip verbatim into the turn header.
+        let segs = [seg(0, 0.0, 4.0, Some("Łukasz"), "budżet na kwartał wygląda dobrze")];
+        let chunks = chunk_transcript("T", "D", &segs);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].contains("(Łukasz)"), "Unicode speaker tag must survive, got: {:?}", chunks[0]);
+        assert!(chunks[0].contains("budżet na kwartał"));
+    }
+
+    #[test]
+    fn chunk_transcript_none_speaker_renders_unknown() {
+        let segs = [seg(0, 0.0, 4.0, None, "unattributed legacy line")];
+        let chunks = chunk_transcript("T", "D", &segs);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].contains("(unknown)"), "None speaker → (unknown), got: {:?}", chunks[0]);
+    }
+
+    #[test]
+    fn chunk_transcript_windows_with_overlap() {
+        // Build enough alternating turns to force several windows; each turn ~120 chars of body.
+        let mut segs = Vec::new();
+        for i in 0..12i64 {
+            let speaker = if i % 2 == 0 { "me" } else { "others" };
+            // ~110-char utterance so a handful of turns exceed the 1000-char window target.
+            let text = format!("this is turn number {i} with a fair amount of spoken content to push the running window past the target size");
+            segs.push(seg(i, i as f64 * 5.0, i as f64 * 5.0 + 4.0, Some(speaker), &text));
+        }
+        let chunks = chunk_transcript("Long", "2026-06-28", &segs);
+        assert!(chunks.len() >= 2, "long transcript must split into multiple windows, got {}", chunks.len());
+        // Every chunk carries the header.
+        for c in &chunks {
+            assert!(c.starts_with("Long · 2026-06-28\n"), "chunk missing header: {c:?}");
+        }
+        // OVERLAP: the LAST turn line of chunk N must reappear as (near) the FIRST body line of chunk N+1
+        // (whole-turn carry). Assert at least one shared turn line across the first boundary.
+        let turn_lines = |c: &str| -> Vec<String> {
+            c.lines().filter(|l| l.starts_with('[')).map(str::to_string).collect::<Vec<_>>()
+        };
+        let a = turn_lines(&chunks[0]);
+        let b = turn_lines(&chunks[1]);
+        let shared = a.iter().rev().take(3).any(|t| b.contains(t));
+        assert!(shared, "sliding window must overlap: a tail turn of chunk 0 must reappear in chunk 1\n0={a:?}\n1={b:?}");
+        // Overlap stays BOUNDED — the carried body must be well under a full window.
+        let carried_chars: usize = b.iter().take_while(|t| a.contains(t)).map(|t| t.len()).sum();
+        assert!(carried_chars <= TRANSCRIPT_CHUNK_CHAR_TARGET / 2, "overlap must be ~15%, not half a window (got {carried_chars} chars)");
+    }
+
+    #[test]
+    fn chunk_transcript_is_deterministic() {
+        let segs = [
+            seg(0, 0.0, 3.0, Some("me"), "deterministic check one"),
+            seg(1, 3.0, 6.0, Some("others"), "deterministic check two"),
+        ];
+        let a = chunk_transcript("T", "D", &segs);
+        let b = chunk_transcript("T", "D", &segs);
+        assert_eq!(a, b, "chunk_transcript must be pure + deterministic");
     }
 
     #[test]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -568,8 +568,8 @@ mod tests {
         seed(&db, "sealed", "Sealed", "budget planning hiring quarter secret", Some("f-lock"));
 
         let emb = crate::embed::active_embedder();
-        db.index_meeting_chunks("open", emb.as_ref()).unwrap();
-        db.index_meeting_chunks("sealed", emb.as_ref()).unwrap();
+        db.index_meeting_chunks("open", &[], emb.as_ref()).unwrap();
+        db.index_meeting_chunks("sealed", &[], emb.as_ref()).unwrap();
         // Seal the folder AFTER indexing (a stray vec row now exists for a sealed meeting).
         db.set_folder_locked("f-lock", true, None).unwrap();
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1277,7 +1277,11 @@ pub(crate) fn index_meeting_if_enabled(
     if !db.meeting_is_visible(meeting_id, unlocked)? {
         return Ok(()); // sealed-not-unlocked: never index its plaintext.
     }
-    db.index_meeting_chunks(meeting_id, embedder)
+    // Load the meeting's RESTORED/visible plaintext segments so transcript chunks (source_type=
+    // 'transcript') are indexed alongside the note-summary chunks. A sealed meeting is already excluded
+    // above, so these are visible plaintext; an empty transcript simply yields zero transcript chunks.
+    let segments = db.get_segments(meeting_id)?;
+    db.index_meeting_chunks(meeting_id, &segments, embedder)
 }
 
 /// brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION (ALWAYS ON). Build the GATED corpus of

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1537,14 +1537,30 @@ impl Db {
     /// (meeting_id, provider_id, chunk_idx)). Caller MUST only invoke this for visible/unlocked
     /// content — a sealed note's plaintext is blank, so this becomes a no-op if it is ever called on
     /// one (nothing to chunk), but the contract is "visible only".
-    pub fn index_meeting_chunks(&self, meeting_id: &str, embedder: &dyn Embedder) -> Result<()> {
-        // Resolve title + date + latest note markdown (all plaintext = visible content).
+    /// Index a meeting's plaintext into the semantic vector layer as two chunk classes, BOTH written
+    /// in ONE clean-replace transaction (purge-then-reinsert so a re-index replaces both classes):
+    ///   - `source_type = 'voice'` — the note-summary chunks ([`crate::embed::chunk_note`]);
+    ///   - `source_type = 'transcript'` — speaker-turn / sliding-window chunks of the SEGMENTS
+    ///     ([`crate::embed::chunk_transcript`]), so paraphrase queries about things SAID-but-not-
+    ///     summarized are retrievable (the note-only chunks miss them; keyword over the transcript
+    ///     already works via the segments FTS table).
+    ///
+    /// `segments` are the meeting's transcript segments; the caller passes the RESTORED/unsealed
+    /// plaintext (a sealed meeting is never indexed — see the gated callers). Vectors are the e5
+    /// `passage:` embedding of both chunk classes; NEVER a stub vector at rest — the CALLERS only reach
+    /// this when the real embed model is present (`embed_model_present()`; mirrors the note path and
+    /// `reindex_meetings_after_unseal`). A meeting with no note AND no segments ends with zero chunks.
+    pub fn index_meeting_chunks(
+        &self,
+        meeting_id: &str,
+        segments: &[Segment],
+        embedder: &dyn Embedder,
+    ) -> Result<()> {
+        // Resolve title + date (plaintext = visible metadata). Note markdown is optional — a meeting
+        // may have transcript segments but no note yet (or vice versa); each class indexes on its own.
         let meeting = self.get_meeting(meeting_id)?;
         let Some(meeting) = meeting else {
             return Ok(()); // unknown meeting — nothing to index.
-        };
-        let Some(note) = self.get_latest_note_for_meeting(meeting_id)? else {
-            return Ok(()); // no note yet.
         };
         let title = meeting.title.clone().unwrap_or_else(|| "(untitled)".to_string());
         let date = meeting
@@ -1553,19 +1569,38 @@ impl Db {
             .next()
             .unwrap_or("")
             .to_string();
-        let chunks = crate::embed::chunk_note(&title, &date, &note.markdown);
 
-        // Always purge this meeting's prior rows first (clean replace), then insert the fresh set in
-        // ONE transaction. A meeting with a now-empty note simply ends up with zero chunks.
-        let provider_id = note.provider_id.clone();
-        // DOCUMENT side: chunks are passages → use the e5 `passage:` prefix convention. The stub
-        // ignores the prefix; the real CandleBertEmbedder needs it for retrieval recall.
-        let vectors = if chunks.is_empty() {
+        // The note is optional now (transcript chunks index even without a note). `provider_id` is
+        // needed for the note_chunks row; when there is no note we tag chunks with a stable sentinel.
+        let note = self.get_latest_note_for_meeting(meeting_id)?;
+        let provider_id = note
+            .as_ref()
+            .map(|n| n.provider_id.clone())
+            .unwrap_or_else(|| "transcript".to_string());
+
+        // NOTE-SUMMARY chunks (source_type='voice') — unchanged chunking + header.
+        let note_chunks = match note.as_ref() {
+            Some(n) => crate::embed::chunk_note(&title, &date, &n.markdown),
+            None => Vec::new(),
+        };
+        // TRANSCRIPT chunks (source_type='transcript') — speaker-turn / sliding-window with provenance.
+        let transcript_chunks = crate::embed::chunk_transcript(&title, &date, segments);
+
+        // Chunks are passages → e5 `passage:` prefix convention. The stub ignores the prefix; the real
+        // CandleBertEmbedder needs it for retrieval recall. Embed each class only when non-empty.
+        let note_vectors = if note_chunks.is_empty() {
             Vec::new()
         } else {
-            embedder.embed_passage(&chunks)?
+            embedder.embed_passage(&note_chunks)?
+        };
+        let transcript_vectors = if transcript_chunks.is_empty() {
+            Vec::new()
+        } else {
+            embedder.embed_passage(&transcript_chunks)?
         };
 
+        // Always purge this meeting's prior rows first (clean replace of BOTH classes), then insert the
+        // fresh set in ONE transaction.
         let this_meeting = [meeting_id.to_string()];
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
@@ -1575,28 +1610,36 @@ impl Db {
                 .prepare(
                     "INSERT INTO note_chunks
                        (meeting_id, provider_id, chunk_idx, source_type, text, content_hash)
-                     VALUES (?1, ?2, ?3, 'voice', ?4, ?5)",
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 )
                 .map_err(map_err)?;
             let mut ins_vec = tx
                 .prepare("INSERT INTO vec_chunks(chunk_id, embedding) VALUES (?1, ?2)")
                 .map_err(map_err)?;
-            for (idx, (text, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
-                let content_hash = format!("{:016x}", chunk_hash(text));
-                ins_chunk
-                    .execute(rusqlite::params![
-                        meeting_id,
-                        provider_id,
-                        idx as i64,
-                        text,
-                        content_hash
-                    ])
-                    .map_err(map_err)?;
-                let chunk_id = tx.last_insert_rowid();
-                let blob = crate::embed::vec_to_blob(vector);
-                ins_vec
-                    .execute(rusqlite::params![chunk_id, blob])
-                    .map_err(map_err)?;
+            // `chunk_idx` is a per-class ordinal; the two classes are distinguished by `source_type`.
+            let classes: [(&str, &[String], &[Vec<f32>]); 2] = [
+                ("voice", &note_chunks, &note_vectors),
+                ("transcript", &transcript_chunks, &transcript_vectors),
+            ];
+            for (source_type, chunks, vectors) in classes {
+                for (idx, (text, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
+                    let content_hash = format!("{:016x}", chunk_hash(text));
+                    ins_chunk
+                        .execute(rusqlite::params![
+                            meeting_id,
+                            provider_id,
+                            idx as i64,
+                            source_type,
+                            text,
+                            content_hash
+                        ])
+                        .map_err(map_err)?;
+                    let chunk_id = tx.last_insert_rowid();
+                    let blob = crate::embed::vec_to_blob(vector);
+                    ins_vec
+                        .execute(rusqlite::params![chunk_id, blob])
+                        .map_err(map_err)?;
+                }
             }
         }
         tx.commit().map_err(map_err)?;
@@ -7530,7 +7573,7 @@ mod tests {
         db.set_note_folder("target", Some("f-open")).unwrap();
         db.set_note_folder("sealed", Some("f-locked")).unwrap();
         for id in ["source", "target", "sealed"] {
-            db.index_meeting_chunks(id, &crate::embed::StubEmbedder).unwrap();
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
         }
         // Lock the sealed folder WITHOUT purging — its chunk row survives, so any exclusion must be
         // the gate doing its job.
@@ -7575,7 +7618,7 @@ mod tests {
             db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z"))
                 .unwrap();
             note_for(&db, id, "claude_code", body);
-            db.index_meeting_chunks(id, &crate::embed::StubEmbedder).unwrap();
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
         }
         let stub = crate::embed::StubEmbedder;
         let nothing = std::collections::HashSet::new();
@@ -7627,7 +7670,7 @@ mod tests {
         db.set_note_folder("m1", Some("f-locked")).unwrap();
 
         // Index while visible (open folder) with the deterministic stub embedder.
-        db.index_meeting_chunks("m1", &crate::embed::StubEmbedder)
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
             .unwrap();
         assert!(chunk_count(&db, "m1") > 0, "expected chunks after indexing");
         assert!(vec_count(&db, "m1") > 0, "expected vectors after indexing");
@@ -7651,6 +7694,233 @@ mod tests {
         );
     }
 
+    // ── transcript chunks (source_type='transcript') ──────────────────────────
+
+    /// Count `note_chunks` of a given `source_type` for a meeting.
+    fn chunk_count_of(db: &Db, meeting_id: &str, source_type: &str) -> i64 {
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM note_chunks WHERE meeting_id = ?1 AND source_type = ?2",
+                rusqlite::params![meeting_id, source_type],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    fn tseg(idx: i64, start: f64, end: f64, speaker: &str, text: &str) -> Segment {
+        Segment {
+            idx,
+            start_s: start,
+            end_s: end,
+            text: text.to_string(),
+            speaker: Some(speaker.to_string()),
+            confidence: None,
+        }
+    }
+
+    /// `index_meeting_chunks` writes BOTH classes: note-summary (`voice`) AND transcript
+    /// (`transcript`), 1:1-paired with vec rows, in one clean-replace tx.
+    #[test]
+    fn index_meeting_chunks_writes_transcript_class() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "Summary paragraph about the budget.");
+        let segs = [
+            tseg(0, 0.0, 3.0, "me", "so what did we decide on the migration"),
+            tseg(1, 3.0, 8.0, "others", "we agreed to defer it to next quarter"),
+        ];
+        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder)
+            .unwrap();
+
+        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note-summary chunks must be written");
+        assert!(
+            chunk_count_of(&db, "m1", "transcript") > 0,
+            "transcript chunks must be written from segments"
+        );
+        // vec rows are 1:1 with note_chunks rows (both classes).
+        assert_eq!(chunk_count(&db, "m1"), vec_count(&db, "m1"), "every chunk (both classes) has a vector");
+    }
+
+    /// RE-INDEX is a CLEAN REPLACE of BOTH classes: re-running with different segments/note leaves no
+    /// stale rows of either class.
+    #[test]
+    fn index_meeting_chunks_reindex_replaces_both_classes() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "First note.");
+        let segs1 = [tseg(0, 0.0, 3.0, "me", "first pass transcript content")];
+        db.index_meeting_chunks("m1", &segs1, &crate::embed::StubEmbedder).unwrap();
+        let v1 = chunk_count_of(&db, "m1", "transcript");
+        assert!(v1 > 0);
+
+        // Re-index with EMPTY segments → transcript class must go to zero (clean replace, no orphans).
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
+        assert_eq!(
+            chunk_count_of(&db, "m1", "transcript"),
+            0,
+            "re-index with no segments must leave zero stale transcript chunks"
+        );
+        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note class still present after re-index");
+        assert_eq!(chunk_count(&db, "m1"), vec_count(&db, "m1"), "1:1 vec pairing preserved after re-index");
+    }
+
+    /// EMPTY segments → no transcript chunks (the "sealed meeting is never chunked" property in the
+    /// db layer: the gated callers pass the RESTORED plaintext; a sealed meeting whose segments are
+    /// blanked yields the empty slice ⇒ zero transcript chunks).
+    #[test]
+    fn index_meeting_chunks_no_segments_writes_no_transcript_class() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "Only a note, no transcript.");
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
+        assert_eq!(chunk_count_of(&db, "m1", "transcript"), 0, "blank/sealed transcript ⇒ no transcript chunks");
+        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note class still indexes independently");
+    }
+
+    /// GATE (semantic): a sealed-and-not-session-unlocked meeting's TRANSCRIPT chunks surface ZERO
+    /// through `search_semantic_visible`. Mirrors `vec_semantic_search_is_gated_by_visibility` but
+    /// with a real transcript-source chunk that is deliberately left in place (folder flipped to
+    /// locked WITHOUT purge) — so exclusion can ONLY come from `visibility_clause`. RED if the gate
+    /// were removed OR if transcript chunks bypassed the shared reader.
+    #[test]
+    fn transcript_chunks_are_gated_by_visibility_semantic() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("sealed", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "sealed", "claude_code", "note body");
+        db.set_note_folder("sealed", Some("f-locked")).unwrap();
+        // Insert a REAL transcript-source chunk (source_type='transcript') + its vector, then lock the
+        // folder WITHOUT purging — the row survives so any exclusion is the gate.
+        {
+            let conn = db.lock();
+            conn.execute(
+                "INSERT INTO note_chunks (meeting_id, provider_id, chunk_idx, source_type, text)
+                 VALUES ('sealed', 'transcript', 0, 'transcript', ?1)",
+                rusqlite::params!["Secret · 2026-06-24\n[00:00-00:05] (others)\nthe secret merger price is confidential"],
+            )
+            .unwrap();
+            let chunk_id = conn.last_insert_rowid();
+            let blob = crate::embed::vec_to_blob(&one_hot(0));
+            conn.execute(
+                "INSERT INTO vec_chunks(chunk_id, embedding) VALUES (?1, ?2)",
+                rusqlite::params![chunk_id, blob],
+            )
+            .unwrap();
+        }
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        let query = one_hot(0);
+        let nothing = std::collections::HashSet::new();
+        let hidden = db.search_semantic_visible(&query, 10, &nothing).unwrap();
+        assert!(
+            !hidden.iter().any(|h| h.meeting.id == "sealed"),
+            "sealed meeting's TRANSCRIPT chunk leaked through the semantic gate"
+        );
+        // Session-unlock → it reappears (proves the row + gate, not purge).
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let shown = db.search_semantic_visible(&query, 10, &unlocked).unwrap();
+        assert!(
+            shown.iter().any(|h| h.meeting.id == "sealed"),
+            "session-unlocked meeting's transcript chunk must reappear in semantic results"
+        );
+    }
+
+    /// GATE (hybrid): the same sealed meeting's transcript chunk is ALSO absent through the fused
+    /// FTS+semantic+graph reader — with BOTH an FTS term AND a matching query vector — so exclusion
+    /// is the shared `visibility_clause`, not purge. Companion to `vec_hybrid_search_is_gated_by_visibility`.
+    #[test]
+    fn transcript_chunks_are_gated_by_visibility_hybrid() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("sealed", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "sealed", "claude_code", "quarterly merger note body");
+        db.set_note_folder("sealed", Some("f-locked")).unwrap();
+        {
+            let conn = db.lock();
+            conn.execute(
+                "INSERT INTO note_chunks (meeting_id, provider_id, chunk_idx, source_type, text)
+                 VALUES ('sealed', 'transcript', 0, 'transcript', ?1)",
+                rusqlite::params!["Secret · 2026-06-24\n[00:00-00:05] (others)\nthe merger budget is confidential"],
+            )
+            .unwrap();
+            let chunk_id = conn.last_insert_rowid();
+            let blob = crate::embed::vec_to_blob(&one_hot(0));
+            conn.execute(
+                "INSERT INTO vec_chunks(chunk_id, embedding) VALUES (?1, ?2)",
+                rusqlite::params![chunk_id, blob],
+            )
+            .unwrap();
+        }
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        let query_vec = one_hot(0);
+        let nothing = std::collections::HashSet::new();
+        let hidden = db.search_hybrid_visible("merger", &query_vec, 10, &nothing).unwrap();
+        assert!(
+            !hidden.iter().any(|h| h.meeting.id == "sealed"),
+            "sealed meeting's TRANSCRIPT chunk leaked through the hybrid gate"
+        );
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let shown = db.search_hybrid_visible("merger", &query_vec, 10, &unlocked).unwrap();
+        assert!(
+            shown.iter().any(|h| h.meeting.id == "sealed"),
+            "session-unlocked meeting's transcript chunk must reappear in hybrid results"
+        );
+    }
+
+    /// PURGE-ON-SEAL covers transcript chunks: index BOTH classes while visible, then seal the folder
+    /// → ZERO transcript-source chunks remain at rest AND the sealed meeting surfaces ZERO through
+    /// both `search_semantic_visible` and `search_hybrid_visible`. RED if the seal purge missed the
+    /// transcript class.
+    #[test]
+    fn transcript_chunks_purged_on_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "budget summary note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        let segs = [
+            tseg(0, 0.0, 4.0, "me", "budget discussion said aloud but not summarized"),
+            tseg(1, 4.0, 9.0, "others", "we will cut the marketing line item next quarter"),
+        ];
+        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder).unwrap();
+        assert!(chunk_count_of(&db, "m1", "transcript") > 0, "transcript chunks present before seal");
+
+        // Seal the folder (blank note + relock blanker → purge_chunks_tx).
+        db.seal_note("m1", "claude_code", b"ciphertext").unwrap();
+        let mut folders = std::collections::HashSet::new();
+        folders.insert("f-locked".to_string());
+        db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+        assert_eq!(
+            chunk_count_of(&db, "m1", "transcript"),
+            0,
+            "transcript chunks must be purged on seal (no said-content at rest)"
+        );
+        assert_eq!(chunk_count(&db, "m1"), 0, "ALL chunk classes purged on seal");
+        assert_eq!(vec_count(&db, "m1"), 0, "all vectors purged on seal");
+
+        // And they surface nowhere through either gated reader.
+        let query = one_hot(0);
+        let nothing = std::collections::HashSet::new();
+        assert!(
+            !db.search_semantic_visible(&query, 10, &nothing).unwrap().iter().any(|h| h.meeting.id == "m1"),
+            "sealed meeting must not surface via semantic search after purge"
+        );
+        assert!(
+            !db.search_hybrid_visible("marketing", &query, 10, &nothing).unwrap().iter().any(|h| h.meeting.id == "m1"),
+            "sealed meeting must not surface via hybrid search after purge"
+        );
+    }
+
     /// `delete_meeting` must also purge the vec0 layer. `vec_chunks` is an FK-less vec0 vtab, so the
     /// `meetings` ON DELETE CASCADE reaches `note_chunks` but NOT `vec_chunks` — without an explicit
     /// purge the deleted meeting's invertible embeddings ORPHAN at rest (and a reused rowid could
@@ -7668,7 +7938,7 @@ mod tests {
             "claude_code",
             "First budget paragraph.\n\nSecond hiring paragraph.",
         );
-        db.index_meeting_chunks("m1", &crate::embed::StubEmbedder)
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
             .unwrap();
         let raw_vecs = |db: &Db| -> i64 {
             db.lock()

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -319,8 +319,8 @@ mod tests {
         // Index BEFORE sealing (content visible) so a vec_chunks row for the sealed meeting exists —
         // proving the READ-time gate (not just absence of an index row) excludes it.
         let emb = crate::embed::active_embedder();
-        db.index_meeting_chunks("open", emb.as_ref()).unwrap();
-        db.index_meeting_chunks("sealed", emb.as_ref()).unwrap();
+        db.index_meeting_chunks("open", &[], emb.as_ref()).unwrap();
+        db.index_meeting_chunks("sealed", &[], emb.as_ref()).unwrap();
         db.set_folder_locked("f-locked", true, None).unwrap();
 
         let qv = emb


### PR DESCRIPTION
## The gap (RAG-coverage: grade D → )
Semantic recall covered **only note summaries + documents** — `index_meeting_chunks` chunked only `note.markdown`. Paraphrase queries about things **said but not summarized** silently fell back to keyword. The `note_chunks.source_type` column already anticipated this; the pipeline just never wrote transcript chunks.

## The change
- **`chunk_transcript(title, date, segments)`** (embed.rs): groups consecutive same-speaker segments into turns, packs them into sliding windows (~1000 chars) with ~15% **whole-turn** overlap (never a mid-turn cut, so provenance stays intact); each turn carries `[mm:ss-mm:ss] (speaker)`; a single oversized turn is its own chunk. Pure, deterministic, unit-tested (overlap %, turn grouping, solo/empty/single/Unicode-Polish).
- **`index_meeting_chunks`** now also writes `source_type='transcript'` chunks in the **same clean-replace transaction** as the note chunks (signature takes `&[Segment]`). Every caller updated: pipeline auto-index, `reindex_embeddings_inner`, and the **#176 unlock re-index** (segments are restored to plaintext before it runs → transcript chunks re-derive on unlock).
- **Model-absent policy mirrors note chunks exactly** (post-#176): transcript chunks are 1:1-paired with vectors, written **only when the e5 model is present**; model absent = nothing written. The segments FTS already covers transcript keyword search, so nothing is lost and there are **no orphan rows / no stub vectors**.

## Lock model
Purge-on-seal covers them automatically (same tables, `purge_chunks_tx` deletes by `meeting_id` with no `source_type` filter); indexing runs only on **restored plaintext** segments; a sealed-not-unlocked meeting surfaces **no** transcript chunk via `search_semantic_visible` / `search_hybrid_visible` / MCP.

## Verification
- **cargo test --lib: 910 passed** — 14 new tests incl. `transcript_chunks_purged_on_seal`, `transcript_chunks_are_gated_by_visibility_{semantic,hybrid}`, `index_meeting_chunks_reindex_replaces_both_classes`.
- **RED-before-GREEN (×2):** neutering `chunk_transcript` fails the writes-transcript test; forcing `visibility_clause` to `1=1` fails the gating test.
- **adversarial-verifier: PASS** — no stub vectors model-absent, clean-replace keeps note chunks, all callers updated, seal-gating holds.
- **lock-security-reviewer: PASS** — transcript chunks of a sealed meeting leak nothing (semantic/hybrid/MCP `visibility_clause`-gated + purged on seal); no content loss; no PII in logs (provenance names/times live only in gated chunk text, never logged).

## Honest bar / follow-ups
The recall improvement is a **hypothesis until the bake-off (#10) runs** with baseline-vs-transcript numbers — this PR proves transcripts are indexed + gated, not that recall improves. Minor deferred: a `(transcript)` label on `SearchHit` (a multi-file DTO change); the chunk-size constants count bytes not chars (slightly smaller chunks on Polish text). Rust-only, no new deps.