### PR TITLE
feat(settings): posture-driven AI & Models redesign

### DIFF
--- a/docs/superpowers/prototypes/2026-07-05-ai-models-redesign.html
+++ b/docs/superpowers/prototypes/2026-07-05-ai-models-redesign.html
@@ -1,0 +1,435 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Murmur · AI &amp; Models — posture-driven redesign (prototype)</title>
+<style>
+  :root {
+    --surface-base:#07070b; --surface-raised:rgba(255,255,255,0.045);
+    --surface-overlay:#1b1b24; --surface-input:rgba(255,255,255,0.035);
+    --surface-solid:#111118; --surface-hover:rgba(255,255,255,0.06);
+    --glass-border:rgba(255,255,255,0.10);
+    --text-primary:#f6f6fa; --text-secondary:#a6a6b6; --text-muted:#6c6c7d; --text-on-accent:#fff;
+    --accent:#6e76ff; --accent-hover:#8a90ff; --accent-active:#5b63f0;
+    --accent-soft:rgba(110,118,255,0.16); --accent-ring:rgba(110,118,255,0.5);
+    --accent-gradient:linear-gradient(135deg,#6e76ff 0%,#9d7bff 100%);
+    --border:rgba(255,255,255,0.09); --border-strong:rgba(255,255,255,0.16); --border-subtle:rgba(255,255,255,0.055);
+    --success:#4ade80; --success-soft:rgba(74,222,128,0.15);
+    --warning:#f5b14c; --warning-soft:rgba(245,177,76,0.14); --danger:#ff6b6b;
+    --radius-sm:9px; --radius-md:13px; --radius-lg:18px; --radius-pill:999px;
+    --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px; --space-6:32px;
+    --shadow-md:0 16px 40px rgba(0,0,0,0.42); --shadow-lg:0 28px 70px rgba(0,0,0,0.55);
+    --transition:200ms cubic-bezier(0.32,0.72,0,1);
+    --font-sans:-apple-system,BlinkMacSystemFont,system-ui,"Segoe UI",sans-serif;
+  }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; background:
+      radial-gradient(1200px 700px at 80% -10%, rgba(110,118,255,0.10), transparent 60%),
+      radial-gradient(900px 600px at -10% 20%, rgba(157,123,255,0.08), transparent 55%),
+      var(--surface-base);
+    color:var(--text-primary); font-family:var(--font-sans);
+    -webkit-font-smoothing:antialiased; line-height:1.5; padding:40px 20px 120px;
+  }
+  .shell { max-width:720px; margin:0 auto; }
+  .proto-note {
+    max-width:720px; margin:0 auto var(--space-5); font-size:0.8rem; color:var(--text-muted);
+    border:1px dashed var(--border-strong); border-radius:var(--radius-md); padding:10px 14px;
+  }
+  .proto-note b { color:var(--text-secondary); }
+  h1.page { font-size:1.7rem; font-weight:700; margin:0 0 var(--space-5); letter-spacing:-0.01em; }
+  h3 { margin:0; font-size:1.05rem; font-weight:650; letter-spacing:-0.01em; }
+  .text-secondary { color:var(--text-secondary); }
+  .text-muted { color:var(--text-muted); }
+  .card {
+    background:var(--surface-raised); border:1px solid var(--glass-border);
+    border-radius:var(--radius-lg); padding:var(--space-5); margin-bottom:var(--space-4);
+    backdrop-filter:blur(30px) saturate(135%);
+  }
+  .head-copy { display:flex; flex-direction:column; gap:6px; margin-bottom:var(--space-4); }
+  .sub { margin:0; font-size:0.875rem; }
+
+  /* ── posture segmented ── */
+  .posture-seg { display:flex; gap:var(--space-2); flex-wrap:wrap; }
+  .posture-opt {
+    display:flex; flex-direction:column; gap:3px; flex:1 1 150px; min-width:0; text-align:left;
+    padding:12px 14px; border:1px solid var(--border-subtle); border-radius:var(--radius-md);
+    background:var(--surface-input); color:var(--text-primary); cursor:pointer;
+    transition:border-color var(--transition), background var(--transition);
+  }
+  .posture-opt:hover { border-color:var(--border-strong); }
+  .posture-opt.is-active { border-color:var(--accent); background:var(--accent-soft); box-shadow:0 0 0 1px var(--accent); }
+  .posture-opt-title { font-size:0.95rem; font-weight:650; }
+  .posture-opt-sub { font-size:0.78rem; line-height:1.4; }
+  .posture-meaning { margin:var(--space-4) 0 0; font-size:0.9rem; line-height:1.6; }
+  .posture-meaning .lead { color:var(--text-primary); font-weight:600; }
+
+  /* ── setup fields ── */
+  .setup-card + .setup-card { margin-top:var(--space-3); }
+  .field { display:flex; flex-direction:column; gap:6px; }
+  .field + .field { margin-top:var(--space-4); }
+  .field-label { font-size:0.9rem; font-weight:600; color:var(--text-secondary); }
+  .field-help { font-size:0.8125rem; color:var(--text-muted); line-height:1.5; }
+  select, input[type=text] {
+    appearance:none; background:var(--surface-input); color:var(--text-primary);
+    border:1px solid var(--border-subtle); border-radius:var(--radius-sm);
+    padding:9px 12px; font:inherit; font-size:0.9rem; width:100%;
+    background-image:url("data:image/svg+xml,%3Csvg width='10' height='6' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23a6a6b6' stroke-width='1.4' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat:no-repeat; background-position:right 12px center; padding-right:32px;
+  }
+  select:focus, input:focus { outline:none; border-color:var(--accent); box-shadow:0 0 0 3px var(--accent-ring); }
+  option { background:var(--surface-overlay); color:var(--text-primary); }
+  .row { display:flex; gap:var(--space-3); align-items:flex-end; flex-wrap:wrap; }
+  .row .field { flex:1 1 220px; }
+  .inline-row { display:flex; gap:var(--space-2); align-items:center; }
+  .inline-row select { flex:1; }
+
+  .btn { border:none; border-radius:var(--radius-sm); font:inherit; font-size:0.875rem; font-weight:600;
+    padding:9px 16px; cursor:pointer; transition:background var(--transition), border-color var(--transition); white-space:nowrap; }
+  .btn-primary { background:var(--accent-gradient); color:var(--text-on-accent); box-shadow:0 8px 24px rgba(110,118,255,0.35); }
+  .btn-primary:hover { filter:brightness(1.06); }
+  .btn-ghost { background:transparent; color:var(--text-secondary); border:1px solid var(--border-subtle); }
+  .btn-ghost:hover { border-color:var(--border-strong); color:var(--text-primary); background:var(--surface-hover); }
+  .btn-sm { padding:6px 12px; font-size:0.8125rem; }
+
+  .pill { display:inline-flex; align-items:center; gap:6px; font-size:0.8rem; font-weight:600;
+    padding:3px 10px; border-radius:var(--radius-pill); border:1px solid var(--border-subtle);
+    background:var(--surface-input); color:var(--text-secondary); }
+  .pill-dot { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:0.8; }
+  .pill.is-success { color:var(--success); background:var(--success-soft); border-color:transparent; }
+  .pill.is-warn { color:var(--warning); background:var(--warning-soft); border-color:transparent; }
+  .pill.is-cloud { color:var(--text-secondary); }
+
+  /* ── the honest map ── */
+  .map-group + .map-group { margin-top:var(--space-4); padding-top:var(--space-4); border-top:1px solid var(--border-subtle); }
+  .map-group-label { font-size:0.78rem; font-weight:650; text-transform:uppercase; letter-spacing:0.03em; color:var(--text-muted); margin:0 0 var(--space-2); display:flex; align-items:center; gap:8px; }
+  .map-row { display:grid; grid-template-columns:minmax(120px,0.6fr) 1fr auto auto; align-items:center; gap:var(--space-3); padding:9px 0; border-top:1px solid var(--border-subtle); }
+  .map-group .map-row:first-of-type { border-top:none; }
+  .map-title { font-size:0.875rem; font-weight:550; color:var(--text-secondary); }
+  .map-engine { font-size:0.875rem; }
+  .map-engine .m-model { color:var(--text-muted); font-size:0.8125rem; }
+  .map-row.is-off .map-title, .map-row.is-off .map-engine { opacity:0.5; }
+  .change-spacer { width:1px; }
+  .empty-cloud { font-size:0.875rem; color:var(--success); display:flex; align-items:center; gap:8px; padding:4px 0; }
+
+  /* ── advanced ── */
+  .adv-toggle { display:flex; align-items:center; gap:var(--space-2); width:100%; text-align:left;
+    padding:14px 16px; background:var(--surface-input); border:1px solid var(--border-subtle);
+    border-radius:var(--radius-md); color:var(--text-secondary); font:inherit; font-size:0.9rem; font-weight:600; cursor:pointer; }
+  .adv-toggle:hover { border-color:var(--border-strong); color:var(--text-primary); }
+  .adv-toggle.is-open { border-bottom-left-radius:0; border-bottom-right-radius:0; border-bottom-color:transparent; }
+  .chev { transition:transform var(--transition); }
+  .chev.is-open { transform:rotate(90deg); }
+  .adv-body { border:1px solid var(--border-subtle); border-top:none; border-radius:0 0 var(--radius-md) var(--radius-md);
+    background:var(--surface-input); padding:var(--space-5); display:none; flex-direction:column; gap:var(--space-4); }
+  .adv-body.is-open { display:flex; }
+  .adv-sub-label { font-size:0.78rem; font-weight:650; text-transform:uppercase; letter-spacing:0.03em; color:var(--text-muted); margin:0; }
+  .eng-row { display:flex; align-items:center; justify-content:space-between; gap:var(--space-3);
+    padding:12px 14px; background:var(--surface-raised); border:1px solid var(--border-subtle); border-radius:var(--radius-md); }
+  .eng-name { font-weight:600; font-size:0.9rem; display:flex; align-items:center; gap:10px; }
+  .eng-desc { font-size:0.8rem; color:var(--text-muted); margin-top:2px; }
+  .role-row { padding:12px 14px; background:var(--surface-raised); border:1px solid var(--border-subtle); border-radius:var(--radius-md); }
+  .role-row + .role-row { margin-top:var(--space-2); }
+  .role-row.hl { animation:flash 1.6s ease; border-color:var(--accent); }
+  @keyframes flash { 0%,100% { box-shadow:none; } 25% { box-shadow:0 0 0 3px var(--accent-ring); } }
+
+  .divider { height:1px; background:var(--border-subtle); margin:var(--space-3) 0; }
+  .save-bar { position:fixed; left:0; right:0; bottom:0; padding:14px 20px; background:linear-gradient(0deg,var(--surface-base),transparent);
+    display:flex; justify-content:center; }
+</style>
+</head>
+<body>
+
+<div class="proto-note">
+  <b>Prototyp (nie apka).</b> Klikaj karty <b>Where your AI runs</b> — sekcje „Your setup" i „What runs where" przebudowują się na żywo, dokładnie jak zrobi to realny silnik.
+  „Change" scrolluje + podświetla właściwy wiersz w Advanced. Silniki chmury / modele lokalne / RAM — realne dane z rejestru.
+</div>
+
+<div class="shell">
+  <h1 class="page">AI &amp; Models</h1>
+
+  <!-- ─────────────────────────────── A. WHERE YOUR AI RUNS ─────────────────────────────── -->
+  <div class="card">
+    <div class="head-copy">
+      <h3>Where your AI runs</h3>
+      <p class="sub text-secondary">Pick how much runs on this Mac. Everything below adapts to your choice — no jargon to untangle.</p>
+    </div>
+    <div class="posture-seg" id="postureSeg">
+      <button class="posture-opt" data-posture="cloud">
+        <span class="posture-opt-title">Cloud</span>
+        <span class="posture-opt-sub text-muted">Fast &amp; smart. Your cloud engine writes everything.</span>
+      </button>
+      <button class="posture-opt" data-posture="hybrid">
+        <span class="posture-opt-title">Hybrid ⭐</span>
+        <span class="posture-opt-sub text-muted">Cloud notes + realtime reactions on this Mac.</span>
+      </button>
+      <button class="posture-opt" data-posture="fully_local">
+        <span class="posture-opt-title">Fully local</span>
+        <span class="posture-opt-sub text-muted">Nothing leaves this Mac. Ever.</span>
+      </button>
+    </div>
+    <p class="posture-meaning" id="postureMeaning"></p>
+  </div>
+
+  <!-- ─────────────────────────────── B. YOUR SETUP (adaptive) ─────────────────────────────── -->
+  <div id="setupHost"></div>
+
+  <!-- ─────────────────────────────── C. WHAT RUNS WHERE (honest map) ─────────────────────────────── -->
+  <div class="card">
+    <div class="head-copy">
+      <h3>What runs where</h3>
+      <p class="sub text-secondary">Every AI job and the engine serving it right now — grouped by where your words go.</p>
+    </div>
+    <div id="mapHost"></div>
+  </div>
+
+  <!-- ─────────────────────────────── D. ADVANCED ─────────────────────────────── -->
+  <div class="adv-toggle" id="advToggle">
+    <svg class="chev" id="advChev" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M4 2l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    Advanced — per-feature overrides &amp; all engines
+  </div>
+  <div class="adv-body" id="advBody">
+    <div>
+      <p class="adv-sub-label">Per-feature overrides</p>
+      <p class="field-help" style="margin:4px 0 12px">Send one feature to a different engine than your posture. Blank = follow the posture above.</p>
+      <div class="role-row" id="role-notes">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+          <div><div style="font-weight:600;font-size:0.9rem">Meeting notes</div><div class="eng-desc">Summaries, digests, briefs, graph</div></div>
+          <select style="flex:0 1 240px"><option>Follow posture (default)</option><option>Claude Code</option><option>Anthropic API</option><option>Ollama</option><option>Kong AI Gateway</option></select>
+        </div>
+      </div>
+      <div class="role-row" id="role-ask">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+          <div><div style="font-weight:600;font-size:0.9rem">Ask &amp; chat</div><div class="eng-desc">Vault Q&amp;A + meeting chat</div></div>
+          <select style="flex:0 1 240px"><option>Follow posture (default)</option><option>On this Mac — built-in</option><option>Off — retrieval only</option><option>Claude Code</option><option>Anthropic API</option><option>Ollama</option><option>Kong AI Gateway</option></select>
+        </div>
+      </div>
+      <div class="role-row" id="role-live">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+          <div><div style="font-weight:600;font-size:0.9rem">Live during meetings</div><div class="eng-desc">@brain threads + voice assistant</div></div>
+          <select style="flex:0 1 240px"><option>Follow posture (default)</option><option>On this Mac — built-in</option><option>Off — retrieval only</option><option>Claude Code</option><option>Anthropic API</option><option>Ollama</option><option>Kong AI Gateway</option></select>
+        </div>
+      </div>
+    </div>
+    <div class="divider"></div>
+    <div>
+      <p class="adv-sub-label">All engines — set up once</p>
+      <p class="field-help" style="margin:4px 0 12px">Where models <em>can</em> run. Configure once; posture and overrides pick which one is used.</p>
+      <div style="display:flex;flex-direction:column;gap:8px">
+        <div class="eng-row"><div><div class="eng-name">On this Mac <span class="pill is-success"><span class="pill-dot"></span>Ready</span></div><div class="eng-desc">Built-in models — nothing leaves this Mac. Powers realtime reactions &amp; Fully local.</div></div><button class="btn btn-ghost btn-sm">Manage models</button></div>
+        <div class="eng-row"><div><div class="eng-name">Ollama <span class="pill is-success"><span class="pill-dot"></span>Ready</span></div><div class="eng-desc">Your own local model server — separate from the built-in models.</div></div><button class="btn btn-ghost btn-sm">Configure</button></div>
+        <div class="eng-row"><div><div class="eng-name">Claude Code <span class="pill is-success"><span class="pill-dot"></span>Ready</span></div><div class="eng-desc">Cloud — redacted first.</div></div><button class="btn btn-ghost btn-sm">Configure</button></div>
+        <div class="eng-row"><div><div class="eng-name">Anthropic API <span class="pill is-warn"><span class="pill-dot"></span>Needs setup</span></div><div class="eng-desc">Cloud — redacted first. No API key set in Keychain.</div></div><button class="btn btn-ghost btn-sm">Configure</button></div>
+        <div class="eng-row"><div><div class="eng-name">Kong AI Gateway <span class="pill is-success"><span class="pill-dot"></span>Ready</span></div><div class="eng-desc">Cloud — redacted first. OpenAI-compatible.</div></div><button class="btn btn-ghost btn-sm">Configure</button></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="save-bar"><button class="btn btn-primary" style="padding:11px 28px">Save settings</button></div>
+
+<script>
+/* ── real model registry (from reason::BRAIN_MODELS + engine list) ── */
+const CLOUD_ENGINES = {
+  claude_code: { name:"Claude Code", models:["default","claude-sonnet-4-6","claude-opus-4-8","claude-haiku-4-5"], status:"ready" },
+  anthropic:   { name:"Anthropic API", models:["claude-opus-4-8","claude-sonnet-4-6","claude-haiku-4-5"], status:"needs" },
+  gateway:     { name:"Kong AI Gateway", models:["gpt-4o","gpt-4o-mini","(your model id)"], status:"ready" },
+};
+const HEAVY = {
+  "qwen3-4b-instruct-2507": { name:"Qwen3 4B Instruct 2507", tag:"multilingual", size:"2.3 GB", ram:"≥6 GB RAM", downloaded:true },
+  "bielik-4.5b-v3":         { name:"Bielik 4.5B v3", tag:"Polish-native", size:"4.6 GB", ram:"≥10 GB RAM", downloaded:false },
+  "bielik-11b-v3":          { name:"Bielik 11B v3", tag:"Polish-native", size:"6.7 GB", ram:"≥10 GB RAM", downloaded:true },
+  "qwen3-14b":              { name:"Qwen3 14B", tag:"multilingual", size:"9.0 GB", ram:"≥14 GB RAM", downloaded:false },
+};
+const LIGHT = {
+  "qwen3-1.7b":     { name:"Qwen3 1.7B", tag:"multilingual", size:"1.0 GB", ram:"≥4 GB RAM", downloaded:true },
+  "bielik-1.5b-v3": { name:"Bielik 1.5B v3", tag:"Polish-native", size:"1.5 GB", ram:"≥4 GB RAM", downloaded:false },
+};
+
+/* ── UI state ── */
+const state = {
+  posture: "cloud",
+  cloudEngine: "claude_code",
+  cloudModel: "default",
+  heavyModel: "bielik-11b-v3",
+  lightModel: "qwen3-1.7b",
+};
+
+const MEANING = {
+  cloud: `<span class="lead">Cloud.</span> Your cloud engine writes your notes, answers and briefs — sent redacted (names stripped) after your consent. Recording, transcription, search and name-detection still happen only on this Mac.`,
+  hybrid: `<span class="lead">Hybrid ⭐ — recommended.</span> Same cloud quality for notes &amp; answers, but realtime in-meeting reactions run on a small model on this Mac, so nothing leaves live.`,
+  fully_local: `<span class="lead">Fully local.</span> Every AI job runs on this Mac using built-in models. Nothing ever leaves — no cloud, no consent needed. Bigger models are slower and need more RAM.`,
+};
+
+function opt(map, sel){ return Object.entries(map).map(([id,m])=>{
+  const dl = m.downloaded ? "" : " · ⬇ download";
+  return `<option value="${id}" ${id===sel?"selected":""}>${m.name} · ${m.tag} · ${m.size}${dl}</option>`;
+}).join(""); }
+
+function cloudEngineCard(){
+  const e = CLOUD_ENGINES[state.cloudEngine];
+  const needs = e.status==="needs";
+  return `
+  <div class="card setup-card">
+    <div class="head-copy"><h3>Your cloud engine</h3>
+      <p class="sub text-secondary">Writes notes, answers and briefs. Text is redacted before it leaves.</p></div>
+    <div class="row">
+      <div class="field"><span class="field-label">Engine</span>
+        <select id="cloudEngineSel">
+          <option value="claude_code" ${state.cloudEngine==="claude_code"?"selected":""}>Claude Code</option>
+          <option value="anthropic" ${state.cloudEngine==="anthropic"?"selected":""}>Anthropic API</option>
+          <option value="gateway" ${state.cloudEngine==="gateway"?"selected":""}>Kong AI Gateway (OpenAI-compatible)</option>
+        </select>
+      </div>
+      <div class="field"><span class="field-label">Model</span>
+        <select id="cloudModelSel">${e.models.map(m=>`<option ${m===state.cloudModel?"selected":""}>${m}</option>`).join("")}</select>
+      </div>
+      <button class="btn btn-ghost" style="height:38px">Test</button>
+    </div>
+    ${needs ? `<p class="field-help" style="color:var(--warning);margin-top:12px">⚠ Needs setup — add your API key under Advanced → All engines.</p>`
+            : `<p class="field-help" style="margin-top:12px"><span class="pill is-cloud"><span class="pill-dot"></span>Cloud — redacted first</span></p>`}
+  </div>`;
+}
+
+function reactionsCard(){
+  const m = LIGHT[state.lightModel];
+  return `
+  <div class="card setup-card">
+    <div class="head-copy"><h3>On-device model — realtime reactions</h3>
+      <p class="sub text-secondary">A small model runs live during meetings for instant reactions &amp; fact-spotting. Stays on this Mac.</p></div>
+    <div class="inline-row">
+      <select id="lightSel">${opt(LIGHT, state.lightModel)}</select>
+      ${m.downloaded ? `<span class="pill is-success"><span class="pill-dot"></span>Ready</span>`
+                     : `<button class="btn btn-primary btn-sm">Download ${m.size}</button>`}
+    </div>
+    <p class="field-help" style="margin-top:10px">${m.ram} · one-time download from Hugging Face, then fully offline.</p>
+  </div>`;
+}
+
+function localModelsCard(){
+  const h = HEAVY[state.heavyModel], l = LIGHT[state.lightModel];
+  const ramWarn = (state.heavyModel==="bielik-11b-v3"||state.heavyModel==="qwen3-14b");
+  return `
+  <div class="card setup-card">
+    <div class="head-copy"><h3>Your on-device models</h3>
+      <p class="sub text-secondary">Everything runs here. Pick the models Murmur uses — bigger = better notes but slower &amp; more RAM.</p></div>
+    <div class="field"><span class="field-label">Notes &amp; Ask <span class="text-muted" style="font-weight:400">— heavy model, runs after the meeting</span></span>
+      <div class="inline-row">
+        <select id="heavySel">${opt(HEAVY, state.heavyModel)}</select>
+        ${h.downloaded ? `<span class="pill is-success"><span class="pill-dot"></span>Ready</span>` : `<button class="btn btn-primary btn-sm">Download ${h.size}</button>`}
+      </div>
+    </div>
+    <div class="field"><span class="field-label">Live &amp; realtime reactions <span class="text-muted" style="font-weight:400">— light model, runs during the meeting</span></span>
+      <div class="inline-row">
+        <select id="lightSel">${opt(LIGHT, state.lightModel)}</select>
+        ${l.downloaded ? `<span class="pill is-success"><span class="pill-dot"></span>Ready</span>` : `<button class="btn btn-primary btn-sm">Download ${l.size}</button>`}
+      </div>
+    </div>
+    ${ramWarn ? `<p class="field-help" style="color:var(--warning);margin-top:12px">⚠ ${h.name} needs ${h.ram} — may be slow alongside recording on a smaller Mac.</p>` : ``}
+  </div>`;
+}
+
+/* ── the honest map: two groups, cloud vs on-mac ── */
+function mapRows(){
+  const ce = CLOUD_ENGINES[state.cloudEngine];
+  const cloudEngineLabel = ce.name;
+  const cloudModelLabel = state.cloudModel==="default" ? "" : state.cloudModel;
+  const heavy = HEAVY[state.heavyModel].name;
+  const light = LIGHT[state.lightModel].name;
+
+  let cloud=[], mac=[];
+  if(state.posture==="cloud"){
+    cloud=[["Notes & summaries",cloudEngineLabel,cloudModelLabel],["Ask & chat",cloudEngineLabel,cloudModelLabel],["Live @brain",cloudEngineLabel,cloudModelLabel]];
+    mac=[["Realtime reactions","— off in Cloud","",true],["Transcription","Whisper","large-v3"],["Search index","Multilingual E5 Small",""],["Name redaction","On-device NER",""]];
+  } else if(state.posture==="hybrid"){
+    cloud=[["Notes & summaries",cloudEngineLabel,cloudModelLabel],["Ask & chat",cloudEngineLabel,cloudModelLabel],["Live @brain",cloudEngineLabel,cloudModelLabel]];
+    mac=[["Realtime reactions",light,""],["Transcription","Whisper","large-v3"],["Search index","Multilingual E5 Small",""],["Name redaction","On-device NER",""]];
+  } else {
+    cloud=[];
+    mac=[["Notes & summaries",heavy,""],["Ask & chat",heavy,""],["Live @brain",light,""],["Realtime reactions",light,""],["Transcription","Whisper","large-v3"],["Search index","Multilingual E5 Small",""],["Name redaction","On-device NER",""]];
+  }
+
+  const routable = new Set(["Notes & summaries","Ask & chat","Live @brain"]);
+  const rowHtml = (r, loc)=>{
+    const off = r[3];
+    const changeBtn = routable.has(r[0]) ? `<button class="btn btn-ghost btn-sm" data-change="${r[0]}">Change</button>` : `<span class="change-spacer"></span>`;
+    return `<div class="map-row ${off?"is-off":""}">
+      <span class="map-title">${r[0]}</span>
+      <span class="map-engine">${r[1]} ${r[2]?`<span class="m-model">· ${r[2]}</span>`:""}</span>
+      <span class="pill ${loc==="mac"?"is-success":"is-cloud"}"><span class="pill-dot"></span>${loc==="mac"?"On this Mac":"Cloud · redacted"}</span>
+      ${changeBtn}
+    </div>`;
+  };
+
+  let html = "";
+  html += `<div class="map-group"><p class="map-group-label">☁ Goes to the cloud — redacted first</p>`;
+  html += cloud.length ? cloud.map(r=>rowHtml(r,"cloud")).join("") : `<div class="empty-cloud">✓ Nothing leaves this Mac in Fully local.</div>`;
+  html += `</div>`;
+  html += `<div class="map-group"><p class="map-group-label">🖥 Stays on your Mac — always private</p>`;
+  html += mac.map(r=>rowHtml(r,"mac")).join("");
+  html += `</div>`;
+  return html;
+}
+
+function renderSetup(){
+  let html="";
+  if(state.posture==="cloud") html = cloudEngineCard();
+  else if(state.posture==="hybrid") html = cloudEngineCard() + reactionsCard();
+  else html = localModelsCard();
+  document.getElementById("setupHost").innerHTML = html;
+  wireSetup();
+}
+function renderMap(){ document.getElementById("mapHost").innerHTML = mapRows(); wireChange(); }
+function renderMeaning(){ document.getElementById("postureMeaning").innerHTML = MEANING[state.posture]; }
+function renderPostureSeg(){
+  document.querySelectorAll(".posture-opt").forEach(b=>{
+    b.classList.toggle("is-active", b.dataset.posture===state.posture);
+  });
+}
+function renderAll(){ renderPostureSeg(); renderMeaning(); renderSetup(); renderMap(); }
+
+function wireSetup(){
+  const ce = document.getElementById("cloudEngineSel");
+  if(ce) ce.onchange = e => { state.cloudEngine = e.target.value; state.cloudModel = CLOUD_ENGINES[state.cloudEngine].models[0]; renderSetup(); renderMap(); };
+  const cm = document.getElementById("cloudModelSel");
+  if(cm) cm.onchange = e => { state.cloudModel = e.target.value; renderMap(); };
+  const hs = document.getElementById("heavySel");
+  if(hs) hs.onchange = e => { state.heavyModel = e.target.value; renderSetup(); renderMap(); };
+  const ls = document.getElementById("lightSel");
+  if(ls) ls.onchange = e => { state.lightModel = e.target.value; renderSetup(); renderMap(); };
+}
+function wireChange(){
+  document.querySelectorAll("[data-change]").forEach(btn=>{
+    btn.onclick = ()=>{
+      const map = {"Notes & summaries":"role-notes","Ask & chat":"role-ask","Live @brain":"role-live"};
+      const id = map[btn.dataset.change];
+      openAdvanced();
+      const el = document.getElementById(id);
+      el.scrollIntoView({behavior:"smooth", block:"center"});
+      el.classList.remove("hl"); void el.offsetWidth; el.classList.add("hl");
+    };
+  });
+}
+
+/* advanced */
+let advOpen=false;
+function openAdvanced(){ advOpen=true; syncAdv(); }
+function syncAdv(){
+  document.getElementById("advBody").classList.toggle("is-open", advOpen);
+  document.getElementById("advToggle").classList.toggle("is-open", advOpen);
+  document.getElementById("advChev").classList.toggle("is-open", advOpen);
+}
+document.getElementById("advToggle").onclick = ()=>{ advOpen=!advOpen; syncAdv(); };
+
+document.getElementById("postureSeg").addEventListener("click", e=>{
+  const b = e.target.closest(".posture-opt"); if(!b) return;
+  state.posture = b.dataset.posture; renderAll();
+});
+
+renderAll();
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-07-05-ai-models-posture-redesign.md
+++ b/docs/superpowers/specs/2026-07-05-ai-models-posture-redesign.md
@@ -1,0 +1,95 @@
+# AI & Models — posture-driven redesign
+
+**Date:** 2026-07-05
+**Status:** design approved (clickable prototype signed off) → implementation
+**Prototype:** `docs/superpowers/prototypes/2026-07-05-ai-models-redesign.html`
+**Scope:** Angular frontend only — `src/app/features/settings/sections/ai/*`. **Backend untouched.**
+
+## Problem (user report, with screenshots)
+
+The current AI & Models settings screen is "still heavy to understand". Three concrete failures:
+
+1. **"Change" button does nothing.** `AiResolvedMapComponent.change()` only calls
+   `store.expandAdvanced()`. The Advanced disclosure expands far below the fold with no
+   scroll and no targeting, so from the user's seat nothing happens.
+2. **"Pick Cloud, but Murmur Brain is suddenly local + some models."** The posture is a
+   preset over *roles*; 4 of the 7 jobs (Transcription, Realtime reactions, Search index,
+   Name redaction) are **always on-device regardless of posture**. The flat "What runs where"
+   list renders these next to the cloud rows with no grouping, so on-device rows read as a
+   contradiction ("I picked Cloud — why is it local?"). Separately, the Advanced → Engines
+   list shows **all 5 engines + the full local-model download aparat regardless of posture**,
+   so even in Cloud the user faces the entire local machinery.
+3. **No organization by posture.** The user's ask: Cloud → cloud models, Hybrid → hybrid,
+   Local → local models. Today everything is shown at once.
+
+## Ground truth of the engine (do not "fix" the backend — it is correct)
+
+- **Posture is DERIVED, never stored** (`settings/postures.rs::derive_posture`). Picking a
+  posture writes several config keys (`apply_posture`): Cloud = `brain_live=false`, clear all
+  `role_*`; Hybrid = `brain_live=true`, clear `role_*`; Fully local = `brain_live=true`,
+  `role_notes/ask=local+heavy`, `role_live=local+light`.
+- **7 jobs** (`settings/ai_map.rs::ai_map_rows`): 3 **routable** (Notes, Ask, Live) + 4 fixed
+  on-device (Realtime reactions [gated by `brain_live`], Transcription [Whisper], Search index
+  [embedder, gated by `semantic_search_enabled`], Name redaction [NER]).
+- **Engines:** on-device = built-in models ("Murmur Brain") + Ollama; cloud (redacted first) =
+  Claude Code, Anthropic API, Kong AI Gateway. Local model registry (`reason::BRAIN_MODELS`):
+  light (Qwen3 1.7B default, Bielik 1.5B) + heavy (Qwen3 4B default, Bielik 4.5B/11B, Qwen3 14B).
+
+## Target structure — 4 sections (replaces today's flat pile)
+
+Posture chooses the lane; the detail area shows **only what that lane needs to configure.**
+
+1. **Where your AI runs** — the posture hero (Cloud / Hybrid ⭐ / Fully local) + a one-line
+   plain-language meaning of the selected posture. Keeps the existing confirm-before-download +
+   progress flow. *(evolves `brain-posture-block.component`)*
+2. **Your setup** — NEW adaptive block, renders by `posture()`:
+   - **Cloud** → one "Your cloud engine" card: engine select (`providerId`: Claude Code /
+     Anthropic / Kong) + model + Test + "Cloud — redacted first".
+   - **Hybrid** → cloud engine card **+** "On-device model — realtime reactions" (light-model
+     picker + download state).
+   - **Fully local** → "Your on-device models": heavy picker (Notes & Ask) + light picker
+     (Live & realtime) + download + RAM warning. No cloud engine shown.
+3. **What runs where** — the same honest resolver mirror, but **grouped into two blocks**:
+   *☁ Goes to the cloud — redacted first* and *🖥 Stays on your Mac — always private*. Fully
+   local shows "✓ Nothing leaves this Mac" in the cloud group. **"Change" on a routable row
+   opens Advanced AND scrolls to + highlights that role's override row.** *(modifies
+   `ai-resolved-map.component`)*
+4. **▸ Advanced** — collapsed power path: **per-feature overrides** (Notes/Ask/Live) +
+   **all engines** (connection cards). The **Default engine** select moves OUT of Advanced up
+   into "Your setup" (§2); Advanced no longer duplicates it. *(evolves `ai-advanced-block`)*
+
+`during-meetings-block`, `on-device-intelligence-block`, `ai-privacy-strip` stay as-is below.
+
+## Component plan
+
+| Component | Change |
+| --- | --- |
+| `settings-ai-section.component` | Reorder/compose: posture → **new setup block** → map → advanced → (unchanged tail). |
+| `brain-posture-block.component` | Heading "What Murmur uses" → **"Where your AI runs"**; add clearer per-posture meaning line; keep download/confirm flow. |
+| **`ai-setup-block.component` (NEW)** | Adaptive per-posture setup (§2). Cloud/Hybrid reuse the `providerId`/`providerModel` FormControls (same controls as old Advanced Default engine — one control, one source of truth). Local/Hybrid model pickers reuse the existing local-models logic (`local-models-list` / brain model store signals). |
+| `ai-resolved-map.component` | Group rows cloud vs on-device (§3); `change(job)` sets a store "highlight role" signal + expands Advanced + scroll-into-view of the role row. |
+| `ai-advanced-block.component` | Remove the Default-engine block (moved to setup); keep connection cards + role rows; accept the highlight target so the map's Change lands on the right row. |
+| `settings.store.ts` | Add `highlightRole` signal (or reuse `advancedExpanded` + a scroll target) for the Change→scroll+flash; expose whatever the setup block needs (light/heavy model catalogs, download actions) that today lives in the brain-engine/local-models path. |
+
+## Naming (approved — simplify)
+
+- "Murmur Brain" (as an engine) → **"On this Mac — built-in models"**.
+- posture heading → **"Where your AI runs"**.
+- keep "Cloud — redacted first", posture labels Cloud / Hybrid ⭐ / Fully local.
+
+## Constraints & Definition of Done
+
+- **Backend untouched.** No new config keys required (setup writes the *existing* keys:
+  `providerId`, `providerModel`, `brain_light_model_id`, `brain_heavy_model_id`, and the
+  posture presets already do the rest). If a store convenience signal is missing it is added
+  FE-side over existing IPC.
+- **Zoneless/signals rules** (angular-zoneless.md): standalone, OnPush, signals, `@if`/`@for`,
+  `afterNextRender` for the scroll (with `{ injector }`), opaque overlays only where floating,
+  no `setTimeout` in a component, no new deps.
+- **No lock/crypto/visibility path touched** → lock-security review not required; the map reads
+  the already-gated `resolved_ai_map` (engine names, not content). **adversarial-verifier owns
+  the PASS/FAIL** (live-repro against `:1420` with mocked invoke; NG0600 / import-cycle / opacity
+  hunts).
+- Gates green: `npx ng lint`, `npx ng build`, `cargo test --lib` (unchanged, sanity), then
+  `scripts/ci.sh` once at the end.
+- Ship: QueaT commit, PR to `murmur` (never direct push), no Claude trailers.

