### PR TITLE
fix(keychain): keychain-access-groups entitlement for the biometric DP keychain

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -30,5 +30,19 @@
          rides the existing redacted-transcript firewall + consent. -->
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
+
+    <!-- Keychain-access-groups — REQUIRED for the data-protection keychain (kSecUseDataProtectionKeychain
+         = true) that stores the biometric/Touch-ID-gated secrets (the per-folder master KEK + the
+         account MK cache). Without an access group, a Developer-ID app (no provisioning profile) has no
+         default DP-keychain group, so SecItemAdd/CopyMatching on those items fail with
+         errSecMissingEntitlement (-34018) — which broke folder lock ("Couldn't change this folder's
+         lock") and sharing ("Sharing is locked this session") on the notarized build. The value MUST
+         carry the Team-ID prefix; com.apple.application-identifier is NOT needed (that's App Store).
+         Does NOT affect the FILE-BASED keychain (the DB DEK via `keyring`) — a separate store that
+         never sees -34018. -->
+    <key>keychain-access-groups</key>
+    <array>
+      <string>BVF778E5QD.com.meetnotes.app</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
The Touch-ID-gated folder-lock KEK + account-MK use the data-protection keychain, which on a Developer-ID app fails with errSecMissingEntitlement (-34018) without a keychain-access-group → folder lock + sharing broke on the notarized build. Adds keychain-access-groups (Team-ID prefix). File-based DEK unaffected.