### PR TITLE
feat(design-system): mur-button — the DS button, wave 1 (brain-source-card)

### DIFF
--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -184,7 +184,11 @@ prototype is the reference implementation). The concrete contract:
   `mur-toggle`); number inputs stay native (`NumberValueAccessor` commits
   numbers — the storage-limit lesson). Before writing ANY new control, check
   the catalog: icon, sidebar, quick-search, toggle, input, select, slider,
-  segmented, kbd, spinner, banner, pill, card, empty-state — and
+  segmented, kbd, spinner, banner, pill, card, empty-state, **button**
+  (`<mur-button variant="…" [busy]="…" [disabled]="…">` — wraps a native
+  `<button>`; variants ride the `.btn` primitives; link-shaped `<a routerLink>`
+  and bespoke icon-square buttons stay on legacy `.btn` classes until it grows
+  href/iconOnly support) — and
   `primitives.css` for class-based primitives (`.btn`, `.seg`, `.menu`,
   `.panel-card`, `.tabbar`…). Extending the catalog beats re-rolling a one-off.
 
@@ -219,6 +223,7 @@ prototype is the reference implementation). The concrete contract:
 | New npm package (FE) | ask the user; reuse `@angular/*` / `rxjs` / `@tauri-apps/api` |
 | `NgModule`, NgRx, a new facade/store abstraction | standalone component + `IpcService` + signals |
 | `standalone: true` in a decorator | omit it — standalone is the v19+ default |
+| raw `class="btn btn-*"` in NEW templates | `<mur-button variant="…">` (legacy call sites migrate in waves; links/icon-squares exempt until covered) |
 | `{ allowSignalWrites: true }` on `effect()` | delete it — writes are allowed since v19 (deprecated no-op) |
 | `provideExperimentalZonelessChangeDetection` | `provideZonelessChangeDetection` (stable) |
 | `@angular-devkit/build-angular` builders | `@angular/build:application` / `@angular/build:dev-server` |

--- a/src/app/design-system/button/button.component.html
+++ b/src/app/design-system/button/button.component.html
@@ -1,0 +1,18 @@
+<button
+  class="btn"
+  [class.btn-primary]="variant() === 'primary'"
+  [class.btn-ghost]="variant() === 'ghost'"
+  [class.btn-danger]="variant() === 'danger'"
+  [class.mur-btn-sm]="size() === 'sm'"
+  [class.is-busy]="busy()"
+  [type]="type()"
+  [disabled]="disabled() || busy()"
+  [attr.aria-label]="ariaLabel()"
+  [attr.aria-expanded]="ariaExpanded()"
+  [attr.aria-busy]="busy() || null"
+>
+  @if (busy()) {
+    <mur-spinner [size]="14" />
+  }
+  <ng-content />
+</button>

--- a/src/app/design-system/button/button.component.scss
+++ b/src/app/design-system/button/button.component.scss
@@ -1,0 +1,30 @@
+/* Visuals live in the .btn primitives (primitives.css) — the component adds
+   ONLY what classes can't express: the typed sm size and the busy state.
+   The HOST is a transparent flex wrapper: width/margins/alignment applied to
+   <mur-button> flow through; the inner native button is the visual box. */
+:host {
+  display: inline-flex;
+}
+:host button {
+  flex: 1 1 auto;
+}
+
+/* A disabled/busy control must not emit host (click)s from its padding. */
+:host(.is-blocked) {
+  pointer-events: none;
+}
+
+/* Compact control — replaces the ten per-feature `.btn-sm` re-declarations
+   (absorbed wave by wave). The 30px height is structural, like .btn's 40px. */
+:host button.mur-btn-sm {
+  height: 30px;
+  padding: 0 var(--space-3);
+  font-size: 0.8125rem;
+  border-radius: var(--radius-sm);
+}
+
+/* In-flight: the spinner announces progress; the muted look rides
+   .btn:disabled (busy also disables the inner button). */
+:host button.is-busy {
+  opacity: 0.7;
+}

