### PR TITLE
Brain competitive 4-steps: Enable-the-brain onboarding + Jira & Slack live connectors + deterministic note verify

### DIFF
--- a/docs/research/2026-07-05-competing-with-clickup-brain.md
+++ b/docs/research/2026-07-05-competing-with-clickup-brain.md
@@ -1,0 +1,78 @@
+<!-- Generated 2026-07-05 via /research (1 code-grounding murmur-researcher + synthesis over 2026-07-02-clickup-brain-gap-analysis.md and 2026-07-05-connectors-live-vs-rag.md). ClickUp facts = point-in-time from the 07-02 report. -->
+# Research: Competing with ClickUp Brain — the plan now that the brain + connectors decisions are in
+
+## TL;DR / Verdict
+
+**The three gaps the 2026-07-02 gap-analysis called "positioning-critical" are now CLOSED in shipped code (0.7.0–0.7.4).** Persistent user memory exists, is injected into all four answer surfaces, is auditable and lock-gated (`user_memory.rs`); threads persist (`assistant_interactions` + `thread_id`); Ask runs on the unified agentic loop with a deterministic floor (`commands.rs::ask_vault`, "PR G"); proactive/ambient ships twice over (zero-egress `proactive.rs` cards + `brain_reactions.rs` "Whisper"). The bake-off validated semantic retrieval (recall@5 1.00 vs 0.42, test corpus).
+
+**What actually separates us from ClickUp Brain today is exactly ONE pillar: connected sources (their 9 vs our 3).** And the connectors research (2026-07-05) already settled the architecture: live, per-source, no RAG index. The competitive plan is therefore short:
+
+1. **Fix the "dead on fresh install" trap first (S).** Memory extraction returns empty on the stub reasoner and semantic falls back to FTS until the user manually downloads models — so the two class-membership features we shipped are OFF for a fresh user. One-click / onboarding-prompted brain-model download is the cheapest, highest-leverage competitive move on the list.
+2. **Ship the dev-stack connectors ClickUp does NOT cover: Jira → Slack → Linear (M each).** Brain MAX indexes Drive/Figma/GitHub/SharePoint/Slack/Dropbox but **not Jira, not Linear, not Notion, not Asana** — the dev/consultant niche is an open flank. Slack is the one overlap and the highest "what did we decide in #eng?" demand.
+3. **Ship the connector-verify pass as the differentiator (M).** `> ✓ confirmed in PROJ-123 / ⧗ conflict` inline markers (deterministic judge, live source) is a feature ClickUp doesn't have and its complaint profile (hallucinations, "~70% accurate" standups) is weakest against.
+4. **Don't chase:** 100+ connector breadth, artifact generation, team multiplayer, auto-executing write agents, multi-model routing.
+
+**The claim we can now honestly earn** (after step 1): *"A real AI knowledge manager — persistent memory, cited answers, proactive recall, and live context from your Slack/Jira — entirely on your Mac, no per-seat AI fee."* ClickUp structurally cannot follow (their privacy is subprocessor contracts; ours is architecture).
+
+## Co już mamy (code-grounded, post-0.7.4)
+
+| Gap (2026-07-02 scoring) | Stan dziś w kodzie |
+|---|---|
+| **Memory 3/10** — "threads RAM-only, facts unconsumed, no user memory" | **CLOSED.** `user_memory.rs`: bitemporal user facts (`user_facts` table), deterministic `synthesize_brief` injected into in-meeting @brain (`transcribe/live.rs:580`), agentic Ask + floor (`commands.rs:2650/2587`), meeting-chat (`commands.rs:1658`); FE audit view `brain-memory/` + `forget_user_fact`/`clear_user_memory`; lock-gated (brief from visible facts only, purge-on-seal tested). Threads persist (`db.rs:355/534`, gated `list_assistant_threads_visible`, FE rehydrates). *Partial star:* entity facts surface via the `get_entity_dossier` tool + live cards, not an always-injected brief (by design). |
+| **Ask 6/10** — "unify onto agentic loop; run bake-off" | **CLOSED (test corpus).** `ask_vault` → `run_agentic_loop` with gated tools + tool-trace to FE; deterministic corpus-pack floor RED-proven byte-identical. Bake-off: semantic recall@5 1.00 vs FTS 0.42. `semantic_search_enabled` default ON — **but e5 model is downloaded-not-bundled → fresh installs run FTS.** |
+| **Proactive** — "pull forward" | **CLOSED.** `proactive.rs` (zero-egress D1 recall cards, UI `proactive-hint-card/`) + `brain_reactions.rs` (Whisper contradiction cards, on-device light reasoner + deterministic reconcile, UI `whisper-card/`). Postures are DERIVED (`postures.rs`) so "Fully Local" can never mislabel an egressing config. |
+| **Connected sources 3/10** | **STILL THE GAP.** Live connectors = `web` + `calendar` only; Slack is a stub (`voice_action.rs:1317` "isn't available yet"). Architecture settled 2026-07-05: live per-source, no RAG index, RAM cache, pin-to-note, verify pass. |
+
+## Findings (synthesis — where the fight actually is)
+
+### (a) What ClickUp Brain has that we don't — filtered by what matters for our ICP
+
+From the 07-02 report (point-in-time), ClickUp's real leads: connected-source breadth (9/3), write-capable agents + artifacts (8/4), team multiplayer, multi-model routing. **For a solo dev/consultant on Obsidian, the only one that changes the felt experience is connected sources** — "the brain knows my tickets and my team's Slack." Artifacts/slides and team-ambient answers are org-shaped; multi-model routing is invisible plumbing (and our counter is sovereignty: a fully-local option they cannot offer). Their complaint profile (G2/reviews, medium conf): inconsistent answers on task data, ~70%-accurate standups, hallucinations on messy data, notetaker missing action items, per-seat billing resentment — i.e. **their weakness is trustworthiness, our verify-pass target.**
+
+### (b) Where we win structurally (they cannot follow)
+
+- **Privacy/ownership 10 vs 4** — on-device brain (Qwen light/heavy, model-presence activated), owned markdown in the user's vault, Touch-ID folder sealing, zero-retention by *architecture* vs their subprocessor *contracts*.
+- **Voice/meetings 9 vs 5** — bot-free far-side capture (ScreenCaptureKit) + live transcription + Whisper reactions during the meeting; their notetaker is a $12/mo bot add-on with no live transcript.
+- **Economics** — no per-seat AI fee; marginal cost = the user's Mac or BYO key. ClickUp charges $9–28/user/mo on every paid seat.
+- **Permission-aware retrieval by construction** — `visibility_clause` everywhere; ClickUp had to acquire Qatalog ($25.4M) for the equivalent.
+- **Single-user live connectors get ACL + freshness free** (2026-07-05 report) — the user's token IS the ACL; no mirrored-index treadmill.
+
+### (c) The minimal set that closes the felt gap "brain draws from my tools"
+
+1. **Brain-model onboarding (S)** — the prerequisite. Today `extract_user_fact_candidates` returns empty on `StubReasoner` (`user_memory.rs:226`) and semantic runs FTS until e5 is downloaded (`config.rs:1189`). A fresh user experiences neither memory nor semantic — the two features that justify "knowledge manager." One prominent onboarding step / one-click "Enable the brain (downloads ~2GB, stays on your Mac)" flips both on. Highest leverage per line of code on this list.
+2. **Jira connector, live (M)** — strongest search API (JQL Lucene), mutable fields fit the verify model, and ClickUp doesn't cover Jira at all. First slice per the connectors report: `parse_results` fixture test → full wiring.
+3. **Slack connector, live (M)** — the highest-demand ask ("what did we decide in #eng?"); replaces the shipped stub; `search.messages` with a pasted `xoxp-` user token (no OAuth server).
+4. **Connector-verify pass (M)** — the differentiator: per-claim `> ✓ confirmed in PROJ-123 (In Progress)` / `> ⚠ not found` / `> ⧗ conflict` inline markers, LLM-extracts + deterministic-compare (reuses `reconcile_facts` + `annotate_unverified` mechanics), on-demand + consented, RAM-cached. Directly attacks ClickUp's trust complaints; nobody in the meeting-notes class has it.
+5. **Linear connector, live (S–M)** — clean GraphQL, dev ICP, also absent from ClickUp's coverage. ClickUp-as-a-source stays last (weakest API; per the connectors report, the only candidate for a scoped index *iff* live underperforms — and "search your ClickUp from Murmur" is a fun competitive story but low demand until users ask).
+
+With 1–4 shipped, the user-felt sentence becomes true: *ask anything, the brain answers from your meetings + notes + memory + your team's Slack/Jira, cites everything, verifies your notes against reality, and none of it leaves your Mac except the redacted queries you consented to.* That is class membership plus a moat, not feature parity.
+
+### (d) What NOT to chase (honest)
+
+- **Connector breadth (100+ / Brain MAX six)** — unwinnable and partly incompatible with local-first; 3 well-chosen dev-stack connectors beat 100 shallow ones for our ICP. ClickUp's own survey: 77.5% of workers indifferent/relieved if half their AI tools disappeared.
+- **Artifact generation** (slides/dashboards/websites) — org-shaped, off-ICP.
+- **Team multiplayer / org knowledge** — contradicts single-user local-first; sharing (0.7.x E2EE) covers the "show a note to someone" case.
+- **Auto-executing write agents** — their complaint magnet; our propose-accept stance is a feature. (Write-out to Jira/Linear via propose-accept is a *later* track, per the 07-01 report — read-first.)
+- **Multi-model auto-routing** — invisible; our posture system already answers the real user question ("what runs where").
+
+## Fit z ograniczeniami Murmur
+
+All five plan items ride existing seams: connectors clone `web.rs` (consent + redaction + ledger free; no new deps), verify reuses `facts.rs`/`grounding.rs`, model onboarding reuses the existing model-download machinery. Nothing touches the lock model beyond already-audited patterns; connector data stays off-disk (live + RAM cache + pin-to-note only). Egress honesty: connector queries are redacted + ledgered + consented per source; verify never enters the zero-egress proactive path.
+
+## Rekomendacja i sekwencja
+
+**Sequence: (1) brain-model onboarding → (2) Jira → (3) Slack → (4) verify pass → (5) Linear → positioning copy.**
+Rationale: 1 activates the already-shipped class-membership features for real users (cheapest win); 2–3 close the only pillar ClickUp actually leads on, aimed at the flank they don't cover (Jira/Linear) plus the highest-demand overlap (Slack); 4 converts their weakness (trust) into our headline; 5 rounds out the dev stack. Then update `COMPETITIVE-LANDSCAPE.md`/README with the earned claim — and resolve the **brain2 vs Brain² naming collision** before any public copy (flagged 07-02, still open).
+
+**First step (smallest verifiable slice):** the onboarding audit — reproduce the fresh-install experience (no models downloaded): confirm memory stays empty and Ask runs FTS, then spec the one-click "Enable the brain" flow. In parallel or next: `JiraConnector::parse_results(fixture_json)` RED-before-GREEN per the connectors report.
+
+## Otwarte pytania
+
+- Does the solo AI-knowledge-manager buyer actually cross-shop ClickUp Brain? (Frame is the user's strategic choice; demand evidence not gathered — unchanged from 07-02.)
+- Real-vault semantic quality (bake-off was a designed test corpus) and user-memory extraction quality (needs a real Mac + model) — both "needs recorded evidence".
+- ClickUp Brain² feature velocity since 06-17 GA — the 07-02 snapshot is 3 days old; re-check before public positioning copy.
+- Slack `search.messages` longevity (legacy API) — migration target exists (`assistant.search.context`) if removed.
+
+## Sources
+
+**Internal:** `docs/research/2026-07-02-clickup-brain-gap-analysis.md` (ClickUp facts + gap matrix, all external URLs there) · `docs/research/2026-07-05-connectors-live-vs-rag.md` (live-vs-RAG verdict + per-source plan) · `docs/research/2026-07-04-rag-bakeoff-results.md` · code: `user_memory.rs` (brief synthesis/injection/audit; stub-empty at `:226`), `commands.rs` (`ask_vault` 2528–2833, memory gates 2329–2424), `transcribe/live.rs:580`, `storage/db.rs:355/534/4777` (thread persistence), `proactive.rs`, `brain_reactions.rs`, `settings/postures.rs`, `settings/config.rs:462/1189` (semantic default-ON, FTS fallback), `voice_action.rs:1317` (Slack stub), `tools.rs:37-38`, `connectors/mod.rs`, FE `brain-memory/`, `whisper-card/`, `proactive-hint-card/`.

--- a/docs/research/2026-07-05-connectors-live-vs-rag.md
+++ b/docs/research/2026-07-05-connectors-live-vs-rag.md
@@ -1,0 +1,127 @@
+<!-- Generated 2026-07-05 via /research (murmur-researcher fan-out: RAG-vs-live decision / competitor index-vs-live architectures / verification-as-a-profile). Builds on the 2026-07-01 + 2026-07-02 connector-architecture briefs (which cover the "how to wire it" question). Vendor facts/pricing/APIs = point-in-time mid-2026. -->
+# Research: Connectors (Slack / Jira / ClickUp / Linear) — should the brain draw from them LIVE, or store their data as a local RAG?
+
+## TL;DR / Verdict
+
+**Keep connectors LIVE, per-source, as gated on-demand tools — do NOT stand up a persistent local RAG over Slack/Jira/ClickUp/Linear.** All three research angles converge on the same answer, and it *confirms* our recorded decision (`connectors/mod.rs:9` — "Connectors are LIVE tools, NOT vectorized"). The one-line reason: **Murmur is single-user and local-first, which collapses the entire cost that makes indexing worthwhile for everyone else to zero.** The user's own OAuth token to Slack/Jira/Linear *is* the complete ACL — a live query returns exactly what they may see, always current, with nothing to mirror, invalidate, seal, or leak.
+
+Three findings, one per angle:
+
+1. **The architecture is a solved, industry-canonical split.** Microsoft states it cleanest: **synced/indexed = org-level, admin-crawled, ACL-mirrored** vs **federated/live (MCP) = user-level, user's-own-token, read-only, no indexing, for "live/dynamic/sensitive data."** Perplexity ships exactly our split (Drive *indexed*, Slack *live/deleted-post-query*); ClickUp *acquired* Qatalog ($25.4M) specifically for a **no-index, permission-aware** engine. Everyone who indexes must build + continuously re-sync a mirrored ACL (Glean webhooks + re-crawl; Onyx 30-min Celery permission-sync, gated behind Enterprise). Everyone who goes live gets permissions + freshness free from the source token. Our "owned notes get vectors / connectors stay live" is the *documented norm*, not an idiosyncrasy.
+
+2. **The "verify" use-case is the single strongest pro-LIVE argument.** The user named two modes — *"o coś pytam"* (ask) and *"coś weryfikuję"* (verify). Staleness degrades ask *gracefully* (slightly old context) but **inverts verify** (a ticket rescheduled yesterday, checked against a week-old index, returns a confident "✓ confirmed" — a false trust signal the user acts on). A wrong "confirmed" is worse than no answer. Verification is precisely the case the RAG-staleness literature calls most dangerous, because the output *is* the trust judgment.
+
+3. **We already have the machinery for both modes — and for verification done *safely*.** "Ask" = the agentic loop (`agent.rs::run_agentic_loop`). "Verify" = the deterministic-judge pattern already shipped in `facts.rs::reconcile_facts` + `brain_reactions.rs` ("the LLM NEVER judges … the VERDICT is deterministic") + the non-destructive `> unverified` markers of `grounding.rs::annotate_unverified`. Pointing that verification engine's *source of truth* at a live connector (instead of a past meeting) is a smaller, safer build than a RAG index — and it neutralizes prompt-injection (the untrusted ticket text is only *extracted from*, never *judged by*).
+
+**Recommendation:** ship all four connectors LIVE (each a clone of `connectors/web.rs`, effort S–M/source) with a **RAM-only, request-scoped hit cache** to tame latency/rate-limits, and **user-pin-to-note** as the *only* path connector data ever enters the vector store (at which point it becomes owned content and rides the existing sealed/gated doc-ingest pipeline). Revisit a *scoped* local index **only for ClickUp**, **only if** its weaker search API measurably underperforms in practice. First slice = **Jira** (strongest native search + mutable fields that fit the verify/reconcile model best).
+
+## Co już mamy (z repo — cytuję symbol; pliki są duże)
+
+- **Connector seam — LIVE, shipped, source-agnostic** (`connectors/mod.rs`): `trait Connector { id, egress_class, async search(redacted_query) -> Vec<ConnectorHit> }`; `ConnectorRegistry::search` redacts the outbound query through the FULL firewall (regex + on-device NER names) *before* the connector sees it, records one content-free egress-ledger row per attempt, fails closed when unconsented. `EgressClass::External` connectors exposed only when `enabled && consented && keyed`. Live today: `web` (Brave), `calendar` (Local). Slack/Jira/ClickUp/Linear **not implemented** — each is a `web.rs` clone (per the 2026-07-01/-07-02 architecture briefs).
+- **Vector/RAG stack — real, scoped to OWNED content only:** two vec0 KNN stores, both 384-dim (`embed.rs` `EMBED_DIM`): `vec_chunks` (note+transcript, `db.rs`) + `doc_vec_chunks` (uploaded docs/typed notes). Embedder = **multilingual-e5-small** (candle BERT / Metal, downloaded-not-bundled, model-presence gated → `StubEmbedder` fallback); `mmlw-retrieval-e5-small` (Polish) selectable, same dim. `semantic_search_enabled` defaults **ON**.
+- **The lock invariant any indexed connector data would collide with:** chunks/vectors are *"invertible PII derived from plaintext, so they exist ONLY for VISIBLE documents — PURGED in the same transaction that seals a folder, re-embeddable on unlock"* (`db.rs`). The `documents` table is anchored to a `folders` row (`folder_id NOT NULL` = the lock gate). Connector rows have **no folder to anchor to** → indexing them forces either a *new* lock domain or an *ungated* leak (fails `lock-security-reviewer`).
+- **Three deterministic-verdict verification engines already shipped** (all read *internal* sources): `grounding.rs::annotate_unverified` (note-vs-transcript, zero-egress, `> unverified` markers); `facts.rs::reconcile_facts`+`extract_fact_candidates` (bitemporal, pure-function verdict, LLM extract-only); `brain_reactions.rs::detect_reactions` (far-side utterance → triple → `reconcile` → Contradiction card citing the OLD fact — "the whisper").
+- **Zero-egress proactive path** (`proactive.rs`, contract D1: no LLM/provider/consent/egress) — verification against a connector **egresses**, so it must stay a separate, consented, on-demand surface, NOT bolted into proactive/reactions.
+- **RAG bake-off** (`docs/research/2026-07-04-rag-bakeoff-results.md`): semantic recall@5 **1.00 vs FTS 0.42** on 12 Polish paraphrase queries over a 43-meeting corpus — but the doc flags it was a *test graveyard* with a query mix *designed* to expose the gap; vectors earn their keep **for owned, stable notes on paraphrase** — a finding that does **not** transfer to volatile external data.
+
+## Findings
+
+### Angle 1 — RAG vs live, the trade-off matrix (each concrete for Murmur)
+
+| Trade-off | LIVE | LOCAL INDEX (RAG) |
+|---|---|---|
+| **Freshness (decisive)** | Always current. Correct for *verify*. | Stale between syncs → **inverts verify** ("confirmed" against an obsolete value). |
+| **ACL / permissions** | Source enforces via the user's token — free, always-correct, instantly-revocable. | Must reconstruct + continuously re-sync ACLs; permission change = delete-243 invalidation; a leak surface. |
+| **Lock model** | Nothing at rest → nothing to seal/gate. | No folder anchor → invent a new lock domain or leak. New at-rest SQLCipher copy of company data. |
+| **Sync/invalidation** | Zero — no scheduler. | Webhooks/polling + delta sync + deleted-ticket/edited-msg/moved-task handling = permanent debt. |
+| **Privacy/egress** | Redacted query egresses on demand + ledgered; nothing stored. | Embedder is on-device (no embed egress) — but a fresh at-rest copy of Slack/Jira lands locally. |
+| **Retrieval quality** | Bounded by the source's search API (weak for ClickUp). | Cross-source semantic ranking + rescues weak APIs — but under-indexes at solo-consultant scale. |
+| **Cost/complexity** | Clone `web.rs`, effort **S–M/source**, reuses redaction/consent/ledger free. | New tables + embed pipeline + sync scheduler + ACL mirror + lock integration, effort **L + ongoing**. |
+
+- **Per-source search-API strength changes the calculus source-by-source** (this is the one nuance that isn't uniform):
+  - **Jira** — JQL `text ~ "..."` = Lucene full-text over summary/description/comments; fuzzy/wildcard/proximity. **Strong** (high conf).
+  - **Slack** — `search.messages` full-text, user-token only (not bot), respects channel membership. **Good** (med).
+  - **Linear** — GraphQL content search across title/description/comments + a built-in similarity/vector search. **Decent** (med).
+  - **ClickUp** — `Get Filtered Team Tasks` = structured filters + text match on **title/description only**, no relevance ranking, no comments/docs full-text. **Weakest** — functional but the *only* plausible local-index candidate (med). (The old "ClickUp has NO full-text search" line is directionally right but not literal.)
+
+### Angle 2 — What competitors actually do (index vs live)
+
+| Player | Model | ACL mechanism | Level |
+|---|---|---|---|
+| **Glean** | Index | ACL **mirrored** via webhook + re-crawl | Org |
+| **Onyx (Danswer)** | Index (Postgres/Vespa→OpenSearch) | ACL **mirrored** via 30-min Celery permission-sync (Enterprise-only) | Org |
+| **Dust** | Index | mirrored, Temporal event-sync | Org |
+| **MS Copilot — synced** | Index | mirrored in Graph | Org (admin creds) |
+| **MS Copilot — federated** | **Live/MCP** | **source enforces, user token** | **User** |
+| **Perplexity — Drive** | Index (S3 + Vespa) | mirrored, dynamic revoke | Org/User |
+| **Perplexity — Slack** | **Live** | **source enforces, context deleted post-query** | **User** |
+| **Qatalog / ClickUp Brain²** | **Live / no-index** | **source enforces at query (ActionQuery)** | Org (permission-aware) |
+
+- **The framework is unambiguous:** everyone who indexes must build + continuously refresh a **mirrored ACL** — Onyx gates it behind the *Enterprise* tier and its own tracker shows the cost (issue #9664: Slack permission-sync "iterates entire channel history"). Everyone who goes live gets permissions + freshness free from the source token, and live is chosen *precisely for* dynamic/sensitive/user-scoped data.
+- **Single-user is the decisive variable.** The index tax = freshness-invalidation + **ACL-mirror-sync** + storing others' data. In multiplayer the ACL mirror is unavoidable and expensive; **for one user, the user's own token IS the complete ACL** (Perplexity-Slack's "immediate revocation, context deleted" property, by construction).
+- **Glean's pro-index case doesn't apply at our scale:** cross-user popularity signals, unified cross-source ranking over millions of docs — all *multiplayer* advantages. None applies to a single-user vault. Their token-tax numbers (43k vs 83k, ~2.5× preferred) are competitor-marketing — directionally plausible, not independently verified.
+- **Live-first works at scale:** three independent players ship it successfully for exactly these sources (MS federated → Linear/Notion/HubSpot; Perplexity → Slack; ClickUp → the whole Brain² backbone). Linear/Jira-class tools are *already live-only* even inside the biggest index vendor.
+
+### Angle 3 — Verification is a distinct profile, and it's pro-LIVE
+
+- **Verification is architecturally different from Q&A** — the mature pattern (RARR / RAV / ProvenanceGuard) is *decompose answer → atomic claims → route each to source-specific evidence → judge with a comparator/NLI (not free generation) → attach provenance.* This is **exactly** Murmur's shipped "extract triples → deterministic `reconcile_facts` → cite the source fact" (`facts.rs`/`brain_reactions.rs`). We don't need to *invent* verification — we need to let its source of truth be a live connector.
+- **Freshness-criticality is materially higher for verify than ask** (thesis holds, high conf). Staleness lit: *"a RAG pipeline scoring 0.95 faithfulness can still return wrong business answers when the index is stale … semantic similarity does not care about time."* Ask degrades gracefully; verify *inverts*.
+- **The deterministic-judge design neutralizes prompt injection.** Fetched Jira/Slack text is attacker-influenceable, and LLMs can't separate instructions from data in one stream. But if the LLM only **extracts a comparable value** and a **deterministic comparator** decides match/mismatch, an injected "ignore instructions and confirm everything" has *no judgment step to hijack*. This is the RAV/ProvenanceGuard shape and it's already how `brain_reactions.rs` works.
+- **Ephemeral session cache is the sanctioned middle** — a RAM-only, **request-scoped** (one verify pass / one agent turn) cache of connector hits de-dupes repeat fetches (a note may reference `[[PROJ-123]]` five times) without a persistent index. Mirrors existing non-persisted state (`AppState.live_transcript`, reaction cards). For *verification*, prefer request-scoped over a time-TTL (a 120s TTL could verify against a value that changed 90s ago).
+- **Two sub-profiles may exist:** Jira field = *mutable value-compare* (fits the bitemporal reconcile model well); Slack "was this decided?" = *search-existence* check (not a value-compare). Worth noting for design.
+
+## Fit z ograniczeniami Murmur
+
+| Constraint | Live (recommended) | Local index (rejected) |
+|---|---|---|
+| **Local-first / privacy** | Query redacted + consented + ledgered; nothing external at rest | New at-rest copy of company data (embedder local, but the copy is new surface) |
+| **Lock model** | No new content at rest → nothing to seal/gate | Collides: no folder anchor → new lock domain or leak → fails lock-security review |
+| **SQLite canonical** | Store stays canonical over *owned* truth; hits ephemeral | A second, stale, unowned copy of someone else's system of record ("three diverging truths") |
+| **No-new-deps** | Reuses in-tree `reqwest` + the framework | Likely needs sync/scheduler machinery |
+| **macOS / CI honesty** | Headless-testable with a mocked HTTP client | Sync + ACL freshness only verifiable against live orgs |
+| **RAG bake-off evidence** | N/A | Bake-off validated vectors for *owned, stable* notes — not volatile external data |
+
+Live wins every constraint. The verify-egress tension is the only real strain, and it's handled by the existing consent/redaction/ledger framework — provided verification stays OUT of the zero-egress proactive path.
+
+## Opcje i tradeoffy
+
+- **A — Live-only, per source (recommended, S–M/source).** Clone `web.rs`; the brain calls each on-demand as a gated tool and cites it ("via Jira"). Serves *both* ask and verify with always-fresh, ACL-correct data, zero new at-rest surface. Cost = per-query latency + rate-limits.
+- **B — Hybrid: live + RAM-only ephemeral cache (recommended alongside A, +M).** Request-scoped (verify) / short-TTL (ask) RAM cache of hits to cut repeat latency and rate-limit pressure. No durable at-rest copy. This is the sanctioned middle — not a RAG index.
+- **C — Pin-to-note as the ONLY path into the vector store (recommended alongside A, +M).** When the user *explicitly pins* a connector hit into a note, it becomes **owned** content and rides the existing `documents`/`import_text` sealed-gated-embeddable pipeline. No new lock domain; the user's deliberate action is the ACL decision.
+- **D — On-demand connector-verify pass (recommended follow-on, M).** Reuse `reconcile_facts` + `annotate_unverified` markers: per note claim tied to a `[[wikilinked]]` entity/ticket → fetch live → LLM *extracts* the comparable field → **deterministic** compare → append non-destructive `> ✓ confirmed in PROJ-123 (In Progress)` / `> ⚠ not found` / `> ⧗ conflict: note says Fri, PROJ-123 due Wed`. On-demand + consent-gated, never proactive.
+- **E — Full local RAG index of connectors (rejected, L + ongoing).** Walks straight into staleness-inverts-verification, an at-rest plaintext shadow of external data (lock strain), a mirrored-ACL subsystem, and a second source of truth — the Onyx/Glean cost with none of the multiplayer benefit.
+- **Rejected also:** generic connector-registry config abstraction at N=4 is fine to defer until a 5th source; crawl-and-index-external breaks local-first and solves a multiplayer problem we don't have.
+
+## Rekomendacja i pierwszy krok
+
+**Ship connectors LIVE (A) + RAM cache (B) + pin-to-note (C); add the deterministic connector-verify pass (D) as the differentiated follow-on; never build the RAG index (E).** This preserves local-first, doesn't fork the lock model, keeps SQLite canonical over *owned* truth, respects no-new-deps, matches the bake-off evidence, and correctly serves the "verify" use-case a stale index would silently break — while being the industry-canonical quadrant for single-user, freshness-critical, privacy-first, user-permissioned data.
+
+**Per-source priority** (search-API strength × verify-fit × demand):
+1. **Jira** — strongest native search (JQL Lucene) + mutable fields fit the reconcile/verify model best. Cleanest *end-to-end* first slice for both ask and verify.
+2. **Slack** — high "what did we decide in #eng?" demand; good `search.messages` (user token). Search-existence sub-profile.
+3. **Linear** — clean GraphQL + built-in similarity search; a proven MS-federated exemplar (confirms live suffices). Smaller install base.
+4. **ClickUp** — live via `Get Filtered Team Tasks` (title/desc); **the one source to revisit for a *scoped* local index** *iff* live retrieval measurably underperforms. Don't build the index speculatively.
+
+**Smallest verifiable first slice / de-risking spike:**
+1. **(no network)** `JiraConnector::parse_results(fixture_json) -> Vec<ConnectorHit>` (JQL `text ~ query` result → hits) + unit test mapping (title = `PROJ-123 …`, browse URL, status/assignee in snippet), mirroring `brave_parser_maps_json_to_hits`. RED-before-GREEN, zero credentials — this is the whole technical risk of the connector.
+2. Real client behind `from_config_if_available` (enable + consent + Keychain token) + `execute_jira_search` dispatcher + ToolSpec + config/consent/Keychain + `lib.rs` regs + FE toggle. Headless-verify: query redaction + consent-fail-closed + one egress-ledger row (mirror the `mod.rs` tests).
+3. **Verify-profile spike (proves D + why freshness is load-bearing):** one headless test where a `reconcile`-style connector-verifier flips **confirmed ↔ conflict** when a *mocked* Jira field value changes for the same note claim. Ship it against ONE field (deadline or status) first.
+4. Then dogfood ask + verify against a real Jira on a signed build. If live latency/recall is good (expected — JQL is strong), the decision generalizes to Slack/Linear; only ClickUp's result quality is worth re-measuring before ruling the index in/out for that one source.
+
+**Sequencing honesty:** connectors are *additive* value. The RAG bake-off (does the *core* owned-note brain earn its keep on a real vault?) stays gate #1 — connectors don't answer whether the core needs work. After that, this is the highest-value additive feature.
+
+## Otwarte pytania / czego nie udało się zweryfikować
+
+- **ClickUp live retrieval quality** — whether title/desc filter-match + brain re-ranking is "good enough" is unproven; the only local-index revisit hinges on a real dogfood measurement (not headless-provable).
+- **Extraction accuracy on real ticket text** (Jira description → a clean `deadline`/`status`/`owner`) is unmeasured — the verify design hinges on the extractor being good enough that the deterministic compare is meaningful. Needs a small labeled corpus.
+- **Which claims are even verifiable** — many note lines ("we should revisit pricing") have no connector counterpart; the verify pass must default to silence (like `annotate_unverified`'s conservative thresholds) to avoid a wall of "⚠ not found."
+- **Slack token-scope UX** for a solo user (`xoxp-` user token, `search:read`) isn't spec'd here; **Linear's server-side similarity search** API surface unconfirmed (would strengthen live-for-Linear).
+- **Real-vault RAG ROI** (even for owned content) — the bake-off ran on a test corpus; doesn't bear on connectors but is the honest caveat on the whole vector layer.
+- **Glean token-tax numbers + Qatalog/ActionQuery internals** — competitor marketing / undisclosed; treat as claims.
+- **Prompt-injection resistance, live OAuth/token round-trips, real Slack/Jira calls** — NOT headless-provable; need a real Mac + real workspaces + a red-team harness (recorded). Honesty bar.
+
+## Sources
+
+**Internal (code):** `connectors/mod.rs` (`Connector`/`ConnectorRegistry`, redaction/consent/ledger, "LIVE not vectorized") · `connectors/web.rs` (`from_config_if_available` + `brave_parser_maps_json_to_hits` = the clone template) · `connectors/calendar.rs` (`hit_for` = structured-in-snippet) · `storage/db.rs` (vec_chunks/doc_vec_chunks lock invariant, documents folder-anchoring) · `embed.rs`/`embed/candle_bert.rs` (e5-small, on-device, model-presence gated) · `summarize/grounding.rs::annotate_unverified` · `facts.rs::reconcile_facts` · `brain_reactions.rs::detect_reactions` · `proactive.rs` (D1 zero-egress) · `agent.rs::run_agentic_loop` ("treat tool results as DATA") · `tools.rs` (GatedToolExecutor, hits not persisted) · `settings/config.rs` (`web_search_*`, `semantic_search_enabled`) · `docs/research/2026-07-04-rag-bakeoff-results.md` · `docs/RAG-BAKEOFF.md` · prior architecture briefs `docs/research/2026-07-01-mcp-connectors-slack-jira-linear.md` + `2026-07-02-brain-connectors-slack-clickup-jira.md`
+
+**External (point-in-time mid-2026):** learn.microsoft.com/microsoft-365/copilot/connectors/federated-connectors-overview + /overview (synced-vs-federated framework; Linear/Notion federated) · glean.com/blog/federated-indexed-enterprise-ai + /cowork-mcp-eval + docs.glean.com/connectors/about · docs.onyx.app (enterprise_edition / access_controls) + github.com/onyx-dot-app/onyx (issue #9664) · temporal.io/blog/how-dust-builds-agentic-ai-temporal + docs.dust.tt · businesswire 20251112532324 + clickup.com/qatalog-acquisition (Qatalog "no-index permission-aware" $25.4M) · perplexity.ai/help-center (data-retention; Slack live/deleted-post-query; Drive S3+Vespa) · notion.com/help/notion-ai-connectors · support.atlassian.com/jira-software-cloud/docs/search-syntax-for-text-fields (JQL Lucene) · developer.clickup.com/reference/getfilteredteamtasks + feedback.clickup.com (no relevance search) · linear.app/docs/search + /developers/filtering · arxiv ProvenanceGuard (2606.18037) + RAV (2505.17762) + temporal-validity (2606.26511) · tianpan.co RAG-freshness + ragaboutit.com RAG-freshness-paradox · unit42.paloaltonetworks.com/ai-agent-prompt-injection + databricks.com/blog mitigating-prompt-injection · simonwillison.net/2025/Jun/16/the-lethal-trifecta

--- a/docs/superpowers/plans/2026-07-05-brain-competitive-4-steps.md
+++ b/docs/superpowers/plans/2026-07-05-brain-competitive-4-steps.md
@@ -1,0 +1,2104 @@
+# Brain Competitive 4-Steps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the only pillar ClickUp Brain leads on: (1) activate the already-shipped brain features for fresh installs ("Enable the brain" onboarding), (2) Jira live connector, (3) Slack live connector, (4) a deterministic connector-verify pass that marks note claims `✓ confirmed / ⚠ not found / ⧗ conflict` against live Jira.
+
+**Architecture:** Each phase is an independent, shippable PR. Phases 2–3 clone the proven `connectors/web.rs` pattern (fail-closed enable+consent+Keychain-key gate, framework-level query redaction + egress ledger, loud source attribution). Phase 4 adds a pure deterministic verifier (`verify.rs`) that reuses the `annotate_unverified` marker mechanics — the LLM is NEVER involved; regex extracts claims, live Jira supplies truth, pure Rust judges. Phase 1 is FE-only (backend download commands already exist).
+
+**Tech Stack:** Rust (Tauri 2.11, `meetnotes_lib` crate), Angular 18 zoneless (standalone, signals), in-tree `reqwest` (rustls) — **zero new dependencies**.
+
+**Research grounding:** `docs/research/2026-07-05-connectors-live-vs-rag.md` (live-not-RAG verdict), `docs/research/2026-07-05-competing-with-clickup-brain.md` (sequence rationale), `docs/research/2026-07-02-brain-connectors-slack-clickup-jira.md` (API shapes).
+
+## Global Constraints
+
+- **Errors:** every fallible fn returns `crate::error::Result<T>` (= `Result<T, AppError>`). NEVER `unwrap()`/`expect()` in non-test code. A locked-content refusal is `AppError::Locked(..)`.
+- **Commands:** every new `#[tauri::command]` in `src-tauri/src/commands.rs` MUST also be added to `tauri::generate_handler![…]` in `src-tauri/src/lib.rs` (~line 51 onward) — a compiled-but-unregistered command is silently un-callable.
+- **Lock model:** every content read/write gated by `meeting_is_unlocked` (`commands.rs:8343`, symbol not line — grep it). Phases 2–4 need a **lock-security-reviewer** pass before merge (new egress class instances + note read/write).
+- **No PII in logs:** connector code logs id + hit counts + HTTP status only — never query text, snippets, tokens, note content.
+- **No new deps:** reuse in-tree `reqwest`, `serde`, `async_trait`. No new crates, no new npm packages.
+- **FE rules:** standalone + OnPush + signals; component = directory `name/name.component.{ts,html,scss}`; `@if`/`@for` only; `inject()` only; tokens (`var(--token)`) only; overlays opaque; no `setTimeout` in components; one typed `IpcService` method per command with the DTO in `src/app/core/models.ts`.
+- **Test loop:** `(cd src-tauri && cargo test --lib)` — NEVER `cargo clippy --all-targets`. FE: `npx ng lint && npx ng build`. Final gate ONCE at the end of each phase: `bash scripts/ci.sh`.
+- **Git:** one branch per phase off `murmur` (`feat/brain-enable-onboarding`, `feat/jira-connector`, `feat/slack-connector`, `feat/note-verify`). Commits authored `QueaT <kgm004a@gmail.com>`, **no Claude trailers**, no backticks in `git commit -m`. Merge via PR (`gh pr create -R murmur-io/murmur`), never direct push (hook-blocked).
+- **Consent flags are PRESERVE-ONLY:** a `*_consented` flag is flipped true ONLY by its dedicated `consent_to_*` command; a settings save must never grant or clear it. Mirror `grant_web_search_consent` (`settings/config.rs:1087`) exactly, including the durable-record pattern its tests assert (`config.rs:1543`).
+- **Anchors drift:** `commands.rs`/`db.rs` are >8k lines. Every `file:line` here is a hint — **grep the symbol** before editing.
+
+---
+
+# Phase 1 — "Enable the brain" onboarding (fix the dead fresh install)
+
+**Problem (code-proven):** `extract_user_fact_candidates` returns empty on `StubReasoner` (`user_memory.rs:226`) and semantic search silently runs FTS until the e5 model exists on disk (`settings/config.rs:1189`, `embed.rs:264 embed_model_present`). A fresh install therefore has user-memory and semantic retrieval OFF even though both flags default ON. Fix = one FE card that downloads the heavy brain GGUF + the e5 embed model with progress, reused in (a) the onboarding wizard as a new step and (b) the Brain page as a nudge banner.
+
+**Backend: NO CHANGES.** All commands exist and are registered: `brain_model_present`, `list_brain_models`, `download_brain_model(model_id)` (emits `EVENT_BRAIN_DOWNLOAD` progress), `embed_model_present`, `download_embed_model` (emits per-file embed progress) — see `src-tauri/src/lib.rs:228-245`.
+
+**Store to reuse:** `src/app/features/settings/settings.store.ts` already wires everything: `brainModels()` (DTOs with `downloaded`, `selectedHeavy`, `selectedLight`), `brainDownloadingId`, `brainPct`, `downloadBrainModel(id)` (`settings.store.ts:1368`), `downloadEmbedModel()` (`settings.store.ts:1747`). **Verify first** that `SettingsStore` is `@Injectable({ providedIn: "root" })` (grep `providedIn` in that file); if it is not, it IS injectable from onboarding only if provided — in that case add `providedIn: "root"` is NOT allowed without checking how settings provides it; instead inject `IpcService` directly and copy the download-call pattern from the store. (Expected: it is root-provided; the tasks below assume that. If not, escalate to the human.)
+
+### Task 1.1: `brain-enable-card` component
+
+**Files:**
+- Create: `src/app/features/brain/brain-enable-card/brain-enable-card.component.ts`
+- Create: `src/app/features/brain/brain-enable-card/brain-enable-card.component.html`
+- Create: `src/app/features/brain/brain-enable-card/brain-enable-card.component.scss`
+
+**Interfaces:**
+- Consumes: `SettingsStore.brainModels()`, `brainDownloadingId()`, `brainPct()`, `downloadBrainModel(id)`, `downloadEmbedModel()`; `IpcService.brainModelPresent()`, `embedModelPresent()`.
+- Produces: `<app-brain-enable-card>` with `output<void>()` named `enabled` (fires when both models are present), and a `computed` `allReady` — Task 1.2 and 1.3 embed it.
+
+- [ ] **Step 1: Read the exemplars.** Open `src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.ts` (store wiring pattern) and `src/app/features/onboarding/onboarding/onboarding.component.ts` (download-progress UX for the Whisper step). Match their idioms exactly.
+
+- [ ] **Step 2: Write the component.**
+
+`brain-enable-card.component.ts`:
+
+```ts
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import { SettingsStore } from "../../settings/settings.store";
+
+/**
+ * "Enable the brain" — the one-click activation card for the two on-device
+ * models a fresh install is missing: the heavy brain GGUF (powers user memory
+ * extraction + on-device Ask) and the e5 embed model (powers semantic search;
+ * until it exists, retrieval silently falls back to FTS).
+ *
+ * Backend untouched: this drives the EXISTING SettingsStore download actions
+ * (downloadBrainModel / downloadEmbedModel) and the existing presence probes.
+ * Everything stays on the user's Mac — the card copy says so loudly.
+ *
+ * Embedded in two places: the onboarding "brain" step and the Brain page
+ * nudge banner (hidden once both models are present).
+ */
+@Component({
+  selector: "app-brain-enable-card",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./brain-enable-card.component.html",
+  styleUrl: "./brain-enable-card.component.scss",
+})
+export class BrainEnableCardComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly store = inject(SettingsStore);
+
+  /** Fires once when both models land (parent may advance the wizard). */
+  readonly enabled = output<void>();
+
+  readonly brainPresent = signal<boolean | null>(null);
+  readonly embedPresent = signal<boolean | null>(null);
+  readonly running = signal(false);
+  readonly stage = signal<"idle" | "brain" | "embed" | "done">("idle");
+  readonly error = signal<string | null>(null);
+
+  /** Live % for the in-flight brain GGUF (store listens to EVENT_BRAIN_DOWNLOAD). */
+  readonly brainPct = this.store.brainPct;
+
+  readonly allReady = computed(
+    () => this.brainPresent() === true && this.embedPresent() === true,
+  );
+
+  /** Total size hint from the registry DTOs (heavy model approx size). */
+  readonly sizeHint = computed(() => {
+    const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
+    if (!heavy?.approxSizeBytes) return "~2 GB";
+    return `~${Math.round(heavy.approxSizeBytes / 1_000_000_000 * 10) / 10} GB`;
+  });
+
+  private readonly _probe = effect(
+    () => {
+      void this.refresh();
+    },
+    { allowSignalWrites: true },
+  );
+
+  async refresh(): Promise<void> {
+    try {
+      const [brain, embed] = await Promise.all([
+        this.ipc.brainModelPresent(),
+        this.ipc.embedModelPresent(),
+      ]);
+      this.brainPresent.set(brain);
+      this.embedPresent.set(embed);
+      if (brain && embed) this.stage.set("done");
+    } catch {
+      // Presence probes never block the card; leave nulls (renders as unknown).
+    }
+  }
+
+  /** The one click: heavy brain model first (big), then the e5 embed model. */
+  async enable(): Promise<void> {
+    if (this.running()) return;
+    this.running.set(true);
+    this.error.set(null);
+    try {
+      if (this.brainPresent() !== true) {
+        this.stage.set("brain");
+        const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
+        if (!heavy) throw new Error("no on-device model available");
+        await this.store.downloadBrainModel(heavy.id);
+      }
+      if (this.embedPresent() !== true) {
+        this.stage.set("embed");
+        await this.store.downloadEmbedModel();
+      }
+      await this.refresh();
+      if (this.allReady()) {
+        this.stage.set("done");
+        this.enabled.emit();
+      }
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+      this.stage.set("idle");
+    } finally {
+      this.running.set(false);
+    }
+  }
+}
+```
+
+**NOTE for the implementer:** field names on the brain-model DTO (`approxSizeBytes`, `selectedHeavy`, `id`, `downloaded`) must be checked against `src/app/core/models.ts` (grep `selectedHeavy`) — use the exact existing names. If `brainModels()` is empty until the settings page loads it, call the store's loader (grep how `ai-setup-block` guarantees it — likely `store.init()`/constructor-loaded) or fall back to `ipc.listBrainModels()` directly.
+
+`brain-enable-card.component.html`:
+
+```html
+<div class="card enable-card">
+  <div class="enable-copy">
+    <h3>Enable the brain</h3>
+    <p class="text-secondary">
+      Downloads two on-device models ({{ sizeHint() }} total). They run
+      entirely on your Mac — nothing is sent anywhere. This switches on
+      <strong>memory</strong> (the brain remembers facts about you) and
+      <strong>semantic search</strong> (find things by meaning, not keywords).
+    </p>
+  </div>
+
+  @if (stage() === "done" || allReady()) {
+    <span class="pill is-success"><span class="pill-dot"></span> Brain enabled</span>
+  } @else if (running()) {
+    <div class="enable-progress">
+      @if (stage() === "brain") {
+        <span class="text-secondary">Downloading the brain model… {{ brainPct() }}%</span>
+      } @else {
+        <span class="text-secondary">Downloading the search model…</span>
+      }
+    </div>
+  } @else {
+    <button type="button" class="btn btn-primary" (click)="enable()">
+      Enable the brain
+    </button>
+  }
+
+  @if (error(); as e) {
+    <p class="banner is-warning" role="alert">Download failed: {{ e }} — try again.</p>
+  }
+</div>
+```
+
+`brain-enable-card.component.scss`:
+
+```scss
+.enable-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.enable-copy h3 {
+  margin: 0 0 var(--space-1);
+}
+.enable-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+```
+
+- [ ] **Step 3: Lint + build.**
+
+Run: `npx ng lint && npx ng build`
+Expected: clean (fix any DTO field-name mismatches surfaced by the compiler).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/app/features/brain/brain-enable-card/
+git commit -m "feat(brain): one-click Enable the brain card (heavy GGUF + e5 embed download)"
+```
+
+### Task 1.2: Onboarding step "brain"
+
+**Files:**
+- Modify: `src/app/features/onboarding/onboarding/onboarding.component.ts` (STEPS at line ~18)
+- Modify: `src/app/features/onboarding/onboarding/onboarding.component.html`
+
+**Interfaces:**
+- Consumes: `<app-brain-enable-card>` from Task 1.1.
+
+- [ ] **Step 1: Extend the wizard.** In `onboarding.component.ts` change:
+
+```ts
+type Step = "welcome" | "model" | "provider" | "brain" | "vault" | "done";
+const STEPS: readonly Step[] = [
+  "welcome",
+  "model",
+  "provider",
+  "brain",
+  "vault",
+  "done",
+];
+```
+
+Add `BrainEnableCardComponent` to the component's `imports: [...]` array and import it at the top. Grep the existing `@switch (currentStep())` / `@if (currentStep() === …)` structure in `onboarding.component.html` and add the new step panel between provider and vault, matching the surrounding markup style exactly:
+
+```html
+@if (currentStep() === "brain") {
+  <section class="step-panel">
+    <app-brain-enable-card />
+    <div class="step-actions">
+      <button type="button" class="btn btn-ghost" (click)="next()">Skip for now</button>
+      <button type="button" class="btn btn-primary" (click)="next()">Continue</button>
+    </div>
+  </section>
+}
+```
+
+(Grep the actual `next()`/advance method name and the actual step-panel/action classes in the file and reuse them — do not invent new ones. "Skip for now" MUST exist: downloading ~2 GB is optional, never a wall.)
+
+- [ ] **Step 2: Lint + build.** Run: `npx ng lint && npx ng build` — clean.
+
+- [ ] **Step 3: Live smoke.** With the dev app running (skill `tauri-dev`: `MURMUR_DEV_DEK=… npm run dev`), drive `http://localhost:1420` via Playwright (mock `window.__TAURI_INTERNALS__.invoke` with `brain_model_present:false`, `embed_model_present:false`, `list_brain_models:[…]`) and screenshot the new step; verify the card renders, the Skip button advances, and clicking Enable calls `download_brain_model` in the mock log.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/app/features/onboarding/
+git commit -m "feat(onboarding): Enable the brain wizard step (skippable)"
+```
+
+### Task 1.3: Brain-page nudge
+
+**Files:**
+- Modify: the Brain page shell component (grep: `ls src/app/features/brain/` — the top-level brain view component; it already renders header status with a "semantic badge on/off/model-absent").
+
+- [ ] **Step 1:** Import `BrainEnableCardComponent` into the brain page component and render it at the top of the page **only when models are missing**:
+
+```html
+@if (!enableCard.allReady()) {
+  <app-brain-enable-card #enableCard (enabled)="refresh()" />
+}
+```
+
+(If a template-ref-driven `@if` on the child's own signal is awkward, hoist: inject `IpcService` in the page, add `readonly brainReady = signal<boolean | null>(null)` probed in an effect via `Promise.all([ipc.brainModelPresent(), ipc.embedModelPresent()])`, and gate on that. `refresh()` = the page's existing overview reload method — grep it.)
+
+- [ ] **Step 2:** `npx ng lint && npx ng build` — clean. Playwright smoke: with mocked `brain_model_present:false` the card shows on /brain; with `true/true` it does not.
+
+- [ ] **Step 3: Commit + PR.**
+
+```bash
+git add src/app/features/brain/
+git commit -m "feat(brain): nudge card on the Brain page while on-device models are missing"
+gh pr create -R murmur-io/murmur --title "Enable-the-brain onboarding (fix the dead fresh install)" --body "Fresh installs had user-memory + semantic search structurally OFF (stub reasoner / FTS fallback). One-click card downloads heavy GGUF + e5; onboarding step + Brain-page nudge. FE-only."
+```
+
+**Phase 1 verify gate:** adversarial-verifier pass (FE-only: lint+build green, Playwright live-reproduces the fresh-install state and the enabled state, no NG0600 — the probe effect writes signals and MUST carry `{ allowSignalWrites: true }`).
+
+---
+
+# Phase 2 — Jira live connector
+
+**Shape:** exact clone of the web connector. New egress class instance ⇒ **lock-security-reviewer required**. Read `connectors/web.rs` + `connectors/mod.rs` fully before starting.
+
+### Task 2.1: `JiraConnector` with fixture-tested parser (RED first)
+
+**Files:**
+- Create: `src-tauri/src/connectors/jira.rs`
+- Modify: `src-tauri/src/connectors/mod.rs` (add `pub mod jira;` after `pub mod calendar;` at line 29; add registry-build line)
+- Modify: `src-tauri/src/secrets/keychain.rs` (const near line 31 + routing arm near line 1564)
+
+**Interfaces:**
+- Produces: `JiraConnector::from_config_if_available(&AppConfig) -> Option<Self>`; `Connector` impl with `id() == "jira"`, `EgressClass::External`; `pub const JIRA_TOKEN_ACCOUNT: &str = "jira_api_token"`; `pub(crate) fn parse_results(body: &str) -> ConnectorResult`; `pub(crate) fn escape_jql(q: &str) -> String`. Task 4.x adds `get_issue` to this struct.
+- Consumes: `AppConfig.jira_enabled / jira_consented / jira_base_url / jira_email` (Task 2.2 — write this file to compile against those names; Task 2.2 lands them).
+
+**Order note:** Tasks 2.1 and 2.2 touch disjoint files but 2.1 compiles only after 2.2's config fields exist. Implement 2.2 FIRST, then 2.1 (kept in this order on paper because the parser is the risk; read both before starting).
+
+- [ ] **Step 1: Write `connectors/jira.rs`** (complete file):
+
+```rust
+//! JIRA connector — live, on-demand issue search via the Jira Cloud REST API (brain2 connectors,
+//! Phase 2 of docs/research/2026-07-05-connectors-live-vs-rag.md).
+//!
+//! ## Egress posture (NEW EGRESS CLASS INSTANCE — audited by the lock-security reviewer)
+//! [`EgressClass::External`]. Exposed to the brain ONLY when ALL of:
+//! - `config.jira_enabled` (master toggle), AND
+//! - `config.jira_consented` (one-time consent, preserve-only, flipped solely by `consent_to_jira`), AND
+//! - `config.jira_base_url` + `config.jira_email` are non-empty, AND
+//! - an API token is present in the Keychain (`jira_api_token`).
+//! Otherwise [`JiraConnector::from_config_if_available`] returns `None` (fail-closed: the tool does
+//! not exist for the session). The framework redacts the query BEFORE it reaches [`Connector::search`].
+//!
+//! ## Endpoint
+//! `POST {base}/rest/api/3/search/jql` with `{"jql": "text ~ \"…\" ORDER BY updated DESC", …}` and
+//! HTTP Basic auth (`email:api_token`). NOTE: the legacy `/rest/api/3/search` endpoint was REMOVED
+//! (HTTP 410) — do not use it.
+//!
+//! ## No PII in logs
+//! Logs carry connector id + hit count + HTTP status only — never the JQL, summaries, or the token.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Connector, ConnectorError, ConnectorHit, ConnectorResult, EgressClass};
+use crate::settings::AppConfig;
+
+/// Keychain account holding the BYO Jira API token. NEVER logged / NEVER sent to the FE.
+pub const JIRA_TOKEN_ACCOUNT: &str = "jira_api_token";
+
+/// Loud attribution label on every hit.
+const SOURCE_LABEL: &str = "Jira";
+
+/// Escape a user query for embedding inside a JQL quoted string: backslashes then double quotes.
+pub(crate) fn escape_jql(q: &str) -> String {
+    q.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+pub struct JiraConnector {
+    base_url: String,
+    email: String,
+    api_token: String,
+}
+
+impl JiraConnector {
+    /// FAIL-CLOSED gate — see the module doc. A Keychain error degrades to `None`, never a crash.
+    pub fn from_config_if_available(config: &AppConfig) -> Option<Self> {
+        if !config.jira_enabled || !config.jira_consented {
+            return None;
+        }
+        let base_url = config.jira_base_url.trim().trim_end_matches('/').to_string();
+        let email = config.jira_email.trim().to_string();
+        if base_url.is_empty() || email.is_empty() {
+            return None;
+        }
+        let token = crate::secrets::get_secret(JIRA_TOKEN_ACCOUNT)
+            .ok()
+            .flatten()
+            .filter(|k| !k.trim().is_empty())?;
+        Some(Self {
+            base_url,
+            email,
+            api_token: token,
+        })
+    }
+
+    /// Parse a `/rest/api/3/search/jql` JSON body into [`ConnectorHit`]s. Pulled out so it is
+    /// unit-testable with a fixture and NO network. Missing `issues` → empty (clean "no results").
+    /// An issue without a key is skipped.
+    pub(crate) fn parse_results(body: &str, base_url: &str) -> ConnectorResult {
+        let parsed: JiraSearchResponse = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("jira response parse: {e}")))?;
+        let hits = parsed
+            .issues
+            .into_iter()
+            .filter_map(|i| {
+                let key = i.key.trim().to_string();
+                if key.is_empty() {
+                    return None;
+                }
+                let f = i.fields;
+                let summary = f.summary.unwrap_or_default();
+                let mut parts: Vec<String> = Vec::new();
+                if let Some(s) = f.status.and_then(|s| s.name) {
+                    parts.push(format!("Status: {s}"));
+                }
+                if let Some(a) = f.assignee.and_then(|a| a.display_name) {
+                    parts.push(format!("Assignee: {a}"));
+                }
+                if let Some(d) = f.duedate {
+                    parts.push(format!("Due: {d}"));
+                }
+                Some(ConnectorHit {
+                    title: format!("{key} — {}", summary.trim()),
+                    snippet: parts.join(" · "),
+                    url: format!("{base_url}/browse/{key}"),
+                    source_label: SOURCE_LABEL.to_string(),
+                })
+            })
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[async_trait]
+impl Connector for JiraConnector {
+    fn id(&self) -> &str {
+        "jira"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        EgressClass::External
+    }
+
+    async fn search(&self, redacted_query: &str) -> ConnectorResult {
+        let q = redacted_query.trim();
+        if q.is_empty() {
+            return Ok(Vec::new());
+        }
+        let jql = format!("text ~ \"{}\" ORDER BY updated DESC", escape_jql(q));
+        let body = serde_json::json!({
+            "jql": jql,
+            "maxResults": 8,
+            "fields": ["summary", "status", "assignee", "duedate"],
+        });
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/rest/api/3/search/jql", self.base_url))
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira request: {}", e.without_url())))?;
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "jira", status = status.as_u16(), "jira search HTTP error");
+            return Err(ConnectorError::Failed(format!("jira HTTP {status}")));
+        }
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira body: {}", e.without_url())))?;
+        let hits = Self::parse_results(&text, &self.base_url)?;
+        tracing::info!(target: "connector", provider = "jira", hits = hits.len(), "jira search returned");
+        Ok(hits)
+    }
+}
+
+/// Only the fields we consume; `#[serde(default)]` everywhere so a missing field never fails.
+#[derive(Debug, Deserialize)]
+struct JiraSearchResponse {
+    #[serde(default)]
+    issues: Vec<JiraIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraIssue {
+    #[serde(default)]
+    key: String,
+    #[serde(default)]
+    fields: JiraFields,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct JiraFields {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    status: Option<JiraStatus>,
+    #[serde(default)]
+    assignee: Option<JiraAssignee>,
+    #[serde(default)]
+    duedate: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraStatus {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraAssignee {
+    #[serde(default, rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jira_parser_maps_json_to_hits() {
+        let body = r#"{
+            "issues": [
+                {"key":"PROJ-123","fields":{"summary":"Fix login flow","status":{"name":"In Progress"},"assignee":{"displayName":"Anna"},"duedate":"2026-07-10"}},
+                {"key":"PROJ-9","fields":{"summary":"Spike","status":{"name":"Done"}}}
+            ],
+            "nextPageToken": "abc"
+        }"#;
+        let hits = JiraConnector::parse_results(body, "https://acme.atlassian.net").unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "PROJ-123 — Fix login flow");
+        assert_eq!(hits[0].snippet, "Status: In Progress · Assignee: Anna · Due: 2026-07-10");
+        assert_eq!(hits[0].url, "https://acme.atlassian.net/browse/PROJ-123");
+        assert_eq!(hits[0].source_label, "Jira");
+        assert_eq!(hits[1].snippet, "Status: Done");
+    }
+
+    #[test]
+    fn jira_parser_tolerates_missing_fields_and_empty() {
+        assert!(JiraConnector::parse_results(r#"{}"#, "https://x").unwrap().is_empty());
+        assert!(JiraConnector::parse_results(r#"{"issues":[]}"#, "https://x").unwrap().is_empty());
+        // Missing key → skipped; missing fields → title still renders.
+        let body = r#"{"issues":[{"key":"","fields":{}},{"key":"A-1","fields":{}}]}"#;
+        let hits = JiraConnector::parse_results(body, "https://x").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "A-1 — ");
+    }
+
+    #[test]
+    fn jira_parser_rejects_malformed_json() {
+        assert!(matches!(
+            JiraConnector::parse_results("not json", "https://x"),
+            Err(ConnectorError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn jql_escaping_neutralizes_quotes_and_backslashes() {
+        assert_eq!(escape_jql(r#"login "bug" \ test"#), r#"login \"bug\" \\ test"#);
+    }
+
+    #[test]
+    fn from_config_fail_closed_when_disabled_or_unconsented_or_unconfigured() {
+        // Default config: everything off → None, and no Keychain read is even attempted for
+        // the disabled cases (enable/consent are checked first).
+        let cfg = AppConfig::default();
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none());
+        let cfg = AppConfig { jira_enabled: true, ..AppConfig::default() };
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none(), "unconsented");
+        let cfg = AppConfig {
+            jira_enabled: true,
+            jira_consented: true,
+            jira_base_url: String::new(),
+            jira_email: "a@b.c".into(),
+            ..AppConfig::default()
+        };
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none(), "no base url");
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module + registry + keychain routing.**
+
+In `connectors/mod.rs`: add `pub mod jira;` next to `pub mod calendar;` (line 29), and in `ConnectorRegistry::build` (line 159) after the web line add:
+
+```rust
+        if let Some(c) = jira::JiraConnector::from_config_if_available(config) {
+            connectors.push(Box::new(c));
+        }
+```
+
+In `secrets/keychain.rs`: near line 31 (next to `ACCOUNT_WEB_SEARCH_KEY`) add:
+
+```rust
+/// Jira connector BYO API token — see [`crate::connectors::jira::JIRA_TOKEN_ACCOUNT`].
+pub const ACCOUNT_JIRA_TOKEN: &str = "jira_api_token";
+```
+
+and add the routing arm in the match near line 1564 (mirror the `ACCOUNT_WEB_SEARCH_KEY` arm exactly):
+
+```rust
+        ACCOUNT_JIRA_TOKEN => ACCOUNT_JIRA_TOKEN,
+```
+
+- [ ] **Step 3: Run the tests** (compiles only after Task 2.2 — see order note).
+
+Run: `cd src-tauri && cargo test --lib jira`
+Expected: all `jira_*` tests PASS; `registry_excludes_web_when_disabled_or_unconsented_failclosed` still PASSES.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src-tauri/src/connectors/ src-tauri/src/secrets/keychain.rs
+git commit -m "feat(connectors): Jira live connector - fail-closed gate, fixture-tested JQL search parser"
+```
+
+### Task 2.2: Config flags (`jira_enabled/_consented/_base_url/_email`)
+
+**Files:**
+- Modify: `src-tauri/src/settings/config.rs`
+
+**Interfaces:**
+- Produces: `AppConfig { jira_enabled: bool, jira_consented: bool, jira_base_url: String, jira_email: String }` + `AppConfig::grant_jira_consent(&mut self, db: &Db) -> Result<()>`.
+
+- [ ] **Step 1: Write failing tests** (append to `config.rs` tests, mirroring `web_search_flags_default_off_and_round_trip` at line 1340, `web_search_consent_grant_persists` at 1366, and `web_search_grant_durable_record_and_flag_agree` at 1543 — copy those three tests, rename `web_search`→`jira`, and extend the round-trip to also persist `jira_base_url`/`jira_email` string values):
+
+```rust
+    #[test]
+    fn jira_flags_default_off_and_round_trip() {
+        let (db, _dir) = test_db();
+        let cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.jira_enabled, "jira must default OFF");
+        assert!(!cfg.jira_consented, "jira consent must default ungranted");
+        assert!(cfg.jira_base_url.is_empty());
+        assert!(cfg.jira_email.is_empty());
+        let cfg = AppConfig {
+            jira_enabled: true,
+            jira_base_url: "https://acme.atlassian.net".into(),
+            jira_email: "me@acme.com".into(),
+            ..cfg
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert!(loaded.jira_enabled);
+        assert_eq!(loaded.jira_base_url, "https://acme.atlassian.net");
+        assert_eq!(loaded.jira_email, "me@acme.com");
+        // PRESERVE-ONLY: a save can never grant consent.
+        assert!(!loaded.jira_consented);
+    }
+
+    #[test]
+    fn jira_consent_grant_persists_and_save_cannot_clobber() {
+        let (db, _dir) = test_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        cfg.grant_jira_consent(&db).unwrap();
+        assert!(cfg.jira_consented);
+        assert!(AppConfig::load(&db).unwrap().jira_consented);
+        // A later plain save must PRESERVE the granted consent.
+        let cfg2 = AppConfig { jira_consented: false, ..AppConfig::load(&db).unwrap() };
+        cfg2.save(&db).unwrap();
+        assert!(AppConfig::load(&db).unwrap().jira_consented, "save must not clear a granted consent");
+    }
+```
+
+**NOTE:** grep the actual test-DB helper name used by the neighboring web tests (`test_db()` here is a guess — copy exactly what `web_search_consent_grant_persists` uses). If the durable-record test (`config.rs:1543`) asserts a separate consent-record row, mirror that assertion too.
+
+- [ ] **Step 2: Run to verify RED.** `cd src-tauri && cargo test --lib jira_flags` → FAIL (fields don't exist).
+
+- [ ] **Step 3: Implement** — mirror the `web_search_*` handling at each of these anchors (grep, don't trust line numbers):
+  - Struct fields near `config.rs:305-317` (copy the doc comments' style; `jira_consented` documented PRESERVE-ONLY, mutated solely by `consent_to_jira`):
+
+```rust
+    /// Master toggle for the Jira connector (Settings ▸ Connectors). Even when ON, the connector is
+    /// exposed only once `jira_consented` is granted and a token + base URL + email are configured.
+    pub jira_enabled: bool,
+    /// One-time egress consent for Jira. PRESERVE-ONLY on save; flipped true solely by the
+    /// dedicated `consent_to_jira` command.
+    pub jira_consented: bool,
+    /// The Jira Cloud site base URL, e.g. `https://acme.atlassian.net` (non-secret).
+    pub jira_base_url: String,
+    /// The Atlassian account email paired with the API token for Basic auth (non-secret).
+    pub jira_email: String,
+```
+
+  - Defaults near `:472`: `jira_enabled: false, jira_consented: false, jira_base_url: String::new(), jira_email: String::new(),`
+  - Key consts near `:542`:
+
+```rust
+const K_JIRA_ENABLED: &str = "jira_enabled";
+const K_JIRA_CONSENTED: &str = "jira_consented";
+const K_JIRA_BASE_URL: &str = "jira_base_url";
+const K_JIRA_EMAIL: &str = "jira_email";
+```
+
+  - Load arms near `:701` (mirror the two web arms; string keys assign directly: `cfg.jira_base_url = v;`).
+  - Save writes near `:946` (mirror the web pattern EXACTLY, including how the preserve-only consent is written — copy the `web_search_consented` save semantics verbatim; strings are saved unconditionally like other string settings — grep how e.g. the ollama base-url string is saved and mirror that).
+  - `grant_jira_consent` next to `grant_web_search_consent` (`:1087`) — copy its body verbatim (including any durable-record write), renamed keys.
+
+- [ ] **Step 4: Run to verify GREEN.** `cd src-tauri && cargo test --lib jira` → PASS; full `cargo test --lib` → no regressions (the config merge tests are sensitive — if `save_config_merge_never_clobbers_or_grants_web_search_consent`-style tests enumerate fields, extend them for jira the way they cover web).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src-tauri/src/settings/config.rs
+git commit -m "feat(config): jira connector flags - enabled, preserve-only consent, base url, email"
+```
+
+### Task 2.3: Tool wiring (`jira_search`)
+
+**Files:**
+- Modify: `src-tauri/src/tools.rs`
+
+**Interfaces:**
+- Produces: `ToolCall::JiraSearch { query: String }`, ToolSpec `"jira_search"`, `pub async fn execute_jira_search(query: &str, config: &AppConfig) -> Result<String>`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tools.rs` tests, mirroring `sync_execute_tool_refuses_websearch` at ~line 833 and `web_search_fail_closed_returns_sentinel_no_egress` at ~856 — copy their exact setup helpers):
+
+```rust
+    #[test]
+    fn sync_execute_tool_refuses_jira_search() {
+        // Copy the body of the WebSearch refusal test, with:
+        //   &ToolCall::JiraSearch { query: "x".into() }
+        // and assert the same InvalidArg refusal.
+    }
+
+    #[test]
+    fn jira_search_fail_closed_returns_sentinel_no_egress() {
+        let cfg = AppConfig::default(); // jira disabled + unconsented
+        let out = block_on(execute_jira_search("login bug", &cfg)).unwrap();
+        assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
+    }
+```
+
+(The first test body is written by copying the existing WebSearch refusal test verbatim and swapping the variant — write the REAL body, the comment above tells you the source.)
+
+- [ ] **Step 2: RED.** `cargo test --lib refuses_jira` → FAIL (variant doesn't exist).
+
+- [ ] **Step 3: Implement** — five surgical edits in `tools.rs`, each mirroring the neighboring `WebSearch` code:
+
+1. `ToolCall` enum (near line 65): add
+
+```rust
+    /// LIVE JIRA SEARCH (consent-gated EXTERNAL connector). Like [`Self::WebSearch`], dispatched
+    /// exclusively via the async [`execute_jira_search`], and ONLY when the Jira connector is
+    /// exposed (enabled + consented + configured + token).
+    JiraSearch { query: String },
+```
+
+2. `tool_specs()` (after the `web_search` entry at line ~151):
+
+```rust
+        ToolSpec {
+            name: "jira_search",
+            description: "Search the user's Jira issues (summary, status, assignee, due date). Only \
+                          available when the user has enabled + consented to the Jira connector; \
+                          results are loud-attributed '(via Jira)'. Use for questions about tickets, \
+                          deadlines, sprint work, or to check an issue's current state.",
+            parameters: str_arg("query", "What to look for in Jira, in the user's own language."),
+            write: false,
+        },
+```
+
+3. `execute_tool` refusal arm (next to the `ToolCall::WebSearch` arm at ~line 355):
+
+```rust
+        ToolCall::JiraSearch { .. } => {
+            return Err(AppError::InvalidArg(
+                "JiraSearch is an egress connector and cannot run through the egress-free tool path; \
+                 use execute_jira_search"
+                    .into(),
+            ))
+        }
+```
+
+4. Async dispatcher (next to `execute_web_search` at ~line 399) — reuses `format_web_hits` (it renders any `ConnectorHit` loudly):
+
+```rust
+/// CONNECTOR DISPATCH — run a LIVE JIRA search through the connector seam. Mirrors
+/// [`execute_web_search`]: fail-closed sentinel when not exposed (NOTHING egresses), redaction +
+/// egress-ledger applied by [`crate::connectors::ConnectorRegistry::search`], loud attribution.
+pub async fn execute_jira_search(query: &str, config: &AppConfig) -> Result<String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok("No Jira results for an empty query.".to_string());
+    }
+    let registry = crate::connectors::ConnectorRegistry::build(config);
+    match registry.search("jira", q).await {
+        Ok(hits) if hits.is_empty() => Ok(format!("No Jira results for \"{q}\".")),
+        Ok(hits) => Ok(format_web_hits(&hits)),
+        Err(crate::connectors::ConnectorError::NeedsConsent) => Ok(
+            "Jira search is not available (not enabled, not consented, or not configured)."
+                .to_string(),
+        ),
+        Err(crate::connectors::ConnectorError::Unconfigured(_)) => {
+            Ok("Jira search is not available (not configured).".to_string())
+        }
+        Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
+    }
+}
+```
+
+5. `GatedToolExecutor`: in `specs()` extend the connector filter arm at ~line 601 to `"web_search" | "calendar_lookup" | "jira_search" => has_app,` and in `run()` add next to the `"web_search"` arm (~line 686):
+
+```rust
+            "jira_search" => match self.app {
+                Some(_) => block_on_tool(execute_jira_search(&s("query"), self.config)),
+                None => Err(AppError::InvalidArg("jira_search needs an AppHandle".into())),
+            },
+```
+
+**Also grep** for where `ToolCall` is parsed from the model's tool-call name (the `match name` / serde mapping that turns `"web_search"` into `ToolCall::WebSearch`) and add the `"jira_search"` ↔ `ToolCall::JiraSearch` mapping there too — a spec without a parse arm is un-invokable.
+
+- [ ] **Step 4: GREEN.** `cargo test --lib jira && cargo test --lib tools` → PASS, no regressions.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src-tauri/src/tools.rs
+git commit -m "feat(tools): jira_search tool - gated dispatch through the connector registry"
+```
+
+### Task 2.4: Commands + registration
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Produces commands: `consent_to_jira`, `set_jira_token(key: String)`, `has_jira_token() -> bool`.
+
+- [ ] **Step 1:** Copy the three web-search commands (`consent_to_web_search` at `commands.rs:4154`, `set_web_search_api_key` at `:4862`, `has_web_search_key` at `:4871`) verbatim, renamed, using `crate::connectors::jira::JIRA_TOKEN_ACCOUNT`:
+
+```rust
+/// One-time Jira egress consent — the ONLY way `jira_consented` flips true. Persists the flag AND
+/// updates the in-memory config cache, so the next `ConnectorRegistry::build` exposes the jira tool
+/// (provided Jira is also enabled + configured + a token is stored). Idempotent.
+#[tauri::command]
+pub fn consent_to_jira(state: State<'_, AppState>) -> Result<(), AppError> {
+    let mut cache = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    cache.grant_jira_consent(&state.db)?;
+    Ok(())
+}
+
+/// Store/replace the BYO Jira API token in the Keychain (account "jira_api_token"). An empty input
+/// clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
+#[tauri::command]
+pub fn set_jira_token(key: String) -> Result<(), AppError> {
+    if key.trim().is_empty() {
+        return secrets::delete_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT);
+    }
+    secrets::set_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT, key.trim())
+}
+
+/// Whether a Jira token is currently stored (UI shows "set"/"not set"; never the value).
+#[tauri::command]
+pub fn has_jira_token() -> Result<bool, AppError> {
+    Ok(
+        secrets::get_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT)?
+            .filter(|k| !k.trim().is_empty())
+            .is_some(),
+    )
+}
+```
+
+Also extend `config_to_dto` (grep it in `commands.rs` — right below `consent_to_web_search`) with the four new fields, mirroring how `web_search_enabled`/`web_search_consented` cross to the DTO.
+
+- [ ] **Step 2:** Register all three in `lib.rs` `generate_handler![…]` next to the web-search entries.
+
+- [ ] **Step 3:** If `commands.rs` has a config-DTO / save path that enumerates fields FE-side (grep `webSearchEnabled` in `commands.rs` — the AppConfig↔DTO mapping), add `jira_enabled`/`jira_base_url`/`jira_email` (+ read-only `jira_consented`) mirroring web. The consent flag mirrors web's BLK-4 comment (`commands.rs:4354`): the save path must copy the LIVE value, never the FE's.
+
+- [ ] **Step 4:** `cargo test --lib` → green. Commit:
+
+```bash
+git add src-tauri/src/commands.rs src-tauri/src/lib.rs
+git commit -m "feat(commands): consent_to_jira + set_jira_token + has_jira_token, registered"
+```
+
+### Task 2.5: FE — settings Connectors section + IPC
+
+**Files:**
+- Modify: `src/app/core/ipc.service.ts`, `src/app/core/models.ts`
+- Modify: `src/app/features/settings/settings.store.ts`
+- Modify: `src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.{html,ts}`
+
+- [ ] **Step 1: IPC + DTO.** In `models.ts` extend `AppConfigDto` with `jiraEnabled: boolean; jiraConsented: boolean; jiraBaseUrl: string; jiraEmail: string;` (match the exact serde casing the backend DTO emits — grep how `webSearchEnabled` crosses; mirror it). In `ipc.service.ts` next to the web methods (line ~471):
+
+```ts
+  /** One-time Jira egress consent — the ONLY way jiraConsented flips true. */
+  consentToJira(): Promise<void> {
+    return invoke<void>("consent_to_jira");
+  }
+  setJiraToken(key: string): Promise<void> {
+    return invoke<void>("set_jira_token", { key });
+  }
+  hasJiraToken(): Promise<boolean> {
+    return invoke<boolean>("has_jira_token");
+  }
+```
+
+- [ ] **Step 2: Store.** In `settings.store.ts` mirror every `webSearchEnabled` touchpoint for `jiraEnabled` + the two strings (form control defaults, load mapping, save mapping) — grep `webSearchEnabled` in the file and replicate each site. Add `hasJiraToken` state + `saveJiraToken(key)` action mirroring the web-key ones (grep `hasWebKey`).
+
+- [ ] **Step 3: Section UI.** In `settings-connectors-section.component.html` append a Jira block AFTER the web-search block, copying its exact structure (toggle-row → egress banner → fieldset): toggle bound to `formControlName="jiraEnabled"`; inside the `@if (form.controls.jiraEnabled.value)` body: the warning banner (copy web's, s/web search/Jira/; state clearly *"your (redacted) query and the matching issue summaries pass through your configured AI model"*), two text inputs bound to `jiraBaseUrl` (`placeholder="https://your-site.atlassian.net"`) and `jiraEmail`, the token password input + Save button (mirror the Brave key row, calling the store's `saveJiraToken`), the key-status pill, and the consent row: if `!cfg.jiraConsented` show a `btn-primary` "Allow Jira access (one-time consent)" calling a component method that runs `await ipc.consentToJira()` then reloads config. Copy the web block's classes verbatim — no new CSS.
+
+- [ ] **Step 4:** `npx ng lint && npx ng build` → clean. Playwright smoke against a mocked invoke: toggling Jira shows banner + fields; consent button calls `consent_to_jira`.
+
+- [ ] **Step 5: Commit + PR.**
+
+```bash
+git add src/app
+git commit -m "feat(settings): Jira connector UI - toggle, base URL, email, token, one-time consent"
+gh pr create -R murmur-io/murmur --title "Jira live connector" --body "Live, fail-closed, consent-gated jira_search tool (JQL text search via /rest/api/3/search/jql, Basic auth, BYO token in Keychain). Clone of the web connector pattern; query redacted at the registry boundary + egress-ledgered. Settings UI mirrors web search."
+```
+
+**Phase 2 verify gates (both required):** (1) **lock-security-reviewer** — new External egress instance: consent fail-closed? query redacted at boundary? ledger row per attempt? token never logged/FE-exposed? inbound Jira text riding the existing RedactingProvider path to cloud reasoners (same posture as web — call it out in the PR body)? (2) **adversarial-verifier** — full `cargo test --lib`, `ng lint`, `ng build`, live Playwright pass, and a REAL round-trip needs a real Jira workspace token (manual smoke: honest bar — record it in the PR).
+
+---
+
+# Phase 3 — Slack live connector
+
+Identical shape to Phase 2. Slack specifics: GET `https://slack.com/api/search.messages` with `Authorization: Bearer xoxp-…` (a **user** token with `search:read` — NOT a bot token; bot tokens cannot call search). **Slack returns HTTP 200 with `{"ok":false,"error":"…"}` on failure — the parser MUST check `ok`.**
+
+### Task 3.1: `SlackConnector` with fixture-tested parser
+
+**Files:**
+- Create: `src-tauri/src/connectors/slack.rs`
+- Modify: `src-tauri/src/connectors/mod.rs` (add `pub mod slack;` + registry line, mirroring Task 2.1 Step 2)
+- Modify: `src-tauri/src/secrets/keychain.rs` (`pub const ACCOUNT_SLACK_TOKEN: &str = "slack_user_token";` + routing arm — mirror Task 2.1 Step 2)
+
+**Interfaces:**
+- Produces: `SlackConnector::from_config_if_available(&AppConfig) -> Option<Self>`; `Connector` impl `id() == "slack"`, `EgressClass::External`; `pub const SLACK_TOKEN_ACCOUNT: &str = "slack_user_token"`.
+- Consumes: `AppConfig.slack_enabled / slack_consented` (Task 3.2).
+
+- [ ] **Step 1: Write `connectors/slack.rs`** (complete file):
+
+```rust
+//! SLACK connector — live, on-demand message search via the Slack Web API (brain2 connectors,
+//! Phase 3 of docs/research/2026-07-05-connectors-live-vs-rag.md).
+//!
+//! ## Egress posture (NEW EGRESS CLASS INSTANCE — audited by the lock-security reviewer)
+//! [`EgressClass::External`]. Exposed ONLY when `slack_enabled && slack_consented && a user token
+//! is in the Keychain` — otherwise absent (fail-closed). The framework redacts the query first.
+//!
+//! ## Endpoint + token model
+//! `GET https://slack.com/api/search.messages?query=…&count=8` with `Authorization: Bearer xoxp-…`.
+//! `search.messages` requires a USER token (`xoxp-`, scope `search:read`) — a bot token cannot
+//! search. The token is BYO: the user creates a single-workspace app, installs it, pastes the token.
+//! QUIRK: Slack answers HTTP 200 with `{"ok":false,"error":"…"}` on failure — `parse_results`
+//! checks `ok` and surfaces the error code (non-PII) as a Failed.
+//!
+//! ## No PII in logs
+//! Connector id + hit count + HTTP status / Slack error CODE only — never queries, message text,
+//! channel names, or the token.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Connector, ConnectorError, ConnectorHit, ConnectorResult, EgressClass};
+use crate::settings::AppConfig;
+
+/// Keychain account holding the BYO Slack user token (`xoxp-…`). NEVER logged / NEVER FE-exposed.
+pub const SLACK_TOKEN_ACCOUNT: &str = "slack_user_token";
+
+const SOURCE_LABEL: &str = "Slack";
+
+/// Cap a message snippet so one long Slack message can't blow the tool budget.
+const SNIPPET_MAX: usize = 300;
+
+pub struct SlackConnector {
+    token: String,
+}
+
+impl SlackConnector {
+    /// FAIL-CLOSED gate — see module doc. Keychain error degrades to `None`.
+    pub fn from_config_if_available(config: &AppConfig) -> Option<Self> {
+        if !config.slack_enabled || !config.slack_consented {
+            return None;
+        }
+        let token = crate::secrets::get_secret(SLACK_TOKEN_ACCOUNT)
+            .ok()
+            .flatten()
+            .filter(|k| !k.trim().is_empty())?;
+        Some(Self { token })
+    }
+
+    /// Parse a `search.messages` body. `ok:false` → Failed carrying ONLY the Slack error CODE.
+    pub(crate) fn parse_results(body: &str) -> ConnectorResult {
+        let parsed: SlackSearchResponse = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("slack response parse: {e}")))?;
+        if !parsed.ok {
+            return Err(ConnectorError::Failed(format!(
+                "slack error: {}",
+                parsed.error.unwrap_or_else(|| "unknown".into())
+            )));
+        }
+        let matches = parsed.messages.map(|m| m.matches).unwrap_or_default();
+        let hits = matches
+            .into_iter()
+            .filter_map(|m| {
+                let mut text = m.text.unwrap_or_default().trim().to_string();
+                if text.is_empty() {
+                    return None;
+                }
+                if text.chars().count() > SNIPPET_MAX {
+                    text = text.chars().take(SNIPPET_MAX).collect::<String>() + "…";
+                }
+                let channel = m
+                    .channel
+                    .and_then(|c| c.name)
+                    .map(|n| format!("#{n}"))
+                    .unwrap_or_else(|| "DM".to_string());
+                let who = m.username.unwrap_or_default();
+                let title = if who.is_empty() {
+                    channel.clone()
+                } else {
+                    format!("{channel} · @{who}")
+                };
+                Some(ConnectorHit {
+                    title,
+                    snippet: text,
+                    url: m.permalink.unwrap_or_default(),
+                    source_label: SOURCE_LABEL.to_string(),
+                })
+            })
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[async_trait]
+impl Connector for SlackConnector {
+    fn id(&self) -> &str {
+        "slack"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        EgressClass::External
+    }
+
+    async fn search(&self, redacted_query: &str) -> ConnectorResult {
+        let q = redacted_query.trim();
+        if q.is_empty() {
+            return Ok(Vec::new());
+        }
+        let client = reqwest::Client::new();
+        let resp = client
+            .get("https://slack.com/api/search.messages")
+            .query(&[("query", q), ("count", "8")])
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("slack request: {}", e.without_url())))?;
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "slack", status = status.as_u16(), "slack search HTTP error");
+            return Err(ConnectorError::Failed(format!("slack HTTP {status}")));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("slack body: {}", e.without_url())))?;
+        let hits = Self::parse_results(&body)?;
+        tracing::info!(target: "connector", provider = "slack", hits = hits.len(), "slack search returned");
+        Ok(hits)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackSearchResponse {
+    #[serde(default)]
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    messages: Option<SlackMessages>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMessages {
+    #[serde(default)]
+    matches: Vec<SlackMatch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMatch {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    permalink: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    channel: Option<SlackChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackChannel {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slack_parser_maps_matches_to_hits() {
+        let body = r#"{
+            "ok": true,
+            "messages": { "matches": [
+                {"text":"We decided to ship Friday","permalink":"https://acme.slack.com/archives/C1/p1","username":"anna","channel":{"name":"eng"}},
+                {"text":"","permalink":"https://x"},
+                {"text":"No channel or user"}
+            ]}
+        }"#;
+        let hits = SlackConnector::parse_results(body).unwrap();
+        assert_eq!(hits.len(), 2, "empty-text match is skipped");
+        assert_eq!(hits[0].title, "#eng · @anna");
+        assert_eq!(hits[0].snippet, "We decided to ship Friday");
+        assert_eq!(hits[0].url, "https://acme.slack.com/archives/C1/p1");
+        assert_eq!(hits[0].source_label, "Slack");
+        assert_eq!(hits[1].title, "DM");
+    }
+
+    #[test]
+    fn slack_ok_false_is_failed_with_error_code_only() {
+        let body = r#"{"ok": false, "error": "invalid_auth"}"#;
+        match SlackConnector::parse_results(body) {
+            Err(ConnectorError::Failed(m)) => assert!(m.contains("invalid_auth")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slack_parser_truncates_long_messages() {
+        let long = "x".repeat(1000);
+        let body = format!(r#"{{"ok":true,"messages":{{"matches":[{{"text":"{long}"}}]}}}}"#);
+        let hits = SlackConnector::parse_results(&body).unwrap();
+        assert!(hits[0].snippet.chars().count() <= 301);
+        assert!(hits[0].snippet.ends_with('…'));
+    }
+
+    #[test]
+    fn slack_parser_rejects_malformed_json() {
+        assert!(matches!(
+            SlackConnector::parse_results("nope"),
+            Err(ConnectorError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn from_config_fail_closed_when_disabled_or_unconsented() {
+        let cfg = AppConfig::default();
+        assert!(SlackConnector::from_config_if_available(&cfg).is_none());
+        let cfg = AppConfig { slack_enabled: true, ..AppConfig::default() };
+        assert!(SlackConnector::from_config_if_available(&cfg).is_none(), "unconsented");
+    }
+}
+```
+
+- [ ] **Step 2:** Registry + keychain wiring exactly as Task 2.1 Step 2 (slack names). RED→GREEN: `cargo test --lib slack` (after Task 3.2 lands the config fields — same ordering note as Phase 2).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src-tauri/src/connectors/ src-tauri/src/secrets/keychain.rs
+git commit -m "feat(connectors): Slack live connector - search.messages, ok:false handling, fixture-tested"
+```
+
+### Task 3.2: Config flags (`slack_enabled/_consented`)
+
+**Files:** Modify `src-tauri/src/settings/config.rs`.
+
+- [ ] **Step 1–4:** Repeat Task 2.2 exactly for `slack_enabled` + `slack_consented` + `grant_slack_consent` (no base-url/email strings — Slack needs only the token). Tests: `slack_flags_default_off_and_round_trip`, `slack_consent_grant_persists_and_save_cannot_clobber` — same bodies as Task 2.2's with `jira`→`slack` and without the string fields. RED → implement → GREEN → commit:
+
+```bash
+git add src-tauri/src/settings/config.rs
+git commit -m "feat(config): slack connector flags - enabled + preserve-only consent"
+```
+
+### Task 3.3: Tool wiring (`slack_search`)
+
+**Files:** Modify `src-tauri/src/tools.rs`.
+
+- [ ] **Step 1–4:** Repeat Task 2.3 exactly with: `ToolCall::SlackSearch { query: String }`, spec:
+
+```rust
+        ToolSpec {
+            name: "slack_search",
+            description: "Search the user's Slack messages (channels + DMs their token can see). Only \
+                          available when the user has enabled + consented to the Slack connector; \
+                          results are loud-attributed '(via Slack)'. Use for 'what did we say/decide \
+                          about X in Slack' questions.",
+            parameters: str_arg("query", "What to look for in Slack, in the user's own language."),
+            write: false,
+        },
+```
+
+`execute_slack_search` mirrors `execute_jira_search` (registry id `"slack"`, sentinel copy s/Jira/Slack/); sync `execute_tool` refusal arm; `specs()` filter becomes `"web_search" | "calendar_lookup" | "jira_search" | "slack_search" => has_app,`; `run()` arm; the name↔variant parse mapping. Tests: `sync_execute_tool_refuses_slack_search` + `slack_search_fail_closed_returns_sentinel_no_egress` (same bodies as 2.3's, renamed). RED → GREEN → commit:
+
+```bash
+git add src-tauri/src/tools.rs
+git commit -m "feat(tools): slack_search tool - gated dispatch through the connector registry"
+```
+
+### Task 3.4: Replace the shipped voice stub
+
+**Files:** Modify `src-tauri/src/voice_action.rs` (arm at line ~222; test `slack_search_is_unavailable` at ~1321).
+
+- [ ] **Step 1:** Open `voice_action.rs` and find how the `WebSearch` voice intent executes (grep `web_search_blocking` — the blocking-bridge helper `tools.rs:792` comments reference). Rewrite the `VoiceIntent::SlackSearch { .. }` arm to mirror the WebSearch arm exactly (same blocking helper, calling `crate::tools::execute_slack_search` with the live config), keeping the current "isn't available yet" text as the sentinel the tool itself returns when unconsented (the tool's own fail-closed sentinel replaces the hardcoded stub message).
+- [ ] **Step 2:** Update the `slack_search_is_unavailable` test: with a default (unconsented) config the result must now carry the tool's fail-closed sentinel (`"not available"` substring) — still a non-answer, still zero egress. RED if you changed the arm wrong; GREEN when the sentinel flows through.
+- [ ] **Step 3:** `cargo test --lib voice_action` → PASS. Commit:
+
+```bash
+git add src-tauri/src/voice_action.rs
+git commit -m "feat(voice): SlackSearch voice intent rides the real connector (fail-closed sentinel when unconsented)"
+```
+
+### Task 3.5: Commands + FE
+
+**Files:** as Phase 2 Tasks 2.4 + 2.5, for Slack.
+
+- [ ] **Step 1:** Commands `consent_to_slack` / `set_slack_token` / `has_slack_token` (copy the jira trio, `SLACK_TOKEN_ACCOUNT`), registered in `lib.rs`. Config-DTO mapping for `slack_enabled` (+read-only `slack_consented`).
+- [ ] **Step 2:** FE: `models.ts` (`slackEnabled`, `slackConsented`), `ipc.service.ts` (three methods), `settings.store.ts` (mirror every `jiraEnabled` touchpoint minus the strings), connectors-section HTML block AFTER Jira (toggle → banner → token fieldset with help copy: *"Paste a user token (xoxp-…) from a single-workspace Slack app with the search:read scope"* → consent button).
+- [ ] **Step 3:** `cargo test --lib` + `npx ng lint && npx ng build` → green. Playwright smoke. Commit + PR:
+
+```bash
+git add src-tauri/src src/app
+git commit -m "feat(settings): Slack connector UI - toggle, user token, one-time consent"
+gh pr create -R murmur-io/murmur --title "Slack live connector" --body "Live, fail-closed, consent-gated slack_search tool (search.messages, xoxp user token in Keychain, ok:false handled, snippets capped). Voice SlackSearch stub replaced by the real connector. Mirrors the web/Jira pattern."
+```
+
+**Phase 3 verify gates:** same two as Phase 2 (lock-security-reviewer + adversarial-verifier). Real-token round-trip = manual smoke, recorded in the PR (honest bar).
+
+---
+
+# Phase 4 — Note verify pass (deterministic, live-Jira)
+
+**Design (from `2026-07-05-connectors-live-vs-rag.md`):** on-demand, consent-gated, NEVER in the zero-egress proactive path. v1 is **fully deterministic — no LLM anywhere**: regex extracts Jira issue keys from the note, live Jira supplies the current issue state, pure Rust judges, non-destructive `> ` blockquote markers mirror `annotate_unverified` (`summarize/grounding.rs:66`). Marker application is **idempotent** (strip-then-reinsert). Depends on Phase 2 (JiraConnector). **lock-security-reviewer required** (note read/write + new lookup egress).
+
+### Task 4.1: `verify.rs` — pure extraction + judgment + markers (no network)
+
+**Files:**
+- Create: `src-tauri/src/verify.rs`
+- Modify: `src-tauri/src/lib.rs` (add `pub mod verify;` next to the other module decls — grep `mod proactive;` and mirror)
+
+**Interfaces:**
+- Produces:
+  - `pub struct IssueSnapshot { pub key: String, pub summary: String, pub status: String, pub due: Option<String>, pub url: String }`
+  - `pub struct VerifyFinding { pub line_no: usize, pub key: String, pub verdict: Verdict, pub detail: String, pub url: String }` with `pub enum Verdict { Confirmed, NotFound, Conflict }` (both `serde::Serialize + Deserialize`, `#[serde(rename_all = "camelCase")]` on the struct, verdict serialized lowercase via `#[serde(rename_all = "lowercase")]`)
+  - `pub fn extract_issue_keys(note_md: &str) -> Vec<(usize, String)>`
+  - `pub fn judge(line_text: &str, key: &str, snap: Option<&IssueSnapshot>) -> (Verdict, String)`
+  - `pub fn apply_verify_markers(note_md: &str, findings: &[VerifyFinding]) -> String`
+
+- [ ] **Step 1: Write the failing tests first** (bottom of the new `verify.rs`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(key: &str, status: &str, due: Option<&str>) -> IssueSnapshot {
+        IssueSnapshot {
+            key: key.into(),
+            summary: "Fix login".into(),
+            status: status.into(),
+            due: due.map(String::from),
+            url: format!("https://acme.atlassian.net/browse/{key}"),
+        }
+    }
+
+    #[test]
+    fn extracts_unique_keys_with_line_numbers_capped() {
+        let md = "---\ntitle: x\n---\n# Notes\n- Ship PROJ-123 by Friday\n- PROJ-123 again\n- also ABC-9\n";
+        let keys = extract_issue_keys(md);
+        // 1-based line numbers COUNT the frontmatter lines: PROJ-123 sits on line 5, ABC-9 on 7.
+        assert_eq!(keys, vec![(5, "PROJ-123".to_string()), (7, "ABC-9".to_string())]);
+        // Cap at 10 unique keys.
+        let many: String = (1..=15).map(|i| format!("- K{i}A-{i}\n")).collect();
+        assert_eq!(extract_issue_keys(&many).len(), 10);
+    }
+
+    #[test]
+    fn frontmatter_and_existing_markers_are_not_scanned() {
+        let md = "---\nref: FM-1\n---\n> ✓ OLD-1 · Status: Done (via Jira)\n- real REAL-2\n";
+        let keys = extract_issue_keys(md);
+        // FM-1 (frontmatter) and OLD-1 (our own marker line) are skipped; REAL-2 is on line 5.
+        assert_eq!(keys, vec![(5, "REAL-2".to_string())]);
+    }
+
+    #[test]
+    fn judge_not_found_confirmed_and_date_conflict() {
+        // Missing issue → NotFound.
+        let (v, d) = judge("- Ship PROJ-1 by 2026-07-08", "PROJ-1", None);
+        assert!(matches!(v, Verdict::NotFound));
+        assert!(d.contains("PROJ-1"));
+        // Found, no date in the line → Confirmed with status/due detail.
+        let s = snap("PROJ-1", "In Progress", Some("2026-07-10"));
+        let (v, d) = judge("- Ship PROJ-1 soon", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Confirmed));
+        assert!(d.contains("In Progress") && d.contains("2026-07-10"));
+        // ISO date in the line ≠ issue due → Conflict naming both dates.
+        let (v, d) = judge("- Ship PROJ-1 by 2026-07-08", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Conflict));
+        assert!(d.contains("2026-07-08") && d.contains("2026-07-10"));
+        // ISO date matching the due → Confirmed.
+        let (v, _) = judge("- Ship PROJ-1 by 2026-07-10", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Confirmed));
+    }
+
+    #[test]
+    fn markers_are_inserted_after_lines_and_idempotent() {
+        let md = "# N\n- Ship PROJ-1 by 2026-07-08\n- other line\n";
+        let f = VerifyFinding {
+            line_no: 2,
+            key: "PROJ-1".into(),
+            verdict: Verdict::Conflict,
+            detail: "note says 2026-07-08, PROJ-1 due 2026-07-10".into(),
+            url: "https://x/browse/PROJ-1".into(),
+        };
+        let once = apply_verify_markers(md, &[f.clone()]);
+        assert!(once.contains("\n> ⧗ note says 2026-07-08, PROJ-1 due 2026-07-10 (via Jira)\n"));
+        // Idempotent: applying again yields byte-identical output (old markers stripped first).
+        let twice = apply_verify_markers(&once, &[f]);
+        assert_eq!(once, twice);
+        // Non-destructive: original lines untouched.
+        assert!(twice.contains("- Ship PROJ-1 by 2026-07-08"));
+        assert!(twice.contains("- other line"));
+    }
+
+    #[test]
+    fn empty_findings_strip_stale_markers_only() {
+        let md = "# N\n- done PROJ-1\n> ✓ PROJ-1 · Status: Done (via Jira)\n";
+        let out = apply_verify_markers(md, &[]);
+        assert!(!out.contains("(via Jira)"), "stale markers removed");
+        assert!(out.contains("- done PROJ-1"));
+    }
+}
+```
+
+- [ ] **Step 2: RED.** `cargo test --lib verify` → FAIL (module doesn't exist).
+
+- [ ] **Step 3: Implement** (top of `verify.rs`; check whether the crate already depends on `regex` — grep `use regex` / `Cargo.toml`; if NOT present, implement the key-matcher with a hand-rolled scanner as below — **no new crates**):
+
+```rust
+//! NOTE VERIFY — deterministic verification of note claims against LIVE connector truth (v1: Jira).
+//!
+//! Design (docs/research/2026-07-05-connectors-live-vs-rag.md): the LLM is NEVER the judge.
+//! `extract_issue_keys` (pure regex-free scanner) finds ticket keys; the caller fetches each
+//! issue's CURRENT state live (staleness would INVERT a verification); `judge` (pure) compares;
+//! `apply_verify_markers` appends non-destructive `> ` blockquote markers exactly like
+//! `summarize/grounding.rs::annotate_unverified` — idempotent (strip old `(via Jira)` markers,
+//! re-insert), byte-preserving for every original line.
+//!
+//! On-demand + consent-gated ONLY (rides the Jira connector gates). NEVER wired into the
+//! zero-egress proactive path (`proactive.rs` contract D1).
+
+use serde::{Deserialize, Serialize};
+
+/// The live state of one Jira issue, fetched at verify time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueSnapshot {
+    pub key: String,
+    pub summary: String,
+    pub status: String,
+    pub due: Option<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    Confirmed,
+    NotFound,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyFinding {
+    /// 1-based line number in the note markdown the claim sits on.
+    pub line_no: usize,
+    pub key: String,
+    pub verdict: Verdict,
+    /// Human detail rendered in the marker/panel. Contains ONLY connector-sourced values +
+    /// dates already present in the note line — never other note content.
+    pub detail: String,
+    pub url: String,
+}
+
+/// Max unique keys verified per pass (bounds egress + latency).
+const MAX_KEYS: usize = 10;
+
+/// A verify marker line we own (and may strip on re-apply).
+fn is_verify_marker(line: &str) -> bool {
+    let t = line.trim_start();
+    (t.starts_with("> ✓") || t.starts_with("> ⚠") || t.starts_with("> ⧗"))
+        && t.trim_end().ends_with("(via Jira)")
+}
+
+/// Scan for Jira-style issue keys (`ABC-123`): 1 uppercase letter + up to 9 uppercase
+/// alphanumerics, a dash, 1–6 digits, on WORD BOUNDARIES. Skips YAML frontmatter and our own
+/// marker lines. Returns (1-based line_no, key), first occurrence per unique key, capped.
+pub fn extract_issue_keys(note_md: &str) -> Vec<(usize, String)> {
+    let mut out: Vec<(usize, String)> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut in_frontmatter = false;
+    for (idx, line) in note_md.lines().enumerate() {
+        let line_no = idx + 1;
+        if idx == 0 && line.trim() == "---" {
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter {
+            if line.trim() == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+        if is_verify_marker(line) {
+            continue;
+        }
+        for key in scan_keys(line) {
+            if out.len() >= MAX_KEYS {
+                return out;
+            }
+            if seen.insert(key.clone()) {
+                out.push((line_no, key));
+            }
+        }
+    }
+    out
+}
+
+/// Hand-rolled key scanner (no `regex` dependency): uppercase run then '-' then digit run,
+/// bounded by non-alphanumerics.
+fn scan_keys(line: &str) -> Vec<String> {
+    let bytes = line.as_bytes();
+    let mut keys = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Word boundary: previous char must not be alphanumeric.
+        if i > 0 && bytes[i - 1].is_ascii_alphanumeric() {
+            i += 1;
+            continue;
+        }
+        // Project part: uppercase letter then 0..=9 uppercase alphanumerics.
+        if !bytes[i].is_ascii_uppercase() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut j = i + 1;
+        while j < bytes.len()
+            && j - start < 10
+            && (bytes[j].is_ascii_uppercase() || bytes[j].is_ascii_digit())
+        {
+            j += 1;
+        }
+        if j < bytes.len() && bytes[j] == b'-' {
+            let dash = j;
+            let mut k = dash + 1;
+            while k < bytes.len() && k - dash <= 6 && bytes[k].is_ascii_digit() {
+                k += 1;
+            }
+            let digits = k - dash - 1;
+            let boundary_ok = k >= bytes.len() || !bytes[k].is_ascii_alphanumeric();
+            if digits >= 1 && boundary_ok {
+                keys.push(line[start..k].to_string());
+                i = k;
+                continue;
+            }
+        }
+        i = j;
+    }
+    keys
+}
+
+/// Find the first ISO date (`YYYY-MM-DD`) in a line, if any (hand-rolled, no regex).
+fn first_iso_date(line: &str) -> Option<String> {
+    let b = line.as_bytes();
+    for i in 0..b.len().saturating_sub(9) {
+        if i > 0 && b[i - 1].is_ascii_digit() {
+            continue;
+        }
+        let w = &b[i..i + 10];
+        let shape = w[0].is_ascii_digit()
+            && w[1].is_ascii_digit()
+            && w[2].is_ascii_digit()
+            && w[3].is_ascii_digit()
+            && w[4] == b'-'
+            && w[5].is_ascii_digit()
+            && w[6].is_ascii_digit()
+            && w[7] == b'-'
+            && w[8].is_ascii_digit()
+            && w[9].is_ascii_digit();
+        let boundary = i + 10 >= b.len() || !b[i + 10].is_ascii_digit();
+        if shape && boundary {
+            return Some(line[i..i + 10].to_string());
+        }
+    }
+    None
+}
+
+/// PURE deterministic verdict — the load-bearing property (mirrors `facts::reconcile_facts`:
+/// the LLM never judges; injected text has no judgment step to hijack).
+pub fn judge(line_text: &str, key: &str, snap: Option<&IssueSnapshot>) -> (Verdict, String) {
+    match snap {
+        None => (Verdict::NotFound, format!("{key} not found in Jira")),
+        Some(s) => {
+            if let (Some(note_date), Some(due)) = (first_iso_date(line_text), s.due.as_deref()) {
+                if note_date != due {
+                    return (
+                        Verdict::Conflict,
+                        format!("note says {note_date}, {key} due {due}"),
+                    );
+                }
+            }
+            let mut detail = format!("{key} · Status: {}", s.status);
+            if let Some(due) = s.due.as_deref() {
+                detail.push_str(&format!(" · due {due}"));
+            }
+            (Verdict::Confirmed, detail)
+        }
+    }
+}
+
+/// Append one non-destructive marker blockquote after each finding's line. IDEMPOTENT: all
+/// existing `(via Jira)` marker lines are stripped first, so re-verifying replaces (never stacks).
+/// Every ORIGINAL line is preserved byte-identically (the annotate_unverified discipline).
+pub fn apply_verify_markers(note_md: &str, findings: &[VerifyFinding]) -> String {
+    // 1) Strip our old markers, remembering the original line numbering AFTER the strip.
+    let kept: Vec<&str> = note_md.lines().filter(|l| !is_verify_marker(l)).collect();
+    // 2) Group findings by line_no (computed against the STRIPPED text — the command recomputes
+    //    findings from the stripped note, see verify_note_sources).
+    let mut out: Vec<String> = Vec::with_capacity(kept.len() + findings.len());
+    for (idx, line) in kept.iter().enumerate() {
+        out.push((*line).to_string());
+        let line_no = idx + 1;
+        for f in findings.iter().filter(|f| f.line_no == line_no) {
+            let glyph = match f.verdict {
+                Verdict::Confirmed => "✓",
+                Verdict::NotFound => "⚠",
+                Verdict::Conflict => "⧗",
+            };
+            out.push(format!("> {glyph} {} (via Jira)", f.detail));
+        }
+    }
+    let mut s = out.join("\n");
+    if note_md.ends_with('\n') {
+        s.push('\n');
+    }
+    s
+}
+```
+
+- [ ] **Step 4: GREEN.** `cargo test --lib verify` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src-tauri/src/verify.rs src-tauri/src/lib.rs
+git commit -m "feat(verify): pure deterministic note-claim extraction, judgment, idempotent markers"
+```
+
+### Task 4.2: `JiraConnector::get_issue` + registry lookup with ledger
+
+**Files:**
+- Modify: `src-tauri/src/connectors/jira.rs`
+- Modify: `src-tauri/src/connectors/mod.rs`
+
+**Interfaces:**
+- Produces: `JiraConnector::get_issue(&self, key: &str) -> Result<Option<crate::verify::IssueSnapshot>, ConnectorError>` (async); `ConnectorRegistry::jira_lookup(&self, key: &str) -> Result<Option<crate::verify::IssueSnapshot>, ConnectorError>` (async; fail-closed + one content-free ledger row per attempt).
+
+- [ ] **Step 1: Failing test** (in `connectors/mod.rs` tests — mirrors `connector_search_records_one_content_free_egress_row`):
+
+```rust
+    #[test]
+    fn jira_lookup_fails_closed_without_ledger_when_not_exposed() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(captured.clone())),
+        );
+        let res = block_on(registry.jira_lookup("PROJ-1"));
+        assert!(matches!(res, Err(ConnectorError::NeedsConsent)));
+        assert!(captured.lock().unwrap().is_empty(), "no egress ⇒ no ledger row");
+    }
+
+    #[test]
+    fn jira_lookup_rejects_malformed_keys_without_egress() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(captured.clone())),
+        );
+        // Even before exposure is checked, a key that isn't a strict issue key is refused.
+        let res = block_on(registry.jira_lookup("not a key; DROP TABLE"));
+        assert!(res.is_err());
+        assert!(captured.lock().unwrap().is_empty());
+    }
+```
+
+- [ ] **Step 2: RED.** `cargo test --lib jira_lookup` → FAIL.
+
+- [ ] **Step 3: Implement.** In `jira.rs` add to `impl JiraConnector`:
+
+```rust
+    /// Fetch ONE issue's current state (verify pass). `Ok(None)` on 404 (not found / no access —
+    /// Jira Cloud returns 404 for both). The KEY is validated by the caller (strict issue-key
+    /// shape) — it is an identifier, not free text, so it needs no PII redaction.
+    pub async fn get_issue(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!(
+                "{}/rest/api/3/issue/{key}?fields=summary,status,duedate",
+                self.base_url
+            ))
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira issue request: {}", e.without_url())))?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "jira", status = status.as_u16(), "jira issue HTTP error");
+            return Err(ConnectorError::Failed(format!("jira HTTP {status}")));
+        }
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira body: {}", e.without_url())))?;
+        Self::parse_issue(&text, &self.base_url)
+    }
+
+    /// Parse a single-issue body into a snapshot (fixture-testable, no network).
+    pub(crate) fn parse_issue(
+        body: &str,
+        base_url: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        let issue: JiraIssue = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("jira issue parse: {e}")))?;
+        if issue.key.trim().is_empty() {
+            return Ok(None);
+        }
+        let f = issue.fields;
+        Ok(Some(crate::verify::IssueSnapshot {
+            key: issue.key.clone(),
+            summary: f.summary.unwrap_or_default(),
+            status: f.status.and_then(|s| s.name).unwrap_or_default(),
+            due: f.duedate,
+            url: format!("{base_url}/browse/{}", issue.key),
+        }))
+    }
+```
+
+Add a fixture test in `jira.rs`:
+
+```rust
+    #[test]
+    fn jira_issue_parser_maps_snapshot() {
+        let body = r#"{"key":"PROJ-1","fields":{"summary":"Fix login","status":{"name":"In Progress"},"duedate":"2026-07-10"}}"#;
+        let s = JiraConnector::parse_issue(body, "https://acme.atlassian.net").unwrap().unwrap();
+        assert_eq!(s.key, "PROJ-1");
+        assert_eq!(s.status, "In Progress");
+        assert_eq!(s.due.as_deref(), Some("2026-07-10"));
+        assert_eq!(s.url, "https://acme.atlassian.net/browse/PROJ-1");
+    }
+```
+
+In `mod.rs` add to `impl ConnectorRegistry` (below `search`):
+
+```rust
+    /// VERIFY-PASS lookup: fetch one Jira issue's live state through the SAME fail-closed +
+    /// ledgered discipline as `search`. The key is a strict issue identifier (validated here),
+    /// not free text — no PII redaction applies, but the attempt IS recorded content-free.
+    pub async fn jira_lookup(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        // Strict shape guard BEFORE anything else (defense-in-depth against URL injection).
+        let valid = crate::verify::extract_issue_keys(key)
+            .first()
+            .map(|(_, k)| k == key)
+            .unwrap_or(false);
+        if !valid {
+            return Err(ConnectorError::Failed("invalid issue key".into()));
+        }
+        let Some(connector) = self.connectors.iter().find(|c| c.id() == "jira") else {
+            return Err(ConnectorError::NeedsConsent);
+        };
+        if connector.egress_class() == EgressClass::External {
+            self.sink.record(EgressEntry {
+                provider_id: "jira".to_string(),
+                destination: "Jira issue lookup (connector)".to_string(),
+                model_requested: String::new(),
+                call_kind: "connector_lookup",
+                meta: CallMeta::default(),
+                redactions: Default::default(),
+                system_bytes: 0,
+                user_bytes: key.len(),
+                meeting_id: None,
+            });
+        }
+        // Downcast-free dispatch: the registry stores `dyn Connector`; the lookup is Jira-only in
+        // v1, so rebuild the concrete connector from the SAME config-derived state is not possible
+        // here — instead expose lookup via the trait with a default "unsupported" impl:
+        connector.lookup(key).await
+    }
+```
+
+and extend the `Connector` trait (in the same file) with a defaulted method so no other connector changes:
+
+```rust
+    /// OPTIONAL identifier lookup (verify pass). Default: unsupported. `id` is a strict,
+    /// caller-validated identifier (e.g. a Jira issue key), never free text.
+    async fn lookup(
+        &self,
+        _id: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        Err(ConnectorError::Unconfigured("lookup not supported".into()))
+    }
+```
+
+then in `jira.rs` implement it on the `Connector` impl:
+
+```rust
+    async fn lookup(
+        &self,
+        id: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        self.get_issue(id).await
+    }
+```
+
+(Check the `redactions: Default::default()` field type — grep the `EgressEntry` struct and its redaction-counts type; if it lacks `Default`, construct the zero-counts value the way the tests at `mod.rs:491` read it.)
+
+- [ ] **Step 4: GREEN.** `cargo test --lib jira_lookup && cargo test --lib jira` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src-tauri/src/connectors/
+git commit -m "feat(connectors): Jira issue lookup via the registry - fail-closed, strict-key, ledgered"
+```
+
+### Task 4.3: Commands `verify_note_sources` + `apply_note_verify_markers`
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`, `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Produces: `verify_note_sources(meeting_id) -> Vec<crate::verify::VerifyFinding>` (async), `apply_note_verify_markers(meeting_id, findings: Vec<crate::verify::VerifyFinding>) -> NoteDto` (sync).
+
+- [ ] **Step 1: Implement** (place next to `update_note`, `commands.rs:1147`; grep `get_latest_note_for_meeting` + copy `update_note`'s save/re-export tail):
+
+```rust
+/// VERIFY PASS (read-only): extract Jira issue keys from the meeting's note and check each against
+/// LIVE Jira. GATED: sealed-not-unlocked meetings refuse (a verify against a blanked note would be
+/// nonsense AND a read-gate bypass). Consent-gated: rides the Jira connector's enable+consent+key
+/// gate (fail-closed `NeedsConsent` maps to `AppError::Unavailable`). NEVER called proactively —
+/// FE-invoked only. Findings are computed against the note WITH OLD MARKERS STRIPPED so line
+/// numbers line up with `apply_verify_markers`' post-strip numbering.
+#[tauri::command]
+pub async fn verify_note_sources(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<crate::verify::VerifyFinding>, AppError> {
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to verify the note".into(),
+        ));
+    }
+    let note = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    // Strip our own old markers so extraction/judgment sees the canonical note lines.
+    let stripped = crate::verify::apply_verify_markers(&note.markdown, &[]);
+    let keys = crate::verify::extract_issue_keys(&stripped);
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let config = state.config.lock().map_err(|_| AppError::Other(anyhow::anyhow!("config lock")))?.clone();
+    let registry = crate::connectors::ConnectorRegistry::build(&config);
+    let lines: Vec<&str> = stripped.lines().collect();
+    let mut findings = Vec::with_capacity(keys.len());
+    for (line_no, key) in keys {
+        let snap = registry.jira_lookup(&key).await.map_err(AppError::from)?;
+        let line_text = lines.get(line_no - 1).copied().unwrap_or("");
+        let (verdict, detail) = crate::verify::judge(line_text, &key, snap.as_ref());
+        let url = snap.map(|s| s.url).unwrap_or_default();
+        findings.push(crate::verify::VerifyFinding { line_no, key, verdict, detail, url });
+    }
+    Ok(findings)
+}
+
+/// Apply verify markers to the note (WRITE — same gate + save/re-export tail as `update_note`).
+/// Takes the findings the user just reviewed in the panel; validates every key's strict shape.
+#[tauri::command]
+pub fn apply_note_verify_markers(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    findings: Vec<crate::verify::VerifyFinding>,
+) -> Result<NoteDto, AppError> {
+    if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to edit the note".into(),
+        ));
+    }
+    for f in &findings {
+        let ok = crate::verify::extract_issue_keys(&f.key)
+            .first()
+            .map(|(_, k)| k == &f.key)
+            .unwrap_or(false);
+        if !ok {
+            return Err(AppError::InvalidArg(format!("invalid issue key in findings")));
+        }
+    }
+    let existing = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    let marked = crate::verify::apply_verify_markers(&existing.markdown, &findings);
+    // Save + re-export — the exact `update_note` tail (commands.rs:1147), with `marked`.
+    let created_at = chrono::Utc::now().to_rfc3339();
+    state.db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.clone(),
+        provider_id: existing.provider_id.clone(),
+        markdown: marked.clone(),
+        created_at,
+        exported_path: existing.exported_path.clone(),
+        model_requested: existing.model_requested.clone(),
+        model_served: existing.model_served.clone(),
+        gateway_host: existing.gateway_host.clone(),
+    })?;
+    if let Some(path) = existing.exported_path.as_deref() {
+        crate::export::overwrite_note(std::path::Path::new(path), &marked)?;
+    }
+    Ok(NoteDto {
+        meeting_id,
+        provider_id: existing.provider_id,
+        markdown: marked,
+        exported_path: existing.exported_path,
+    })
+}
+```
+
+(Verify the `NoteRecord`/`NoteDto` field lists against the current `update_note` before compiling — they are copied from it; if `update_note` gained fields since, mirror the current tail.) Also grep how `state.config` is actually accessed in async commands (`commands.rs` has many examples — e.g. `execute_web_search` callers; copy the exact lock/clone idiom used there instead of my sketch if it differs).
+
+- [ ] **Step 2:** Register both in `lib.rs` `generate_handler![…]`.
+
+- [ ] **Step 3: Tests** (in `commands.rs` tests — grep how neighboring command tests build a test `AppState`; if command-level tests aren't the local pattern, cover the gate indirectly): the load-bearing unit tests already live in `verify.rs`; add ONE gate test if the file's test harness supports building `AppState` (grep `fn build_state` in commands tests — memory says it exists): sealed meeting → `verify_note_sources` returns `AppError::Locked` (RED-before-GREEN by asserting on a sealed fixture).
+
+- [ ] **Step 4:** `cargo test --lib` → green. Commit:
+
+```bash
+git add src-tauri/src/commands.rs src-tauri/src/lib.rs
+git commit -m "feat(commands): verify_note_sources + apply_note_verify_markers - gated, consent-riding, strict-key"
+```
+
+### Task 4.4: FE — Verify panel in the note detail
+
+**Files:**
+- Create: `src/app/features/detail/verify-panel/verify-panel.component.{ts,html,scss}`
+- Modify: `src/app/core/ipc.service.ts`, `src/app/core/models.ts`
+- Modify: `src/app/features/detail/detail/detail.component.{ts,html}` (the Note tab)
+
+**Interfaces:**
+- Consumes: `verify_note_sources` / `apply_note_verify_markers` commands.
+- Produces: `<app-verify-panel [meetingId]="…" (noteChanged)="…">`.
+
+- [ ] **Step 1: DTO + IPC.** `models.ts`:
+
+```ts
+export interface VerifyFindingDto {
+  lineNo: number;
+  key: string;
+  verdict: "confirmed" | "notfound" | "conflict";
+  detail: string;
+  url: string;
+}
+```
+
+(**Check the serde casing**: `Verdict::NotFound` with `rename_all = "lowercase"` serializes as `"notfound"` — confirm against a quick `cargo test` debug or adjust the backend to `#[serde(rename_all = "snake_case")]` → `"not_found"` and mirror here; pick ONE and test it.)
+
+`ipc.service.ts`:
+
+```ts
+  verifyNoteSources(meetingId: string): Promise<VerifyFindingDto[]> {
+    return invoke<VerifyFindingDto[]>("verify_note_sources", { meetingId });
+  }
+  applyNoteVerifyMarkers(meetingId: string, findings: VerifyFindingDto[]): Promise<NoteDto> {
+    return invoke<NoteDto>("apply_note_verify_markers", { meetingId, findings });
+  }
+```
+
+- [ ] **Step 2: Component.** `verify-panel.component.ts`:
+
+```ts
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { VerifyFindingDto } from "../../../core/models";
+
+/**
+ * VERIFY WITH JIRA — on-demand deterministic check of the note's ticket claims against LIVE Jira
+ * (docs/research/2026-07-05-connectors-live-vs-rag.md). On-demand ONLY (an explicit click = the
+ * egress consent moment is visible); results render as a list; "Add markers to note" persists the
+ * non-destructive > blockquote markers through the gated backend command.
+ */
+@Component({
+  selector: "app-verify-panel",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./verify-panel.component.html",
+  styleUrl: "./verify-panel.component.scss",
+})
+export class VerifyPanelComponent {
+  private readonly ipc = inject(IpcService);
+
+  readonly meetingId = input.required<string>();
+  /** Fires after markers are applied so the parent reloads the note. */
+  readonly noteChanged = output<void>();
+
+  readonly running = signal(false);
+  readonly applied = signal(false);
+  readonly findings = signal<VerifyFindingDto[] | null>(null);
+  readonly error = signal<string | null>(null);
+
+  glyph(v: VerifyFindingDto["verdict"]): string {
+    return v === "confirmed" ? "✓" : v === "conflict" ? "⧗" : "⚠";
+  }
+
+  async verify(): Promise<void> {
+    if (this.running()) return;
+    this.running.set(true);
+    this.error.set(null);
+    this.applied.set(false);
+    try {
+      this.findings.set(await this.ipc.verifyNoteSources(this.meetingId()));
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+
+  async apply(): Promise<void> {
+    const f = this.findings();
+    if (!f || this.running()) return;
+    this.running.set(true);
+    try {
+      await this.ipc.applyNoteVerifyMarkers(this.meetingId(), f);
+      this.applied.set(true);
+      this.noteChanged.emit();
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+}
+```
+
+`verify-panel.component.html`:
+
+```html
+<div class="verify-panel">
+  <div class="verify-head">
+    <button type="button" class="btn btn-ghost" (click)="verify()" [disabled]="running()">
+      @if (running()) { Checking Jira… } @else { Verify with Jira }
+    </button>
+    @if (findings(); as f) {
+      @if (f.length > 0 && !applied()) {
+        <button type="button" class="btn btn-primary" (click)="apply()" [disabled]="running()">
+          Add markers to note
+        </button>
+      }
+    }
+  </div>
+
+  @if (findings(); as f) {
+    @if (f.length === 0) {
+      <p class="text-secondary">No ticket references found in this note.</p>
+    } @else {
+      <ul class="verify-list">
+        @for (item of f; track item.key) {
+          <li class="verify-item" [class]="'is-' + item.verdict">
+            <span class="verify-glyph">{{ glyph(item.verdict) }}</span>
+            <span class="verify-detail">{{ item.detail }}</span>
+            @if (item.url) {
+              <a [href]="item.url" target="_blank" rel="noopener">{{ item.key }}</a>
+            }
+          </li>
+        }
+      </ul>
+    }
+  }
+  @if (applied()) {
+    <p class="text-secondary">Markers added — the note now carries the verification inline.</p>
+  }
+  @if (error(); as e) {
+    <p class="banner is-warning" role="alert">{{ e }}</p>
+  }
+</div>
+```
+
+`verify-panel.component.scss`:
+
+```scss
+.verify-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.verify-head {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.verify-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.verify-item {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+  &.is-conflict .verify-glyph { color: var(--live, orange); }
+  &.is-notfound .verify-glyph { color: var(--text-secondary); }
+  &.is-confirmed .verify-glyph { color: var(--accent); }
+}
+```
+
+(Token names `--live`/`--accent`/`--text-secondary` — grep `src/design-tokens/colors.css` for the real warn/success tokens and use those; never a raw hex.)
+
+- [ ] **Step 3: Mount in detail.** In `detail.component.html`, inside the Note tab (grep the tab structure — memory: Note/Audio/Share tabs from #194), below the note body render:
+
+```html
+@if (config()?.jiraEnabled && config()?.jiraConsented && !detail()?.locked) {
+  <app-verify-panel [meetingId]="meetingId()" (noteChanged)="reloadDetail()" />
+}
+```
+
+(Grep the component's real signals: the config signal, the locked flag on the detail DTO, the note-reload method — use the actual names; the panel must be HIDDEN for locked meetings and when Jira isn't consented.) Add `VerifyPanelComponent` to `imports`.
+
+- [ ] **Step 4:** `npx ng lint && npx ng build` → clean. Playwright smoke with mocked invoke: `verify_note_sources` returns a 3-finding fixture (one of each verdict) → panel renders glyphs; `apply_note_verify_markers` called on Apply; panel absent when `locked:true`.
+
+- [ ] **Step 5: Commit + PR.**
+
+```bash
+git add src/app src-tauri/src
+git commit -m "feat(detail): Verify with Jira panel - findings list + inline note markers"
+gh pr create -R murmur-io/murmur --title "Note verify pass (deterministic, live Jira)" --body "On-demand verify: regex-extracted ticket claims checked against LIVE Jira (no LLM judge - pure deterministic compare, injection-resistant by construction), idempotent non-destructive markers mirroring annotate_unverified. Gated by meeting_is_unlocked + the Jira connector consent; every lookup egress-ledgered; never proactive."
+```
+
+**Phase 4 verify gates (both required):** (1) **lock-security-reviewer** — sealed meeting refuses both commands (`AppError::Locked`)? markers never applied to a blanked note? lookup fail-closed + ledgered + strict-key? findings' `detail` carries only connector values + note-line dates (no note content beyond the claim's own date)? (2) **adversarial-verifier** — full gates + live Playwright + the idempotency property (apply twice = byte-identical) + RED-before-GREEN on the sealed-refusal test. Real-Jira round-trip = manual smoke, recorded.
+
+---
+
+## Execution order & dependencies
+
+```
+Phase 1 (FE-only)            — independent, ship first (highest leverage)
+Phase 2 (Jira)               — independent of 1
+Phase 3 (Slack)              — after 2 merges (same files: config.rs, tools.rs, mod.rs, connectors section — rebase, don't parallelize)
+Phase 4 (Verify)             — after 2 merges (extends JiraConnector); independent of 3
+```
+
+Each phase: branch → tasks in order → `bash scripts/ci.sh` ONCE at the end → PR → the phase's verify gates → merge. The implementer NEVER self-certifies — the adversarial-verifier (and lock-security-reviewer where marked) owns PASS/FAIL.
+
+## Post-plan follow-ups (explicitly OUT of scope)
+
+- Linear connector (same clone; after Slack).
+- Slack existence-check sub-profile in the verify pass (search-existence, not value-compare).
+- Session RAM cache for connector hits (add only if dogfooding shows repeat-fetch latency).
+- Pin-to-note (connector hit → owned document via `import_text`).
+- Write-out (create Jira issue via propose-accept) — separate track, lethal-trifecta review required.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -249,6 +249,25 @@ pub struct AppConfigDto {
     /// neither grant nor clear web-search egress consent. `#[serde(default)]` = false (fail-closed).
     #[serde(default)]
     pub web_search_consented: bool,
+    /// brain2 connectors (Phase 2) — the JIRA master toggle. Settable from the DTO (the Settings UI
+    /// owns the toggle). An omitted value deserializes to `false` (`#[serde(default)]`), so a
+    /// partial/older save can never silently enable it. Even ON, the connector is exposed only once
+    /// `jira_consented` is granted AND a base URL + email + token are configured.
+    #[serde(default)]
+    pub jira_enabled: bool,
+    /// brain2 connectors — one-time JIRA egress consent. PRESERVE-ONLY on this DTO, exactly like
+    /// `web_search_consented`: `get_config` carries the current value OUT (so the FE can show consent
+    /// status), but `dto_to_config` IGNORES the incoming value and PRESERVES the stored one. The ONLY
+    /// mutator is the dedicated `consent_to_jira` command. `#[serde(default)]` = false (fail-closed).
+    #[serde(default)]
+    pub jira_consented: bool,
+    /// The Jira Cloud site base URL (non-secret). Settable from the DTO. Default `""` (unset).
+    #[serde(default)]
+    pub jira_base_url: String,
+    /// The Atlassian account email paired with the token for Basic auth (non-secret). Settable from
+    /// the DTO. Default `""` (unset).
+    #[serde(default)]
+    pub jira_email: String,
     /// Opt-in: inherit the shell environment into the `claude` CLI subprocess (restores the older
     /// behavior where an env `ANTHROPIC_API_KEY` reached the CLI). Settable from the DTO (the Settings
     /// UI owns the toggle). An omitted value deserializes to `false` (`#[serde(default)]`) = the
@@ -3803,6 +3822,39 @@ pub fn consent_to_web_search(state: State<'_, AppState>) -> Result<(), AppError>
     Ok(())
 }
 
+/// One-time Jira egress consent — the ONLY way `jira_consented` flips true. Persists the flag AND
+/// updates the in-memory config cache, so the next `ConnectorRegistry::build` exposes the jira tool
+/// (provided Jira is also enabled + configured + a token is stored). Idempotent.
+#[tauri::command]
+pub fn consent_to_jira(state: State<'_, AppState>) -> Result<(), AppError> {
+    let mut cache = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    cache.grant_jira_consent(&state.db)?;
+    Ok(())
+}
+
+/// Store/replace the BYO Jira API token in the Keychain (account "jira_api_token"). An empty input
+/// clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
+#[tauri::command]
+pub fn set_jira_token(key: String) -> Result<(), AppError> {
+    if key.trim().is_empty() {
+        return secrets::delete_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT);
+    }
+    secrets::set_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT, key.trim())
+}
+
+/// Whether a Jira token is currently stored (UI shows "set"/"not set"; never the value).
+#[tauri::command]
+pub fn has_jira_token() -> Result<bool, AppError> {
+    Ok(
+        secrets::get_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT)?
+            .filter(|k| !k.trim().is_empty())
+            .is_some(),
+    )
+}
+
 fn config_to_dto(c: &AppConfig) -> AppConfigDto {
     AppConfigDto {
         provider_id: c.provider_id.clone(),
@@ -3851,6 +3903,12 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         // DISPLAY-ONLY out: lets the FE show "consented" status; the FE cannot set it back (preserved
         // in `dto_to_config`).
         web_search_consented: c.web_search_consented,
+        jira_enabled: c.jira_enabled,
+        // DISPLAY-ONLY out: lets the FE show "consented" status; the FE cannot set it back (preserved
+        // in `dto_to_config`).
+        jira_consented: c.jira_consented,
+        jira_base_url: c.jira_base_url.clone(),
+        jira_email: c.jira_email.clone(),
         claude_code_inherit_env: c.claude_code_inherit_env,
         gateway_base_url: c.gateway_base_url.clone(),
         gateway_model: c.gateway_model.clone(),
@@ -3997,6 +4055,16 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // live value (BLK-4 mirror). Only `consent_to_web_search` may flip it, so a settings save can
         // neither grant nor clear web-search egress consent.
         web_search_consented: current.web_search_consented,
+        // brain2 connectors (Phase 2): the Jira master toggle + non-secret base URL/email ARE settable
+        // from the DTO (Settings owns them). An omitted toggle already defaulted to OFF on the DTO, so
+        // a partial save can't enable it.
+        jira_enabled: d.jira_enabled,
+        // brain2 connectors (NEW EGRESS CLASS): consent is NEVER set from the DTO — preserved from the
+        // live value (BLK-4 mirror). Only `consent_to_jira` may flip it, so a settings save can
+        // neither grant nor clear Jira egress consent.
+        jira_consented: current.jira_consented,
+        jira_base_url: d.jira_base_url,
+        jira_email: d.jira_email,
         // Opt-in env inheritance for the `claude` CLI IS settable from the DTO (the Settings UI owns
         // the toggle). Default OFF on the DTO (`#[serde(default)]`), so a partial/older save can never
         // silently enable it. Even ON, the DB keys are never inherited (claude_code.rs `harden_env`).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -268,6 +268,18 @@ pub struct AppConfigDto {
     /// the DTO. Default `""` (unset).
     #[serde(default)]
     pub jira_email: String,
+    /// brain2 connectors (Phase 3) — the SLACK master toggle. Settable from the DTO (the Settings UI
+    /// owns the toggle). An omitted value deserializes to `false` (`#[serde(default)]`), so a
+    /// partial/older save can never silently enable it. Even ON, the connector is exposed only once
+    /// `slack_consented` is granted AND a user token is configured.
+    #[serde(default)]
+    pub slack_enabled: bool,
+    /// brain2 connectors — one-time SLACK egress consent. PRESERVE-ONLY on this DTO, exactly like
+    /// `jira_consented`: `get_config` carries the current value OUT (so the FE can show consent
+    /// status), but `dto_to_config` IGNORES the incoming value and PRESERVES the stored one. The ONLY
+    /// mutator is the dedicated `consent_to_slack` command. `#[serde(default)]` = false (fail-closed).
+    #[serde(default)]
+    pub slack_consented: bool,
     /// Opt-in: inherit the shell environment into the `claude` CLI subprocess (restores the older
     /// behavior where an env `ANTHROPIC_API_KEY` reached the CLI). Settable from the DTO (the Settings
     /// UI owns the toggle). An omitted value deserializes to `false` (`#[serde(default)]`) = the
@@ -3855,6 +3867,39 @@ pub fn has_jira_token() -> Result<bool, AppError> {
     )
 }
 
+/// One-time Slack egress consent — the ONLY way `slack_consented` flips true. Persists the flag AND
+/// updates the in-memory config cache, so the next `ConnectorRegistry::build` exposes the slack tool
+/// (provided Slack is also enabled + a token is stored). Idempotent.
+#[tauri::command]
+pub fn consent_to_slack(state: State<'_, AppState>) -> Result<(), AppError> {
+    let mut cache = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    cache.grant_slack_consent(&state.db)?;
+    Ok(())
+}
+
+/// Store/replace the BYO Slack user token in the Keychain (account "slack_user_token"). An empty
+/// input clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
+#[tauri::command]
+pub fn set_slack_token(key: String) -> Result<(), AppError> {
+    if key.trim().is_empty() {
+        return secrets::delete_secret(crate::connectors::slack::SLACK_TOKEN_ACCOUNT);
+    }
+    secrets::set_secret(crate::connectors::slack::SLACK_TOKEN_ACCOUNT, key.trim())
+}
+
+/// Whether a Slack token is currently stored (UI shows "set"/"not set"; never the value).
+#[tauri::command]
+pub fn has_slack_token() -> Result<bool, AppError> {
+    Ok(
+        secrets::get_secret(crate::connectors::slack::SLACK_TOKEN_ACCOUNT)?
+            .filter(|k| !k.trim().is_empty())
+            .is_some(),
+    )
+}
+
 fn config_to_dto(c: &AppConfig) -> AppConfigDto {
     AppConfigDto {
         provider_id: c.provider_id.clone(),
@@ -3909,6 +3954,10 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         jira_consented: c.jira_consented,
         jira_base_url: c.jira_base_url.clone(),
         jira_email: c.jira_email.clone(),
+        slack_enabled: c.slack_enabled,
+        // DISPLAY-ONLY out: lets the FE show "consented" status; the FE cannot set it back (preserved
+        // in `dto_to_config`).
+        slack_consented: c.slack_consented,
         claude_code_inherit_env: c.claude_code_inherit_env,
         gateway_base_url: c.gateway_base_url.clone(),
         gateway_model: c.gateway_model.clone(),
@@ -4065,6 +4114,13 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         jira_consented: current.jira_consented,
         jira_base_url: d.jira_base_url,
         jira_email: d.jira_email,
+        // brain2 connectors (Phase 3): the Slack master toggle IS settable from the DTO (Settings owns
+        // it). An omitted toggle already defaulted to OFF on the DTO, so a partial save can't enable it.
+        slack_enabled: d.slack_enabled,
+        // brain2 connectors (NEW EGRESS CLASS): consent is NEVER set from the DTO — preserved from the
+        // live value (BLK-4 mirror). Only `consent_to_slack` may flip it, so a settings save can
+        // neither grant nor clear Slack egress consent.
+        slack_consented: current.slack_consented,
         // Opt-in env inheritance for the `claude` CLI IS settable from the DTO (the Settings UI owns
         // the toggle). Default OFF on the DTO (`#[serde(default)]`), so a partial/older save can never
         // silently enable it. Even ON, the DB keys are never inherited (claude_code.rs `harden_env`).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1217,6 +1217,121 @@ pub fn update_note(
     })
 }
 
+/// VERIFY PASS (read-only): extract Jira issue keys from the meeting's note and check each against
+/// LIVE Jira. GATED: sealed-not-unlocked meetings refuse (a verify against a blanked note would be
+/// nonsense AND a read-gate bypass). Consent-gated: rides the Jira connector's enable+consent+key
+/// gate (fail-closed `NeedsConsent` maps to `AppError::Unavailable`). NEVER called proactively —
+/// FE-invoked only. Findings are computed against the note WITH OLD MARKERS STRIPPED so line
+/// numbers line up with `apply_verify_markers`' post-strip numbering.
+#[tauri::command]
+pub async fn verify_note_sources(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<crate::verify::VerifyFinding>, AppError> {
+    verify_note_sources_inner(state.inner(), meeting_id).await
+}
+
+pub(crate) async fn verify_note_sources_inner(
+    state: &AppState,
+    meeting_id: String,
+) -> Result<Vec<crate::verify::VerifyFinding>, AppError> {
+    if !meeting_is_unlocked(state, &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to verify the note".into(),
+        ));
+    }
+    let note = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    // Strip our own old markers so extraction/judgment sees the canonical note lines.
+    let stripped = crate::verify::apply_verify_markers(&note.markdown, &[]);
+    let keys = crate::verify::extract_issue_keys(&stripped);
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Other(anyhow::anyhow!("config lock")))?
+        .clone();
+    let registry = crate::connectors::ConnectorRegistry::build(&config);
+    let lines: Vec<&str> = stripped.lines().collect();
+    let mut findings = Vec::with_capacity(keys.len());
+    for (line_no, key) in keys {
+        let snap = registry.jira_lookup(&key).await.map_err(AppError::from)?;
+        let line_text = lines.get(line_no - 1).copied().unwrap_or("");
+        let (verdict, detail) = crate::verify::judge(line_text, &key, snap.as_ref());
+        let url = snap.map(|s| s.url).unwrap_or_default();
+        findings.push(crate::verify::VerifyFinding {
+            line_no,
+            key,
+            verdict,
+            detail,
+            url,
+        });
+    }
+    Ok(findings)
+}
+
+/// Apply verify markers to the note (WRITE — same gate + save/re-export tail as `update_note`).
+/// Takes the findings the user just reviewed in the panel; validates every key's strict shape.
+#[tauri::command]
+pub fn apply_note_verify_markers(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    findings: Vec<crate::verify::VerifyFinding>,
+) -> Result<NoteDto, AppError> {
+    apply_note_verify_markers_inner(state.inner(), meeting_id, findings)
+}
+
+pub(crate) fn apply_note_verify_markers_inner(
+    state: &AppState,
+    meeting_id: String,
+    findings: Vec<crate::verify::VerifyFinding>,
+) -> Result<NoteDto, AppError> {
+    if !meeting_is_unlocked(state, &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to edit the note".into(),
+        ));
+    }
+    for f in &findings {
+        let ok = crate::verify::extract_issue_keys(&f.key)
+            .first()
+            .map(|(_, k)| k == &f.key)
+            .unwrap_or(false);
+        if !ok {
+            return Err(AppError::InvalidArg("invalid issue key in findings".into()));
+        }
+    }
+    let existing = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    let marked = crate::verify::apply_verify_markers(&existing.markdown, &findings);
+    // Save + re-export — the exact `update_note` tail, with `marked`.
+    let created_at = chrono::Utc::now().to_rfc3339();
+    state.db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.clone(),
+        provider_id: existing.provider_id.clone(),
+        markdown: marked.clone(),
+        created_at,
+        exported_path: existing.exported_path.clone(),
+        model_requested: existing.model_requested.clone(),
+        model_served: existing.model_served.clone(),
+        gateway_host: existing.gateway_host.clone(),
+    })?;
+    if let Some(path) = existing.exported_path.as_deref() {
+        crate::export::overwrite_note(std::path::Path::new(path), &marked)?;
+    }
+    Ok(NoteDto {
+        meeting_id,
+        provider_id: existing.provider_id,
+        markdown: marked,
+        exported_path: existing.exported_path,
+    })
+}
+
 /// brain2 realtime typed @brain notes — persist the user's free-text notes typed DURING a meeting
 /// (the FE autosaves the whole buffer here). The buffer (a) feeds the in-meeting brain's system
 /// prompt while recording and (b) is folded into the finalized note at summarize time.
@@ -10219,6 +10334,74 @@ mod lifecycle_tests {
             .build()
             .unwrap()
             .block_on(f)
+    }
+
+    /// PHASE-4 lock gate (RED-before-GREEN): `verify_note_sources` + `apply_note_verify_markers` on a
+    /// SEALED-and-not-session-unlocked meeting MUST refuse with `AppError::Locked` BEFORE any note
+    /// read / connector egress — a locked note can neither be verified nor marker-written. Runs with
+    /// NO Jira configured, so once session-unlocked the verify falls through to the fail-closed
+    /// connector gate (`Unavailable`), proving `Locked` was the FIRST gate, not a downstream error.
+    #[test]
+    fn verify_commands_refuse_a_sealed_meeting() {
+        let state = build_state("verify-lockgate");
+        make_open_folder(&state.db, "f-vlock", "Secret");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-vlock".to_string(),
+                started_at: "2026-07-05T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Sprint".to_string()),
+                duration_s: 600,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: Some("f-vlock".to_string()),
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m-vlock".to_string(),
+                provider_id: "claude_code".to_string(),
+                markdown: "# N\n- Ship PROJ-1 by 2026-07-08\n".to_string(),
+                created_at: "2026-07-05T09:10:00Z".to_string(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state.db.set_note_folder("m-vlock", Some("f-vlock")).unwrap();
+        state
+            .db
+            .set_folder_locked("f-vlock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        // NOT session-unlocked: both commands fail closed with Locked.
+        let e1 = block_on(verify_note_sources_inner(&state, "m-vlock".to_string())).unwrap_err();
+        assert!(matches!(e1, AppError::Locked(_)), "verify must fail Locked, got: {e1:?}");
+        let finding = crate::verify::VerifyFinding {
+            line_no: 2,
+            key: "PROJ-1".into(),
+            verdict: crate::verify::Verdict::NotFound,
+            detail: "PROJ-1 not found in Jira".into(),
+            url: String::new(),
+        };
+        let e2 =
+            apply_note_verify_markers_inner(&state, "m-vlock".to_string(), vec![finding]).unwrap_err();
+        assert!(matches!(e2, AppError::Locked(_)), "apply must fail Locked, got: {e2:?}");
+
+        // Session-unlock → the lock gate passes; verify now falls to the fail-closed connector gate
+        // (no Jira configured ⇒ jira_lookup NeedsConsent ⇒ Unavailable), proving Locked was the gate.
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-vlock".to_string());
+        let e3 = block_on(verify_note_sources_inner(&state, "m-vlock".to_string())).unwrap_err();
+        assert!(
+            matches!(e3, AppError::Unavailable(_)),
+            "past the lock gate, an unconfigured Jira verify fails Unavailable, got: {e3:?}"
+        );
     }
 
     /// M3-CLIENT lock gate (spec §7 inv. 1): `share_note_to_link` on a SEALED-and-not-session-unlocked

--- a/src-tauri/src/connectors/jira.rs
+++ b/src-tauri/src/connectors/jira.rs
@@ -99,6 +99,59 @@ impl JiraConnector {
             .collect();
         Ok(hits)
     }
+
+    /// Fetch ONE issue's current state (verify pass). `Ok(None)` on 404 (not found / no access —
+    /// Jira Cloud returns 404 for both). The KEY is validated by the caller (strict issue-key
+    /// shape) — it is an identifier, not free text, so it needs no PII redaction.
+    pub async fn get_issue(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!(
+                "{}/rest/api/3/issue/{key}?fields=summary,status,duedate",
+                self.base_url
+            ))
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira issue request: {}", e.without_url())))?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "jira", status = status.as_u16(), "jira issue HTTP error");
+            return Err(ConnectorError::Failed(format!("jira HTTP {status}")));
+        }
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira body: {}", e.without_url())))?;
+        Self::parse_issue(&text, &self.base_url)
+    }
+
+    /// Parse a single-issue body into a snapshot (fixture-testable, no network).
+    pub(crate) fn parse_issue(
+        body: &str,
+        base_url: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        let issue: JiraIssue = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("jira issue parse: {e}")))?;
+        if issue.key.trim().is_empty() {
+            return Ok(None);
+        }
+        let f = issue.fields;
+        Ok(Some(crate::verify::IssueSnapshot {
+            key: issue.key.clone(),
+            summary: f.summary.unwrap_or_default(),
+            status: f.status.and_then(|s| s.name).unwrap_or_default(),
+            due: f.duedate,
+            url: format!("{base_url}/browse/{}", issue.key),
+        }))
+    }
 }
 
 #[async_trait]
