### PR TITLE
fix(settings): connector egress banner layout

### DIFF
--- a/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.scss
+++ b/src/app/features/settings/sections/settings-connectors-section/settings-connectors-section.component.scss
@@ -18,6 +18,10 @@
   gap: var(--space-4);
 }
 .connector-egress {
+  /* The global .banner is a FLEX row (icon + copy layouts elsewhere); here the content is one
+     prose paragraph with an inline <strong>, which flex splits into two columns ("This sends
+     data off your Mac." stacking one word per line). Flow it as a normal paragraph. */
+  display: block;
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.55;


### PR DESCRIPTION
The global .banner primitive is a flex row; the connector egress banners are one prose paragraph with an inline strong, which flex split into a word-per-line column. Scoped display:block on .connector-egress (all three banners). Verified live on :1420 (screenshot in session).