### PR TITLE
feat(share): keep sharing account unlocked across restarts with Touch ID

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7721,6 +7721,11 @@ pub struct AccountStatus {
     pub share_consented: bool,
     /// Whether a sharing server is configured (a share is impossible without one).
     pub server_configured: bool,
+    /// True iff logged in AND a biometric-gated MK cache exists — so a locked session can be restored
+    /// with one Touch ID tap (`unlock_sharing_with_biometric`) instead of a password re-login. The FE
+    /// shows the "Unlock with Touch ID" button only when this is set (and `unlockedForSharing` is not).
+    /// NO Touch ID prompt is presented to compute this (existence probe only).
+    pub biometric_unlock_available: bool,
 }
 
 /// One row of `list_my_shares` (camelCase). Content-free by construction — the server holds no
@@ -7775,6 +7780,8 @@ pub fn account_status(state: State<'_, AppState>) -> Result<AccountStatus, AppEr
             None => (false, None, false),
         },
     };
+    // Existence-only probe (NO Touch ID prompt): can a locked session be restored biometrically?
+    let biometric_unlock_available = logged_in && crate::secrets::keychain::account_mk_cached()?;
     let cfg = state
         .config
         .lock()
@@ -7785,6 +7792,7 @@ pub fn account_status(state: State<'_, AppState>) -> Result<AccountStatus, AppEr
         unlocked_for_sharing: unlocked,
         share_consented: cfg.share_egress_consented,
         server_configured: !cfg.share_base_url.trim().is_empty(),
+        biometric_unlock_available,
     })
 }
 
@@ -7997,13 +8005,14 @@ pub async fn account_login(
     let mk = crate::e2ee::keys::unwrap_mk_pw(&key_material.mk_wrap_pw, &kek_pw, &acct_id)?;
     let generation = key_material.current_generation.unwrap_or(1);
 
-    // Persist tokens to the Keychain (never SQLite, never logged).
+    // Persist tokens + the non-secret generation to the Keychain (never SQLite, never logged).
     crate::share::store_tokens(&crate::share::PersistedTokens {
         access_token: access_token.clone(),
         refresh_token,
         device_id: device_id.clone(),
         email: acct_id.clone(),
         account_id: acct_id.clone(),
+        generation,
     })?;
 
     // Cache the session (MK in RAM, zeroized on drop).
@@ -8020,6 +8029,18 @@ pub async fn account_login(
             generation,
             access_token,
         });
+    }
+
+    // Cache the MK biometric-gated (WRITE — no Touch ID prompt) so a later restart restores the session
+    // with one Touch ID tap (`unlock_sharing_with_biometric`) instead of a password re-login. Non-fatal:
+    // a cache failure just means the FE won't offer the Touch ID button — login still succeeds. The MK
+    // is never logged.
+    if let Err(e) = crate::secrets::keychain::cache_account_mk_biometric(&mk) {
+        tracing::warn!(
+            target: "share",
+            error = %e,
+            "could not cache the account key for biometric unlock (non-fatal — password unlock still works)"
+        );
     }
 
     crate::share::ledger_row(&state.db, &client.host(), "account_login", 0);
@@ -8039,11 +8060,55 @@ pub async fn account_logout(state: State<'_, AppState>) -> Result<(), AppError> 
             }
         }
     }
-    crate::share::clear_tokens()?;
+    // Drop the in-RAM session FIRST so a fallible keychain clear below can't early-return (`?`) and
+    // leave the live MK sitting in memory (lock-security review, 2026-07-05).
     if let Ok(mut session) = state.account_session.lock() {
         *session = None; // drops the AccountSession → zeroizes MK.
     }
+    crate::share::clear_tokens()?;
+    crate::secrets::keychain::clear_account_mk()?; // drop the biometric MK cache too (idempotent).
     Ok(())
+}
+
+/// `unlock_sharing_with_biometric() -> AccountStatus` — restore a logged-in-but-locked sharing session
+/// (the MK is lost on restart, held only in RAM) by releasing the biometric-cached account master key
+/// with a single Touch ID tap, instead of re-typing the account password.
+///
+/// Rebuilds the in-RAM [`crate::share::AccountSession`] from the persisted tokens + the biometric-
+/// released MK + the persisted `generation`. Fails CLOSED — [`AppError::Unavailable`] when not signed
+/// in or no MK is cached, [`AppError::BiometricFailed`] on a cancelled/failed tap — so the FE can fall
+/// back to the password login. The MK never touches the log.
+#[tauri::command]
+pub async fn unlock_sharing_with_biometric(
+    state: State<'_, AppState>,
+) -> Result<AccountStatus, AppError> {
+    // Must be logged in (tokens present) to have anything to restore.
+    let tokens = crate::share::load_tokens()?
+        .ok_or_else(|| AppError::Unavailable("not signed in to the sharing account".into()))?;
+
+    // Release the cached MK behind a Touch ID prompt (signed build). Held zeroizing from here on;
+    // fails closed if no cache exists or the user cancels the sheet.
+    let mk = Zeroizing::new(crate::secrets::keychain::read_account_mk_biometric(
+        "Unlock Murmur sharing",
+    )?);
+
+    // Rebuild the session from the persisted tokens + released MK (MK moved in, zeroized on drop).
+    {
+        let mut session = state
+            .account_session
+            .lock()
+            .map_err(|_| AppError::Storage("account-session mutex poisoned".into()))?;
+        *session = Some(crate::share::AccountSession {
+            account_id: tokens.account_id,
+            email: tokens.email,
+            device_id: tokens.device_id,
+            mk,
+            generation: tokens.generation,
+            access_token: tokens.access_token,
+        });
+    }
+
+    account_status(state)
 }
 
 /// `share_note_to_link(meeting_id, expires_days?, password?, max_downloads?) -> String` — create a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,7 @@ pub fn run() {
             commands::account_send_code,
             commands::account_login,
             commands::account_logout,