@@ -147,6 +200,13 @@ impl Connector for JiraConnector {
         let hits = Self::parse_results(&text, &self.base_url)?;
         tracing::info!(target: "connector", provider = "jira", hits = hits.len(), "jira search returned");
         Ok(hits)
+    }
+
+    async fn lookup(
+        &self,
+        id: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        self.get_issue(id).await
     }
 }
 
@@ -228,6 +288,16 @@ mod tests {
             JiraConnector::parse_results("not json", "https://x"),
             Err(ConnectorError::Failed(_))
         ));
+    }
+
+    #[test]
+    fn jira_issue_parser_maps_snapshot() {
+        let body = r#"{"key":"PROJ-1","fields":{"summary":"Fix login","status":{"name":"In Progress"},"duedate":"2026-07-10"}}"#;
+        let s = JiraConnector::parse_issue(body, "https://acme.atlassian.net").unwrap().unwrap();
+        assert_eq!(s.key, "PROJ-1");
+        assert_eq!(s.status, "In Progress");
+        assert_eq!(s.due.as_deref(), Some("2026-07-10"));
+        assert_eq!(s.url, "https://acme.atlassian.net/browse/PROJ-1");
     }
 
     #[test]

--- a/src-tauri/src/connectors/jira.rs
+++ b/src-tauri/src/connectors/jira.rs
@@ -111,6 +111,10 @@ impl Connector for JiraConnector {
         EgressClass::External
     }
 
