### PR TITLE
feat(share): account onboarding rebuild + prod-ready email flow

### DIFF
--- a/.claude/skills/deploy-murmur-server/SKILL.md
+++ b/.claude/skills/deploy-murmur-server/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: deploy-murmur-server
+description: Deploy, redeploy, monitor, debug, and manage the murmur-server backend (the zero-knowledge E2EE sharing relay) on Railway. The complete, hard-won flow — project/service IDs, the token model, the GraphQL-API-not-CLI approach, deploy/logs/vars/domain/restore, and every gotcha that bit during the first deploy (env-freeze on redeploy, the Postgres name-collision DNS trap, raw-postgres password-init, the Dockerfile fixes). Use whenever the user wants to deploy/redeploy/check/fix/scale the Murmur server, read its logs, change its env, or manage its Railway hosting.
+---
+
+# Deploy & manage murmur-server on Railway
+
+The Murmur backend (`murmur-io/murmur-server`, private) runs on **Railway**. This skill is the full operational playbook — it captures the exact flow + the gotchas that cost hours on the first deploy so they never bite again.
+
+## What's deployed (the live instance)
+
+| Thing | Value |
+|---|---|
+| Repo | `murmur-io/murmur-server` (private, AGPL-intended) — local at `/Users/jakubgawronski/Projects/murmur-server` |
+| Public URL | `https://murmur-server-production-b9e8.up.railway.app` (`/healthz` → `{"status":"ok",...}`) |
+| Railway project | `murmur-server` · id `27e7b5a4-b5db-40ad-a63a-2a4d8276b29b` |
+| Environment | `production` · id `8ef5a21d-96c6-4141-80ed-be4b7fc2f855` |
+| Server service | `murmur-server` · id `4d55d97c-1a99-4a51-a947-657a012a9cfc` |
+| Database | a **managed Railway Postgres** named `Postgres` · id `570954b2-32bc-42f4-b6c1-80d76959951d` — the server reads it via the variable reference `DATABASE_URL = ${{Postgres.DATABASE_URL}}` |
+| GraphQL API | `https://backboard.railway.com/graphql/v2` |
+
+The server has **no AI** on it — it's a dumb zero-knowledge relay (ciphertext blobs + auth + key relay). So it needs no GPU; a tiny instance is plenty.
+
+## Tokens — ALREADY PERSISTED (no need to ask the user)
+
+The user does NOT touch Railway. The credentials are already stored so any future session can manage the deploy hands-off:
+- **`$RAILWAY_API_TOKEN`** — the Railway account/team token, set in `~/.claude/settings.json` `env` → available in every tool call's environment. Use it for the GraphQL API (`Authorization: Bearer $RAILWAY_API_TOKEN`).
+- **`~/.murmur/railway-token`** (600) — the same account/team token, on disk (fallback if the env var is absent).
+- **`~/.murmur/railway-projtoken`** (600) — the project token scoped to this project+env, for `RAILWAY_TOKEN=... railway up`.
+- **`~/.murmur/railway-ids`** — the project / env / server-service / postgres-service ids + the domain, one per line (same as the table above).
+
+⚠️ SECURITY: the account/team token has broad access to the user's whole Railway account (not just this project). It's stored only in user-local files (`~/.claude/settings.json` + `~/.murmur/`, both non-repo, 600). The user chose convenience over scoping. If it's ever exposed, rotate it at `railway.com/account/tokens` and update both locations. Note: a project-scoped token does NOT work for the GraphQL API (only for `railway up`/`status`), so the team token is the minimum for full management.
+
+## Tokens (the auth model — this tripped us up)
+
+Railway has **two** token types with different powers:
+
+- **Account/Team token** — created at `railway.com/account/tokens` (NOT the workspace "Developer" page, which is OAuth apps). Use it as the `Authorization: Bearer <tok>` header for the **GraphQL API** (create projects/services, set vars, deploy, read logs). ⚠️ The CLI `railway whoami`/`railway list` FAIL with a team token because they call the `me` query (a team token has no user) — but `railway status`/`railway up` work, and the API `projects` query works. Don't be fooled by "Unauthorized" on `whoami`.
+- **Project token** — created via the API (`projectTokenCreate`) for a specific project+environment. Use it as `RAILWAY_TOKEN=<tok>` for `railway up` / `railway status` (the CLI's native path).
+
+The user provides an account/team token (paste it in chat, then **revoke it after** at `railway.com/account/tokens`). Store it locally to avoid re-typing:
+```bash
+umask 077 && printf '<TOKEN>' > /tmp/.railway-token   # account/team token
+```
+Create a project token from it (once per project) for `railway up`:
+```bash
+# needs the project + environment ids
+mutation { projectTokenCreate(input: { name: "deploy", projectId: "<PID>", environmentId: "<EID>" }) }
+# store it: printf '<projtoken>' > /tmp/.railway-projtoken
+```
+
+## The GraphQL helper (use this for everything API-side)
+
+⚠️ Railway's API 403s the default Python-urllib User-Agent — **always send a `User-Agent` header**. Reusable pattern:
+```python
+import json, os, urllib.request
+TOK=os.environ.get("RAILWAY_API_TOKEN") or open(os.path.expanduser("~/.murmur/railway-token")).read().strip()
+PID="27e7b5a4-b5db-40ad-a63a-2a4d8276b29b"; EID="8ef5a21d-96c6-4141-80ed-be4b7fc2f855"
+def gql(q):
+    req=urllib.request.Request("https://backboard.railway.com/graphql/v2",
+        data=json.dumps({"query":q}).encode(),
+        headers={"Authorization":f"Bearer {TOK}","Content-Type":"application/json","User-Agent":"murmur-deploy/1.0"})
+    r=json.load(urllib.request.urlopen(req))
+    if r.get("errors"): raise SystemExit("ERR:"+json.dumps(r["errors"]))
+    return r["data"]
+```
+(`curl -H "Authorization: Bearer $TOK" -H "User-Agent: x" -H "Content-Type: application/json" -d '{"query":"..."}' https://backboard.railway.com/graphql/v2` works too.)
+
+## Common operations
+
+### Deploy / redeploy the server code
+`railway up` is the ONLY reliable way to deploy with the CURRENT env (see the env-freeze gotcha). It uploads the local dir (respecting `.gitignore`, so `/target` is skipped) and builds the Dockerfile.
+```bash
+cd /Users/jakubgawronski/Projects/murmur-server
+export RAILWAY_TOKEN="$(cat ~/.murmur/railway-projtoken)"
+railway up --service murmur-server --detach   # prints a Build Logs URL; build runs on Railway
+```
+
+### Check deployment status
+```python
+def st(sid):
+    e=gql(f'query {{ deployments(first:1, input:{{projectId:"{PID}", environmentId:"{EID}", serviceId:"{sid}"}}){{ edges {{ node {{ id status }} }} }} }}')["deployments"]["edges"]
+    return (e[0]["node"]["id"], e[0]["node"]["status"]) if e else (None,"NONE")
+# statuses: BUILDING -> DEPLOYING -> SUCCESS | FAILED | CRASHED
+```
+
+### Read logs (the debugging workhorse)
+```python
+did,_=st("4d55d97c-1a99-4a51-a947-657a012a9cfc")   # server service id
+# build failures:
+for m in gql(f'query {{ buildLogs(deploymentId:"{did}", limit:40){{ message }} }}')["buildLogs"]: print(m["message"][:200])
+# runtime/boot failures (crash loops, DB errors):
+for m in gql(f'query {{ deploymentLogs(deploymentId:"{did}", limit:40){{ message }} }}')["deploymentLogs"]: print(m["message"][:200])
+```
+
+### Set / change an env variable
+```python
+gql(f'mutation {{ variableUpsert(input:{{projectId:"{PID}", environmentId:"{EID}", serviceId:"<svc>", name:"NAME", value:"VALUE"}}) }}')
+# read current values (returns a name->value map):
+gql(f'query {{ variables(projectId:"{PID}", environmentId:"{EID}", serviceId:"<svc>") }}')
+```
+⚠️ A variable change only takes effect on the NEXT deploy that reads CURRENT env — for the server that means `railway up` (NOT `serviceInstanceRedeploy`, see gotcha). Server vars: `DATABASE_URL=${{Postgres.DATABASE_URL}}` (reference), `SHARE_BASE_URL=https://<domain>`, `RUST_LOG=info`. `PORT` is injected by Railway; the server binds `0.0.0.0:$PORT`.
+
+### Generate / see the public domain
+```python
+gql(f'mutation {{ serviceDomainCreate(input:{{serviceId:"<svc>", environmentId:"{EID}"}}){{ domain }} }}')
+```
+
+### Verify it's live
+```bash
+curl -s https://murmur-server-production-b9e8.up.railway.app/healthz     # -> {"status":"ok","version":"0.1.0"}
+# full end-to-end (blob round-trip, unauth path):
+URL=https://murmur-server-production-b9e8.up.railway.app
+BID=$(curl -s -X POST "$URL/v1/blobs" --data-binary 'test' -H 'content-type: application/octet-stream' | python3 -c "import sys,json;print(json.load(sys.stdin)['blobId'])")
+curl -s "$URL/v1/blobs/$BID"; echo; curl -s -o /dev/null -w "%{http_code}\n" "$URL/v1/blobs/00000000-0000-4000-8000-000000000000"  # -> 404
+```
+
+### List services / find IDs
+```python
+for e in gql(f'query {{ project(id:"{PID}"){{ services {{ edges {{ node {{ id name }} }} }} }} }}')["project"]["services"]["edges"]:
+    print(e["node"]["name"], e["node"]["id"])
+```
+
+## GOTCHAS — the hard-won lessons (do not relearn these)
+
+1. **`serviceInstanceRedeploy` / `serviceInstanceDeploy` FREEZE the env.** They replay a past deployment's config and IGNORE variable changes. To apply new vars to the server, use **`railway up`** (creates a genuinely new deployment snapshotting current env). This wasted the most time — the server kept connecting with a stale `DATABASE_URL`.
+
+2. **Postgres name collision breaks `*.railway.internal` DNS.** Two services named `Postgres` and `postgres` both map to `postgres.railway.internal` → the server hits the WRONG one (different password) → `password authentication failed`. Keep exactly ONE Postgres. **Use the MANAGED Railway Postgres** (has `DATABASE_URL`, `PGHOST`, `PGPASSWORD` vars) and point the server at it with the reference `DATABASE_URL=${{Postgres.DATABASE_URL}}` — never a raw `postgres:16` image.
+
+3. **A raw `postgres` image sets its password only on FIRST init** — and a persistent volume makes it "skip initialization" forever, so later `POSTGRES_PASSWORD`/`PGDATA` changes are ignored and the DB keeps the stale password. Don't fight it — use the managed Postgres. (If you ever must use a raw image: no volume = fresh init every deploy = ephemeral; or `PGDATA=/var/lib/.../pgdata-subdir` avoids the `lost+found` initdb error, but you STILL need a fresh empty subdir + a fresh-env deploy.)
+
+4. **Dockerfile (`docker/Dockerfile`) requirements** (already fixed + committed): build on the **full `rust:1.96-bookworm`** (the `-slim` variant lacks the C toolchain `ring`/rustls needs, and deps now require `rustc >= 1.88`); **no cargo-chef** (its `cargo install` step failed and Railway doesn't persist its cache); do **NOT** hardcode `ENV BIND_ADDR` (let `$PORT` win so Railway can route). Railway DOES cache Docker layers, so repeat `railway up` builds are fast.
+
+5. **`railway.json`** (committed at repo root) sets `build.dockerfilePath = docker/Dockerfile` + a `/healthz` healthcheck. Without it Railway won't find the non-root Dockerfile.
+
+6. **The CLI is finicky with tokens:** `railway add`/`railway link` fail ("Project not found") with a project token — provision databases via the **API** (or the dashboard), not `railway add`. `railway up`/`railway status` are the CLI commands that work.
+
+7. **Migrations run automatically** on server boot (`sqlx::migrate!`), so a fresh DB is set up on first successful deploy — no manual migration step.
+
+## Deploy-from-scratch (if the project is ever recreated)
+
+1. Create project → capture project id + production environment id (`projectCreate`).
+2. Add a **managed Postgres** (dashboard "Add PostgreSQL", or a Postgres template deploy).
+3. Create the server service (`serviceCreate` name `murmur-server`) → set `DATABASE_URL=${{Postgres.DATABASE_URL}}`, `RUST_LOG=info`.
+4. Create a project token (`projectTokenCreate`) → `railway up --service murmur-server` from the repo.
+5. `serviceDomainCreate` → set `SHARE_BASE_URL=https://<domain>` → `railway up` again to apply.
+6. Verify `/healthz` + a blob round-trip + the restore posture.
+
+## What's NOT done yet (for a real public launch — see docs/research)
+
+The live instance is a **test/demo deploy**. For a real public launch (per `docs/research/2026-07-04-murmur-server-hosting-decision.md` + `agent-managed-hosting.md`): a proper domain (EU registrar for the immortal share domain), the abuse/DSA/legal posture, invite-only scoping to shrink the abuse surface, backups + a restore drill, and the go/no-go on solo-managed-vs-abuse-desk. Managing the *tech* ops loop (deploy/monitor/backup/restore) is fully agent-doable; the legal/abuse residue needs a reachable human. The strategic pick if this becomes the permanent home is Hetzner-EU + the verbatim compose (this Railway deploy trades the self-host-artifact property for one-command ease).

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -356,6 +356,9 @@ deferred it twice is now removed, so it's unblocked for the GA cut.
     modelSize: "large-v3",
     voiceTrigger: true,
     onboarded: true,
+    // The demo world has already resolved the first-run sharing choice, so the
+    // /welcome gateway never intercepts a screenshot route.
+    sharingChoiceMade: true,
     noteStyle: "structured",
     autoOrganize: true,
     noteLanguage: "en",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -171,6 +171,15 @@ pub struct AppConfigDto {
     /// `revoke_share_egress`, so a settings save can neither grant nor clear it.
     #[serde(default)]
     pub share_egress_consented: bool,
+    /// Sharing-onboarding gate — whether the user has RESOLVED the first-run sharing decision
+    /// (chose local-only OR went through the account door). DISPLAY-ONLY on this DTO, same
+    /// preserve-only discipline as `share_egress_consented`: `get_config` carries the stored value
+    /// OUT so the init gateway (`/welcome`) knows whether to show, but `dto_to_config` PRESERVES the
+    /// stored value — a settings save can never set/clear it. Mutated ONLY by the dedicated
+    /// `mark_sharing_choice_made` command. `#[serde(default)]` = false (a pre-existing install sees
+    /// the gateway once).
+    #[serde(default)]
+    pub sharing_choice_made: bool,
     /// Phase H — which reasoner powers the on-device "brain" pre-analysis (Flow A): `cloud` |
     /// `local` | `off`. Unlike `cloud_egress_consented`, this IS settable from the DTO (the Settings
     /// UI owns the brain toggle). An omitted/unknown value deserializes to the default `Cloud`
@@ -3752,6 +3761,9 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         cloud_egress_consented: c.cloud_egress_consented,
         // DISPLAY-ONLY out (M3-CLIENT): FE shows share-egress consent status; cannot set it back.
         share_egress_consented: c.share_egress_consented,
+        // DISPLAY-ONLY out: the init gateway reads this to know whether the first-run sharing
+        // choice was already made; the FE cannot set it back (preserved in `dto_to_config`).
+        sharing_choice_made: c.sharing_choice_made,
         brain_backend: c.brain_backend,
         realtime_reactions: c.realtime_reactions,
         brain_model_id: c.brain_model_id.clone(),
@@ -3852,6 +3864,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // BLK-4 (M3-CLIENT): share-egress consent is NEVER set from the DTO — preserve the live value.
         // Only `consent_to_share_egress` may flip it. An omitting/zeroed save is inert.
         share_egress_consented: current.share_egress_consented,
+        // Sharing-onboarding gate: the first-run choice latch is NEVER set from the DTO — preserve the
+        // live value. Only `mark_sharing_choice_made` may flip it, so a settings save can never set or
+        // clear it (a re-save from an older FE that omits the key can't accidentally reopen the gate).
+        sharing_choice_made: current.sharing_choice_made,
         // brain2 RAG: the semantic-search master flag IS carried on the settings DTO (the Settings
         // UI owns the toggle). Plain bool; an omitted value already defaulted to OFF on the DTO
         // (`#[serde(default)]`), so a partial/older save can never silently enable it. Unlike
@@ -7772,6 +7788,21 @@ pub fn revoke_share_egress(state: State<'_, AppState>) -> Result<(), AppError> {
     Ok(())
 }
 
+/// `mark_sharing_choice_made` — persist that the user has RESOLVED the first-run sharing decision
+/// (either "use Murmur locally" OR they went through the account door), so the init gateway
+/// (`/welcome`) never nags again. One-way latch: the ONLY mutator that sets it true; a normal
+/// settings save PRESERVES it (`dto_to_config`). Idempotent — safe to call repeatedly. Carries no
+/// egress and no PII.
+#[tauri::command]
+pub fn mark_sharing_choice_made(state: State<'_, AppState>) -> Result<(), AppError> {
+    let mut cfg = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    cfg.set_sharing_choice_made(&state.db)?;
+    Ok(())
+}
+
 /// `account_signup(email, password, save_recovery)` — create a sharing account (spec §3.1a/§4.3).
 ///
 /// Runs the OPAQUE CLIENT registration, generates the account MK + identity keypair + (skippable)
@@ -7791,8 +7822,18 @@ pub async fn account_signup(
     let client = crate::share::client::ShareClient::new(&base)?;
     let password = Zeroizing::new(password);
 
-    // 1. Exchange the emailed verification code for a single-use signup token.
-    let signup_token = client.verify_email(email.trim(), code.trim()).await?;
+    // 1. Exchange the emailed verification code for a single-use signup token. A rejected/expired/
+    //    too-many-tries code comes back as a 4xx → InvalidArg; give the user a clear, actionable
+    //    message. Connectivity errors (Unavailable) pass through so "can't reach" still means that.
+    let signup_token = client
+        .verify_email(email.trim(), code.trim())
+        .await
+        .map_err(|e| match e {
+            AppError::InvalidArg(_) | AppError::Auth(_) => AppError::InvalidArg(
+                "That verification code is incorrect or has expired — request a new one.".into(),
+            ),
+            other => other,
+        })?;
 
     // 2. OPAQUE registration step 1 → server RegistrationResponse.
     let reg_start = crate::share::opaque_client::client_registration_start(password.as_bytes())?;
@@ -7858,6 +7899,29 @@ pub async fn account_signup(
 
     // Signup does NOT auto-login (the FE prompts a login next); no tokens stored yet.
     Ok(recovery_phrase)
+}
+
+/// `account_send_code(email)` — the PRE-SIGNUP send-code step (the leg the old inline form was
+/// missing). Triggers the server to email a 6-digit verification code
+/// (`POST /v1/auth/signup {email}` → 202). Needs NO account session (it runs before signup).
+///
+/// ANTI-ENUMERATION: the server ALWAYS returns 202 whether or not the address is already registered,
+/// so this resolves `Ok(())` regardless — it never reveals account existence to the caller. The
+/// email is trimmed; an empty email is rejected `InvalidArg` before any network call. Network/HTTP
+/// failures map to `AppError::Unavailable` (inside `ShareClient`), never a raw reqwest string. The
+/// email itself is never logged (the content-free ledger row carries only host + a coarse size).
+#[tauri::command]
+pub async fn account_send_code(state: State<'_, AppState>, email: String) -> Result<(), AppError> {
+    let email = email.trim();
+    if email.is_empty() {
+        return Err(AppError::InvalidArg("email is required".into()));
+    }
+    let base = share_base_url(state.inner())?;
+    let client = crate::share::client::ShareClient::new(&base)?;
+    client.signup(email).await?;
+    // Content-free ledger row for the send-code egress (host + a coarse size; no email, no code).
+    crate::share::ledger_row(&state.db, &client.host(), "account_send_code", 0);
+    Ok(())
 }
 
 /// `account_login(email, password) -> AccountStatus` — OPAQUE login; unwrap MK from the server's
@@ -11849,6 +11913,42 @@ mod lifecycle_tests {
         assert!(
             !dto_to_config(dto2, &current2).cloud_egress_consented,
             "a settings save must NEVER grant consent — only the dedicated command may (BLK-4)"
+        );
+    }
+
+    /// Sharing-onboarding gate: `sharing_choice_made` is PRESERVE-ONLY on the settings DTO exactly
+    /// like the consent flags. `config_to_dto` carries the stored value OUT (so the init gateway can
+    /// read it), but `dto_to_config` PRESERVES the live value — a save carrying `false` can't reopen
+    /// an already-made choice, and a save carrying `true` can't set it (only the dedicated
+    /// `mark_sharing_choice_made` command latches it).
+    #[test]
+    fn save_config_merge_never_clobbers_or_sets_sharing_choice_made() {
+        // OUT: config_to_dto reflects the live value.
+        let cfg_made = AppConfig {
+            sharing_choice_made: true,
+            ..AppConfig::default()
+        };
+        assert!(config_to_dto(&cfg_made).sharing_choice_made);
+
+        // (a) an omitting/false save must NOT reopen an already-made choice.
+        let mut dto = config_to_dto(&AppConfig::default());
+        dto.sharing_choice_made = false;
+        let current = AppConfig {
+            sharing_choice_made: true,
+            ..AppConfig::default()
+        };
+        assert!(
+            dto_to_config(dto, &current).sharing_choice_made,
+            "an omitting/false save must NOT clear the first-run sharing latch"
+        );
+
+        // (b) a save carrying true cannot SET the latch (default-off stays off — only the command latches).
+        let mut dto2 = config_to_dto(&AppConfig::default());
+        dto2.sharing_choice_made = true;
+        let current2 = AppConfig::default(); // latch off
+        assert!(
+            !dto_to_config(dto2, &current2).sharing_choice_made,
+            "a settings save must NEVER set the sharing latch — only mark_sharing_choice_made may"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,10 +114,12 @@ pub fn run() {
             // M3-CLIENT — sharing account + zero-knowledge link shares (mode A).
             commands::account_status,
             commands::account_signup,
+            commands::account_send_code,
             commands::account_login,
             commands::account_logout,
             commands::consent_to_share_egress,
             commands::revoke_share_egress,
+            commands::mark_sharing_choice_made,
             commands::share_note_to_link,
             commands::list_my_shares,
             commands::revoke_share,

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -216,6 +216,18 @@ pub struct AppConfig {
     /// (fail-closed — a pre-existing install has NOT consented to share egress).
     #[serde(default)]
     pub share_egress_consented: bool,
+    /// Sharing-onboarding gate — has the user RESOLVED the first-run sharing decision? Either they
+    /// chose "use Murmur locally (no account)" OR they went through the account door. A one-way
+    /// latch: once `true` it is never auto-cleared, so the init gateway (`/welcome`) never nags a
+    /// user who has already decided. It is NOT a consent flag (no egress rides on it) — it purely
+    /// suppresses the first-run prompt. Same preserve-only discipline as `share_egress_consented`:
+    /// it round-trips through the DTO for DISPLAY (so the gateway gate can read it) but
+    /// `dto_to_config`/`save_config` PRESERVE the stored value — a normal settings save can never
+    /// set or clear it; the dedicated `mark_sharing_choice_made` command is the ONLY mutator.
+    /// `#[serde(default)]` ⇒ a config persisted before this field existed loads as `false`, so a
+    /// pre-existing install sees the gateway once (until it makes a choice).
+    #[serde(default)]
+    pub sharing_choice_made: bool,
     /// brain2 RAG Tier 1 — master gate for the on-device semantic (vector) retrieval layer.
     /// Default ON (`#[serde(default = "default_true")]` ⇒ a config persisted before this field existed
     /// loads as `true`). SAFE to default on: when the e5 model is PRESENT, note chunks auto-index on
@@ -446,6 +458,7 @@ impl Default for AppConfig {
             relock_on_screenshare: true,
             cloud_egress_consented: false,
             share_egress_consented: false,
+            sharing_choice_made: false,
             semantic_search_enabled: true,
             embed_model_id: None,
             brain_model_path: None,
@@ -461,7 +474,10 @@ impl Default for AppConfig {
             claude_code_inherit_env: false,
             gateway_base_url: String::new(),
             gateway_model: String::new(),
-            share_base_url: String::new(),
+            // Hosted sharing relay (murmur-io/murmur-server) — the default so Murmur↔Murmur sharing
+            // works out of the box; self-hosters override it in Settings. Swap for the production
+            // domain at release (this is the current Railway instance).
+            share_base_url: "https://murmur-server-production-b9e8.up.railway.app".to_string(),
             proactive_hints_enabled: true,
             user_memory_enabled: true,
             ground_summary: false,
@@ -512,6 +528,7 @@ const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 const K_CLOUD_EGRESS_CONSENTED: &str = "cloud_egress_consented";
 const K_SHARE_EGRESS_CONSENTED: &str = "share_egress_consented";
+const K_SHARING_CHOICE_MADE: &str = "sharing_choice_made";
 const K_SEMANTIC_SEARCH_ENABLED: &str = "semantic_search_enabled";
 const K_EMBED_MODEL_ID: &str = "embed_model_id";
 const K_BRAIN_MODEL_PATH: &str = "brain_model_path";
@@ -651,6 +668,9 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_SHARE_EGRESS_CONSENTED)? {
             cfg.share_egress_consented = v == "true";
         }
+        if let Some(v) = db.get_setting(K_SHARING_CHOICE_MADE)? {
+            cfg.sharing_choice_made = v == "true";
+        }
         if let Some(v) = db.get_setting(K_SEMANTIC_SEARCH_ENABLED)? {
             cfg.semantic_search_enabled = v == "true";
         }
@@ -694,8 +714,12 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_GATEWAY_MODEL)? {
             cfg.gateway_model = v;
         }
-        // M3-CLIENT sharing-server base URL — `""` (unset) is valid; take it verbatim.
-        if let Some(v) = db.get_setting(K_SHARE_BASE_URL)? {
+        // M3-CLIENT sharing-server base URL — a NON-EMPTY stored value overrides the hosted default;
+        // an absent/empty setting keeps the default so sharing works out of the box.
+        if let Some(v) = db
+            .get_setting(K_SHARE_BASE_URL)?
+            .filter(|s| !s.trim().is_empty())
+        {
             cfg.share_base_url = v;
         }
         if let Some(v) = db.get_setting(K_PROACTIVE_HINTS_ENABLED)? {
@@ -860,6 +884,14 @@ impl AppConfig {
         db.set_setting(
             K_SHARE_EGRESS_CONSENTED,
             if self.share_egress_consented {
+                "true"
+            } else {
+                "false"
+            },
+        )?;
+        db.set_setting(
+            K_SHARING_CHOICE_MADE,
+            if self.sharing_choice_made {
                 "true"
             } else {
                 "false"
@@ -1031,6 +1063,17 @@ impl AppConfig {
     pub fn revoke_share_egress(&mut self, db: &Db) -> Result<()> {
         self.share_egress_consented = false;
         db.set_setting(K_SHARE_EGRESS_CONSENTED, "false")
+    }
+
+    /// Latch that the user has RESOLVED the first-run sharing decision (chose local-only OR went
+    /// through the account door), so the init gateway never shows again. Mirrors
+    /// [`grant_share_egress_consent`]'s fail-safe ordering: persist FIRST, flip the in-memory flag
+    /// ONLY on a durable write success. One-way latch — the ONLY mutator that sets it true, so it
+    /// can never be set (or cleared) as a settings-save side effect. Idempotent.
+    pub fn set_sharing_choice_made(&mut self, db: &Db) -> Result<()> {
+        db.set_setting(K_SHARING_CHOICE_MADE, "true")?;
+        self.sharing_choice_made = true;
+        Ok(())
     }
 
     /// brain2 connector framework — record the user's one-time consent to send the (redacted) web
@@ -1689,6 +1732,26 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(!AppConfig::load(&db).unwrap().proactive_hints_enabled);
+    }
+
+    /// Sharing-onboarding gate: `sharing_choice_made` defaults OFF (a fresh/pre-existing install
+    /// sees the gateway once), and the dedicated `set_sharing_choice_made` mutator persists it as a
+    /// one-way latch that survives reload. Mirrors the consent-mutator persistence test.
+    #[test]
+    fn sharing_choice_made_defaults_off_and_latches_via_mutator() {
+        // In-memory default + empty settings table (key never written) ⇒ OFF (gateway shows).
+        assert!(!AppConfig::default().sharing_choice_made);
+        let db = temp_db();
+        assert!(!AppConfig::load(&db).unwrap().sharing_choice_made);
+
+        // The dedicated mutator persists it, and the value survives a reload (one-way latch).
+        let mut cfg = AppConfig::load(&db).unwrap();
+        cfg.set_sharing_choice_made(&db).unwrap();
+        assert!(cfg.sharing_choice_made, "mutator flips the in-memory flag");
+        assert!(
+            AppConfig::load(&db).unwrap().sharing_choice_made,
+            "the latch persists across reload"
+        );
     }
 
     /// Cross-meeting USER MEMORY — the master gate defaults ON for fresh installs AND for configs

--- a/src-tauri/src/share/client.rs
+++ b/src-tauri/src/share/client.rs
@@ -63,11 +63,16 @@ impl ShareClient {
     }
 
     /// Map a response status to a typed error WITHOUT surfacing the reqwest Display (which can echo
-    /// the URL). 401 → Auth (re-login), 404/uniform → Unavailable("not found"), else Unavailable.
+    /// the URL). A 4xx is a REQUEST problem (bad/expired code, used token) → `InvalidArg`, so the UI
+    /// never renders it as "can't reach the server" — only a genuine connection failure (the `.send()`
+    /// map_err → `Unavailable`) or a 5xx is unavailability. 401 → Auth (re-login).
     fn status_err(ctx: &str, status: StatusCode) -> AppError {
         match status {
             StatusCode::UNAUTHORIZED => AppError::Auth(format!("{ctx}: not authenticated")),
-            StatusCode::NOT_FOUND => AppError::Unavailable(format!("{ctx}: not found")),
+            StatusCode::TOO_MANY_REQUESTS => {
+                AppError::InvalidArg(format!("{ctx}: too many attempts — wait a bit and try again"))
+            }
+            s if s.is_client_error() => AppError::InvalidArg(format!("{ctx}: rejected ({})", s.as_u16())),
             s => AppError::Unavailable(format!("{ctx}: server returned {}", s.as_u16())),
         }
     }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -126,8 +126,23 @@ export class AppComponent implements OnInit {
 
     try {
       const cfg = await this.ipc.getConfig();
+      // Core onboarding STRICTLY precedes the optional sharing gate — a
+      // brand-new user goes to /onboarding first (its finish() then hands off
+      // to /welcome when the sharing gate is still open).
       if (!cfg.onboarded) {
         await this.router.navigateByUrl("/onboarding");
+        return;
+      }
+      // First-run SHARING gate (single source of truth:
+      // `!sharingChoiceMade && !accountStatus.loggedIn`). A returning logged-in
+      // user, a user who picked local, or one who logged in then out (choice
+      // made) never sees it again — "never nag".
+      if (!cfg.sharingChoiceMade) {
+        const st = await this.ipc.accountStatus().catch(() => null);
+        if (!st?.loggedIn) {
+          await this.router.navigateByUrl("/welcome");
+          return;
+        }
       }
     } catch {
       // Config unavailable — don't trap the user; the app loads normally.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -88,6 +88,16 @@ export const routes: Routes = [
             (m) => m.OnboardingComponent,
           ),
       },
+      {
+        // First-run SHARING gateway (a shell child, router-mounted so the
+        // packaged WKWebView style-resolves it — trap T4). Shown after the
+        // onboarding gate when `!sharingChoiceMade && !accountStatus.loggedIn`.
+        path: "welcome",
+        loadComponent: () =>
+          import("./features/sharing/sharing-gateway.component").then(
+            (m) => m.SharingGatewayComponent,
+          ),
+      },
       { path: "", pathMatch: "full", redirectTo: "record" },
       { path: "**", redirectTo: "record" },
     ],

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -231,6 +231,33 @@ export class IpcService {
   }
 
   /**
+   * THE missing send-code step of the sign-up flow. Builds a `ShareClient` from
+   * the configured `shareBaseUrl` and calls `POST /v1/auth/signup {email}` → 202,
+   * which triggers the server to EMAIL the 6-digit verification code. Resolves
+   * regardless of whether the email exists (the server always 202s for
+   * anti-enumeration), so a resolved promise means "the code was sent if the
+   * address is valid" — surface a neutral "check your inbox" notice, never a
+   * "user exists" signal. Rejects (`InvalidArg`) on an empty email, and
+   * (`Unavailable`) when the server is unreachable. Do NOT call
+   * {@link accountSignup} to send the code — that command consumes the
+   * single-use signup token. Mirrors {@link accountLogin} in shape.
+   */
+  accountSendCode(email: string): Promise<void> {
+    return invoke<void>("account_send_code", { email });
+  }
+
+  /**
+   * Persist that the user resolved the first-run sharing decision (local-only OR
+   * the account door), so the init gateway (`/welcome`) never shows again. The
+   * SOLE mutator that flips `sharingChoiceMade` true (a one-way latch — a normal
+   * `saveConfig` can never set/clear it, PRESERVE-ONLY, exactly like the consent
+   * flags). Idempotent, unit return. Mirrors {@link consentToShareEgress}.
+   */
+  markSharingChoiceMade(): Promise<void> {
+    return invoke<void>("mark_sharing_choice_made");
+  }
+
+  /**
    * Create a sharing account. Runs the OPAQUE client registration on-device (the password never
    * leaves the Mac), generates the account key material + (skippable) recovery phrase, and uploads
    * it. `code` is the 6-digit email verification code. Returns the 24-word recovery phrase ONLY when

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -107,6 +107,20 @@ export interface AppConfigDto {
   modelSize: string;
   voiceTrigger: boolean;
   onboarded: boolean;
+  /**
+   * First-run SHARING decision latch (mirrors Rust `AppConfigDto.sharing_choice_made`).
+   * `false` (default) means the user has NOT yet resolved the first-run sharing
+   * choice — the init gateway (`/welcome`) is shown when this is false AND no
+   * account is logged in (`!sharingChoiceMade && !accountStatus.loggedIn`).
+   * Picking "use locally" OR completing the account flow flips it true via the
+   * dedicated `mark_sharing_choice_made` command, so the gateway never nags again
+   * (a one-way latch). PRESERVE-ONLY on `saveConfig` — a normal settings save can
+   * never set or clear it (the backend's `dto_to_config` carries the stored value
+   * back), exactly like `shareEgressConsented`. `onboarding.persistConfig()` must
+   * still round-trip it (`base?.sharingChoiceMade ?? false`) since all DTO fields
+   * are required. Display-only otherwise.
+   */
+  sharingChoiceMade: boolean;
   noteStyle: string;
   /** ENHANCE-MY-NOTES: how typed in-meeting notes shape the summary — "enhance" (they
    *  become the skeleton of the note) | "append" (verbatim `## My notes` section). */

--- a/src/app/features/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding.component.ts
@@ -1755,7 +1755,18 @@ export class OnboardingComponent implements OnInit {
           // Grant failed — recoverable post-wizard; don't block finishing.
         }
       }
-      await this.router.navigate(["/record"]);
+      // Hand off to the first-run SHARING gateway when its gate is still open,
+      // else straight to /record — reusing the SAME condition as app.component
+      // (`!sharingChoiceMade && !accountStatus.loggedIn`). So a fresh install
+      // flows /onboarding → (finish) → /welcome → pick → /record.
+      let dest = "/record";
+      if (!this.loadedConfig?.sharingChoiceMade) {
+        const st = await this.ipc.accountStatus().catch(() => null);
+        if (!st?.loggedIn) {
+          dest = "/welcome";
+        }
+      }
+      await this.router.navigate([dest]);
     } catch {
       // If saving the final flag fails, let them retry rather than trap them.
       this.finishing.set(false);
@@ -1799,6 +1810,10 @@ export class OnboardingComponent implements OnInit {
       modelSize: this.modelSize(),
       voiceTrigger: base?.voiceTrigger ?? false,
       onboarded: markOnboarded ? true : (base?.onboarded ?? false),
+      // First-run sharing latch — preserve-only here (the /welcome gateway owns
+      // it via mark_sharing_choice_made). Round-trip the snapshot so onboarding
+      // never clears it; the backend's dto_to_config preserves it regardless.
+      sharingChoiceMade: base?.sharingChoiceMade ?? false,
       noteStyle: base?.noteStyle ?? "standard",
       notesMode: base?.notesMode ?? "enhance",
       autoOrganize: base?.autoOrganize ?? false,

--- a/src/app/features/settings/sections/settings-account-section.component.ts
+++ b/src/app/features/settings/sections/settings-account-section.component.ts
@@ -1,9 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
   computed,
   inject,
   signal,
+  viewChild,
 } from "@angular/core";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { IpcService } from "../../../core/ipc.service";
@@ -12,6 +16,7 @@ import type {
   FolderNode,
   ShareInboxItem,
 } from "../../../core/models";
+import { SharingAuthFlowComponent } from "../../sharing/sharing-auth-flow.component";
 
 /** A flattened, depth-indented folder option for the accept-into picker. */
 interface FolderOption {
@@ -25,19 +30,23 @@ interface FolderOption {
  * settings-privacy-section shape (`:host { display: contents }` + `.section-stack`
  * + frosted `.card`, global `.btn`/`.btn-primary`/`.btn-ghost`, `var(--token)`).
  *
- * Everything talks to the Rust core through {@link IpcService}: `accountStatus`
- * loads once into a signal on init; login / signup / logout write the resulting
- * `AccountStatus` back into that signal. The sharing-server base URL round-trips
- * through the normal config path (`getConfig` → mutate `shareBaseUrl` → `saveConfig`).
+ * REBUILT: the cramped all-at-once login+signup form (which never issued the
+ * send-code call → the "broken signup" bug) is gone. When signed out, a single
+ * primary button opens the SAME reusable `<app-sharing-auth-flow>` used by the
+ * `/welcome` gateway — here inside an OPAQUE modal (`var(--surface-overlay)`,
+ * `backdrop-filter: none`, `border-strong`, `shadow-lg` — trap T3, never the
+ * frosted `.card`). The signed-in state, the sharing-server editor, and the M5
+ * incoming-shares inbox are unchanged.
  *
- * SECURITY: the password lives ONLY in a per-form FormControl and is cleared after
- * each submit — it is never stored in a persistent signal and never logged.
+ * Everything talks to the Rust core through {@link IpcService}: `accountStatus`
+ * loads once into a signal on init; the flow's `completed` output triggers a
+ * reload that flips the section to its signed-in state.
  */
 @Component({
   selector: "app-settings-account-section",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, SharingAuthFlowComponent],
   template: `
     <div class="section-stack">
       <div class="card account-card">
@@ -135,146 +144,47 @@ interface FolderOption {
                   Sign out
                 </button>
               </div>
+              <p class="text-secondary account-note">
+                Your notes live on this Mac. Signing out only turns off sharing —
+                it never deletes, moves, or uploads a note.
+              </p>
               @if (!st.unlockedForSharing) {
                 <p class="text-secondary account-note">
                   Sign in again to share — your account key isn't loaded in this
                   session.
                 </p>
-              }
-            </div>
-          } @else {
-            <!-- (2b) Login form (primary path) -->
-            <div class="account-section">
-              <span class="account-section-label text-muted">Sign in</span>
-              <div class="field-grid">
-                <input
-                  type="email"
-                  class="text-input"
-                  [formControl]="emailControl"
-                  placeholder="you@example.com"
-                  autocomplete="username"
-                  spellcheck="false"
-                  aria-label="Email"
-                />
-                <input
-                  type="password"
-                  class="text-input"
-                  [formControl]="passwordControl"
-                  placeholder="Password"
-                  autocomplete="current-password"
-                  aria-label="Password"
-                />
-              </div>
-              <div class="account-actions">
-                <button
-                  type="button"
-                  class="btn btn-primary"
-                  (click)="login()"
-                  [disabled]="busy()"
-                >
-                  {{ busy() ? "Signing in…" : "Sign in" }}
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-ghost"
-                  (click)="toggleSignup()"
-                >
-                  {{ showSignup() ? "Cancel" : "Create an account" }}
-                </button>
-              </div>
-              @if (loginError(); as lerr) {
-                <p class="text-danger account-note">{{ lerr }}</p>
-              }
-            </div>
-
-            <!-- (2c) Sign-up (secondary, collapsed under a toggle) -->
-            @if (showSignup()) {
-              <div class="account-section signup-section">
-                <span class="account-section-label text-muted"
-                  >Create an account</span
-                >
-                <p class="text-secondary account-note">
-                  Enter your email to receive a 6-digit code, then set a
-                  password. Your password never leaves this Mac.
-                </p>
-                <div class="field-grid">
-                  <input
-                    type="email"
-                    class="text-input"
-                    [formControl]="signupEmailControl"
-                    placeholder="you@example.com"
-                    autocomplete="username"
-                    spellcheck="false"
-                    aria-label="Email"
-                  />
-                  <input
-                    type="text"
-                    inputmode="numeric"
-                    class="text-input"
-                    [formControl]="signupCodeControl"
-                    placeholder="6-digit code"
-                    autocomplete="one-time-code"
-                    spellcheck="false"
-                    aria-label="Verification code"
-                  />
-                  <input
-                    type="password"
-                    class="text-input"
-                    [formControl]="signupPasswordControl"
-                    placeholder="Choose a password"
-                    autocomplete="new-password"
-                    aria-label="Password"
-                  />
-                </div>
-                <label class="toggle-row">
-                  <span class="toggle-copy">
-                    <span class="toggle-title">Save a recovery phrase</span>
-                    <span class="text-secondary toggle-sub">
-                      Generates a 24-word recovery phrase — the only way to
-                      recover a forgotten password. You can skip this.
-                    </span>
-                  </span>
-                  <input type="checkbox" [formControl]="saveRecoveryControl" />
-                </label>
                 <div class="account-actions">
                   <button
                     type="button"
                     class="btn btn-primary"
-                    (click)="signup()"
-                    [disabled]="busy()"
+                    (click)="openFlow()"
                   >
-                    {{ busy() ? "Creating…" : "Create account" }}
+                    Sign in to share
                   </button>
                 </div>
-                @if (signupError(); as serr) {
-                  <p class="text-danger account-note">{{ serr }}</p>
-                }
-                @if (signupNotice(); as note) {
-                  <p class="text-secondary account-note">{{ note }}</p>
-                }
-                @if (recoveryPhrase(); as phrase) {
-                  <div class="recovery">
-                    <span class="account-section-label text-muted"
-                      >Recovery phrase</span
-                    >
-                    <p class="recovery-block" role="text">{{ phrase }}</p>
-                    <div class="account-actions">
-                      <button
-                        type="button"
-                        class="btn"
-                        (click)="copyRecovery(phrase)"
-                      >
-                        {{ recoveryCopied() ? "Copied" : "Copy" }}
-                      </button>
-                    </div>
-                    <p class="text-secondary account-note">
-                      Save this — it's the only way to recover a forgotten
-                      password.
-                    </p>
-                  </div>
-                }
+              }
+            </div>
+          } @else {
+            <!-- (2b) Signed-out: ONE button opens the reusable flow -->
+            <div class="account-section">
+              <span class="account-section-label text-muted">Account</span>
+              <p class="text-secondary account-note">
+                Create a sharing account or sign in to this Mac to start sharing
+                notes as end-to-end-encrypted links.
+              </p>
+              <div class="account-actions">
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  (click)="openFlow()"
+                >
+                  Create or sign in to a sharing account
+                </button>
               </div>
-            }
+              @if (accountError(); as aerr) {
+                <p class="text-danger account-note">{{ aerr }}</p>
+              }
+            </div>
           }
         } @else {
           <p class="text-muted account-note">Loading account…</p>
@@ -408,6 +318,29 @@ interface FolderOption {
         }
       }
     </div>
+
+    <!-- The reusable flow, hosted in an OPAQUE modal (trap T3 — never .card).
+         Dismissal = the flow's own Cancel (dismissed) or Escape on the panel —
+         matching the repo's share-verify-sheet modal (no scrim-click handler, so
+         the a11y lint rules stay clean). -->
+    @if (showFlow()) {
+      <div class="flow-scrim">
+        <div
+          #flowPanel
+          class="flow-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Sharing account"
+          tabindex="-1"
+          (keydown.escape)="closeFlow()"
+        >
+          <app-sharing-auth-flow
+            (completed)="onFlowDone()"
+            (dismissed)="closeFlow()"
+          />
+        </div>
+      </div>
+    }
   `,
   styles: [
     `
@@ -467,10 +400,6 @@ interface FolderOption {
         flex-direction: column;
         gap: var(--space-2);
       }
-      .signup-section {
-        padding-top: var(--space-4);
-        border-top: 1px solid var(--border-subtle);
-      }
       .account-section-label {
         font-size: 0.8125rem;
         font-weight: 550;
@@ -516,13 +445,6 @@ interface FolderOption {
         flex: none;
       }
 
-      .field-grid {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2);
-        max-width: 24rem;
-      }
-
       .account-actions {
         display: flex;
         align-items: center;
@@ -542,55 +464,6 @@ interface FolderOption {
       }
       .signed-pill {
         align-self: flex-start;
-      }
-
-      /* Recovery-phrase toggle (mirrors the privacy-section toggle rows). */
-      .toggle-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--space-4);
-        cursor: pointer;
-        max-width: 24rem;
-      }
-      .toggle-copy {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-1);
-      }
-      .toggle-title {
-        color: var(--text-primary);
-        font-size: 0.95rem;
-        font-weight: 550;
-      }
-      .toggle-sub {
-        font-size: 0.85rem;
-        line-height: 1.55;
-      }
-
-      /* The revealed recovery phrase — a quiet inset well, selectable. */
-      .recovery {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2);
-        padding: var(--space-4);
-        border-radius: var(--radius-md);
-        background: var(--surface-input);
-        border: 1px solid var(--border-subtle);
-      }
-      .recovery-block {
-        margin: 0;
-        padding: var(--space-3);
-        border-radius: var(--radius-md);
-        background: var(--surface-raised);
-        border: 1px solid var(--glass-border);
-        color: var(--text-primary);
-        font-family: var(--font-mono);
-        font-size: 0.875rem;
-        line-height: 1.7;
-        user-select: text;
-        -webkit-user-select: text;
-        overflow-wrap: anywhere;
       }
 
       /* --- Incoming shares (M5-CLIENT inbox) --- */
@@ -696,23 +569,89 @@ interface FolderOption {
         color: var(--text-muted);
         font-size: 0.8125rem;
       }
+
+      /* --- The reusable-flow OPAQUE modal (trap T3) --- */
+      .flow-scrim {
+        position: fixed;
+        inset: 0;
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--space-5);
+        background: rgba(0, 0, 0, 0.5);
+        -webkit-backdrop-filter: blur(2px);
+        backdrop-filter: blur(2px);
+        animation: scrim-in 180ms var(--transition) both;
+      }
+      @keyframes scrim-in {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+      .flow-modal {
+        width: 100%;
+        max-width: 460px;
+        max-height: calc(100vh - 2 * var(--space-5));
+        overflow-y: auto;
+        padding: var(--space-6);
+        /* OPAQUE overlay — NOT the frosted .card (trap T3). */
+        background: var(--surface-overlay);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-lg);
+        -webkit-backdrop-filter: none;
+        backdrop-filter: none;
+        animation: modal-in 220ms var(--ease-spring) both;
+      }
+      .flow-modal:focus-visible {
+        outline: none;
+      }
+      @keyframes modal-in {
+        from {
+          opacity: 0;
+          transform: translateY(10px) scale(0.985);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .flow-scrim,
+        .flow-modal {
+          animation: none !important;
+        }
+      }
     `,
   ],
 })
 export class SettingsAccountSectionComponent {
   private readonly ipc = inject(IpcService);
+  private readonly injector = inject(Injector);
 
   /** The current sharing-account session; `null` until the first load resolves. */
   private readonly _status = signal<AccountStatus | null>(null);
   readonly status = this._status.asReadonly();
 
-  /** True while any login/signup/logout IPC call is in flight (debounces clicks). */
+  /** True while a logout IPC call is in flight (debounces the Sign out button). */
   private readonly _busy = signal(false);
   readonly busy = this._busy.asReadonly();
 
-  /** Whether the secondary sign-up affordance is expanded (login stays primary). */
-  private readonly _showSignup = signal(false);
-  readonly showSignup = this._showSignup.asReadonly();
+  /** A general account error (status load / logout failure). */
+  private readonly _accountError = signal<string | null>(null);
+  readonly accountError = this._accountError.asReadonly();
+
+  /** Whether the reusable-flow modal is open. */
+  private readonly _showFlow = signal(false);
+  readonly showFlow = this._showFlow.asReadonly();
+
+  /** The modal panel — focused on open so Escape works immediately. */
+  private readonly flowPanel =
+    viewChild<ElementRef<HTMLElement>>("flowPanel");
 
   // ── Server base URL ──────────────────────────────────────────────────────
   readonly serverControl = new FormControl("", { nonNullable: true });
@@ -720,27 +659,6 @@ export class SettingsAccountSectionComponent {
   readonly savingServer = this._savingServer.asReadonly();
   private readonly _serverError = signal<string | null>(null);
   readonly serverError = this._serverError.asReadonly();
-
-  // ── Login form (password lives ONLY here; cleared after submit) ───────────
-  readonly emailControl = new FormControl("", { nonNullable: true });
-  readonly passwordControl = new FormControl("", { nonNullable: true });
-  private readonly _loginError = signal<string | null>(null);
-  readonly loginError = this._loginError.asReadonly();
-
-  // ── Sign-up form ─────────────────────────────────────────────────────────
-  readonly signupEmailControl = new FormControl("", { nonNullable: true });
-  readonly signupCodeControl = new FormControl("", { nonNullable: true });
-  readonly signupPasswordControl = new FormControl("", { nonNullable: true });
-  readonly saveRecoveryControl = new FormControl(false, { nonNullable: true });
-  private readonly _signupError = signal<string | null>(null);
-  readonly signupError = this._signupError.asReadonly();
-  private readonly _signupNotice = signal<string | null>(null);
-  readonly signupNotice = this._signupNotice.asReadonly();
-  /** The 24-word recovery phrase, shown once after a `saveRecovery` signup. */
-  private readonly _recoveryPhrase = signal<string | null>(null);
-  readonly recoveryPhrase = this._recoveryPhrase.asReadonly();
-  private readonly _recoveryCopied = signal(false);
-  readonly recoveryCopied = this._recoveryCopied.asReadonly();
 
   // ── Incoming shares (M5-CLIENT inbox) ────────────────────────────────────
   private readonly _inbox = signal<ShareInboxItem[]>([]);
@@ -796,7 +714,7 @@ export class SettingsAccountSectionComponent {
       st = await this.ipc.accountStatus();
       this._status.set(st);
     } catch (e) {
-      this._loginError.set(String(e));
+      this._accountError.set(String(e));
     }
     try {
       const cfg = await this.ipc.getConfig();
@@ -839,8 +757,26 @@ export class SettingsAccountSectionComponent {
     }
   }
 
-  toggleSignup(): void {
-    this._showSignup.update((v) => !v);
+  // ── The reusable flow (modal host) ───────────────────────────────────────
+
+  /** Open the OPAQUE modal + focus its panel so Escape/keyboard work at once. */
+  openFlow(): void {
+    this._accountError.set(null);
+    this._showFlow.set(true);
+    afterNextRender(() => this.flowPanel()?.nativeElement.focus(), {
+      injector: this.injector,
+    });
+  }
+
+  /** Dismissed (user backed out) — just close. */
+  closeFlow(): void {
+    this._showFlow.set(false);
+  }
+
+  /** Completed (signed in) — close + reload so the section flips to signed-in. */
+  async onFlowDone(): Promise<void> {
+    this._showFlow.set(false);
+    await this.reload();
   }
 
   /** Persist the sharing-server base URL through the normal config round-trip. */
@@ -863,69 +799,6 @@ export class SettingsAccountSectionComponent {
     }
   }
 
-  /** Sign in (OPAQUE) — writes the returned AccountStatus into the status signal. */
-  async login(): Promise<void> {
-    if (this._busy()) return;
-    const email = this.emailControl.value.trim();
-    const password = this.passwordControl.value;
-    if (!email || !password) {
-      this._loginError.set("Enter your email and password.");
-      return;
-    }
-    this._loginError.set(null);
-    this._busy.set(true);
-    try {
-      const st = await this.ipc.accountLogin(email, password);
-      this._status.set(st);
-      this.passwordControl.setValue(""); // never persist the password
-    } catch (e) {
-      this._loginError.set(String(e));
-    } finally {
-      this._busy.set(false);
-    }
-  }
-
-  /**
-   * Create a sharing account. `accountSignup` returns the 24-word recovery
-   * phrase ONLY when saveRecovery is checked (else null → "now sign in").
-   */
-  async signup(): Promise<void> {
-    if (this._busy()) return;
-    const email = this.signupEmailControl.value.trim();
-    const code = this.signupCodeControl.value.trim();
-    const password = this.signupPasswordControl.value;
-    const saveRecovery = this.saveRecoveryControl.value;
-    if (!email || !code || !password) {
-      this._signupError.set("Enter your email, the 6-digit code, and a password.");
-      return;
-    }
-    this._signupError.set(null);
-    this._signupNotice.set(null);
-    this._recoveryPhrase.set(null);
-    this._busy.set(true);
-    try {
-      const phrase = await this.ipc.accountSignup(
-        email,
-        code,
-        password,
-        saveRecovery,
-      );
-      if (phrase) {
-        this._recoveryPhrase.set(phrase);
-      } else {
-        this._signupNotice.set("Account created — now sign in.");
-      }
-      // Prefill the login form for the freshly-created account; clear secrets.
-      this.emailControl.setValue(email);
-      this.signupPasswordControl.setValue("");
-      this.signupCodeControl.setValue("");
-    } catch (e) {
-      this._signupError.set(String(e));
-    } finally {
-      this._busy.set(false);
-    }
-  }
-
   /** Sign out (server family-revoke + clear tokens + drop session MK), then reload. */
   async logout(): Promise<void> {
     if (this._busy()) return;
@@ -934,19 +807,9 @@ export class SettingsAccountSectionComponent {
       await this.ipc.accountLogout();
       await this.reload();
     } catch (e) {
-      this._loginError.set(String(e));
+      this._accountError.set(String(e));
     } finally {
       this._busy.set(false);
-    }
-  }
-
-  /** Copy the recovery phrase to the clipboard and briefly confirm. */
-  async copyRecovery(phrase: string): Promise<void> {
-    try {
-      await navigator.clipboard.writeText(phrase);
-      this._recoveryCopied.set(true);
-    } catch {
-      // Clipboard unavailable — the phrase stays visible and selectable.
     }
   }
 

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -310,6 +310,14 @@ export class SettingsStore {
   private loadedShareBaseUrl = "";
   private loadedShareEgressConsented = false;
 
+  /**
+   * First-run sharing-choice latch — preserve-only here (the /welcome gateway is
+   * its sole writer via mark_sharing_choice_made). Snapshotted + round-tripped on
+   * save() so the shell "Save settings" never clears it (the backend also
+   * PRESERVES it in dto_to_config, so this is belt-and-braces).
+   */
+  private loadedSharingChoiceMade = false;
+
   /** Cloud-egress consent state — drives the "Cloud processing" section; round-tripped on save. */
   private readonly _cloudConsented = signal(false);
   readonly cloudConsented = this._cloudConsented.asReadonly();
@@ -960,6 +968,8 @@ export class SettingsStore {
       // save() round-trips them unchanged (owned by Settings → Account).
       this.loadedShareBaseUrl = cfg.shareBaseUrl ?? "";
       this.loadedShareEgressConsented = cfg.shareEgressConsented ?? false;
+      // First-run sharing latch — snapshot so save() round-trips it unchanged.
+      this.loadedSharingChoiceMade = cfg.sharingChoiceMade ?? false;
       this._cloudConsented.set(cfg.cloudEgressConsented ?? false);
       // brain2 connectors — web-search consent is preserve-only (granted only via
       // consent_to_web_search); snapshot it so save() round-trips it unchanged.
@@ -1567,6 +1577,9 @@ export class SettingsStore {
       // (the Account section is the sole owner of these values).
       shareBaseUrl: this.loadedShareBaseUrl,
       shareEgressConsented: this.loadedShareEgressConsented,
+      // First-run sharing latch — preserve-only (the /welcome gateway owns it);
+      // carry the snapshot back so the shell Save never clears it.
+      sharingChoiceMade: this.loadedSharingChoiceMade,
     };
     try {
       await this.ipc.saveConfig(cfg);

--- a/src/app/features/sharing/sharing-auth-flow.component.ts
+++ b/src/app/features/sharing/sharing-auth-flow.component.ts
@@ -1,0 +1,1183 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  inject,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { IpcService } from "../../core/ipc.service";
+import type { AccountStatus } from "../../core/models";
+
+/**
+ * The reusable multi-step sharing-account flow. One state machine, two entry
+ * doors (create / sign in), driven by the SAME component whether it is launched
+ * from the init gateway (`/welcome`) or from Settings → Account.
+ */
+type Step =
+  | "choose" // "Create account" | "I already have one"
+  | "create-email" // email input + [Send code]
+  | "create-code" // 6-digit code input (verified later, inside account_signup)
+  | "create-password" // password + confirm + optional recovery → [Create account]
+  | "create-recovery" // reveal the 24-word phrase (only when saveRecovery)
+  | "signin" // email + password → [Sign in]
+  | "done"; // brief success, completed already emitted
+
+/**
+ * SharingAuthFlowComponent — the ONE reusable account surface (contract §4).
+ *
+ * SURFACE-AGNOSTIC: `:host { display: contents }` and NO own frosted/opaque
+ * background — the HOST owns the surface (the gateway wraps this in a full-bleed
+ * `.card` over the aurora; Settings wraps it in an OPAQUE `--surface-overlay`
+ * modal). That is what keeps this clear of trap T3 — this component never paints
+ * a floating panel of its own.
+ *
+ * State: non-secret step state lives in signals; passwords live ONLY in
+ * transient `FormControl`s, read at submit and cleared immediately after — never
+ * a persistent signal, never logged (mirrors the retired inline form's
+ * discipline). IPC results (an `AccountStatus`) land in the `completed` output.
+ *
+ * THE BUG THIS FIXES: the create path's first leg calls `accountSendCode(email)`
+ * → `account_send_code` → `ShareClient::signup` → `POST /v1/auth/signup`, which
+ * is what actually triggers the server to EMAIL the 6-digit code. The retired
+ * form never issued that call, so no code was ever sent. After collecting the
+ * code we call the existing `account_signup` (which verify_email-exchanges the
+ * code internally) and CHAIN `account_login` so the user ends up signed in in
+ * one pass (account_signup opens no session).
+ */
+@Component({
+  selector: "app-sharing-auth-flow",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <div class="flow">
+      @switch (step()) {
+        <!-- ─────────────────────────── CHOOSE ─────────────────────────── -->
+        @case ("choose") {
+          <div class="flow-head">
+            <h2 class="flow-title">Sharing account</h2>
+            <p class="flow-sub text-secondary">
+              Share a note as a private, end-to-end-encrypted link. Only
+              ciphertext and wrapped keys ever leave this Mac — the server can
+              never read your notes.
+            </p>
+          </div>
+          <div class="doors">
+            <button
+              type="button"
+              class="door"
+              (click)="startCreate()"
+              [disabled]="busy()"
+            >
+              <span class="door-icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" width="20" height="20" fill="none">
+                  <circle
+                    cx="10"
+                    cy="7"
+                    r="3.2"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M4.5 16.2c.9-2.6 3-4 5.5-4s4.6 1.4 5.5 4"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </span>
+              <span class="door-name">Create an account</span>
+              <span class="door-sub text-secondary">
+                New here — set up sharing in a few steps.
+              </span>
+            </button>
+
+            <button
+              type="button"
+              class="door"
+              (click)="startSignin()"
+              [disabled]="busy()"
+            >
+              <span class="door-icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20" width="20" height="20" fill="none">
+                  <path
+                    d="M9 3.5H5.5A1.5 1.5 0 0 0 4 5v10a1.5 1.5 0 0 0 1.5 1.5H9M12.5 13l3-3-3-3M15 10H8"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span class="door-name">I already have one</span>
+              <span class="door-sub text-secondary">
+                Sign in to this Mac to start sharing.
+              </span>
+            </button>
+          </div>
+
+          @if (advancedOpen()) {
+            <div class="adv-well">
+              <span class="flow-label text-muted">Sharing server</span>
+              <p class="flow-note text-secondary">
+                The server that stores the encrypted note. It can't read your
+                notes — only ciphertext and wrapped keys leave this Mac.
+              </p>
+              <div class="row">
+                <input
+                  type="url"
+                  class="field-input"
+                  [value]="serverUrl()"
+                  (input)="onServerUrl($event)"
+                  placeholder="https://share.example.com"
+                  autocomplete="off"
+                  spellcheck="false"
+                  aria-label="Sharing server base URL"
+                />
+                <button
+                  type="button"
+                  class="btn"
+                  (click)="saveServer()"
+                  [disabled]="serverSaving()"
+                >
+                  {{ serverSaving() ? "Saving…" : "Save" }}
+                </button>
+              </div>
+            </div>
+          } @else {
+            <button
+              type="button"
+              class="link-btn text-muted adv-toggle"
+              (click)="toggleAdvanced()"
+            >
+              Advanced — sharing server
+            </button>
+          }
+
+          <div class="flow-nav">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="cancel()"
+              [disabled]="busy()"
+            >
+              Cancel
+            </button>
+          </div>
+        }
+
+        <!-- ─────────────────────────── CREATE — EMAIL ──────────────────── -->
+        @case ("create-email") {
+          <div class="flow-head">
+            <h2 class="flow-title">Create your account</h2>
+            <p class="flow-sub text-secondary">
+              Enter your email and we'll send a 6-digit code to confirm it.
+            </p>
+          </div>
+          <label class="field">
+            <span class="flow-label">Email</span>
+            <input
+              #emailField
+              type="email"
+              class="field-input"
+              [value]="email()"
+              (input)="onEmail($event)"
+              (keydown.enter)="sendCode()"
+              placeholder="you@example.com"
+              autocomplete="username"
+              spellcheck="false"
+              [disabled]="busy()"
+            />
+          </label>
+
+          @if (advancedOpen()) {
+            <div class="adv-well">
+              <span class="flow-label text-muted">Sharing server</span>
+              <div class="row">
+                <input
+                  type="url"
+                  class="field-input"
+                  [value]="serverUrl()"
+                  (input)="onServerUrl($event)"
+                  placeholder="https://share.example.com"
+                  autocomplete="off"
+                  spellcheck="false"
+                  aria-label="Sharing server base URL"
+                />
+                <button
+                  type="button"
+                  class="btn"
+                  (click)="saveServer()"
+                  [disabled]="serverSaving()"
+                >
+                  {{ serverSaving() ? "Saving…" : "Save" }}
+                </button>
+              </div>
+            </div>
+          } @else {
+            <button
+              type="button"
+              class="link-btn text-muted adv-toggle"
+              (click)="toggleAdvanced()"
+            >
+              Advanced — sharing server
+            </button>
+          }
+
+          @if (error(); as err) {
+            <p class="flow-error text-danger" role="alert">{{ err }}</p>
+          }
+
+          <div class="flow-nav">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="backToChoose()"
+              [disabled]="busy()"
+            >
+              Back
+            </button>
+            <span class="flow-nav-spacer"></span>
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="sendCode()"
+              [disabled]="busy()"
+            >
+              {{ busy() ? "Sending…" : "Send code" }}
+            </button>
+          </div>
+        }
+
+        <!-- ─────────────────────────── CREATE — CODE ───────────────────── -->
+        @case ("create-code") {
+          <div class="flow-head">
+            <h2 class="flow-title">Enter the code</h2>
+            <p class="flow-sub text-secondary">
+              We sent a 6-digit code to
+              <span class="flow-email">{{ email() }}</span
+              >. Enter it below. If it doesn't arrive, check your spam or resend.
+            </p>
+          </div>
+          <label class="field">
+            <span class="flow-label">Verification code</span>
+            <input
+              #codeField
+              type="text"
+              inputmode="numeric"
+              class="field-input code-input"
+              [value]="code()"
+              (input)="onCode($event)"
+              (keydown.enter)="codeContinue()"
+              placeholder="000000"
+              autocomplete="one-time-code"
+              spellcheck="false"
+              maxlength="6"
+              [disabled]="busy()"
+            />
+          </label>
+
+          @if (notice(); as note) {
+            <p class="flow-note text-secondary" role="status">{{ note }}</p>
+          }
+          @if (error(); as err) {
+            <p class="flow-error text-danger" role="alert">{{ err }}</p>
+          }
+
+          <div class="flow-nav">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="goEmail()"
+              [disabled]="busy()"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              class="link-btn text-muted resend"
+              (click)="resendCode()"
+              [disabled]="busy()"
+            >
+              {{ busy() ? "Sending…" : "Resend code" }}
+            </button>
+            <span class="flow-nav-spacer"></span>
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="codeContinue()"
+              [disabled]="busy()"
+            >
+              Continue
+            </button>
+          </div>
+        }
+
+        <!-- ─────────────────────────── CREATE — PASSWORD ───────────────── -->
+        @case ("create-password") {
+          <div class="flow-head">
+            <h2 class="flow-title">Choose a password</h2>
+            <p class="flow-sub text-secondary">
+              Your password never leaves this Mac — it unlocks your account key
+              on-device.
+            </p>
+          </div>
+          <label class="field">
+            <span class="flow-label">Password</span>
+            <input
+              #passwordField
+              type="password"
+              class="field-input"
+              [formControl]="passwordControl"
+              (keydown.enter)="createAccount()"
+              placeholder="At least 8 characters"
+              autocomplete="new-password"
+            />
+          </label>
+          <label class="field">
+            <span class="flow-label">Confirm password</span>
+            <input
+              type="password"
+              class="field-input"
+              [formControl]="confirmControl"
+              (keydown.enter)="createAccount()"
+              placeholder="Re-enter your password"
+              autocomplete="new-password"
+            />
+          </label>
+
+          <label class="toggle-row">
+            <span class="toggle-copy">
+              <span class="toggle-title">Save a recovery phrase</span>
+              <span class="text-secondary toggle-sub">
+                Generates a 24-word recovery phrase — the only way to recover a
+                forgotten password. You can skip this.
+              </span>
+            </span>
+            <input
+              type="checkbox"
+              [checked]="saveRecovery()"
+              (change)="onSaveRecovery($event)"
+              [disabled]="busy()"
+            />
+          </label>
+
+          @if (error(); as err) {
+            <p class="flow-error text-danger" role="alert">{{ err }}</p>
+          }
+
+          <div class="flow-nav">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="goCode()"
+              [disabled]="busy()"
+            >
+              Back
+            </button>
+            <span class="flow-nav-spacer"></span>
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="createAccount()"
+              [disabled]="busy()"
+            >
+              {{ busy() ? "Creating…" : "Create account" }}
+            </button>
+          </div>
+        }
+
+        <!-- ─────────────────────────── CREATE — RECOVERY ───────────────── -->
+        @case ("create-recovery") {
+          <div class="flow-head">
+            <h2 class="flow-title">Save your recovery phrase</h2>
+            <p class="flow-sub text-secondary">
+              These 24 words are the ONLY way to recover a forgotten password.
+              Write them down and keep them somewhere safe — they're shown once.
+            </p>
+          </div>
+          @if (recoveryPhrase(); as phrase) {
+            <p class="recovery-block" role="text">{{ phrase }}</p>
+            <div class="flow-nav">
+              <button type="button" class="btn" (click)="copyRecovery(phrase)">
+                {{ recoveryCopied() ? "Copied" : "Copy" }}
+              </button>
+              <span class="flow-nav-spacer"></span>
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="recoveryDone()"
+              >
+                I've saved it — continue
+              </button>
+            </div>
+          }
+        }
+
+        <!-- ─────────────────────────── SIGN IN ─────────────────────────── -->
+        @case ("signin") {
+          <div class="flow-head">
+            <h2 class="flow-title">Sign in</h2>
+            <p class="flow-sub text-secondary">
+              Sign in to load your account key on this Mac so you can share.
+            </p>
+          </div>
+          <label class="field">
+            <span class="flow-label">Email</span>
+            <input
+              #signinEmailField
+              type="email"
+              class="field-input"
+              [value]="email()"
+              (input)="onEmail($event)"
+              (keydown.enter)="signIn()"
+              placeholder="you@example.com"
+              autocomplete="username"
+              spellcheck="false"
+              [disabled]="busy()"
+            />
+          </label>
+          <label class="field">
+            <span class="flow-label">Password</span>
+            <input
+              type="password"
+              class="field-input"
+              [formControl]="signinPwControl"
+              (keydown.enter)="signIn()"
+              placeholder="Password"
+              autocomplete="current-password"
+            />
+          </label>
+
+          @if (error(); as err) {
+            <p class="flow-error text-danger" role="alert">{{ err }}</p>
+          }
+
+          <div class="flow-nav">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="backToChoose()"
+              [disabled]="busy()"
+            >
+              Back
+            </button>
+            <span class="flow-nav-spacer"></span>
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="signIn()"
+              [disabled]="busy()"
+            >
+              {{ busy() ? "Signing in…" : "Sign in" }}
+            </button>
+          </div>
+        }
+
+        <!-- ─────────────────────────── DONE ────────────────────────────── -->
+        @case ("done") {
+          <div class="flow-done">
+            <span class="done-mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="26" height="26">
+                <path
+                  d="M5 12.5 10 17.5 19.5 7"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.4"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <h2 class="flow-title">You're signed in</h2>
+            <p class="flow-sub text-secondary">Your account is ready to share.</p>
+          </div>
+        }
+      }
+
+      <!-- Step progress (create sub-flow only). -->
+      @if (createProgress(); as prog) {
+        <div class="flow-progress" role="group" aria-label="Account setup progress">
+          <div class="dots">
+            @for (i of progressDots(); track i) {
+              <span
+                class="dot"
+                [class.is-done]="i < prog.index - 1"
+                [class.is-active]="i === prog.index - 1"
+                aria-hidden="true"
+              ></span>
+            }
+          </div>
+          <span class="step-count">Step {{ prog.index }} of {{ prog.total }}</span>
+        </div>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      /* Surface-agnostic: the host paints NO background of its own — the gateway
+         card / settings modal that hosts this owns the surface (trap T3). */
+      :host {
+        display: contents;
+      }
+      .flow {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+
+      .flow-head {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .flow-title {
+        margin: 0;
+        font-size: 1.35rem;
+        font-weight: 650;
+        letter-spacing: -0.02em;
+      }
+      .flow-sub {
+        margin: 0;
+        font-size: 0.95rem;
+        line-height: 1.55;
+      }
+      .flow-email {
+        color: var(--text-primary);
+        font-weight: 600;
+        overflow-wrap: anywhere;
+      }
+      .flow-note {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.55;
+      }
+      .flow-error {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.5;
+      }
+
+      /* Two big choice doors on the 'choose' step. */
+      .doors {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-3);
+      }
+      @media (max-width: 520px) {
+        .doors {
+          grid-template-columns: 1fr;
+        }
+      }
+      .door {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        text-align: left;
+        padding: var(--space-4);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font-family: inherit;
+        cursor: pointer;
+        transition:
+          border-color var(--transition),
+          background var(--transition),
+          transform var(--transition-fast);
+      }
+      .door:hover {
+        border-color: var(--border-strong);
+        background: var(--surface-hover);
+      }
+      .door:active {
+        transform: translateY(1px);
+      }
+      .door:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .door:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+      .door-icon {
+        display: inline-flex;
+        color: var(--accent-hover);
+        margin-bottom: var(--space-1);
+      }
+      .door-name {
+        font-size: 0.95rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .door-sub {
+        font-size: 0.8125rem;
+        line-height: 1.45;
+      }
+
+      /* Fields. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .flow-label {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        font-weight: 550;
+      }
+      .field-input {
+        height: 38px;
+        padding: 0 var(--space-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        color: var(--text-primary);
+        font: inherit;
+        font-size: 0.9rem;
+      }
+      .field-input::placeholder {
+        color: var(--text-muted);
+      }
+      .field-input:focus-visible {
+        outline: none;
+        border-color: var(--accent-hover);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      .code-input {
+        font-family: var(--font-mono);
+        letter-spacing: 0.35em;
+        font-size: 1.05rem;
+      }
+
+      .row {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .row .field-input {
+        flex: 1 1 16rem;
+        min-width: 0;
+      }
+      .row .btn {
+        flex: none;
+      }
+
+      /* Advanced disclosure — a quiet inset well, still tokenized. */
+      .adv-toggle {
+        align-self: flex-start;
+      }
+      .adv-well {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--border-subtle);
+      }
+      .link-btn {
+        padding: 0;
+        border: none;
+        background: none;
+        font: inherit;
+        font-size: 0.8125rem;
+        font-weight: 550;
+        cursor: pointer;
+        text-align: left;
+      }
+      .link-btn:hover {
+        color: var(--text-secondary);
+      }
+      .link-btn:focus-visible {
+        outline: none;
+        text-decoration: underline;
+      }
+      .link-btn:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+
+      /* Recovery-phrase toggle (mirrors the retired section's toggle rows). */
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        cursor: pointer;
+      }
+      .toggle-copy {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .toggle-title {
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        font-weight: 550;
+      }
+      .toggle-sub {
+        font-size: 0.85rem;
+        line-height: 1.55;
+      }
+
+      .recovery-block {
+        margin: 0;
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--surface-input);
+        border: 1px solid var(--glass-border);
+        color: var(--text-primary);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        line-height: 1.8;
+        user-select: text;
+        -webkit-user-select: text;
+        overflow-wrap: anywhere;
+      }
+
+      /* Footer nav. */
+      .flow-nav {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .flow-nav-spacer {
+        flex: 1;
+      }
+      .resend {
+        font-size: 0.85rem;
+      }
+
+      /* Done. */
+      .flow-done {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: var(--space-2);
+        padding: var(--space-4) 0;
+      }
+      .done-mark {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 56px;
+        height: 56px;
+        margin-bottom: var(--space-1);
+        border-radius: 50%;
+        background: var(--success-soft);
+        color: var(--success);
+      }
+
+      /* Step progress dots. */
+      .flow-progress {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding-top: var(--space-1);
+      }
+      .dots {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+      }
+      .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: var(--radius-pill);
+        background: var(--border-strong);
+        transition:
+          width var(--transition),
+          background var(--transition);
+      }
+      .dot.is-done {
+        background: var(--accent);
+      }
+      .dot.is-active {
+        width: 22px;
+        background: var(--accent-gradient);
+      }
+      .step-count {
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        font-variant-numeric: tabular-nums;
+      }
+    `,
+  ],
+})
+export class SharingAuthFlowComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly injector = inject(Injector);
+
+  /** Fired once the session is logged in (after sign-in, or signup → auto-login). */
+  readonly completed = output<AccountStatus>();
+  /** Fired when the user backs all the way out of the 'choose' step. */
+  readonly dismissed = output<void>();
+
+  // ── Non-secret step state (signals) ──────────────────────────────────────
+  readonly step = signal<Step>("choose");
+  /** Shared across create + sign-in. */
+  readonly email = signal("");
+  readonly code = signal("");
+  readonly saveRecovery = signal(false);
+  /** Debounces every IPC leg. */
+  readonly busy = signal(false);
+  readonly error = signal<string | null>(null);
+  /** A neutral "code sent" notice (never reveals whether the email exists). */
+  readonly notice = signal<string | null>(null);
+  /** Gates advance from create-email (a code was requested at least once). */
+  readonly codeSent = signal(false);
+  /** The 24-word phrase, shown once on create-recovery when saveRecovery is on. */
+  readonly recoveryPhrase = signal<string | null>(null);
+  readonly recoveryCopied = signal(false);
+
+  // ── Secrets: FormControls ONLY, read at submit + cleared right after ──────
+  readonly passwordControl = new FormControl("", { nonNullable: true });
+  readonly confirmControl = new FormControl("", { nonNullable: true });
+  readonly signinPwControl = new FormControl("", { nonNullable: true });
+
+  // ── Advanced (optional) sharing-server disclosure ────────────────────────
+  readonly advancedOpen = signal(false);
+  readonly serverUrl = signal("");
+  private readonly _serverSaving = signal(false);
+  readonly serverSaving = this._serverSaving.asReadonly();
+
+  /** The AccountStatus captured at auto-login, emitted after the recovery step. */
+  private capturedStatus: AccountStatus | null = null;
+
+  // ── Per-step focus targets ───────────────────────────────────────────────
+  private readonly emailField =
+    viewChild<ElementRef<HTMLInputElement>>("emailField");
+  private readonly codeField =
+    viewChild<ElementRef<HTMLInputElement>>("codeField");
+  private readonly passwordField =
+    viewChild<ElementRef<HTMLInputElement>>("passwordField");
+  private readonly signinEmailField =
+    viewChild<ElementRef<HTMLInputElement>>("signinEmailField");
+
+  /** Create sub-flow progress (null on choose/signin/done). */
+  readonly createProgress = computed<{ index: number; total: number } | null>(
+    () => {
+      const order: Step[] = [
+        "create-email",
+        "create-code",
+        "create-password",
+        "create-recovery",
+      ];
+      const idx = order.indexOf(this.step());
+      if (idx < 0) {
+        return null;
+      }
+      return { index: idx + 1, total: this.saveRecovery() ? 4 : 3 };
+    },
+  );
+
+  /** The dot indices to render for the current create-progress total. */
+  readonly progressDots = computed<number[]>(() => {
+    const prog = this.createProgress();
+    if (!prog) {
+      return [];
+    }
+    return Array.from({ length: prog.total }, (_, i) => i);
+  });
+
+  constructor() {
+    // Fire-and-forget one-shot: seed the Advanced server field from config so
+    // it's prefilled if the user opens the disclosure. No signal is read here,
+    // so no effect / NG0600.
+    void this.seedServer();
+  }
+
+  private async seedServer(): Promise<void> {
+    try {
+      const cfg = await this.ipc.getConfig();
+      this.serverUrl.set(cfg.shareBaseUrl ?? "");
+      // Only auto-expand when no server is set (the Railway default means this
+      // is usually already configured → the disclosure stays collapsed).
+      if (!(cfg.shareBaseUrl ?? "").trim()) {
+        this.advancedOpen.set(true);
+      }
+    } catch {
+      // No config yet — leave the field empty + collapsed.
+    }
+  }
+
+  // ── Input handlers (non-secret signals) ──────────────────────────────────
+  onEmail(event: Event): void {
+    this.email.set((event.target as HTMLInputElement).value);
+  }
+
+  onCode(event: Event): void {
+    const digits = (event.target as HTMLInputElement).value
+      .replace(/\D/g, "")
+      .slice(0, 6);
+    this.code.set(digits);
+  }
+
+  onSaveRecovery(event: Event): void {
+    this.saveRecovery.set((event.target as HTMLInputElement).checked);
+  }
+
+  onServerUrl(event: Event): void {
+    this.serverUrl.set((event.target as HTMLInputElement).value);
+  }
+
+  toggleAdvanced(): void {
+    this.advancedOpen.update((v) => !v);
+  }
+
+  /** Persist the Advanced sharing-server URL through the normal config round-trip. */
+  async saveServer(): Promise<void> {
+    if (this._serverSaving()) {
+      return;
+    }
+    this._serverSaving.set(true);
+    this.error.set(null);
+    try {
+      const cfg = await this.ipc.getConfig();
+      await this.ipc.saveConfig({
+        ...cfg,
+        shareBaseUrl: this.serverUrl().trim(),
+      });
+    } catch (e) {
+      this.error.set(this.friendly(e));
+    } finally {
+      this._serverSaving.set(false);
+    }
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+  startCreate(): void {
+    this.error.set(null);
+    this.notice.set(null);
+    this.goto("create-email");
+  }
+
+  startSignin(): void {
+    this.error.set(null);
+    this.goto("signin");
+  }
+
+  backToChoose(): void {
+    this.error.set(null);
+    this.goto("choose");
+  }
+
+  goEmail(): void {
+    this.error.set(null);
+    this.goto("create-email");
+  }
+
+  goCode(): void {
+    this.error.set(null);
+    this.goto("create-code");
+  }
+
+  cancel(): void {
+    this.dismissed.emit();
+  }
+
+  private goto(step: Step): void {
+    this.step.set(step);
+    // Focus this step's primary field AFTER it renders — the sanctioned zoneless
+    // pattern (rule §5). Called from click handlers (outside the field-init
+    // injection context), so pass the injector.
+    afterNextRender(
+      () => {
+        switch (step) {
+          case "create-email":
+            this.emailField()?.nativeElement.focus();
+            break;
+          case "create-code":
+            this.codeField()?.nativeElement.focus();
+            break;
+          case "create-password":
+            this.passwordField()?.nativeElement.focus();
+            break;
+          case "signin":
+            this.signinEmailField()?.nativeElement.focus();
+            break;
+          default:
+            break;
+        }
+      },
+      { injector: this.injector },
+    );
+  }
+
+  // ── create-email [Send code] ─────────────────────────────────────────────
+  async sendCode(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    const email = this.email().trim();
+    if (!email) {
+      this.error.set("Enter your email.");
+      return;
+    }
+    this.error.set(null);
+    this.notice.set(null);
+    this.busy.set(true);
+    try {
+      await this.ipc.accountSendCode(email);
+      this.codeSent.set(true);
+      // The server always 202s (anti-enumeration), so this notice is honest and
+      // privacy-preserving — never a "user exists" signal.
+      this.notice.set(`If ${email} is valid, a 6-digit code is on its way.`);
+      this.goto("create-code");
+    } catch (e) {
+      this.error.set(this.friendly(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /** Re-send the code without advancing (stays on create-code). */
+  async resendCode(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    const email = this.email().trim();
+    if (!email) {
+      this.error.set("Enter your email.");
+      return;
+    }
+    this.error.set(null);
+    this.busy.set(true);
+    try {
+      await this.ipc.accountSendCode(email);
+      this.notice.set("Code re-sent — check your inbox.");
+    } catch (e) {
+      this.error.set(this.friendly(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  // ── create-code [Continue] (no server call — verified inside account_signup) ─
+  codeContinue(): void {
+    if (this.code().trim().length === 0) {
+      this.error.set("Enter the 6-digit code from your email.");
+      return;
+    }
+    this.error.set(null);
+    this.goto("create-password");
+  }
+
+  // ── create-password [Create account] → auto-login chain ──────────────────
+  async createAccount(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    const password = this.passwordControl.value;
+    const confirm = this.confirmControl.value;
+    if (password.length < 8) {
+      this.error.set("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirm) {
+      this.error.set("Passwords do not match.");
+      return;
+    }
+    this.error.set(null);
+    this.busy.set(true);
+    try {
+      const phrase = await this.ipc.accountSignup(
+        this.email().trim(),
+        this.code().trim(),
+        password,
+        this.saveRecovery(),
+      );
+      // account_signup opens NO session — chain a login so the user ends up
+      // signed in in one pass.
+      const status = await this.ipc.accountLogin(this.email().trim(), password);
+      // Clear the secrets immediately after the successful round-trip.
+      this.passwordControl.setValue("");
+      this.confirmControl.setValue("");
+      this.capturedStatus = status;
+      if (phrase) {
+        this.recoveryPhrase.set(phrase);
+        this.goto("create-recovery");
+      } else {
+        this.goto("done");
+        this.completed.emit(status);
+      }
+    } catch (e) {
+      // Bad/expired code, weak password, or email taken — surface it and let the
+      // user step Back to the code to correct it.
+      this.error.set(this.friendly(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  // ── create-recovery [I've saved it] ──────────────────────────────────────
+  recoveryDone(): void {
+    this.goto("done");
+    if (this.capturedStatus) {
+      this.completed.emit(this.capturedStatus);
+    }
+  }
+
+  async copyRecovery(phrase: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(phrase);
+      this.recoveryCopied.set(true);
+    } catch {
+      // Clipboard unavailable — the phrase stays visible and selectable.
+    }
+  }
+
+  // ── signin [Sign in] ─────────────────────────────────────────────────────
+  async signIn(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    const email = this.email().trim();
+    const password = this.signinPwControl.value;
+    if (!email || !password) {
+      this.error.set("Enter your email and password.");
+      return;
+    }
+    this.error.set(null);
+    this.busy.set(true);
+    try {
+      const status = await this.ipc.accountLogin(email, password);
+      this.signinPwControl.setValue("");
+      this.goto("done");
+      this.completed.emit(status);
+    } catch (e) {
+      this.error.set(this.friendly(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /** Map a raw backend error to a friendly, non-crashy inline message. */
+  private friendly(e: unknown): string {
+    const raw = String(e);
+    // Only a genuine connectivity / no-server-set problem gets the "can't reach" guidance. A 4xx
+    // (wrong or expired code, too many tries, bad password) is NOT unreachability — it arrives as a
+    // clear sentence we surface as-is (below).
+    if (/could not reach|unreachable|no sharing server|failed to build|network|timed? ?out/i.test(raw)) {
+      return "Can't reach the sharing server. Check the server URL under Advanced, then try again.";
+    }
+    // AppError serializes as "invalid argument: <msg>" / "authentication error: <msg>" etc. — strip
+    // the variant prefix so the user reads the clean message.
+    return raw.replace(
+      /^(invalid argument|authentication error|provider unavailable|config error|storage error|secrets error|locked): /i,
+      "",
+    );
+  }
+}

--- a/src/app/features/sharing/sharing-gateway.component.ts
+++ b/src/app/features/sharing/sharing-gateway.component.ts
@@ -1,0 +1,400 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from "@angular/core";
+import { Router } from "@angular/router";
+import { IpcService } from "../../core/ipc.service";
+import { SharingAuthFlowComponent } from "./sharing-auth-flow.component";
+
+/**
+ * SharingGatewayComponent — the first-run SHARING gateway at route `/welcome`.
+ *
+ * A full-bleed welcome (a shell child route, so the packaged WKWebView
+ * style-resolves it — trap T4: a screen must be router-mounted, never rendered
+ * directly in AppComponent's static host). Shown by `app.component.ts` (and the
+ * onboarding handoff) only when `!cfg.sharingChoiceMade && !accountStatus.loggedIn`.
+ *
+ * Two doors ARE the first-run decision — there is no silent skip:
+ *   - "Use Murmur locally — no account" → `markSharingChoiceMade()` then `/record`.
+ *   - "Create or sign in to a sharing account" → the reusable `<app-sharing-auth-flow>`.
+ *
+ * The gate NEVER traps: every IPC failure is caught and falls through to
+ * `/record`, so a broken/unavailable backend can never strand the user here.
+ *
+ * The gateway hosts the flow inside its OWN full-bleed frosted `.card` panel
+ * (this is a whole PAGE, in-flow — not a floating popover, so the frosted card
+ * is correct; the OPAQUE-overlay rule T3 is for the Settings modal host).
+ */
+@Component({
+  selector: "app-sharing-gateway",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SharingAuthFlowComponent],
+  template: `
+    <div class="gw">
+      <div class="gw-stage">
+        @switch (mode()) {
+          @case ("pick") {
+            <div class="gw-hero">
+              <span class="orb-brand" aria-hidden="true">
+                <span class="orb-core"></span>
+              </span>
+              <h1 class="gw-title">
+                <span class="brand-dot" aria-hidden="true"></span>
+                Share your notes — or keep it all local
+              </h1>
+              <p class="gw-lede text-secondary">
+                Murmur works fully offline. If you want to share a note as a
+                private, end-to-end-encrypted link, you can add a sharing account
+                — otherwise everything stays on this Mac.
+              </p>
+            </div>
+
+            <div class="gw-cards">
+              <button
+                type="button"
+                class="gw-card"
+                (click)="chooseLocal()"
+                [disabled]="busy()"
+              >
+                <span class="gw-card-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+                    <rect
+                      x="4"
+                      y="5"
+                      width="16"
+                      height="10"
+                      rx="1.8"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                    />
+                    <path
+                      d="M8.5 19h7M12 15v4"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </span>
+                <span class="gw-card-name">Use Murmur locally — no account</span>
+                <span class="gw-card-sub text-secondary">
+                  Everything stays on this Mac. You can add an account later in
+                  Settings.
+                </span>
+                <span class="gw-card-cta">
+                  {{ busy() ? "Starting…" : "Continue" }}
+                  <span class="cta-arrow" aria-hidden="true">→</span>
+                </span>
+              </button>
+
+              <button
+                type="button"
+                class="gw-card is-accent"
+                (click)="openAccount()"
+                [disabled]="busy()"
+              >
+                <span class="gw-card-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+                    <path
+                      d="M12 2.5 4.5 5.5v5.2c0 4.6 3.1 8.1 7.5 9.3 4.4-1.2 7.5-4.7 7.5-9.3V5.5L12 2.5Z"
+                      stroke="currentColor"
+                      stroke-width="1.4"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M9 11.5 11 13.5 15 9"
+                      stroke="currentColor"
+                      stroke-width="1.6"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </span>
+                <span class="gw-card-name">
+                  Create or sign in to a sharing account
+                </span>
+                <span class="gw-card-sub text-secondary">
+                  End-to-end-encrypted note sharing. Only ciphertext leaves this
+                  Mac.
+                </span>
+                <span class="gw-card-cta">
+                  Set up sharing
+                  <span class="cta-arrow" aria-hidden="true">→</span>
+                </span>
+              </button>
+            </div>
+          }
+
+          @case ("account") {
+            <div class="gw-panel card">
+              <app-sharing-auth-flow
+                (completed)="onCompleted()"
+                (dismissed)="onDismissed()"
+              />
+            </div>
+          }
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .gw {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - 120px);
+        padding: var(--space-5) 0 var(--space-7);
+      }
+      .gw-stage {
+        position: relative;
+        width: 100%;
+        max-width: 620px;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-5);
+        animation: gw-in 460ms var(--ease-spring) both;
+      }
+      @keyframes gw-in {
+        from {
+          opacity: 0;
+          transform: translateY(14px) scale(0.985);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
+      /* Hero. */
+      .gw-hero {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: var(--space-3);
+      }
+      .orb-brand {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 88px;
+        height: 88px;
+        margin-bottom: var(--space-1);
+      }
+      .orb-core {
+        width: 58px;
+        height: 58px;
+        border-radius: 50%;
+        background: var(--accent-gradient);
+        box-shadow:
+          var(--shadow-accent),
+          0 0 40px rgba(110, 118, 255, 0.55),
+          inset 0 2px 6px rgba(255, 255, 255, 0.4);
+        animation: orb-float 4s ease-in-out infinite;
+      }
+      .orb-brand::before,
+      .orb-brand::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        border: 1.5px solid var(--accent);
+        opacity: 0.5;
+        animation: orb-ring 3s ease-in-out infinite;
+      }
+      .orb-brand::after {
+        animation-delay: 1.5s;
+      }
+      @keyframes orb-ring {
+        0% {
+          transform: scale(0.66);
+          opacity: 0.6;
+        }
+        100% {
+          transform: scale(1.1);
+          opacity: 0;
+        }
+      }
+      @keyframes orb-float {
+        0%,
+        100% {
+          transform: translateY(0) scale(1);
+        }
+        50% {
+          transform: translateY(-6px) scale(1.03);
+        }
+      }
+      .gw-title {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin: 0;
+        font-size: 1.6rem;
+        font-weight: 650;
+        letter-spacing: -0.025em;
+        max-width: 22ch;
+      }
+      .brand-dot {
+        width: 10px;
+        height: 10px;
+        min-width: 10px;
+        border-radius: 50%;
+        background: var(--accent-gradient);
+        box-shadow: var(--shadow-accent);
+      }
+      .gw-lede {
+        margin: 0;
+        max-width: 46ch;
+        font-size: 1.0125rem;
+        line-height: 1.6;
+      }
+
+      /* The two choice cards. */
+      .gw-cards {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+      }
+      @media (max-width: 560px) {
+        .gw-cards {
+          grid-template-columns: 1fr;
+        }
+      }
+      .gw-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        text-align: left;
+        padding: var(--space-5);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-lg);
+        background: var(--surface-raised);
+        color: var(--text-primary);
+        font-family: inherit;
+        cursor: pointer;
+        transition:
+          border-color var(--transition),
+          background var(--transition),
+          box-shadow var(--transition),
+          transform var(--transition-fast);
+      }
+      .gw-card:hover {
+        border-color: var(--border-strong);
+        background: var(--surface-hover);
+        transform: translateY(-2px);
+      }
+      .gw-card:active {
+        transform: translateY(0);
+      }
+      .gw-card:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px var(--accent-ring);
+      }
+      .gw-card:disabled {
+        opacity: 0.6;
+        cursor: default;
+        transform: none;
+      }
+      .gw-card.is-accent {
+        border-color: transparent;
+        background: var(--accent-soft);
+        box-shadow: 0 0 0 1px var(--accent-ring);
+      }
+      .gw-card-icon {
+        display: inline-flex;
+        color: var(--accent-hover);
+        margin-bottom: var(--space-1);
+      }
+      .gw-card-name {
+        font-size: 1.02rem;
+        font-weight: 620;
+        letter-spacing: -0.01em;
+        line-height: 1.35;
+      }
+      .gw-card-sub {
+        font-size: 0.875rem;
+        line-height: 1.5;
+        flex: 1;
+      }
+      .gw-card-cta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin-top: var(--space-2);
+        color: var(--accent-hover);
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+      .cta-arrow {
+        transition: transform var(--transition);
+      }
+      .gw-card:hover .cta-arrow {
+        transform: translateX(3px);
+      }
+
+      /* Account panel — a full-bleed frosted card hosting the reusable flow.
+         This is a whole PAGE (in-flow), so the frosted .card is correct here;
+         the OPAQUE-overlay rule (T3) governs the Settings floating modal. */
+      .gw-panel {
+        padding: var(--space-6);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .orb-core,
+        .orb-brand::before,
+        .orb-brand::after,
+        .gw-stage {
+          animation: none !important;
+        }
+      }
+    `,
+  ],
+})
+export class SharingGatewayComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly router = inject(Router);
+
+  /** `pick` = the two doors; `account` = the reusable multi-step flow. */
+  readonly mode = signal<"pick" | "account">("pick");
+  /** Debounces the local-choice button (its IPC + navigate). */
+  readonly busy = signal(false);
+
+  /** Door (a): resolve the decision as local-only, then enter the app. */
+  async chooseLocal(): Promise<void> {
+    if (this.busy()) {
+      return;
+    }
+    this.busy.set(true);
+    try {
+      await this.ipc.markSharingChoiceMade();
+    } catch {
+      // Never trap the user on a persistence failure — the gate re-offers next
+      // launch, which is acceptable (they made no lasting decision).
+    }
+    await this.router.navigate(["/record"]);
+  }
+
+  /** Door (b): open the account flow inside the gateway's card panel. */
+  openAccount(): void {
+    this.mode.set("account");
+  }
+
+  /** The flow logged the user in → mark the choice made, then enter the app. */
+  async onCompleted(): Promise<void> {
+    try {
+      await this.ipc.markSharingChoiceMade();
+    } catch {
+      // Non-fatal — proceed into the app regardless.
+    }
+    await this.router.navigate(["/record"]);
+  }
+
+  /** The user backed out of the flow → return to the two doors. */
+  onDismissed(): void {
+    this.mode.set("pick");
+  }
+}


### PR DESCRIPTION
Rebuilds the sharing-account onboarding as a full-screen /welcome gateway (local-only vs sharing account) + a reusable multi-step account flow (email → send code → code → password → recovery, auto-login after signup), launched from the gateway AND from Settings. Adds `account_send_code`, defaults `share_base_url` to the hosted relay, clearer errors (a 4xx is no longer mis-shown as "can't reach"), and a logout note clarifying notes stay on-device.

Gates: `cargo test --lib` 1017 · `ng lint` + `ng build` green. Adversarial + lock-security reviews PASS (both from the build workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)