+            commands::unlock_sharing_with_biometric,
             commands::consent_to_share_egress,
             commands::revoke_share_egress,
             commands::mark_sharing_choice_made,

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -40,6 +40,15 @@ pub const ACCOUNT_GATEWAY_KEY: &str = "gateway_api_key";
 /// Callers may override per call-site (e.g. "Unlock this folder").
 pub const KEK_DEFAULT_REASON: &str = "Unlock this folder";
 
+/// Keychain account holding the BIOMETRIC-GATED cache of the sharing-account master key (MK).
+///
+/// The sharing account's MK lives in RAM for the session ([`crate::share::AccountSession`]); it is
+/// lost on restart, forcing a password re-login. Caching it here — behind a `kSecAttrAccessControl`
+/// requiring user presence, exactly like [`ACCOUNT_MASTER_KEK`] — lets a single Touch ID tap restore
+/// the session ([`cache_account_mk_biometric`] / [`read_account_mk_biometric`]). SEPARATE from the
+/// folder-lock KEK item (different account) so the two never collide. Cleared on logout.
+pub const ACCOUNT_SHARE_MK: &str = "murmur_account_mk";
+
 /// Return the SQLCipher DEK as a 64-char hex string (32 random bytes), creating + persisting it
 /// in the Keychain on first use. Released at launch with no biometric prompt — this layer
 /// protects against database FILE theft, not against an attacker on the unlocked machine