+    fn egress_attribution(&self) -> (&'static str, &'static str) {
+        ("jira_search", "Jira (connector)")
+    }
+
     async fn search(&self, redacted_query: &str) -> ConnectorResult {
         let q = redacted_query.trim();
         if q.is_empty() {

--- a/src-tauri/src/connectors/jira.rs
+++ b/src-tauri/src/connectors/jira.rs
@@ -107,7 +107,7 @@ impl JiraConnector {
         &self,
         key: &str,
     ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
-        let client = reqwest::Client::new();
+        let client = super::http_client();
         let resp = client
             .get(format!(
                 "{}/rest/api/3/issue/{key}?fields=summary,status,duedate",
@@ -179,7 +179,7 @@ impl Connector for JiraConnector {
             "maxResults": 8,
             "fields": ["summary", "status", "assignee", "duedate"],
         });
-        let client = reqwest::Client::new();
+        let client = super::http_client();
         let resp = client
             .post(format!("{}/rest/api/3/search/jql", self.base_url))
             .basic_auth(&self.email, Some(&self.api_token))

--- a/src-tauri/src/connectors/jira.rs
+++ b/src-tauri/src/connectors/jira.rs
@@ -1,0 +1,251 @@
+//! JIRA connector — live, on-demand issue search via the Jira Cloud REST API (brain2 connectors,
+//! Phase 2 of docs/research/2026-07-05-connectors-live-vs-rag.md).
+//!
+//! ## Egress posture (NEW EGRESS CLASS INSTANCE — audited by the lock-security reviewer)
+//! [`EgressClass::External`]. Exposed to the brain ONLY when ALL of:
+//! - `config.jira_enabled` (master toggle), AND
+//! - `config.jira_consented` (one-time consent, preserve-only, flipped solely by `consent_to_jira`), AND
+//! - `config.jira_base_url` + `config.jira_email` are non-empty, AND
+//! - an API token is present in the Keychain (`jira_api_token`).
+//! Otherwise [`JiraConnector::from_config_if_available`] returns `None` (fail-closed: the tool does
+//! not exist for the session). The framework redacts the query BEFORE it reaches [`Connector::search`].
+//!
+//! ## Endpoint
+//! `POST {base}/rest/api/3/search/jql` with `{"jql": "text ~ \"…\" ORDER BY updated DESC", …}` and
+//! HTTP Basic auth (`email:api_token`). NOTE: the legacy `/rest/api/3/search` endpoint was REMOVED
+//! (HTTP 410) — do not use it.
+//!
+//! ## No PII in logs
+//! Logs carry connector id + hit count + HTTP status only — never the JQL, summaries, or the token.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Connector, ConnectorError, ConnectorHit, ConnectorResult, EgressClass};
+use crate::settings::AppConfig;
+
+/// Keychain account holding the BYO Jira API token. NEVER logged / NEVER sent to the FE.
+pub const JIRA_TOKEN_ACCOUNT: &str = "jira_api_token";
+
+/// Loud attribution label on every hit.
+const SOURCE_LABEL: &str = "Jira";
+
+/// Escape a user query for embedding inside a JQL quoted string: backslashes then double quotes.
+pub(crate) fn escape_jql(q: &str) -> String {
+    q.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+pub struct JiraConnector {
+    base_url: String,
+    email: String,
+    api_token: String,
+}
+
+impl JiraConnector {
+    /// FAIL-CLOSED gate — see the module doc. A Keychain error degrades to `None`, never a crash.
+    pub fn from_config_if_available(config: &AppConfig) -> Option<Self> {
+        if !config.jira_enabled || !config.jira_consented {
+            return None;
+        }
+        let base_url = config.jira_base_url.trim().trim_end_matches('/').to_string();
+        let email = config.jira_email.trim().to_string();
+        if base_url.is_empty() || email.is_empty() {
+            return None;
+        }
+        let token = crate::secrets::get_secret(JIRA_TOKEN_ACCOUNT)
+            .ok()
+            .flatten()
+            .filter(|k| !k.trim().is_empty())?;
+        Some(Self {
+            base_url,
+            email,
+            api_token: token,
+        })
+    }
+
+    /// Parse a `/rest/api/3/search/jql` JSON body into [`ConnectorHit`]s. Pulled out so it is
+    /// unit-testable with a fixture and NO network. Missing `issues` → empty (clean "no results").
+    /// An issue without a key is skipped.
+    pub(crate) fn parse_results(body: &str, base_url: &str) -> ConnectorResult {
+        let parsed: JiraSearchResponse = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("jira response parse: {e}")))?;
+        let hits = parsed
+            .issues
+            .into_iter()
+            .filter_map(|i| {
+                let key = i.key.trim().to_string();
+                if key.is_empty() {
+                    return None;
+                }
+                let f = i.fields;
+                let summary = f.summary.unwrap_or_default();
+                let mut parts: Vec<String> = Vec::new();
+                if let Some(s) = f.status.and_then(|s| s.name) {
+                    parts.push(format!("Status: {s}"));
+                }
+                if let Some(a) = f.assignee.and_then(|a| a.display_name) {
+                    parts.push(format!("Assignee: {a}"));
+                }
+                if let Some(d) = f.duedate {
+                    parts.push(format!("Due: {d}"));
+                }
+                Some(ConnectorHit {
+                    title: format!("{key} — {}", summary.trim()),
+                    snippet: parts.join(" · "),
+                    url: format!("{base_url}/browse/{key}"),
+                    source_label: SOURCE_LABEL.to_string(),
+                })
+            })
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[async_trait]
+impl Connector for JiraConnector {
+    fn id(&self) -> &str {
+        "jira"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        EgressClass::External
+    }
+
+    async fn search(&self, redacted_query: &str) -> ConnectorResult {
+        let q = redacted_query.trim();
+        if q.is_empty() {
+            return Ok(Vec::new());
+        }
+        let jql = format!("text ~ \"{}\" ORDER BY updated DESC", escape_jql(q));
+        let body = serde_json::json!({
+            "jql": jql,
+            "maxResults": 8,
+            "fields": ["summary", "status", "assignee", "duedate"],
+        });
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/rest/api/3/search/jql", self.base_url))
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira request: {}", e.without_url())))?;
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "jira", status = status.as_u16(), "jira search HTTP error");
+            return Err(ConnectorError::Failed(format!("jira HTTP {status}")));
+        }
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("jira body: {}", e.without_url())))?;
+        let hits = Self::parse_results(&text, &self.base_url)?;
+        tracing::info!(target: "connector", provider = "jira", hits = hits.len(), "jira search returned");
+        Ok(hits)
+    }
+}
+
+/// Only the fields we consume; `#[serde(default)]` everywhere so a missing field never fails.
+#[derive(Debug, Deserialize)]
+struct JiraSearchResponse {
+    #[serde(default)]
+    issues: Vec<JiraIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraIssue {
+    #[serde(default)]
+    key: String,
+    #[serde(default)]
+    fields: JiraFields,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct JiraFields {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    status: Option<JiraStatus>,
+    #[serde(default)]
+    assignee: Option<JiraAssignee>,
+    #[serde(default)]
+    duedate: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraStatus {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraAssignee {
+    #[serde(default, rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jira_parser_maps_json_to_hits() {
+        let body = r#"{
+            "issues": [
+                {"key":"PROJ-123","fields":{"summary":"Fix login flow","status":{"name":"In Progress"},"assignee":{"displayName":"Anna"},"duedate":"2026-07-10"}},
+                {"key":"PROJ-9","fields":{"summary":"Spike","status":{"name":"Done"}}}
+            ],
+            "nextPageToken": "abc"
+        }"#;
+        let hits = JiraConnector::parse_results(body, "https://acme.atlassian.net").unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "PROJ-123 — Fix login flow");
+        assert_eq!(hits[0].snippet, "Status: In Progress · Assignee: Anna · Due: 2026-07-10");
+        assert_eq!(hits[0].url, "https://acme.atlassian.net/browse/PROJ-123");
+        assert_eq!(hits[0].source_label, "Jira");
+        assert_eq!(hits[1].snippet, "Status: Done");
+    }
+
+    #[test]
+    fn jira_parser_tolerates_missing_fields_and_empty() {
+        assert!(JiraConnector::parse_results(r#"{}"#, "https://x").unwrap().is_empty());
+        assert!(JiraConnector::parse_results(r#"{"issues":[]}"#, "https://x").unwrap().is_empty());
+        // Missing key → skipped; missing fields → title still renders.
+        let body = r#"{"issues":[{"key":"","fields":{}},{"key":"A-1","fields":{}}]}"#;
+        let hits = JiraConnector::parse_results(body, "https://x").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "A-1 — ");
+    }
+
+    #[test]
+    fn jira_parser_rejects_malformed_json() {
+        assert!(matches!(
+            JiraConnector::parse_results("not json", "https://x"),
+            Err(ConnectorError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn jql_escaping_neutralizes_quotes_and_backslashes() {
+        assert_eq!(escape_jql(r#"login "bug" \ test"#), r#"login \"bug\" \\ test"#);
+    }
+
+    #[test]
+    fn from_config_fail_closed_when_disabled_or_unconsented_or_unconfigured() {
+        // Default config: everything off → None, and no Keychain read is even attempted for
+        // the disabled cases (enable/consent are checked first).
+        let cfg = AppConfig::default();
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none());
+        let cfg = AppConfig { jira_enabled: true, ..AppConfig::default() };
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none(), "unconsented");
+        let cfg = AppConfig {
+            jira_enabled: true,
+            jira_consented: true,
+            jira_base_url: String::new(),
+            jira_email: "a@b.c".into(),
+            ..AppConfig::default()
+        };
+        assert!(JiraConnector::from_config_if_available(&cfg).is_none(), "no base url");
+    }
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -38,6 +38,17 @@ use crate::summarize::egress_log::{active_sink, EgressEntry, EgressSink};
 use crate::summarize::meta::CallMeta;
 use crate::summarize::redact::{active_name_redactor, redact_connector_query, NameRedactor};
 
+/// Shared HTTP client for connector calls — bounded so a stalled external service can never hang
+/// the scoped tool worker or the Ask loop indefinitely. 20s overall per request.
+pub(crate) fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        // Builder only fails on TLS-backend misconfig; fall back to the default client rather
+        // than panicking (default has no timeout, but a request still goes out).
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
 /// Whether a connector reaches OFF the device. The framework gates every [`External`] connector
 /// behind enable + consent; a [`Local`] connector (none yet) would be exempt, exactly as `ollama` is
 /// exempt from the cloud-egress gate.

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -123,6 +123,17 @@ pub trait Connector: Send + Sync {
     /// The egress class — `External` connectors are consent-gated by the framework.
     fn egress_class(&self) -> EgressClass;
 
+    /// The TRUTHFUL egress-ledger attribution for THIS connector: the `(call_kind, destination)`
+    /// pair the framework records in the content-free ledger row so the Analytics "receipt of what
+    /// left your Mac" names the RIGHT external service — a Jira egress is labeled Jira, a web search
+    /// is labeled web, never one masquerading as the other. Each field is a non-PII `&'static str`
+    /// (a fixed label, never query content). The default is a GENERIC fallback so a connector that
+    /// forgets to declare its own is still audited (never mis-attributed to web); every real
+    /// `External` connector OVERRIDES it with its own truthful pair.
+    fn egress_attribution(&self) -> (&'static str, &'static str) {
+        ("connector_search", "external connector")
+    }
+
     /// Run the search for an ALREADY-REDACTED query (the registry redacts before calling this — see
     /// [`ConnectorRegistry::search`]). Returns the hits, each carrying a loud `source_label`.
     async fn search(&self, redacted_query: &str) -> ConnectorResult;
@@ -198,9 +209,10 @@ impl ConnectorRegistry {
     /// into vault content.
     ///
     /// LEDGER: for an EXTERNAL connector we record ONE content-free [`EgressEntry`] on the attempt
-    /// (a failed HTTP call is still attempted egress), carrying provider/destination, a
-    /// `"web_search"` call_kind, the scrubbed-query BYTE SIZE, and the redaction COUNTS — never the
-    /// query text (the ledger is content-free by design).
+    /// (a failed HTTP call is still attempted egress), carrying provider/destination, a per-connector
+    /// `call_kind`/`destination` (from [`Connector::egress_attribution`] — so a Jira egress is
+    /// labeled Jira, not a web search), the scrubbed-query BYTE SIZE, and the redaction COUNTS —
+    /// never the query text (the ledger is content-free by design).
     pub async fn search(&self, id: &str, query: &str) -> ConnectorResult {
         let Some(connector) = self.connectors.iter().find(|c| c.id() == id) else {
             // Not exposed → fail closed. NOTHING egresses, so nothing is recorded.
@@ -215,11 +227,14 @@ impl ConnectorRegistry {
         // of the scrubbed query (never its text); `system_bytes` is 0 (a connector has no system
         // prompt). `meta` is default (a search backend reports no token usage).
         if connector.egress_class() == EgressClass::External {
+            // Per-connector truthful attribution (both are non-PII fixed labels) so the ledger row
+            // names the RIGHT external service — a Jira egress is never recorded as a web search.
+            let (call_kind, destination) = connector.egress_attribution();
             self.sink.record(EgressEntry {
                 provider_id: connector.id().to_string(),
-                destination: "web search (connector)".to_string(),
+                destination: destination.to_string(),
                 model_requested: String::new(),
-                call_kind: "web_search",
+                call_kind,
                 meta: CallMeta::default(),
                 redactions: counts,
                 system_bytes: 0,
@@ -462,7 +477,9 @@ mod tests {
     }
 
     /// (b) LEDGER — a connector search records EXACTLY ONE content-free egress row: provider "capture"
-    /// (the connector id), call_kind "web_search", the SCRUBBED-query byte size, and the redaction
+    /// (the connector id), the GENERIC-FALLBACK attribution (`"capture"` declares no
+    /// `egress_attribution` override → `call_kind "connector_search"` / destination
+    /// "external connector"), the SCRUBBED-query byte size, and the redaction
     /// COUNTS (1 email + 1 name here). Copies the content-free invariant from redact.rs's
     /// `egress_entry_is_content_free_and_captures_meta_and_counts`: NO query text / NO PII appears in
     /// ANY field of the recorded entry (asserted over the full Debug output).
@@ -485,10 +502,11 @@ mod tests {
         assert_eq!(rows.len(), 1, "exactly one content-free ledger row per connector search");
         let row = &rows[0];
 
-        // Shape: connector-attributed, web_search kind, sizes + counts only.
+        // Shape: connector-attributed via the GENERIC FALLBACK (the fake "capture" connector does
+        // not override egress_attribution), sizes + counts only.
         assert_eq!(row.provider_id, "capture");
-        assert_eq!(row.call_kind, "web_search");
-        assert_eq!(row.destination, "web search (connector)");
+        assert_eq!(row.call_kind, "connector_search");
+        assert_eq!(row.destination, "external connector");
         assert_eq!(row.model_requested, "");
         assert_eq!(row.system_bytes, 0);
         assert!(row.user_bytes > 0, "the scrubbed-query byte SIZE is recorded");
@@ -532,9 +550,68 @@ mod tests {
         assert!(matches!(res, Err(ConnectorError::Failed(_))), "the failure surfaces");
         let rows = recorded.lock().unwrap();
         assert_eq!(rows.len(), 1, "a failed attempt is still audited as attempted egress");
-        assert_eq!(rows[0].call_kind, "web_search");
+        // "capture" declares no override → generic fallback attribution.
+        assert_eq!(rows[0].call_kind, "connector_search");
         assert_eq!(rows[0].redactions.email, 1);
         let debug = format!("{:?}", rows[0]);
         assert!(!debug.contains("bob@acme.com"), "email must NOT appear in ledger row: {debug}");
+    }
+
+    /// (c) PER-CONNECTOR ATTRIBUTION — RED-before-GREEN: a `"jira"`-id connector must record its OWN
+    /// truthful ledger attribution, NOT the web-search label. On the pre-fix code (the framework
+    /// hardcoded `call_kind: "web_search"` / destination "web search (connector)" for EVERY External
+    /// connector) a Jira egress was recorded as a web search — this test asserts RED there. GREEN once
+    /// the framework reads `Connector::egress_attribution` (jira → "jira_search" / "Jira (connector)").
+    #[test]
+    fn jira_connector_search_is_attributed_to_jira_not_web() {
+        struct JiraLikeConnector;
+        #[async_trait::async_trait]
+        impl Connector for JiraLikeConnector {
+            fn id(&self) -> &str {
+                "jira"
+            }
+            fn egress_class(&self) -> EgressClass {
+                EgressClass::External
+            }
+            fn egress_attribution(&self) -> (&'static str, &'static str) {
+                ("jira_search", "Jira (connector)")
+            }
+            async fn search(&self, _redacted_query: &str) -> ConnectorResult {
+                Ok(vec![ConnectorHit {
+                    title: "t".into(),
+                    snippet: "s".into(),
+                    url: "https://example.atlassian.net/browse/ABC-1".into(),
+                    source_label: "jira · fake".into(),
+                }])
+            }
+        }
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![Box::new(JiraLikeConnector)],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(recorded.clone())),
+        );
+        block_on(registry.search("jira", "sprint status for ABC")).unwrap();
+
+        let rows = recorded.lock().unwrap();
+        assert_eq!(rows.len(), 1, "exactly one ledger row for the jira search");
+        let row = &rows[0];
+        assert_eq!(row.provider_id, "jira");
+        assert!(
+            row.call_kind.contains("jira"),
+            "a jira egress must be attributed to jira, not web: call_kind={}",
+            row.call_kind
+        );
+        assert_eq!(row.call_kind, "jira_search");
+        assert_eq!(row.destination, "Jira (connector)");
+        assert_ne!(
+            row.call_kind, "web_search",
+            "a jira egress must NOT be mislabeled as a web search"
+        );
+        assert!(
+            !row.destination.to_lowercase().contains("web search"),
+            "a jira destination must not read as a web search: {}",
+            row.destination
+        );
     }
 }

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -138,6 +138,15 @@ pub trait Connector: Send + Sync {
     /// Run the search for an ALREADY-REDACTED query (the registry redacts before calling this — see
     /// [`ConnectorRegistry::search`]). Returns the hits, each carrying a loud `source_label`.
     async fn search(&self, redacted_query: &str) -> ConnectorResult;
+
+    /// OPTIONAL identifier lookup (verify pass). Default: unsupported. `id` is a strict,
+    /// caller-validated identifier (e.g. a Jira issue key), never free text.
+    async fn lookup(
+        &self,
+        _id: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        Err(ConnectorError::Unconfigured("lookup not supported".into()))
+    }
 }
 
 /// The registry of connectors AVAILABLE to the brain for the current config. It exposes ONLY the
@@ -248,6 +257,46 @@ impl ConnectorRegistry {
         }
 
         connector.search(&redacted).await
+    }
+
+    /// VERIFY-PASS lookup: fetch one Jira issue's live state through the SAME fail-closed +
+    /// ledgered discipline as [`ConnectorRegistry::search`]. The key is a strict issue identifier
+    /// (validated here via [`crate::verify::extract_issue_keys`] round-trip), not free text — no PII
+    /// redaction applies, but the attempt IS recorded content-free. A malformed key is refused
+    /// BEFORE any exposure/egress; an unexposed jira connector fails closed WITHOUT a ledger row.
+    pub async fn jira_lookup(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<crate::verify::IssueSnapshot>, ConnectorError> {
+        // Strict shape guard BEFORE anything else (defense-in-depth against URL injection): the key
+        // must round-trip through the issue-key scanner as EXACTLY itself.
+        let valid = crate::verify::extract_issue_keys(key)
+            .first()
+            .map(|(_, k)| k == key)
+            .unwrap_or(false);
+        if !valid {
+            return Err(ConnectorError::Failed("invalid issue key".into()));
+        }
+        let Some(connector) = self.connectors.iter().find(|c| c.id() == "jira") else {
+            // Not exposed → fail closed. NOTHING egresses, so nothing is recorded.
+            return Err(ConnectorError::NeedsConsent);
+        };
+        // Record ONE content-free ledger row for this external egress ATTEMPT, BEFORE the network
+        // call. A lookup is a DISTINCT call_kind from a search — attribute it truthfully as such.
+        if connector.egress_class() == EgressClass::External {
+            self.sink.record(EgressEntry {
+                provider_id: "jira".to_string(),
+                destination: "Jira issue lookup (connector)".to_string(),
+                model_requested: String::new(),
+                call_kind: "connector_lookup",
+                meta: CallMeta::default(),
+                redactions: Default::default(),
+                system_bytes: 0,
+                user_bytes: key.len(),
+                meeting_id: None,
+            });
+        }
+        connector.lookup(key).await
     }
 
     /// TEST-ONLY: build a registry around injected connectors + an explicit name redactor + sink, so
@@ -432,6 +481,33 @@ mod tests {
             !ConnectorRegistry::build(&consented_disabled).has("web"),
             "consented-but-disabled web search must be excluded (fail-closed on enable)"
         );
+    }
+
+    #[test]
+    fn jira_lookup_fails_closed_without_ledger_when_not_exposed() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(captured.clone())),
+        );
+        let res = block_on(registry.jira_lookup("PROJ-1"));
+        assert!(matches!(res, Err(ConnectorError::NeedsConsent)));
+        assert!(captured.lock().unwrap().is_empty(), "no egress ⇒ no ledger row");
+    }
+
+    #[test]
+    fn jira_lookup_rejects_malformed_keys_without_egress() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(captured.clone())),
+        );
+        // Even before exposure is checked, a key that isn't a strict issue key is refused.
+        let res = block_on(registry.jira_lookup("not a key; DROP TABLE"));
+        assert!(res.is_err());
+        assert!(captured.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -27,6 +27,7 @@
 //! result snippets, or the API key.
 
 pub mod calendar;
+pub mod jira;
 pub mod web;
 
 use std::sync::Arc;
@@ -159,6 +160,9 @@ impl ConnectorRegistry {
     pub fn build(config: &AppConfig) -> Self {
         let mut connectors: Vec<Box<dyn Connector>> = Vec::new();
         if let Some(c) = web::WebConnector::from_config_if_available(config) {
+            connectors.push(Box::new(c));
+        }
+        if let Some(c) = jira::JiraConnector::from_config_if_available(config) {
             connectors.push(Box::new(c));
         }
         Self {

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod calendar;
 pub mod jira;
+pub mod slack;
 pub mod web;
 
 use std::sync::Arc;
@@ -174,6 +175,9 @@ impl ConnectorRegistry {
             connectors.push(Box::new(c));
         }
         if let Some(c) = jira::JiraConnector::from_config_if_available(config) {
+            connectors.push(Box::new(c));
+        }
+        if let Some(c) = slack::SlackConnector::from_config_if_available(config) {
             connectors.push(Box::new(c));
         }
         Self {
@@ -611,6 +615,62 @@ mod tests {
         assert!(
             !row.destination.to_lowercase().contains("web search"),
             "a jira destination must not read as a web search: {}",
+            row.destination
+        );
+    }
+
+    /// (c, cont.) PER-CONNECTOR ATTRIBUTION for Slack — a `"slack"`-id connector must record its OWN
+    /// truthful ledger attribution ("slack_search" / "Slack (connector)"), NOT the web-search label.
+    /// Mirrors `jira_connector_search_is_attributed_to_jira_not_web`.
+    #[test]
+    fn slack_connector_search_is_attributed_to_slack_not_web() {
+        struct SlackLikeConnector;
+        #[async_trait::async_trait]
+        impl Connector for SlackLikeConnector {
+            fn id(&self) -> &str {
+                "slack"
+            }
+            fn egress_class(&self) -> EgressClass {
+                EgressClass::External
+            }
+            fn egress_attribution(&self) -> (&'static str, &'static str) {
+                ("slack_search", "Slack (connector)")
+            }
+            async fn search(&self, _redacted_query: &str) -> ConnectorResult {
+                Ok(vec![ConnectorHit {
+                    title: "t".into(),
+                    snippet: "s".into(),
+                    url: "https://acme.slack.com/archives/C1/p1".into(),
+                    source_label: "slack · fake".into(),
+                }])
+            }
+        }
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let registry = ConnectorRegistry::with_parts(
+            vec![Box::new(SlackLikeConnector)],
+            std::sync::Arc::new(NoopNameRedactor),
+            std::sync::Arc::new(CaptureEgressSink(recorded.clone())),
+        );
+        block_on(registry.search("slack", "what did we decide about launch")).unwrap();
+
+        let rows = recorded.lock().unwrap();
+        assert_eq!(rows.len(), 1, "exactly one ledger row for the slack search");
+        let row = &rows[0];
+        assert_eq!(row.provider_id, "slack");
+        assert!(
+            row.call_kind.contains("slack"),
+            "a slack egress must be attributed to slack, not web: call_kind={}",
+            row.call_kind
+        );
+        assert_eq!(row.call_kind, "slack_search");
+        assert_eq!(row.destination, "Slack (connector)");
+        assert_ne!(
+            row.call_kind, "web_search",
+            "a slack egress must NOT be mislabeled as a web search"
+        );
+        assert!(
+            !row.destination.to_lowercase().contains("web search"),
+            "a slack destination must not read as a web search: {}",
             row.destination
         );
     }

--- a/src-tauri/src/connectors/slack.rs
+++ b/src-tauri/src/connectors/slack.rs
@@ -110,7 +110,7 @@ impl Connector for SlackConnector {
         if q.is_empty() {
             return Ok(Vec::new());
         }
-        let client = reqwest::Client::new();
+        let client = super::http_client();
         let resp = client
             .get("https://slack.com/api/search.messages")
             .query(&[("query", q), ("count", "8")])

--- a/src-tauri/src/connectors/slack.rs
+++ b/src-tauri/src/connectors/slack.rs
@@ -1,0 +1,227 @@
+//! SLACK connector — live, on-demand message search via the Slack Web API (brain2 connectors,
+//! Phase 3 of docs/research/2026-07-05-connectors-live-vs-rag.md).
+//!
+//! ## Egress posture (NEW EGRESS CLASS INSTANCE — audited by the lock-security reviewer)
+//! [`EgressClass::External`]. Exposed ONLY when `slack_enabled && slack_consented && a user token
+//! is in the Keychain` — otherwise absent (fail-closed). The framework redacts the query first.
+//!
+//! ## Endpoint + token model
+//! `GET https://slack.com/api/search.messages?query=…&count=8` with `Authorization: Bearer xoxp-…`.
+//! `search.messages` requires a USER token (`xoxp-`, scope `search:read`) — a bot token cannot
+//! search. The token is BYO: the user creates a single-workspace app, installs it, pastes the token.
+//! QUIRK: Slack answers HTTP 200 with `{"ok":false,"error":"…"}` on failure — `parse_results`
+//! checks `ok` and surfaces the error code (non-PII) as a Failed.
+//!
+//! ## No PII in logs
+//! Connector id + hit count + HTTP status / Slack error CODE only — never queries, message text,
+//! channel names, or the token.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Connector, ConnectorError, ConnectorHit, ConnectorResult, EgressClass};
+use crate::settings::AppConfig;
+
+/// Keychain account holding the BYO Slack user token (`xoxp-…`). NEVER logged / NEVER FE-exposed.
+pub const SLACK_TOKEN_ACCOUNT: &str = "slack_user_token";
+
+const SOURCE_LABEL: &str = "Slack";
+
+/// Cap a message snippet so one long Slack message can't blow the tool budget.
+const SNIPPET_MAX: usize = 300;
+
+pub struct SlackConnector {
+    token: String,
+}
+
+impl SlackConnector {
+    /// FAIL-CLOSED gate — see module doc. Keychain error degrades to `None`.
+    pub fn from_config_if_available(config: &AppConfig) -> Option<Self> {
+        if !config.slack_enabled || !config.slack_consented {
+            return None;
+        }
+        let token = crate::secrets::get_secret(SLACK_TOKEN_ACCOUNT)
+            .ok()
+            .flatten()
+            .filter(|k| !k.trim().is_empty())?;
+        Some(Self { token })
+    }
+
+    /// Parse a `search.messages` body. `ok:false` → Failed carrying ONLY the Slack error CODE.
+    pub(crate) fn parse_results(body: &str) -> ConnectorResult {
+        let parsed: SlackSearchResponse = serde_json::from_str(body)
+            .map_err(|e| ConnectorError::Failed(format!("slack response parse: {e}")))?;
+        if !parsed.ok {
+            return Err(ConnectorError::Failed(format!(
+                "slack error: {}",
+                parsed.error.unwrap_or_else(|| "unknown".into())
+            )));
+        }
+        let matches = parsed.messages.map(|m| m.matches).unwrap_or_default();
+        let hits = matches
+            .into_iter()
+            .filter_map(|m| {
+                let mut text = m.text.unwrap_or_default().trim().to_string();
+                if text.is_empty() {
+                    return None;
+                }
+                if text.chars().count() > SNIPPET_MAX {
+                    text = text.chars().take(SNIPPET_MAX).collect::<String>() + "…";
+                }
+                let channel = m
+                    .channel
+                    .and_then(|c| c.name)
+                    .map(|n| format!("#{n}"))
+                    .unwrap_or_else(|| "DM".to_string());
+                let who = m.username.unwrap_or_default();
+                let title = if who.is_empty() {
+                    channel.clone()
+                } else {
+                    format!("{channel} · @{who}")
+                };
+                Some(ConnectorHit {
+                    title,
+                    snippet: text,
+                    url: m.permalink.unwrap_or_default(),
+                    source_label: SOURCE_LABEL.to_string(),
+                })
+            })
+            .collect();
+        Ok(hits)
+    }
+}
+
+#[async_trait]
+impl Connector for SlackConnector {
+    fn id(&self) -> &str {
+        "slack"
+    }
+
+    fn egress_class(&self) -> EgressClass {
+        EgressClass::External
+    }
+
+    fn egress_attribution(&self) -> (&'static str, &'static str) {
+        ("slack_search", "Slack (connector)")
+    }
+
+    async fn search(&self, redacted_query: &str) -> ConnectorResult {
+        let q = redacted_query.trim();
+        if q.is_empty() {
+            return Ok(Vec::new());
+        }
+        let client = reqwest::Client::new();
+        let resp = client
+            .get("https://slack.com/api/search.messages")
+            .query(&[("query", q), ("count", "8")])
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("slack request: {}", e.without_url())))?;
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!(target: "connector", provider = "slack", status = status.as_u16(), "slack search HTTP error");
+            return Err(ConnectorError::Failed(format!("slack HTTP {status}")));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| ConnectorError::Failed(format!("slack body: {}", e.without_url())))?;
+        let hits = Self::parse_results(&body)?;
+        tracing::info!(target: "connector", provider = "slack", hits = hits.len(), "slack search returned");
+        Ok(hits)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackSearchResponse {
+    #[serde(default)]
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    messages: Option<SlackMessages>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMessages {
+    #[serde(default)]
+    matches: Vec<SlackMatch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMatch {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    permalink: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    channel: Option<SlackChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackChannel {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slack_parser_maps_matches_to_hits() {
+        let body = r#"{
+            "ok": true,
+            "messages": { "matches": [
+                {"text":"We decided to ship Friday","permalink":"https://acme.slack.com/archives/C1/p1","username":"anna","channel":{"name":"eng"}},
+                {"text":"","permalink":"https://x"},
+                {"text":"No channel or user"}
+            ]}
+        }"#;
+        let hits = SlackConnector::parse_results(body).unwrap();
+        assert_eq!(hits.len(), 2, "empty-text match is skipped");
+        assert_eq!(hits[0].title, "#eng · @anna");
+        assert_eq!(hits[0].snippet, "We decided to ship Friday");
+        assert_eq!(hits[0].url, "https://acme.slack.com/archives/C1/p1");
+        assert_eq!(hits[0].source_label, "Slack");
+        assert_eq!(hits[1].title, "DM");
+    }
+
+    #[test]
+    fn slack_ok_false_is_failed_with_error_code_only() {
+        let body = r#"{"ok": false, "error": "invalid_auth"}"#;
+        match SlackConnector::parse_results(body) {
+            Err(ConnectorError::Failed(m)) => assert!(m.contains("invalid_auth")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slack_parser_truncates_long_messages() {
+        let long = "x".repeat(1000);
+        let body = format!(r#"{{"ok":true,"messages":{{"matches":[{{"text":"{long}"}}]}}}}"#);
+        let hits = SlackConnector::parse_results(&body).unwrap();
+        assert!(hits[0].snippet.chars().count() <= 301);
+        assert!(hits[0].snippet.ends_with('…'));
+    }
+
+    #[test]
+    fn slack_parser_rejects_malformed_json() {
+        assert!(matches!(
+            SlackConnector::parse_results("nope"),
+            Err(ConnectorError::Failed(_))
+        ));
+    }
+
+    #[test]
+    fn from_config_fail_closed_when_disabled_or_unconsented() {
+        let cfg = AppConfig::default();
+        assert!(SlackConnector::from_config_if_available(&cfg).is_none());
+        let cfg = AppConfig { slack_enabled: true, ..AppConfig::default() };
+        assert!(SlackConnector::from_config_if_available(&cfg).is_none(), "unconsented");
+    }
+}

--- a/src-tauri/src/connectors/web.rs
+++ b/src-tauri/src/connectors/web.rs
@@ -204,6 +204,10 @@ impl Connector for WebConnector {
         EgressClass::External
     }
 
+    fn egress_attribution(&self) -> (&'static str, &'static str) {
+        ("web_search", "web search (connector)")
+    }
+
     async fn search(&self, redacted_query: &str) -> ConnectorResult {
         let trimmed = redacted_query.trim();
         if trimmed.is_empty() {

--- a/src-tauri/src/connectors/web.rs
+++ b/src-tauri/src/connectors/web.rs
@@ -104,7 +104,7 @@ impl WebSearchProvider for BraveSearch {
     }
 
     async fn search(&self, redacted_query: &str, api_key: &str) -> ConnectorResult {
-        let client = reqwest::Client::new();
+        let client = super::http_client();
         let resp = client
             .get(&self.base_url)
             .query(&[("q", redacted_query)])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,6 +139,7 @@ pub fn run() {
             commands::revoke_cloud_egress,
             commands::consent_to_web_search,
             commands::consent_to_jira,
+            commands::consent_to_slack,
             // M3-CLIENT — sharing account + zero-knowledge link shares (mode A).
             commands::account_status,
             commands::account_signup,
@@ -172,6 +173,8 @@ pub fn run() {
             commands::has_web_search_key,
             commands::set_jira_token,
             commands::has_jira_token,
+            commands::set_slack_token,
+            commands::has_slack_token,
             commands::provider_statuses,
             commands::resummarize,
             commands::list_meetings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,8 @@ pub fn run() {
             commands::output_is_builtin_speakers,
             commands::get_last_note,
             commands::update_note,
+            commands::verify_note_sources,
+            commands::apply_note_verify_markers,
             commands::save_manual_notes,
             commands::get_manual_notes,
             commands::import_document,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub mod tools;
 pub mod transcribe;
 pub mod update;
 pub mod user_memory;
+pub mod verify;
 pub mod voice_action;
 
 use tauri::window::{Effect, EffectsBuilder};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,7 @@ pub fn run() {
             commands::consent_to_cloud_egress,
             commands::revoke_cloud_egress,
             commands::consent_to_web_search,
+            commands::consent_to_jira,
             // M3-CLIENT — sharing account + zero-knowledge link shares (mode A).
             commands::account_status,
             commands::account_signup,
@@ -169,6 +170,8 @@ pub fn run() {
             commands::get_egress_ledger,
             commands::set_web_search_api_key,
             commands::has_web_search_key,
+            commands::set_jira_token,
+            commands::has_jira_token,
             commands::provider_statuses,
             commands::resummarize,
             commands::list_meetings,

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -226,6 +226,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::ListRecentMeetings { .. } => "Recent meetings",
         ToolCall::WebSearch { .. } => "Web search",
         ToolCall::CalendarLookup { .. } => "Calendar",
+        ToolCall::JiraSearch { .. } => "Jira",
     }
 }
 

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -227,6 +227,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::WebSearch { .. } => "Web search",
         ToolCall::CalendarLookup { .. } => "Calendar",
         ToolCall::JiraSearch { .. } => "Jira",
+        ToolCall::SlackSearch { .. } => "Slack",
     }
 }
 

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -30,6 +30,11 @@ pub const ACCOUNT_ANTHROPIC_KEY: &str = "anthropic_api_key";
 /// recognizes it as a known fixed account (no per-call string leak in [`leak_account`]).
 pub const ACCOUNT_WEB_SEARCH_KEY: &str = "web_search_api_key";
 
+/// Keychain account holding the BYO Jira connector API token. Mirrors
+/// [`crate::connectors::jira::JIRA_TOKEN_ACCOUNT`]. Named here so the data-protection routing
+/// recognizes it as a known fixed account (no per-call string leak in [`leak_account`]).
+pub const ACCOUNT_JIRA_TOKEN: &str = "jira_api_token";
+
 /// Keychain account holding the AI Gateway API key. Mirrors `summarize::GATEWAY_KEY_ACCOUNT` and
 /// `commands::GATEWAY_KEY_ACCOUNT`. Strictly separate from [`ACCOUNT_ANTHROPIC_KEY`] — never a
 /// fallback (R3). Named here so the data-protection routing recognizes it as a known fixed account
@@ -1483,6 +1488,7 @@ fn leak_account(account: &str) -> &'static str {
         ACCOUNT_MCP_TOKEN => ACCOUNT_MCP_TOKEN,
         ACCOUNT_ANTHROPIC_KEY => ACCOUNT_ANTHROPIC_KEY,
         ACCOUNT_WEB_SEARCH_KEY => ACCOUNT_WEB_SEARCH_KEY,
+        ACCOUNT_JIRA_TOKEN => ACCOUNT_JIRA_TOKEN,
         ACCOUNT_GATEWAY_KEY => ACCOUNT_GATEWAY_KEY,
         other => Box::leak(other.to_string().into_boxed_str()),
     }

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -35,6 +35,11 @@ pub const ACCOUNT_WEB_SEARCH_KEY: &str = "web_search_api_key";
 /// recognizes it as a known fixed account (no per-call string leak in [`leak_account`]).
 pub const ACCOUNT_JIRA_TOKEN: &str = "jira_api_token";
 
+/// Keychain account holding the BYO Slack connector user token (`xoxp-…`). Mirrors
+/// [`crate::connectors::slack::SLACK_TOKEN_ACCOUNT`]. Named here so the data-protection routing
+/// recognizes it as a known fixed account (no per-call string leak in [`leak_account`]).
+pub const ACCOUNT_SLACK_TOKEN: &str = "slack_user_token";
+
 /// Keychain account holding the AI Gateway API key. Mirrors `summarize::GATEWAY_KEY_ACCOUNT` and
 /// `commands::GATEWAY_KEY_ACCOUNT`. Strictly separate from [`ACCOUNT_ANTHROPIC_KEY`] — never a
 /// fallback (R3). Named here so the data-protection routing recognizes it as a known fixed account
@@ -1489,6 +1494,7 @@ fn leak_account(account: &str) -> &'static str {
         ACCOUNT_ANTHROPIC_KEY => ACCOUNT_ANTHROPIC_KEY,
         ACCOUNT_WEB_SEARCH_KEY => ACCOUNT_WEB_SEARCH_KEY,
         ACCOUNT_JIRA_TOKEN => ACCOUNT_JIRA_TOKEN,
+        ACCOUNT_SLACK_TOKEN => ACCOUNT_SLACK_TOKEN,
         ACCOUNT_GATEWAY_KEY => ACCOUNT_GATEWAY_KEY,
         other => Box::leak(other.to_string().into_boxed_str()),
     }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -337,6 +337,20 @@ pub struct AppConfig {
     /// `""` (unset). `#[serde(default)]` ⇒ pre-existing configs load as `""`.
     #[serde(default)]
     pub jira_email: String,
+    /// brain2 connector framework (Phase 3) — master toggle for the SLACK connector (Settings ▸
+    /// Connectors). Default OFF (`#[serde(default)]` ⇒ a config persisted before this field existed
+    /// loads as `false`). Even when ON, the connector is exposed only once `slack_consented` is
+    /// granted AND a user token is in the Keychain — see
+    /// `connectors::slack::SlackConnector::from_config_if_available`.
+    #[serde(default)]
+    pub slack_enabled: bool,
+    /// brain2 connector framework — one-time SLACK egress consent. The Slack connector reaches an
+    /// EXTERNAL service (a NEW EGRESS CLASS): the outgoing (redacted) query leaves the device.
+    /// PRESERVE-ONLY: `dto_to_config` ignores the incoming DTO value and a plain `save` never writes
+    /// it, so a normal settings save can neither grant nor clear it. Flipped true SOLELY by the
+    /// dedicated `consent_to_slack` command. `#[serde(default)]` ⇒ pre-existing configs load as `false`.
+    #[serde(default)]
+    pub slack_consented: bool,
     /// Opt-in: restore the OLDER-VERSION behavior of INHERITING the shell environment into the
     /// `claude` CLI subprocess, so env vars set in the user's shell — `ANTHROPIC_API_KEY`,
     /// `ANTHROPIC_BASE_URL`, proxy vars (`HTTPS_PROXY`) — reach the CLI again. The F2 audit hardening
@@ -497,6 +511,8 @@ impl Default for AppConfig {
             jira_consented: false,
             jira_base_url: String::new(),
             jira_email: String::new(),
+            slack_enabled: false,
+            slack_consented: false,
             claude_code_inherit_env: false,
             gateway_base_url: String::new(),
             gateway_model: String::new(),
@@ -571,6 +587,8 @@ const K_JIRA_ENABLED: &str = "jira_enabled";
 const K_JIRA_CONSENTED: &str = "jira_consented";
 const K_JIRA_BASE_URL: &str = "jira_base_url";
 const K_JIRA_EMAIL: &str = "jira_email";
+const K_SLACK_ENABLED: &str = "slack_enabled";
+const K_SLACK_CONSENTED: &str = "slack_consented";
 const K_CLAUDE_CODE_INHERIT_ENV: &str = "claude_code_inherit_env";
 const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
@@ -746,6 +764,12 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_JIRA_EMAIL)? {
             cfg.jira_email = v;
+        }
+        if let Some(v) = db.get_setting(K_SLACK_ENABLED)? {
+            cfg.slack_enabled = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_SLACK_CONSENTED)? {
+            cfg.slack_consented = v == "true";
         }
         if let Some(v) = db.get_setting(K_CLAUDE_CODE_INHERIT_ENV)? {
             cfg.claude_code_inherit_env = v == "true";
@@ -1012,6 +1036,13 @@ impl AppConfig {
         db.set_setting(K_JIRA_BASE_URL, &self.jira_base_url)?;
         db.set_setting(K_JIRA_EMAIL, &self.jira_email)?;
         db.set_setting(
+            K_SLACK_ENABLED,
+            if self.slack_enabled { "true" } else { "false" },
+        )?;
+        // PRESERVE-ONLY: `slack_consented` is NEVER written by a plain save — it is persisted solely
+        // by `grant_slack_consent`, so a settings save can neither grant nor clear the egress consent
+        // (stronger than the DTO-layer preserve; a save carrying `false` can never clobber the grant).
+        db.set_setting(
             K_CLAUDE_CODE_INHERIT_ENV,
             if self.claude_code_inherit_env {
                 "true"
@@ -1155,6 +1186,20 @@ impl AppConfig {
     pub fn grant_jira_consent(&mut self, db: &Db) -> Result<()> {
         db.set_setting(K_JIRA_CONSENTED, "true")?;
         self.jira_consented = true;
+        Ok(())
+    }
+
+    /// brain2 connectors (Phase 3) — record the user's one-time consent to send the (redacted) Slack
+    /// search query to an EXTERNAL service. Mirrors [`grant_jira_consent`]: the ONLY supported mutator
+    /// of `slack_consented` (deliberately separate from `save_config`), so Slack egress consent can
+    /// never be granted as an incidental side effect of a settings write. Until granted, the Slack
+    /// connector is absent from the brain's tool registry.
+    ///
+    /// FAIL-CLOSED ORDERING — persist FIRST, flip the in-memory flag ONLY on a durable success, so a
+    /// failed write leaves the session unconsented (no Slack egress on a consent that wasn't recorded).
+    pub fn grant_slack_consent(&mut self, db: &Db) -> Result<()> {
+        db.set_setting(K_SLACK_CONSENTED, "true")?;
+        self.slack_consented = true;
         Ok(())
     }
 }
@@ -1666,6 +1711,48 @@ mod tests {
         assert!(
             AppConfig::load(&db).unwrap().jira_consented,
             "grant_jira_consent's durable record survives; consent flips true only via the grant path"
+        );
+    }
+
+    #[test]
+    fn slack_flags_default_off_and_round_trip() {
+        let db = temp_db();
+        // Fail-closed defaults: both flags OFF until explicitly set/granted.
+        let cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.slack_enabled, "slack must default OFF");
+        assert!(!cfg.slack_consented, "slack consent must default ungranted");
+
+        let cfg = AppConfig {
+            slack_enabled: true,
+            ..cfg
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert!(loaded.slack_enabled);
+        // PRESERVE-ONLY: a save can never grant consent.
+        assert!(!loaded.slack_consented);
+    }
+
+    #[test]
+    fn slack_consent_grant_persists_and_save_cannot_clobber() {
+        let db = temp_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        cfg.grant_slack_consent(&db).unwrap();
+        assert!(cfg.slack_consented);
+        assert!(AppConfig::load(&db).unwrap().slack_consented);
+        // Durable record persisted (persist-first).
+        assert_eq!(
+            db.get_setting(K_SLACK_CONSENTED).unwrap().as_deref(),
+            Some("true"),
+            "durable slack consent record persisted (persist-first)"
+        );
+        // A later plain save must PRESERVE the granted consent — a plain `save` never writes the flag,
+        // so this proves the durable record is not clobbered by a save that carries false.
+        let cfg2 = AppConfig { slack_consented: false, ..AppConfig::load(&db).unwrap() };
+        cfg2.save(&db).unwrap();
+        assert!(
+            AppConfig::load(&db).unwrap().slack_consented,
+            "grant_slack_consent's durable record survives; consent flips true only via the grant path"
         );
     }
 

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -315,6 +315,28 @@ pub struct AppConfig {
     /// as `false`.
     #[serde(default)]
     pub web_search_consented: bool,
+    /// brain2 connector framework (Phase 2) — master toggle for the JIRA connector (Settings ▸
+    /// Connectors). Default OFF (`#[serde(default)]` ⇒ a config persisted before this field existed
+    /// loads as `false`). Even when ON, the connector is exposed only once `jira_consented` is granted
+    /// AND a base URL + email + API token are configured — see
+    /// `connectors::jira::JiraConnector::from_config_if_available`.
+    #[serde(default)]
+    pub jira_enabled: bool,
+    /// brain2 connector framework — one-time JIRA egress consent. The Jira connector reaches an
+    /// EXTERNAL service (a NEW EGRESS CLASS): the outgoing (redacted) query leaves the device.
+    /// PRESERVE-ONLY: `dto_to_config` ignores the incoming DTO value and a plain `save` never writes
+    /// it, so a normal settings save can neither grant nor clear it. Flipped true SOLELY by the
+    /// dedicated `consent_to_jira` command. `#[serde(default)]` ⇒ pre-existing configs load as `false`.
+    #[serde(default)]
+    pub jira_consented: bool,
+    /// The Jira Cloud site base URL, e.g. `https://acme.atlassian.net` (non-secret). Default `""`
+    /// (unset). `#[serde(default)]` ⇒ pre-existing configs load as `""`.
+    #[serde(default)]
+    pub jira_base_url: String,
+    /// The Atlassian account email paired with the API token for Basic auth (non-secret). Default
+    /// `""` (unset). `#[serde(default)]` ⇒ pre-existing configs load as `""`.
+    #[serde(default)]
+    pub jira_email: String,
     /// Opt-in: restore the OLDER-VERSION behavior of INHERITING the shell environment into the
     /// `claude` CLI subprocess, so env vars set in the user's shell — `ANTHROPIC_API_KEY`,
     /// `ANTHROPIC_BASE_URL`, proxy vars (`HTTPS_PROXY`) — reach the CLI again. The F2 audit hardening
@@ -471,6 +493,10 @@ impl Default for AppConfig {
             realtime_reactions: false,
             web_search_enabled: false,
             web_search_consented: false,
+            jira_enabled: false,
+            jira_consented: false,
+            jira_base_url: String::new(),
+            jira_email: String::new(),
             claude_code_inherit_env: false,
             gateway_base_url: String::new(),
             gateway_model: String::new(),
@@ -541,6 +567,10 @@ const K_BRAIN_HEAVY_MODEL_ID: &str = "brain_heavy_model_id";
 const K_BRAIN_CONTRADICTION_CARDS: &str = "brain_contradiction_cards";
 const K_WEB_SEARCH_ENABLED: &str = "web_search_enabled";
 const K_WEB_SEARCH_CONSENTED: &str = "web_search_consented";
+const K_JIRA_ENABLED: &str = "jira_enabled";
+const K_JIRA_CONSENTED: &str = "jira_consented";
+const K_JIRA_BASE_URL: &str = "jira_base_url";
+const K_JIRA_EMAIL: &str = "jira_email";
 const K_CLAUDE_CODE_INHERIT_ENV: &str = "claude_code_inherit_env";
 const K_GATEWAY_BASE_URL: &str = "gateway_base_url";
 const K_GATEWAY_MODEL: &str = "gateway_model";
@@ -702,6 +732,20 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_WEB_SEARCH_CONSENTED)? {
             cfg.web_search_consented = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_JIRA_ENABLED)? {
+            cfg.jira_enabled = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_JIRA_CONSENTED)? {
+            cfg.jira_consented = v == "true";
+        }
+        // `""` is valid (= unset) for the jira string fields, so take the stored value verbatim
+        // (mirrors the gateway fields).
+        if let Some(v) = db.get_setting(K_JIRA_BASE_URL)? {
+            cfg.jira_base_url = v;
+        }
+        if let Some(v) = db.get_setting(K_JIRA_EMAIL)? {
+            cfg.jira_email = v;
         }
         if let Some(v) = db.get_setting(K_CLAUDE_CODE_INHERIT_ENV)? {
             cfg.claude_code_inherit_env = v == "true";
@@ -958,6 +1002,16 @@ impl AppConfig {
             },
         )?;
         db.set_setting(
+            K_JIRA_ENABLED,
+            if self.jira_enabled { "true" } else { "false" },
+        )?;
+        // PRESERVE-ONLY: `jira_consented` is NEVER written by a plain save — it is persisted solely by
+        // `grant_jira_consent`, so a settings save can neither grant nor clear the egress consent
+        // (stronger than the DTO-layer preserve; a save carrying `false` can never clobber the grant).
+        // The non-secret base URL + email ARE saved verbatim (like the gateway fields); `""` = unset.
+        db.set_setting(K_JIRA_BASE_URL, &self.jira_base_url)?;
+        db.set_setting(K_JIRA_EMAIL, &self.jira_email)?;
+        db.set_setting(
             K_CLAUDE_CODE_INHERIT_ENV,
             if self.claude_code_inherit_env {
                 "true"
@@ -1087,6 +1141,20 @@ impl AppConfig {
     pub fn grant_web_search_consent(&mut self, db: &Db) -> Result<()> {
         db.set_setting(K_WEB_SEARCH_CONSENTED, "true")?;
         self.web_search_consented = true;
+        Ok(())
+    }
+
+    /// brain2 connectors (Phase 2) — record the user's one-time consent to send the (redacted) Jira
+    /// search query to an EXTERNAL service. Mirrors [`grant_web_search_consent`]: the ONLY supported
+    /// mutator of `jira_consented` (deliberately separate from `save_config`), so Jira egress consent
+    /// can never be granted as an incidental side effect of a settings write. Until granted, the Jira
+    /// connector is absent from the brain's tool registry.
+    ///
+    /// FAIL-CLOSED ORDERING — persist FIRST, flip the in-memory flag ONLY on a durable success, so a
+    /// failed write leaves the session unconsented (no Jira egress on a consent that wasn't recorded).
+    pub fn grant_jira_consent(&mut self, db: &Db) -> Result<()> {
+        db.set_setting(K_JIRA_CONSENTED, "true")?;
+        self.jira_consented = true;
         Ok(())
     }
 }
@@ -1550,6 +1618,54 @@ mod tests {
             db.get_setting(K_WEB_SEARCH_CONSENTED).unwrap().as_deref(),
             Some("true"),
             "durable web-search consent record persisted (persist-first)"
+        );
+    }
+
+    #[test]
+    fn jira_flags_default_off_and_round_trip() {
+        let db = temp_db();
+        // Fail-closed defaults: both flags OFF + strings empty until explicitly set/granted.
+        let cfg = AppConfig::load(&db).unwrap();
+        assert!(!cfg.jira_enabled, "jira must default OFF");
+        assert!(!cfg.jira_consented, "jira consent must default ungranted");
+        assert!(cfg.jira_base_url.is_empty());
+        assert!(cfg.jira_email.is_empty());
+
+        let cfg = AppConfig {
+            jira_enabled: true,
+            jira_base_url: "https://acme.atlassian.net".into(),
+            jira_email: "me@acme.com".into(),
+            ..cfg
+        };
+        cfg.save(&db).unwrap();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert!(loaded.jira_enabled);
+        assert_eq!(loaded.jira_base_url, "https://acme.atlassian.net");
+        assert_eq!(loaded.jira_email, "me@acme.com");
+        // PRESERVE-ONLY: a save can never grant consent.
+        assert!(!loaded.jira_consented);
+    }
+
+    #[test]
+    fn jira_consent_grant_persists_and_save_cannot_clobber() {
+        let db = temp_db();
+        let mut cfg = AppConfig::load(&db).unwrap();
+        cfg.grant_jira_consent(&db).unwrap();
+        assert!(cfg.jira_consented);
+        assert!(AppConfig::load(&db).unwrap().jira_consented);
+        // Durable record persisted (persist-first).
+        assert_eq!(
+            db.get_setting(K_JIRA_CONSENTED).unwrap().as_deref(),
+            Some("true"),
+            "durable jira consent record persisted (persist-first)"
+        );
+        // A later plain save must PRESERVE the granted consent — a plain `save` writes the flag
+        // verbatim, so this proves the durable record is not clobbered by a save that carries false.
+        let cfg2 = AppConfig { jira_consented: false, ..AppConfig::load(&db).unwrap() };
+        cfg2.save(&db).unwrap();
+        assert!(
+            AppConfig::load(&db).unwrap().jira_consented,
+            "grant_jira_consent's durable record survives; consent flips true only via the grant path"
         );
     }
 

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -70,6 +70,11 @@ pub enum ToolCall {
     /// [`execute_tool`] does not have. So, like `WebSearch`, it is dispatched ONLY via the async
     /// [`execute_calendar_search`], NEVER through `execute_tool`.
     CalendarLookup { query: String },
+    /// CONNECTOR — LIVE JIRA SEARCH (consent-gated EXTERNAL connector). Like [`Self::WebSearch`],
+    /// dispatched exclusively via the async [`execute_jira_search`], and ONLY when the Jira connector
+    /// is exposed (enabled + consented + configured + token). It EGRESSES: the redacted query reaches
+    /// the user's Jira Cloud site through the consent-gated, redacting connector framework.
+    JiraSearch { query: String },
 }
 
 /// Model-facing description of one tool the agentic brain may call. `parameters` is a JSON-schema
@@ -157,6 +162,15 @@ pub fn tool_specs() -> Vec<ToolSpec> {
             name: "calendar_lookup",
             description: "Look up the user's local (on-device) calendar for recent/upcoming events.",
             parameters: str_arg("query", "What meeting / agenda detail to find."),
+            write: false,
+        },
+        ToolSpec {
+            name: "jira_search",
+            description: "Search the user's Jira issues (summary, status, assignee, due date). Only \
+                          available when the user has enabled + consented to the Jira connector; \
+                          results are loud-attributed '(via Jira)'. Use for questions about tickets, \
+                          deadlines, sprint work, or to check an issue's current state.",
+            parameters: str_arg("query", "What to look for in Jira, in the user's own language."),
             write: false,
         },
         ToolSpec {
@@ -375,6 +389,17 @@ pub fn execute_tool(
                     .to_string(),
             ))
         }
+        ToolCall::JiraSearch { .. } => {
+            // EGRESS GUARD (mirror of WebSearch): the synchronous, egress-free `execute_tool` is the
+            // MCP surface's only entry, so it MUST NOT run a connector that reaches off-device. Jira
+            // search is dispatched exclusively via the async `execute_jira_search`. Reaching here is a
+            // programming error in a caller, never a leak — refuse loudly, egress nothing.
+            Err(AppError::InvalidArg(
+                "JiraSearch is an egress connector and cannot run through the egress-free tool path; \
+                 use execute_jira_search"
+                    .to_string(),
+            ))
+        }
     }
 }
 
@@ -414,6 +439,29 @@ pub async fn execute_web_search(query: &str, config: &AppConfig) -> Result<Strin
             Ok("Web search is not available (not configured).".to_string())
         }
         // A real external failure (network/HTTP/parse) is surfaced; the caller logs + skips it.
+        Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
+    }
+}
+
+/// CONNECTOR DISPATCH — run a LIVE JIRA search through the connector seam. Mirrors
+/// [`execute_web_search`]: fail-closed sentinel when not exposed (NOTHING egresses), redaction +
+/// egress-ledger applied by [`crate::connectors::ConnectorRegistry::search`], loud attribution.
+pub async fn execute_jira_search(query: &str, config: &AppConfig) -> Result<String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok("No Jira results for an empty query.".to_string());
+    }
+    let registry = crate::connectors::ConnectorRegistry::build(config);
+    match registry.search("jira", q).await {
+        Ok(hits) if hits.is_empty() => Ok(format!("No Jira results for \"{q}\".")),
+        Ok(hits) => Ok(format_web_hits(&hits)),
+        Err(crate::connectors::ConnectorError::NeedsConsent) => Ok(
+            "Jira search is not available (not enabled, not consented, or not configured)."
+                .to_string(),
+        ),
+        Err(crate::connectors::ConnectorError::Unconfigured(_)) => {
+            Ok("Jira search is not available (not configured).".to_string())
+        }
         Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
     }
 }
@@ -598,7 +646,7 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             .into_iter()
             .filter(|s| match s.name {
                 // Connectors require the AppHandle (async sidecar / consent path).
-                "web_search" | "calendar_lookup" => has_app,
+                "web_search" | "calendar_lookup" | "jira_search" => has_app,
                 // The draft tool is advertised only on surfaces with a notes flow / Accept
                 // affordance (in-meeting yes, the vault-wide Ask page no).
                 "propose_note" => self.note_drafts,
@@ -692,6 +740,10 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                 None => Err(AppError::InvalidArg(
                     "calendar_lookup needs an AppHandle".into(),
                 )),
+            },
+            "jira_search" => match self.app {
+                Some(_) => block_on_tool(execute_jira_search(&s("query"), self.config)),
+                None => Err(AppError::InvalidArg("jira_search needs an AppHandle".into())),
             },
             // ── PROPOSE (always-on, NO DB side effect): the model signals the user asked for a note.
             //    Records the draft in interior-mutable scratch; the caller threads it onto the result so
@@ -889,6 +941,34 @@ mod tests {
             matches!(res, Err(AppError::InvalidArg(_))),
             "the synchronous tool path must refuse CalendarLookup (needs the async AppHandle path)"
         );
+    }
+
+    /// EGRESS GUARD: the synchronous, egress-free `execute_tool` MUST refuse a `JiraSearch` — like
+    /// `WebSearch`, it can never run a connector that reaches off-device.
+    #[test]
+    fn sync_execute_tool_refuses_jira_search() {
+        let db = tmp_db();
+        let nothing = HashSet::new();
+        let cfg = AppConfig::default();
+        let res = execute_tool(
+            &ToolCall::JiraSearch { query: "login bug".into() },
+            &db,
+            &nothing,
+            &cfg,
+        );
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "the egress-free tool path must refuse JiraSearch (no connector through MCP)"
+        );
+    }
+
+    /// FAIL-CLOSED: with the default config (jira disabled + unconsented), `execute_jira_search`
+    /// returns the graceful "not available" sentinel and EGRESSES NOTHING — no token, no network.
+    #[test]
+    fn jira_search_fail_closed_returns_sentinel_no_egress() {
+        let cfg = AppConfig::default(); // jira disabled + unconsented
+        let out = block_on(execute_jira_search("login bug", &cfg)).unwrap();
+        assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
     }
 
     /// LOUD: calendar hits render with their `[calendar]` source label + the bounded context block,

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -75,6 +75,11 @@ pub enum ToolCall {
     /// is exposed (enabled + consented + configured + token). It EGRESSES: the redacted query reaches
     /// the user's Jira Cloud site through the consent-gated, redacting connector framework.
     JiraSearch { query: String },
+    /// CONNECTOR — LIVE SLACK SEARCH (consent-gated EXTERNAL connector). Like [`Self::WebSearch`],
+    /// dispatched exclusively via the async [`execute_slack_search`], and ONLY when the Slack connector
+    /// is exposed (enabled + consented + user token). It EGRESSES: the redacted query reaches the
+    /// user's Slack workspace through the consent-gated, redacting connector framework.
+    SlackSearch { query: String },
 }
 
 /// Model-facing description of one tool the agentic brain may call. `parameters` is a JSON-schema
@@ -171,6 +176,15 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                           results are loud-attributed '(via Jira)'. Use for questions about tickets, \
                           deadlines, sprint work, or to check an issue's current state.",
             parameters: str_arg("query", "What to look for in Jira, in the user's own language."),
+            write: false,
+        },
+        ToolSpec {
+            name: "slack_search",
+            description: "Search the user's Slack messages (channels + DMs their token can see). Only \
+                          available when the user has enabled + consented to the Slack connector; \
+                          results are loud-attributed '(via Slack)'. Use for 'what did we say/decide \
+                          about X in Slack' questions.",
+            parameters: str_arg("query", "What to look for in Slack, in the user's own language."),
             write: false,
         },
         ToolSpec {
@@ -400,6 +414,17 @@ pub fn execute_tool(
                     .to_string(),
             ))
         }
+        ToolCall::SlackSearch { .. } => {
+            // EGRESS GUARD (mirror of WebSearch): the synchronous, egress-free `execute_tool` is the
+            // MCP surface's only entry, so it MUST NOT run a connector that reaches off-device. Slack
+            // search is dispatched exclusively via the async `execute_slack_search`. Reaching here is a
+            // programming error in a caller, never a leak — refuse loudly, egress nothing.
+            Err(AppError::InvalidArg(
+                "SlackSearch is an egress connector and cannot run through the egress-free tool path; \
+                 use execute_slack_search"
+                    .to_string(),
+            ))
+        }
     }
 }
 
@@ -461,6 +486,29 @@ pub async fn execute_jira_search(query: &str, config: &AppConfig) -> Result<Stri
         ),
         Err(crate::connectors::ConnectorError::Unconfigured(_)) => {
             Ok("Jira search is not available (not configured).".to_string())
+        }
+        Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
+    }
+}
+
+/// CONNECTOR DISPATCH — run a LIVE SLACK search through the connector seam. Mirrors
+/// [`execute_web_search`]: fail-closed sentinel when not exposed (NOTHING egresses), redaction +
+/// egress-ledger applied by [`crate::connectors::ConnectorRegistry::search`], loud attribution.
+pub async fn execute_slack_search(query: &str, config: &AppConfig) -> Result<String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok("No Slack results for an empty query.".to_string());
+    }
+    let registry = crate::connectors::ConnectorRegistry::build(config);
+    match registry.search("slack", q).await {
+        Ok(hits) if hits.is_empty() => Ok(format!("No Slack results for \"{q}\".")),
+        Ok(hits) => Ok(format_web_hits(&hits)),
+        Err(crate::connectors::ConnectorError::NeedsConsent) => Ok(
+            "Slack search is not available (not enabled, not consented, or not configured)."
+                .to_string(),
+        ),
+        Err(crate::connectors::ConnectorError::Unconfigured(_)) => {
+            Ok("Slack search is not available (not configured).".to_string())
         }
         Err(e @ crate::connectors::ConnectorError::Failed(_)) => Err(e.into()),
     }
@@ -646,7 +694,7 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             .into_iter()
             .filter(|s| match s.name {
                 // Connectors require the AppHandle (async sidecar / consent path).
-                "web_search" | "calendar_lookup" | "jira_search" => has_app,
+                "web_search" | "calendar_lookup" | "jira_search" | "slack_search" => has_app,
                 // The draft tool is advertised only on surfaces with a notes flow / Accept
                 // affordance (in-meeting yes, the vault-wide Ask page no).
                 "propose_note" => self.note_drafts,
@@ -744,6 +792,10 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             "jira_search" => match self.app {
                 Some(_) => block_on_tool(execute_jira_search(&s("query"), self.config)),
                 None => Err(AppError::InvalidArg("jira_search needs an AppHandle".into())),
+            },
+            "slack_search" => match self.app {
+                Some(_) => block_on_tool(execute_slack_search(&s("query"), self.config)),
+                None => Err(AppError::InvalidArg("slack_search needs an AppHandle".into())),
             },
             // ── PROPOSE (always-on, NO DB side effect): the model signals the user asked for a note.
             //    Records the draft in interior-mutable scratch; the caller threads it onto the result so
@@ -968,6 +1020,34 @@ mod tests {
     fn jira_search_fail_closed_returns_sentinel_no_egress() {
         let cfg = AppConfig::default(); // jira disabled + unconsented
         let out = block_on(execute_jira_search("login bug", &cfg)).unwrap();
+        assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
+    }
+
+    /// EGRESS GUARD: the synchronous, egress-free `execute_tool` MUST refuse a `SlackSearch` — like
+    /// `WebSearch`, it can never run a connector that reaches off-device.
+    #[test]
+    fn sync_execute_tool_refuses_slack_search() {
+        let db = tmp_db();
+        let nothing = HashSet::new();
+        let cfg = AppConfig::default();
+        let res = execute_tool(
+            &ToolCall::SlackSearch { query: "raport".into() },
+            &db,
+            &nothing,
+            &cfg,
+        );
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "the egress-free tool path must refuse SlackSearch (no connector through MCP)"
+        );
+    }
+
+    /// FAIL-CLOSED: with the default config (slack disabled + unconsented), `execute_slack_search`
+    /// returns the graceful "not available" sentinel and EGRESSES NOTHING — no token, no network.
+    #[test]
+    fn slack_search_fail_closed_returns_sentinel_no_egress() {
+        let cfg = AppConfig::default(); // slack disabled + unconsented
+        let out = block_on(execute_slack_search("raport", &cfg)).unwrap();
         assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
     }
 

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -1,0 +1,308 @@
+//! NOTE VERIFY — deterministic verification of note claims against LIVE connector truth (v1: Jira).
+//!
+//! Design (docs/research/2026-07-05-connectors-live-vs-rag.md): the LLM is NEVER the judge.
+//! `extract_issue_keys` (pure regex-free scanner) finds ticket keys; the caller fetches each
+//! issue's CURRENT state live (staleness would INVERT a verification); `judge` (pure) compares;
+//! `apply_verify_markers` appends non-destructive `> ` blockquote markers exactly like
+//! `summarize/grounding.rs::annotate_unverified` — idempotent (strip old `(via Jira)` markers,
+//! re-insert), byte-preserving for every original line.
+//!
+//! On-demand + consent-gated ONLY (rides the Jira connector gates). NEVER wired into the
+//! zero-egress proactive path (`proactive.rs` contract D1).
+
+use serde::{Deserialize, Serialize};
+
+/// The live state of one Jira issue, fetched at verify time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueSnapshot {
+    pub key: String,
+    pub summary: String,
+    pub status: String,
+    pub due: Option<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    Confirmed,
+    NotFound,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyFinding {
+    /// 1-based line number in the note markdown the claim sits on.
+    pub line_no: usize,
+    pub key: String,
+    pub verdict: Verdict,
+    /// Human detail rendered in the marker/panel. Contains ONLY connector-sourced values +
+    /// dates already present in the note line — never other note content.
+    pub detail: String,
+    pub url: String,
+}
+
+/// Max unique keys verified per pass (bounds egress + latency).
+const MAX_KEYS: usize = 10;
+
+/// A verify marker line we own (and may strip on re-apply).
+fn is_verify_marker(line: &str) -> bool {
+    let t = line.trim_start();
+    (t.starts_with("> ✓") || t.starts_with("> ⚠") || t.starts_with("> ⧗"))
+        && t.trim_end().ends_with("(via Jira)")
+}
+
+/// Scan for Jira-style issue keys (`ABC-123`): 1 uppercase letter + up to 9 uppercase
+/// alphanumerics, a dash, 1–6 digits, on WORD BOUNDARIES. Skips YAML frontmatter and our own
+/// marker lines. Returns (1-based line_no, key), first occurrence per unique key, capped.
+pub fn extract_issue_keys(note_md: &str) -> Vec<(usize, String)> {
+    let mut out: Vec<(usize, String)> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut in_frontmatter = false;
+    for (idx, line) in note_md.lines().enumerate() {
+        let line_no = idx + 1;
+        if idx == 0 && line.trim() == "---" {
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter {
+            if line.trim() == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+        if is_verify_marker(line) {
+            continue;
+        }
+        for key in scan_keys(line) {
+            if out.len() >= MAX_KEYS {
+                return out;
+            }
+            if seen.insert(key.clone()) {
+                out.push((line_no, key));
+            }
+        }
+    }
+    out
+}
+
+/// Hand-rolled key scanner (no `regex` dependency): uppercase run then '-' then digit run,
+/// bounded by non-alphanumerics.
+fn scan_keys(line: &str) -> Vec<String> {
+    let bytes = line.as_bytes();
+    let mut keys = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Word boundary: previous char must not be alphanumeric.
+        if i > 0 && bytes[i - 1].is_ascii_alphanumeric() {
+            i += 1;
+            continue;
+        }
+        // Project part: uppercase letter then 0..=9 uppercase alphanumerics.
+        if !bytes[i].is_ascii_uppercase() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut j = i + 1;
+        while j < bytes.len()
+            && j - start < 10
+            && (bytes[j].is_ascii_uppercase() || bytes[j].is_ascii_digit())
+        {
+            j += 1;
+        }
+        if j < bytes.len() && bytes[j] == b'-' {
+            let dash = j;
+            let mut k = dash + 1;
+            while k < bytes.len() && k - dash <= 6 && bytes[k].is_ascii_digit() {
+                k += 1;
+            }
+            let digits = k - dash - 1;
+            let boundary_ok = k >= bytes.len() || !bytes[k].is_ascii_alphanumeric();
+            if digits >= 1 && boundary_ok {
+                keys.push(line[start..k].to_string());
+                i = k;
+                continue;
+            }
+        }
+        i = j;
+    }
+    keys
+}
+
+/// Find the first ISO date (`YYYY-MM-DD`) in a line, if any (hand-rolled, no regex).
+fn first_iso_date(line: &str) -> Option<String> {
+    let b = line.as_bytes();
+    for i in 0..b.len().saturating_sub(9) {
+        if i > 0 && b[i - 1].is_ascii_digit() {
+            continue;
+        }
+        let w = &b[i..i + 10];
+        let shape = w[0].is_ascii_digit()
+            && w[1].is_ascii_digit()
+            && w[2].is_ascii_digit()
+            && w[3].is_ascii_digit()
+            && w[4] == b'-'
+            && w[5].is_ascii_digit()
+            && w[6].is_ascii_digit()
+            && w[7] == b'-'
+            && w[8].is_ascii_digit()
+            && w[9].is_ascii_digit();
+        let boundary = i + 10 >= b.len() || !b[i + 10].is_ascii_digit();
+        if shape && boundary {
+            return Some(line[i..i + 10].to_string());
+        }
+    }
+    None
+}
+
+/// PURE deterministic verdict — the load-bearing property (mirrors `facts::reconcile_facts`:
+/// the LLM never judges; injected text has no judgment step to hijack).
+pub fn judge(line_text: &str, key: &str, snap: Option<&IssueSnapshot>) -> (Verdict, String) {
+    match snap {
+        None => (Verdict::NotFound, format!("{key} not found in Jira")),
+        Some(s) => {
+            if let (Some(note_date), Some(due)) = (first_iso_date(line_text), s.due.as_deref()) {
+                if note_date != due {
+                    return (
+                        Verdict::Conflict,
+                        format!("note says {note_date}, {key} due {due}"),
+                    );
+                }
+            }
+            let mut detail = format!("{key} · Status: {}", s.status);
+            if let Some(due) = s.due.as_deref() {
+                detail.push_str(&format!(" · due {due}"));
+            }
+            (Verdict::Confirmed, detail)
+        }
+    }
+}
+
+/// Append one non-destructive marker blockquote after each finding's line. IDEMPOTENT: all
+/// existing `(via Jira)` marker lines are stripped first, so re-verifying replaces (never stacks).
+/// Every ORIGINAL line is preserved byte-identically (the annotate_unverified discipline).
+pub fn apply_verify_markers(note_md: &str, findings: &[VerifyFinding]) -> String {
+    // 1) Strip our old markers, remembering the original line numbering AFTER the strip.
+    let kept: Vec<&str> = note_md.lines().filter(|l| !is_verify_marker(l)).collect();
+    // 2) Group findings by line_no (computed against the STRIPPED text — the command recomputes
+    //    findings from the stripped note, see verify_note_sources).
+    let mut out: Vec<String> = Vec::with_capacity(kept.len() + findings.len());
+    for (idx, line) in kept.iter().enumerate() {
+        out.push((*line).to_string());
+        let line_no = idx + 1;
+        for f in findings.iter().filter(|f| f.line_no == line_no) {
+            let glyph = match f.verdict {
+                Verdict::Confirmed => "✓",
+                Verdict::NotFound => "⚠",
+                Verdict::Conflict => "⧗",
+            };
+            out.push(format!("> {glyph} {} (via Jira)", f.detail));
+        }
+    }
+    let mut s = out.join("\n");
+    if note_md.ends_with('\n') {
+        s.push('\n');
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(key: &str, status: &str, due: Option<&str>) -> IssueSnapshot {
+        IssueSnapshot {
+            key: key.into(),
+            summary: "Fix login".into(),
+            status: status.into(),
+            due: due.map(String::from),
+            url: format!("https://acme.atlassian.net/browse/{key}"),
+        }
+    }
+
+    #[test]
+    fn extracts_unique_keys_with_line_numbers_capped() {
+        let md = "---\ntitle: x\n---\n# Notes\n- Ship PROJ-123 by Friday\n- PROJ-123 again\n- also ABC-9\n";
+        let keys = extract_issue_keys(md);
+        // 1-based line numbers COUNT the frontmatter lines: PROJ-123 sits on line 5, ABC-9 on 7.
+        assert_eq!(keys, vec![(5, "PROJ-123".to_string()), (7, "ABC-9".to_string())]);
+        // Cap at 10 unique keys.
+        let many: String = (1..=15).map(|i| format!("- K{i}A-{i}\n")).collect();
+        assert_eq!(extract_issue_keys(&many).len(), 10);
+    }
+
+    #[test]
+    fn frontmatter_and_existing_markers_are_not_scanned() {
+        let md = "---\nref: FM-1\n---\n> ✓ OLD-1 · Status: Done (via Jira)\n- real REAL-2\n";
+        let keys = extract_issue_keys(md);
+        // FM-1 (frontmatter) and OLD-1 (our own marker line) are skipped; REAL-2 is on line 5.
+        assert_eq!(keys, vec![(5, "REAL-2".to_string())]);
+    }
+
+    #[test]
+    fn judge_not_found_confirmed_and_date_conflict() {
+        // Missing issue → NotFound.
+        let (v, d) = judge("- Ship PROJ-1 by 2026-07-08", "PROJ-1", None);
+        assert!(matches!(v, Verdict::NotFound));
+        assert!(d.contains("PROJ-1"));
+        // Found, no date in the line → Confirmed with status/due detail.
+        let s = snap("PROJ-1", "In Progress", Some("2026-07-10"));
+        let (v, d) = judge("- Ship PROJ-1 soon", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Confirmed));
+        assert!(d.contains("In Progress") && d.contains("2026-07-10"));
+        // ISO date in the line ≠ issue due → Conflict naming both dates.
+        let (v, d) = judge("- Ship PROJ-1 by 2026-07-08", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Conflict));
+        assert!(d.contains("2026-07-08") && d.contains("2026-07-10"));
+        // ISO date matching the due → Confirmed.
+        let (v, _) = judge("- Ship PROJ-1 by 2026-07-10", "PROJ-1", Some(&s));
+        assert!(matches!(v, Verdict::Confirmed));
+    }
+
+    #[test]
+    fn markers_are_inserted_after_lines_and_idempotent() {
+        let md = "# N\n- Ship PROJ-1 by 2026-07-08\n- other line\n";
+        let f = VerifyFinding {
+            line_no: 2,
+            key: "PROJ-1".into(),
+            verdict: Verdict::Conflict,
+            detail: "note says 2026-07-08, PROJ-1 due 2026-07-10".into(),
+            url: "https://x/browse/PROJ-1".into(),
+        };
+        let once = apply_verify_markers(md, &[f.clone()]);
+        assert!(once.contains("\n> ⧗ note says 2026-07-08, PROJ-1 due 2026-07-10 (via Jira)\n"));
+        // Idempotent: applying again yields byte-identical output (old markers stripped first).
+        let twice = apply_verify_markers(&once, &[f]);
+        assert_eq!(once, twice);
+        // Non-destructive: original lines untouched.
+        assert!(twice.contains("- Ship PROJ-1 by 2026-07-08"));
+        assert!(twice.contains("- other line"));
+    }
+
+    #[test]
+    fn empty_findings_strip_stale_markers_only() {
+        let md = "# N\n- done PROJ-1\n> ✓ PROJ-1 · Status: Done (via Jira)\n";
+        let out = apply_verify_markers(md, &[]);
+        assert!(!out.contains("(via Jira)"), "stale markers removed");
+        assert!(out.contains("- done PROJ-1"));
+    }
+
+    #[test]
+    fn verdict_serde_casing_is_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&Verdict::NotFound).unwrap(),
+            "\"notfound\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Verdict::Confirmed).unwrap(),
+            "\"confirmed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Verdict::Conflict).unwrap(),
+            "\"conflict\""
+        );
+    }
+}

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -199,7 +199,17 @@ pub fn apply_verify_markers(note_md: &str, findings: &[VerifyFinding]) -> String
                 Verdict::NotFound => "⚠",
                 Verdict::Conflict => "⧗",
             };
-            out.push(format!("> {glyph} {} (via Jira)", f.detail));
+            // Collapse any CR/LF in the FE-round-tripped detail to a single space (trimmed) so the
+            // marker is ALWAYS one line ending in "(via Jira)" — a newline would spawn a second line
+            // that `is_verify_marker` can't strip → residue that accumulates on re-apply + injects
+            // markdown into the user's own note. Defense at the formatting point covers every caller.
+            let detail = f
+                .detail
+                .replace(['\r', '\n'], " ")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            out.push(format!("> {glyph} {detail} (via Jira)"));
         }
     }
     let mut s = out.join("\n");
@@ -288,6 +298,25 @@ mod tests {
         let out = apply_verify_markers(md, &[]);
         assert!(!out.contains("(via Jira)"), "stale markers removed");
         assert!(out.contains("- done PROJ-1"));
+    }
+
+    #[test]
+    fn multiline_detail_cannot_break_marker_idempotency() {
+        let md = "# N\n- Ship PROJ-1\n";
+        let f = VerifyFinding {
+            line_no: 2,
+            key: "PROJ-1".into(),
+            verdict: Verdict::Confirmed,
+            detail: "PROJ-1 · Status: Done\ninjected line".into(),
+            url: String::new(),
+        };
+        let once = apply_verify_markers(md, &[f.clone()]);
+        // Every marker-originated line is strippable: re-applying with no findings removes ALL of it.
+        let cleaned = apply_verify_markers(&once, &[]);
+        assert_eq!(cleaned, md, "a multiline detail must not leave residue after strip");
+        // And idempotency holds.
+        let twice = apply_verify_markers(&once, &[f]);
+        assert_eq!(once, twice);
     }
 
     #[test]

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -219,11 +219,34 @@ pub fn handle_voice_action(
             }
             note_aside(text, db, unlocked, meeting_id)
         }
-        VoiceIntent::SlackSearch { .. } => VoiceActionResult::new(
-            "slack_search",
-            "unavailable",
-            "Slack search isn't available yet.",
-        ),
+        VoiceIntent::SlackSearch { query } => {
+            // Ride the REAL connector: dispatch through `execute_slack_search` (fail-closed,
+            // redacted, egress-ledgered inside the connector framework). When the Slack connector is
+            // not exposed (default: disabled + unconsented) the tool returns its own graceful
+            // "not available" sentinel — a non-answer that EGRESSES NOTHING, exactly like before,
+            // but now a consented + configured user gets live Slack results. A real external failure
+            // degrades to the same "not available" notice (non-PII), never a panic.
+            let q = query.trim();
+            let query_for_retrieval = if q.is_empty() {
+                literal_command.trim()
+            } else {
+                q
+            };
+            match slack_search_blocking(query_for_retrieval, config) {
+                Ok(text) => {
+                    let text = text.trim();
+                    if text.is_empty() || is_empty_tool_result(text) {
+                        // Not exposed / no results → non-answer notice, still zero egress.
+                        VoiceActionResult::new("slack_search", "unavailable", text.to_string())
+                    } else {
+                        VoiceActionResult::new("slack_search", "ok", text.to_string())
+                    }
+                }
+                Err(e) => {
+                    VoiceActionResult::new("slack_search", "unavailable", non_pii_error(&e))
+                }
+            }
+        }
         VoiceIntent::Unknown { .. } => VoiceActionResult::new(
             "unknown",
             "unrecognized",
@@ -670,6 +693,26 @@ fn web_search_blocking(query: &str, config: &AppConfig) -> crate::error::Result<
     })
 }
 
+/// Run the async SLACK-search connector to completion from this SYNCHRONOUS dispatch. Mirrors
+/// [`web_search_blocking`]: a dedicated scoped OS thread with its own current-thread runtime, so we
+/// never "start a runtime within a runtime" and the future never crosses a thread boundary (only the
+/// `Result<String>` does). The egress/consent/redaction discipline all lives inside
+/// `execute_slack_search` → the connector registry (fail-closed when the Slack connector is absent).
+fn slack_search_blocking(query: &str, config: &AppConfig) -> crate::error::Result<String> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| AppError::Summarize(format!("slack search runtime build: {e}")))?;
+                rt.block_on(crate::tools::execute_slack_search(query, config))
+            })
+            .join()
+            .map_err(|_| AppError::Summarize("slack search worker thread panicked".into()))?
+    })
+}
+
 /// INTENT GATE for the calendar leg: does this request read like a calendar/meeting question? We
 /// fire the local calendar lookup ONLY for these — so a plain "what's the weather" research never
 /// drags in calendar noise, while "who's in my next meeting" / "what's on my agenda" / "kto jest na
