### PR TITLE
fix(recording): surface the 4-hour cap + auto-finalize (cap_reached was dead code)

### DIFF
--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -81,6 +81,17 @@ impl Shared {
 /// 4 hours comfortably covers any real meeting while bounding worst-case memory.
 pub const MAX_RECORDING_SECONDS: u64 = 4 * 60 * 60;
 
+/// Pure RISING-EDGE decision for the "maximum recording length reached" notice: given the current
+/// [`Recorder::cap_reached`] state and whether the notice was ALREADY emitted for this recording,
+/// decide whether to emit it NOW. Emit iff the cap is reached AND it hasn't been emitted yet — so a
+/// status poll that ticks many times a second surfaces the notice exactly ONCE per recording (on the
+/// false→true transition), never re-firing while it stays capped and never firing when not capped.
+///
+/// Extracted as a pure fn so the rising-edge logic is headless-testable without a live capture.
+pub fn should_emit_cap_notice(capped: bool, already_emitted: bool) -> bool {
+    capped && !already_emitted
+}
+
 /// Message sent from the capture thread back to the owner once the stream is built.
 struct StartInfo {
     source_sample_rate: u32,
@@ -616,5 +627,39 @@ mod tests {
             first,
             "anchor must never move after the first frame"
         );
+    }
+
+    /// The 4h-cap NOTICE fires exactly ONCE per recording, on the RISING edge (capped false→true).
+    /// This is the rule that makes the status poll surface "max recording length reached" once —
+    /// never re-firing while it stays capped, never firing when not capped.
+    #[test]
+    fn cap_notice_emits_only_on_rising_edge() {
+        // Not capped → never emit, regardless of the emitted flag.
+        assert!(!should_emit_cap_notice(false, false), "not capped: no emit");
+        assert!(!should_emit_cap_notice(false, true), "not capped: no emit even if flagged");
+
+        // Rising edge: capped and NOT yet emitted → emit ONCE.
+        assert!(should_emit_cap_notice(true, false), "rising edge: capped + not yet emitted → emit");
+
+        // Stays capped after the emit → do NOT re-emit (the flag suppresses the repeat).
+        assert!(!should_emit_cap_notice(true, true), "already emitted while still capped → no re-emit");
+    }
+
+    /// Simulate the per-recording poll loop: many ticks, the cap trips partway, the notice must be
+    /// emitted on exactly one tick. Mirrors how `recording_level` polls `should_emit_cap_notice`
+    /// against a per-recording `capped_notified` flag.
+    #[test]
+    fn cap_notice_fires_once_across_a_poll_loop() {
+        let mut already_emitted = false;
+        let mut emits = 0;
+        // Ticks 0..3 uncapped, then capped from tick 3 onward (the 4h cap trips at tick 3).
+        for tick in 0..10 {
+            let capped = tick >= 3;
+            if should_emit_cap_notice(capped, already_emitted) {
+                emits += 1;
+                already_emitted = true;
+            }
+        }
+        assert_eq!(emits, 1, "the cap notice must fire exactly once across the whole recording");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -344,6 +344,12 @@ pub async fn start_recording(
         }
     }
 
+    // Fresh recording ⇒ re-arm the 4h-cap rising-edge notice (see `recording_level`). If a previous
+    // recording hit the cap and set this, the next recording must be able to fire the notice again.
+    state
+        .capped_notified
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+
     let meeting_uuid = uuid::Uuid::new_v4();
     let meeting_id = meeting_uuid.to_string();
     let started_at = chrono::Utc::now().to_rfc3339();
@@ -570,14 +576,47 @@ fn compute_duration_s(
     }
 }
 
