### PR TITLE
fix(brain): make voiceprint suggestion + rename-enroll actually reachable

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4286,6 +4286,16 @@ pub(crate) fn rename_speaker_inner(
         .ok_or_else(|| AppError::InvalidArg("no timeline for this meeting yet".into()))?;
     let mut tl: crate::storage::models::MeetingTimeline = serde_json::from_str(&json)
         .map_err(|e| AppError::InvalidArg(format!("bad timeline data: {e}")))?;
+
+    // Reconstruct the diarized CLUSTER for the OLD label BEFORE the rename rewrites it away. The FE
+    // passes the DISPLAY label the lane shows ("Speaker 1"), not the raw `others-N` tag, so first try
+    // the raw-tag parse (legacy / a raw-tag timeline), then fall back to segment↔turn overlap against
+    // the still-original turns. A label with no overlapping diarized cluster (the "me" lane, or a
+    // non-diarized meeting with no segments) → None → enroll nothing.
+    let old_cluster = parse_others_cluster(old_label).or_else(|| {
+        reconcile_meeting_speakers(state, meeting_id, Some(&tl.speakers)).cluster_for_label(old_label)
+    });
+
     for turn in &mut tl.speakers {
         if turn.speaker == old_label {
             turn.speaker = new_label.to_string();
@@ -4295,13 +4305,14 @@ pub(crate) fn rename_speaker_inner(
         .map_err(|e| AppError::Storage(format!("serialize timeline: {e}")))?;
     state.db.set_timeline_data(meeting_id, &updated)?;
 
-    // ENROLL-ON-RENAME (Phase 2, opt-in): if the OLD label is a diarized cluster (`others-{n}`) and
+    // ENROLL-ON-RENAME (Phase 2, opt-in): if the OLD label resolves to a diarized cluster (either a
+    // raw `others-{n}` tag or, via the reconciliation above, the display label the FE lane showed) and
     // the meeting produced a voiceprint for that cluster, bind the new person name to it so the next
-    // meeting can re-identify this voice. Best-effort + no-op when: the opt-in is off, `others-{n}`
-    // doesn't parse, or no voiceprint exists for that cluster (pre-opt-in recording). The rename
-    // itself already succeeded regardless — a failed/absent enroll never fails the command. The WRITE
-    // is anchored to THIS (already-unlocked) meeting; no other meeting's voiceprint is read/written.
-    if let Some(cluster_index) = parse_others_cluster(old_label) {
+    // meeting can re-identify this voice. Best-effort + no-op when: the opt-in is off, the label maps
+    // to no cluster, or no voiceprint exists for that cluster (pre-opt-in recording). The rename itself
+    // already succeeded regardless — a failed/absent enroll never fails the command. The WRITE is
+    // anchored to THIS (already-unlocked) meeting; no other meeting's voiceprint is read/written.
+    if let Some(cluster_index) = old_cluster {
         let enabled = state
             .config
             .lock()
@@ -4410,14 +4421,59 @@ pub(crate) fn suggest_speaker_labels_inner(
 
     let suggestions =
         suggest_voiceprint_labels(&cluster_refs, &labeled_refs, VOICEPRINT_MATCH_THRESHOLD);
+
+    // RE-KEY by the DISPLAY label the FE lane actually shows: the timeline is LLM-generated, so lane
+    // `speaker` = "Speaker 1"/a real name, NOT the raw `others-N` tag. Reconcile the cluster → that
+    // display label via segment↔turn time-overlap so `suggestionByLabel().get(lane.speaker)` matches
+    // for both multi-cluster and single-cluster 1:1. Best-effort: if the meeting has no timeline / no
+    // segments (legacy, sealed-then-unlocked), reconciliation yields nothing → fall back to the raw
+    // `others-N` tag (harmless — a legacy raw-tag timeline still matches; an LLM one just won't chip).
+    let reconciliation = reconcile_meeting_speakers(state, meeting_id, None);
     Ok(suggestions
         .into_iter()
-        .map(|s| SpeakerSuggestion {
-            speaker: format!("{}-{}", crate::audio::merge::SPEAKER_OTHERS, s.cluster_index),
-            suggested_label: s.label,
-            score: s.score,
+        .map(|s| {
+            let cluster = s.cluster_index as i64;
+            let speaker = reconciliation
+                .label_for_cluster(cluster)
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    format!("{}-{}", crate::audio::merge::SPEAKER_OTHERS, s.cluster_index)
+                });
+            SpeakerSuggestion { speaker, suggested_label: s.label, score: s.score }
         })
         .collect())
+}
+
+/// Build the cluster↔display-label reconciliation for THIS meeting from segment↔turn time-overlap.
+/// Best-effort + gated by the caller (both call sites first pass `meeting_is_unlocked`): reads ONLY
+/// this meeting's segments + its stored (or supplied) timeline turns — never another meeting's data,
+/// so an enroll can never reach a sealed/other cluster. A missing timeline or missing segments (a
+/// legacy or sealed-then-unlocked meeting) yields an empty reconciliation → no-suggestion / no-enroll,
+/// never an error, never a fabricated cluster. Pass `turns` when the caller already parsed the
+/// timeline (avoids a redundant DB read); pass `None` to load it from the DB. NO PII is logged.
+fn reconcile_meeting_speakers(
+    state: &AppState,
+    meeting_id: &str,
+    turns: Option<&[crate::storage::models::SpeakerTurn]>,
+) -> crate::transcribe::diarize::SpeakerReconciliation {
+    use crate::transcribe::diarize::{reconcile_speakers, TurnRef};
+    let segments = state.db.get_segments(meeting_id).unwrap_or_default();
+    // Own the turns when we have to load them, so the borrow outlives the ref view below.
+    let loaded: Vec<crate::storage::models::SpeakerTurn> = match turns {
+        Some(_) => Vec::new(),
+        None => match state.db.get_timeline_data(meeting_id) {
+            Ok(Some(json)) => serde_json::from_str::<MeetingTimeline>(&json)
+                .map(|t| t.speakers)
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        },
+    };
+    let turns = turns.unwrap_or(&loaded);
+    let turn_refs: Vec<TurnRef<'_>> = turns
+        .iter()
+        .map(|t| TurnRef { start_s: t.start_s, end_s: t.end_s, label: &t.speaker })
+        .collect();
+    reconcile_speakers(&segments, &turn_refs)
 }
 
 /// List stored voiceprints for a management view (label + source meeting + cluster + dim), GATED —
@@ -7899,6 +7955,198 @@ mod lifecycle_tests {
         assert!(
             list_voiceprints_inner(&state).unwrap()[0].label.is_none(),
             "opt-in OFF ⇒ no enroll"
+        );
+    }
+
+    /// Insert diarization-tagged segments + an LLM-DISPLAY-labeled timeline for a meeting (overwrites
+    /// `seed_meeting`'s placeholder segments/timeline). Each `(start, end, tag)` segment carries the
+    /// RAW diarization tag; each `(start, end, label)` turn carries the LLM DISPLAY label the FE lane
+    /// renders — the two key spaces the reconciler must bridge.
+    fn seed_diarized(
+        db: &Db,
+        mid: &str,
+        segs: &[(f64, f64, &str)],
+        turns: &[(f64, f64, &str)],
+    ) {
+        let segments: Vec<Segment> = segs
+            .iter()
+            .enumerate()
+            .map(|(idx, (s, e, tag))| Segment {
+                idx: idx as i64,
+                start_s: *s,
+                end_s: *e,
+                text: "x".to_string(),
+                speaker: Some((*tag).to_string()),
+                confidence: None,
+            })
+            .collect();
+        db.insert_segments(mid, &segments).unwrap();
+        let speakers: String = turns
+            .iter()
+            .map(|(s, e, l)| format!("{{\"speaker\":\"{l}\",\"startS\":{s},\"endS\":{e}}}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        db.set_timeline_data(mid, &format!("{{\"topics\":[],\"speakers\":[{speakers}]}}"))
+            .unwrap();
+    }
+
+    /// CRUX (RED-before-GREEN): the timeline is LLM-generated, so the FE lane's `speaker` is the
+    /// DISPLAY label ("Speaker 2"), NOT the raw `others-N` tag. The suggestion MUST be keyed by that
+    /// display label so `suggestionByLabel().get(lane.speaker)` matches and the "Looks like Anna?"
+    /// chip renders. The OLD tag-keyed code emits `speaker == "others-1"` → the FE lookup misses →
+    /// the chip never renders. This asserts the reconciled display-label key.
+    #[test]
+    fn suggest_speaker_labels_keys_by_llm_display_label() {
+        let state = build_state("vp-suggest-display");
+        state.config.lock().unwrap().voiceprint_enabled = true;
+
+        // A prior LABELED voiceprint ("Anna").
+        seed_meeting(&state.db, "prior", "prior", None);
+        let anna = vec![1.0f32, 0.0, 0.0];
+        state
+            .db
+            .insert_voiceprint("vp-prior", "prior", 0, Some("Anna"), &anna, "2026-07-01T00:00:00Z")
+            .unwrap();
+
+        // Current meeting: diarized cluster 1 (segments tagged `others-1`), whose timeline lane the
+        // LLM labeled "Speaker 2"; its voiceprint is near-identical to Anna's.
+        seed_meeting(&state.db, "cur", "cur", None);
+        seed_diarized(
+            &state.db,
+            "cur",
+            &[(0.0, 5.0, "others-1")],
+            &[(0.0, 5.0, "Speaker 2")],
+        );
+        let cur = vec![0.99f32, 0.14, 0.0];
+        state
+            .db
+            .insert_voiceprint("vp-cur", "cur", 1, None, &cur, "2026-07-02T00:00:00Z")
+            .unwrap();
+
+        let sugg = suggest_speaker_labels_inner(&state, "cur").unwrap();
+        assert_eq!(sugg.len(), 1, "the prior match surfaces one suggestion");
+        assert_eq!(
+            sugg[0].speaker, "Speaker 2",
+            "suggestion MUST be keyed by the DISPLAY label the FE lane shows (not the raw others-1 tag)"
+        );
+        assert_eq!(sugg[0].suggested_label, "Anna");
+    }
+
+    /// ENROLL via the DISPLAY label: the FE passes the lane label "Speaker 2" (not `others-1`), so
+    /// enroll must reconstruct cluster 1 from segment↔turn overlap. The OLD
+    /// `parse_others_cluster("Speaker 2") = None` code enrolls nothing (RED).
+    #[test]
+    fn rename_speaker_enrolls_via_display_label() {
+        let state = build_state("vp-enroll-display");
+        state.config.lock().unwrap().voiceprint_enabled = true;
+        seed_meeting(&state.db, "m1", "note", None);
+        seed_diarized(
+            &state.db,
+            "m1",
+            &[(0.0, 5.0, "others-1")],
+            &[(0.0, 5.0, "Speaker 2")],
+        );
+        state
+            .db
+            .insert_voiceprint("vp1", "m1", 1, None, &[0.6f32, 0.8], "2026-07-01T00:00:00Z")
+            .unwrap();
+
+        // Rename the DISPLAY-labeled lane "Speaker 2" → "Anna": cluster 1 gets enrolled.
+        let tl = rename_speaker_inner(&state, "m1", "Speaker 2", "Anna").unwrap();
+        assert!(
+            tl.speakers.iter().any(|t| t.speaker == "Anna"),
+            "the display rename still persists in the timeline"
+        );
+        let listed = list_voiceprints_inner(&state).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].label.as_deref(),
+            Some("Anna"),
+            "enroll reconstructed cluster 1 from the display label via overlap"
+        );
+        assert_eq!(listed[0].cluster_index, 1);
+    }
+
+    /// Single-cluster 1:1 end-to-end: plain `others` segments ↔ cluster 0, LLM lane "Speaker 1".
+    /// Both suggest (keyed by "Speaker 1") and enroll (reconstruct cluster 0) work — and the 1:1 case
+    /// is inferred from the SEGMENT tag shape, not the {0}-only voiceprint set.
+    #[test]
+    fn suggest_and_enroll_single_cluster_1to1() {
+        let state = build_state("vp-1to1");
+        state.config.lock().unwrap().voiceprint_enabled = true;
+
+        // Prior labeled "Sam".
+        seed_meeting(&state.db, "prior", "prior", None);
+        let sam = vec![0.0f32, 1.0, 0.0];
+        state
+            .db
+            .insert_voiceprint("vp-prior", "prior", 0, Some("Sam"), &sam, "2026-07-01T00:00:00Z")
+            .unwrap();
+
+        // Current single-cluster meeting: plain `others` segments, LLM lane "Speaker 1", cluster 0.
+        seed_meeting(&state.db, "cur", "cur", None);
+        seed_diarized(
+            &state.db,
+            "cur",
+            &[(0.0, 6.0, "others"), (7.0, 9.0, "others")],
+            &[(0.0, 9.0, "Speaker 1")],
+        );
+        let cur = vec![0.02f32, 0.99, 0.0];
+        state
+            .db
+            .insert_voiceprint("vp-cur", "cur", 0, None, &cur, "2026-07-02T00:00:00Z")
+            .unwrap();
+
+        // Suggest is keyed by the display label.
+        let sugg = suggest_speaker_labels_inner(&state, "cur").unwrap();
+        assert_eq!(sugg.len(), 1);
+        assert_eq!(sugg[0].speaker, "Speaker 1", "1:1 suggestion keyed by the display label");
+        assert_eq!(sugg[0].suggested_label, "Sam");
+
+        // Enroll via the display label reconstructs cluster 0.
+        rename_speaker_inner(&state, "cur", "Speaker 1", "Sam").unwrap();
+        let cur_row = list_voiceprints_inner(&state)
+            .unwrap()
+            .into_iter()
+            .find(|v| v.meeting_id == "cur")
+            .unwrap();
+        assert_eq!(cur_row.label.as_deref(), Some("Sam"), "1:1 enroll bound cluster 0");
+        assert_eq!(cur_row.cluster_index, 0);
+    }
+
+    /// Renaming a lane that maps to NO diarized cluster (the "me" lane / a non-diarized display label)
+    /// enrolls NOTHING — no fabricated cluster — while a real diarized lane in the same meeting still
+    /// enrolls. Guards against the reconciler over-reaching.
+    #[test]
+    fn rename_speaker_non_diarized_lane_enrolls_nothing() {
+        let state = build_state("vp-me-lane");
+        state.config.lock().unwrap().voiceprint_enabled = true;
+        seed_meeting(&state.db, "m1", "note", None);
+        // A diarized cluster 0 lane ("Speaker 1") AND a disjoint "me" lane the LLM labeled "Jakub".
+        seed_diarized(
+            &state.db,
+            "m1",
+            &[(0.0, 4.0, "others-0"), (4.0, 8.0, "me")],
+            &[(0.0, 4.0, "Speaker 1"), (4.0, 8.0, "Jakub")],
+        );
+        state
+            .db
+            .insert_voiceprint("vp0", "m1", 0, None, &[1.0f32, 0.0], "2026-07-01T00:00:00Z")
+            .unwrap();
+
+        // Renaming the "me"-mapped lane "Jakub" enrolls nothing (it overlaps only "me"/None segments).
+        rename_speaker_inner(&state, "m1", "Jakub", "Jakub K").unwrap();
+        assert!(
+            list_voiceprints_inner(&state).unwrap()[0].label.is_none(),
+            "a non-diarized (me) lane must never fabricate/enroll a cluster"
+        );
+
+        // The real diarized lane still enrolls (positive control).
+        rename_speaker_inner(&state, "m1", "Speaker 1", "Anna").unwrap();
+        assert_eq!(
+            list_voiceprints_inner(&state).unwrap()[0].label.as_deref(),
+            Some("Anna"),
+            "the diarized lane still enrolls its cluster"
         );
     }
 

--- a/src-tauri/src/transcribe/diarize.rs
+++ b/src-tauri/src/transcribe/diarize.rs
@@ -105,6 +105,129 @@ pub fn relabel_others(segments: &mut [Segment], spans: &[SpeakerSpan]) {
     }
 }
 
+// ── Cluster ↔ display-label reconciliation (voiceprint chip + enroll reachability) ─────────────────
+//
+// The meeting timeline is LLM-generated: the summarizer maps each RAW diarization tag
+// (`me`/`others`/`others-N`) to a DISPLAY label ("Speaker 1"/"Speaker 2"/a real name) and the FE
+// renders one lane per display label. The voiceprint suggester keys by the raw cluster index and the
+// FE looks the chip up by the display label — two different key spaces that never match, so the
+// "Looks like Anna?" chip never renders and rename→enroll never fires. This reconciles the two
+// PURELY from segment↔turn TIME-OVERLAP (mirrors `relabel_others`'s max-overlap idea): no timeline
+// schema change, no seal-format change, no I/O here (the caller passes already-gated, this-meeting
+// data). It is bidirectional so BOTH the suggest key (cluster → label) and the enroll lookup
+// (label → cluster) resolve.
+
+/// A timeline turn viewed for reconciliation: its [start,end] seconds + the LLM DISPLAY label.
+#[derive(Clone, Copy)]
+pub struct TurnRef<'a> {
+    pub start_s: f64,
+    pub end_s: f64,
+    pub label: &'a str,
+}
+
+/// A resolved bidirectional map between diarization cluster indices (the `others-{n}` suffix, or 0
+/// for the single-cluster plain-`others` case) and the timeline's display labels, computed from
+/// segment↔turn time-overlap. Empty maps (no timeline, no segments, no overlap) degrade the caller
+/// to no-suggestion / no-enroll — never an error, never a fabricated cluster.
+#[derive(Debug, Default, Clone)]
+pub struct SpeakerReconciliation {
+    cluster_to_label: std::collections::HashMap<i64, String>,
+    label_to_cluster: std::collections::HashMap<String, i64>,
+}
+
+impl SpeakerReconciliation {
+    /// The DISPLAY label the FE lane shows for a diarized cluster index (max total overlap), if any
+    /// turn overlaps that cluster's segments. Drives the suggestion key so `suggestionByLabel().get`
+    /// matches the lane.
+    pub fn label_for_cluster(&self, cluster_index: i64) -> Option<&str> {
+        self.cluster_to_label.get(&cluster_index).map(String::as_str)
+    }
+
+    /// The dominant diarized cluster index under the turns carrying `label` (max total overlap), if
+    /// any of this meeting's segments overlap them. Drives enroll-on-rename from the display label.
+    /// Returns None for a label with no overlapping diarized cluster (e.g. the "me" lane, or a
+    /// non-diarized meeting) — enroll then fabricates nothing.
+    pub fn cluster_for_label(&self, label: &str) -> Option<i64> {
+        self.label_to_cluster.get(label).copied()
+    }
+}
+
+/// True iff `tag` is a NUMBERED diarized cluster tag (`others-N`, N an integer).
+fn tag_is_numbered_cluster(tag: &str) -> bool {
+    tag.strip_prefix(SPEAKER_OTHERS)
+        .and_then(|r| r.strip_prefix('-'))
+        .map(|n| n.parse::<i64>().is_ok())
+        .unwrap_or(false)
+}
+
+/// Map a raw diarization segment tag to its cluster index for reconciliation. `others-N` → N. Plain
+/// `others` → 0 ONLY when the meeting is single-cluster 1:1 — inferred from the tags PRESENT on the
+/// segments (`has_numbered == false`), NOT from the stored-voiceprint set. `me`, an unknown tag, or a
+/// stray plain `others` inside a multi-cluster meeting → None (never a fabricated cluster).
+fn cluster_index_of_tag(tag: &str, has_numbered: bool) -> Option<i64> {
+    if let Some(rest) = tag.strip_prefix(SPEAKER_OTHERS).and_then(|r| r.strip_prefix('-')) {
+        rest.parse::<i64>().ok()
+    } else if tag == SPEAKER_OTHERS && !has_numbered {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+/// Reconcile diarization clusters ↔ timeline display labels from segment↔turn time-overlap. For each
+/// segment whose raw tag maps to a cluster, accumulate its overlap seconds against each turn's display
+/// label; then take the argmax per cluster (→ its label) and per label (→ its cluster). Deterministic:
+/// ties break to the lexicographically-smaller label (cluster → label) / the smaller cluster index
+/// (label → cluster). PURE (no I/O, no FFI) — the caller passes only this (unlocked) meeting's data.
+pub fn reconcile_speakers(segments: &[Segment], turns: &[TurnRef<'_>]) -> SpeakerReconciliation {
+    // Single-cluster 1:1 is inferred from the SEGMENT tags, not the voiceprint set (secondary-bug fix).
+    let has_numbered = segments
+        .iter()
+        .any(|s| s.speaker.as_deref().map(tag_is_numbered_cluster).unwrap_or(false));
+
+    // Total overlap seconds per (cluster_index, display_label).
+    let mut overlap: std::collections::HashMap<(i64, String), f64> = std::collections::HashMap::new();
+    for seg in segments {
+        let Some(tag) = seg.speaker.as_deref() else { continue };
+        let Some(cluster) = cluster_index_of_tag(tag, has_numbered) else { continue };
+        for turn in turns {
+            let ov = (seg.end_s.min(turn.end_s) - seg.start_s.max(turn.start_s)).max(0.0);
+            if ov > 0.0 {
+                *overlap.entry((cluster, turn.label.to_string())).or_insert(0.0) += ov;
+            }
+        }
+    }
+
+    // Deterministic argmax: sort (cluster asc, label asc) then keep the first-seen running-max, so
+    // ties resolve independent of HashMap iteration order.
+    let mut entries: Vec<((i64, String), f64)> = overlap.into_iter().collect();
+    entries.sort_by(|a, b| a.0 .0.cmp(&b.0 .0).then_with(|| a.0 .1.cmp(&b.0 .1)));
+
+    let mut cluster_best: std::collections::HashMap<i64, (f64, String)> = std::collections::HashMap::new();
+    let mut label_best: std::collections::HashMap<String, (f64, i64)> = std::collections::HashMap::new();
+    for ((cluster, label), ov) in entries {
+        // cluster → best label (strictly-greater ⇒ first-seen wins a tie = smaller label).
+        match cluster_best.get(&cluster) {
+            Some((best, _)) if *best >= ov => {}
+            _ => {
+                cluster_best.insert(cluster, (ov, label.clone()));
+            }
+        }
+        // label → best cluster (strictly-greater ⇒ first-seen wins a tie = smaller cluster).
+        match label_best.get(&label) {
+            Some((best, _)) if *best >= ov => {}
+            _ => {
+                label_best.insert(label, (ov, cluster));
+            }
+        }
+    }
+
+    SpeakerReconciliation {
+        cluster_to_label: cluster_best.into_iter().map(|(k, (_, v))| (k, v)).collect(),
+        label_to_cluster: label_best.into_iter().map(|(k, (_, v))| (k, v)).collect(),
+    }
+}
+
 // ── Voiceprints (opt-in): a per-cluster CAM++ speaker embedding for the diarized "others" ──────────
 //
 // PRIVACY: an embedding here is a VOICE BIOMETRIC of a remote participant. It is derived from the
@@ -366,6 +489,84 @@ mod tests {
             speaker: None,
             confidence: None,
         }
+    }
+
+    fn tagged(start_s: f64, end_s: f64, tag: &str) -> Segment {
+        Segment { speaker: Some(tag.into()), ..seg(start_s, end_s) }
+    }
+
+    #[test]
+    fn reconcile_multi_cluster_maps_tag_to_display_label() {
+        // The LLM timeline carries DISPLAY labels ("Speaker 1"/"Speaker 2"), NOT the raw tags; the
+        // segments carry the raw diarization tags. Reconcile via time-overlap.
+        let segs = vec![
+            tagged(0.0, 4.0, "others-0"),
+            tagged(5.0, 9.0, "others-1"),
+            tagged(2.0, 3.0, "me"), // ignored: "me" never maps to a cluster
+        ];
+        let turns = vec![
+            TurnRef { start_s: 0.0, end_s: 4.5, label: "Speaker 1" },
+            TurnRef { start_s: 4.5, end_s: 9.0, label: "Speaker 2" },
+        ];
+        let rec = reconcile_speakers(&segs, &turns);
+        // cluster → the display label the FE lane shows.
+        assert_eq!(rec.label_for_cluster(0), Some("Speaker 1"));
+        assert_eq!(rec.label_for_cluster(1), Some("Speaker 2"));
+        // display label → the diarized cluster (enroll direction).
+        assert_eq!(rec.cluster_for_label("Speaker 1"), Some(0));
+        assert_eq!(rec.cluster_for_label("Speaker 2"), Some(1));
+        // A label that overlaps no diarized cluster (e.g. a "me" lane) → nothing.
+        assert_eq!(rec.cluster_for_label("Nobody"), None);
+    }
+
+    #[test]
+    fn reconcile_single_cluster_plain_others_is_cluster_zero() {
+        // Single remote speaker → segments stay plain "others" (no suffix) + voiceprint cluster 0.
+        let segs = vec![tagged(0.0, 5.0, "others"), tagged(6.0, 9.0, "others")];
+        let turns = vec![TurnRef { start_s: 0.0, end_s: 9.0, label: "Anna" }];
+        let rec = reconcile_speakers(&segs, &turns);
+        assert_eq!(rec.label_for_cluster(0), Some("Anna"));
+        assert_eq!(rec.cluster_for_label("Anna"), Some(0));
+    }
+
+    #[test]
+    fn reconcile_plain_others_is_ignored_when_numbered_tags_present() {
+        // A stray unattributed plain "others" inside a MULTI-cluster meeting must NOT collapse to
+        // cluster 0 (single-cluster 1:1 is inferred from the tag shape).
+        let segs = vec![
+            tagged(0.0, 4.0, "others-1"),
+            tagged(10.0, 12.0, "others"), // stray unattributed → contributes no cluster mapping
+        ];
+        let turns = vec![
+            TurnRef { start_s: 0.0, end_s: 4.0, label: "Speaker 2" },
+            TurnRef { start_s: 10.0, end_s: 12.0, label: "Mystery" },
+        ];
+        let rec = reconcile_speakers(&segs, &turns);
+        assert_eq!(rec.label_for_cluster(1), Some("Speaker 2"));
+        assert_eq!(rec.cluster_for_label("Mystery"), None, "plain others → no cluster 0 here");
+        assert_eq!(rec.label_for_cluster(0), None);
+    }
+
+    #[test]
+    fn reconcile_empty_when_no_timeline_or_no_segments() {
+        // No timeline turns → empty maps (best-effort degrade, never fabricate).
+        let segs = vec![tagged(0.0, 4.0, "others-0")];
+        assert!(reconcile_speakers(&segs, &[]).label_for_cluster(0).is_none());
+        // No segments → empty maps.
+        let turns = vec![TurnRef { start_s: 0.0, end_s: 4.0, label: "Speaker 1" }];
+        assert!(reconcile_speakers(&[], &turns).cluster_for_label("Speaker 1").is_none());
+    }
+
+    #[test]
+    fn reconcile_picks_majority_overlap_label() {
+        // Cluster-0 segment 0..10 overlaps "Speaker 1" for 3s and "Speaker 2" for 7s → Speaker 2.
+        let segs = vec![tagged(0.0, 10.0, "others-0")];
+        let turns = vec![
+            TurnRef { start_s: 0.0, end_s: 3.0, label: "Speaker 1" },
+            TurnRef { start_s: 3.0, end_s: 10.0, label: "Speaker 2" },
+        ];
+        let rec = reconcile_speakers(&segs, &turns);
+        assert_eq!(rec.label_for_cluster(0), Some("Speaker 2"));
     }
 
     #[test]

--- a/src/app/features/detail/detail.component.ts
+++ b/src/app/features/detail/detail.component.ts
@@ -3259,8 +3259,20 @@ export class DetailComponent implements OnInit {
           bg: "rgba(157, 123, 255, 0.16)",
           fg: "#b9a4ff",
         };
-      default:
+      default: {
+        // A diarized remote cluster tag ("others-{n}") → a "Speaker {n+1}" chip (same neutral
+        // violet as "Others"). Presentational only; independent of the timeline lanes' LLM/renamed
+        // labels. Any other/legacy value stays unlabeled (null).
+        const m = /^others-(\d+)$/.exec(speaker ?? "");
+        if (m) {
+          return {
+            label: `Speaker ${Number(m[1]) + 1}`,
+            bg: "rgba(157, 123, 255, 0.16)",
+            fg: "#b9a4ff",
+          };
+        }
         return null;
+      }
     }
   }
 


### PR DESCRIPTION
## The real bug (deeper than the audit found)
The "Looks like Anna?" suggestion chip **and** rename→enroll never fired for **any** meeting shape. The timeline is **LLM-generated** — `summarize/timeline.rs` maps each diarization tag (`others`/`others-N`) to a **display** label ("Speaker 1"/a real name). The FE renders lanes from `timeline.speakers[].speaker` (= the display label) and looks up the chip via `suggestionByLabel().get(lane.speaker)`. But `suggest_speaker_labels_inner` keyed suggestions by the **raw tag**, and `rename_speaker_inner` did `parse_others_cluster(display_label)` = `None`. Tag-space and display-label-space never met. (A first attempt fixed only the "1:1 keys others-0" symptom; its own adversarial-verifier caught that the chip still never rendered because the lanes are "Speaker N", not raw tags.)

## The fix (backend reconciliation)
A deterministic reconciler (`diarize.rs` `reconcile_speakers`) maps each cluster ↔ the timeline display label via **segment time-overlap** (argmax per cluster/label, deterministic tie-break), mirroring `relabel_others`. **No timeline schema or seal-format change.**
- `suggest_speaker_labels_inner` now keys each suggestion by the **reconciled display label** the FE lane shows → `suggestionByLabel().get(lane.speaker)` matches for both multi-cluster ("Speaker 2") and 1:1 ("Speaker 1").
- `rename_speaker_inner` reconstructs the cluster from the display label (overlap) before enrolling. Single-cluster 1:1 is inferred from the **segment tag shape**, not the voiceprint set. `me`/non-diarized lanes enroll nothing.
- FE `speakerChip` maps `others-{n}` transcript-segment tags to a "Speaker {n+1}" chip (was `null`).

## Verification
- **cargo test --lib: 937 passed**; **ng lint + ng build green**.
- **RED-before-GREEN (the crux the first attempt lacked):** `suggest_speaker_labels_keys_by_llm_display_label` asserts `suggestion.speaker == "Speaker 2"` (the FE lane label) — **fails** on the old tag-keyed code (`left: "others-1"`). Plus rename-enrolls-via-display-label, 1:1 end-to-end, and me/non-diarized-enrolls-nothing, all RED-verified.
- **adversarial-verifier: PASS** — confirmed (not assumed) the chip renders against an LLM-labeled timeline by reading both the FE seam and the timeline prompt; attacked overlap ties / merged clusters / legacy-sealed degrade.
- **lock-security-reviewer: PASS** — reconciliation reads only *this* unlocked meeting's own segments+timeline (enroll can't touch another/sealed meeting's cluster); voiceprint reads stay `list_voiceprints_visible`-gated; raw embedding never crosses IPC; purge-on-seal untouched.

## Honest bar
This fixes **reachability** — the chip now renders and rename now enrolls. Cross-meeting re-identification **accuracy** (the 0.5 threshold, DER) is still unproven and needs the DER run on a signed Mac. The feature remains opt-in (`diarize_others` + `voiceprint_enabled` default-off). No new deps.