@@ -790,6 +833,8 @@ fn is_empty_tool_result(text: &str) -> bool {
         || t.starts_with("Semantic search is disabled")
         || t.starts_with("No web results")
         || t.starts_with("Web search is not available")
+        || t.starts_with("No Slack results")
+        || t.starts_with("Slack search is not available")
         || t.starts_with("No calendar events")
 }
 
@@ -1330,7 +1375,15 @@ mod tests {
             None,
         );
         assert_eq!(res.intent_kind, "slack_search");
+        // The SlackSearch intent now rides the REAL connector: with a default (unconsented) config it
+        // returns the tool's OWN fail-closed sentinel — a non-answer under the "unavailable" status,
+        // still zero egress (no token, no network).
         assert_eq!(res.status, "unavailable");
+        assert!(
+            res.summary.contains("not available"),
+            "fail-closed connector sentinel flows through (zero egress): {}",
+            res.summary
+        );
     }
 
     #[test]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -493,6 +493,31 @@ export class IpcService {
     return invoke<boolean>("has_web_search_key");
   }
 
+  /**
+   * brain2 connectors (Phase 2) — grant the one-time consent for JIRA egress. The ONLY
+   * supported way to flip `jiraConsented` true: the backend persists the flag AND updates
+   * its in-memory config cache, so the next brain/Ask answer may expose the Jira connector
+   * (provided Jira is enabled AND configured AND a token is stored). Idempotent. Mirrors
+   * {@link consentToWebSearch}.
+   */
+  consentToJira(): Promise<void> {
+    return invoke<void>("consent_to_jira");
+  }
+
+  /**
+   * brain2 connectors — store/replace the BYO Jira API token in the Keychain. An empty
+   * string clears it. NEVER logged / NEVER returned to the FE — only {@link hasJiraToken}
+   * reports presence. Mirrors {@link setWebSearchApiKey}.
+   */
+  setJiraToken(key: string): Promise<void> {
+    return invoke<void>("set_jira_token", { key });
+  }
+
+  /** Whether a Jira API token is currently stored. Never the value. */
+  hasJiraToken(): Promise<boolean> {
+    return invoke<boolean>("has_jira_token");
+  }
+
   providerStatuses(): Promise<ProviderStatus[]> {
     return invoke<ProviderStatus[]>("provider_statuses");
   }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -518,6 +518,31 @@ export class IpcService {
     return invoke<boolean>("has_jira_token");
   }
 
