### PR TITLE
fix(brain): correct Bielik 1.5B/4.5B GGUF download URLs (was 404)

### DIFF
--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -116,9 +116,9 @@ pub static BRAIN_MODELS: &[BrainModel] = &[
     BrainModel {
         id: "bielik-1.5b-v3",
         name: "Bielik 1.5B v3 (light · Polish-native)",
-        filename: "Bielik-1.5B-v3.0-Instruct.Q4_K_M.gguf",
-        url: "https://huggingface.co/speakleash/Bielik-1.5B-v3.0-Instruct-GGUF/resolve/main/Bielik-1.5B-v3.0-Instruct.Q4_K_M.gguf",
-        approx_size_bytes: 1_050_000_000, // ~1.0 GB (verify on first download)
+        filename: "Bielik-1.5B-v3.0-Instruct.Q8_0.gguf",
+        url: "https://huggingface.co/speakleash/Bielik-1.5B-v3.0-Instruct-GGUF/resolve/main/Bielik-1.5B-v3.0-Instruct.Q8_0.gguf",
+        approx_size_bytes: 1_650_000_000, // ~1.65 GB Q8_0 — speakleash publishes only fp16 + Q8_0 for 1.5B (no Q4_K_M)
         min_ram_gb: 4,
         languages: &["pl", "en"],
         arch: "llama",
@@ -141,10 +141,10 @@ pub static BRAIN_MODELS: &[BrainModel] = &[
     BrainModel {
         id: "bielik-4.5b-v3",
         name: "Bielik 4.5B v3 (heavy · Polish-native)",
-        filename: "Bielik-4.5B-v3.0-Instruct.Q4_K_M.gguf",
-        url: "https://huggingface.co/speakleash/Bielik-4.5B-v3.0-Instruct-GGUF/resolve/main/Bielik-4.5B-v3.0-Instruct.Q4_K_M.gguf",
-        approx_size_bytes: 2_800_000_000, // ~2.8 GB (verify on first download)
-        min_ram_gb: 8,
+        filename: "Bielik-4.5B-v3.0-Instruct.Q8_0.gguf",
+        url: "https://huggingface.co/speakleash/Bielik-4.5B-v3.0-Instruct-GGUF/resolve/main/Bielik-4.5B-v3.0-Instruct.Q8_0.gguf",
+        approx_size_bytes: 4_900_000_000, // ~4.9 GB Q8_0 — speakleash publishes only fp16 + Q8_0 for 4.5B (no Q4_K_M)
+        min_ram_gb: 10,
         languages: &["pl", "en"],
         arch: "llama",
         class: ModelClass::Heavy,


### PR DESCRIPTION
**Bug (user-hit while testing the posture redesign):** selecting Hybrid / Fully local auto-downloads the smallest on-device model, which 404'd — `summarizer error: brain model download HTTP 404 Not Found`.

**Cause:** the registry pointed **Bielik-1.5B-v3** and **Bielik-4.5B-v3** at `.Q4_K_M.gguf`, but speakleash's 1.5B and 4.5B GGUF repos publish **only fp16 + Q8_0** (no Q4_K_M) — verified via the HF API (`/api/models/speakleash/Bielik-1.5B-v3.0-Instruct-GGUF`). Every other registry URL (qwen3-1.7b, qwen3-4b-2507, bielik-11b, qwen3-14b) was verified correct as-is.

**Fix:** point both Bieliks at the real `.Q8_0.gguf` files + correct sizes (1.5B → ~1.65 GB, 4.5B → ~4.9 GB, min_ram 8→10). As a side-effect the light auto-pick now prefers **qwen3-1.7b** (Q4_K_M, ~1.1 GB, verified) since Bielik-1.5B Q8_0 is now the larger light — so the common Hybrid/Fully-local path uses only verified-working URLs.

**Note:** const-literal-only change. Couldn't run `cargo test` in the review worktree (trunk's `murmur-protocol` path-dep points at a `murmur-server` checkout absent here — unrelated to this change); the new Q8_0 filenames are confirmed present on HF. `sha256` stays `None` (verify-skip) as before.