### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.6.4"
+version = "0.7.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 0.6.4 → 0.7.0. The big release — Murmur Brain (on-device) + zero-knowledge E2EE sharing + note-detail Note/Audio/Share redesign + posture-first AI settings + reliability/privacy hardening. Security-reviewed (GO) + full MINOR hardening backlog closed.