+  /**
+   * brain2 connectors (Phase 3) — grant the one-time consent for SLACK egress. The ONLY
+   * supported way to flip `slackConsented` true: the backend persists the flag AND updates
+   * its in-memory config cache, so the next brain/Ask answer may expose the Slack connector
+   * (provided Slack is enabled AND a user token is stored). Idempotent. Mirrors
+   * {@link consentToJira}.
+   */
+  consentToSlack(): Promise<void> {
+    return invoke<void>("consent_to_slack");
+  }
+
+  /**
+   * brain2 connectors — store/replace the BYO Slack user token in the Keychain. An empty
+   * string clears it. NEVER logged / NEVER returned to the FE — only {@link hasSlackToken}
+   * reports presence. Mirrors {@link setJiraToken}.
+   */
+  setSlackToken(key: string): Promise<void> {
+    return invoke<void>("set_slack_token", { key });
+  }
+
+  /** Whether a Slack user token is currently stored. Never the value. */
+  hasSlackToken(): Promise<boolean> {
+    return invoke<boolean>("has_slack_token");
+  }
+
   providerStatuses(): Promise<ProviderStatus[]> {
     return invoke<ProviderStatus[]>("provider_statuses");
   }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -53,6 +53,7 @@ import type {
   PruneSummary,
   StorageReport,
   UserMemory,
+  VerifyFindingDto,
   ProviderStatus,
   SavedRecipe,
   SearchHit,
@@ -174,6 +175,23 @@ export class IpcService {
   /** Replace a meeting's note markdown (in-app edit) + re-write the vault file in place. */
   updateNote(meetingId: string, markdown: string): Promise<NoteDto> {
     return invoke<NoteDto>("update_note", { meetingId, markdown });
+  }
+
+  /**
+   * VERIFY PASS: check the note's Jira ticket claims against LIVE Jira (deterministic — the LLM is
+   * never the judge). On-demand only; rides the Jira connector's enable+consent gate and refuses a
+   * locked meeting. Returns one finding per referenced ticket.
+   */
+  verifyNoteSources(meetingId: string): Promise<VerifyFindingDto[]> {
+    return invoke<VerifyFindingDto[]>("verify_note_sources", { meetingId });
+  }
+
+  /** Persist the reviewed verify findings as non-destructive inline `> ` markers in the note. */
+  applyNoteVerifyMarkers(
+    meetingId: string,
+    findings: VerifyFindingDto[],
+  ): Promise<NoteDto> {
+    return invoke<NoteDto>("apply_note_verify_markers", { meetingId, findings });
   }
 
   getConfig(): Promise<AppConfigDto> {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -229,6 +229,20 @@ export interface AppConfigDto {
    */
   jiraEmail: string;
   /**
+   * brain2 connectors (Phase 3) — the SLACK connector MASTER toggle. NEW CLOUD EGRESS:
+   * when on (AND `slackConsented` AND a user token is configured), the brain/Ask answer
+   * may send a REDACTED query off-device to the user's Slack workspace. A settable flag,
+   * round-tripped on every `save_config`. Default false. Mirrors Rust `AppConfigDto.slack_enabled`.
+   */
+  slackEnabled: boolean;
+  /**
+   * brain2 connectors — one-time consent for the Slack egress. Like `jiraConsented`,
+   * PRESERVE-ONLY on `save_config` (a normal save carries the current value back, never
+   * flips it) and granted SOLELY by the dedicated `consent_to_slack` command. Default
+   * false (fail-closed). Mirrors Rust `AppConfigDto.slack_consented`.
+   */
+  slackConsented: boolean;
+  /**
    * Opt-in: pass the shell environment through to the `claude` CLI subprocess, so an env
    * `ANTHROPIC_API_KEY` (and proxy / base-url vars) reach it again — restores how older versions
    * authenticated the CLI before the env-hardening. Settable flag, round-tripped on `save_config`.

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -204,6 +204,31 @@ export interface AppConfigDto {
    */
   webSearchConsented: boolean;
   /**
+   * brain2 connectors (Phase 2) — the JIRA connector MASTER toggle. NEW CLOUD EGRESS:
+   * when on (AND `jiraConsented` AND a base URL + email + API token are configured),
+   * the brain/Ask answer may send a REDACTED query off-device to the user's Jira Cloud
+   * site. A settable flag, round-tripped on every `save_config`. Default false.
+   * Mirrors Rust `AppConfigDto.jira_enabled`.
+   */
+  jiraEnabled: boolean;
+  /**
+   * brain2 connectors — one-time consent for the Jira egress. Like `webSearchConsented`,
+   * PRESERVE-ONLY on `save_config` (a normal save carries the current value back, never
+   * flips it) and granted SOLELY by the dedicated `consent_to_jira` command. Default
+   * false (fail-closed). Mirrors Rust `AppConfigDto.jira_consented`.
+   */
+  jiraConsented: boolean;
+  /**
+   * The Jira Cloud site base URL, e.g. `https://acme.atlassian.net` (non-secret).
+   * Settable, round-tripped on `save_config`. Default "". Mirrors Rust `AppConfigDto.jira_base_url`.
+   */
+  jiraBaseUrl: string;
+  /**
+   * The Atlassian account email paired with the API token for Basic auth (non-secret).
+   * Settable, round-tripped on `save_config`. Default "". Mirrors Rust `AppConfigDto.jira_email`.
+   */
+  jiraEmail: string;
+  /**
    * Opt-in: pass the shell environment through to the `claude` CLI subprocess, so an env
    * `ANTHROPIC_API_KEY` (and proxy / base-url vars) reach it again — restores how older versions
    * authenticated the CLI before the env-hardening. Settable flag, round-tripped on `save_config`.

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -671,6 +671,20 @@ export interface NoteDto {
   exportedPath: string | null;
 }
 
+/**
+ * One deterministic note-verify finding: a ticket claim in the note checked against LIVE Jira.
+ * Mirrors Rust `crate::verify::VerifyFinding`. NOTE the serde casing — `Verdict` derives
+ * `#[serde(rename_all = "lowercase")]`, so `Verdict::NotFound` serializes as `"notfound"`
+ * (NOT `"not_found"`); keep this union in lockstep with the backend enum.
+ */
+export interface VerifyFindingDto {
+  lineNo: number;
+  key: string;
+  verdict: "confirmed" | "notfound" | "conflict";
+  detail: string;
+  url: string;
+}
+
 export interface StartResult {
   meetingId: string;
 }

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.html
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.html
@@ -1,0 +1,31 @@
+<div class="card enable-card">
+  <div class="enable-copy">
+    <h3>Enable the brain</h3>
+    <p class="text-secondary">
+      Downloads two on-device models ({{ sizeHint() }} total). They run
+      entirely on your Mac — nothing is sent anywhere. This switches on
+      <strong>memory</strong> (the brain remembers facts about you) and
+      <strong>semantic search</strong> (find things by meaning, not keywords).
+    </p>
+  </div>
+
+  @if (stage() === "done" || allReady()) {
+    <span class="pill is-success"><span class="pill-dot"></span> Brain enabled</span>
+  } @else if (running()) {
+    <div class="enable-progress">
+      @if (stage() === "brain") {
+        <span class="text-secondary">Downloading the brain model… {{ brainPct() }}</span>
+      } @else {
+        <span class="text-secondary">Downloading the search model…</span>
+      }
+    </div>
+  } @else {
+    <button type="button" class="btn btn-primary" (click)="enable()">
+      Enable the brain
+    </button>
+  }
+
+  @if (error(); as e) {
+    <p class="banner is-warning" role="alert">Download failed: {{ e }} — try again.</p>
+  }
+</div>

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.scss
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.scss
@@ -1,0 +1,13 @@
+.enable-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.enable-copy h3 {
+  margin: 0 0 var(--space-1);
+}
+.enable-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
@@ -1,0 +1,163 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  output,
+  signal,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../../core/ipc.service";
+import { SettingsStore } from "../../settings/settings.store";
+
+/**
+ * "Enable the brain" — the one-click activation card for the two on-device
+ * models a fresh install is missing: the heavy brain GGUF (powers user memory
+ * extraction + on-device Ask) and the e5 embed model (powers semantic search;
+ * until it exists, retrieval silently falls back to FTS).
+ *
+ * Backend untouched: this drives the EXISTING SettingsStore download actions
+ * (downloadBrainModel / downloadEmbedModel) and the existing presence probes.
+ * Everything stays on the user's Mac — the card copy says so loudly.
+ *
+ * Embedded in two places: the onboarding "brain" step and the Brain page
+ * nudge banner (hidden once both models are present).
+ *
+ * NOTE: SettingsStore is component-scoped (provided only by the Settings shell),
+ * so this card provides its OWN instance. It never calls the store's heavy
+ * `load()` (which arms auto-save + patches the config form) — only the safe,
+ * read-only registry loader + the download actions. The store's own download
+ * progress stream is only armed by `load()`, so the live % is self-subscribed
+ * here instead.
+ */
+@Component({
+  selector: "app-brain-enable-card",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [SettingsStore],
+  templateUrl: "./brain-enable-card.component.html",
+  styleUrl: "./brain-enable-card.component.scss",
+})
+export class BrainEnableCardComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly store = inject(SettingsStore);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Fires once when both models land (parent may advance the wizard). */
+  readonly enabled = output<void>();
+
+  readonly brainPresent = signal<boolean | null>(null);
+  readonly embedPresent = signal<boolean | null>(null);
+  readonly running = signal(false);
+  readonly stage = signal<"idle" | "brain" | "embed" | "done">("idle");
+  readonly error = signal<string | null>(null);
+
+  /** 0..1 progress for the in-flight brain GGUF (self-subscribed, best-effort). */
+  private readonly _brainFrac = signal(0);
+  /** Whole-percent label for the in-flight brain-model download. */
+  readonly brainPct = computed(() => Math.round(this._brainFrac() * 100) + "%");
+  private unlistenBrainDownload: UnlistenFn | null = null;
+
+  readonly allReady = computed(
+    () => this.brainPresent() === true && this.embedPresent() === true,
+  );
+
+  /** Total size hint from the registry DTOs (heavy model approx size). */
+  readonly sizeHint = computed(() => {
+    const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
+    if (!heavy?.approxSizeBytes) return "~2 GB";
+    return `~${Math.round((heavy.approxSizeBytes / 1_000_000_000) * 10) / 10} GB`;
+  });
+
+  private readonly _probe = effect(
+    () => {
+      void this.refresh();
+    },
+    { allowSignalWrites: true },
+  );
+
+  constructor() {
+    void this.subscribeBrainDownload();
+  }
+
+  /**
+   * Subscribe directly to the brain-download progress stream (the isolated
+   * store's own subscription is only armed by the heavy Settings `load()`,
+   * which we intentionally never call). Best-effort: a missing stream just
+   * leaves the bar inert — the download still resolves via the command promise.
+   */
+  private async subscribeBrainDownload(): Promise<void> {
+    try {
+      this.unlistenBrainDownload = await this.ipc.onBrainDownload((p) => {
+        if (this.stage() !== "brain") return;
+        if (p.total && p.total > 0) {
+          this._brainFrac.set(Math.min(1, p.downloaded / p.total));
+        }
+        if (p.done) this._brainFrac.set(1);
+      });
+      this.destroyRef.onDestroy(() => this.unlistenBrainDownload?.());
+    } catch {
+      // No stream available — progress stays inert.
+    }
+  }
+
+  async refresh(): Promise<void> {
+    try {
+      // The registry is empty until something loads it; ensure it's populated so
+      // the heavy-model lookup + size hint work outside the Settings page.
+      if (this.store.brainModels().length === 0) {
+        await this.store.refreshBrainModels();
+      }
+      const [brain, embed] = await Promise.all([
+        this.ipc.brainModelPresent(),
+        this.ipc.embedModelPresent(),
+      ]);
+      this.brainPresent.set(brain);
+      this.embedPresent.set(embed);
+      if (brain && embed) this.stage.set("done");
+    } catch {
+      // Presence probes never block the card; leave nulls (renders as unknown).
+    }
+  }
+
+  /** The one click: heavy brain model first (big), then the e5 embed model. */
+  async enable(): Promise<void> {
+    if (this.running()) return;
+    this.running.set(true);
+    this.error.set(null);
+    try {
+      if (this.brainPresent() !== true) {
+        this.stage.set("brain");
+        this._brainFrac.set(0);
+        const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
+        if (!heavy) throw new Error("no on-device model available");
+        await this.store.downloadBrainModel(heavy.id);
+      }
+      if (this.embedPresent() !== true) {
+        this.stage.set("embed");
+        await this.store.downloadEmbedModel();
+      }
+      await this.refresh();
+      if (this.allReady()) {
+        this.stage.set("done");
+        this.enabled.emit();
+      } else {
+        // The store swallows download failures into its own signals — surface
+        // them so a failed download never looks like a silent no-op.
+        this.error.set(
+          this.store.brainError() ??
+            this.store.embedDownloadError() ??
+            "The download didn't finish. Please try again.",
+        );
+        this.stage.set("idle");
+      }
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+      this.stage.set("idle");
+    } finally {
+      this.running.set(false);
+    }
+  }
+}

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -1,4 +1,9 @@
 <section class="brain">
+  <!-- 0 — ENABLE-THE-BRAIN NUDGE (only while an on-device model is missing) -->
+  @if (brainReady() === false) {
+    <app-brain-enable-card (enabled)="onBrainEnabled()" />
+  }
+
   <!-- 1 — STATUS HEADER ------------------------------------------------- -->
   <header class="b-head card">
     <div class="b-head-top">

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
 import { ToastService } from "../../../services/toast.service";
+import { BrainEnableCardComponent } from "../brain-enable-card/brain-enable-card.component";
 import { BrainMapComponent } from "../brain-map/brain-map.component";
 import { BrainMemoryComponent } from "../brain-memory/brain-memory.component";
 import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor.component";
@@ -74,6 +75,7 @@ interface FolderOption {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     RouterLink,
+    BrainEnableCardComponent,
     BrainSourceCardComponent,
     BrainNoteEditorComponent,
     BrainMapComponent,
@@ -86,6 +88,16 @@ export class BrainComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+
+  // ── "Enable the brain" nudge — shown only when an on-device model is missing ─
+  /**
+   * Both on-device models present? null = unknown (probe in flight / failed).
+   * The nudge card renders ONLY when this is confirmed `false` (never flashes on
+   * an already-set-up brain, never shows behind a failed probe). Hoisted here
+   * rather than read off the child (a template-ref can't gate its own creation);
+   * the card re-probes and emits `enabled` when the download lands.
+   */
+  readonly brainReady = signal<boolean | null>(null);
 
   // ── status header ──────────────────────────────────────────────────────
   readonly overview = signal<BrainOverview | null>(null);
@@ -278,6 +290,9 @@ export class BrainComponent {
     // Ensure the folder tree is loaded so the selector has options.
     void this.folders.load();
 
+    // Probe whether the two on-device models are present (drives the nudge).
+    void this.probeBrainReady();
+
     // Default the selection to "All folders" once options resolve, and keep it
     // valid if the tree changes (a removed folder falls back to "All"). Tracked
     // effect that writes the selection (NG0600 guard). ALL_FOLDERS_ID is always
@@ -343,6 +358,25 @@ export class BrainComponent {
       },
       { allowSignalWrites: true },
     );
+  }
+
+  /** Probe both on-device models; null on any failure (nudge stays hidden). */
+  private async probeBrainReady(): Promise<void> {
+    try {
+      const [brain, embed] = await Promise.all([
+        this.ipc.brainModelPresent(),
+        this.ipc.embedModelPresent(),
+      ]);
+      this.brainReady.set(brain && embed);
+    } catch {
+      this.brainReady.set(null);
+    }
+  }
+
+  /** The card landed both models — hide the nudge + refresh the header counts. */
+  protected onBrainEnabled(): void {
+    this.brainReady.set(true);
+    void this.fetchOverview();
   }
 
   private async fetchOverview(): Promise<void> {

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -237,6 +237,12 @@
             (copyPath)="copy(d.note?.exportedPath ?? '')"
             (openRelated)="openRelated($event)"
           />
+          @if (config()?.jiraEnabled && config()?.jiraConsented && !locked()) {
+            <app-verify-panel
+              [meetingId]="d.meeting.id"
+              (noteChanged)="reloadDetail()"
+            />
+          }
         }
         @case ("audio") {
           <app-audio-panel

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -16,6 +16,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../../core/ipc.service";
 import type {
+  AppConfigDto,
   AssistantInteraction,
   FolderNode,
   GraphPayload,
@@ -43,6 +44,7 @@ import {
   type ParsedNote,
 } from "../note-panel/note-panel.component";
 import { SharePanelComponent } from "../share-panel/share-panel.component";
+import { VerifyPanelComponent } from "../verify-panel/verify-panel.component";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 interface ActionItem {
@@ -61,6 +63,7 @@ interface ActionItem {
     NotePanelComponent,
     AudioPanelComponent,
     SharePanelComponent,
+    VerifyPanelComponent,
   ],
   templateUrl: "./detail.component.html",
   styleUrl: "./detail.component.scss",
@@ -78,6 +81,13 @@ export class DetailComponent implements OnInit {
   readonly loading = signal(true);
   readonly busy = signal(false);
   readonly msg = signal("");
+
+  /**
+   * Install config snapshot — gates the "Verify with Jira" panel (shown only when
+   * `jiraEnabled && jiraConsented`, and never for a locked meeting). Loaded per
+   * meeting alongside `keepsMasters`; null until the first load resolves.
+   */
+  readonly config = signal<AppConfigDto | null>(null);
 
   // --- Phase 0.5 lock gate -------------------------------------------------
   /**
@@ -375,8 +385,11 @@ export class DetailComponent implements OnInit {
     // actions. Install-global, so load it regardless of lock state (best-effort;
     // a failure simply hides the actions). The backend remains the real gate.
     try {
-      this.keepsMasters.set((await this.ipc.getConfig()).keepHiresMasters);
+      const cfg = await this.ipc.getConfig();
+      this.config.set(cfg);
+      this.keepsMasters.set(cfg.keepHiresMasters);
     } catch {
+      this.config.set(null);
       this.keepsMasters.set(false);
     }
     // Locked (masked) meetings render the lock gate only — skip priming the
@@ -777,6 +790,17 @@ export class DetailComponent implements OnInit {
       this.saveError.set("Couldn’t save: " + String(e));
     } finally {
       this.saving.set(false);
+    }
+  }
+
+  /**
+   * Re-fetch the current meeting into the view — used after the Verify panel writes inline
+   * markers so the rendered note reflects the newly-applied `> ` blockquotes.
+   */
+  async reloadDetail(): Promise<void> {
+    const id = this.detail()?.meeting.id;
+    if (id) {
+      await this.loadMeeting(id);
     }
   }
 

--- a/src/app/features/detail/verify-panel/verify-panel.component.html
+++ b/src/app/features/detail/verify-panel/verify-panel.component.html
@@ -1,0 +1,38 @@
+<div class="verify-panel">
+  <div class="verify-head">
+    <button type="button" class="btn btn-ghost" (click)="verify()" [disabled]="running()">
+      @if (running()) { Checking Jira… } @else { Verify with Jira }
+    </button>
+    @if (findings(); as f) {
+      @if (f.length > 0 && !applied()) {
+        <button type="button" class="btn btn-primary" (click)="apply()" [disabled]="running()">
+          Add markers to note
+        </button>
+      }
+    }
+  </div>
+
+  @if (findings(); as f) {
+    @if (f.length === 0) {
+      <p class="text-secondary">No ticket references found in this note.</p>
+    } @else {
+      <ul class="verify-list">
+        @for (item of f; track item.key) {
+          <li class="verify-item" [class]="'is-' + item.verdict">
+            <span class="verify-glyph">{{ glyph(item.verdict) }}</span>
+            <span class="verify-detail">{{ item.detail }}</span>
+            @if (item.url) {
+              <a [href]="item.url" target="_blank" rel="noopener">{{ item.key }}</a>
+            }
+          </li>
+        }
+      </ul>
+    }
+  }
+  @if (applied()) {
+    <p class="text-secondary">Markers added — the note now carries the verification inline.</p>
+  }
+  @if (error(); as e) {
+    <p class="banner is-warning" role="alert">{{ e }}</p>
+  }
+</div>

--- a/src/app/features/detail/verify-panel/verify-panel.component.scss
+++ b/src/app/features/detail/verify-panel/verify-panel.component.scss
@@ -1,0 +1,33 @@
+.verify-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.verify-head {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.verify-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.verify-item {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+
+  &.is-conflict .verify-glyph {
+    color: var(--warning);
+  }
+  &.is-notfound .verify-glyph {
+    color: var(--text-secondary);
+  }
+  &.is-confirmed .verify-glyph {
+    color: var(--success);
+  }
+}

--- a/src/app/features/detail/verify-panel/verify-panel.component.ts
+++ b/src/app/features/detail/verify-panel/verify-panel.component.ts
@@ -1,0 +1,73 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { VerifyFindingDto } from "../../../core/models";
+
+/**
+ * VERIFY WITH JIRA — on-demand deterministic check of the note's ticket claims against LIVE Jira
+ * (docs/research/2026-07-05-connectors-live-vs-rag.md). On-demand ONLY (an explicit click = the
+ * egress consent moment is visible); results render as a list; "Add markers to note" persists the
+ * non-destructive > blockquote markers through the gated backend command.
+ */
+@Component({
+  selector: "app-verify-panel",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./verify-panel.component.html",
+  styleUrl: "./verify-panel.component.scss",
+})
+export class VerifyPanelComponent {
+  private readonly ipc = inject(IpcService);
+
+  readonly meetingId = input.required<string>();
+  /** Fires after markers are applied so the parent reloads the note. */
+  readonly noteChanged = output<void>();
+
+  readonly running = signal(false);
+  readonly applied = signal(false);
+  readonly findings = signal<VerifyFindingDto[] | null>(null);
+  readonly error = signal<string | null>(null);
+
+  glyph(v: VerifyFindingDto["verdict"]): string {
+    return v === "confirmed" ? "✓" : v === "conflict" ? "⧗" : "⚠";
+  }
+
+  async verify(): Promise<void> {
+    if (this.running()) {
+      return;
+    }
+    this.running.set(true);
+    this.error.set(null);
+    this.applied.set(false);
+    try {
+      this.findings.set(await this.ipc.verifyNoteSources(this.meetingId()));
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+
+  async apply(): Promise<void> {
+    const f = this.findings();
+    if (!f || this.running()) {
+      return;
+    }
+    this.running.set(true);
+    try {
+      await this.ipc.applyNoteVerifyMarkers(this.meetingId(), f);
+      this.applied.set(true);
+      this.noteChanged.emit();
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+}

--- a/src/app/features/onboarding/onboarding/onboarding.component.html
+++ b/src/app/features/onboarding/onboarding/onboarding.component.html
@@ -429,6 +429,21 @@
           }
         }
 
+        <!-- ──────────────────────── ENABLE THE BRAIN ─────────────────── -->
+        @case ("brain") {
+          <div class="ob-head">
+            <span class="ob-eyebrow">On-device intelligence</span>
+            <h2 class="ob-title">Enable the brain</h2>
+            <p class="ob-sub text-secondary">
+              Two small models make Murmur remember facts about you and search
+              your notes by meaning — all on this Mac. Optional, and you can do
+              it later from the Brain page.
+            </p>
+          </div>
+
+          <app-brain-enable-card (enabled)="next()" />
+        }
+
         <!-- ──────────────────────── VAULT (OPTIONAL) ────────────────── -->
         @case ("vault") {
           <div class="ob-head">
@@ -559,6 +574,15 @@
             (click)="skipProvider()"
           >
             I’ll set this up later
+          </button>
+        }
+        @if (currentStep() === "brain") {
+          <button
+            type="button"
+            class="btn btn-ghost ob-skip"
+            (click)="next()"
+          >
+            Skip for now
           </button>
         }
         @if (currentStep() === "vault") {

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -561,6 +561,10 @@ export class OnboardingComponent implements OnInit {
       jiraConsented: base?.jiraConsented ?? false,
       jiraBaseUrl: base?.jiraBaseUrl ?? "",
       jiraEmail: base?.jiraEmail ?? "",
+      // brain2 connectors (Phase 3) — Slack toggle + preserve-only consent; round-trip
+      // the snapshot so onboarding never resets them (default off, no egress).
+      slackEnabled: base?.slackEnabled ?? false,
+      slackConsented: base?.slackConsented ?? false,
       // Opt-in claude-CLI env inheritance — round-trip the snapshot so onboarding never resets it.
       claudeCodeInheritEnv: base?.claudeCodeInheritEnv ?? false,
       // AI Gateway — the base URL is now wizard-editable (the gateway tile);

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -13,13 +13,15 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { hostIsLoopback } from "../../../core/loopback";
 import type { AppConfigDto, ProviderStatus } from "../../../core/models";
+import { BrainEnableCardComponent } from "../../brain/brain-enable-card/brain-enable-card.component";
 
 /** The wizard steps, in order. Drives the dot indicator + progress copy. */
-type Step = "welcome" | "model" | "provider" | "vault" | "done";
+type Step = "welcome" | "model" | "provider" | "brain" | "vault" | "done";
 const STEPS: readonly Step[] = [
   "welcome",
   "model",
   "provider",
+  "brain",
   "vault",
   "done",
 ];
@@ -79,6 +81,7 @@ const SIZE_HINTS: Record<string, string> = {
   selector: "app-onboarding",
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BrainEnableCardComponent],
   templateUrl: "./onboarding.component.html",
   styleUrl: "./onboarding.component.scss",
 })

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -555,6 +555,12 @@ export class OnboardingComponent implements OnInit {
       // the snapshot so onboarding never resets them, both default off (no egress).
       webSearchEnabled: base?.webSearchEnabled ?? false,
       webSearchConsented: base?.webSearchConsented ?? false,
+      // brain2 connectors (Phase 2) — Jira toggle + preserve-only consent + non-secret
+      // site/email; round-trip the snapshot so onboarding never resets them (default off).
+      jiraEnabled: base?.jiraEnabled ?? false,
+      jiraConsented: base?.jiraConsented ?? false,
+      jiraBaseUrl: base?.jiraBaseUrl ?? "",
+      jiraEmail: base?.jiraEmail ?? "",
       // Opt-in claude-CLI env inheritance — round-trip the snapshot so onboarding never resets it.
       claudeCodeInheritEnv: base?.claudeCodeInheritEnv ?? false,
       // AI Gateway — the base URL is now wizard-editable (the gateway tile);

--- a/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.html
+++ b/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.html
@@ -248,6 +248,114 @@
                 }
               </div>
             }
+
+            <!-- Slack connector -->
+            <label class="toggle-row">
+              <span class="toggle-copy">
+                <span class="toggle-title">Slack</span>
+                <span class="text-secondary toggle-sub">
+                  When enabled (and allowed below, with a user token), the assistant
+                  can search your Slack messages and cite them. Answers stay grounded
+                  in your notes first; Slack results are added as “via Slack” sources.
+                </span>
+              </span>
+              <mur-toggle formControlName="slackEnabled" />
+            </label>
+
+            @if (form.controls.slackEnabled.value) {
+              <!-- Egress banner — make the new off-device path impossible to miss. -->
+              <p class="banner is-warning connector-egress" role="note">
+                <strong>This sends data off your Mac.</strong> When the brain runs a
+                Slack search, your (redacted) query and the matching messages pass
+                through your configured AI model and your Slack workspace. Only the
+                query is sent to Slack — never your notes or transcript. Disable this,
+                or skip the consent below, to keep everything local.
+              </p>
+
+              <!-- BYO user token -->
+              <fieldset class="connector-fieldset">
+                <legend>Slack user token</legend>
+                <div class="key-status">
+                  <span class="text-secondary">Status</span>
+                  @if (hasSlackToken()) {
+                    <span class="pill is-success">
+                      <span class="pill-dot"></span>
+                      Token set ✓
+                    </span>
+                  } @else {
+                    <span class="pill">
+                      <span class="pill-dot"></span>
+                      Not set
+                    </span>
+                  }
+                </div>
+                <span class="row">
+                  <input
+                    type="password"
+                    [formControl]="slackTokenControl"
+                    placeholder="Slack user token (xoxp-…)"
+                    autocomplete="off"
+                  />
+                  <button
+                    type="button"
+                    class="btn"
+                    (click)="saveSlackToken()"
+                    [disabled]="savingSlackToken()"
+                  >
+                    {{ savingSlackToken() ? "Saving…" : "Save token" }}
+                  </button>
+                </span>
+                <span class="field-help text-muted">
+                  Paste a user token (xoxp-…) from a single-workspace Slack app with
+                  the search:read scope. It's stored in your macOS Keychain, never
+                  logged, and never leaves with your notes.
+                </span>
+                @if (slackTokenError(); as skerr) {
+                  <p class="text-danger brain-error">{{ skerr }}</p>
+                }
+              </fieldset>
+
+              <!-- One-time egress consent (mirrors the Jira UX) -->
+              <div class="privacy-section connector-consent">
+                <span class="privacy-section-label text-muted"
+                  >Allow Slack access</span
+                >
+                <p class="text-secondary privacy-note">
+                  Your search query leaves this device for your Slack workspace
+                  (redacted first). Until you allow this once, Slack search stays off
+                  and no query is ever sent.
+                </p>
+                @if (slackConsented()) {
+                  <span class="pill is-success cloud-consent-pill">
+                    <span class="pill-dot"></span>
+                    Slack access allowed
+                  </span>
+                } @else {
+                  <div class="cloud-consent-row">
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      (click)="allowSlack()"
+                      [disabled]="slackConsenting()"
+                    >
+                      @if (slackConsenting()) {
+                        <span class="spin-ring" aria-hidden="true"></span>
+                        Enabling…
+                      } @else {
+                        Allow Slack access (one-time consent)
+                      }
+                    </button>
+                    <span class="text-muted cloud-consent-hint">
+                      One-time. The brain works fully offline on your notes without
+                      it.
+                    </span>
+                  </div>
+                }
+                @if (slackConsentError(); as scerr) {
+                  <p class="text-danger privacy-note">{{ scerr }}</p>
+                }
+              </div>
+            }
           </div>
 </div>
   

--- a/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.html
+++ b/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.html
@@ -115,6 +115,139 @@
                 }
               </div>
             }
+
+            <!-- Jira connector -->
+            <label class="toggle-row">
+              <span class="toggle-copy">
+                <span class="toggle-title">Jira</span>
+                <span class="text-secondary toggle-sub">
+                  When enabled (and allowed below, with a site, email, and API
+                  token), the assistant can search your Jira issues and cite them.
+                  Answers stay grounded in your notes first; Jira results are added
+                  as “via Jira” sources.
+                </span>
+              </span>
+              <mur-toggle formControlName="jiraEnabled" />
+            </label>
+
+            @if (form.controls.jiraEnabled.value) {
+              <!-- Egress banner — make the new off-device path impossible to miss. -->
+              <p class="banner is-warning connector-egress" role="note">
+                <strong>This sends data off your Mac.</strong> When the brain runs a
+                Jira search, your (redacted) query and the matching issue summaries
+                pass through your configured AI model and your Jira Cloud site. Only
+                the query is sent to Jira — never your notes or transcript. Disable
+                this, or skip the consent below, to keep everything local.
+              </p>
+
+              <!-- Site + account (non-secret) -->
+              <fieldset class="connector-fieldset">
+                <legend>Jira site</legend>
+                <span class="row">
+                  <input
+                    type="text"
+                    formControlName="jiraBaseUrl"
+                    placeholder="https://your-site.atlassian.net"
+                    autocomplete="off"
+                  />
+                </span>
+                <span class="row">
+                  <input
+                    type="text"
+                    formControlName="jiraEmail"
+                    placeholder="you@company.com"
+                    autocomplete="off"
+                  />
+                </span>
+                <span class="field-help text-muted">
+                  Your Atlassian site URL and the account email paired with the API
+                  token below (used for Basic auth).
+                </span>
+              </fieldset>
+
+              <!-- BYO API token -->
+              <fieldset class="connector-fieldset">
+                <legend>Jira API token</legend>
+                <div class="key-status">
+                  <span class="text-secondary">Status</span>
+                  @if (hasJiraToken()) {
+                    <span class="pill is-success">
+                      <span class="pill-dot"></span>
+                      Token set ✓
+                    </span>
+                  } @else {
+                    <span class="pill">
+                      <span class="pill-dot"></span>
+                      Not set
+                    </span>
+                  }
+                </div>
+                <span class="row">
+                  <input
+                    type="password"
+                    [formControl]="jiraTokenControl"
+                    placeholder="Jira API token"
+                    autocomplete="off"
+                  />
+                  <button
+                    type="button"
+                    class="btn"
+                    (click)="saveJiraToken()"
+                    [disabled]="savingJiraToken()"
+                  >
+                    {{ savingJiraToken() ? "Saving…" : "Save token" }}
+                  </button>
+                </span>
+                <span class="field-help text-muted">
+                  Bring your own token — it's stored in your macOS Keychain, never
+                  logged, and never leaves with your notes.
+                </span>
+                @if (jiraTokenError(); as jkerr) {
+                  <p class="text-danger brain-error">{{ jkerr }}</p>
+                }
+              </fieldset>
+
+              <!-- One-time egress consent (mirrors the web-search UX) -->
+              <div class="privacy-section connector-consent">
+                <span class="privacy-section-label text-muted"
+                  >Allow Jira access</span
+                >
+                <p class="text-secondary privacy-note">
+                  Your search query leaves this device for your Jira Cloud site
+                  (redacted first). Until you allow this once, Jira search stays off
+                  and no query is ever sent.
+                </p>
+                @if (jiraConsented()) {
+                  <span class="pill is-success cloud-consent-pill">
+                    <span class="pill-dot"></span>
+                    Jira access allowed
+                  </span>
+                } @else {
+                  <div class="cloud-consent-row">
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      (click)="allowJira()"
+                      [disabled]="jiraConsenting()"
+                    >
+                      @if (jiraConsenting()) {
+                        <span class="spin-ring" aria-hidden="true"></span>
+                        Enabling…
+                      } @else {
+                        Allow Jira access (one-time consent)
+                      }
+                    </button>
+                    <span class="text-muted cloud-consent-hint">
+                      One-time. The brain works fully offline on your notes without
+                      it.
+                    </span>
+                  </div>
+                }
+                @if (jiraConsentError(); as jcerr) {
+                  <p class="text-danger privacy-note">{{ jcerr }}</p>
+                }
+              </div>
+            }
           </div>
 </div>
   

--- a/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.ts
+++ b/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.ts
@@ -38,6 +38,15 @@ export class SettingsConnectorsSectionComponent {
   readonly jiraConsenting = this.store.jiraConsenting;
   readonly jiraConsentError = this.store.jiraConsentError;
 
+  // brain2 connectors (Phase 3) — Slack.
+  readonly slackTokenControl = this.store.slackTokenControl;
+  readonly hasSlackToken = this.store.hasSlackToken;
+  readonly savingSlackToken = this.store.savingSlackToken;
+  readonly slackTokenError = this.store.slackTokenError;
+  readonly slackConsented = this.store.slackConsented;
+  readonly slackConsenting = this.store.slackConsenting;
+  readonly slackConsentError = this.store.slackConsentError;
+
   saveWebKey(): void {
     void this.store.saveWebKey();
   }
@@ -52,5 +61,13 @@ export class SettingsConnectorsSectionComponent {
 
   allowJira(): void {
     void this.store.allowJira();
+  }
+
+  saveSlackToken(): void {
+    void this.store.saveSlackToken();
+  }
+
+  allowSlack(): void {
+    void this.store.allowSlack();
   }
 }

--- a/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.ts
+++ b/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.ts
@@ -29,11 +29,28 @@ export class SettingsConnectorsSectionComponent {
   readonly webConsenting = this.store.webConsenting;
   readonly webConsentError = this.store.webConsentError;
 
+  // brain2 connectors (Phase 2) — Jira.
+  readonly jiraTokenControl = this.store.jiraTokenControl;
+  readonly hasJiraToken = this.store.hasJiraToken;
+  readonly savingJiraToken = this.store.savingJiraToken;
+  readonly jiraTokenError = this.store.jiraTokenError;
+  readonly jiraConsented = this.store.jiraConsented;
+  readonly jiraConsenting = this.store.jiraConsenting;
+  readonly jiraConsentError = this.store.jiraConsentError;
+
   saveWebKey(): void {
     void this.store.saveWebKey();
   }
 
   allowWebSearch(): void {
     void this.store.allowWebSearch();
+  }
+
+  saveJiraToken(): void {
+    void this.store.saveJiraToken();
+  }
+
+  allowJira(): void {
+    void this.store.allowJira();
   }
 }

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -167,6 +167,11 @@ export class SettingsStore {
     semanticSearchEnabled: false,
     // brain2 connectors — web-search master toggle (NEW EGRESS; round-tripped).
     webSearchEnabled: false,
+    // brain2 connectors (Phase 2) — Jira master toggle (NEW EGRESS) + non-secret
+    // base URL / email, round-tripped on save.
+    jiraEnabled: false,
+    jiraBaseUrl: "",
+    jiraEmail: "",
     // AI Gateway (Phase 1) — base URL and model, round-tripped on save.
     gatewayBaseUrl: "",
     gatewayModel: "",
@@ -189,6 +194,8 @@ export class SettingsStore {
   readonly keyControl = new FormControl("", { nonNullable: true });
   /** BYO Brave Search API key input (web-search connector). Cleared after save. */
   readonly webKeyControl = new FormControl("", { nonNullable: true });
+  /** BYO Jira API token input (Jira connector). Cleared after save. */
+  readonly jiraTokenControl = new FormControl("", { nonNullable: true });
 
   /**
    * PROTOTYPE auto-save (no Save button): every committed form change persists
@@ -417,6 +424,27 @@ export class SettingsStore {
   /** Surfaced if storing the web-search key rejects. */
   private readonly _webKeyError = signal<string | null>(null);
   readonly webKeyError = this._webKeyError.asReadonly();
+
+  // ── brain2 connectors — Jira (Phase 2, NEW EGRESS) ─────────────────────
+
+  /** Jira egress consent state — drives the "Allow Jira access" row; round-tripped on save. */
+  private readonly _jiraConsented = signal(false);
+  readonly jiraConsented = this._jiraConsented.asReadonly();
+  /** True while the one-time Jira consent command is in flight. */
+  private readonly _jiraConsenting = signal(false);
+  readonly jiraConsenting = this._jiraConsenting.asReadonly();
+  /** Surfaced if granting Jira consent rejects. */
+  private readonly _jiraConsentError = signal<string | null>(null);
+  readonly jiraConsentError = this._jiraConsentError.asReadonly();
+  /** Whether a Jira API token is stored (has-token check; never the value). */
+  private readonly _hasJiraToken = signal(false);
+  readonly hasJiraToken = this._hasJiraToken.asReadonly();
+  /** True while the BYO token is being saved. */
+  private readonly _savingJiraToken = signal(false);
+  readonly savingJiraToken = this._savingJiraToken.asReadonly();
+  /** Surfaced if storing the Jira token rejects. */
+  private readonly _jiraTokenError = signal<string | null>(null);
+  readonly jiraTokenError = this._jiraTokenError.asReadonly();
 
   // ── AI Gateway (Phase 1) — key management + destination computed signals ──
 
@@ -1159,6 +1187,9 @@ export class SettingsStore {
       // brain2 connectors — web-search consent is preserve-only (granted only via
       // consent_to_web_search); snapshot it so save() round-trips it unchanged.
       this._webConsented.set(cfg.webSearchConsented ?? false);
+      // brain2 connectors (Phase 2) — Jira consent is preserve-only (granted only via
+      // consent_to_jira); snapshot it so save() round-trips it unchanged.
+      this._jiraConsented.set(cfg.jiraConsented ?? false);
       this.form.patchValue({
         providerId: cfg.providerId,
         vaultPath: cfg.vaultPath ?? "",
@@ -1201,6 +1232,10 @@ export class SettingsStore {
         // Mirrors backend default semantic_search_enabled = true (settings/config.rs; #159/#160).
         semanticSearchEnabled: cfg.semanticSearchEnabled ?? true,
         webSearchEnabled: cfg.webSearchEnabled ?? false,
+        // brain2 connectors (Phase 2) — Jira toggle + non-secret base URL/email.
+        jiraEnabled: cfg.jiraEnabled ?? false,
+        jiraBaseUrl: cfg.jiraBaseUrl ?? "",
+        jiraEmail: cfg.jiraEmail ?? "",
         // AI Gateway (Phase 1) — base URL + model, default "" for pre-existing configs.
         gatewayBaseUrl: cfg.gatewayBaseUrl ?? "",
         gatewayModel: cfg.gatewayModel ?? "",
@@ -1246,6 +1281,7 @@ export class SettingsStore {
       this._voiceprints.set(await this.ipc.listVoiceprints().catch(() => []));
       this._hasKey.set(await this.ipc.hasAnthropicKey());
       this._hasWebKey.set(await this.ipc.hasWebSearchKey().catch(() => false));
+      this._hasJiraToken.set(await this.ipc.hasJiraToken().catch(() => false));
       this._hasGatewayKey.set(await this.ipc.hasGatewayKey().catch(() => false));
       this._modelPresent.set(await this.ipc.modelPresent());
       // Whisper transcribe-model download-progress stream (best-effort).
@@ -1900,6 +1936,13 @@ export class SettingsStore {
       // just carries the current value back instead of letting the backend default it.
       webSearchEnabled: v.webSearchEnabled,
       webSearchConsented: this.webConsented(),
+      // brain2 connectors (Phase 2) — Jira toggle + non-secret base URL/email are
+      // settable from the form; its consent is PRESERVE-ONLY (granted via allowJira's
+      // dedicated command), so a save just carries the current value back.
+      jiraEnabled: v.jiraEnabled,
+      jiraConsented: this.jiraConsented(),
+      jiraBaseUrl: v.jiraBaseUrl,
+      jiraEmail: v.jiraEmail,
       // Round-trip the Stage E security flags so a settings save never silently
       // resets them. Cloud-egress consent is GRANTED only via the dedicated
       // command (allowCloudProcessing) — here we just carry the current value back.
@@ -2086,6 +2129,46 @@ export class SettingsStore {
       this._webConsentError.set(String(e));
     } finally {
       this._webConsenting.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors (Phase 2) — store/replace the BYO Jira API token in the
+   * Keychain, then re-probe presence so the "Token set ✓" pill flips. The value is
+   * cleared from the input after saving (it's never shown back). Mirrors saveWebKey().
+   */
+  async saveJiraToken(): Promise<void> {
+    const key = this.jiraTokenControl.value;
+    if (!key.trim()) return;
+    this._jiraTokenError.set(null);
+    this._savingJiraToken.set(true);
+    try {
+      await this.ipc.setJiraToken(key);
+      this.jiraTokenControl.setValue("");
+      this._hasJiraToken.set(await this.ipc.hasJiraToken());
+    } catch (e) {
+      this._jiraTokenError.set(String(e));
+    } finally {
+      this._savingJiraToken.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors (Phase 2) — grant the one-time Jira egress consent via the
+   * dedicated command (an explicit, auditable user act — NOT a side effect of a normal
+   * settings save). After it resolves the brain may expose the Jira connector (when Jira
+   * is enabled AND configured AND a token is stored). Mirrors allowWebSearch().
+   */
+  async allowJira(): Promise<void> {
+    this._jiraConsentError.set(null);
+    this._jiraConsenting.set(true);
+    try {
+      await this.ipc.consentToJira();
+      this._jiraConsented.set(true);
+    } catch (e) {
+      this._jiraConsentError.set(String(e));
+    } finally {
+      this._jiraConsenting.set(false);
     }
   }
 

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -172,6 +172,8 @@ export class SettingsStore {
     jiraEnabled: false,
     jiraBaseUrl: "",
     jiraEmail: "",
+    // brain2 connectors (Phase 3) — Slack master toggle (NEW EGRESS; round-tripped).
+    slackEnabled: false,
     // AI Gateway (Phase 1) — base URL and model, round-tripped on save.
     gatewayBaseUrl: "",
     gatewayModel: "",
@@ -196,6 +198,8 @@ export class SettingsStore {
   readonly webKeyControl = new FormControl("", { nonNullable: true });
   /** BYO Jira API token input (Jira connector). Cleared after save. */
   readonly jiraTokenControl = new FormControl("", { nonNullable: true });
+  /** BYO Slack user token input (Slack connector). Cleared after save. */
+  readonly slackTokenControl = new FormControl("", { nonNullable: true });
 
   /**
    * PROTOTYPE auto-save (no Save button): every committed form change persists
@@ -445,6 +449,27 @@ export class SettingsStore {
   /** Surfaced if storing the Jira token rejects. */
   private readonly _jiraTokenError = signal<string | null>(null);
   readonly jiraTokenError = this._jiraTokenError.asReadonly();
+
+  // ── brain2 connectors — Slack (Phase 3, NEW EGRESS) ────────────────────
+
+  /** Slack egress consent state — drives the "Allow Slack access" row; round-tripped on save. */
+  private readonly _slackConsented = signal(false);
+  readonly slackConsented = this._slackConsented.asReadonly();
+  /** True while the one-time Slack consent command is in flight. */
+  private readonly _slackConsenting = signal(false);
+  readonly slackConsenting = this._slackConsenting.asReadonly();
+  /** Surfaced if granting Slack consent rejects. */
+  private readonly _slackConsentError = signal<string | null>(null);
+  readonly slackConsentError = this._slackConsentError.asReadonly();
+  /** Whether a Slack user token is stored (has-token check; never the value). */
+  private readonly _hasSlackToken = signal(false);
+  readonly hasSlackToken = this._hasSlackToken.asReadonly();
+  /** True while the BYO token is being saved. */
+  private readonly _savingSlackToken = signal(false);
+  readonly savingSlackToken = this._savingSlackToken.asReadonly();
+  /** Surfaced if storing the Slack token rejects. */
+  private readonly _slackTokenError = signal<string | null>(null);
+  readonly slackTokenError = this._slackTokenError.asReadonly();
 
   // ── AI Gateway (Phase 1) — key management + destination computed signals ──
 
@@ -1190,6 +1215,9 @@ export class SettingsStore {
       // brain2 connectors (Phase 2) — Jira consent is preserve-only (granted only via
       // consent_to_jira); snapshot it so save() round-trips it unchanged.
       this._jiraConsented.set(cfg.jiraConsented ?? false);
+      // brain2 connectors (Phase 3) — Slack consent is preserve-only (granted only via
+      // consent_to_slack); snapshot it so save() round-trips it unchanged.
+      this._slackConsented.set(cfg.slackConsented ?? false);
       this.form.patchValue({
         providerId: cfg.providerId,
         vaultPath: cfg.vaultPath ?? "",
@@ -1236,6 +1264,8 @@ export class SettingsStore {
         jiraEnabled: cfg.jiraEnabled ?? false,
         jiraBaseUrl: cfg.jiraBaseUrl ?? "",
         jiraEmail: cfg.jiraEmail ?? "",
+        // brain2 connectors (Phase 3) — Slack toggle.
+        slackEnabled: cfg.slackEnabled ?? false,
         // AI Gateway (Phase 1) — base URL + model, default "" for pre-existing configs.
         gatewayBaseUrl: cfg.gatewayBaseUrl ?? "",
         gatewayModel: cfg.gatewayModel ?? "",
@@ -1282,6 +1312,7 @@ export class SettingsStore {
       this._hasKey.set(await this.ipc.hasAnthropicKey());
       this._hasWebKey.set(await this.ipc.hasWebSearchKey().catch(() => false));
       this._hasJiraToken.set(await this.ipc.hasJiraToken().catch(() => false));
+      this._hasSlackToken.set(await this.ipc.hasSlackToken().catch(() => false));
       this._hasGatewayKey.set(await this.ipc.hasGatewayKey().catch(() => false));
       this._modelPresent.set(await this.ipc.modelPresent());
       // Whisper transcribe-model download-progress stream (best-effort).
@@ -1943,6 +1974,11 @@ export class SettingsStore {
       jiraConsented: this.jiraConsented(),
       jiraBaseUrl: v.jiraBaseUrl,
       jiraEmail: v.jiraEmail,
+      // brain2 connectors (Phase 3) — Slack toggle is settable from the form; its
+      // consent is PRESERVE-ONLY (granted via allowSlack's dedicated command), so a
+      // save just carries the current value back.
+      slackEnabled: v.slackEnabled,
+      slackConsented: this.slackConsented(),
       // Round-trip the Stage E security flags so a settings save never silently
       // resets them. Cloud-egress consent is GRANTED only via the dedicated
       // command (allowCloudProcessing) — here we just carry the current value back.
@@ -2169,6 +2205,46 @@ export class SettingsStore {
       this._jiraConsentError.set(String(e));
     } finally {
       this._jiraConsenting.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors (Phase 3) — store/replace the BYO Slack user token in the
+   * Keychain, then re-probe presence so the "Token set ✓" pill flips. The value is
+   * cleared from the input after saving (it's never shown back). Mirrors saveJiraToken().
+   */
+  async saveSlackToken(): Promise<void> {
+    const key = this.slackTokenControl.value;
+    if (!key.trim()) return;
+    this._slackTokenError.set(null);
+    this._savingSlackToken.set(true);
+    try {
+      await this.ipc.setSlackToken(key);
+      this.slackTokenControl.setValue("");
+      this._hasSlackToken.set(await this.ipc.hasSlackToken());
+    } catch (e) {
+      this._slackTokenError.set(String(e));
+    } finally {
+      this._savingSlackToken.set(false);
+    }
+  }
+
+  /**
+   * brain2 connectors (Phase 3) — grant the one-time Slack egress consent via the
+   * dedicated command (an explicit, auditable user act — NOT a side effect of a normal
+   * settings save). After it resolves the brain may expose the Slack connector (when Slack
+   * is enabled AND a token is stored). Mirrors allowJira().
+   */
+  async allowSlack(): Promise<void> {
+    this._slackConsentError.set(null);
+    this._slackConsenting.set(true);
+    try {
+      await this.ipc.consentToSlack();
+      this._slackConsented.set(true);
+    } catch (e) {
+      this._slackConsentError.set(String(e));
+    } finally {
+      this._slackConsenting.set(false);
     }
   }
 


### PR DESCRIPTION
Four phases from docs/superpowers/plans/2026-07-05-brain-competitive-4-steps.md (research: docs/research/2026-07-05-connectors-live-vs-rag.md + 2026-07-05-competing-with-clickup-brain.md), built subagent-driven with per-phase spec+quality reviews and three final gates.

## Phase 1 — Enable the brain (FE-only)
Fresh installs had user-memory + semantic search structurally OFF (StubReasoner empty extraction / FTS fallback until models are downloaded). New brain-enable-card (one click: heavy GGUF then e5 embed, live progress, error banner), a skippable onboarding "brain" step, and a Brain-page nudge that disappears once both models are present. Backend untouched.

## Phase 2 — Jira live connector
Clone of the web-connector pattern: JiraConnector (JQL text search via POST /rest/api/3/search/jql, Basic auth email:api-token, BYO token in Keychain), fail-closed absent-until-enabled+consented+configured+keyed, framework-redacted queries, jira_search tool, consent_to_jira/set_jira_token/has_jira_token, settings Connectors UI block. Consent is preserve-only via BOTH mechanisms (save never writes the key AND dto_to_config preserves the live value).

Includes a framework fix: the egress ledger previously hard-coded call_kind "web_search" for every External connector — now per-connector truthful attribution (Connector::egress_attribution, RED-proven tests).

## Phase 3 — Slack live connector
Same pattern: search.messages with a pasted xoxp- user token (search:read), the HTTP-200-ok:false quirk handled (error CODE only), snippets capped at 300 chars, slack_search tool + settings block; the shipped "Slack search isn't available yet" voice stub now rides the real connector (fail-closed sentinel when unconsented, zero egress).

## Phase 4 — Deterministic note verify (live Jira)
On-demand "Verify with Jira" in the note detail: a pure verify.rs module (hand-rolled scanners, NO regex dep) extracts ticket keys, ConnectorRegistry::jira_lookup fetches each issue's LIVE state (strict-key-validated before egress, content-free ledger row per attempt), a PURE deterministic judge produces confirmed / not-found / conflict (the LLM never judges - injection-resistant by construction), and idempotent non-destructive markers (> marker (via Jira)) mirror annotate_unverified. Both commands gate on meeting_is_unlocked FIRST (RED-proven: verify_commands_refuse_a_sealed_meeting). Never wired into the zero-egress proactive path.

## Hardening (final-review fixes)
20s timeout on every connector HTTP call (shared connectors::http_client) + multiline-detail sanitize in verify markers (RED-proven idempotency-hole test).

## Verification
- cargo test --lib: 1069 passed / 0 failed (21+ new tests, RED-before-GREEN throughout); ng lint + ng build clean.
- lock-security-reviewer: PASS (gates first, fail-closed egress, preserve-only consent, content-free ledger, tokens never logged/FE-exposed).
- adversarial-verifier: PASS (gates observed green; lock gate RED-proven by neutering it).
- Final whole-branch review: READY (after the two cheap fixes above, both landed).
- Live Playwright smoke over mocked Tauri IPC: 11/11 (nudge, Enable download order, connectors blocks, verify panel glyphs + apply, no NG0600, no import-cycle errors).

## Honest bar (needs a real Mac / real tokens)
Real Jira/Slack API round-trips (parsers fixture-tested only), real ~2GB model downloads end-to-end, DP-keychain token storage on a signed build, NER name-scrub with a real model installed.

Follow-ups filed in the plan doc: rule-of-three connector HTTP/dispatch dedup, duplicate presence probes on /brain, judge status-compare v2, a11y labels on connector inputs, onboarding auto-advance UX.