### PR TITLE
release(0.8.0): two-stage notes + current-first brain cascade + OOM/MCP/lock fixes

### DIFF
--- a/docs/research/2026-07-05-connector-note-enrichment.md
+++ b/docs/research/2026-07-05-connector-note-enrichment.md
@@ -1,0 +1,114 @@
+<!-- Generated 2026-07-05 via /research (murmur-researcher fan-out, 3 angles). Pricing/competitor facts = point-in-time mid-2026. -->
+# Research: Connector-driven note enrichment (fold live Jira/Slack context INTO the note)
+
+## Scope note (2026-07-05, user clarification)
+
+**The vision is EVERY connector, not Jira.** Enrichment must be a **connector-agnostic engine over the `ConnectorRegistry`** — any consented connector (Jira, Slack, web, calendar, and future Linear/ClickUp/Drive) can contribute a `> [!context] (via <source>)` block. The architecture already supports this: the `Connector` trait (`connectors/mod.rs`) is generic (`search` + optional `lookup`), the registry dispatches to any registered connector, and redaction/consent/ledger/`source_label`/`egress_attribution` are all per-connector and generic. Jira is only sequenced FIRST because Verify-with-Jira already ships — NOT because the design is Jira-specific. Build the engine source-agnostic from day one (matches the standing "connectors = live source-agnostic tools" decision).
+
+**The one axis that matters for a generic engine — connectors split into two enrichment modes:**
+- **Identifier lookup** (Jira `lookup(PROJ-123)`): a strict identifier already *in the note* → deterministic, high-precision, tiny egress, no LLM, low noise. This is the safe, high-signal mode.
+- **Free-text search** (Slack/web `search(note-derived query)`): a query derived from the meeting → fuzzy relevance, larger redacted-egress surface, note-spam risk. Higher-risk mode.
+- **Local** (calendar, `EgressClass::Local`): zero egress, but still the async path.
+
+The write path, lock gate, consent, redaction, ledger, and `> [!context] (via …)` callout are **identical and generic** across all connectors (`apply_context_markers` is already `source`-parameterized). Only the *candidate-detection + noise/privacy policy* differs by mode: lean into identifier-lookup enrichment (precise), gate free-text-search enrichment harder (show the query, tighter relevance threshold, caps).
+
+## TL;DR / Verdict
+
+**The idea is sound and ~90% already built — but the AUTOMATIC "enrich every note on finalize" trigger the user imagined is the wrong first move; build the on-demand, review-first, dated, CONNECTOR-AGNOSTIC version instead.**
+
+Three things all three research angles agree on:
+1. **Jira enrichment already ships as "Verify-with-Jira"** (0.7.5 / PR #214): extract issue keys → live `jira_lookup` → append `> ✓ PROJ-1 · Status: Done (via Jira)` into the note, persisted + re-exported, gated + ledgered. The user's Jira ask is a cosmetic reframe of that marker into a `> [!context]` callout.
+2. **Use Verify's write path (`upsert_note` → DB canonical → seals with the note), NOT Re-Truth's** — Re-Truth writes the vault `.md` only (`overwrite_note`, never `upsert_note`), so its callout is **not** in `notes.markdown` and is dropped on seal. Copying Re-Truth's path would silently lose the enrichment on lock. (This trap is the single most important finding.)
+3. **Do NOT auto-fire connector calls on note-finalize.** It trades away the literal "nothing leaves unless you ask" promise (one-time consent replaces per-action), re-imports the staleness-inverts-verify trap the team already reasoned away, courts the #1 documented AI-notes complaint (verbosity/clutter), and adds N blocking external calls to the finalize path — for a thin delta over one click. **No competitor auto-injects live ticket/Slack context into the note body** (they push OUT, or enrich the Q&A answer, not the document).
+
+**Recommendation:** build one **connector-agnostic enrichment engine over the registry** — on-demand + review-first + dated snapshot + append-only `> [!context] (via <source>)`. Sequence by RISK, not by connector identity: **identifier-lookup enrichment first** (Jira keys — already 90% shipped as Verify; the highest-precision, lowest-egress mode), then **free-text-search enrichment** (Slack/web — gated harder). Add a **zero-egress candidate-detector card** (Re-Truth shape) as the differentiated follow-on. **Before deepening at all, dogfood the shipped Verify on a real workspace** — we don't yet know if users keep connector markers.
+
+## Co już mamy (z repo)
+
+- **Verify-with-Jira = Jira enrichment, minus the callout styling.** `verify_note_sources_inner` (`commands.rs:1234`, `meeting_is_unlocked`-gated `:1238`) extracts keys (`verify.rs::extract_issue_keys`, `MAX_KEYS=10`), calls `registry.jira_lookup` per key, pure `judge()` verdict (LLM never judges); `apply_note_verify_markers_inner` (`commands.rs:1288`, gated `:1293`) writes via `apply_verify_markers` → **`upsert_note` (DB canonical, `:1314`)** → `overwrite_note` re-export only if `exported_path` set (`:1324`). FE: `features/detail/verify-panel/verify-panel.component.ts`.
+- **`apply_verify_markers` (`verify.rs:187`)** — idempotent strip-then-append (`is_verify_marker` owns the `(via …)` fence), byte-preserving every original line. Unit-proven idempotency + non-destruction (`verify.rs:276,296,304`).
+- **Re-Truth = the review-card + byte-exact-undo UX** — `preview/apply/undo_supersessions` (`commands.rs:~2698/2753`), append-only `append_under_section` under a managed `## Re-Truth updates` heading (`obsidian.rs:398/407/444`), durable pristine pre-image undo. **BUT writes vault-file-only (`overwrite_note`, never `upsert_note`)** → dropped on seal. FE hides-on-empty card: `features/record/re-truth-card/`.
+- **ConnectorRegistry (`connectors/mod.rs`)** — every outbound query redacted (regex + on-device NER, `:247`) BEFORE the connector sees it; exactly one **content-free egress-ledger row** per attempt (`:257`, truthful `egress_attribution`); fail-closed unless `enabled && consented && key-in-Keychain`; 20s HTTP timeout (`:45`). Jira `jira_lookup` → tight `IssueSnapshot {key,summary,status,due,url}`. Slack = free-text `search.messages` (`xoxp-`, `search:read`, `count=8`, `SNIPPET_MAX=300`).
+- **Seal truth** — `lock_folder_inner` encrypts `n.markdown` (the DB column) with verify-before-destroy (`commands.rs:6989`); `seal_note` sets `content_blob`, `markdown=''` (`db.rs:3905`). So **enrichment in `notes.markdown` seals for free — no new table, no new purge path** (the opposite of Re-Truth, which needed `supersessions` wired into 3 purge paths).
+- **Prior team decisions:** `docs/research/2026-07-05-connectors-live-vs-rag.md` already chose connectors **live, not vectorized** (a persisted stale copy **inverts verify**), option C = pin-to-note, option D = on-demand verify. `docs/research/2026-07-05-competing-with-clickup-brain.md`: sequence Jira→Slack→verify (shipped) → Linear + dogfooding.
+
+## Findings (per angle)
+
+### A. Architecture fit — build it as generalized Verify, not copied Re-Truth (confidence: high)
+- **F1** Jira enrichment is ~90% shipped as Verify; the new surface is Slack + the trigger UX.
+- **F2 (load-bearing)** Verify persists to DB (`upsert_note`, seals with the note); Re-Truth persists vault-only (dropped on seal). Enrichment is note content → **must use Verify's DB-persist shape.**
+- **F3** Slack enrichment egresses **free text** (note-derived query), a materially larger privacy surface than Jira's bare validated key. Show the derived query before egress.
+- **F4** Single-line callout `> [!context] … (via Jira/Slack)` reuses the existing line-strip undo; a multi-line block needs a managed-section strip. Either gives strip-based undo with **no pre-image machinery** (simpler than Re-Truth).
+- **F5** Because enrichment is note markdown, it inherits every gate for free (seal/blank/restore/read-gate) — no new leak/loss path.
+
+### B. Trigger/UX/prior art — on-demand, never auto (confidence: high)
+- **Industry consensus = user-triggered pull-in.** Fellow: `/jira` slash-command + user-confirmed AI suggestion, **explicitly does not auto-inject**. Granola/Fireflies/Circleback push OUT (create tickets). Notion/Linear/Slack = user-pasted live-syncing embeds. Notion AI/Glean enrich the **answer, not the document**. **Nobody auto-appends live context to the note body** — the market already rejected it. [5][7][8][9]
+- **Staleness fix everyone uses = a live-refreshing embed, which an inert `.md` structurally cannot be.** So the only honest options are **idempotent re-enrich + "as of <ts>" timestamp** (what `apply_verify_markers` already does) — lean into dated snapshots, don't fake "live". [7][8][9]
+- **Verbosity/clutter is the #1 documented AI-notes complaint** (Otter "overly verbose"; users left for Granola's concision) → argues for TIGHT blocks + default-to-silence. Obsidian **foldable `> [!context]-` (collapsed by default)** is the native noise-control primitive. [10][11]
+- UX: **on-demand "Enrich" button (clone verify-panel) first; then a zero-egress candidate-detector card (clone re-truth-card, hides-on-empty)** — detection is free/local, egress+write require a click.
+
+### C. Cost/privacy/worth-it — defer the auto trigger (confidence: high)
+- **Review-first gates the WRITE, not the EGRESS.** For Re-Truth the supersession is computed from *local* facts (zero egress) so review-first gates everything; a *connector* fetch has already left the Mac by the time the user reviews. You cannot have both "automatic/no-per-action-ask" AND "egress-gated-by-review". Auto ⇒ standing consent replaces per-action consent — a real weakening of the promise.
+- **Latency:** Verify loops keys **sequentially** awaiting each 20s-timeout `jira_lookup` (`commands.rs:1261`) → up to ~200s worst case; must be async-after-note-shown + parallelized, never blocking note availability.
+- **Jira enrichment needs no LLM** (pure `judge()` + string-format an `IssueSnapshot`); Slack-thread ranking optionally does → another reason the two sub-features aren't one.
+- **The auto version re-imports the staleness trap** the team rejected (`connectors-live-vs-rag.md`): "In Progress" baked into a note nobody re-runs. On-demand verify is self-correcting (idempotent, re-runnable); a passive auto-block is not. **Mitigation: date it as a snapshot, never as a live truth claim.**
+- **Note-spam line = precision vs recall.** Explicit `PROJ-123` → status = high-precision, earns its place. Meeting-topic → "8 maybe-relevant Slack messages" = low-signal bloat. Jira-key enrichment is safe; fuzzy Slack enrichment is where it becomes spam.
+- **Worth-it:** the delta of AUTO over the shipped on-demand Verify is thin (live-ask already works; Verify already persists on demand). The genuine wedge — **user-initiated persistence of high-precision DATED connector snapshots into owned, offline, searchable notes** — is real and moat-aligned, and is delivered by Verify + a pin-to-note action. The automatic firing is the part that adds egress/staleness/clutter for marginal gain.
+
+## Fit z ograniczeniami Murmur
+
+| Constraint | Verdict |
+|---|---|
+| Local-first / "nothing leaves unless you ask" | **Fits on-demand; STRAINS if auto** (one-time replaces per-action consent). Keep per-action ask; if auto ever built → separate default-OFF opt-in + posture downgrade + loud ledger. |
+| Obsidian-native / owned files | **Fits** — append-only `> [!context]-` callout, prose byte-preserved; the actual wedge. |
+| SQLite canonical | **Fits with discipline** — persist via `upsert_note` (DB), connector hits RAM-only, no new at-rest external store. |
+| Provider seam + redaction | **Fits** — rides `ConnectorRegistry::search` (redact + ledger) unchanged; v1 needs no LLM. |
+| Lock model | **Fits with discipline** — write `meeting_is_unlocked`-gated; enrichment seals with the note (verify-before-destroy) since it's in `notes.markdown`. |
+| macOS / CI honesty | **Partial** — the pure marker function is headless-testable RED-before-GREEN; real Jira/Slack round-trips + detector precision + "which Slack thread" need a signed build + real workspaces. |
+
+## Opcje i tradeoffy
+
+- **Option A — On-demand "Add live context" button (generalized Verify). Effort: S–M.** `apply_context_markers` (source-parameterized, idempotent, byte-preserving) + `enrich_note_context_inner`/`apply_note_context_inner` (clone Verify's gates, `upsert_note` + re-export). Jira keys first. Industry-aligned, zero auto-egress, lowest risk. **Captures most of the value.**
+- **Option B — Zero-egress candidate-detector card (Re-Truth shape) + Option A. Effort: M.** Local scan detects Jira keys / connector-mapped `[[entities]]`; if a connector is consented, surface a dismissible card ("3 tickets referenced — pull current status? (1 Jira call)"); accept → egress → preview → append/Undo. **The differentiated version.** Risk = detector precision (mitigated by default-to-silence + dismissible + per-note "don't ask again").
+- **Option C — Auto-enrich on note-finalize. Effort: M. DEFER/REJECT for now.** Standing auto-egress + staleness + clutter for a thin delta. Only revisit if users explicitly ask, and even then: Jira-keys-only, dated snapshots, separate default-OFF opt-in, non-blocking async, posture-downgraded, ledgered, write-gated.
+- **Slack enrichment** = a separate increment on top of A (free-text `registry.search("slack", q)`), carefully scoped (show query pre-egress, caps, dedup) — higher privacy + noise risk than Jira.
+
+## Rekomendacja i pierwszy krok
+
+**Ship A, spec B, defer C. Slack after Jira. Never auto-on-finalize (for now).** Unify enrichment with Verify: both are faces of one "live context" callout — verify *compares a claim* to live truth; enrich *appends context that wasn't claimed*. Share the marker-fence, idempotency, gating, and ledger.
+
+**Noise-control rules to bake into the writer:** one consolidated collapsed `> [!context]-` callout under a stable heading (not one-per-reference); idempotent strip-and-reapply (re-enrich replaces, never stacks); default to silence below a relevance threshold (a real Jira key / connector-mapped `[[entity]]`); caps + dedup (≤5 tickets, ≤3 Slack hits, dedup by key/permalink); honest "as of <ts>" timestamp; prose never touched.
+
+**Smallest verifiable first slice (headless, zero network/credentials):** the pure `apply_context_markers(note_md, hits) -> String` — appends ONE collapsed `> [!context]-` callout, idempotent (strip-and-reapply its own fence), byte-preserving every original line. RED-before-GREEN on idempotency + non-destruction (mirror `verify.rs:276/296`), **plus a seal round-trip test** that a note carrying a `[!context]` block seals → `content_blob` → restores byte-identical (reuse `db.rs:2672` pattern — this is the exact thing Re-Truth's vault-only path would fail). That one test captures the entire formatting + lock risk.
+
+**But the honest zeroth step (cheapest de-risk):** dogfood the **already-shipped Verify-with-Jira** on a real Jira workspace on a signed build and measure (a) key-extraction accuracy on real ticket text, (b) how often users KEEP the markers, (c) how many note lines even have a verifiable connector counterpart. If users keep them → spec B. Only if they then say "do this automatically" does C earn a spike.
+
+## Otwarte pytania / czego nie udało się zweryfikować
+
+- **Do users want enrich (append context) vs just verify (check a claim)?** Unvalidated; verify may be the higher-value sibling. Needs dogfood, not headless.
+- **Detector precision on a real vault** (false-candidate → card annoyance) + **which Slack thread is "the relevant one"** — search-quality questions, not headless-provable; need a real Obsidian vault + real Slack workspace.
+- **Is Re-Truth's vault-only callout intended or a latent loss-on-seal?** Verified it never calls `upsert_note` and `seal_note` seals the DB markdown → the `[!superseded]` callout isn't in the seal blob. Deliberate (cross-note pointer not preserved into an encrypted island) vs gap = a separate audit; not a blocker here, but it's WHY enrichment must use Verify's DB-persist shape.
+- **Real connector OAuth round-trips, rate limits, prompt-injection on fetched ticket/message text** — deterministic `judge()` neutralizes injection for verify; an LLM-summarized Slack block would re-open it. Needs real workspaces + a red-team harness (recorded).
+- Competitor facts are point-in-time (mid-2026), vendor/marketing-sourced; directionally cross-confirmed but treat exact claims as claims.
+
+## Sources
+
+**Code (this repo):**
+- `src-tauri/src/connectors/mod.rs` — `ConnectorRegistry::{search:240, jira_lookup:278}` (redact-before-egress + content-free ledger + fail-closed), 20s `http_client:45`, `egress_attribution`.
+- `src-tauri/src/verify.rs` — `extract_issue_keys:60`, pure `judge:163`, `apply_verify_markers:187` (idempotent/byte-preserving), `is_verify_marker:51`, `MAX_KEYS:48`; tests `:276,296,304`.
+- `src-tauri/src/commands.rs` — `verify_note_sources_inner:1234` (gate `:1238`), `apply_note_verify_markers_inner:1288` (gate `:1293`, `upsert_note:1314`, re-export `:1324`), `apply_supersessions_inner:2753` (vault-only `overwrite_note:2846`, **no `upsert_note`**), `source_is_stampable:2649`, `persist_facts_for_meeting:2416`.
+- `src-tauri/src/export/obsidian.rs` — `append_under_section:444` / `append_supersession_callout:407` (append-only, idempotent, managed heading `:398`).
+- `src-tauri/src/connectors/slack.rs:39,108` (free-text `search.messages`), `connectors/jira.rs:47,159` (`from_config_if_available`, `lookup`→`IssueSnapshot`).
+- `src-tauri/src/storage/db.rs:3905,3916` (`seal_note`/`restore_note_markdown`), `commands.rs:6989` (seal encrypts `n.markdown`), `db.rs:2672` (seal round-trip test pattern).
+- `src-tauri/src/proactive.rs:10` (contract D1 zero-egress — enrichment egresses, can never live there).
+- FE: `src/app/features/detail/verify-panel/verify-panel.component.ts`, `src/app/features/record/re-truth-card/re-truth-card.component.ts`, `src/app/core/ipc.service.ts:187,192`.
+- `docs/research/2026-07-05-connectors-live-vs-rag.md`, `docs/research/2026-07-05-competing-with-clickup-brain.md`.
+
+**Web (point-in-time mid-2026):**
+- [5] https://fellow.ai/blog/fellow-jira-integration/ — Fellow `/jira` slash-command + user-confirmed, does not auto-inject.
+- [7] https://linear.app/integrations/notion — Linear→Notion "paste as preview" live-syncing embed.
+- [8] https://api.slack.com/reference/messaging/link-unfurling — Slack unfurl.
+- [9] https://www.notion.com/help/guides/notion-api-link-previews-feature — Notion live synced link previews.
+- [10] https://circleback.ai/compare/granola-vs-otter-ai — Otter "overly verbose"; Granola concision.
+- [11] https://www.obsibrain.com/blog/obsidian-callouts-complete-guide-syntax-and-customization — foldable `[!type]-` collapsed-by-default = clutter-free metadata.
+- [1] https://www.granola.ai/blog/granola-integrations-complete-guide-connecting-meeting-tools · [3] https://techcrunch.com/2025/04/23/ai-powered-notetaker-fireflies-ai-release-mini-apps-to-extract-insights-out-of-meeting-notes/ · [4] https://circleback.ai/how-to/best-ai-meeting-notes-software-with-crm-integrations — push-OUT patterns.

--- a/docs/research/2026-07-06-note-and-brain-architecture.md
+++ b/docs/research/2026-07-06-note-and-brain-architecture.md
@@ -1,0 +1,320 @@
+# Murmur — Two-Stage Notes + Current-First Brain Cascade: Architecture Design
+
+**Status:** Decision-ready architect design. Grounded against the current tree (`src-tauri/src`, branch `murmur`, shipped 0.7.5). Cite-by-symbol throughout; line anchors in `commands.rs`/`db.rs` drift (>8k lines) — grep the symbol.
+
+---
+
+## 1. Executive summary
+
+Murmur today generates a note in a **single pass with a single egress**, and it deliberately mixes cross-meeting context *into that one generation prompt*. `pipeline.rs:summarize_and_export` unconditionally builds a gated cross-meeting grounding corpus (`orchestrate::orchestrate_context` → `related_context::build_related_context`) and hands `transcript + related_context + user_notes + vault_titles` to the model together via `template.rs:render_user_content`. Because the on-device model is weak, this pre-generation mixing is exactly the failure mode the small-model RAG literature warns about (context *utilization*, not retrieval, is the bottleneck), and it is the confirmed source of the "qwen-4B pasted another meeting's `## Action items`" bleed. The current defense — `grounding.rs:strip_ungrounded_action_items`, an always-on lexical word-overlap deletion of generated checklist units — is a hack that treats the symptom and risks deleting *real* content.
+
+The **target replaces model-trust and lexical heuristics with structural separation**:
+
+- **NOTE-GEN → two stages.** *Stage 1* generates the note from **only this meeting's transcript + the user's typed notes** — `related_context: None`, provably zero cross-meeting bleed (the `render_user_content` no-context path is already byte-identical for `None`). *Stage 2* is an **additive, idempotent, byte-exact-undo post-pass** over the finished note that appends cross-meeting `[[links]]` + a Related/Context section **without touching** the core action items/decisions — reusing the already-shipped `enrich.rs:apply_context_markers` writer and the `apply_note_enrichment` persist seam. `reference_gist` (task-free by construction) is repurposed as the Stage-2 link renderer, so a linked note *cannot* drag its action items in. Connector enrichment (`enrich.rs`) is folded in as **Lane B** of that same Stage 2, not duplicated.
+
+- **BRAIN → current-first cascade.** *Tier 1* answers from the **current meeting in isolation** (live RAM buffer while recording; that meeting's segments/note when past). *Tier 2* broadens to the vault. *Tier 3* reaches connectors/web. The escalation is **structurally deterministic** (which tools each tier may reach, enforced by `GatedToolExecutor::specs()`), while retrieval *within* a tier stays model-driven — never prompt-nudge-only, which is today's failure mode. The answer surfaces **which tier answered**. The wrong-meeting bug ("o czym to spotkanie" → an arbitrary saved meeting) is killed by threading an explicit `meeting_id` FE→IPC→loop instead of relying on the recorder-lifecycle `state.current_meeting`.
+
+- **CONTEXT MODEL.** The **durable/long-term substrate is solid and stays as-is** (SQLite canonical; facts/user_facts/chunks/entities/interactions uniformly derived, purged-on-seal, visibility-gated). The **working-memory + conversation layer is the thin spot** and gets a small, explicit model: a durable per-thread `meeting_id` binding, and a clear RAM-vs-DB split for the live buffer vs the finalized note.
+
+**The single most important decision:** whether **Stage 2 is deterministic (link + `reference_gist`, zero egress)** — the strongest privacy posture and the recommended default — or uses an LLM prose pass behind the existing consent+redaction envelope. Everything else follows from that fork.
+
+---
+
+## 2. Current state (grounded)
+
+### 2.1 Note generation — single-pass, single-egress, context-mixed
+
+`pipeline.rs:run_inner` transcribes → merges → `insert_segments` (status `Transcribed`) → `build_transcript_feed` → delegates to `pipeline.rs:summarize_and_export` (`pipeline.rs:866`). That function, in order:
+
+1. Resolves the fail-closed, redaction-wrapped Notes provider (`make_provider_resolved` → `RedactingProvider`, gated on `cloud_egress_consented`; cloud egress with no consent returns `Unavailable`).
+2. `list_vault_titles`.
+3. **Always** builds the cross-meeting corpus: `orchestrate::orchestrate_context(...)` (`pipeline.rs:930`) → `build_grounding_context` → `related_context::{salient_query, build_related_context}`. Double visibility-gated (`db.search_visible(...)` candidate gate + `db.get_note_if_visible(...)` body gate), self-excluding (`if m.id == this_meeting_id { continue }`), budgeted, weak-vs-strong split (`is_weak_provider` → link-only header; strong → `reference_gist` prose).
+4. Reads `db.get_manual_notes(meeting_id)`.
+5. Assembles **one** `SummarizeRequest{transcript, related_context, user_notes, vault_titles, template}`; `template.rs:render_user_content` (`template.rs:204`) emits the "Related prior notes" block, the user-notes skeleton, then the transcript — **all in one prompt**.
+6. **The only egress in the whole pipeline:** `provider.summarize_with_meta(&request)`.
+7. `finalize_note_markdown` (folds `## My notes` / enhance marker).
+8. `grounding::strip_ungrounded_action_items(&markdown, &segments)` (`pipeline.rs:998`) — **always-on in auto-language**; deletes generated checklist/decision units at zero transcript overlap. `annotate_unverified` is opt-in (default OFF).
+9. `upsert_note` → semantic index → derive title → auto-file subfolder → provenance/privacy frontmatter → atomic vault write → `seal_auto_filed_note` (if the target folder is locked) → build entities.
+
+**Timeline and action-items are NOT in this pipeline** — timeline is `summarize::timeline::generate` (a separate command), action items are parsed on demand (`parse_action_items` via `get_action_items`/`patch_note_tasks`). A Stage-2 block that keeps checklist lines byte-identical won't disturb them.
+
+**What's wrong:** cross-meeting context is injected *pre-generation into the weak model's one prompt* — the exact structural cause of the `## Action items` bleed. `strip_ungrounded_action_items` exists *only* to clean up that bleed and is a lexical hack that can delete real generated content.
+
+### 2.2 Brain / @brain assistant — one vault-wide loop, wrong-meeting bug
+
+`ask_assistant_text`/`ask_assistant_chat` → `run_assistant_query` (`transcribe/live.rs:424`) → `run_informational` (`transcribe/live.rs:513`) → `agent::run_agentic_loop`. Every turn advertises the **full** gated tool catalog (search_meetings, search_semantic, list_recent, get_meeting, commitments, dossier, + web/jira/slack/calendar). **There is no tier isolation** — the current meeting is only a system-prompt hint (a 6k `live_transcript` tail + typed notes); the model can freely call vault tools.
+
+- Meeting scope = `state.current_meeting`, set **only** at `start_recording`, cleared at `stop_recording`. Idle ⇒ `None` ⇒ `meeting_id == ""`.
+- The FE **never sends a meeting_id** for @brain (`ipc.service.ts:askAssistantChat` omits it; the store privately tracks `_meetingId`).
+- **Wrong-meeting mechanism:** empty `meeting_id` ⇒ `gated_live_context` returns `("","")` ⇒ `assistant_system_prompt` falls into the "ground answers in the vault" branch ⇒ "what is this meeting about" is answered by `search_meetings`/`list_recent_meetings` describing an *arbitrary saved meeting*.
+- Even while recording, current-meeting grounding is prompt-only and mitigation is model-obedience-dependent — the tool catalog is unchanged.
+- Citations are `[[Title]]` scraped from concatenated tool output (`voice_action::extract_citations`); **no tier/source tag**.
+
+Existing primitives worth reusing: `commands.rs:chat_meeting` (meeting-scoped, explicit `meeting_id`, direct transcript injection, one completion, no tools — a de-facto "Tier 1"), and `commands.rs:ask_vault` with its **agentic-attempt → deterministic floor** fallthrough (`ask_vault_agentic_attempt` → `ask_vault_floor`) — the escalation shape a tier ladder should mirror. `GatedToolExecutor::specs()` (`tools.rs`) **already filters the catalog per surface** (`has_app`, `note_drafts`, `allow_writes`) and `run()` re-enforces the allowlist — the exact seam for per-tier gating.
+
+### 2.3 Context management — durable layer solid, working/conversation layer thin
+
+- **Long-term (DB, durable):** SQLite canonical (`segments`, `notes`, `timelines`, `manual_notes`); everything derived (`assistant_interactions`, `facts`, `user_facts`, `note_chunks`, `entities`) is uniformly purged-on-seal + visibility-gated. Bitemporal facts/user-memory is a genuinely good long-term design (`user_memory::synthesize_brief`). **This is closed and well-factored — keep it.**
+- **Session (RAM, `AppState`):** `unlocked_folders`, `master_kek`, `account_session` — clear lifetimes, solid.
+- **Working (RAM, per-recording):** the **only** structured live-meeting memory is `state.live_transcript: Mutex<String>` (16k cap, 6k injected, mic-only, cleared at Stop). `state.current_meeting` is a *recording* pointer, not a *focus* pointer — the root scoping fragility.
+- **Conversation:** the backend is **stateless per turn** — the FE resends the whole (12-turn-capped, `CHAT_CONTEXT_TURNS=12`) history each call; `run_assistant_query` re-snapshots config + unlocked-set + meeting-id fresh per turn; the agentic ReAct scratchpad is discarded at turn end. `assistant_interactions` exists for rehydration/attribution/purge, **not** server-side context reconstruction. The per-thread meeting binding lives *only* on the FE and is dropped at the IPC boundary.
+
+### 2.4 The connector-enrichment feature (already built, headless)
+
+`enrich_note_context_inner` (read/egress preview → `Vec<ContextHit>`) + `apply_note_enrichment_inner` (write). `enrich.rs:apply_context_markers` (`enrich.rs:55`) is a pure, deterministic, append-only, byte-preserving, **idempotent** (`apply(apply(x))==apply(x)`), **byte-exact-undo** (empty hits strips), injection-hardened (`sanitize()` neutralizes fence-forging) writer that fences one `> [!context]-` callout. Both commands are `meeting_is_unlocked`-gated before any egress or write; the write persists to **canonical `notes.markdown`** via `upsert_note` **and** re-exports via `export::overwrite_note`, so it **seals with the note** (deliberately not Re-Truth's vault-only path that drops on seal). **No FE surface yet** — IPC + models exist, no component calls them.
+
+---
+
+## 3. Target NOTE-GENERATION flow
+
+Mapping the user's desired flow onto the two-stage model:
+
+```
+transcription
+  → [Stage 1] isolated note  (THIS transcript + typed notes ONLY)   ← single gated egress, or fully local
+  → [Stage 2] cross-meeting links/context (Lane A local + Lane B connectors)  ← additive, on finished note
+  → final output (upsert_note canonical + atomic vault export + seal-if-locked)
+```
+
+"Enhance (typed notes)" is **not a separate stage** — it is part of Stage 1 (the manual-notes buffer already rides Stage 1 as the enhance skeleton or the append `## My notes`). Connector enrichment is **Lane B of Stage 2**, reusing `enrich.rs`.
+
+### Stage 0 — Transcription (unchanged)
+- **In:** audio. **Out:** merged segments persisted via `insert_segments`; `build_transcript_feed` → `TranscriptFeed{retrieval_text, summary_text, labeled}`; status `Transcribed`.
+- **Egress:** none. **Seam:** `pipeline.rs:run_inner` (unchanged).
+
+### Stage 1 — Isolated note (transcript + typed notes only)
+- **In:** `feed.summary_text` + `db.get_manual_notes(meeting_id)` (as enhance skeleton when `notes_mode == "enhance"`, else folded as `## My notes` after generation) + `vault_titles`. **No `related_context`.**
+- **Out:** a note grounded **provably** only in its own transcript; `upsert_note` (status `Summarized`).
+- **Egress:** the **single** gated egress `provider.summarize_with_meta` through the `make_provider_resolved` fail-closed `cloud_egress_consented` gate + `RedactingProvider`. For a fully-local provider, nothing leaves.
+- **Seam to build:** in `pipeline.rs:summarize_and_export`, **skip the `orchestrate_context` call (`pipeline.rs:930`)** and set `SummarizeRequest.related_context = None`. `render_user_content` already emits a **byte-identical no-context prompt** for `None` (test `render_user_content_none_is_unchanged`, `template.rs:305`) — so Stage 1's prompt carries only transcript + user_notes + vault_titles. Everything from `provider.summarize_with_meta` through `upsert_note` stays as Stage 1.
+
+**RIP OUT (for Stage 1):**
+1. The always-on injection: the `orchestrate_context` call (`pipeline.rs:930`), the `related_context` wiring into `SummarizeRequest`, and the "Related prior notes" block in `render_user_content` (`template.rs:204`, the `if let Some(ctx)` arm).
+2. `grounding::strip_ungrounded_action_items` + `strip_applies_for_language` + its call at `pipeline.rs:998`. Its **sole purpose** is cleaning cross-meeting bleed from the injection being removed; once Stage 1 is transcript-only, the bleed class is gone by construction and the lexical deletion (which risks removing real generated content) is dead weight. **This is the "DROP Layer-2 hack" decision, realized.**
+
+**KEEP (orthogonal):** `annotate_unverified` (opt-in `ground_summary`, grounds against *this* transcript only) and the `[UNCLEAR]` preventive marking in `build_transcript_feed`. With cross-meeting injection gone, Stage-1 transcript-only grounding becomes the *primary* anti-hallucination guard — a candidate to promote `annotate_unverified` to default-ON (open question).
+
+### Stage 2 — Cross-meeting linking + context (two lanes, one writer)
+A **post-pass over the finished Stage-1 note**, modeled on `apply_note_enrichment_inner`. Two lanes fan out to sub-sources but share **one writer + one persist seam + one strip**.
+
+**Lane A — local cross-meeting linking (zero egress).**
+- **In:** the finished note markdown + a gated retrieval over owned notes (repurpose `related_context::salient_query` + `build_related_context`, double-gated on the live unlock set, self-excluding; optionally the `orchestrate_context` reasoner plan).
+- **Out:** an additive fenced section (e.g. `> [!related]-` / `## Related notes`) of `[[Title]]` + **`reference_gist`** one-liners. `reference_gist` (`related_context.rs:200`) is **task-free by construction** (never emits an action-items/decisions/tasks section, EN+PL) — so a linked note *cannot* drag its checklist in. Model cross-meeting links as `ContextHit{source:"Murmur", detail:gist, url:"[[Note]]"/obsidian://}` — **no new DTO**; the writer already renders `(via <source>)` + link.
+- **Egress:** **none** (deterministic link + gist). Because it never egresses, Lane A is **auto-eligible on finalize**.
+
+**Lane B — connector enrichment (egress, on-demand).**
+- **In:** the finished note; the existing `enrich_note_context_inner` path (Jira issue-key lookup + free-text title search of Slack/web through the redaction+ledger `ConnectorRegistry`).
+- **Out:** the `> [!context]-` callout of `ContextHit`s.
+- **Egress:** through the registry's fail-closed consent + `redact_connector_query` + content-free ledger row. **Stays explicit/on-demand** — a one-time auto-consent would weaken "nothing leaves unless you ask".
+
+**Shared writer/persist (build once, reuse for both lanes + fold in `verify.rs`):**
+- **Writer:** `enrich::apply_context_markers` — append-only, idempotent, byte-exact-undo, sanitize-hardened, seal-safe. Emit **distinct managed blocks** per lane (`murmur:links` fence for Lane A, existing `murmur:context` fence for Lane B). Consolidate the older `verify.rs:apply_verify_markers` onto this engine — do **not** ship a third fence format.
+- **Persist seam:** the tail of `apply_note_enrichment_inner`: `meeting_is_unlocked` gate → `upsert_note` (DB canonical, seals) → `export::overwrite_note` (vault re-export if `exported_path`) → `NoteDto`. **Cross-meeting links MUST use this DB-canonical path** — not Re-Truth's vault-only `overwrite_note` (which drops on seal). This is the #1 integration trap.
+- **One strip-all step:** at the start of Stage 2, strip *all* managed blocks (links + context + verify) so re-running is idempotent across lanes (today each feature strips only its own fence).
+
+**Where Stage 2 runs in the AUTO pipeline (open question, recommend deferred pass):** run Lane A as a **deferred post-`Exported` pass** (like enrich) rather than inline before `export::write_note`. This sidesteps the `SealInto` auto-file branch (`seal_auto_filed_note`) and the no-vault branch, and matches the "self-healing link graph" semantics — re-running Lane A over old notes re-links them against current DB state without re-summarizing (mirror `resummarize_existing`, link-only). The tradeoff: the *first* exported `.md` won't carry links until the deferred pass runs (seconds later).
+
+**Egress/gate invariants preserved across both stages:** any content leaving the device passes `make_provider_resolved`'s fail-closed consent gate + `RedactingProvider`; any cross-meeting read routes through `search_visible`/`get_note_if_visible`/`meeting_is_visible` on the live unlocked set. A deterministic Stage 2 (Lane A) **egresses nothing**; an LLM Stage 2 re-enters the same gated single-egress envelope.
+
+---
+
+## 4. Target BRAIN / CONVERSATION cascade
+
+```
+conversation turn (with explicit meeting_id)
+  → Tier 1: current meeting IN ISOLATION   (live buffer if recording, else this meeting's note+segments)
+  → Tier 2: broaden to vault notes          (existing vault-wide loop/tools)
+  → Tier 3: connectors / web                (consent+egress-gated tools)
+  → answer + "answered_from: TierN" badge + tier-appropriate citations
+```
+
+**Never amputate cross-note search** — Tier 2/3 keep the full existing capability; the cascade just gives it the right *order* and *default*.
+
+### Escalation mechanism — recommend **structurally-deterministic escalation, model-driven retrieval**
+
+The genuine fork is *how* a tier decides "I can't answer, escalate". Two options:
+
+- **(A) Deterministic tool-gating (RECOMMENDED).** Each tier runs `run_agentic_loop` with a **scoped executor** that advertises only that tier's tools (`GatedToolExecutor::specs()` + a new `scope`/`tier` field). Within the tier, tool choice stays model-driven. The tier's system prompt says "answer ONLY from this tier; if not answerable reply exactly `{\"answer\":\"__ESCALATE__\"}`". The caller detects the sentinel and re-runs at the next tier — reusing the proven `ask_vault_agentic_attempt` fallthrough shape, chaining tiers instead of a single loop→floor.
+- **(B) Pure model-driven** (one loop, all tools, prompt says "prefer current meeting"). **Rejected** — this is *exactly today's failure mode*: prompt nudges do not keep a weak model in scope, and it produces the wrong-meeting bug.
+
+**Justification:** the small-model literature is decisive that weak models are easily distracted and cannot be trusted to self-restrict scope via prompt text. The escalation *boundary* (which tools are reachable) must be **code-enforced** (`run()` already hard-rejects un-advertised tools). The *retrieval within a tier* can stay model-driven (honoring "no hardcoded routing"). This is "deterministic escalation, model-driven retrieval".
+
+**Escalation signal:** the caller inspects `outcome.answer` for the `__ESCALATE__` sentinel — `Ok(Some(sentinel))` = "no answer here, go up"; `Ok(None)` still = non-convergence (out of steps) → floor within the tier. Optionally add a typed `no_answer` variant to `AgentOutcome` for cleanliness. This distinguishes "this tier has no answer" from "the loop ran out of steps", which today are conflated (`agent.rs` returns `Ok(None)` for both).
+
+### How `meeting_id` threads through (kills the wrong-meeting bug)
+- **Seam 1:** add `meetingId?: string` to `ipc.service.ts:askAssistantText/askAssistantChat`; pass `this._meetingId()` from `meeting-conversation.store.ts`. Add `meeting_id: Option<String>` to `commands.rs:ask_assistant_text/ask_assistant_chat`; thread through `run_assistant_query` → `run_informational`, **resolving as `fe_meeting_id.or(state.current_meeting)`** so a live recording still works and a past/anchored thread scopes correctly. `GatedToolExecutor.meeting_id` and `gated_live_context` already key on this id.
+- **Durable binding:** persist the thread's `meeting_id` on the `assistant_interactions` row (`persist_interaction` currently keys on the *current recording* meeting only) so a thread always answers about its own meeting even when idle. **Resolution precedence** (open question): a bound past-meeting thread should win over `state.current_meeting` when a *different* meeting is recording.
+
+### Tier grounding sources
+- **Tier 1, LIVE meeting:** the `live_transcript` RAM tail — segments aren't persisted until Stop, so a DB-reading tool returns nothing during recording. Tier 1 must read the RAM buffer (single-shot completion over the buffer, like `chat_meeting`, is likely cleaner than a loop here).
+- **Tier 1, PAST meeting:** that meeting's note + segments — exactly `chat_meeting`'s read shape (`get_segments` + `get_note_if_visible`, gated by `meeting_is_unlocked`).
+- **Tier 2:** the existing vault-wide loop/tools (search_meetings/semantic/get_meeting/list_recent/commitments/dossier).
+- **Tier 3:** connectors/web (already consent+egress-gated via `has_app` in `specs()`).
+
+### Sources reflect the tier
+Add `answered_from`/`tier` to `AgentOutcome` + `VoiceActionResult` + `AskVaultResult`, set **deterministically from which tier converged** (the ladder knows) — never string-sniffed. Tier 1 must **add the current meeting's own `[[Title]]`** to citations (prompt-injected content produces no wikilink in `gathered`; resolve via `db.get_meeting(meeting_id).title`). Strengthen Tier 3 by capturing connector loud-lines the way `voice_action::rag_answer` does, so web/jira/slack answers are attributed even when the model omits "(via …)". Surface the badge to the user (silent auto-escalation vs a visible "not in this meeting, searching your vault…" chip is an open UX question; the tool-trace event stream can carry a tier badge).
+
+### Reuse of the note pipeline's retrieval
+Tier 2 retrieval and Stage-2 Lane-A retrieval are the **same substrate** — `search_visible`/`search_hybrid_visible` + `salient_query` + (optionally) the `orchestrate_context` reasoner plan, all visibility-gated. Build the gated-retrieval helper once; both the note Stage-2 and brain Tier-2 call it. `orchestrate.rs` is the one existing staged-retrieval-with-planner and the natural place to generalize.
+
+### Preserve the correct vault-wide Ask page
+`commands.rs:ask_vault` (vault-scoped executor `meeting_id:""`, `ASK_MAX_STEPS=6`, agentic-attempt→floor) is **already correct** for a *deliberately vault-wide* surface — it is not the wrong-meeting bug. **Leave it as-is.** The cascade applies to the *in-meeting @brain surface* where "current meeting" is the intended default. `chat_meeting` and `run_recipe` are already meeting-scoped single-shots; the cascade can subsume the in-meeting @brain path while leaving these standalone commands intact (open question whether to unify them).
+
+---
+
+## 5. Unified CONTEXT-MANAGEMENT model
+
+**Direct answer to the user's question:** the long-term/durable substrate is **already solid — do not rebuild it**. The **working-memory + conversation layer is thin and fragmented** and is the one place the target work needs a new (small, layered) model. It is *not* a rewrite.
+
+### What is held where today
+
+| Horizon | Where | Contents | Lifetime | Verdict |
+|---|---|---|---|---|
+| Long-term | SQLite (SQLCipher) | `segments`, `notes`, `timelines`, `manual_notes` canonical; `facts`/`user_facts`/`note_chunks`/`entities`/`assistant_interactions` derived | durable; derived layers purged-on-seal, visibility-gated | **Solid, closed** |
+| Session | `AppState` RAM | `unlocked_folders`, `master_kek`, `account_session` | session / until relock / until logout | **Solid** |
+| Working (live meeting) | `AppState` RAM | `live_transcript` (single flat string, 16k, mic-only); `current_meeting` (recording pointer) | cleared at Stop | **Thin** |
+| Conversation | **FE only** | 12-turn window resent per call; agentic scratchpad discarded per turn | ephemeral; `assistant_interactions` for rehydration only | **Fragmented** |
+
+The gap sits **exactly on the boundary the target work occupies**: "holding the evolving state of a live meeting (two-stage note)" and "an ongoing brain conversation (cascade across turns)".
+
+### Target working-memory model (layered over the solid store)
+
+Map onto the 2025 RAM/disk memory analogy (Anthropic context-engineering + Weaviate/MemGPT): **context window = RAM (working memory); SQLite = disk (long-term)**. Concretely:
+
+1. **Decouple "current focus" from "recording".** Introduce a focus pointer (viewed/anchored meeting) distinct from `state.current_meeting` ("Some while recording"). The brain's Tier-1 "this meeting" resolves against **focus**, with a clear precedence rule (bound thread meeting > focus > recording). This is what makes the cascade deterministic when idle.
+
+2. **Per-thread meeting binding is durable.** Persist `meeting_id` on the `assistant_interactions` thread row (§4). The conversation object stays **FE-owned by default** (the "FE owns, backend stateless" rule is load-bearing simplicity) — but the backend gains a **durable thread→meeting binding** and can reconstruct a rolling summarized history + accumulated citations from the already-gated `assistant_interactions` on cold start. Do **not** move the whole conversation into the backend unless a measured latency/quality need appears.
+
+3. **Two-stage note working memory = RAM buffer + finalized DB note.** Stage 1's working set is *only* transcript+template; Stage 2's working set is *only* draft+filtered-corpus — **neither stage ever holds full transcript AND cross-doc bodies at once** (sub-agent isolation / clean context windows). Whether Stage 1 needs a *durable* staging column (survives crash) or a RAM buffer + spill-file (mirroring `spill_writer`) is an open question — but any durable Stage-1 plaintext MUST be seal-gated like segments/notes.
+
+4. **Compaction tuned to the weak model's small window.** The agentic loop already implements Anthropic's compaction discipline (`RESULT_BUDGET=4000`/step, no-repeat guard, treat tool results as data). Add an explicit "summarize when the transcript nears the window" trigger for the weak model, and keep the stage-2 refiner (if any) off the caption tick (skip-if-busy worker, like reactions).
+
+5. **Mandatory invariant inheritance.** Every new stage/buffer/tier MUST: route reads through `meeting_is_visible`/`visibility_clause`/`meeting_is_unlocked`; clear/gate on relock (as `gated_live_context` + `clear_live_transcript_if_idle` already do); be purged-on-seal if derived; egress only through the redaction+consent firewall; log no PII.
+
+**Verdict:** add a small **`WorkingSet`/focus-pointer + durable thread binding** layer; preserve everything durable. Not a new unified store — a thin working-memory model over the canonical one.
+
+---
+
+## 6. Integration with the concurrent connector-enrichment work
+
+**`enrich.rs` is the EXTERNAL half of Stage 2 (Lane B) — adjacent, not identical, to cross-meeting linking (Lane A).** The target is **one Stage-2 orchestrator, two lanes, one writer, one persist seam, one strip** — do **not** build two parallel write pipelines.
+
+- **Do not duplicate the writer.** Lane A (local links) routes through `enrich::apply_context_markers` (or a lightly-generalized sibling emitting a `murmur:links` fence) — inheriting idempotency, byte-exact undo, sanitize-hardening, seal-safety for free. Fold `verify.rs:apply_verify_markers` into the same engine (three fence formats today → one).
+- **Do not duplicate the persist seam.** Lane A links persist via the `apply_note_enrichment_inner` tail (`upsert_note` DB-canonical → `overwrite_note`), **not** Re-Truth's vault-only path — or links drop on seal (the flagged trap).
+- **Trigger asymmetry (correct by privacy):** Lane A (zero egress) is **auto-eligible on finalize**; Lane B (egress) **stays on-demand**. The research doc's rejection of AUTO applies only to the egress path.
+- **FE:** enrich has **no UI yet**. Build **one** Stage-2 review panel (clone `verify-panel.component.ts`) showing Lane A local link candidates (free) and Lane B connector hits (the egress button) as one consolidated block.
+- **Coordination:** if the enrich FE ships before this redesign, build it as the Lane-B panel from the start so it doesn't have to be reworked. The `ContextHit{source, detail, url}` DTO already covers Lane A (`source:"Murmur"`) — no schema change needed. Confirm with whoever owns the enrich branch that the `murmur:links` vs `murmur:context` fence split and the single strip-all step land together.
+
+---
+
+## 7. What competitors / patterns validate or warn against
+
+1. **Single-source draft is the industry norm — validate Stage 1.** Every meeting tool (Granola, Fireflies, Otter, Fathom, tl;dv) generates the note from *that meeting's transcript alone* and keeps cross-meeting context **out of the note body**. Granola's Enhance explicitly uses "that meeting's transcript only". Murmur's current in-prompt cross-note mixing is the *unusual* choice — the two-stage split moves Murmur *toward* the validated pattern. **Differentiation:** Murmur's Stage-1 draft can be **fully local/on-device** (fast, private) where competitors are cloud.
+
+2. **Prompt chaining beats a single mixed prompt (academic).** arXiv 2406.00507 — a unified "stepwise" prompt only *simulates* refinement; genuine chaining (draft → refine) wins. Self-Refine reports ~20% gains from a real second pass. This is the direct justification for splitting Stage 1 / Stage 2.
+
+3. **For weak models the bottleneck is context *utilization*, not retrieval — warn against pre-generation mixing.** arXiv 2603.11513 + Lost-in-the-Middle (2307.03172) + The Distracting Effect (ACL 2025): small models are far more easily distracted by adjacent passages; the fix is **fewer, higher-precision passages + structural separation** of retrieved content from the generation task. This is precisely why cross-doc context must leave the Stage-1 draft prompt — and why the fix is *structural*, not the lexical `strip_ungrounded_action_items`.
+
+4. **Two-scope Q&A + tier-tagged citations are table-stakes.** Fireflies ("Global AskFred" vs per-meeting), Fathom (account-wide + link-to-exact-moment), tl;dv (single vs multi-meeting), Otter (cross-conversation Chat) all split "this meeting" vs "workspace" and cite back to source. Murmur's cascade with an `answered_from` badge is the **auto-scope superset** of the industry two-scope split. **Differentiation:** every retrieval seam is **visibility-gated (crypto-sealed)** — no competitor gates retrieval by a per-folder lock.
+
+5. **Nobody auto-injects live external context into the note body — validate on-demand Lane B.** Notion/ClickUp/Glean fold connectors into the *answer*; Granola/Fireflies push *out* to tickets; Fellow's `/jira` is user-confirmed. Auto-appending live context invites the #1 complaint (verbosity/staleness). Murmur's dated, foldable, on-demand `> [!context]-` callout is the right posture. **Differentiation:** owned Obsidian `.md` with `[[wikilinks]]`/block-refs, no cloud index, no multi-hour indexing lag (Notion ~3h), no manual reindex (Copilot).
+
+6. **Activate the dormant semantic recall.** Every knowledge competitor ships embeddings; Murmur's e5 is present-but-dormant and the repo bake-off showed recall@5 1.00 semantic vs 0.42 FTS. Stage-2 Lane A "related meetings" and Tier-2 vault recall are the place to turn it on — **on-device**, matching Obsidian Smart Connections/Reflect, which is Murmur's uncopyable lane (local-first + on-device embeddings + far-side capture + sealed retrieval).
+
+**Anti-patterns to avoid:** Otter-style verbosity (default concise + foldable), cloud-indexing all content, indexing lag, manual reindex.
+
+---
+
+## 8. Phased implementation plan
+
+Each phase: goal, files/symbols, verification, gates. Backend (Rust) and FE (Angular) are largely disjoint → parallelize, serialize shared files. Lock/egress-touching phases require the **lock-security-reviewer** as a second gate; every phase requires the **adversarial-verifier** (implementer never self-certifies). Real gates: `cargo test --lib`, `npx ng lint`, `npx ng build`, `scripts/ci.sh`. RED-before-GREEN for every bug fix.
+
+### Phase 0 — Land the separate lock/data-loss fix (S, no dependency)
+- **Goal:** ship the `move_into_locked_folder` session-restore fix (the already-built lock fix). It is **independent** of the note/brain redesign and should not be entangled with it.
+- **Files:** the `move_into_locked_folder`/session-restore path (per the established decision this is separate).
+- **Verify + gate:** `cargo test --lib`; **lock-security-reviewer required** (lock-touching); adversarial-verifier RED-before-GREEN for the data-loss regression.
+
+### Phase 1 — Stage 1 isolation + rip out the Layer-2 hack (M, backend)
+- **Goal:** Stage-1 note is provably transcript-only; delete the lexical hack.
+- **Symbols:** `pipeline.rs:summarize_and_export` — remove the `orchestrate_context` call (`pipeline.rs:930`), set `SummarizeRequest.related_context = None`; remove the "Related prior notes" arm in `template.rs:render_user_content`; delete `grounding::strip_ungrounded_action_items` + `strip_applies_for_language` + the call at `pipeline.rs:998`.
+- **Verify:** existing `render_user_content_none_is_unchanged` proves byte-identical prompt; add a RED-before-GREEN test that a note generated with a "poisoned" vault (another meeting with `## Action items`) contains **zero** of that meeting's action items (the bleed regression, now structurally impossible). Dev-app boot clean.
+- **Gate:** adversarial-verifier (hunt content-loss + bleed); **lock-security-reviewer** (egress surface changed — one fewer thing in the prompt, confirm no gate weakened).
+- **Note:** this phase alone eliminates the bleed class and retires `strip_ungrounded_action_items`. Consider promoting `annotate_unverified` to default-ON here (separate decision).
+
+### Phase 2 — Stage 2 shared writer + persist seam + Lane A local linking (M–L, backend)
+- **Goal:** additive cross-meeting `[[links]]` + Related section on the finished note, deterministic, zero-egress; unify the writer.
+- **Symbols:** generalize `enrich::apply_context_markers` to emit a `murmur:links` fence (Lane A) alongside `murmur:context` (Lane B); add a strip-all-managed-blocks step; new `link_related_notes` pass mirroring `apply_note_enrichment_inner` (gate → retrieve via `related_context::salient_query` + `build_related_context` → render `[[Title]]` + `reference_gist` as `ContextHit{source:"Murmur"}` → `upsert_note` → `overwrite_note`). Run as a **deferred post-`Exported` pass**. Fold `verify.rs:apply_verify_markers` into the shared engine.
+- **Verify:** idempotency test `apply(apply(x))==apply(x)` across all three fences; `enriched_note_seals_and_restores_byte_identical`-style seal round-trip for the links block; a test proving Lane A links contain **no action-items** (guaranteed by `reference_gist`); self-exclusion + visibility-gate tests (reuse `build_related_context_excludes_sealed_until_unlocked`).
+- **Gate:** **lock-security-reviewer required** (persist path + seal-safety + visibility-gated retrieval); adversarial-verifier (idempotency, byte-exact undo, no plaintext left in a sealed dir).
+
+### Phase 3 — Stage-2 Lane B integration + unified review panel (M, backend light + FE)
+- **Goal:** fold the existing connector enrichment in as Lane B; build the one Stage-2 review panel.
+- **Symbols:** `enrich_note_context_inner`/`apply_note_enrichment_inner` (already built) become Lane B under the shared strip/writer/persist; FE clones `verify-panel.component.ts` into a Stage-2 panel showing Lane A (free) + Lane B (egress button) in one consolidated block; wire `ipc.service.ts:enrichNoteContext/applyNoteEnrichment` (currently unreachable).
+- **Verify:** `enrich_commands_refuse_a_sealed_meeting` still passes; Playwright against `:1420` with mocked `invoke` drives the panel; `ng lint` + `ng build` (16k budget).
+- **Gate:** **lock-security-reviewer** (egress lane); adversarial-verifier (fence-forging via hostile Slack/web hits — `sanitize` coverage).
+
+### Phase 4 — Brain: thread meeting_id + kill wrong-meeting bug (S–M, backend + FE)
+- **Goal:** explicit, durable meeting scope for @brain.
+- **Symbols:** Seam 1 — `ipc.service.ts:askAssistantText/askAssistantChat` add `meetingId`; `meeting-conversation.store.ts` passes `_meetingId()`; `commands.rs:ask_assistant_text/ask_assistant_chat` add `meeting_id: Option<String>` → `run_assistant_query`/`run_informational`, resolve `fe_id.or(current_meeting)`; persist `meeting_id` on the `assistant_interactions` thread row (`persist_interaction`).
+- **Verify:** RED-before-GREEN — "o czym to spotkanie" on an idle past-meeting thread returns *that* meeting, not an arbitrary one; a live-recording thread still scopes to the recording; a bound past thread wins over a *different* recording meeting (precedence rule).
+- **Gate:** adversarial-verifier (the specific wrong-meeting reproduction); lock-security-reviewer (Tier-1 reads gated).
+
+### Phase 5 — Brain: tier ladder (deterministic escalation) (L, backend)
+- **Goal:** Tier 1 (isolated) → Tier 2 (vault) → Tier 3 (connectors), structural tool-gating.
+- **Symbols:** add a `scope`/`tier` enum field to `GatedToolExecutor` + a `specs()` filter arm; restructure `run_informational` into a Tier1→Tier2→Tier3 ladder with the `__ESCALATE__` sentinel (mirror `ask_vault_agentic_attempt`→floor, chained); Tier-1 LIVE = single-shot over `live_transcript` (like `chat_meeting`), Tier-1 PAST = `chat_meeting` read shape; per-tier step budgets (T1 1–2, T2 3–4, T3 2–3) to stay live-safe; add `answered_from`/`tier` to `AgentOutcome`/`VoiceActionResult`/`AskVaultResult`; Tier-1 injects the current meeting's own `[[Title]]`; strengthen Tier-3 connector loud-line attribution (like `rag_answer`).
+- **Verify:** each tier's executor advertises only its tools (`run()` rejects higher-tier tools); escalation fires only on the sentinel, not on generic non-convergence; tier badge is set deterministically; Playwright drives a question answerable only at Tier 2 and confirms the badge + escalation trace.
+- **Gate:** **lock-security-reviewer required** (every tier read gated; Tier-3 egress consent-gated); adversarial-verifier (a Tier-1 question must NOT reach vault tools — prove the model *cannot*, not just *shouldn't*).
+- **Preserve:** `ask_vault` unchanged (deliberately vault-wide).
+
+### Phase 6 — Context-management layer: focus pointer + working-memory discipline (M, backend)
+- **Goal:** decouple focus from recording; formalize the working-memory model.
+- **Symbols:** add a focus pointer to `AppState` distinct from `current_meeting`; precedence rule (bound thread > focus > recording); optional compaction trigger for the weak model; confirm relock clears every new buffer (extend `clear_live_transcript_if_idle` discipline).
+- **Verify:** focus-vs-recording precedence tests; relock clears the new working set; no PII in logs.
+- **Gate:** lock-security-reviewer (clear-on-relock); adversarial-verifier.
+
+### Phase 7 (optional) — Activate dormant e5 semantic recall for Lane A + Tier 2 (M–L, needs model)
+- **Goal:** semantic "related meetings" + vault recall on-device.
+- **Symbols:** `embed.rs:rrf_fuse` / `db.search_hybrid_visible` behind the same gated-retrieval helper; rerank-and-reduce with a tight passage budget for the weak model.
+- **Verify:** real-vault (incl. Polish) recall eval, not just the small test corpus; **needs the model present + a real Mac** — cannot be fully verified headless (honesty bar).
+- **Gate:** adversarial-verifier; lock-security-reviewer (retrieval gated).
+
+**Dependencies:** Phase 0 independent (ship first). Phase 1 → Phase 2 → Phase 3 (Stage-2 chain). Phase 4 → Phase 5 → Phase 6 (brain chain). Phase 1 and Phase 4 can run in parallel (disjoint files). Phase 7 depends on Phase 2/5 and the embed model.
+
+**How the reverted Layer 2 folds in:** the `strip_ungrounded_action_items` removal is **Phase 1** — it is retired the moment Stage 1 is transcript-only, because its only job was cleaning the injection being removed. **How the built lock fix folds in:** it is **Phase 0**, shipped independently, entangled with nothing here.
+
+---
+
+## 9. Risks + open questions
+
+**Risks**
+- **Strong-provider regression:** moving `related_context` out of the draft may *reduce* quality for strong cloud providers (which benefit from cross-doc grounding and aren't distracted). May need a **provider-tiered pipeline** (strong = single-pass with context; weak = strict two-stage) rather than a uniform split. Unverified — needs the notes bake-off on a real Mac.
+- **Latency/thermal:** a genuine second pass (if Stage 2 uses an LLM) doubles inference on Apple Silicon; deterministic Lane A avoids this. No measured on-device numbers for qwen3-4b draft-vs-enrich delta.
+- **Weak-model escalation gate:** Self-RAG/FLARE assume a model calibrated enough to say "I don't know / escalate". The `__ESCALATE__` sentinel on qwen3-4b is unproven; may need a deterministic coverage backstop. Structural tool-gating de-risks this (the model can't reach the wrong tier even if it mis-judges).
+- **Seal-safety of new writes:** any Stage-2 or Tier read that writes/reads plaintext in a sealed dir is a leak/loss bug. The `upsert_note`→`overwrite_note` (not vault-only) discipline and the visibility gates are mandatory — hence lock-security-reviewer on Phases 2/3/5/6.
+- **Line-anchor drift:** `commands.rs`/`db.rs` >8k lines; every citation here is by *symbol* — grep, don't trust numbers.
+
+**Open questions** (technical, resolvable in-build)
+- Durable Stage-1 staging column vs RAM buffer + spill-file? (Any durable plaintext must be seal-gated.)
+- Deferred post-`Exported` Lane A pass vs inline before `export::write_note`? (Deferred recommended for the `SealInto`/no-vault branches.)
+- Should Lane A backfill/refresh over historical notes, and what triggers it (new meeting, manual, cron)?
+- Losing inline body `[[Title]]` citations (Stage-2 links in a separate section) — acceptable, or should Stage 2 also inject wikilinks into the body?
+- Tier-1 LIVE single-shot vs small loop with a `get_current_meeting` tool (DB tools return nothing during recording).
+- Precedence when a past-meeting thread is open while a *different* meeting records.
+- Promote `annotate_unverified` to default-ON in Phase 1 (now the primary anti-hallucination guard)?
+- Is GBNF/JSON constrained decoding actually wired through `LocalReasoner::structured`, or schema-in-prompt + `parse_first_json`? (Apply to extract legs only — "alignment tax" on free prose.)
+
+**Cannot be verified headless (honesty bar):** on-device draft-vs-enrich quality/latency, real-vault (Polish) semantic recall, Touch ID / lock-at-rest / screen-share auto-relock — need a **signed build on a real Mac** with the model present.
+
+---
+
+## 10. Decisions needed from the user
+
+The genuine forks (things the user must choose, not things the architect can decide):
+
+1. **Stage-2 mode (THE central fork):** deterministic (link + `reference_gist`, **zero egress** — recommended) vs an LLM prose pass behind the consent+redaction envelope. Everything downstream depends on this.
+2. **Provider-tiered vs uniform note pipeline:** strict two-stage for everyone, or two-stage only for the weak on-device model while strong cloud providers keep a single-pass with cross-doc context.
+3. **Lane A auto vs on-demand:** auto-run local cross-meeting linking on finalize (zero egress, so the privacy objection doesn't apply — recommended) vs keep it user-invoked like Lane B.
+4. **Escalation surfacing (UX):** silent auto-escalation across tiers vs a visible "not in this meeting → searching your vault…" chip.
+5. **Conversation ownership:** keep FE-owned + backend durable thread→meeting binding (recommended, minimal) vs move the conversation working set into the backend as source of truth.
+6. **Cascade scope:** does the current-first cascade subsume `chat_meeting`/`run_recipe`, or stay a record-screen-only @brain feature with those standalone commands intact?
+7. **Activate dormant e5 semantic recall now (Phase 7) or defer** until the two-stage/cascade structure lands.

--- a/docs/research/2026-07-07-perf-memory-audit.md
+++ b/docs/research/2026-07-07-perf-memory-audit.md
@@ -1,0 +1,118 @@
+# Performance / memory audit — the "open a 1h meeting → OOM kills Murmur + Chrome" crash
+
+**Date:** 2026-07-07
+**Trigger:** Recorded a ~1h meeting, opened it in Detail → system-wide OOM (macOS killed Murmur *and* other apps, incl. Chrome). A system-wide kill = a **multi-GB** allocation, not a big DOM.
+**Method:** inline code recon + `murmur.log` evidence, then a 6-finder adversarial Workflow (fe-render, fe-memory, record-pipeline, on-open-cascade completed; crash-chain + be-memory were cut off by a session limit — their ground is covered by my own recon + on-open-cascade). Every claim below was confirmed against the current working tree (symbols, not line numbers — the files drift).
+
+---
+
+## 1. Root cause of the crash
+
+The crash is **cumulative on-device model residency with no memory-pressure guard anywhere**, tipped over the edge by the work Murmur fires when a meeting opens. It is *not* a single 6.3 GB model — the earlier "Bielik loads on open" framing was **corrected** (see the ⚠️ box).
+
+**The residency baseline after a 1h recording (all never-evicted):** `murmur.log` shows the user is on `brain_backend = Local` with **whisper large-v3** and **`brain_live` (Realtime Reactions) ON**. So during/after the recording, resident at once:
+- whisper `WhisperContext` (`transcribe/whisper.rs` `Transcriber`, held for reuse) — **large-v3 ≈ 3.1 GB**;
+- **Qwen3-1.7B** light brain (1.28 GB) — loaded by `brain_reactions::reactions_scan` **every ~21 s** during recording (`transcribe/live.rs`, `REACTIONS_SCAN_EVERY=7 × TICK=3 s`), then never freed;
+- **Qwen3-4B** heavy brain (2.50 GB) — loaded once, never freed (`reason/mistral.rs` `model_cache` **"REFUSES rather than evicts"**, `MODEL_CACHE_CAP=2`, drop-leaks #723/#865);
+- e5 embedder (470 MB), + the record-pipeline **Stop-time peak (~1.4–2 GB transient**, see P1).
+
+That is already **~8–9 GB** of Murmur RSS by the time the recording finishes — with **zero** device-RAM awareness: `MODEL_CACHE_CAP` gates a *count*, not memory, and the `residency_fits`/`combined_residency_gb` estimators (`reason.rs`) are only called by read-only capability probes, **never on the load path** (mem-1).
+
+**What opening the meeting adds (the tipping point):**
+- `detail.component.ts › loadMeeting()` calls `void this.loadTimeline()` on **every** unlocked open (and in `unlock()`), no guard — even though the timeline only renders on the Audio tab (default tab is `note`). → `get_timeline` → for an uncached meeting, `summarize/timeline.rs › generate()` joins **all** segments into **one un-chunked prompt** (~15–25k tokens for 1h).
+- The default Note tab also mounts `<app-related-meetings>` (`note-panel.component.html`), whose effect fires `relatedMeetings()` → `embed_passage()` → the **e5 embedder** runs on open (confirmed by repeated `local embed model ready e5-small` in the log), concurrent with the timeline work.
+- **KV scales with the actual prompt length.** mistralrs plans for `AutoDeviceMapParams::DEFAULT_MAX_SEQ_LEN = 4096` (PagedAttention OFF), but a 1h transcript blows past it → **several GB of prefill KV** at runtime on top of the resident weights. (A truncating path would also derive the timeline from only the first ~4096 tokens ≈ first minutes — latent correctness bug.)
+
+Stacked on the ~8–9 GB baseline, this tips a 16 GB Mac past physical RAM → macOS memory-pressure kill of Murmur **and** other apps (Chrome).
+
+> ⚠️ **CORRECTION — the timeline/note path uses the CLOUD provider by DEFAULT, not the local brain.** `summarize/roles.rs resolve(Role::Notes)` returns `legacy_default_target` = `cfg.provider_id` (default `claude_code`); the unit test `resolve_identity_matrix_with_keys_absent` asserts *"Notes ignores brain_backend entirely"*. **Only `Ask`/`Live` map `brain_backend → Local`.** So `get_timeline`/note-generation run a **local** model **only if the user explicitly set `role_notes_connection = local`** (the per-role AI-settings picker). Whether the on-open timeline was itself a local call therefore depends on the user's config; regardless, the ~8–9 GB baseline + the on-open e5 + KV spike is the mechanism, and the selected heavy model is **Qwen3-4B (2.5 GB)**, not Bielik (Bielik is downloaded but the logs show Qwen loading).
+
+> ✅ **BF16 question — RESOLVED (false alarm), verified in mistralrs-core 0.8.1:** GGUF weights **stay quantized** (`models/quantized_llama.rs` — every attn/FFN matrix is `GgufMatMul` over a `QTensor`; only `tok_embeddings` is dequantized). `DType selected is BF16` is the compute/activation dtype (`utils/normal.rs`), not a weight dequant. So a Q4 model stays ~its on-disk size in RAM, **not** ~3× larger.
+
+**Immediate mitigation (no code):** (1) switch the recording model from **whisper large-v3 → small** (saves ~2.6 GB resident); (2) turn **Realtime Reactions (`brain_live`) OFF** (drops the resident light model + the every-21 s inference); (3) if notes are set to a local model, switch that role to **Cloud**. Any one buys headroom; together they almost certainly stop the OOM today.
+
+---
+
+## 2. P0 — stop the crash (surgical)
+
+**P0.1 — Do NOT auto-generate the timeline on open.** *(highest leverage; FE-only)*
+Move `void this.loadTimeline()` out of `loadMeeting()` **and** `unlock()`. Trigger it lazily only when the Audio tab first activates and it's still empty:
+```ts
+private readonly _timelineOnAudioTab = effect(() => {
+  if (this.activeTab() === 'audio' && this.detail() && !this.locked()
+      && !this.timeline() && !this.timelineLoading()) {
+    void this.loadTimeline();
+  }
+}, { allowSignalWrites: true });
+```
+- File: `src/app/features/detail/detail/detail.component.ts`.
+- **RED test** (Playwright @ `:1420`, mocked `invoke`): open a meeting → assert `getTimeline` is **not** invoked while `activeTab==='note'`; click Audio → assert it's invoked exactly once. Fails on current code, passes after.
+
+**P0.2 — Cap the transcript fed to ANY local model — timeline AND note generation.** *(backend; the KV lever)*
+The KV cost is driven by **prompt length** (mistralrs plans for `max_seq_len=4096`; the bug is feeding a ~15–25k-token 1h transcript past it). Two call sites join **all** segments with **no cap** and hand them to a local model:
+- `summarize/timeline.rs › generate()` — the on-open timeline path.
+- ✅ **DONE (2026-07-08)** — **`summarize/template.rs › render_prompt()`** — the **note-generation** on-device path. `render_prompt` serves *only* local mistralrs + Ollama (cloud uses `render_user_content` directly), so it now caps the transcript to `LOCAL_NOTE_MAX_CHARS = 40_000` (matching `chat.rs`/`recipes.rs`) — the OOM twin of the timeline cap, on the primary recording flow (mem-2). Cloud note quality is untouched. Tests: `on_device_note_prompt_caps_long_transcript` + `_short_transcript_unchanged`. Full suite 1162 green.
+Fix: window/chunk or hard-cap the transcript for local/weak providers (provider-aware, like `related_context.rs::budget_for`); a shared helper so both cap consistently. Optionally enable `.with_paged_attn(...)` in `reason/mistral.rs › model()` and/or lower `max_num_seqs` from 32.
+- **RED test**: `template.rs` unit test mirroring `recipes.rs::truncates_long_transcript` — `req.transcript = "word ".repeat(20_000)`; assert `render_user_content(&req)` is char-bounded + contains `[transcript truncated]`. Fails today, passes after. Same for `timeline::generate()`.
+
+**P0.3 — Refuse instead of OOM: a real device-RAM guard on EVERY on-device model load.** *(the config-robust systemic fix — mem-1)*
+Today **nothing** checks memory before a load: `reason/mistral.rs › model()` gates only on `cache.len() >= MODEL_CACHE_CAP` (a *count*), and the `residency_fits` / `combined_residency_gb` estimators (`reason.rs`) are only called by read-only capability probes (`brain_live_ram_ok`, `brain_model_dtos`) — **never on the load path**. Fix: gate `model()` *before* `GgufModelBuilder::build()` on projected combined residency, returning `AppError::Unavailable` so the caller degrades to the deterministic floor instead of OOM-ing the machine. Two musts: (1) probe **FREE/available** RAM (`sysctl vm.page_free_count × page size` — no new crate), not just `total_ram_gb()` (`hw.memsize`), so co-resident pressure is caught; (2) make `combined_residency_gb`'s KV term **scale with prompt length** instead of the flat `KV_PER_MODEL_GB=1` (`reason.rs`). Apply the same pre-load guard to whisper (`whisper.rs`), e5 (`candle_bert.rs`), NER (`ner_deberta.rs`). **RED test**: parameterize `model()`'s RAM ceiling (like `residency_fits`'s `Option<u64>`) and assert it refuses when a small injected ceiling is exceeded — no forward pass needed.
+
+**P0.4 — Stale-result / in-flight guard on `loadTimeline()`.**
+Mirror `resummarize()`: capture `id`, and after the await only `this.timeline.set(...)` if `this.detail()?.meeting.id === id`; short-circuit if a generation for the same id is already in flight.
+*Provider-agnostic* (the timeline provider is whatever `Role::Notes` maps to — a local heavy model only when `brain_backend=Local`). Effect of an overlap differs: on **Cloud** two concurrent generations just waste a subprocess call / double tokens+egress (no OOM); on **Local** they overlap **KV-cache / prefill working set** — **not** the weights, which are a single shared `Arc<Model>` in the never-evict `model_cache` (loaded once, not duplicated). So this is a belt-and-braces cost/robustness fix, **not** an ogniwo of the OOM — after P0.1 (no timeline on open) its practical window is only "opened the Audio tab, then rapidly switched meetings".
+
+---
+
+## 3. P1 — high-impact perf / memory
+
+- **Defer the `related-meetings` embed off the on-open path** *(HIGH, memory)* — `related-meetings.component.ts` fires `relatedMeetings()` (→ e5 forward pass) the instant `meetingId` is set, on the default tab. Wrap in `@defer (on viewport)` / fire on idle, and never concurrently with a timeline generation. Consider caching the meeting centroid so "Related" is a cheap KNN, not an on-open embedding pass. *(It already has a stale guard — the problem is the eager embed, not a leak.)*
+- ✅ **DONE (2026-07-09) — Record Stop-time peak** *(CRASH-class, memory)* — `pipeline.rs › run_inner`: the source-rate mic buffer `samples` (~691 MB/h @48 kHz) is now wrapped in `Option` and **dropped immediately after resample** in the common (no-hi-res-masters, default) path, so it no longer co-resides with `mic_16k` + `sys_16k` + `archive_16k` — roughly halving the pre-whisper Stop-time peak. When `keep_hires_masters` is on, `samples` is retained (`Some`) and the faithful `.mic.wav` master write after finalize is byte-identical (no error-path change). 1163 lib tests green. *(Remaining micro-opts — `mic_16k_archive` early drop, the redundant `resample_to_16k` inside `write_wav_16k_mono` — left as follow-ups; the `drop(samples)` is the dominant win.)*
+- ✅ **DONE (2026-07-09) — Whisper whole-hour unchunked decode** *(CRASH-class, memory)* — `pipeline.rs › transcribe_stream` now tiles every region through a new pure `decode_windows(start, end, window_len)` with `MAX_WINDOW_S = 120`, so a VAD-less/whole-buffer or long continuous region never decodes >120 s at once (bounds whisper's mel + `set_n_max_text_ctx(16384)` working set to O(window)); per-window timestamp offsetting preserved. 3 tiling tests (`decode_windows_*`). *(Real memory delta needs a signed-Mac run; logic is unit-verified.)*
+- 🔴 **DEFERRED (needs a signed-Mac session) — Whole-recording PCM in RAM** *(HIGH, memory)* — `audio/recorder.rs`: the authoritative mic buffer is a single growing `Vec<f32>` for the whole recording (~700 MB/h; `MAX_RECORDING_SECONDS=4h` ⇒ ~2.8 GB cap). The fix (bounded rolling RAM window + stream authoritative PCM to the existing `SpillWriter` + reconstruct/transcribe from disk in chunks at Stop) rewrites the live-capture path — **audio integrity (no dropouts, crash-safety) cannot be verified headless or in a mock; it needs real capture on a signed Mac.** Not blind-shipped to real users. Plan: (1) cap `Shared.samples` to a rolling window sized for `snapshot_tail` live-ASR; (2) make `SpillWriter` the authoritative full-PCM sink; (3) at Stop, `run_inner` sources the full buffer from the spill file instead of the drained RAM `Vec`. Verify with a real 1h recording + waveform/transcript diff against the current path.
+- **Live + batch whisper contexts coexist** *(MEDIUM, memory)* — `transcribe/live.rs` self-terminates only on its next 3 s tick, so at Stop both the live and batch `Transcriber` (model weights + Metal buffers, up to ~2.9 GB each for large-v3) can be resident for ~3 s. Signal+join the live thread (or share one `Transcriber`, it's `Send+Sync`) before loading the batch model.
+- ✅ **DONE (2026-07-09) — Transcript CD storm + DOM count.** Two parts: (1) the per-fragment **method** binding is gone — `audio-panel.component` derives `activeSegKeys = computed<Set<number>>` (one O(n) scan per `currentTime` tick), template binds `[class.is-active]="activeSegKeys().has(s.idx)"` (O(1)/fragment; a Set preserves highlighting every active fragment when me/others overlap) — kills the ~8k-eval/s storm. (2) **Windowing:** `renderedTurns` caps the rendered turns at `RENDER_CAP = 80` (always extended to include the karaoke-active turn, so auto-scroll never targets an un-rendered row) behind a "Show all N turns" expander — a 1h meeting no longer materializes thousands of `<button>` nodes at once. e2e `transcript-cap.spec.ts` (100 turns → 80 render → Show all → 100) + `timeline-defer` green; ng lint+build green. *(Follow-up: true viewport windowing bounded even during deep playback, and optional `currentTime` throttle to 2–4 Hz.)*
+
+---
+
+## 4. P2 — cleanups
+
+- `meeting-timeline.component`: `isActive()/isActiveChapter()/range()/fmt()` bound as methods, re-run per span each tick → precompute `activeBlockOrder`/`activeTopicOrder` computeds + precompute `range`/label as fields on the geometry object.
+- `audio-panel › _karaokeScroll` and `meeting-conversation.component` scroll effect: re-register `afterNextRender` on every tick / every `notes()` change (forced reflow via full `turnRows()` scan). Register once / gate on actual content growth.
+- `meeting-conversation.store.ts` (root singleton): `_notes`/threads retained until a different meeting id is set (bounded to one meeting, not the OOM). Clear on leaving the record surface / soft-cap threads.
+- `double-mic-copy-when-aec-or-postaec` (`pipeline.rs`): extra full-length 16k mic copies — lower priority (opt-in, `post_aec_enabled`/`keep_hires_masters` default OFF); mostly neutralized by the early `drop(samples)` in P1.
+- Note-tab IPC fan-out: `getConfig`, `getMeetingTags`, `folders.load`, `getActionItems`, `listBuiltin/SavedRecipes` all fire eagerly on open. Cache `getConfig` app-level; put non-critical sections behind `@defer (on viewport)`.
+
+**Verified NOT a bug (don't chase):** FE event streams all hold+release `UnlistenFn`; no `.subscribe()`-to-field; no full-WAV read into JS (audio is `convertFileSrc`/`asset:` streaming only); `live_transcript` RAM tail is bounded (`MAX_LIVE_TRANSCRIPT_CHARS=16_000`); FE live caption is `set` not append; `SpillWriter` streams only the delta; Library list rows are lightweight (no N+1); Graph is a bounded card list; no `track $index` on keyed data anywhere.
+
+---
+
+## 5. Suggested execution order
+
+1. **P0.3** (device-RAM refuse-not-OOM) — the **config-robust** first fix: it stops the machine dying regardless of which role/model/backend the user picked. Ship it first. *(`rust-tauri-dev` → `adversarial-verifier`.)*
+1b. **P0.1** (FE, no timeline on open) — removes the on-open KV spike + e5 co-load for the common path. RED Playwright test. *(No lock/crypto surface; `get_timeline` already gates on `meeting_is_unlocked`.)*
+2. **P0.4** (stale guard) — trivial, same file, same PR as P0.1.
+3. **P0.2 + P0.3** (backend context cap + RAM-refuse) — one Rust unit (`rust-tauri-dev`), `cargo test --lib` RED→GREEN. Touches `reason/mistral.rs` + `summarize/timeline.rs` — **not** a lock path, so no lock-security-reviewer needed; still route through `adversarial-verifier`.
+4. **P1 record-pipeline trio** (drop(samples), whisper chunk cap, live/batch context) — one Rust unit; note `pipeline.rs`/`live.rs`/`state.rs` are already dirty (two-stage-notes WIP) — coordinate to avoid co-mingling.
+5. **P1 FE** (defer related-meetings; transcript virtualization + activeFragKey) — `angular-zoneless-dev`; `ng build` + Playwright.
+6. **P2** — batch cleanup pass.
+
+**Needs a signed build / real Mac to verify (honesty bar):** the actual RSS of the resident model set + prefill KV for a real 1h prompt (source confirms Q4 weights stay ~on-disk size; KV is estimated, not measured); the real 1h capture memory curve; and that the machine no longer OOMs on open after P0. Headless `cargo test` / `ng build` prove the code paths, **not** the live memory behavior (a forward pass never runs in tests).
+
+---
+
+## 6. Re-analysis addendum (2026-07-08) — corrections + newly-found items
+
+**Two corrections to the first-pass framing** (both now folded into §1):
+- **Notes routes to CLOUD by default** — `roles.rs resolve(Role::Notes) = legacy_default_target` (test: *"Notes ignores brain_backend entirely"*). The on-open timeline / note generation runs a **local** model only if the user explicitly set `role_notes_connection = local`. Only `Ask`/`Live` follow `brain_backend`.
+- **BF16 dequant was a false alarm** — GGUF weights stay quantized; a Q4 model stays ~on-disk size in RAM. The active heavy model in the logs is **Qwen3-4B (2.5 GB)**, not Bielik.
+
+**New findings (from the be-memory + broaden re-analysis; verify agents for the broaden set were cut off by a session limit — treat those as finder-reported, re-verify before acting):**
+- **mem-1 (HIGH → P0.3):** no device-RAM guard on any model load — see P0.3.
+- **mem-2 (HIGH → P0.2):** the note-generation path (`template.rs render_user_content`) lacks the `MAX_TRANSCRIPT_CHARS` cap that `chat.rs`/`recipes.rs` have — see P0.2.
+- **F4 / mem-3 (MEDIUM → P1):** `embed::active_embedder()` builds a **fresh `CandleBertEmbedder` per call** (per-instance cache), so e5 (470 MB) reloads on every related-meetings / MCP / Ask op. Give it a process-global load-once cache like the brain's `model_cache`. (Trade-off: keeping it resident costs ~470 MB steady — gate residency behind the P0.3 RAM guard, or keep the transient-reload-then-free which is gentler under memory pressure.)
+- ✅ **F5 DONE (2026-07-09):** `db.rs graph_edges_visible` now appends `LIMIT 600` after `ORDER BY weight DESC` — the unbounded quadratic self-join returns only the strongest edges (the brain-map shows ≤60 nodes). The LIMIT sits *after* the `visibility_clause` WHERE, so it only trims magnitude and can never widen visibility (pending lock-security-review confirm).
+- **F7 (LOW → DEFERRED):** `db.rs list_entities_visible` no-LIMIT. **NOT** blanket-LIMIT'd on purpose — it's shared with `brain_reactions`/`proactive`, which match *freshly-mentioned* (low-count) entities; an `ORDER BY cnt DESC LIMIT` would drop exactly those → a reactions regression. Correct fix = window-filter the recording-time scan paths (or an additive index to bound the GROUP BY cost). Deferred, not forced.
+- **F7 (LOW → P2, perf):** `db.rs list_entities_visible` is an unbounded full-vault `GROUP BY` with **no LIMIT**, re-run on every reactions scan (~21 s during recording) and every graph open. Push the window/limit into SQL for the scan paths.
+- **F6 (by-design, watch):** Realtime Reactions runs the light GGUF every ~21 s during recording (`brain_live` ON) — correctly gated + off the tick thread, but it sets the high memory floor documented in §1. Consider not keeping the light model resident once reactions stop.
+- **F8 (verified clean):** app startup loads **no** model and builds no index — the heavy work is all on-demand at first inference. Not a boot-time problem.

--- a/e2e/detail/timeline-defer.spec.ts
+++ b/e2e/detail/timeline-defer.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * P0.1 (OOM fix) — the on-open timeline trigger is GONE.
+ *
+ * The 1h-meeting Detail-open OOM was rooted in `detail.component.ts loadMeeting()`
+ * calling `void this.loadTimeline()` UNCONDITIONALLY on every open — firing
+ * `get_timeline` (→ on a local Notes role, a multi-GB model load + a whole-transcript
+ * prompt) even though the timeline only renders on the Audio tab (default tab = Note).
+ *
+ * The fix defers `loadTimeline()` to an effect keyed on `activeTab() === 'audio'`.
+ * This spec pins that behavior against the REAL FE bundle (only the Tauri IPC boundary
+ * is mocked): `get_timeline` must NOT be invoked while the Note tab is showing, and must
+ * fire exactly ONCE when the user opens the Audio tab.
+ *
+ * RED contract: on the pre-fix code `loadMeeting()` calls `loadTimeline()` immediately,
+ * so `__tlCalls` would already be 1 right after open → the `toBe(0)` assertion fails.
+ */
+test.describe("Detail — timeline generation deferred to the Audio tab (P0.1)", () => {
+  test("get_timeline is NOT called on Note-tab open, fires once on Audio", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // Count invocations PAGE-SIDE (the override is serialized — no test-scope closures)
+      // and return a minimal-but-valid MeetingTimeline so the Audio tab renders cleanly.
+      get_timeline: () => {
+        const w = window as unknown as { __tlCalls?: number };
+        w.__tlCalls = (w.__tlCalls ?? 0) + 1;
+        return { speakers: [], topics: [] };
+      },
+    });
+
+    await page.goto("/meeting/m-atlas-roadmap");
+
+    // The detail landed (its tab bar rendered) — default tab is Note.
+    await expect(page.getByRole("tab", { name: "Audio" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // P0.1: opening the meeting (Note tab) must NOT trigger timeline generation.
+    // Give any stray on-open effect a beat to (fail to) fire.
+    await page.waitForTimeout(600);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __tlCalls?: number }).__tlCalls ?? 0,
+      ),
+    ).toBe(0);
+
+    // Opening the Audio tab defer-loads the timeline exactly once.
+    await page.getByRole("tab", { name: "Audio" }).click();
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => (window as unknown as { __tlCalls?: number }).__tlCalls ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe(1);
+  });
+});

--- a/e2e/detail/transcript-cap.spec.ts
+++ b/e2e/detail/transcript-cap.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * P1 (render) — the transcript is windowed so a long (1h) meeting does not materialize thousands of
+ * `<button>` fragments at once. `audio-panel.component` renders the first `RENDER_CAP` (80) turns
+ * (extended to include the karaoke-active turn) behind a "Show all N turns" expander.
+ *
+ * This drives the REAL FE bundle (only the Tauri IPC boundary is mocked) with a 100-turn meeting:
+ * exactly 80 `li.turn` render, a "Show all" affordance offers the remaining 20, and clicking it
+ * reveals all 100. RED contract: before the cap the `@for` iterated `visibleTurns()` → all 100
+ * would render and there would be no "Show all" button.
+ */
+test.describe("Detail — transcript render cap (P1 virtualization)", () => {
+  test("caps at 80 turns with a Show-all expander that reveals the rest", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // A 100-turn meeting: alternating me/others so every segment is its own turn (turns fold
+      // only CONSECUTIVE same-speaker segments). No audio (audioPath null) keeps the test off the
+      // asset protocol; the transcript renders from segments regardless.
+      get_meeting_detail: () => {
+        const segments = [];
+        for (let i = 0; i < 100; i++) {
+          segments.push({
+            idx: i,
+            startS: i * 5,
+            endS: i * 5 + 5,
+            text: `Turn number ${i} content.`,
+            speaker: i % 2 === 0 ? "me" : "others",
+          });
+        }
+        return {
+          meeting: {
+            id: "m-atlas-roadmap",
+            startedAt: "2026-07-01T09:00:00Z",
+            endedAt: "2026-07-01T09:50:00Z",
+            title: "Long meeting",
+            durationS: 3000,
+            audioPath: null,
+            status: "EXPORTED",
+            folderId: null,
+          },
+          note: null,
+          segments,
+          assistantInteractions: [],
+          locked: false,
+          aiProvider: null,
+          aiModel: null,
+          modelServed: null,
+        };
+      },
+    });
+
+    await page.goto("/meeting/m-atlas-roadmap");
+    await page.getByRole("tab", { name: "Audio" }).click();
+
+    // Only the first RENDER_CAP (80) turns render.
+    const turns = page.locator("li.turn");
+    await expect(turns).toHaveCount(80, { timeout: 10_000 });
+
+    // The expander offers the remaining 20.
+    const showAll = page.getByRole("button", { name: /Show all 100 turns/ });
+    await expect(showAll).toBeVisible();
+
+    // Revealing renders all 100 and drops the expander.
+    await showAll.click();
+    await expect(turns).toHaveCount(100);
+    await expect(showAll).toHaveCount(0);
+  });
+});

--- a/e2e/record/stop-optimistic.spec.ts
+++ b/e2e/record/stop-optimistic.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Long-meeting Stop UX — the Stop button must flip out of the recording state IMMEDIATELY on click.
+ *
+ * `stop_recording` runs the whole pipeline inline (transcribe the entire recording + generate the
+ * note), which for a long meeting takes minutes. The store's `stop()` now sets `_stage` to
+ * "transcribing" BEFORE awaiting that IPC (mirroring `resummarize`), so `isRecording()` goes false
+ * at once: the recording strip (with the Stop button) is swapped for the processing view. Before the
+ * fix, `_stage` stayed "recording" until the pipeline resolved — the Stop button kept rendering and
+ * stayed clickable, so the UI looked frozen and a double-Stop was possible.
+ *
+ * RED contract: with `stop_recording` hanging (never resolving), the pre-fix code leaves the Stop
+ * button visible → `toHaveCount(0)` fails.
+ */
+test.describe("Record — Stop flips to processing immediately", () => {
+  test("clicking Stop swaps the recording strip for the processing view before the pipeline returns", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-rec",
+        startedAt: "2026-07-01T09:00:00Z",
+      }),
+      // The whole transcribe+summarize pipeline runs inside this call — simulate a long-running
+      // (never-resolving) invocation so the assertion lands DURING processing.
+      stop_recording: () => new Promise(() => {}),
+    });
+
+    await page.goto("/record");
+
+    // Start → the recording strip with the Stop button.
+    await page.locator("button.start-btn").click();
+    const stop = page.locator("button.stop-btn");
+    await expect(stop).toBeVisible({ timeout: 10_000 });
+
+    // Stop: the pipeline has NOT returned (mock hangs), yet the UI must leave the recording strip at
+    // once — Stop button gone, processing view shown.
+    await stop.click();
+    await expect(stop).toHaveCount(0);
+    await expect(
+      page.getByText(/Transcribing|Summarizing|Exporting|Processing/i).first(),
+    ).toBeVisible();
+  });
+});

--- a/e2e/settings-ai/stage2-panel.spec.ts
+++ b/e2e/settings-ai/stage2-panel.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "./mock-invoke";
+
+/**
+ * Smoke — the Live-context panel (connector enrichment) mounted right after the note summary in the
+ * meeting-detail Note tab. Mocks the two enrich commands so the panel is fully drivable with no Rust
+ * core:
+ *   enrich_note_context  → a couple of ContextHits
+ *   apply_note_enrichment → a NoteDto (records the hits it was called with)
+ *
+ * Confirms: the egress hint is present + loud; fetch → preview renders with (via …) attribution;
+ * Add → apply called with the hits; Clear → apply called with []; NO NG0600 / ɵcmp / console error.
+ * (Lane A "Refresh links" was removed — links auto-refresh on finalize.)
+ */
+test("live-context panel drives fetch/add/clear with attribution and no console errors", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    enrich_note_context: () => [
+      { source: "Jira", detail: "ATLAS-42 — Windows loopback spike (In Progress)", url: "https://example.atlassian.net/browse/ATLAS-42" },
+      { source: "Slack", detail: "#eng — Marcus: shared sync layer merged", url: null },
+    ],
+    // Record what apply was called with on window so the test can assert it.
+    apply_note_enrichment: (args: { meetingId: string; hits: unknown[] }) => {
+      (window as unknown as { __applyCalls: unknown[] }).__applyCalls ??= [];
+      (window as unknown as { __applyCalls: unknown[][] }).__applyCalls.push(args.hits);
+      return {
+        meetingId: args.meetingId,
+        providerId: "claude_code",
+        markdown: "# Q2 Roadmap Planning\n\n> [!context]- Live context\n> updated",
+        exportedPath: "/Users/demo/Obsidian/Sonora/Meetings/Q2-Roadmap-Planning.md",
+      };
+    },
+  });
+
+  await page.goto("/meeting/m-atlas-roadmap");
+
+  const panel = page.locator("app-stage2-panel");
+  await expect(panel).toBeVisible();
+
+  // The egress affordance is present and loud (compact one-line hint, not the old warning block).
+  await expect(panel.locator(".live-hint")).toContainText(/sends a redacted query/i);
+
+  // ── Fetch (the egress moment) → preview renders with (via …) attribution. ──
+  await panel.getByRole("button", { name: "Fetch live context" }).click();
+  const hits = panel.locator(".hit-item");
+  await expect(hits).toHaveCount(2);
+  await expect(hits.nth(0)).toContainText("via Jira");
+  await expect(hits.nth(0)).toContainText("ATLAS-42");
+  await expect(hits.nth(1)).toContainText("via Slack");
+
+  // ── Add to note → apply_note_enrichment called with the 2 hits. ──
+  await panel.getByRole("button", { name: "Add to note" }).click();
+  await expect(panel.getByText(/the note now carries the live context/i)).toBeVisible();
+  const afterAdd = await page.evaluate(
+    () => (window as unknown as { __applyCalls: unknown[][] }).__applyCalls,
+  );
+  expect(afterAdd).toHaveLength(1);
+  expect(afterAdd[0]).toHaveLength(2);
+
+  // Re-fetch so Clear is available again (Add cleared the applied latch on next fetch).
+  await panel.getByRole("button", { name: "Fetch live context" }).click();
+  await expect(panel.locator(".hit-item")).toHaveCount(2);
+
+  // ── Clear → apply_note_enrichment called with [] (byte-exact undo). ──
+  await panel.getByRole("button", { name: "Clear" }).click();
+  await expect(panel.getByText(/the live-context callout was removed/i)).toBeVisible();
+  const afterClear = await page.evaluate(
+    () => (window as unknown as { __applyCalls: unknown[][] }).__applyCalls,
+  );
+  expect(afterClear).toHaveLength(2);
+  expect(afterClear[1]).toHaveLength(0);
+
+  // No NG0600 / ɵcmp / any other console error surfaced through the whole drive.
+  expect(consoleErrors).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.7.5"
+version = "0.8.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -24,6 +24,21 @@
 use crate::error::Result;
 use crate::reason::LocalReasoner;
 
+/// The BRAIN CASCADE escalation sentinel (Phase 5). A tier's system prompt instructs the model to
+/// reply EXACTLY `{"answer":"__ESCALATE__"}` when the question is NOT answerable at that tier. The
+/// ladder caller ([`crate::transcribe::live`]) detects this in `outcome.answer` and re-runs at the
+/// next tier. It is a DISTINCT signal from `Ok(None)` (the loop ran out of steps → floor WITHIN the
+/// tier): "escalate" means "this tier has no answer, go up"; non-convergence means "I couldn't
+/// converge here". Kept as a shared const so the prompt text and the detector never drift.
+pub const ESCALATE_SENTINEL: &str = "__ESCALATE__";
+
+/// Does this converged answer request escalation to the next cascade tier? True ONLY when the whole
+/// (trimmed) answer IS the sentinel — a substring match would let a real answer that merely mentions
+/// the token escalate by accident. So a genuine Tier-1 answer NEVER escalates.
+pub fn is_escalation(answer: &str) -> bool {
+    answer.trim() == ESCALATE_SENTINEL
+}
+
 /// The outcome of one agentic turn: the brain's final answer, the gated tool-call trace, and the
 /// `[[Title]]` / `(web)` / `(calendar)` citations extracted from GATED tool output only.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,6 +363,20 @@ mod tests {
             !out.steps[0].ok,
             "a failed tool is recorded ok=false, never panics"
         );
+    }
+
+    /// Phase 5: the escalation detector fires ONLY on the exact sentinel (trimmed), never on a real
+    /// answer that merely mentions the token — so a genuine Tier-1 answer does NOT escalate.
+    #[test]
+    fn is_escalation_fires_only_on_the_exact_sentinel() {
+        assert!(is_escalation(ESCALATE_SENTINEL));
+        assert!(is_escalation("  __ESCALATE__  "), "trims surrounding whitespace");
+        assert!(
+            !is_escalation("The meeting is about the __ESCALATE__ feature."),
+            "a real answer that MENTIONS the token must NOT escalate"
+        );
+        assert!(!is_escalation("This is answerable here."), "a real answer never escalates");
+        assert!(!is_escalation(""), "an empty answer is not an escalation");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -398,6 +398,47 @@ pub struct MeetingDetailDto {
 
 // ── Commands (PHASE0-PLAN §7) ──
 
+/// PHASE 6 — set (or clear) the FOCUS meeting: the meeting the user is currently VIEWING /
+/// anchored to, DISTINCT from the recording pointer (`state.current_meeting`, `Some` only while
+/// recording). The FE calls this with `Some(id)` when it opens a meeting-detail / conversation
+/// view and `None` when it closes, so the brain's Tier-1 "this meeting" scope
+/// ([`crate::transcribe::live::resolve_scope_meeting`]) is deterministic even when nothing is
+/// recording AND when a DIFFERENT meeting is recording — the backend safety-net for any assistant
+/// path that falls back off an explicit FE `meeting_id` (the voice/wake twin). This stores ONLY an
+/// id (never meeting content), so there is no seal/verify-before-destroy or clear-on-relock to do:
+/// a relock re-masks the focused meeting's CONTENT through the existing `meeting_is_visible` gate
+/// (`gated_live_context` fail-closes), and the stale id itself leaks nothing. A blank/whitespace
+/// id is treated as clear (`None`). Fail-safe: a poisoned focus mutex recovers via `into_inner()`
+/// (the pointer carries no invariant) rather than bricking the setter. No PII (opaque id only).
+#[tauri::command]
+pub fn set_focus_meeting(
+    state: State<'_, AppState>,
+    meeting_id: Option<String>,
+) -> Result<(), AppError> {
+    set_focus_meeting_inner(state.inner(), meeting_id);
+    Ok(())
+}
+
+/// Inner of [`set_focus_meeting`] taking `&AppState` so it is headless-testable without a
+/// `tauri::State`. Normalizes a blank/whitespace id to `None` (clear) and fail-safes on a poisoned
+/// focus mutex via `into_inner()` (the pointer carries no invariant, so recovering it is safe and
+/// never bricks the setter). No PII (opaque id only).
+pub(crate) fn set_focus_meeting_inner(state: &AppState, meeting_id: Option<String>) {
+    let normalized = meeting_id
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let mut focus = state
+        .focus_meeting
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *focus = normalized;
+    tracing::debug!(
+        target: "brain",
+        has_focus = focus.is_some(),
+        "focus meeting updated"
+    );
+}
+
 /// Begin mic capture. Inserts a Meeting(Draft→Recording), stores Recorder in state,
 /// sets current_meeting. Returns the new meeting id. Errors if already recording.
 #[tauri::command]
@@ -983,11 +1024,16 @@ pub(crate) fn end_voice_command_inner(state: &AppState) -> Result<VoiceCommandEn
 /// `thread_id` is OPTIONAL: the FE passes an @brain thread's id to keep the exchange in that
 /// thread; when absent (the voice/wake twin sends none) the backend GENERATES a UUID v4 inside the
 /// turn, so every persisted exchange carries a thread identity going forward.
+/// `meeting_id` (FE camelCase `meetingId`) is the OPTIONAL scope meeting this thread is bound to
+/// (Phase 4): the backend resolves `meeting_id.or(state.current_meeting)`, so an explicit FE id wins
+/// (a past/anchored thread scopes correctly) while a `None` keeps the live-recording pointer. This is
+/// what kills the wrong-meeting bug (idle @brain no longer defaults to a vault-wide arbitrary meeting).
 #[tauri::command]
 pub fn ask_assistant_text(
     app: AppHandle,
     text: String,
     thread_id: Option<String>,
+    meeting_id: Option<String>,
 ) -> Result<(), AppError> {
     let text = text.trim().to_string();
     if text.is_empty() {
@@ -997,7 +1043,7 @@ pub fn ask_assistant_text(
         crate::events::EVENT_VOICE_COMMAND_PROCESSING,
         crate::events::VoiceCommandProcessingPayload { active: true },
     );
-    crate::transcribe::live::spawn_assistant_turn(app, text, thread_id);
+    crate::transcribe::live::spawn_assistant_turn(app, text, thread_id, meeting_id);
     Ok(())
 }
 
@@ -1053,12 +1099,18 @@ fn format_chat(messages: &[ChatMsg]) -> Result<(String, String), AppError> {
 /// the @brain thread this exchange belongs to, and the note text the thread was anchored to. A
 /// missing `thread_id` is backend-generated (UUID v4) so every persisted exchange carries one. The
 /// PERSISTED row's `command` is `latest` — the user's newest message, never the rendered history.
+/// `meeting_id` (FE camelCase `meetingId`) is the OPTIONAL scope meeting the FE binds this thread to
+/// (Phase 4): resolved as `meeting_id.or(state.current_meeting)` so an explicit FE id wins (a bound
+/// past/anchored thread answers about ITS meeting even while a different meeting records) and a
+/// `None` keeps the live-recording pointer. The resolved id is what `gated_live_context` /
+/// the executor scope to AND what the persisted thread row is bound to — killing the wrong-meeting bug.
 #[tauri::command]
 pub async fn ask_assistant_chat(
     app: AppHandle,
     messages: Vec<ChatMsg>,
     thread_id: Option<String>,
     anchor_text: Option<String>,
+    meeting_id: Option<String>,
 ) -> Result<crate::voice_action::VoiceActionResult, AppError> {
     let (latest, conversation) = format_chat(&messages)?;
     let thread_id = crate::transcribe::live::ensure_thread_id(thread_id);
@@ -1070,6 +1122,7 @@ pub async fn ask_assistant_chat(
             crate::events::EVENT_CHAT_TOOL,
             &thread_id,
             anchor_text.as_deref(),
+            meeting_id.as_deref(),
         )
     })
     .await
@@ -1330,6 +1383,299 @@ pub(crate) fn apply_note_verify_markers_inner(
         markdown: marked,
         exported_path: existing.exported_path,
     })
+}
+
+/// `enrich_note_context(meeting_id) -> Vec<ContextHit>` — CONNECTOR-AGNOSTIC preview of live context
+/// to fold into the note. Read side: gathers hits from EVERY exposed (enabled + consented + keyed)
+/// connector via the same registry the brain uses. Two modes (see the research brief):
+/// - **Identifier lookup** (precise, minimal egress): Jira issue keys already in the note → live
+///   `jira_lookup`. Only a validated `PROJ-123` leaves the Mac — never note content.
+/// - **Free-text search** (fuzzy): every OTHER exposed connector (Slack/web) is searched for the
+///   meeting's TITLE, through the framework's redaction + content-free egress ledger.
+///
+/// This is the EGRESS moment (an explicit user action, like `verify_note_sources`); the returned
+/// hits are reviewed in the FE and only WRITTEN by `apply_note_enrichment`. Lock-gated: a
+/// sealed-not-unlocked meeting refuses BEFORE any connector call. Empty vec = nothing to add.
+#[tauri::command]
+pub async fn enrich_note_context(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<crate::enrich::ContextHit>, AppError> {
+    enrich_note_context_inner(state.inner(), meeting_id).await
+}
+
+/// How many free-text search hits to keep per connector (bounds egress-result noise; the caller
+/// still reviews + can drop each before applying).
+const ENRICH_SEARCH_HITS_PER_CONNECTOR: usize = 3;
+
+pub(crate) async fn enrich_note_context_inner(
+    state: &AppState,
+    meeting_id: String,
+) -> Result<Vec<crate::enrich::ContextHit>, AppError> {
+    // READ-GATE FIRST — a sealed-not-unlocked meeting refuses before ANY connector egress.
+    if !meeting_is_unlocked(state, &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to add live context".into(),
+        ));
+    }
+    let note = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    // Clean base = the note with our own prior context block stripped, so key-extraction sees the
+    // canonical prose (never our appended callout).
+    let base = crate::enrich::apply_context_markers(&note.markdown, &[], "");
+    let title = state
+        .db
+        .get_meeting(&meeting_id)?
+        .and_then(|m| m.title)
+        .unwrap_or_default();
+
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Other(anyhow::anyhow!("config lock")))?
+        .clone();
+    let registry = crate::connectors::ConnectorRegistry::build(&config);
+
+    let mut hits: Vec<crate::enrich::ContextHit> = Vec::new();
+
+    // ── Identifier-lookup mode (precise): Jira issue keys → live status. Egresses only the key. ──
+    if registry.has("jira") {
+        for (_line, key) in crate::verify::extract_issue_keys(&base) {
+            if let Ok(Some(snap)) = registry.jira_lookup(&key).await {
+                let mut detail = format!("{} · {}", snap.key, snap.status);
+                if let Some(due) = snap.due.as_deref().filter(|d| !d.is_empty()) {
+                    detail.push_str(&format!(" · due {due}"));
+                }
+                if !snap.summary.is_empty() {
+                    detail.push_str(&format!(" — {}", snap.summary));
+                }
+                hits.push(crate::enrich::ContextHit {
+                    source: "Jira".to_string(),
+                    detail,
+                    url: Some(snap.url).filter(|u| !u.is_empty()),
+                });
+            }
+        }
+    }
+
+    // ── Free-text search mode (fuzzy): every OTHER exposed connector, queried on the meeting title.
+    // The query is redacted + ledgered by the registry; skip when there is no title to search on. ──
+    if !title.trim().is_empty() {
+        for id in registry.ids() {
+            if id == "jira" {
+                continue; // handled precisely above — never double-pull Jira.
+            }
+            if let Ok(results) = registry.search(id, &title).await {
+                for hit in results.into_iter().take(ENRICH_SEARCH_HITS_PER_CONNECTOR) {
+                    let detail = if hit.snippet.trim().is_empty() {
+                        hit.title
+                    } else {
+                        format!("{} — {}", hit.title, hit.snippet)
+                    };
+                    hits.push(crate::enrich::ContextHit {
+                        // Loud attribution from the connector itself (e.g. "Slack", "web · Brave").
+                        source: hit.source_label,
+                        detail,
+                        url: Some(hit.url).filter(|u| !u.is_empty()),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(hits)
+}
+
+/// `apply_note_enrichment(meeting_id, hits) -> NoteDto` — WRITE the reviewed context hits into the
+/// note as one consolidated `> [!context]-` callout (dated now), via the EXACT `update_note` save +
+/// re-export tail — so it persists in the CANONICAL DB note markdown and SEALS with the note under
+/// the folder lock (NOT the vault-file-only path). No egress here (the hits were fetched by
+/// `enrich_note_context`). Lock-gated. Passing an empty `hits` STRIPS the block (byte-exact undo).
+#[tauri::command]
+pub fn apply_note_enrichment(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    hits: Vec<crate::enrich::ContextHit>,
+) -> Result<NoteDto, AppError> {
+    apply_note_enrichment_inner(state.inner(), meeting_id, hits)
+}
+
+pub(crate) fn apply_note_enrichment_inner(
+    state: &AppState,
+    meeting_id: String,
+    hits: Vec<crate::enrich::ContextHit>,
+) -> Result<NoteDto, AppError> {
+    // BLK-1 / TOCTOU: hold the lifecycle guard across the whole check-then-write so a concurrent seal
+    // cannot slip between the gate and the `upsert_note`+`overwrite_note` (same leak class Lane A's
+    // `link_related_notes_inner` guards). Lock order `lifecycle ⊃ db`.
+    let _lifecycle = lifecycle_guard(state);
+    if !meeting_is_unlocked(state, &meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to edit the note".into(),
+        ));
+    }
+    // SEAL-SAFETY GATE (mirrors Lane A): a SEALED note (any provider row carries a content_blob) has a
+    // TRANSIENT `markdown` column — blanked on relock, restored from `content_blob` on unlock. Writing
+    // enriched markdown into it would be silently dropped on the next relock (content_blob is
+    // canonical), and — for the auto-file-into-locked case where the column is blank but the folder is
+    // session-unlocked — could re-materialize plaintext into a sealed note. So refuse enrichment on a
+    // sealed note even when the session has it unlocked.
+    let sealed = state
+        .db
+        .sealable_notes_for_meeting(&meeting_id)?
+        .iter()
+        .any(|n| n.content_blob.is_some());
+    if sealed {
+        return Err(AppError::Locked(
+            "this meeting's note is sealed — enrichment can't be persisted while locked".into(),
+        ));
+    }
+    let existing = state
+        .db
+        .get_latest_note_for_meeting(&meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no note for meeting {meeting_id}")))?;
+    let as_of = chrono::Utc::now().to_rfc3339();
+    let enriched = crate::enrich::apply_context_markers(&existing.markdown, &hits, &as_of);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    state.db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.clone(),
+        provider_id: existing.provider_id.clone(),
+        markdown: enriched.clone(),
+        created_at,
+        exported_path: existing.exported_path.clone(),
+        model_requested: existing.model_requested.clone(),
+        model_served: existing.model_served.clone(),
+        gateway_host: existing.gateway_host.clone(),
+    })?;
+    if let Some(path) = existing.exported_path.as_deref() {
+        crate::export::overwrite_note(std::path::Path::new(path), &enriched)?;
+    }
+    Ok(NoteDto {
+        meeting_id,
+        provider_id: existing.provider_id,
+        markdown: enriched,
+        exported_path: existing.exported_path,
+    })
+}
+
+/// Max cross-meeting links Lane A appends to a note (small + high-precision — a note gains a handful
+/// of related links, not a research dump).
+const MAX_RELATED_LINKS: usize = 4;
+
+/// Stage 2 / Lane A — the DETERMINISTIC, ZERO-EGRESS cross-meeting LINKING pass over a FINISHED note.
+///
+/// Mirrors [`apply_note_enrichment_inner`] (the shipped Lane B persist seam): gate → retrieve →
+/// render → `upsert_note` (DB-canonical, so the links SEAL with the note) → re-export the vault
+/// `.md`. Retrieval is [`related_context::related_note_links`], which is DOUBLE visibility-gated
+/// (`search_visible` + `get_note_if_visible` on the live unlock set) and self-excluding — a
+/// sealed-not-unlocked related note contributes NO link. Empty hits STRIP any stale links block
+/// (byte-exact undo), so re-running self-heals the link graph. Idempotent + reversible via
+/// `apply_link_markers`.
+///
+/// EGRESS: NONE. Lane A is fully local — a search over OWNED notes plus a local task-free gist. No
+/// provider, no connector, no consent gate needed (nothing leaves the device).
+///
+/// SEAL-SAFETY (stronger than the read gate, load-bearing): after the `meeting_is_unlocked` read
+/// gate, we ALSO require the note to be genuinely UNSEALED (`content_blob IS NULL` on every provider
+/// row). A note in a locked folder is SEALED: its `markdown` column is transient (blanked on relock,
+/// restored from `content_blob` on unlock) and its durable source of truth is `content_blob`.
+/// Writing links into a sealed note's `markdown` column would either corrupt a just-sealed (blanked)
+/// column (the auto-file-into-locked case, where the column is empty but the folder is session-
+/// unlocked) or be silently dropped on the next relock (the column is discarded, `content_blob` is
+/// canonical). So a sealed meeting is skipped even when the session happens to have it unlocked —
+/// which is exactly what makes "persist DB-canonical so it SEALS with the note" true here.
+pub(crate) fn link_related_notes_inner(state: &AppState, meeting_id: &str) -> Result<(), AppError> {
+    // BLK-1 / TOCTOU: hold the lifecycle guard for the WHOLE check-then-write so a concurrent
+    // `lock_folder`/`move_into_locked_folder`/`relock` cannot seal this meeting BETWEEN the seal-safety
+    // gate below and the `upsert_note`+`overwrite_note` — which would re-materialize a plaintext `.md`
+    // into a now-locked folder's vault dir (the Phase-2 lock-security TOCTOU leak). Every seal path
+    // holds this same guard (`lock_folder_inner`/`move_into_locked_folder`/`relock_all_inner`/
+    // `remove_lock_inner`), and the storage-prune was forced to take it by a prior TOCTOU finding.
+    // Lock order is `lifecycle ⊃ db` (matching `lock_folder_inner`).
+    let _lifecycle = lifecycle_guard(state);
+    // READ GATE: a sealed-not-session-unlocked meeting is silently skipped — never link a locked note.
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Ok(());
+    }
+    // SEAL-SAFETY GATE: only write the markdown COLUMN of an UNSEALED note (durable canonical). A
+    // sealed note (any provider row has a content_blob) is skipped even if session-unlocked. Read
+    // UNDER the lifecycle guard, so a seal cannot slip in after this check and before the write.
+    let sealed = state
+        .db
+        .sealable_notes_for_meeting(meeting_id)?
+        .iter()
+        .any(|n| n.content_blob.is_some());
+    if sealed {
+        return Ok(());
+    }
+    let Some(existing) = state.db.get_latest_note_for_meeting(meeting_id)? else {
+        return Ok(()); // no note yet → nothing to link.
+    };
+    let title = state
+        .db
+        .get_meeting(meeting_id)?
+        .and_then(|m| m.title)
+        .unwrap_or_default();
+    // Derive the salient query from the CANONICAL prose — strip our OWN links block first so a
+    // re-link never keys the query off a previous run's `[[Title]]` links (stable / self-healing).
+    let base = crate::enrich::apply_link_markers(&existing.markdown, &[]);
+    let query = crate::summarize::related_context::salient_query(
+        (!title.trim().is_empty()).then_some(title.as_str()),
+        &base,
+    );
+    // Snapshot the live unlocked set (the SAME gate the retrieval keys on).
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    let hits = crate::summarize::related_context::related_note_links(
+        &state.db,
+        meeting_id,
+        &query,
+        &unlocked,
+        MAX_RELATED_LINKS,
+    )?;
+    // Empty hits ⇒ `apply_link_markers` strips any stale links block (byte-exact). Non-empty ⇒ replace.
+    // No `as_of`: cross-meeting links are timeless (owned notes), so the block is a pure function of
+    // (note, hits) → the `linked == existing.markdown` short-circuit below skips a rewrite when the
+    // link set is unchanged, so the deferred auto-pass never churns the note / vault `.md`.
+    let linked = crate::enrich::apply_link_markers(&existing.markdown, &hits);
+    // No change (no hits AND no stale block) ⇒ nothing to persist; avoid a needless write + re-export.
+    if linked == existing.markdown {
+        return Ok(());
+    }
+    let created_at = chrono::Utc::now().to_rfc3339();
+    state.db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.to_string(),
+        provider_id: existing.provider_id.clone(),
+        markdown: linked.clone(),
+        created_at,
+        exported_path: existing.exported_path.clone(),
+        model_requested: existing.model_requested.clone(),
+        model_served: existing.model_served.clone(),
+        gateway_host: existing.gateway_host.clone(),
+    })?;
+    if let Some(path) = existing.exported_path.as_deref() {
+        crate::export::overwrite_note(std::path::Path::new(path), &linked)?;
+    }
+    Ok(())
+}
+
+/// `link_related_notes(meeting_id)` — MANUAL re-link / backfill trigger for the Stage 2 / Lane A
+/// pass. The AUTO pipeline runs the same [`link_related_notes_inner`] as a deferred post-`Exported`
+/// pass; this command lets the user (or a backfill over old notes) re-run it on demand. Lock-gated +
+/// seal-safe (a sealed meeting is a silent no-op) and ZERO egress.
+#[tauri::command]
+pub fn link_related_notes(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<(), AppError> {
+    link_related_notes_inner(state.inner(), &meeting_id)
 }
 
 /// brain2 realtime typed @brain notes — persist the user's free-text notes typed DURING a meeting
@@ -3236,9 +3582,9 @@ pub async fn ask_vault(
     .await
 }
 
-/// Max agentic rounds for the Ask surface. Not live-latency-bound like the in-meeting loop
-/// (`CLOUD_MAX_STEPS` = 4), so it gets a little more room to search + read before answering —
-/// still strictly bounded.
+/// Max agentic rounds for the Ask surface. Not live-latency-bound like the in-meeting cascade tiers
+/// (`TIER1/2/3_MAX_STEPS` in `transcribe::live`, kept small so up-to-three tiers stay live-safe), so
+/// the deliberately vault-wide Ask page gets a little more room to search + read — still bounded.
 const ASK_MAX_STEPS: usize = 6;
 
 /// Cap the incoming Ask history to the last [`CHAT_CONTEXT_TURNS`] turns — the same discipline as
@@ -3280,6 +3626,10 @@ fn ask_vault_agentic_attempt(
         app: Some(app),
         allow_writes: false,
         note_drafts: false,
+        // The Ask page is DELIBERATELY vault-wide (Phase 5 preserves it unchanged) — the FULL
+        // per-surface catalog, NOT a cascade tier: it is not the in-meeting @brain surface the
+        // current-first cascade governs.
+        scope: crate::tools::AssistantScope::Full,
         proposed_note: std::sync::Mutex::new(None),
     };
     let sink = crate::transcribe::live::ToolEventSink {
@@ -3602,6 +3952,7 @@ mod ask_vault_tests {
             app: None,
             allow_writes: false,
             note_drafts: false,
+            scope: crate::tools::AssistantScope::Full,
             proposed_note: Mutex::new(None),
         }
     }
@@ -3899,6 +4250,7 @@ mod ask_vault_tests {
             app: None,
             allow_writes: false,
             note_drafts: true,
+            scope: crate::tools::AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         assert!(
@@ -4325,6 +4677,64 @@ pub fn get_config(state: State<'_, AppState>) -> Result<AppConfigDto, AppError> 
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
     Ok(config_to_dto(&config))
+}
+
+/// Build the ready-to-paste Claude Code MCP config block for the localhost MCP server, WITH the
+/// bearer token when `mcp_require_token` is on (the default). Fixes the handshake failure where
+/// the copied snippet had no token so Claude Code got `-32001 unauthorized` on `initialize`.
+///
+/// Shape (pretty-printed, 2-space indent — `type: "http"` is required by Claude Code):
+/// ```json
+/// {
+///   "mcpServers": {
+///     "murmur": {
+///       "type": "http",
+///       "url": "http://127.0.0.1:8765",
+///       "headers": { "Authorization": "Bearer <token>" }
+///     }
+///   }
+/// }
+/// ```
+/// When `mcp_require_token` is OFF the server serves unauthenticated, so the `headers` block is
+/// omitted entirely (no stale/placeholder Authorization header is ever emitted).
+///
+/// SECURITY: this surfaces the MCP bearer token to the LOCAL frontend for display in Settings so
+/// the user can paste it into their own Claude Code config. It is NOT network egress — the token
+/// never leaves the machine except by the user's manual copy. When the token flag is off no token
+/// is read at all. Lock-security review requested.
+#[tauri::command]
+pub fn get_mcp_config(state: State<'_, AppState>) -> Result<String, AppError> {
+    get_mcp_config_inner(state.inner())
+}
+
+/// Headless core of [`get_mcp_config`] — testable without a Tauri `State`.
+pub(crate) fn get_mcp_config_inner(state: &AppState) -> Result<String, AppError> {
+    // Read the flag the same way lib.rs does: fail CLOSED (require the token) on a poisoned lock,
+    // so a broken config never emits an unauthenticated config for a server that DOES enforce.
+    let require_token = state
+        .config
+        .lock()
+        .map(|c| c.mcp_require_token)
+        .unwrap_or(true);
+
+    let url = format!("http://127.0.0.1:{}", crate::mcp::MCP_PORT);
+    let mut server = serde_json::json!({
+        "type": "http",
+        "url": url,
+    });
+    if require_token {
+        // Only read/mint the token when the server actually enforces it. On a keychain failure this
+        // returns AppError (the FE shows an error) — never a config with an empty/placeholder token.
+        let token = crate::secrets::get_or_create_mcp_token()?;
+        server["headers"] = serde_json::json!({
+            "Authorization": format!("Bearer {token}"),
+        });
+    }
+    let config = serde_json::json!({
+        "mcpServers": { "murmur": server },
+    });
+    serde_json::to_string_pretty(&config)
+        .map_err(|e| AppError::Other(anyhow::anyhow!("serialize MCP config: {e}")))
 }
 
 /// Persist config to settings table + refresh in-memory cache. Does NOT touch Keychain.
@@ -6743,6 +7153,33 @@ fn move_into_locked_folder(
     // association), THEN seal that one meeting's note + extras under the folder CK.
     state.db.set_meeting_folder(meeting_id, Some(folder_id))?;
     seal_moved_note(state, folder_id, meeting_id, &ck)?;
+
+    // The destination folder is SESSION-UNLOCKED (checked above), so the moved note MUST be READABLE
+    // in-session exactly like its folder-mates — otherwise it shows EMPTY under the open padlock (the
+    // seal just blanked its plaintext and nothing restored it: the "private note came back empty"
+    // bug). Decrypt the just-sealed note markdown + transcript/timeline/audio back into the plaintext
+    // columns FOR THE SESSION; every `content_blob`/`*_blob`/`.enc` STAYS at rest (folder is still
+    // `locked=1` on disk), so a relock/app-kill re-seals cleanly with no plaintext left behind. This
+    // is verify-clean by construction: `seal_moved_note` above already proved each blob decrypts back
+    // byte-identical BEFORE it blanked anything, so this restore can only reproduce that same content.
+    // Mirrors `unlock_folder`'s per-meeting restore, scoped to this one moved meeting. Under the
+    // lifecycle guard held for the whole move, so no relock can interleave.
+    for n in &state.db.sealable_notes_for_meeting(meeting_id)? {
+        let Some(blob) = &n.content_blob else { continue };
+        let aad = aad_content(folder_id, meeting_id, &n.provider_id, "note");
+        let pt = crate::crypto::decrypt(&ck, blob, &aad)?;
+        let markdown = String::from_utf8(pt)
+            .map_err(|_| AppError::Storage("decrypted moved note is not valid UTF-8".into()))?;
+        state
+            .db
+            .restore_note_markdown(meeting_id, &n.provider_id, &markdown)?;
+    }
+    unseal_meeting_extras(state, folder_id, meeting_id, &ck)?;
+    // Re-index this one meeting so semantic search / related-meetings recover in-session (its note
+    // markdown was just restored above). Model-gated (never a stub vector); best-effort — a re-index
+    // hiccup must not fail (or half-undo) the completed move.
+    let meeting_embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    reindex_meetings_after_unseal(state, &[meeting_id.to_string()], meeting_embedder.as_deref());
     Ok(())
 }
 
@@ -8442,6 +8879,71 @@ fn reindex_meetings_after_unseal(
     }
 }
 
+/// SESSION-unseal the transcript + timeline + typed notes + audio of ONE meeting back into its
+/// plaintext columns under the folder CK, KEEPING every `*_blob` / `.enc` at rest (the folder is
+/// still `locked=1` on disk). Extracted verbatim from `unseal_folder_extras`'s per-meeting body so
+/// the SAME verified restore serves both a full folder unlock AND a single note MOVED into a
+/// session-unlocked locked folder — the moved note must read identically to its folder-mates, never
+/// come back blank under the open padlock. Does NOT restore the note MARKDOWN (that is per-provider,
+/// keyed on `content_blob`, and the callers restore it before/after this) nor re-index (also caller's
+/// job — after markdown is back).
+fn unseal_meeting_extras(
+    state: &AppState,
+    folder_id: &str,
+    mid: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    for s in state.db.raw_segments(mid)? {
+        let Some(blob) = &s.text_blob else { continue };
+        let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "segment");
+        let pt = crate::crypto::decrypt(ck, blob, &aad)?;
+        let text = String::from_utf8(pt)
+            .map_err(|_| AppError::Storage("decrypted segment is not valid UTF-8".into()))?;
+        state.db.restore_segment_text(mid, s.idx, &text)?;
+    }
+    if let Some(tl) = state.db.raw_timeline(mid)? {
+        if let Some(blob) = &tl.data_blob {
+            let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "timeline");
+            let pt = crate::crypto::decrypt(ck, blob, &aad)?;
+            let data = String::from_utf8(pt)
+                .map_err(|_| AppError::Storage("decrypted timeline is not valid UTF-8".into()))?;
+            state.db.restore_timeline_data(mid, &data)?;
+        }
+    }
+    // Typed notes: decrypt the sealed blob back into the plaintext column for the session (the
+    // blob is kept — the folder is still locked on disk). Mirrors the timeline unseal.
+    if let Some(rn) = state.db.raw_manual_notes(mid)? {
+        if let Some(blob) = &rn.blob {
+            let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "manual_notes");
+            let pt = crate::crypto::decrypt(ck, blob, &aad)?;
+            let text = String::from_utf8(pt)
+                .map_err(|_| AppError::Storage("decrypted manual notes is not valid UTF-8".into()))?;
+            state.db.set_manual_notes(mid, &text)?;
+        }
+    }
+    // Audio at rest: materialize a playable WAV for the session (playback + both masters), each
+    // decrypted through the role→role-less AAD ladder (a pre-role master still decrypts); the
+    // .enc is kept (folder still locked on disk).
+    let (pb_role, pb_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Playback);
+    if let Some(plain) = session_unseal_audio(
+        ck,
+        state.db.get_meeting(mid)?.and_then(|m| m.audio_path),
+        &[&pb_role, &pb_less],
+    )? {
+        state.db.set_meeting_audio_path(mid, Some(&plain))?;
+    }
+    let (mic, sys) = state.db.get_meeting_master_paths(mid)?;
+    let (mic_role, mic_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Mic);
+    if let Some(plain) = session_unseal_audio(ck, mic, &[&mic_role, &mic_less])? {
+        state.db.set_meeting_mic_master_path(mid, Some(&plain))?;
+    }
+    let (sys_role, sys_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Sys);
+    if let Some(plain) = session_unseal_audio(ck, sys, &[&sys_role, &sys_less])? {
+        state.db.set_meeting_sys_master_path(mid, Some(&plain))?;
+    }
+    Ok(())
+}
+
 /// `meeting_embedder` is the model-gated embedder for the MEETING re-index, resolved by the CALLER
 /// (`embed_model_present().then(active_embedder)`) and passed in — `Some(real e5)` re-indexes the
 /// folder's meetings, `None` (model absent) writes nothing (never a stub vector). It is injected
@@ -8456,56 +8958,7 @@ fn unseal_folder_extras(
 ) -> Result<(), AppError> {
     let meeting_ids = state.db.meeting_ids_in_folder(folder_id)?;
     for mid in &meeting_ids {
-        for s in state.db.raw_segments(mid)? {
-            let Some(blob) = &s.text_blob else { continue };
-            let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "segment");
-            let pt = crate::crypto::decrypt(ck, blob, &aad)?;
-            let text = String::from_utf8(pt)
-                .map_err(|_| AppError::Storage("decrypted segment is not valid UTF-8".into()))?;
-            state.db.restore_segment_text(mid, s.idx, &text)?;
-        }
-        if let Some(tl) = state.db.raw_timeline(mid)? {
-            if let Some(blob) = &tl.data_blob {
-                let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "timeline");
-                let pt = crate::crypto::decrypt(ck, blob, &aad)?;
-                let data = String::from_utf8(pt).map_err(|_| {
-                    AppError::Storage("decrypted timeline is not valid UTF-8".into())
-                })?;
-                state.db.restore_timeline_data(mid, &data)?;
-            }
-        }
-        // Typed notes: decrypt the sealed blob back into the plaintext column for the session (the
-        // blob is kept — the folder is still locked on disk). Mirrors the timeline unseal.
-        if let Some(rn) = state.db.raw_manual_notes(mid)? {
-            if let Some(blob) = &rn.blob {
-                let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "manual_notes");
-                let pt = crate::crypto::decrypt(ck, blob, &aad)?;
-                let text = String::from_utf8(pt).map_err(|_| {
-                    AppError::Storage("decrypted manual notes is not valid UTF-8".into())
-                })?;
-                state.db.set_manual_notes(mid, &text)?;
-            }
-        }
-        // Audio at rest: materialize a playable WAV for the session (playback + both masters), each
-        // decrypted through the role→role-less AAD ladder (a pre-role master still decrypts); the
-        // .enc is kept (folder still locked on disk).
-        let (pb_role, pb_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Playback);
-        if let Some(plain) = session_unseal_audio(
-            ck,
-            state.db.get_meeting(mid)?.and_then(|m| m.audio_path),
-            &[&pb_role, &pb_less],
-        )? {
-            state.db.set_meeting_audio_path(mid, Some(&plain))?;
-        }
-        let (mic, sys) = state.db.get_meeting_master_paths(mid)?;
-        let (mic_role, mic_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Mic);
-        if let Some(plain) = session_unseal_audio(ck, mic, &[&mic_role, &mic_less])? {
-            state.db.set_meeting_mic_master_path(mid, Some(&plain))?;
-        }
-        let (sys_role, sys_less) = audio_decrypt_ladder(mid, folder_id, StreamRole::Sys);
-        if let Some(plain) = session_unseal_audio(ck, sys, &[&sys_role, &sys_less])? {
-            state.db.set_meeting_sys_master_path(mid, Some(&plain))?;
-        }
+        unseal_meeting_extras(state, folder_id, mid, ck)?;
     }
     // Document ingestion: decrypt each sealed document's text back into the plaintext column for the
     // session (the blob is kept — folder still locked on disk), then RE-EMBED so semantic search /
@@ -10964,6 +11417,7 @@ mod lifecycle_tests {
             config: Arc::new(Mutex::new(AppConfig::default())),
             reasoner: crate::reason::ReasonerCell::fixed(Arc::new(crate::reason::StubReasoner)),
             current_meeting: Mutex::new(None),
+            focus_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
             capped_notified: std::sync::atomic::AtomicBool::new(false),
             reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
@@ -11049,6 +11503,271 @@ mod lifecycle_tests {
         assert!(
             matches!(e3, AppError::Unavailable(_)),
             "past the lock gate, an unconfigured Jira verify fails Unavailable, got: {e3:?}"
+        );
+    }
+
+    /// `get_mcp_config` must emit a ready-to-paste Claude Code config: `type: "http"`, the
+    /// localhost url, and — when `mcp_require_token` is ON (the default the server enforces) — an
+    /// `Authorization: Bearer <token>` header with a NON-EMPTY token (fixes the `-32001 unauthorized`
+    /// handshake). When the flag is OFF the server serves unauthenticated, so NO `headers` block is
+    /// emitted (no stale/placeholder header). Runs in a debug/test build, so `get_or_create_mcp_token`
+    /// mints into the dev-secrets file store — no Keychain, no `security` CLI.
+    #[test]
+    fn get_mcp_config_carries_token_when_required_and_omits_it_when_off() {
+        let state = build_state("mcp-config");
+
+        // require_token ON (default) → type/url present + a real bearer token in headers.
+        state.config.lock().unwrap().mcp_require_token = true;
+        let on = get_mcp_config_inner(&state).unwrap();
+        let v_on: serde_json::Value = serde_json::from_str(&on).expect("config is valid JSON");
+        let server = &v_on["mcpServers"]["murmur"];
+        assert_eq!(server["type"], "http", "config must declare type: http");
+        assert_eq!(
+            server["url"],
+            format!("http://127.0.0.1:{}", crate::mcp::MCP_PORT),
+            "config url must be the localhost MCP address"
+        );
+        let auth = server["headers"]["Authorization"]
+            .as_str()
+            .expect("Authorization header present when token required");
+        let bearer = auth
+            .strip_prefix("Bearer ")
+            .expect("Authorization is a Bearer header");
+        assert!(
+            !bearer.is_empty(),
+            "the bearer token must be non-empty (never a placeholder), got: {auth:?}"
+        );
+
+        // require_token OFF → the server is unauthenticated, so NO headers block is emitted.
+        state.config.lock().unwrap().mcp_require_token = false;
+        let off = get_mcp_config_inner(&state).unwrap();
+        let v_off: serde_json::Value = serde_json::from_str(&off).expect("config is valid JSON");
+        let server_off = &v_off["mcpServers"]["murmur"];
+        assert_eq!(server_off["type"], "http");
+        assert!(
+            server_off.get("headers").is_none(),
+            "no Authorization header when the token flag is off, got: {off}"
+        );
+    }
+
+    /// ENRICH lock gate (RED-before-GREEN): both `enrich_note_context` (read/egress) and
+    /// `apply_note_enrichment` (write) MUST refuse a SEALED-and-not-session-unlocked meeting with
+    /// `AppError::Locked` BEFORE any note read / connector egress / write. With NO connectors
+    /// configured, once unlocked the preview returns an empty vec (nothing to add — graceful),
+    /// proving Locked was the FIRST gate.
+    #[test]
+    fn enrich_commands_refuse_a_sealed_meeting() {
+        let state = build_state("enrich-lockgate");
+        make_open_folder(&state.db, "f-elock", "Secret");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-elock".to_string(),
+                started_at: "2026-07-05T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Sprint".to_string()),
+                duration_s: 600,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: Some("f-elock".to_string()),
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m-elock".to_string(),
+                provider_id: "claude_code".to_string(),
+                markdown: "# N\n- Ship PROJ-1 by 2026-07-08\n".to_string(),
+                created_at: "2026-07-05T09:10:00Z".to_string(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state.db.set_note_folder("m-elock", Some("f-elock")).unwrap();
+        state
+            .db
+            .set_folder_locked("f-elock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        // Sealed → both refuse Locked before any egress/write.
+        let e1 = block_on(enrich_note_context_inner(&state, "m-elock".to_string())).unwrap_err();
+        assert!(matches!(e1, AppError::Locked(_)), "preview must fail Locked, got: {e1:?}");
+        let hit = crate::enrich::ContextHit {
+            source: "Jira".into(),
+            detail: "PROJ-1 · Done".into(),
+            url: None,
+        };
+        let e2 =
+            apply_note_enrichment_inner(&state, "m-elock".to_string(), vec![hit]).unwrap_err();
+        assert!(matches!(e2, AppError::Locked(_)), "apply must fail Locked, got: {e2:?}");
+
+        // Session-unlock → the lock gate passes; with no connectors the preview is graceful-empty.
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-elock".to_string());
+        let hits = block_on(enrich_note_context_inner(&state, "m-elock".to_string())).unwrap();
+        assert!(hits.is_empty(), "no connectors configured ⇒ nothing to enrich, got: {hits:?}");
+    }
+
+    /// The enrich WRITE path persists a reviewed context block into the canonical DB note and
+    /// strips it byte-exact on an empty apply — through the real command tail (upsert + re-export).
+    #[test]
+    fn apply_note_enrichment_writes_then_strips_byte_exact() {
+        let state = build_state("enrich-write");
+        make_open_folder(&state.db, "f-open", "Project");
+        seed_meeting(&state.db, "m1", "# Notes\n- decided to ship\n", Some("f-open"));
+        let original = state
+            .db
+            .get_latest_note_for_meeting("m1")
+            .unwrap()
+            .unwrap()
+            .markdown;
+
+        let hits = vec![crate::enrich::ContextHit {
+            source: "Jira".into(),
+            detail: "PROJ-1 · In Progress".into(),
+            url: Some("https://x/browse/PROJ-1".into()),
+        }];
+        let dto = apply_note_enrichment_inner(&state, "m1".to_string(), hits).unwrap();
+        assert!(dto.markdown.contains("> [!context]-"), "the context callout was written");
+        assert!(dto.markdown.contains("PROJ-1 · In Progress (via Jira)"), "loud attribution present");
+        assert!(dto.markdown.starts_with(&original), "the original note is preserved verbatim");
+        // The DB note now carries the block.
+        assert!(state
+            .db
+            .get_latest_note_for_meeting("m1")
+            .unwrap()
+            .unwrap()
+            .markdown
+            .contains("[!context]-"));
+
+        // Empty apply strips it byte-exact back to the original.
+        let undone = apply_note_enrichment_inner(&state, "m1".to_string(), vec![]).unwrap();
+        assert_eq!(undone.markdown, original, "empty enrichment strips the block byte-for-byte");
+    }
+
+    /// Stage 2 / Lane A happy path: over a FINISHED note in an OPEN folder, `link_related_notes_inner`
+    /// appends a `> [!related]-` block of `[[Title]]` links + TASK-FREE gists, persisted DB-canonical,
+    /// preserving the original body — and is idempotent (the block never stacks).
+    #[test]
+    fn link_related_notes_writes_related_block_in_open_folder() {
+        let state = build_state("lanea-open");
+        make_open_folder(&state.db, "f-open", "Project");
+        // The note we link FROM. Kept lean so the salient query is a subset of the related note's
+        // terms (FTS5 MATCH is implicit-AND — every query term must be present in the related note).
+        seed_meeting(&state.db, "this", "Apollo migration.\n", Some("f-open"));
+        state.db.set_meeting_title("this", "Apollo Migration").unwrap();
+        // A related PRIOR note (open folder → visible) whose Summary is the ideal task-free gist and
+        // whose Action items must NEVER enter the link detail.
+        seed_meeting(
+            &state.db,
+            "prior",
+            "## Summary\n\nApollo migration groundwork and rollout roadmap.\n\n## Action items\n\n- [ ] SECRET-TASK\n",
+            Some("f-open"),
+        );
+        state.db.set_meeting_title("prior", "Apollo Kickoff").unwrap();
+
+        link_related_notes_inner(&state, "this").unwrap();
+
+        let md = state
+            .db
+            .get_latest_note_for_meeting("this")
+            .unwrap()
+            .unwrap()
+            .markdown;
+        assert!(md.contains("> [!related]- Related notes"), "the Related block was written; got: {md}");
+        assert!(md.contains("[[Apollo Kickoff]]"), "the [[Title]] link is present; got: {md}");
+        assert!(md.contains("(via Murmur)"), "loud Murmur attribution; got: {md}");
+        assert!(md.contains("groundwork and rollout"), "the task-free gist prose is present; got: {md}");
+        assert!(!md.contains("SECRET-TASK"), "an action item must NEVER enter a link detail; got: {md}");
+        assert!(
+            md.starts_with("Apollo migration.\n"),
+            "the original note body is preserved verbatim; got: {md}"
+        );
+
+        // Idempotent: re-linking does not stack the block.
+        link_related_notes_inner(&state, "this").unwrap();
+        let md2 = state
+            .db
+            .get_latest_note_for_meeting("this")
+            .unwrap()
+            .unwrap()
+            .markdown;
+        assert_eq!(
+            md2.matches("<!-- murmur:links -->").count(),
+            1,
+            "the links block never stacks on re-link"
+        );
+    }
+
+    /// SEAL-SAFETY (RED-before-GREEN, load-bearing): Lane A must NEVER write the transient `markdown`
+    /// column of a SEALED note — even when the session happens to have its folder unlocked (so the
+    /// `meeting_is_unlocked` read gate passes). Without the `content_blob` guard, Lane A would derive a
+    /// query from the title, retrieve a visible related note, and upsert plaintext links into the
+    /// blanked column — resurrecting content that would be lost on the next relock. The guard makes it
+    /// a no-op: the sealed column stays blank and `content_blob` stays intact.
+    #[test]
+    fn link_related_notes_never_touches_a_sealed_note() {
+        let state = build_state("lanea-sealsafe");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "sealed", "# Secret body\n", Some("f-lock"));
+        state
+            .db
+            .set_meeting_title("sealed", "Atlas Acquisition Roadmap")
+            .unwrap();
+        // A visible related note in an OPEN folder that the sealed meeting's title WOULD retrieve.
+        make_open_folder(&state.db, "f-open", "Open");
+        seed_meeting(
+            &state.db,
+            "prior",
+            "## Summary\n\nAtlas acquisition roadmap groundwork.\n",
+            Some("f-open"),
+        );
+        state.db.set_meeting_title("prior", "Atlas Kickoff").unwrap();
+
+        // Seal the note (content_blob present, markdown blanked), lock the folder, and SESSION-UNLOCK it
+        // so the read gate passes and ONLY the seal-safety guard can stop the write.
+        state
+            .db
+            .seal_note("sealed", "claude_code", &b"ciphertext-blob"[..])
+            .unwrap();
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-lock".to_string());
+
+        assert!(
+            meeting_is_unlocked(&state, "sealed").unwrap(),
+            "precondition: the sealed meeting is session-unlocked (so meeting_is_unlocked passes)"
+        );
+        link_related_notes_inner(&state, "sealed").unwrap();
+
+        // The sealed note's transient markdown column is untouched (still blank) — no plaintext links.
+        let md = state
+            .db
+            .get_latest_note_for_meeting("sealed")
+            .unwrap()
+            .unwrap()
+            .markdown;
+        assert_eq!(md, "", "a sealed note's transient markdown column must NEVER be written by Lane A");
+        // The seal (content_blob) is intact.
+        assert!(
+            state
+                .db
+                .sealable_notes_for_meeting("sealed")
+                .unwrap()
+                .iter()
+                .any(|n| n.content_blob.is_some()),
+            "the seal (content_blob) is left intact"
         );
     }
 
@@ -12633,6 +13352,72 @@ mod lifecycle_tests {
         );
     }
 
+    /// PHASE 6: `set_focus_meeting` sets and clears the focus pointer; a blank/whitespace id clears.
+    #[test]
+    fn set_focus_meeting_sets_and_clears_the_pointer() {
+        let state = build_state("focus-set-clear");
+        assert!(
+            state.focus_meeting.lock().unwrap().is_none(),
+            "precondition: no focus set"
+        );
+
+        // Set a focus id.
+        set_focus_meeting_inner(&state, Some("m-focused".to_string()));
+        assert_eq!(
+            state.focus_meeting.lock().unwrap().as_deref(),
+            Some("m-focused"),
+            "focus is set to the viewed meeting"
+        );
+
+        // A whitespace id normalizes to a clear (None), not a blank string.
+        set_focus_meeting_inner(&state, Some("   ".to_string()));
+        assert!(
+            state.focus_meeting.lock().unwrap().is_none(),
+            "a blank/whitespace focus id clears the pointer"
+        );
+
+        // Set again, then explicitly clear with None (meeting-view close).
+        set_focus_meeting_inner(&state, Some(" m-2 ".to_string()));
+        assert_eq!(
+            state.focus_meeting.lock().unwrap().as_deref(),
+            Some("m-2"),
+            "focus is trimmed and set"
+        );
+        set_focus_meeting_inner(&state, None);
+        assert!(
+            state.focus_meeting.lock().unwrap().is_none(),
+            "None clears the focus pointer on view close"
+        );
+    }
+
+    /// PHASE 6 fail-safe: a POISONED focus mutex must not brick the setter — it recovers the guard
+    /// via `into_inner()` (the pointer carries no invariant) and still writes the new value.
+    #[test]
+    fn set_focus_meeting_recovers_from_a_poisoned_mutex() {
+        let state = build_state("focus-poisoned");
+        // Poison the focus mutex.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = state.focus_meeting.lock().unwrap();
+            panic!("poison the focus mutex");
+        }));
+        assert!(
+            state.focus_meeting.is_poisoned(),
+            "precondition: the focus mutex is poisoned"
+        );
+
+        // The setter still works (fail-safe recovery).
+        set_focus_meeting_inner(&state, Some("m-after-poison".to_string()));
+        let g = state
+            .focus_meeting
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            g.as_deref(),
+            Some("m-after-poison"),
+            "a poisoned focus mutex fails safe and still sets the pointer"
+        );
+    }
+
     /// brain2 realtime notes: with the meeting in an OPEN folder (or no folder) the gate is open, so
     /// `save`/`get` round-trip the buffer.
     #[test]
@@ -13851,9 +14636,15 @@ mod lifecycle_tests {
         assert!(n.content_blob.is_none(), "never sealed");
     }
 
-    /// BLK-2 (seal half): moving a note INTO a locked + SESSION-UNLOCKED folder seals it to the
-    /// folder's at-rest shape — `content_blob` set, `markdown` blanked, transcript blanked — so no
-    /// plaintext ever lands in a locked folder, and the note is reassigned to the target.
+    /// BLK-2 (seal half): moving a note INTO a locked + SESSION-UNLOCKED folder seals it AT REST
+    /// (`content_blob`/`text_blob` set) but keeps it READABLE IN-SESSION — the restored plaintext
+    /// markdown + transcript come back exactly like the folder's other unlocked notes, so it never
+    /// shows blank under the open padlock, and no vault `.md` is left behind.
+    ///
+    /// REGRESSION (RED-before-GREEN): before the fix, `seal_moved_note` blanked the plaintext and
+    /// nothing restored it, so a note moved into a session-unlocked folder came back EMPTY under the
+    /// open padlock (the "private note came back empty" bug the user hit). The OLD assertion
+    /// `markdown.is_empty()` enshrined that bug; this asserts the correct in-session-readable state.
     #[test]
     fn move_into_locked_unlocked_folder_seals_the_moved_note() {
         const MID: &str = "m-blk2s";
@@ -13876,7 +14667,8 @@ mod lifecycle_tests {
 
         move_into_locked_folder(&state, MID, TARGET).unwrap();
 
-        // Reassigned into the target AND sealed at rest (blob set, plaintext blanked).
+        // Reassigned into the target, sealed AT REST (blob set) but READABLE IN-SESSION (plaintext
+        // restored — the folder is session-unlocked, so it must read like its folder-mates).
         assert_eq!(
             state.db.folder_for_meeting(MID).unwrap().as_deref(),
             Some(TARGET)
@@ -13884,20 +14676,42 @@ mod lifecycle_tests {
         let n = &state.db.sealable_notes_for_meeting(MID).unwrap()[0];
         assert!(
             n.content_blob.is_some(),
-            "moved note must be sealed (content_blob set)"
+            "moved note must be sealed at rest (content_blob set)"
         );
-        assert!(
-            n.markdown.is_empty(),
-            "moved note plaintext markdown blanked at rest"
+        assert_eq!(
+            n.markdown, MD,
+            "moved note must stay READABLE in-session (regression: it used to come back empty under the open padlock)"
         );
         assert!(
             n.exported_path.is_none(),
             "no vault .md for a note in a locked folder"
         );
-        // Transcript sealed too (text blanked, text_blob present).
+        // The visible read path (what the meeting-detail UI uses) returns the note, NON-empty.
+        let unlocked = state.unlocked_folders.lock().unwrap().clone();
+        let visible = state
+            .db
+            .get_note_if_visible(MID, &unlocked)
+            .unwrap()
+            .expect("note is visible while its folder is session-unlocked");
+        assert_eq!(
+            visible.markdown, MD,
+            "the meeting-detail read must show the moved note's content, not an empty note"
+        );
+        // Transcript: blob kept AT REST, but plaintext RESTORED for the session (not left blank).
+        let restored_transcript: String = state
+            .db
+            .raw_segments(MID)
+            .unwrap()
+            .iter()
+            .map(|s| s.text.clone())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            !restored_transcript.trim().is_empty(),
+            "transcript must be restored for the session (regression: left blank)"
+        );
         for s in state.db.raw_segments(MID).unwrap() {
-            assert!(s.text.is_empty(), "segment text blanked");
-            assert!(s.text_blob.is_some(), "segment text_blob present");
+            assert!(s.text_blob.is_some(), "segment text_blob kept at rest");
         }
 
         // And it round-trips: a permanent remove-lock restores the original plaintext (no loss).
@@ -13960,8 +14774,10 @@ mod lifecycle_tests {
     }
 
     /// Auto-organize seam (seal half): a note auto-filed into a session-unlocked locked folder via
-    /// [`seal_auto_filed_note`] is sealed to the folder's at-rest shape (blob set, markdown blanked)
-    /// and reassigned — exactly like a manual move. No plaintext survives in the sealed dir.
+    /// [`seal_auto_filed_note`] is sealed AT REST (blob set) but stays READABLE IN-SESSION (plaintext
+    /// restored) and reassigned — exactly like a manual move. No plaintext `.md` survives in the
+    /// sealed dir, and it never comes back empty under the open padlock (same regression as the manual
+    /// move: the old `markdown.is_empty()` assertion enshrined the "came back empty" bug).
     #[test]
     fn seal_auto_filed_note_seals_into_unlocked_locked_folder() {
         const MID: &str = "m-autofile";
@@ -13989,11 +14805,22 @@ mod lifecycle_tests {
         let n = &state.db.sealable_notes_for_meeting(MID).unwrap()[0];
         assert!(
             n.content_blob.is_some(),
-            "auto-filed note sealed (content_blob set)"
+            "auto-filed note sealed at rest (content_blob set)"
         );
-        assert!(
-            n.markdown.is_empty(),
-            "auto-filed note plaintext blanked at rest"
+        assert_eq!(
+            n.markdown, MD,
+            "auto-filed note must stay READABLE in-session (regression: it used to come back empty)"
+        );
+        // Visible read path returns the note, non-empty.
+        let unlocked = state.unlocked_folders.lock().unwrap().clone();
+        assert_eq!(
+            state
+                .db
+                .get_note_if_visible(MID, &unlocked)
+                .unwrap()
+                .expect("auto-filed note visible while its folder is session-unlocked")
+                .markdown,
+            MD
         );
     }
 

--- a/src-tauri/src/enrich.rs
+++ b/src-tauri/src/enrich.rs
@@ -1,0 +1,400 @@
+//! Connector-agnostic note ENRICHMENT primitive.
+//!
+//! The write-half of "fold live connector context INTO the note" (see
+//! `docs/research/2026-07-05-connector-note-enrichment.md`). This is the pure, deterministic,
+//! headless-testable core — no network, no connectors, no clock, no LLM. Given the note markdown +
+//! a set of already-fetched [`ContextHit`]s (each from ANY connector — Jira, Slack, web, Linear,
+//! …, loud-attributed by its own `source`), it appends ONE consolidated, collapsed Obsidian
+//! `> [!context]-` callout, dated with a caller-supplied `as_of`.
+//!
+//! Design (mirrors the shipped `verify::apply_verify_markers` discipline, generalized to any source):
+//! - **Append-only + byte-preserving.** Every ORIGINAL line of the note is preserved byte-identically;
+//!   we only add (or replace) our own managed block at the end. Front-matter and prose are untouched.
+//! - **Idempotent.** The block lives inside a stable HTML-comment fence (invisible in rendered
+//!   Obsidian). Re-enriching STRIPS the old fenced block first, then re-appends — never stacks.
+//! - **Byte-exact undo.** `apply_context_markers(md, &[], _)` strips the block and returns the note
+//!   exactly as it was before enrichment. `apply(apply(md, h, t), h, t) == apply(md, h, t)`.
+//! - **Pure.** `as_of` is an INPUT (the caller passes the enrichment timestamp), so the function is
+//!   deterministic and unit-testable without a clock; production passes `chrono::Utc::now()`.
+//!
+//! WHERE it must be persisted (NOT decided here — the command layer's job): into the CANONICAL DB
+//! note markdown via `upsert_note` (so it SEALS with the note under the folder lock), exactly like
+//! `apply_note_verify_markers`. NOT the vault-file-only path Re-Truth uses (`overwrite_note`), which
+//! is dropped on seal. See the research brief §F2.
+
+use serde::{Deserialize, Serialize};
+
+/// The fence that delimits our managed enrichment block. HTML comments render as nothing in
+/// Obsidian, and are our own marker so the strip is unambiguous and can never collide with prose.
+const FENCE_START: &str = "<!-- murmur:context -->";
+const FENCE_END: &str = "<!-- /murmur:context -->";
+
+/// Lane A (Stage 2) — the CROSS-MEETING local LINKS managed block. A DISTINCT fence from the
+/// connector `murmur:context` block above so the two lanes are INDEPENDENT, self-managed blocks:
+/// each strips + reapplies ONLY its own fence, so a note can carry BOTH at once and neither disturbs
+/// the other. Lane A is deterministic + ZERO-EGRESS (local `[[Title]]` links + task-free gists).
+const LINKS_FENCE_START: &str = "<!-- murmur:links -->";
+const LINKS_FENCE_END: &str = "<!-- /murmur:links -->";
+
+/// Defense cap on hits rendered in one block (the CALLER should pre-filter for relevance; this only
+/// bounds a runaway from turning a note into a wall). Kept generous — real callers pass a handful.
+const MAX_CONTEXT_HITS: usize = 12;
+
+/// One already-fetched, already-redaction-safe piece of connector context to fold into the note.
+/// Connector-AGNOSTIC: `source` is the truthful connector label (matching the connector's
+/// `egress_attribution` / `source_label` — e.g. "Jira", "Slack", "Linear", "web") so every line is
+/// loudly attributed `(via <source>)`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextHit {
+    /// Truthful connector label, e.g. "Jira" / "Slack" / "Linear". Rendered as `(via {source})`.
+    pub source: String,
+    /// One-line human summary containing ONLY connector-sourced values (status/assignee/snippet).
+    /// Any CR/LF is collapsed to a single space so a hit can never spawn a second, un-strippable line.
+    pub detail: String,
+    /// Optional deep link back to the source item (issue / message permalink).
+    pub url: Option<String>,
+}
+
+/// Append (or idempotently replace) the managed `> [!context]-` block carrying `hits` (Lane B,
+/// connector context), dated `as_of`. `hits` empty ⇒ the block is STRIPPED and the original note
+/// returned byte-identical. See the module docs for the invariants.
+pub fn apply_context_markers(note_md: &str, hits: &[ContextHit], as_of: &str) -> String {
+    let callout = format!("> [!context]- Live context (as of {})", sanitize(as_of));
+    let body: Vec<String> = hits.iter().take(MAX_CONTEXT_HITS).map(render_hit_line).collect();
+    apply_fenced_block(note_md, FENCE_START, FENCE_END, &callout, &body)
+}
+
+/// Lane A (Stage 2) — append (or idempotently replace) the managed `> [!related]- Related notes`
+/// block carrying cross-meeting `hits` (each a task-free gist + a `[[Title]]` wikilink), under the
+/// DISTINCT `murmur:links` fence. `hits` empty ⇒ the block is STRIPPED and the note returned
+/// byte-identical (so re-running self-heals the link graph). INDEPENDENT of the connector
+/// `> [!context]-` block: the two coexist and each strips only its OWN fence. Same idempotency /
+/// byte-exact-undo / sanitize-hardening / seal-safety as [`apply_context_markers`].
+///
+/// UNLIKE Lane B, this block carries NO `as_of` timestamp: cross-meeting links point at OWNED notes
+/// (timeless) not a live external snapshot, so the rendered block is a pure function of `(note, hits)`.
+/// That determinism is load-bearing — it lets the caller's `linked == existing` short-circuit skip a
+/// rewrite when the link set is unchanged, so the deferred auto-pass never churns the note / vault
+/// `.md` on every re-summarize (Phase-2 finding #3).
+pub fn apply_link_markers(note_md: &str, hits: &[ContextHit]) -> String {
+    let callout = "> [!related]- Related notes";
+    let body: Vec<String> = hits.iter().take(MAX_CONTEXT_HITS).map(render_hit_line).collect();
+    apply_fenced_block(note_md, LINKS_FENCE_START, LINKS_FENCE_END, callout, &body)
+}
+
+/// Render ONE hit as a collapsed, sanitized, loudly-attributed callout body line (no trailing
+/// newline — the block writer adds the break). Shared by BOTH lanes (context + links) so the line
+/// shape + injection-hardening are identical everywhere.
+fn render_hit_line(h: &ContextHit) -> String {
+    let detail = sanitize(&h.detail);
+    let via = format!("(via {})", sanitize(&h.source));
+    match h.url.as_deref().map(str::trim).filter(|u| !u.is_empty()) {
+        Some(u) => format!("> - {detail} {via} — {}", sanitize(u)),
+        None => format!("> - {detail} {via}"),
+    }
+}
+
+/// Shared strip+append engine for ONE managed fenced block. Strips this note's EXISTING block for
+/// `(fence_start, fence_end)` via [`strip_fenced_block`], then — if `body_lines` is non-empty —
+/// appends a fresh block `\n\n{fence_start}\n{callout_line}\n{body…}\n{fence_end}`. An EMPTY
+/// `body_lines` returns the stripped note byte-for-byte (byte-exact undo). Callers MUST pre-
+/// [`sanitize`] every value flowing into `callout_line` / `body_lines`.
+fn apply_fenced_block(
+    note_md: &str,
+    fence_start: &str,
+    fence_end: &str,
+    callout_line: &str,
+    body_lines: &[String],
+) -> String {
+    let base = strip_fenced_block(note_md, fence_start, fence_end);
+    if body_lines.is_empty() {
+        return base;
+    }
+    let mut block = String::new();
+    block.push_str(fence_start);
+    block.push('\n');
+    block.push_str(callout_line);
+    block.push('\n');
+    for line in body_lines {
+        block.push_str(line);
+        block.push('\n');
+    }
+    block.push_str(fence_end);
+    // Append at the very end, separated from the note body by a blank line. `strip_fenced_block`
+    // removes exactly this leading separator + fenced region, so append/strip are byte-exact inverses.
+    format!("{base}\n\n{block}")
+}
+
+/// Remove the managed fenced block for `(fence_start, fence_end)` (and the `\n\n` separator inserted
+/// before it), restoring the note byte-for-byte to its pre-block state for THAT fence. A no-op when
+/// the note carries no such block. Only this fence's block is touched — a sibling lane's block (a
+/// different fence) is left intact, which is what lets the links + context blocks coexist.
+fn strip_fenced_block(md: &str, fence_start: &str, fence_end: &str) -> String {
+    let Some(start) = md.rfind(fence_start) else {
+        return md.to_string();
+    };
+    // The end fence must follow the start fence; if a note somehow carries a lone start fence, leave
+    // it untouched rather than truncate real content.
+    let Some(end_rel) = md[start..].find(fence_end) else {
+        return md.to_string();
+    };
+    let end = start + end_rel + fence_end.len();
+    // Reclaim the separator we wrote before the fence (`\n\n`), or a lone `\n`, if present.
+    let before = &md[..start];
+    let cut_start = if before.ends_with("\n\n") {
+        start - 2
+    } else if before.ends_with('\n') {
+        start - 1
+    } else {
+        start
+    };
+    let mut out = String::with_capacity(md.len());
+    out.push_str(&md[..cut_start]);
+    out.push_str(&md[end..]);
+    out
+}
+
+/// Make a connector-supplied value safe to embed in the callout:
+/// - collapse CR/LF + whitespace runs to single spaces so it can never spawn a second line that
+///   escapes the block / injects a line-start callout (mirrors `verify::apply_verify_markers`);
+/// - NEUTRALIZE HTML-comment delimiters (`<!--` / `-->`) so a hostile or attacker-influenced hit
+///   (any web snippet / Slack message the search returns) can never contain — or FORGE — EITHER
+///   managed-block fence (`murmur:context` or `murmur:links`). Without this, a value carrying
+///   `<!-- /murmur:context -->` would make the next `strip_fenced_block` match that embedded marker
+///   first and cut mid-block, permanently breaking the byte-exact undo / idempotency invariant
+///   (2026-07-05 lock-security finding). The broken tokens render as harmless literal text.
+fn sanitize(s: &str) -> String {
+    s.replace(['\r', '\n'], " ")
+        .replace("<!--", "<! --")
+        .replace("-->", "-- >")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const AS_OF: &str = "2026-07-05T14:32:00Z";
+
+    fn hit(source: &str, detail: &str, url: Option<&str>) -> ContextHit {
+        ContextHit {
+            source: source.into(),
+            detail: detail.into(),
+            url: url.map(String::from),
+        }
+    }
+
+    fn jira_slack() -> Vec<ContextHit> {
+        vec![
+            hit("Jira", "PROJ-123 · In Progress · due 2026-07-10", Some("https://acme.atlassian.net/browse/PROJ-123")),
+            hit("Slack", "\"ship it Friday\" in #eng", Some("https://acme.slack.com/archives/C1/p123")),
+        ]
+    }
+
+    /// Lane A links: task-free gists + `[[Title]]` wikilinks, source "Murmur".
+    fn related_hits() -> Vec<ContextHit> {
+        vec![
+            hit("Murmur", "We agreed the Q3 roadmap and the budget runway.", Some("[[Q2 Planning]]")),
+            hit("Murmur", "The bed comfort trial went well.", Some("[[Bed Comfort]]")),
+        ]
+    }
+
+    #[test]
+    fn appends_one_collapsed_callout_attributed_per_source() {
+        let md = "---\ntitle: Sync\n---\n# Notes\n- decided to ship\n";
+        let out = apply_context_markers(md, &jira_slack(), AS_OF);
+        // Original body preserved verbatim (prefix unchanged).
+        assert!(out.starts_with(md), "prose + front-matter preserved byte-for-byte");
+        // One foldable callout, dated, each line loud-attributed to the RIGHT source.
+        assert!(out.contains("> [!context]- Live context (as of 2026-07-05T14:32:00Z)"));
+        assert!(out.contains("> - PROJ-123 · In Progress · due 2026-07-10 (via Jira) — https://acme.atlassian.net/browse/PROJ-123"));
+        assert!(out.contains("> - \"ship it Friday\" in #eng (via Slack) — https://acme.slack.com/archives/C1/p123"));
+        assert_eq!(out.matches("[!context]-").count(), 1, "exactly one consolidated block");
+        assert_eq!(out.matches(FENCE_START).count(), 1);
+    }
+
+    #[test]
+    fn is_idempotent_reenrich_replaces_never_stacks() {
+        let md = "# Notes\n- a line\n";
+        let once = apply_context_markers(md, &jira_slack(), AS_OF);
+        let twice = apply_context_markers(&once, &jira_slack(), AS_OF);
+        assert_eq!(once, twice, "re-enriching with the same hits+timestamp is a no-op");
+        assert_eq!(twice.matches(FENCE_START).count(), 1, "the block never stacks");
+    }
+
+    #[test]
+    fn empty_hits_strips_the_block_byte_exact_undo() {
+        for md in [
+            "# Notes\n- a\n- b\n",          // trailing newline
+            "# Notes\n- a\n- b",            // no trailing newline
+            "---\nk: v\n---\n# T\nbody\n",  // front-matter
+            "",                             // empty note
+        ] {
+            let enriched = apply_context_markers(md, &jira_slack(), AS_OF);
+            assert_ne!(enriched, md, "enrichment actually added the block");
+            let undone = apply_context_markers(&enriched, &[], AS_OF);
+            assert_eq!(undone, md, "empty-hits strip restores the note byte-for-byte: {md:?}");
+        }
+    }
+
+    #[test]
+    fn reenrich_with_new_values_replaces_old_block() {
+        let md = "# Notes\n";
+        let stale = apply_context_markers(md, &[hit("Jira", "PROJ-1 · In Progress", None)], "2026-07-01T00:00:00Z");
+        let fresh = apply_context_markers(&stale, &[hit("Jira", "PROJ-1 · Done", None)], AS_OF);
+        assert!(fresh.contains("PROJ-1 · Done (via Jira)"));
+        assert!(!fresh.contains("In Progress"), "the stale snapshot is replaced, not stacked");
+        assert!(fresh.contains("as of 2026-07-05T14:32:00Z"), "the timestamp is refreshed");
+        assert_eq!(fresh.matches(FENCE_START).count(), 1);
+    }
+
+    #[test]
+    fn a_multiline_detail_cannot_break_the_block_or_inject_markdown() {
+        // A hostile/rich connector value with newlines + markdown must collapse to ONE line inside
+        // the callout — never escape the fence (which would leave un-strippable residue).
+        let nasty = hit("Slack", "line one\n> [!danger] injected\nline two", None);
+        let out = apply_context_markers("# N\n", &[nasty], AS_OF);
+        assert_eq!(out.matches("[!context]-").count(), 1);
+        // The collapse keeps the value on ONE `> - ` body line, so the injected `[!danger]` lands
+        // mid-line as inert text — it never becomes a line-START callout Obsidian would render, and
+        // never spawns an extra line that would escape the fence.
+        assert_eq!(
+            out.lines().filter(|l| l.trim_start().starts_with("> [!danger")).count(),
+            0,
+            "the injected callout never reaches a line-start position"
+        );
+        assert_eq!(
+            out.lines().filter(|l| l.trim_start().starts_with("> [!")).count(),
+            1,
+            "only our own context callout is a real callout"
+        );
+        // And it still round-trips: strip restores the original byte-for-byte.
+        assert_eq!(apply_context_markers(&out, &[], AS_OF), "# N\n");
+    }
+
+    /// A hit that tries to FORGE our managed-block fence (an attacker-influenced web/Slack result
+    /// carrying `<!-- /murmur:context -->` in its text/url) must NOT break the strip: the delimiters
+    /// are neutralized, so only the real fence pair exists and the block still round-trips byte-exact.
+    /// (2026-07-05 lock-security finding — the fence-injection case.)
+    #[test]
+    fn a_hit_forging_the_fence_cannot_break_strip() {
+        let evil = hit(
+            "web",
+            "legit <!-- /murmur:context --> gotcha <!-- murmur:context -->",
+            Some("https://x/<!-- /murmur:context -->"),
+        );
+        let out = apply_context_markers("# N\n- keep me\n", std::slice::from_ref(&evil), AS_OF);
+        // Exactly ONE real fence pair — the value's forged fences were broken by sanitize.
+        assert_eq!(out.matches(FENCE_START).count(), 1, "no forged start fence");
+        assert_eq!(out.matches(FENCE_END).count(), 1, "no forged end fence");
+        // Byte-exact undo still holds despite the hostile value.
+        assert_eq!(apply_context_markers(&out, &[], AS_OF), "# N\n- keep me\n");
+        // And idempotent (re-enrich with the same evil hit replaces, never stacks).
+        let twice = apply_context_markers(&out, std::slice::from_ref(&evil), AS_OF);
+        assert_eq!(out, twice);
+    }
+
+    /// SEAL-SAFETY (the point of persisting via the DB note markdown, not the vault-only path): an
+    /// enriched note round-trips through the folder-lock seal byte-identical. This is what Re-Truth's
+    /// `overwrite_note`-only path would FAIL — the enrichment must live inside `notes.markdown` so it
+    /// seals into `content_blob` and restores intact. (Crypto round-trip stands in for the DB seal;
+    /// `seal_note` encrypts exactly this markdown — see commands.rs `lock_folder_inner`.)
+    #[test]
+    fn enriched_note_seals_and_restores_byte_identical() {
+        let md = "---\ntitle: Board\n---\n# Notes\n- ship Friday\n";
+        let enriched = apply_context_markers(md, &jira_slack(), AS_OF);
+        let key = crate::crypto::random_key().unwrap();
+        let aad = b"murmur:content:v1|folder=f|meeting=m|provider=claude_code|type=note";
+        let blob = crate::crypto::encrypt(&key, enriched.as_bytes(), aad).unwrap();
+        let restored = crate::crypto::decrypt(&key, &blob, aad).unwrap();
+        assert_eq!(
+            restored,
+            enriched.as_bytes(),
+            "the enriched note (context block included) must seal + restore byte-identical"
+        );
+    }
+
+    // ── Lane A (`apply_link_markers`) — same invariants, distinct fence ───────────────────────────
+
+    /// Idempotent: re-linking with the same hits+timestamp is a no-op and the block never stacks.
+    #[test]
+    fn apply_link_markers_is_idempotent() {
+        let md = "# Notes\n- a line\n";
+        let once = apply_link_markers(md, &related_hits());
+        let twice = apply_link_markers(&once, &related_hits());
+        assert_eq!(once, twice, "re-linking with the same hits is a no-op");
+        assert_eq!(twice.matches(LINKS_FENCE_START).count(), 1, "the links block never stacks");
+        assert!(once.contains("> [!related]- Related notes"), "the Related-notes callout header");
+        assert!(once.contains("[[Q2 Planning]]"), "the [[Title]] wikilink is rendered");
+        assert!(once.contains("(via Murmur)"), "loud Murmur attribution");
+    }
+
+    /// Empty hits STRIP the links block byte-exact (self-healing / byte-exact undo).
+    #[test]
+    fn apply_link_markers_empty_strips_byte_exact() {
+        for md in [
+            "# N\n- a\n- b\n",
+            "# N\n- a\n- b",
+            "---\nk: v\n---\n# T\nbody\n",
+            "",
+        ] {
+            let linked = apply_link_markers(md, &related_hits());
+            assert_ne!(linked, md, "linking actually added the block");
+            let undone = apply_link_markers(&linked, &[]);
+            assert_eq!(undone, md, "empty-hits strip restores the note byte-for-byte: {md:?}");
+        }
+    }
+
+    /// A links block + a context block COEXIST as independent self-managed blocks: each strips +
+    /// reapplies ONLY its own fence, so neither disturbs the other. This is the Lane A / Lane B
+    /// coexistence contract.
+    #[test]
+    fn links_and_context_blocks_coexist_independently() {
+        let md = "# Notes\n- decided to ship\n";
+        let with_links = apply_link_markers(md, &related_hits());
+        let both = apply_context_markers(&with_links, &jira_slack(), AS_OF);
+        // Both managed blocks present, each exactly once, original body preserved.
+        assert!(both.starts_with(md), "prose preserved byte-for-byte");
+        assert_eq!(both.matches("[!related]-").count(), 1);
+        assert_eq!(both.matches("[!context]-").count(), 1);
+        assert_eq!(both.matches(LINKS_FENCE_START).count(), 1);
+        assert_eq!(both.matches(FENCE_START).count(), 1);
+        // Stripping the CONTEXT block leaves the LINKS block byte-exact (== the links-only note).
+        let links_only = apply_context_markers(&both, &[], AS_OF);
+        assert_eq!(links_only, with_links, "stripping context restores the links-only note byte-exact");
+        assert_eq!(links_only.matches("[!related]-").count(), 1);
+        // Stripping the LINKS block leaves the CONTEXT block byte-exact (== the context-only note).
+        let context_only = apply_link_markers(&both, &[]);
+        assert_eq!(
+            context_only,
+            apply_context_markers(md, &jira_slack(), AS_OF),
+            "stripping links restores the context-only note byte-exact"
+        );
+        assert_eq!(context_only.matches("[!related]-").count(), 0);
+        assert_eq!(context_only.matches("[!context]-").count(), 1);
+    }
+
+    /// A hostile Lane-A hit forging the links fence in its detail/url must NOT break the strip: the
+    /// delimiters are neutralized so only the real fence pair exists and byte-exact undo still holds.
+    #[test]
+    fn apply_link_markers_forging_the_fence_is_sanitized() {
+        let evil = hit(
+            "Murmur",
+            "legit <!-- /murmur:links --> gotcha <!-- murmur:links -->",
+            Some("[[Note <!-- /murmur:links -->]]"),
+        );
+        let out = apply_link_markers("# N\n- keep me\n", std::slice::from_ref(&evil));
+        assert_eq!(out.matches(LINKS_FENCE_START).count(), 1, "no forged start fence");
+        assert_eq!(out.matches(LINKS_FENCE_END).count(), 1, "no forged end fence");
+        assert_eq!(
+            apply_link_markers(&out, &[]),
+            "# N\n- keep me\n",
+            "byte-exact undo holds despite the hostile value"
+        );
+        let twice = apply_link_markers(&out, std::slice::from_ref(&evil));
+        assert_eq!(out, twice, "idempotent with the hostile hit");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod connectors;
 pub mod crypto;
 pub mod e2ee;
 pub mod embed;
+pub mod enrich;
 pub mod error;
 pub mod eval;
 pub mod events;
@@ -111,6 +112,7 @@ pub fn run() {
                 .build(),
         )
         .invoke_handler(tauri::generate_handler![
+            commands::set_focus_meeting,
             commands::start_recording,
             commands::stop_recording,
             commands::recording_level,
@@ -127,6 +129,9 @@ pub fn run() {
             commands::update_note,
             commands::verify_note_sources,
             commands::apply_note_verify_markers,
+            commands::enrich_note_context,
+            commands::apply_note_enrichment,
+            commands::link_related_notes,
             commands::save_manual_notes,
             commands::get_manual_notes,
             commands::import_document,
@@ -143,6 +148,7 @@ pub fn run() {
             commands::apply_supersessions,
             commands::undo_supersessions,
             commands::get_config,
+            commands::get_mcp_config,
             commands::save_config,
             commands::get_storage_report,
             commands::free_up_space,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -160,27 +160,58 @@ fn transcribe_stream(
         None => vec![(0, samples_16k.len())],
     };
 
+    // Bound each whisper decode to a fixed window so the mel-spectrogram + decoder working set stay
+    // O(window), not O(recording length). Without this, the VAD-less fallback region (the WHOLE
+    // buffer) or a very long continuous speech region hands an hour of audio to whisper.cpp in ONE
+    // decode — a full-length mel + a 16384-max-text-ctx allocation (P1 whisper-batch-cap). Each
+    // window re-offsets its timestamps exactly like the per-region loop already does; boundaries fall
+    // at most every MAX_WINDOW_S (a rare, minor continuity cost only inside a >2-min unbroken region).
+    const MAX_WINDOW_S: usize = 120;
+    let window_len = MAX_WINDOW_S * crate::audio::TARGET_RATE_HZ as usize;
+
     let mut out: Vec<crate::transcribe::types::Segment> = Vec::new();
     let mut idx: i64 = 0;
     for (start, end) in regions {
-        if end <= start {
-            continue;
-        }
-        let offset_s = start as f64 / crate::audio::TARGET_RATE_HZ as f64;
-        let tx = transcriber.transcribe_with(
-            &samples_16k[start..end],
-            lang,
-            TranscribeQuality::Accurate,
-        )?;
-        for mut seg in tx.segments {
-            seg.idx = idx;
-            seg.start_s += offset_s;
-            seg.end_s += offset_s;
-            idx += 1;
-            out.push(seg);
+        for (win_start, win_end) in decode_windows(start, end, window_len) {
+            let offset_s = win_start as f64 / crate::audio::TARGET_RATE_HZ as f64;
+            let tx = transcriber.transcribe_with(
+                &samples_16k[win_start..win_end],
+                lang,
+                TranscribeQuality::Accurate,
+            )?;
+            for mut seg in tx.segments {
+                seg.idx = idx;
+                seg.start_s += offset_s;
+                seg.end_s += offset_s;
+                idx += 1;
+                out.push(seg);
+            }
         }
     }
     Ok(out)
+}
+
+/// Split a `[start, end)` sample range into fixed-length decode windows of at most `window_len`
+/// samples, so a single whisper decode never spans more than one window (bounds whisper's mel +
+/// decoder working memory to O(window), not O(recording length)). Windows tile the range with no
+/// gaps or overlaps; the final window is whatever remains. An empty/degenerate range yields no
+/// windows. Pure + deterministic, so the windowing contract is unit-tested without a whisper model.
+fn decode_windows(start: usize, end: usize, window_len: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    if end <= start {
+        return out;
+    }
+    if window_len == 0 {
+        out.push((start, end));
+        return out;
+    }
+    let mut s = start;
+    while s < end {
+        let e = (s + window_len).min(end);
+        out.push((s, e));
+        s = e;
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -224,6 +255,18 @@ async fn run_inner(
     let system_scratch = ScratchWav::new(system_wav);
 
     let mut mic_16k = audio::resample_to_16k(&samples, src_rate)?;
+    // P1 Stop-time peak: in the common case (no hi-res masters — the default) the source-rate mic
+    // buffer (~0.7 GB/hr at 48 kHz) is never needed again, so free it NOW — before the 16k AEC / mix /
+    // transcription buffers allocate — instead of holding it to the end of `run_inner`. This roughly
+    // halves the pre-whisper Stop-time peak (source + mic_16k + sys_16k + archive_16k → just the 16k
+    // set). When masters ARE kept we must retain it for the faithful PRE-resample `.mic.wav` written
+    // after finalize (below), so keep it only in that case.
+    let samples: Option<Vec<f32>> = if config.keep_hires_masters {
+        Some(samples)
+    } else {
+        drop(samples);
+        None
+    };
     // AEC'd mic for the ASR feed (rec #5): when the VPIO helper produced a WAV, transcribe THAT and
     // keep the RAW cpal mic for the archive (`mic_16k_archive`); otherwise archive == ASR (today).
     // `mem::replace` avoids cloning the (large) mic buffer in the common no-AEC path.
@@ -367,16 +410,21 @@ async fn run_inner(
     // rest by the lock lifecycle exactly like audio_path. Best-effort: a write failure never fails
     // the recording. NOT exposed to the FE — reachable only via the gated export commands.
     if config.keep_hires_masters {
-        let mic_master = wav_dir.join(format!("{meeting_id}.mic.wav"));
-        if let Err(e) = audio::write_wav_f32(&mic_master, &samples, src_rate, 1) {
-            tracing::warn!(target: "audio", error = %e, "mic master write failed");
-        } else if let Err(e) = state
-            .db
-            .set_meeting_mic_master_path(meeting_id, Some(mic_master.to_string_lossy().as_ref()))
-        {
-            // Best-effort: a stranded, untracked master plaintext is unreferenced + ungated-out;
-            // never fail the recording over it.
-            tracing::warn!(target: "audio", error = %e, "persisting mic master path failed");
+        // `samples` is retained as `Some` exactly when keep_hires_masters is on (see the resample
+        // site, where it is dropped early otherwise). Written from the PRE-resample buffer so it
+        // stays faithful; path persistence + error handling are byte-identical to before.
+        if let Some(samples) = &samples {
+            let mic_master = wav_dir.join(format!("{meeting_id}.mic.wav"));
+            if let Err(e) = audio::write_wav_f32(&mic_master, samples, src_rate, 1) {
+                tracing::warn!(target: "audio", error = %e, "mic master write failed");
+            } else if let Err(e) = state
+                .db
+                .set_meeting_mic_master_path(meeting_id, Some(mic_master.to_string_lossy().as_ref()))
+            {
+                // Best-effort: a stranded, untracked master plaintext is unreferenced + ungated-out;
+                // never fail the recording over it.
+                tracing::warn!(target: "audio", error = %e, "persisting mic master path failed");
+            }
         }
         if let Some((sys, sys_rate)) = &sys_native {
             let sys_master = wav_dir.join(format!("{meeting_id}.sys.wav"));
@@ -677,6 +725,12 @@ async fn run_inner(
 /// as the rest of the transcript before any cloud egress — it rides no side channel.
 pub(crate) struct TranscriptFeed {
     /// Flat text (assistant-directed segments dropped) for retrieval — byte-identical to the legacy join.
+    /// `#[allow(dead_code)]`: Phase 1 (two-stage notes) removed the pre-generation cross-meeting
+    /// grounding injection (`orchestrate_context`) that was this field's only PRODUCTION consumer, so
+    /// the note is now generated from `summary_text` alone. The flat-join field is retained as the
+    /// canonical retrieval text (its no-regression properties are still pinned by the feed tests, and
+    /// it is the seam any future/optional grounding re-wire keys off) — not dead history.
+    #[allow(dead_code)]
     pub retrieval_text: String,
     /// What the model summarizes: speaker-labeled when `labeled`, else identical to `retrieval_text`.
     pub summary_text: String,
@@ -899,47 +953,18 @@ async fn summarize_and_export(
         _ => Vec::new(),
     };
 
-    // brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION (ALWAYS ON). Ground the new note in
-    // related PRIOR notes so notes compound ("last time you decided X"). GATED by the LIVE session
-    // unlock set: the retrieval routes through `search_visible` + `get_note_if_visible` (inside
-    // `build_grounding_context` → `build_related_context`), so a sealed-and-not-session-unlocked
-    // prior note contributes NOTHING. This matters because the corpus EGRESSES to the provider in
-    // the prompt — but it is the SAME provider call (`make_provider` → RedactingProvider +
-    // fail-closed `cloud_egress_consented` gate) the summary already makes, so always-on adds NO
-    // new egress class and does NOT bypass consent (local provider stays local; no consent → the
-    // summary already fails closed). Best-effort: a retrieval error logs (target rag, no PII) and
-    // proceeds with NO context, and an empty corpus yields `None` (byte-identical to no-context) —
-    // it NEVER fails the pipeline.
-    let unlocked = state
-        .unlocked_folders
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or_default();
-    let related_title = state
-        .db
-        .get_meeting(meeting_id)
-        .ok()
-        .flatten()
-        .and_then(|m| m.title);
-    // Phase B step 3 (Flow A) — the local brain DECIDES what context to fetch. With no real model
-    // (the StubReasoner, the default build) `orchestrate_context` falls through to the EXACT
-    // deterministic `build_grounding_context` path below (byte-identical, zero behavior change). With
-    // a real reasoner it runs a gated pre-analysis → retrieval plan, but the deterministic
-    // salient-query path stays the FALLBACK FLOOR. The reasoner call is synchronous, so this keeps
-    // the existing inline shape (no extra await). Best-effort + GATED: same egress/consent envelope.
-    let related_context = crate::orchestrate::orchestrate_context(
-        // Brain Live ON ⇒ the LOCAL light engine for retrieval planning (no egress); a missing light
-        // model degrades to the stub ⇒ the deterministic `build_grounding_context` floor below — never
-        // silently to cloud (spec §3.4). OFF ⇒ today's Notes reasoner.
-        &*state.reasoner.extraction_reasoner(),
-        &state.db,
-        meeting_id,
-        related_title.as_deref(),
-        // Retrieval query planning reads the FLAT text — unperturbed by `(speaker)` tag tokens.
-        &feed.retrieval_text,
-        &unlocked,
-        config,
-    );
+    // STAGE 1 (two-stage note redesign — Phase 1). The note is generated PROVABLY from ONLY this
+    // meeting's transcript + the user's typed notes: NO cross-meeting context is injected into the
+    // generation prompt (`related_context: None` below). This eliminates the cross-meeting `## Action
+    // items` bleed class BY CONSTRUCTION — the weak on-device model can no longer be handed another
+    // meeting's tasks in its one prompt. The retrieval machinery stays in the tree UNTOUCHED for
+    // Phase 2 (a deferred, additive, link-only post-pass on the FINISHED note):
+    // `orchestrate::orchestrate_context`, `build_grounding_context`, and everything in
+    // `related_context.rs` are retained, just not called here. `render_user_content` for
+    // `related_context: None` is byte-identical to the pre-injection prompt (test
+    // `render_user_content_none_is_unchanged`), so Stage 1's prompt carries only transcript +
+    // user_notes + vault_titles. See docs/research/2026-07-06-note-and-brain-architecture.md
+    // (§3 Stage 1, §8 Phase 1).
 
     // ENHANCE-MY-NOTES: fetch the typed-notes buffer BEFORE building the request — in
     // "enhance" mode the notes ride INSIDE the prompt as the skeleton (a NEW, deliberate,
@@ -961,7 +986,9 @@ async fn summarize_and_export(
         },
         template: template::build_template(&config.note_style, &config.note_language, feed.labeled),
         vault_titles,
-        related_context,
+        // STAGE 1 — no cross-meeting context in the generation prompt (Phase 1). Phase 2 will add
+        // links additively on the finished note, not via this field.
+        related_context: None,
         user_notes: if config.notes_mode == "enhance" && !manual_notes.trim().is_empty() {
             Some(manual_notes.clone())
         } else {
@@ -977,18 +1004,24 @@ async fn summarize_and_export(
     // every (re)summarize re-reads it fresh in EITHER mode; empty buffer ⇒ byte-identical.
     let markdown = finalize_note_markdown(&generated, &manual_notes, &config.notes_mode);
 
+    // GROUNDING reads THIS meeting's OWN segments (the SAME plaintext the pipeline just summarized) —
+    // NO new read path, NO cross-meeting read, NO egress (pure local string ops). A `get_segments`
+    // failure degrades to no segments ⇒ the opt-in grounding pass below returns the note
+    // byte-identical; it NEVER fails the pipeline. Runs BEFORE `upsert_note` + the vault write so the
+    // DB copy and the exported `.md` carry the same grounded body.
+    //
+    // NOTE (Phase 1): the always-on lexical anti-bleed pass (`strip_ungrounded_action_items`, gated by
+    // `strip_applies_for_language`) that used to run here has been DELETED. It existed ONLY to clean up
+    // the cross-meeting injection removed above (Stage 1); with the note now transcript-only, the bleed
+    // class is gone by construction and the lexical deletion (which risked removing real generated
+    // content) is dead weight.
     // Tier 3b (B) — DETERMINISTIC GROUNDING (anti-hallucination). Annotate summary units this
     // meeting's OWN transcript does not support with a non-destructive `> unverified` line (or
     // `(low audio confidence)` when the overlap was acoustically shaky). Gated by `ground_summary`
     // (default OFF / opt-in until the overlap thresholds are calibrated on real data — an over-flag
     // would `> unverified` a legitimately-abstractive sentence in the note 100% of users read).
-    // GATE/EGRESS posture: reads ONLY `get_segments(meeting_id)` — this meeting's own
-    // segments, the SAME plaintext the pipeline just summarized — so it adds NO new read path, NO
-    // cross-meeting read, and NO egress (pure local string ops). The markers become part of the note
-    // markdown and are sealed WITH it. Best-effort: a `get_segments` failure degrades to no segments
-    // ⇒ `annotate_unverified` returns the note byte-identical; it NEVER fails the pipeline. Runs
-    // BEFORE `upsert_note` + the vault write so the DB copy and the exported `.md` carry the same
-    // grounded body.
+    // The markers become part of the note markdown and are sealed WITH it. The meeting's own
+    // segments are fetched ONLY on this opt-in path (the default OFF path does no wasted DB read).
     let markdown = if config.ground_summary {
         let segments = state.db.get_segments(meeting_id).unwrap_or_default();
         crate::summarize::grounding::annotate_unverified(&markdown, &segments)
@@ -1193,6 +1226,29 @@ async fn summarize_and_export(
         crate::commands::build_and_persist_entities(state, meeting_id, &title, &markdown).await
     {
         tracing::warn!(target: "graph", error = %e, "graph entity persist failed (note export unaffected)");
+    }
+
+    // Stage 2 / Lane A — DEFERRED, best-effort cross-meeting LINKING. Runs AFTER the note reaches
+    // `Exported` so the first `.md` is written promptly; the `[[links]]` + Related block land seconds
+    // later on a DB-canonical re-persist + re-export. Fully LOCAL (ZERO egress) + lock/seal-safe (see
+    // `link_related_notes_inner`), so it is auto-eligible on finalize. It must NEVER fail or delay the
+    // pipeline: a detached worker (the same `std::thread::spawn` + `app.state::<AppState>()` shape the
+    // proactive/reactions workers use), any error swallowed with an IDs-only log (no PII).
+    {
+        let app_bg = app.clone();
+        let mid = meeting_id.to_string();
+        std::thread::spawn(move || {
+            use tauri::Manager;
+            let state = app_bg.state::<AppState>();
+            if let Err(e) = crate::commands::link_related_notes_inner(state.inner(), &mid) {
+                tracing::warn!(
+                    target: "stage2",
+                    meeting_id = %mid,
+                    error = %e,
+                    "deferred cross-meeting linking failed (note unaffected)"
+                );
+            }
+        });
     }
 
     Ok(PipelineResult {
@@ -1492,6 +1548,48 @@ fn should_auto_index(semantic_enabled: bool, embed_model_present: bool) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── whisper decode windowing (P1 whisper-batch-cap) ────────────────────────────────────────
+    /// A long region is tiled into ≤window_len windows that fully cover it with no gaps/overlaps, so
+    /// whisper never decodes more than one window at a time. Pre-cap the whole region was one decode
+    /// (this helper + tiling contract did not exist).
+    #[test]
+    fn decode_windows_tiles_long_region() {
+        let hz = crate::audio::TARGET_RATE_HZ as usize;
+        let w = 120 * hz;
+        let wins = decode_windows(0, 300 * hz, w);
+        assert_eq!(
+            wins,
+            vec![(0, 120 * hz), (120 * hz, 240 * hz), (240 * hz, 300 * hz)]
+        );
+        assert_eq!(wins.first().unwrap().0, 0);
+        assert_eq!(wins.last().unwrap().1, 300 * hz);
+        for pair in wins.windows(2) {
+            assert_eq!(pair[0].1, pair[1].0, "windows must be contiguous");
+        }
+        for (s, e) in &wins {
+            assert!(e - s <= w, "no window exceeds the cap");
+        }
+    }
+
+    /// A region already within budget is a single window (byte-identical to the pre-cap behavior);
+    /// a non-zero start offset is preserved.
+    #[test]
+    fn decode_windows_short_region_is_one_window() {
+        let hz = crate::audio::TARGET_RATE_HZ as usize;
+        assert_eq!(decode_windows(0, 30 * hz, 120 * hz), vec![(0, 30 * hz)]);
+        assert_eq!(
+            decode_windows(5 * hz, 20 * hz, 120 * hz),
+            vec![(5 * hz, 20 * hz)]
+        );
+    }
+
+    /// Degenerate ranges yield nothing (subsumes the old `if end <= start { continue }`).
+    #[test]
+    fn decode_windows_empty_on_degenerate_range() {
+        assert!(decode_windows(100, 100, 16_000).is_empty());
+        assert!(decode_windows(200, 100, 16_000).is_empty());
+    }
 
     // ── Tier 4c: privacy_receipt_facts (per-note egress self-report wiring) ────────────────────
     //

--- a/src-tauri/src/reason/mistral.rs
+++ b/src-tauri/src/reason/mistral.rs
@@ -53,6 +53,93 @@ use crate::reason::{parse_first_json, GenOptions, LocalReasoner};
 /// §3.3). REFUSE-don't-evict at the cap (see the module header).
 const MODEL_CACHE_CAP: usize = 2;
 
+/// KV / activation / runtime headroom factor applied to a GGUF's on-disk (weights) size to estimate
+/// its true peak resident footprint (P0.3, perf-memory-audit §2). The GGUF weights stay quantized in
+/// RAM (~on-disk size — audit §1 BF16 note), but the prefill KV cache + Metal buffers + activations
+/// add substantially on top for a long prompt. `1.5×` is DELIBERATELY CONSERVATIVE (low, so we do not
+/// false-refuse a healthy machine): the goal is to catch "load a multi-GB model when free RAM is
+/// already nearly exhausted", not to reject a normal load. Integer-scaled as `× 3 / 2` to stay in
+/// `u64` without a float.
+const MODEL_RAM_HEADROOM_NUM: u64 = 3;
+const MODEL_RAM_HEADROOM_DEN: u64 = 2;
+
+/// Only guard loads for models at least this large on disk. Tiny GGUFs (e.g. an embedding-sized
+/// model) never move the needle on a memory-pressure kill, and probing/estimating for them just
+/// risks a false refuse — so a small model always loads (fail-open by size).
+const MODEL_RAM_GUARD_MIN_DISK_BYTES: u64 = 1_500_000_000; // ~1.5 GB
+
+/// Decide whether there is enough FREE system RAM to load a model of `model_disk_bytes` on top of
+/// what is ALREADY resident. PURE + injectable (no OS probe here) so it is unit-testable.
+///
+/// - `free_bytes = None` ⇒ the OS probe FAILED — FAIL OPEN (return `true`). We never block a working
+///   setup because the RAM probe broke; we only refuse when we AFFIRMATIVELY measure that a load
+///   would not fit. (The never-evict `model_cache` means an already-resident model stays put; this
+///   check is purely about the headroom for the NEXT load.)
+/// - a small model (`< MODEL_RAM_GUARD_MIN_DISK_BYTES`) ⇒ always `true` (never worth guarding).
+/// - otherwise ⇒ `true` iff `free_bytes >= model_disk_bytes × headroom`.
+fn ram_permits_load(free_bytes: Option<u64>, model_disk_bytes: u64) -> bool {
+    if model_disk_bytes < MODEL_RAM_GUARD_MIN_DISK_BYTES {
+        return true; // tiny model — never the OOM driver; don't risk a false refuse.
+    }
+    let Some(free) = free_bytes else {
+        return true; // probe failed → fail OPEN (never break a working machine on a broken probe).
+    };
+    let needed = model_disk_bytes
+        .saturating_mul(MODEL_RAM_HEADROOM_NUM)
+        / MODEL_RAM_HEADROOM_DEN;
+    free >= needed
+}
+
+/// Best-effort AVAILABLE (free + reclaimable) system RAM in bytes, macOS, via `vm_stat` (no new
+/// crate/FFI — mirrors the `sysctl` pattern in `commands.rs::total_ram_gb`). Sums the page classes
+/// macOS can hand to a new allocation WITHOUT swapping — free + inactive + speculative + purgeable
+/// (NOT wired/active/compressed, which are in use) — times the page size. Returns `None` on ANY
+/// parse/exec failure so the caller FAILS OPEN (never refuses a load because the probe broke). This
+/// is a coarse estimate, deliberately so: the guard is a swap-death backstop, not an accountant.
+fn available_ram_bytes() -> Option<u64> {
+    let out = std::process::Command::new("vm_stat").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(out.stdout).ok()?;
+    // Header line: "Mach Virtual Memory Statistics: (page size of 16384 bytes)".
+    let page_size = text
+        .lines()
+        .next()
+        .and_then(|l| l.split("page size of ").nth(1))
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(4096);
+    // Parse "Pages free: 12345." style lines into a page count.
+    let pages = |label: &str| -> u64 {
+        text.lines()
+            .find(|l| l.trim_start().starts_with(label))
+            .and_then(|l| l.rsplit(':').next())
+            .map(|v| v.trim().trim_end_matches('.').replace(',', ""))
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0)
+    };
+    let free = pages("Pages free");
+    let inactive = pages("Pages inactive");
+    let speculative = pages("Pages speculative");
+    let purgeable = pages("Pages purgeable");
+    let avail_pages = free
+        .saturating_add(inactive)
+        .saturating_add(speculative)
+        .saturating_add(purgeable);
+    // A zero result means we couldn't read any of the classes → treat as probe failure (fail open).
+    if avail_pages == 0 {
+        return None;
+    }
+    Some(avail_pages.saturating_mul(page_size))
+}
+
+/// The on-disk size (bytes) of the GGUF at `path`, or `None` if it can't be stat'd — the estimate
+/// input for [`ram_permits_load`]. A stat failure yields `None` ⇒ the guard fails OPEN.
+fn model_disk_bytes(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
 /// The resident-model list: (canonical GGUF path → loaded engine), capped at [`MODEL_CACHE_CAP`].
 type ResidentModels = Vec<(PathBuf, Arc<Model>)>;
 
@@ -132,6 +219,30 @@ impl MistralReasoner {
             return Err(AppError::Summarize(format!(
                 "Murmur Brain holds at most {MODEL_CACHE_CAP} models at once; restart to switch models"
             )));
+        }
+        // P0.3 — REFUSE-don't-OOM: gate the NEXT load on measured free RAM (the model is NOT yet
+        // resident here — the early `find` returned an already-loaded engine). We refuse ONLY when we
+        // AFFIRMATIVELY measure that this GGUF + KV headroom won't fit the currently-available RAM;
+        // a failed probe or an unreadable file size fails OPEN (never blocks a working machine). This
+        // catches the "load a 6.3 GB model on a 16 GB Mac already under pressure" swap-death without
+        // false-refusing a healthy one (headroom is a conservative 1.5× of the on-disk size). Returns
+        // `Unavailable` so the caller degrades to the deterministic floor / Cloud instead of OOM-ing.
+        let disk = model_disk_bytes(&self.model_path);
+        if let Some(bytes) = disk {
+            if !ram_permits_load(available_ram_bytes(), bytes) {
+                let gb = bytes as f64 / 1_073_741_824.0;
+                tracing::warn!(
+                    target: "reason",
+                    model = %self.model_file,
+                    model_gb = format_args!("{gb:.1}"),
+                    "refusing on-device model load: insufficient free memory"
+                );
+                return Err(AppError::Unavailable(format!(
+                    "not enough free memory to load this on-device model ({}, {gb:.1} GB) — \
+                     switch the brain to Cloud in Settings or pick a smaller model",
+                    self.model_file
+                )));
+            }
         }
         let builder = GgufModelBuilder::new(
             self.model_dir.to_string_lossy().to_string(),
@@ -226,4 +337,72 @@ where
 {
     std::thread::scope(|scope| scope.spawn(|| rt.block_on(fut)).join())
         .map_err(|_| AppError::Summarize("brain inference worker thread panicked".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GB: u64 = 1_073_741_824;
+
+    /// P0.3 — the pure RAM decision. A HEALTHY machine (plenty of free RAM) permits loading a big
+    /// model; a machine already under pressure (tiny free RAM vs a big model) REFUSES it.
+    #[test]
+    fn ram_permits_load_ok_when_free_and_refuses_under_pressure() {
+        let big_model = 6 * GB + GB / 2; // ~6.3 GB heavy model (Bielik-class)
+
+        // Plenty free (24 GB free): 6.3 GB × 1.5 = ~9.5 GB needed ≤ 24 GB → OK.
+        assert!(
+            ram_permits_load(Some(24 * GB), big_model),
+            "a healthy machine with 24 GB free must permit a 6.3 GB model"
+        );
+
+        // Under pressure (only 4 GB free): 9.5 GB needed > 4 GB → REFUSE (the OOM case).
+        assert!(
+            !ram_permits_load(Some(4 * GB), big_model),
+            "4 GB free must REFUSE a 6.3 GB model (would swap-death the machine)"
+        );
+
+        // Borderline: free exactly equals the headroom estimate → OK (>=, conservative-but-permits).
+        let needed = big_model * MODEL_RAM_HEADROOM_NUM / MODEL_RAM_HEADROOM_DEN;
+        assert!(ram_permits_load(Some(needed), big_model));
+        assert!(!ram_permits_load(Some(needed - 1), big_model));
+    }
+
+    /// FAIL OPEN: a failed RAM probe (`None`) must NEVER block a load — we only refuse on an
+    /// affirmative measurement of insufficient memory, never because the probe broke.
+    #[test]
+    fn ram_permits_load_fails_open_on_broken_probe() {
+        let big_model = 9 * GB;
+        assert!(
+            ram_permits_load(None, big_model),
+            "a broken RAM probe must fail OPEN (never break a working setup)"
+        );
+    }
+
+    /// A SMALL model is never guarded (never the OOM driver) — it loads even with almost no free RAM,
+    /// so the guard can't false-refuse a tiny model / embedder-sized GGUF.
+    #[test]
+    fn ram_permits_load_small_model_always_ok() {
+        let tiny = MODEL_RAM_GUARD_MIN_DISK_BYTES - 1;
+        assert!(
+            ram_permits_load(Some(100 * 1024 * 1024), tiny),
+            "a sub-1.5 GB model must always load regardless of pressure"
+        );
+        // ...but a model at/above the threshold IS guarded.
+        assert!(!ram_permits_load(
+            Some(1024 * 1024 * 1024),
+            MODEL_RAM_GUARD_MIN_DISK_BYTES + GB
+        ));
+    }
+
+    /// The best-effort `available_ram_bytes` probe is crash-safe: it returns EITHER `Some(>0)` on a
+    /// real macOS `vm_stat`, OR `None` if the tool/parse fails — never a panic, never `Some(0)`.
+    #[test]
+    fn available_ram_probe_is_crash_safe() {
+        // `None` (probe unavailable in this environment) is the fail-open path — fine, nothing to assert.
+        if let Some(b) = available_ram_bytes() {
+            assert!(b > 0, "a Some result must be a positive byte count");
+        }
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -137,7 +137,26 @@ pub struct AppState {
     /// handle), caching only the expensive local GGUF instance. Consumers call
     /// `state.reasoner.current()` per turn — never hold a resolved reasoner across turns.
     pub reasoner: crate::reason::ReasonerCell,
+    /// The RECORDING pointer: `Some` ONLY while a recording is in flight — set at
+    /// `start_recording`, `take()`-cleared at `stop_recording`. It is NOT a "what the user is
+    /// looking at" pointer; a past meeting the user opens while idle (or while a DIFFERENT meeting
+    /// records) is NOT here. Using it as the brain's "this meeting" scope was the root of the
+    /// wrong-meeting fragility — that role now belongs to [`AppState::focus_meeting`] (Phase 6),
+    /// with `current_meeting` demoted to the last-resort recording fallback in
+    /// [`crate::transcribe::live::resolve_scope_meeting`].
     pub current_meeting: Mutex<Option<uuid::Uuid>>,
+    /// PHASE 6 — the FOCUS pointer: the meeting the user is currently VIEWING / anchored to (a
+    /// meeting-detail or conversation the FE opened), INDEPENDENT of recording. The FE sets it via
+    /// `set_focus_meeting(Some(id))` when it opens a meeting view and clears it (`None`) when it
+    /// closes — so the brain's Tier-1 "this meeting" scope is deterministic even when nothing is
+    /// recording AND when a different meeting is recording. Precedence
+    /// (`resolve_scope_meeting`): an explicit FE-sent `meeting_id` (a bound thread) wins over
+    /// `focus_meeting`, which wins over `current_meeting` (recording). This is ONLY an id (never
+    /// meeting content), so it needs no
+    /// seal/clear-on-relock — a relock re-masks the focused meeting's CONTENT through the same
+    /// `meeting_is_visible` gate `gated_live_context` already fail-closes on; the stale id itself
+    /// leaks nothing. Blank/whitespace counts as absent. No PII (opaque id only).
+    pub focus_meeting: Mutex<Option<String>>,
     /// Accumulated rough transcript of the recording IN PROGRESS, built from the live captions
     /// (`transcribe::live`). Segments aren't persisted until Stop, so this is the ONLY in-flight
     /// view of "what's being said right now" — the in-meeting assistant injects it so it can answer
@@ -259,6 +278,7 @@ impl AppState {
             config,
             reasoner,
             current_meeting: Mutex::new(None),
+            focus_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
             capped_notified: AtomicBool::new(false),
             reactions_shadow_count: AtomicU64::new(0),

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5115,6 +5115,12 @@ impl Db {
     pub fn graph_edges_visible(&self, unlocked: &HashSet<String>) -> Result<Vec<GraphEdge>> {
         let conn = self.lock();
         let visible = visibility_clause("n", unlocked);
+        // F5: bound the quadratic co-occurrence self-join — return only the strongest edges. The
+        // graph UI (brain-map, ≤60 nodes) consumes only the heaviest connections, so an unbounded
+        // ORDER BY over every co-mentioned entity pair is wasted serialization on a large vault.
+        // Visibility is already enforced in WHERE; a trailing LIMIT trims magnitude only — it can
+        // never widen what is visible.
+        const MAX_GRAPH_EDGES: usize = 600;
         let sql = format!(
             "SELECT a.entity_id, b.entity_id, COUNT(*) AS weight
                FROM entity_mentions a
@@ -5130,7 +5136,8 @@ impl Db {
                       )
                     )
               GROUP BY a.entity_id, b.entity_id
-              ORDER BY weight DESC"
+              ORDER BY weight DESC
+              LIMIT {MAX_GRAPH_EDGES}"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
@@ -7649,6 +7656,51 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "the thread reader has nothing to return after the purge"
+        );
+    }
+
+    /// Phase 4 durable thread→meeting binding: a thread row persisted against a PAST meeting
+    /// (the resolved FE-bound scope, `fe_id.or(current_meeting)` in `run_assistant_query`) is
+    /// retrievable under THAT meeting and is INVISIBLE under a DIFFERENT (e.g. currently-recording)
+    /// meeting — proving a bound thread durably answers about its own meeting, not whatever is
+    /// recording. The binding needs NO schema change: it rides the existing `meeting_id` column
+    /// (the resolved scope is what `persist_interaction` stores). RED if `run_assistant_query` had
+    /// kept binding to `current_meeting` while the FE viewed a past meeting.
+    #[test]
+    fn thread_binds_to_its_own_meeting_not_a_different_recording() {
+        let db = mem_db();
+        // The PAST meeting the FE thread is bound to, and a DIFFERENT meeting that is "recording".
+        db.insert_meeting(&sample_meeting("m-past", "2026-07-01T09:00:00Z"))
+            .unwrap();
+        db.insert_meeting(&sample_meeting("m-recording", "2026-07-06T09:00:00Z"))
+            .unwrap();
+        // Persist the exchange against the RESOLVED scope (the FE-bound past meeting) — this is what
+        // `run_assistant_query` now does with
+        // `resolve_scope_meeting(Some("m-past"), None, Some("m-recording"))` (Phase 6: fe > focus > recording).
+        db.insert_assistant_interaction(
+            "m-past",
+            "o czym to spotkanie",
+            "It was the Q3 budget review.",
+            &["[[Budget review]]".to_string()],
+            "ok",
+            Some("research"),
+            Some("t-past"),
+            Some("budget review"),
+            "2026-07-06T09:05:00Z",
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        // The bound past meeting owns the thread.
+        let past = db.list_assistant_threads_visible("m-past", &nothing).unwrap();
+        assert_eq!(past.len(), 1, "the bound past meeting must own its thread row");
+        assert_eq!(past[0].thread_id, "t-past");
+        // The recording meeting must NOT see it — the binding is durable to the past meeting.
+        assert!(
+            db.list_assistant_threads_visible("m-recording", &nothing)
+                .unwrap()
+                .is_empty(),
+            "a different (recording) meeting must NOT surface the bound thread"
         );
     }
 

--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -225,15 +225,32 @@ fn is_wikilink_only(content: &str) -> bool {
     !remainder.chars().any(|c| c.is_alphanumeric())
 }
 
-/// Whether a heading opens a section that legitimately carries content NOT in the transcript (the
-/// user's typed `## My notes`, the `## Related prior notes` grounding corpus) — those must never be
-/// flagged as unverified. Case-insensitive, tolerant of a title suffix.
-fn is_skipped_heading(trimmed_heading: &str) -> bool {
-    let title = trimmed_heading
+/// The lowercased, `#`-stripped title of a heading line (`"## My Notes"` → `"my notes"`). One
+/// source of truth for the EN+PL heading matchers.
+fn section_title(trimmed_heading: &str) -> String {
+    trimmed_heading
         .trim_start_matches('#')
         .trim()
-        .to_lowercase();
-    title.starts_with("my notes") || title.starts_with("related prior notes")
+        .to_lowercase()
+}
+
+/// Whether a heading opens a PROTECTED section that legitimately carries content NOT in THIS
+/// transcript (the user's typed `## My notes`, the `## Related prior notes` grounding corpus, an
+/// `## Also discussed` recap) — those must NEVER be flagged unverified NOR have a unit removed by
+/// the anti-bleed pass. EN + PL, case-insensitive, suffix-tolerant.
+fn is_skipped_heading(trimmed_heading: &str) -> bool {
+    let title = section_title(trimmed_heading);
+    const KEYS: &[&str] = &[
+        // English
+        "my notes",
+        "related prior notes",
+        "also discussed",
+        // Polish
+        "moje notatki",
+        "powiązane notatki",
+        "pozostałe",
+    ];
+    KEYS.iter().any(|k| title.starts_with(k))
 }
 
 /// Whether the first non-empty line at/after `start` is already a `> unverified` marker (either

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -17,6 +17,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::enrich::ContextHit;
 use crate::error::Result;
 use crate::storage::models::VaultSource;
 use crate::storage::Db;
@@ -31,11 +32,22 @@ const MIN_TERM_LEN: usize = 3;
 /// Cap on the number of salient terms in the derived FTS query.
 const MAX_QUERY_TERMS: usize = 8;
 
+/// WEAK on-device providers: tiny-context, low-instruction-following local models whose failure mode
+/// is COPYING corpus text verbatim (the confirmed cross-meeting bleed where a qwen-4B pasted another
+/// note's `## Action items` into a new note). For these the grounding corpus carries ONLY LINKABLE
+/// context (a `[[Title]]` header) — never a copyable body — so there is nothing to plagiarize.
+/// `pub(crate)` so the pipeline/tests can reason about the same classification.
+pub(crate) fn is_weak_provider(provider_id: &str) -> bool {
+    provider_id == crate::summarize::roles::CONN_LOCAL
+        || provider_id == crate::summarize::roles::CONN_AFM
+        || provider_id == crate::summarize::PROVIDER_OLLAMA
+}
+
 /// Char budget for the grounding corpus, by provider. Smaller than the Ask-My-Vault budget on
 /// purpose — this rides ON TOP of the full transcript in the same prompt, so it must stay lean.
-/// Local quantized models (Ollama) have tiny context windows → cap much tighter.
+/// Weak local models (Ollama / on-device brain / Apple) have tiny context windows → cap much tighter.
 pub(crate) fn budget_for(provider_id: &str) -> usize {
-    if provider_id == "ollama" {
+    if is_weak_provider(provider_id) {
         3_000
     } else {
         24_000
@@ -81,6 +93,192 @@ pub(crate) fn tokenize(s: &str) -> Vec<String> {
         .filter(|t| !t.is_empty())
         .map(|t| t.to_lowercase())
         .collect()
+}
+
+/// Max chars of `reference_gist` output — a short, linkable one-liner, never a copyable block.
+const GIST_MAX_CHARS: usize = 280;
+
+/// The lowercased, `#`-stripped title of a markdown heading line (e.g. `"## Action Items"` →
+/// `"action items"`). One source of truth for the EN+PL heading matchers below.
+fn section_title(heading_line: &str) -> String {
+    heading_line.trim_start_matches('#').trim().to_lowercase()
+}
+
+/// A heading that opens a SUMMARY-style section whose prose is the ideal task-free gist. EN + PL,
+/// suffix-tolerant (`starts_with`) so `"Summary of the call"` / `"Podsumowanie spotkania"` match.
+fn is_summary_heading(heading_line: &str) -> bool {
+    let t = section_title(heading_line);
+    const KEYS: &[&str] = &[
+        // English
+        "summary", "tl;dr", "overview", // Polish
+        "podsumowanie", "streszczenie", "przegląd",
+    ];
+    KEYS.iter().any(|k| t.starts_with(k))
+}
+
+/// A heading that opens a COPYABLE, task-like section whose contents must NEVER enter the gist —
+/// action items / decisions / tasks / next-steps / follow-ups / risks. EN + PL, suffix-tolerant.
+/// This is the anti-bleed core: a weak model copies these verbatim, so the corpus never carries them.
+fn is_forbidden_section_heading(heading_line: &str) -> bool {
+    let t = section_title(heading_line);
+    const KEYS: &[&str] = &[
+        // English
+        "action items",
+        "decisions",
+        "tasks",
+        "next steps",
+        "follow-ups",
+        "follow ups",
+        "risks",
+        // Polish
+        "zadania",
+        "działania",
+        "do zrobienia",
+        "elementy do wykonania",
+        "decyzje",
+        "ustalenia",
+        "postanowienia",
+        "następne kroki",
+        "kolejne kroki",
+        "dalsze kroki",
+        "działania następcze",
+        "ryzyka",
+        "ryzyko",
+    ];
+    KEYS.iter().any(|k| t.starts_with(k))
+}
+
+/// Whether a trimmed line is a Markdown CHECKLIST item (`- [ ]` / `- [x]` / `* [ ]` / `+ [X]` …) —
+/// a language-independent task marker that must never appear in the gist.
+fn is_checklist_line(trimmed: &str) -> bool {
+    let b = trimmed.as_bytes();
+    b.len() >= 5
+        && matches!(b[0], b'-' | b'*' | b'+')
+        && b[1] == b' '
+        && b[2] == b'['
+        && matches!(b[3], b' ' | b'x' | b'X')
+        && b[4] == b']'
+}
+
+/// Strip a leading plain-bullet / numbered-list marker so a summary bullet reads as prose. Leaves a
+/// non-list line untouched.
+fn strip_list_marker(trimmed: &str) -> &str {
+    for b in ["- ", "* ", "+ "] {
+        if let Some(r) = trimmed.strip_prefix(b) {
+            return r.trim_start();
+        }
+    }
+    let digits = trimmed.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0 {
+        let after = &trimmed[digits..];
+        if let Some(r) = after.strip_prefix(". ").or_else(|| after.strip_prefix(") ")) {
+            return r.trim_start();
+        }
+    }
+    trimmed
+}
+
+/// Strip a leading YAML front-matter block (`---\n … \n---\n`), returning the body. A note that is
+/// only an unterminated front-matter block yields an empty body.
+fn strip_frontmatter(md: &str) -> &str {
+    let Some(rest) = md.strip_prefix("---\n") else {
+        return md;
+    };
+    match rest.find("\n---\n") {
+        Some(pos) => &rest[pos + "\n---\n".len()..],
+        None => "",
+    }
+}
+
+/// A SHORT (≤ [`GIST_MAX_CHARS`], char-boundary-safe), TASK-FREE gist of a note — the LINKABLE
+/// context a related-note corpus may carry WITHOUT handing a weak model something copyable.
+///
+/// Anti-bleed contract (the fix for the confirmed cross-meeting `## Action items` copy): the gist is
+/// the note's SUMMARY-section prose, or — absent a summary — the FIRST non-heading prose paragraph
+/// OUTSIDE any task/decision section. It NEVER contains an action-items / decisions / tasks /
+/// next-steps / follow-ups / risks section (EN or PL — see [`is_forbidden_section_heading`]) nor any
+/// checklist line. Pure + dependency-free (no DB, no egress); YAML front-matter is stripped first.
+pub fn reference_gist(markdown: &str) -> String {
+    let body = strip_frontmatter(markdown);
+
+    // Section kinds we walk through: Summary (preferred prose), Forbidden (never entered), Other
+    // (preamble + any non-task heading — the fallback source). We collect the summary prose AND the
+    // first Other/preamble prose paragraph in one pass; summary wins if present.
+    #[derive(PartialEq)]
+    enum Kind {
+        Summary,
+        Forbidden,
+        Other,
+    }
+    let mut kind = Kind::Other; // preamble (before any heading) is fallback-eligible
+    let mut in_code = false;
+    let mut summary: Vec<String> = Vec::new();
+    let mut fallback: Vec<String> = Vec::new();
+    let mut fallback_done = false;
+
+    for raw in body.split('\n') {
+        let t = raw.trim();
+
+        if t.starts_with("```") || t.starts_with("~~~") {
+            in_code = !in_code;
+            if !fallback.is_empty() {
+                fallback_done = true; // a fence ends the current fallback paragraph
+            }
+            continue;
+        }
+        if in_code {
+            continue;
+        }
+        if t.starts_with('#') {
+            kind = if is_summary_heading(t) {
+                Kind::Summary
+            } else if is_forbidden_section_heading(t) {
+                Kind::Forbidden
+            } else {
+                Kind::Other
+            };
+            if !fallback.is_empty() {
+                fallback_done = true; // a heading ends the current fallback paragraph
+            }
+            continue;
+        }
+        if t.is_empty() {
+            if !fallback.is_empty() {
+                fallback_done = true; // a blank line ends the current fallback paragraph
+            }
+            continue;
+        }
+        // Never let a checklist line or a blockquote/callout into the gist.
+        if is_checklist_line(t) || t.starts_with('>') {
+            continue;
+        }
+        let text = strip_list_marker(t).trim();
+        if text.is_empty() {
+            continue;
+        }
+        match kind {
+            Kind::Summary => summary.push(text.to_string()),
+            Kind::Forbidden => {} // task/decision content is NEVER copyable context
+            Kind::Other => {
+                if !fallback_done {
+                    fallback.push(text.to_string());
+                }
+            }
+        }
+    }
+
+    let gist = if !summary.is_empty() {
+        summary.join(" ")
+    } else {
+        fallback.join(" ")
+    };
+    let gist = gist.trim();
+    // Char-boundary-safe truncation (collect by chars, never slice mid-codepoint — PL diacritics).
+    if gist.chars().count() <= GIST_MAX_CHARS {
+        gist.to_string()
+    } else {
+        gist.chars().take(GIST_MAX_CHARS).collect()
+    }
 }
 
 /// Derive a short, deterministic FTS query from a meeting: the title's content tokens first (the
@@ -135,6 +333,60 @@ pub fn salient_query(title: Option<&str>, transcript: &str) -> String {
     terms.join(" ")
 }
 
+/// PHASE 7 — the SHARED, gated candidate retriever behind BOTH [`build_related_context`] (the
+/// grounding corpus) and [`related_note_links`] (Lane A links). ONE source of truth for the
+/// FTS↔hybrid switch + the fallback rules, so the two callers can never drift.
+///
+/// - `embedder = Some(e)` (the real e5 model is present) ⇒ embed `query` with the e5 `query:` prefix
+///   and retrieve via [`Db::search_hybrid_visible`] (FTS ⊕ semantic-KNN ⊕ entity-graph, RRF-fused).
+/// - `embedder = None` (no model), OR an embed that yields an empty/degenerate vector, OR an embedder
+///   error ⇒ EXACTLY today's [`Db::search_visible`] FTS path — NO vector is computed, NO `vec_chunks`
+///   row is touched (NEVER a stub vector), byte-identical to the pre-Phase-7 behaviour. A semantic
+///   error degrades to FTS, never fails the caller.
+///
+/// LOCK INVARIANT: both retrievers apply the SAME `visibility_clause` (semantic + FTS + graph legs are
+/// each gated), so every candidate is FIRST-gate visible on the live `unlocked` set regardless of
+/// which branch runs. The SECOND gate ([`Db::get_note_if_visible`]) stays in each caller.
+fn gated_candidates(
+    db: &Db,
+    query: &str,
+    limit: i64,
+    unlocked: &HashSet<String>,
+    embedder: Option<&dyn crate::embed::Embedder>,
+) -> Result<Vec<crate::storage::SearchHit>> {
+    // CONTRACT (both paths): a query with no usable terms yields NO candidates. The FTS path honors
+    // this via `fts_match_query("")==None`, but the semantic path would NOT: an empty/whitespace query
+    // still embeds to a NON-empty vector, and `search_semantic_visible`'s KNN has no similarity floor,
+    // so it would return an ARBITRARY nearest note — a spurious cross-meeting link/grounding for a
+    // low-content (all-stopwords → `salient_query==""`) meeting whenever the e5 model is present
+    // (Phase-7 precision finding). Short-circuit here so the contract holds identically on both paths
+    // (and a construction-failed stub embedder can't turn a degenerate query into garbage KNN either).
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(e) = embedder else {
+        // No real model ⇒ the pre-Phase-7 FTS path, no vector touched.
+        return db.search_visible(query, limit, unlocked);
+    };
+    // QUERY side: e5 `query:` prefix (asymmetric with the `passage:` index side), matching the
+    // MCP/Ask query path in `tools.rs`.
+    match e.embed_query(std::slice::from_ref(&query.to_string())) {
+        Ok(v) => match v.into_iter().next() {
+            Some(qv) if !qv.is_empty() => db.search_hybrid_visible(query, &qv, limit, unlocked),
+            // Empty/degenerate query vector → FTS (never a stub-vector KNN).
+            _ => db.search_visible(query, limit, unlocked),
+        },
+        Err(err) => {
+            tracing::warn!(
+                target: "embed",
+                error = %err,
+                "related-context: query embed failed; falling back to FTS candidate retrieval"
+            );
+            db.search_visible(query, limit, unlocked)
+        }
+    }
+}
+
 /// Build the GATED related-prior-notes corpus for grounding a new note. Returns `(corpus, sources)`.
 ///
 /// - Candidate meetings come from [`Db::search_visible`] against the live `unlocked` set (FIRST
@@ -148,7 +400,15 @@ pub fn salient_query(title: Option<&str>, transcript: &str) -> String {
 ///   `### [[Title]] · date · id:` citation so the model can cite `[[Title]]`.
 ///
 /// An empty/whitespace `query` (e.g. a transcript that was all stopwords) yields an empty corpus —
-/// `search_visible` returns nothing for a query with no usable terms.
+/// the retriever returns nothing for a query with no usable terms.
+///
+/// PHASE 7 — SEMANTIC RECALL (candidate retrieval only): mirrors [`related_note_links`]. WHEN the
+/// real e5 model is present ([`crate::embed::embed_model_present`]) candidates come from the gated
+/// HYBRID retriever ([`Db::search_hybrid_visible`]); ABSENT the model, EXACTLY today's gated FTS
+/// [`Db::search_visible`] with NO vector computed (byte-identical, never a stub vector). The double
+/// visibility gate, self-exclusion, budget, weak-provider header-only rule and [`reference_gist`] are
+/// all UNCHANGED — only the CANDIDATE query switches. The embedder is resolved internally, so this
+/// signature (and the `pipeline` call site) is untouched.
 pub fn build_related_context(
     db: &Db,
     this_meeting_id: &str,
@@ -159,7 +419,14 @@ pub fn build_related_context(
     let budget = budget_for(provider_id);
     // Over-fetch a little: the self-meeting and any second-gate misses are dropped below, so ask for
     // more candidates than we intend to keep.
-    let hits = db.search_visible(query, (MAX_RELATED_NOTES as i64) + 6, unlocked)?;
+    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    let hits = gated_candidates(
+        db,
+        query,
+        (MAX_RELATED_NOTES as i64) + 6,
+        unlocked,
+        embedder.as_deref(),
+    )?;
 
     let mut corpus = String::new();
     let mut sources: Vec<VaultSource> = Vec::new();
@@ -188,9 +455,16 @@ pub fn build_related_context(
         if remaining < 200 {
             break;
         }
-        let chunk: String = note.markdown.chars().take(remaining).collect();
         corpus.push_str(&header);
-        corpus.push_str(&chunk);
+        // ANTI-BLEED: WEAK providers (see `is_weak_provider`) get the LINKABLE `[[Title]]` header
+        // ONLY — nothing copyable, so a low-instruction-following local model cannot paste another
+        // meeting's `## Action items` into this note. STRONG providers additionally get a SHORT,
+        // task-free `reference_gist` (never a full note body, never a task/decision section).
+        if !is_weak_provider(provider_id) {
+            let gist = reference_gist(&note.markdown);
+            let chunk: String = gist.chars().take(remaining).collect();
+            corpus.push_str(&chunk);
+        }
         sources.push(VaultSource {
             meeting_id: m.id,
             title,
@@ -199,6 +473,94 @@ pub fn build_related_context(
     }
 
     Ok((corpus, sources))
+}
+
+/// Stage 2 / Lane A — build the DETERMINISTIC, ZERO-EGRESS cross-meeting LINK set for a FINISHED
+/// note. Mirrors [`build_related_context`]'s double gate EXACTLY — candidates via
+/// [`Db::search_visible`] (FIRST gate on the live `unlocked` set), self-exclusion of the note being
+/// linked, and each body pulled through [`Db::get_note_if_visible`] (SECOND gate) — but emits
+/// LINKABLE [`ContextHit`]s (a `[[Title]]` wikilink + a TASK-FREE [`reference_gist`]) instead of a
+/// copyable grounding corpus.
+///
+/// LOCK INVARIANT: a sealed-and-NOT-session-unlocked related meeting contributes NO link (the two
+/// gates on the live `unlocked` set), and the meeting being linked is never linked to itself. Because
+/// the detail is a `reference_gist` (task-free by construction — never an action-items / decisions /
+/// tasks section, EN+PL), a linked note can never drag its checklist into this note.
+///
+/// NO provider, NO network — Lane A egresses NOTHING (search over OWNED notes + local gist only), so
+/// it is auto-eligible on finalize. Notes with an empty gist (nothing task-free to show) are skipped.
+///
+/// PHASE 7 — SEMANTIC RECALL (candidate retrieval only): WHEN the REAL on-device e5 model is present
+/// ([`crate::embed::embed_model_present`]) the candidate list comes from the HYBRID retriever
+/// ([`Db::search_hybrid_visible`] = FTS ⊕ semantic-KNN ⊕ entity-graph, RRF-fused) so a
+/// same-meaning-different-words prior note is found (embedding recall ≈ 1.0 in the repo bake-off vs
+/// ≈ 0.42 keyword FTS). WHEN the model is ABSENT the retriever is EXACTLY today's FTS
+/// [`Db::search_visible`] — no vector is embedded, no `vec_chunks` row is touched, byte-identical to
+/// the pre-Phase-7 behaviour (NEVER a stub vector: a no-model install runs pure FTS). The embedder is
+/// resolved HERE (no signature change ripples to the pipeline/command call sites), and any
+/// embedder-construction / embed error falls back to FTS rather than failing the pass. The DOUBLE
+/// visibility gate is unchanged: the retriever gates every candidate (`visibility_clause`) and each
+/// body is re-checked through [`Db::get_note_if_visible`] on the live `unlocked` set.
+pub fn related_note_links(
+    db: &Db,
+    this_meeting_id: &str,
+    query: &str,
+    unlocked: &HashSet<String>,
+    max: usize,
+) -> Result<Vec<ContextHit>> {
+    // Activate semantic recall ONLY on real-model presence; else the embedder is None → FTS.
+    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    related_note_links_with_embedder(db, this_meeting_id, query, unlocked, max, embedder.as_deref())
+}
+
+/// Deterministic core of [`related_note_links`] with the embedder injected (so gating/semantic tests
+/// can drive the HYBRID branch with a known [`crate::embed::Embedder`] + pre-indexed vectors WITHOUT
+/// a real model on disk — mirrors `Db::related_meetings_visible`'s injected-embedder idiom).
+///
+/// `embedder = Some(e)` ⇒ embed `query` (e5 `query:` prefix) and retrieve candidates via the gated
+/// [`Db::search_hybrid_visible`]. `embedder = None` (or an embed that yields an empty/failed vector)
+/// ⇒ the pre-Phase-7 [`Db::search_visible`] FTS path, byte-identical, with NO vector computed. The
+/// self-exclusion, [`Db::get_note_if_visible`] body gate, task-free [`reference_gist`] and `max` cap
+/// are IDENTICAL on both branches — only the CANDIDATE query changes.
+pub(crate) fn related_note_links_with_embedder(
+    db: &Db,
+    this_meeting_id: &str,
+    query: &str,
+    unlocked: &HashSet<String>,
+    max: usize,
+    embedder: Option<&dyn crate::embed::Embedder>,
+) -> Result<Vec<ContextHit>> {
+    // Over-fetch a little: the self-meeting, second-gate misses, and empty-gist notes are dropped
+    // below, so ask for more candidates than we intend to keep.
+    let hits = gated_candidates(db, query, (max as i64) + 6, unlocked, embedder)?;
+    let mut out: Vec<ContextHit> = Vec::new();
+    for hit in hits {
+        if out.len() >= max {
+            break;
+        }
+        let m = hit.meeting;
+        // Never link a note to itself.
+        if m.id == this_meeting_id {
+            continue;
+        }
+        // SECOND gate: only pull the body if the note is visible under the live unlock set — a
+        // sealed-not-unlocked note contributes NO link even if it slipped the candidate filter.
+        let Some(note) = db.get_note_if_visible(&m.id, unlocked)? else {
+            continue;
+        };
+        // The link detail is the TASK-FREE gist — never a copyable action-items/decisions section.
+        let gist = reference_gist(&note.markdown);
+        if gist.trim().is_empty() {
+            continue; // nothing task-free to show for this note → no link.
+        }
+        let title = m.title.clone().unwrap_or_else(|| "(untitled)".to_string());
+        out.push(ContextHit {
+            source: "Murmur".to_string(),
+            detail: gist,
+            url: Some(format!("[[{title}]]")),
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -401,6 +763,188 @@ mod tests {
         assert!(sources2.iter().any(|s| s.meeting_id == "sealed"));
     }
 
+    // ── reference_gist: task-free, EN+PL heading-aware, char-boundary-safe ────────────────────────
+
+    /// The gist keeps the SUMMARY prose and DROPS the `## Action items` section + its checklist
+    /// lines (the copyable content that bled cross-meeting). Front-matter is stripped first.
+    #[test]
+    fn reference_gist_keeps_summary_drops_tasks() {
+        let note = "---\ntitle: X\n---\n\n## Summary\n\nWe reviewed the bed comfort design and the memory foam felt better.\n\n## Action items\n\n- [ ] Weronika weryfikować Alcon\n- [ ] Order more foam samples\n";
+        let gist = reference_gist(note);
+        assert!(
+            gist.contains("memory foam felt better"),
+            "summary prose must be kept; got: {gist}"
+        );
+        assert!(!gist.contains("Weronika"), "action items must be excluded; got: {gist}");
+        assert!(!gist.contains("foam samples"), "checklist tasks must be excluded; got: {gist}");
+        assert!(!gist.contains("Action items"), "the heading must not be in the gist; got: {gist}");
+    }
+
+    /// CORRECTION #3 (Polish leak), RED-before-GREEN: a Polish note whose FIRST section is a prose
+    /// `## Decyzje` (decisions) must NOT leak the decision text into the gist — with PL recognition
+    /// the gist falls through to the next non-task section. Without `"decyzje"` in the forbidden
+    /// list this test goes RED (the decision bullet becomes the fallback prose).
+    #[test]
+    fn reference_gist_polish_decyzje_never_leaks() {
+        let note = "## Decyzje\n\n- Weronika ma weryfikować rampę Alcon do piątku.\n\n## Notatki\n\nJakieś inne uwagi na później.\n";
+        let gist = reference_gist(note);
+        assert!(!gist.contains("Weronika"), "PL decisions must not leak into the gist; got: {gist}");
+        assert!(!gist.contains("Alcon"), "PL decisions must not leak into the gist; got: {gist}");
+        assert!(
+            gist.contains("Jakieś inne uwagi"),
+            "the first non-task prose must be the gist; got: {gist}"
+        );
+    }
+
+    /// A Polish SUMMARY heading (`## Podsumowanie`) is recognized, and a trailing PL `## Zadania`
+    /// checklist section never leaks.
+    #[test]
+    fn reference_gist_polish_summary_recognized() {
+        let note = "## Podsumowanie\n\nRozmawialiśmy o komforcie łóżka i wygodzie materaca.\n\n## Zadania\n\n- [ ] Weronika weryfikować rampę Alcon\n";
+        let gist = reference_gist(note);
+        assert!(
+            gist.contains("komforcie łóżka"),
+            "PL summary prose must be kept; got: {gist}"
+        );
+        assert!(!gist.contains("Weronika"), "PL tasks must not leak; got: {gist}");
+    }
+
+    /// Char-boundary-safe truncation: a long multi-byte (PL diacritic) summary is capped at 280
+    /// CHARS without panicking on a codepoint boundary.
+    #[test]
+    fn reference_gist_truncates_on_char_boundary() {
+        let body = "ą".repeat(300); // 300 two-byte chars
+        let note = format!("## Summary\n\n{body}\n");
+        let gist = reference_gist(&note);
+        assert!(gist.chars().count() <= 280, "gist must be ≤ 280 chars");
+        assert!(gist.chars().count() >= 200, "a long summary must still produce a gist");
+    }
+
+    // ── build_related_context: weak providers get NOTHING copyable ────────────────────────────────
+
+    /// A WEAK provider (ollama / on-device brain / apple) gets the `[[Title]]` header ONLY — never
+    /// the summary prose, and NEVER an action item — so it cannot copy another meeting's tasks.
+    #[test]
+    fn build_related_context_weak_provider_header_only() {
+        let db = temp_db();
+        seed_note(&db, "this", "Bed Comfort", "unrelated bed comfort trial", None);
+        seed_note(
+            &db,
+            "prior",
+            "Bed Comfort Review",
+            "## Summary\n\nThe bed comfort trial went well and the SUPERCOMFY foam won.\n\n## Action items\n\n- [ ] Weronika weryfikować Alcon\n",
+            None,
+        );
+        let nothing = HashSet::new();
+        // provider_id = ollama → weak.
+        let (corpus, sources) =
+            build_related_context(&db, "this", "bed comfort trial foam", &nothing, "ollama")
+                .unwrap();
+        assert!(corpus.contains("[[Bed Comfort Review]]"), "header must be cited; got: {corpus}");
+        assert!(corpus.contains("id:prior"), "header id must be cited; got: {corpus}");
+        assert!(
+            !corpus.contains("SUPERCOMFY"),
+            "weak provider must NOT get the gist body; got: {corpus}"
+        );
+        assert!(
+            !corpus.contains("Weronika"),
+            "weak provider must NEVER get an action item; got: {corpus}"
+        );
+        assert!(sources.iter().any(|s| s.meeting_id == "prior"));
+    }
+
+    /// A STRONG provider DOES get the task-free gist prose (but still never the action items).
+    #[test]
+    fn build_related_context_strong_provider_gets_gist() {
+        let db = temp_db();
+        seed_note(&db, "this", "Bed Comfort", "unrelated bed comfort trial", None);
+        seed_note(
+            &db,
+            "prior",
+            "Bed Comfort Review",
+            "## Summary\n\nThe bed comfort trial went well and the SUPERCOMFY foam won.\n\n## Action items\n\n- [ ] Weronika weryfikować Alcon\n",
+            None,
+        );
+        let nothing = HashSet::new();
+        let (corpus, _sources) =
+            build_related_context(&db, "this", "bed comfort trial foam", &nothing, "anthropic")
+                .unwrap();
+        assert!(corpus.contains("SUPERCOMFY"), "strong provider gets the gist prose; got: {corpus}");
+        assert!(
+            !corpus.contains("Weronika"),
+            "even a strong provider never gets copyable action items; got: {corpus}"
+        );
+    }
+
+    // ── related_note_links (Lane A): GATED, self-excluded, task-free, zero-egress ─────────────────
+
+    /// LOCK INVARIANT (RED-if-ungated) + self-exclusion + task-free gist, in one:
+    /// - a sealed-and-NOT-session-unlocked related note contributes NO link, and reappears once its
+    ///   folder is session-unlocked (the double gate an ungated `search`+`get_note` would fail);
+    /// - the meeting being linked is never linked to itself;
+    /// - the link detail is a task-free gist (no action items), and its url is `[[Title]]`.
+    #[test]
+    fn related_note_links_gated_self_excluded_and_task_free() {
+        let db = temp_db();
+        // The note we're linking FROM (its own content also matches the query → must be self-excluded).
+        seed_note(&db, "this", "Acquisition Talk", "PROJECT atlas acquisition terms roadmap", None);
+        seed_folder(&db, "f-locked", false);
+        seed_note(
+            &db,
+            "sealed",
+            "Secret Acquisition",
+            "## Summary\n\nPROJECT atlas acquisition roadmap review.\n\n## Action items\n\n- [ ] SEALED-SECRET follow-up\n",
+            Some("f-locked"),
+        );
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        // Not session-unlocked → the sealed related note yields NO link, and "this" links nothing to itself.
+        let nothing = HashSet::new();
+        let links = related_note_links(&db, "this", "PROJECT atlas acquisition roadmap", &nothing, 4).unwrap();
+        assert!(
+            links.iter().all(|h| h.url.as_deref() != Some("[[Secret Acquisition]]")),
+            "sealed-not-unlocked related note must not be linked (gate violation)"
+        );
+        assert!(
+            links.iter().all(|h| h.url.as_deref() != Some("[[Acquisition Talk]]")),
+            "a note must never be linked to itself"
+        );
+        assert!(
+            links.iter().all(|h| !h.detail.contains("SEALED-SECRET")),
+            "sealed content must not leak into a link detail"
+        );
+
+        // Session-unlock the folder → the related note is now legitimately linkable.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let links2 = related_note_links(&db, "this", "PROJECT atlas acquisition roadmap", &unlocked, 4).unwrap();
+        let link = links2
+            .iter()
+            .find(|h| h.url.as_deref() == Some("[[Secret Acquisition]]"))
+            .expect("unlocked related note must be linked");
+        assert_eq!(link.source, "Murmur");
+        assert!(
+            link.detail.contains("acquisition roadmap review"),
+            "the task-free gist prose must be the link detail; got: {}",
+            link.detail
+        );
+        assert!(
+            !link.detail.contains("SEALED-SECRET"),
+            "the link detail must be TASK-FREE (no action items); got: {}",
+            link.detail
+        );
+    }
+
+    /// An empty query (transcript was all stopwords) yields no links — never a panic, never a leak.
+    #[test]
+    fn related_note_links_empty_query_is_empty() {
+        let db = temp_db();
+        seed_note(&db, "this", "Standup", "daily standup notes", None);
+        seed_note(&db, "prior", "Old Standup", "## Summary\n\nolder standup summary\n", None);
+        let nothing = HashSet::new();
+        assert!(related_note_links(&db, "this", "", &nothing, 4).unwrap().is_empty());
+    }
+
     /// An empty query (transcript was all stopwords) yields an empty corpus — never a panic, never
     /// a leak.
     #[test]
@@ -413,5 +957,315 @@ mod tests {
             build_related_context(&db, "this", "", &nothing, "anthropic").unwrap();
         assert!(corpus.is_empty());
         assert!(sources.is_empty());
+    }
+
+    // ── PHASE 7: semantic recall for Lane A candidate retrieval ───────────────────────────────────
+    //
+    // The switch is `related_note_links` → `related_note_links_with_embedder(embedder)`:
+    //   - `embedder = None` (real model absent) → EXACTLY today's FTS `search_visible` path, NO
+    //     vector computed (a no-model install is byte-identical);
+    //   - `embedder = Some(e)` (real model present) → gated HYBRID `search_hybrid_visible`.
+    // We inject a KNOWN embedder + pre-index vectors so the hybrid branch is deterministic WITHOUT a
+    // model on disk (mirrors `Db::related_meetings_visible`'s injected-embedder test idiom).
+
+    /// A deterministic test embedder that maps by CONCEPT, not by literal keyword: any text about the
+    /// "sleep comfort" concept (the marker tokens) → `one_hot(0)`; everything else → `one_hot(7)`.
+    /// This lets a SEMANTICALLY related note (mattress ↔ sleeping surface) align with a query that
+    /// shares NO literal FTS token — the exact case pure-keyword FTS misses. Deterministic, dim ==
+    /// EMBED_DIM. It overrides `embed` (the raw method both `embed_query`/`embed_passage` route
+    /// through), so the e5 `query: `/`passage: ` prefixes are handled by the substring match.
+    struct ConceptEmbedder;
+    impl crate::embed::Embedder for ConceptEmbedder {
+        fn dim(&self) -> usize {
+            crate::embed::EMBED_DIM
+        }
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            const SLEEP_CONCEPT: &[&str] = &[
+                "mattress",
+                "sleeping",
+                "sleep",
+                "bed",
+                "comfort",
+                "comfortable",
+                "ergonomic",
+                "ergonomics",
+                "surface",
+            ];
+            Ok(texts
+                .iter()
+                .map(|t| {
+                    let lc = t.to_lowercase();
+                    let dim = if SLEEP_CONCEPT.iter().any(|k| lc.contains(k)) {
+                        0
+                    } else {
+                        7
+                    };
+                    let mut v = vec![0f32; crate::embed::EMBED_DIM];
+                    v[dim] = 1.0;
+                    v
+                })
+                .collect())
+        }
+    }
+
+    /// Index a meeting's note into the vector layer with the injected embedder — the passage side of
+    /// the same `ConceptEmbedder` that will embed the query, so vectors align by concept.
+    fn index_with(db: &Db, meeting_id: &str, embedder: &dyn crate::embed::Embedder) {
+        db.index_meeting_chunks(meeting_id, &[], embedder).unwrap();
+    }
+
+    /// PHASE 7 core (RED-before-GREEN): a SEMANTICALLY related prior note whose words DON'T overlap
+    /// the query is found by the HYBRID (model-present) branch but MISSED by the FTS-only branch.
+    ///   - RED assertion: `embedder = None` (today's FTS path) does NOT link the mattress note for the
+    ///     keyword-disjoint query "sleeping surface ergonomics" — proving FTS alone misses it.
+    ///   - GREEN assertion: `embedder = Some(ConceptEmbedder)` (model present) DOES link it via the
+    ///     semantic KNN leg of `search_hybrid_visible`.
+    #[test]
+    fn related_note_links_semantic_finds_what_fts_misses() {
+        let db = temp_db();
+        // Current meeting we link FROM (its own words don't matter — it is self-excluded).
+        seed_note(&db, "this", "Product Sync", "roadmap sync agenda", None);
+        // A genuinely related PRIOR note — about the SAME concept, but with NO word the query uses.
+        seed_note(
+            &db,
+            "prior",
+            "Mattress Review",
+            "## Summary\n\nThe mattress felt very comfortable and supportive overnight.\n",
+            None,
+        );
+        // Index the prior note's vectors with the concept embedder (passage side).
+        index_with(&db, "prior", &ConceptEmbedder);
+
+        // The query shares the CONCEPT (sleep/comfort) but ZERO literal token with the prior note.
+        let query = "sleeping surface ergonomics";
+        let nothing = HashSet::new();
+
+        // RED: FTS-only (real model absent) must MISS the semantically-related note (disjoint words).
+        let fts_only =
+            related_note_links_with_embedder(&db, "this", query, &nothing, 4, None).unwrap();
+        assert!(
+            fts_only
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Mattress Review]]")),
+            "FTS-only must MISS the keyword-disjoint semantic match (this is the recall gap Phase 7 closes); got: {fts_only:?}"
+        );
+
+        // GREEN: HYBRID (model present) FINDS it via the semantic KNN leg.
+        let embedder = ConceptEmbedder;
+        let hybrid = related_note_links_with_embedder(
+            &db,
+            "this",
+            query,
+            &nothing,
+            4,
+            Some(&embedder as &dyn crate::embed::Embedder),
+        )
+        .unwrap();
+        let link = hybrid
+            .iter()
+            .find(|h| h.url.as_deref() == Some("[[Mattress Review]]"))
+            .expect("hybrid (semantic) branch must find the concept-related note FTS missed");
+        assert_eq!(link.source, "Murmur");
+        assert!(
+            link.detail.contains("comfortable and supportive"),
+            "the task-free gist prose must be the link detail; got: {}",
+            link.detail
+        );
+    }
+
+    /// PHASE-7 PRECISION FINDING: an empty/whitespace query yields NO links EVEN WITH THE MODEL
+    /// PRESENT. Without the `gated_candidates` short-circuit, the empty query would still embed to a
+    /// non-empty vector and the floor-less semantic KNN would return an ARBITRARY indexed note — a
+    /// spurious cross-meeting link for a low-content (all-stopwords → `salient_query==""`) meeting.
+    /// RED before the short-circuit (a `[[Mattress Review]]` link appears for `""`/`"   "`); GREEN now.
+    #[test]
+    fn related_note_links_empty_query_is_empty_even_with_model_present() {
+        let db = temp_db();
+        seed_note(&db, "this", "Product Sync", "roadmap sync agenda", None);
+        seed_note(
+            &db,
+            "prior",
+            "Mattress Review",
+            "## Summary\n\nThe mattress felt very comfortable and supportive overnight.\n",
+            None,
+        );
+        index_with(&db, "prior", &ConceptEmbedder);
+        let nothing = HashSet::new();
+        let embedder = ConceptEmbedder;
+        for degenerate in ["", "   ", "\n\t "] {
+            let links = related_note_links_with_embedder(
+                &db,
+                "this",
+                degenerate,
+                &nothing,
+                4,
+                Some(&embedder as &dyn crate::embed::Embedder),
+            )
+            .unwrap();
+            assert!(
+                links.is_empty(),
+                "a degenerate query {degenerate:?} must yield NO links even with the model present (no floor-less KNN spurious match); got: {links:?}"
+            );
+        }
+    }
+
+    /// NEVER A STUB VECTOR: with the real model ABSENT (`embedder = None`) the candidate retrieval is
+    /// BYTE-IDENTICAL to the historical FTS `search_visible` path — same links, same order — as the
+    /// public `related_note_links` (which resolves `embed_model_present()` = false on a no-model test
+    /// machine). A keyword match IS still found; a semantic-only match is NOT (no vector is computed).
+    #[test]
+    fn related_note_links_model_absent_is_byte_identical_fts() {
+        let db = temp_db();
+        seed_note(&db, "this", "Budget Talk", "budget planning agenda", None);
+        // A KEYWORD-overlapping prior (shares "budget"/"planning") — FTS finds this.
+        seed_note(
+            &db,
+            "kw",
+            "Q2 Budget",
+            "## Summary\n\nWe reviewed the budget planning for the next quarter.\n",
+            None,
+        );
+        // A SEMANTIC-only prior (concept match, no shared word) with vectors indexed — FTS must NOT
+        // find it, and the model-absent path must NOT reach the vectors (no stub-vector KNN).
+        seed_note(
+            &db,
+            "sem",
+            "Mattress Review",
+            "## Summary\n\nThe mattress felt very comfortable overnight.\n",
+            None,
+        );
+        index_with(&db, "sem", &ConceptEmbedder);
+
+        let query = "budget planning";
+        let nothing = HashSet::new();
+
+        // The injected-None core and the public entry point agree (public resolves model-absent → None
+        // on a no-model test machine). Assert byte-identical link sets.
+        let via_core =
+            related_note_links_with_embedder(&db, "this", query, &nothing, 4, None).unwrap();
+        // Keyword prior is found; semantic-only prior is NOT (no vector touched on the None path).
+        assert!(
+            via_core
+                .iter()
+                .any(|h| h.url.as_deref() == Some("[[Q2 Budget]]")),
+            "FTS must still find the keyword-overlapping prior; got: {via_core:?}"
+        );
+        assert!(
+            via_core
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Mattress Review]]")),
+            "model-absent path must NOT reach the semantic vectors (no stub vector); got: {via_core:?}"
+        );
+
+        // On a no-model machine the public entry resolves to the SAME (None) path → identical output.
+        if !crate::embed::embed_model_present() {
+            let via_public = related_note_links(&db, "this", query, &nothing, 4).unwrap();
+            let core_urls: Vec<_> = via_core.iter().map(|h| h.url.clone()).collect();
+            let public_urls: Vec<_> = via_public.iter().map(|h| h.url.clone()).collect();
+            assert_eq!(
+                core_urls, public_urls,
+                "public related_note_links must be byte-identical to the FTS path when no model is present"
+            );
+        }
+    }
+
+    /// LOCK INVARIANT under the HYBRID branch: a sealed-and-NOT-session-unlocked related note yields
+    /// NO link even when the semantic model is present + its vectors are indexed. Mirrors
+    /// `related_note_links_gated_self_excluded_and_task_free` for the model-present path — the
+    /// double gate (semantic leg's `visibility_clause` FIRST + `get_note_if_visible` SECOND) must
+    /// exclude it, and it must reappear once its folder is session-unlocked.
+    #[test]
+    fn related_note_links_hybrid_respects_lock_gate() {
+        let db = temp_db();
+        seed_note(&db, "this", "Product Sync", "roadmap sync agenda", None);
+        seed_folder(&db, "f-locked", false);
+        seed_note(
+            &db,
+            "sealed",
+            "Mattress Review",
+            "## Summary\n\nThe mattress felt very comfortable and supportive. SEALED-SECRET price.\n",
+            Some("f-locked"),
+        );
+        // Index the sealed note's vectors WHILE it is still open (a chunk exists in vec_chunks); then
+        // seal it. The gate — not purge — must exclude it under the hybrid semantic leg.
+        index_with(&db, "sealed", &ConceptEmbedder);
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        let query = "sleeping surface ergonomics";
+        let embedder = ConceptEmbedder;
+
+        // Not session-unlocked → the sealed semantic match yields NO link.
+        let nothing = HashSet::new();
+        let hidden = related_note_links_with_embedder(
+            &db,
+            "this",
+            query,
+            &nothing,
+            4,
+            Some(&embedder as &dyn crate::embed::Embedder),
+        )
+        .unwrap();
+        assert!(
+            hidden
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Mattress Review]]")),
+            "sealed-not-unlocked note must not be linked via the hybrid semantic leg (gate violation)"
+        );
+        assert!(
+            hidden.iter().all(|h| !h.detail.contains("SEALED-SECRET")),
+            "sealed content must not leak into a hybrid link detail"
+        );
+
+        // Session-unlock → reappears (note plaintext is restored on real unlock; here it was never
+        // blanked at the column level in this fixture, so the second gate admits it once unlocked).
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let shown = related_note_links_with_embedder(
+            &db,
+            "this",
+            query,
+            &unlocked,
+            4,
+            Some(&embedder as &dyn crate::embed::Embedder),
+        )
+        .unwrap();
+        assert!(
+            shown
+                .iter()
+                .any(|h| h.url.as_deref() == Some("[[Mattress Review]]")),
+            "unlocked semantic match must be linkable"
+        );
+    }
+
+    /// The HYBRID branch keeps SELF-EXCLUSION: even if the current meeting's own note is the nearest
+    /// semantic neighbour, it is never linked to itself.
+    #[test]
+    fn related_note_links_hybrid_self_excluded() {
+        let db = temp_db();
+        seed_note(
+            &db,
+            "this",
+            "Mattress Review",
+            "## Summary\n\nThe mattress felt very comfortable and supportive.\n",
+            None,
+        );
+        index_with(&db, "this", &ConceptEmbedder);
+        let embedder = ConceptEmbedder;
+        let nothing = HashSet::new();
+        let links = related_note_links_with_embedder(
+            &db,
+            "this",
+            "sleeping surface ergonomics",
+            &nothing,
+            4,
+            Some(&embedder as &dyn crate::embed::Embedder),
+        )
+        .unwrap();
+        assert!(
+            links
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Mattress Review]]")),
+            "a note must never be linked to itself under the hybrid branch; got: {links:?}"
+        );
     }
 }

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -190,7 +190,30 @@ tags do not support."
 /// use this. Providers with a separate system/user channel (Anthropic) use
 /// [`default_template`] (or `req.template`) as the system prompt and
 /// [`render_user_content`] as the user message.
+/// On-device note prompts are bounded to this many transcript chars to protect the local engine's
+/// prefill KV cache from an unbounded 1h transcript (P0.2 / mem-2 — the note-generation twin of the
+/// `timeline.rs` guard). Matches the `MAX_TRANSCRIPT_CHARS` cap `chat.rs`/`recipes.rs` already apply.
+/// Cloud providers call [`render_user_content`] directly and are NOT capped (they handle the full
+/// transcript; the RAM-refuse guard in `reason/mistral.rs` is the true OOM backstop).
+const LOCAL_NOTE_MAX_CHARS: usize = 40_000;
+
 pub fn render_prompt(req: &SummarizeRequest) -> String {
+    // `render_prompt` serves ONLY the on-device combined-prompt providers (local mistralrs +
+    // Ollama); cloud providers (Anthropic, Claude Code) render via `render_user_content` directly.
+    // So cap the transcript HERE — it bounds the local prefill KV for a long meeting without
+    // touching cloud note quality. `..req.clone()` keeps every other field byte-identical; a
+    // within-budget transcript borrows the original req unchanged (no clone, byte-identical output).
+    let capped;
+    let req = if req.transcript.chars().count() > LOCAL_NOTE_MAX_CHARS {
+        let head: String = req.transcript.chars().take(LOCAL_NOTE_MAX_CHARS).collect();
+        capped = SummarizeRequest {
+            transcript: format!("{head}\n[transcript truncated]"),
+            ..req.clone()
+        };
+        &capped
+    } else {
+        req
+    };
     format!(
         "{instructions}\n\n{user}",
         instructions = req.template,
@@ -228,20 +251,13 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
         }
     }
 
-    // brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION. When `related_context` is present
-    // (the flag is ON and the gated retrieval found visible prior notes), prepend it as a clearly
-    // labelled, read-only block BEFORE the transcript so the model can reference prior decisions /
-    // owed items and cite them as `[[Title]]`. When `None` (the default + flag-OFF case) this whole
-    // block is skipped, so the output is BYTE-IDENTICAL to before this field existed — no regression.
-    if let Some(ctx) = &req.related_context {
-        if !ctx.trim().is_empty() {
-            out.push_str(
-                "\n## Related prior notes (context only — do not copy, cite as [[Title]])\n",
-            );
-            out.push_str(ctx);
-            out.push('\n');
-        }
-    }
+    // STAGE 1 (two-stage note redesign — Phase 1): the Stage-1 generation prompt carries ONLY this
+    // meeting's transcript + the user's typed notes. Cross-meeting `related_context` is NOT rendered
+    // here — the pipeline sets it `None` (see `pipeline::summarize_and_export`), and even if a caller
+    // sets it, this renderer never folds it into the prompt, so a related note's `## Action items`
+    // can never bleed into the Stage-1 note by construction. The `related_context` field is retained
+    // on `SummarizeRequest` for Phase 2 (a deferred additive link/context post-pass on the finished
+    // note). See docs/research/2026-07-06-note-and-brain-architecture.md (§3 Stage 1, §8 Phase 1).
 
     // ENHANCE-MY-NOTES: the user's typed notes become the SKELETON of the note. The block is
     // instruction + verbatim notes; absent/blank ⇒ byte-identical output (mirrors
@@ -312,29 +328,81 @@ mod tests {
         assert_eq!(out, expected);
     }
 
-    /// Flag ON: a `Some(context)` prepends the labelled, read-only block BEFORE the transcript.
+    /// mem-2 (P0.2): the ON-DEVICE note prompt (`render_prompt`, used only by local mistralrs +
+    /// Ollama) caps the transcript so a 1h meeting cannot blow the local engine's prefill KV, while
+    /// the CLOUD path (`render_user_content`) stays uncapped. RED before the cap (the full ~100k-char
+    /// transcript rendered verbatim, no marker, unbounded length); GREEN after.
     #[test]
-    fn render_user_content_some_prepends_block() {
-        let ctx = "\n\n### [[Q2 Planning]] · 2026-04-01 · id:m-prev\nWe decided to delay launch.";
-        let out = render_user_content(&req(Some(ctx.to_string())));
-        let block_at = out
-            .find("## Related prior notes (context only — do not copy, cite as [[Title]])")
-            .expect("related block present");
-        let transcript_at = out.find("\nTRANSCRIPT\n").expect("transcript present");
+    fn on_device_note_prompt_caps_long_transcript() {
+        let mut r = req(None);
+        r.transcript = "word ".repeat(20_000); // ~100k chars ≈ a full 1h transcript
+
+        let on_device = render_prompt(&r);
         assert!(
-            block_at < transcript_at,
-            "related block must precede the transcript"
+            on_device.contains("[transcript truncated]"),
+            "render_prompt must truncate a long transcript for the on-device path",
         );
-        assert!(out.contains("Q2 Planning"));
-        assert!(out.contains("We decided to delay launch."));
+        assert!(
+            on_device.chars().count() < LOCAL_NOTE_MAX_CHARS + 2_000,
+            "render_prompt output must be bounded near LOCAL_NOTE_MAX_CHARS; got {}",
+            on_device.chars().count(),
+        );
+
+        // The cloud path is deliberately NOT capped (it handles the full transcript).
+        let cloud = render_user_content(&r);
+        assert!(
+            !cloud.contains("[transcript truncated]"),
+            "render_user_content (cloud) must NOT truncate",
+        );
+        assert!(
+            cloud.chars().count() >= LOCAL_NOTE_MAX_CHARS,
+            "the cloud path must carry the full transcript",
+        );
     }
 
-    /// An empty/whitespace context is treated as None (no block, byte-identical to the None path).
+    /// A within-budget transcript is byte-identical through `render_prompt` (no clone, no marker) —
+    /// the cap is inert for normal meetings.
     #[test]
-    fn render_user_content_empty_context_is_skipped() {
+    fn on_device_note_prompt_short_transcript_unchanged() {
+        let r = req(None);
+        let p = render_prompt(&r);
+        assert!(!p.contains("[transcript truncated]"));
+        assert!(p.contains("TRANSCRIPT\nWe shipped v2 and agreed Anna owns the rollout."));
+    }
+
+    /// STAGE 1 BLEED REGRESSION (Phase 1): a POISONED `related_context` — another meeting's
+    /// `## Action items` — is STRUCTURALLY ABSENT from the Stage-1 generation prompt. The renderer no
+    /// longer folds `related_context` into the prompt at all, so cross-meeting tasks can never reach
+    /// the weak model's one prompt (the confirmed source of the `## Action items` bleed). RED before
+    /// Phase 1 (the old code prepended a "## Related prior notes" block, so `Weronika`/`Alcon` and the
+    /// heading WOULD appear); GREEN after. The transcript still renders, and `related_context: None`
+    /// (what the pipeline actually sets) trivially satisfies this too.
+    #[test]
+    fn poisoned_related_note_is_absent_from_stage1_prompt() {
+        // A hostile prior note whose action items must NEVER bleed into this meeting's note.
+        let poison = "\n\n### [[Other Meeting]] · 2026-04-01 · id:m-other\n\
+                      ## Action items\n- [ ] Weronika — weryfikować rampę Alcon\n";
+        let out = render_user_content(&req(Some(poison.to_string())));
+
+        // The Stage-1 prompt still carries THIS meeting's transcript.
+        assert!(
+            out.contains("\nTRANSCRIPT\nWe shipped v2"),
+            "the transcript must be present in the Stage-1 prompt; got:\n{out}"
+        );
+        // …and ZERO cross-meeting content: no related-notes block, no foreign task text.
+        assert!(
+            !out.contains("Related prior notes"),
+            "no '## Related prior notes' block may appear in the Stage-1 prompt; got:\n{out}"
+        );
+        assert!(
+            !out.contains("Weronika") && !out.contains("Alcon"),
+            "a poisoned related note's action items must be structurally absent; got:\n{out}"
+        );
+        // Because the field is now inert, ANY related_context renders identically to `None`.
         assert_eq!(
-            render_user_content(&req(Some("   \n".to_string()))),
-            render_user_content(&req(None))
+            out,
+            render_user_content(&req(None)),
+            "related_context must not affect the rendered Stage-1 prompt"
         );
     }
 
@@ -356,22 +424,21 @@ mod tests {
         );
     }
 
-    /// The skeleton block lands AFTER the related-notes block and BEFORE the transcript,
-    /// carries the notes verbatim, and instructs the `## Also discussed` / no-`My notes` contract.
+    /// The skeleton block lands BEFORE the transcript, carries the notes verbatim, and instructs the
+    /// `## Also discussed` / no-`My notes` contract. (Stage 1, Phase 1: there is no longer a
+    /// related-notes block — the user notes are the only pre-transcript content besides metadata.)
     #[test]
-    fn user_notes_block_renders_between_related_and_transcript() {
-        let mut r = req(Some(
-            "### [[Prior]] · 2026-06-01 · id:x\nprior body".to_string(),
-        ));
+    fn user_notes_block_renders_before_transcript() {
+        let mut r = req(None);
         r.user_notes = Some("ship Friday\nAnna owns QA".to_string());
         let s = render_user_content(&r);
-        let related_at = s
-            .find("## Related prior notes")
-            .expect("related block present");
         let notes_at = s.find("ship Friday\nAnna owns QA").expect("notes verbatim");
         let transcript_at = s.find("\nTRANSCRIPT\n").expect("transcript section");
-        assert!(related_at < notes_at, "skeleton after related notes");
         assert!(notes_at < transcript_at, "skeleton before transcript");
+        assert!(
+            !s.contains("Related prior notes"),
+            "no related-notes block in the Stage-1 prompt"
+        );
         assert!(
             s.contains("## Also discussed"),
             "instructs the Also discussed section"

--- a/src-tauri/src/summarize/timeline.rs
+++ b/src-tauri/src/summarize/timeline.rs
@@ -27,29 +27,122 @@ with its start/end span; sequential spans covering the discussion.\n\
 - Use only timestamps from the transcript; the final endS should be near the meeting end.\n\
 - Output ONLY the JSON object, nothing before or after it.";
 
+/// OOM guard (P0.2, perf-memory-audit §2): the max joined-transcript size fed to an ON-DEVICE
+/// model when deriving the timeline. A 1h meeting joins to ~15–25k tokens; the local mistralrs
+/// engine plans for `max_seq_len = 4096`, so a whole-hour prompt blows past it and the prefill KV
+/// cache balloons several GB on top of the resident weights → the machine OOMs. The timeline is a
+/// COARSE speaker/topic map — it does not need every word — so we cap the joined transcript that
+/// reaches a local model. ~14k chars ≈ a few thousand tokens, comfortably inside the 4096 window
+/// with headroom for the system prompt + the JSON reply. Cloud providers are NOT capped (big
+/// context windows, and they are not the OOM path — see `generate`). Bytes, not tokens: cheap,
+/// deterministic, pure-testable.
+const LOCAL_TIMELINE_MAX_CHARS: usize = 14_000;
+
+/// True when `provider_id` names an ON-DEVICE model (the on-device brain, Ollama, or Apple
+/// Foundation Models) — the residency-bound engines the transcript cap protects. Mirrors
+/// `related_context::is_weak_provider` (same three connection ids) so the two OOM-relevant
+/// classifications never drift; kept local + private to timeline.rs so this file owns its guard.
+fn is_on_device_provider(provider_id: &str) -> bool {
+    provider_id == crate::summarize::roles::CONN_LOCAL
+        || provider_id == crate::summarize::roles::CONN_AFM
+        || provider_id == crate::summarize::PROVIDER_OLLAMA
+}
+
+/// Render ONE transcript line for a segment, preserving its real `[start-end]` timestamps + the
+/// canonical diarization tag (me / others / others-N) so the LLM-derived timeline AGREES with the
+/// segment speaker labels (and its time-spans stay anchored to real meeting time) instead of
+/// inventing its own.
+fn render_segment_line(s: &Segment) -> String {
+    let who = s.speaker.as_deref().unwrap_or("?");
+    format!("[{:.1}-{:.1}] ({}) {}", s.start_s, s.end_s, who, s.text.trim())
+}
+
+/// Build the timestamped transcript fed to the provider.
+///
+/// For an ON-DEVICE model we bound the prompt to `LOCAL_TIMELINE_MAX_CHARS` (the KV/OOM lever, P0.2)
+/// via UNIFORM DECIMATION — NOT head-truncation. A naive head-cut would derive the whole timeline
+/// from only the first minutes of a 1h meeting (a correctness bug); instead we keep an EVENLY-SPACED
+/// stride of segments across the FULL duration, so the coarse timeline still spans the entire
+/// meeting, just at lower resolution. We always keep the FIRST and LAST segment (the timeline's real
+/// start/end anchors). Deterministic + pure over `segments` (unit-tested). Cloud providers pass every
+/// segment (`on_device == false` ⇒ no cap, no decimation — byte-identical to the pre-guard prompt).
+fn build_transcript(segments: &[Segment], on_device: bool) -> String {
+    let full = |segs: &[Segment]| {
+        segs.iter()
+            .map(render_segment_line)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    if !on_device {
+        return full(segments);
+    }
+    let joined = full(segments);
+    if joined.chars().count() <= LOCAL_TIMELINE_MAX_CHARS || segments.len() <= 2 {
+        // Already within budget (short meeting), or too few segments to decimate meaningfully.
+        return joined;
+    }
+    // Pick an EVENLY-SPACED subset that fits the char budget by its ACTUAL rendered cost — NOT a
+    // mean-line estimate + a trailing `take()`. The estimate approach was wrong on non-uniform
+    // transcripts: a few long monologue turns make the mean under-count the strided subset's real
+    // size, the estimate overshoots the budget, and a tail trim then silently DROPS the last kept
+    // segments — re-introducing the very head-only coverage this guards against (adversarial finding
+    // 2026-07-08). Instead we START from an even-stride subset and SHRINK `keep` until the real joined
+    // cost is within budget, so the FIRST + LAST segment (the timeline's end anchors) always survive
+    // and the tail is never chopped.
+    let n = segments.len();
+    // Cost of a strided subset of `keep` segments (rendered line chars + '\n' joins), without
+    // allocating the whole string each time — sum the picked lines' lengths.
+    let stride_indices = |keep: usize| -> Vec<usize> {
+        let mut idxs: Vec<usize> = Vec::with_capacity(keep);
+        for k in 0..keep {
+            // k ∈ [0, keep-1] → index in [0, n-1]; k=0 → first, k=keep-1 → last.
+            let idx = (k * (n - 1)) / (keep - 1);
+            if idxs.last() != Some(&idx) {
+                idxs.push(idx);
+            }
+        }
+        idxs
+    };
+    let cost = |idxs: &[usize]| -> usize {
+        let chars: usize = idxs
+            .iter()
+            .map(|&i| render_segment_line(&segments[i]).chars().count())
+            .sum();
+        chars + idxs.len().saturating_sub(1) // '\n' joins
+    };
+    // Start from a generous even-stride guess, then shrink proportionally until within budget. Each
+    // step strictly decreases `keep` (min(scaled, keep-1)) so it terminates; the floor is 2 (just the
+    // first + last anchors), which we accept even if two pathological giant anchor segments exceed the
+    // budget — keeping BOTH ends beats dropping the last.
+    let mut keep = segments.len();
+    loop {
+        let idxs = stride_indices(keep);
+        let c = cost(&idxs);
+        if c <= LOCAL_TIMELINE_MAX_CHARS || keep <= 2 {
+            return idxs
+                .iter()
+                .map(|&i| render_segment_line(&segments[i]))
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
+        // Proportional shrink, but force progress (at least -1) so we can't stall on a slight overage.
+        let scaled = (keep.saturating_mul(LOCAL_TIMELINE_MAX_CHARS)) / c.max(1);
+        keep = scaled.min(keep - 1).max(2);
+    }
+}
+
 /// Ask the provider to derive the timeline from `segments`, then parse strict JSON out of
 /// the (possibly noisy) reply.
+///
+/// OOM guard (P0.2): for an ON-DEVICE provider the transcript is decimated to
+/// `LOCAL_TIMELINE_MAX_CHARS` (uniform-stride, full-coverage) so a 1h prompt cannot balloon the
+/// local engine's prefill KV cache and OOM the machine. Cloud providers pass the full transcript.
 pub async fn generate(
     provider: &dyn SummarizerProvider,
     segments: &[Segment],
     _duration_s: i64,
 ) -> Result<MeetingTimeline> {
-    let transcript: String = segments
-        .iter()
-        .map(|s| {
-            // Feed the canonical diarization tag (me / others / others-N) so the LLM-derived
-            // timeline AGREES with the segment speaker labels instead of inventing its own.
-            let who = s.speaker.as_deref().unwrap_or("?");
-            format!(
-                "[{:.1}-{:.1}] ({}) {}",
-                s.start_s,
-                s.end_s,
-                who,
-                s.text.trim()
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let transcript = build_transcript(segments, is_on_device_provider(provider.id()));
 
     // Minimal JSON schema for the timeline — passed to the gateway for native constrained decoding;
     // the DEFAULT `complete_json` impl only stringifies it into the system prompt (same parse path
@@ -378,5 +471,185 @@ mod tests {
         repair_coverage(&mut tl, &[]);
         assert_eq!(tl.speakers[0].end_s, 5.0);
         assert_eq!(tl.topics[0].end_s, 5.0);
+    }
+
+    // ── P0.2: bound the transcript fed to a LOCAL model (the KV/OOM lever) ─────────────────────────
+
+    /// Build a synthetic ~1h transcript: many segments, each with realistic text, spread evenly
+    /// across `dur_s` seconds. Returns segments whose joined form vastly exceeds
+    /// `LOCAL_TIMELINE_MAX_CHARS` so the cap is exercised.
+    fn hour_of_segments(n: usize, dur_s: f64) -> Vec<Segment> {
+        (0..n)
+            .map(|i| {
+                let start = (i as f64) * dur_s / (n as f64);
+                let end = start + (dur_s / (n as f64));
+                Segment {
+                    idx: i as i64,
+                    start_s: start,
+                    end_s: end,
+                    // ~60-char line of real-ish content so the join is big.
+                    text: format!(
+                        "segment {i} discussing the quarterly roadmap and budget details here"
+                    ),
+                    speaker: Some(if i % 2 == 0 { "me" } else { "others" }.into()),
+                    confidence: None,
+                }
+            })
+            .collect()
+    }
+
+    /// RED-before-GREEN (OOM guard): an ON-DEVICE provider ("local") gets a transcript BOUNDED to
+    /// `LOCAL_TIMELINE_MAX_CHARS`, while a CLOUD provider ("anthropic") gets the FULL transcript
+    /// (no regression — cloud has a big context window and is not the OOM path).
+    #[test]
+    fn local_transcript_is_capped_cloud_is_not() {
+        // ~1h of dense conversation: 1200 segments × ~75 chars ≈ 90k chars — well past the 14k cap.
+        let segments = hour_of_segments(1200, 3600.0);
+
+        let full = build_transcript(&segments, false); // cloud provider
+        let capped = build_transcript(&segments, true); // on-device provider
+
+        // Cloud: every segment present, uncapped.
+        assert_eq!(
+            full.lines().count(),
+            segments.len(),
+            "cloud provider must receive the FULL transcript (no cap)"
+        );
+        assert!(
+            full.chars().count() > LOCAL_TIMELINE_MAX_CHARS,
+            "the synthetic 1h transcript must exceed the cap so the test is meaningful"
+        );
+
+        // On-device: bounded to the cap.
+        assert!(
+            capped.chars().count() <= LOCAL_TIMELINE_MAX_CHARS,
+            "on-device transcript must be capped at {LOCAL_TIMELINE_MAX_CHARS}, got {}",
+            capped.chars().count()
+        );
+        assert!(
+            capped.chars().count() < full.chars().count(),
+            "the on-device transcript must be strictly smaller than the full one"
+        );
+    }
+
+    /// COVERAGE (not head-truncation): the decimated on-device transcript must still SPAN the whole
+    /// meeting — the LAST kept segment's start time must be in the LATTER portion of the recording,
+    /// and the FIRST kept line must be near the start. A naive head-cut would fail this (its last
+    /// line would be in the first minutes). Parses the `[start-end]` prefix of the kept lines.
+    #[test]
+    fn local_transcript_preserves_full_coverage() {
+        let dur_s = 3600.0;
+        let segments = hour_of_segments(1200, dur_s);
+        let capped = build_transcript(&segments, true);
+
+        // Parse the leading `[start-` float off each kept line.
+        let starts: Vec<f64> = capped
+            .lines()
+            .filter_map(|l| {
+                let inner = l.strip_prefix('[')?;
+                let dash = inner.find('-')?;
+                inner[..dash].parse::<f64>().ok()
+            })
+            .collect();
+        assert!(starts.len() >= 2, "expected multiple kept lines, got {starts:?}");
+
+        let first = *starts.first().unwrap();
+        let last = *starts.last().unwrap();
+        assert!(
+            first < dur_s * 0.05,
+            "first kept segment must be near the start (< 3 min of a 1h meeting), got {first}s"
+        );
+        assert!(
+            last > dur_s * 0.9,
+            "COVERAGE: last kept segment must be in the final tenth of the meeting (not head-only), got {last}s"
+        );
+        // Kept lines are in time order (evenly-spaced stride), so the span is monotonic.
+        assert!(
+            starts.windows(2).all(|w| w[0] <= w[1]),
+            "kept segments must stay in time order"
+        );
+    }
+
+    /// COVERAGE under NON-UNIFORM line lengths — the adversarial regression (2026-07-08). A minority
+    /// of long monologue turns (~2000 chars) among short turns made the OLD `mean_line` estimate
+    /// under-count the strided subset, overshoot the budget, and then a trailing `take()` silently
+    /// DROPPED the last kept lines — re-introducing head-only coverage (repro: last kept ≈ 3160s of
+    /// 3600s; extreme: 0s). This asserts the fix: the LAST segment always survives and the prompt is
+    /// still bounded, regardless of length skew. RED on the old mean-estimate + tail-`take()` code.
+    #[test]
+    fn local_transcript_coverage_survives_length_skew() {
+        let dur_s = 3600.0;
+        let n = 600usize;
+        // 10% long monologues (~2000 chars), 90% short (~200 chars), spread across the hour.
+        let segments: Vec<Segment> = (0..n)
+            .map(|i| {
+                let start = (i as f64) * dur_s / (n as f64);
+                let end = start + dur_s / (n as f64);
+                let text = if i % 10 == 0 {
+                    format!("monologue {i} ").repeat(140) // ~2000 chars
+                } else {
+                    format!("turn {i} ").repeat(25) // ~200 chars
+                };
+                Segment {
+                    idx: i as i64,
+                    start_s: start,
+                    end_s: end,
+                    text,
+                    speaker: Some(if i % 2 == 0 { "me" } else { "others" }.into()),
+                    confidence: None,
+                }
+            })
+            .collect();
+
+        let capped = build_transcript(&segments, true);
+        // Bounded (the OOM guarantee): the on-device prompt stays within budget despite the skew.
+        assert!(
+            capped.chars().count() <= LOCAL_TIMELINE_MAX_CHARS,
+            "skewed on-device transcript must stay within the cap, got {}",
+            capped.chars().count()
+        );
+        // COVERAGE: the LAST kept line's start must be in the final tenth — the last segment (≈3600s)
+        // is never dropped. This is the exact assertion the old tail-`take()` failed (last ≈ 3160s).
+        let starts: Vec<f64> = capped
+            .lines()
+            .filter_map(|l| {
+                let inner = l.strip_prefix('[')?;
+                let dash = inner.find('-')?;
+                inner[..dash].parse::<f64>().ok()
+            })
+            .collect();
+        let last = *starts.last().expect("kept lines");
+        assert!(
+            last > dur_s * 0.9,
+            "COVERAGE under skew: last kept segment must reach the final tenth (not head-only), got {last}s"
+        );
+    }
+
+    /// A SHORT meeting (already within budget) is fed verbatim to an on-device model — no decimation,
+    /// no lost segments — so small meetings are byte-identical for local + cloud.
+    #[test]
+    fn local_transcript_short_meeting_is_unchanged() {
+        let segments = hour_of_segments(6, 30.0); // ~6 short lines, well under 14k chars
+        let capped = build_transcript(&segments, true);
+        let full = build_transcript(&segments, false);
+        assert_eq!(
+            capped, full,
+            "a short meeting under the cap must be identical for local + cloud"
+        );
+        assert_eq!(capped.lines().count(), segments.len());
+    }
+
+    /// `is_on_device_provider` classifies exactly the three residency-bound connection ids (mirrors
+    /// `related_context::is_weak_provider`); cloud providers are NOT on-device.
+    #[test]
+    fn on_device_provider_classification() {
+        assert!(is_on_device_provider(crate::summarize::roles::CONN_LOCAL));
+        assert!(is_on_device_provider(crate::summarize::roles::CONN_AFM));
+        assert!(is_on_device_provider(crate::summarize::PROVIDER_OLLAMA));
+        assert!(!is_on_device_provider(crate::summarize::PROVIDER_ANTHROPIC));
+        assert!(!is_on_device_provider(
+            crate::summarize::PROVIDER_CLAUDE_CODE
+        ));
+        assert!(!is_on_device_provider(crate::summarize::PROVIDER_GATEWAY));
     }
 }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -32,6 +32,65 @@ use crate::error::{AppError, Result};
 use crate::settings::AppConfig;
 use crate::storage::Db;
 
+/// The BRAIN CASCADE tier a [`GatedToolExecutor`] runs at (Phase 5). It is the STRUCTURAL escalation
+/// boundary: which tools the model may reach this turn is decided by CODE (`specs()` filter +
+/// `run()` allowlist), not prompt-trust. A weak model that mis-judges scope STILL cannot reach a
+/// higher tier's tools — the loop literally has no allowlisted way to call them.
+///
+/// - [`Self::CurrentMeeting`] (Tier 1): NO retrieval tools at all. Tier 1 answers from the current
+///   meeting IN ISOLATION — its content is prompt-injected (live RAM buffer / this meeting's
+///   note+segments), so it needs no tool to reach it, and it must NOT be able to reach the vault.
+/// - [`Self::Vault`] (Tier 2): the owned-vault read tools only (search/get_meeting/list_recent/
+///   commitments/dossier) — NO connectors/web.
+/// - [`Self::Connectors`] (Tier 3): the connector/web tools (already `has_app`-gated for
+///   consent/egress). Vault tools stay reachable here too so Tier 3 can still ground in owned notes
+///   while reaching out.
+/// - [`Self::Full`]: the pre-cascade full catalog (per surface flags) — the DELIBERATELY vault-wide
+///   surfaces (the Ask page, MCP-shaped read executors) keep this so their behavior is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssistantScope {
+    /// Tier 1 — the current meeting in isolation (no retrieval tools).
+    CurrentMeeting,
+    /// Tier 2 — the owned vault (search/get_meeting/list_recent/commitments/dossier; no connectors).
+    Vault,
+    /// Tier 3 — connectors/web (+ vault reads for grounding).
+    Connectors,
+    /// The full per-surface catalog (deliberately vault-wide surfaces: Ask page, MCP-shaped reads).
+    Full,
+}
+
+impl AssistantScope {
+    /// Is `tool` reachable at THIS scope? The tiered gate, applied on top of the per-surface flags
+    /// (`has_app`/`note_drafts`/`allow_writes`) in [`GatedToolExecutor::specs`]. The vault READ tools
+    /// and the connector tools are partitioned here; `propose_note` / write tools are governed by the
+    /// surface flags, not the tier, so they are allowed through the tier gate and left to those flags.
+    fn allows(self, tool: &str) -> bool {
+        const VAULT_READS: [&str; 6] = [
+            "search_meetings",
+            "search_semantic",
+            "get_meeting",
+            "list_recent_meetings",
+            "get_open_commitments",
+            "get_entity_dossier",
+        ];
+        const CONNECTORS: [&str; 4] = ["web_search", "calendar_lookup", "jira_search", "slack_search"];
+        match self {
+            // Tier 1 reaches NEITHER vault reads NOR connectors — it answers from injected
+            // current-meeting content only. (propose_note / writes still pass the tier gate; the
+            // surface flags decide those.)
+            AssistantScope::CurrentMeeting => {
+                !VAULT_READS.contains(&tool) && !CONNECTORS.contains(&tool)
+            }
+            // Tier 2 reaches the owned vault only — NO connectors.
+            AssistantScope::Vault => !CONNECTORS.contains(&tool),
+            // Tier 3 reaches connectors AND (for grounding) the vault reads.
+            AssistantScope::Connectors => true,
+            // The full catalog leaves the tier gate open; the surface flags alone decide.
+            AssistantScope::Full => true,
+        }
+    }
+}
+
 /// A single read-only tool INVOCATION. This enum holds the 8 read-only calls the brain can run
 /// against the vault: the 6 the MCP surface advertises (`mcp.rs::tools_spec`) — `search_meetings`,
 /// `get_meeting`, `list_recent_meetings`, `search_semantic`, `get_open_commitments`,
@@ -681,6 +740,13 @@ pub struct GatedToolExecutor<'a> {
     /// with no notes flow (the vault-wide Ask page), where a drafted note could never be accepted.
     /// The tool stays implemented either way — un-advertised, the `run()` allowlist refuses it.
     pub note_drafts: bool,
+    /// The BRAIN CASCADE tier this executor runs at (Phase 5) — the STRUCTURAL escalation boundary.
+    /// [`AssistantScope::CurrentMeeting`] advertises NO retrieval tools (Tier 1 answers from injected
+    /// current-meeting content only); [`AssistantScope::Vault`] advertises the owned-vault reads but NO
+    /// connectors; [`AssistantScope::Connectors`] adds connectors; [`AssistantScope::Full`] is the
+    /// pre-cascade behavior for the deliberately vault-wide surfaces (Ask page). The `run()` allowlist
+    /// re-checks `specs()`, so a model at a lower tier literally CANNOT reach a higher tier's tools.
+    pub scope: AssistantScope,
     /// The note draft the model proposed this turn (via `propose_note`), if any. `None` ⇒ the reply
     /// is a plain ANSWER; `Some(content)` ⇒ a NOTE PROPOSAL the FE should offer to add. No DB effect.
     pub proposed_note: std::sync::Mutex<Option<String>>,
@@ -690,8 +756,14 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
     fn specs(&self) -> Vec<ToolSpec> {
         let has_app = self.app.is_some();
         let allow_writes = self.allow_writes;
+        let scope = self.scope;
         tool_specs()
             .into_iter()
+            // TIER GATE (Phase 5, STRUCTURAL): drop any tool this cascade tier may not reach BEFORE
+            // the per-surface flags. Tier 1 keeps no retrieval tool; Tier 2 keeps no connector; etc.
+            // Applied first so a lower tier cannot advertise (and therefore cannot run) a higher
+            // tier's tool regardless of the surface flags below.
+            .filter(|s| scope.allows(s.name))
             .filter(|s| match s.name {
                 // Connectors require the AppHandle (async sidecar / consent path).
                 "web_search" | "calendar_lookup" | "jira_search" | "slack_search" => has_app,
@@ -1198,6 +1270,7 @@ mod tests {
             app: None,
             allow_writes: true,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let names: Vec<&str> = writeable.specs().iter().map(|s| s.name).collect();
@@ -1223,6 +1296,7 @@ mod tests {
             app: None,
             allow_writes: false,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let ro_names: Vec<&str> = readonly.specs().iter().map(|s| s.name).collect();
@@ -1257,6 +1331,7 @@ mod tests {
             app: None,
             allow_writes: true,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
 
@@ -1319,6 +1394,7 @@ mod tests {
             app: None,
             allow_writes: true,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "secret note" }));
@@ -1349,6 +1425,7 @@ mod tests {
             app: None,
             allow_writes: true,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("save_note", &serde_json::json!({ "text": "orphan note" }));
@@ -1374,6 +1451,7 @@ mod tests {
             app: None,
             allow_writes: false, // read-only — write tools not advertised
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run(
@@ -1408,6 +1486,7 @@ mod tests {
                 app: None,
                 allow_writes,
                 note_drafts: true,
+                scope: AssistantScope::Full,
                 proposed_note: Mutex::new(None),
             };
             let names: Vec<&str> = exec.specs().iter().map(|s| s.name).collect();
@@ -1444,6 +1523,7 @@ mod tests {
             app: None,
             allow_writes: false, // propose works even read-only
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
 
@@ -1498,6 +1578,7 @@ mod tests {
             app: None,
             allow_writes: false,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         // A plain read tool (the kind a question would use) does NOT set a proposal.
@@ -1528,6 +1609,7 @@ mod tests {
             app: None,
             allow_writes: false,
             note_drafts: true,
+            scope: AssistantScope::Full,
             proposed_note: Mutex::new(None),
         };
         let res = exec.run("propose_note", &serde_json::json!({ "content": "   " }));
@@ -1539,5 +1621,138 @@ mod tests {
             exec.proposed_note.lock().unwrap().is_none(),
             "no draft recorded for an empty proposal"
         );
+    }
+
+    // ── Phase 5: PER-TIER TOOL GATING (STRUCTURAL escalation boundary) ──────────────────────────────
+    // The cascade tier is enforced by CODE (`specs()` filter + `run()` allowlist), never prompt-trust.
+    // A model at a lower tier literally CANNOT reach a higher tier's tools — proven here, not "shouldn't".
+
+    fn exec_at<'a>(
+        db: &'a Db,
+        unlocked: &'a Mutex<HashSet<String>>,
+        cfg: &'a AppConfig,
+        scope: AssistantScope,
+    ) -> GatedToolExecutor<'a> {
+        GatedToolExecutor {
+            db,
+            unlocked,
+            config: cfg,
+            meeting_id: "live1",
+            // AppHandle present so the connector tools are NOT gated out by `has_app` — this isolates
+            // the TIER gate: any connector absence here is the tier, not the missing AppHandle. But
+            // `GatedToolExecutor` needs a real `&AppHandle`, which a headless test cannot mint. So we
+            // set `app: None` and, for the Tier-3 advertise test, assert via the TIER predicate
+            // directly (below) — the run()-rejection tests below cover the enforcement path.
+            app: None,
+            allow_writes: false,
+            note_drafts: true,
+            scope,
+            proposed_note: Mutex::new(None),
+        }
+    }
+
+    /// TIER 1 (CurrentMeeting): the executor advertises NO retrieval tools (no vault reads, no
+    /// connectors) — Tier 1 answers from injected current-meeting content only. RED-able: drop the
+    /// `scope.allows(..)` filter in `specs()` and the vault tools reappear at Tier 1.
+    #[test]
+    fn tier1_advertises_no_retrieval_tools() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = exec_at(&db, &unlocked, &cfg, AssistantScope::CurrentMeeting);
+        let names: Vec<&str> = exec.specs().iter().map(|s| s.name).collect();
+        for banned in [
+            "search_meetings",
+            "search_semantic",
+            "get_meeting",
+            "list_recent_meetings",
+            "get_open_commitments",
+            "get_entity_dossier",
+            "web_search",
+            "jira_search",
+            "slack_search",
+            "calendar_lookup",
+        ] {
+            assert!(
+                !names.contains(&banned),
+                "Tier 1 must NOT advertise {banned}: {names:?}"
+            );
+        }
+        // propose_note (a note-draft, not a retrieval tool) is still allowed at Tier 1 (note_drafts).
+        assert!(
+            names.contains(&"propose_note"),
+            "Tier 1 keeps the note-draft tool: {names:?}"
+        );
+    }
+
+    /// TIER 1 STRUCTURAL ENFORCEMENT: a Tier-1 executor `run()`s a vault tool → REFUSED by the
+    /// allowlist (`AppError::InvalidArg`), and NOTHING is read. The model CANNOT reach the vault at
+    /// Tier 1 even if it names a vault tool directly. RED-able: drop the tier filter and this passes
+    /// through to a real (leaking) read.
+    #[test]
+    fn tier1_run_refuses_a_vault_tool() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = exec_at(&db, &unlocked, &cfg, AssistantScope::CurrentMeeting);
+        let res = exec.run("search_meetings", &serde_json::json!({ "query": "anything" }));
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "Tier 1 must REFUSE search_meetings (structural, not prompt-trust): {res:?}"
+        );
+        let res = exec.run("get_meeting", &serde_json::json!({ "meetingId": "m1" }));
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "Tier 1 must REFUSE get_meeting: {res:?}"
+        );
+    }
+
+    /// TIER 2 (Vault): advertises the owned-vault reads but NO connectors. And `run()` REFUSES a
+    /// connector at Tier 2 — a Tier-2 loop cannot reach off-device. RED-able: drop the tier filter
+    /// and jira_search would run (egress at the wrong tier).
+    #[test]
+    fn tier2_advertises_vault_reads_and_refuses_connectors() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = exec_at(&db, &unlocked, &cfg, AssistantScope::Vault);
+        let names: Vec<&str> = exec.specs().iter().map(|s| s.name).collect();
+        assert!(
+            names.contains(&"search_meetings") && names.contains(&"get_meeting"),
+            "Tier 2 advertises the owned-vault reads: {names:?}"
+        );
+        for connector in ["web_search", "jira_search", "slack_search", "calendar_lookup"] {
+            assert!(
+                !names.contains(&connector),
+                "Tier 2 must NOT advertise the connector {connector}: {names:?}"
+            );
+        }
+        // Even a direct, mis-named connector call is refused by the allowlist at Tier 2.
+        let res = exec.run("jira_search", &serde_json::json!({ "query": "login bug" }));
+        assert!(
+            matches!(res, Err(AppError::InvalidArg(_))),
+            "Tier 2 must REFUSE a connector tool (no egress at Tier 2): {res:?}"
+        );
+    }
+
+    /// The TIER PREDICATE partitions the catalog correctly across tiers (the source-of-truth the
+    /// `specs()` filter applies). Tier 3 reaches connectors AND vault reads; `Full` leaves the gate open.
+    #[test]
+    fn tier_predicate_partitions_the_catalog() {
+        // Tier 1: neither vault reads nor connectors.
+        assert!(!AssistantScope::CurrentMeeting.allows("search_meetings"));
+        assert!(!AssistantScope::CurrentMeeting.allows("web_search"));
+        assert!(AssistantScope::CurrentMeeting.allows("propose_note"));
+        // Tier 2: vault reads yes, connectors no.
+        assert!(AssistantScope::Vault.allows("search_meetings"));
+        assert!(!AssistantScope::Vault.allows("web_search"));
+        assert!(!AssistantScope::Vault.allows("jira_search"));
+        // Tier 3: connectors AND vault reads.
+        assert!(AssistantScope::Connectors.allows("web_search"));
+        assert!(AssistantScope::Connectors.allows("jira_search"));
+        assert!(AssistantScope::Connectors.allows("search_meetings"));
+        // Full: everything passes the tier gate (surface flags alone decide downstream).
+        assert!(AssistantScope::Full.allows("search_meetings"));
+        assert!(AssistantScope::Full.allows("web_search"));
     }
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -272,7 +272,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                                 crate::events::VoiceCommandProcessingPayload { active: true },
                             );
                             // No FE thread here (spoken turn) → the turn generates its own id.
-                            spawn_assistant_turn(app.clone(), command, None);
+                            // No FE meeting_id (voice twin) → scope falls back to the live recording.
+                            spawn_assistant_turn(app.clone(), command, None, None);
                         }
                         ManualCaptureDecision::NothingHeard => {
                             // Budget expired with nothing heard → graceful, NOT a confusing
@@ -340,7 +341,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                         );
                         if dispatch {
                             // No FE thread here (wake-word turn) → the turn generates its own id.
-                            spawn_assistant_turn(app.clone(), payload.command.clone(), None);
+                            // No FE meeting_id (wake twin) → scope falls back to the live recording.
+                            spawn_assistant_turn(app.clone(), payload.command.clone(), None, None);
                         }
                         let _ = app.emit(crate::events::EVENT_WAKE_DETECTED, payload);
                     }
@@ -360,8 +362,35 @@ fn should_dispatch(config: &crate::settings::AppConfig) -> bool {
     config.realtime_reactions
 }
 
-/// Max agentic rounds on the cloud brain (decide → tool → … → answer). Bounded for live latency.
-const CLOUD_MAX_STEPS: usize = 4;
+// ── Phase 5 tier system-prompt SUFFIXES ─────────────────────────────────────────────────────────
+// Each is appended to the shared `assistant_system_prompt` (which injects the current-meeting live
+// buffer / typed notes / memory brief). They give the tier its SCOPE contract + the `__ESCALATE__`
+// escalation instruction. The suffix is prose only — the actual tool boundary is STRUCTURAL
+// (`AssistantScope` in the executor), so a model that ignores the prose still cannot reach a higher
+// tier's tools. `__ESCALATE__` must exactly match `crate::agent::ESCALATE_SENTINEL`.
+
+/// Tier 1 — answer ONLY from THIS meeting's own content (the injected live transcript / typed notes),
+/// never the vault. If it is not answerable from this meeting, escalate.
+const TIER1_SUFFIX: &str = "SCOPE — CURRENT MEETING ONLY: Answer STRICTLY from THIS meeting's own \
+    content shown above (its live transcript and the user's typed notes). Do NOT use any outside \
+    knowledge or other saved meetings. You have NO search tools at this step — that is intentional. \
+    If — and only if — the question CANNOT be answered from THIS meeting's content, reply with \
+    EXACTLY this JSON and nothing else: {\"answer\":\"__ESCALATE__\"}. Otherwise answer normally.";
+
+/// Tier 2 — answer from the user's OWN VAULT (their saved meetings/notes) via the gated search tools;
+/// if the vault doesn't cover it, escalate.
+const TIER2_SUFFIX: &str = "SCOPE — YOUR VAULT: Answer from the user's OWN saved meetings and notes, \
+    using the gated vault search tools to ground your answer. Cite meetings by their [[Title]] \
+    wikilink. If — and only if — the answer is NOT in the user's vault (it needs the web, Jira, \
+    Slack, or the calendar), reply with EXACTLY this JSON and nothing else: \
+    {\"answer\":\"__ESCALATE__\"}. Otherwise answer normally.";
+
+/// Tier 3 — TERMINAL: reach the consent-gated connectors/web. If it still can't be answered, say so
+/// honestly — there is NO further tier, so NEVER emit the escalation sentinel here.
+const TIER3_SUFFIX: &str = "SCOPE — CONNECTORS & WEB (last resort): Use the consent-gated connector \
+    and web tools (and the vault tools for grounding) to answer. Loud-attribute external facts \
+    (\"(via web)\", \"(via Jira)\", \"(via Slack)\"). This is the LAST step — if you still cannot \
+    find the answer, say so plainly; do NOT emit any escalation marker.";
 
 /// Resolve the turn's THREAD id: the FE-supplied id when present (an @brain thread), else a fresh
 /// UUID v4 (the voice/wake path and the single-shot text composer send none), so EVERY persisted
@@ -374,22 +403,61 @@ pub(crate) fn ensure_thread_id(explicit: Option<String>) -> String {
     }
 }
 
+/// Resolve the SCOPE meeting for an assistant turn — the id the brain grounds "this meeting" in
+/// (both `GatedToolExecutor.meeting_id` and `gated_live_context`). Precedence (Phase 6 generalizes
+/// the Phase-4 fix): an EXPLICIT FE-sent `meeting_id` (a bound past/anchored @brain thread) WINS
+/// over the FOCUS pointer (`state.focus_meeting` — the meeting the user is looking at), which in
+/// turn WINS over `state.current_meeting` (the recording pointer, `Some` only while recording). So:
+/// a bound thread scopes to ITS meeting even while a different one records; an idle user viewing a
+/// past meeting scopes to THAT meeting (the exact idle wrong-meeting root); and a voice/wake twin
+/// that sends none AND has no focus still falls back to the live recording — so recording keeps
+/// working. A blank/whitespace id at ANY level counts as ABSENT. The empty string means "no scope"
+/// (no FE id, no focus, not recording) — the fail-closed default `gated_live_context` treats as
+/// not-visible. PURE + headless-testable; no PII (opaque ids only).
+pub(crate) fn resolve_scope_meeting(
+    fe_meeting_id: Option<&str>,
+    focus_meeting: Option<&str>,
+    current_meeting: Option<&str>,
+) -> String {
+    let norm = |s: Option<&str>| -> Option<String> {
+        s.map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    norm(fe_meeting_id)
+        .or_else(|| norm(focus_meeting))
+        .or_else(|| norm(current_meeting))
+        .unwrap_or_default()
+}
+
 /// Spawn ONE assistant turn on a DETACHED OS thread — the SINGLE entry to the in-meeting brain for the
 /// wake path, the manual button, AND the text composer (all three funnel here with a `command` string).
 /// The brain + tools can take seconds, so it MUST run off-thread; the whole body is best-effort +
 /// panic-free and runs on its own thread, so even an unexpected panic is contained and can never
 /// disrupt recording or the caption.
-pub fn spawn_assistant_turn(app: AppHandle, command: String, thread_id: Option<String>) {
+pub fn spawn_assistant_turn(
+    app: AppHandle,
+    command: String,
+    thread_id: Option<String>,
+    meeting_id: Option<String>,
+) {
     let _ = std::thread::Builder::new()
         .name("murmur-assistant-turn".into())
-        .spawn(move || run_assistant_turn(&app, command, thread_id));
+        .spawn(move || run_assistant_turn(&app, command, thread_id, meeting_id));
 }
 
 /// The CARD path (wake / manual button / single-shot text composer): run the shared query core, then
 /// EMIT `EVENT_VOICE_ACTION_RESULT` so the assistant card resolves the pending row. The per-tool trace
 /// streams via `EVENT_ASSISTANT_TOOL`. A missing `thread_id` (voice/wake) is backend-generated here,
 /// so the persisted row + every emitted payload of this turn carry the SAME thread identity.
-fn run_assistant_turn(app: &AppHandle, command: String, thread_id: Option<String>) {
+/// `meeting_id` is the OPTIONAL FE-supplied scope meeting (Phase 4): when present it wins over
+/// `state.current_meeting`; the voice/wake twin sends none, so the live recording still scopes.
+fn run_assistant_turn(
+    app: &AppHandle,
+    command: String,
+    thread_id: Option<String>,
+    meeting_id: Option<String>,
+) {
     let thread_id = ensure_thread_id(thread_id);
     let result = run_assistant_query(
         app,
@@ -398,6 +466,7 @@ fn run_assistant_turn(app: &AppHandle, command: String, thread_id: Option<String
         crate::events::EVENT_ASSISTANT_TOOL,
         &thread_id,
         None,
+        meeting_id.as_deref(),
     );
     let _ = app.emit(crate::events::EVENT_VOICE_ACTION_RESULT, result);
 }
@@ -421,6 +490,16 @@ fn run_assistant_turn(app: &AppHandle, command: String, thread_id: Option<String
 /// — it is threaded onto every trace payload, the returned result, and the persisted row, so
 /// simultaneous threads never cross-attribute. `anchor_text` is the note text an @brain thread was
 /// anchored to (persisted with the row; `None` for voice/unanchored turns).
+///
+/// `fe_meeting_id` (Phase 4) is the EXPLICIT scope meeting the FE binds this thread to. It is
+/// resolved as `fe_meeting_id.or(state.focus_meeting).or(state.current_meeting)` via
+/// [`resolve_scope_meeting`] (Phase 6): an explicit FE id WINS (so a past/anchored @brain thread
+/// scopes to ITS meeting even while a DIFFERENT meeting records, and "o czym to spotkanie" on an
+/// idle thread no longer defaults to a vault-wide arbitrary meeting); when the FE sends none, the
+/// FOCUS pointer (the meeting the user is viewing) applies — the backend safety-net for the
+/// voice/wake fallback path; and only when there is neither does the live-recording pointer apply.
+/// The RESOLVED id is used for the executor scope, `gated_live_context`, AND the persisted
+/// thread binding — so a thread durably answers about its OWN meeting.
 pub fn run_assistant_query(
     app: &AppHandle,
     command: &str,
@@ -428,6 +507,7 @@ pub fn run_assistant_query(
     tool_event: &'static str,
     thread_id: &str,
     anchor_text: Option<&str>,
+    fe_meeting_id: Option<&str>,
 ) -> crate::voice_action::VoiceActionResult {
     let state = app.state::<AppState>();
     let config = match state.config.lock() {
@@ -447,12 +527,27 @@ pub fn run_assistant_query(
                 .with_thread_id(thread_id)
         }
     };
-    let meeting_id = state
+    // Phase 6 precedence (generalizes Phase 4): FE-sent `fe_meeting_id` (a bound thread) WINS over
+    // the FOCUS pointer (the meeting the user is viewing — the backend safety-net for any fallback
+    // path, e.g. the voice/wake twin), which WINS over the recording pointer (`current_meeting`,
+    // Some only while recording). Resolved ONCE here and used for the executor scope,
+    // `gated_live_context`, AND the persisted thread binding. A poisoned focus mutex fails safe (as
+    // if unset) — the resolver just falls through to the recording pointer.
+    let focus_meeting = state
+        .focus_meeting
+        .lock()
+        .ok()
+        .and_then(|f| f.clone());
+    let current_meeting = state
         .current_meeting
         .lock()
         .ok()
-        .and_then(|m| m.map(|id| id.to_string()))
-        .unwrap_or_default();
+        .and_then(|m| m.map(|id| id.to_string()));
+    let meeting_id = resolve_scope_meeting(
+        fe_meeting_id,
+        focus_meeting.as_deref(),
+        current_meeting.as_deref(),
+    );
 
     // Resolve an intent for the FLOOR only (its read fan-out + surfaced kind) — it NO LONGER routes
     // writes. The agentic loop (with writes) is the single executive path; the agent DECIDES.
@@ -536,86 +631,72 @@ fn run_informational(
     if !crate::summarize::roles::resolve(crate::summarize::roles::Role::Live, config)
         .is_reasoner_only()
     {
-        let executor = crate::tools::GatedToolExecutor {
-            db: &state.db,
-            // The LIVE set behind its Mutex — re-read per tool call (C6), so a mid-loop relock is gated
-            // out immediately. (The deterministic floor below still uses the per-turn `unlocked` snapshot.)
-            unlocked: &state.unlocked_folders,
-            config,
-            meeting_id,
-            app: Some(app),
-            // PROPOSE-then-ACCEPT model (Rev 2): the in-meeting agent is READ-ONLY — it GENERATES
-            // content (incl. note drafts enriched with the live context) but NEVER auto-writes. The
-            // user commits a draft via the FE's "Add to notes" (→ `save_manual_notes`). The
-            // `save_note`/`create_reminder` write tools stay DORMANT (not advertised while read-only)
-            // for a future structured "agent acts" iteration. The dispatch still routes EVERY request
-            // through this loop (no hardcoded write classifier), so the model decides answer-vs-draft.
-            allow_writes: false,
-            // In-meeting surfaces HAVE the notes flow + "Add to notes" Accept affordance, so the
-            // draft tool is advertised here (the vault-wide Ask page sets this false).
-            note_drafts: true,
-            // The `propose_note` tool records its draft HERE (no DB write). We read it after
-            // the loop to mark the reply as a NOTE PROPOSAL vs a plain ANSWER. The model decides which.
-            proposed_note: std::sync::Mutex::new(None),
-        };
-        let sink = ToolEventSink {
-            app: app.clone(),
-            event: tool_event,
-            thread_id: thread_id.to_string(),
-        };
-        // Inject the LIVE transcript of the recording IN PROGRESS + the user's OWN typed notes for
-        // the CURRENT meeting (segments aren't persisted until Stop, and typed notes carry the
-        // user's emphasis). Both are read through `gated_live_context` — gated by
-        // `meeting_is_visible` on the LIVE per-turn `unlocked` set (fail-closed) — and egress
-        // through the SAME redaction firewall as every prompt (`RedactingProvider::complete`
-        // scrubs `system` + `user`), only when cloud egress is consented (this branch is
-        // Cloud-only). NO new egress class.
-        let (live, typed_notes) =
-            gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
-        // Phase 3 CROSS-MEETING USER MEMORY: synthesize the memory brief from the currently-VISIBLE
-        // user facts only (sealed-source facts are excluded by `list_user_facts_visible`), and inject
-        // it next to the live-transcript section. It rides the SAME redaction firewall + cloud-consent
-        // gate as every other prompt segment — NO new egress class (design spec C3). Suppressed
-        // entirely when memory is turned off (`user_memory_enabled == false`).
-        let memory_brief = gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled);
-        // Is a recording LIVE right now? (recorder present ⇒ capture in progress.) This lets the
-        // prompt scope "this meeting/conversation" to the recording in progress even before any
-        // caption lands — so an empty live buffer no longer sends the agent off to describe OTHER
-        // saved meetings. Best-effort: a poisoned lock degrades to `false` (the vault-grounding
-        // branch), never a failure.
-        let recording_in_progress = state.recorder.lock().map(|g| g.is_some()).unwrap_or(false);
-        let system =
-            assistant_system_prompt(&live, &typed_notes, &memory_brief, recording_in_progress);
-        match crate::agent::run_agentic_loop(
+        // Phase 5 — the CURRENT-FIRST BRAIN CASCADE. Try each tier in order (current meeting →
+        // vault → connectors), each with a STRUCTURALLY-scoped executor (`AssistantScope`) that
+        // advertises only that tier's tools. The tier's prompt instructs the model to reply with the
+        // `__ESCALATE__` sentinel when the question is not answerable at that tier; the ladder detects
+        // it and steps up. This is "deterministic escalation, model-driven retrieval": which tools are
+        // reachable is code-enforced, retrieval within a tier stays model-driven.
+        if let Some(result) = run_cascade(
+            app, state, config, unlocked, meeting_id, loop_user, intent, tool_event, thread_id,
             &*reasoner,
-            &system,
-            loop_user,
-            &executor,
-            CLOUD_MAX_STEPS,
-            Some(&sink as &dyn crate::agent::DeltaSink),
         ) {
-            Ok(Some(outcome)) => {
-                // Read the model's NOTE PROPOSAL (if it called `propose_note` this turn) off the
-                // executor scratch and thread it onto the result — `Some` ⇒ a note draft, `None` ⇒ a
-                // plain answer. No DB write happened; the FE commits the draft on Accept.
-                let proposed = executor.proposed_note.lock().ok().and_then(|g| g.clone());
-                return crate::voice_action::VoiceActionResult::from_agent(intent, outcome)
-                    .with_proposed_note(proposed);
-            }
-            Ok(None) => tracing::debug!(
-                target: "voice",
-                "agentic loop did not converge; flooring to deterministic retrieval"
-            ),
-            Err(e) => tracing::debug!(
-                target: "voice",
-                error = %e,
-                "agentic loop unavailable/failed; flooring to deterministic retrieval"
-            ),
+            return result;
         }
+        // No tier converged (out of steps / no answer at any tier) → fall through to the floor.
     }
     // FLOOR — deterministic, gated, cited, needs_consent-aware, INFORMATIONAL ONLY. `floor_intent_for`
     // demotes a write intent to a Research so the floor NEVER performs a hardcoded write (a write
     // happens only when the AGENT chooses it; the floor is the read safety net).
+    //
+    // RECORDING AWARENESS on the FLOOR (back-ported from the cascade): the SAME recorder-lock flag the
+    // cascade computes (`run_cascade`) — a bool, NOT a content read — so the floor knows a meeting is
+    // being recorded RIGHT NOW even when the live buffer is still empty (meeting just started).
+    let recording_in_progress = state.recorder.lock().map(|g| g.is_some()).unwrap_or(false);
+
+    // ── TIER 1 — DETERMINISTIC CURRENT-FIRST (the structural fix) ────────────────────────────────
+    // When the user is CLEARLY asking about THIS meeting ("o czym jest to spotkanie", "summarize this
+    // recording", "co tu ustaliliśmy"), answer from the CURRENT meeting IN ISOLATION — NO vault
+    // fan-out, NO web leg, NO calendar. This is what stops "o czym to spotkanie" (topic ≈ "spotkanie")
+    // from web-searching the WORD "meeting" and drowning the weak local model in generic definition
+    // pages. Deterministic, NOT model-driven: the weak floor model can't be trusted to route.
+    //
+    // The current content comes from `tier1_current_content` — the SAME visibility gate as the
+    // fan-out floor, but ALSO reading a VIEWED PAST meeting's own gated transcript+note (the gap:
+    // `floor_current_context` reads only the live buffer, so a viewed saved meeting was empty →
+    // wrongly fell through to fan-out). A sealed-not-unlocked meeting yields "" (fail-closed) → the
+    // honest "no content" branch, NEVER a leak and NEVER a fan-out.
+    if crate::voice_action::is_about_current_meeting(command) {
+        let current_content =
+            tier1_current_content(&state.db, &state.live_transcript, meeting_id, unlocked);
+        let title = current_meeting_title(&state.db, meeting_id, unlocked);
+        // `intent_kind` for the card: keep the demoted read discriminant (research/recall stay as-is;
+        // a write intent is surfaced as research so the card style matches the informational floor).
+        let floor_intent = floor_intent_for(intent, command);
+        let kind = crate::voice_action::intent_kind_str(&floor_intent);
+        return crate::voice_action::answer_current_meeting_isolated(
+            kind,
+            command,
+            &current_content,
+            recording_in_progress,
+            title.as_deref(),
+            &*reasoner,
+        );
+    }
+
+    // ── TIER 2/3 — the EXISTING fan-out floor (UNCHANGED) ────────────────────────────────────────
+    // NOT a current-meeting question → the vault + web + calendar fan-out, exactly as before, so
+    // cross-note ("co ustaliliśmy z Weroniką" → vault) and world ("jaka pogoda" → web) questions still
+    // work. Because the current-first branch returned early above, the web leg now ONLY ever fires for
+    // genuinely non-current questions — precisely the fix.
+    //
+    // Fetch THIS meeting's context through the SAME GATED reader the cascade uses
+    // (`gated_live_context` → fail-closed on `meeting_is_visible`: a sealed-not-visible meeting yields
+    // empty), and hand it to the floor as the PRIMARY, clearly-labeled grounding. No new read path, no
+    // new egress class (it rides the same RedactingProvider + consent gate inside `handle_voice_action`).
+    let (live, typed_notes) =
+        gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
+    let current_meeting_context = floor_current_context(&live, &typed_notes);
     let floor_intent = floor_intent_for(intent, command);
     crate::voice_action::handle_voice_action(
         &floor_intent,
@@ -625,8 +706,297 @@ fn run_informational(
         config,
         meeting_id,
         command,
+        &current_meeting_context,
+        recording_in_progress,
         Some(app),
     )
+}
+
+/// Assemble the CURRENT meeting's gated context (its live-transcript tail + the user's typed notes)
+/// into one compact, labeled block for the deterministic floor's PRIMARY grounding. Inputs come from
+/// [`gated_live_context`] (already visibility-gated — a sealed-not-visible meeting yields two empty
+/// strings), so this only ever formats VISIBLE content. Both parts are truncated to the same recent
+/// tail the live system prompt uses ([`LIVE_TRANSCRIPT_INJECT_CHARS`]) to keep the local reasoner's
+/// window bounded. Returns "" when there is nothing to inject (idle / not-yet-captured / not visible),
+/// so the floor stays byte-identical to before for a no-context turn.
+fn floor_current_context(live: &str, typed_notes: &str) -> String {
+    let mut out = String::new();
+    let live = live.trim();
+    if !live.is_empty() {
+        out.push_str("Live transcript (so far):\n");
+        out.push_str(&tail_chars(live, LIVE_TRANSCRIPT_INJECT_CHARS));
+    }
+    let typed = typed_notes.trim();
+    if !typed.is_empty() {
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str("Your typed notes:\n");
+        out.push_str(&tail_chars(typed, LIVE_TRANSCRIPT_INJECT_CHARS));
+    }
+    out
+}
+
+/// TIER-1 CURRENT-MEETING CONTENT for the DETERMINISTIC FLOOR (reasoner-only / local backend). Unlike
+/// [`floor_current_context`] (which reads ONLY the live RAM buffer), this ALSO reads a VIEWED PAST
+/// meeting's own gated content — the gap that made "o czym to spotkanie" on a viewed saved meeting
+/// fall through to the vault+web fan-out (its live buffer is empty for a non-recording meeting).
+///
+/// Two GATED sources, in order:
+///   1. LIVE (recording in progress OR the live buffer/typed-notes are non-empty for a VISIBLE
+///      meeting): the `floor_current_context` block (live tail + typed notes), already
+///      visibility-gated by `gated_live_context` (a sealed-not-visible meeting yields "").
+///   2. PAST (a viewed saved meeting): the meeting's OWN transcript (`get_segments`) + note
+///      (`get_note_if_visible`), read ONLY when `meeting_is_visible` — a sealed-not-unlocked meeting
+///      is INVISIBLE, so BOTH the visibility check and `get_note_if_visible` fail closed and this
+///      returns "". This mirrors the `chat_meeting` gated read shape but stays inside `live.rs` over
+///      `db` (no call into `commands.rs`).
+///
+/// Returns the assembled current-meeting content (possibly ""). NEVER reads ungated content: the
+/// visibility gate is checked before ANY segment/note read.
+fn tier1_current_content(
+    db: &crate::storage::Db,
+    live_transcript: &std::sync::Mutex<String>,
+    meeting_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+) -> String {
+    // 1) LIVE buffer + typed notes (gated). Non-empty for a visible in-progress / focused meeting.
+    let (live, typed_notes) = gated_live_context(db, live_transcript, meeting_id, unlocked);
+    let live_block = floor_current_context(&live, &typed_notes);
+    if !live_block.trim().is_empty() {
+        return live_block;
+    }
+
+    // 2) PAST viewed meeting — read its OWN gated content. GATE FIRST: a sealed-not-unlocked meeting
+    // is invisible → return "" (no read). This is the same fail-closed gate `chat_meeting` uses,
+    // implemented here over `db` so we never touch `commands.rs`.
+    if meeting_id.is_empty() || !db.meeting_is_visible(meeting_id, unlocked).unwrap_or(false) {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    // Transcript (gated by the visibility check above; a sealed meeting's segments are blanked at
+    // rest anyway). Rendered like `chat_meeting`'s transcript, bounded to the recent tail.
+    if let Ok(segments) = db.get_segments(meeting_id) {
+        let transcript = segments
+            .iter()
+            .filter(|s| !s.text.trim().is_empty())
+            .map(|s| format!("[{:.0}s] {}", s.start_s, s.text.trim()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let transcript = transcript.trim();
+        if !transcript.is_empty() {
+            out.push_str("Transcript:\n");
+            out.push_str(&tail_chars(transcript, LIVE_TRANSCRIPT_INJECT_CHARS));
+        }
+    }
+    // Note (VISIBILITY-GATED read: a sealed-not-unlocked meeting yields None).
+    if let Ok(Some(note)) = db.get_note_if_visible(meeting_id, unlocked) {
+        let md = note.markdown.trim();
+        if !md.is_empty() {
+            if !out.is_empty() {
+                out.push_str("\n\n");
+            }
+            out.push_str("Note:\n");
+            out.push_str(&tail_chars(md, LIVE_TRANSCRIPT_INJECT_CHARS));
+        }
+    }
+    out
+}
+
+/// The current meeting's OWN gated title (for the Tier-1 isolated answer's `[[Title]]` citation).
+/// GATE (fail-closed): resolved ONLY for a VISIBLE meeting — a sealed-not-unlocked meeting is
+/// invisible and yields `None` (no title leak). Mirrors [`tier_extra_citations`]'s gated resolution.
+fn current_meeting_title(
+    db: &crate::storage::Db,
+    meeting_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+) -> Option<String> {
+    if meeting_id.is_empty() || !db.meeting_is_visible(meeting_id, unlocked).unwrap_or(false) {
+        return None;
+    }
+    match db.get_meeting(meeting_id) {
+        Ok(Some(m)) => m
+            .title
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Per-tier step budgets (Phase 5) — kept SMALL so the cascade stays live-safe (a live turn can run
+/// up to all three tiers back-to-back). Tier 1 answers from injected content (no retrieval tool), so
+/// it converges in one model turn — a budget of 2 leaves room for a `propose_note` + answer. Tier 2
+/// (vault retrieval) gets 4; Tier 3 (connectors) gets 3.
+const TIER1_MAX_STEPS: usize = 2;
+const TIER2_MAX_STEPS: usize = 4;
+const TIER3_MAX_STEPS: usize = 3;
+
+/// Run the CURRENT-FIRST BRAIN CASCADE (Phase 5): Tier 1 (current meeting in isolation) → Tier 2
+/// (vault) → Tier 3 (connectors), each with a STRUCTURALLY-scoped executor. Returns
+/// `Some(VoiceActionResult)` when a tier CONVERGED to a real (non-escalation) answer — the tier badge
+/// is set DETERMINISTICALLY to that tier. Returns `None` when no tier answered (each either escalated
+/// to the next, or ran out of steps / errored) → the caller floors to the deterministic path.
+///
+/// ESCALATION is deterministic: the tier prompt asks the model to reply EXACTLY the
+/// [`crate::agent::ESCALATE_SENTINEL`] when it cannot answer at that tier; [`crate::agent::is_escalation`]
+/// detects it (whole-answer match, never a substring) and the ladder steps up. A NON-convergence
+/// (`Ok(None)`) or an `Err` at a tier is handled WITHIN the ladder (try the next tier if there is one,
+/// else `None`) — it is NOT conflated with escalation.
+#[allow(clippy::too_many_arguments)]
+fn run_cascade(
+    app: &AppHandle,
+    state: &AppState,
+    config: &crate::settings::AppConfig,
+    unlocked: &std::collections::HashSet<String>,
+    meeting_id: &str,
+    loop_user: &str,
+    intent: &crate::audio::wake::VoiceIntent,
+    tool_event: &'static str,
+    thread_id: &str,
+    reasoner: &dyn crate::reason::LocalReasoner,
+) -> Option<crate::voice_action::VoiceActionResult> {
+    // Shared per-turn injected context (gated). Tier 1 leans on the live buffer + typed notes for the
+    // CURRENT meeting (read through `gated_live_context`, fail-closed on the LIVE unlocked set); the
+    // memory brief + recording flag ride along exactly as before. NO new egress class — every segment
+    // goes through the same RedactingProvider + cloud-consent gate.
+    let (live, typed_notes) =
+        gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
+    let memory_brief = gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled);
+    let recording_in_progress = state.recorder.lock().map(|g| g.is_some()).unwrap_or(false);
+    let base_system =
+        assistant_system_prompt(&live, &typed_notes, &memory_brief, recording_in_progress);
+
+    // The ladder, in order. Each entry: (scope, per-tier prompt suffix, step budget, badge, whether
+    // it may escalate). Tier 3 is TERMINAL — it never escalates (there is no higher tier).
+    use crate::tools::AssistantScope;
+    use crate::voice_action::AnsweredFrom;
+    let tiers: [(AssistantScope, &str, usize, AnsweredFrom, bool); 3] = [
+        (
+            AssistantScope::CurrentMeeting,
+            TIER1_SUFFIX,
+            TIER1_MAX_STEPS,
+            AnsweredFrom::CurrentMeeting,
+            true,
+        ),
+        (
+            AssistantScope::Vault,
+            TIER2_SUFFIX,
+            TIER2_MAX_STEPS,
+            AnsweredFrom::Vault,
+            true,
+        ),
+        (
+            AssistantScope::Connectors,
+            TIER3_SUFFIX,
+            TIER3_MAX_STEPS,
+            AnsweredFrom::Connectors,
+            false,
+        ),
+    ];
+
+    for (scope, suffix, max_steps, badge, may_escalate) in tiers {
+        let executor = crate::tools::GatedToolExecutor {
+            db: &state.db,
+            // The LIVE set behind its Mutex — re-read per tool call (C6), so a mid-loop relock is gated
+            // out immediately at every tier.
+            unlocked: &state.unlocked_folders,
+            config,
+            meeting_id,
+            app: Some(app),
+            // PROPOSE-then-ACCEPT model (Rev 2): the in-meeting agent is READ-ONLY at every tier — it
+            // GENERATES content (incl. note drafts) but NEVER auto-writes; the user commits via "Add to
+            // notes". The dispatch still routes EVERY request through the loop (no hardcoded classifier).
+            allow_writes: false,
+            note_drafts: true,
+            // Phase 5: the STRUCTURAL escalation boundary — this tier's executor advertises only its
+            // tools; `run()` refuses any other. A weak model CANNOT reach a higher tier's tools.
+            scope,
+            proposed_note: std::sync::Mutex::new(None),
+        };
+        let sink = ToolEventSink {
+            app: app.clone(),
+            event: tool_event,
+            thread_id: thread_id.to_string(),
+        };
+        let system = format!("{base_system}\n\n{suffix}");
+        match crate::agent::run_agentic_loop(
+            reasoner,
+            &system,
+            loop_user,
+            &executor,
+            max_steps,
+            Some(&sink as &dyn crate::agent::DeltaSink),
+        ) {
+            Ok(Some(outcome)) => {
+                // ESCALATION vs a REAL answer. `is_escalation` matches the WHOLE answer (never a
+                // substring) so a genuine answer that mentions the token does not mis-escalate.
+                if crate::agent::is_escalation(&outcome.answer) {
+                    if may_escalate {
+                        tracing::debug!(target: "voice", "tier escalating to the next tier");
+                        continue; // try the next tier
+                    }
+                    // Terminal tier said escalate but there is no higher tier → treat as "no answer
+                    // here" and fall to the deterministic floor (never surface the sentinel).
+                    tracing::debug!(target: "voice", "terminal tier requested escalation; flooring");
+                    return None;
+                }
+                // REAL answer at this tier — set the badge DETERMINISTICALLY from the tier that
+                // converged (never string-sniffed). Add the tier-appropriate extra citations.
+                let extra = tier_extra_citations(&state.db, meeting_id, badge, unlocked);
+                let proposed = executor.proposed_note.lock().ok().and_then(|g| g.clone());
+                return Some(
+                    crate::voice_action::VoiceActionResult::from_agent(intent, outcome, badge, extra)
+                        .with_proposed_note(proposed),
+                );
+            }
+            // Non-convergence at a tier is NOT escalation — try the next tier if there is one, else
+            // let the caller floor. This distinguishes "out of steps here" from "escalate".
+            Ok(None) => {
+                tracing::debug!(target: "voice", "tier did not converge; trying the next tier / floor");
+                continue;
+            }
+            // An error (e.g. Unavailable = no cloud consent) is fatal to the whole cascade — the same
+            // provider is used at every tier, so a re-attempt would fail identically. Floor.
+            Err(e) => {
+                tracing::debug!(target: "voice", error = %e, "cascade tier unavailable/failed; flooring");
+                return None;
+            }
+        }
+    }
+    None
+}
+
+/// The tier-specific extra citations the loop's `gathered`-scraped citations miss. Tier 1's answer is
+/// grounded in PROMPT-INJECTED current-meeting content (which produces no `[[Title]]` in `gathered`),
+/// so we resolve the CURRENT meeting's OWN title to a `[[Title]]` and prepend it — GATED: only when
+/// the meeting is VISIBLE to the live `unlocked` set (never a title for a sealed-not-unlocked
+/// meeting), and only when it has a non-empty title. Tier 2/3 rely on the loop's own gated citations
+/// + (Tier 3) the connector loud-lines the agent's answer already carries, so they add nothing here.
+fn tier_extra_citations(
+    db: &crate::storage::Db,
+    meeting_id: &str,
+    badge: crate::voice_action::AnsweredFrom,
+    unlocked: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    if badge != crate::voice_action::AnsweredFrom::CurrentMeeting || meeting_id.is_empty() {
+        return Vec::new();
+    }
+    // GATE (fail-closed): resolve the title ONLY for a VISIBLE meeting — a sealed-not-unlocked meeting
+    // is invisible and contributes no citation (its live buffer was already masked to "" by
+    // `gated_live_context`, so Tier 1 could only have answered "just started" anyway).
+    if !db.meeting_is_visible(meeting_id, unlocked).unwrap_or(false) {
+        return Vec::new();
+    }
+    match db.get_meeting(meeting_id) {
+        Ok(Some(m)) => match m.title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+            Some(title) => vec![format!("[[{title}]]")],
+            None => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
 }
 
 /// The intent the INFORMATIONAL FLOOR runs with. Read intents (Research / Recall / SlackSearch /
@@ -1223,6 +1593,14 @@ fn assistant_system_prompt(
                 note about the decisions\", \"save that we ship Friday\"), call the propose_note tool \
                 with the note content enriched from the meeting context — that drafts a note for the \
                 user to review and accept; do NOT call propose_note for ordinary questions.";
+    // NOTE (shared recording-awareness wording): the three load-bearing phrases below —
+    // "recorded RIGHT NOW", "meeting just started", and the "do NOT search the vault for other saved
+    // meetings" substitution ban — are ALSO the deterministic FLOOR's phrases, defined ONCE as
+    // `voice_action::{RECORDING_NOW_PHRASE, MEETING_JUST_STARTED_PHRASE,
+    // NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE}` and consumed by `voice_action::rag_answer` so the
+    // local-model floor frames a live recording IDENTICALLY to this cascade prompt. This prose is kept
+    // LITERAL here (not wired to the consts) because the cascade prompt tests pin these exact
+    // substrings verbatim — the duplication is deliberate and cross-referenced; keep the two in sync.
     let t = live_transcript.trim();
     let mut prompt = if t.is_empty() {
         if recording_in_progress {
@@ -2019,6 +2397,70 @@ mod tests {
         assert_eq!(*live.lock().unwrap(), "sealed meeting tail still in RAM");
     }
 
+    /// (B/gate) RED-before-GREEN (2026-07-08): the deterministic floor's CURRENT-meeting grounding is
+    /// built from `gated_live_context` → `floor_current_context`. A sealed-not-visible meeting yields
+    /// EMPTY gated context, so the floor's current-meeting block is empty (nothing sealed leaks into
+    /// the local-brain floor prompt). A VISIBLE meeting produces a labeled, non-empty block.
+    #[test]
+    fn floor_current_context_is_empty_for_sealed_meeting_and_labeled_for_visible() {
+        let db = tmp_db("floor-ctx");
+        // Sealed-not-unlocked meeting → gated context is empty → floor current block is empty.
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_meeting(&db, "sealed", Some("f1"));
+        db.set_manual_notes("sealed", "SECRET typed note").unwrap();
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        let live = std::sync::Mutex::new("SECRET live tail".to_string());
+        let unlocked = std::collections::HashSet::new();
+        let (l, n) = gated_live_context(&db, &live, "sealed", &unlocked);
+        let ctx = floor_current_context(&l, &n);
+        assert!(
+            ctx.is_empty(),
+            "a sealed-not-visible meeting must contribute NO floor current-meeting grounding: {ctx}"
+        );
+        assert!(
+            !ctx.contains("SECRET"),
+            "sealed content must NOT leak into the floor grounding"
+        );
+
+        // A visible in-progress recording → non-empty, labeled block containing tail + typed notes.
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-rec".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: None,
+            duration_s: 0,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Recording,
+            folder_id: None,
+        })
+        .unwrap();
+        db.set_manual_notes("m-rec", "ship Friday").unwrap();
+        let live2 = std::sync::Mutex::new("we agreed to ship friday".to_string());
+        let (l2, n2) = gated_live_context(&db, &live2, "m-rec", &unlocked);
+        let ctx2 = floor_current_context(&l2, &n2);
+        assert!(
+            ctx2.contains("Live transcript"),
+            "the visible meeting's live tail must be labeled in the floor grounding: {ctx2}"
+        );
+        assert!(
+            ctx2.contains("we agreed to ship friday"),
+            "the visible live tail must be present: {ctx2}"
+        );
+        assert!(
+            ctx2.contains("ship Friday"),
+            "the visible typed notes must be present: {ctx2}"
+        );
+    }
+
     #[test]
     fn gated_live_context_injects_for_visible_meeting_and_masks_without_one() {
         let db = tmp_db("visible");
@@ -2083,6 +2525,277 @@ mod tests {
         assert!(gated_live_context(&db, &live, "m1", &unlocked).0.is_empty());
         unlocked.insert("f1".to_string());
         assert_eq!(gated_live_context(&db, &live, "m1", &unlocked).0, "tail");
+    }
+
+    // ── Phase 4: explicit-meeting_id scope resolution (kills the wrong-meeting bug) ────────────────
+
+    #[test]
+    fn resolve_scope_meeting_fe_id_wins_over_current_meeting() {
+        // The precedence rule: an EXPLICIT FE-sent meeting_id (a bound past/anchored @brain thread)
+        // WINS over state.current_meeting (the recording pointer). This is the exact case the
+        // wrong-meeting bug lived in — viewing a PAST meeting while a DIFFERENT meeting records must
+        // scope to the viewed meeting, not the recording. RED on the pre-phase code, which read ONLY
+        // current_meeting and ignored any FE id. (Phase 6: focus is None here.)
+        assert_eq!(
+            resolve_scope_meeting(Some("past-thread-meeting"), None, Some("recording-meeting")),
+            "past-thread-meeting",
+            "an explicit FE meeting_id must win over the recording pointer"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_falls_back_to_recording_when_fe_none() {
+        // The voice/wake twin (and a live thread that omits it) sends None → with no focus either,
+        // the live recording pointer still scopes, so recording keeps working exactly as before.
+        assert_eq!(
+            resolve_scope_meeting(None, None, Some("recording-meeting")),
+            "recording-meeting",
+            "a None FE id + no focus falls back to the current recording meeting"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_past_thread_when_idle_no_recording() {
+        // The headline fix: idle (nothing recording ⇒ current_meeting None, no focus) + a bound
+        // past-meeting thread ⇒ scope is THAT meeting, NOT empty. Empty was the whole bug: it fell
+        // through to gated_live_context → ("","") → the "ground answers in the vault" branch → an
+        // arbitrary saved meeting. With a bound id the scope is concrete.
+        assert_eq!(
+            resolve_scope_meeting(Some("m-past"), None, None),
+            "m-past",
+            "an idle bound past-meeting thread scopes to its own meeting, not empty"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_blank_counts_as_absent_both_sides() {
+        // Blank/whitespace at ANY level is ABSENT. A blank FE id falls to focus/recording; a blank
+        // FE id + blank focus + blank recording yields "" (no scope — the fail-closed default,
+        // which gated_live_context treats as not-visible).
+        assert_eq!(resolve_scope_meeting(Some("  "), None, Some("m-rec")), "m-rec");
+        assert_eq!(resolve_scope_meeting(Some(""), None, None), "");
+        assert_eq!(resolve_scope_meeting(None, None, Some("   ")), "");
+        assert_eq!(resolve_scope_meeting(Some(" m-x "), None, None), "m-x");
+    }
+
+    #[test]
+    fn resolve_scope_meeting_focus_wins_over_recording_when_fe_none() {
+        // PHASE 6: the FOCUS pointer (the meeting the user is VIEWING) wins over the recording
+        // pointer when the FE sends no explicit id — the idle wrong-meeting root. Viewing a past
+        // meeting while a DIFFERENT meeting records must scope to the VIEWED (focus) meeting, not
+        // the recording. RED on the Phase-4 two-arg resolver (no focus arg existed).
+        assert_eq!(
+            resolve_scope_meeting(None, Some("m-focused-past"), Some("m-recording")),
+            "m-focused-past",
+            "the focus pointer must win over the recording pointer when the FE sends none"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_fe_id_wins_over_focus() {
+        // PHASE 6: an explicit FE-bound thread id is the TOP of the precedence — it wins even over
+        // the focus pointer (a thread durably answers about its OWN bound meeting regardless of what
+        // the user happens to be looking at).
+        assert_eq!(
+            resolve_scope_meeting(Some("m-bound"), Some("m-focused"), Some("m-recording")),
+            "m-bound",
+            "an explicit FE meeting_id must win over both focus and recording"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_focus_used_when_idle_no_recording() {
+        // PHASE 6: focus makes the cascade Tier-1 scope deterministic even when NOTHING records
+        // (current_meeting None) and the FE sent no id — the user is just viewing a meeting.
+        assert_eq!(
+            resolve_scope_meeting(None, Some("m-focused"), None),
+            "m-focused",
+            "focus scopes an idle view when there is no FE id and no recording"
+        );
+    }
+
+    #[test]
+    fn resolve_scope_meeting_blank_focus_falls_through() {
+        // A blank/whitespace focus is ABSENT and falls through to the recording pointer.
+        assert_eq!(resolve_scope_meeting(None, Some("   "), Some("m-rec")), "m-rec");
+        // A blank focus + no recording yields "".
+        assert_eq!(resolve_scope_meeting(None, Some("  "), None), "");
+        // A blank FE id + a real focus uses the focus.
+        assert_eq!(resolve_scope_meeting(Some(" "), Some("m-focus"), Some("m-rec")), "m-focus");
+    }
+
+    #[test]
+    fn resolved_past_meeting_scope_grounds_gated_context_in_that_meeting() {
+        // End-to-end for the resolution seam: a bound PAST (not-recording) meeting id, resolved with
+        // NO recording pointer, drives gated_live_context to read THAT meeting's own gated context
+        // (its typed notes) — not empty/arbitrary. Proves the FE id reaches the gate as the scope.
+        let db = tmp_db("phase4-scope");
+        // A visible past meeting (no folder → trivially visible) with its OWN typed notes.
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-past".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: Some("2026-07-01T10:00:00Z".to_string()),
+            title: Some("Budget review".to_string()),
+            duration_s: 3600,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.set_manual_notes("m-past", "cut the Q3 travel line").unwrap();
+
+        // Idle: no recording pointer, no focus. The FE binds the thread to m-past.
+        let scope = resolve_scope_meeting(Some("m-past"), None, None);
+        assert_eq!(scope, "m-past");
+
+        let live = std::sync::Mutex::new(String::new()); // not recording → no live tail
+        let unlocked = std::collections::HashSet::new();
+        let (_tail, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert_eq!(
+            notes, "cut the Q3 travel line",
+            "the resolved past-meeting scope must read THAT meeting's gated context, not empty/arbitrary"
+        );
+
+        // Contrast: the pre-phase behavior (ignore FE id + focus, use only the empty recording
+        // pointer) would have scoped to "" → no context read → the vault-wide-arbitrary fallback.
+        let empty_scope = resolve_scope_meeting(None, None, None);
+        assert_eq!(empty_scope, "");
+        let (_t, n) = gated_live_context(&db, &live, &empty_scope, &unlocked);
+        assert!(
+            n.is_empty(),
+            "the pre-phase empty scope reads NO meeting context (the fallback that caused the bug)"
+        );
+    }
+
+    #[test]
+    fn resolved_scope_still_masks_a_sealed_not_visible_bound_meeting() {
+        // The visibility gate must still hold for the RESOLVED scope: binding a thread to a
+        // sealed-and-not-session-unlocked meeting must inject NOTHING (fail-closed) — Phase 4 threads
+        // the id but never bypasses meeting_is_visible.
+        let db = tmp_db("phase4-sealed");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m1", Some("f1"));
+        db.set_manual_notes("m1", "secret budget cuts").unwrap();
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        // The FE binds the thread to the sealed meeting; the scope resolves to it — but the gate masks.
+        let scope = resolve_scope_meeting(Some("m1"), None, None);
+        assert_eq!(scope, "m1");
+        let live = std::sync::Mutex::new("sealed tail in RAM".to_string());
+        let unlocked = std::collections::HashSet::new();
+        let (tail, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert!(
+            tail.is_empty() && notes.is_empty(),
+            "a bound-but-sealed meeting must inject nothing (the visibility gate still holds)"
+        );
+
+        // A session unlock re-exposes it (the gate is reversible, not a wipe).
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f1".to_string());
+        let (_t, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert_eq!(
+            notes, "secret budget cuts",
+            "a session-unlocked bound meeting injects its own context"
+        );
+    }
+
+    #[test]
+    fn focused_past_meeting_scopes_to_itself_even_while_a_different_meeting_records() {
+        // PHASE 6 — the exact idle/cross-meeting wrong-meeting root: the FE sends NO explicit id
+        // (the voice/wake fallback path), a DIFFERENT meeting is recording, and the user is viewing
+        // (focus) a PAST meeting. The scope must resolve to the FOCUSED past meeting and read ITS
+        // gated context — NOT the recording, NOT an arbitrary vault meeting.
+        let db = tmp_db("phase6-focus-scope");
+        // A past, saved meeting the user is looking at, with its own typed notes.
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-focused-past".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: Some("2026-07-01T10:00:00Z".to_string()),
+            title: Some("Roadmap review".to_string()),
+            duration_s: 3600,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.set_manual_notes("m-focused-past", "ship the connector in Q3")
+            .unwrap();
+
+        // Resolution: no FE id, focus = the past meeting, recording = a DIFFERENT live meeting.
+        let scope = resolve_scope_meeting(None, Some("m-focused-past"), Some("m-recording-now"));
+        assert_eq!(
+            scope, "m-focused-past",
+            "focus must win over the recording pointer for the fallback path"
+        );
+
+        let live = std::sync::Mutex::new("live tail of the OTHER meeting".to_string());
+        let unlocked = std::collections::HashSet::new();
+        let (_tail, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert_eq!(
+            notes, "ship the connector in Q3",
+            "the focused past meeting grounds context in ITSELF, not the recording"
+        );
+    }
+
+    #[test]
+    fn relock_re_masks_the_focused_meeting_content() {
+        // PHASE 6 clear-on-relock discipline: focus is only an ID (no content), so a relock does not
+        // need to clear the focus pointer — but any CONTENT read against the focused meeting MUST
+        // re-mask when its folder relocks (the same visibility gate live_transcript rides). This
+        // proves the focused meeting's content is masked after relock and reversible on re-unlock.
+        let db = tmp_db("phase6-relock-mask");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f-focus".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m-focus", Some("f-focus"));
+        db.set_manual_notes("m-focus", "secret roadmap").unwrap();
+
+        // The user is viewing (focus) this meeting; the folder is session-UNLOCKED → content shows.
+        let scope = resolve_scope_meeting(None, Some("m-focus"), None);
+        assert_eq!(scope, "m-focus");
+        let live = std::sync::Mutex::new(String::new());
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-focus".to_string());
+        // Seal the folder (locked=1) but keep it in the session-unlocked set → visible.
+        db.set_folder_locked("f-focus", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        let (_t, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert_eq!(
+            notes, "secret roadmap",
+            "a session-unlocked focused meeting shows its content"
+        );
+
+        // RELOCK: the folder leaves the session-unlocked set (as relock_all_inner/relock_folder do).
+        // The focus id may stay — but the CONTENT read must now re-mask (fail-closed).
+        unlocked.remove("f-focus");
+        let (tail, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert!(
+            tail.is_empty() && notes.is_empty(),
+            "after relock, the focused meeting's content must be re-masked"
+        );
+
+        // Reversible: a fresh session unlock re-exposes it.
+        unlocked.insert("f-focus".to_string());
+        let (_t, notes) = gated_live_context(&db, &live, &scope, &unlocked);
+        assert_eq!(
+            notes, "secret roadmap",
+            "unlock re-exposes the focused meeting's content (the gate is reversible)"
+        );
     }
 
     // ── PR-A #1/#3: clearing the buffer at Stop + lock-surface hygiene ─────────────────────────────
@@ -2361,5 +3074,295 @@ mod tests {
             gated_user_memory_brief(&db, &unlocked, false).is_empty(),
             "memory disabled must suppress the brief even for a visible fact"
         );
+    }
+
+    // ── Phase 5: the cascade tier suffixes + badge determinism + Tier-1 citation gate ───────────────
+
+    /// The tier prompt suffixes carry the EXACT escalation sentinel (must match
+    /// `crate::agent::ESCALATE_SENTINEL`) at Tiers 1/2, and the TERMINAL Tier 3 must NOT instruct the
+    /// sentinel (there is no higher tier to escalate to). Prompt-drift guard.
+    #[test]
+    fn tier_suffixes_carry_the_sentinel_except_terminal_tier() {
+        assert!(
+            TIER1_SUFFIX.contains(crate::agent::ESCALATE_SENTINEL),
+            "Tier 1 must instruct the escalation sentinel"
+        );
+        assert!(
+            TIER2_SUFFIX.contains(crate::agent::ESCALATE_SENTINEL),
+            "Tier 2 must instruct the escalation sentinel"
+        );
+        assert!(
+            !TIER3_SUFFIX.contains(crate::agent::ESCALATE_SENTINEL),
+            "the TERMINAL Tier 3 must NEVER instruct the escalation sentinel"
+        );
+        // Tier 1's scope contract really is "this meeting only".
+        assert!(
+            TIER1_SUFFIX.contains("CURRENT MEETING ONLY"),
+            "Tier 1 must scope to the current meeting only"
+        );
+    }
+
+    /// DETERMINISTIC BADGE: `from_agent` stamps the tier the ladder passes — never string-sniffed —
+    /// and Tier 1 PREPENDS its `extra_citations` (the current meeting's own [[Title]]) ahead of the
+    /// loop's gated citations, de-duplicated in first-seen order.
+    #[test]
+    fn from_agent_sets_the_tier_badge_and_prepends_extra_citations() {
+        let outcome = crate::agent::AgentOutcome {
+            answer: "We decided to ship Friday.".to_string(),
+            steps: Vec::new(),
+            citations: vec!["[[Other Meeting]]".to_string()],
+        };
+        let res = crate::voice_action::VoiceActionResult::from_agent(
+            &VoiceIntent::Research { topic: "ship".into() },
+            outcome,
+            crate::voice_action::AnsweredFrom::CurrentMeeting,
+            vec!["[[This Meeting]]".to_string()],
+        );
+        assert_eq!(
+            res.answered_from,
+            Some(crate::voice_action::AnsweredFrom::CurrentMeeting),
+            "the badge is the tier the ladder passed, deterministically"
+        );
+        assert_eq!(
+            res.citations,
+            vec!["[[This Meeting]]".to_string(), "[[Other Meeting]]".to_string()],
+            "Tier 1's own [[Title]] is prepended ahead of the loop's gated citations"
+        );
+    }
+
+    /// TIER-1 CITATION GATE: for a VISIBLE current meeting, Tier 1 resolves its own [[Title]]; for a
+    /// SEALED-not-unlocked meeting it resolves NOTHING (fail-closed — no title leaks behind a lock).
+    #[test]
+    fn tier_extra_citations_gates_the_current_meeting_title() {
+        use crate::voice_action::AnsweredFrom;
+        let db = tmp_db("tier1-cite");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m1", Some("f1")); // title "Sync", foldered into f1
+
+        // OPEN folder → visible → Tier 1 cites its own [[Sync]].
+        let open = std::collections::HashSet::new();
+        assert_eq!(
+            tier_extra_citations(&db, "m1", AnsweredFrom::CurrentMeeting, &open),
+            vec!["[[Sync]]".to_string()],
+            "a visible current meeting contributes its own [[Title]] citation"
+        );
+
+        // A non-Tier-1 badge adds nothing here (Tier 2/3 use the loop's own gated citations).
+        assert!(
+            tier_extra_citations(&db, "m1", AnsweredFrom::Vault, &open).is_empty(),
+            "Tier 2 adds no extra citation from here"
+        );
+        assert!(
+            tier_extra_citations(&db, "m1", AnsweredFrom::Connectors, &open).is_empty(),
+            "Tier 3 adds no extra citation from here"
+        );
+
+        // SEAL the folder + nothing unlocked → invisible → NO title citation (fail-closed).
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..])).unwrap();
+        let sealed = std::collections::HashSet::new();
+        assert!(
+            !db.meeting_is_visible("m1", &sealed).unwrap(),
+            "seed self-check: the sealed meeting is invisible"
+        );
+        assert!(
+            tier_extra_citations(&db, "m1", AnsweredFrom::CurrentMeeting, &sealed).is_empty(),
+            "a sealed-not-unlocked current meeting must contribute NO [[Title]] (no leak behind a lock)"
+        );
+
+        // An empty meeting_id (idle, no scope) contributes nothing.
+        assert!(
+            tier_extra_citations(&db, "", AnsweredFrom::CurrentMeeting, &open).is_empty(),
+            "no scope meeting ⇒ no citation"
+        );
+    }
+
+    // ── Tier-1 current-meeting reader: live + PAST, both gated (2026-07-09 structural fix) ─────────
+
+    fn seg(idx: i64, start_s: f64, text: &str) -> crate::transcribe::types::Segment {
+        crate::transcribe::types::Segment {
+            idx,
+            start_s,
+            end_s: start_s + 1.0,
+            text: text.to_string(),
+            speaker: None,
+            confidence: None,
+        }
+    }
+
+    /// RED-TODAY GAP: a VIEWED PAST (not-recording) meeting has an EMPTY live buffer, so the old
+    /// `floor_current_context` yielded "" → the floor wrongly fanned out. `tier1_current_content`
+    /// ALSO reads the past meeting's OWN gated transcript + note, so a viewed meeting is answerable
+    /// from itself. (On the pre-fix code this content path did not exist.)
+    #[test]
+    fn tier1_current_content_reads_a_viewed_past_meetings_gated_transcript_and_note() {
+        let db = tmp_db("tier1-past");
+        // A visible past meeting (no folder → trivially visible) with its OWN transcript + note.
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-past".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: Some("2026-07-01T10:00:00Z".to_string()),
+            title: Some("Roadmap Sync".to_string()),
+            duration_s: 3600,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.insert_segments(
+            "m-past",
+            &[
+                seg(0, 0.0, "We decided to cut the Q3 travel budget."),
+                seg(1, 5.0, "Alice will own the migration."),
+            ],
+        )
+        .unwrap();
+        db.upsert_note(&crate::storage::NoteRecord {
+            meeting_id: "m-past".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "## Decisions\n- Cut Q3 travel\n- Alice owns migration".to_string(),
+            created_at: "2026-07-01T10:05:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+
+        // NOT recording → empty live buffer. The reader must still surface the past meeting's content.
+        let live = std::sync::Mutex::new(String::new());
+        let unlocked = std::collections::HashSet::new();
+
+        // RED-documenting the gap: the OLD floor reader (gated_live_context → floor_current_context)
+        // reads ONLY the live buffer + manual notes, so for a viewed past meeting it is EMPTY — which
+        // is exactly why the floor wrongly fanned out. `tier1_current_content` closes that gap.
+        let (old_live, old_typed) = gated_live_context(&db, &live, "m-past", &unlocked);
+        assert!(
+            floor_current_context(&old_live, &old_typed).is_empty(),
+            "the OLD reader was empty for a viewed past meeting (the fan-out cause this fix closes)"
+        );
+
+        let ctx = tier1_current_content(&db, &live, "m-past", &unlocked);
+        assert!(
+            ctx.contains("cut the Q3 travel budget"),
+            "the viewed past meeting's OWN transcript must be read (RED today): {ctx}"
+        );
+        assert!(
+            ctx.contains("Alice owns migration"),
+            "the viewed past meeting's OWN note must be read: {ctx}"
+        );
+        // The title is resolvable (gated) for the [[Title]] citation.
+        assert_eq!(
+            current_meeting_title(&db, "m-past", &unlocked),
+            Some("Roadmap Sync".to_string())
+        );
+    }
+
+    /// GATE (fail-closed): a SEALED-not-unlocked viewed past meeting yields NOTHING from the Tier-1
+    /// reader — its transcript/note are never read, its title never resolved. No leak behind a lock.
+    #[test]
+    fn tier1_current_content_yields_nothing_for_a_sealed_not_unlocked_meeting() {
+        let db = tmp_db("tier1-sealed");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-sealed".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: Some("2026-07-01T10:00:00Z".to_string()),
+            title: Some("Confidential Terms".to_string()),
+            duration_s: 3600,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.insert_segments("m-sealed", &[seg(0, 0.0, "SECRET acquisition price is 40M.")])
+            .unwrap();
+        db.upsert_note(&crate::storage::NoteRecord {
+            meeting_id: "m-sealed".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "SECRET terms".to_string(),
+            created_at: "2026-07-01T10:05:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_meeting_folder("m-sealed", Some("f1")).unwrap();
+        db.set_note_folder("m-sealed", Some("f1")).unwrap();
+        // Seal the folder → sealed-not-session-unlocked.
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..])).unwrap();
+
+        let live = std::sync::Mutex::new(String::new());
+        let sealed = std::collections::HashSet::new(); // folder NOT in the session unlock set
+        // Self-check: the meeting is invisible to the sealed session.
+        assert!(!db.meeting_is_visible("m-sealed", &sealed).unwrap());
+
+        let ctx = tier1_current_content(&db, &live, "m-sealed", &sealed);
+        assert!(
+            ctx.is_empty(),
+            "a sealed-not-unlocked viewed meeting must yield NO Tier-1 content: {ctx}"
+        );
+        assert!(
+            !ctx.contains("SECRET") && !ctx.contains("40M"),
+            "sealed content must NEVER leak into the Tier-1 reader"
+        );
+        // The title must not resolve either (no title leak behind a lock).
+        assert_eq!(
+            current_meeting_title(&db, "m-sealed", &sealed),
+            None,
+            "no [[Title]] for a sealed-not-unlocked meeting"
+        );
+
+        // A SESSION UNLOCK makes it readable again (reversible, not a wipe).
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f1".to_string());
+        let ctx2 = tier1_current_content(&db, &live, "m-sealed", &unlocked);
+        assert!(
+            ctx2.contains("SECRET acquisition price") || ctx2.contains("SECRET terms"),
+            "after session unlock the Tier-1 reader surfaces the content again: {ctx2}"
+        );
+    }
+
+    /// The LIVE buffer still wins for an in-progress recording (unchanged): `tier1_current_content`
+    /// returns the live block without touching the past-meeting read path.
+    #[test]
+    fn tier1_current_content_prefers_the_live_buffer_for_a_recording() {
+        let db = tmp_db("tier1-live");
+        db.insert_meeting(&crate::storage::Meeting {
+            id: "m-rec".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: None,
+            duration_s: 0,
+            audio_path: None,
+            status: crate::storage::MeetingStatus::Recording,
+            folder_id: None,
+        })
+        .unwrap();
+        db.set_manual_notes("m-rec", "ship Friday").unwrap();
+        let live = std::sync::Mutex::new("we agreed to ship friday".to_string());
+        let unlocked = std::collections::HashSet::new();
+        let ctx = tier1_current_content(&db, &live, "m-rec", &unlocked);
+        assert!(
+            ctx.contains("Live transcript") && ctx.contains("we agreed to ship friday"),
+            "the live buffer is the Tier-1 source for a recording: {ctx}"
+        );
+        assert!(ctx.contains("ship Friday"), "typed notes come along: {ctx}");
     }
 }

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -37,6 +37,22 @@ use crate::settings::AppConfig;
 use crate::storage::Db;
 use crate::tools::{execute_tool, ToolCall};
 
+/// Which BRAIN CASCADE tier answered this turn (Phase 5) — set DETERMINISTICALLY by the ladder from
+/// the tier that CONVERGED, never string-sniffed from the answer. Surfaced to the FE (as
+/// `answeredFrom`) so it can render a "answered from: this meeting / your vault / connectors" chip.
+/// `None` ⇒ this result did not run through the cascade (the deterministic floor, an error, or a
+/// non-cascade surface).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnsweredFrom {
+    /// Tier 1 — answered from the current meeting in isolation.
+    CurrentMeeting,
+    /// Tier 2 — answered from the owned vault.
+    Vault,
+    /// Tier 3 — answered with the help of connectors/web.
+    Connectors,
+}
+
 /// The outcome of dispatching one [`VoiceIntent`], emitted to the FE as a live event. Carries NO raw
 /// transcript beyond the user's own dictated command — `summary` is the brain's answer (research/
 /// recall) or a short status line; `citations` are the `[[Title]]` wikilinks the answer was grounded
@@ -70,6 +86,10 @@ pub struct VoiceActionResult {
     /// the right pending bubble. Serializes to `threadId`; the dispatch threads it on via
     /// [`Self::with_thread_id`]. NOT PII (an opaque UUID).
     pub thread_id: Option<String>,
+    /// Which BRAIN CASCADE tier answered (Phase 5), set DETERMINISTICALLY by the ladder from the tier
+    /// that converged — never string-sniffed. Serializes to `answeredFrom`. `None` when this result
+    /// did not run through the cascade (the deterministic floor / error / a non-cascade surface).
+    pub answered_from: Option<AnsweredFrom>,
 }
 
 impl VoiceActionResult {
@@ -82,6 +102,7 @@ impl VoiceActionResult {
             citations: Vec::new(),
             proposed_note: None,
             thread_id: None,
+            answered_from: None,
         }
     }
 
@@ -115,21 +136,42 @@ impl VoiceActionResult {
     /// Map a converged agentic-loop [`crate::agent::AgentOutcome`] onto the FE result DTO. The intent
     /// KIND comes from the resolved intent (recall vs research); the answer + GATED citations come
     /// straight off the loop. `command` is threaded on by the caller via [`Self::with_command`].
-    pub fn from_agent(intent: &VoiceIntent, outcome: crate::agent::AgentOutcome) -> Self {
+    ///
+    /// Phase 5: `answered_from` is set DETERMINISTICALLY by the ladder to the tier that converged
+    /// (never string-sniffed). `extra_citations` lets the ladder PREPEND tier-specific attributions
+    /// that the loop's `gathered`-scraped citations miss: Tier 1's own `[[Title]]` (prompt-injected
+    /// current-meeting content produces no wikilink in `gathered`), and Tier 3 connector loud-lines
+    /// (like `rag_answer`). They are merged in FIRST-SEEN order, de-duplicated against the loop's own.
+    pub fn from_agent(
+        intent: &VoiceIntent,
+        outcome: crate::agent::AgentOutcome,
+        answered_from: AnsweredFrom,
+        extra_citations: Vec<String>,
+    ) -> Self {
         let intent_kind = match intent {
             VoiceIntent::Recall { .. } => "recall",
             _ => "research",
         };
+        // Merge tier-specific citations FIRST, then the loop's gated ones, de-duplicated in
+        // first-seen order (mirrors `extract_citations`'s de-dup discipline).
+        let mut citations: Vec<String> = Vec::new();
+        for c in extra_citations.into_iter().chain(outcome.citations) {
+            let c = c.trim().to_string();
+            if !c.is_empty() && !citations.contains(&c) {
+                citations.push(c);
+            }
+        }
         Self {
             intent_kind: intent_kind.to_string(),
             status: "ok".to_string(),
             summary: outcome.answer,
             command: String::new(),
-            citations: outcome.citations,
+            citations,
             // The caller (`run_informational`) threads any `propose_note` draft on via
             // `with_proposed_note` after reading the executor; the loop outcome itself has none.
             proposed_note: None,
             thread_id: None,
+            answered_from: Some(answered_from),
         }
     }
 
@@ -154,6 +196,29 @@ impl VoiceActionResult {
 const NO_MODEL_ANSWER_NOTICE: &str = "No AI model is available to answer — showing matching notes \
     instead. Pick a provider or download an on-device model in Settings.";
 
+/// RECORDING-AWARENESS phrases — the THREE load-bearing substrings the CLOUD cascade prompt
+/// ([`crate::transcribe::live::assistant_system_prompt`]) already asserts (test
+/// `assistant_system_prompt_scopes_empty_buffer_to_the_live_recording`), lifted into ONE place so the
+/// deterministic FLOOR (`rag_answer`, reasoner-only backend that skips the cascade) frames a live
+/// recording IDENTICALLY and the two prompts cannot drift. These are BARE substrings composed into the
+/// prose below — NOT the whole clause — so both prompts read naturally while sharing the exact wording
+/// the cascade test pins.
+///
+/// - [`RECORDING_NOW_PHRASE`]: a meeting is being **recorded RIGHT NOW** (both the empty-buffer and
+///   has-content recording cases open with it).
+/// - [`MEETING_JUST_STARTED_PHRASE`]: the honest empty-buffer answer — the **meeting just started** and
+///   little has been captured.
+/// - [`NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE`]: the substitution BAN — **do NOT search the vault for
+///   other saved meetings** and describe them as if they were this one.
+///
+/// The cascade `assistant_system_prompt` duplicates this wording verbatim (its own tests pin the exact
+/// substrings); wiring these consts INTO it would risk those verified tests, so it keeps its literal
+/// prose with a cross-reference comment. The shared consts are the single source the FLOOR uses.
+pub(crate) const RECORDING_NOW_PHRASE: &str = "recorded RIGHT NOW";
+pub(crate) const MEETING_JUST_STARTED_PHRASE: &str = "meeting just started";
+pub(crate) const NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE: &str =
+    "do NOT search the vault for other saved meetings";
+
 /// Dispatch one parsed [`VoiceIntent`] over the GATED vault + consent-gated brain. Synchronous (the
 /// live loop spawns it off-thread) and PANIC-FREE: every fallible step degrades to a graceful
 /// `VoiceActionResult`.
@@ -166,6 +231,20 @@ const NO_MODEL_ANSWER_NOTICE: &str = "No AI model is available to answer — sho
 /// "pogoda"), NOT a brain-translated/normalized topic that the exact-term FTS would miss. The brain
 /// topic is still used for SYNTHESIS + as an additional retrieval leg; the literal terms are the
 /// must-have. Empty/whitespace falls back to the intent topic alone.
+///
+/// `current_meeting_context` is the CURRENT (recording / focused-and-viewed) meeting's gated live
+/// context — its live transcript tail + the user's typed notes, ALREADY visibility-gated by the
+/// caller through `gated_live_context` (a sealed-not-visible meeting yields an EMPTY string, so this
+/// path never reads ungated content). When non-empty it is PREPENDED to the vault grounding as the
+/// PRIMARY, clearly-labeled source so the floor answers about THIS meeting first (fixing the
+/// "describes other meetings" symptom on the local/reasoner-only backend that skips the cascade).
+/// EMPTY ⇒ vault-only grounding, byte-identical to the prior floor.
+///
+/// `recording_in_progress` is the recorder-lock flag (`state.recorder.lock().map(|g| g.is_some())`),
+/// NOT a content read — the same bool the CLOUD cascade computes. It gives the FLOOR RECORDING
+/// AWARENESS so a live recording is framed as the current meeting being **recorded RIGHT NOW** (see
+/// [`RECORDING_NOW_PHRASE`] and the two recording branches in [`rag_answer`]). `false` ⇒ the prior
+/// viewed-past-meeting / idle behavior is byte-compatible.
 #[allow(clippy::too_many_arguments)] // cohesive dispatch surface: intent + gated state + the AppHandle.
 pub fn handle_voice_action(
     intent: &VoiceIntent,
@@ -175,6 +254,8 @@ pub fn handle_voice_action(
     config: &AppConfig,
     meeting_id: &str,
     literal_command: &str,
+    current_meeting_context: &str,
+    recording_in_progress: bool,
     app: Option<&tauri::AppHandle>,
 ) -> VoiceActionResult {
     match intent {
@@ -182,6 +263,8 @@ pub fn handle_voice_action(
             "research",
             topic,
             literal_command,
+            current_meeting_context,
+            recording_in_progress,
             reasoner,
             db,
             unlocked,
@@ -192,6 +275,8 @@ pub fn handle_voice_action(
             "recall",
             entity,
             literal_command,
+            current_meeting_context,
+            recording_in_progress,
             reasoner,
             db,
             unlocked,
@@ -354,6 +439,330 @@ fn retrieval_queries(topic: &str, literal_command: &str) -> Vec<String> {
     queries
 }
 
+/// The coarse `intent_kind` discriminant for a [`VoiceIntent`] — the SAME mapping the card path uses
+/// (`from_agent`): `Recall` → `"recall"`, everything else → `"research"`. Used by the deterministic
+/// current-first floor to badge its Tier-1 answer consistently with the fan-out floor. Since the
+/// floor only ever runs read intents (`floor_intent_for` demotes writes to `Research`), this is
+/// always `research` or `recall` on the floor.
+pub(crate) fn intent_kind_str(intent: &VoiceIntent) -> &'static str {
+    match intent {
+        VoiceIntent::Recall { .. } => "recall",
+        _ => "research",
+    }
+}
+
+/// TIER-1 CLASSIFIER (deterministic, EN + PL) — is the user asking about the CURRENT meeting itself
+/// ("what is THIS meeting about", "summarize this recording", "co tu ustaliliśmy")? A CONSERVATIVE
+/// match: it fires ONLY on a clear "this meeting / this conversation / here" question so the
+/// current-first floor can answer from the current meeting in ISOLATION (no vault fan-out, no web
+/// leg). When unsure it returns `false`, and the floor behaves EXACTLY as before (the vault + web
+/// fan-out), so cross-meeting ("co ustaliliśmy z Weroniką") and world ("jaka pogoda") questions are
+/// untouched.
+///
+/// This is the structural fix for "o czym jest to spotkanie" web-searching the WORD "meeting":
+/// deterministically recognizing a current-meeting question lets the floor STOP at the current
+/// meeting instead of fanning a `research` intent out to the web.
+///
+/// The matcher is intentionally lexical (substring over a normalized command), not a model call —
+/// the whole point of the deterministic floor is that a weak local model can't be trusted to route.
+pub(crate) fn is_about_current_meeting(command: &str) -> bool {
+    // Normalize: lowercase + strip Polish diacritics so "rozmowę"/"rozmowe" and "spotkaniu" match on
+    // stems, and collapse whitespace. We match on stems/substrings, never whole-word equality, so
+    // inflected Polish endings (spotkani-e/-u/-a, rozmow-a/-e/-ie) all hit.
+    let norm = normalize_for_match(command);
+    let n = norm.as_str();
+    if n.is_empty() {
+        return false;
+    }
+
+    // A "HERE" DEICTIC — "tu"/"tutaj"/"here" ONLY (NOT "to"/"this"), for the `pl_here_verb` rule
+    // ("co TU ustaliliśmy"). Deliberately excludes "to"/"this": the Polish relative pronoun "to co"
+    // ("that which") in a CROSS-MEETING "podsumuj TO CO ustaliliśmy na spotkaniach" carries "to" but
+    // is NOT a here-anchor, and matching it stole that request into current-meeting isolation
+    // (adversarial 2026-07-09 round 2). Whole-token "tu" so it never sub-matches "sta**tu**s".
+    let has_here = n.contains(" tu ")
+        || n.starts_with("tu ")
+        || n.ends_with(" tu")
+        || n.contains(" tutaj")
+        || n.contains("tutaj ")
+        || n.contains(" here")
+        || n.contains("here ");
+
+    // A "THIS MEETING" PHRASE — the deictic IMMEDIATELY ADJACENT to a current-meeting noun (EN + PL
+    // singular, diacritics stripped). This is the load-bearing discriminant: matching a bare "this"
+    // + a "meeting" noun ANYWHERE in the string false-matched "summarize THIS WEEK'S MEETINGS" /
+    // "podsumuj TO co ustaliliśmy NA SPOTKANIACH" (deictic modifies "week's", not the meeting; the
+    // noun is plural/cross-meeting) → those got stolen from the vault fan-out (adversarial 2026-07-09).
+    // Requiring adjacency ("this meeting" / "to spotkanie" / "tę rozmowę") keeps the current-meeting
+    // cases and rejects "this week's meetings" (not adjacent). PL feminine list uses singular forms
+    // only ("ta/te/tej rozmow…", "te rozmowe" = tę rozmowę acc) so "te rozmowy" (plural) doesn't hit.
+    const THIS_MEETING_PHRASES: &[&str] = &[
+        // English "this <meeting-noun>".
+        "this meeting", "this conversation", "this call", "this recording",
+        // Polish neuter (spotkanie / nagranie): to/tego/tym <noun>.
+        "to spotkani", "tego spotkani", "tym spotkani", "to nagrani", "tego nagrani", "tym nagrani",
+        // Polish feminine (rozmowa) — SINGULAR only.
+        "ta rozmow", "te rozmowe", "tej rozmow",
+    ];
+    let has_this_meeting_phrase = THIS_MEETING_PHRASES.iter().any(|p| n.contains(p));
+
+    // "what is X about" / "o czym (jest) X" — the canonical describe-this question.
+    let about_phrasing = n.contains("what is")
+        || n.contains("what's")
+        || n.contains("whats ")
+        || n.contains("o czym");
+    if about_phrasing && has_this_meeting_phrase {
+        return true;
+    }
+
+    // A reference to ANOTHER PARTY ("with X" / "z X") makes it a CROSS-MEETING question
+    // ("co ustaliliśmy z Weroniką", "what did we decide with Weronika") — never current-first.
+    let has_other_party = n.contains(" with ") || n.contains(" z ");
+
+    // "summarize / recap / streść / podsumuj THIS meeting|recording|conversation". REQUIRES the
+    // adjacent "this <meeting-noun>" phrase AND no other party — so a CROSS-MEETING summarize
+    // ("podsumuj moje spotkania", "summarize my meetings", "summarize this week's meetings",
+    // "podsumuj spotkania z Weroniką") is NOT stolen from the vault fan-out. A bare "summarize this"
+    // (verb + deictic, no meeting noun) is deliberately NOT matched — it degrades to the fan-out floor
+    // (a MISS is safe; a false-steal is a regression).
+    let summarize_verb = n.contains("summarize")
+        || n.contains("summarise")
+        || n.contains("recap")
+        || n.contains("podsumuj")
+        || n.contains("streszcz") // streść → strescz after diacritic-strip of ś→s, ć→c
+        || n.contains("stresc");
+    if summarize_verb && has_this_meeting_phrase && !has_other_party {
+        return true;
+    }
+
+    // PL "co (tu/tutaj) ustaliliśmy / omówiliśmy / zdecydowaliśmy / powiedziano" — a "what happened
+    // HERE" question. REQUIRES the HERE deictic ("tu"/"tutaj") — NOT a bare "to" — so a cross-meeting
+    // "co ustaliliśmy z Weroniką" (no here-anchor) and "podsumuj to co ustaliliśmy na spotkaniach"
+    // (relative "to co", plural "na spotkaniach") do NOT match.
+    let pl_here_verb = n.contains("ustalili")
+        || n.contains("omowili")
+        || n.contains("zdecydowali")
+        || n.contains("powiedziano")
+        || n.contains("powiedzielismy");
+    if pl_here_verb && has_here && !has_other_party {
+        return true;
+    }
+
+    // EN "what did we (just) discuss / decide (here)" — SELF-ANCHORING to the current conversation
+    // ("we, now"), so it fires WITHOUT a separate deictic — UNLESS it references another party
+    // ("...with Weronika"), which makes it cross-meeting.
+    let en_self_verb = n.contains("did we discuss")
+        || n.contains("did we decide")
+        || n.contains("we just discuss")
+        || n.contains("we just decide")
+        || n.contains("we just talk");
+    if en_self_verb && !has_other_party {
+        return true;
+    }
+
+    false
+}
+
+/// Lowercase + strip common Polish diacritics + collapse internal whitespace, so the current-meeting
+/// classifier can stem-match inflected Polish ("rozmowę"→"rozmowe", "streść"→"stresc") without a
+/// dependency. Pure + total; never panics.
+fn normalize_for_match(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_ws = true; // trim leading whitespace
+    for ch in s.chars() {
+        let lc = match ch {
+            'ą' | 'Ą' => 'a',
+            'ć' | 'Ć' => 'c',
+            'ę' | 'Ę' => 'e',
+            'ł' | 'Ł' => 'l',
+            'ń' | 'Ń' => 'n',
+            'ó' | 'Ó' => 'o',
+            'ś' | 'Ś' => 's',
+            'ż' | 'Ż' | 'ź' | 'Ź' => 'z',
+            other => other,
+        };
+        if lc.is_whitespace() {
+            if !last_ws {
+                out.push(' ');
+                last_ws = true;
+            }
+        } else {
+            for c in lc.to_lowercase() {
+                out.push(c);
+            }
+            last_ws = false;
+        }
+    }
+    // trim trailing whitespace
+    while out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// TIER-1 ISOLATED ANSWER (deterministic current-first floor): synthesize a concise answer over ONLY
+/// the CURRENT meeting's own content — NO vault fan-out, NO web leg, NO calendar. The caller
+/// (`run_informational`) has already assembled `current_content` through a VISIBILITY-GATED reader
+/// (live buffer via `gated_live_context`, OR a viewed past meeting's `get_segments` +
+/// `get_note_if_visible` under `meeting_is_visible`); a sealed-not-unlocked meeting yields an EMPTY
+/// string, so this path never reads or synthesizes sealed content.
+///
+/// EMPTY `current_content` ⇒ an HONEST short notice in the user's language (recording → "just
+/// started / nothing captured yet"; viewed past meeting → "no transcript/notes to summarize"), with
+/// NO fan-out. This is what stops "o czym jest to spotkanie" from web-searching the word "meeting".
+///
+/// The prompt deliberately does NOT hand the model a literal "THIS MEETING" section header (which the
+/// weak local model would echo as its opening words) — it frames the content as "the transcript and
+/// notes below" and instructs the model not to preface with a label.
+///
+/// `meeting_title` is the current meeting's OWN gated title (resolved by the caller via
+/// `get_meeting`, VISIBLE-only) — cited as `[[Title]]` so the answer attributes itself to the
+/// current meeting, never to a vault/web source.
+///
+/// EGRESS: rides the SAME consent-gated reasoner as every other floor answer (a Cloud reasoner routes
+/// through `make_provider`'s consent gate + RedactingProvider). No new egress class; the ONLY content
+/// that reaches the model is the already-gated current meeting.
+pub(crate) fn answer_current_meeting_isolated(
+    intent_kind: &str,
+    literal_command: &str,
+    current_content: &str,
+    recording_in_progress: bool,
+    meeting_title: Option<&str>,
+    reasoner: &dyn LocalReasoner,
+) -> VoiceActionResult {
+    let content = current_content.trim();
+    let citations: Vec<String> = meeting_title
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(|t| vec![format!("[[{t}]]")])
+        .unwrap_or_default();
+
+    // EMPTY current content ⇒ honest "just started / no content" notice, in the user's language. NO
+    // fan-out, NO web, NO other-meeting substitution. We ask the reasoner ONLY to translate a short
+    // honest sentence into the user's language (with an English fallback baked in), so even here the
+    // model never sees vault/web content and never describes another meeting.
+    if content.is_empty() {
+        let english = if recording_in_progress {
+            "This meeting just started — nothing has been captured from it yet, so there is \
+             nothing to summarize."
+        } else {
+            "This meeting has no transcript or notes to summarize."
+        };
+        // STUB / no brain: return the English notice verbatim (no translation available). Honest,
+        // no fan-out.
+        if reasoner.id() == "stub" {
+            return VoiceActionResult {
+                intent_kind: intent_kind.to_string(),
+                status: "ok".to_string(),
+                summary: english.to_string(),
+                command: String::new(),
+                citations,
+                proposed_note: None,
+                thread_id: None,
+                answered_from: Some(AnsweredFrom::CurrentMeeting),
+            };
+        }
+        let system = "You are an in-meeting assistant. Reply with EXACTLY the sentence below, \
+                      translated into the SAME language the user wrote their request in (look at \
+                      the user's OWN words, NOT this English instruction). Do not add anything, do \
+                      not mention other meetings, do not search anything.";
+        let user = format!(
+            "User's request (their own words): {}\n\nSentence to translate: {english}",
+            literal_command.trim()
+        );
+        let summary = match reasoner.reason(system, &user) {
+            Ok(a) if !a.trim().is_empty() => a.trim().to_string(),
+            // Any failure (incl. no-consent Unavailable) ⇒ the honest English notice, never a
+            // fan-out. The user still gets a truthful, non-leaking answer.
+            _ => english.to_string(),
+        };
+        return VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "ok".to_string(),
+            summary,
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        };
+    }
+
+    // STUB / no real brain: cannot synthesize. Return the honest no-model notice + KEEP the current
+    // meeting's own citation (mirrors the `rag_answer` stub shim), never a fan-out.
+    if reasoner.id() == "stub" {
+        return VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "unavailable".to_string(),
+            summary: NO_MODEL_ANSWER_NOTICE.to_string(),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        };
+    }
+
+    // ISOLATED SYNTHESIS over ONLY the current meeting. No "THIS MEETING" label the model can parrot;
+    // no instruction to consult the vault or the web. Language directive mirrors the fan-out floor.
+    let system = "You are summarizing the meeting the user is currently in. Answer their question \
+                  about it CONCISELY (2-4 sentences) using ONLY the transcript and notes provided \
+                  below — do not use any other source and do not invent facts. Do NOT preface your \
+                  answer with a label or heading (no \"This meeting:\"); answer naturally. Write \
+                  your answer in the SAME language the user actually wrote in — look at the user's \
+                  OWN words below, NOT the language of this instruction or of the transcript. If the \
+                  user wrote in Polish, answer in Polish; NEVER default to English.";
+    let user = format!(
+        "User's request (their own words): {}\n\nThe meeting's transcript and the user's notes:\n{content}",
+        literal_command.trim()
+    );
+    match reasoner.reason(system, &user) {
+        Ok(answer) if !answer.trim().is_empty() => VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "ok".to_string(),
+            summary: answer.trim().to_string(),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        },
+        Ok(_) => VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "ok".to_string(),
+            summary: "I have this meeting's transcript but couldn't compose a summary just now."
+                .to_string(),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        },
+        // No cloud consent ⇒ fail closed with a graceful notice — NEVER a fan-out to the web.
+        Err(AppError::Unavailable(_)) => VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "needs_consent".to_string(),
+            summary: "The cloud brain needs your one-time consent to answer (Settings ▸ Privacy)."
+                .to_string(),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        },
+        Err(e) => VoiceActionResult {
+            intent_kind: intent_kind.to_string(),
+            status: "error".to_string(),
+            summary: non_pii_error(&e),
+            command: String::new(),
+            citations,
+            proposed_note: None,
+            thread_id: None,
+            answered_from: Some(AnsweredFrom::CurrentMeeting),
+        },
+    }
+}
+
 /// Local-first RAG over the user's OWN gated vault (NOT a web search): run the gated read tools for
 /// the topic/entity, feed ONLY the gated results to the brain, return a brief cited answer.
 ///
@@ -365,6 +774,8 @@ fn rag_answer(
     intent_kind: &str,
     topic: &str,
     literal_command: &str,
+    current_meeting_context: &str,
+    recording_in_progress: bool,
     reasoner: &dyn LocalReasoner,
     db: &Db,
     unlocked: &HashSet<String>,
@@ -510,6 +921,17 @@ fn rag_answer(
     }
     let grounding = grounding.trim();
 
+    // CURRENT-MEETING-FIRST (fixes the "describes other meetings" symptom on the local/reasoner-only
+    // floor): the caller already fetched THIS meeting's live transcript + typed notes through the
+    // GATED `gated_live_context` (a sealed-not-visible meeting yields ""), so it is safe to use here —
+    // no ungated read happens in this function. When present, it becomes the PRIMARY, clearly-labeled
+    // grounding section, PREPENDED before the vault notes, so the brain answers about THIS meeting
+    // first and only reaches for the vault for cross-meeting context. EMPTY ⇒ vault-only, byte-
+    // identical to the prior floor. It does NOT feed vault-citation extraction below (it is the
+    // current meeting, not a cross-note citation) and its presence alone counts as real grounding.
+    let current_ctx = current_meeting_context.trim();
+    let has_current = !current_ctx.is_empty();
+
     // CITATIONS: derived from a GATED `search_visible` over the SAME live unlocked set — every hit
     // names a VISIBLE meeting (a sealed-not-unlocked meeting is filtered out by visibility_clause),
     // rendered as `[[Title]]`. Plus any `[[Title]]` wikilinks the tool grounding already carried
@@ -562,8 +984,10 @@ fn rag_answer(
         }
     }
 
-    // No grounding at all → don't burn a brain call; return a clean "nothing found".
-    if grounding.is_empty() {
+    // No grounding at all → don't burn a brain call; return a clean "nothing found". The CURRENT
+    // meeting's gated context counts as grounding, so a live/focused meeting is always answerable from
+    // itself even when the vault legs found nothing.
+    if grounding.is_empty() && !has_current {
         return VoiceActionResult::new(
             intent_kind,
             "ok",
@@ -588,22 +1012,98 @@ fn rag_answer(
             citations,
             proposed_note: None,
             thread_id: None,
+            // The deterministic floor is not a cascade tier.
+            answered_from: None,
         };
     }
 
     // The brain may now ground its answer on BOTH the user's vault notes AND any web results. The
     // prompt allows web facts (attributed) so a "what's the weather" question the vault can't answer
     // is still answered from the web leg, while vault-answerable questions stay vault-grounded.
-    let system = "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 \
-                  sentences) using ONLY the provided context: the user's own meeting notes AND any \
-                  WEB results (lines beginning \"[web\"). Cite vault meetings by their [[Title]] \
-                  wikilink and attribute web facts as \"(via web)\". If the context doesn't cover \
-                  it, say so plainly. Do not invent facts.";
-    let user = format!("Request: {display_query}\n\nNotes from the vault:\n{grounding}");
+    //
+    // CURRENT-FIRST: when THIS meeting's gated context is present the prompt tells the brain to answer
+    // about "this meeting" from its own transcript FIRST and treat the vault notes as SECONDARY (cross-
+    // meeting) context only — this is what stops the local floor from describing OTHER meetings.
+    //
+    // LANGUAGE (fixes the English-answer symptom): mirror the cascade/agent directive
+    // (agent.rs) — the final answer must be in the SAME language the USER actually wrote in (their own
+    // words in the request, NOT the language of these English instructions). Polish in → Polish out.
+    // The user's literal command is echoed into the `user` message below so the model can see the
+    // original words even when `display_query` is a brain-translated/normalized topic.
+    // RECORDING AWARENESS (back-ported from the CLOUD cascade's `assistant_system_prompt`): when a
+    // recording is IN PROGRESS the floor must frame the current meeting as the LIVE recording, not a
+    // viewed past meeting — and, critically, when the live buffer is EMPTY (meeting just started) it
+    // must NOT let the vault grounding be described as if it were this meeting. The exact wording of
+    // the three load-bearing phrases is SHARED with the cascade via the `*_PHRASE` consts so the two
+    // prompts cannot drift. Three cases (see the four-way matrix on recording × has_current):
+    //   1. recording + buffer HAS content  → THIS MEETING section is the live transcript; answer from
+    //      it FIRST, vault is cross-meeting context only.
+    //   2. recording + buffer EMPTY         → the gap this task closes: say plainly the meeting just
+    //      started; forbid substituting other saved meetings even though vault grounding is present.
+    //   3. NOT recording                    → unchanged prior behavior (viewed-past-meeting clause when
+    //      has_current; empty otherwise) — no regression for the Ask page / idle / viewed-meeting.
+    let current_clause = if recording_in_progress && has_current {
+        format!(
+            " A meeting is being {RECORDING_NOW_PHRASE} and the THIS MEETING section is its LIVE \
+             transcript (plus the user's own typed notes) so far — answer about THIS meeting from that \
+             section FIRST. When the user asks what \"this meeting\"/\"this conversation\"/\"ta \
+             rozmowa\" is about, answer FROM that live transcript; {NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE} \
+             and describe them as if they were this one. The vault notes are cross-meeting context only, \
+             never the primary subject."
+        )
+    } else if recording_in_progress {
+        // Buffer EMPTY while recording: the meeting just started (or the user hasn't spoken / captions
+        // lag). Vault grounding may still be present for an EXPLICIT saved-notes question, but the
+        // framing FORBIDS treating it as the current meeting.
+        format!(
+            " A meeting is being {RECORDING_NOW_PHRASE} but nothing has been transcribed from it yet \
+             (it just started or the user has not spoken much). If the user asks about THIS \
+             meeting/\"this conversation\"/\"ta rozmowa\", say plainly the {MEETING_JUST_STARTED_PHRASE} \
+             and little has been captured so far — {NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE} and describe \
+             them as if they were this one. Use the vault notes ONLY when the user EXPLICITLY asks about \
+             their saved notes/past meetings."
+        )
+    } else if has_current {
+        " The provided context includes a THIS MEETING section (the current meeting's live transcript \
+         and the user's own typed notes) — answer about THIS meeting from that section FIRST, and use \
+         the vault notes only for cross-meeting context, not as the primary subject."
+            .to_string()
+    } else {
+        String::new()
+    };
+    let system = format!(
+        "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 sentences) using \
+         ONLY the provided context: the current meeting, the user's own meeting notes AND any WEB \
+         results (lines beginning \"[web\").{current_clause} Cite vault meetings by their [[Title]] \
+         wikilink and attribute web facts as \"(via web)\". If the context doesn't cover it, say so \
+         plainly. Do not invent facts. Write your final answer in the SAME language the USER actually \
+         wrote in — look at the user's OWN words in their request below, NOT at the language of these \
+         instructions or the surrounding context (which are in English). If the user wrote in Polish, \
+         answer in Polish; match the user's language exactly and NEVER default to English."
+    );
+    // The user message leads with the user's ORIGINAL dictated words (so the model can match their
+    // language even when `display_query` is a normalized/translated topic), then the CURRENT meeting's
+    // gated context as the PRIMARY source, then the vault notes as SECONDARY context.
+    let original_words = {
+        let lit = literal_command.trim();
+        if lit.is_empty() { display_query.as_str() } else { lit }
+    };
+    let mut user = format!("Request (user's own words): {original_words}");
+    if !display_query.is_empty() && display_query != original_words {
+        user.push_str(&format!("\nTopic: {display_query}"));
+    }
+    if has_current {
+        user.push_str(&format!(
+            "\n\nTHIS MEETING (current transcript + your notes):\n{current_ctx}"
+        ));
+    }
+    if !grounding.is_empty() {
+        user.push_str(&format!("\n\nNotes from the vault (secondary context):\n{grounding}"));
+    }
 
     // EGRESS SEAM: a Cloud reasoner routes through make_provider (consent gate + RedactingProvider).
     // A no-consent refusal comes back as AppError::Unavailable → graceful "needs consent", no leak.
-    match reasoner.reason(system, &user) {
+    match reasoner.reason(&system, &user) {
         Ok(answer) => {
             let answer = answer.trim();
             let summary = if answer.is_empty() {
@@ -619,6 +1119,8 @@ fn rag_answer(
                 citations,
                 proposed_note: None,
                 thread_id: None,
+                // The deterministic floor is not a cascade tier.
+                answered_from: None,
             }
         }
         Err(AppError::Unavailable(_)) => VoiceActionResult {
@@ -632,6 +1134,7 @@ fn rag_answer(
             citations,
             proposed_note: None,
             thread_id: None,
+            answered_from: None,
         },
         Err(e) => VoiceActionResult {
             intent_kind: intent_kind.to_string(),
@@ -641,6 +1144,7 @@ fn rag_answer(
             citations,
             proposed_note: None,
             thread_id: None,
+            answered_from: None,
         },
     }
 }
@@ -1064,6 +1568,7 @@ mod tests {
             app: None,
             allow_writes: false,
             note_drafts: true,
+            scope: crate::tools::AssistantScope::Full,
             proposed_note: std::sync::Mutex::new(None),
         };
 
@@ -1159,6 +1664,8 @@ mod tests {
             &cfg,
             "live-mtg",
             "",
+            "",
+            false,
             None,
         );
 
@@ -1207,6 +1714,8 @@ mod tests {
             &AppConfig::default(),
             "live-mtg",
             "",
+            "",
+            false,
             None,
         );
 
@@ -1261,6 +1770,8 @@ mod tests {
             &AppConfig::default(),
             "live-mtg",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.intent_kind, "recall");
@@ -1287,6 +1798,8 @@ mod tests {
             &AppConfig::default(),
             "live-mtg",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "ok");
@@ -1324,6 +1837,8 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.intent_kind, "note_aside");
@@ -1349,6 +1864,8 @@ mod tests {
             &AppConfig::default(),
             "sealed1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "error");
@@ -1372,6 +1889,8 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.intent_kind, "slack_search");
@@ -1400,6 +1919,8 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "unrecognized");
@@ -1425,6 +1946,8 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "error");
@@ -1451,6 +1974,8 @@ mod tests {
             &AppConfig::default(),
             "live1",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "needs_consent");
@@ -1738,6 +2263,8 @@ mod tests {
             &cfg,
             "live-mtg",
             "jaka była pogoda",
+            "",
+            false,
             None,
         );
         assert_eq!(res.status, "ok");
@@ -1771,6 +2298,8 @@ mod tests {
             &cfg,
             "live-mtg",
             "",
+            "",
+            false,
             None,
         );
         assert_eq!(res2.status, "ok");
@@ -1782,5 +2311,513 @@ mod tests {
             reasoner2.last_user.lock().unwrap().is_none(),
             "no grounding ⇒ no brain call on the translated-only path"
         );
+    }
+
+    /// A reasoner that records BOTH the system and user strings it was handed, so we can assert the
+    /// synthesis prompt (system) and the grounding order (user). Echoes a fixed answer.
+    struct CaptureReasoner {
+        last_system: std::sync::Mutex<Option<String>>,
+        last_user: std::sync::Mutex<Option<String>>,
+    }
+    impl CaptureReasoner {
+        fn new() -> Self {
+            Self {
+                last_system: std::sync::Mutex::new(None),
+                last_user: std::sync::Mutex::new(None),
+            }
+        }
+    }
+    impl LocalReasoner for CaptureReasoner {
+        fn id(&self) -> &str {
+            "capture"
+        }
+        fn reason(&self, system: &str, user: &str) -> crate::error::Result<String> {
+            *self.last_system.lock().unwrap() = Some(system.to_string());
+            *self.last_user.lock().unwrap() = Some(user.to_string());
+            Ok("ok".to_string())
+        }
+        fn structured(
+            &self,
+            _system: &str,
+            _user: &str,
+            _schema: &Value,
+        ) -> crate::error::Result<Value> {
+            Ok(Value::Null)
+        }
+    }
+
+    /// (A) RED-before-GREEN (2026-07-08, local-brain English-answer bug): the deterministic floor's
+    /// synthesis SYSTEM prompt MUST carry a same-language directive (Polish in → Polish out), mirroring
+    /// the cloud cascade/agent path. RED on the pre-fix prompt (no language line at all).
+    #[test]
+    fn floor_synthesis_prompt_has_same_language_directive() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // non-empty vault grounding ⇒ the brain is actually called.
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            "", // no current-meeting context on this leg — vault-only, tests the language line
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let system = reasoner
+            .last_system
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the brain MUST be called with vault grounding present");
+        assert!(
+            system.contains("SAME language"),
+            "synthesis prompt must instruct answering in the user's OWN language; got: {system}"
+        );
+        assert!(
+            system.contains("Polish"),
+            "the language directive must name the Polish→Polish case like the agent path; got: {system}"
+        );
+    }
+
+    /// (B) RED-before-GREEN: given a CURRENT-meeting grounding string, it MUST appear in the reasoner's
+    /// USER input labeled as THIS meeting AND BEFORE the vault notes (current-FIRST). Vault retrieval is
+    /// PRESERVED — the vault notes are still present, just SECONDARY. RED on the pre-fix `rag_answer`
+    /// (no current-meeting param, no "THIS MEETING" section).
+    #[test]
+    fn floor_prepends_current_meeting_before_vault_notes() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // "Atlas Kickoff" note is the VAULT (secondary) grounding.
+        let reasoner = CaptureReasoner::new();
+        let current = "Live transcript (so far):\nAlice: let's finalize the CURRENT-Q3-BUDGET today.";
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            current,
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner
+            .last_user
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the brain MUST be called");
+        let this_meeting_at = user
+            .find("THIS MEETING")
+            .expect("the current meeting must be labeled 'THIS MEETING' in the brain input");
+        assert!(
+            user.contains("CURRENT-Q3-BUDGET"),
+            "the current-meeting transcript must reach the brain input: {user}"
+        );
+        // Vault retrieval is PRESERVED (current-FIRST, not vault-only): the vault note is still there…
+        let vault_at = user
+            .find("Atlas Kickoff")
+            .expect("the vault note must STILL be present as secondary grounding");
+        // …but AFTER the current meeting.
+        assert!(
+            this_meeting_at < vault_at,
+            "the current meeting MUST come BEFORE the vault notes (current-first); user: {user}"
+        );
+        // The synthesis prompt must tell the brain the current meeting is the primary subject.
+        let system = reasoner.last_system.lock().unwrap().clone().unwrap();
+        assert!(
+            system.contains("THIS MEETING"),
+            "the system prompt must scope the answer to THIS meeting first; got: {system}"
+        );
+    }
+
+    /// (B2) Byte-identical guard: an EMPTY current-meeting context yields NO "THIS MEETING" section —
+    /// the vault-only floor behaves exactly as before. Guards the backward-compatibility promise for
+    /// every existing caller (which passes "").
+    #[test]
+    fn floor_empty_current_context_is_vault_only_no_this_meeting_section() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db);
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            "", // empty ⇒ no current-meeting section
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        assert!(
+            !user.contains("THIS MEETING"),
+            "empty current context must NOT inject a THIS MEETING section: {user}"
+        );
+        // Vault grounding is still present and drives the answer.
+        assert!(
+            user.contains("Atlas Kickoff"),
+            "the vault note must still be the grounding when no current context: {user}"
+        );
+    }
+
+    /// (C) RED-before-GREEN (2026-07-09, recording-awareness back-port): the CORE SYMPTOM. During a
+    /// LIVE recording whose buffer is still EMPTY (meeting just started), asking the LOCAL floor about
+    /// "this meeting" must NOT let the vault grounding be described as if it were the current meeting.
+    /// The synthesis SYSTEM prompt MUST say a meeting is being recorded RIGHT NOW, offer the honest
+    /// "meeting just started" answer, and FORBID substituting other saved meetings — the SAME wording
+    /// the cloud cascade already uses (shared via the `*_PHRASE` consts). RED on the pre-fix floor:
+    /// with `recording_in_progress` absent the empty-buffer prompt carried no recording awareness at
+    /// all, so the brain summarized unrelated vault meetings as "this meeting". Vault grounding is
+    /// present here (seeded), so the early "nothing found" return does NOT fire — we reach the brain.
+    #[test]
+    fn floor_recording_empty_buffer_forbids_substituting_other_meetings() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // non-empty vault grounding ("Atlas Kickoff") ⇒ the brain runs.
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            "", // EMPTY current context — the meeting just started
+            true, // recording_in_progress
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let system = reasoner
+            .last_system
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the brain MUST be called (vault grounding present)");
+        assert!(
+            system.contains(RECORDING_NOW_PHRASE),
+            "must tell the model a meeting is being recorded now; got: {system}"
+        );
+        assert!(
+            system.contains(MEETING_JUST_STARTED_PHRASE),
+            "must offer the honest 'meeting just started' answer for an empty buffer; got: {system}"
+        );
+        assert!(
+            system.contains(NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE),
+            "must forbid substituting other saved meetings for the current one; got: {system}"
+        );
+        // These exact substrings are the SAME ones the cloud cascade prompt test pins — the shared
+        // consts guarantee the floor and cascade cannot drift.
+        assert_eq!(RECORDING_NOW_PHRASE, "recorded RIGHT NOW");
+        assert_eq!(MEETING_JUST_STARTED_PHRASE, "meeting just started");
+        assert_eq!(
+            NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE,
+            "do NOT search the vault for other saved meetings"
+        );
+    }
+
+    /// (D) RED-before-GREEN: during a LIVE recording WITH transcribed content, the floor must frame the
+    /// THIS MEETING section as the live recording ("recorded RIGHT NOW"), still current-first with the
+    /// vault as secondary. RED on the pre-fix floor: the has_current clause never mentioned an active
+    /// recording (it read like a viewed PAST meeting).
+    #[test]
+    fn floor_recording_with_content_frames_live_transcript_current_first() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // "Atlas Kickoff" = the SECONDARY vault grounding.
+        let reasoner = CaptureReasoner::new();
+        let current = "Live transcript (so far):\nAlice: let's finalize the CURRENT-Q3-BUDGET today.";
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            current,
+            true, // recording_in_progress
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let system = reasoner.last_system.lock().unwrap().clone().unwrap();
+        assert!(
+            system.contains(RECORDING_NOW_PHRASE),
+            "a live recording with content must be framed as recorded RIGHT NOW; got: {system}"
+        );
+        assert!(
+            system.contains("THIS MEETING"),
+            "still scopes the answer to THIS meeting first; got: {system}"
+        );
+        // Current-first ordering is PRESERVED: the current transcript reaches the brain BEFORE the vault.
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        let this_at = user.find("THIS MEETING").expect("THIS MEETING labeled in user input");
+        let vault_at = user
+            .find("Atlas Kickoff")
+            .expect("vault note still present as secondary grounding");
+        assert!(
+            this_at < vault_at,
+            "the live meeting must come BEFORE the vault notes (current-first); user: {user}"
+        );
+    }
+
+    /// (E) NO-REGRESSION: when NOT recording (viewed past meeting / idle / Ask page), the floor must
+    /// make NO "recorded RIGHT NOW" claim — the language directive + current-first from the prior fix
+    /// stay, but nothing frames the context as a live recording. Guards byte-compatibility for the
+    /// `recording_in_progress=false` path that every legacy caller now passes.
+    #[test]
+    fn floor_not_recording_makes_no_live_recording_claim() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db);
+        let reasoner = CaptureReasoner::new();
+        // A viewed PAST meeting (has_current) but NOT recording.
+        let viewed = "Live transcript (so far):\nWe reviewed last quarter's numbers.";
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            viewed,
+            false, // NOT recording — viewed past meeting
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let system = reasoner.last_system.lock().unwrap().clone().unwrap();
+        assert!(
+            !system.contains(RECORDING_NOW_PHRASE),
+            "no live-recording claim when not recording; got: {system}"
+        );
+        assert!(
+            !system.contains(MEETING_JUST_STARTED_PHRASE),
+            "no 'meeting just started' claim when not recording; got: {system}"
+        );
+        // The prior viewed-past-meeting behavior is intact: still THIS-MEETING-first + the language line.
+        assert!(
+            system.contains("THIS MEETING"),
+            "viewed-meeting current-first framing preserved; got: {system}"
+        );
+        assert!(
+            system.contains("SAME language"),
+            "the same-language directive from the prior fix stays; got: {system}"
+        );
+    }
+
+    // ── Tier-1 current-first classifier + isolated answer (2026-07-09 structural fix) ─────────────
+
+    /// The current-meeting classifier fires on CLEAR "this meeting" questions (EN + PL, inflected),
+    /// and does NOT fire on cross-meeting or world questions (so the fan-out stays for those).
+    #[test]
+    fn is_about_current_meeting_matches_this_meeting_questions() {
+        // Polish "what is this meeting/recording/conversation about".
+        for q in [
+            "o czym jest to spotkanie",
+            "o czym jest to spotkanie?",
+            "o czym jest ta rozmowa",
+            "o czym to nagranie",
+            "o czym jest ta rozmowę", // inflected accusative — stem-matches
+            "Claudku, o czym jest to spotkanie",
+        ] {
+            assert!(is_about_current_meeting(q), "should match PL about-this: {q}");
+        }
+        // Polish "summarize / streść THIS meeting/recording/conversation" — the summarize rule
+        // requires the deictic AND a meeting-noun (a bare "streść to" with no meeting-noun is a
+        // deliberate MISS → fan-out, so a cross-meeting "podsumuj moje spotkania" can't slip in).
+        for q in [
+            "podsumuj to spotkanie",
+            "podsumuj to nagranie",
+            "streść tę rozmowę",
+        ] {
+            assert!(is_about_current_meeting(q), "should match PL summarize-this: {q}");
+        }
+        // Polish "what did we (here) decide / discuss".
+        for q in [
+            "co tu ustaliliśmy",
+            "co tutaj ustaliliśmy",
+            "co tu omówiliśmy",
+            "co tu zdecydowaliśmy",
+        ] {
+            assert!(is_about_current_meeting(q), "should match PL here-verb: {q}");
+        }
+        // English.
+        for q in [
+            "what is this meeting about",
+            "what's this conversation about",
+            "summarize this meeting",
+            "recap this call",
+            "what did we just discuss",
+            "what did we decide here",
+        ] {
+            assert!(is_about_current_meeting(q), "should match EN about-this: {q}");
+        }
+    }
+
+    /// Conservative: cross-meeting and world questions do NOT match, so they still fan out to the
+    /// vault / web on the floor (no regression). This is the load-bearing negative case.
+    #[test]
+    fn is_about_current_meeting_ignores_cross_note_and_world_questions() {
+        for q in [
+            "co ustaliliśmy z Weroniką",           // cross-meeting (a person), NOT "here"
+            "jaka pogoda",                          // world / web
+            "jaka jest pogoda w Warszawie",         // world / web
+            "moje otwarte zadania",                 // vault, not this-meeting
+            "co wiemy o projekcie Atlas",           // cross-note recall
+            "what's the weather",                   // world / web
+            "who won the game yesterday",           // world / web
+            "what did we decide with Weronika",     // cross-meeting (no deictic)
+            // CROSS-MEETING SUMMARIZE (adversarial 2026-07-09 regression): a summarize verb + a
+            // PLURAL/possessive-other meeting noun with NO "this/here" deictic must fan out to the
+            // vault, NOT be stolen to the current-meeting isolation.
+            "podsumuj moje spotkania",              // summarize MY meetings (plural, no deictic)
+            "summarize my meetings",
+            "podsumuj wszystkie spotkania",         // summarize ALL meetings
+            "streść wszystkie moje rozmowy",        // summarize ALL my conversations
+            "podsumuj spotkania z Weroniką",        // summarize meetings WITH a person
+            "recap my last call with Bob",          // recap a call WITH a person
+            "podsumuj nasze rozmowy z tego tygodnia", // summarize this week's conversations (plural)
+            // DEICTIC-NOT-ADJACENT (adversarial 2026-07-09 round 2): "this" modifies a TIME word, not
+            // the meeting-noun → cross-meeting/vault, must NOT be stolen to the current-meeting isolation.
+            "summarize this week's meetings",       // "this" → "week's", meetings is plural/cross
+            "summarize this month's meetings",
+            "recap this week's calls",
+            "podsumuj to co ustaliliśmy na spotkaniach", // relative "to co" + plural "na spotkaniach"
+            "",                                     // empty
+            "   ",                                  // whitespace
+        ] {
+            assert!(
+                !is_about_current_meeting(q),
+                "must NOT match (should fan out): {q:?}"
+            );
+        }
+    }
+
+    /// Tier-1 ISOLATION: given a current-meeting question WITH current content, the answer is
+    /// synthesized from ONLY that content — the model's user message contains the current content and
+    /// NOTHING vault/web, the system prompt has NO "THIS MEETING" label to parrot, and the citation is
+    /// the current meeting's own [[Title]] (never a vault/web source).
+    #[test]
+    fn tier1_isolated_answer_uses_only_current_content_no_fanout_no_label() {
+        let reasoner = CaptureReasoner::new();
+        let current = "Transcript:\n[0s] We agreed to ship the connector on Friday.";
+        let res = answer_current_meeting_isolated(
+            "research",
+            "o czym jest to spotkanie",
+            current,
+            /* recording */ true,
+            Some("Connector Sync"),
+            &reasoner,
+        );
+        assert_eq!(res.status, "ok");
+        assert_eq!(res.answered_from, Some(AnsweredFrom::CurrentMeeting));
+        // The citation is the CURRENT meeting's own title — not a vault/web source.
+        assert_eq!(res.citations, vec!["[[Connector Sync]]".to_string()]);
+        // The model saw ONLY the current content — nothing was fanned out.
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        assert!(
+            user.contains("We agreed to ship the connector on Friday"),
+            "the current content must be handed to the model: {user}"
+        );
+        assert!(
+            !user.contains("vault") && !user.contains("web") && !user.to_lowercase().contains("secondary"),
+            "NO vault/web/secondary grounding in the isolated Tier-1 prompt: {user}"
+        );
+        // NO literal "THIS MEETING" label the weak model would echo as its opening words.
+        let system = reasoner.last_system.lock().unwrap().clone().unwrap();
+        assert!(
+            !system.contains("THIS MEETING"),
+            "the Tier-1 prompt must not hand the model a 'THIS MEETING' label: {system}"
+        );
+        // The same-language directive is preserved (Polish in → Polish out).
+        assert!(
+            system.contains("SAME language"),
+            "the Tier-1 isolated prompt keeps the same-language directive: {system}"
+        );
+    }
+
+    /// Tier-1 EMPTY: an about-current question with NO current content → an HONEST "just started / no
+    /// content" answer, NO fan-out, NO web. The model is only asked to TRANSLATE a short honest
+    /// sentence (it never sees vault/web/other-meeting content).
+    #[test]
+    fn tier1_empty_current_content_is_honest_and_never_fans_out() {
+        // Recording, buffer empty → "just started" phrasing. Reasoner echoes; assert honest content.
+        let reasoner = CaptureReasoner::new();
+        let res = answer_current_meeting_isolated(
+            "research",
+            "o czym jest to spotkanie",
+            "", // NO current content
+            /* recording */ true,
+            None,
+            &reasoner,
+        );
+        assert_eq!(res.status, "ok");
+        assert_eq!(res.answered_from, Some(AnsweredFrom::CurrentMeeting));
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        // The ONLY thing handed to the model is an honest sentence to translate — no vault/web.
+        assert!(
+            user.contains("just started"),
+            "recording+empty ⇒ 'just started' honest sentence: {user}"
+        );
+        assert!(
+            !user.to_lowercase().contains("vault") && !user.to_lowercase().contains("[["),
+            "empty Tier-1 must NOT fan out to the vault: {user}"
+        );
+
+        // A STUB reasoner (no brain) ⇒ the honest English notice verbatim, still no fan-out.
+        let stub = crate::reason::StubReasoner;
+        let res2 = answer_current_meeting_isolated(
+            "research",
+            "summarize this meeting",
+            "",
+            /* recording */ false, // viewed past meeting with no content
+            None,
+            &stub,
+        );
+        assert_eq!(res2.status, "ok");
+        assert!(
+            res2.summary.contains("no transcript or notes"),
+            "viewed+empty ⇒ 'no transcript or notes' honest notice: {}",
+            res2.summary
+        );
+        assert!(res2.citations.is_empty(), "no citations when there is no content");
+    }
+
+    /// Tier-1 with a STUB reasoner but PRESENT content ⇒ honest no-model notice + KEEP the current
+    /// meeting's own citation, still NO fan-out.
+    #[test]
+    fn tier1_stub_with_content_returns_no_model_notice_and_own_citation() {
+        let stub = crate::reason::StubReasoner;
+        let res = answer_current_meeting_isolated(
+            "research",
+            "o czym to spotkanie",
+            "Transcript:\n[0s] Budget approved.",
+            true,
+            Some("Budget Review"),
+            &stub,
+        );
+        assert_eq!(res.status, "unavailable");
+        assert_eq!(res.summary, NO_MODEL_ANSWER_NOTICE);
+        assert_eq!(res.citations, vec!["[[Budget Review]]".to_string()]);
+        assert_eq!(res.answered_from, Some(AnsweredFrom::CurrentMeeting));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -7,6 +7,7 @@ import type {
   AiMapRow,
   Analytics,
   AppConfigDto,
+  ContextHit,
   MyShareEntry,
   RecipientPreview,
   ShareToUserResult,
@@ -197,6 +198,36 @@ export class IpcService {
   }
 
   /**
+   * ENRICH: preview live context to fold into the note, from EVERY consented connector (Jira via
+   * precise issue-key lookup; other connectors via a title search). This is the egress moment
+   * (explicit, like verify); refuses a locked meeting; returns `[]` when there is nothing to add.
+   */
+  enrichNoteContext(meetingId: string): Promise<ContextHit[]> {
+    return invoke<ContextHit[]>("enrich_note_context", { meetingId });
+  }
+
+  /**
+   * Persist the reviewed context hits as ONE consolidated, dated `> [!context]-` callout appended to
+   * the note (byte-exact undo: pass `[]` to strip it). No egress — the hits were already fetched.
+   */
+  applyNoteEnrichment(meetingId: string, hits: ContextHit[]): Promise<NoteDto> {
+    return invoke<NoteDto>("apply_note_enrichment", { meetingId, hits });
+  }
+
+  /**
+   * STAGE 2 / LANE A — MANUAL re-link / backfill of cross-meeting `[[links]]` over a FINISHED note.
+   * ZERO egress: the pass retrieves over the user's OWN visible notes (double visibility-gated,
+   * self-excluding) and appends an additive, idempotent, byte-exact-undo `> [!related]-` block —
+   * nothing leaves the device. The AUTO pipeline runs the same pass as a deferred post-`Exported`
+   * step; this is the on-demand refresh so the panel can re-link after later meetings land. Lock-
+   * gated + seal-safe (a sealed meeting is a silent no-op). Re-fetch the note (getMeetingDetail)
+   * after it resolves to render the refreshed links.
+   */
+  linkRelatedNotes(meetingId: string): Promise<void> {
+    return invoke<void>("link_related_notes", { meetingId });
+  }
+
+  /**
    * Re-Truth — preview the facts a just-finished meeting SUPERSEDES from earlier
    * notes (pending only; `applied` always false). Returns `[]` when nothing moved on.
    */
@@ -219,6 +250,16 @@ export class IpcService {
 
   getConfig(): Promise<AppConfigDto> {
     return invoke<AppConfigDto>("get_config");
+  }
+
+  /**
+   * The ready-to-paste Claude Code MCP config block (pretty JSON, `type: "http"`),
+   * carrying the localhost URL and — when `mcp_require_token` is on (default) — the
+   * `Authorization: Bearer <token>` header so the handshake authenticates. When the
+   * token flag is off the config has no headers block.
+   */
+  getMcpConfig(): Promise<string> {
+    return invoke<string>("get_mcp_config");
   }
 
   saveConfig(config: AppConfigDto): Promise<void> {
@@ -1199,6 +1240,22 @@ export class IpcService {
   }
 
   /**
+   * Phase 6 — tell the backend which meeting the user is currently VIEWING /
+   * anchored to (the FOCUS pointer), distinct from the recording pointer. Call
+   * with the meeting id when a meeting-detail / conversation view opens, and with
+   * `null` when it closes. This is a backend SAFETY-NET: the brain resolves its
+   * "this meeting" scope as `explicit meetingId > focus > recording`, so any
+   * assistant path that falls back off an explicit id (the voice/wake twin) still
+   * scopes to the meeting on screen — even when nothing is recording, and even
+   * when a DIFFERENT meeting is recording. Focus is only an id (never content);
+   * the sealed-content gate is unchanged (a relocked meeting stays masked).
+   * Best-effort — a failure never blocks opening the view.
+   */
+  setFocusMeeting(meetingId: string | null): Promise<void> {
+    return invoke<void>("set_focus_meeting", { meetingId });
+  }
+
+  /**
    * Ask the in-meeting assistant a TYPED question (the text composer — the twin of
    * the voice trigger). Routes the typed command through the SAME gated agentic
    * brain as voice: the model decides which gated tools to call, the live tool
@@ -1208,9 +1265,19 @@ export class IpcService {
    *
    * Pass `threadId` to persist the exchange under that thread (the result +
    * tool-trace events come back stamped with it); omit it for an anchorless ask.
+   *
+   * Pass `meetingId` (Phase 4) to bind the turn to a SPECIFIC meeting: the backend
+   * resolves `meetingId ?? state.current_meeting`, so an explicit id wins (a
+   * past/anchored @brain thread scopes to ITS meeting) while omitting it keeps the
+   * live-recording scope. Omitting it preserves the pre-Phase-4 behavior for the
+   * voice/wake twin.
    */
-  askAssistantText(text: string, threadId?: string): Promise<void> {
-    return invoke<void>("ask_assistant_text", { text, threadId });
+  askAssistantText(
+    text: string,
+    threadId?: string,
+    meetingId?: string,
+  ): Promise<void> {
+    return invoke<void>("ask_assistant_text", { text, threadId, meetingId });
   }
 
   /**
@@ -1227,16 +1294,25 @@ export class IpcService {
    * a UUID itself and the exchange STILL persists (it then rehydrates as a
    * standalone anchorless thread). Always pass the thread's own id so its
    * exchanges stay grouped.
+   *
+   * Pass `meetingId` (Phase 4) to bind the thread to a SPECIFIC meeting so the
+   * brain scopes "this meeting" correctly: the backend resolves
+   * `meetingId ?? state.current_meeting`, so an explicit id wins (a past/anchored
+   * thread answers about ITS meeting even while a different meeting records) and
+   * omitting it keeps the live-recording scope. This is what kills the
+   * wrong-meeting bug — always pass the thread's bound meeting id.
    */
   askAssistantChat(
     messages: ChatMsg[],
     threadId?: string,
     anchorText?: string,
+    meetingId?: string,
   ): Promise<VoiceActionResultPayload> {
     return invoke<VoiceActionResultPayload>("ask_assistant_chat", {
       messages,
       threadId,
       anchorText,
+      meetingId,
     });
   }
 

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -3,6 +3,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "./ipc.service";
 import { FoldersService } from "../services/folders.service";
 import type {
+  AnsweredFrom,
   AssistantThreadRow,
   AssistantToolPayload,
   ChatMsg,
@@ -100,6 +101,13 @@ export interface ThreadTurn {
    * draft (not the whole reply) is appended to the notes.
    */
   proposedNote: string | null;
+  /**
+   * Agent only (Phase 5): which BRAIN CASCADE tier answered — current meeting /
+   * vault / connectors — set deterministically by the backend ladder. `null`
+   * while pending, on an error, or on an older backend that omits it. Drives the
+   * visible tier chip ("answered from: this meeting / your vault / connectors").
+   */
+  answeredFrom: AnsweredFrom | null;
   /** Agent only: true once the user has ACCEPTED this turn's draft into the main notes. */
   accepted: boolean;
   /**
@@ -481,6 +489,10 @@ export class MeetingConversationStore {
   setMeetingId(id: string | null): void {
     if (id === this._meetingId()) return;
     this._meetingId.set(id);
+    // Phase 6 — mirror the viewed meeting into the backend FOCUS pointer (safety-net for any
+    // assistant path that falls back off an explicit id, e.g. the voice/wake twin). Best-effort;
+    // a failure never blocks the view. Cleared (null) when the store points at no meeting.
+    void this.ipc.setFocusMeeting(id);
     const token = ++this.notesLoadToken;
     if (!id) {
       // No meeting to load → nothing to wait on; the composer stays enabled.
@@ -616,6 +628,7 @@ export class MeetingConversationStore {
             trace: [],
             citations: [],
             proposedNote: null,
+            answeredFrom: null,
             accepted: false,
             dismissed: false,
           });
@@ -627,6 +640,7 @@ export class MeetingConversationStore {
             trace: [],
             citations: parseCitations(row.citations),
             proposedNote: null,
+            answeredFrom: null,
             accepted: false,
             dismissed: false,
           });
@@ -728,6 +742,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -739,6 +754,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -788,6 +804,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -799,6 +816,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -843,6 +861,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -854,6 +873,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -876,9 +896,11 @@ export class MeetingConversationStore {
   /**
    * Ship a thread's OWN turns (its history) to `ask_assistant_chat` (multi-turn
    * memory scoped to THIS thread) and resolve the given pending agent turn with
-   * the reply. Ships the note's `threadId` + its anchor text (the note line) so
-   * the backend PERSISTS the exchange under the thread — a reopened meeting
-   * rebuilds it via `list_assistant_threads`. The live tool-trace lands via
+   * the reply. Ships the note's `threadId` + its anchor text (the note line) +
+   * the store's anchored `meetingId` (Phase 4 — so the brain scopes "this meeting"
+   * to the bound meeting, not whatever is recording), so the backend PERSISTS the
+   * exchange under the thread — a reopened meeting rebuilds it via
+   * `list_assistant_threads`. The live tool-trace lands via
    * {@link onTool} (routed by the payload's threadId when stamped, else the most
    * recent pending agent turn). Always clears the thread's `threadPending` flag.
    */
@@ -907,12 +929,19 @@ export class MeetingConversationStore {
         payload,
         note?.threadId ?? undefined,
         note?.text.trim() || undefined,
+        // Phase 4: bind this thread to the store's anchored meeting so the brain
+        // scopes "this meeting" to it (a past/anchored thread answers about ITS
+        // meeting; omitting it would fall back to state.current_meeting → the
+        // wrong-meeting bug). Null → undefined so the backend uses the recording.
+        this._meetingId() ?? undefined,
       );
       this.resolveTurn(noteId, agentTurnId, {
         status: reply.status,
         text: reply.summary || "(no answer)",
         citations: parseCitations(reply.citations),
         proposedNote: reply.proposedNote,
+        // Phase 5: the deterministic tier badge from the ladder (or null).
+        answeredFrom: reply.answeredFrom ?? null,
       });
     } catch {
       this.resolveTurn(noteId, agentTurnId, {
@@ -920,6 +949,7 @@ export class MeetingConversationStore {
         text: "Couldn't reach the assistant.",
         citations: [],
         proposedNote: null,
+        answeredFrom: null,
       });
     }
   }
@@ -937,6 +967,7 @@ export class MeetingConversationStore {
       text: string;
       citations: AssistantCitation[];
       proposedNote: string | null;
+      answeredFrom: AnsweredFrom | null;
     },
   ): void {
     this._notes.update((ns) =>
@@ -953,6 +984,7 @@ export class MeetingConversationStore {
                   text: patch.text,
                   citations: patch.citations,
                   proposedNote: patch.proposedNote,
+                  answeredFrom: patch.answeredFrom,
                 }
               : turn,
           ),
@@ -1054,6 +1086,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -1065,6 +1098,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -1094,6 +1128,7 @@ export class MeetingConversationStore {
         text: "Couldn't start the listener.",
         citations: [],
         proposedNote: null,
+        answeredFrom: null,
       });
       throw e;
     }
@@ -1131,6 +1166,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -1142,6 +1178,7 @@ export class MeetingConversationStore {
       trace: [],
       citations: [],
       proposedNote: null,
+      answeredFrom: null,
       accepted: false,
       dismissed: false,
     };
@@ -1440,6 +1477,7 @@ export class MeetingConversationStore {
         trace: [],
         citations: [],
         proposedNote: null,
+        answeredFrom: null,
         accepted: false,
         dismissed: false,
       };
@@ -1451,6 +1489,8 @@ export class MeetingConversationStore {
         trace: [],
         citations: parseCitations(p.citations),
         proposedNote: p.proposedNote,
+        // Phase 5: the deterministic tier badge (current meeting / vault / connectors), or null.
+        answeredFrom: p.answeredFrom ?? null,
         accepted: false,
         dismissed: false,
       };
@@ -1487,6 +1527,8 @@ export class MeetingConversationStore {
               text: p.summary,
               citations: parseCitations(p.citations),
               proposedNote: p.proposedNote,
+              // Phase 5: the deterministic tier badge from the ladder (or null).
+              answeredFrom: p.answeredFrom ?? null,
             };
             // Backfill the heard command onto the preceding empty user turn.
             const prev = thread[i - 1];

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -521,6 +521,16 @@ export type VoiceActionStatus =
   | "error";
 
 /**
+ * Phase 5 — which BRAIN CASCADE tier answered an in-meeting @brain turn. Set
+ * DETERMINISTICALLY by the backend ladder (never string-sniffed): the current
+ * meeting in isolation, the user's vault, or the connectors/web. Mirrors the
+ * backend `AnsweredFrom` enum (`voice_action.rs`, serialized `snake_case`).
+ * Absent/null when the turn didn't run through the cascade (the deterministic
+ * floor, an error, or the vault-wide Ask page).
+ */
+export type AnsweredFrom = "current_meeting" | "vault" | "connectors";
+
+/**
  * Phase H — the result of a voice action (`EVENT_VOICE_ACTION_RESULT`): the
  * HEARD command (the user's own dictated words, so the card can show
  * "usłyszano: {command}"; empty when nothing was heard), a short summary +
@@ -549,6 +559,12 @@ export interface VoiceActionResultPayload {
    * routing. Lets the FE resolve the RIGHT thread when several are in flight.
    */
   threadId?: string | null;
+  /**
+   * Phase 5 — which BRAIN CASCADE tier answered (current meeting / vault /
+   * connectors), set deterministically by the backend ladder. Absent/null when
+   * the turn did not run through the cascade. Drives the visible tier chip.
+   */
+  answeredFrom?: AnsweredFrom | null;
 }
 
 /**
@@ -683,6 +699,16 @@ export interface VerifyFindingDto {
   verdict: "confirmed" | "notfound" | "conflict";
   detail: string;
   url: string;
+}
+
+/**
+ * One piece of live connector context to fold into a note (connector-agnostic — `source` is the
+ * truthful connector label, e.g. "Jira" / "Slack"). Mirrors the Rust `enrich::ContextHit`.
+ */
+export interface ContextHit {
+  source: string;
+  detail: string;
+  url: string | null;
 }
 
 export interface StartResult {

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -191,6 +191,15 @@ export class RecorderStore {
   }
 
   async stop(): Promise<void> {
+    // OPTIMISTIC flip BEFORE the await: `stopRecording` runs the WHOLE pipeline inline (transcribe
+    // the entire recording + generate the note), which for a long meeting takes minutes. Without
+    // this, `_stage` stays "recording" for that whole time — the Stop button keeps rendering
+    // (`isRecording()` true) and stays clickable, so the UI looks frozen and a double-Stop is
+    // possible. Moving to "transcribing" now (mirrors `resummarize`'s optimistic set) instantly
+    // swaps the recording strip for the processing view; the backend's status events + the resolved
+    // StopResult then reconcile the exact stage.
+    this._error.set(null);
+    this._stage.set("transcribing");
     try {
       const res = await this.ipc.stopRecording();
       // Optimistic preview from the StopResult; then reconcile with the

--- a/src/app/features/detail/audio-panel/audio-panel.component.html
+++ b/src/app/features/detail/audio-panel/audio-panel.component.html
@@ -161,7 +161,7 @@
     @if (visibleTurns().length) {
       <div #scroller class="transcript-card panel-card">
         <ul class="turns">
-          @for (t of visibleTurns(); track t.key) {
+          @for (t of renderedTurns(); track t.key) {
             <li
               #turnRow
               class="turn"
@@ -191,7 +191,7 @@
                   <button
                     type="button"
                     class="frag"
-                    [class.is-active]="isActiveSegment(s.startS, s.endS)"
+                    [class.is-active]="activeSegKeys().has(s.idx)"
                     [disabled]="!audioSrc()"
                     (click)="seekTo(s.startS)"
                   >{{ s.text }} </button>
@@ -204,6 +204,16 @@
             </li>
           }
         </ul>
+        @if (hiddenTurnCount() > 0) {
+          <button
+            type="button"
+            class="btn btn-ghost show-all"
+            (click)="showAllTurns()"
+          >
+            Show all {{ visibleTurns().length }} turns
+            <span class="count">+{{ hiddenTurnCount() }}</span>
+          </button>
+        }
       </div>
     } @else if (segments().length) {
       <div class="empty-card panel-card">

--- a/src/app/features/detail/audio-panel/audio-panel.component.scss
+++ b/src/app/features/detail/audio-panel/audio-panel.component.scss
@@ -378,4 +378,10 @@
     animation: none;
   }
 }
+
+// "Show all N turns" — the transcript-cap expander (renders below the windowed turn list).
+.show-all {
+  display: block;
+  margin: var(--space-3) auto 0;
+}
     

--- a/src/app/features/detail/audio-panel/audio-panel.component.ts
+++ b/src/app/features/detail/audio-panel/audio-panel.component.ts
@@ -108,6 +108,14 @@ export class AudioPanelComponent {
   // --- Transcript find + karaoke ------------------------------------------
   /** Live text filter for the transcript turns (case-insensitive substring). */
   readonly query = signal("");
+  /**
+   * Cap on how many turns render at once. A 1h meeting folds to hundreds of turns / thousands of
+   * `<button>` fragments, so materializing them all is tens of MB of DOM + layout. We render the
+   * first `RENDER_CAP` (always extended to include the turn the playhead is inside, so karaoke
+   * auto-scroll never targets an un-rendered row) until the user asks for the whole transcript.
+   */
+  private readonly RENDER_CAP = 80;
+  readonly transcriptExpanded = signal(false);
   /** The scrolling transcript container + one element per rendered turn. */
   private readonly scroller = viewChild<ElementRef<HTMLElement>>("scroller");
   private readonly turnRows =
@@ -161,6 +169,53 @@ export class AudioPanelComponent {
       }
     }
     return null;
+  });
+
+  /**
+   * The turns actually rendered — the first `RENDER_CAP`, always extended to include the turn the
+   * playhead is inside (so karaoke auto-scroll never targets an un-rendered row), or ALL turns once
+   * the user expands or when the (possibly filtered) list is already within the cap. This bounds the
+   * DOM node count for a long meeting without breaking the play/seek/highlight surfaces.
+   */
+  readonly renderedTurns = computed<Turn[]>(() => {
+    const all = this.visibleTurns();
+    if (this.transcriptExpanded() || all.length <= this.RENDER_CAP) {
+      return all;
+    }
+    let cap = this.RENDER_CAP;
+    const activeKey = this.activeTurnKey();
+    if (activeKey) {
+      const activeIdx = all.findIndex((t) => t.key === activeKey);
+      if (activeIdx >= 0) {
+        cap = Math.max(cap, activeIdx + 1);
+      }
+    }
+    return all.slice(0, cap);
+  });
+
+  /** How many turns sit behind the "Show all" affordance (0 when the whole transcript is rendered). */
+  readonly hiddenTurnCount = computed(
+    () => this.visibleTurns().length - this.renderedTurns().length,
+  );
+
+  /**
+   * The set of segment `idx`es whose [startS, endS) currently contains the playhead — the karaoke
+   * highlight targets. A single `computed`, scanned ONCE per `currentTime` tick (O(n)); the template
+   * then does an O(1) `.has(s.idx)` per fragment. Replaces the former `isActiveSegment()` METHOD
+   * binding, which Angular re-ran O(n) per fragment on EVERY change-detection pass (~4×/s during
+   * playback → an ~8k-eval/s storm for a 1h transcript). A Set (not a single key) preserves the
+   * original behavior of highlighting EVERY active fragment when me/others segments overlap in
+   * wall-clock time.
+   */
+  readonly activeSegKeys = computed<Set<number>>(() => {
+    const t = this.currentTime();
+    const out = new Set<number>();
+    for (const s of this.segments()) {
+      if (t >= s.startS && t < s.endS) {
+        out.add(s.idx);
+      }
+    }
+    return out;
   });
 
   /** Progress as a 0–100 percentage for the seek-bar fill. */
@@ -339,12 +394,6 @@ export class AudioPanelComponent {
     void el.play();
   }
 
-  /** True when playback is inside [startS, endS) — highlights the live fragment. */
-  isActiveSegment(startS: number, endS: number): boolean {
-    const t = this.currentTime();
-    return t >= startS && t < endS;
-  }
-
   /** Find-box input handler → the `query` signal. */
   onQuery(event: Event): void {
     this.query.set((event.target as HTMLInputElement).value);
@@ -353,6 +402,11 @@ export class AudioPanelComponent {
   /** Clear the Find box. */
   clearQuery(): void {
     this.query.set("");
+  }
+
+  /** Reveal the full transcript (drops the `RENDER_CAP` window). */
+  showAllTurns(): void {
+    this.transcriptExpanded.set(true);
   }
 
   /**

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -276,6 +276,7 @@
             (draftInput)="draft.set($event)"
             (copyPath)="copy(d.note?.exportedPath ?? '')"
             (openRelated)="openRelated($event)"
+            (noteChanged)="reloadDetail()"
           />
           @if (config()?.jiraEnabled && config()?.jiraConsented && !locked()) {
             <app-verify-panel

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
   afterNextRender,
   computed,
+  effect,
   inject,
   signal,
   viewChild,
@@ -274,6 +275,34 @@ export class DetailComponent implements OnInit {
   // --- Interactive timeline (speaker + topic viz) -------------------------
   readonly timeline = signal<MeetingTimeline | null>(null);
   readonly timelineLoading = signal(false);
+
+  /**
+   * PERF/OOM (P0.1): generate the timeline LAZILY — only when the Audio tab (the only surface that
+   * renders it) is first opened for an unlocked meeting and it isn't already loaded / in flight.
+   * `loadMeeting`/`unlock` no longer kick it off on open, so a plain Note-tab open never triggers the
+   * multi-GB on-device LLM pass that OOM-killed the Mac. `allowSignalWrites` because `loadTimeline`
+   * writes `timelineLoading` (which this effect reads) — the `!timelineLoading()` guard makes the
+   * re-run a no-op, so there is no loop. See docs/research/2026-07-07-perf-memory-audit.md.
+   */
+  private readonly _timelineOnAudioTab = effect(
+    () => {
+      if (
+        this.activeTab() === "audio" &&
+        this.detail() &&
+        !this.locked() &&
+        !this.timeline() &&
+        !this.timelineLoading() &&
+        // Do NOT auto-retry after a failure: a persistent `get_timeline` error would otherwise
+        // re-fire this effect every time `timelineLoading` flips back to false → an infinite retry
+        // loop (and repeated multi-GB model loads). A failed load surfaces the Retry button, which
+        // clears `timelineError` and re-calls `loadTimeline` explicitly.
+        !this.timelineError()
+      ) {
+        void this.loadTimeline();
+      }
+    },
+    { allowSignalWrites: true },
+  );
   readonly timelineError = signal(false);
   /**
    * Speaker voiceprint suggestions (opt-in) — one per diarized `others-{n}` lane
@@ -406,10 +435,12 @@ export class DetailComponent implements OnInit {
       });
       return;
     }
-    // Kick the timeline off after the detail load; never blocks the page and
-    // tolerates the first-call LLM latency (backend caches the result).
+    // PERF/OOM (P0.1): do NOT generate the timeline on open. It only renders on the Audio tab
+    // (default is Note), and `get_timeline` on a fresh meeting runs an on-device LLM over the WHOLE
+    // transcript — with a local heavy model (Bielik-11B, 6.3 GB, never-evict) that multi-GB load
+    // on every open OOM-killed the Mac. It is now generated LAZILY when the Audio tab first opens
+    // (`_timelineOnAudioTab` effect below). See docs/research/2026-07-07-perf-memory-audit.md.
     if (this.detail()) {
-      void this.loadTimeline();
       // Prime the folder tree so the read-only folder/lock badge + the move
       // picker have state on a direct navigation (idempotent; the root component
       // also loads it). Non-blocking — a failure just hides the badge.
@@ -491,9 +522,9 @@ export class DetailComponent implements OnInit {
       this.detail.set(fresh);
       if (fresh && !fresh.locked) {
         // Refresh the folder tree so the header lock badge reflects the unlock,
-        // then prime the timeline + tags the masked load skipped. Non-blocking.
+        // then prime the tags the masked load skipped. Non-blocking. The timeline is
+        // NOT generated here (P0.1) — it loads lazily when the Audio tab opens.
         void this.folders.load();
-        void this.loadTimeline();
         try {
           this.tags.set(await this.ipc.getMeetingTags(id));
         } catch {
@@ -548,16 +579,27 @@ export class DetailComponent implements OnInit {
   /** Fetch (or re-fetch, via Retry) the AI-derived speaker + topic timeline. */
   async loadTimeline(): Promise<void> {
     const id = this.detail()?.meeting.id;
-    if (!id) {
+    // In-flight guard: never start a second generation while one is running (the Audio-tab effect
+    // could otherwise re-fire). P0.4.
+    if (!id || this.timelineLoading()) {
       return;
     }
     this.timelineError.set(false);
     this.timelineLoading.set(true);
     try {
-      this.timeline.set(await this.ipc.getTimeline(id));
+      const tl = await this.ipc.getTimeline(id);
+      // STALE-RESULT guard: `get_timeline` can take many seconds (on-device LLM). If the user
+      // switched meetings mid-flight, drop this result so we never paint meeting A's timeline over
+      // meeting B (mirrors `resummarize`). P0.4.
+      if (this.detail()?.meeting.id !== id) {
+        return;
+      }
+      this.timeline.set(tl);
     } catch {
-      this.timeline.set(null);
-      this.timelineError.set(true);
+      if (this.detail()?.meeting.id === id) {
+        this.timeline.set(null);
+        this.timelineError.set(true);
+      }
     } finally {
       this.timelineLoading.set(false);
     }

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -321,6 +321,12 @@
     }
   </section>
 
+  <!-- LIVE CONTEXT — enrich this note with fresh detail from connected tools (Jira / Slack / web).
+       Sits right after the note summary; egress is on-demand + kept loud. Only rendered for an
+       unlocked meeting (note-panel itself is under the detail view's `@else (!locked())`). Bubbles
+       apply/clear up via (noteChanged) so the parent reloads the note. -->
+  <app-stage2-panel [meetingId]="meetingId()" (noteChanged)="noteChanged.emit()" />
+
   <!-- ASSISTANT Q&A (persisted in-meeting voice exchanges). -->
   @if (interactions().length) {
     <section class="block print-keep">
@@ -373,6 +379,18 @@
   </section>
 
   <!-- RELATED BY MEANING (semantic neighbors; silent when empty). -->
-  <app-related-meetings [meetingId]="meetingId()" (open)="openRelated.emit($event)" />
+  <!-- PERF/OOM (P1): defer until it scrolls into view. Its `_load` effect fires the on-device e5
+       embedder the instant it mounts; on a fresh meeting open that ran CONCURRENTLY with the
+       timeline's heavy model load (a second resident model) — a compounding factor in the open-a-1h
+       -meeting OOM. `on viewport` means a plain Note-tab open (Related sits below the fold) never
+       loads the embedder until the user actually scrolls to it. docs/research/2026-07-07-perf-memory-audit.md -->
+  @defer (on viewport) {
+    <app-related-meetings
+      [meetingId]="meetingId()"
+      (open)="openRelated.emit($event)"
+    />
+  } @placeholder {
+    <div class="related-defer-placeholder" aria-hidden="true"></div>
+  }
 </div>
   

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -16,6 +16,7 @@ import { MeetingActionsComponent } from "../meeting-actions/meeting-actions.comp
 import { MeetingChatComponent } from "../meeting-chat/meeting-chat.component";
 import { MeetingRecipesComponent } from "../meeting-recipes/meeting-recipes.component";
 import { RelatedMeetingsComponent } from "../related-meetings/related-meetings.component";
+import { Stage2PanelComponent } from "../stage2-panel/stage2-panel.component";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 export interface ActionItemLine {
@@ -83,6 +84,7 @@ export interface AssistantQa {
     MeetingChatComponent,
     MeetingRecipesComponent,
     RelatedMeetingsComponent,
+    Stage2PanelComponent,
   ],
   templateUrl: "./note-panel.component.html",
   styleUrl: "./note-panel.component.scss",
@@ -146,6 +148,8 @@ export class NotePanelComponent {
   readonly saveAudio = output<void>();
   readonly exportMaster = output<"mic" | "sys">();
   readonly linkGraph = output<void>();
+  /** Bubbles the live-context panel's apply/clear up so the parent reloads the note. */
+  readonly noteChanged = output<void>();
   readonly edit = output<void>();
   readonly cancelEdit = output<void>();
   readonly saveNote = output<void>();

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.html
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.html
@@ -1,0 +1,79 @@
+<div class="stage2-panel">
+  <!-- LIVE CONTEXT — connector enrichment (EGRESS, on-demand). Compact button row +
+       a one-line egress hint (the query-leaves-the-device moment stays LOUD, without
+       the old full-width warning block). -->
+  <section class="lane live-lane">
+    <div class="lane-actions">
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="fetchContext()"
+        [disabled]="running()"
+      >
+        @if (running() && hits() === null) {
+          Fetching…
+        } @else {
+          Fetch live context
+        }
+      </button>
+      @if (hits(); as h) {
+        @if (h.length > 0) {
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="addToNote()"
+            [disabled]="running() || applied()"
+          >
+            Add to note
+          </button>
+        }
+        <button
+          type="button"
+          class="btn btn-ghost"
+          (click)="clearContext()"
+          [disabled]="running()"
+        >
+          Clear
+        </button>
+      }
+    </div>
+
+    <p class="live-hint text-secondary" role="note">
+      <span class="pill is-warning">Connectors · sends a query out</span>
+      Sends a redacted query to your connected tools (Jira / Slack / web) to fold
+      fresh detail into this note — the moment a query leaves your device.
+    </p>
+
+    @if (hits(); as h) {
+      @if (h.length === 0) {
+        <p class="text-secondary">No live context found for this note.</p>
+      } @else {
+        <ul class="hit-list">
+          @for (hit of h; track hit.source + "|" + hit.detail) {
+            <li class="hit-item">
+              <span class="pill hit-source">via {{ hit.source }}</span>
+              <span class="hit-detail">{{ hit.detail }}</span>
+              @if (hit.url) {
+                <a [href]="hit.url" target="_blank" rel="noopener">Open</a>
+              }
+            </li>
+          }
+        </ul>
+      }
+    }
+
+    @if (applied()) {
+      <p class="text-secondary">
+        Added — the note now carries the live context in a foldable callout.
+      </p>
+    }
+    @if (cleared()) {
+      <p class="text-secondary">
+        Cleared — the live-context callout was removed from the note.
+      </p>
+    }
+    @if (error(); as e) {
+      <p class="banner is-warning" role="alert">{{ e }}</p>
+    }
+  </section>
+</div>

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.scss
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.scss
@@ -1,0 +1,56 @@
+.stage2-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.lane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.lane-actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* One-line egress hint under the Fetch button — the "sends a query out" pill + a
+   terse sentence keep the query-leaves-the-device moment visible, without the old
+   full-width warning banner. */
+.live-hint {
+  margin: 0;
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+  flex-wrap: wrap;
+
+  .pill {
+    flex: none;
+  }
+}
+
+.hit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.hit-item {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
+}
+
+.hit-source {
+  flex: none;
+}
+
+.hit-detail {
+  flex: 1 1 auto;
+}

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.ts
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.ts
@@ -1,0 +1,155 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { ContextHit } from "../../../core/models";
+
+/**
+ * LIVE-CONTEXT affordance (docs/research/2026-07-06-note-and-brain-architecture.md §3 / §6 / §8-Phase 3).
+ *
+ * A compact "Fetch live context" control mounted right after the note summary (note-panel). It is the
+ * explicit connector-enrichment EGRESS moment: "Fetch live context" sends a redacted query out to the
+ * consented Jira/Slack/web connectors via the fail-closed registry gate; the returned `ContextHit[]`
+ * render as a review preview; "Add to note" persists the reviewed hits and "Clear" strips the block
+ * (byte-exact undo via an empty-hits apply). The egress is kept LOUD — a "sends a query out" pill +
+ * a one-line hint sit beside the button — consistent with the app's other cloud-egress affordances,
+ * without the old full-width warning block.
+ *
+ * (Lane A — the local, zero-egress "Refresh links" backfill — was removed: links auto-refresh on
+ * finalize, and the `Related notes` LIST lives in `app-related-meetings`.)
+ *
+ * Every write / clear goes through the ALREADY-GATED backend commands (`meeting_is_unlocked` before
+ * any egress or write); the panel adds NO new ungated read path — the parent only mounts it for a
+ * NON-locked meeting. IPC results land in signals; the parent reloads the note via `noteChanged`.
+ */
+@Component({
+  selector: "app-stage2-panel",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./stage2-panel.component.html",
+  styleUrl: "./stage2-panel.component.scss",
+})
+export class Stage2PanelComponent {
+  private readonly ipc = inject(IpcService);
+
+  readonly meetingId = input.required<string>();
+  /** Fires after Lane A links / Lane B hits are applied so the parent reloads the note. */
+  readonly noteChanged = output<void>();
+
+  // ── Connector enrichment (EGRESS, on-demand) ────────────────────────────
+  /** True while any Lane-B IPC (fetch / add / clear) is in flight. */
+  readonly running = signal(false);
+  /** The reviewed live-context hits — null before a fetch, `[]` when the fetch found nothing. */
+  readonly hits = signal<ContextHit[] | null>(null);
+  /** Latched after a successful "Add to note" write so the panel can confirm. */
+  readonly applied = signal(false);
+  /** Latched after a successful "Clear" (strip) so the panel can confirm. */
+  readonly cleared = signal(false);
+  /** Inline error for the Lane-B path (surfaced in a warning banner). */
+  readonly error = signal<string | null>(null);
+
+  /**
+   * RESET on meeting change (the load-bearing correctness guard). The parent reuses this SAME
+   * component instance across in-place meeting navigation (`detail()` is never nulled, so the
+   * `@if (!locked())` mount never tears down) — so without this, a previous meeting's fetched
+   * `hits()` (and the applied/cleared/linked confirmations) would survive onto the NEXT meeting and
+   * "Add to note" would write meeting A's live-context into meeting B's note (a wrong-note write).
+   * Tracking `meetingId()` re-runs this whenever the input id changes, wiping all Lane-A/B preview
+   * state. Paired with a per-op stale-id guard in `fetchContext`/`addToNote`/`clearContext` below
+   * (belt-and-braces: the reset clears the UI; the guard blocks a write racing a mid-flight nav).
+   */
+  private readonly _resetOnMeetingChange = effect(
+    () => {
+      this.meetingId(); // track
+      this.hits.set(null);
+      this.applied.set(false);
+      this.cleared.set(false);
+      this.error.set(null);
+    },
+    { allowSignalWrites: true },
+  );
+
+  /**
+   * The EGRESS moment: fetch live context from the consented connectors.
+   * Lands the returned hits in `hits()` for review; the write is a SEPARATE step
+   * (`addToNote`). No-op while a Lane-B call is already running.
+   */
+  async fetchContext(): Promise<void> {
+    if (this.running()) {
+      return;
+    }
+    this.running.set(true);
+    this.error.set(null);
+    this.applied.set(false);
+    this.cleared.set(false);
+    try {
+      this.hits.set(await this.ipc.enrichNoteContext(this.meetingId()));
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+
+  /**
+   * LANE B — persist the reviewed hits as the `> [!context]-` callout. NO egress
+   * (the hits were already fetched); then reload the note. No-op with no hits.
+   */
+  async addToNote(): Promise<void> {
+    const h = this.hits();
+    if (!h || h.length === 0 || this.running()) {
+      return;
+    }
+    // Capture the target meeting BEFORE the write. If the user navigates mid-flight, the reset
+    // effect wipes `hits()`, but this guard is the hard stop that prevents writing THIS meeting's
+    // reviewed hits into a DIFFERENT meeting's note (wrong-note write).
+    const id = this.meetingId();
+    this.running.set(true);
+    this.error.set(null);
+    try {
+      await this.ipc.applyNoteEnrichment(id, h);
+      if (id !== this.meetingId()) {
+        return; // navigated away mid-write — do not confirm/reload against the new meeting.
+      }
+      this.applied.set(true);
+      this.noteChanged.emit();
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+
+  /**
+   * LANE B — byte-exact undo: apply an EMPTY hit set to strip the context block,
+   * then reload the note. NO egress. No-op while a Lane-B call is running.
+   */
+  async clearContext(): Promise<void> {
+    if (this.running()) {
+      return;
+    }
+    const id = this.meetingId();
+    this.running.set(true);
+    this.error.set(null);
+    try {
+      await this.ipc.applyNoteEnrichment(id, []);
+      if (id !== this.meetingId()) {
+        return; // navigated away mid-clear — do not touch the new meeting's state.
+      }
+      this.hits.set(null);
+      this.cleared.set(true);
+      this.applied.set(false);
+      this.noteChanged.emit();
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.running.set(false);
+    }
+  }
+}

--- a/src/app/features/record/note-item/note-item.component.html
+++ b/src/app/features/record/note-item/note-item.component.html
@@ -130,6 +130,16 @@
                 @if (turn.citations.length > 0) {
                   <app-assistant-sources [citations]="turn.citations" />
                 }
+                <!-- Phase 5: the visible tier chip — WHICH cascade tier answered
+                     (current meeting / vault / connectors), set deterministically
+                     by the backend ladder. Hidden when the turn didn't run through
+                     the cascade (answeredFrom null) or is still pending. -->
+                @if (tierLabel(turn); as tier) {
+                  <div class="tier-chip" role="note">
+                    <span class="tier-chip-dot" aria-hidden="true"></span>
+                    answered from: {{ tier }}
+                  </div>
+                }
 
                 <!-- Propose → accept: shown ONLY when the agent proposed a
                      NOTE (proposedNote != null). The DRAFT CONTENT is the

--- a/src/app/features/record/note-item/note-item.component.scss
+++ b/src/app/features/record/note-item/note-item.component.scss
@@ -445,6 +445,24 @@
   }
 }
 
+// Phase 5 — the "answered from: <tier>" chip. A quiet, muted inline note under the
+// answer/citations that names WHICH cascade tier answered (deterministic backend badge).
+.tier-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.tier-chip-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .turn-bubble,
   .dots span,

--- a/src/app/features/record/note-item/note-item.component.ts
+++ b/src/app/features/record/note-item/note-item.component.ts
@@ -185,4 +185,22 @@ export class NoteItemComponent {
         return "(no answer)";
     }
   }
+
+  /**
+   * Phase 5 — the human label for the BRAIN CASCADE tier that answered
+   * (`answeredFrom`), e.g. "this meeting" / "your vault" / "connectors". Empty
+   * for a turn that didn't run through the cascade (`null`) so the chip hides.
+   */
+  protected tierLabel(turn: ThreadTurn): string {
+    switch (turn.answeredFrom) {
+      case "current_meeting":
+        return "this meeting";
+      case "vault":
+        return "your vault";
+      case "connectors":
+        return "connectors";
+      default:
+        return "";
+    }
+  }
 }

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
@@ -200,6 +200,7 @@
                     type="button"
                     class="btn mcp-copy-btn"
                     [class.is-copied]="configCopied()"
+                    [disabled]="!mcpConfig()"
                     (click)="copyMcpConfig()"
                     [attr.aria-label]="
                       configCopied() ? 'Copied' : 'Copy config to clipboard'
@@ -254,12 +255,24 @@
                     }
                   </button>
                 </div>
-                <pre class="mcp-config-block" role="text">{{ mcpConfig }}</pre>
+                @if (mcpConfig()) {
+                  <pre class="mcp-config-block" role="text">{{ mcpConfig() }}</pre>
+                } @else {
+                  <p class="mcp-config-error text-secondary" role="alert">
+                    Couldn't read the local server token. Reopen Settings, or
+                    restart Murmur — the config appears here once the token is
+                    available.
+                  </p>
+                }
               </div>
 
-              <span class="mcp-hint text-muted">
-                Add this to your Claude Desktop config, then restart Claude Desktop.
-              </span>
+              @if (mcpConfig()) {
+                <span class="mcp-hint text-muted">
+                  Add this to your Claude config, then restart Claude. This block
+                  includes a private access token for your local server — keep it
+                  to yourself.
+                </span>
+              }
             </div>
           </div>
 </div>

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -321,14 +321,14 @@ export class SettingsStore {
   /** The localhost MCP server address — shown inline and embedded in the config. */
   readonly mcpUrl = "http://127.0.0.1:8765";
 
-  /** Exact JSON to drop into the Claude Desktop config — copied verbatim. */
-  readonly mcpConfig = `{
-  "mcpServers": {
-    "murmur": {
-      "url": "${this.mcpUrl}"
-    }
-  }
-}`;
+  /**
+   * Exact JSON to drop into the Claude Code config — fetched from the backend
+   * (`get_mcp_config`) because it carries the private bearer token needed for the
+   * MCP handshake when `mcp_require_token` is on (the default). Populated by
+   * `load()`; empty until then. `copyMcpConfig()` copies whatever is in the signal.
+   */
+  private readonly _mcpConfig = signal<string>("");
+  readonly mcpConfig = this._mcpConfig.asReadonly();
 
   /** Flips true for ~1.6s after copying the MCP config — drives the button's confirmed state. */
   private readonly _configCopied = signal(false);
@@ -1343,6 +1343,11 @@ export class SettingsStore {
       this._appInfo.set(await this.ipc.appInfo().catch(() => null));
       // Recording-storage usage report (best-effort; drives the Storage section + Library bar).
       await this.loadStorageReport();
+      // MCP config block for Claude Code — carries the private bearer token so the copied
+      // snippet authenticates (fixes the `-32001 unauthorized` handshake). Best-effort: on a
+      // keychain read failure it stays empty and the copy button no-ops rather than pasting a
+      // tokenless config that would fail.
+      await this.refreshMcpConfig();
       // Only a SUCCESSFUL load arms auto-save — arming after a failed load
       // would let the pristine defaults overwrite the user's stored config.
       this.autoSaveReady = true;
@@ -2026,9 +2031,17 @@ export class SettingsStore {
       // re-check presence so the download hint stays honest (was previously done
       // by onModelChoiceChange's direct save, now retired).
       this._modelPresent.set(await this.ipc.modelPresent().catch(() => false));
+      // A save may have flipped `mcp_require_token` (or minted the token on first use) — re-fetch
+      // the MCP config so the copy block never shows a stale token-bearing / tokenless snippet.
+      await this.refreshMcpConfig();
     } catch (e) {
       this._loadError.set("Save failed: " + String(e));
     }
+  }
+
+  /** Re-fetch the token-bearing MCP config into its signal (after load / config save). */
+  private async refreshMcpConfig(): Promise<void> {
+    this._mcpConfig.set(await this.ipc.getMcpConfig().catch(() => ""));
   }
 
   async saveKey(): Promise<void> {
@@ -2365,8 +2378,17 @@ export class SettingsStore {
    * The <pre> block stays selectable as a fallback if the clipboard is blocked.
    */
   async copyMcpConfig(): Promise<void> {
+    // Guard the silent-empty-copy: if the config never loaded (keychain read failed → ""), do NOT
+    // copy an empty string and flash a misleading "Copied". Re-fetch once; if still empty, surface
+    // the error line and no-op so the user isn't handed a blank config that "does nothing".
+    if (!this.mcpConfig().trim()) {
+      await this.refreshMcpConfig();
+      if (!this.mcpConfig().trim()) {
+        return;
+      }
+    }
     try {
-      await navigator.clipboard.writeText(this.mcpConfig);
+      await navigator.clipboard.writeText(this.mcpConfig());
       this._configCopied.set(true);
       if (this.mcpCopyResetTimer) clearTimeout(this.mcpCopyResetTimer);
       this.mcpCopyResetTimer = setTimeout(

--- a/src/styles.css
+++ b/src/styles.css
@@ -207,9 +207,6 @@ app-shell {
   height: 48px;
 }
 
-  50% { transform: scaleY(1); }
-}
-
 /* --- Quick actions (Search ⌘K / New note ⌘N) — the top of the rail --------- */
 .sidebar-quick {
   display: flex;


### PR DESCRIPTION
Release 0.8.0. Two-stage note generation (isolated Stage-1 + cross-meeting linking / connector enrichment Stage-2), current-first brain cascade + Tier-1 isolation on the local floor (fixes the local-model wrong-meeting / web-searching-'meeting' bug), OOM remediation (no model-load on meeting open + RAM guard), MCP config token fix, and the move-into-locked-folder session-restore data-integrity fix. crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204). scripts/ci.sh all gates green (clippy -D warnings, cargo test 1171, audit, deny, build, ng lint/build, headless E2E).