-/// Current mic peak level 0.0..=1.0 for the meter (0.0 when idle). Cheap, polled by UI.
+/// Current mic peak level 0.0..=1.0 for the meter (0.0 when idle). Cheap, polled by UI ~10x/s.
+///
+/// This is ALSO the detection site for the 4h `MAX_RECORDING_SECONDS` hard TIME cap. The live-caption
+/// loop (`transcribe::live`) is only spawned when a whisper model resolves — a user with no model
+/// downloaded gets no live loop, yet the recording (and the cap) still happen — so the live loop is
+/// NOT a reliable place to detect the cap. The FE polls THIS command every 100 ms while recording
+/// (`recorder.store.ts` `level`), unconditionally, for the whole recording — making it the site that
+/// ALWAYS runs. On the RISING edge (cap reached, notice not yet emitted this recording) we emit
+/// [`crate::events::EVENT_RECORDING_CAPPED`] exactly once so the FE can surface the notice and call
+/// `stop_recording` to finalize the meeting (the capped buffer is intact — Stop still yields a note).
+/// Best-effort: a failed emit only warns; the meter read is unaffected.
 #[tauri::command]
-pub fn recording_level(state: State<'_, AppState>) -> Result<f32, AppError> {
+pub fn recording_level(app: AppHandle, state: State<'_, AppState>) -> Result<f32, AppError> {
     let recorder = state
         .recorder
         .lock()
         .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
-    Ok(recorder.as_ref().map(|r| r.level()).unwrap_or(0.0))
+    let Some(r) = recorder.as_ref() else {
+        return Ok(0.0);
+    };
+    let level = r.level();
+    // 4h TIME cap: fire the "maximum recording length reached" notice exactly ONCE per recording,
+    // on the false→true transition. `capped_notified` is the per-recording rising-edge latch,
+    // re-armed at each `start_recording`.
+    if r.cap_reached() {
+        let already = state
+            .capped_notified
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if crate::audio::recorder::should_emit_cap_notice(true, already) {
+            state
+                .capped_notified
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            // PII rule (§8): log the flag only — never any content.
+            tracing::warn!(
+                target: "audio",
+                "maximum recording length reached — surfacing cap notice to finalize the meeting"
+            );
+            crate::events::emit_recording_capped(&app);
+        }
+    }
+    Ok(level)
 }
 
 /// Live-toggle the microphone mute mid-recording (no stream teardown). While muted, the cpal
@@ -7392,6 +7431,7 @@ mod lifecycle_tests {
             reasoner: crate::reason::ReasonerCell::fixed(Arc::new(crate::reason::StubReasoner)),
             current_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
+            capped_notified: std::sync::atomic::AtomicBool::new(false),
             unlocked_folders: Arc::new(Mutex::new(HashSet::new())),
             master_kek: Mutex::new(None),
             lifecycle: Mutex::new(()),

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use tauri::{AppHandle, Emitter};
 
 pub const EVENT_STATUS: &str = "meetnotes://status";
 
@@ -246,4 +247,41 @@ pub const EVENT_STORAGE_PRUNED: &str = "murmur://storage-pruned";
 pub struct StoragePrunedPayload {
     pub freed_bytes: u64,
     pub pruned_count: u64,
+}
+
+/// Emitted ONCE per recording when the mic capture hits the [`crate::audio::recorder::MAX_RECORDING_SECONDS`]
+/// (4h) hard TIME cap and self-stops: past this point the capture thread has torn the stream down,
+/// the meter reads 0, and everything spoken is silently dropped. Fires on the RISING edge only
+/// (capped false→true, deduped per recording). The FE surfaces a "maximum recording length reached"
+/// notice and finalizes the meeting by invoking `stop_recording` (the buffer is capped-but-intact,
+/// so Stop still produces a note). This is a TIME cap — distinct from the byte/size-based
+/// [`EVENT_STORAGE_PRUNED`] storage cap. Carries a length, NO PII.
+pub const EVENT_RECORDING_CAPPED: &str = "murmur://recording-capped";
+
+/// Payload for [`EVENT_RECORDING_CAPPED`]. The cap length in seconds only — NO PII (no content,
+/// no meeting id, no path).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingCappedPayload {
+    /// The maximum recording length (seconds) that was reached — i.e. the cap.
+    pub limit_seconds: u64,
+}
+
+/// Emit [`EVENT_RECORDING_CAPPED`] to the FE (best-effort). The caller decides WHEN to fire (once,
+/// on the rising edge — see [`crate::audio::recorder::should_emit_cap_notice`]); this only performs
+/// the emit and swallows the failure with a `tracing::warn!` so a failed emit can NEVER break the
+/// live status poll or the recording. NO PII is logged (a flag only).
+pub fn emit_recording_capped(app: &AppHandle) {
+    if let Err(e) = app.emit(
+        EVENT_RECORDING_CAPPED,
+        RecordingCappedPayload {
+            limit_seconds: crate::audio::recorder::MAX_RECORDING_SECONDS,
+        },
+    ) {
+        tracing::warn!(
+            target: "audio",
+            error = %e,
+            "failed to emit recording-capped notice"
+        );
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use crate::audio::listener::VoiceListener;
@@ -129,6 +130,12 @@ pub struct AppState {
     /// view of "what's being said right now" — the in-meeting assistant injects it so it can answer
     /// questions about the current meeting. Cleared at each recording start; bounded in size.
     pub live_transcript: Mutex<String>,
+    /// RISING-EDGE dedup for the 4h [`crate::audio::recorder::MAX_RECORDING_SECONDS`] cap notice.
+    /// The status poll (`recording_level`) checks `Recorder::cap_reached()` on every tick; this flag
+    /// makes the resulting [`crate::events::EVENT_RECORDING_CAPPED`] fire EXACTLY ONCE per recording.
+    /// Reset to `false` at each `start_recording`; latched `true` the first tick the cap is reached.
+    /// Distinct from the byte/size storage cap — this is the wall-clock TIME cap.
+    pub capped_notified: AtomicBool,
     /// Folder ids unlocked in the current session: sealed folders decrypted for in-app view +
     /// MCP until relock (cleared on screen-share start or app exit). Arc so the MCP server
     /// thread shares the SAME set as the command surface.
@@ -216,6 +223,7 @@ impl AppState {
             reasoner,
             current_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
+            capped_notified: AtomicBool::new(false),
             unlocked_folders: Arc::new(Mutex::new(std::collections::HashSet::new())),
             master_kek: Mutex::new(None),
             lifecycle: Mutex::new(()),

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -50,6 +50,7 @@ import type {
   StartResult,
   StatusPayload,
   EchoSuppressedPayload,
+  RecordingCappedPayload,
   StopResult,
   TopicThread,
   VoiceActionResultPayload,
@@ -92,6 +93,8 @@ export const EVENT_REINDEX = "murmur://reindex-embeddings";
 export const EVENT_NER_DOWNLOAD = "murmur://ner-download";
 // Recording-storage: an AUTO-prune freed ≥1 old recording's audio to stay under the cap.
 export const EVENT_STORAGE_PRUNED = "murmur://storage-pruned";
+// Recording hit the 4h hard TIME cap and self-stopped (distinct from the byte-based prune).
+export const EVENT_RECORDING_CAPPED = "murmur://recording-capped";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -1055,6 +1058,19 @@ export class IpcService {
     return listen<{ freedBytes: number; prunedCount: number }>(
       EVENT_STORAGE_PRUNED,
       (e) => cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires ONCE per recording when the 4h hard TIME cap (`MAX_RECORDING_SECONDS`)
+   * is reached and the capture self-stops. The FE surfaces a notice and finalizes
+   * the meeting via `stop_recording`. Length only, no PII.
+   */
+  onRecordingCapped(
+    cb: (p: RecordingCappedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<RecordingCappedPayload>(EVENT_RECORDING_CAPPED, (e) =>
+      cb(e.payload),
     );
   }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -22,6 +22,15 @@ export interface EchoSuppressedPayload {
 }
 
 /**
+ * Payload of murmur://recording-capped — the 4h `MAX_RECORDING_SECONDS` hard
+ * TIME cap was reached and the capture self-stopped. Length only, NO PII (no
+ * content, meeting id, or path). Fires once per recording (rising edge).
+ */
+export interface RecordingCappedPayload {
+  limitSeconds: number;
+}
+
+/**
  * GitHub-release update check (`check_for_update`). Mirrors the Rust `UpdateInfo`
  * (serde camelCase). `updateAvailable` is the sole "should we nudge" flag;
  * `releaseName` / `releaseNotes` are null when GitHub omits them. The command

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -107,6 +107,7 @@ export class RecorderStore {
   private unlistenLive: UnlistenFn | null = null;
   private unlistenEcho: UnlistenFn | null = null;
   private unlistenStoragePruned: UnlistenFn | null = null;
+  private unlistenCapped: UnlistenFn | null = null;
 
   async init(): Promise<void> {
     if (this.unlisten) return;
@@ -136,6 +137,19 @@ export class RecorderStore {
       this.toast.info(
         `Freed ${humanBytes(p.freedBytes)} — removed ${p.prunedCount} old recording${p.prunedCount === 1 ? "" : "s"} to stay under your storage limit`,
       );
+    });
+    // 4h TIME-cap notice: the backend capture self-stopped at MAX_RECORDING_SECONDS and everything
+    // spoken past it is dropped. Surface the notice + AUTO-FINALIZE via the existing stop() action so
+    // the meeting still produces a note (the capped buffer is intact). IDEMPOTENT: only dispatch stop()
+    // while we're still in the "recording" stage — a second cap event or a user Stop already in flight
+    // has moved the stage past "recording", so this becomes a no-op (no double stop_recording).
+    this.unlistenCapped = await this.ipc.onRecordingCapped(() => {
+      this.toast.info(
+        "Maximum recording length (4 h) reached — recording stopped; generating your note…",
+      );
+      if (this._stage() === "recording") {
+        void this.stop();
+      }
     });
     await this.refreshLastNote();
   }


### PR DESCRIPTION
## The bug
At the 4-hour cap the capture thread self-stops, but `Recorder::cap_reached` — whose own doc said it exists "for the status poll so the UI can surface a notice and finalize the meeting" — had **zero callers**. So after hour 4 the UI timer kept counting, the level meter read 0, and everything spoken was **silently discarded** until manual Stop.

## The fix
- **Detection site:** the `recording_level` command, which the FE polls every 100 ms **unconditionally**. (Not the live loop — its spawn is gated on a whisper model being present, so a model-less recording would miss the cap entirely.)
- **Rising edge, exactly once:** a pure `should_emit_cap_notice(capped, already_emitted)` fn + an `AppState.capped_notified` latch reset per recording. Emits a typed `murmur://recording-capped` event (added to `events.rs` with a helper — no ad-hoc event names), best-effort (a failed emit only warns).
- **FE:** `RecorderStore.init()` subscribes once (same `Promise<UnlistenFn>` idiom as the sibling event subs), toasts *"Maximum recording length (4 h) reached — recording stopped; generating your note…"*, and **auto-finalizes** via the existing stop action, **idempotency-guarded on `stage === "recording"`** so a second trigger (or a user Stop already in flight) is a no-op. Stop after the cap is safe — the buffer is capped-but-intact.

## Verification
- **cargo test --lib: 912 passed** (+2: `cap_notice_emits_only_on_rising_edge` covers the full truth table; `cap_notice_fires_once_across_a_poll_loop`). **ng lint + ng build green.**
- **RED:** `git grep cap_reached origin/murmur` → definition + doc only, zero call sites (dead API).
- **adversarial-verifier: PASS** — confirmed the detection site always runs, exactly-once rising-edge, the pure fn is truth-table-tested, event name byte-identical BE↔FE, subscribe-once + teardown, no NG0600/setInterval, and browser-mocked the store handler to prove the **double-finalize race** (cap after a user Stop) is a no-op. No collision with #174's `EVENT_STORAGE_PRUNED` (that's the byte/size cap; this is the wall-clock time cap).

**Honest bar:** an actual 4-hour capture + the real cap-trip round-trip is **not runnable headless** — the event/emit/subscribe/idempotency wiring is unit- and browser-mock-proven; the live trip needs an endurance run on a signed build. Not a lock-model change (status event only, no read/export/seal surface). No new deps.