--- a/src/app/design-system/button/button.component.ts
+++ b/src/app/design-system/button/button.component.ts
@@ -1,0 +1,54 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { MurSpinnerComponent } from "../spinner/spinner.component";
+
+/** Visual variants — mirror the `.btn` primitive family (primitives.css). */
+export type MurButtonVariant = "default" | "primary" | "ghost" | "danger";
+
+/**
+ * Design System — `<mur-button>`: the button. Renders a NATIVE `<button>`
+ * inside, so platform semantics (type, disabled, focus order, Enter/Space
+ * activation) stay real; the component owns the typed visual variant, the
+ * `sm` size, and the in-flight `busy` state (ring spinner + muted
+ * interaction). Callers bind `(click)` on the host as usual — the inner
+ * button's click bubbles up, and a disabled/busy host swallows pointer events
+ * entirely (`pointer-events: none`), so no phantom clicks from the padding.
+ *
+ * The visuals RIDE the `.btn` class primitives rather than re-declaring them,
+ * so a migrated call site is pixel-identical to a legacy `class="btn …"` one —
+ * the wave migration can proceed screen by screen with zero visual drift.
+ *
+ * Not yet covered (still legacy `class="btn …"`, migrate in a later wave):
+ * link-shaped buttons (`<a routerLink>`) and icon-only squares with bespoke
+ * geometry — they need `href`/`iconOnly` support here first.
+ */
+@Component({
+  selector: "mur-button",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MurSpinnerComponent],
+  templateUrl: "./button.component.html",
+  styleUrl: "./button.component.scss",
+  host: {
+    // Disabled/busy must also kill clicks on the HOST box (the caller's
+    // (click) listener lives there), not just on the inner native button.
+    "[class.is-blocked]": "disabled() || busy()",
+  },
+})
+export class MurButtonComponent {
+  /** Visual variant; "default" is the frosted neutral `.btn`. */
+  readonly variant = input<MurButtonVariant>("default");
+  /** "sm" = compact 30px control (inline row actions, card footers). */
+  readonly size = input<"md" | "sm">("md");
+  /**
+   * In-flight state: prepends a ring spinner and mutes interaction.
+   * Semantically distinct from `disabled` — callers own that separately.
+   */
+  readonly busy = input(false);
+  /** Mirrors the native `disabled` onto the inner `<button>`. */
+  readonly disabled = input(false);
+  /** Native button type; defaults to "button" so forms never submit by accident. */
+  readonly type = input<"button" | "submit">("button");
+  /** Accessible name for icon-only content (→ inner `aria-label`). */
+  readonly ariaLabel = input<string | null>(null);
+  /** Disclosure state for toggle buttons (→ inner `aria-expanded`). */
+  readonly ariaExpanded = input<boolean | null>(null);
+}

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.html
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.html
@@ -35,6 +35,8 @@
 
   @if (linkTo(); as href) {
     <!-- Read-only source: just a link to its own page. -->
+    <!-- Link-shaped button: stays on the legacy .btn classes until
+         <mur-button> grows href/routerLink support (follow-up wave). -->
     <a class="btn btn-ghost sc-link" [routerLink]="href">
       {{ linkLabel() }}
       <svg viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
@@ -50,9 +52,10 @@
   } @else {
     <!-- Editable source: add affordance + expandable item list. -->
     <div class="sc-actions">
-      <button
-        type="button"
-        class="btn btn-primary sc-add"
+      <mur-button
+        variant="primary"
+        class="sc-add"
+        [busy]="busy()"
         [disabled]="busy() || blocked()"
         (click)="add.emit()"
       >
@@ -69,16 +72,16 @@
           </svg>
           {{ addLabel() }}
         }
-      </button>
+      </mur-button>
       @if (items().length > 0) {
-        <button
-          type="button"
-          class="btn btn-ghost sc-toggle"
-          [attr.aria-expanded]="expanded()"
+        <mur-button
+          variant="ghost"
+          class="sc-toggle"
+          [ariaExpanded]="expanded()"
           (click)="toggleList.emit()"
         >
           {{ expanded() ? "Hide" : "Show" }} list
-        </button>
+        </mur-button>
       }
     </div>
 

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.ts
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.ts
@@ -5,6 +5,7 @@ import {
   output,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import { MurButtonComponent } from "../../../design-system/button/button.component";
 import type { DocumentInfo } from "../../../core/models";
 
 /**
@@ -24,7 +25,7 @@ import type { DocumentInfo } from "../../../core/models";
 @Component({
   selector: "app-brain-source-card",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, MurButtonComponent],
   templateUrl: "./brain-source-card.component.html",
   styleUrl: "./brain-source-card.component.scss",
 })


### PR DESCRIPTION
Stacked on #218 (the new component follows the Angular 22 conventions from that PR — merge #218 first, then retarget/merge this).

## What

The design system had every control except the most common one: **173** raw `class="btn …"` template usages plus **23** ad-hoc `*-btn` classes (and `.btn-sm` re-declared in **10** different component stylesheets) — with no component to hold the line. This adds it:

```html
<mur-button variant="primary" [busy]="importing()" [disabled]="blocked()" (click)="add()">
  + Add document
</mur-button>
```

- **`<mur-button>`** (src/app/design-system/button/) wraps a **native `<button>`** — type/disabled/focus/keyboard semantics stay real; `(click)` binds on the host as usual (bubbles from the inner button). When `disabled`/`busy`, the host swallows pointer events so the caller's handler can't phantom-fire from the padding — the classic wrapper-button bug, handled.
- API: `variant` (default/primary/ghost/danger), `size="sm"` (will absorb the 10 `.btn-sm` copies), `[busy]` (ring spinner + `aria-busy` + disables), `[disabled]`, `type` (defaults to "button"), `ariaLabel`/`ariaExpanded` (passed to the inner button, where AT actually reads them).
- Visuals **ride the existing `.btn` primitives** — a migrated call site is pixel-identical to a legacy one, so the wave migration can't cause visual drift by construction.

## Wave 1

`brain-source-card` (the Brain page "Documents"/"Notes" cards): **+ Add** (primary — now shows a busy spinner during import, previously label-swap only) and **Show/Hide list** (ghost, `ariaExpanded`). The `<a routerLink>` link-button and the 34px icon-square delete stay on legacy classes **deliberately** — they need `href`/`iconOnly` support first (next wave).

Rules updated: the DS catalog lists button; new templates must use `mur-button` (raw `.btn` classes are legacy-only, links/icon-squares exempt until covered).

## Verification

`ng build` + `ng lint` green. Adversarial-verifier pass (phantom-click probe on a blocked card, busy state, pixel-parity vs legacy siblings, a11y attr placement, /brain console sweep under the mocked Tauri seam) **in flight** — result will be posted as a comment before merge.