--- a/src/app/features/settings/sections/ai/ai-advanced-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-advanced-block.component.ts
@@ -1,28 +1,25 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
   effect,
   inject,
 } from "@angular/core";
-import { ReactiveFormsModule } from "@angular/forms";
 import { SettingsStore } from "../../settings.store";
 import { AiConnectionCardsComponent } from "./ai-connection-cards.component";
 import { AiRoleRowsComponent } from "./ai-role-rows.component";
 
 /**
- * AI & Models → Collapsed "Advanced" disclosure block (Task 4).
+ * AI & Models → Collapsed "Advanced" disclosure block (Task 4, posture redesign).
  *
- * A plain in-flow toggle button ("⚙ Advanced — connections, models, per-feature")
- * expands a region that shows, in order:
- *   1. `<app-ai-connection-cards />` — the provider Connections block (moved here
- *      from the top-level `settings-ai-section`).
- *   2. Default AI `<select>` + Default model / reasoning-effort (`brain-tuning`)
- *      — moved verbatim from `AiDefaultsBlockComponent`.
- *   3. `<app-ai-role-rows />` — Customize per feature (moved from AiDefaultsBlock).
+ * A plain in-flow toggle button expands the power path, in order:
+ *   1. `<app-ai-connection-cards />` — every engine's connection card (keys,
+ *      base URLs, Test), split On-this-Mac vs Cloud.
+ *   2. `<app-ai-role-rows />` — per-feature overrides (Notes / Ask / Live).
  *
- * When `posture() === "fully_local"` the Default-AI select is rendered disabled
- * (the on-device pipeline runs notes itself) with a "Not used — Fully local" note.
+ * The Default AI engine + Default model controls used to live here; they moved
+ * UP into "Your setup" (`<app-ai-setup-block />`), which owns the same
+ * `providerId` / `providerModel` / `providerEffort` FormControls — one source
+ * of truth, no duplicate writer. Advanced no longer touches them.
  *
  * NOT an overlay — the expanded content is IN-FLOW (no `--surface-overlay`, no
  * `backdrop-filter`). See angular-zoneless.md T3.
@@ -31,7 +28,7 @@ import { AiRoleRowsComponent } from "./ai-role-rows.component";
   selector: "app-ai-advanced-block",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, AiConnectionCardsComponent, AiRoleRowsComponent],
+  imports: [AiConnectionCardsComponent, AiRoleRowsComponent],
   template: `
     <div class="adv-wrap">
       <button
@@ -57,147 +54,15 @@ import { AiRoleRowsComponent } from "./ai-role-rows.component";
             stroke-linejoin="round"
           />
         </svg>
-        ⚙ Advanced — engines & routing
+        ⚙ Advanced — per-feature overrides &amp; all engines
       </button>
 
       @if (expanded()) {
         <div class="adv-body">
-          <!-- Block 1: Provider Connections (moved from settings-ai-section top) -->
+          <!-- Block 1: every engine's connection card (keys, URLs, Test). -->
           <app-ai-connection-cards />
 
-          <!-- Block 2: Default AI + Default model / reasoning effort -->
-          <div class="adv-defaults card" [formGroup]="form">
-            <label class="field">
-              <span class="field-label">Default engine</span>
-              <!--
-                Disabled when posture is "fully_local" — the on-device pipeline
-                runs notes on the selected GGUF, so this picker has no effect.
-                Reactive-forms controls can't be disabled via [attr.disabled]
-                (the ControlValueAccessor strips it), so _syncProviderDisable
-                toggles the FormControl's own .disable()/.enable() — see its
-                comment below. save() uses getRawValue(), so a disabled
-                providerId still persists.
-              -->
-              <select
-                formControlName="providerId"
-                (change)="onDefaultAiChanged($event)"
-              >
-                <option value="claude_code">Claude Code (default)</option>
-                <option value="anthropic">Anthropic API</option>
-                <option value="ollama">Ollama</option>
-                <option value="gateway">Kong AI Gateway (OpenAI-compatible)</option>
-              </select>
-              @if (fullyLocal()) {
-                <span class="field-help text-muted">
-                  Not used — Fully local runs notes on-device.
-                </span>
-              } @else {
-                <span class="field-help text-muted">
-                  Runs Notes, Ask and &#64;brain unless a per-feature override
-                  below says otherwise. Cloud engines are redacted first. Set
-                  engines up in the Engines block above.
-                </span>
-              }
-            </label>
-
-            <!--
-              Model + reasoning-effort overrides. providerModel steers ONLY the
-              claude_code/anthropic arms (gateway/ollama read gateway_model /
-              ollama_model instead), so the dropdown renders only for those two —
-              for gateway/ollama we point at the connection card that actually
-              holds the model. The old "Anthropic model" free-text is intentionally
-              UNRENDERED (its FormControl still round-trips in the store).
-            -->
-            <div class="brain-tuning">
-              @switch (form.controls.providerId.value) {
-                @case ("gateway") {
-                  <p class="brain-note text-muted">
-                    The model for Kong AI Gateway is set in its connection card above.
-                  </p>
-                }
-                @case ("ollama") {
-                  <p class="brain-note text-muted">
-                    The model for Ollama is set in its connection card above.
-                  </p>
-                }
-                @default {
-                  <!-- div.field (not label) — the control sits in a nested row div,
-                       same as the gateway card's Model field. -->
-                  <div class="field">
-                    <span class="field-label">Default model</span>
-                    <!--
-                      Options come from list_models (the backend Claude-id constant —
-                      single source of truth, no hardcoded ids here). Empty catalog
-                      (fetch failed / older backend) → free-text fallback; a saved
-                      model missing from the catalog stays selectable as "(custom)"
-                      — the gateway picker's keep-manually-typed pattern.
-                    -->
-                    <div class="default-model-row">
-                      @if (defaultModelCatalog().length > 0) {
-                        <select
-                          formControlName="providerModel"
-                          class="default-model-select"
-                        >
-                          <option value="">Default (provider's pick)</option>
-                          @for (id of defaultModelCatalog(); track id) {
-                            <option [value]="id">{{ id }}</option>
-                          }
-                          @if (defaultModelIsCustom()) {
-                            <option [value]="form.controls.providerModel.value">
-                              {{ form.controls.providerModel.value }} (custom)
-                            </option>
-                          }
-                        </select>
-                      } @else {
-                        <input
-                          formControlName="providerModel"
-                          placeholder="Model id (blank = provider's pick)"
-                          autocomplete="off"
-                          spellcheck="false"
-                          class="default-model-input"
-                        />
-                      }
-                      <button
-                        type="button"
-                        class="btn btn-ghost default-model-refresh"
-                        (click)="refreshDefaultModels()"
-                        [disabled]="defaultModelsLoading()"
-                        title="Fetch this provider's model list"
-                      >
-                        @if (defaultModelsLoading()) {
-                          Loading…
-                        } @else {
-                          ↻ Refresh
-                        }
-                      </button>
-                    </div>
-                    <span class="field-help text-muted">
-                      Used for everything Murmur writes with AI: meeting notes,
-                      answers, digests and briefs. Default lets the provider choose.
-                    </span>
-                  </div>
-                }
-              }
-
-              @if (form.controls.providerId.value === "anthropic") {
-                <label class="field">
-                  <span class="field-label">Reasoning effort</span>
-                  <select formControlName="providerEffort">
-                    <option value="">Default</option>
-                    <option value="low">Low</option>
-                    <option value="medium">Medium</option>
-                    <option value="high">High</option>
-                  </select>
-                  <span class="field-help text-muted">
-                    Applies to the Anthropic provider — higher effort spends more
-                    thinking on harder questions.
-                  </span>
-                </label>
-              }
-            </div>
-          </div>
-
-          <!-- Block 3: Customize per feature (Ask / Notes / Live override rows) -->
+          <!-- Block 2: per-feature overrides (Ask / Notes / Live). -->
           <app-ai-role-rows />
         </div>
       }
@@ -268,70 +133,14 @@ import { AiRoleRowsComponent } from "./ai-role-rows.component";
         border-bottom-right-radius: var(--radius-md);
         background: var(--surface-input);
       }
-
-      /* ── Default AI + model block ── */
-      .adv-defaults {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-4);
-      }
-
-      .brain-tuning {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-4);
-      }
-      .brain-note {
-        margin: 0;
-        font-size: 0.8125rem;
-        line-height: 1.5;
-      }
-
-      /* Default-model picker — select-or-input + the catalog refresh. */
-      .default-model-row {
-        display: flex;
-        align-items: center;
-        gap: var(--space-2);
-        flex-wrap: wrap;
-      }
-      .default-model-select,
-      .default-model-input {
-        flex: 1 1 220px;
-        min-width: 0;
-      }
-      .default-model-refresh {
-        flex: none;
-        white-space: nowrap;
-      }
-
-      /* ── Stacked label + control ── */
-      .field {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-1);
-      }
-      .field-label {
-        color: var(--text-secondary);
-        font-size: 0.9rem;
-        font-weight: 550;
-      }
-      .field-help {
-        font-size: 0.8125rem;
-        line-height: 1.5;
-      }
     `,
   ],
 })
 export class AiAdvancedBlockComponent {
   private readonly store = inject(SettingsStore);
 
-  readonly form = this.store.form;
-
   /** Whether the Advanced disclosure is open — store-owned so the map's "Change" opens it. */
   readonly expanded = this.store.advancedExpanded;
-
-  /** True when the committed posture is "fully_local" — disables the Default-AI select. */
-  readonly fullyLocal = computed(() => this.store.posture() === "fully_local");
 
   /**
    * Auto-open once when any per-feature role override is active, or the legacy
@@ -353,40 +162,7 @@ export class AiAdvancedBlockComponent {
     { allowSignalWrites: true },
   );
 
-  readonly defaultModelCatalog = this.store.defaultModelCatalog;
-  readonly defaultModelsLoading = this.store.defaultModelsLoading;
-  readonly defaultModelIsCustom = this.store.defaultModelIsCustom;
-
-  /**
-   * Keep the native `<select disabled>` state in sync with the posture signal.
-   * Angular reactive forms owns the disabled property — we must call
-   * `.disable()` / `.enable()` on the FormControl itself, not `[attr.disabled]`
-   * (which Angular's control-value-accessor removes). `{ emitEvent: false }`
-   * avoids a spurious `valueChanges` emission. No signal write → no NG0600.
-   * `getRawValue()` in the store still includes disabled controls for save. ✓
-   */
-  private readonly _syncProviderDisable = effect(() => {
-    if (this.fullyLocal()) {
-      this.form.controls.providerId.disable({ emitEvent: false });
-    } else {
-      this.form.controls.providerId.enable({ emitEvent: false });
-    }
-  });
-
   toggle(): void {
     this.store.advancedExpanded.update((v) => !v);
-  }
-
-  /** Prefetch the newly-picked Default AI's model catalog (claude_code/anthropic only). */
-  onDefaultAiChanged(e: Event): void {
-    const id = (e.target as HTMLSelectElement).value;
-    if (id === "claude_code" || id === "anthropic") {
-      void this.store.ensureModels(id);
-    }
-  }
-
-  /** Re-fetch the Default-model catalog for the current provider. */
-  refreshDefaultModels(): void {
-    void this.store.refreshModels(this.form.controls.providerId.value);
   }
 }

--- a/src/app/features/settings/sections/ai/ai-connection-cards.component.ts
+++ b/src/app/features/settings/sections/ai/ai-connection-cards.component.ts
@@ -50,8 +50,7 @@ const CONNECTIONS: readonly ConnectionDef[] = [
       <div class="conn-head">
         <h3>Engines</h3>
         <p class="text-secondary conn-sub">
-          Where models can run. Set each engine up once — pick which one Murmur
-          uses under Default engine below.
+          Where models can run. Set each engine up once.
         </p>
       </div>
 

--- a/src/app/features/settings/sections/ai/ai-resolved-map.component.ts
+++ b/src/app/features/settings/sections/ai/ai-resolved-map.component.ts
@@ -1,13 +1,25 @@
-import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from "@angular/core";
+import type { AiMapRow } from "../../../../core/models";
 import { SettingsStore } from "../../settings.store";
 
 /**
  * AI & Models → "What runs where": the resolved-map card. A read-only,
  * always-visible mirror of the backend role resolver (`resolved_ai_map`) —
- * one row per AI job with the engine serving it RIGHT NOW. This is the
- * honesty layer of the posture redesign: the posture preset chooses, this
- * table shows the outcome, and a routable row's "Change" opens Advanced.
- * In-flow card (frosted .card is correct — not a floating overlay).
+ * one row per AI job with the engine serving it RIGHT NOW, split into two
+ * honest groups: rows whose text LEAVES the Mac (cloud, redacted first) and
+ * rows that STAY on the Mac. This grouping is the fix for the "I picked Cloud —
+ * why is transcription local?" confusion: the always-on-device jobs (Whisper,
+ * search, NER, reactions) live under their own heading instead of reading as a
+ * contradiction next to the cloud rows.
+ *
+ * A routable row's "Change" opens Advanced AND asks the role rows to scroll to +
+ * flash that role's override row (`requestHighlightRole`). In-flow card (frosted
+ * .card is correct — not a floating overlay).
  */
 @Component({
   selector: "app-ai-resolved-map",
@@ -18,42 +30,86 @@ import { SettingsStore } from "../../settings.store";
       <div class="map-head">
         <h3>What runs where</h3>
         <p class="text-secondary map-sub">
-          Every AI job and the engine serving it right now.
+          Every AI job and the engine serving it right now — grouped by where your
+          words go.
         </p>
       </div>
-      <div class="map-rows">
-        @for (row of rows(); track row.job) {
-          <div class="map-row" [class.is-inactive]="!row.active">
-            <span class="map-title">{{ row.title }}</span>
-            <span class="map-engine">
-              {{ row.engine }}
-              @if (row.model) {
-                <span class="map-model text-muted">· {{ row.model }}</span>
-              }
-              @if (!row.active) {
-                <span class="map-off text-muted">— off</span>
-              }
-            </span>
-            <span class="pill map-loc" [class.is-success]="row.onDevice">
-              <span class="pill-dot"></span>
-              {{ row.onDevice ? "On this Mac" : "Cloud · redacted" }}
-            </span>
-            @if (row.routable) {
-              <button
-                type="button"
-                class="btn btn-ghost btn-sm map-change"
-                (click)="change()"
-              >
-                Change
-              </button>
-            } @else {
-              <span class="map-change-spacer" aria-hidden="true"></span>
+
+      @if (rows().length === 0) {
+        <p class="text-muted map-empty">Loading the routing map…</p>
+      } @else {
+        <!-- ☁ Cloud group — text leaves the Mac (redacted first). -->
+        <div class="map-group">
+          <p class="map-group-label">☁ Goes to the cloud — redacted first</p>
+          @if (groups().cloud.length > 0) {
+            @for (row of groups().cloud; track row.job) {
+              <div class="map-row" [class.is-inactive]="!row.active">
+                <span class="map-title">{{ row.title }}</span>
+                <span class="map-engine">
+                  {{ row.engine }}
+                  @if (row.model) {
+                    <span class="map-model text-muted">· {{ row.model }}</span>
+                  }
+                  @if (!row.active) {
+                    <span class="map-off text-muted">— off</span>
+                  }
+                </span>
+                <span class="pill map-loc">
+                  <span class="pill-dot"></span>
+                  {{ row.redacted ? "Cloud · redacted" : "Cloud" }}
+                </span>
+                @if (row.routable) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm map-change"
+                    (click)="change(row.job)"
+                  >
+                    Change
+                  </button>
+                } @else {
+                  <span class="map-change-spacer" aria-hidden="true"></span>
+                }
+              </div>
             }
-          </div>
-        } @empty {
-          <p class="text-muted map-empty">Loading the routing map…</p>
-        }
-      </div>
+          } @else {
+            <p class="map-empty-cloud">✓ Nothing leaves this Mac.</p>
+          }
+        </div>
+
+        <!-- 🖥 On-Mac group — always private. -->
+        <div class="map-group">
+          <p class="map-group-label">🖥 Stays on your Mac — always private</p>
+          @for (row of groups().mac; track row.job) {
+            <div class="map-row" [class.is-inactive]="!row.active">
+              <span class="map-title">{{ row.title }}</span>
+              <span class="map-engine">
+                {{ row.engine }}
+                @if (row.model) {
+                  <span class="map-model text-muted">· {{ row.model }}</span>
+                }
+                @if (!row.active) {
+                  <span class="map-off text-muted">— off</span>
+                }
+              </span>
+              <span class="pill map-loc is-success">
+                <span class="pill-dot"></span>
+                On this Mac
+              </span>
+              @if (row.routable) {
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-sm map-change"
+                  (click)="change(row.job)"
+                >
+                  Change
+                </button>
+              } @else {
+                <span class="map-change-spacer" aria-hidden="true"></span>
+              }
+            </div>
+          }
+        </div>
+      }
     </div>
   `,
   styles: [
@@ -77,11 +133,32 @@ import { SettingsStore } from "../../settings.store";
       .map-sub {
         margin: 0;
         font-size: 0.8125rem;
+        line-height: 1.5;
       }
-      .map-rows {
+
+      /* ── Cloud vs on-Mac group ── */
+      .map-group + .map-group {
+        margin-top: var(--space-2);
+        padding-top: var(--space-4);
+        border-top: 1px solid var(--border-subtle);
+      }
+      .map-group-label {
         display: flex;
-        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+        margin: 0 0 var(--space-1);
+        font-size: 0.78rem;
+        font-weight: 650;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: var(--text-muted);
       }
+      .map-empty-cloud {
+        margin: var(--space-1) 0 0;
+        font-size: 0.875rem;
+        color: var(--success);
+      }
+
       .map-row {
         display: grid;
         grid-template-columns: minmax(150px, 0.55fr) 1fr auto auto;
@@ -90,7 +167,7 @@ import { SettingsStore } from "../../settings.store";
         padding: var(--space-2) 0;
         border-top: 1px solid var(--border-subtle);
       }
-      .map-row:first-of-type {
+      .map-group-label + .map-row {
         border-top: none;
       }
       .map-row.is-inactive .map-title,
@@ -141,8 +218,25 @@ export class AiResolvedMapComponent {
   private readonly store = inject(SettingsStore);
   readonly rows = this.store.aiMap;
 
-  /** A routable row's Change → open the Advanced disclosure below. */
-  change(): void {
+  /** Rows split by egress: cloud (`!onDevice`) vs on-Mac (`onDevice`). */
+  readonly groups = computed<{
+    cloud: readonly AiMapRow[];
+    mac: readonly AiMapRow[];
+  }>(() => {
+    const all = this.rows();
+    return {
+      cloud: all.filter((r) => !r.onDevice),
+      mac: all.filter((r) => r.onDevice),
+    };
+  });
+
+  /**
+   * A routable row's "Change" → open Advanced AND ask the role rows to scroll
+   * to + flash that role's override row. `job` is `notes`/`ask`/`live` on
+   * routable rows (the only rows with a Change button — backend `ai_map_rows`).
+   */
+  change(job: string): void {
     this.store.expandAdvanced();
+    this.store.requestHighlightRole(job as "notes" | "ask" | "live");
   }
 }

--- a/src/app/features/settings/sections/ai/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows.component.ts
@@ -1,10 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
   computed,
   effect,
   inject,
   signal,
+  viewChild,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { SettingsStore } from "../../settings.store";
@@ -81,9 +85,9 @@ interface RoleRowVm {
       </button>
 
       @if (expanded()) {
-        <div class="role-rows">
+        <div class="role-rows" #rolesContainer>
           @for (row of rows(); track row.role) {
-            <div class="role-row">
+            <div class="role-row" [attr.data-role]="row.role">
               <div class="role-row-head">
                 <span class="role-title">{{ row.title }}</span>
                 <span class="role-what text-muted">{{ row.what }}</span>
@@ -276,6 +280,25 @@ interface RoleRowVm {
         background: var(--surface-input);
         border: 1px solid var(--border-subtle);
       }
+      /* Flash when the map's "Change" scrolls to this row (accent ring pulse). */
+      .role-row.hl {
+        animation: role-hl 1.6s ease;
+        border-color: var(--accent);
+      }
+      @keyframes role-hl {
+        0%,
+        100% {
+          box-shadow: none;
+        }
+        25% {
+          box-shadow: 0 0 0 3px var(--accent-ring);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .role-row.hl {
+          animation: none;
+        }
+      }
       .role-row-head {
         display: flex;
         align-items: baseline;
@@ -327,15 +350,53 @@ interface RoleRowVm {
 })
 export class AiRoleRowsComponent {
   private readonly store = inject(SettingsStore);
+  private readonly injector = inject(Injector);
 
   readonly form = this.store.form;
 
   /** Disclosure state — collapsed by default (overrides are the power path). */
   readonly expanded = signal(false);
 
+  /** The `.role-rows` container — the anchor for the map's "Change" scroll. */
+  private readonly rolesContainer =
+    viewChild<ElementRef<HTMLElement>>("rolesContainer");
+
   toggleExpanded(): void {
     this.expanded.update((v) => !v);
   }
+
+  /**
+   * When the map's "Change" asks for a role (store.highlightRole()), open the
+   * disclosure and, after the row renders, scroll it into view + flash it, then
+   * clear the request. `allowSignalWrites` covers the synchronous `expanded`
+   * write (the store clear runs later, inside afterNextRender, so it's outside
+   * this effect's reactive context — no NG0600 either way). The store's
+   * null-then-set makes a repeat Change on the same row re-fire this effect.
+   */
+  private readonly _highlight = effect(
+    () => {
+      const role = this.store.highlightRole();
+      if (!role) return;
+      this.expanded.set(true);
+      afterNextRender(
+        () => {
+          const el = this.rolesContainer()?.nativeElement.querySelector<HTMLElement>(
+            `[data-role="${role}"]`,
+          );
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Restart the flash even if the class is already present.
+            el.classList.remove("hl");
+            void el.offsetWidth; // force reflow
+            el.classList.add("hl");
+          }
+          this.store.clearHighlightRole();
+        },
+        { injector: this.injector },
+      );
+    },
+    { allowSignalWrites: true },
+  );
 
   /**
    * Auto-open once when any override is active (loaded from config or just

--- a/src/app/features/settings/sections/ai/ai-setup-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-setup-block.component.ts
@@ -1,0 +1,658 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import type { BrainModelDto, ModelClass } from "../../../../core/models";
+import { SettingsStore } from "../../settings.store";
+
+/**
+ * One on-device model picker's derived view — everything the template needs to
+ * render a class's `<select>` + its download/ready/progress state + RAM nudge,
+ * computed once from the store's brain-model signals. Shared by the Hybrid
+ * "realtime reactions" light card and the Fully-local heavy+light pickers so the
+ * two never duplicate the resolution logic (spec §"On-device model picker").
+ */
+interface PickerVm {
+  readonly cls: ModelClass;
+  /** The model id the select currently reflects (selected, else auto-picked). */
+  readonly selectedId: string;
+  readonly selected: BrainModelDto | null;
+  readonly options: readonly { readonly id: string; readonly label: string }[];
+  /** This picker's chosen model is the one currently downloading. */
+  readonly downloading: boolean;
+  /** Chosen model is on disk (show a "Ready" pill). */
+  readonly ready: boolean;
+  /** Chosen model is not on disk yet (show a Download button). */
+  readonly needsDownload: boolean;
+  /** Warn: the chosen model may be tight on this Mac's RAM. */
+  readonly ramWarn: boolean;
+  readonly ramGb: number;
+  readonly name: string;
+}
+
+/**
+ * AI & Models → "Your setup" (NEW, posture-adaptive) — the second section of
+ * the posture-driven redesign (docs/superpowers/specs/2026-07-05-…). Posture
+ * picks the lane; this block shows ONLY what that lane needs to configure:
+ *
+ *   - Cloud            → the Default AI engine card.
+ *   - Hybrid           → engine card + an on-device light-model card (reactions).
+ *   - Fully local      → an on-device models card (heavy + light pickers + GGUF).
+ *   - Custom           → engine card + on-device models card + a "Custom mix" note.
+ *
+ * The Default-engine + Default-model controls are the SAME `providerId` /
+ * `providerModel` / `providerEffort` FormControls the old Advanced → Default
+ * engine block owned (moved here verbatim, one source of truth — no new second
+ * writer of any config key). The on-device pickers drive the existing store
+ * `useBrainModel` / `downloadBrainModel` actions. Backend untouched.
+ *
+ * Rendering is posture-driven via a `setupCards()` computed → `@for` + inner
+ * `@switch` so each card's markup is authored exactly once (no `ng-template` —
+ * this codebase has zero, and `@for`/`@switch` keep it DRY). In-flow cards, not
+ * overlays (T3).
+ */
+@Component({
+  selector: "app-ai-setup-block",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    @for (card of setupCards(); track card) {
+      @switch (card) {
+        @case ("engine") {
+          <div class="card setup-card" [formGroup]="form">
+            <div class="setup-head">
+              <h3>Your default AI engine</h3>
+              <p class="text-secondary setup-sub">
+                Writes your notes, answers and briefs. Cloud engines are redacted
+                before anything leaves.
+              </p>
+            </div>
+
+            <label class="field">
+              <span class="field-label">Engine</span>
+              <select formControlName="providerId" (change)="onEngineChanged($event)">
+                <option value="claude_code">Claude Code (default)</option>
+                <option value="anthropic">Anthropic API</option>
+                <option value="ollama">Ollama</option>
+                <option value="gateway">Kong AI Gateway (OpenAI-compatible)</option>
+              </select>
+            </label>
+
+            <!--
+              Model + reasoning-effort. providerModel steers ONLY the claude_code
+              /anthropic arms (gateway/ollama read their own connection-card
+              model), so the picker renders for those two — for gateway/ollama we
+              point at the connection card, now under Advanced.
+            -->
+            @switch (form.controls.providerId.value) {
+              @case ("gateway") {
+                <p class="field-help text-muted">
+                  The model for Kong AI Gateway is set in its connection card
+                  under Advanced.
+                </p>
+              }
+              @case ("ollama") {
+                <p class="field-help text-muted">
+                  The model for Ollama is set in its connection card under
+                  Advanced.
+                </p>
+              }
+              @default {
+                <div class="field">
+                  <span class="field-label">Model</span>
+                  <div class="model-row">
+                    @if (defaultModelCatalog().length > 0) {
+                      <select formControlName="providerModel" class="model-select">
+                        <option value="">Default (provider's pick)</option>
+                        @for (id of defaultModelCatalog(); track id) {
+                          <option [value]="id">{{ id }}</option>
+                        }
+                        @if (defaultModelIsCustom()) {
+                          <option [value]="form.controls.providerModel.value">
+                            {{ form.controls.providerModel.value }} (custom)
+                          </option>
+                        }
+                      </select>
+                    } @else {
+                      <input
+                        formControlName="providerModel"
+                        placeholder="Model id (blank = provider's pick)"
+                        autocomplete="off"
+                        spellcheck="false"
+                        class="model-input"
+                      />
+                    }
+                    <button
+                      type="button"
+                      class="btn btn-ghost model-refresh"
+                      (click)="refreshDefaultModels()"
+                      [disabled]="defaultModelsLoading()"
+                      title="Fetch this provider's model list"
+                    >
+                      @if (defaultModelsLoading()) {
+                        Loading…
+                      } @else {
+                        ↻ Refresh
+                      }
+                    </button>
+                  </div>
+                </div>
+              }
+            }
+
+            @if (form.controls.providerId.value === "anthropic") {
+              <label class="field">
+                <span class="field-label">Reasoning effort</span>
+                <select formControlName="providerEffort">
+                  <option value="">Default</option>
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                </select>
+              </label>
+            }
+
+            <div class="setup-foot">
+              @if (providerIsCloud()) {
+                <span class="pill">
+                  <span class="pill-dot"></span>
+                  Cloud · redacted first
+                </span>
+              } @else {
+                <span class="pill is-success">
+                  <span class="pill-dot"></span>
+                  On this Mac · nothing leaves
+                </span>
+              }
+              <button type="button" class="setup-link" (click)="expandAdvanced()">
+                Set up &amp; test engines →
+              </button>
+            </div>
+          </div>
+        }
+
+        @case ("reactions") {
+          <div class="card setup-card">
+            <div class="setup-head">
+              <h3>On-device model — realtime reactions</h3>
+              <p class="text-secondary setup-sub">
+                A small model runs live during meetings for instant reactions &amp;
+                fact-spotting. Stays on this Mac.
+              </p>
+            </div>
+            @if (lightPicker(); as vm) {
+              <div class="inline-row">
+                <select
+                  class="picker-select"
+                  [value]="vm.selectedId"
+                  (change)="pick($any($event.target).value)"
+                >
+                  @for (o of vm.options; track o.id) {
+                    <option [value]="o.id">{{ o.label }}</option>
+                  }
+                </select>
+                @if (vm.downloading) {
+                  <div class="brain-progress" role="status">
+                    <div class="brain-progress-track" aria-hidden="true">
+                      <div
+                        class="brain-progress-fill"
+                        [style.width.%]="brainDownloadFrac() * 100"
+                      ></div>
+                    </div>
+                    <span class="brain-progress-label text-muted">
+                      {{ brainPct() }}
+                    </span>
+                  </div>
+                } @else if (vm.needsDownload) {
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-sm"
+                    (click)="download(vm.selectedId)"
+                    [disabled]="brainDownloadingId() !== null"
+                  >
+                    Download
+                  </button>
+                } @else if (vm.ready) {
+                  <span class="pill is-success">
+                    <span class="pill-dot"></span>
+                    Ready
+                  </span>
+                }
+              </div>
+              @if (vm.ramWarn) {
+                <span class="ram-warn">
+                  ⚠ {{ vm.name }} needs ≥{{ vm.ramGb }} GB RAM — may be slow
+                  alongside recording on a smaller Mac.
+                </span>
+              }
+            }
+          </div>
+        }
+
+        @case ("local") {
+          <div class="card setup-card">
+            <div class="setup-head">
+              <h3>Your on-device models</h3>
+              <p class="text-secondary setup-sub">
+                Everything runs here. Pick the models Murmur uses — bigger = better
+                notes but slower &amp; more RAM.
+              </p>
+            </div>
+
+            @if (heavyPicker(); as vm) {
+              <div class="field">
+                <span class="field-label">
+                  Notes &amp; Ask
+                  <span class="text-muted picker-sub">
+                    — heavy model, runs after the meeting
+                  </span>
+                </span>
+                <div class="inline-row">
+                  <select
+                    class="picker-select"
+                    [value]="vm.selectedId"
+                    (change)="pick($any($event.target).value)"
+                  >
+                    @for (o of vm.options; track o.id) {
+                      <option [value]="o.id">{{ o.label }}</option>
+                    }
+                  </select>
+                  @if (vm.downloading) {
+                    <div class="brain-progress" role="status">
+                      <div class="brain-progress-track" aria-hidden="true">
+                        <div
+                          class="brain-progress-fill"
+                          [style.width.%]="brainDownloadFrac() * 100"
+                        ></div>
+                      </div>
+                      <span class="brain-progress-label text-muted">
+                        {{ brainPct() }}
+                      </span>
+                    </div>
+                  } @else if (vm.needsDownload) {
+                    <button
+                      type="button"
+                      class="btn btn-primary btn-sm"
+                      (click)="download(vm.selectedId)"
+                      [disabled]="brainDownloadingId() !== null"
+                    >
+                      Download
+                    </button>
+                  } @else if (vm.ready) {
+                    <span class="pill is-success">
+                      <span class="pill-dot"></span>
+                      Ready
+                    </span>
+                  }
+                </div>
+                @if (vm.ramWarn) {
+                  <span class="ram-warn">
+                    ⚠ {{ vm.name }} needs ≥{{ vm.ramGb }} GB RAM — may be slow
+                    alongside recording on a smaller Mac.
+                  </span>
+                }
+              </div>
+            }
+
+            @if (lightPicker(); as vm) {
+              <div class="field">
+                <span class="field-label">
+                  Live &amp; realtime reactions
+                  <span class="text-muted picker-sub">
+                    — light model, runs during the meeting
+                  </span>
+                </span>
+                <div class="inline-row">
+                  <select
+                    class="picker-select"
+                    [value]="vm.selectedId"
+                    (change)="pick($any($event.target).value)"
+                  >
+                    @for (o of vm.options; track o.id) {
+                      <option [value]="o.id">{{ o.label }}</option>
+                    }
+                  </select>
+                  @if (vm.downloading) {
+                    <div class="brain-progress" role="status">
+                      <div class="brain-progress-track" aria-hidden="true">
+                        <div
+                          class="brain-progress-fill"
+                          [style.width.%]="brainDownloadFrac() * 100"
+                        ></div>
+                      </div>
+                      <span class="brain-progress-label text-muted">
+                        {{ brainPct() }}
+                      </span>
+                    </div>
+                  } @else if (vm.needsDownload) {
+                    <button
+                      type="button"
+                      class="btn btn-primary btn-sm"
+                      (click)="download(vm.selectedId)"
+                      [disabled]="brainDownloadingId() !== null"
+                    >
+                      Download
+                    </button>
+                  } @else if (vm.ready) {
+                    <span class="pill is-success">
+                      <span class="pill-dot"></span>
+                      Ready
+                    </span>
+                  }
+                </div>
+                @if (vm.ramWarn) {
+                  <span class="ram-warn">
+                    ⚠ {{ vm.name }} needs ≥{{ vm.ramGb }} GB RAM — may be slow
+                    alongside recording on a smaller Mac.
+                  </span>
+                }
+              </div>
+            }
+
+            @if (posture() === "fully_local") {
+              <label class="field">
+                <span class="field-label">Custom GGUF model</span>
+                <input
+                  [value]="customGgufValue()"
+                  (input)="setCustomGguf($any($event.target).value)"
+                  placeholder="/path/to/model.gguf or a registry id"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <span class="field-help text-muted">
+                  Point at your own .gguf file, or type a registry id. Saved with
+                  your settings.
+                </span>
+              </label>
+            }
+
+            @if (brainError(); as berr) {
+              <p class="text-danger setup-error">{{ berr }}</p>
+            }
+          </div>
+        }
+
+        @case ("custom-note") {
+          <p class="custom-note text-muted">
+            Custom mix — you've routed features individually. See
+            <strong>What runs where</strong> below, tune under <strong>Advanced</strong>.
+          </p>
+        }
+      }
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+
+      .setup-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .setup-head {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .setup-head h3 {
+        margin: 0;
+      }
+      .setup-sub {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }
+
+      /* Stacked label + control (mirrors the other AI blocks). */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .field-label {
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        font-weight: 550;
+      }
+      .field-help {
+        margin: 0;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+      .picker-sub {
+        font-weight: 400;
+      }
+
+      /* Select-or-input + catalog refresh. */
+      .model-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .model-select,
+      .model-input {
+        flex: 1 1 220px;
+        min-width: 0;
+      }
+      .model-refresh {
+        flex: none;
+        white-space: nowrap;
+      }
+
+      /* On-device picker row: select + state. */
+      .inline-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .picker-select {
+        flex: 1 1 240px;
+        min-width: 0;
+      }
+
+      .setup-foot {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .setup-link {
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.85rem;
+        font-weight: 550;
+        transition: color var(--transition);
+      }
+      .setup-link:hover {
+        color: var(--text-primary);
+      }
+
+      .ram-warn {
+        font-size: 0.8125rem;
+        line-height: 1.5;
+        color: var(--warning);
+      }
+      .setup-error {
+        margin: 0;
+        font-size: 0.85rem;
+      }
+      .custom-note {
+        margin: 0 0 var(--space-4);
+        font-size: 0.85rem;
+        line-height: 1.55;
+      }
+      .custom-note strong {
+        color: var(--text-secondary);
+        font-weight: 600;
+      }
+
+      /* Download progress (reused shape from local-models-list). */
+      .brain-progress {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 120px;
+      }
+      .brain-progress-track {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--surface-raised);
+        overflow: hidden;
+      }
+      .brain-progress-fill {
+        height: 100%;
+        background: var(--accent);
+        border-radius: 3px;
+        transition: width var(--transition);
+      }
+      .brain-progress-label {
+        font-size: 0.75rem;
+      }
+
+      .btn-sm {
+        height: 32px;
+        padding: 0 var(--space-3);
+        font-size: 0.8125rem;
+      }
+    `,
+  ],
+})
+export class AiSetupBlockComponent {
+  private readonly store = inject(SettingsStore);
+
+  readonly form = this.store.form;
+
+  // ── posture / engine wires ────────────────────────────────────────────────
+  readonly posture = this.store.posture;
+  readonly providerIsCloud = this.store.providerIsCloud;
+  readonly defaultModelCatalog = this.store.defaultModelCatalog;
+  readonly defaultModelsLoading = this.store.defaultModelsLoading;
+  readonly defaultModelIsCustom = this.store.defaultModelIsCustom;
+
+  // ── on-device model wires ─────────────────────────────────────────────────
+  readonly brainDownloadingId = this.store.brainDownloadingId;
+  readonly brainDownloadFrac = this.store.brainDownloadFrac;
+  readonly brainPct = this.store.brainPct;
+  readonly brainError = this.store.brainError;
+  readonly customGgufValue = this.store.customGgufValue;
+
+  /**
+   * Which cards this posture shows, in order — the `@for`+`@switch` driver.
+   * Cloud=engine; Hybrid=engine+reactions; Fully local=local; Custom=both+note.
+   * Null (pre-load) → no cards (the map card below owns the loading state).
+   */
+  readonly setupCards = computed<readonly string[]>(() => {
+    switch (this.posture()) {
+      case "cloud":
+        return ["engine"];
+      case "hybrid":
+        return ["engine", "reactions"];
+      case "fully_local":
+        return ["local"];
+      case "custom":
+        return ["engine", "local", "custom-note"];
+      default:
+        return [];
+    }
+  });
+
+  /** The heavy-class on-device picker (Notes & Ask). */
+  readonly heavyPicker = computed(() => this.buildPicker("heavy"));
+  /** The light-class on-device picker (Live & realtime reactions). */
+  readonly lightPicker = computed(() => this.buildPicker("light"));
+
+  /** Prefetch the newly-picked engine's model catalog (claude_code/anthropic). */
+  onEngineChanged(e: Event): void {
+    const id = (e.target as HTMLSelectElement).value;
+    if (id === "claude_code" || id === "anthropic") {
+      void this.store.ensureModels(id);
+    }
+  }
+
+  /** Re-fetch the Default-model catalog for the current provider. */
+  refreshDefaultModels(): void {
+    void this.store.refreshModels(this.form.controls.providerId.value);
+  }
+
+  /** Open the Advanced disclosure (keys/URLs/Test live there). */
+  expandAdvanced(): void {
+    this.store.expandAdvanced();
+  }
+
+  /** Make a picker's chosen model the active on-device model. */
+  pick(id: string): void {
+    if (id) void this.store.useBrainModel(id);
+  }
+
+  /** Download a picker's chosen (not-yet-present) model. */
+  download(id: string): void {
+    if (id) void this.store.downloadBrainModel(id);
+  }
+
+  /** Route a typed custom GGUF value to the right store control. */
+  setCustomGguf(v: string): void {
+    this.store.setCustomGguf(v);
+  }
+
+  /**
+   * Build a class's picker view from the store's brain-model signals. The select
+   * reflects the SELECTED model of that class, else the auto-pick (smallest that
+   * fits RAM), else the first available — so it always shows the model that would
+   * actually run. Runs inside a `computed`, so reads are tracked.
+   */
+  private buildPicker(cls: ModelClass): PickerVm {
+    const models = this.store.brainModels().filter((m) => m.class === cls);
+    const selectedId =
+      models.find((m) => m.selected)?.id ??
+      this.store.autoPickForClass(cls)?.id ??
+      models[0]?.id ??
+      "";
+    const selected = models.find((m) => m.id === selectedId) ?? null;
+    const options = models.map((m) => {
+      const langs = m.languages.length ? m.languages.join("/") : "";
+      const parts = [m.name, langs, this.sizeLabel(m.approxSizeBytes)].filter(
+        (p) => p.length > 0,
+      );
+      let label = parts.join(" · ");
+      if (!m.downloaded) label += " · ⬇ download";
+      return { id: m.id, label };
+    });
+    return {
+      cls,
+      selectedId,
+      selected,
+      options,
+      downloading: !!selectedId && this.store.brainDownloadingId() === selectedId,
+      ready: !!selected?.downloaded,
+      needsDownload: !!selected && !selected.downloaded,
+      // Warn when it won't fit, or it's a large heavy model (RAM-hungry alongside
+      // recording) — data-driven (minRamGb), no hardcoded ids.
+      ramWarn:
+        !!selected &&
+        (!selected.fitsRam || (cls === "heavy" && selected.minRamGb >= 10)),
+      ramGb: selected?.minRamGb ?? 0,
+      name: selected?.name ?? "",
+    };
+  }
+
+  /** Friendly "~1.1 GB" / "~620 MB" size label from a byte count. */
+  private sizeLabel(bytes: number): string {
+    const gb = 1024 * 1024 * 1024;
+    return bytes >= gb
+      ? (bytes / gb).toFixed(1) + " GB"
+      : Math.round(bytes / (1024 * 1024)) + " MB";
+  }
+}

--- a/src/app/features/settings/sections/ai/brain-engine-card.component.ts
+++ b/src/app/features/settings/sections/ai/brain-engine-card.component.ts
@@ -25,7 +25,7 @@ import { LocalModelsListComponent } from "./local-models-list.component";
     <div class="brain-card">
       <div class="brain-row">
         <div class="brain-main">
-          <span class="brain-name">Murmur Brain</span>
+          <span class="brain-name">On this Mac — built-in models</span>
           @if (ready()) {
             <span class="pill is-success">
               <span class="pill-dot"></span>

--- a/src/app/features/settings/sections/ai/brain-posture-block.component.ts
+++ b/src/app/features/settings/sections/ai/brain-posture-block.component.ts
@@ -27,9 +27,9 @@ import { SettingsStore } from "../../settings.store";
     <div class="card posture-card">
       <!-- Intro header — frames the section before the posture chooser. -->
       <div class="posture-head-copy">
-        <h3>What Murmur uses</h3>
+        <h3>Where your AI runs</h3>
         <p class="text-secondary posture-intro">
-          Pick how much runs on this Mac. The map below shows exactly what runs where — tune it under Advanced.
+          Pick how much runs on this Mac. Everything below adapts to your choice — no jargon to untangle.
         </p>
       </div>
 
@@ -114,6 +114,18 @@ import { SettingsStore } from "../../settings.store";
             </span>
           </button>
         </div>
+
+        <!--
+          Plain-language meaning of the SELECTED posture (keyed on posture()),
+          so the choice reads in words, not jargon. Shown for every posture
+          incl. the derived "custom" state; hidden pre-load (null).
+        -->
+        @if (postureMeaning(); as meaning) {
+          <p class="posture-meaning">
+            <span class="posture-meaning-lead">{{ meaning.lead }}</span>
+            {{ meaning.body }}
+          </p>
+        }
 
         <!--
           Contextual state area — replaces the old static field-help and the
@@ -201,7 +213,6 @@ import { SettingsStore } from "../../settings.store";
               Staying on your current setup until it's ready.
             </span>
           } @else {
-            <p class="text-secondary posture-now">{{ postureStateLine() }}</p>
             @for (n of neededModels(); track n.role) {
               <span class="pill" [class.is-success]="n.model?.downloaded">
                 <span class="pill-dot"></span>{{ n.role === "notes" ? "Notes & Ask" : "Reactions" }}: {{ n.model?.name ?? "—" }}{{ n.model?.downloaded ? " ✓" : "" }}
@@ -334,16 +345,22 @@ import { SettingsStore } from "../../settings.store";
         line-height: 1.4;
       }
 
+      /* ── Selected-posture meaning line ── */
+      .posture-meaning {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+      .posture-meaning-lead {
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+
       /* ── Contextual state area ── */
       .posture-state {
         display: flex;
         flex-direction: column;
         gap: var(--space-2);
-      }
-      .posture-now {
-        margin: 0;
-        font-size: 0.875rem;
-        line-height: 1.55;
       }
       /* Confirm-before-download card: an explicit opt-in, not an auto-fetch. */
       .posture-confirm-title {
@@ -442,7 +459,6 @@ export class BrainPostureBlockComponent {
   readonly pendingConfirm = this.store.pendingConfirm;
   readonly confirmModels = this.store.confirmModels;
   readonly confirmDownloadBytes = this.store.confirmDownloadBytes;
-  readonly postureStateLine = this.store.postureStateLine;
   readonly neededModels = this.store.neededModels;
   readonly brainDownloadingId = this.store.brainDownloadingId;
   readonly brainDownloadFrac = this.store.brainDownloadFrac;
@@ -453,6 +469,39 @@ export class BrainPostureBlockComponent {
 
   /** Full model list — used to resolve the downloading model's display name. */
   private readonly brainModels = this.store.brainModels;
+
+  /**
+   * Plain-language meaning of the selected posture — a `{ lead, body }` pair so
+   * the template can bold the lead. Null before the posture loads (no flash).
+   */
+  readonly postureMeaning = computed(
+    (): { lead: string; body: string } | null => {
+      switch (this.posture()) {
+        case "cloud":
+          return {
+            lead: "Cloud.",
+            body: "Your default engine writes your notes, answers and briefs — sent redacted after your consent. Recording, transcription, search and name-detection still happen only on this Mac.",
+          };
+        case "hybrid":
+          return {
+            lead: "Hybrid ⭐ — recommended.",
+            body: "Same cloud quality for notes & answers, but realtime in-meeting reactions run on a small model on this Mac, so nothing leaves live.",
+          };
+        case "fully_local":
+          return {
+            lead: "Fully local.",
+            body: "Every AI job runs on this Mac using built-in models. Nothing ever leaves. Bigger models are slower and need more RAM.",
+          };
+        case "custom":
+          return {
+            lead: "Custom mix.",
+            body: "You've routed features individually — see What runs where below, tune under Advanced.",
+          };
+        default:
+          return null;
+      }
+    },
+  );
 
   /**
    * Display name of the model currently downloading, looked up from

--- a/src/app/features/settings/sections/settings-ai-section.component.ts
+++ b/src/app/features/settings/sections/settings-ai-section.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { AiAdvancedBlockComponent } from "./ai/ai-advanced-block.component";
 import { AiPrivacyStripComponent } from "./ai/ai-privacy-strip.component";
 import { AiResolvedMapComponent } from "./ai/ai-resolved-map.component";
+import { AiSetupBlockComponent } from "./ai/ai-setup-block.component";
 import { BrainPostureBlockComponent } from "./ai/brain-posture-block.component";
 import { DuringMeetingsBlockComponent } from "./ai/during-meetings-block.component";
 import { OnDeviceIntelligenceBlockComponent } from "./ai/on-device-intelligence-block.component";
@@ -9,17 +10,18 @@ import { OnDeviceIntelligenceBlockComponent } from "./ai/on-device-intelligence-
 /**
  * Settings → "AI & Models" section (Stage-2 hub): the former Brain & AI +
  * Providers sections (and General's provider dropdown) collapsed into one
- * surface, per docs/research/2026-07-02-unify-model-settings.md. Five
- * blocks, each its own child under ./ai (keeps every component well under
- * the style budget):
- *   A — Brain posture (Cloud / Hybrid / Fully local preset — Task 2);
- *   B — Advanced disclosure (Task 4): collapsed expander wrapping provider
- *       connection cards + Default AI + per-feature role rows;
- *   C — Live during meetings (Task 5): in-meeting voice assistant +
- *       proactive hints toggles + cloud-egress consent warning;
- *   D — On-device intelligence (Task 5): always-on badges + semantic
- *       search toggle + embedding-model download + re-index controls;
- *   E — Privacy strip (where-your-text-goes consent Allow/Revoke).
+ * surface, per docs/research/2026-07-02-unify-model-settings.md and the
+ * posture-driven redesign (docs/superpowers/specs/2026-07-05-…). Blocks,
+ * each its own child under ./ai (keeps every component well under the style
+ * budget):
+ *   A — Where your AI runs (Cloud / Hybrid / Fully local posture hero);
+ *   B — Your setup (posture-adaptive): the Default AI engine and/or the
+ *       on-device model pickers for the chosen lane;
+ *   C — What runs where: the resolved map, grouped cloud vs on-Mac;
+ *   D — Advanced disclosure: connection cards + per-feature role rows;
+ *   E — Live during meetings: in-meeting voice assistant + proactive hints;
+ *   F — On-device intelligence: always-on badges + semantic search + models;
+ *   G — Privacy strip (where-your-text-goes consent Allow/Revoke).
  * All state stays in the shell-provided SettingsStore.
  */
 @Component({
@@ -28,6 +30,7 @@ import { OnDeviceIntelligenceBlockComponent } from "./ai/on-device-intelligence-
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     BrainPostureBlockComponent,
+    AiSetupBlockComponent,
     AiResolvedMapComponent,
     AiAdvancedBlockComponent,
     DuringMeetingsBlockComponent,
@@ -36,6 +39,7 @@ import { OnDeviceIntelligenceBlockComponent } from "./ai/on-device-intelligence-
   ],
   template: `
     <app-brain-posture-block />
+    <app-ai-setup-block />
     <app-ai-resolved-map />
     <app-ai-advanced-block />
     <app-during-meetings-block />

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -848,6 +848,32 @@ export class SettingsStore {
   }
 
   /**
+   * The per-feature role row the map's "Change" wants the Advanced block to
+   * scroll to + flash. Written by `requestHighlightRole`, consumed by
+   * `AiRoleRowsComponent` (which opens the disclosure, scrolls the row into
+   * view, and flashes it), then cleared via `clearHighlightRole` once handled.
+   */
+  private readonly _highlightRole = signal<"notes" | "ask" | "live" | null>(
+    null,
+  );
+  readonly highlightRole = this._highlightRole.asReadonly();
+
+  /**
+   * Ask the role rows to scroll to + flash `role`. The null-then-set makes a
+   * REPEAT click on the same row's "Change" re-fire the highlight even when the
+   * value is unchanged (a plain `.set(role)` would be a no-op for the effect).
+   */
+  requestHighlightRole(role: "notes" | "ask" | "live"): void {
+    this._highlightRole.set(null);
+    this._highlightRole.set(role);
+  }
+
+  /** Clear the highlight request once the role rows have handled it. */
+  clearHighlightRole(): void {
+    this._highlightRole.set(null);
+  }
+
+  /**
    * The posture mid-download (drives the target-card progress indicator).
    * Non-null only while `setPosture` is downloading absent needed models.
    */
@@ -903,28 +929,9 @@ export class SettingsStore {
     this.neededModelsFor(this.posture()),
   );
 
-  /**
-   * The "right now" one-sentence summary for the active posture — for the
-   * posture state-line in the redesigned AI & Models block (Task 2).
-   *
-   * Returns "" when `posture()` is null (not yet loaded), so the template never
-   * shows "Custom" as a pre-load flash. "Custom" is returned only for the actual
-   * `"custom"` posture value.
-   */
-  readonly postureStateLine = computed((): string => {
-    switch (this.posture()) {
-      case "cloud":
-        return "Claude Code writes everything — notes, answers, briefs. Only transcription runs on this Mac.";
-      case "hybrid":
-        return "Claude writes notes; your Mac runs realtime reactions and keeps fact-extraction on-device.";
-      case "fully_local":
-        return "Everything runs on this Mac. Nothing leaves. @brain answers run on-device (private, a little slower live).";
-      case "custom":
-        return "Custom — some features run on-device, some in the cloud.";
-      default:
-        return ""; // null = posture not yet loaded — show nothing rather than a misleading "Custom"
-    }
-  });
+  // (The old `postureStateLine` summary was replaced by the per-posture
+  // `postureMeaning()` line in brain-posture-block — more accurate about which
+  // jobs stay on-device, and not hardcoded to "Claude Code" as the writer.)
 
   /**
    * The installed-base retirement nudge (`brain_model_retirement_nudge`), or null.


### PR DESCRIPTION
## Why

The **AI & Models** settings screen was "still heavy to understand" (user report, with screenshots). Three concrete failures:

1. **"Change" did nothing** — it only expanded a far-below-the-fold Advanced with no scroll, so nothing visibly happened.
2. **"Pick Cloud, but things are suddenly local"** — the flat *What runs where* list rendered the always-on-device jobs (transcription, search, name-redaction, reactions) next to the cloud rows with no grouping, reading as a contradiction. Advanced also showed every engine + the whole local-model download machinery regardless of posture.
3. **No organization by posture** — everything shown at once.

## What

Posture picks the lane; each section shows **only what that posture needs**. Backend untouched (pure Angular re-composition of `src/app/features/settings/sections/ai/*` + one store signal).

- **Where your AI runs** — posture hero (Cloud / Hybrid ⭐ / Fully local) + a per-posture plain-language meaning line.
- **Your setup** (NEW `ai-setup-block`) — adaptive: Cloud → default AI engine card; Hybrid → engine + on-device realtime-reactions model; Fully local → on-device heavy/light pickers + custom GGUF; Custom → both.
- **What runs where** — the same honest resolver mirror, now grouped **☁ Goes to the cloud — redacted first** vs **🖥 Stays on your Mac — always private** (strictly by the resolver DTO's `onDevice`). Fully local shows "✓ Nothing leaves this Mac." The pill reads the DTO `redacted` field.
- **Change** now opens Advanced **and** scrolls to + flashes the targeted role's override row (new `highlightRole` signal + role-rows highlight effect via `afterNextRender`).
- **▸ Advanced** — collapsed power path: per-feature overrides + all engine connections. The Default-engine controls moved up into *Your setup* (relocated, single writer — no new second writer of posture/role keys).
- Naming simplified: "Murmur Brain" engine label → **"On this Mac — built-in models"**; posture heading → **"Where your AI runs"**.

## How verified

- Design signed off via a clickable prototype (`docs/superpowers/prototypes/2026-07-05-ai-models-redesign.html`); spec at `docs/superpowers/specs/2026-07-05-ai-models-posture-redesign.md`.
- `npx ng lint` — clean; `npx ng build` — clean (only the pre-existing, untouched `library.component.ts` budget warning).
- **adversarial-verifier: PASS** — live-reproduced all 4 postures + the Change scroll/flash against `:1420` with a mocked stateful Tauri `invoke`; 0 console errors, no NG0600; confirmed the map groups strictly by the DTO `onDevice` (no hardcoded locality) and the relocated `providerId`/`providerModel` are a single writer that still saves. Two findings (a hardcoded pill string; a redundant idle line) fixed in this branch.
- FE-only — backend byte-identical to trunk; `cargo test --lib` unaffected.