### PR TITLE
fix(ai): hide + block Live-during-meetings under the Cloud posture

### DIFF
--- a/src-tauri/src/settings/postures.rs
+++ b/src-tauri/src/settings/postures.rs
@@ -130,6 +130,10 @@ pub fn apply_posture(cfg: &mut AppConfig, posture: Posture) {
     match posture {
         Posture::Cloud => {
             cfg.brain_live = false;
+            // The in-meeting voice assistant is "only meaningful while brain_live is on" (it needs the
+            // on-device light engine for wake detection), so it CANNOT run in Cloud — force it off so
+            // the state matches the UI (which hides it) and it can never be a dangling-on setting.
+            cfg.realtime_reactions = false;
             cfg.brain_backend = BrainBackend::Cloud;
             clear_role(cfg, Role::Notes);
             clear_role(cfg, Role::Ask);

--- a/src/app/features/settings/sections/ai/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows.component.ts
@@ -434,7 +434,8 @@ export class AiRoleRowsComponent {
   );
 
   /** The three override rows, derived from the store's role/catalog signals. */
-  readonly rows = computed<RoleRowVm[]>(() => [
+  readonly rows = computed<RoleRowVm[]>(() => {
+    const all: RoleRowVm[] = [
     this.buildRow(
       "notes",
       "Meeting notes",
@@ -471,7 +472,15 @@ export class AiRoleRowsComponent {
       this.store.roleLiveModelValue(),
       this.store.assistantInheritSummary(),
     ),
-  ]);
+    ];
+    // "Live during meetings" (@brain threads + the voice assistant) is HIDDEN under the Cloud posture:
+    // the voice assistant can't run there (it needs the on-device light engine, which Cloud turns off),
+    // and @brain threads just inherit the cloud default — so a per-feature override is moot. Shown in
+    // Hybrid / Fully local / Custom.
+    return this.store.posture() === "cloud"
+      ? all.filter((r) => r.role !== "live")
+      : all;
+  });
 
   private buildRow(
     role: RoleRowVm["role"],

--- a/src/app/features/settings/sections/ai/during-meetings-block.component.ts
+++ b/src/app/features/settings/sections/ai/during-meetings-block.component.ts
@@ -25,17 +25,23 @@ import { SettingsStore } from "../../settings.store";
       <div class="use-group">
         <span class="use-group-label text-muted">Live during meetings</span>
 
-        <label class="toggle-row">
-          <span class="toggle-copy">
-            <span class="toggle-title">In-meeting voice assistant</span>
-            <span class="text-secondary toggle-sub">
-              Listen for your wake phrase during a recording and answer
-              grounded questions live, with sources. Off by default — it adds
-              listening and (for cloud) sends audio-derived text mid-meeting.
+        <!-- The in-meeting voice assistant needs the on-device light engine for wake detection
+             (brain_live), which the Cloud posture turns off — so it CANNOT run there. Hide it in
+             Cloud rather than show a toggle that does nothing (the Cloud preset also forces it off
+             backend-side). It stays available in Hybrid / Fully local. -->
+        @if (posture() !== "cloud") {
+          <label class="toggle-row">
+            <span class="toggle-copy">
+              <span class="toggle-title">In-meeting voice assistant</span>
+              <span class="text-secondary toggle-sub">
+                Listen for your wake phrase during a recording and answer
+                grounded questions live, with sources. Off by default — it adds
+                listening and (for cloud) sends audio-derived text mid-meeting.
+              </span>
             </span>
-          </span>
-          <input type="checkbox" formControlName="realtimeReactions" />
-        </label>
+            <input type="checkbox" formControlName="realtimeReactions" />
+          </label>
+        }
 
         <label class="toggle-row">
           <span class="toggle-copy">
@@ -63,6 +69,7 @@ import { SettingsStore } from "../../settings.store";
           correct (no opaque overlay needed).
         -->
         @if (
+          posture() !== "cloud" &&
           form.controls.realtimeReactions.value &&
           liveTargetIsCloud() &&
           !cloudConsented()
@@ -209,6 +216,9 @@ export class DuringMeetingsBlockComponent {
   readonly consenting = this.store.consenting;
   readonly consentError = this.store.consentError;
   readonly liveTargetIsCloud = this.store.liveTargetIsCloud;
+  /** The derived brain posture — the in-meeting voice assistant is hidden under `cloud` (it needs the
+   * on-device light engine, which Cloud turns off, so it can't be enabled there). */
+  readonly posture = this.store.posture;
 
   allowCloudProcessing(): void {
     void this.store.allowCloudProcessing();


### PR DESCRIPTION
The in-meeting voice assistant needs the on-device light engine (brain_live), which Cloud turns off — so it can't run in Cloud. Hide the toggle + the per-feature engine row there, and force realtime_reactions off in the Cloud preset. Proactive hints (on-device) stay. Green gates.