### PR TITLE
feat(settings): confirm before downloading a posture's on-device model

### DIFF
--- a/e2e/settings-ai/brain-posture-block.spec.ts
+++ b/e2e/settings-ai/brain-posture-block.spec.ts
@@ -71,16 +71,21 @@ test.describe("brain-posture-block", () => {
     await expect(page.getByText("Enable Murmur Brain Live")).toHaveCount(0);
   });
 
-  test("(c) clicking Fully local shows progress bar for Qwen3 4B + Cancel button", async ({
+  test("(c) Fully local ASKS first (names the model), then confirming shows the download + Cancel", async ({
     page,
   }) => {
     await page.getByRole("button", { name: /Fully local/ }).click();
-    // The stalled download keeps brainDownloadingId = "qwen3-4b"; the component
-    // looks up the name in brainModels() → "Qwen3 4B" appears in the label.
-    await expect(page.getByText(/Qwen3 4B/)).toBeVisible({ timeout: 10_000 });
+    // Confirm-first: the card appears and names the model + size — nothing downloads yet.
+    await expect(page.getByText(/Fully local needs/)).toBeVisible();
+    await expect(page.getByText(/Qwen3 4B/)).toBeVisible();
+    // Explicit opt-in → the stalled download keeps brainDownloadingId set → the
+    // download state (progress + a Cancel button) appears.
+    await page
+      .getByRole("button", { name: /Download .* enable Fully local/ })
+      .click();
     await expect(
       page.getByRole("button", { name: "Cancel" }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test("(d) cloud right-now line renders postureStateLine copy", async ({

--- a/e2e/settings-ai/posture-auto-download.spec.ts
+++ b/e2e/settings-ai/posture-auto-download.spec.ts
@@ -2,15 +2,16 @@ import { test, expect } from "@playwright/test";
 import { mockTauri } from "./mock-invoke";
 
 /**
- * Verifies that picking "Fully local" posture auto-downloads the absent heavy
- * model BEFORE committing the posture, AND selects ALL needed models (not just
- * the newly-downloaded subset). The expected order is:
+ * Verifies the CONFIRM-FIRST flow: picking "Fully local" when a model is absent
+ * shows a confirm card and starts NOTHING; only clicking "Download & enable" runs
+ * the download, then selects ALL needed models (not just the newly-downloaded
+ * subset) and commits. The expected order after confirming is:
  *   1. download_brain_model (heavy, absent)
  *   2. select_brain_model  (heavy — just downloaded)
  *   3. select_brain_model  (light — already on disk but not selected)
  *   4. set_brain_posture   (commit)
  */
-test("picking Fully local auto-downloads the absent heavy model then selects all needed and commits", async ({
+test("picking Fully local asks first, then on confirm downloads + selects all needed + commits", async ({
   page,
 }) => {
   await mockTauri(page, {
@@ -71,11 +72,22 @@ test("picking Fully local auto-downloads the absent heavy model then selects all
   await page.goto("/settings");
   // Reveal the AI & Models section
   await page.getByText("AI & Models").first().click();
-  // Click the "Fully local" posture button
+  // Click the "Fully local" posture button — this must ASK, not download.
   await page.getByRole("button", { name: /Fully local/ }).click();
 
-  // The store must: (1) download the absent heavy model, (2) select ALL needed
-  // models in neededModelsFor order (heavy → light), (3) commit posture.
+  // Confirm card is shown; NOTHING has downloaded/committed on the single tap.
+  await expect(page.getByText(/Fully local needs/)).toBeVisible();
+  expect(await page.evaluate(() => (window as any).__test_calls__ ?? [])).toEqual(
+    [],
+  );
+
+  // Explicit opt-in: click "Download & enable Fully local".
+  await page
+    .getByRole("button", { name: /Download .* enable Fully local/ })
+    .click();
+
+  // Now: (1) download the absent heavy model, (2) select ALL needed models in
+  // neededModelsFor order (heavy → light), (3) commit posture.
   await expect
     .poll(
       () =>

--- a/src/app/features/settings/sections/ai/brain-posture-block.component.ts
+++ b/src/app/features/settings/sections/ai/brain-posture-block.component.ts
@@ -127,9 +127,55 @@ import { SettingsStore } from "../../settings.store";
           neededModels() in the pending branch.
         -->
         <div class="posture-state">
-          @if (pendingPosture(); as pend) {
+          @if (pendingConfirm(); as confirm) {
+            <!--
+              CONFIRM step (opt-in): the picked posture needs an on-device model, so
+              we ASK before fetching — what model, how big, what it does + a button.
+              A multi-GB download never starts on a single tap.
+            -->
+            <p class="posture-confirm-title">
+              {{ pendingLabel(confirm) }} needs
+              {{ confirmModels().length > 1 ? "models" : "a model" }} on your Mac
+            </p>
+            @for (n of confirmModels(); track n.role) {
+              <span class="pill" [class.is-success]="n.model?.downloaded">
+                <span class="pill-dot"></span>{{ n.role === "notes" ? "Notes &amp; Ask" : "Reactions" }}: {{ n.model?.name ?? "—" }}@if (n.model) { · {{ sizeLabel(n.model.approxSizeBytes) }} }@if (n.model?.downloaded) { ✓ ready }
+              </span>
+            }
+            <span class="text-secondary posture-confirm-copy">
+              {{ confirmDescription(confirm) }}
+            </span>
+            @if (confirmDownloadBytes() > 0) {
+              <span class="text-muted brain-live-note">
+                One-time {{ sizeLabel(confirmDownloadBytes()) }} download from Hugging
+                Face — it stays on this Mac.
+              </span>
+            }
+            @if (!brainLiveRamOk()) {
+              <span class="brain-live-ram-warn">
+                ⚠ Your Mac may not have enough RAM to run this smoothly alongside
+                recording.
+              </span>
+            }
+            <div class="posture-confirm-actions">
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="confirmPostureDownload()"
+              >
+                Download &amp; enable {{ pendingLabel(confirm) }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost"
+                (click)="cancelPendingPosture()"
+              >
+                Cancel
+              </button>
+            </div>
+          } @else if (pendingPosture()) {
             <p class="text-secondary">
-              {{ pendingLabel(pend) }} — downloading on-device models…
+              {{ downloadingLabel() }} — downloading on-device models…
             </p>
             @if (brainDownloadingId()) {
               <div class="semantic-progress" role="status">
@@ -299,6 +345,29 @@ import { SettingsStore } from "../../settings.store";
         font-size: 0.875rem;
         line-height: 1.55;
       }
+      /* Confirm-before-download card: an explicit opt-in, not an auto-fetch. */
+      .posture-confirm-title {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 600;
+      }
+      .posture-confirm-copy {
+        font-size: 0.85rem;
+        line-height: 1.55;
+      }
+      .posture-confirm-actions {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+        margin-top: var(--space-1);
+      }
+      .posture-confirm-actions .btn {
+        flex: none;
+      }
+      .brain-live-note {
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
       .brain-live-ram-warn {
         font-size: 0.8125rem;
         line-height: 1.5;
@@ -370,6 +439,9 @@ export class BrainPostureBlockComponent {
   readonly postureBusy = this.store.postureBusy;
   readonly postureError = this.store.postureError;
   readonly pendingPosture = this.store.pendingPosture;
+  readonly pendingConfirm = this.store.pendingConfirm;
+  readonly confirmModels = this.store.confirmModels;
+  readonly confirmDownloadBytes = this.store.confirmDownloadBytes;
   readonly postureStateLine = this.store.postureStateLine;
   readonly neededModels = this.store.neededModels;
   readonly brainDownloadingId = this.store.brainDownloadingId;
@@ -398,6 +470,12 @@ export class BrainPostureBlockComponent {
     return this.brainModels().find((m) => m.id === id)?.name ?? id;
   });
 
+  /** Label of the posture currently downloading (the `@else if` block can't alias it). */
+  readonly downloadingLabel = computed((): string => {
+    const p = this.pendingPosture();
+    return p ? this.pendingLabel(p) : "";
+  });
+
   // ── Actions ───────────────────────────────────────────────────────────────
 
   /** Apply a Murmur Brain posture preset (`cloud` / `hybrid` / `fully_local`). */
@@ -408,6 +486,33 @@ export class BrainPostureBlockComponent {
   /** Abort an in-flight posture download; the committed posture is unchanged. */
   cancelPostureDownload(): void {
     this.store.cancelPostureDownload();
+  }
+
+  /** Confirm the pending posture → start the on-device download, then commit. */
+  confirmPostureDownload(): void {
+    void this.store.confirmPostureDownload();
+  }
+
+  /** Dismiss the confirm card without downloading; the posture stays unchanged. */
+  cancelPendingPosture(): void {
+    this.store.cancelPendingPosture();
+  }
+
+  /** Format a byte count as a friendly "~1.1 GB" / "~620 MB" size label. */
+  sizeLabel(bytes: number): string {
+    const gb = 1024 * 1024 * 1024;
+    return bytes >= gb
+      ? "~" + (bytes / gb).toFixed(1) + " GB"
+      : "~" + Math.round(bytes / (1024 * 1024)) + " MB";
+  }
+
+  /** One-line description of what a posture runs on-device (for the confirm card). */
+  confirmDescription(p: Posture): string {
+    if (p === "hybrid")
+      return "Your Default AI keeps writing all notes; your Mac runs realtime reactions and keeps fact-extraction on-device.";
+    if (p === "fully_local")
+      return "Everything runs on this Mac — notes, answers, and reactions. Nothing leaves.";
+    return "";
   }
 
   /** Download + select the Apache-licensed replacement for the retired model. */

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -830,6 +830,29 @@ export class SettingsStore {
   private readonly _pendingPosture = signal<Posture | null>(null);
   readonly pendingPosture = this._pendingPosture.asReadonly();
 
+  /**
+   * A posture the user PICKED that needs an on-device download, awaiting explicit
+   * confirmation. Non-null shows the confirm card (what model, size, what it does
+   * + a Download button) — nothing downloads until `confirmPostureDownload()`. This
+   * is the deliberate opt-in step: a multi-GB download never starts on a single tap.
+   */
+  private readonly _pendingConfirm = signal<Posture | null>(null);
+  readonly pendingConfirm = this._pendingConfirm.asReadonly();
+
+  /** The models the pending-confirm posture would download (name/size for the card). */
+  readonly confirmModels = computed(() => {
+    const p = this._pendingConfirm();
+    return p ? this.neededModelsFor(p) : [];
+  });
+
+  /** Total bytes the pending-confirm download would fetch (absent models only). */
+  readonly confirmDownloadBytes = computed(() =>
+    this.confirmModels()
+      .map((n) => n.model)
+      .filter((m): m is BrainModelDto => !!m && !m.downloaded)
+      .reduce((sum, m) => sum + m.approxSizeBytes, 0),
+  );
+
   /** Flip to true via `cancelPostureDownload()` to abort an in-flight download loop. */
   private _cancelDownload = false;
 
@@ -1299,7 +1322,7 @@ export class SettingsStore {
   async setPosture(p: Posture): Promise<void> {
     if (p === "custom") return; // derived-only label — never settable
     this._postureError.set(null);
-    this._postureBusy.set(true);
+    this._pendingConfirm.set(null);
 
     const needed = this.neededModelsFor(p);
     const absent = needed
@@ -1307,9 +1330,11 @@ export class SettingsStore {
       .filter((m): m is BrainModelDto => !!m && !m.downloaded);
 
     if (absent.length === 0) {
-      // Fast path: all needed models already on disk — select them all, then commit.
-      // Selecting unconditionally ensures the backend role pins point at the
-      // auto-picked models, not the registry default (which may differ and be absent).
+      // Fast path: all needed models already on disk (Cloud, or a local posture whose
+      // models are present) — select them all, then commit immediately. Selecting
+      // unconditionally pins the backend roles at the auto-picked models, not the
+      // registry default (which may differ and be absent).
+      this._postureBusy.set(true);
       try {
         await this.selectNeeded(needed);
         await this.commitPosture(p);
@@ -1321,7 +1346,36 @@ export class SettingsStore {
       return;
     }
 
-    // Slow path: at least one model needs downloading before we can commit.
+    // Needs a download → ASK FIRST. Show the confirm card (model, size, what it does
+    // + a Download button); nothing downloads until confirmPostureDownload(). A
+    // multi-GB fetch must never start on a single tap.
+    this._pendingConfirm.set(p);
+  }
+
+  /** Dismiss the pending-confirm card without downloading. The posture stays unchanged. */
+  cancelPendingPosture(): void {
+    this._pendingConfirm.set(null);
+  }
+
+  /**
+   * Confirm the pending posture: download its absent on-device models (progress via
+   * `pendingPosture`/`brainDownloadFrac`), then select all needed models and commit.
+   * On failure/cancel, clears state, surfaces `postureError` (cancel is silent), and
+   * refreshes the display back to the unchanged backend posture. Never commits an
+   * incomplete state.
+   */
+  async confirmPostureDownload(): Promise<void> {
+    const p = this._pendingConfirm();
+    if (!p) return;
+    this._pendingConfirm.set(null);
+    this._postureError.set(null);
+    this._postureBusy.set(true);
+
+    const needed = this.neededModelsFor(p);
+    const absent = needed
+      .map((n) => n.model)
+      .filter((m): m is BrainModelDto => !!m && !m.downloaded);
+
     this._pendingPosture.set(p);
     this._cancelDownload = false;
     try {
@@ -1338,9 +1392,8 @@ export class SettingsStore {
       // Honor cancel between the last download and the select+commit, so a cancel
       // during the only/final download does not still commit the posture.
       if (this._cancelDownload) throw new Error("cancelled");
-      // Select ALL needed models (not just the newly-downloaded subset) so that a
-      // model that was already on disk but not selected also gets pinned to the
-      // right role before the posture commit.
+      // Select ALL needed models (not just the newly-downloaded subset) so a model
+      // already on disk but unselected also gets pinned to the right role first.
       await this.selectNeeded(needed);
       await this.commitPosture(p);
     } catch (e) {
@@ -1357,7 +1410,7 @@ export class SettingsStore {
     }
   }
 
-  /** Abort an in-flight `setPosture` download loop. The posture stays unchanged. */
+  /** Abort an in-flight download loop. The posture stays unchanged. */
   cancelPostureDownload(): void {
     this._cancelDownload = true;
   }


### PR DESCRIPTION
**User feedback:** switching to Hybrid / Fully local **auto-downloaded** a multi-GB model on a single tap — jarring. It should ask first (info + button), not fetch instantly.

**Change:** picking a posture that needs an absent on-device model now shows a **confirm card** — what model(s), their size, what runs locally, a one-time-download note — with **Download & enable** / **Cancel**. Nothing downloads until you opt in. `setPosture()` sets a `pendingConfirm` state; the new `confirmPostureDownload()` runs the existing download → select-all-needed → commit flow (progress + Cancel unchanged). The fast path (models already present → immediate commit, e.g. Cloud) is unchanged. e2e specs updated to the confirm-first flow.

**Verification:** `ng lint` + `ng build` clean; my posture specs pass. **Note:** `live-and-ondevice.spec.ts (e)` (cloud-consent warning) fails, but it **fails on clean trunk too** (confirmed by stashing this change) — a PRE-EXISTING regression unrelated to this PR (likely from the #188 account/onboarding merge), tracked separately.