@@ -130,6 +139,300 @@ pub fn get_or_create_master_kek_with_reason(reason: &str) -> Result<[u8; 32]> {
         let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
         set_secret(ACCOUNT_MASTER_KEK, &hex)?;
         Ok(bytes)
+    }
+}
+
+// ─────────────────────── biometric-gated sharing-account MK cache (public API) ───────────────────────
+//
+// "Keep me unlocked for sharing with Touch ID": the sharing-account master key (MK) normally lives
+// only in RAM ([`crate::share::AccountSession`]) and is lost on restart. These four functions cache it
+// behind a biometric-gated keychain item so a single Touch ID tap can restore the session instead of a
+// full password re-login. WRITE + existence-probe never prompt; only READ presents Touch ID (signed
+// build). The MK is NEVER logged.
+//
+// DEBUG builds (`tauri dev`, `cargo test`): mirror the MURMUR_DEV_DEK / MURMUR_DEV_KEK posture — an
+// unsigned dev binary can neither satisfy Touch ID nor reliably read a biometric-ACL item across
+// rebuilds. So a debug build persists the MK (hex) in the plaintext DEV file store (the same store the
+// non-gated dev secrets use), with an optional fixed `MURMUR_DEV_ACCOUNT_MK` (64-hex) env hatch. That
+// keeps the session restorable across dev rebuilds WITHOUT a Touch ID prompt. This whole debug path is
+// compiled out of release; a signed release uses the biometric-gated data-protection item below.
+
+/// Cache the sharing-account master key (MK) so a later restart can restore the session with one Touch
+/// ID tap. WRITE — MUST NOT prompt Touch ID. Idempotent (create-or-replace). Never logs the MK.
+pub fn cache_account_mk_biometric(mk: &[u8; 32]) -> Result<()> {
+    #[cfg(debug_assertions)]
+    {
+        cache_account_mk_at(&dev_secrets_path()?, mk)
+    }
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
+    {
+        dp_biometric_write(ACCOUNT_SHARE_MK, mk)
+    }
+    #[cfg(all(not(target_os = "macos"), not(debug_assertions)))]
+    {
+        // Non-macOS release never ships; keep the legacy keyring path so CI cross-builds compile.
+        let hex: String = mk.iter().map(|b| format!("{b:02x}")).collect();
+        legacy_set_secret(ACCOUNT_SHARE_MK, &hex)
+    }
+}
+
+/// Release the cached sharing-account MK. READ — presents the Touch ID / passcode sheet with `reason`
+/// on a signed build. Fails closed ([`AppError::Unavailable`] when no cache exists,
+/// [`AppError::BiometricFailed`] when the tap is cancelled/fails) so the FE can fall back to password.
+pub fn read_account_mk_biometric(reason: &str) -> Result<[u8; 32]> {
+    #[cfg(debug_assertions)]
+    {
+        let _ = reason;
+        // Fixed env hatch wins (no Touch ID, survives rebuilds), then the dev file store.
+        if let Ok(dev) = std::env::var("MURMUR_DEV_ACCOUNT_MK") {
+            if let Some(k) = hex_to_key32(&dev) {
+                return Ok(k);
+            }
+        }
+        read_account_mk_at(&dev_secrets_path()?)
+    }
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
+    {
+        dp_biometric_read(ACCOUNT_SHARE_MK, reason)
+    }
+    #[cfg(all(not(target_os = "macos"), not(debug_assertions)))]
+    {
+        let _ = reason;
+        match legacy_get_secret(ACCOUNT_SHARE_MK)? {
+            Some(hex) => {
+                hex_to_key32(&hex).ok_or_else(|| AppError::Secrets("cached account MK is malformed".into()))
+            }
+            None => Err(AppError::Unavailable("no cached account key to unlock".into())),
+        }
+    }
+}
+
+/// Does a cached account MK exist? NO Touch ID prompt (existence probe only) — for
+/// `account_status.biometric_unlock_available` so the FE can show/hide the "Unlock with Touch ID" button.
+pub fn account_mk_cached() -> Result<bool> {
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(dev) = std::env::var("MURMUR_DEV_ACCOUNT_MK") {
+            if hex_to_key32(&dev).is_some() {
+                return Ok(true);
+            }
+        }
+        account_mk_cached_at(&dev_secrets_path()?)
+    }
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
+    {
+        dp_biometric_exists(ACCOUNT_SHARE_MK)
+    }
+    #[cfg(all(not(target_os = "macos"), not(debug_assertions)))]
+    {
+        Ok(legacy_get_secret(ACCOUNT_SHARE_MK)?.is_some())
+    }
+}
+
+/// Remove the cached account MK (logout / account reset). Idempotent; never prompts.
+pub fn clear_account_mk() -> Result<()> {
+    #[cfg(debug_assertions)]
+    {
+        clear_account_mk_at(&dev_secrets_path()?)
+    }
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
+    {
+        dp_biometric_delete(ACCOUNT_SHARE_MK)
+    }
+    #[cfg(all(not(target_os = "macos"), not(debug_assertions)))]
+    {
+        legacy_delete_secret(ACCOUNT_SHARE_MK)
+    }
+}
+
+// DEBUG dev-file-store helpers for the account MK (explicit-path test seam, mirrors the non-gated
+// dev-secret `*_at` helpers). No env hatch here — that is handled by the public wrappers — so these
+// are a pure file round-trip a test can drive against a temp path.
+#[cfg(debug_assertions)]
+fn cache_account_mk_at(path: &std::path::Path, mk: &[u8; 32]) -> Result<()> {
+    let hex: String = mk.iter().map(|b| format!("{b:02x}")).collect();
+    dev_set_secret_at(path, ACCOUNT_SHARE_MK, &hex)
+}
+#[cfg(debug_assertions)]
+fn read_account_mk_at(path: &std::path::Path) -> Result<[u8; 32]> {
+    match dev_get_secret_at(path, ACCOUNT_SHARE_MK)? {
+        Some(hex) => {
+            hex_to_key32(&hex).ok_or_else(|| AppError::Secrets("cached account MK is malformed".into()))
+        }
+        None => Err(AppError::Unavailable("no cached account key to unlock".into())),
+    }
+}
+#[cfg(debug_assertions)]
+fn account_mk_cached_at(path: &std::path::Path) -> Result<bool> {
+    Ok(dev_get_secret_at(path, ACCOUNT_SHARE_MK)?.is_some())
+}
+#[cfg(debug_assertions)]
+fn clear_account_mk_at(path: &std::path::Path) -> Result<()> {
+    dev_delete_secret_at(path, ACCOUNT_SHARE_MK)
+}
+
+// Generic biometric-gated data-protection ops parameterized by account (release macOS only). Mirror
+// the `MacKekStore` methods exactly but for an arbitrary account, so the sharing-account MK cache
+// reuses the proven user-presence pattern WITHOUT touching the folder-lock KEK path. Compiled only in
+// a release macOS build (the debug/test path uses the dev file store above), which also keeps them
+// dead-code-free in debug.
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+fn dp_biometric_write(account: &str, key: &[u8; 32]) -> Result<()> {
+    use core_foundation::base::TCFType;
+    use core_foundation::data::CFData;
+    use security_framework::access_control::{ProtectionMode, SecAccessControl};
+    use security_framework_sys::access_control::kSecAccessControlUserPresence;
+    use security_framework_sys::base::{errSecDuplicateItem, errSecSuccess};
+    use security_framework_sys::item::{kSecAttrAccessControl, kSecValueData};
+    use security_framework_sys::keychain_item::SecItemAdd;
+
+    let access = SecAccessControl::create_with_protection(
+        Some(ProtectionMode::AccessibleWhenUnlockedThisDeviceOnly),
+        kSecAccessControlUserPresence,
+    )
+    .map_err(|e| AppError::Secrets(format!("build account-MK access control: {e}")))?;
+
+    let data = CFData::from_buffer(key);
+    let add = |access: &SecAccessControl| -> i32 {
+        let mut q = dp_base_query(account);
+        unsafe {
+            q.add(&(kSecAttrAccessControl as *const _), &access.as_CFTypeRef());
+            q.add(&(kSecValueData as *const _), &data.as_CFTypeRef());
+        }
+        let dict = q.to_immutable();
+        let mut out: core_foundation::base::CFTypeRef = std::ptr::null();
+        let s = unsafe { SecItemAdd(dict.as_concrete_TypeRef(), &mut out) };
+        if !out.is_null() {
+            unsafe { drop(core_foundation::base::CFType::wrap_under_create_rule(out)) };
+        }
+        s
+    };
+
+    let status = add(&access);
+    if status == errSecSuccess {
+        return Ok(());
+    }
+    if status == errSecDuplicateItem {
+        dp_biometric_delete(account)?;
+        let status2 = add(&access);
+        if status2 == errSecSuccess {
+            return Ok(());
+        }
+        return Err(map_osstatus("add account-MK item (after replace)", status2));
+    }
+    Err(map_osstatus("add account-MK item", status))
+}
+
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+fn dp_biometric_read(account: &str, reason: &str) -> Result<[u8; 32]> {
+    use crate::secrets::keychain::sec_consts::{
+        ERR_SEC_INTERACTION_NOT_ALLOWED, ERR_SEC_USER_CANCELED,
+    };
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::boolean::CFBoolean;
+    use core_foundation::data::CFData;
+    use core_foundation::string::CFString;
+    use security_framework_sys::base::{errSecAuthFailed, errSecSuccess};
+    use security_framework_sys::item::{kSecMatchLimit, kSecReturnData};
+    use security_framework_sys::keychain_item::SecItemCopyMatching;
+
+    let prompt = CFString::new(reason);
+    let mut q = dp_base_query(account);
+    unsafe {
+        q.add(
+            &(kSecReturnData as *const _),
+            &CFBoolean::true_value().as_CFTypeRef(),
+        );
+        q.add(
+            &(kSecMatchLimit as *const _),
+            &(sec_consts::kSecMatchLimitOne as *const _),
+        );
+        q.add(
+            &(sec_consts::kSecUseOperationPrompt as *const _),
+            &prompt.as_CFTypeRef(),
+        );
+    }
+    let dict = q.to_immutable();
+    let mut out: core_foundation::base::CFTypeRef = std::ptr::null();
+    let status = unsafe { SecItemCopyMatching(dict.as_concrete_TypeRef(), &mut out) };
+
+    if status != errSecSuccess {
+        if !out.is_null() {
+            unsafe { drop(CFType::wrap_under_create_rule(out)) };
+        }
+        return match status {
+            s if s == ERR_SEC_USER_CANCELED => {
+                Err(AppError::BiometricFailed("Touch ID was cancelled".into()))
+            }
+            s if s == errSecAuthFailed => {
+                Err(AppError::BiometricFailed("authentication failed".into()))
+            }
+            s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => Err(AppError::BiometricFailed(
+                "interaction not allowed (no UI context to present Touch ID)".into(),
+            )),
+            other => Err(map_osstatus("read account-MK item", other)),
+        };
+    }
+    if out.is_null() {
+        return Err(AppError::Secrets(
+            "account-MK read returned success but no data".into(),
+        ));
+    }
+    let data = unsafe { CFData::wrap_under_create_rule(out as *const _) };
+    let bytes = data.bytes();
+    let k: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| AppError::Secrets("cached account MK has wrong length".into()))?;
+    Ok(k)
+}
+
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+fn dp_biometric_exists(account: &str) -> Result<bool> {
+    use crate::secrets::keychain::sec_consts::ERR_SEC_INTERACTION_NOT_ALLOWED;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::boolean::CFBoolean;
+    use security_framework_sys::base::{errSecItemNotFound, errSecSuccess};
+    use security_framework_sys::item::kSecUseAuthenticationUISkip;
+    use security_framework_sys::item::{kSecReturnAttributes, kSecUseAuthenticationUI};
+    use security_framework_sys::keychain_item::SecItemCopyMatching;
+
+    let mut q = dp_base_query(account);
+    unsafe {
+        q.add(
+            &(kSecReturnAttributes as *const _),
+            &CFBoolean::true_value().as_CFTypeRef(),
+        );
+        q.add(
+            &(kSecUseAuthenticationUI as *const _),
+            &(kSecUseAuthenticationUISkip as *const _),
+        );
+    }
+    let dict = q.to_immutable();
+    let mut out: core_foundation::base::CFTypeRef = std::ptr::null();
+    let status = unsafe { SecItemCopyMatching(dict.as_concrete_TypeRef(), &mut out) };
+    if !out.is_null() {
+        unsafe { drop(CFType::wrap_under_create_rule(out)) };
+    }
+    match status {
+        s if s == errSecSuccess => Ok(true),
+        s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => Ok(true),
+        s if s == errSecItemNotFound => Ok(false),
+        other => Err(map_osstatus("probe account-MK item", other)),
+    }
+}
+
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+fn dp_biometric_delete(account: &str) -> Result<()> {
+    use core_foundation::base::TCFType;
+    use security_framework_sys::base::{errSecItemNotFound, errSecSuccess};
+    use security_framework_sys::keychain_item::SecItemDelete;
+
+    let dict = dp_base_query(account).to_immutable();
+    let status = unsafe { SecItemDelete(dict.as_concrete_TypeRef()) };
+    if status == errSecSuccess || status == errSecItemNotFound {
+        Ok(())
+    } else {
+        Err(map_osstatus("delete account-MK item", status))
     }
 }
 
