### PR TITLE
fix(brain): P0 hotfixes — vault_titles person-name fallback, stub-echo guard, live-path resource discipline

### DIFF
--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -128,3 +128,9 @@
 - **Caught by:** operator (seeding the loop).
 - **Lesson:** the bullets above; full detail in `.claude/rules/rust-tauri.md` + `lock-model.md`.
 - **Status:** distilled (2026-07-02)
+
+### [2026-07-09 brain-p0-hotfixes] Scope resource bounds to the surface that needs them
+- **Pattern:** a wall-clock timeout added to `MistralReasoner` for the LIVE path was wired at the lowest seam (`reason_with_opts`) and silently applied to EVERY local generation — FullyLocal note-gen (legit 30–90s) and the Ask floor (200k-char prefill) would have started failing `Unavailable`, and first-gen Metal shader compile (CLT-only Macs, `MISTRALRS_METAL_PRECOMPILE=0`) could always eat the first call.
+- **Caught by:** adversarial-verifier (`.claude/tmp/brain-p0-hotfixes/adversarial-verify.json`, MAJOR) — builder's tests were green; the regression was on paths the new tests didn't cover.
+- **Lesson:** carry per-call bounds IN the options struct (`GenOptions.timeout: Option<Duration>`, default None = old behavior; presets opt in), never as a blanket const at the lowest layer. Before bounding a shared seam, enumerate every caller class (live / notes / floor / background extraction) and ask which of them legitimately exceeds the bound.
+- **Status:** journal