@@ -1192,6 +1495,49 @@ mod tests {
         assert!(ct_eq(&a, &b));
         b[17] ^= 0x01;
         assert!(!ct_eq(&a, &b));
+    }
+
+    /// Debug-path (dev file store) round-trip for the biometric sharing-account MK cache. A LIVE
+    /// biometric read can't run headlessly, so this exercises the debug seam the same way a dev build
+    /// caches/restores the MK: cache → `cached()` true → read back byte-identical → clear → `cached()`
+    /// false → a subsequent read fails closed with `Unavailable`. Runs against an explicit temp path
+    /// (hermetic — never touches the real dev-secrets file).
+    #[test]
+    fn account_mk_dev_cache_round_trips() {
+        let dir = std::env::temp_dir().join(format!("murmur-mk-cache-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("dev-secrets.json");
+
+        let mk: [u8; 32] = std::array::from_fn(|i| (i as u8).wrapping_mul(7).wrapping_add(3));
+
+        // Absent to start.
+        assert!(!account_mk_cached_at(&path).unwrap());
+        assert!(matches!(
+            read_account_mk_at(&path),
+            Err(AppError::Unavailable(_))
+        ));
+
+        // Cache → present → reads back byte-identical.
+        cache_account_mk_at(&path, &mk).unwrap();
+        assert!(account_mk_cached_at(&path).unwrap());
+        assert_eq!(read_account_mk_at(&path).unwrap(), mk);
+
+        // Overwrite is idempotent (create-or-replace).
+        let mk2: [u8; 32] = std::array::from_fn(|i| (i as u8).wrapping_add(1));
+        cache_account_mk_at(&path, &mk2).unwrap();
+        assert_eq!(read_account_mk_at(&path).unwrap(), mk2);
+
+        // Clear → absent → fails closed.
+        clear_account_mk_at(&path).unwrap();
+        assert!(!account_mk_cached_at(&path).unwrap());
+        assert!(matches!(
+            read_account_mk_at(&path),
+            Err(AppError::Unavailable(_))
+        ));
+        // Clear is idempotent.
+        clear_account_mk_at(&path).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── Migration value-preservation tests (the keychain calls behind a thin seam) ──

--- a/src-tauri/src/share/mod.rs
+++ b/src-tauri/src/share/mod.rs
@@ -40,18 +40,28 @@ const KC_DEVICE_ID: &str = "murmur_share_device_id";
 const KC_ACCOUNT_EMAIL: &str = "murmur_share_account_email";
 /// Keychain account name for the account id (server user id).
 const KC_ACCOUNT_ID: &str = "murmur_share_account_id";
+/// Keychain account name for the identity-key GENERATION (non-secret key-rotation counter). Persisted
+/// alongside the tokens so a biometric session restore can rebuild the identity-slot AAD without a
+/// re-login — the MK itself is cached separately + biometric-gated (see `secrets::keychain`).
+const KC_GENERATION: &str = "murmur_share_generation";
 
 /// The persisted (Keychain) half of a login: what survives an app restart so a share can be created
-/// without re-logging-in, as long as the MK can be recovered. NOTE: the MK is NOT persisted here — it
-/// is unwrapped fresh from the server key material at login. After a restart, `account_status` reports
-/// "logged in but locked" until the user re-authenticates to re-derive MK (a follow-up refinement can
-/// wrap MK under the biometric account KEK for silent restore, per spec §4.2; deferred here).
+/// without re-logging-in, as long as the MK can be recovered. NOTE: the MK is NOT persisted here — the
+/// secret MK is cached SEPARATELY behind a biometric-gated keychain item
+/// (`secrets::keychain::cache_account_mk_biometric`). After a restart, `account_status` reports
+/// "logged in but locked"; the user restores the session with a single Touch ID tap
+/// (`unlock_sharing_with_biometric`), which pairs the biometric-released MK with the non-secret
+/// `generation` persisted here — or falls back to a full password re-login.
 pub struct PersistedTokens {
     pub access_token: String,
     pub refresh_token: String,
     pub device_id: String,
     pub email: String,
     pub account_id: String,
+    /// The identity-key generation at login (non-secret rotation counter). Needed to rebuild the
+    /// `AccountSession` on a biometric restore; defaults to 1 for sessions persisted before this field
+    /// existed (see `load_tokens`).
+    pub generation: u32,
 }
 
 /// Persist the session tokens + device id + account identity to the Keychain (delete-before-add
@@ -62,6 +72,7 @@ pub fn store_tokens(t: &PersistedTokens) -> Result<()> {
     crate::secrets::set_secret(KC_DEVICE_ID, &t.device_id)?;
     crate::secrets::set_secret(KC_ACCOUNT_EMAIL, &t.email)?;
     crate::secrets::set_secret(KC_ACCOUNT_ID, &t.account_id)?;
+    crate::secrets::set_secret(KC_GENERATION, &t.generation.to_string())?;
     Ok(())
 }
 
@@ -76,12 +87,21 @@ pub fn load_tokens() -> Result<Option<PersistedTokens>> {
     ) else {
         return Ok(None);
     };
+    // `generation` is persisted since the biometric-restore feature. A session stored before it existed
+    // has no entry → default to 1 (the pre-rotation generation). This never misleads the biometric
+    // restore: that path only trusts `generation` when an MK was ALSO cached, and MK-caching + the
+    // generation write happen in the SAME post-feature login (`account_login`), so whenever a cached MK
+    // exists so does its matching generation.
+    let generation = crate::secrets::get_secret(KC_GENERATION)?
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(1);
     Ok(Some(PersistedTokens {
         access_token,
         refresh_token,
         device_id,
         email,
         account_id,
+        generation,
     }))
 }
 
@@ -97,6 +117,7 @@ pub fn clear_tokens() -> Result<()> {
     crate::secrets::delete_secret(KC_DEVICE_ID)?;
     crate::secrets::delete_secret(KC_ACCOUNT_EMAIL)?;
     crate::secrets::delete_secret(KC_ACCOUNT_ID)?;
+    crate::secrets::delete_secret(KC_GENERATION)?;
     Ok(())
 }
 

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -278,6 +278,19 @@ export class IpcService {
     return invoke<AccountStatus>("account_login", { email, password });
   }
 
+  /**
+   * Re-unlock the session for sharing with a SINGLE Touch ID sheet — no password.
+   * Requires being logged in with a cached account key on this device (mirror of
+   * {@link AccountStatus.biometricUnlockAvailable}); presents one biometric prompt,
+   * restores the session MK, and returns the fresh {@link AccountStatus} (now
+   * `unlockedForSharing: true`). Fails closed with an `AppError`: `Unavailable`
+   * ("not signed in" / "no cached account key") or `BiometricFailed` on
+   * cancel/failure — callers fall back to the password sign-in flow.
+   */
+  unlockSharingWithBiometric(): Promise<AccountStatus> {
+    return invoke<AccountStatus>("unlock_sharing_with_biometric");
+  }
+
   /** Log out: server family-revoke (best-effort) + clear Keychain tokens + drop the session MK. */
   accountLogout(): Promise<void> {
     return invoke<void>("account_logout");

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1288,6 +1288,13 @@ export interface AccountStatus {
   shareConsented: boolean;
   /** A sharing server base URL is configured (sharing is impossible without one). */
   serverConfigured: boolean;
+  /**
+   * A one-tap Touch ID unlock is possible: logged in AND a cached account key
+   * exists on this device, so `unlock_sharing_with_biometric` can restore the
+   * session MK with a single biometric sheet (no password re-entry). When false,
+   * fall back to the password sign-in flow to re-unlock for sharing.
+   */
+  biometricUnlockAvailable: boolean;
 }
 
 /** Mirrors Rust `commands::MyShareEntry` — one row of the user's shares. Content-free: `title` is

--- a/src/app/features/detail/share-panel.component.ts
+++ b/src/app/features/detail/share-panel.component.ts
@@ -98,9 +98,23 @@ export interface LinkShareRow {
           @if (gateError(); as err) {
             <p class="msg msg-error" role="alert">{{ err }}</p>
           }
-          <button type="button" class="btn btn-primary" (click)="setupSharing.emit()">
-            {{ gateCta() }}
-          </button>
+          <!-- When the ONLY missing precondition is the session share-key and a
+               cached account key exists, offer a one-tap Touch ID unlock inline;
+               otherwise route to the password path via the shell (setupSharing). -->
+          @if (canBiometricUnlock()) {
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="unlockWithBiometric()"
+              [disabled]="unlocking()"
+            >
+              {{ unlocking() ? "Unlocking…" : "Unlock with Touch ID" }}
+            </button>
+          } @else {
+            <button type="button" class="btn btn-primary" (click)="setupSharing.emit()">
+              {{ gateCta() }}
+            </button>
+          }
         </div>
       } @else {
         <!-- ============================================================== -->
@@ -533,7 +547,10 @@ export interface LinkShareRow {
         flex-direction: column;
         /* §5 rhythm: --space-6 between top-level sections (calm whitespace). */
         gap: var(--space-6);
-        max-width: 40rem;
+        /* Fill the note-detail content column (like the Note panel) — no inset
+           cap, so the Share cards + controls use the full width instead of
+           leaving dead space on the right. */
+        width: 100%;
         animation: rise 320ms var(--transition) both;
       }
       .panel-card {
@@ -951,11 +968,38 @@ export class SharePanelComponent {
   private readonly accountStatus = signal<AccountStatus | null>(null);
   readonly loading = signal(false);
   readonly gateError = signal<string | null>(null);
+  /** True while the one-tap Touch ID unlock IPC is in flight ("Unlocking…"). */
+  readonly unlocking = signal(false);
+  /**
+   * Latches true when a Touch ID unlock attempt fails, so the gate falls back to
+   * the password CTA instead of re-offering the biometric sheet. Cleared on the
+   * next `refresh()` (a fresh gate state re-enables Touch ID).
+   */
+  private readonly _biometricFailed = signal(false);
 
   /** Sharing can actually happen: server set + signed in + unlocked for sharing. */
   readonly gateReady = computed(() => {
     const s = this.accountStatus();
     return !this.locked() && !!s && s.serverConfigured && s.loggedIn && s.unlockedForSharing;
+  });
+
+  /**
+   * Offer the one-tap Touch ID unlock in the gate: the ONLY blocker is the
+   * session share-key (server set + signed in, just not unlocked this run) AND a
+   * cached account key exists AND no prior attempt just failed. Otherwise the
+   * password CTA (`setupSharing`) is the fallback.
+   */
+  readonly canBiometricUnlock = computed(() => {
+    const s = this.accountStatus();
+    return (
+      !this.locked() &&
+      !!s &&
+      s.serverConfigured &&
+      s.loggedIn &&
+      !s.unlockedForSharing &&
+      s.biometricUnlockAvailable &&
+      !this._biometricFailed()
+    );
   });
   /** Whether the one-time share-egress consent is granted (drives the inline consent). */
   readonly shareConsented = computed(() => this.accountStatus()?.shareConsented ?? false);
@@ -1141,6 +1185,8 @@ export class SharePanelComponent {
     }
     this.listError.set(null);
     this.gateError.set(null);
+    // A fresh gate state re-enables the Touch ID path (drop any prior fail latch).
+    this._biometricFailed.set(false);
     this.loading.set(true);
     try {
       const st = await this.ipc.accountStatus();
@@ -1163,6 +1209,45 @@ export class SharePanelComponent {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /**
+   * One-tap Touch ID unlock from the gate: presents a single biometric sheet,
+   * restores the session MK, then re-reads status + loads this note's shares so
+   * the gate opens straight into the share UI. On ANY failure it fails closed to
+   * the password CTA (latch the fallback + surface a friendly gate message).
+   */
+  async unlockWithBiometric(): Promise<void> {
+    if (this.unlocking()) {
+      return;
+    }
+    this.unlocking.set(true);
+    this.gateError.set(null);
+    try {
+      await this.ipc.unlockSharingWithBiometric();
+      // Re-read the (now unlocked) status + load the shares for this note.
+      await this.refresh();
+      if (!this.accountStatus()?.unlockedForSharing) {
+        // Resolved but still locked — fall back to the password path.
+        this._biometricFailed.set(true);
+        this.gateError.set(
+          "Couldn't unlock this session. Use Unlock for sharing to unlock with your password.",
+        );
+      }
+    } catch (e) {
+      this._biometricFailed.set(true);
+      this.gateError.set(this.friendlyUnlockError(String(e)));
+    } finally {
+      this.unlocking.set(false);
+    }
+  }
+
+  /** Turn a raw biometric-unlock error into a friendly fall-back message. */
+  private friendlyUnlockError(raw: string): string {
+    if (/cancel/i.test(raw)) {
+      return "Touch ID was cancelled. Use Unlock for sharing to unlock with your password.";
+    }
+    return "Couldn't unlock with Touch ID. Use Unlock for sharing to unlock with your password.";
   }
 
   // --- CONFIGURE handlers ---------------------------------------------------

--- a/src/app/features/settings/sections/settings-account-section.component.ts
+++ b/src/app/features/settings/sections/settings-account-section.component.ts
@@ -127,9 +127,12 @@ interface FolderOption {
 
         @if (status(); as st) {
           @if (st.loggedIn) {
-            <!-- (2a) Signed-in state -->
+            <!-- (2a) Signed-in state. IDENTITY (who you are) is separated from
+                 the SESSION share-key state (loaded this run or not) — the two
+                 used to be conflated into a contradictory "signed in / sign in
+                 to share". -->
             <div class="account-section">
-              <span class="account-section-label text-muted">Signed in</span>
+              <span class="account-section-label text-muted">Signed in as</span>
               <div class="signed-in-row">
                 <span class="pill is-success signed-pill">
                   <span class="pill-dot"></span>
@@ -148,20 +151,48 @@ interface FolderOption {
                 Your notes live on this Mac. Signing out only turns off sharing —
                 it never deletes, moves, or uploads a note.
               </p>
-              @if (!st.unlockedForSharing) {
+
+              <!-- SESSION share-key state — distinct from identity above. -->
+              @if (st.unlockedForSharing) {
+                <span class="pill is-success signed-pill">
+                  <span class="pill-dot"></span>
+                  Ready to share this session
+                </span>
+              } @else {
                 <p class="text-secondary account-note">
-                  Sign in again to share — your account key isn't loaded in this
-                  session.
+                  @if (canBiometricUnlock()) {
+                    Sharing is locked this session — unlock with Touch ID to
+                    share without re-entering your password.
+                  } @else {
+                    Sharing is locked this session — sign in again to load your
+                    account key.
+                  }
                 </p>
                 <div class="account-actions">
-                  <button
-                    type="button"
-                    class="btn btn-primary"
-                    (click)="openFlow()"
-                  >
-                    Sign in to share
-                  </button>
+                  @if (canBiometricUnlock()) {
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      (click)="unlockWithBiometric()"
+                      [disabled]="unlocking()"
+                    >
+                      {{ unlocking() ? "Unlocking…" : "Unlock with Touch ID" }}
+                    </button>
+                  } @else {
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      (click)="openFlow()"
+                    >
+                      Sign in to share
+                    </button>
+                  }
                 </div>
+                @if (unlockError(); as uerr) {
+                  <p class="text-secondary account-note" role="status">
+                    {{ uerr }}
+                  </p>
+                }
               }
             </div>
           } @else {
@@ -645,6 +676,37 @@ export class SettingsAccountSectionComponent {
   private readonly _accountError = signal<string | null>(null);
   readonly accountError = this._accountError.asReadonly();
 
+  /** True while the one-tap Touch ID unlock IPC is in flight ("Unlocking…"). */
+  private readonly _unlocking = signal(false);
+  readonly unlocking = this._unlocking.asReadonly();
+
+  /** A friendly, non-crashy message shown when the Touch ID unlock fails. */
+  private readonly _unlockError = signal<string | null>(null);
+  readonly unlockError = this._unlockError.asReadonly();
+
+  /**
+   * Latches true when a Touch ID unlock attempt fails, so the row falls back to
+   * the password "Sign in to share" path instead of looping the biometric sheet.
+   * Cleared on the next status reload (a fresh state re-enables Touch ID).
+   */
+  private readonly _biometricFailed = signal(false);
+
+  /**
+   * Whether to offer the one-tap Touch ID unlock: logged in, NOT yet unlocked
+   * this session, a cached account key exists, and no prior attempt just failed.
+   * When false the password sign-in flow is the fallback.
+   */
+  readonly canBiometricUnlock = computed(() => {
+    const st = this._status();
+    return (
+      !!st &&
+      st.loggedIn &&
+      !st.unlockedForSharing &&
+      st.biometricUnlockAvailable &&
+      !this._biometricFailed()
+    );
+  });
+
   /** Whether the reusable-flow modal is open. */
   private readonly _showFlow = signal(false);
   readonly showFlow = this._showFlow.asReadonly();
@@ -709,6 +771,9 @@ export class SettingsAccountSectionComponent {
 
   /** Load the current account status + seed the server URL input from config. */
   private async reload(): Promise<void> {
+    // A fresh status re-enables the Touch ID path (drops any prior fail latch).
+    this._biometricFailed.set(false);
+    this._unlockError.set(null);
     let st: AccountStatus | null = null;
     try {
       st = await this.ipc.accountStatus();
@@ -797,6 +862,42 @@ export class SettingsAccountSectionComponent {
     } finally {
       this._savingServer.set(false);
     }
+  }
+
+  /**
+   * One-tap Touch ID unlock for sharing: presents a single biometric sheet,
+   * restores the session MK, and flips the row to "Ready to share". On ANY
+   * failure it fails closed to the password sign-in flow (latch the fallback +
+   * surface a friendly message) — never a dead end.
+   */
+  async unlockWithBiometric(): Promise<void> {
+    if (this._unlocking()) return;
+    this._unlocking.set(true);
+    this._unlockError.set(null);
+    try {
+      const st = await this.ipc.unlockSharingWithBiometric();
+      this._status.set(st);
+      if (!st.unlockedForSharing) {
+        // Resolved but still locked — fall back to the password path.
+        this._biometricFailed.set(true);
+        this._unlockError.set(
+          "Couldn't unlock this session. Sign in with your password to share.",
+        );
+      }
+    } catch (e) {
+      this._biometricFailed.set(true);
+      this._unlockError.set(this.friendlyUnlockError(String(e)));
+    } finally {
+      this._unlocking.set(false);
+    }
+  }
+
+  /** Turn a raw biometric-unlock error into a friendly fall-back message. */
+  private friendlyUnlockError(raw: string): string {
+    if (/cancel/i.test(raw)) {
+      return "Touch ID was cancelled. Sign in with your password to share instead.";
+    }
+    return "Couldn't unlock with Touch ID. Sign in with your password to share instead.";
   }
 
   /** Sign out (server family-revoke + clear tokens + drop session MK), then reload. */


### PR DESCRIPTION
Caches the account MK biometric-gated (user-presence + this-device-only, non-syncable) so a Touch ID tap restores the sharing session instead of re-typing the password each launch. New unlock_sharing_with_biometric command + biometricUnlockAvailable + 'Unlock with Touch ID' in Account & the Share gate + copy fix. lock-security PASS; cargo test --lib 1024, ng lint/build green. Debug uses a dev-file cache (compiled out of release) so dev rebuilds stop re-prompting for the password.