--- a/docs/research/2026-07-09-brain-v2-architecture-spec.md
+++ b/docs/research/2026-07-09-brain-v2-architecture-spec.md
@@ -1,0 +1,127 @@
+<!-- Generated 2026-07-09 via 3 parallel code-architect blueprints (L1+L2 / P0+L3 / L4+L5), synthesized. Companion to 2026-07-09-brain-v2-architecture.md (the research + problem analysis). Cite-by-symbol; line anchors drift. -->
+# Brain v2 — Implementation Architecture Spec (decision-ready)
+
+**Status:** architect-designed, grounded against the 0.8.0 tree, not yet implemented. The research grounding, problem list, and best-practice citations live in `2026-07-09-brain-v2-architecture.md`. This doc is the build plan: data model, seams, phases, gates, and the consolidated open-decision list.
+
+**Design stance:** workflow-first, agent-when-needed; measured, budgeted, gated. The substrate (SQLite canonical, lock gating, provider seam + redaction + ledger, structural tiering, two-stage notes) is untouched. Everything below is **additive** — new tables via `CREATE TABLE IF NOT EXISTS` / `add_column_if_missing`, new modules, extended signatures; zero destructive migration.
+
+---
+
+## 0. Module map (new + touched)
+
+**New modules (all `src-tauri/src/`):** `router.rs`, `prompts.rs`, `rerank.rs`, `memory.rs`, `summarize/temporal.rs`, `transcribe/bullets.rs`, `brief_runner.rs`, `connectors/mcp_client.rs`, `connectors/mcp.rs`, `eval/fixtures/rag-bakeoff-sample.json`, `eval/results/` (artifact dir).
+
+**New tables (all additive):** `topic_chunks` + `topic_vec_chunks` + `fts_topic_chunks`, `note_chunks.aug_text` (column), `fts_user_facts`, `memory_scores`, `memory_rollups`, `live_bullets`, `brief_schedules` + `brief_runs`, `mcp_servers`.
+
+**New AppState fields:** `in_flight_turns: Mutex<HashMap<String,u32>>`, `user_turn_in_progress: AtomicBool`, `live_bullets: Mutex<String>`, `live_bullets_tracker: Mutex<BulletsTracker>`, `verify_cache: Mutex<HashMap<String, Vec<VerifyFinding>>>`.
+
+**New config keys (all `#[serde(default)]`):** `brain_heavy_grammar_enabled` (false), `ask_jit_retrieval` (false→true after eval), `loop_transcript_compaction` (true), `live_bullets_enabled` (true-if-model-present).
+
+---
+
+## P0 — Hotfixes (one PR, ship first)
+
+### P0.1 `vault_titles` leak — corrected root cause
+The NER title filter in `redact.rs::summarize_with_meta` **exists and works** — but only when the NER model is downloaded. On installs without it, `NoopNameRedactor` returns every title unchanged (`name_hits` always empty) so `[[Anna Kowalska]].md` egresses. **Fix:** a conservative syntactic fallback active only when `!ner_model_present()`: `title_looks_like_person_name()` — 2–4 Title-Case words, no digits/acronyms, not on a PL+EN `COMMON_TITLE_WORDS` blocklist (Meeting/Notes/Sync/Spotkanie/Notatki/Przegląd/…). A false positive drops a wikilink target, never content. **RED test:** `person_name_title_is_dropped_when_no_ner_model_present` (EchoProvider captures what reaches the "cloud").
+
+### P0.2 Stub-echo guard — corrected path
+The echo reaches users on the **floor** path (`run_informational` → `voice_action` → `reasoner.reason()`), not the cascade (local-only config already skips the cascade via `is_reasoner_only()`). **Fix:** the canonical `reasoner.id() == "stub"` guard (same as `orchestrate.rs`/`user_memory.rs`) right after reasoner resolution in `run_informational` (+ audit `ask_vault` floor), returning a graceful "The on-device brain model is not downloaded yet — enable it in Settings → Brain & AI." **RED test:** stub config → answer contains no `[stub-reason]`.
+
+### P0.3 Live-path resource discipline
+- **Token caps:** `run_agentic_loop` gains an `opts: GenOptions` param and calls `structured_with`; new presets `GenOptions::live_answer()` (1024) and `ask_answer()` (2048). Effective today on the local GGUF path (the only truly unbounded one); a best-effort hint for cloud.
+- **Wall-clock timeout:** `MistralReasoner::reason_with_timeout` — the blocking call runs on a spawned thread, caller waits `recv_timeout(GENERATION_TIMEOUT = 30s)`, on expiry returns `AppError::Unavailable` and **leaks the task** (mistralrs generations are uncancellable; drop-leak issues #723/#865 forbid dropping the model). The cascade already handles `Err` by tiering down / flooring.
+- **In-flight dedup:** `AppState.in_flight_turns` per-meeting counter; a second concurrent turn for the same meeting is **dropped with a log** (not queued — no stale-answer backlog).
+- **Priority:** `AppState.user_turn_in_progress: AtomicBool`; the reactions worker defers (returns empty) while a user turn is in flight. Approximate but correct — reactions are best-effort.
+
+---
+
+## L1 — Indexing & retrieval
+
+### L1.1 Topic-segment indexing
+Pure `embed::segment_topics(&[Segment]) -> Vec<TopicSegment>` — deterministic boundaries from three signals (any one fires): **lull ≥ 30s**, **speaker-flip after a ≥5-segment run**, **Jaccard lexical shift < 0.15 over a 6-turn window**; segments < 60s merge forward (over-segmentation preferred over under-). Stored in `topic_chunks` (+ `topic_vec_chunks` vec0 + `fts_topic_chunks` external-content FTS5 with triggers). **Purge-on-seal:** added to `purge_chunks_tx` — the single choke point covers every seal path. **Backfill:** `backfill_topic_chunks_idempotent()` at startup on `spawn_blocking`, batches of 20, content-hash idempotent.
+
+### L1.2 Deterministic contextual augmentation
+`embed::augment_chunk_text(title, date, attendees≤5, active_facts≤8, raw)` → `"<title> | <date> | <attendees> | <facts>\n<raw>"`, stored as `aug_text` (topic chunks + new `note_chunks.aug_text` column) and indexed in BOTH FTS and `embed_passage` legs (raw `text` kept for snippet display). Attendees/facts come from `visibility_clause`-gated readers; sealed-not-unlocked ⇒ empty header (no PII in index rows that outlive a seal — and the rows purge on seal anyway). This is Anthropic's contextual-retrieval mechanism at zero LLM cost (our entity graph + facts make the situating context templatable).
+
+### L1.3 Score fusion (RRF stays as fallback)
+`embed::score_fuse(fts, knn, graph)` — per-leg min-max normalization (KNN distance inverted via `1/(1+d)`), weighted blend `0.4/0.4/0.2` (named consts, calibrated by the eval gate). `search_hybrid_visible` uses it when raw scores are available; falls back to `rrf_fuse` otherwise. `fuse_doc_hits` unchanged.
+
+### L1.4 Reranker seam (Ask-only)
+`rerank.rs`: `trait Reranker { fn rerank(query, candidates, timeout_ms) -> Vec<String> }` — **degrades to input order on any failure/timeout, never errors**. Impl 1: `PromptedReranker` — pointwise yes/no relevance on the already-resident Qwen3-1.7B (`max_tokens: 32`), deadline-checked between candidates (`RERANK_TIMEOUT_MS = 3000`). Impl 2: `StubReranker`. Future `BgeReranker` (bge-reranker-v2-m3 via candle, `ner_deberta.rs` load pattern) sits behind the same trait — decision deferred to the measured bake-off. Wired in `vault_context.rs` after top-k, before `pack_meetings`; reorders already-gated candidates only (no new read path).
+
+### L1.5 Time-aware query expansion
+`summarize/temporal.rs::parse_temporal_constraint(query, today) -> Option<(from, to)>` — pure PL+EN regex parser (last week/zeszłym tygodniu, this month, yesterday/wczoraj, last N days, ISO dates). Threads `date_filter: Option<(String,String)>` into `search_hybrid_visible` (`AND m.started_at >= ? AND < ?` on all three legs). Original query text is NOT stripped — BM25 tolerates the extra tokens. **RED test:** date-filtered search excludes an out-of-window meeting.
+
+### L1.6 Eval gate (the discipline that makes it "Anthropic-level")
+- Commit `eval/fixtures/rag-bakeoff-sample.json` — 20 queries, 4 categories (entity-anchored / paraphrase / cross-lingual PL↔EN / temporal), `expected_meeting_ids` filled by the user against the real dev vault (WAL-copy + dev DEK per `docs/RAG-BAKEOFF.md`; the harness `run_bakeoff_over_real_db_from_env` already exists, env-driven: `MURMUR_BAKEOFF_DB/DEK/SET/K`, new `MURMUR_BAKEOFF_OUT` writes the artifact).
+- Committed artifact `eval/results/rag-bakeoff-latest.md`: date, commit sha, config consts, recall@5/nDCG@5/MRR per mode (fts / semantic / hybrid / hybrid+rerank — new `RetrievalMode::Reranked`).
+- **Merge rule (manual, adversarial-verifier-checked, not CI):** any retrieval-touching PR updates the artifact and hybrid recall@5 ≥ baseline. CI can't run it (needs model + real DB) — `scripts/ci.sh` gets a comment saying so.
+
+## L2 — Memory
+
+### L2.1 Consolidation/reflection job
+`memory.rs` + hourly `tokio::spawn` from `lib.rs` setup (never holds the DB lock across an LLM call; `tracing::warn` on error, never exits). Deterministic scoring per the generative-agents recipe: `composite = 0.4·recency(0.995^hours) + 0.4·importance/10 + 0.2·relevance` into `memory_scores` (FK `ON DELETE CASCADE` to `user_facts` ⇒ purge-on-seal is transitive). Reflection: entity groups (≥3 facts or importance ≥7) → light-reasoner synthesis (256 tokens) → `memory_rollups` (`entity:<id>` / `weekly:<YYYY-WNN>`) → exported as `.md` to `<vault>/brain/memory/`. Rollups are cross-meeting synthesis: **not** purged on seal but **regenerated** next run from still-visible facts only (the job reads via `list_user_facts_visible`).
+
+### L2.2 Relevance-filtered memory brief
+New `fts_user_facts` (external-content FTS over `subject predicate: object`) + gated `Db::search_user_facts_visible(query, k=8, unlocked)`. `build_memory_brief(db, query, unlocked)`: query-empty (note-gen path) or FTS-empty ⇒ fall back to today's all-facts `synthesize_brief` — behavior-preserving fallback, `MEMORY_BRIEF_MAX_CHARS` unchanged.
+
+### L2.3 Memory import (ClickUp parity, S)
+`import_memories(text) -> usize` IPC command: paste ChatGPT/Claude memory export → `extract_imported_memories` (reuses `extract_user_fact_candidates` machinery, stub ⇒ empty) → `reconcile_facts` dedup → anchored to a **synthetic `Memory Import` meeting row** (no folder ⇒ visible via the existing INNER JOIN; deleting that meeting undoes the whole import — no change to the fail-closed NULL-meeting_id rule). Minimal FE: `memory-import` component inside the existing brain-memory audit view. Zero egress.
+
+## L3 — Reasoning & orchestration
+
+- **`router.rs`:** explicit, testable `route(RouterInput) -> RouteDecision { DeterministicFloor | LocalLight | LocalHeavy | CloudAgentic{connection} }` over the existing roles/postures data (no new struct in the dispatch path initially — additive explicitness). `QueryClass` (Recall/Synthesis/External/Unknown) from the 1.7B or keywords.
+- **Escalation = ledgered event:** cascade tier escalation writes a content-free `egress_log` row with `call_kind: "escalation"` — visible in the privacy receipt.
+- **Constrained grammar for tiny local schemas:** `GenOptions.use_grammar_constraint` — `MistralReasoner` uses mistralrs `Constraint::JsonSchema` only for schemas < 512 bytes (the Bielik overflow was a huge schema; a 3-key enum is not that), graceful fallback to schema-in-prompt; gated by `brain_heavy_grammar_enabled` (default false until real-Mac tested).
+- **JIT retrieval for ask_vault** (behind `ask_jit_retrieval`): replace the 200k-char corpus pre-stuff with a ~2.4k-char meeting **listing** (id | title | date × 30) + a new `get_meeting` tool (**gated by `meeting_is_unlocked` — lock-security review required**) returning title + note + first 4k transcript chars. The non-agentic floor keeps its packed corpus (small-model efficiency wins there).
+- **Loop compaction:** deterministic `compact_transcript` at `TRANSCRIPT_BUDGET = 32k` chars (~8k tokens — inside small-model effective context): keep user request + last 2 tool results verbatim + `[N earlier results omitted]`.
+- **History budget:** `trim_history_to_budget` (64k chars) in `ask_assistant_chat` — token-ish budget replaces the turn-only cap, trims oldest-first.
+- **Structured-output hardening:** one retry-with-error-appended on malformed JSON in `run_agentic_loop`; `SummarizerProvider::supports_native_json()` capability flag (gateway ⇒ true) so `CloudReasoner` can pick native JSON mode when available.
+- **`prompts.rs`:** all templates + `PROMPT_VERSION` + single-sourced wake phrases; migrated incrementally (live.rs/agent.rs/vault_chat.rs first) via re-exports, zero behavior change; eval artifacts stamp the version.
+
+## L4 — The live incremental brain
+
+- **Novelty gatekeeper** (`NoveltyState`, pure, on the tick thread): fires on ≥120 new chars / any `?` / entity hit (via a 60-tick-cached entity list shared with `reactions_scan`) / 42s lull; hard floor 15s. Replaces `% REACTIONS_SCAN_EVERY == 0`. The optional 1.7B yes/no confirm is explicitly deferred (Metal-contention risk on the tick thread).
+- **Incremental bullets** (`transcribe/bullets.rs::update_bullets`): prefix-prompted light-reasoner call (previous bullets + delta → ≤3 new bullets or `NOTHING`; 200 tokens, temp 0.1), runs on the reactions worker behind `reactions_busy`. State: `AppState.live_bullets` (RAM, 4k cap) + additive `live_bullets` table for crash recovery — **blanked on seal like `assistant_interactions`**, cleared at Stop/relock; reads gated by `meeting_is_unlocked`.
+- **New substrate:** reactions read `bullets + last-300-chars verbatim` instead of the raw 600-char tail; the live inject for questions becomes `2k bullets + 2k verbatim` (tighter than today's 6k — better for small models). **At Stop, bullets become a Stage-1 input:** new `SummarizeRequest.live_bullets` field, rendered as a labeled section before the transcript (rides `RedactingProvider` like everything else).
+- **Boundary-timed surfacing:** whisper/proactive cards queue in the tick thread (`mpsc` from workers) and emit at a boundary — lull ≥8s or sentence-final char — with `MAX_HOLD_TICKS = 10` (30s) force-emit and drain-on-Stop. **Event payloads unchanged** — FE untouched. (Deliberately NOT shared with the L1 topic segmenter: live detector is coarse+cheap, batch segmenter is offline — coupling them would hurt both.)
+
+## L5 — Agents & surfaces
+
+- **Scheduled briefs** (`brief_runner.rs`, 60s tokio interval): `brief_schedules` uses **structured columns** (day_of_week/hour/minute — no `cron` crate, no new dep) + `brief_runs` (propose-accept staging; `meeting_ids` = ids only). Corpus = gated deterministic reads (`list_meetings_visible` window + commitments + facts); synthesis reuses `digest.rs::build_digest_prompt`; **quiet-if-empty**, max one run/schedule/day. Output: `EVENT_BRIEF_PROPOSED` → FE `BriefsStore` + `briefs/` feature; accept ⇒ vault export, dismiss ⇒ row deleted.
+- **MCP client** (`connectors/mcp_client.rs` + `connectors/mcp.rs`): **hand-rolled JSON-RPC 2.0 (~150 lines) over existing reqwest/tokio — no new crates**; transports HTTP + stdio (SSE deferred). One `McpConnector` per configured server (`mcp_servers` table: per-server `consented` flag), riding the existing consent + redaction + egress-ledger seam with truthful per-server attribution. Discovered tools surface **only at Tier 3** as `mcp_<server>_query` with sanitized, 100-char-capped descriptions — **tool descriptions are untrusted input and are never interpolated into system prompts**; results truncated at `RESULT_BUDGET`. stdio servers = code execution: absolute-path-only + explicit trust warning in the add-server UI. **Lock-security review required (new egress class).**
+- **Verify pass:** v1 stays **deterministic** (Anthropic's top verification tier): existing `extract_issue_keys` + `jira_lookup` + `judge`, extended with `judge_with_detail` and an idempotent `> [!verify]-` fenced callout (`apply_verify_callout`, byte-exact-undo, `enrich.rs` fence discipline) alongside the inline markers; session `verify_cache` in AppState (RAM-only, cleared on relock); persists via `upsert_note` (canonical, seals with the note) + vault re-export. LLM claim-extraction is explicitly **not** in v1.
+
+---
+
+## Phase / PR plan
+
+| PR | Content | Gates |
+|---|---|---|
+| **1. P0 hotfixes** | P0.1 + P0.2 + P0.3 (redact heuristic, stub guard, caps/timeout/dedup/priority, `run_agentic_loop` opts param) | RED tests for all three; `cargo test --lib`; **lock-security** (redaction change); adversarial-verifier |
+| **2. Eval gate bootstrap** | fixture + `RetrievalMode::Reranked` + `format_report_markdown` + `MURMUR_BAKEOFF_OUT`; user labels the 20 queries; **run baseline, commit artifact** | first committed numbers = the baseline every later PR beats |
+| **3. L1 retrieval** | topic segmentation + augmentation + score fusion + temporal filter + reranker seam (prompted-Qwen) | re-run eval, artifact updated, recall@5 ≥ baseline; **lock-security** (new tables/purge paths) |
+| **4. L2 memory** | relevance-filtered brief → consolidation job → memory import | RED tests; **lock-security** (`search_user_facts_visible`, import, rollup vault writes) |
+| **5. L3 orchestration** | router + prompts.rs + JIT ask (flag) + compaction + history budget + JSON retry + native-JSON flag | eval re-run for JIT (answer faithfulness); **lock-security** (`get_meeting` tool) |
+| **6. L4 live** | gatekeeper → bullets → boundary surfacing → bullets-as-Stage-1 | `cargo test --lib` + real-Mac recording session; **lock-security** (`live_bullets` seal semantics) |
+| **7. L5 agents** | scheduled briefs → MCP client → verify callout | **lock-security** (MCP egress, verify cache); real-Mac for stdio MCP + Obsidian callout render |
+
+Dependencies: PR1 first (touches `live.rs`/`agent.rs` seams others build on); PR2 before PR3 (no retrieval change without a baseline); PR3⊥PR4 can parallel; PR6 phases internally (gatekeeper → {bullets, boundary}); PR7's three items are mutually independent.
+
+**Honest verification limits (say so in every DoD):** reranker latency, live boundary-timing UX, bullets quality, grammar-constraint feasibility on Qwen3-4B, MCP stdio lifecycle, Obsidian callout rendering — all need a real Mac (and some need real meetings); headless green is not proof for them.
+
+---
+
+## Consolidated open decisions (user input wanted)
+
+1. **P0.1 heuristic aggressiveness** — conservative blocklist that may false-positive on two-word project names ("Atlas Project" survives only if blocklisted patterns don't match). Recommendation: ship conservative, expand blocklist from observed dev false-positives.
+2. **P0.3 timeout: hardcode 30s or config key** (`brain_generation_timeout_secs`)? Recommendation: hardcode now, config later if older-Mac reports come in.
+3. **`ask_jit_retrieval` default** — recommendation: false until the eval run compares JIT vs packed-corpus answer faithfulness on the real vault.
+4. **Grammar constraint** — needs a real-Mac spike on Qwen3-4B + mistralrs 0.8.1 `Constraint::JsonSchema` with a tiny schema; stays flag-gated false until proven.
+5. **Reranker k and timeout** — 10 candidates / 3s to start; first eval run decides (or drops k to 5). bge-reranker-via-candle stays deferred behind the trait.
+6. **Eval fixture labeling** — needs YOU: ~20 real queries with expected meeting ids over your dev vault (protocol: `docs/RAG-BAKEOFF.md` Stage 1, then fill the fixture). This is the one step the agent can't do alone.
+7. **Importance scoring cost** — LLM call per new fact at write time vs batch in the hourly job. Recommendation: batch in the job (zero pipeline latency), revisit after profiling.
+8. **MCP SSE transport** — v1 = HTTP + stdio only; confirm no target server needs SSE before building it.
+9. **`live_bullets_enabled` default** — recommendation: true when a local model is present (it's the substrate for better reactions), off on stub.
+10. **Brief zero-egress strictness** — briefs use the current provider (consent-gated) by default; add `brief_zero_egress` flag only if you want briefs strictly local even with cloud configured.
+11. **brain2 vs ClickUp Brain² naming** — unchanged hard blocker before any public copy.

--- a/docs/research/2026-07-09-brain-v2-architecture.md
+++ b/docs/research/2026-07-09-brain-v2-architecture.md
@@ -1,0 +1,235 @@
+<!-- Generated 2026-07-09 via /research (2 code-explorer traces + 2 murmur-researcher angles: ClickUp Brain² competitive + academic/industry best practices). Pricing/versions = point-in-time. -->
+# Research: Brain v2 — architecture analysis, problems, and the proposal
+
+**Scope:** deep analysis of the brain as shipped in 0.8.0 (local model flow, live reactions, live questions, cloud flow, context management), measured against Anthropic's published engineering guidance + the academic memory/retrieval/streaming literature + ClickUp Brain² (GA 2026-06), ending in a Brain v2 architecture proposal.
+
+---
+
+## TL;DR / Verdict
+
+**Murmur already owns every primitive the literature says matters** — lexical index (FTS5), dense index (e5 + sqlite-vec), entity graph, bitemporal facts, user memory, an agentic tool loop with structural tier gating, small local models, a cloud seam with redaction + consent + egress ledger. **Brain v2 is an orchestration, consolidation, and quality-measurement problem, not a missing-component problem.** The three structural deltas vs state of the art:
+
+1. **Retrieval quality is unmeasured and un-reranked.** Hybrid RRF exists (A-grade design) but: no reranker (audit grade F, still true), char-based whole-meeting chunks with zero contextual augmentation, rank-fusion instead of score-fusion, k=60 uncalibrated, and the eval harness has never produced a number. Anthropic's own numbers say contextual augmentation + reranking cuts retrieval failure 67%; LongMemEval's three fixes (session decomposition, fact-augmented keys, time-aware expansion) map 1:1 onto tables we already have.
+2. **Context management is stuff-and-pray, not engineered.** The Ask corpus packs up to 200k chars into the system prompt (vs Anthropic's just-in-time retrieval + compaction guidance); the agentic loop transcript grows monotonically with no compaction; the live buffer is a naive word-overlap merge with no rolling summary state; the memory brief is always-injected regardless of relevance; @brain history has a turn cap but no token budget. Small local models get the worst of it: NoLiMa shows semantic-only retrieval into long small-model context is the single worst combination (effective context for 1.7B/4B ≈ 8–16k tokens).
+3. **The live brain is a fixed-cadence scanner, not a gated incremental summarizer.** Reactions fire every ~21s on a 600-char tail through an unconstrained-JSON 1.7B call; there is no novelty gatekeeper, no boundary-aware timing, no incremental running state, no priority of user questions over background scans, no token cap or wall-clock timeout on user answers. The published production pattern (incremental bullets + cheap classifier gatekeeper + empty-response-if-nothing-new) is directly applicable and *reduces* RAM/latency.
+
+**Vs ClickUp Brain²:** architecture parity is closer than the marketing suggests — their Context Engine ≈ our hybrid retrieval + graph + facts; their memory ≈ our `user_facts` (we're even ahead on auditability and bitemporality). The real deltas are **memory import** (they import ChatGPT/Claude memories), **schedule-as-a-first-class-agent-trigger**, and **MCP-as-client** connector fabric. Their complaint profile ("confident wrong answers on messy data") confirms the verify-pass remains our headline differentiator. **Nobody occupies proactive-live-on-device** — Fireflies is the only proactive live competitor and it's bot-dependent + cloud; Limitless was acquired by Meta and Rewind is dead, so the local-first memory niche just vacated.
+
+**The verdict in one line:** keep the substrate (storage, lock model, provider seam, tiering — all A-grade), rebuild the *middle* — indexing/consolidation as measured workflows, context assembly as engineered budgets, the live loop as a gated incremental summarizer — and add the three cheap ClickUp-parity moves (memory import, scheduled briefs, MCP client) plus the verify pass.
+
+---
+
+## Part 1 — The brain as it exists (code-grounded)
+
+### 1.1 Layered map (as-is)
+
+```
+INGEST    audio (cpal + SCK sidecar) → dual-stream merge → whisper.cpp (VAD, 120s windows)
+          → TranscriptFeed{retrieval_text, summary_text, labeled}         pipeline.rs
+INDEX     e5-small 384-dim (candle) → note chunks (800 chars) + transcript turns
+          (1000 chars, 150 overlap) → sqlite-vec KNN; FTS5 (BM25, diacritics-folded);
+          deterministic NER → entities/entity_mentions; facts + user_facts (bitemporal,
+          reconcile pipeline)                                              embed.rs, db.rs, facts.rs
+RETRIEVE  search_visible (FTS) / search_hybrid_visible (RRF k=60: FTS + KNN + entity leg)
+          — every branch visibility_clause-gated, note bodies double-gated
+                                                                           tools.rs, db.rs, vault_context.rs
+REASON    LocalReasoner trait: MistralReasoner (GGUF, MODEL_CACHE cap 2, refuse-not-evict,
+          RAM guard ×1.5) | CloudReasoner (→ make_provider → consent → RedactingProvider)
+          | StubReasoner | AfmReasoner                                     reason.rs, reason/mistral.rs
+ACT       two-stage notes (Stage-1 isolated gen → Stage-2 additive enrich lanes A/B);
+          agentic Ask (run_agentic_loop + GatedToolExecutor); MCP server; obsidian export
+                                                                           pipeline.rs, enrich.rs, agent.rs, mcp.rs
+```
+
+### 1.2 Live reactions (100% local, never cloud)
+
+- Live caption thread ticks every **3s**, snapshots a **14s** overlapping audio tail, transcribes with the Fast/greedy profile, merges into `state.live_transcript` (`Mutex<String>`, **16k char cap**, mic-only — far side is batch-only after Stop) via word-level suffix-prefix overlap removal (`live.rs:merge_live_caption`).
+- Every **7th tick (~21s)**, if a `reactions_busy` AtomicBool is clear, a worker thread runs `brain_reactions.rs:reactions_scan`: takes the last **600 chars** of the buffer, matches visible entity names, calls the **light reasoner only** (`reasoner.light()` = qwen3-1.7B or stub — structurally never cloud) with `GenOptions::light_extraction()` (128 tokens, temp 0.2, thinking off), recovers triples via `parse_first_json` (schema-in-prompt, **not grammar-constrained**), then a **pure deterministic** `reconcile_facts` produces contradiction WhisperCards. Session-dedup by `entity|predicate|old_quote` HashSet.
+- `proactive.rs` is fully deterministic (zero LLM): delta-tracked scan every ~30s, cooldown ≥120s, recency-decay scoring over commitments/facts/FTS terms.
+
+### 1.3 Live questions (the current-first cascade)
+
+Three entries (wake word, button+voice capture, typed @brain) converge on `live.rs:run_assistant_query`:
+
+- Scope = `fe_meeting_id → focus_meeting → current_meeting` (the wrong-meeting bug is mitigated but the durable per-thread binding is still FE-only).
+- Reasoner = `Role::Live` resolution (roles/postures). **If the target is local-GGUF-only, the agentic cascade is skipped entirely** and the deterministic floor (`run_informational` → keyword check → `handle_voice_action` fan-out) runs instead — the agentic loop only ever executes on `CloudReasoner` (incl. loopback Ollama).
+- Cloud cascade: shared system prompt = persona + **≤6k-char live-buffer tail** + **≤6k-char typed notes** + **≤2k-char always-injected memory brief**; then Tier 1 (no tools, 2 steps) → `__ESCALATE__` → Tier 2 (vault search tools, 4 steps) → Tier 3 (connectors/web, 3 steps). Tier gating is **structural** (`GatedToolExecutor::specs()` + re-checked allowlist per call) — this part matches best practice. Cloud egress passes consent → NER+regex redaction → egress ledger.
+- Loop mechanics: transcript string grows monotonically ("User request: …" + `[tool result]` blocks truncated at **4k chars each**); no compaction, no total budget, **no token cap on the answer** (`GenOptions::default()`), **no wall-clock timeout**, no in-flight dedup of concurrent turns, no app-level priority between a background reactions scan and a user question sharing the same runtime.
+
+### 1.4 Ask-my-vault & notes (non-live)
+
+- `ask_vault`: hybrid retrieval → `pack_meetings` corpus (**4k chars for Ollama, 200k chars for cloud**) pre-stuffed into the prompt + agentic loop (6 steps, `AssistantScope::Full`) with deterministic corpus-pack floor fallback.
+- Notes (0.8.0 two-stage): Stage-1 generates from **this meeting only** (`related_context = None` — the cross-meeting-bleed fix, structurally sound); Stage-2 additive lanes: A = zero-egress `[[links]]` via task-free `reference_gist`, B = connector context callout; both idempotent, byte-exact-undo (`enrich.rs`). Weak providers (local/ollama) get a 3k-char link-only grounding budget — the decimation the small-model literature retroactively validates.
+- Conversation layer: backend stateless per turn; FE resends 12-turn history; threads persist in `assistant_interactions` for rehydration only.
+
+### 1.5 Provider capability matrix
+
+| Provider | Streaming | Native tools | Native JSON | Redaction | Ledger |
+|---|---|---|---|---|---|
+| claude_code (CLI) | no | no | no (schema-in-prompt) | yes | yes |
+| anthropic (API) | no | no | no | yes | yes |
+| gateway (OpenAI-compat) | no | no | **yes** (json_schema) | yes | yes |
+| ollama loopback | no | no | no | no (on-device) | no |
+| local GGUF (mistralrs) | no | no | no (JsonSchema constraint abandoned — context overflow on Bielik-11B) | n/a | n/a |
+
+No backend streams; only gateway has constrained decoding; the agentic loop is JSON-in-prompt everywhere, with no retry on malformed JSON (a malformed step breaks the loop).
+
+---
+
+## Part 2 — What best practice says (research synthesis)
+
+### 2.1 Anthropic's guidance (all fetched)
+
+- **Workflows vs agents**: predictable-step tasks (note gen, digest, extraction, consolidation) should be *workflows*; reserve the agent loop for genuinely open-ended queries. "Add multi-step agentic systems only when simpler solutions fall short."
+- **Context engineering**: context = a depleting attention budget ("context rot"). Named techniques: compaction, structured note-taking outside context, **just-in-time retrieval over lightweight identifiers** (vs pre-stuffing 200k-char corpora), sub-agent context isolation.
+- **Verification hierarchy**: rules-based feedback > visual > LLM-as-judge ("generally not very robust") — a direct endorsement of Murmur's deterministic verify approach.
+- **Tool design**: fewer, higher-level tools; token-efficient returns; meaningful text over UUIDs; response-format enums.
+- **Contextual retrieval numbers**: contextual embeddings −35% retrieval failures; + contextual BM25 −49%; **+ reranking −67%**. Under ~200k tokens, skip RAG and stuff — i.e., *within one meeting stuff the transcript; retrieval is a cross-meeting problem*.
+
+### 2.2 Memory science
+
+- The systems that win on LoCoMo/LongMemEval are **extraction-and-consolidation pipelines over structured stores** (Mem0: +26% vs OpenAI memory, >90% token savings; graph variant adds only ~2%), not raw-transcript vector dumps and not agent-self-managed memory. Murmur's facts/entities/FTS is already this shape.
+- **LongMemEval's three validated fixes** (all cheap for us): session decomposition (index topic-segments, not whole meetings), fact-augmented index keys (prepend extracted facts/entities to chunks), time-aware query expansion (meetings are timestamped).
+- **Generative-agents consolidation recipe**: score = recency (0.995/hr decay) + LLM importance (1–10 at write) + relevance; periodic *reflection* synthesizes higher-level memories. Cheap to implement as a SQLite view + periodic job.
+- Effective small-model context: RULER — only half of models hold up at their claimed 32k; NoLiMa — 11/13 models drop below 50% of baseline at 32k without lexical overlap; plan for **~8–16k effective** on Qwen3-1.7B/4B and keep lexical/entity anchors in retrieval (FTS-first is scientifically correct here).
+
+### 2.3 Real-time / streaming patterns
+
+- The deployed-production template (arXiv 2510.06677): **prefix prompting** — send previous bullets + recent turns, model emits *only new bullets or empty*; a ~100M classifier (F1 0.895, p50 20ms) gates trivial output. p50 600ms.
+- Proactive timing: lightweight signal detectors match LLM wake-deciders (arXiv 2605.30152); **boundary-timed interventions are accepted, mid-task ones dismissed** (arXiv 2601.10253); the "Goldilocks window" is a tunable policy, not a fixed cadence.
+- Cascades: FrugalGPT (up to 98% cost cut at held quality), RouteLLM (routers transfer across model pairs). For us "cost" = RAM + latency + privacy egress; the architecture is identical: 1.7B classify/filter → 4B extract/summarize → cloud (redacted, visible) on escalation.
+- Small-model tool use: **Qwen3-1.7B scores 7.8% on BFCL** (function calling), 4B ~40% even with specialized training — the current code's refusal to run the agentic loop on local GGUF is *scientifically correct*; the fix is honest marketing + a constrained few-tool grammar path for the 4B, not "turn the loop on".
+
+### 2.4 ClickUp Brain² (GA 2026-06) & the class
+
+- Brain²: event-sourced Context Engine, hybrid vector+graph retrieval, permission-aware; **editable + importable memory** (import from ChatGPT/Claude — their cold-start killer); multi-model routing (invisible plumbing); **MCP as connector fabric** (1,000+ tools); agents with **schedule as a first-class trigger** (Autopilot/Super Agents, Ambient Answers); "verified answers" via sandboxed compute; $9–28/user/mo (monthly $18/$68), every-seat billing. Complaints unchanged: confident wrong answers on messy data, agents need tight scoping.
+- Live in-meeting AI is **commodity and pull-based** everywhere (Zoom free tier, Teams, Granola "Ask", Otter's voice agent). The only proactive-push competitor is Fireflies Live Assist (dynamic suggestion cards) — bot-required, cloud-processed. **Proactive + on-device + zero-egress is an empty position we already hold.**
+- Meta acquired Limitless (Dec 2025), Rewind shut down — the local-first personal-memory niche is vacated. Windows Recall's failure shows "local + encrypted" doesn't sell alone; a killer use-case + visible trust story does.
+- Legal: Otter (4 consolidated federal suits) and Fireflies (2 BIPA suits) over bot recording — our bot-free on-device capture is a defensive asset.
+
+---
+
+## Part 3 — Problems (prioritized)
+
+**P0 — correctness/privacy bugs (fix regardless of v2):**
+
+1. **`vault_titles` egress leak** — every `.md` stem (incl. auto-created `[[Person Name]].md`) reaches cloud providers past the NER layer on every cloud summarize (`pipeline.rs` → `redact.rs` filters only regex-altered titles). Confirmed in the 07-04 truth audit, still unpatched.
+2. **StubReasoner echo surfaces as a real @brain answer** (`run_informational` lacks the `id()=="stub"` guard that `orchestrate.rs` has) — fresh installs get `[stub-reason] system=N chars…` as an "answer".
+3. **No token cap / no wall-clock timeout on live user answers** (`GenOptions::default()` in the question path; loop bounded by steps only) — a chatty local generation occupies Metal indefinitely; contributes to the OOM/latency incident class.
+4. **No priority or cancellation between background reactions and user questions** sharing `brain_rt`; no in-flight dedup of concurrent assistant turns.
+
+**P1 — context-management debt (the "not Anthropic-level" core):**
+
+5. Corpus **pre-stuffing** (200k chars) instead of just-in-time retrieval; agentic-loop transcript grows with no compaction or total budget; @brain history capped by turns, not tokens.
+6. **Memory brief always injected**, never relevance-filtered; no consolidation/reflection pass, no importance/recency scoring — facts accumulate but never synthesize.
+7. Live buffer = naive word-overlap merge, no rolling incremental state; the 600-char reaction window and 6k inject caps are unprincipled constants; live is mic-only (far side invisible to the live brain).
+8. Prompts are string literals scattered in `live.rs`/`agent.rs` (EN+PL mixed), no registry, no versioning, duplicated wake-phrases across files.
+
+**P2 — retrieval quality debt:**
+
+9. **No reranker** (audit F, still true); RRF k=60 (TREC-scale) uncalibrated; rank-fusion where score-fusion measures ~6% better.
+10. Char-based chunking, whole-meeting index granularity, **zero contextual augmentation** (no title/date/attendees/facts on chunks), no time-aware query expansion.
+11. **Evals exist but never run** — bakeoff/diarization harnesses have zero committed result artifacts; retrieval and answer faithfulness are unmeasured on a real vault; citations never checked against cited content (C−).
+
+**P3 — reliability/robustness debt:**
+
+12. JSON-in-prompt everywhere with no retry (a malformed step kills the loop); only gateway has constrained decoding; local grammar constraint abandoned instead of scoped.
+13. Agentic loop silently unavailable on local GGUF (correct per BFCL science, but undocumented and marketed otherwise).
+14. `commands.rs` god-file (>8k lines) as the single coupling point.
+
+**P4 — capability gaps vs ClickUp Brain²:**
+
+15. No memory import (their cold-start killer is a paste-and-extract away for us, fully local).
+16. No user-facing scheduled agents (we have digest/proactive machinery, no generality).
+17. MCP server only — no MCP *client* (their 1,000-tool fabric pattern).
+18. Verify-pass (✓ confirmed in PROJ-123) still unshipped — the headline trust differentiator their complaint profile begs for.
+
+---
+
+## Part 4 — Brain v2 proposal
+
+**Design stance:** *workflow-first, agent-when-needed; measured, budgeted, gated.* Keep the substrate untouched (SQLite canonical, lock gating, provider seam + redaction + ledger, structural tiering, two-stage notes). Rebuild the middle in five layers:
+
+### L1 — Indexing & retrieval ("the consolidation brain") — effort M, highest evidence-per-effort
+
+- **Topic-segment indexing**: segment transcripts at topic boundaries (deterministic: speaker-run + lull + lexical-shift heuristic) and index segments, not whole meetings (LongMemEval session decomposition).
+- **Deterministic contextual augmentation**: prepend `title | date | attendees | active facts` to every chunk for BOTH FTS and embedding (Anthropic contextual retrieval mechanism at zero LLM cost — our facts/entities make the "situating context" templatable).
+- **Time-aware query expansion** (parse "last week/w zeszłym tygodniu" → date constraint on `search_hybrid_visible`).
+- **Score-fusion instead of rank-fusion**; calibrate k on the eval set.
+- **Rerank stage behind a trait** — bake-off prompted Qwen3-1.7B pointwise (already resident) vs bge-reranker-v2-m3 on M-series; ship whichever wins latency×recall; Ask-only (too slow for live).
+- **Gate: the eval harness runs.** Fixed ~20-query set over a real dev vault; recall@5 per config + RAGAS-style judged faithfulness on Ask answers; a committed results artifact per architecture change. No retrieval change merges without a number.
+
+### L2 — Memory — effort S–M
+
+- **Consolidation/reflection job** (generative-agents recipe): score facts/interactions by recency-decay + importance + relevance; periodic local-model reflection synthesizes per-entity and weekly rollup summaries as *retrievable objects* (GraphRAG's one killer idea; digest/entity pages are 70% there). Output = plain `.md` + wikilinks (Obsidian-native, A-MEM-validated).
+- **Relevance-filtered memory brief**: retrieve top-k user facts against the query instead of always injecting the full 2k brief.
+- **Memory import** (ClickUp parity, S): paste ChatGPT/Claude exported memories → local extraction into `user_facts` → auditable in the existing brain-memory view, lock-gated, zero egress.
+
+### L3 — Reasoning & orchestration — effort M
+
+- **Formalize the cascade as a router** (FrugalGPT/RouteLLM shape, already latent in roles/postures): 1.7B = classify/filter/route; 4B = extraction + short grounded summarization + (new) a *constrained few-tool grammar path* so local users get limited tool use honestly; cloud = the agent loop + long-context synthesis. Escalation to cloud is a **visible privacy event**: ledgered, redaction unconditionally after the router.
+- **Engineered context budgets**: replace 200k pre-stuffing with just-in-time retrieval over lightweight identifiers (ids/titles → `get_meeting` on demand); compaction of the loop transcript when it crosses a budget; token (not turn) budget for @brain history; most-important-context at prompt start/end (lost-in-the-middle).
+- **Robust structured output**: native JSON mode where the backend has it (gateway today, anthropic tools later); one retry-with-error on malformed JSON; scoped grammar constraint for the small local schemas (triples, route decisions — tiny schemas won't overflow context like Bielik did).
+- **Hard resource discipline**: token caps + wall-clock timeouts on every live-path generation; a tiny priority queue in front of `brain_rt` (user turn preempts/queues ahead of background scans); in-flight turn dedup.
+- **Prompt registry**: one module owning all prompt templates + versions; wake-phrases single-sourced; enables A/B on the eval set.
+
+### L4 — The live brain ("gated incremental summarizer") — effort M, needs real-meeting tuning
+
+- Rebuild the live loop on the production incremental-summarization template:
+  1. **Novelty gatekeeper** (deterministic signals + optional 1.7B yes/no; p50 ~ms) decides whether anything happened worth a model call — replaces the fixed every-7-ticks cadence.
+  2. **Incremental running bullets**: prefix-prompted local call emits *only new bullets or empty*; the running state lives beside the verbatim tail (rolling-summary + recent-verbatim shape) and replaces the raw 600-char reaction window as the reactions/questions substrate.
+  3. **Boundary-timed surfacing**: cards/hints surface at topic shifts/lulls, not mid-utterance (field-study finding); cadence becomes a policy, not a constant.
+  4. **Meeting end**: the running bullets become Stage-1 note input (faster finals, less re-reading), and the live brain finally sees far-side text if/when live system-audio transcription lands (flagged, not required for v2).
+- Whisper contradiction cards stay deterministic-reconcile (that part is best-practice already); they just read the better substrate.
+
+### L5 — Agents & surfaces (the ClickUp-parity layer) — effort M–L
+
+- **Scheduled briefs** ("every Monday 9am: open action items + stale threads"): generalize digest/proactive into user-defined schedules over local tools, propose-accept for anything write-shaped, zero-egress by default. Low-cadence, high-precision (the 77.5% AI-fatigue survey is the design constraint).
+- **MCP client** behind the existing consent + redaction + ledger seam — one integration multiplies source coverage (Linear/Notion/anything) instead of bespoke connectors; per-server consent, loud egress.
+- **Verify pass** (✓ confirmed in PROJ-123 / ⧗ conflict) — deterministic compare against live connectors; the headline trust feature; rules-based verification is literally Anthropic's top verification tier.
+
+### Sequencing
+
+| Phase | Content | Size |
+|---|---|---|
+| **P0 hotfixes** | vault_titles leak, stub-echo guard, token caps + timeouts + turn dedup on live path | S |
+| **P1 retrieval + eval** | eval set runs first (baseline numbers!) → topic-segments + contextual augmentation + score-fusion → reranker bake-off | M |
+| **P2 memory** | relevance-filtered brief → consolidation job → memory import | S–M |
+| **P3 orchestration** | router formalization, JIT context + compaction, prompt registry, structured-output hardening | M |
+| **P4 live rebuild** | gatekeeper → incremental bullets → boundary surfacing → bullets-as-Stage-1-input | M |
+| **P5 agents** | scheduled briefs → MCP client → verify pass | M–L |
+
+Explicitly rejected for v2: multi-agent Ask (15× tokens, wrong shape for a single-user vault), GraphRAG wholesale (Mem0: graphs add ~2% for QA; keep ours for navigation + community summaries only), agent-self-managed memory (pipeline beats self-management in every benchmark), multi-cloud model routing as a feature (invisible; our posture story is stronger), local-GGUF full agent loop (BFCL 7.8% says no).
+
+---
+
+## Fit with Murmur constraints
+
+- **Local-first**: everything in L1/L2/L4 is zero-egress; extraction-based memory *reduces* egress; the router makes cloud escalation an explicit, ledgered, redacted event. MCP client is new egress → per-server consent like `web.rs`-cloned connectors.
+- **Obsidian-native**: consolidation output is `.md` + wikilinks; scheduled briefs export as notes.
+- **SQLite-canonical**: every new structure (segments index, scored memory view, rollups, running bullets) is rows in the one store; "write to SQLite, pass back an id" is the artifact pattern.
+- **Lock model**: all new reads ride `visibility_clause`; rollups/bullets purge-on-seal like facts; the reranker sees only already-gated candidates. Lock-security review required for L1 (new index tables) and L4 (running-bullets persistence).
+- **macOS / honesty**: retrieval + memory + orchestration are fully evaluable headless; live-timing UX and reranker latency need a real Mac; say so in any DoD.
+
+## Recommendation & first step
+
+**Adopt the phased plan; start with P0 + the P1 eval spike in one slice.** The single smallest verifiable step: **run the existing bake-off harness on the real dev vault with a fixed ~20-query set and commit the baseline numbers** (recall@5 for FTS/dense/hybrid; judged faithfulness for 5 Ask answers). It costs a day, produces the first real quality numbers in the project's history, and every subsequent Brain-v2 change gets measured against it — which is precisely the discipline that separates "Anthropic-level" from vibes. In parallel, patch the vault_titles leak and the stub-echo (both S, both user-facing today).
+
+## Open questions
+
+- On-device reranker latency on Apple Silicon — no credible public number; needs local measurement (P1 bake-off).
+- mistralrs stable-prefix KV-cache reuse — matters for incremental-bullets local latency; unverified.
+- Topic-boundary detection quality on Polish bilingual meetings — needs real recordings.
+- Brain² Context Engine internals are vendor claims (no independent teardown); the inferred patterns are pattern-matching.
+- Live far-side (system audio) streaming transcription cost — required for the live brain to see the whole meeting; parked pending the perf/OOM headroom work.
+- brain2 vs Brain² naming collision — now GA'd and marketed by ClickUp; hard blocker before public copy.
+
+## Sources
+
+**Code (this repo, symbols not line numbers):** `transcribe/live.rs` (tick loop, merge_live_caption, run_assistant_query, run_cascade, assistant_system_prompt, TIER*_SUFFIX), `brain_reactions.rs` (reactions_scan, detect_reactions, cards_from_reconcile), `proactive.rs`, `agent.rs` (run_agentic_loop, ESCALATE_SENTINEL, RESULT_BUDGET), `tools.rs` (AssistantScope, GatedToolExecutor), `reason.rs` + `reason/mistral.rs` (MODEL_CACHE, ram_permits_load, GenOptions), `summarize/{provider,redact,roles,related_context,vault_context,gateway,egress_log}.rs`, `settings/postures.rs`, `embed.rs`, `facts.rs`, `user_memory.rs`, `pipeline.rs`, `enrich.rs`, `orchestrate.rs`; prior docs: `docs/research/2026-07-06-note-and-brain-architecture.md`, `2026-07-04-truth-audit-brain-vs-best-practices.md`, `2026-07-05-competing-with-clickup-brain.md`.
+
+**Anthropic (fetched):** building-effective-agents; effective-context-engineering-for-ai-agents; building-agents-with-the-claude-agent-sdk; built-multi-agent-research-system; writing-tools-for-agents; contextual-retrieval; prompt-caching.
+
+**Academic (fetched):** MemGPT arXiv:2310.08560; Generative Agents arXiv:2304.03442; A-MEM arXiv:2502.12110; Mem0 arXiv:2504.19413; LoCoMo arXiv:2402.17753; LongMemEval arXiv:2410.10813; GraphRAG arXiv:2404.16130; Lost-in-the-Middle arXiv:2307.03172; RULER arXiv:2404.06654; NoLiMa arXiv:2502.05167; Qwen3 arXiv:2505.09388; RouteLLM arXiv:2406.18665; FrugalGPT arXiv:2305.05176; incremental summarization arXiv:2510.06677; proactive wake arXiv:2605.30152; boundary timing arXiv:2601.10253; Goldilocks arXiv:2504.09332; Fission-GRPO (BFCL baselines) arXiv:2601.15625; Weaviate hybrid-fusion blog.
+
+**Competitive (fetched):** clickup.com/brain + /blog/brain-2-launch + help.clickup.com Autopilot/Ambient Answers + zenpilot Brain² review + dupple Brain MAX; Fireflies Live Assist guide; granola.ai/updates; Otter Meeting Agent blog + Forbes + Fast Company; Zoom AI Companion 3.0; MS Learn Teams Copilot; Slack huddle notes; Notion AI meeting notes + tldv review; hedy.ai (Meta/Limitless, Rewind shutdown); tldv lawsuits roundup; XDA + GeekWire on Windows Recall; ClickUp AI-sprawl survey.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -22,7 +22,7 @@
 //!   `tool+args` into "already retrieved" instead of burning the budget.
 
 use crate::error::Result;
-use crate::reason::LocalReasoner;
+use crate::reason::{GenOptions, LocalReasoner};
 
 /// The BRAIN CASCADE escalation sentinel (Phase 5). A tier's system prompt instructs the model to
 /// reply EXACTLY `{"answer":"__ESCALATE__"}` when the question is NOT answerable at that tier. The
@@ -84,6 +84,13 @@ const RESULT_BUDGET: usize = 4000;
 /// Drive the brain in a bounded decide-or-finish loop over the gated executor. See the module-level
 /// contract. PANIC-FREE: a tool error is recorded `ok=false` and the loop continues; a `structured()`
 /// error is propagated for the caller to floor on.
+///
+/// `opts` (Brain v2 P0.3) is the per-step [`GenOptions`] threaded into EVERY model turn via
+/// [`LocalReasoner::structured_with`] — the live path passes [`GenOptions::live_answer`] (1024-token
+/// cap + 30 s wall-clock timeout), the Ask path [`GenOptions::ask_answer`] (2048 + 30 s). Honored on
+/// the on-device GGUF reasoner (`GenOptions::default()` carries NO timeout — those steps run
+/// unbounded, the pre-P0 behavior); a best-effort no-op on the stub/cloud (their default
+/// `structured_with` delegates to `structured`).
 pub fn run_agentic_loop(
     reasoner: &dyn LocalReasoner,
     system: &str,
@@ -91,6 +98,7 @@ pub fn run_agentic_loop(
     executor: &dyn ToolExecutor,
     max_steps: usize,
     sink: Option<&dyn DeltaSink>,
+    opts: GenOptions,
 ) -> Result<Option<AgentOutcome>> {
     let catalog = render_catalog(&executor.specs());
     let agent_system = format!(
@@ -115,7 +123,8 @@ pub fn run_agentic_loop(
 
     for _ in 0..max_steps {
         // PROPAGATE a structured() error (esp. Unavailable on no-consent) — never swallow it.
-        let v = reasoner.structured(&agent_system, &transcript, &step_schema)?;
+        // P0.3: every step rides the caller's GenOptions (token cap; timeout on the GGUF path).
+        let v = reasoner.structured_with(&agent_system, &transcript, &step_schema, opts)?;
 
         if let Some(answer) = v.get("answer").and_then(|a| a.as_str()) {
             let answer = answer.trim();
@@ -294,6 +303,7 @@ mod tests {
             &EchoExec,
             4,
             Some(&sink as &dyn DeltaSink),
+            GenOptions::default(),
         )
         .unwrap()
         .expect("converged → Some");
@@ -320,7 +330,7 @@ mod tests {
             serde_json::json!({ "tool": "search_meetings", "args": { "query": "a" } }),
             serde_json::json!({ "tool": "search_meetings", "args": { "query": "b" } }),
         ]);
-        let out = run_agentic_loop(&r, "sys", "q", &EchoExec, 2, None).unwrap();
+        let out = run_agentic_loop(&r, "sys", "q", &EchoExec, 2, None, GenOptions::default()).unwrap();
         assert!(
             out.is_none(),
             "non-convergence must return Ok(None), not a fabricated answer"
@@ -332,7 +342,7 @@ mod tests {
         // structured() errors (e.g. no-consent cloud) → the loop PROPAGATES Err, never swallows it,
         // so the caller can floor + emit needs_consent.
         let r = ScriptReasoner::with(vec![Err(AppError::Unavailable("no consent".into()))]);
-        let res = run_agentic_loop(&r, "sys", "q", &EchoExec, 4, None);
+        let res = run_agentic_loop(&r, "sys", "q", &EchoExec, 4, None, GenOptions::default());
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),
             "Unavailable must propagate"
@@ -354,7 +364,7 @@ mod tests {
             serde_json::json!({ "tool": "search_meetings", "args": {} }),
             serde_json::json!({ "answer": "done despite the error" }),
         ]);
-        let out = run_agentic_loop(&r, "sys", "q", &ErrExec, 4, None)
+        let out = run_agentic_loop(&r, "sys", "q", &ErrExec, 4, None, GenOptions::default())
             .unwrap()
             .unwrap();
         assert_eq!(out.answer, "done despite the error");
@@ -388,7 +398,7 @@ mod tests {
             serde_json::json!({ "tool": "search_meetings", "args": { "query": "x" } }),
             serde_json::json!({ "answer": "answered after a dedup" }),
         ]);
-        let out = run_agentic_loop(&r, "sys", "q", &EchoExec, 5, None)
+        let out = run_agentic_loop(&r, "sys", "q", &EchoExec, 5, None, GenOptions::default())
             .unwrap()
             .unwrap();
         assert_eq!(out.answer, "answered after a dedup");

--- a/src-tauri/src/brain_reactions.rs
+++ b/src-tauri/src/brain_reactions.rs
@@ -161,6 +161,14 @@ pub fn reactions_scan(app: &tauri::AppHandle, now: &str) -> ReactionScan {
         emit: false,
     };
     let st = app.state::<crate::state::AppState>();
+    // Brain v2 P0.3 — USER-TURN PRIORITY: a user-initiated assistant turn is in flight → defer this
+    // background scan entirely (before any config/model/DB work), so the background light-model
+    // extraction never competes with a user-facing answer for the on-device engine. The next
+    // scheduled scan (~21 s later) picks up naturally once the turn's RAII guard clears the flag.
+    if should_defer_scan(&st.user_turn_in_progress) {
+        tracing::debug!(target: "reactions", "user turn in flight; deferring scan");
+        return empty;
+    }
     let (brain_live, emit) = match st.config.lock() {
         Ok(c) => (c.brain_live, c.brain_contradiction_cards),
         Err(_) => return empty,
@@ -210,6 +218,14 @@ pub fn reactions_scan(app: &tauri::AppHandle, now: &str) -> ReactionScan {
             .collect()
     };
     ReactionScan { cards, emit }
+}
+
+/// Brain v2 P0.3 — the PURE deferral decision for [`reactions_scan`]: defer while a user-initiated
+/// assistant turn is in flight (`AppState::user_turn_in_progress`). Factored off `AppHandle` so the
+/// contract is headless-testable; `Relaxed` suffices — this is an advisory scheduling hint, not a
+/// synchronization edge.
+fn should_defer_scan(user_turn_in_progress: &std::sync::atomic::AtomicBool) -> bool {
+    user_turn_in_progress.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// The last `n` chars of `s` on a char boundary.
@@ -307,6 +323,19 @@ mod tests {
     fn no_candidates_no_cards() {
         let existing = vec![fact("f1", "Project Atlas", "deadline", "May 30 firm", "m-kickoff")];
         assert!(cards_from_reconcile(&existing, &[], "2026-07-04T00:00:00Z").is_empty());
+    }
+
+    /// Brain v2 P0.3 — the deferral decision: the scan defers exactly while the user-turn priority
+    /// flag is set, and resumes once the turn's RAII guard clears it. (The `reactions_scan` wiring
+    /// itself needs an `AppHandle` and is exercised on a real Mac; this pins the pure decision.)
+    #[test]
+    fn scan_defers_only_while_a_user_turn_is_in_flight() {
+        let flag = std::sync::atomic::AtomicBool::new(false);
+        assert!(!should_defer_scan(&flag), "idle: the scan runs");
+        flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(should_defer_scan(&flag), "user turn in flight: defer");
+        flag.store(false, std::sync::atomic::Ordering::Relaxed);
+        assert!(!should_defer_scan(&flag), "turn ended: the scan resumes");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3686,8 +3686,17 @@ fn ask_vault_loop(
 ) -> Result<Option<AskVaultResult>, AppError> {
     let system = crate::summarize::vault_chat::agentic_system(memory_brief);
     let user = crate::summarize::vault_chat::render_conversation(history, question);
-    let Some(outcome) =
-        crate::agent::run_agentic_loop(reasoner, &system, &user, executor, ASK_MAX_STEPS, sink)?
+    let Some(outcome) = crate::agent::run_agentic_loop(
+        reasoner,
+        &system,
+        &user,
+        executor,
+        ASK_MAX_STEPS,
+        sink,
+        // P0.3: the ASK preset — a 2048-token cap (roomier than live, still bounded; the GGUF path
+        // additionally rides the 30 s wall-clock generation timeout). No-op on stub/cloud.
+        crate::reason::GenOptions::ask_answer(),
+    )?
     else {
         return Ok(None);
     };
@@ -11422,6 +11431,8 @@ mod lifecycle_tests {
             capped_notified: std::sync::atomic::AtomicBool::new(false),
             reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
             reactions_emitted: Mutex::new(HashSet::new()),
+            in_flight_turns: Mutex::new(std::collections::HashMap::new()),
+            user_turn_in_progress: std::sync::atomic::AtomicBool::new(false),
             unlocked_folders: Arc::new(Mutex::new(HashSet::new())),
             master_kek: Mutex::new(None),
             account_session: Mutex::new(None),

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -843,16 +843,52 @@ pub struct GenOptions {
     /// Whether to allow qwen3 "thinking" traces. Default `false` (the derived bool default) — we never
     /// want thinking in structured extraction; on non-thinking models this is a no-op.
     pub enable_thinking: bool,
+    /// Wall-clock bound on ONE on-device generation (honored only by the local GGUF path —
+    /// [`mistral::MistralReasoner`]; a no-op elsewhere). `None` (the default) = UNBOUNDED, exactly the
+    /// pre-P0 behavior — load-bearing for FullyLocal note generation (30–90 s on Qwen3-4B), the
+    /// FullyLocal Ask floor (a huge prefill), and the FIRST local generation on a CLT-only Mac
+    /// (`MISTRALRS_METAL_PRECOMPILE=0` defers Metal shader compile into the first request). The LIVE
+    /// presets set `Some(30 s)` — the P0.3 live-path discipline (spec §P0.3).
+    pub timeout: Option<std::time::Duration>,
 }
 
 impl GenOptions {
     /// The LIGHT realtime-extraction preset: a hard 128-token cap, low temperature, no thinking
-    /// (spec §4.3 — triples are short; the cap is the contention lever).
+    /// (spec §4.3 — triples are short; the cap is the contention lever). Carries the 30 s wall-clock
+    /// timeout too: reactions are a live BACKGROUND scan, so a hung 128-token extraction must not
+    /// wedge the worker — degrading one scan beats blocking the loop.
     pub fn light_extraction() -> Self {
         Self {
             max_tokens: Some(128),
             temperature: Some(0.2),
             enable_thinking: false,
+            timeout: Some(std::time::Duration::from_secs(30)),
+        }
+    }
+
+    /// Brain v2 P0.3 — the LIVE in-meeting answer preset: a hard 1024-token cap so a runaway
+    /// on-device decode can't saturate Metal mid-recording (effective on the local GGUF path — the
+    /// only truly unbounded one; a best-effort no-op elsewhere), plus a 30 s wall-clock timeout —
+    /// the live path must answer promptly or degrade to the floor. Model-default temperature; never
+    /// thinking traces in a live answer.
+    pub fn live_answer() -> Self {
+        Self {
+            max_tokens: Some(1024),
+            temperature: None,
+            enable_thinking: false,
+            timeout: Some(std::time::Duration::from_secs(30)),
+        }
+    }
+
+    /// Brain v2 P0.3 — the ASK (vault Q&A) answer preset: a 2048-token cap — roomier than the live
+    /// path (Ask answers can run longer) but still bounded, with the same 30 s wall-clock timeout
+    /// (an interactive Ask that hasn't started answering in 30 s should degrade, not hang the UI).
+    pub fn ask_answer() -> Self {
+        Self {
+            max_tokens: Some(2048),
+            temperature: None,
+            enable_thinking: false,
+            timeout: Some(std::time::Duration::from_secs(30)),
         }
     }
 }
@@ -866,6 +902,14 @@ pub trait LocalReasoner: Send + Sync {
 
     /// Free-form reasoning: run `system` + `user` and return the model's text.
     fn reason(&self, system: &str, user: &str) -> Result<String>;
+
+    /// Free-form reasoning WITH generation options (a token cap etc. — Brain v2 P0.3). Default:
+    /// IGNORE the options and delegate to [`reason`](Self::reason) — the Stub / Cloud / AFM
+    /// reasoners have no local sampler to bound, so this is non-breaking for every implementor.
+    /// [`mistral::MistralReasoner`] OVERRIDES it to honor the cap on the on-device GGUF path.
+    fn reason_with(&self, system: &str, user: &str, _opts: GenOptions) -> Result<String> {
+        self.reason(system, user)
+    }
 
     /// Structured reasoning: run `system` + `user` and return a JSON value. `json_schema` is the
     /// shape the output must conform to. NONE of the shipped impls hard-constrain the decode: the
@@ -1130,6 +1174,38 @@ impl LocalReasoner for CloudReasoner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Brain v2 P0.3 — the answer presets carry the intended hard caps + the 30 s live-path
+    /// wall-clock timeout and never enable thinking; the DEFAULT options carry NO timeout (note-gen
+    /// / the FullyLocal floor legitimately run past 30 s — the pre-P0 unbounded behavior); the
+    /// trait's default `reason_with` ignores the options (non-breaking for stub/cloud).
+    #[test]
+    fn gen_option_presets_cap_tokens_and_default_reason_with_delegates() {
+        let live = GenOptions::live_answer();
+        assert_eq!(live.max_tokens, Some(1024));
+        assert!(live.temperature.is_none());
+        assert!(!live.enable_thinking);
+        assert_eq!(live.timeout, Some(std::time::Duration::from_secs(30)));
+
+        let ask = GenOptions::ask_answer();
+        assert_eq!(ask.max_tokens, Some(2048));
+        assert!(ask.temperature.is_none());
+        assert!(!ask.enable_thinking);
+        assert_eq!(ask.timeout, Some(std::time::Duration::from_secs(30)));
+
+        let light = GenOptions::light_extraction();
+        assert_eq!(light.timeout, Some(std::time::Duration::from_secs(30)));
+
+        // The DEFAULT (note generation, the Ask floor, agent default steps) is UNBOUNDED in time —
+        // scoping the timeout to the live presets is the whole point of the fix.
+        assert!(GenOptions::default().timeout.is_none());
+
+        // The default trait method delegates to `reason` — the stub answers identically with or
+        // without options, proving implementors without a sampler are untouched.
+        let with = StubReasoner.reason_with("s", "u", GenOptions::live_answer()).unwrap();
+        let without = StubReasoner.reason("s", "u").unwrap();
+        assert_eq!(with, without);
+    }
 
     #[test]
     fn extracts_object_from_surrounding_prose() {

--- a/src-tauri/src/reason/mistral.rs
+++ b/src-tauri/src/reason/mistral.rs
@@ -258,26 +258,34 @@ impl MistralReasoner {
         Ok(arc)
     }
 
-    /// Free-form generation with explicit [`GenOptions`] — the load-bearing path. The token cap
-    /// (`set_sampler_max_len`) bounds a runaway decode; `enable_thinking(false)` keeps qwen3 thinking
-    /// traces out (a no-op on non-thinking models). An in-flight generation is NOT cancellable once
-    /// submitted — the cap is the only per-call bound (spec §4.3).
-    fn reason_with(&self, system: &str, user: &str, opts: GenOptions) -> Result<String> {
+    /// Free-form generation with explicit [`GenOptions`] — the load-bearing path. Two OPTIONAL
+    /// bounds compose (Brain v2 P0.3, SCOPED per-call via the options — spec §P0.3 is LIVE-path
+    /// discipline, not a blanket bound):
+    /// - the token cap (`set_sampler_max_len`) bounds a runaway decode LENGTH;
+    /// - `opts.timeout` (`Some` on the live/ask/extraction presets) bounds runaway decode TIME: the
+    ///   blocking generation runs on a spawned worker thread ([`run_with_timeout`]) and a reply that
+    ///   misses the deadline yields `AppError::Unavailable` while the worker is deliberately LEAKED
+    ///   (an in-flight mistralrs generation is NOT cancellable; the model lives in the
+    ///   process-global cache and is never dropped).
+    ///
+    /// `opts.timeout = None` (the `GenOptions::default()` path — note generation, the FullyLocal
+    /// Ask floor, default agent steps) runs `generate_blocking` DIRECTLY on the current thread,
+    /// UNBOUNDED — exactly the pre-P0 behavior. This is deliberate: FullyLocal note generation
+    /// legitimately takes 30–90 s on Qwen3-4B, a huge Ask-floor prefill can too, and the FIRST
+    /// generation on a CLT-only Mac pays the deferred Metal shader compile
+    /// (`MISTRALRS_METAL_PRECOMPILE=0`) inside `send_chat_request` — a blanket 30 s timeout would
+    /// kill all three.
+    ///
+    /// The MODEL LOAD (`self.model()`) deliberately stays OUTSIDE any timeout: a first-call
+    /// multi-GB load is not a runaway generation, is already gated by the RAM guard, and may
+    /// legitimately exceed 30 s on a cold disk.
+    fn reason_with_opts(&self, system: &str, user: &str, opts: GenOptions) -> Result<String> {
         let model = self.model()?;
-        let mut req = RequestBuilder::new()
-            .add_message(TextMessageRole::System, system)
-            .add_message(TextMessageRole::User, user)
-            .enable_thinking(opts.enable_thinking);
-        if let Some(t) = opts.temperature {
-            req = req.set_sampler_temperature(t);
-        }
-        if let Some(n) = opts.max_tokens {
-            req = req.set_sampler_max_len(n);
-        }
-        let rt = brain_rt().ok_or_else(|| AppError::Summarize("brain runtime unavailable".into()))?;
-        let resp = block_on(rt, model.send_chat_request(req))?
-            .map_err(|e| AppError::Summarize(format!("brain generation failed: {e}")))?;
-        Self::first_content(resp)
+        let system = system.to_string();
+        let user = user.to_string();
+        run_bounded(opts.timeout, move || {
+            generate_blocking(&model, &system, &user, opts)
+        })
     }
 
     /// Structured generation with explicit [`GenOptions`]: instruct the JSON schema in the prompt
@@ -289,7 +297,7 @@ impl MistralReasoner {
             "{system}\n\nRespond with ONLY a single JSON object conforming to this schema: \
              {json_schema}. No prose, no markdown fences."
         );
-        let content = self.reason_with(&sys, user, opts)?;
+        let content = self.reason_with_opts(&sys, user, opts)?;
         parse_first_json(&content)
     }
 
@@ -309,7 +317,11 @@ impl LocalReasoner for MistralReasoner {
     }
 
     fn reason(&self, system: &str, user: &str) -> Result<String> {
-        self.reason_with(system, user, GenOptions::default())
+        self.reason_with_opts(system, user, GenOptions::default())
+    }
+
+    fn reason_with(&self, system: &str, user: &str, opts: GenOptions) -> Result<String> {
+        self.reason_with_opts(system, user, opts)
     }
 
     fn structured(&self, system: &str, user: &str, json_schema: &Value) -> Result<Value> {
@@ -324,6 +336,97 @@ impl LocalReasoner for MistralReasoner {
         opts: GenOptions,
     ) -> Result<Value> {
         self.structured_with_opts(system, user, json_schema, opts)
+    }
+}
+
+/// The BLOCKING generation core: build one chat request over an already-resolved engine and drive
+/// it to completion. Runs on the [`run_with_timeout`] worker thread — that thread has no ambient
+/// runtime, so the inner scoped `block_on` is safe regardless of caller context. `enable_thinking`
+/// / temperature / token cap come from the [`GenOptions`].
+fn generate_blocking(
+    model: &Arc<Model>,
+    system: &str,
+    user: &str,
+    opts: GenOptions,
+) -> Result<String> {
+    let mut req = RequestBuilder::new()
+        .add_message(TextMessageRole::System, system)
+        .add_message(TextMessageRole::User, user)
+        .enable_thinking(opts.enable_thinking);
+    if let Some(t) = opts.temperature {
+        req = req.set_sampler_temperature(t);
+    }
+    if let Some(n) = opts.max_tokens {
+        req = req.set_sampler_max_len(n);
+    }
+    let rt = brain_rt().ok_or_else(|| AppError::Summarize("brain runtime unavailable".into()))?;
+    let resp = block_on(rt, model.send_chat_request(req))?
+        .map_err(|e| AppError::Summarize(format!("brain generation failed: {e}")))?;
+    MistralReasoner::first_content(resp)
+}
+
+/// Brain v2 P0.3 (revised) — the SCOPED bound seam: apply the wall-clock timeout ONLY when the
+/// caller's [`GenOptions`] asked for one.
+///
+/// - `Some(timeout)` (the live / ask / light-extraction presets) ⇒ [`run_with_timeout`] on a
+///   spawned worker thread — the live-path discipline.
+/// - `None` (`GenOptions::default()` — note generation, the FullyLocal Ask floor, default agent
+///   steps) ⇒ run `work` DIRECTLY on the current thread, UNBOUNDED — the pre-P0 behavior. Those
+///   paths legitimately exceed 30 s (Qwen3-4B note-gen runs 30–90 s; the first generation on a
+///   CLT-only Mac pays the deferred Metal shader compile), so they must never be timeout-killed.
+///
+/// Factored as a seam (not inlined in `reason_with_opts`) so the branch decision is unit-testable
+/// headless, without a model.
+fn run_bounded<T: Send + 'static>(
+    timeout: Option<std::time::Duration>,
+    work: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    match timeout {
+        Some(t) => run_with_timeout(t, work),
+        None => work(),
+    }
+}
+
+/// Brain v2 P0.3 — the testable WAIT MECHANIC of the generation timeout: run `work` on a spawned
+/// (detached) OS thread and wait at most `timeout` for its result over an mpsc channel.
+///
+/// - In time ⇒ the worker's own `Result` is returned verbatim.
+/// - TIMEOUT ⇒ `AppError::Unavailable` and the worker thread is deliberately LEAKED — the caller
+///   must never block on (or cancel) an uncancellable mistralrs generation, and the model itself
+///   is never dropped (it lives in the process-global [`model_cache`]). The eventual send into the
+///   dropped channel is a no-op.
+/// - Worker PANIC ⇒ the sender is dropped without a message ⇒ `Disconnected` ⇒ a graceful `Err`
+///   (never a hang, never a propagated panic).
+///
+/// Factored generic over `work` precisely so the mechanics are unit-testable headless, without a
+/// real model (`cargo test --lib` never runs a forward pass here — see the module header).
+fn run_with_timeout<T: Send + 'static>(
+    timeout: std::time::Duration,
+    work: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    let (tx, rx) = std::sync::mpsc::channel::<Result<T>>();
+    std::thread::Builder::new()
+        .name("murmur-brain-gen".into())
+        .spawn(move || {
+            let _ = tx.send(work());
+        })
+        .map_err(|e| AppError::Summarize(format!("brain generation worker spawn failed: {e}")))?;
+    match rx.recv_timeout(timeout) {
+        Ok(res) => res,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            // NO PII: duration only. The worker keeps running detached (leaked by design).
+            tracing::warn!(
+                target: "reason",
+                timeout_s = timeout.as_secs(),
+                "on-device brain generation timed out; leaking the worker (generations are uncancellable)"
+            );
+            Err(AppError::Unavailable(
+                "on-device brain generation timed out".into(),
+            ))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(AppError::Summarize(
+            "brain generation worker exited without a result".into(),
+        )),
     }
 }
 
@@ -394,6 +497,96 @@ mod tests {
             Some(1024 * 1024 * 1024),
             MODEL_RAM_GUARD_MIN_DISK_BYTES + GB
         ));
+    }
+
+    /// Brain v2 P0.3 — the timeout wait mechanic, fast path: a worker that finishes within the
+    /// deadline returns its own result verbatim (Ok and Err alike).
+    #[test]
+    fn run_with_timeout_returns_fast_result() {
+        let ok = run_with_timeout(std::time::Duration::from_secs(5), || Ok(42u32));
+        assert!(matches!(ok, Ok(42)));
+
+        let err: Result<u32> = run_with_timeout(std::time::Duration::from_secs(5), || {
+            Err(AppError::Summarize("inner failure".into()))
+        });
+        assert!(
+            matches!(err, Err(AppError::Summarize(_))),
+            "a worker's own error must pass through verbatim"
+        );
+    }
+
+    /// Brain v2 P0.3 — the timeout path: a worker that outlives the deadline yields
+    /// `AppError::Unavailable` (the caller degrades to the floor / a lower tier) and is LEAKED,
+    /// never joined — the call returns promptly instead of hanging on the slow worker.
+    #[test]
+    fn run_with_timeout_times_out_gracefully_and_leaks_the_worker() {
+        let started = std::time::Instant::now();
+        let res: Result<u32> = run_with_timeout(std::time::Duration::from_millis(50), || {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            Ok(1)
+        });
+        match res {
+            Err(AppError::Unavailable(msg)) => {
+                assert!(
+                    msg.contains("timed out"),
+                    "the timeout error must say so: {msg}"
+                );
+            }
+            other => panic!("timeout must be Unavailable, got {other:?}"),
+        }
+        // Prompt return: we did NOT wait for the 500 ms worker (leaked by design).
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(400),
+            "the caller must not block on the leaked worker"
+        );
+    }
+
+    /// Brain v2 P0.3 (revised) — DEFAULT options carry NO timeout, and the `None` branch of
+    /// [`run_bounded`] runs the work INLINE on the CURRENT thread, unbounded — the pre-P0 behavior
+    /// note generation / the FullyLocal Ask floor / first-gen shader compile depend on. A slow
+    /// worker (well past what a live-preset deadline would allow) still completes.
+    #[test]
+    fn default_gen_options_do_not_timeout() {
+        // The default preset requests no wall-clock bound...
+        assert!(GenOptions::default().timeout.is_none());
+
+        // ...and the None branch executes inline on the caller's thread (no worker, no deadline):
+        // a 200 ms "generation" — 4× the 50 ms deadline the timeout test uses — returns Ok.
+        let caller = std::thread::current().id();
+        let res = run_bounded(None, move || {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            Ok(std::thread::current().id())
+        });
+        match res {
+            Ok(id) => assert_eq!(
+                id, caller,
+                "the unbounded path must run on the current thread (no timeout worker)"
+            ),
+            Err(e) => panic!("the unbounded path must never time out, got {e:?}"),
+        }
+
+        // The Some branch still delegates to the timeout wrapper: a deadline miss is Unavailable.
+        let bounded: Result<u32> = run_bounded(Some(std::time::Duration::from_millis(50)), || {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            Ok(1)
+        });
+        assert!(
+            matches!(bounded, Err(AppError::Unavailable(_))),
+            "a Some(timeout) must still bound the work, got {bounded:?}"
+        );
+    }
+
+    /// Brain v2 P0.3 — worker-panic safety: a panicking worker drops the channel sender, which
+    /// surfaces as a graceful `Err` (never a hang until the deadline, never a propagated panic).
+    #[test]
+    fn run_with_timeout_surfaces_worker_panic_as_err() {
+        let res: Result<u32> = run_with_timeout(std::time::Duration::from_secs(5), || {
+            panic!("worker exploded")
+        });
+        assert!(
+            matches!(res, Err(AppError::Summarize(_))),
+            "a worker panic must become a graceful Err, got {res:?}"
+        );
     }
 
     /// The best-effort `available_ram_bytes` probe is crash-safe: it returns EITHER `Some(>0)` on a

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -177,6 +177,18 @@ pub struct AppState {
     /// Prevents the same contradiction re-emitting every ~21 s scan (and re-inflating the shadow count)
     /// — the "does not resurface this session" contract (deep-review). Cleared at each `start_recording`.
     pub reactions_emitted: Mutex<std::collections::HashSet<String>>,
+    /// Brain v2 P0.3 — per-meeting IN-FLIGHT assistant-turn counter: how many assistant turns are
+    /// currently running for each scope meeting (key = the FE-sent meeting id, "" for the unscoped
+    /// voice/wake path). `spawn_assistant_turn` DEDUPS on it: a second turn for the same key while one
+    /// is in flight is dropped (the overlapping-wake / double-click pile-up guard), so at most one
+    /// generation per scope contends for Metal at a time. Keys are OPAQUE meeting ids — no PII.
+    /// Incremented via `try_begin_turn`, decremented by the turn's panic-safe RAII guard.
+    pub in_flight_turns: Mutex<std::collections::HashMap<String, u32>>,
+    /// Brain v2 P0.3 — USER-TURN PRIORITY flag: `true` while ANY user-initiated assistant turn is in
+    /// flight (set at turn start, cleared by the same RAII guard on every exit path incl. panic). The
+    /// background Realtime-Reactions scan checks it and DEFERS its light-model extraction, so a
+    /// user-facing answer never competes with a background scan for the on-device engine. No PII.
+    pub user_turn_in_progress: std::sync::atomic::AtomicBool,
     /// Folder ids unlocked in the current session: sealed folders decrypted for in-app view +
     /// MCP until relock (cleared on screen-share start or app exit). Arc so the MCP server
     /// thread shares the SAME set as the command surface.
@@ -283,6 +295,8 @@ impl AppState {
             capped_notified: AtomicBool::new(false),
             reactions_shadow_count: AtomicU64::new(0),
             reactions_emitted: Mutex::new(std::collections::HashSet::new()),
+            in_flight_turns: Mutex::new(std::collections::HashMap::new()),
+            user_turn_in_progress: AtomicBool::new(false),
             unlocked_folders: Arc::new(Mutex::new(std::collections::HashSet::new())),
             master_kek: Mutex::new(None),
             account_session: Mutex::new(None),

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -249,6 +249,16 @@ pub trait NameRedactor: Send + Sync {
     /// Scrub personal names out of `text`. Returns `(scrubbed_text, token→name pairs)`, where each
     /// token is a placeholder to be restored verbatim in the provider's reply.
     fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>);
+
+    /// `true` ONLY for the dependency-free no-op fallback ([`NoopNameRedactor`]) — i.e. NO real NER
+    /// model is active and names pass through UNCHANGED. The vault-title filter in
+    /// [`RedactingProvider::summarize_with_meta`] keys its conservative SYNTACTIC person-name
+    /// fallback ([`title_looks_like_person_name`]) on this, so person-page titles are still dropped
+    /// on installs without the NER model (Brain v2 P0.1). Default `false`: every REAL redactor
+    /// (DeBERTa NER, test fixtures) keeps the unchanged NER-detector path.
+    fn is_noop(&self) -> bool {
+        false
+    }
 }
 
 /// Default name redactor: a NO-OP. Returns the text unchanged and an empty map, so names egress
@@ -262,6 +272,109 @@ impl NameRedactor for NoopNameRedactor {
     fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>) {
         (text.to_string(), Vec::new())
     }
+
+    /// The one redactor that detects NOTHING — the vault-title filter compensates with the
+    /// syntactic person-name fallback (see [`NameRedactor::is_noop`]).
+    fn is_noop(&self) -> bool {
+        true
+    }
+}
+
+// ── P0.1 (Brain v2) — the NO-NER person-name title fallback ─────────────────────────────────────
+
+/// Words (case-insensitive) that mark a vault title as a MEETING-SHAPED title, not a person page.
+/// Any title containing one of these is NEVER treated as a person name by
+/// [`title_looks_like_person_name`] — the false-positive guard for the syntactic fallback.
+/// EN + PL, matching the languages Murmur serves. Extend from observed dev false-positives
+/// (conservative-ship decision, spec §P0.1).
+const COMMON_TITLE_WORDS: &[&str] = &[
+    // EN
+    "meeting",
+    "notes",
+    "call",
+    "sync",
+    "review",
+    "planning",
+    "standup",
+    "retrospective",
+    "sprint",
+    "kickoff",
+    "workshop",
+    "demo",
+    "interview",
+    "briefing",
+    "agenda",
+    "project",
+    "roadmap",
+    "update",
+    "weekly",
+    "daily",
+    "monthly",
+    // PL
+    "spotkanie",
+    "notatki",
+    "raport",
+    "przegląd",
+    "planowanie",
+    "synchronizacja",
+    "projekt",
+    "tygodniowy",
+    "aktualizacja",
+];
+
+/// Conservative SYNTACTIC detector for a vault title that is (very likely) a bare PERSON NAME —
+/// the shape of an auto-created `[[Anna Kowalska]].md` person page. Active ONLY as the vault-title
+/// egress fallback when the real NER model is absent ([`NameRedactor::is_noop`]); with the model
+/// present the NER detector governs, unchanged.
+///
+/// A title "looks like a person name" iff ALL hold:
+/// - 2–4 whitespace-separated words (a single word or a long phrase is not a name shape);
+/// - every word is name-like: starts uppercase, contains NO digits, uses only alphabetic chars
+///   plus internal hyphens/apostrophes ("Anne-Marie", "O'Brien"), and is NOT an all-uppercase
+///   acronym ("OKR", "CI");
+/// - NO word (case-insensitive) is on the [`COMMON_TITLE_WORDS`] blocklist ("Meeting Notes",
+///   "Atlas Project", "Spotkanie Zarządu" are titles, not people).
+///
+/// Deliberately conservative: a false POSITIVE only drops a `[[wikilink]]` target from the prompt
+/// (never content); a false NEGATIVE leaks a name — so the blocklist errs toward dropping.
+/// Unicode-aware (`char::is_uppercase` / `is_alphabetic`), so Polish diacritics work.
+pub(crate) fn title_looks_like_person_name(title: &str) -> bool {
+    let words: Vec<&str> = title.split_whitespace().collect();
+    if words.len() < 2 || words.len() > 4 {
+        return false;
+    }
+    for word in &words {
+        if COMMON_TITLE_WORDS.contains(&word.to_lowercase().as_str()) {
+            return false; // a known title word ⇒ this is a meeting-shaped title, not a person.
+        }
+        if !word_is_name_like(word) {
+            return false;
+        }
+    }
+    true
+}
+
+/// One word of a person-name shape: uppercase-first, digit-free, alphabetic (with internal
+/// hyphen/apostrophe), and not an all-caps acronym. See [`title_looks_like_person_name`].
+fn word_is_name_like(word: &str) -> bool {
+    let Some(first) = word.chars().next() else {
+        return false;
+    };
+    if !first.is_uppercase() {
+        return false;
+    }
+    if !word
+        .chars()
+        .all(|c| c.is_alphabetic() || c == '-' || c == '\'' || c == '\u{2019}')
+    {
+        return false; // digits or punctuation ("Q3", "Offer:", "R&D") ⇒ not a name word.
+    }
+    // Reject an ALL-CAPS acronym ("OKR", "CI") — every alphabetic char uppercase, len ≥ 2.
+    let alpha: Vec<char> = word.chars().filter(|c| c.is_alphabetic()).collect();
+    if alpha.len() >= 2 && alpha.iter().all(|c| c.is_uppercase()) {
+        return false;
+    }
+    true
 }
 
 /// Restore name placeholders produced by a [`NameRedactor`] back to the original names. Disjoint
@@ -443,7 +556,9 @@ impl SummarizerProvider for RedactingProvider {
     ///   instruction/label strings).
     /// - `vault_titles` (the `[[wikilink]]` target list embedded in `render_user_content`, incl.
     ///   auto-created `[[Person Name]].md` pages) — FILTERED: any title the firewall would alter
-    ///   is DROPPED before egress (design B — see the inline rationale below).
+    ///   is DROPPED before egress (design B — see the inline rationale below). With NO NER model
+    ///   installed the conservative syntactic fallback [`title_looks_like_person_name`] drops
+    ///   bare person-name titles too (Brain v2 P0.1).
     /// - `meta.date_iso`, `meta.language`, `meta.duration_s` — deliberately UN-scrubbed non-PII
     ///   format flags (an ISO date / language code / integer; scrubbing a date would false-positive
     ///   as a PHONE and garble the note). Any NEW string field MUST be classified here and is
@@ -513,6 +628,13 @@ impl SummarizerProvider for RedactingProvider {
         // The predicate uses standalone `redact` + the active name layer purely as DETECTORS (their
         // scrubbed output is discarded — no title tokens enter the shared restore map). A clean vault
         // (no PII in any title) is byte-identical: every title survives the filter unchanged.
+        //
+        // P0.1 (Brain v2) — the NO-NER fallback: when the active name layer is the no-op (no NER
+        // model on this install), the NER detector below flags NOTHING, so an auto-created
+        // `[[Anna Kowalska]].md` person page would egress verbatim. The conservative SYNTACTIC
+        // detector `title_looks_like_person_name` covers that gap — active ONLY under the no-op, so
+        // model-present installs keep the unchanged NER behavior.
+        let noop_ner = self.names.is_noop();
         let red_titles: Vec<String> = req
             .vault_titles
             .iter()
@@ -521,6 +643,9 @@ impl SummarizerProvider for RedactingProvider {
                 let (regex_scrubbed, _) = redact(title);
                 if regex_scrubbed.as_str() != title {
                     return false; // an email/card/phone in the title → drop it
+                }
+                if noop_ner && title_looks_like_person_name(title) {
+                    return false; // no NER model → syntactic person-name fallback drops it
                 }
                 let (name_scrubbed, name_hits) = self.names.redact_names(title);
                 // a PERSON detected in the title → drop it (only fires when a NER model is present)
@@ -1478,6 +1603,80 @@ mod tests {
         );
     }
 
+    /// P0.1 (Brain v2) — the NO-NER person-name fallback. On an install WITHOUT the NER model the
+    /// active name layer is the [`NoopNameRedactor`] (`name_hits` always empty), so an auto-created
+    /// `[[Anna Kowalska]].md` person page rode `vault_titles` to the cloud VERBATIM — the exact
+    /// side-channel the NER title filter closes on model-present installs. The fix is a conservative
+    /// SYNTACTIC fallback ([`title_looks_like_person_name`]) active ONLY when the name layer is the
+    /// no-op: a Title-Case 2–4-word, digit-free, non-blocklisted title is dropped before egress.
+    ///
+    /// RED-before-GREEN: on the unpatched code this test FAILED — "Anna Kowalska" reached the inner
+    /// provider (the no-op detector flags nothing). Confirmed failing before the fix.
+    #[test]
+    fn person_name_title_is_dropped_when_no_ner_model_present() {
+        let mut req = sample_req("no PII in transcript");
+        req.vault_titles = vec![
+            "Anna Kowalska".to_string(), // person-page stem → MUST be dropped under the no-op NER
+            "Meeting Notes".to_string(), // blocklisted common title words → survives
+            "Q3 OKRs".to_string(),       // digits/acronym → survives
+        ];
+        let inner = std::sync::Arc::new(CapturingInner(std::sync::Mutex::new(None)));
+        // The PRODUCTION no-model shape: the explicit NoopNameRedactor (what `active_name_redactor`
+        // returns when the NER model is absent).
+        let provider =
+            RedactingProvider::with_name_redactor(inner.clone(), Arc::new(NoopNameRedactor));
+        block_on(provider.summarize(&req)).unwrap();
+        let egressed = inner.0.lock().unwrap().clone().expect("inner was called");
+        assert!(
+            !egressed.vault_titles.iter().any(|t| t == "Anna Kowalska"),
+            "a person-name title must NOT egress when no NER model is present: {:?}",
+            egressed.vault_titles
+        );
+        assert!(
+            egressed.vault_titles.iter().any(|t| t == "Meeting Notes"),
+            "a common-words title must survive as a link target: {:?}",
+            egressed.vault_titles
+        );
+        assert!(
+            egressed.vault_titles.iter().any(|t| t == "Q3 OKRs"),
+            "a digit/acronym title must survive as a link target: {:?}",
+            egressed.vault_titles
+        );
+        // The rendered egress surface carries no trace of the person name either.
+        let egress = rendered_egress(&egressed);
+        assert!(
+            !egress.contains("Anna Kowalska"),
+            "the person name must not appear anywhere in the egressed content: {egress}"
+        );
+    }
+
+    /// P0.1 — the conservative syntactic person-name predicate, tested directly. Positives are the
+    /// bare person-page shapes; negatives cover blocklisted title words, digits, acronyms, single
+    /// words, lowercase words, and long phrases.
+    #[test]
+    fn title_looks_like_person_name_predicate() {
+        // POSITIVE — person-page shapes (2–4 Title-Case, digit-free, non-blocklisted words).
+        assert!(title_looks_like_person_name("Anna Kowalska"));
+        assert!(title_looks_like_person_name("Jan Maria Rokita"));
+        assert!(title_looks_like_person_name("Anne-Marie O'Brien")); // internal hyphen/apostrophe
+        assert!(title_looks_like_person_name("Łukasz Gawroński")); // Unicode uppercase + diacritics
+
+        // NEGATIVE — meeting-shaped / non-name titles must survive the filter.
+        assert!(!title_looks_like_person_name("Meeting Notes")); // EN blocklist
+        assert!(!title_looks_like_person_name("Spotkanie Zarządu")); // PL blocklist
+        assert!(!title_looks_like_person_name("Przegląd Kwartalny")); // PL blocklist (diacritics)
+        assert!(!title_looks_like_person_name("Q3 OKRs")); // digit word
+        assert!(!title_looks_like_person_name("Atlas Project")); // blocklisted "project"
+        assert!(!title_looks_like_person_name("Budget 2026")); // digits
+        assert!(!title_looks_like_person_name("Anna")); // single word
+        assert!(!title_looks_like_person_name("CI CD Pipeline")); // all-caps acronyms
+        assert!(!title_looks_like_person_name("Clean retained title")); // lowercase words
+        assert!(!title_looks_like_person_name(
+            "Five Word Long Phrase Here"
+        )); // > 4 words
+        assert!(!title_looks_like_person_name("")); // empty
+    }
+
     /// DEFENSE-IN-DEPTH: a user-authored custom `template` (rides the SYSTEM prompt) and
     /// `meta.title_hint` (rides `render_user_content`) previously carried any email/card/phone the
     /// user typed straight past the firewall inside `req.clone()`. Both are now scrubbed through the
@@ -1536,7 +1735,11 @@ mod tests {
             template: "recipe s-template@leak.example".to_string(), // SCRUBBED (regex, system prompt)
             vault_titles: vec![
                 "Offer - s-title@leak.example".to_string(), // SCRUBBED (design B filter → dropped)
-                "Clean Retained Title".to_string(),         // control: a clean title must survive
+                // Control: a clean title must survive. NOT Title-Case-throughout on purpose — a
+                // 2–4-word all-Title-Case title now trips the P0.1 no-NER person-name fallback
+                // (this test runs the production no-op name layer), which would be CORRECT
+                // filtering, not a leak; the control pins that ordinary titles still pass.
+                "Clean retained title".to_string(),
             ],
             related_context: Some("s-related@leak.example".to_string()), // SCRUBBED (regex + NER)
             user_notes: Some("s-notes@leak.example".to_string()),        // SCRUBBED (regex + NER)
@@ -1570,7 +1773,7 @@ mod tests {
         );
         // A clean vault title must NOT be over-filtered.
         assert!(
-            egress.contains("Clean Retained Title"),
+            egress.contains("Clean retained title"),
             "clean titles must survive the filter as valid link targets"
         );
     }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -435,15 +435,113 @@ pub(crate) fn resolve_scope_meeting(
 /// The brain + tools can take seconds, so it MUST run off-thread; the whole body is best-effort +
 /// panic-free and runs on its own thread, so even an unexpected panic is contained and can never
 /// disrupt recording or the caption.
+///
+/// Brain v2 P0.3 — IN-FLIGHT DEDUP + USER-TURN PRIORITY:
+/// - At most ONE turn per scope key (the FE-sent `meeting_id`, "" for the voice/wake path) runs at a
+///   time. A second spawn while one is in flight is DROPPED ([`try_begin_turn`]) — the overlapping-
+///   wake / double-click pile-up guard, so duplicate turns never stack generations on Metal. The
+///   already-running turn still resolves the FE's pending card via `EVENT_VOICE_ACTION_RESULT`.
+/// - While the turn runs, `AppState::user_turn_in_progress` is `true` so the background
+///   Realtime-Reactions scan defers. Both the per-key decrement and the flag reset are guaranteed on
+///   EVERY exit path (including a panic inside the turn, and a failed thread spawn) by the RAII
+///   [`TurnGuard`] moved into the worker closure.
 pub fn spawn_assistant_turn(
     app: AppHandle,
     command: String,
     thread_id: Option<String>,
     meeting_id: Option<String>,
 ) {
+    // Scope key = the FE-sent meeting id (matching how the turn scopes itself); the voice/wake twin
+    // sends none → the shared "" key. Opaque id only — no PII.
+    let key = meeting_id
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .to_string();
+    {
+        let state = app.state::<AppState>();
+        if !try_begin_turn(&state.in_flight_turns, &key) {
+            // NO PII: no command text, no id content — just the dedup decision.
+            tracing::debug!(target: "voice", "turn dedup: turn already in flight; dropping");
+            return;
+        }
+    }
+    // The guard is created NOW and moved into the closure: if the spawn itself fails, the closure
+    // (and the guard inside it) is dropped → the counter is decremented and the flag cleared, so a
+    // failed spawn can never wedge the dedup registry.
+    let guard = TurnGuard {
+        app: app.clone(),
+        key,
+    };
     let _ = std::thread::Builder::new()
         .name("murmur-assistant-turn".into())
-        .spawn(move || run_assistant_turn(&app, command, thread_id, meeting_id));
+        .spawn(move || {
+            let _guard = guard; // held for the WHOLE turn; Drop runs on every exit incl. panic.
+            _guard
+                .app
+                .state::<AppState>()
+                .user_turn_in_progress
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            run_assistant_turn(&app, command, thread_id, meeting_id)
+        });
+}
+
+/// Brain v2 P0.3 — the PURE in-flight registry decision: begin a turn for `key` unless one is
+/// already in flight. Returns `true` (and increments the counter) when the caller may proceed;
+/// `false` when a turn for the same key is already running (the caller drops the duplicate). A
+/// poisoned lock is recovered via `into_inner` — the map is a plain counter registry, always valid.
+/// Factored off `AppHandle` so the dedup contract is headless-testable.
+pub(crate) fn try_begin_turn(
+    registry: &std::sync::Mutex<std::collections::HashMap<String, u32>>,
+    key: &str,
+) -> bool {
+    let mut map = match registry.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let count = map.entry(key.to_string()).or_insert(0);
+    if *count > 0 {
+        return false;
+    }
+    *count += 1;
+    true
+}
+
+/// Brain v2 P0.3 — end a turn for `key`: decrement its in-flight count (saturating) and drop the
+/// entry at zero so the registry never grows unboundedly across meetings. Counterpart of
+/// [`try_begin_turn`]; called from [`TurnGuard::drop`] (and directly by tests).
+pub(crate) fn end_turn(
+    registry: &std::sync::Mutex<std::collections::HashMap<String, u32>>,
+    key: &str,
+) {
+    let mut map = match registry.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    if let Some(count) = map.get_mut(key) {
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            map.remove(key);
+        }
+    }
+}
+
+/// RAII guard for ONE assistant turn (Brain v2 P0.3): on drop — normal return, early return, panic
+/// inside the turn, or a failed thread spawn — it clears the user-turn priority flag and decrements
+/// the per-key in-flight counter. Mirrors the panic-safe `BusyReset` pattern of the reactions worker
+/// (see `run`), so a wedged flag/counter can never silently kill all further turns or scans.
+struct TurnGuard {
+    app: AppHandle,
+    key: String,
+}
+impl Drop for TurnGuard {
+    fn drop(&mut self) {
+        let state = self.app.state::<AppState>();
+        state
+            .user_turn_in_progress
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        end_turn(&state.in_flight_turns, &self.key);
+    }
 }
 
 /// The CARD path (wake / manual button / single-shot text composer): run the shared query core, then
@@ -929,6 +1027,9 @@ fn run_cascade(
             &executor,
             max_steps,
             Some(&sink as &dyn crate::agent::DeltaSink),
+            // P0.3: the LIVE preset — a 1024-token cap (+ the GGUF 30 s wall-clock timeout) so a
+            // runaway on-device decode can't saturate Metal mid-recording. No-op on stub/cloud.
+            crate::reason::GenOptions::live_answer(),
         ) {
             Ok(Some(outcome)) => {
                 // ESCALATION vs a REAL answer. `is_escalation` matches the WHOLE answer (never a
@@ -1670,6 +1771,54 @@ fn assistant_system_prompt(
 mod tests {
     use super::*;
     use crate::audio::wake::VoiceIntent;
+
+    // ── Brain v2 P0.3: in-flight assistant-turn dedup registry ────────────────────────────────────
+
+    /// The dedup contract of `spawn_assistant_turn` (headless — the registry helpers off `AppHandle`):
+    /// the FIRST begin for a key wins; a SECOND begin for the SAME key while in flight is refused;
+    /// after the turn ends (the guard's decrement) the key begins again. RED before P0.3:
+    /// `try_begin_turn` did not exist — overlapping wakes stacked concurrent generations.
+    #[test]
+    fn turn_dedup_refuses_second_in_flight_then_allows_after_end() {
+        let registry = std::sync::Mutex::new(std::collections::HashMap::new());
+        assert!(try_begin_turn(&registry, "m1"), "first begin must proceed");
+        assert!(
+            !try_begin_turn(&registry, "m1"),
+            "a second turn for the same key while one is in flight must be dropped"
+        );
+        end_turn(&registry, "m1");
+        assert!(
+            try_begin_turn(&registry, "m1"),
+            "after the in-flight turn ends the key must begin again"
+        );
+        end_turn(&registry, "m1");
+        assert!(
+            registry.lock().unwrap().is_empty(),
+            "a fully-ended key is removed — the registry never grows across meetings"
+        );
+    }
+
+    /// Dedup is PER KEY: a turn scoped to a different meeting (or the unscoped "" voice key) is NOT
+    /// blocked by another meeting's in-flight turn. And ending a never-begun / already-ended key is a
+    /// harmless no-op (never an underflow/panic).
+    #[test]
+    fn turn_dedup_is_per_key_and_end_is_saturating() {
+        let registry = std::sync::Mutex::new(std::collections::HashMap::new());
+        assert!(try_begin_turn(&registry, "m1"));
+        assert!(
+            try_begin_turn(&registry, "m2"),
+            "a different meeting's turn must not be blocked"
+        );
+        assert!(
+            try_begin_turn(&registry, ""),
+            "the unscoped voice/wake key is independent too"
+        );
+        // Ending an unknown key / double-ending never panics or underflows.
+        end_turn(&registry, "never-began");
+        end_turn(&registry, "m1");
+        end_turn(&registry, "m1"); // double end — saturating no-op
+        assert!(try_begin_turn(&registry, "m1"), "m1 is free again");
+    }
 
     // ── PR D thread identity: backend UUID fallback + thread-stamped trace payloads ───────────────
 

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 
 use crate::audio::wake::VoiceIntent;
 use crate::error::AppError;
-use crate::reason::LocalReasoner;
+use crate::reason::{GenOptions, LocalReasoner};
 use crate::settings::AppConfig;
 use crate::storage::Db;
 use crate::tools::{execute_tool, ToolCall};
@@ -670,7 +670,9 @@ pub(crate) fn answer_current_meeting_isolated(
             "User's request (their own words): {}\n\nSentence to translate: {english}",
             literal_command.trim()
         );
-        let summary = match reasoner.reason(system, &user) {
+        // P0.3: a LIVE user-facing answer rides the live preset (capped decode; the GGUF path also
+        // gets the 30 s wall-clock timeout). Best-effort no-op on stub/cloud reasoners.
+        let summary = match reasoner.reason_with(system, &user, GenOptions::live_answer()) {
             Ok(a) if !a.trim().is_empty() => a.trim().to_string(),
             // Any failure (incl. no-consent Unavailable) ⇒ the honest English notice, never a
             // fan-out. The user still gets a truthful, non-leaking answer.
@@ -716,7 +718,8 @@ pub(crate) fn answer_current_meeting_isolated(
         "User's request (their own words): {}\n\nThe meeting's transcript and the user's notes:\n{content}",
         literal_command.trim()
     );
-    match reasoner.reason(system, &user) {
+    // P0.3: LIVE answer preset — bounded decode so the isolated Tier-1 synthesis can't run away.
+    match reasoner.reason_with(system, &user, GenOptions::live_answer()) {
         Ok(answer) if !answer.trim().is_empty() => VoiceActionResult {
             intent_kind: intent_kind.to_string(),
             status: "ok".to_string(),
@@ -1103,7 +1106,8 @@ fn rag_answer(
 
     // EGRESS SEAM: a Cloud reasoner routes through make_provider (consent gate + RedactingProvider).
     // A no-consent refusal comes back as AppError::Unavailable → graceful "needs consent", no leak.
-    match reasoner.reason(&system, &user) {
+    // P0.3: the floor's user-facing synthesis is a LIVE answer — ride the live (capped) preset.
+    match reasoner.reason_with(&system, &user, GenOptions::live_answer()) {
         Ok(answer) => {
             let answer = answer.trim();
             let summary = if answer.is_empty() {
@@ -1630,9 +1634,17 @@ mod tests {
                 .into(),
             ),
         };
-        let outcome = run_agentic_loop(&brain, "sys", "what are the secret terms?", &exec, 5, None)
-            .unwrap()
-            .expect("the brain answered");
+        let outcome = run_agentic_loop(
+            &brain,
+            "sys",
+            "what are the secret terms?",
+            &exec,
+            5,
+            None,
+            crate::reason::GenOptions::default(),
+        )
+        .unwrap()
+        .expect("the brain answered");
         assert!(
             !outcome
                 .citations
@@ -1752,6 +1764,68 @@ mod tests {
             !res.citations.iter().any(|c| c.contains("Secret")),
             "SEALED meeting must NOT be cited on the stub floor: {:?}",
             res.citations
+        );
+    }
+
+    /// P0.2 (Brain v2) — the stub-echo guard, pinned END-TO-END on both deterministic-floor answer
+    /// paths `run_informational` dispatches to (the fan-out floor via `handle_voice_action` and the
+    /// Tier-1 isolated current-meeting answer). With the StubReasoner (brain Off / no GGUF), the
+    /// user-facing summary must (a) NEVER carry the `[stub-reason]` diagnostic echo and (b) point
+    /// the user at Settings so they know how to enable a real brain.
+    ///
+    /// HONEST RED/GREEN NOTE: this test was run BEFORE any P0 change and already PASSED — the
+    /// per-call-site guards shipped in #172 ("don't surface StubReasoner echo") and the 0.8.0
+    /// cascade work already cover every `reason()` call on the floor. It is kept as the regression
+    /// pin for the P0.2 invariant rather than a RED-first bug capture.
+    #[test]
+    fn stub_floor_hints_settings_and_never_echoes_stub() {
+        // 1) The fan-out floor over a seeded vault (non-empty grounding → the synthesis point).
+        let db = tmp_db();
+        seed_visible_and_sealed(&db);
+        let stub = crate::reason::StubReasoner;
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &stub,
+            &db,
+            &empty_unlocked(),
+            &AppConfig::default(),
+            "live-mtg",
+            "",
+            "",
+            false,
+            None,
+        );
+        assert!(
+            !res.summary.contains("[stub-reason]"),
+            "the stub echo must never surface on the fan-out floor: {}",
+            res.summary
+        );
+        assert!(
+            res.summary.contains("Settings"),
+            "the no-model notice must point at Settings: {}",
+            res.summary
+        );
+
+        // 2) The Tier-1 isolated current-meeting answer with content present.
+        let res2 = answer_current_meeting_isolated(
+            "research",
+            "o czym to spotkanie",
+            "Transcript:\n[0s] Budget approved.",
+            true,
+            Some("Budget Review"),
+            &stub,
+        );
+        assert!(
+            !res2.summary.contains("[stub-reason]"),
+            "the stub echo must never surface on the Tier-1 isolated answer: {}",
+            res2.summary
+        );
+        assert!(
+            res2.summary.contains("Settings"),
+            "the Tier-1 no-model notice must point at Settings: {}",
+            res2.summary
         );
     }
 


### PR DESCRIPTION
Brain v2 PR 1 of the phased plan in `docs/research/2026-07-09-brain-v2-architecture-spec.md` (analysis: `2026-07-09-brain-v2-architecture.md`, both included here).

## P0.1 — vault_titles person-name egress fallback (`summarize/redact.rs`)
The NER title filter only works when the DeBERTa model is downloaded; on no-model installs `NoopNameRedactor` passed person-name titles (auto-created `[[Person Name]].md` pages) to cloud providers. New conservative `title_looks_like_person_name` heuristic (2–4 Title-Case words, PL+EN meeting-word blocklist) fires **only** when the name redactor `is_noop()`. Drop-only: a false positive costs a wikilink target, never content. NER-present behavior byte-unchanged. RED-first test.

## P0.2 — stub-echo guard (regression pin)
Audit found the per-call-site `id()=="stub"` guards from #172 already cover every floor `reason()` call; the adversarial pass hunted a counterexample and found none. Pinned with an end-to-end regression test (`stub_floor_hints_settings_and_never_echoes_stub`) so the invariant can't silently regress.

## P0.3 — live-path resource discipline
- `GenOptions::live_answer()` (1024 tok) / `ask_answer()` (2048) threaded through `run_agentic_loop` and the floor synthesis calls.
- Opt-in wall-clock timeout via `GenOptions.timeout`: live/ask/light presets carry 30s (leak-the-worker — mistralrs generations are uncancellable); `default()` = unbounded, so FullyLocal note generation and the Ask floor are untouched.
- Per-meeting in-flight assistant-turn dedup (`AppState.in_flight_turns` + panic-safe RAII guard).
- Reactions scans defer while a user turn is in flight (`user_turn_in_progress`).

## Verification
- Adversarial-verifier: initial **FAIL** (blanket 30s timeout would regress FullyLocal note-gen 30–90s, Ask-floor 200k prefill, first-gen Metal shader compile) → fixed by scoping the timeout into `GenOptions` → re-verified **PASS**.
- Lock-security-reviewer: **PASS** — title filter is drop-only, no gate lost, no PII in new logs, leaked timeout worker's result provably unreachable.
- `cargo test --lib`: 1182 passed / 0 failed. `scripts/ci.sh`: ✅ all gates green (clippy -D warnings, lint, build, headless E2E).

## Known limitations (documented, spec-conformant)
- `user_turn_in_progress` is a single bool — overlapping differently-keyed turns can end the reactions deferral early.
- Wake-word turns (key `""`) and FE-scoped turns don't dedup against each other.
- No-NER heuristic misses lowercase/particle names ("jan de vries") — follow-up candidate: also apply it when the NER layer signals a degraded pass.
- Real 30s-timeout firing, Metal contention relief, and first-gen shader-compile behavior need a real Mac with models present.