### PR TITLE
feat(brain): L1 retrieval — topic indexing, augmentation, score fusion, temporal expansion, reranker seam

### DIFF
--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -134,3 +134,9 @@
 - **Caught by:** adversarial-verifier (`.claude/tmp/brain-p0-hotfixes/adversarial-verify.json`, MAJOR) — builder's tests were green; the regression was on paths the new tests didn't cover.
 - **Lesson:** carry per-call bounds IN the options struct (`GenOptions.timeout: Option<Duration>`, default None = old behavior; presets opt in), never as a blanket const at the lowest layer. Before bounding a shared seam, enumerate every caller class (live / notes / floor / background extraction) and ask which of them legitimately exceeds the bound.
 - **Status:** journal
+
+### [2026-07-10 brain-l1-retrieval] MSRV-gated std items: no `LazyLock` — use the repo's `OnceLock` accessor pattern
+- **Pattern:** new module used `std::sync::LazyLock` for static regexes; `cargo test --lib` was green but the ci.sh clippy `-D warnings` stage failed with 36 MSRV errors (`LazyLock` stable since 1.80, crate MSRV 1.77).
+- **Caught by:** scripts/ci.sh clippy stage (and initially MASKED by piping ci.sh through `| tail` — the pipe's exit code hid the failure; always capture ci.sh exit directly).
+- **Lesson:** for lazy statics use the established repo pattern — `fn re_x() -> &'static Regex { static R: OnceLock<Regex> = OnceLock::new(); R.get_or_init(|| ...) }` (see redact.rs email_re). Check clippy.toml/Cargo.toml MSRV before reaching for newer std items.
+- **Status:** journal

--- a/eval/results/rag-bakeoff-latest.md
+++ b/eval/results/rag-bakeoff-latest.md
@@ -1,0 +1,14 @@
+# RAG bake-off
+
+- date: 2026-07-10
+- commit: 2f5eae1-dirty
+- corpus: synthetic (eval::corpus, 16 seeded meetings, anchor 2026-06-29)
+- labeled set: src-tauri/src/eval/fixtures/rag-bakeoff-synthetic.json (20 queries, k=5)
+- config: score_fuse 0.4/0.4/0.2 + topic legs + temporal filter (RRF_K=60 fallback)
+- embedder: multilingual-e5-small (REAL model — semantic/hybrid rows are a genuine quality signal)
+
+| mode | recall@5 | ndcg@5 | mrr |
+|---|---:|---:|---:|
+| fts | 0.4500 | 0.4500 | 0.4500 |
+| semantic | 0.8417 | 0.7020 | 0.6801 |
+| hybrid | 0.9000 | 0.8250 | 0.8146 |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,8 +8,7 @@ use crate::events::{StatusPayload, EVENT_STATUS};
 use crate::settings::{AppConfig, BrainBackend};
 use crate::state::AppState;
 use crate::storage::models::{
-    ActionItem, Analytics, AskVaultResult, BrainOverview, BuiltinRecipe,
-    CalendarContext,
+    ActionItem, Analytics, AskVaultResult, BrainOverview, BuiltinRecipe, CalendarContext,
     CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, DocumentInfo,
     EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus, MeetingTimeline,
     NoteRecord, PersonCard, PinResult, RecipeRecord, SearchHit, TopicThread,
@@ -657,11 +656,7 @@ pub async fn stop_recording(
     // A POISONED `spill_writer` mutex (`.lock().ok()` ⇒ None) merely DEFERS this clean-stop cleanup:
     // the spill lingers to next launch, where `claim_inflight` sees the row is no longer RECORDING and
     // DiscardOrphans it — benign (no leak, no content loss), so tolerating the poison here is correct.
-    let _spill_guard = state
-        .spill_writer
-        .lock()
-        .ok()
-        .and_then(|mut s| s.take());
+    let _spill_guard = state.spill_writer.lock().ok().and_then(|mut s| s.take());
 
     // The recording is definitively over — clear the accumulated live-caption buffer NOW so a
     // stale tail can never be injected into assistant prompts after Stop (nor keep egressing once
@@ -1671,10 +1666,7 @@ pub(crate) fn link_related_notes_inner(state: &AppState, meeting_id: &str) -> Re
 /// pass; this command lets the user (or a backfill over old notes) re-run it on demand. Lock-gated +
 /// seal-safe (a sealed meeting is a silent no-op) and ZERO egress.
 #[tauri::command]
-pub fn link_related_notes(
-    state: State<'_, AppState>,
-    meeting_id: String,
-) -> Result<(), AppError> {
+pub fn link_related_notes(state: State<'_, AppState>, meeting_id: String) -> Result<(), AppError> {
     link_related_notes_inner(state.inner(), &meeting_id)
 }
 
@@ -3064,7 +3056,8 @@ pub(crate) fn preview_supersessions_inner(
         };
         // The superseding meeting is now known-unlocked, so its title is safe to surface (`None` only
         // when it was never exported to the vault).
-        let superseding_note_title = note_file_for(state, &r.superseding_meeting_id)?.map(|(_, s)| s);
+        let superseding_note_title =
+            note_file_for(state, &r.superseding_meeting_id)?.map(|(_, s)| s);
         out.push(SupersessionDto {
             id: r.id,
             entity: r.entity,
@@ -3172,9 +3165,11 @@ pub(crate) fn apply_supersessions_inner(
         // between write and mark-applied still leaves a recoverable un-stamped pre-image. `COALESCE`
         // never clobbers an already-stored pristine backup and, combined with the pristine cache, the
         // stored bytes are NEVER a re-snapshot of a stamped file.
-        state
-            .db
-            .store_supersession_pre_images(id, Some(&source_pre), superseding_pre.as_deref())?;
+        state.db.store_supersession_pre_images(
+            id,
+            Some(&source_pre),
+            superseding_pre.as_deref(),
+        )?;
 
         // Stamp the SOURCE note: append the callout to the CURRENT on-disk content (idempotent — a
         // retry over an already-stamped file is a no-op). The undo pre-image is the pristine cache
@@ -3571,6 +3566,14 @@ pub async fn ask_vault(
     // Gated cross-meeting USER MEMORY brief (parity with the @brain loop): VISIBLE facts only under
     // this same unlock snapshot, empty when memory is disabled ⇒ the floor prompt is byte-identical.
     let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked);
+    // Brain v2 L1.4 — the Ask-only reranker: resolve from the LIVE Ask-role reasoner.
+    // `active_reranker` degrades stub/cloud reasoners to the identity StubReranker (rerank is
+    // strictly on-device — a cloud reasoner would turn each pointwise judgment into egress).
+    let reranker = crate::rerank::active_reranker(
+        state
+            .reasoner
+            .current_for(crate::summarize::roles::Role::Ask),
+    );
     ask_vault_floor(
         &state.db,
         &config,
@@ -3578,6 +3581,7 @@ pub async fn ask_vault(
         &question,
         &history,
         &memory_brief,
+        Some(reranker.as_ref()),
     )
     .await
 }
@@ -3771,6 +3775,7 @@ fn build_ask_vault_floor_prompt(
     question: &str,
     history: &[ChatTurn],
     memory_brief: &str,
+    reranker: Option<&dyn crate::rerank::Reranker>,
 ) -> Result<AskFloorPrompt, AppError> {
     // Phase 2b (gated): when semantic search is ON, pick candidates by HYBRID retrieval (FTS ∪
     // vector KNN, RRF-fused) — embedding the query with the active embedder — then pack with the
@@ -3793,7 +3798,7 @@ fn build_ask_vault_floor_prompt(
             .next()
             .unwrap_or_default();
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
-            db, question, &ask_conn, &query_vec, unlocked,
+            db, question, &ask_conn, &query_vec, unlocked, reranker,
         )?
     } else {
         crate::summarize::vault_context::build_vault_context_visible(
@@ -3828,8 +3833,17 @@ async fn ask_vault_floor(
     question: &str,
     history: &[ChatTurn],
     memory_brief: &str,
+    reranker: Option<&dyn crate::rerank::Reranker>,
 ) -> Result<AskVaultResult, AppError> {
-    match build_ask_vault_floor_prompt(db, config, unlocked, question, history, memory_brief)? {
+    match build_ask_vault_floor_prompt(
+        db,
+        config,
+        unlocked,
+        question,
+        history,
+        memory_brief,
+        reranker,
+    )? {
         AskFloorPrompt::Empty(result) => Ok(result),
         AskFloorPrompt::Ready {
             system,
@@ -4020,7 +4034,7 @@ mod ask_vault_tests {
         let (want_system, want_user) =
             crate::summarize::vault_chat::build(&corpus, &history, q, "");
 
-        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "").unwrap() {
+        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None).unwrap() {
             AskFloorPrompt::Ready {
                 system,
                 user,
@@ -4051,7 +4065,7 @@ mod ask_vault_tests {
 
         // The empty-vault early return keeps the EXACT pre-change canned answer.
         let empty = tmp_db();
-        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "").unwrap() {
+        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None).unwrap() {
             AskFloorPrompt::Empty(r) => {
                 assert_eq!(
                     r.answer,
@@ -4091,6 +4105,7 @@ mod ask_vault_tests {
             "atlas?",
             &[],
             "",
+            None,
         ));
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),
@@ -5826,7 +5841,8 @@ pub(crate) fn rename_speaker_inner(
     // the still-original turns. A label with no overlapping diarized cluster (the "me" lane, or a
     // non-diarized meeting with no segments) → None → enroll nothing.
     let old_cluster = parse_others_cluster(old_label).or_else(|| {
-        reconcile_meeting_speakers(state, meeting_id, Some(&tl.speakers)).cluster_for_label(old_label)
+        reconcile_meeting_speakers(state, meeting_id, Some(&tl.speakers))
+            .cluster_for_label(old_label)
     });
 
     for turn in &mut tl.speakers {
@@ -5978,9 +5994,17 @@ pub(crate) fn suggest_speaker_labels_inner(
                 .label_for_cluster(cluster)
                 .map(str::to_string)
                 .unwrap_or_else(|| {
-                    format!("{}-{}", crate::audio::merge::SPEAKER_OTHERS, s.cluster_index)
+                    format!(
+                        "{}-{}",
+                        crate::audio::merge::SPEAKER_OTHERS,
+                        s.cluster_index
+                    )
                 });
-            SpeakerSuggestion { speaker, suggested_label: s.label, score: s.score }
+            SpeakerSuggestion {
+                speaker,
+                suggested_label: s.label,
+                score: s.score,
+            }
         })
         .collect())
 }
@@ -6012,7 +6036,11 @@ fn reconcile_meeting_speakers(
     let turns = turns.unwrap_or(&loaded);
     let turn_refs: Vec<TurnRef<'_>> = turns
         .iter()
-        .map(|t| TurnRef { start_s: t.start_s, end_s: t.end_s, label: &t.speaker })
+        .map(|t| TurnRef {
+            start_s: t.start_s,
+            end_s: t.end_s,
+            label: &t.speaker,
+        })
         .collect();
     reconcile_speakers(&segments, &turn_refs)
 }
@@ -6348,7 +6376,10 @@ pub fn brain_model_retirement_nudge(
         c.brain_model_id.clone()
     };
     let dir = crate::transcribe::models_dir()?;
-    Ok(crate::reason::retired_model_nudge(selected.as_deref(), &dir))
+    Ok(crate::reason::retired_model_nudge(
+        selected.as_deref(),
+        &dir,
+    ))
 }
 
 /// The DERIVED Murmur Brain posture (spec §2.1) for the Settings display — computed from the live
@@ -6842,6 +6873,12 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
                         if let Err(e) = db.index_meeting_chunks(&m.id, &segments, embedder) {
                             // Never abort the whole backfill on one bad note — log (no PII) and continue.
                             tracing::warn!(target: "rag", error = %e, "reindex: indexing one meeting failed (skipped)");
+                        } else if let Err(e) =
+                            db.index_meeting_topic_chunks(&m.id, &segments, embedder, unlocked)
+                        {
+                            // Brain v2 L1.1 — topic chunks follow the note/transcript index (whose
+                            // clean-replace purge covers all chunk classes). Same best-effort posture.
+                            tracing::warn!(target: "rag", error = %e, "reindex: topic indexing failed (skipped)");
                         }
                     }
                     Err(e) => {
@@ -7174,7 +7211,9 @@ fn move_into_locked_folder(
     // Mirrors `unlock_folder`'s per-meeting restore, scoped to this one moved meeting. Under the
     // lifecycle guard held for the whole move, so no relock can interleave.
     for n in &state.db.sealable_notes_for_meeting(meeting_id)? {
-        let Some(blob) = &n.content_blob else { continue };
+        let Some(blob) = &n.content_blob else {
+            continue;
+        };
         let aad = aad_content(folder_id, meeting_id, &n.provider_id, "note");
         let pt = crate::crypto::decrypt(&ck, blob, &aad)?;
         let markdown = String::from_utf8(pt)
@@ -7188,7 +7227,11 @@ fn move_into_locked_folder(
     // markdown was just restored above). Model-gated (never a stub vector); best-effort — a re-index
     // hiccup must not fail (or half-undo) the completed move.
     let meeting_embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
-    reindex_meetings_after_unseal(state, &[meeting_id.to_string()], meeting_embedder.as_deref());
+    reindex_meetings_after_unseal(
+        state,
+        &[meeting_id.to_string()],
+        meeting_embedder.as_deref(),
+    );
     Ok(())
 }
 
@@ -7576,9 +7619,7 @@ pub async fn unlock_folder(
                             crate::secrets::list_master_kek_candidates("Recover the folder key")
                         })
                         .await
-                        .map_err(|e| {
-                            AppError::Auth(format!("kek-recovery task join failed: {e}"))
-                        })?
+                        .map_err(|e| AppError::Auth(format!("kek-recovery task join failed: {e}")))?
                         .unwrap_or_else(|_| Zeroizing::new(Vec::new()));
                         match try_unwrap_ck_with_candidates(&candidates, &wrapped, &folder_id, None)
                         {
@@ -8884,6 +8925,21 @@ fn reindex_meetings_after_unseal(
         };
         if let Err(e) = state.db.index_meeting_chunks(mid, &segments, embedder) {
             tracing::warn!(target: "rag", error = %e, "meeting re-index on unlock failed (note plaintext already restored)");
+        } else {
+            // Brain v2 L1.1 — rebuild the TOPIC chunks too (the seal purged them via the shared
+            // choke point). The folder was just session-unlocked, so pass the LIVE unlock set —
+            // the visibility gate inside must see this meeting as visible.
+            let unlocked = state
+                .unlocked_folders
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_default();
+            if let Err(e) = state
+                .db
+                .index_meeting_topic_chunks(mid, &segments, embedder, &unlocked)
+            {
+                tracing::warn!(target: "rag", error = %e, "topic re-index on unlock failed (content unaffected)");
+            }
         }
     }
 }
@@ -8925,8 +8981,9 @@ fn unseal_meeting_extras(
         if let Some(blob) = &rn.blob {
             let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "manual_notes");
             let pt = crate::crypto::decrypt(ck, blob, &aad)?;
-            let text = String::from_utf8(pt)
-                .map_err(|_| AppError::Storage("decrypted manual notes is not valid UTF-8".into()))?;
+            let text = String::from_utf8(pt).map_err(|_| {
+                AppError::Storage("decrypted manual notes is not valid UTF-8".into())
+            })?;
             state.db.set_manual_notes(mid, &text)?;
         }
     }
@@ -9641,8 +9698,8 @@ pub fn account_status(state: State<'_, AppState>) -> Result<AccountStatus, AppEr
     // ("no cached account key") and the FE falls back to the password CTA. The probe result still
     // short-circuits `true` when it does find the item.
     let probe_says_cached = crate::secrets::keychain::account_mk_cached().unwrap_or(false);
-    let biometric_unlock_available = logged_in
-        && (probe_says_cached || cfg!(all(target_os = "macos", not(debug_assertions))));
+    let biometric_unlock_available =
+        logged_in && (probe_says_cached || cfg!(all(target_os = "macos", not(debug_assertions))));
     let cfg = state
         .config
         .lock()
@@ -10003,7 +10060,14 @@ pub async fn share_note_to_link(
     password: Option<String>,
     max_downloads: Option<u32>,
 ) -> Result<String, AppError> {
-    share_note_to_link_inner(state.inner(), meeting_id, expires_days, password, max_downloads).await
+    share_note_to_link_inner(
+        state.inner(),
+        meeting_id,
+        expires_days,
+        password,
+        max_downloads,
+    )
+    .await
 }
 
 /// Core of [`share_note_to_link`] over `&AppState` so the lock gate + consent gate are unit-testable
@@ -10841,7 +10905,12 @@ async fn finalize_accepted_share(
         &chrono::Utc::now().to_rfc3339(),
     )?;
     state.db.delete_pending_share_accept(share_id)?;
-    crate::share::ledger_row(&state.db, &client.host(), "share_accept", content_cell.len());
+    crate::share::ledger_row(
+        &state.db,
+        &client.host(),
+        "share_accept",
+        content_cell.len(),
+    );
     Ok(result)
 }
 
@@ -11484,14 +11553,20 @@ mod lifecycle_tests {
                 gateway_host: None,
             })
             .unwrap();
-        state.db.set_note_folder("m-vlock", Some("f-vlock")).unwrap();
+        state
+            .db
+            .set_note_folder("m-vlock", Some("f-vlock"))
+            .unwrap();
         state
             .db
             .set_folder_locked("f-vlock", true, Some(&b"wrapped"[..]))
             .unwrap();
         // NOT session-unlocked: both commands fail closed with Locked.
         let e1 = block_on(verify_note_sources_inner(&state, "m-vlock".to_string())).unwrap_err();
-        assert!(matches!(e1, AppError::Locked(_)), "verify must fail Locked, got: {e1:?}");
+        assert!(
+            matches!(e1, AppError::Locked(_)),
+            "verify must fail Locked, got: {e1:?}"
+        );
         let finding = crate::verify::VerifyFinding {
             line_no: 2,
             key: "PROJ-1".into(),
@@ -11499,9 +11574,12 @@ mod lifecycle_tests {
             detail: "PROJ-1 not found in Jira".into(),
             url: String::new(),
         };
-        let e2 =
-            apply_note_verify_markers_inner(&state, "m-vlock".to_string(), vec![finding]).unwrap_err();
-        assert!(matches!(e2, AppError::Locked(_)), "apply must fail Locked, got: {e2:?}");
+        let e2 = apply_note_verify_markers_inner(&state, "m-vlock".to_string(), vec![finding])
+            .unwrap_err();
+        assert!(
+            matches!(e2, AppError::Locked(_)),
+            "apply must fail Locked, got: {e2:?}"
+        );
 
         // Session-unlock → the lock gate passes; verify now falls to the fail-closed connector gate
         // (no Jira configured ⇒ jira_lookup NeedsConsent ⇒ Unavailable), proving Locked was the gate.
@@ -11596,7 +11674,10 @@ mod lifecycle_tests {
                 gateway_host: None,
             })
             .unwrap();
-        state.db.set_note_folder("m-elock", Some("f-elock")).unwrap();
+        state
+            .db
+            .set_note_folder("m-elock", Some("f-elock"))
+            .unwrap();
         state
             .db
             .set_folder_locked("f-elock", true, Some(&b"wrapped"[..]))
@@ -11604,15 +11685,20 @@ mod lifecycle_tests {
 
         // Sealed → both refuse Locked before any egress/write.
         let e1 = block_on(enrich_note_context_inner(&state, "m-elock".to_string())).unwrap_err();
-        assert!(matches!(e1, AppError::Locked(_)), "preview must fail Locked, got: {e1:?}");
+        assert!(
+            matches!(e1, AppError::Locked(_)),
+            "preview must fail Locked, got: {e1:?}"
+        );
         let hit = crate::enrich::ContextHit {
             source: "Jira".into(),
             detail: "PROJ-1 · Done".into(),
             url: None,
         };
-        let e2 =
-            apply_note_enrichment_inner(&state, "m-elock".to_string(), vec![hit]).unwrap_err();
-        assert!(matches!(e2, AppError::Locked(_)), "apply must fail Locked, got: {e2:?}");
+        let e2 = apply_note_enrichment_inner(&state, "m-elock".to_string(), vec![hit]).unwrap_err();
+        assert!(
+            matches!(e2, AppError::Locked(_)),
+            "apply must fail Locked, got: {e2:?}"
+        );
 
         // Session-unlock → the lock gate passes; with no connectors the preview is graceful-empty.
         state
@@ -11621,7 +11707,10 @@ mod lifecycle_tests {
             .unwrap()
             .insert("f-elock".to_string());
         let hits = block_on(enrich_note_context_inner(&state, "m-elock".to_string())).unwrap();
-        assert!(hits.is_empty(), "no connectors configured ⇒ nothing to enrich, got: {hits:?}");
+        assert!(
+            hits.is_empty(),
+            "no connectors configured ⇒ nothing to enrich, got: {hits:?}"
+        );
     }
 
     /// The enrich WRITE path persists a reviewed context block into the canonical DB note and
@@ -11630,7 +11719,12 @@ mod lifecycle_tests {
     fn apply_note_enrichment_writes_then_strips_byte_exact() {
         let state = build_state("enrich-write");
         make_open_folder(&state.db, "f-open", "Project");
-        seed_meeting(&state.db, "m1", "# Notes\n- decided to ship\n", Some("f-open"));
+        seed_meeting(
+            &state.db,
+            "m1",
+            "# Notes\n- decided to ship\n",
+            Some("f-open"),
+        );
         let original = state
             .db
             .get_latest_note_for_meeting("m1")
@@ -11644,9 +11738,18 @@ mod lifecycle_tests {
             url: Some("https://x/browse/PROJ-1".into()),
         }];
         let dto = apply_note_enrichment_inner(&state, "m1".to_string(), hits).unwrap();
-        assert!(dto.markdown.contains("> [!context]-"), "the context callout was written");
-        assert!(dto.markdown.contains("PROJ-1 · In Progress (via Jira)"), "loud attribution present");
-        assert!(dto.markdown.starts_with(&original), "the original note is preserved verbatim");
+        assert!(
+            dto.markdown.contains("> [!context]-"),
+            "the context callout was written"
+        );
+        assert!(
+            dto.markdown.contains("PROJ-1 · In Progress (via Jira)"),
+            "loud attribution present"
+        );
+        assert!(
+            dto.markdown.starts_with(&original),
+            "the original note is preserved verbatim"
+        );
         // The DB note now carries the block.
         assert!(state
             .db
@@ -11658,7 +11761,10 @@ mod lifecycle_tests {
 
         // Empty apply strips it byte-exact back to the original.
         let undone = apply_note_enrichment_inner(&state, "m1".to_string(), vec![]).unwrap();
-        assert_eq!(undone.markdown, original, "empty enrichment strips the block byte-for-byte");
+        assert_eq!(
+            undone.markdown, original,
+            "empty enrichment strips the block byte-for-byte"
+        );
     }
 
     /// Stage 2 / Lane A happy path: over a FINISHED note in an OPEN folder, `link_related_notes_inner`
@@ -11671,7 +11777,10 @@ mod lifecycle_tests {
         // The note we link FROM. Kept lean so the salient query is a subset of the related note's
         // terms (FTS5 MATCH is implicit-AND — every query term must be present in the related note).
         seed_meeting(&state.db, "this", "Apollo migration.\n", Some("f-open"));
-        state.db.set_meeting_title("this", "Apollo Migration").unwrap();
+        state
+            .db
+            .set_meeting_title("this", "Apollo Migration")
+            .unwrap();
         // A related PRIOR note (open folder → visible) whose Summary is the ideal task-free gist and
         // whose Action items must NEVER enter the link detail.
         seed_meeting(
@@ -11680,7 +11789,10 @@ mod lifecycle_tests {
             "## Summary\n\nApollo migration groundwork and rollout roadmap.\n\n## Action items\n\n- [ ] SECRET-TASK\n",
             Some("f-open"),
         );
-        state.db.set_meeting_title("prior", "Apollo Kickoff").unwrap();
+        state
+            .db
+            .set_meeting_title("prior", "Apollo Kickoff")
+            .unwrap();
 
         link_related_notes_inner(&state, "this").unwrap();
 
@@ -11690,11 +11802,26 @@ mod lifecycle_tests {
             .unwrap()
             .unwrap()
             .markdown;
-        assert!(md.contains("> [!related]- Related notes"), "the Related block was written; got: {md}");
-        assert!(md.contains("[[Apollo Kickoff]]"), "the [[Title]] link is present; got: {md}");
-        assert!(md.contains("(via Murmur)"), "loud Murmur attribution; got: {md}");
-        assert!(md.contains("groundwork and rollout"), "the task-free gist prose is present; got: {md}");
-        assert!(!md.contains("SECRET-TASK"), "an action item must NEVER enter a link detail; got: {md}");
+        assert!(
+            md.contains("> [!related]- Related notes"),
+            "the Related block was written; got: {md}"
+        );
+        assert!(
+            md.contains("[[Apollo Kickoff]]"),
+            "the [[Title]] link is present; got: {md}"
+        );
+        assert!(
+            md.contains("(via Murmur)"),
+            "loud Murmur attribution; got: {md}"
+        );
+        assert!(
+            md.contains("groundwork and rollout"),
+            "the task-free gist prose is present; got: {md}"
+        );
+        assert!(
+            !md.contains("SECRET-TASK"),
+            "an action item must NEVER enter a link detail; got: {md}"
+        );
         assert!(
             md.starts_with("Apollo migration.\n"),
             "the original note body is preserved verbatim; got: {md}"
@@ -11738,7 +11865,10 @@ mod lifecycle_tests {
             "## Summary\n\nAtlas acquisition roadmap groundwork.\n",
             Some("f-open"),
         );
-        state.db.set_meeting_title("prior", "Atlas Kickoff").unwrap();
+        state
+            .db
+            .set_meeting_title("prior", "Atlas Kickoff")
+            .unwrap();
 
         // Seal the note (content_blob present, markdown blanked), lock the folder, and SESSION-UNLOCK it
         // so the read gate passes and ONLY the seal-safety guard can stop the write.
@@ -11769,7 +11899,10 @@ mod lifecycle_tests {
             .unwrap()
             .unwrap()
             .markdown;
-        assert_eq!(md, "", "a sealed note's transient markdown column must NEVER be written by Lane A");
+        assert_eq!(
+            md, "",
+            "a sealed note's transient markdown column must NEVER be written by Lane A"
+        );
         // The seal (content_blob) is intact.
         assert!(
             state
@@ -11881,8 +12014,15 @@ mod lifecycle_tests {
         let (bytes, winner, idx) =
             try_unwrap_ck_with_candidates(&candidates, &wrapped, "f-rec", Some(&kek_new))
                 .expect("recovery must find the sealing KEK among the candidates");
-        assert_eq!(bytes.as_slice(), ck.as_slice(), "recovered CK must be the original");
-        assert_eq!(*winner, kek_old, "the winner is the KEK that sealed the folder");
+        assert_eq!(
+            bytes.as_slice(),
+            ck.as_slice(),
+            "recovered CK must be the original"
+        );
+        assert_eq!(
+            *winner, kek_old,
+            "the winner is the KEK that sealed the folder"
+        );
         assert_eq!(idx, 1);
 
         // No matching candidate → None (the caller surfaces the primary error).
@@ -11925,8 +12065,7 @@ mod lifecycle_tests {
         );
 
         // Enumeration COMPLETED with a candidate that unwraps → recoverable → refuse (Ok(false)).
-        let recoverable: Result<Zeroizing<Vec<[u8; 32]>>, AppError> =
-            Ok(Zeroizing::new(vec![kek]));
+        let recoverable: Result<Zeroizing<Vec<[u8; 32]>>, AppError> = Ok(Zeroizing::new(vec![kek]));
         assert!(
             !discard_proof_complete(recoverable, &wrapped, "f-x").unwrap(),
             "a completed enumeration with a matching candidate is RECOVERABLE (refuse)"
@@ -12103,7 +12242,9 @@ mod lifecycle_tests {
 
         // The session survives untouched — nothing cleared, refresh token still spendable.
         let g = state.account_session.lock().unwrap();
-        let s = g.as_ref().expect("session must NOT be cleared on a transient failure");
+        let s = g
+            .as_ref()
+            .expect("session must NOT be cleared on a transient failure");
         assert_eq!(s.refresh_token, "r0");
     }
 
@@ -12648,14 +12789,19 @@ mod lifecycle_tests {
         let db = &state.db;
         make_open_folder(db, "f-sealed", "Secret");
         make_open_folder(db, "f-open", "Standups");
-        seed_titled_meeting(db, "m-sealed", "Board strategy", "/data/m-sealed.wav.enc", "f-sealed");
+        seed_titled_meeting(
+            db,
+            "m-sealed",
+            "Board strategy",
+            "/data/m-sealed.wav.enc",
+            "f-sealed",
+        );
         seed_titled_meeting(db, "m-open", "Open standup", "/data/m-open.wav", "f-open");
         db.set_folder_locked("f-sealed", true, Some(&b"wrapped"[..]))
             .unwrap();
         // NOT session-unlocked: `unlocked_folders` stays empty.
 
-        let masked =
-            mask_locked_meetings(&state, db.list_meetings(200).unwrap()).unwrap();
+        let masked = mask_locked_meetings(&state, db.list_meetings(200).unwrap()).unwrap();
         let sealed = masked.iter().find(|m| m.id == "m-sealed").unwrap();
         assert_eq!(
             sealed.title.as_deref(),
@@ -12683,8 +12829,7 @@ mod lifecycle_tests {
             .lock()
             .unwrap()
             .insert("f-sealed".to_string());
-        let unmasked =
-            mask_locked_meetings(&state, db.list_meetings(200).unwrap()).unwrap();
+        let unmasked = mask_locked_meetings(&state, db.list_meetings(200).unwrap()).unwrap();
         let now = unmasked.iter().find(|m| m.id == "m-sealed").unwrap();
         assert_eq!(now.title.as_deref(), Some("Board strategy"));
         assert_eq!(now.audio_path.as_deref(), Some("/data/m-sealed.wav.enc"));
@@ -13096,12 +13241,7 @@ mod lifecycle_tests {
     /// `seed_meeting`'s placeholder segments/timeline). Each `(start, end, tag)` segment carries the
     /// RAW diarization tag; each `(start, end, label)` turn carries the LLM DISPLAY label the FE lane
     /// renders — the two key spaces the reconciler must bridge.
-    fn seed_diarized(
-        db: &Db,
-        mid: &str,
-        segs: &[(f64, f64, &str)],
-        turns: &[(f64, f64, &str)],
-    ) {
+    fn seed_diarized(db: &Db, mid: &str, segs: &[(f64, f64, &str)], turns: &[(f64, f64, &str)]) {
         let segments: Vec<Segment> = segs
             .iter()
             .enumerate()
@@ -13139,7 +13279,14 @@ mod lifecycle_tests {
         let anna = vec![1.0f32, 0.0, 0.0];
         state
             .db
-            .insert_voiceprint("vp-prior", "prior", 0, Some("Anna"), &anna, "2026-07-01T00:00:00Z")
+            .insert_voiceprint(
+                "vp-prior",
+                "prior",
+                0,
+                Some("Anna"),
+                &anna,
+                "2026-07-01T00:00:00Z",
+            )
             .unwrap();
 
         // Current meeting: diarized cluster 1 (segments tagged `others-1`), whose timeline lane the
@@ -13214,7 +13361,14 @@ mod lifecycle_tests {
         let sam = vec![0.0f32, 1.0, 0.0];
         state
             .db
-            .insert_voiceprint("vp-prior", "prior", 0, Some("Sam"), &sam, "2026-07-01T00:00:00Z")
+            .insert_voiceprint(
+                "vp-prior",
+                "prior",
+                0,
+                Some("Sam"),
+                &sam,
+                "2026-07-01T00:00:00Z",
+            )
             .unwrap();
 
         // Current single-cluster meeting: plain `others` segments, LLM lane "Speaker 1", cluster 0.
@@ -13234,7 +13388,10 @@ mod lifecycle_tests {
         // Suggest is keyed by the display label.
         let sugg = suggest_speaker_labels_inner(&state, "cur").unwrap();
         assert_eq!(sugg.len(), 1);
-        assert_eq!(sugg[0].speaker, "Speaker 1", "1:1 suggestion keyed by the display label");
+        assert_eq!(
+            sugg[0].speaker, "Speaker 1",
+            "1:1 suggestion keyed by the display label"
+        );
         assert_eq!(sugg[0].suggested_label, "Sam");
 
         // Enroll via the display label reconstructs cluster 0.
@@ -13244,7 +13401,11 @@ mod lifecycle_tests {
             .into_iter()
             .find(|v| v.meeting_id == "cur")
             .unwrap();
-        assert_eq!(cur_row.label.as_deref(), Some("Sam"), "1:1 enroll bound cluster 0");
+        assert_eq!(
+            cur_row.label.as_deref(),
+            Some("Sam"),
+            "1:1 enroll bound cluster 0"
+        );
         assert_eq!(cur_row.cluster_index, 0);
     }
 
@@ -13604,11 +13765,17 @@ mod lifecycle_tests {
 
         // A buffer added into the folder AFTER the seal (as if typed during a later session-unlock):
         // its note plaintext is the ONLY copy, content_blob stays NULL (never sealed).
-        seed_meeting(&state.db, "m2", "NEVER SEALED — the only copy", Some("f-lock"));
+        seed_meeting(
+            &state.db,
+            "m2",
+            "NEVER SEALED — the only copy",
+            Some("f-lock"),
+        );
 
         // Make the folder unrecoverable (foreign wrapped key no candidate holds).
         let foreign_wrapped =
-            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock")).unwrap();
+            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock"))
+                .unwrap();
         state
             .db
             .set_folder_locked("f-lock", true, Some(&foreign_wrapped))
@@ -14310,7 +14477,8 @@ mod lifecycle_tests {
         for n in state.db.notes_in_folder(folder_id).unwrap() {
             if let Some(blob) = &n.content_blob {
                 let aad = aad_content(folder_id, &n.meeting_id, &n.provider_id, "note");
-                let md = String::from_utf8(crate::crypto::decrypt(&ck, blob, &aad).unwrap()).unwrap();
+                let md =
+                    String::from_utf8(crate::crypto::decrypt(&ck, blob, &aad).unwrap()).unwrap();
                 state
                     .db
                     .restore_note_markdown(&n.meeting_id, &n.provider_id, &md)
@@ -14344,14 +14512,31 @@ mod lifecycle_tests {
         );
         // Index while the folder is OPEN (the stub stands in for a present model, as every other
         // meeting-chunk test does) → chunks + vectors present.
-        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
-        assert!(state.db.note_chunk_count("m1").unwrap() > 0, "precondition: chunked while open");
-        assert!(state.db.note_vec_count("m1").unwrap() > 0, "precondition: vectored while open");
+        state
+            .db
+            .index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
+            .unwrap();
+        assert!(
+            state.db.note_chunk_count("m1").unwrap() > 0,
+            "precondition: chunked while open"
+        );
+        assert!(
+            state.db.note_vec_count("m1").unwrap() > 0,
+            "precondition: vectored while open"
+        );
 
         // LOCK (production seal) → meeting chunks + vectors purged.
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();
-        assert_eq!(state.db.note_chunk_count("m1").unwrap(), 0, "note_chunks purged on lock");
-        assert_eq!(state.db.note_vec_count("m1").unwrap(), 0, "vec_chunks purged on lock");
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "note_chunks purged on lock"
+        );
+        assert_eq!(
+            state.db.note_vec_count("m1").unwrap(),
+            0,
+            "vec_chunks purged on lock"
+        );
 
         // Restore note markdown exactly as `unlock_folder` does BEFORE `unseal_folder_extras`.
         let ck = restore_notes_and_ck(&state, "f-lock");
@@ -14398,11 +14583,21 @@ mod lifecycle_tests {
             "# Roadmap\n\nrevisit auth and the billing migration next sprint",
             Some("f-lock"),
         );
-        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
-        assert!(state.db.note_chunk_count("m1").unwrap() > 0, "precondition: chunked while open");
+        state
+            .db
+            .index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
+            .unwrap();
+        assert!(
+            state.db.note_chunk_count("m1").unwrap() > 0,
+            "precondition: chunked while open"
+        );
 
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();
-        assert_eq!(state.db.note_chunk_count("m1").unwrap(), 0, "purged on lock");
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "purged on lock"
+        );
 
         // `remove_lock_inner` restores the note markdown (Step 1) BEFORE `unseal_folder_extras_permanent`.
         let ck = restore_notes_and_ck(&state, "f-lock");
@@ -14422,12 +14617,16 @@ mod lifecycle_tests {
 
         // MODEL-PRESENT (Some): permanent unseal re-indexes the now-open folder's meetings. RED on the
         // pre-fix code (unseal_folder_extras_permanent had no meeting re-index → stayed 0).
-        unseal_folder_extras_permanent(&state, "f-lock", &ck, Some(&crate::embed::StubEmbedder)).unwrap();
+        unseal_folder_extras_permanent(&state, "f-lock", &ck, Some(&crate::embed::StubEmbedder))
+            .unwrap();
         assert!(
             state.db.note_chunk_count("m1").unwrap() > 0,
             "remove-lock re-indexes meeting note_chunks when the e5 model is present (was DEAD before the fix)"
         );
-        assert!(state.db.note_vec_count("m1").unwrap() > 0, "remove-lock re-indexes meeting vec_chunks");
+        assert!(
+            state.db.note_vec_count("m1").unwrap() > 0,
+            "remove-lock re-indexes meeting vec_chunks"
+        );
     }
 
     /// RELOCK re-purges the freshly-rebuilt meeting chunks: a lock → unlock (re-index) → relock cycle
@@ -14444,11 +14643,18 @@ mod lifecycle_tests {
             "# Notes\n\nlaunch on the 14th; hire two engineers",
             Some("f-lock"),
         );
-        state.db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
+        state
+            .db
+            .index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
+            .unwrap();
 
         // Lock → purge.
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();
-        assert_eq!(state.db.note_chunk_count("m1").unwrap(), 0, "purged on lock");
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "purged on lock"
+        );
 
         // Session-unlock: restore markdown + the PRODUCTION unseal with a present (stub) model, which
         // rebuilds the meeting chunks — so the relock below has something to re-purge.
@@ -14463,7 +14669,10 @@ mod lifecycle_tests {
             state.db.note_chunk_count("m1").unwrap() > 0,
             "precondition: meeting re-indexed while session-unlocked"
         );
-        assert!(state.db.note_vec_count("m1").unwrap() > 0, "precondition: vectors rebuilt");
+        assert!(
+            state.db.note_vec_count("m1").unwrap() > 0,
+            "precondition: vectors rebuilt"
+        );
 
         // RELOCK → re-purge. Zero meeting chunks AND zero vectors at rest.
         relock_all_inner(&state).unwrap();
@@ -16095,7 +16304,10 @@ mod lifecycle_tests {
             ],
             "2026-06-20T00:00:00Z",
         );
-        assert!(self_rows.is_empty(), "same-meeting refinement is not a cross-note supersession");
+        assert!(
+            self_rows.is_empty(),
+            "same-meeting refinement is not a cross-note supersession"
+        );
     }
 
     /// Seed a summarized meeting in a folder, its note pointing at an on-disk `.md` (or a DB-only path
@@ -16109,7 +16321,12 @@ mod lifecycle_tests {
         filename: &str,
         md_bytes: Option<&str>,
     ) -> std::path::PathBuf {
-        seed_meeting(&state.db, mid, md_bytes.unwrap_or("# note"), Some(folder_id));
+        seed_meeting(
+            &state.db,
+            mid,
+            md_bytes.unwrap_or("# note"),
+            Some(folder_id),
+        );
         state.db.set_note_folder(mid, Some(folder_id)).unwrap();
         let dir = vault.join(folder_name);
         std::fs::create_dir_all(&dir).unwrap();
@@ -16132,9 +16349,25 @@ mod lifecycle_tests {
         let vault = tmp_vault("retruth-gate");
         let state = build_state_with_vault("retruth-gate", &vault);
         make_open_folder(&state.db, "f-src", "Work");
-        seed_note_on_disk(&state, &vault, "m1", "f-src", "Work", "kickoff.md", Some("# Kickoff\n"));
+        seed_note_on_disk(
+            &state,
+            &vault,
+            "m1",
+            "f-src",
+            "Work",
+            "kickoff.md",
+            Some("# Kickoff\n"),
+        );
         make_open_folder(&state.db, "f-new", "Reviews");
-        seed_note_on_disk(&state, &vault, "m2", "f-new", "Reviews", "review.md", Some("# Review\n"));
+        seed_note_on_disk(
+            &state,
+            &vault,
+            "m2",
+            "f-new",
+            "Reviews",
+            "review.md",
+            Some("# Review\n"),
+        );
         state
             .db
             .record_supersessions(&[SupersessionRow {
@@ -16161,7 +16394,9 @@ mod lifecycle_tests {
             .set_folder_locked("f-src", true, Some(&b"wrapped"[..]))
             .unwrap();
         assert!(
-            preview_supersessions_inner(&state, "m2").unwrap().is_empty(),
+            preview_supersessions_inner(&state, "m2")
+                .unwrap()
+                .is_empty(),
             "a sealed source contributes nothing"
         );
 
@@ -16173,7 +16408,9 @@ mod lifecycle_tests {
             .unwrap()
             .insert("f-src".to_string());
         assert!(
-            preview_supersessions_inner(&state, "m2").unwrap().is_empty(),
+            preview_supersessions_inner(&state, "m2")
+                .unwrap()
+                .is_empty(),
             "session-unlock does not re-open a sealed source for stamping"
         );
     }
@@ -16243,7 +16480,10 @@ mod lifecycle_tests {
         assert_eq!(res.skipped_sealed, 0);
 
         let src_after = std::fs::read_to_string(&src_md).unwrap();
-        assert!(src_after.contains("## Re-Truth updates"), "section: {src_after}");
+        assert!(
+            src_after.contains("## Re-Truth updates"),
+            "section: {src_after}"
+        );
         assert!(
             src_after.contains(
                 "> **status** — in-progress → shipped · see [[2026-06-20 1000 - Launch review]]"
@@ -16264,7 +16504,10 @@ mod lifecycle_tests {
         let res2 = apply_supersessions_inner(&state, &["s1".to_string()]).unwrap();
         assert_eq!(res2.applied, 0, "already-applied row is not re-stamped");
         assert_eq!(
-            std::fs::read_to_string(&src_md).unwrap().matches("> **status** — in-progress → shipped").count(),
+            std::fs::read_to_string(&src_md)
+                .unwrap()
+                .matches("> **status** — in-progress → shipped")
+                .count(),
             1,
             "no duplicate callout body"
         );
@@ -16311,7 +16554,15 @@ mod lifecycle_tests {
             Some(src_original),
         );
         make_open_folder(&state.db, "f-new", "Reviews");
-        seed_note_on_disk(&state, &vault, "m2", "f-new", "Reviews", "review.md", Some("# Review\n"));
+        seed_note_on_disk(
+            &state,
+            &vault,
+            "m2",
+            "f-new",
+            "Reviews",
+            "review.md",
+            Some("# Review\n"),
+        );
         state
             .db
             .record_supersessions(&[SupersessionRow {
@@ -16338,7 +16589,10 @@ mod lifecycle_tests {
 
         let res = apply_supersessions_inner(&state, &["s1".to_string()]).unwrap();
         assert_eq!(res.applied, 0);
-        assert_eq!(res.skipped_sealed, 1, "a source sealed after preview is skipped");
+        assert_eq!(
+            res.skipped_sealed, 1,
+            "a source sealed after preview is skipped"
+        );
         // The `.md` was NOT touched (no callout written into a locked folder).
         assert_eq!(
             std::fs::read_to_string(&src_md).unwrap(),
@@ -16346,15 +16600,13 @@ mod lifecycle_tests {
             "never write into a locked folder"
         );
         // Still pending (not marked applied).
-        assert!(
-            state
-                .db
-                .get_supersession("s1")
-                .unwrap()
-                .unwrap()
-                .applied_at
-                .is_none()
-        );
+        assert!(state
+            .db
+            .get_supersession("s1")
+            .unwrap()
+            .unwrap()
+            .applied_at
+            .is_none());
     }
 
     /// GATE BOTH SIDES: `preview_supersessions` must EXCLUDE a row whose SUPERSEDING meeting is sealed
@@ -16367,9 +16619,25 @@ mod lifecycle_tests {
         let vault = tmp_vault("retruth-supgate");
         let state = build_state_with_vault("retruth-supgate", &vault);
         make_open_folder(&state.db, "f-src", "Work");
-        seed_note_on_disk(&state, &vault, "m1", "f-src", "Work", "kickoff.md", Some("# Kickoff\n"));
+        seed_note_on_disk(
+            &state,
+            &vault,
+            "m1",
+            "f-src",
+            "Work",
+            "kickoff.md",
+            Some("# Kickoff\n"),
+        );
         make_open_folder(&state.db, "f-new", "Reviews");
-        seed_note_on_disk(&state, &vault, "m2", "f-new", "Reviews", "review.md", Some("# Review\n"));
+        seed_note_on_disk(
+            &state,
+            &vault,
+            "m2",
+            "f-new",
+            "Reviews",
+            "review.md",
+            Some("# Review\n"),
+        );
         state
             .db
             .record_supersessions(&[SupersessionRow {
@@ -16396,7 +16664,9 @@ mod lifecycle_tests {
             .set_folder_locked("f-new", true, Some(&b"wrapped"[..]))
             .unwrap();
         assert!(
-            preview_supersessions_inner(&state, "m2").unwrap().is_empty(),
+            preview_supersessions_inner(&state, "m2")
+                .unwrap()
+                .is_empty(),
             "a sealed superseding meeting must surface no new_value (gate BOTH sides)"
         );
     }
@@ -16413,8 +16683,15 @@ mod lifecycle_tests {
         let state = build_state_with_vault("retruth-retry", &vault);
         let original = "# Kickoff\n\nAtlas is in progress.\n";
         make_open_folder(&state.db, "f-src", "Work");
-        let src_md =
-            seed_note_on_disk(&state, &vault, "m1", "f-src", "Work", "kickoff.md", Some(original));
+        let src_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m1",
+            "f-src",
+            "Work",
+            "kickoff.md",
+            Some(original),
+        );
         // Superseding meeting stays open but WITHOUT a vault file we care about — the backlink is
         // irrelevant to this source-undo test (no superseding stem link ⇒ simpler assertions).
         make_open_folder(&state.db, "f-new", "Reviews");
@@ -16495,12 +16772,33 @@ mod lifecycle_tests {
         let state = build_state_with_vault("retruth-multi", &vault);
         // One open folder holding the superseding note + two old source notes.
         make_open_folder(&state.db, "f", "Work");
-        let new_md =
-            seed_note_on_disk(&state, &vault, "m-new", "f", "Work", "new.md", Some("# New\n"));
-        let old1_md =
-            seed_note_on_disk(&state, &vault, "m-old1", "f", "Work", "old1.md", Some("# Old one\n"));
-        let old2_md =
-            seed_note_on_disk(&state, &vault, "m-old2", "f", "Work", "old2.md", Some("# Old two\n"));
+        let new_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-new",
+            "f",
+            "Work",
+            "new.md",
+            Some("# New\n"),
+        );
+        let old1_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-old1",
+            "f",
+            "Work",
+            "old1.md",
+            Some("# Old one\n"),
+        );
+        let old2_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-old2",
+            "f",
+            "Work",
+            "old2.md",
+            Some("# Old two\n"),
+        );
 
         // Three rows, ALL superseded by m-new:
         //   r1, r2 → SOURCE m-old1 (two facts from one old note ⇒ shared SOURCE note)
@@ -16540,17 +16838,26 @@ mod lifecycle_tests {
         assert_eq!(res.skipped_sealed, 0);
         // The shared superseding note carries all THREE backlinks; each source its own callout(s).
         assert_eq!(
-            std::fs::read_to_string(&new_md).unwrap().matches("> [!supersedes]").count(),
+            std::fs::read_to_string(&new_md)
+                .unwrap()
+                .matches("> [!supersedes]")
+                .count(),
             3,
             "shared superseding note accumulates all backlinks"
         );
         assert_eq!(
-            std::fs::read_to_string(&old1_md).unwrap().matches("> [!superseded]").count(),
+            std::fs::read_to_string(&old1_md)
+                .unwrap()
+                .matches("> [!superseded]")
+                .count(),
             2,
             "shared source note accumulates both callouts"
         );
         assert_eq!(
-            std::fs::read_to_string(&old2_md).unwrap().matches("> [!superseded]").count(),
+            std::fs::read_to_string(&old2_md)
+                .unwrap()
+                .matches("> [!superseded]")
+                .count(),
             1
         );
 
@@ -16593,12 +16900,33 @@ mod lifecycle_tests {
         let vault = tmp_vault("retruth-partial");
         let state = build_state_with_vault("retruth-partial", &vault);
         make_open_folder(&state.db, "f", "Work");
-        let new_md =
-            seed_note_on_disk(&state, &vault, "m-new", "f", "Work", "new.md", Some("# New\n"));
-        let old1_md =
-            seed_note_on_disk(&state, &vault, "m-old1", "f", "Work", "old1.md", Some("# Old one\n"));
-        let old2_md =
-            seed_note_on_disk(&state, &vault, "m-old2", "f", "Work", "old2.md", Some("# Old two\n"));
+        let new_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-new",
+            "f",
+            "Work",
+            "new.md",
+            Some("# New\n"),
+        );
+        let old1_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-old1",
+            "f",
+            "Work",
+            "old1.md",
+            Some("# Old one\n"),
+        );
+        let old2_md = seed_note_on_disk(
+            &state,
+            &vault,
+            "m-old2",
+            "f",
+            "Work",
+            "old2.md",
+            Some("# Old two\n"),
+        );
         let mk = |id: &str, source: &str, predicate: &str, old: &str, new: &str| SupersessionRow {
             id: id.into(),
             superseding_meeting_id: "m-new".into(),
@@ -16634,36 +16962,85 @@ mod lifecycle_tests {
         undo_supersessions_inner(&state, &["r1".to_string()]).unwrap();
 
         // r2, r3 stay applied; r1 cleared.
-        assert!(state.db.get_supersession("r1").unwrap().unwrap().applied_at.is_none());
-        assert!(state.db.get_supersession("r2").unwrap().unwrap().applied_at.is_some());
-        assert!(state.db.get_supersession("r3").unwrap().unwrap().applied_at.is_some());
+        assert!(state
+            .db
+            .get_supersession("r1")
+            .unwrap()
+            .unwrap()
+            .applied_at
+            .is_none());
+        assert!(state
+            .db
+            .get_supersession("r2")
+            .unwrap()
+            .unwrap()
+            .applied_at
+            .is_some());
+        assert!(state
+            .db
+            .get_supersession("r3")
+            .unwrap()
+            .unwrap()
+            .applied_at
+            .is_some());
 
         // old1.md: r2's callout SURVIVES, r1's is GONE.
         let old1 = std::fs::read_to_string(&old1_md).unwrap();
-        assert!(old1.contains("> **owner** — Anna → Bob"), "r2 (survivor) callout kept: {old1}");
+        assert!(
+            old1.contains("> **owner** — Anna → Bob"),
+            "r2 (survivor) callout kept: {old1}"
+        );
         assert!(
             !old1.contains("> **status** — in-progress → shipped"),
             "r1 (undone) callout removed: {old1}"
         );
         // new.md: r2 + r3 backlinks SURVIVE, r1's is GONE.
         let new = std::fs::read_to_string(&new_md).unwrap();
-        assert!(new.contains("> **owner** — supersedes Anna → Bob in [[old1]]"), "r2 backlink kept: {new}");
-        assert!(new.contains("> **stage** — supersedes alpha → beta in [[old2]]"), "r3 backlink kept: {new}");
+        assert!(
+            new.contains("> **owner** — supersedes Anna → Bob in [[old1]]"),
+            "r2 backlink kept: {new}"
+        );
+        assert!(
+            new.contains("> **stage** — supersedes alpha → beta in [[old2]]"),
+            "r3 backlink kept: {new}"
+        );
         assert!(
             !new.contains("> **status** — supersedes in-progress → shipped in [[old1]]"),
             "r1 backlink removed: {new}"
         );
         // old2.md: r3 untouched (never in an undo set).
-        assert_eq!(std::fs::read(&old2_md).unwrap(), old2_after_apply, "r3's source note unchanged");
+        assert_eq!(
+            std::fs::read(&old2_md).unwrap(),
+            old2_after_apply,
+            "r3's source note unchanged"
+        );
 
         // Now UNDO r2, r3 → every file byte-identical to pristine, all rows unapplied.
         undo_supersessions_inner(&state, &["r2".to_string(), "r3".to_string()]).unwrap();
-        assert_eq!(std::fs::read(&new_md).unwrap(), new_pre, "superseding note back to pristine");
-        assert_eq!(std::fs::read(&old1_md).unwrap(), old1_pre, "shared source note back to pristine");
-        assert_eq!(std::fs::read(&old2_md).unwrap(), old2_pre, "other source note back to pristine");
+        assert_eq!(
+            std::fs::read(&new_md).unwrap(),
+            new_pre,
+            "superseding note back to pristine"
+        );
+        assert_eq!(
+            std::fs::read(&old1_md).unwrap(),
+            old1_pre,
+            "shared source note back to pristine"
+        );
+        assert_eq!(
+            std::fs::read(&old2_md).unwrap(),
+            old2_pre,
+            "other source note back to pristine"
+        );
         for id in ["r1", "r2", "r3"] {
             assert!(
-                state.db.get_supersession(id).unwrap().unwrap().applied_at.is_none(),
+                state
+                    .db
+                    .get_supersession(id)
+                    .unwrap()
+                    .unwrap()
+                    .applied_at
+                    .is_none(),
                 "row {id} unapplied after full undo"
             );
         }

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -48,6 +48,49 @@ const TRANSCRIPT_CHUNK_OVERLAP_CHARS: usize = 150;
 /// rank position; 60 is the widely-used default from the original RRF paper.
 pub const RRF_K: f64 = 60.0;
 
+// ── Brain v2 L1.1 — topic segmentation constants (spec §L1.1; named, eval-tunable) ──────────────
+
+/// A silence gap of at least this many seconds between consecutive spoken segments opens a new
+/// topic (a lull usually marks an agenda transition).
+pub const TOPIC_LULL_GAP_S: f64 = 30.0;
+
+/// A speaker flip AFTER a run of at least this many consecutive same-speaker segments opens a new
+/// topic (a long monologue ending is a strong topical boundary; ordinary turn-taking is not).
+pub const TOPIC_SPEAKER_RUN_MIN: usize = 5;
+
+/// Window size (in segments, each side) for the lexical-shift boundary signal.
+pub const TOPIC_LEXICAL_WINDOW: usize = 6;
+
+/// A Jaccard similarity BELOW this between the token sets of the two adjacent
+/// [`TOPIC_LEXICAL_WINDOW`]-segment windows opens a new topic (vocabulary shifted).
+pub const TOPIC_LEXICAL_JACCARD_MIN: f64 = 0.15;
+
+/// Topic segments SHORTER than this (seconds) merge forward into the next topic —
+/// over-segmentation is preferred over under-segmentation, but slivers carry no retrieval value.
+pub const TOPIC_MERGE_MIN_DURATION_S: f64 = 60.0;
+
+/// Minimum token length (chars) counted by the lexical-shift signal (shorter tokens are noise).
+const TOPIC_TOKEN_MIN_CHARS: usize = 3;
+
+// ── Brain v2 L1.2 — contextual augmentation caps (spec §L1.2) ───────────────────────────────────
+
+/// Max attendees rendered into an augmented-chunk header.
+pub const AUG_MAX_ATTENDEES: usize = 5;
+
+/// Max facts rendered into an augmented-chunk header.
+pub const AUG_MAX_FACTS: usize = 8;
+
+// ── Brain v2 L1.3 — score-fusion weights (spec §L1.3; named consts, calibrated by the eval gate) ─
+
+/// Weight of the keyword (FTS/BM25) leg in [`score_fuse`].
+pub const SCORE_FUSE_W_FTS: f64 = 0.4;
+
+/// Weight of the vector-KNN leg in [`score_fuse`].
+pub const SCORE_FUSE_W_KNN: f64 = 0.4;
+
+/// Weight of the entity-graph leg in [`score_fuse`].
+pub const SCORE_FUSE_W_GRAPH: f64 = 0.2;
+
 /// The swappable embedding backend. Pure + synchronous: `embed` maps a batch of texts to a batch
 /// of `dim()`-length vectors. The real model implements this over multilingual-e5-small; tests +
 /// the no-model floor use [`StubEmbedder`].
@@ -434,26 +477,30 @@ fn group_turns(segments: &[crate::transcribe::types::Segment]) -> Vec<Turn> {
     let mut cur_start = 0.0f64;
     let mut cur_end = 0.0f64;
 
-    let flush = |turns: &mut Vec<Turn>, speaker: &Option<String>, text: &str, start: f64, end: f64| {
-        let text = text.trim();
-        if text.is_empty() {
-            return;
-        }
-        let label = match speaker {
-            Some(s) if !s.trim().is_empty() => s.trim(),
-            _ => "unknown",
+    let flush =
+        |turns: &mut Vec<Turn>, speaker: &Option<String>, text: &str, start: f64, end: f64| {
+            let text = text.trim();
+            if text.is_empty() {
+                return;
+            }
+            let label = match speaker {
+                Some(s) if !s.trim().is_empty() => s.trim(),
+                _ => "unknown",
+            };
+            turns.push(Turn {
+                line: format!("[{}-{}] ({label})\n{text}", mmss(start), mmss(end)),
+            });
         };
-        turns.push(Turn {
-            line: format!("[{}-{}] ({label})\n{text}", mmss(start), mmss(end)),
-        });
-    };
 
     for seg in segments {
         let text = seg.text.trim();
         if text.is_empty() {
             continue; // pure-gap segment — no content to attribute.
         }
-        let same = cur_speaker.as_ref().map(|s| s == &seg.speaker).unwrap_or(false);
+        let same = cur_speaker
+            .as_ref()
+            .map(|s| s == &seg.speaker)
+            .unwrap_or(false);
         if same {
             if !cur_text.is_empty() {
                 cur_text.push(' ');
@@ -515,7 +562,11 @@ pub fn chunk_transcript(
 
     for turn in &turns {
         let line = turn.line.as_str();
-        let add = if window.is_empty() { line.len() } else { line.len() + 1 };
+        let add = if window.is_empty() {
+            line.len()
+        } else {
+            line.len() + 1
+        };
         // Close the current window before it overflows (but never emit an empty one).
         if !window.is_empty() && window_len + add > TRANSCRIPT_CHUNK_CHAR_TARGET {
             emit(&mut chunks, &window);
@@ -524,7 +575,11 @@ pub fn chunk_transcript(
             let mut carry: Vec<&str> = Vec::new();
             let mut carry_len = 0usize;
             for &prev in window.iter().rev() {
-                let plen = if carry.is_empty() { prev.len() } else { prev.len() + 1 };
+                let plen = if carry.is_empty() {
+                    prev.len()
+                } else {
+                    prev.len() + 1
+                };
                 if carry_len + plen > TRANSCRIPT_CHUNK_OVERLAP_CHARS && !carry.is_empty() {
                     break;
                 }
@@ -533,18 +588,296 @@ pub fn chunk_transcript(
             }
             carry.reverse();
             window = carry;
-            window_len = window
-                .iter()
-                .map(|l| l.len())
-                .sum::<usize>()
-                + window.len().saturating_sub(1);
+            window_len =
+                window.iter().map(|l| l.len()).sum::<usize>() + window.len().saturating_sub(1);
         }
-        let add = if window.is_empty() { line.len() } else { line.len() + 1 };
+        let add = if window.is_empty() {
+            line.len()
+        } else {
+            line.len() + 1
+        };
         window.push(line);
         window_len += add;
     }
     emit(&mut chunks, &window);
     chunks
+}
+
+/// One TOPIC segment (Brain v2 L1.1): a contiguous, topically-coherent span of transcript
+/// segments, carrying its wall-clock span and the merged speaker-tagged text. Pure output of
+/// [`segment_topics`]; persisted by `Db::index_meeting_topic_chunks`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TopicSegment {
+    /// Start of the topic (seconds into the meeting, from the first contributing segment).
+    pub start_s: f64,
+    /// End of the topic (seconds, from the last contributing segment).
+    pub end_s: f64,
+    /// The topic's raw text: one `(speaker) text` line per contributing non-blank segment,
+    /// newline-joined. Deterministic for identical input.
+    pub text: String,
+}
+
+/// Lexical-shift tokens: lowercased alphanumeric tokens of at least [`TOPIC_TOKEN_MIN_CHARS`]
+/// chars, with EN+PL stopwords removed (shares the single `is_stopword` list — no second set to
+/// drift). Returned as a set (Jaccard is set-based).
+fn topic_tokens(text: &str) -> std::collections::HashSet<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.chars().count() >= TOPIC_TOKEN_MIN_CHARS)
+        .filter(|t| !crate::summarize::related_context::is_stopword(t))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Jaccard similarity of two token sets. Both empty ⇒ 1.0 (no evidence of a shift); one empty ⇒
+/// 1.0 as well (an empty window can't attest a boundary — fail toward NO boundary).
+fn jaccard(a: &std::collections::HashSet<String>, b: &std::collections::HashSet<String>) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 1.0;
+    }
+    let inter = a.intersection(b).count() as f64;
+    let union = a.union(b).count() as f64;
+    if union == 0.0 {
+        1.0
+    } else {
+        inter / union
+    }
+}
+
+/// Brain v2 L1.1 — deterministic TOPIC segmentation of a meeting's transcript segments.
+///
+/// A boundary opens BEFORE segment `i` when ANY of three signals fires (spec §L1.1):
+/// 1. **Lull** — `start_s(i) - end_s(i-1) >= `[`TOPIC_LULL_GAP_S`];
+/// 2. **Speaker flip after a long run** — the speaker changes at `i` AND the outgoing speaker held
+///    at least [`TOPIC_SPEAKER_RUN_MIN`] consecutive segments;
+/// 3. **Lexical shift** — the Jaccard similarity between the token sets of the previous and next
+///    [`TOPIC_LEXICAL_WINDOW`]-segment windows is below [`TOPIC_LEXICAL_JACCARD_MIN`]
+///    (tokens: lowercase alnum ≥ [`TOPIC_TOKEN_MIN_CHARS`] chars, EN+PL stopwords removed).
+///
+/// Topics shorter than [`TOPIC_MERGE_MIN_DURATION_S`] merge FORWARD into the next topic (a
+/// trailing short topic merges backward). Blank-text segments are skipped for content (their
+/// timestamps still shape the lull signal via their neighbours' spans). Pure + deterministic:
+/// identical segments always yield identical topics — the property `content_hash` idempotency
+/// rides on. Empty/all-blank input yields no topics.
+pub fn segment_topics(segments: &[crate::transcribe::types::Segment]) -> Vec<TopicSegment> {
+    // Work over the non-blank segments only (blank rows carry no content to attribute).
+    let spoken: Vec<&crate::transcribe::types::Segment> = segments
+        .iter()
+        .filter(|s| !s.text.trim().is_empty())
+        .collect();
+    if spoken.is_empty() {
+        return Vec::new();
+    }
+
+    // Precompute per-segment token sets once (the lexical windows re-use them).
+    let tokens: Vec<std::collections::HashSet<String>> =
+        spoken.iter().map(|s| topic_tokens(&s.text)).collect();
+
+    // boundary[i] == true ⇒ a new topic starts AT spoken[i].
+    let n = spoken.len();
+    let mut boundary = vec![false; n];
+    let mut run_len = 1usize; // consecutive same-speaker run ending at i-1.
+    for i in 1..n {
+        let prev = spoken[i - 1];
+        let cur = spoken[i];
+
+        // 1) lull.
+        let lull = cur.start_s - prev.end_s >= TOPIC_LULL_GAP_S;
+
+        // 2) speaker flip after a long same-speaker run.
+        let flip = cur.speaker != prev.speaker && run_len >= TOPIC_SPEAKER_RUN_MIN;
+
+        // 3) lexical shift over the two adjacent windows.
+        let lo = i.saturating_sub(TOPIC_LEXICAL_WINDOW);
+        let hi = (i + TOPIC_LEXICAL_WINDOW).min(n);
+        let mut before: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for t in &tokens[lo..i] {
+            before.extend(t.iter().cloned());
+        }
+        let mut after: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for t in &tokens[i..hi] {
+            after.extend(t.iter().cloned());
+        }
+        let shift = jaccard(&before, &after) < TOPIC_LEXICAL_JACCARD_MIN;
+
+        if lull || flip || shift {
+            boundary[i] = true;
+        }
+        run_len = if cur.speaker == prev.speaker {
+            run_len + 1
+        } else {
+            1
+        };
+    }
+
+    // Materialize raw topics from the boundary vector.
+    let render = |seg: &crate::transcribe::types::Segment| -> String {
+        let label = match &seg.speaker {
+            Some(s) if !s.trim().is_empty() => s.trim(),
+            _ => "unknown",
+        };
+        format!("({label}) {}", seg.text.trim())
+    };
+    let mut topics: Vec<TopicSegment> = Vec::new();
+    let mut start_idx = 0usize;
+    for i in 1..=n {
+        if i == n || boundary[i] {
+            let span = &spoken[start_idx..i];
+            let text = span
+                .iter()
+                .map(|s| render(s))
+                .collect::<Vec<_>>()
+                .join("\n");
+            topics.push(TopicSegment {
+                start_s: span[0].start_s,
+                end_s: span[span.len() - 1].end_s,
+                text,
+            });
+            start_idx = i;
+        }
+    }
+
+    // Merge short topics FORWARD (< TOPIC_MERGE_MIN_DURATION_S); a trailing short one merges back.
+    let mut merged: Vec<TopicSegment> = Vec::new();
+    let mut carry: Option<TopicSegment> = None;
+    for t in topics {
+        let t = match carry.take() {
+            Some(c) => TopicSegment {
+                start_s: c.start_s,
+                end_s: t.end_s,
+                text: format!("{}\n{}", c.text, t.text),
+            },
+            None => t,
+        };
+        if t.end_s - t.start_s < TOPIC_MERGE_MIN_DURATION_S {
+            carry = Some(t); // too short — merge into the NEXT topic.
+        } else {
+            merged.push(t);
+        }
+    }
+    if let Some(c) = carry {
+        // Trailing short topic: merge backward into the previous, or stand alone if it is all we have.
+        match merged.last_mut() {
+            Some(last) => {
+                last.end_s = c.end_s;
+                last.text = format!("{}\n{}", last.text, c.text);
+            }
+            None => merged.push(c),
+        }
+    }
+    merged
+}
+
+/// Brain v2 L1.2 — deterministic CONTEXTUAL AUGMENTATION of a chunk (Anthropic's
+/// contextual-retrieval mechanism at zero LLM cost): prepend a one-line situating header —
+/// `<title> | <date> | <attendees> | <facts>` — to the raw chunk text, so both the FTS tokens and
+/// the passage embedding carry the meeting's provenance and entity/fact context. Empty parts are
+/// skipped; attendees are capped at [`AUG_MAX_ATTENDEES`] and facts at [`AUG_MAX_FACTS`]
+/// (defensive — the gated readers already cap). Pure string formatting.
+pub fn augment_chunk_text(
+    title: &str,
+    date: &str,
+    attendees: &[String],
+    facts: &[String],
+    raw: &str,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if !title.trim().is_empty() {
+        parts.push(title.trim().to_string());
+    }
+    if !date.trim().is_empty() {
+        parts.push(date.trim().to_string());
+    }
+    let attendees_s = attendees
+        .iter()
+        .map(|a| a.trim())
+        .filter(|a| !a.is_empty())
+        .take(AUG_MAX_ATTENDEES)
+        .collect::<Vec<_>>()
+        .join(", ");
+    if !attendees_s.is_empty() {
+        parts.push(attendees_s);
+    }
+    let facts_s = facts
+        .iter()
+        .map(|f| f.trim())
+        .filter(|f| !f.is_empty())
+        .take(AUG_MAX_FACTS)
+        .collect::<Vec<_>>()
+        .join("; ");
+    if !facts_s.is_empty() {
+        parts.push(facts_s);
+    }
+    if parts.is_empty() {
+        return raw.to_string();
+    }
+    format!("{}\n{raw}", parts.join(" | "))
+}
+
+/// Brain v2 L1.3 — weighted SCORE FUSION of the three retrieval legs (spec §L1.3). Replaces
+/// rank-only RRF when raw scores are available; [`rrf_fuse`] stays as the fallback.
+///
+/// Leg contracts:
+/// - `fts` — HIGHER-better raw relevance per meeting (callers pass `-bm25`, since SQLite FTS5
+///   `bm25()` is lower/more-negative = better);
+/// - `knn` — RAW vector DISTANCES per meeting (lower = better); inverted here via
+///   `sim = 1 / (1 + d)` per the spec;
+/// - `graph` — HIGHER-better (e.g. `1/rank` of the entity-neighbourhood ordering).
+///
+/// Each leg is min-max normalized to `[0, 1]` independently (a constant/single-entry leg
+/// normalizes to all-1.0 — presence in a leg is signal), then blended
+/// `0.4·fts + 0.4·knn + 0.2·graph` ([`SCORE_FUSE_W_FTS`]/[`SCORE_FUSE_W_KNN`]/
+/// [`SCORE_FUSE_W_GRAPH`]). Returns `(id, fused)` sorted DESC, ties broken by id ASC (stable,
+/// deterministic). Pure — no DB, no model.
+pub fn score_fuse(
+    fts: &[(String, f64)],
+    knn: &[(String, f64)],
+    graph: &[(String, f64)],
+) -> Vec<(String, f64)> {
+    fn minmax(leg: &[(String, f64)]) -> Vec<(String, f64)> {
+        if leg.is_empty() {
+            return Vec::new();
+        }
+        let min = leg.iter().map(|(_, s)| *s).fold(f64::INFINITY, f64::min);
+        let max = leg
+            .iter()
+            .map(|(_, s)| *s)
+            .fold(f64::NEG_INFINITY, f64::max);
+        leg.iter()
+            .map(|(id, s)| {
+                let norm = if max > min {
+                    (s - min) / (max - min)
+                } else {
+                    1.0
+                };
+                (id.clone(), norm)
+            })
+            .collect()
+    }
+
+    // Invert KNN distances into similarities BEFORE normalizing (spec: sim = 1/(1+d)).
+    let knn_sim: Vec<(String, f64)> = knn
+        .iter()
+        .map(|(id, d)| (id.clone(), 1.0 / (1.0 + d.max(0.0))))
+        .collect();
+
+    let mut scores: HashMap<String, f64> = HashMap::new();
+    for (leg, w) in [
+        (minmax(fts), SCORE_FUSE_W_FTS),
+        (minmax(&knn_sim), SCORE_FUSE_W_KNN),
+        (minmax(graph), SCORE_FUSE_W_GRAPH),
+    ] {
+        for (id, s) in leg {
+            *scores.entry(id).or_insert(0.0) += w * s;
+        }
+    }
+    let mut fused: Vec<(String, f64)> = scores.into_iter().collect();
+    fused.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    fused
 }
 
 /// Reciprocal Rank Fusion over any number of ranked id-lists (each already ordered best-first).
@@ -724,7 +1057,13 @@ mod tests {
         assert_eq!(chunk_note("T", "D", &big).len(), 2);
     }
 
-    fn seg(idx: i64, start: f64, end: f64, speaker: Option<&str>, text: &str) -> crate::transcribe::types::Segment {
+    fn seg(
+        idx: i64,
+        start: f64,
+        end: f64,
+        speaker: Option<&str>,
+        text: &str,
+    ) -> crate::transcribe::types::Segment {
         crate::transcribe::types::Segment {
             idx,
             start_s: start,
@@ -737,10 +1076,19 @@ mod tests {
 
     #[test]
     fn chunk_transcript_empty_and_blank_yield_no_chunks() {
-        assert!(chunk_transcript("T", "D", &[]).is_empty(), "no segments → no chunks");
+        assert!(
+            chunk_transcript("T", "D", &[]).is_empty(),
+            "no segments → no chunks"
+        );
         // Segments with only whitespace text carry no content → no chunks.
-        let blanks = [seg(0, 0.0, 1.0, Some("me"), "   "), seg(1, 1.0, 2.0, Some("others"), "")];
-        assert!(chunk_transcript("T", "D", &blanks).is_empty(), "all-blank transcript → no chunks");
+        let blanks = [
+            seg(0, 0.0, 1.0, Some("me"), "   "),
+            seg(1, 1.0, 2.0, Some("others"), ""),
+        ];
+        assert!(
+            chunk_transcript("T", "D", &blanks).is_empty(),
+            "all-blank transcript → no chunks"
+        );
     }
 
     #[test]
@@ -749,8 +1097,14 @@ mod tests {
         let chunks = chunk_transcript("Quarterly Sync", "2026-06-28", &segs);
         assert_eq!(chunks.len(), 1);
         let c = &chunks[0];
-        assert!(c.starts_with("Quarterly Sync · 2026-06-28\n"), "must carry the <title> · <date> header, got: {c:?}");
-        assert!(c.contains("[00:05-00:12] (me)"), "must carry [mm:ss-mm:ss] (speaker) provenance, got: {c:?}");
+        assert!(
+            c.starts_with("Quarterly Sync · 2026-06-28\n"),
+            "must carry the <title> · <date> header, got: {c:?}"
+        );
+        assert!(
+            c.contains("[00:05-00:12] (me)"),
+            "must carry [mm:ss-mm:ss] (speaker) provenance, got: {c:?}"
+        );
         assert!(c.contains("let us discuss the budget"));
     }
 
@@ -767,10 +1121,17 @@ mod tests {
         assert_eq!(chunks.len(), 1, "short transcript fits one chunk");
         let body = &chunks[0];
         // Exactly two turn headers (me merged, others separate).
-        assert_eq!(body.matches("(me)").count(), 1, "consecutive me segments must merge into one turn");
+        assert_eq!(
+            body.matches("(me)").count(),
+            1,
+            "consecutive me segments must merge into one turn"
+        );
         assert_eq!(body.matches("(others)").count(), 1);
         // The merged me turn spans 0:00-0:06 and joins both texts.
-        assert!(body.contains("[00:00-00:06] (me)\nhello there and welcome"), "got: {body:?}");
+        assert!(
+            body.contains("[00:00-00:06] (me)\nhello there and welcome"),
+            "got: {body:?}"
+        );
         assert!(body.contains("[00:06-00:09] (others)"));
     }
 
@@ -790,10 +1151,20 @@ mod tests {
     #[test]
     fn chunk_transcript_unicode_polish_speaker_tag_preserved() {
         // A non-me/others Unicode speaker label (Polish) must round-trip verbatim into the turn header.
-        let segs = [seg(0, 0.0, 4.0, Some("Łukasz"), "budżet na kwartał wygląda dobrze")];
+        let segs = [seg(
+            0,
+            0.0,
+            4.0,
+            Some("Łukasz"),
+            "budżet na kwartał wygląda dobrze",
+        )];
         let chunks = chunk_transcript("T", "D", &segs);
         assert_eq!(chunks.len(), 1);
-        assert!(chunks[0].contains("(Łukasz)"), "Unicode speaker tag must survive, got: {:?}", chunks[0]);
+        assert!(
+            chunks[0].contains("(Łukasz)"),
+            "Unicode speaker tag must survive, got: {:?}",
+            chunks[0]
+        );
         assert!(chunks[0].contains("budżet na kwartał"));
     }
 
@@ -802,7 +1173,11 @@ mod tests {
         let segs = [seg(0, 0.0, 4.0, None, "unattributed legacy line")];
         let chunks = chunk_transcript("T", "D", &segs);
         assert_eq!(chunks.len(), 1);
-        assert!(chunks[0].contains("(unknown)"), "None speaker → (unknown), got: {:?}", chunks[0]);
+        assert!(
+            chunks[0].contains("(unknown)"),
+            "None speaker → (unknown), got: {:?}",
+            chunks[0]
+        );
     }
 
     #[test]
@@ -813,26 +1188,49 @@ mod tests {
             let speaker = if i % 2 == 0 { "me" } else { "others" };
             // ~110-char utterance so a handful of turns exceed the 1000-char window target.
             let text = format!("this is turn number {i} with a fair amount of spoken content to push the running window past the target size");
-            segs.push(seg(i, i as f64 * 5.0, i as f64 * 5.0 + 4.0, Some(speaker), &text));
+            segs.push(seg(
+                i,
+                i as f64 * 5.0,
+                i as f64 * 5.0 + 4.0,
+                Some(speaker),
+                &text,
+            ));
         }
         let chunks = chunk_transcript("Long", "2026-06-28", &segs);
-        assert!(chunks.len() >= 2, "long transcript must split into multiple windows, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "long transcript must split into multiple windows, got {}",
+            chunks.len()
+        );
         // Every chunk carries the header.
         for c in &chunks {
-            assert!(c.starts_with("Long · 2026-06-28\n"), "chunk missing header: {c:?}");
+            assert!(
+                c.starts_with("Long · 2026-06-28\n"),
+                "chunk missing header: {c:?}"
+            );
         }
         // OVERLAP: the LAST turn line of chunk N must reappear as (near) the FIRST body line of chunk N+1
         // (whole-turn carry). Assert at least one shared turn line across the first boundary.
         let turn_lines = |c: &str| -> Vec<String> {
-            c.lines().filter(|l| l.starts_with('[')).map(str::to_string).collect::<Vec<_>>()
+            c.lines()
+                .filter(|l| l.starts_with('['))
+                .map(str::to_string)
+                .collect::<Vec<_>>()
         };
         let a = turn_lines(&chunks[0]);
         let b = turn_lines(&chunks[1]);
         let shared = a.iter().rev().take(3).any(|t| b.contains(t));
         assert!(shared, "sliding window must overlap: a tail turn of chunk 0 must reappear in chunk 1\n0={a:?}\n1={b:?}");
         // Overlap stays BOUNDED — the carried body must be well under a full window.
-        let carried_chars: usize = b.iter().take_while(|t| a.contains(t)).map(|t| t.len()).sum();
-        assert!(carried_chars <= TRANSCRIPT_CHUNK_CHAR_TARGET / 2, "overlap must be ~15%, not half a window (got {carried_chars} chars)");
+        let carried_chars: usize = b
+            .iter()
+            .take_while(|t| a.contains(t))
+            .map(|t| t.len())
+            .sum();
+        assert!(
+            carried_chars <= TRANSCRIPT_CHUNK_CHAR_TARGET / 2,
+            "overlap must be ~15%, not half a window (got {carried_chars} chars)"
+        );
     }
 
     #[test]
@@ -844,6 +1242,294 @@ mod tests {
         let a = chunk_transcript("T", "D", &segs);
         let b = chunk_transcript("T", "D", &segs);
         assert_eq!(a, b, "chunk_transcript must be pure + deterministic");
+    }
+
+    // ── L1.1 segment_topics ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn segment_topics_empty_and_blank_yield_nothing() {
+        assert!(segment_topics(&[]).is_empty());
+        let blanks = [
+            seg(0, 0.0, 1.0, Some("me"), "   "),
+            seg(1, 1.0, 2.0, Some("others"), ""),
+        ];
+        assert!(segment_topics(&blanks).is_empty());
+    }
+
+    #[test]
+    fn segment_topics_splits_on_lull() {
+        // Two long conversational blocks separated by a 40s silence — the lull is the boundary.
+        // Each block is > 60s so neither merges away.
+        let mut segs = Vec::new();
+        for i in 0..4i64 {
+            segs.push(seg(
+                i,
+                i as f64 * 20.0,
+                i as f64 * 20.0 + 18.0,
+                Some("me"),
+                "planning the atlas budget numbers",
+            ));
+        }
+        // Block 2 starts 40s after block 1 ended (78.0 + 40 = 118.0).
+        for i in 0..4i64 {
+            segs.push(seg(
+                4 + i,
+                118.0 + i as f64 * 20.0,
+                118.0 + i as f64 * 20.0 + 18.0,
+                Some("me"),
+                "planning the atlas budget numbers",
+            ));
+        }
+        let topics = segment_topics(&segs);
+        assert_eq!(
+            topics.len(),
+            2,
+            "a ≥30s lull must open a new topic, got {topics:?}"
+        );
+        assert!(topics[0].end_s <= 78.0 + 1e-9);
+        assert!((topics[1].start_s - 118.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn segment_topics_splits_on_lexical_shift() {
+        // Same speaker, no lull — but the vocabulary flips completely between two 6-segment
+        // windows, so the Jaccard-shift signal must fire. Both halves are > 60s.
+        let mut segs = Vec::new();
+        for i in 0..6i64 {
+            segs.push(seg(
+                i,
+                i as f64 * 15.0,
+                i as f64 * 15.0 + 14.0,
+                Some("me"),
+                "budżet finanse kwartał wydatki koszty licencje",
+            ));
+        }
+        for i in 6..12i64 {
+            segs.push(seg(
+                i,
+                i as f64 * 15.0,
+                i as f64 * 15.0 + 14.0,
+                Some("me"),
+                "rekrutacja kandydat rozmowa oferta zatrudnienie zespół",
+            ));
+        }
+        let topics = segment_topics(&segs);
+        assert_eq!(
+            topics.len(),
+            2,
+            "a lexical shift must open a new topic, got {topics:?}"
+        );
+        assert!(topics[0].text.contains("budżet"));
+        assert!(!topics[0].text.contains("rekrutacja"));
+        assert!(topics[1].text.contains("rekrutacja"));
+    }
+
+    #[test]
+    fn segment_topics_speaker_flip_needs_a_long_run() {
+        // Ordinary turn-taking (1-2 segment runs) must NOT split; a flip after a ≥5-run must.
+        // Use a SHARED vocabulary so the lexical signal stays silent.
+        let text = "wspólny temat projektu atlas status zadania postęp";
+        let mut segs = Vec::new();
+        // 6-segment "me" run…
+        for i in 0..6i64 {
+            segs.push(seg(
+                i,
+                i as f64 * 15.0,
+                i as f64 * 15.0 + 14.0,
+                Some("me"),
+                text,
+            ));
+        }
+        // …then "others" takes over for 6 segments (flip AFTER a 6-run ⇒ boundary).
+        for i in 6..12i64 {
+            segs.push(seg(
+                i,
+                i as f64 * 15.0,
+                i as f64 * 15.0 + 14.0,
+                Some("others"),
+                text,
+            ));
+        }
+        let topics = segment_topics(&segs);
+        assert_eq!(
+            topics.len(),
+            2,
+            "flip after a ≥5-run must split, got {topics:?}"
+        );
+
+        // Pure alternation (run length 1) must stay ONE topic.
+        let mut alt = Vec::new();
+        for i in 0..12i64 {
+            let sp = if i % 2 == 0 { "me" } else { "others" };
+            alt.push(seg(
+                i,
+                i as f64 * 15.0,
+                i as f64 * 15.0 + 14.0,
+                Some(sp),
+                text,
+            ));
+        }
+        assert_eq!(
+            segment_topics(&alt).len(),
+            1,
+            "ordinary turn-taking must not split"
+        );
+    }
+
+    #[test]
+    fn segment_topics_merges_short_topics_forward() {
+        // A 30s sliver before a lull merges into the (long) following topic instead of standing
+        // alone. Shared vocabulary keeps the lexical signal out of the picture.
+        let text = "wspólny temat projektu atlas status zadania postęp";
+        let mut segs = Vec::new();
+        segs.push(seg(0, 0.0, 30.0, Some("me"), text)); // 30s sliver…
+                                                        // …lull ≥ 30s opens a boundary, then a 90s block.
+        for i in 0..6i64 {
+            segs.push(seg(
+                1 + i,
+                70.0 + i as f64 * 15.0,
+                70.0 + i as f64 * 15.0 + 14.0,
+                Some("me"),
+                text,
+            ));
+        }
+        let topics = segment_topics(&segs);
+        assert_eq!(
+            topics.len(),
+            1,
+            "a <60s topic must merge forward, got {topics:?}"
+        );
+        assert!(
+            (topics[0].start_s - 0.0).abs() < 1e-9,
+            "merged topic keeps the sliver's start"
+        );
+    }
+
+    #[test]
+    fn segment_topics_is_deterministic_and_tags_speakers() {
+        let segs = [
+            seg(0, 0.0, 4.0, Some("me"), "deterministic topic check"),
+            seg(
+                1,
+                4.0,
+                8.0,
+                Some("Łukasz"),
+                "deterministyczna kontrola tematu",
+            ),
+        ];
+        let a = segment_topics(&segs);
+        let b = segment_topics(&segs);
+        assert_eq!(a, b, "segment_topics must be pure + deterministic");
+        assert_eq!(a.len(), 1);
+        assert!(a[0].text.contains("(me) deterministic topic check"));
+        assert!(a[0]
+            .text
+            .contains("(Łukasz) deterministyczna kontrola tematu"));
+    }
+
+    // ── L1.2 augment_chunk_text ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn augment_chunk_text_formats_header_and_caps() {
+        let attendees: Vec<String> = (0..7).map(|i| format!("Person {i}")).collect();
+        let facts: Vec<String> = (0..10).map(|i| format!("fact {i}")).collect();
+        let out = augment_chunk_text(
+            "Quarterly Sync",
+            "2026-06-28",
+            &attendees,
+            &facts,
+            "raw body",
+        );
+        let header = out.lines().next().unwrap();
+        assert!(header.starts_with("Quarterly Sync | 2026-06-28 | "));
+        assert!(header.contains("Person 0, Person 1, Person 2, Person 3, Person 4"));
+        assert!(
+            !header.contains("Person 5"),
+            "attendees must cap at {AUG_MAX_ATTENDEES}"
+        );
+        assert!(header.contains("fact 7"));
+        assert!(
+            !header.contains("fact 8"),
+            "facts must cap at {AUG_MAX_FACTS}"
+        );
+        assert!(out.ends_with("\nraw body"));
+    }
+
+    #[test]
+    fn augment_chunk_text_skips_empty_parts() {
+        // No attendees/facts ⇒ just "title | date\nraw".
+        let out = augment_chunk_text("T", "2026-01-01", &[], &[], "raw");
+        assert_eq!(out, "T | 2026-01-01\nraw");
+        // Everything empty ⇒ the raw text unchanged (no dangling header line).
+        assert_eq!(augment_chunk_text("", " ", &[], &[], "raw"), "raw");
+        // Deterministic.
+        assert_eq!(
+            augment_chunk_text("T", "D", &["A".into()], &["f".into()], "r"),
+            augment_chunk_text("T", "D", &["A".into()], &["f".into()], "r"),
+        );
+    }
+
+    // ── L1.3 score_fuse ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn score_fuse_single_leg_preserves_order() {
+        let fts = vec![
+            ("a".to_string(), 5.0),
+            ("b".to_string(), 3.0),
+            ("c".to_string(), 1.0),
+        ];
+        let fused = score_fuse(&fts, &[], &[]);
+        let ids: Vec<&str> = fused.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+        // Empty legs contribute nothing; the leg's best gets the full leg weight.
+        assert!((fused[0].1 - SCORE_FUSE_W_FTS).abs() < 1e-9);
+    }
+
+    #[test]
+    fn score_fuse_two_legs_reward_agreement() {
+        // "m2" is mid-pack in FTS but is also a KNN hit; "m1" tops FTS only, "m3" KNN only.
+        let fts = vec![
+            ("m1".to_string(), 9.0),
+            ("m2".to_string(), 5.0),
+            ("x".to_string(), 1.0),
+        ];
+        let knn = vec![
+            ("m3".to_string(), 0.1),
+            ("m2".to_string(), 0.2),
+            ("y".to_string(), 2.0),
+        ];
+        let fused = score_fuse(&fts, &knn, &[]);
+        let pos = |want: &str| fused.iter().position(|(id, _)| id == want).unwrap();
+        assert!(
+            pos("m2") < pos("m3"),
+            "a both-legs hit must beat a one-leg hit: {fused:?}"
+        );
+        assert!(pos("m2") < pos("x"));
+    }
+
+    #[test]
+    fn score_fuse_inverts_knn_distances() {
+        // Smaller distance = better: d=0.1 must outrank d=1.5.
+        let knn = vec![("far".to_string(), 1.5), ("near".to_string(), 0.1)];
+        let fused = score_fuse(&[], &knn, &[]);
+        assert_eq!(
+            fused[0].0, "near",
+            "smaller KNN distance must fuse higher: {fused:?}"
+        );
+        assert!(fused[0].1 > fused[1].1);
+    }
+
+    #[test]
+    fn score_fuse_empty_legs_and_ties() {
+        assert!(score_fuse(&[], &[], &[]).is_empty());
+        // A constant leg normalizes to all-1.0 (presence is signal), ties break by id ASC.
+        let graph = vec![("b".to_string(), 1.0), ("a".to_string(), 1.0)];
+        let fused = score_fuse(&[], &[], &graph);
+        assert_eq!(fused[0].0, "a");
+        assert!(
+            (fused[0].1 - fused[1].1).abs() < 1e-12,
+            "constant leg ⇒ equal scores"
+        );
     }
 
     #[test]

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -3,11 +3,20 @@
 //!
 //! ## Modes
 //!
-//! - **FTS** — `Db::search_visible(query)` → the meeting ids in BM25 order.
+//! - **FTS** — `Db::search_visible_in_range(query, …, temporal-window)` → the meeting ids in BM25
+//!   order (with the Brain v2 L1.5 date filter + temporal window fallback, exactly as the
+//!   `search_meetings` tool queries it).
 //! - **Semantic** — embed the query (asymmetric `embed_query`), then
 //!   `Db::search_semantic_visible(query_vec)` → the meeting ids in vector-distance order.
-//! - **Hybrid** — RRF-fuse the FTS and semantic id lists via [`crate::embed::rrf_fuse`] (the same
-//!   fusion the app uses for documents) → the fused meeting-id order.
+//! - **Hybrid** — the REAL `Db::search_hybrid_visible` (Brain v2 L1.3 score fusion over the
+//!   FTS ∪ topic-FTS, KNN ∪ topic-KNN, and entity-graph legs, plus the L1.5 date filter) — the
+//!   bake-off measures the retrieval the app actually ships, not a local re-implementation.
+//! - **Reranked** (optional) — hybrid + a [`crate::rerank::Reranker`] pass over the top
+//!   [`crate::rerank::RERANK_TOP_K`] candidates (Brain v2 L1.4).
+//!
+//! `today` is an EXPLICIT parameter (never `now()`): the synthetic runner passes the FIXED
+//! [`crate::eval::corpus::CORPUS_ANCHOR_DATE`] so temporal gold labels never rot; the real-vault
+//! runner passes the actual date.
 //!
 //! ## Gating (read the lock-model note in `mod.rs`)
 //!
@@ -25,16 +34,27 @@
 
 use std::collections::HashSet;
 
-use crate::embed::{rrf_fuse, Embedder, RRF_K};
+use crate::embed::Embedder;
 use crate::error::{AppError, Result};
 use crate::eval::{aggregate_metrics, BakeoffReport, LabeledSet, ModeMetrics, RetrievalMode};
+use crate::rerank::Reranker;
+use crate::storage::models::SearchHit;
 use crate::storage::Db;
+use crate::summarize::temporal::extract_date_filter;
 
-/// Retrieve the FTS meeting-id ranking for one query (BM25 order, deduped, visibility-gated).
-fn fts_ranked(db: &Db, query: &str, k: usize, unlocked: &HashSet<String>) -> Result<Vec<String>> {
+/// Retrieve the FTS meeting-id ranking for one query (BM25 order, deduped, visibility-gated),
+/// with the L1.5 temporal window — exactly the `search_meetings` tool path.
+fn fts_ranked(
+    db: &Db,
+    query: &str,
+    k: usize,
+    unlocked: &HashSet<String>,
+    today: chrono::NaiveDate,
+) -> Result<Vec<String>> {
     // Fetch a few extra candidates so the top-k cutoff is applied to a full list, not a truncated one.
     let limit = (k.max(1) * 4) as i64;
-    let hits = db.search_visible(query, limit, unlocked)?;
+    let date_filter = extract_date_filter(query, today);
+    let hits = db.search_visible_in_range(query, limit, unlocked, date_filter)?;
     Ok(hits.into_iter().map(|h| h.meeting.id).collect())
 }
 
@@ -62,25 +82,63 @@ fn semantic_ranked(
     Ok(hits.into_iter().map(|h| h.meeting.id).collect())
 }
 
-/// RRF-fuse the FTS and semantic rankings into one meeting-id order (the hybrid leg). Either list may
-/// be empty; RRF over the remaining one preserves its order. Uses the app's [`RRF_K`].
-fn hybrid_ranked(fts: &[String], semantic: &[String]) -> Vec<String> {
-    let fused = rrf_fuse(&[fts.to_vec(), semantic.to_vec()], RRF_K);
-    fused.into_iter().map(|(id, _score)| id).collect()
+/// The REAL hybrid retrieval, as shipped: `Db::search_hybrid_visible` (score fusion over
+/// FTS ∪ topic-FTS, KNN ∪ topic-KNN, entity graph) with the L1.5 temporal window.
+fn hybrid_hits(
+    db: &Db,
+    embedder: &dyn Embedder,
+    query: &str,
+    k: usize,
+    unlocked: &HashSet<String>,
+    today: chrono::NaiveDate,
+) -> Result<Vec<SearchHit>> {
+    let query_vec = embedder
+        .embed_query(&[query.to_string()])?
+        .into_iter()
+        .next()
+        .unwrap_or_default();
+    let date_filter = extract_date_filter(query, today);
+    db.search_hybrid_visible(
+        query,
+        &query_vec,
+        (k.max(1) * 4) as i64,
+        unlocked,
+        date_filter,
+    )
 }
 
-/// Run the full bake-off over `set` at cutoff `k`, returning per-mode averaged metrics.
-///
-/// For each labeled query we compute the three rankings, then average recall@k / nDCG@k / MRR across
-/// the set per mode. READ-ONLY + visibility-gated (see the module note). `k` is clamped to `>= 1`.
-/// A meaningful semantic/hybrid result requires a REAL embedder + an indexed vault; with the stub or
-/// an empty index the semantic leg is uninformative (documented, not an error).
+/// Run the full bake-off over `set` at cutoff `k`, returning per-mode averaged metrics
+/// (fts / semantic / hybrid). Delegates to [`run_bakeoff_with_rerank`] with no reranker.
 pub fn run_bakeoff(
     db: &Db,
     embedder: &dyn Embedder,
     set: &LabeledSet,
     k: usize,
     unlocked: &HashSet<String>,
+    today: chrono::NaiveDate,
+) -> Result<BakeoffReport> {
+    run_bakeoff_with_rerank(db, embedder, None, set, k, unlocked, today)
+}
+
+/// Run the full bake-off over `set` at cutoff `k`, returning per-mode averaged metrics.
+///
+/// For each labeled query we compute the rankings, then average recall@k / nDCG@k / MRR across
+/// the set per mode. READ-ONLY + visibility-gated (see the module note). `k` is clamped to `>= 1`.
+/// A meaningful semantic/hybrid result requires a REAL embedder + an indexed vault; with the stub or
+/// an empty index the semantic leg is uninformative (documented, not an error).
+///
+/// `reranker`: `Some` adds the fourth `hybrid+rerank` mode — the hybrid ranking's top
+/// [`crate::rerank::RERANK_TOP_K`] candidates reordered by the reranker (candidate text =
+/// title + snippet, exactly the Ask wiring in `vault_context`). Pass the PROMPTED reranker only
+/// when a real local model is resident; a stub reranker would measure the identity.
+pub fn run_bakeoff_with_rerank(
+    db: &Db,
+    embedder: &dyn Embedder,
+    reranker: Option<&dyn Reranker>,
+    set: &LabeledSet,
+    k: usize,
+    unlocked: &HashSet<String>,
+    today: chrono::NaiveDate,
 ) -> Result<BakeoffReport> {
     let k = k.max(1);
     if set.is_empty() {
@@ -92,21 +150,33 @@ pub fn run_bakeoff(
     let mut fts_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
     let mut sem_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
     let mut hyb_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
+    let mut rr_rankings: Vec<Vec<String>> = Vec::with_capacity(set.len());
 
     for q in &set.0 {
-        let fts = fts_ranked(db, &q.query, k, unlocked)?;
+        let fts = fts_ranked(db, &q.query, k, unlocked, today)?;
         let sem = semantic_ranked(db, embedder, &q.query, k, unlocked)?;
-        let hyb = hybrid_ranked(&fts, &sem);
+        let hyb = hybrid_hits(db, embedder, &q.query, k, unlocked, today)?;
+        if let Some(rr) = reranker {
+            rr_rankings.push(rerank_hits(rr, &q.query, &hyb));
+        }
         fts_rankings.push(fts);
         sem_rankings.push(sem);
-        hyb_rankings.push(hyb);
+        hyb_rankings.push(hyb.into_iter().map(|h| h.meeting.id).collect());
     }
 
-    let modes: Vec<ModeMetrics> = vec![
+    let mut modes: Vec<ModeMetrics> = vec![
         aggregate_metrics(RetrievalMode::Fts, set, &fts_rankings, k),
         aggregate_metrics(RetrievalMode::Semantic, set, &sem_rankings, k),
         aggregate_metrics(RetrievalMode::Hybrid, set, &hyb_rankings, k),
     ];
+    if reranker.is_some() {
+        modes.push(aggregate_metrics(
+            RetrievalMode::Reranked,
+            set,
+            &rr_rankings,
+            k,
+        ));
+    }
 
     Ok(BakeoffReport {
         k,
@@ -115,43 +185,82 @@ pub fn run_bakeoff(
     })
 }
 
+/// Reorder a hybrid hit list's top [`crate::rerank::RERANK_TOP_K`] via `reranker` — the same
+/// candidate shape (`id`, `title\nsnippet`) and degrade-safety as the Ask wiring in
+/// `vault_context::build_vault_context_hybrid_visible`.
+fn rerank_hits(reranker: &dyn Reranker, query: &str, hits: &[SearchHit]) -> Vec<String> {
+    let ids: Vec<String> = hits.iter().map(|h| h.meeting.id.clone()).collect();
+    let k = crate::rerank::RERANK_TOP_K.min(hits.len());
+    if k < 2 {
+        return ids;
+    }
+    let candidates: Vec<(String, String)> = hits[..k]
+        .iter()
+        .map(|h| {
+            let title = h.meeting.title.clone().unwrap_or_default();
+            (h.meeting.id.clone(), format!("{title}\n{}", h.snippet))
+        })
+        .collect();
+    let order = reranker.rerank(query, &candidates, crate::rerank::RERANK_TIMEOUT_MS);
+    let mut head: Vec<String> = Vec::with_capacity(k);
+    let mut pool: Vec<String> = ids[..k].to_vec();
+    for id in order {
+        if let Some(pos) = pool.iter().position(|x| *x == id) {
+            head.push(pool.remove(pos));
+        }
+    }
+    head.extend(pool);
+    head.extend_from_slice(&ids[k..]);
+    head
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn hybrid_ranked_fuses_both_legs() {
-        // m2 appears in both legs (high in each) → should outrank m1/m3 (each in only one leg).
-        let fts = vec!["m1".to_string(), "m2".to_string()];
-        let sem = vec!["m3".to_string(), "m2".to_string(), "m1".to_string()];
-        let fused = hybrid_ranked(&fts, &sem);
-        let pos = |id: &str| fused.iter().position(|x| x == id).unwrap();
-        assert!(
-            pos("m2") < pos("m3"),
-            "m2 (both legs) must outrank m3 (one leg)"
-        );
-        assert!(
-            pos("m1") < pos("m3"),
-            "m1 (both legs) must outrank m3 (one leg)"
-        );
-        // Dedup: every id appears once.
-        assert_eq!(fused.len(), 3);
+    /// The fixed anchor the synthetic corpus + labeled set were authored against.
+    fn anchor_date() -> chrono::NaiveDate {
+        chrono::NaiveDate::parse_from_str(crate::eval::corpus::CORPUS_ANCHOR_DATE, "%Y-%m-%d")
+            .expect("valid corpus anchor")
     }
 
     #[test]
-    fn hybrid_ranked_handles_empty_leg() {
-        // Semantic leg empty (e.g. no model / punctuation query) → hybrid preserves the FTS order.
-        let fts = vec!["a".to_string(), "b".to_string()];
-        let fused = hybrid_ranked(&fts, &[]);
-        assert_eq!(fused, vec!["a".to_string(), "b".to_string()]);
-        // FTS leg empty → hybrid preserves the semantic order.
-        let sem = vec!["x".to_string(), "y".to_string()];
-        assert_eq!(
-            hybrid_ranked(&[], &sem),
-            vec!["x".to_string(), "y".to_string()]
-        );
-        // Both empty → empty.
-        assert!(hybrid_ranked(&[], &[]).is_empty());
+    fn rerank_hits_reorders_topk_and_keeps_tail() {
+        // A reranker that reverses the candidate order; ids beyond RERANK_TOP_K must keep their
+        // positions, and a reranker that "loses" an id must not drop it (degrade-safety).
+        struct Reverser;
+        impl crate::rerank::Reranker for Reverser {
+            fn id(&self) -> &str {
+                "rev-test"
+            }
+            fn rerank(&self, _q: &str, candidates: &[(String, String)], _t: u64) -> Vec<String> {
+                let mut ids: Vec<String> = candidates.iter().map(|(id, _)| id.clone()).collect();
+                ids.reverse();
+                ids.pop(); // "lose" one id — rerank_hits must restore it.
+                ids
+            }
+        }
+        let mk = |id: &str| SearchHit {
+            meeting: crate::storage::models::Meeting {
+                id: id.to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                ended_at: None,
+                title: Some(id.to_string()),
+                duration_s: 60,
+                audio_path: None,
+                status: crate::storage::models::MeetingStatus::Summarized,
+                folder_id: None,
+            },
+            snippet: String::new(),
+            matched_in: "note".to_string(),
+        };
+        let hits: Vec<SearchHit> = (0..12).map(|i| mk(&format!("m{i}"))).collect();
+        let out = rerank_hits(&Reverser, "q", &hits);
+        assert_eq!(out.len(), 12, "no id may be dropped");
+        // Top-10 reversed (m9..m1), the lost m0 re-appended, then the untouched tail m10, m11.
+        assert_eq!(out[0], "m9");
+        assert_eq!(out[9], "m0", "an id the reranker lost must be restored");
+        assert_eq!(&out[10..], &["m10", "m11"]);
     }
 
     #[test]
@@ -161,7 +270,7 @@ mod tests {
         let set = LabeledSet(vec![]);
         let db = throwaway_db("bakeoff-empty");
         let stub = crate::embed::StubEmbedder;
-        let err = run_bakeoff(&db, &stub, &set, 5, &HashSet::new()).unwrap_err();
+        let err = run_bakeoff(&db, &stub, &set, 5, &HashSet::new(), anchor_date()).unwrap_err();
         assert!(matches!(err, AppError::InvalidArg(_)));
     }
 
@@ -178,7 +287,7 @@ mod tests {
             lang: "en".to_string(),
             expected_meeting_ids: vec!["m-nonexistent".to_string()],
         }]);
-        let report = run_bakeoff(&db, &stub, &set, 5, &HashSet::new()).unwrap();
+        let report = run_bakeoff(&db, &stub, &set, 5, &HashSet::new(), anchor_date()).unwrap();
         assert_eq!(report.modes.len(), 3, "all three modes must be reported");
         assert_eq!(report.k, 5);
         assert_eq!(report.queries, 1);
@@ -232,7 +341,19 @@ mod tests {
         let embedder = crate::embed::active_embedder();
         // Empty unlocked set = eval OPEN content only. To include a sealed folder, unlock it in the
         // app and copy the WAL'd DB, or extend this to accept a folder-id list.
-        let report = run_bakeoff(&db, embedder.as_ref(), &set, k, &HashSet::new()).unwrap();
+        // Real vault ⇒ the REAL query-time anchor (the labeled set is authored against it).
+        let today = chrono::Utc::now().date_naive();
+        let reranker = local_reranker_or_note();
+        let report = run_bakeoff_with_rerank(
+            &db,
+            embedder.as_ref(),
+            reranker.as_deref(),
+            &set,
+            k,
+            &HashSet::new(),
+            today,
+        )
+        .unwrap();
         println!("\n{}", crate::eval::format_report_table(&report));
 
         // Spec §L1.6: honor MURMUR_BAKEOFF_OUT — write the committed markdown artifact. The corpus
@@ -275,7 +396,19 @@ mod tests {
 
         let set = LabeledSet::from_json(include_str!("fixtures/rag-bakeoff-synthetic.json"))
             .expect("parse synthetic labeled set");
-        let report = run_bakeoff(&db, embedder.as_ref(), &set, 5, &HashSet::new()).unwrap();
+        // The FIXED anchor (never now()) — the temporal gold labels are authored against it.
+        let today = anchor_date();
+        let reranker = local_reranker_or_note();
+        let report = run_bakeoff_with_rerank(
+            &db,
+            embedder.as_ref(),
+            reranker.as_deref(),
+            &set,
+            5,
+            &HashSet::new(),
+            today,
+        )
+        .unwrap();
 
         let ctx = crate::eval::ReportContext {
             date: today_utc(),
@@ -286,7 +419,13 @@ mod tests {
                 crate::eval::corpus::CORPUS_ANCHOR_DATE
             ),
             labeled_set: "src-tauri/src/eval/fixtures/rag-bakeoff-synthetic.json".to_string(),
-            config: format!("RRF_K={}", crate::embed::RRF_K),
+            config: format!(
+                "score_fuse {}/{}/{} + topic legs + temporal filter (RRF_K={} fallback)",
+                crate::embed::SCORE_FUSE_W_FTS,
+                crate::embed::SCORE_FUSE_W_KNN,
+                crate::embed::SCORE_FUSE_W_GRAPH,
+                crate::embed::RRF_K
+            ),
             embedder_id: crate::embed::selected_embed_model().id.to_string(),
             embedder_real: real,
         };
@@ -309,8 +448,8 @@ mod tests {
         let set =
             LabeledSet::from_json(include_str!("fixtures/rag-bakeoff-synthetic.json")).unwrap();
         assert_eq!(set.len(), 20);
-        let report = run_bakeoff(&db, &stub, &set, 5, &HashSet::new()).unwrap();
-        assert_eq!(report.modes.len(), 3, "no reranker yet — exactly 3 rows");
+        let report = run_bakeoff(&db, &stub, &set, 5, &HashSet::new(), anchor_date()).unwrap();
+        assert_eq!(report.modes.len(), 3, "no reranker passed — exactly 3 rows");
         let fts = report
             .modes
             .iter()
@@ -334,6 +473,27 @@ mod tests {
         let md = crate::eval::format_report_markdown(&report, &ctx);
         assert!(md.contains("| fts |") && md.contains("| semantic |") && md.contains("| hybrid |"));
         assert!(md.contains("WARNING — STUB EMBEDDER"));
+    }
+
+    /// Resolve the PROMPTED reranker over the LOCAL brain model when one is on disk, else `None`
+    /// (a stub reranker would measure the identity — the row is skipped with a printed note).
+    /// Test-only helper shared by both `#[ignore]` runners.
+    fn local_reranker_or_note() -> Option<Box<dyn crate::rerank::Reranker>> {
+        let cfg = crate::settings::AppConfig {
+            brain_backend: crate::settings::BrainBackend::Local,
+            ..Default::default()
+        };
+        let reranker = crate::rerank::active_reranker(std::sync::Arc::from(
+            crate::reason::active_reasoner(&cfg),
+        ));
+        if reranker.id() == "stub" {
+            eprintln!(
+                "NOTE: no local brain model on disk — the hybrid+rerank row is SKIPPED \
+                 (a stub reranker is the identity and would measure nothing)."
+            );
+            return None;
+        }
+        Some(reranker)
     }
 
     /// Write the artifact to `$MURMUR_BAKEOFF_OUT` when set (creating parent dirs). Test-only

--- a/src-tauri/src/eval/corpus.rs
+++ b/src-tauri/src/eval/corpus.rs
@@ -453,8 +453,11 @@ pub fn seed_synthetic_corpus(db: &Db, embedder: &dyn Embedder) -> Result<Vec<Str
             .collect();
         db.insert_segments(m.id, &segments)?;
         // Mirror the pipeline's auto-index: both chunk classes (note 'voice' + 'transcript'),
-        // embedded with the caller's embedder.
+        // embedded with the caller's embedder — plus the Brain v2 L1.1 topic chunks, exactly as
+        // `index_meeting_if_enabled` writes them (index_meeting_chunks FIRST — its clean-replace
+        // purge covers all chunk classes — then the topic pass).
         db.index_meeting_chunks(m.id, &segments, embedder)?;
+        db.index_meeting_topic_chunks(m.id, &segments, embedder, &Default::default())?;
         ids.push(m.id.to_string());
     }
     tracing::info!(target: "eval", meetings = ids.len(), "synthetic bake-off corpus seeded");

--- a/src-tauri/src/eval/mod.rs
+++ b/src-tauri/src/eval/mod.rs
@@ -563,7 +563,10 @@ mod tests {
         assert!(md.contains("- labeled set: rag-bakeoff-synthetic.json (20 queries, k=5)"));
         assert!(md.contains("- config: RRF_K=60"));
         assert!(md.contains("- embedder: multilingual-e5-small (REAL model"));
-        assert!(!md.contains("STUB"), "real run must NOT carry the stub warning");
+        assert!(
+            !md.contains("STUB"),
+            "real run must NOT carry the stub warning"
+        );
         assert!(md.contains("| mode | recall@5 | ndcg@5 | mrr |"));
         assert!(md.contains("| fts | 0.5000 | 0.4500 | 0.5100 |"));
         assert!(md.contains("| semantic | 0.7000 | 0.6500 | 0.7100 |"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod orchestrate;
 pub mod pipeline;
 pub mod proactive;
 pub mod reason;
+pub mod rerank;
 pub mod screenshare;
 pub mod secrets;
 pub mod settings;
@@ -367,6 +368,38 @@ pub fn run() {
                     // reasoner-dispatch poison posture (unreadable config never relaxes auth).
                     .unwrap_or(true);
                 crate::mcp::spawn(db_path, unlocked, require_token);
+            }
+            // Brain v2 L1.1 — TOPIC-CHUNK startup backfill: index topic segments for every VISIBLE
+            // meeting that has a transcript, content-hash idempotent (an already-indexed vault is a
+            // cheap probe pass), in batches of 20 on a blocking worker so setup never stalls.
+            // Skipped entirely when the real embed model is absent (the no-stub-vector-at-rest
+            // invariant) — the default install writes nothing.
+            {
+                let state = app.state::<AppState>();
+                let db = state.db.clone();
+                // Respect the feature flag: with semantic search OFF the pipeline never
+                // auto-indexes, so the backfill must not write topic plaintext either
+                // (flag discipline — same posture as `should_auto_index`).
+                let semantic_enabled = state
+                    .config
+                    .lock()
+                    .map(|c| c.semantic_search_enabled)
+                    .unwrap_or(false);
+                tauri::async_runtime::spawn_blocking(move || {
+                    if !semantic_enabled || !crate::embed::embed_model_present() {
+                        return;
+                    }
+                    let embedder = crate::embed::active_embedder();
+                    match db.backfill_topic_chunks_idempotent(embedder.as_ref()) {
+                        Ok(indexed) if indexed > 0 => {
+                            tracing::info!(target: "rag", indexed, "topic-chunk backfill complete");
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(target: "rag", error = %e, "topic-chunk backfill failed");
+                        }
+                    }
+                });
             }
             // Screen-share auto-relock watcher: on capture START, relock all session-unlocked
             // folders + zeroize the KEK and toast the UI. Gated by K_RELOCK_ON_SCREENSHARE.

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -417,10 +417,10 @@ async fn run_inner(
             let mic_master = wav_dir.join(format!("{meeting_id}.mic.wav"));
             if let Err(e) = audio::write_wav_f32(&mic_master, samples, src_rate, 1) {
                 tracing::warn!(target: "audio", error = %e, "mic master write failed");
-            } else if let Err(e) = state
-                .db
-                .set_meeting_mic_master_path(meeting_id, Some(mic_master.to_string_lossy().as_ref()))
-            {
+            } else if let Err(e) = state.db.set_meeting_mic_master_path(
+                meeting_id,
+                Some(mic_master.to_string_lossy().as_ref()),
+            ) {
                 // Best-effort: a stranded, untracked master plaintext is unreferenced + ungated-out;
                 // never fail the recording over it.
                 tracing::warn!(target: "audio", error = %e, "persisting mic master path failed");
@@ -1362,7 +1362,10 @@ pub(crate) fn index_meeting_if_enabled(
     // 'transcript') are indexed alongside the note-summary chunks. A sealed meeting is already excluded
     // above, so these are visible plaintext; an empty transcript simply yields zero transcript chunks.
     let segments = db.get_segments(meeting_id)?;
-    db.index_meeting_chunks(meeting_id, &segments, embedder)
+    db.index_meeting_chunks(meeting_id, &segments, embedder)?;
+    // Brain v2 L1.1 — TOPIC chunks ride the same gate, AFTER the note/transcript index (whose
+    // clean-replace purge covers all chunk classes via the shared `purge_chunks_tx` choke point).
+    db.index_meeting_topic_chunks(meeting_id, &segments, embedder, unlocked)
 }
 
 /// brain2 RAG Phase 4 — RETRIEVAL-AUGMENTED NOTE GENERATION (ALWAYS ON). Build the GATED corpus of

--- a/src-tauri/src/rerank.rs
+++ b/src-tauri/src/rerank.rs
@@ -1,0 +1,290 @@
+//! Brain v2 L1.4 — the RERANKER seam (Ask-only). A [`Reranker`] reorders an ALREADY-RETRIEVED,
+//! ALREADY-GATED candidate list; it opens NO new read path (candidates arrive as `(id, text)`
+//! pairs the caller assembled from visibility-gated readers) and NO egress (the prompted impl
+//! runs on the on-device reasoner ONLY — a cloud or stub reasoner resolves to the identity
+//! [`StubReranker`], see [`active_reranker`]).
+//!
+//! HARD CONTRACT: `rerank` NEVER errors and NEVER drops a candidate — on any failure, timeout, or
+//! deadline expiry it degrades to the input order (retrieval quality falls back to the fused
+//! ranking; nothing breaks). This is why the trait returns `Vec<String>`, not `Result`.
+
+use std::time::{Duration, Instant};
+
+use crate::reason::{GenOptions, LocalReasoner};
+
+/// Total wall-clock budget for ONE rerank pass (all candidates together). Spec §L1.4: 3 s to
+/// start; the eval gate decides whether to tighten it or shrink the candidate count.
+pub const RERANK_TIMEOUT_MS: u64 = 3_000;
+
+/// How many top candidates a caller should hand to the reranker (spec §L1.4: 10 to start).
+pub const RERANK_TOP_K: usize = 10;
+
+/// Hard decode cap per pointwise relevance call — the answer is a one-key JSON bool.
+const RERANK_MAX_TOKENS: usize = 32;
+
+/// A swappable candidate reranker. `candidates` are `(id, text)` pairs, best-first per the
+/// upstream fused ranking; the return is the SAME ids, complete, reordered (or identical).
+pub trait Reranker: Send + Sync {
+    /// Stable id of the backing implementation (`"stub"` / `"prompted"`).
+    fn id(&self) -> &str;
+
+    /// Reorder `candidates` by relevance to `query` within `timeout_ms`. MUST return every input
+    /// id exactly once and MUST degrade to the input order on any failure/timeout — never `Err`.
+    fn rerank(&self, query: &str, candidates: &[(String, String)], timeout_ms: u64) -> Vec<String>;
+}
+
+/// The identity reranker: input order out. The no-model / cloud-brain floor.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StubReranker;
+
+impl Reranker for StubReranker {
+    fn id(&self) -> &str {
+        "stub"
+    }
+
+    fn rerank(
+        &self,
+        _query: &str,
+        candidates: &[(String, String)],
+        _timeout_ms: u64,
+    ) -> Vec<String> {
+        candidates.iter().map(|(id, _)| id.clone()).collect()
+    }
+}
+
+/// POINTWISE prompted reranker over the resident on-device reasoner (spec §L1.4): one strict-JSON
+/// `{"relevant": bool}` call per candidate, deadline-checked BETWEEN candidates via [`Instant`],
+/// each call bounded by [`RERANK_MAX_TOKENS`] + the remaining wall-clock budget (the P0.3
+/// `GenOptions.timeout` pattern — resource bounds scoped to the surface that needs them).
+///
+/// Output order: candidates judged relevant first (stable, input-relative), then the rest — a
+/// candidate whose call fails or falls past the deadline is treated as RELEVANT (it keeps its
+/// fused position; degrading toward the input order, never away from it). No PII is logged —
+/// counts and durations only.
+pub struct PromptedReranker {
+    reasoner: std::sync::Arc<dyn LocalReasoner>,
+}
+
+impl PromptedReranker {
+    pub fn new(reasoner: std::sync::Arc<dyn LocalReasoner>) -> Self {
+        Self { reasoner }
+    }
+}
+
+impl Reranker for PromptedReranker {
+    fn id(&self) -> &str {
+        "prompted"
+    }
+
+    fn rerank(&self, query: &str, candidates: &[(String, String)], timeout_ms: u64) -> Vec<String> {
+        if candidates.len() < 2 {
+            return candidates.iter().map(|(id, _)| id.clone()).collect();
+        }
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "relevant": { "type": "boolean" } },
+            "required": ["relevant"]
+        });
+        let system = "You judge search relevance. Reply ONLY with JSON: {\"relevant\": true} if \
+                      the document could help answer the query, {\"relevant\": false} otherwise.";
+
+        // relevance[i]: true = keep in the front group (default on failure — degrade to input order).
+        let mut relevance = vec![true; candidates.len()];
+        let mut judged = 0usize;
+        for (i, (_id, text)) in candidates.iter().enumerate() {
+            let now = Instant::now();
+            if now >= deadline {
+                break; // out of budget — the rest keep their fused positions.
+            }
+            let remaining = deadline - now;
+            let user = format!("Query: {query}\n\nDocument:\n{text}");
+            let opts = GenOptions {
+                max_tokens: Some(RERANK_MAX_TOKENS),
+                temperature: Some(0.0),
+                enable_thinking: false,
+                timeout: Some(remaining),
+            };
+            match self.reasoner.structured_with(system, &user, &schema, opts) {
+                Ok(v) => {
+                    if let Some(rel) = v.get("relevant").and_then(|b| b.as_bool()) {
+                        relevance[i] = rel;
+                        judged += 1;
+                    }
+                    // Malformed shape ⇒ leave `true` (input order).
+                }
+                Err(_) => {
+                    // Any failure ⇒ leave `true` (input order). No PII in logs — not even the error
+                    // formatting here; the count below is the observability.
+                }
+            }
+        }
+        tracing::debug!(
+            target: "rerank",
+            candidates = candidates.len(),
+            judged,
+            "prompted rerank pass"
+        );
+
+        // Stable partition: relevant candidates first, both groups in input-relative order.
+        let mut front: Vec<String> = Vec::with_capacity(candidates.len());
+        let mut back: Vec<String> = Vec::new();
+        for (i, (id, _)) in candidates.iter().enumerate() {
+            if relevance[i] {
+                front.push(id.clone());
+            } else {
+                back.push(id.clone());
+            }
+        }
+        front.extend(back);
+        front
+    }
+}
+
+/// Resolve the ACTIVE reranker for a resolved reasoner: the prompted impl when a REAL on-device
+/// model backs it, else the identity stub. A `"stub"` reasoner has no model; a `"cloud:*"`
+/// reasoner would EGRESS candidate snippets per pointwise call — the reranker seam is deliberately
+/// on-device-only (spec §L1.4: the resident Qwen), so cloud resolves to the stub too.
+pub fn active_reranker(reasoner: std::sync::Arc<dyn LocalReasoner>) -> Box<dyn Reranker> {
+    let id = reasoner.id();
+    if id == "stub" || id.starts_with("cloud:") {
+        return Box::new(StubReranker);
+    }
+    Box::new(PromptedReranker::new(reasoner))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Result;
+    use serde_json::Value;
+    use std::sync::Arc;
+
+    fn cands(n: usize) -> Vec<(String, String)> {
+        (0..n)
+            .map(|i| (format!("m{i}"), format!("candidate text {i}")))
+            .collect()
+    }
+
+    #[test]
+    fn stub_reranker_is_identity() {
+        let c = cands(4);
+        let out = StubReranker.rerank("query", &c, RERANK_TIMEOUT_MS);
+        assert_eq!(out, vec!["m0", "m1", "m2", "m3"]);
+        assert_eq!(StubReranker.id(), "stub");
+        // Empty input → empty output, no panic.
+        assert!(StubReranker.rerank("q", &[], 10).is_empty());
+    }
+
+    /// The prompted reranker over the STUB reasoner: the stub's `structured` returns a JSON object
+    /// with NO `relevant` key, so every candidate keeps its default-true flag ⇒ identity order —
+    /// the degrade contract, exercised end-to-end through the real code path.
+    #[test]
+    fn prompted_with_stub_reasoner_degrades_to_identity() {
+        let rr = PromptedReranker::new(Arc::new(crate::reason::StubReasoner));
+        let c = cands(3);
+        let out = rr.rerank("budget", &c, RERANK_TIMEOUT_MS);
+        assert_eq!(
+            out,
+            vec!["m0", "m1", "m2"],
+            "unparseable judgments must keep input order"
+        );
+        assert_eq!(out.len(), c.len(), "no candidate may be dropped");
+    }
+
+    /// A reasoner that answers deterministically: relevant iff the candidate text contains the
+    /// query token. Proves the relevant-first stable partition.
+    struct KeywordReasoner;
+    impl crate::reason::LocalReasoner for KeywordReasoner {
+        fn id(&self) -> &str {
+            "keyword-test"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+            Ok(String::new())
+        }
+        fn structured(&self, _s: &str, user: &str, _schema: &Value) -> Result<Value> {
+            // `user` = "Query: <q>\n\nDocument:\n<text>".
+            let q = user
+                .lines()
+                .next()
+                .and_then(|l| l.strip_prefix("Query: "))
+                .unwrap_or_default()
+                .to_string();
+            let doc = user.split("Document:\n").nth(1).unwrap_or_default();
+            Ok(serde_json::json!({ "relevant": doc.contains(&q) }))
+        }
+    }
+
+    #[test]
+    fn prompted_moves_relevant_candidates_first_stably() {
+        let rr = PromptedReranker::new(Arc::new(KeywordReasoner));
+        let c = vec![
+            ("a".to_string(), "nothing here".to_string()),
+            ("b".to_string(), "the budget line".to_string()),
+            ("c".to_string(), "also nothing".to_string()),
+            ("d".to_string(), "budget again".to_string()),
+        ];
+        let out = rr.rerank("budget", &c, RERANK_TIMEOUT_MS);
+        assert_eq!(
+            out,
+            vec!["b", "d", "a", "c"],
+            "relevant first, stable within groups"
+        );
+    }
+
+    /// A reasoner that blocks long enough to blow the deadline on the very first call — the pass
+    /// must still return EVERY id, in input order (deadline degrade, never a drop or an Err).
+    struct SlowReasoner;
+    impl crate::reason::LocalReasoner for SlowReasoner {
+        fn id(&self) -> &str {
+            "slow-test"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+            Ok(String::new())
+        }
+        fn structured(&self, _s: &str, _u: &str, _schema: &Value) -> Result<Value> {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            // Judge everything IRRELEVANT — if the deadline logic failed, order would change.
+            Ok(serde_json::json!({ "relevant": false }))
+        }
+    }
+
+    #[test]
+    fn prompted_deadline_degrades_to_input_order_for_the_rest() {
+        let rr = PromptedReranker::new(Arc::new(SlowReasoner));
+        let c = cands(6);
+        // 10ms budget vs a 50ms first call: the FIRST candidate is judged (its pre-check happens
+        // at t≈0, before the deadline) and comes back irrelevant; every LATER candidate falls past
+        // the deadline and keeps its default-true flag ⇒ input order, ahead of the demoted one.
+        let out = rr.rerank("q", &c, 10);
+        assert_eq!(out.len(), 6, "every id must survive a deadline expiry");
+        assert_eq!(
+            out[5], "m0",
+            "the one judged irrelevant moves back; the unjudged keep order"
+        );
+        assert_eq!(&out[..5], &["m1", "m2", "m3", "m4", "m5"]);
+    }
+
+    #[test]
+    fn active_reranker_resolves_stub_cloud_and_local() {
+        // Stub reasoner → stub reranker.
+        let r = active_reranker(Arc::new(crate::reason::StubReasoner));
+        assert_eq!(r.id(), "stub");
+        // A cloud-id reasoner → stub reranker (rerank must never egress).
+        struct CloudLike;
+        impl crate::reason::LocalReasoner for CloudLike {
+            fn id(&self) -> &str {
+                "cloud:claude_code"
+            }
+            fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+                Ok(String::new())
+            }
+            fn structured(&self, _s: &str, _u: &str, _schema: &Value) -> Result<Value> {
+                Ok(serde_json::json!({}))
+            }
+        }
+        assert_eq!(active_reranker(Arc::new(CloudLike)).id(), "stub");
+        // A local-model-like id → prompted.
+        assert_eq!(active_reranker(Arc::new(KeywordReasoner)).id(), "prompted");
+    }
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -542,6 +542,16 @@ impl Db {
         // Phase 2a — vector retrieval layer (note_chunks + the vec0 KNN table). Additive + guarded
         // (CREATE TABLE / CREATE VIRTUAL TABLE IF NOT EXISTS) so migrate() stays idempotent.
         Self::migrate_vector(&conn)?;
+        // Brain v2 L1.2 — contextual augmentation: the AUGMENTED text a note chunk was embedded
+        // from ("<title> | <date> | <attendees> | <facts>\n<raw>"). The raw `text` column stays for
+        // snippets. Additive + guarded; NULL on legacy rows (they re-fill on the next re-index).
+        Self::add_column_if_missing(&conn, "note_chunks", "aug_text", "TEXT")?;
+        // Brain v2 L1.1 — topic-segment retrieval layer (topic_chunks + its vec0 KNN table + its
+        // external-content FTS5 index). Additive + guarded so migrate() stays idempotent. Lock
+        // model: topic chunks are plaintext DERIVED from transcript segments (like note_chunks),
+        // so they exist ONLY for visible content — purged in the SAME `purge_chunks_tx` choke
+        // point that covers note_chunks on every seal path.
+        Self::migrate_topic(&conn)?;
         // Document ingestion — PARALLEL doc tables (documents + doc_chunks + the doc_vec0 KNN table),
         // deliberately separate from note_chunks so the load-bearing meeting-gating joins stay
         // untouched. Additive + guarded so migrate() stays idempotent.
@@ -896,6 +906,64 @@ impl Db {
              );",
             dim = crate::embed::EMBED_DIM
         ))
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Brain v2 L1.1 — idempotent TOPIC-CHUNK schema: `topic_chunks` (the plaintext topic-segment
+    /// store: span + raw text + augmented text + content hash), `topic_vec_chunks` (the vec0 KNN
+    /// table, 1:1 by `chunk_id == topic_chunks.id`), and `fts_topic_chunks` (external-content FTS5
+    /// over `aug_text`, kept exact by the standard `_ai`/`_ad`/`_au` trigger trio — mirrors
+    /// `migrate_fts`; the DELETE trigger purges tokens when `purge_chunks_tx` drops the base rows
+    /// on seal, so no sealed-content token survives the index).
+    ///
+    /// Lock model: rows are DERIVED plaintext and exist ONLY for visible meetings — indexed by the
+    /// gated `index_meeting_topic_chunks`, purged on seal/delete via `purge_chunks_tx`.
+    fn migrate_topic(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS topic_chunks (
+               id INTEGER PRIMARY KEY,
+               meeting_id TEXT NOT NULL,
+               seg_index INTEGER NOT NULL,
+               start_s REAL NOT NULL,
+               end_s REAL NOT NULL,
+               text TEXT NOT NULL,
+               aug_text TEXT NOT NULL,
+               content_hash TEXT,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_topic_chunks_meeting ON topic_chunks(meeting_id);",
+        )
+        .map_err(map_err)?;
+        // The vec0 column width is the embedder's EMBED_DIM (compile-time const — no user input).
+        conn.execute_batch(&format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS topic_vec_chunks USING vec0(
+                 chunk_id INTEGER PRIMARY KEY,
+                 embedding float[{dim}]
+             );",
+            dim = crate::embed::EMBED_DIM
+        ))
+        .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_topic_chunks USING fts5(
+                 aug_text,
+                 content='topic_chunks',
+                 content_rowid='id',
+                 tokenize = 'unicode61 remove_diacritics 2'
+             );
+             CREATE TRIGGER IF NOT EXISTS fts_topic_chunks_ai AFTER INSERT ON topic_chunks BEGIN
+                 INSERT INTO fts_topic_chunks(rowid, aug_text) VALUES (new.id, new.aug_text);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_topic_chunks_ad AFTER DELETE ON topic_chunks BEGIN
+                 INSERT INTO fts_topic_chunks(fts_topic_chunks, rowid, aug_text)
+                   VALUES ('delete', old.id, old.aug_text);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_topic_chunks_au AFTER UPDATE ON topic_chunks BEGIN
+                 INSERT INTO fts_topic_chunks(fts_topic_chunks, rowid, aug_text)
+                   VALUES ('delete', old.id, old.aug_text);
+                 INSERT INTO fts_topic_chunks(rowid, aug_text) VALUES (new.id, new.aug_text);
+             END;",
+        )
         .map_err(map_err)?;
         Ok(())
     }
@@ -1693,8 +1761,7 @@ impl Db {
                 .map_err(map_err)?
         };
         // Exclude the rows salvage claimed this launch — it owns their final status.
-        let to_reconcile: Vec<&String> =
-            ids.iter().filter(|id| !claimed.contains(id)).collect();
+        let to_reconcile: Vec<&String> = ids.iter().filter(|id| !claimed.contains(id)).collect();
         if to_reconcile.is_empty() {
             return Ok(0);
         }
@@ -2015,7 +2082,10 @@ impl Db {
         let Some(meeting) = meeting else {
             return Ok(()); // unknown meeting — nothing to index.
         };
-        let title = meeting.title.clone().unwrap_or_else(|| "(untitled)".to_string());
+        let title = meeting
+            .title
+            .clone()
+            .unwrap_or_else(|| "(untitled)".to_string());
         let date = meeting
             .started_at
             .split(['T', ' '])
@@ -2039,17 +2109,35 @@ impl Db {
         // TRANSCRIPT chunks (source_type='transcript') — speaker-turn / sliding-window with provenance.
         let transcript_chunks = crate::embed::chunk_transcript(&title, &date, segments);
 
-        // Chunks are passages → e5 `passage:` prefix convention. The stub ignores the prefix; the real
-        // CandleBertEmbedder needs it for retrieval recall. Embed each class only when non-empty.
-        let note_vectors = if note_chunks.is_empty() {
-            Vec::new()
-        } else {
-            embedder.embed_passage(&note_chunks)?
+        // Brain v2 L1.2 — contextual augmentation: batch-read the meeting's gated attendees + facts
+        // ONCE, then situate every chunk with the `<title> | <date> | <attendees> | <facts>` header.
+        // FAIL-CLOSED: the reads run under an EMPTY unlock set, so a sealed folder's entity/fact
+        // context is NEVER persisted into an index row (a session-unlocked sealed meeting simply
+        // gets an empty header — strictly safer; open-folder meetings, the common case, get the
+        // full header). The RAW `text` column keeps the un-augmented chunk for snippet display.
+        let (attendees, facts) =
+            self.augment_header_inputs(meeting_id, &std::collections::HashSet::new())?;
+        let aug = |chunks: &[String]| -> Vec<String> {
+            chunks
+                .iter()
+                .map(|c| crate::embed::augment_chunk_text(&title, &date, &attendees, &facts, c))
+                .collect()
         };
-        let transcript_vectors = if transcript_chunks.is_empty() {
+        let note_aug = aug(&note_chunks);
+        let transcript_aug = aug(&transcript_chunks);
+
+        // Chunks are passages → e5 `passage:` prefix convention. The stub ignores the prefix; the real
+        // CandleBertEmbedder needs it for retrieval recall. Embed each class only when non-empty —
+        // on the AUGMENTED text (L1.2: the situating header rides the embedding AND the FTS legs).
+        let note_vectors = if note_aug.is_empty() {
             Vec::new()
         } else {
-            embedder.embed_passage(&transcript_chunks)?
+            embedder.embed_passage(&note_aug)?
+        };
+        let transcript_vectors = if transcript_aug.is_empty() {
+            Vec::new()
+        } else {
+            embedder.embed_passage(&transcript_aug)?
         };
 
         // Always purge this meeting's prior rows first (clean replace of BOTH classes), then insert the
@@ -2062,8 +2150,8 @@ impl Db {
             let mut ins_chunk = tx
                 .prepare(
                     "INSERT INTO note_chunks
-                       (meeting_id, provider_id, chunk_idx, source_type, text, content_hash)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                       (meeting_id, provider_id, chunk_idx, source_type, text, aug_text, content_hash)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 )
                 .map_err(map_err)?;
             let mut ins_vec = tx
@@ -2071,12 +2159,24 @@ impl Db {
                 .map_err(map_err)?;
             // `chunk_idx` is a per-class ordinal; the two classes are distinguished by `source_type`.
             let classes = [
-                ("voice", &note_chunks, &note_vectors),
-                ("transcript", &transcript_chunks, &transcript_vectors),
+                ("voice", &note_chunks, &note_aug, &note_vectors),
+                (
+                    "transcript",
+                    &transcript_chunks,
+                    &transcript_aug,
+                    &transcript_vectors,
+                ),
             ];
-            for (source_type, chunks, vectors) in classes {
-                for (idx, (text, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
-                    let content_hash = format!("{:016x}", chunk_hash(text));
+            for (source_type, chunks, augs, vectors) in classes {
+                for (idx, ((text, aug_text), vector)) in chunks
+                    .iter()
+                    .zip(augs.iter())
+                    .zip(vectors.iter())
+                    .enumerate()
+                {
+                    // The hash covers the AUGMENTED text (the embedded bytes) so a facts/attendee
+                    // change re-embeds on the next re-index.
+                    let content_hash = format!("{:016x}", chunk_hash(aug_text));
                     ins_chunk
                         .execute(rusqlite::params![
                             meeting_id,
@@ -2084,6 +2184,7 @@ impl Db {
                             idx as i64,
                             source_type,
                             text,
+                            aug_text,
                             content_hash
                         ])
                         .map_err(map_err)?;
@@ -2097,6 +2198,298 @@ impl Db {
         }
         tx.commit().map_err(map_err)?;
         Ok(())
+    }
+
+    /// Brain v2 L1.2 — the gated AUGMENTATION-HEADER inputs for one meeting, batched (ONE read per
+    /// meeting, never per chunk): up to [`crate::embed::AUG_MAX_ATTENDEES`] visible entity names
+    /// (person-kind first) and up to [`crate::embed::AUG_MAX_FACTS`] visible facts rendered as
+    /// `subject predicate: object`. Both reads apply the SAME visibility predicate as every other
+    /// graph/fact read, so a sealed-and-not-in-`unlocked` meeting yields an EMPTY header — the
+    /// L1.2 fail-closed contract.
+    fn augment_header_inputs(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<(Vec<String>, Vec<String>)> {
+        let attendees = self.list_entities_for_meeting_visible(meeting_id, unlocked)?;
+        let facts = self.facts_for_meeting_visible(meeting_id, unlocked)?;
+        Ok((attendees, facts))
+    }
+
+    /// Gated NARROW reader (Brain v2 L1.2): the names of entities mentioned in ONE meeting, capped
+    /// at [`crate::embed::AUG_MAX_ATTENDEES`], person-kind first then alphabetical. The meeting
+    /// must be visible under the standard predicate (`EXISTS(visible note) OR NOT EXISTS(any
+    /// note)`) — a sealed-and-not-unlocked meeting returns an EMPTY list, never its attendees.
+    pub fn list_entities_for_meeting_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT e.name FROM entities e
+               JOIN entity_mentions em ON em.entity_id = e.id
+               JOIN meetings m ON m.id = em.meeting_id
+              WHERE em.meeting_id = ?1
+                AND (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                     OR EXISTS (SELECT 1 FROM notes n
+                                 LEFT JOIN folders f ON f.id = n.folder_id
+                                WHERE n.meeting_id = m.id AND {visible}))
+              ORDER BY CASE WHEN e.kind = 'person' THEN 0 ELSE 1 END, e.name ASC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![meeting_id, crate::embed::AUG_MAX_ATTENDEES as i64],
+                |r| r.get::<_, String>(0),
+            )
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Gated NARROW reader (Brain v2 L1.2): the facts derived from ONE meeting, rendered
+    /// `subject predicate: object`, current (open `valid_to`) first, capped at
+    /// [`crate::embed::AUG_MAX_FACTS`]. Applies the SAME visibility predicate as
+    /// [`Self::list_facts_visible`], keyed on the fact's source meeting — a
+    /// sealed-and-not-unlocked meeting surfaces NOTHING (and its facts are purged on seal anyway;
+    /// this is the defense-in-depth read gate).
+    pub fn facts_for_meeting_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT ft.subject, ft.predicate, ft.object
+               FROM facts ft
+               JOIN meetings m ON m.id = ft.meeting_id
+              WHERE ft.meeting_id = ?1
+                AND (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                     OR EXISTS (SELECT 1 FROM notes n
+                                 LEFT JOIN folders f ON f.id = n.folder_id
+                                WHERE n.meeting_id = m.id AND {visible}))
+              ORDER BY (ft.valid_to IS NULL) DESC, ft.valid_from DESC, ft.id DESC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![meeting_id, crate::embed::AUG_MAX_FACTS as i64],
+                |r| {
+                    let s: String = r.get(0)?;
+                    let p: String = r.get(1)?;
+                    let o: String = r.get(2)?;
+                    Ok(format!("{s} {p}: {o}"))
+                },
+            )
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Brain v2 L1.1 — (re)index one VISIBLE meeting's TOPIC segments into `topic_chunks` +
+    /// `topic_vec_chunks` (+ `fts_topic_chunks` via triggers): [`crate::embed::segment_topics`]
+    /// over the plaintext segments, each topic AUGMENTED with the gated
+    /// `<title> | <date> | <attendees> | <facts>` header ([`crate::embed::augment_chunk_text`])
+    /// before embedding/FTS.
+    ///
+    /// GATED: a sealed-and-not-in-`unlocked` meeting is a NO-OP (`meeting_is_visible` — the same
+    /// predicate as every read; its plaintext is never chunked). IDEMPOTENT by `content_hash`
+    /// (over the AUGMENTED text): when the stored hash sequence equals the fresh one, the call
+    /// returns without re-embedding — what makes the startup backfill cheap on every launch.
+    /// Otherwise: PURGE-then-INSERT of this meeting's topic rows in ONE transaction (clean
+    /// replace). Call AFTER [`Self::index_meeting_chunks`] at shared call sites — its clean
+    /// replace purges ALL chunk classes (the shared `purge_chunks_tx` choke point), topic rows
+    /// included. Vectors follow the no-stub-vector-at-rest policy: callers only pass a real
+    /// embedder (same contract as `index_meeting_chunks`).
+    pub fn index_meeting_topic_chunks(
+        &self,
+        meeting_id: &str,
+        segments: &[Segment],
+        embedder: &dyn Embedder,
+        unlocked: &HashSet<String>,
+    ) -> Result<()> {
+        if !self.meeting_is_visible(meeting_id, unlocked)? {
+            return Ok(()); // sealed-not-unlocked: never index its plaintext.
+        }
+        let Some(meeting) = self.get_meeting(meeting_id)? else {
+            return Ok(());
+        };
+        let title = meeting
+            .title
+            .clone()
+            .unwrap_or_else(|| "(untitled)".to_string());
+        let date = meeting
+            .started_at
+            .split(['T', ' '])
+            .next()
+            .unwrap_or("")
+            .to_string();
+
+        let topics = crate::embed::segment_topics(segments);
+        let (attendees, facts) = self.augment_header_inputs(meeting_id, unlocked)?;
+        let augs: Vec<String> = topics
+            .iter()
+            .map(|t| crate::embed::augment_chunk_text(&title, &date, &attendees, &facts, &t.text))
+            .collect();
+        let hashes: Vec<String> = augs
+            .iter()
+            .map(|a| format!("{:016x}", chunk_hash(a)))
+            .collect();
+
+        // Idempotency probe: identical stored hash sequence ⇒ nothing to do (no re-embed).
+        {
+            let conn = self.lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT content_hash FROM topic_chunks WHERE meeting_id = ?1 ORDER BY seg_index",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |r| {
+                    r.get::<_, Option<String>>(0)
+                })
+                .map_err(map_err)?;
+            let mut existing: Vec<String> = Vec::new();
+            for r in rows {
+                existing.push(r.map_err(map_err)?.unwrap_or_default());
+            }
+            if existing == hashes {
+                return Ok(());
+            }
+        }
+
+        let vectors = if augs.is_empty() {
+            Vec::new()
+        } else {
+            embedder.embed_passage(&augs)?
+        };
+
+        // PURGE-then-INSERT this meeting's topic rows in ONE transaction (clean replace).
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        // TOCTOU re-check INSIDE the write tx: the visibility gate above ran BEFORE the slow
+        // embed, and the caller's `unlocked` snapshot can be stale by now. A `lock_folder`
+        // committing mid-embed blanks the note plaintext (`markdown=''`, `content_blob` kept) —
+        // that DB-side sealed-at-rest invariant is session-independent, so key the re-check on
+        // it instead of the snapshot: if the meeting is sealed at rest RIGHT NOW, writing its
+        // derived plaintext topic rows would leave sealed content on disk until the next
+        // relock/startup reconcile. Refuse (rollback via drop) instead.
+        let sealed_at_rest: bool = tx
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM notes
+                    WHERE meeting_id = ?1
+                      AND content_blob IS NOT NULL
+                      AND (markdown IS NULL OR markdown = '')
+                 )",
+                rusqlite::params![meeting_id],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if sealed_at_rest {
+            return Ok(());
+        }
+        tx.execute(
+            "DELETE FROM topic_vec_chunks WHERE chunk_id IN
+               (SELECT id FROM topic_chunks WHERE meeting_id = ?1)",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM topic_chunks WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        {
+            let mut ins_chunk = tx
+                .prepare(
+                    "INSERT INTO topic_chunks
+                       (meeting_id, seg_index, start_s, end_s, text, aug_text, content_hash)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                )
+                .map_err(map_err)?;
+            let mut ins_vec = tx
+                .prepare("INSERT INTO topic_vec_chunks(chunk_id, embedding) VALUES (?1, ?2)")
+                .map_err(map_err)?;
+            for (idx, ((topic, aug_text), vector)) in topics
+                .iter()
+                .zip(augs.iter())
+                .zip(vectors.iter())
+                .enumerate()
+            {
+                ins_chunk
+                    .execute(rusqlite::params![
+                        meeting_id,
+                        idx as i64,
+                        topic.start_s,
+                        topic.end_s,
+                        topic.text,
+                        aug_text,
+                        hashes[idx]
+                    ])
+                    .map_err(map_err)?;
+                let chunk_id = tx.last_insert_rowid();
+                let blob = crate::embed::vec_to_blob(vector);
+                ins_vec
+                    .execute(rusqlite::params![chunk_id, blob])
+                    .map_err(map_err)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        tracing::debug!(
+            target: "rag",
+            meeting_id,
+            topics = topics.len(),
+            "topic chunks indexed"
+        );
+        Ok(())
+    }
+
+    /// Brain v2 L1.1 — STARTUP BACKFILL: index topic chunks for every VISIBLE meeting that has
+    /// segments, in batches of 20 (with a short pause between batches
+    /// so the shared connection lock breathes). Content-hash idempotent — an already-indexed
+    /// meeting is a cheap probe, so re-running on every launch is fine. Runs under an EMPTY unlock
+    /// set (nothing is session-unlocked at startup; sealed meetings are skipped by the gate and
+    /// their topic rows are re-derived on unlock via `reindex_meetings_after_unseal`). Returns how
+    /// many meetings were (re)indexed. Per-meeting failures WARN (ids only, no PII) and continue.
+    pub fn backfill_topic_chunks_idempotent(&self, embedder: &dyn Embedder) -> Result<usize> {
+        const TOPIC_BACKFILL_BATCH: usize = 20;
+        let unlocked: HashSet<String> = HashSet::new();
+        let meetings = self.list_meetings_visible(100_000, &unlocked)?;
+        let mut indexed = 0usize;
+        for batch in meetings.chunks(TOPIC_BACKFILL_BATCH) {
+            for m in batch {
+                let segments = match self.get_segments(&m.id) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(target: "rag", error = %e, "topic backfill: segments read failed (skipped)");
+                        continue;
+                    }
+                };
+                if segments.is_empty() {
+                    continue;
+                }
+                match self.index_meeting_topic_chunks(&m.id, &segments, embedder, &unlocked) {
+                    Ok(()) => indexed += 1,
+                    Err(e) => {
+                        tracing::warn!(target: "rag", error = %e, "topic backfill: indexing one meeting failed (skipped)");
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        Ok(indexed)
     }
 
     /// Purge (delete) every `note_chunks` + `vec_chunks` row for the given meetings. The vec0 row is
@@ -2162,7 +2555,10 @@ impl Db {
     /// (superseding OR source) within an EXISTING transaction, so a deleted meeting leaves no dangling
     /// supersession behind. The table carries no foreign key (a row references two meetings), so this
     /// explicit purge — mirroring `purge_facts_tx` — is what keeps `delete_meeting` clean. Idempotent.
-    fn purge_supersessions_tx(tx: &rusqlite::Transaction<'_>, meeting_ids: &[String]) -> Result<()> {
+    fn purge_supersessions_tx(
+        tx: &rusqlite::Transaction<'_>,
+        meeting_ids: &[String],
+    ) -> Result<()> {
         for mid in meeting_ids {
             tx.execute(
                 "DELETE FROM supersessions
@@ -2230,6 +2626,21 @@ impl Db {
             .map_err(map_err)?;
             tx.execute(
                 "DELETE FROM note_chunks WHERE meeting_id = ?1",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+            // Brain v2 L1.1 — TOPIC chunks ride the SAME choke point, so every seal path
+            // (lock_folder / blank_sealed_notes_in_folders / reblank_locked_folders_at_rest /
+            // delete_meeting) purges them atomically with the note chunks. vec0 first (FK-less),
+            // then the base rows (whose `_ad` FTS trigger purges the aug_text tokens).
+            tx.execute(
+                "DELETE FROM topic_vec_chunks WHERE chunk_id IN
+                   (SELECT id FROM topic_chunks WHERE meeting_id = ?1)",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+            tx.execute(
+                "DELETE FROM topic_chunks WHERE meeting_id = ?1",
                 rusqlite::params![mid],
             )
             .map_err(map_err)?;
@@ -2405,38 +2816,202 @@ impl Db {
         Ok(hits)
     }
 
-    /// Hybrid retrieval (GraphRAG-lite, Phase 2d): fuse THREE already-visibility-gated ranked lists
-    /// by Reciprocal Rank Fusion — the FTS5/BM25 `search_visible` ranking, the vector
-    /// `search_semantic_visible` ranking, AND the entity-graph neighbourhood
-    /// (`meetings_mentioning_entities_visible` for the entities the query names) — dedup by meeting,
-    /// return up to `limit` hits best-first. The graph leg is what a flat-RAG competitor lacks: a
-    /// query naming a known entity ("Project Atlas", "Anna") pulls in that entity's whole
-    /// cross-meeting neighbourhood, not just lexical/semantic hits. All three inputs route through
-    /// the SAME `visibility_clause`, so the fused output stays gated. When the query names no known
-    /// VISIBLE entity the graph list is empty and the fusion is byte-identical to the prior
-    /// FTS∪vector behaviour (RRF over an empty list is a no-op).
+    /// The FTS leg with RAW SCORES (Brain v2 L1.3): best-per-meeting `-bm25` (HIGHER = better)
+    /// over ALL FOUR lexical sources — `fts_meetings` ∪ `fts_segments` ∪ `fts_notes` ∪ the
+    /// topic-chunk `fts_topic_chunks` (whose AUGMENTED text carries the attendee/fact header).
+    /// Gated by the SAME visibility predicate as `search_visible`; optional `started_at` window.
+    fn fts_meeting_scores(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+        date_filter: Option<&(String, String)>,
+    ) -> Result<Vec<(String, f64)>> {
+        let q = query.trim();
+        let Some(match_expr) = fts_match_query(q) else {
+            return Ok(Vec::new());
+        };
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let date = date_clause(date_filter);
+        let sql = format!(
+            "WITH hits(meeting_id, rank) AS (
+                 SELECT m.id, bm25(fts_meetings)
+                   FROM fts_meetings
+                   JOIN meetings m ON m.rowid = fts_meetings.rowid
+                  WHERE fts_meetings MATCH ?1
+                 UNION ALL
+                 SELECT s.meeting_id, bm25(fts_segments)
+                   FROM fts_segments
+                   JOIN segments s ON s.rowid = fts_segments.rowid
+                  WHERE fts_segments MATCH ?1
+                 UNION ALL
+                 SELECT n.meeting_id, bm25(fts_notes)
+                   FROM fts_notes
+                   JOIN notes n ON n.rowid = fts_notes.rowid
+                  WHERE fts_notes MATCH ?1
+                 UNION ALL
+                 SELECT tc.meeting_id, bm25(fts_topic_chunks)
+                   FROM fts_topic_chunks
+                   JOIN topic_chunks tc ON tc.id = fts_topic_chunks.rowid
+                  WHERE fts_topic_chunks MATCH ?1
+             ),
+             ranked(meeting_id, rank) AS (
+                 SELECT meeting_id, MIN(rank) FROM hits GROUP BY meeting_id
+             )
+             SELECT m.id, r.rank
+               FROM ranked r
+               JOIN meetings m ON m.id = r.meeting_id
+              WHERE (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                 OR EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = m.id AND {visible}
+                    )){date}
+              ORDER BY r.rank ASC, m.started_at DESC, m.id DESC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![match_expr, limit], |r| {
+                let id: String = r.get(0)?;
+                let rank: f64 = r.get(1)?;
+                Ok((id, -rank)) // FTS5 bm25() is lower/more-negative = better ⇒ negate to higher-better.
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// The KNN leg with RAW DISTANCES (Brain v2 L1.3): best-per-meeting (smallest) vec0 distance
+    /// over BOTH vector tables — `vec_chunks` (note/transcript chunks) ∪ `topic_vec_chunks`
+    /// (topic chunks). LOWER = better; `score_fuse` inverts via `1/(1+d)`. Gated by the SAME
+    /// visibility predicate as `search_semantic_visible`; optional `started_at` window.
+    fn knn_meeting_distances(
+        &self,
+        query_vec: &[f32],
+        k: i64,
+        unlocked: &HashSet<String>,
+        date_filter: Option<&(String, String)>,
+    ) -> Result<Vec<(String, f64)>> {
+        if query_vec.is_empty() || k <= 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let date = date_clause(date_filter);
+        // Each vec0 table gets its own single-MATCH CTE (a vec0 query allows exactly one MATCH+k
+        // constraint); the union + visibility + window join happen OUTSIDE the KNN CTEs.
+        let sql = format!(
+            "WITH knn_note(chunk_id, distance) AS (
+                 SELECT chunk_id, distance FROM vec_chunks
+                  WHERE embedding MATCH ?1 AND k = ?2
+             ),
+             knn_topic(chunk_id, distance) AS (
+                 SELECT chunk_id, distance FROM topic_vec_chunks
+                  WHERE embedding MATCH ?1 AND k = ?2
+             ),
+             hits(meeting_id, distance) AS (
+                 SELECT nc.meeting_id, kn.distance
+                   FROM knn_note kn JOIN note_chunks nc ON nc.id = kn.chunk_id
+                 UNION ALL
+                 SELECT tc.meeting_id, kt.distance
+                   FROM knn_topic kt JOIN topic_chunks tc ON tc.id = kt.chunk_id
+             ),
+             best(meeting_id, distance) AS (
+                 SELECT meeting_id, MIN(distance) FROM hits GROUP BY meeting_id
+             )
+             SELECT m.id, b.distance
+               FROM best b
+               JOIN meetings m ON m.id = b.meeting_id
+              WHERE EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = m.id AND {visible}
+                    ){date}
+              ORDER BY b.distance ASC, m.id ASC"
+        );
+        let blob = crate::embed::vec_to_blob(query_vec);
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![blob, k], |r| {
+                let id: String = r.get(0)?;
+                let d: f64 = r.get(1)?;
+                Ok((id, d))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Hybrid retrieval (GraphRAG-lite, Phase 2d; SCORE FUSION since Brain v2 L1.3): blend THREE
+    /// already-visibility-gated legs — keyword FTS (now incl. the augmented topic-chunk index),
+    /// vector KNN (now over note ∪ topic vectors), and the entity-graph neighbourhood
+    /// (`meetings_mentioning_entities_visible` for the entities the query names) — via
+    /// [`crate::embed::score_fuse`] over RAW scores (per-leg min-max, weights 0.4/0.4/0.2), dedup
+    /// by meeting, return up to `limit` hits best-first. [`crate::embed::rrf_fuse`] remains the
+    /// FALLBACK when no raw-scored leg produced anything but the plain hit lists did (defensive).
+    ///
+    /// `date_filter` (Brain v2 L1.5) is an optional `(from_iso, to_iso_exclusive)` `started_at`
+    /// window applied to EVERY leg (FTS + KNN in SQL; the graph leg + the fallback in Rust) — a
+    /// temporal query retrieves only in-window meetings. With a window and NO lexical FTS match,
+    /// the window itself becomes the FTS leg (visible meetings in range, newest-first) — the
+    /// "what did we discuss last week" shape. All legs route through the SAME
+    /// `visibility_clause`, so the fused output stays gated.
     pub fn search_hybrid_visible(
         &self,
         query: &str,
         query_vec: &[f32],
         limit: i64,
         unlocked: &HashSet<String>,
+        date_filter: Option<(String, String)>,
     ) -> Result<Vec<SearchHit>> {
-        let fts = self.search_visible(query, limit, unlocked)?;
+        let range = date_filter.as_ref();
+        let in_range = |m: &Meeting| -> bool {
+            match range {
+                Some((from, to)) => {
+                    m.started_at.as_str() >= from.as_str() && m.started_at.as_str() < to.as_str()
+                }
+                None => true,
+            }
+        };
+
+        // Snippet-bearing hit lists (each already gated); ordering comes from the scored legs.
+        let fts = self.search_visible_impl(query, limit, unlocked, range)?;
         let semantic = self.search_semantic_visible(query_vec, limit, unlocked)?;
 
         // GraphRAG-lite leg: resolve the query to known VISIBLE entities (deterministic, no LLM),
         // then gather their co-mention neighbourhood. Both the resolver and the neighbour reader
-        // apply the same visibility predicate, so a sealed-not-unlocked meeting can never enter
-        // here. No entity match → empty vec → graph leg contributes nothing to the fusion.
+        // apply the same visibility predicate; the temporal window is applied here in Rust.
         let matched_entities = self.entities_matching_query(query, unlocked)?;
-        let graph = self.meetings_mentioning_entities_visible(&matched_entities, unlocked)?;
+        let mut graph = self.meetings_mentioning_entities_visible(&matched_entities, unlocked)?;
+        graph.retain(|m| in_range(m));
 
-        // The three ranked id-lists (each already best-first) feed RRF; capture them BEFORE moving
-        // the hits into the lookup map.
-        let fts_ids: Vec<String> = fts.iter().map(|h| h.meeting.id.clone()).collect();
-        let sem_ids: Vec<String> = semantic.iter().map(|h| h.meeting.id.clone()).collect();
-        let graph_ids: Vec<String> = graph.iter().map(|m| m.id.clone()).collect();
+        // RAW-SCORED legs (L1.3). FTS: -bm25 higher-better over all four lexical sources. KNN:
+        // raw distances over both vector tables. Graph: 1/rank of the neighbourhood ordering.
+        let mut fts_scored = self.fts_meeting_scores(query, limit, unlocked, range)?;
+        if fts_scored.is_empty() && range.is_some() {
+            // Temporal fallback (L1.5): no lexical match inside the window ⇒ the window IS the
+            // query — visible in-range meetings, newest-first, positionally scored.
+            let in_window = self.meetings_in_range_visible(range, limit, unlocked)?;
+            fts_scored = in_window
+                .iter()
+                .enumerate()
+                .map(|(i, m)| (m.id.clone(), 1.0 / (i as f64 + 1.0)))
+                .collect();
+        }
+        let knn_scored = self.knn_meeting_distances(query_vec, limit, unlocked, range)?;
+        let graph_scored: Vec<(String, f64)> = graph
+            .iter()
+            .enumerate()
+            .map(|(i, m)| (m.id.clone(), 1.0 / (i as f64 + 1.0)))
+            .collect();
 
         // One hit per meeting id. Insert the graph leg FIRST (lowest snippet priority): a meeting
         // also hit by FTS/vector keeps the lexical/semantic snippet the user actually queried;
@@ -2457,17 +3032,100 @@ impl Db {
         for h in semantic {
             by_id.insert(h.meeting.id.clone(), h);
         }
-        for h in fts {
-            by_id.insert(h.meeting.id.clone(), h);
+        for h in &fts {
+            by_id.insert(h.meeting.id.clone(), h.clone());
         }
 
-        let fused = crate::embed::rrf_fuse(&[fts_ids, sem_ids, graph_ids], crate::embed::RRF_K);
+        let mut fused = crate::embed::score_fuse(&fts_scored, &knn_scored, &graph_scored);
+        if fused.is_empty() {
+            // Defensive RRF fallback: raw-scored legs empty but a plain hit list is not (should
+            // not happen — same queries — but never return less than the pre-L1.3 behavior).
+            // Respect the window: semantic hits are filtered in Rust (their SQL has no date arm).
+            let fts_ids: Vec<String> = fts.iter().map(|h| h.meeting.id.clone()).collect();
+            let sem_ids: Vec<String> = by_id
+                .values()
+                .filter(|h| h.matched_in == "semantic" && in_range(&h.meeting))
+                .map(|h| h.meeting.id.clone())
+                .collect();
+            fused = crate::embed::rrf_fuse(&[fts_ids, sem_ids], crate::embed::RRF_K);
+        }
+
         let cap = if limit < 0 { 0 } else { limit as usize };
         let mut out = Vec::new();
         for (id, _score) in fused.into_iter().take(cap) {
             if let Some(hit) = by_id.remove(&id) {
                 out.push(hit);
+                continue;
             }
+            // A meeting surfaced ONLY by a topic leg (augmented FTS / topic KNN) or the temporal
+            // fallback has no snippet-bearing hit yet — synthesize one. The id came from a GATED
+            // leg, so reading the meeting row + a topic snippet here is gated-by-construction.
+            if let Some(meeting) = self.get_meeting(&id)? {
+                let snippet = self
+                    .first_topic_snippet(&id)?
+                    .or_else(|| meeting.title.clone())
+                    .unwrap_or_default();
+                out.push(SearchHit {
+                    meeting,
+                    snippet,
+                    matched_in: "topic".to_string(),
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    /// First topic-chunk RAW text for a meeting (snippet synthesis for topic-leg-only hybrid
+    /// hits). Rows exist only for visible meetings (purged on seal); callers reach here only with
+    /// ids from gated legs.
+    fn first_topic_snippet(&self, meeting_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT text FROM topic_chunks WHERE meeting_id = ?1 ORDER BY seg_index LIMIT 1",
+            rusqlite::params![meeting_id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Visible meetings whose `started_at` falls in the half-open `(from, to)` window,
+    /// newest-first (the L1.5 temporal-fallback corpus). Same visibility predicate as
+    /// [`Self::list_meetings_visible`]. `None` window ⇒ empty (callers only reach here with one).
+    fn meetings_in_range_visible(
+        &self,
+        date_filter: Option<&(String, String)>,
+        limit: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<Meeting>> {
+        let Some(range) = date_filter else {
+            return Ok(Vec::new());
+        };
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let date = date_clause(Some(range));
+        let sql = format!(
+            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
+                    (SELECT nf.folder_id FROM notes nf
+                      WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1)
+                      AS folder_id
+               FROM meetings m
+              WHERE (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                 OR EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = m.id AND {visible}
+                    )){date}
+              ORDER BY m.started_at DESC, m.id DESC
+              LIMIT ?1"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![limit], row_to_meeting)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)??);
         }
         Ok(out)
     }
@@ -3595,8 +4253,7 @@ impl Db {
     pub fn discard_folder_seal(&self, folder_id: &str) -> Result<Vec<String>> {
         // Meetings that belong to THIS folder (folder_id lives on the notes row — the same join the
         // seal/relock paths use). Documents anchor on the folder row directly.
-        const FOLDER_MEETINGS: &str =
-            "SELECT DISTINCT meeting_id FROM notes WHERE folder_id = ?1";
+        const FOLDER_MEETINGS: &str = "SELECT DISTINCT meeting_id FROM notes WHERE folder_id = ?1";
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
 
@@ -3648,7 +4305,9 @@ impl Db {
         )
         .map_err(map_err)?;
         tx.execute(
-            &format!("UPDATE segments SET text_blob = NULL WHERE meeting_id IN ({FOLDER_MEETINGS})"),
+            &format!(
+                "UPDATE segments SET text_blob = NULL WHERE meeting_id IN ({FOLDER_MEETINGS})"
+            ),
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
@@ -3658,7 +4317,9 @@ impl Db {
         )
         .map_err(map_err)?;
         tx.execute(
-            &format!("UPDATE timelines SET data_blob = NULL WHERE meeting_id IN ({FOLDER_MEETINGS})"),
+            &format!(
+                "UPDATE timelines SET data_blob = NULL WHERE meeting_id IN ({FOLDER_MEETINGS})"
+            ),
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
@@ -3669,7 +4330,9 @@ impl Db {
         )
         .map_err(map_err)?;
         tx.execute(
-            &format!("UPDATE meetings SET manual_notes_blob = NULL WHERE id IN ({FOLDER_MEETINGS})"),
+            &format!(
+                "UPDATE meetings SET manual_notes_blob = NULL WHERE id IN ({FOLDER_MEETINGS})"
+            ),
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
@@ -3691,8 +4354,15 @@ impl Db {
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
+        // Brain v2 L1.1 — TOPIC chunks are the same purge class (vec0 rows first, then base rows).
+        tx.execute(
+            &format!("DELETE FROM topic_vec_chunks WHERE chunk_id IN (SELECT id FROM topic_chunks WHERE meeting_id IN ({FOLDER_MEETINGS}))"),
+            rusqlite::params![folder_id],
+        )
+        .map_err(map_err)?;
         for table in [
             "note_chunks",
+            "topic_chunks",
             "correction_log",
             "assistant_interactions",
             "facts",
@@ -4066,6 +4736,22 @@ impl Db {
         .map_err(map_err)?;
         tx.execute(
             &format!("DELETE FROM note_chunks WHERE meeting_id IN ({LOCKED_MEETINGS})"),
+            [],
+        )
+        .map_err(map_err)?;
+        // Brain v2 L1.1 LOCK-SAFETY: TOPIC chunks are the same class of plaintext-derived data —
+        // purge them (vec0 rows first, then the base rows whose `_ad` FTS trigger drops the
+        // aug_text tokens) in this same reconciliation transaction.
+        tx.execute(
+            &format!(
+                "DELETE FROM topic_vec_chunks WHERE chunk_id IN \
+                   (SELECT id FROM topic_chunks WHERE meeting_id IN ({LOCKED_MEETINGS}))"
+            ),
+            [],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            &format!("DELETE FROM topic_chunks WHERE meeting_id IN ({LOCKED_MEETINGS})"),
             [],
         )
         .map_err(map_err)?;
@@ -4515,12 +5201,55 @@ impl Db {
         limit: i64,
         unlocked: &HashSet<String>,
     ) -> Result<Vec<SearchHit>> {
+        self.search_visible_impl(query, limit, unlocked, None)
+    }
+
+    /// Brain v2 L1.5 — [`Self::search_visible`] with an optional `started_at` window
+    /// (`(from_iso, to_iso_exclusive)`, from `summarize::temporal`). TEMPORAL FALLBACK: when a
+    /// window is present and the lexical FTS match finds nothing inside it (the common shape of a
+    /// pure "what did we discuss last week?" query — no content token survives the implicit-AND
+    /// match), the window ITSELF becomes the query: the visible meetings in range are returned
+    /// newest-first, `matched_in: "temporal"`. Same visibility gate on both paths.
+    pub fn search_visible_in_range(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+        date_filter: Option<(String, String)>,
+    ) -> Result<Vec<SearchHit>> {
+        let hits = self.search_visible_impl(query, limit, unlocked, date_filter.as_ref())?;
+        if !hits.is_empty() || date_filter.is_none() {
+            return Ok(hits);
+        }
+        let range = date_filter.as_ref();
+        let meetings = self.meetings_in_range_visible(range, limit, unlocked)?;
+        Ok(meetings
+            .into_iter()
+            .map(|m| {
+                let snippet = m.title.clone().unwrap_or_default();
+                SearchHit {
+                    meeting: m,
+                    snippet,
+                    matched_in: "temporal".to_string(),
+                }
+            })
+            .collect())
+    }
+
+    fn search_visible_impl(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+        date_filter: Option<&(String, String)>,
+    ) -> Result<Vec<SearchHit>> {
         let q = query.trim();
         let Some(match_expr) = fts_match_query(q) else {
             return Ok(Vec::new());
         };
         let conn = self.lock();
         let visible = visibility_clause("n", unlocked);
+        let date = date_clause(date_filter);
         // FTS5/BM25 candidates (same UNION/MIN(bm25) ranking as `search`), THEN gated by exactly the
         // prior visibility predicate so a sealed-and-not-session-unlocked meeting is excluded: keep
         // a meeting iff it has NO note rows, OR it has at least one VISIBLE note row (folder
@@ -4556,12 +5285,12 @@ impl Db {
                       AS folder_id
                FROM ranked r
                JOIN meetings m ON m.id = r.meeting_id
-              WHERE NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+              WHERE (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
                  OR EXISTS (
                       SELECT 1 FROM notes n
                        LEFT JOIN folders f ON f.id = n.folder_id
                        WHERE n.meeting_id = m.id AND {visible}
-                    )
+                    )){date}
               ORDER BY r.rank ASC, m.started_at DESC, m.id DESC
               LIMIT ?2"
         );
@@ -5573,7 +6302,10 @@ impl Db {
     /// this dedupe is the belt-and-suspenders guard). Returns how many NEW rows were inserted. Each
     /// row is inserted UNAPPLIED (`applied_at` + both pre-images NULL); the pre-images are filled only
     /// at apply time. One atomic transaction for the batch.
-    pub fn record_supersessions(&self, rows: &[crate::storage::models::SupersessionRow]) -> Result<usize> {
+    pub fn record_supersessions(
+        &self,
+        rows: &[crate::storage::models::SupersessionRow],
+    ) -> Result<usize> {
         if rows.is_empty() {
             return Ok(0);
         }
@@ -5644,7 +6376,10 @@ impl Db {
             )
             .map_err(map_err)?;
         let rows = stmt
-            .query_map(rusqlite::params![superseding_meeting_id], row_to_supersession)
+            .query_map(
+                rusqlite::params![superseding_meeting_id],
+                row_to_supersession,
+            )
             .map_err(map_err)?;
         let mut out = Vec::new();
         for r in rows {
@@ -6215,6 +6950,22 @@ fn visibility_clause(_alias: &str, unlocked: &HashSet<String>) -> String {
     clause
 }
 
+/// Brain v2 L1.5 — the optional `started_at` window predicate (half-open `[from, to)`), rendered
+/// as an ` AND …` suffix for the gated retrieval readers. Empty for `None`. The bounds are
+/// app-generated ISO `YYYY-MM-DD` strings (from `summarize::temporal`) — compared
+/// lexicographically against the ISO-8601 `started_at` column — but single quotes are still
+/// escaped defensively (mirrors `visibility_clause`).
+fn date_clause(date_filter: Option<&(String, String)>) -> String {
+    match date_filter {
+        Some((from, to)) => format!(
+            " AND m.started_at >= '{}' AND m.started_at < '{}'",
+            from.replace('\'', "''"),
+            to.replace('\'', "''")
+        ),
+        None => String::new(),
+    }
+}
+
 /// Minimum entity-name length (in chars) eligible for QUERY→ENTITY resolution (GraphRAG-lite).
 /// Names shorter than this are too noisy as whole-query tokens (e.g. 2-letter initials) and are
 /// never resolved.
@@ -6316,9 +7067,7 @@ fn row_to_user_fact(row: &Row<'_>) -> rusqlite::Result<crate::facts::Fact> {
 /// Map a `supersessions` row (id, superseding_meeting_id, source_meeting_id, entity, predicate,
 /// old_value, new_value, created_at, applied_at, source_pre_image, superseding_pre_image) to a row
 /// struct.
-fn row_to_supersession(
-    row: &Row<'_>,
-) -> rusqlite::Result<crate::storage::models::SupersessionRow> {
+fn row_to_supersession(row: &Row<'_>) -> rusqlite::Result<crate::storage::models::SupersessionRow> {
     Ok(crate::storage::models::SupersessionRow {
         id: row.get(0)?,
         superseding_meeting_id: row.get(1)?,
@@ -7692,8 +8441,14 @@ mod tests {
 
         let nothing = std::collections::HashSet::new();
         // The bound past meeting owns the thread.
-        let past = db.list_assistant_threads_visible("m-past", &nothing).unwrap();
-        assert_eq!(past.len(), 1, "the bound past meeting must own its thread row");
+        let past = db
+            .list_assistant_threads_visible("m-past", &nothing)
+            .unwrap();
+        assert_eq!(
+            past.len(),
+            1,
+            "the bound past meeting must own its thread row"
+        );
         assert_eq!(past[0].thread_id, "t-past");
         // The recording meeting must NOT see it — the binding is durable to the past meeting.
         assert!(
@@ -8553,7 +9308,7 @@ mod tests {
         // Empty unlock set → the sealed meeting is absent through the whole fused reader.
         let nothing = std::collections::HashSet::new();
         let hidden = db
-            .search_hybrid_visible("budget", &query_vec, 10, &nothing)
+            .search_hybrid_visible("budget", &query_vec, 10, &nothing, None)
             .unwrap();
         assert!(
             !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -8564,7 +9319,7 @@ mod tests {
         let mut unlocked = std::collections::HashSet::new();
         unlocked.insert("f-locked".to_string());
         let shown = db
-            .search_hybrid_visible("budget", &query_vec, 10, &unlocked)
+            .search_hybrid_visible("budget", &query_vec, 10, &unlocked, None)
             .unwrap();
         assert!(
             shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -8962,7 +9717,8 @@ mod tests {
         db.set_note_folder("target", Some("f-open")).unwrap();
         db.set_note_folder("sealed", Some("f-locked")).unwrap();
         for id in ["source", "target", "sealed"] {
-            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder)
+                .unwrap();
         }
         // Lock the sealed folder WITHOUT purging — its chunk row survives, so any exclusion must be
         // the gate doing its job.
@@ -9010,7 +9766,8 @@ mod tests {
             db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z"))
                 .unwrap();
             note_for(&db, id, "claude_code", body);
-            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder)
+                .unwrap();
         }
         let stub = crate::embed::StubEmbedder;
         let nothing = std::collections::HashSet::new();
@@ -9122,21 +9879,39 @@ mod tests {
         let db = mem_db();
         db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
             .unwrap();
-        note_for(&db, "m1", "claude_code", "Summary paragraph about the budget.");
+        note_for(
+            &db,
+            "m1",
+            "claude_code",
+            "Summary paragraph about the budget.",
+        );
         let segs = [
             tseg(0, 0.0, 3.0, "me", "so what did we decide on the migration"),
-            tseg(1, 3.0, 8.0, "others", "we agreed to defer it to next quarter"),
+            tseg(
+                1,
+                3.0,
+                8.0,
+                "others",
+                "we agreed to defer it to next quarter",
+            ),
         ];
         db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder)
             .unwrap();
 
-        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note-summary chunks must be written");
+        assert!(
+            chunk_count_of(&db, "m1", "voice") > 0,
+            "note-summary chunks must be written"
+        );
         assert!(
             chunk_count_of(&db, "m1", "transcript") > 0,
             "transcript chunks must be written from segments"
         );
         // vec rows are 1:1 with note_chunks rows (both classes).
-        assert_eq!(chunk_count(&db, "m1"), vec_count(&db, "m1"), "every chunk (both classes) has a vector");
+        assert_eq!(
+            chunk_count(&db, "m1"),
+            vec_count(&db, "m1"),
+            "every chunk (both classes) has a vector"
+        );
     }
 
     /// RE-INDEX is a CLEAN REPLACE of BOTH classes: re-running with different segments/note leaves no
@@ -9148,19 +9923,28 @@ mod tests {
             .unwrap();
         note_for(&db, "m1", "claude_code", "First note.");
         let segs1 = [tseg(0, 0.0, 3.0, "me", "first pass transcript content")];
-        db.index_meeting_chunks("m1", &segs1, &crate::embed::StubEmbedder).unwrap();
+        db.index_meeting_chunks("m1", &segs1, &crate::embed::StubEmbedder)
+            .unwrap();
         let v1 = chunk_count_of(&db, "m1", "transcript");
         assert!(v1 > 0);
 
         // Re-index with EMPTY segments → transcript class must go to zero (clean replace, no orphans).
-        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
+            .unwrap();
         assert_eq!(
             chunk_count_of(&db, "m1", "transcript"),
             0,
             "re-index with no segments must leave zero stale transcript chunks"
         );
-        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note class still present after re-index");
-        assert_eq!(chunk_count(&db, "m1"), vec_count(&db, "m1"), "1:1 vec pairing preserved after re-index");
+        assert!(
+            chunk_count_of(&db, "m1", "voice") > 0,
+            "note class still present after re-index"
+        );
+        assert_eq!(
+            chunk_count(&db, "m1"),
+            vec_count(&db, "m1"),
+            "1:1 vec pairing preserved after re-index"
+        );
     }
 
     /// EMPTY segments → no transcript chunks (the "sealed meeting is never chunked" property in the
@@ -9172,9 +9956,17 @@ mod tests {
         db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
             .unwrap();
         note_for(&db, "m1", "claude_code", "Only a note, no transcript.");
-        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder).unwrap();
-        assert_eq!(chunk_count_of(&db, "m1", "transcript"), 0, "blank/sealed transcript ⇒ no transcript chunks");
-        assert!(chunk_count_of(&db, "m1", "voice") > 0, "note class still indexes independently");
+        db.index_meeting_chunks("m1", &[], &crate::embed::StubEmbedder)
+            .unwrap();
+        assert_eq!(
+            chunk_count_of(&db, "m1", "transcript"),
+            0,
+            "blank/sealed transcript ⇒ no transcript chunks"
+        );
+        assert!(
+            chunk_count_of(&db, "m1", "voice") > 0,
+            "note class still indexes independently"
+        );
     }
 
     /// GATE (semantic): a sealed-and-not-session-unlocked meeting's TRANSCRIPT chunks surface ZERO
@@ -9258,14 +10050,18 @@ mod tests {
 
         let query_vec = one_hot(0);
         let nothing = std::collections::HashSet::new();
-        let hidden = db.search_hybrid_visible("merger", &query_vec, 10, &nothing).unwrap();
+        let hidden = db
+            .search_hybrid_visible("merger", &query_vec, 10, &nothing, None)
+            .unwrap();
         assert!(
             !hidden.iter().any(|h| h.meeting.id == "sealed"),
             "sealed meeting's TRANSCRIPT chunk leaked through the hybrid gate"
         );
         let mut unlocked = std::collections::HashSet::new();
         unlocked.insert("f-locked".to_string());
-        let shown = db.search_hybrid_visible("merger", &query_vec, 10, &unlocked).unwrap();
+        let shown = db
+            .search_hybrid_visible("merger", &query_vec, 10, &unlocked, None)
+            .unwrap();
         assert!(
             shown.iter().any(|h| h.meeting.id == "sealed"),
             "session-unlocked meeting's transcript chunk must reappear in hybrid results"
@@ -9285,11 +10081,27 @@ mod tests {
         note_for(&db, "m1", "claude_code", "budget summary note");
         db.set_note_folder("m1", Some("f-locked")).unwrap();
         let segs = [
-            tseg(0, 0.0, 4.0, "me", "budget discussion said aloud but not summarized"),
-            tseg(1, 4.0, 9.0, "others", "we will cut the marketing line item next quarter"),
+            tseg(
+                0,
+                0.0,
+                4.0,
+                "me",
+                "budget discussion said aloud but not summarized",
+            ),
+            tseg(
+                1,
+                4.0,
+                9.0,
+                "others",
+                "we will cut the marketing line item next quarter",
+            ),
         ];
-        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder).unwrap();
-        assert!(chunk_count_of(&db, "m1", "transcript") > 0, "transcript chunks present before seal");
+        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder)
+            .unwrap();
+        assert!(
+            chunk_count_of(&db, "m1", "transcript") > 0,
+            "transcript chunks present before seal"
+        );
 
         // Seal the folder (blank note + relock blanker → purge_chunks_tx).
         db.seal_note("m1", "claude_code", b"ciphertext").unwrap();
@@ -9302,18 +10114,28 @@ mod tests {
             0,
             "transcript chunks must be purged on seal (no said-content at rest)"
         );
-        assert_eq!(chunk_count(&db, "m1"), 0, "ALL chunk classes purged on seal");
+        assert_eq!(
+            chunk_count(&db, "m1"),
+            0,
+            "ALL chunk classes purged on seal"
+        );
         assert_eq!(vec_count(&db, "m1"), 0, "all vectors purged on seal");
 
         // And they surface nowhere through either gated reader.
         let query = one_hot(0);
         let nothing = std::collections::HashSet::new();
         assert!(
-            !db.search_semantic_visible(&query, 10, &nothing).unwrap().iter().any(|h| h.meeting.id == "m1"),
+            !db.search_semantic_visible(&query, 10, &nothing)
+                .unwrap()
+                .iter()
+                .any(|h| h.meeting.id == "m1"),
             "sealed meeting must not surface via semantic search after purge"
         );
         assert!(
-            !db.search_hybrid_visible("marketing", &query, 10, &nothing).unwrap().iter().any(|h| h.meeting.id == "m1"),
+            !db.search_hybrid_visible("marketing", &query, 10, &nothing, None)
+                .unwrap()
+                .iter()
+                .any(|h| h.meeting.id == "m1"),
             "sealed meeting must not surface via hybrid search after purge"
         );
     }
@@ -9383,7 +10205,7 @@ mod tests {
 
         let nothing = std::collections::HashSet::new();
         let hits = db
-            .search_hybrid_visible("alpha", &query, 10, &nothing)
+            .search_hybrid_visible("alpha", &query, 10, &nothing, None)
             .unwrap();
         let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
         // One hit per meeting (dedup).
@@ -9449,7 +10271,7 @@ mod tests {
         );
         // The query names entity Atlas → graph leg pulls in its neighbour B.
         let hits = db
-            .search_hybrid_visible("atlas status", &empty_vec, 10, &nothing)
+            .search_hybrid_visible("atlas status", &empty_vec, 10, &nothing, None)
             .unwrap();
         assert!(
             hits.iter().any(|h| h.meeting.id == "B"),
@@ -9558,7 +10380,7 @@ mod tests {
                 .collect();
 
         let got: Vec<String> = db
-            .search_hybrid_visible("budget planning", &query, 10, &nothing)
+            .search_hybrid_visible("budget planning", &query, 10, &nothing, None)
             .unwrap()
             .into_iter()
             .map(|h| h.meeting.id)
@@ -9595,7 +10417,7 @@ mod tests {
 
         let nothing = std::collections::HashSet::new();
         let hits = db
-            .search_hybrid_visible("atlas budget", &query, 10, &nothing)
+            .search_hybrid_visible("atlas budget", &query, 10, &nothing, None)
             .unwrap();
         let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
         // Dedup: each meeting once.
@@ -9634,10 +10456,224 @@ mod tests {
         .unwrap()
     }
 
+    // ── Brain v2 L1: topic chunks + temporal filter ───────────────────────────
+
+    fn topic_chunk_count(db: &Db, meeting_id: &str) -> i64 {
+        let conn = db.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM topic_chunks WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn topic_vec_count(db: &Db, meeting_id: &str) -> i64 {
+        let conn = db.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM topic_vec_chunks v
+               JOIN topic_chunks tc ON tc.id = v.chunk_id
+              WHERE tc.meeting_id = ?1",
+            rusqlite::params![meeting_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn long_seg(idx: i64, start: f64, end: f64, text: &str) -> Segment {
+        Segment {
+            idx,
+            start_s: start,
+            end_s: end,
+            text: text.into(),
+            speaker: Some("me".into()),
+            confidence: None,
+        }
+    }
+
+    /// L1.1 ROUND-TRIP + IDEMPOTENCY: indexing writes topic rows 1:1 with vec0 rows, the aug_text
+    /// carries the `<title> | <date>` header, a same-content re-index is a NO-OP (no row rewrite —
+    /// the content-hash probe), and changed segments produce a clean replace.
+    #[test]
+    fn topic_index_round_trips_and_is_idempotent() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "budget notes");
+        let segs = vec![long_seg(
+            0,
+            0.0,
+            120.0,
+            "we planned the quarterly budget in detail",
+        )];
+        db.insert_segments("m1", &segs).unwrap();
+        let nothing = std::collections::HashSet::new();
+
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        assert!(
+            topic_chunk_count(&db, "m1") > 0,
+            "topic rows must be written"
+        );
+        assert_eq!(
+            topic_chunk_count(&db, "m1"),
+            topic_vec_count(&db, "m1"),
+            "topic chunks and vectors must be 1:1"
+        );
+        let aug: String = {
+            let conn = db.lock();
+            conn.query_row(
+                "SELECT aug_text FROM topic_chunks WHERE meeting_id = 'm1' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert!(
+            aug.starts_with("(untitled) | 2026-06-24\n"),
+            "aug_text must carry the `<title> | <date>` header, got: {aug:?}"
+        );
+
+        // Same content ⇒ NO rewrite (the content-hash probe short-circuits before any delete).
+        // Sentinel: mutate a column OUTSIDE the hash — a purge-then-reinsert would reset it, a
+        // true no-op preserves it.
+        {
+            let conn = db.lock();
+            conn.execute(
+                "UPDATE topic_chunks SET start_s = 999.0 WHERE meeting_id = 'm1'",
+                [],
+            )
+            .unwrap();
+        }
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        let sentinel: f64 = {
+            let conn = db.lock();
+            conn.query_row(
+                "SELECT MIN(start_s) FROM topic_chunks WHERE meeting_id = 'm1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            sentinel, 999.0,
+            "same-content re-index must be a no-op (content_hash idempotency)"
+        );
+
+        // Changed content ⇒ clean replace (old text gone, new text present, still 1:1 with vec0).
+        let segs2 = vec![long_seg(
+            0,
+            0.0,
+            120.0,
+            "completely different hiring topic now",
+        )];
+        db.insert_segments("m1", &segs2).unwrap();
+        db.index_meeting_topic_chunks("m1", &segs2, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        let texts: Vec<String> = {
+            let conn = db.lock();
+            let mut stmt = conn
+                .prepare("SELECT text FROM topic_chunks WHERE meeting_id = 'm1' ORDER BY seg_index")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap();
+            rows
+        };
+        assert!(
+            texts.iter().all(|t| t.contains("hiring")) && !texts.is_empty(),
+            "changed content must clean-replace the topic rows, got: {texts:?}"
+        );
+        assert!(
+            texts.iter().all(|t| !t.contains("budget")),
+            "old topic text must be gone after the clean replace"
+        );
+        assert_eq!(topic_chunk_count(&db, "m1"), topic_vec_count(&db, "m1"));
+    }
+
+    /// L1.5 RED-contrast: WITHOUT a date filter an out-of-window meeting that matches lexically IS
+    /// returned by hybrid search (the pre-L1.5 behavior — the RED half); WITH the window it is
+    /// EXCLUDED while the in-window match stays (the GREEN half). FTS-only hybrid (empty query
+    /// vector) so the assertion isolates the lexical leg.
+    #[test]
+    fn hybrid_date_filter_excludes_out_of_window_lexical_match() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-in", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        db.insert_meeting(&sample_meeting("m-out", "2026-05-01T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m-in", "claude_code", "budżet kwartalny omówiony");
+        note_for(&db, "m-out", "claude_code", "budżet roczny omówiony");
+        let nothing = std::collections::HashSet::new();
+
+        // RED baseline (no filter): BOTH lexical matches surface.
+        let unfiltered = db
+            .search_hybrid_visible("budżet", &[], 10, &nothing, None)
+            .unwrap();
+        assert!(unfiltered.iter().any(|h| h.meeting.id == "m-in"));
+        assert!(
+            unfiltered.iter().any(|h| h.meeting.id == "m-out"),
+            "without a window the out-of-window lexical match must still be returned"
+        );
+
+        // GREEN: the "last week of the 2026-06-29 anchor" window excludes m-out on EVERY leg.
+        let window = Some(("2026-06-22".to_string(), "2026-06-29".to_string()));
+        let filtered = db
+            .search_hybrid_visible("budżet", &[], 10, &nothing, window)
+            .unwrap();
+        assert!(
+            filtered.iter().any(|h| h.meeting.id == "m-in"),
+            "the in-window lexical match must survive the filter"
+        );
+        assert!(
+            !filtered.iter().any(|h| h.meeting.id == "m-out"),
+            "date-filtered hybrid search must exclude an out-of-window meeting that matches lexically"
+        );
+    }
+
+    /// L1.5 temporal FALLBACK: a query whose tokens match NOTHING lexically but that carries a
+    /// window returns the visible meetings IN the window (`matched_in: "temporal"`), newest-first —
+    /// and never an out-of-window one.
+    #[test]
+    fn search_visible_in_range_falls_back_to_temporal_window() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-in", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        db.insert_meeting(&sample_meeting("m-out", "2026-05-01T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m-in", "claude_code", "retro zespołu wnioski");
+        note_for(&db, "m-out", "claude_code", "kickoff projektu");
+        let nothing = std::collections::HashSet::new();
+
+        let window = Some(("2026-06-22".to_string(), "2026-06-29".to_string()));
+        // No token of this query appears in any note ⇒ pure window fallback.
+        let hits = db
+            .search_visible_in_range("what did we discuss", 10, &nothing, window)
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "only the in-window meeting may be returned: {hits:?}"
+        );
+        assert_eq!(hits[0].meeting.id, "m-in");
+        assert_eq!(hits[0].matched_in, "temporal");
+
+        // Without a window the same no-match query returns nothing (unchanged FTS behavior).
+        let none = db
+            .search_visible_in_range("what did we discuss", 10, &nothing, None)
+            .unwrap();
+        assert!(
+            none.is_empty(),
+            "no window + no lexical match ⇒ empty, as before"
+        );
+    }
+
     #[test]
     fn prunable_candidates_are_oldest_first_and_exclude_locked_folders() {
-        const GOOD_KEY: &str =
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        const GOOD_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         let p = unique_temp_path("murmur-prunable", "sqlite");
         let _ = std::fs::remove_file(&p);
         let db = Db::open_with_key(&p, GOOD_KEY).unwrap();
@@ -10563,6 +11599,220 @@ mod lock_tests {
         })
     }
 
+    // ── Brain v2 L1.1/L1.2: topic chunks under the lock model ─────────────────
+
+    fn topic_counts(db: &Db, meeting_id: &str) -> (i64, i64) {
+        let conn = db.lock();
+        let chunks: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM topic_chunks WHERE meeting_id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let vecs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM topic_vec_chunks v
+                   JOIN topic_chunks tc ON tc.id = v.chunk_id
+                  WHERE tc.meeting_id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        (chunks, vecs)
+    }
+
+    /// Raw fts_topic_chunks MATCH count for a term — proves the `_ad` trigger purged the sealed
+    /// content's tokens from the FTS index, not just the base rows.
+    fn topic_fts_matches(db: &Db, term: &str) -> i64 {
+        let conn = db.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM fts_topic_chunks WHERE fts_topic_chunks MATCH ?1",
+            rusqlite::params![format!("\"{term}\"")],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn one_topic_segment(text: &str) -> Vec<Segment> {
+        vec![Segment {
+            idx: 0,
+            start_s: 0.0,
+            end_s: 120.0,
+            text: text.to_string(),
+            speaker: Some("me".to_string()),
+            confidence: None,
+        }]
+    }
+
+    /// PURGE-ON-SEAL (L1.1, lock-critical): sealing a folder via `blank_sealed_notes_in_folders`
+    /// (the same tx that blanks the plaintext) must drop the meeting's topic_chunks AND their
+    /// topic_vec_chunks rows AND the aug_text tokens from fts_topic_chunks. RED-before-GREEN:
+    /// without the topic deletes in `purge_chunks_tx` the rows + tokens survive the seal.
+    #[test]
+    fn seal_purges_topic_chunks_vectors_and_fts_tokens() {
+        let db = file_db("topic-purge-seal");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m1", "sealed content", Some("f-lock"));
+        let segs = one_topic_segment("tajny wątek fuzji zebra omawiany szczegółowo");
+        db.insert_segments("m1", &segs).unwrap();
+        let nothing = HashSet::new();
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        let (chunks, vecs) = topic_counts(&db, "m1");
+        assert!(chunks > 0 && vecs == chunks, "indexed before seal");
+        assert!(
+            topic_fts_matches(&db, "zebra") > 0,
+            "aug tokens indexed before seal"
+        );
+
+        // Seal: flip the folder + run the shared blank/purge tx (the lock_folder path).
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        let mut folders = HashSet::new();
+        folders.insert("f-lock".to_string());
+        db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+        let (chunks, vecs) = topic_counts(&db, "m1");
+        assert_eq!(chunks, 0, "topic_chunks must be purged on seal");
+        assert_eq!(vecs, 0, "topic_vec_chunks must be purged on seal");
+        assert_eq!(
+            topic_fts_matches(&db, "zebra"),
+            0,
+            "sealed aug_text tokens must be purged from fts_topic_chunks"
+        );
+    }
+
+    /// STARTUP RECONCILE (crash-while-unlocked): `reblank_locked_folders_at_rest` must purge topic
+    /// rows of every locked folder's meeting — a crash after a session re-index cannot leave a
+    /// sealed meeting's topic vectors at rest. Mirrors the note_chunks reconcile test.
+    #[test]
+    fn reblank_at_rest_purges_topic_chunks() {
+        let db = file_db("topic-purge-reblank");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m1", "sealed content", Some("f-lock"));
+        let segs = one_topic_segment("poufny plan przejęcia gepard w toku");
+        db.insert_segments("m1", &segs).unwrap();
+        let nothing = HashSet::new();
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        assert!(topic_counts(&db, "m1").0 > 0);
+
+        // Simulate the crash-while-unlocked shape: folder locked on disk, derived rows present.
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        db.reblank_locked_folders_at_rest().unwrap();
+
+        let (chunks, vecs) = topic_counts(&db, "m1");
+        assert_eq!(
+            chunks, 0,
+            "startup reconcile must purge sealed topic chunks"
+        );
+        assert_eq!(vecs, 0, "startup reconcile must purge sealed topic vectors");
+        assert_eq!(topic_fts_matches(&db, "gepard"), 0);
+    }
+
+    /// L1.2 GATING: the augmentation header carries the meeting's VISIBLE attendees + facts; a
+    /// sealed-and-not-unlocked meeting is a NO-OP for the topic indexer (nothing is chunked at
+    /// all — the visibility gate fires before any read).
+    #[test]
+    fn topic_aug_header_is_gated_and_sealed_meeting_is_never_indexed() {
+        let db = file_db("topic-aug-gate");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m1", "atlas planning", Some("f-lock"));
+        let anna = db.upsert_entity("Anna Nowak", EntityKind::Person).unwrap();
+        db.add_mention(&anna, "m1").unwrap();
+        db.apply_fact_ops(&[add_op(
+            &anna,
+            "deadline",
+            "Q3",
+            "2026-06-01T00:00:00Z",
+            "m1",
+        )])
+        .unwrap();
+        let segs = one_topic_segment("omawiamy harmonogram projektu atlas");
+        db.insert_segments("m1", &segs).unwrap();
+        let nothing = HashSet::new();
+
+        // OPEN folder: the header carries the gated attendee + fact.
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        let aug: String = {
+            let conn = db.lock();
+            conn.query_row(
+                "SELECT aug_text FROM topic_chunks WHERE meeting_id = 'm1' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        let header = aug.lines().next().unwrap_or_default().to_string();
+        assert!(
+            header.contains("Anna Nowak"),
+            "attendee missing from header: {header:?}"
+        );
+        assert!(
+            header.contains("deadline: Q3"),
+            "fact missing from header: {header:?}"
+        );
+
+        // Seal + purge, then try to index again while NOT unlocked: must stay empty (gate no-op).
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(topic_counts(&db, "m1").0, 0);
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &nothing)
+            .unwrap();
+        assert_eq!(
+            topic_counts(&db, "m1").0,
+            0,
+            "a sealed-not-unlocked meeting must never be topic-indexed"
+        );
+
+        // Session-unlocked: indexing is allowed again (the unlock re-index path).
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &unlocked)
+            .unwrap();
+        assert!(
+            topic_counts(&db, "m1").0 > 0,
+            "session-unlocked meeting indexes again"
+        );
+    }
+
+    /// TOCTOU (lock-security finding, PR 3): a `lock_folder` committing BETWEEN the indexer's
+    /// pre-embed visibility gate and its write transaction must not leave freshly-written
+    /// sealed-meeting plaintext at rest. Simulated by sealing the note at rest (markdown blanked,
+    /// `content_blob` kept — exactly what `blank_sealed_notes_in_folders` leaves) while the
+    /// CALLER'S unlocked snapshot is stale and still names the folder: the pre-gate passes, and
+    /// only the in-tx sealed-at-rest re-check can refuse the write.
+    #[test]
+    fn topic_index_refuses_write_when_sealed_at_rest_mid_flight() {
+        let db = file_db("topic-toctou");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m1", "atlas planning", Some("f-lock"));
+        let segs = one_topic_segment("omawiamy harmonogram projektu atlas");
+        db.insert_segments("m1", &segs).unwrap();
+
+        // "lock_folder committed mid-embed": folder locked + note sealed at rest…
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        {
+            let conn = db.lock();
+            conn.execute(
+                "UPDATE notes SET markdown = '', content_blob = X'00' WHERE meeting_id = 'm1'",
+                [],
+            )
+            .unwrap();
+        }
+        // …while the caller's snapshot is STALE and still says the folder is unlocked.
+        let mut stale = HashSet::new();
+        stale.insert("f-lock".to_string());
+        db.index_meeting_topic_chunks("m1", &segs, &crate::embed::StubEmbedder, &stale)
+            .unwrap();
+        assert_eq!(
+            topic_counts(&db, "m1").0,
+            0,
+            "the in-tx sealed-at-rest re-check must refuse writing topic plaintext"
+        );
+    }
+
     /// apply_fact_ops persists an open fact; a later reconcile of a CHANGED object closes the old
     /// (valid_to set) and opens the new — both rows survive (bitemporal history). RED-before-GREEN:
     /// without the Invalidate UPDATE the old fact stays open (two open rows), failing the assertions.
@@ -10733,7 +11983,11 @@ mod lock_tests {
 
     // ── Re-Truth (supersessions): record/dedup/lifecycle + purge-on-delete + purge-on-seal ──
 
-    fn supersession_row(id: &str, superseding: &str, source: &str) -> crate::storage::models::SupersessionRow {
+    fn supersession_row(
+        id: &str,
+        superseding: &str,
+        source: &str,
+    ) -> crate::storage::models::SupersessionRow {
         crate::storage::models::SupersessionRow {
             id: id.to_string(),
             superseding_meeting_id: superseding.to_string(),
@@ -10774,7 +12028,8 @@ mod lock_tests {
         // Durably store a pre-image (undo scratch), THEN mark applied (applied_at is the last write).
         db.store_supersession_pre_images("s1", Some(&b"ORIGINAL"[..]), None)
             .unwrap();
-        db.mark_supersession_applied("s1", "2026-06-21T00:00:00Z").unwrap();
+        db.mark_supersession_applied("s1", "2026-06-21T00:00:00Z")
+            .unwrap();
         assert!(
             db.unapplied_supersessions_for("m2").unwrap().is_empty(),
             "an applied row is no longer pending"
@@ -10826,7 +12081,8 @@ mod lock_tests {
         // Simulate apply having stored the plaintext pre-image + marked applied.
         db.store_supersession_pre_images("s1", Some(&b"PLAINTEXT NOTE"[..]), None)
             .unwrap();
-        db.mark_supersession_applied("s1", "2026-06-21T00:00:00Z").unwrap();
+        db.mark_supersession_applied("s1", "2026-06-21T00:00:00Z")
+            .unwrap();
         // Seal the source meeting's folder → the seal purge tx runs for m1.
         db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
         assert!(
@@ -10856,7 +12112,8 @@ mod lock_tests {
         for id in ["s-src", "s-sup"] {
             db.store_supersession_pre_images(id, Some(&b"PLAINTEXT NOTE"[..]), None)
                 .unwrap();
-            db.mark_supersession_applied(id, "2026-06-21T00:00:00Z").unwrap();
+            db.mark_supersession_applied(id, "2026-06-21T00:00:00Z")
+                .unwrap();
         }
         assert!(db.get_supersession("s-src").unwrap().is_some());
         assert!(db.get_supersession("s-sup").unwrap().is_some());

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -8,19 +8,19 @@ use crate::summarize::provider::SummarizerProvider;
 
 pub mod action_items;
 pub mod anthropic;
-pub mod egress_log;
-pub mod gateway;
-pub mod meta;
 pub mod chat;
 pub mod claude_code;
 pub mod digest;
 pub mod dossier;
+pub mod egress_log;
+pub mod gateway;
 pub mod graph;
 /// Tier 3b (B) anti-hallucination — DETERMINISTIC GROUNDING of the generated note against its own
 /// transcript segments. Pure, on-device, zero-egress; annotates unsupported summary units with a
 /// non-destructive `> unverified` marker.
 pub mod grounding;
 pub mod local;
+pub mod meta;
 /// The REAL on-device PERSON-name NER redactor (Phase D). ALWAYS compiled; the real impl is selected
 /// at runtime by `redact::active_name_redactor` when the NER model dir is present, else the
 /// byte-identical `NoopNameRedactor` (so a no-model build's name egress is unchanged).
@@ -33,6 +33,8 @@ pub mod redact;
 pub mod related_context;
 pub mod roles;
 pub mod template;
+/// Brain v2 L1.5 — pure PL+EN temporal-constraint parser for time-aware retrieval.
+pub mod temporal;
 pub mod threads;
 pub mod timeline;
 pub mod vault_chat;
@@ -218,7 +220,9 @@ fn make_provider_resolved(
                 ));
             }
             // R3 — resolve the GATEWAY key only; NEVER falls back to the Anthropic key.
-            let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT).ok().flatten();
+            let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT)
+                .ok()
+                .flatten();
             let model = if target.model.trim().is_empty() {
                 config.gateway_model.clone()
             } else {
@@ -345,7 +349,9 @@ pub fn all_providers(config: &AppConfig) -> Vec<Arc<dyn SummarizerProvider>> {
     ];
     // Gateway: include only when configured; a bad URL is omitted, never a panic.
     if !config.gateway_base_url.trim().is_empty() {
-        let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT).ok().flatten();
+        let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT)
+            .ok()
+            .flatten();
         if let Ok(gw) = crate::summarize::gateway::OpenAiCompatProvider::new(
             config.gateway_base_url.clone(),
             config.gateway_model.clone(),
@@ -515,7 +521,10 @@ mod tests {
         }
         for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
             assert!(
-                matches!(provider_for(role, &cfg), Err(crate::error::AppError::Unavailable(_))),
+                matches!(
+                    provider_for(role, &cfg),
+                    Err(crate::error::AppError::Unavailable(_))
+                ),
                 "provider_for {role:?} must refuse after revoke"
             );
         }
@@ -627,7 +636,10 @@ mod tests {
         let cfg = AppConfig::default(); // consent OFF
         for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
             assert!(
-                matches!(provider_for(role, &cfg), Err(crate::error::AppError::Unavailable(_))),
+                matches!(
+                    provider_for(role, &cfg),
+                    Err(crate::error::AppError::Unavailable(_))
+                ),
                 "fallback {role:?} must be consent-gated"
             );
         }
@@ -636,8 +648,12 @@ mod tests {
         let cases: [(&str, ConfigTweak); 4] = [
             ("claude_code", |_| {}),
             ("anthropic", |_| {}),
-            ("gateway", |c| c.gateway_base_url = "http://127.0.0.1:4000/v1".into()),
-            ("ollama", |c| c.ollama_base_url = "https://ollama.remote.example/api".into()),
+            ("gateway", |c| {
+                c.gateway_base_url = "http://127.0.0.1:4000/v1".into()
+            }),
+            ("ollama", |c| {
+                c.ollama_base_url = "https://ollama.remote.example/api".into()
+            }),
         ];
         for (conn, extra) in cases {
             let mut cfg = AppConfig {
@@ -715,14 +731,26 @@ mod tests {
             effort: String::new(),
         };
         // An explicit resolved model always wins.
-        assert_eq!(effective_model_requested(&t("anthropic", "claude-sonnet-4-6"), &cfg), "claude-sonnet-4-6");
+        assert_eq!(
+            effective_model_requested(&t("anthropic", "claude-sonnet-4-6"), &cfg),
+            "claude-sonnet-4-6"
+        );
         // Empty model → the connection's own default (THE anthropic fix).
-        assert_eq!(effective_model_requested(&t("anthropic", ""), &cfg), "claude-opus-4-8");
-        assert_eq!(effective_model_requested(&t("ollama", ""), &cfg), "llama3.1");
+        assert_eq!(
+            effective_model_requested(&t("anthropic", ""), &cfg),
+            "claude-opus-4-8"
+        );
+        assert_eq!(
+            effective_model_requested(&t("ollama", ""), &cfg),
+            "llama3.1"
+        );
         assert_eq!(effective_model_requested(&t("gateway", ""), &cfg), "gpt-4o");
         // claude_code's default is the CLI's own — unknowable here, stays "".
         assert_eq!(effective_model_requested(&t("claude_code", ""), &cfg), "");
-        assert_eq!(effective_model_requested(&t("claude_code", "claude-haiku-4-5"), &cfg), "claude-haiku-4-5");
+        assert_eq!(
+            effective_model_requested(&t("claude_code", "claude-haiku-4-5"), &cfg),
+            "claude-haiku-4-5"
+        );
     }
 
     /// Task 1.3 — `egress_is_cloud` explicitly classifies `PROVIDER_GATEWAY` as cloud.

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -110,8 +110,12 @@ fn is_summary_heading(heading_line: &str) -> bool {
     let t = section_title(heading_line);
     const KEYS: &[&str] = &[
         // English
-        "summary", "tl;dr", "overview", // Polish
-        "podsumowanie", "streszczenie", "przegląd",
+        "summary",
+        "tl;dr",
+        "overview", // Polish
+        "podsumowanie",
+        "streszczenie",
+        "przegląd",
     ];
     KEYS.iter().any(|k| t.starts_with(k))
 }
@@ -171,7 +175,10 @@ fn strip_list_marker(trimmed: &str) -> &str {
     let digits = trimmed.bytes().take_while(u8::is_ascii_digit).count();
     if digits > 0 {
         let after = &trimmed[digits..];
-        if let Some(r) = after.strip_prefix(". ").or_else(|| after.strip_prefix(") ")) {
+        if let Some(r) = after
+            .strip_prefix(". ")
+            .or_else(|| after.strip_prefix(") "))
+        {
             return r.trim_start();
         }
     }
@@ -372,7 +379,11 @@ fn gated_candidates(
     // MCP/Ask query path in `tools.rs`.
     match e.embed_query(std::slice::from_ref(&query.to_string())) {
         Ok(v) => match v.into_iter().next() {
-            Some(qv) if !qv.is_empty() => db.search_hybrid_visible(query, &qv, limit, unlocked),
+            // No temporal window here: the grounding query is a derived salient-term string, not
+            // a user question (a temporal phrase in it would be note prose, not intent).
+            Some(qv) if !qv.is_empty() => {
+                db.search_hybrid_visible(query, &qv, limit, unlocked, None)
+            }
             // Empty/degenerate query vector → FTS (never a stub-vector KNN).
             _ => db.search_visible(query, limit, unlocked),
         },
@@ -510,7 +521,14 @@ pub fn related_note_links(
 ) -> Result<Vec<ContextHit>> {
     // Activate semantic recall ONLY on real-model presence; else the embedder is None → FTS.
     let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
-    related_note_links_with_embedder(db, this_meeting_id, query, unlocked, max, embedder.as_deref())
+    related_note_links_with_embedder(
+        db,
+        this_meeting_id,
+        query,
+        unlocked,
+        max,
+        embedder.as_deref(),
+    )
 }
 
 /// Deterministic core of [`related_note_links`] with the embedder injected (so gating/semantic tests
@@ -775,9 +793,18 @@ mod tests {
             gist.contains("memory foam felt better"),
             "summary prose must be kept; got: {gist}"
         );
-        assert!(!gist.contains("Weronika"), "action items must be excluded; got: {gist}");
-        assert!(!gist.contains("foam samples"), "checklist tasks must be excluded; got: {gist}");
-        assert!(!gist.contains("Action items"), "the heading must not be in the gist; got: {gist}");
+        assert!(
+            !gist.contains("Weronika"),
+            "action items must be excluded; got: {gist}"
+        );
+        assert!(
+            !gist.contains("foam samples"),
+            "checklist tasks must be excluded; got: {gist}"
+        );
+        assert!(
+            !gist.contains("Action items"),
+            "the heading must not be in the gist; got: {gist}"
+        );
     }
 
     /// CORRECTION #3 (Polish leak), RED-before-GREEN: a Polish note whose FIRST section is a prose
@@ -788,8 +815,14 @@ mod tests {
     fn reference_gist_polish_decyzje_never_leaks() {
         let note = "## Decyzje\n\n- Weronika ma weryfikować rampę Alcon do piątku.\n\n## Notatki\n\nJakieś inne uwagi na później.\n";
         let gist = reference_gist(note);
-        assert!(!gist.contains("Weronika"), "PL decisions must not leak into the gist; got: {gist}");
-        assert!(!gist.contains("Alcon"), "PL decisions must not leak into the gist; got: {gist}");
+        assert!(
+            !gist.contains("Weronika"),
+            "PL decisions must not leak into the gist; got: {gist}"
+        );
+        assert!(
+            !gist.contains("Alcon"),
+            "PL decisions must not leak into the gist; got: {gist}"
+        );
         assert!(
             gist.contains("Jakieś inne uwagi"),
             "the first non-task prose must be the gist; got: {gist}"
@@ -806,7 +839,10 @@ mod tests {
             gist.contains("komforcie łóżka"),
             "PL summary prose must be kept; got: {gist}"
         );
-        assert!(!gist.contains("Weronika"), "PL tasks must not leak; got: {gist}");
+        assert!(
+            !gist.contains("Weronika"),
+            "PL tasks must not leak; got: {gist}"
+        );
     }
 
     /// Char-boundary-safe truncation: a long multi-byte (PL diacritic) summary is capped at 280
@@ -817,7 +853,10 @@ mod tests {
         let note = format!("## Summary\n\n{body}\n");
         let gist = reference_gist(&note);
         assert!(gist.chars().count() <= 280, "gist must be ≤ 280 chars");
-        assert!(gist.chars().count() >= 200, "a long summary must still produce a gist");
+        assert!(
+            gist.chars().count() >= 200,
+            "a long summary must still produce a gist"
+        );
     }
 
     // ── build_related_context: weak providers get NOTHING copyable ────────────────────────────────
@@ -827,7 +866,13 @@ mod tests {
     #[test]
     fn build_related_context_weak_provider_header_only() {
         let db = temp_db();
-        seed_note(&db, "this", "Bed Comfort", "unrelated bed comfort trial", None);
+        seed_note(
+            &db,
+            "this",
+            "Bed Comfort",
+            "unrelated bed comfort trial",
+            None,
+        );
         seed_note(
             &db,
             "prior",
@@ -840,8 +885,14 @@ mod tests {
         let (corpus, sources) =
             build_related_context(&db, "this", "bed comfort trial foam", &nothing, "ollama")
                 .unwrap();
-        assert!(corpus.contains("[[Bed Comfort Review]]"), "header must be cited; got: {corpus}");
-        assert!(corpus.contains("id:prior"), "header id must be cited; got: {corpus}");
+        assert!(
+            corpus.contains("[[Bed Comfort Review]]"),
+            "header must be cited; got: {corpus}"
+        );
+        assert!(
+            corpus.contains("id:prior"),
+            "header id must be cited; got: {corpus}"
+        );
         assert!(
             !corpus.contains("SUPERCOMFY"),
             "weak provider must NOT get the gist body; got: {corpus}"
@@ -857,7 +908,13 @@ mod tests {
     #[test]
     fn build_related_context_strong_provider_gets_gist() {
         let db = temp_db();
-        seed_note(&db, "this", "Bed Comfort", "unrelated bed comfort trial", None);
+        seed_note(
+            &db,
+            "this",
+            "Bed Comfort",
+            "unrelated bed comfort trial",
+            None,
+        );
         seed_note(
             &db,
             "prior",
@@ -869,7 +926,10 @@ mod tests {
         let (corpus, _sources) =
             build_related_context(&db, "this", "bed comfort trial foam", &nothing, "anthropic")
                 .unwrap();
-        assert!(corpus.contains("SUPERCOMFY"), "strong provider gets the gist prose; got: {corpus}");
+        assert!(
+            corpus.contains("SUPERCOMFY"),
+            "strong provider gets the gist prose; got: {corpus}"
+        );
         assert!(
             !corpus.contains("Weronika"),
             "even a strong provider never gets copyable action items; got: {corpus}"
@@ -887,7 +947,13 @@ mod tests {
     fn related_note_links_gated_self_excluded_and_task_free() {
         let db = temp_db();
         // The note we're linking FROM (its own content also matches the query → must be self-excluded).
-        seed_note(&db, "this", "Acquisition Talk", "PROJECT atlas acquisition terms roadmap", None);
+        seed_note(
+            &db,
+            "this",
+            "Acquisition Talk",
+            "PROJECT atlas acquisition terms roadmap",
+            None,
+        );
         seed_folder(&db, "f-locked", false);
         seed_note(
             &db,
@@ -900,13 +966,24 @@ mod tests {
 
         // Not session-unlocked → the sealed related note yields NO link, and "this" links nothing to itself.
         let nothing = HashSet::new();
-        let links = related_note_links(&db, "this", "PROJECT atlas acquisition roadmap", &nothing, 4).unwrap();
+        let links = related_note_links(
+            &db,
+            "this",
+            "PROJECT atlas acquisition roadmap",
+            &nothing,
+            4,
+        )
+        .unwrap();
         assert!(
-            links.iter().all(|h| h.url.as_deref() != Some("[[Secret Acquisition]]")),
+            links
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Secret Acquisition]]")),
             "sealed-not-unlocked related note must not be linked (gate violation)"
         );
         assert!(
-            links.iter().all(|h| h.url.as_deref() != Some("[[Acquisition Talk]]")),
+            links
+                .iter()
+                .all(|h| h.url.as_deref() != Some("[[Acquisition Talk]]")),
             "a note must never be linked to itself"
         );
         assert!(
@@ -917,7 +994,14 @@ mod tests {
         // Session-unlock the folder → the related note is now legitimately linkable.
         let mut unlocked = HashSet::new();
         unlocked.insert("f-locked".to_string());
-        let links2 = related_note_links(&db, "this", "PROJECT atlas acquisition roadmap", &unlocked, 4).unwrap();
+        let links2 = related_note_links(
+            &db,
+            "this",
+            "PROJECT atlas acquisition roadmap",
+            &unlocked,
+            4,
+        )
+        .unwrap();
         let link = links2
             .iter()
             .find(|h| h.url.as_deref() == Some("[[Secret Acquisition]]"))
@@ -940,9 +1024,17 @@ mod tests {
     fn related_note_links_empty_query_is_empty() {
         let db = temp_db();
         seed_note(&db, "this", "Standup", "daily standup notes", None);
-        seed_note(&db, "prior", "Old Standup", "## Summary\n\nolder standup summary\n", None);
+        seed_note(
+            &db,
+            "prior",
+            "Old Standup",
+            "## Summary\n\nolder standup summary\n",
+            None,
+        );
         let nothing = HashSet::new();
-        assert!(related_note_links(&db, "this", "", &nothing, 4).unwrap().is_empty());
+        assert!(related_note_links(&db, "this", "", &nothing, 4)
+            .unwrap()
+            .is_empty());
     }
 
     /// An empty query (transcript was all stopwords) yields an empty corpus — never a panic, never

--- a/src-tauri/src/summarize/temporal.rs
+++ b/src-tauri/src/summarize/temporal.rs
@@ -1,0 +1,533 @@
+//! Brain v2 L1.5 — time-aware query expansion: a pure PL+EN parser that extracts a calendar
+//! window from a natural-language query ("what did we discuss last week?" / "jakie wnioski z
+//! zeszłego tygodnia?") so retrieval can add a `started_at` range filter to every leg.
+//!
+//! Pure + deterministic: `parse_temporal_constraint(query, today)` takes the anchor date
+//! EXPLICITLY (the app passes `chrono::Utc::now().date_naive()`; the eval harness passes the
+//! FIXED corpus anchor so the labeled set never rots). The ORIGINAL query text is NOT stripped —
+//! BM25 tolerates the extra temporal tokens (spec §L1.5).
+//!
+//! Weeks are Monday-anchored (the PL convention and ISO-8601). All returned ranges are
+//! half-open: `(from_inclusive, to_exclusive)`.
+
+use chrono::{Datelike, Days, NaiveDate};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// EN month names → month number (1-based).
+const MONTHS_EN: [&str; 12] = [
+    "january",
+    "february",
+    "march",
+    "april",
+    "may",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+];
+
+/// PL month names in the GENITIVE (the form that follows "tygodniu"/"tydzień": "czerwca",
+/// "pierwszym tygodniu czerwca"), plus diacritic-stripped variants folded in [`pl_month_number`].
+const MONTHS_PL: [&str; 12] = [
+    "stycznia",
+    "lutego",
+    "marca",
+    "kwietnia",
+    "maja",
+    "czerwca",
+    "lipca",
+    "sierpnia",
+    "września",
+    "października",
+    "listopada",
+    "grudnia",
+];
+
+fn en_month_number(name: &str) -> Option<u32> {
+    MONTHS_EN
+        .iter()
+        .position(|m| *m == name)
+        .map(|i| i as u32 + 1)
+}
+
+fn pl_month_number(name: &str) -> Option<u32> {
+    let stripped: String = name
+        .chars()
+        .map(|c| match c {
+            'ś' => 's',
+            'ź' => 'z',
+            'ż' => 'z',
+            'ą' => 'a',
+            'ę' => 'e',
+            'ó' => 'o',
+            'ł' => 'l',
+            'ć' => 'c',
+            'ń' => 'n',
+            other => other,
+        })
+        .collect();
+    MONTHS_PL
+        .iter()
+        .position(|m| {
+            let m_stripped: String = m
+                .chars()
+                .map(|c| match c {
+                    'ś' => 's',
+                    'ź' => 'z',
+                    'ż' => 'z',
+                    'ą' => 'a',
+                    'ę' => 'e',
+                    'ó' => 'o',
+                    'ł' => 'l',
+                    'ć' => 'c',
+                    'ń' => 'n',
+                    other => other,
+                })
+                .collect();
+            m_stripped == stripped
+        })
+        .map(|i| i as u32 + 1)
+}
+
+/// The Monday of the ISO week containing `d`.
+fn monday_of(d: NaiveDate) -> NaiveDate {
+    let back = d.weekday().num_days_from_monday() as u64;
+    d.checked_sub_days(Days::new(back)).unwrap_or(d)
+}
+
+/// First day of `d`'s month.
+fn month_start(d: NaiveDate) -> NaiveDate {
+    NaiveDate::from_ymd_opt(d.year(), d.month(), 1).unwrap_or(d)
+}
+
+/// First day of the month AFTER `d`'s month.
+fn next_month_start(d: NaiveDate) -> NaiveDate {
+    let (y, m) = if d.month() == 12 {
+        (d.year() + 1, 1)
+    } else {
+        (d.year(), d.month() + 1)
+    };
+    NaiveDate::from_ymd_opt(y, m, 1).unwrap_or(d)
+}
+
+/// A small EN+PL number-word map for "two weeks ago"/"dwa tygodnie temu". Digits are handled by
+/// the regexes directly.
+fn number_word(w: &str) -> Option<u64> {
+    match w {
+        "one" | "jeden" => Some(1),
+        "two" | "dwa" => Some(2),
+        "three" | "trzy" => Some(3),
+        "four" | "cztery" => Some(4),
+        "five" | "pięć" | "piec" => Some(5),
+        _ => w.parse::<u64>().ok(),
+    }
+}
+
+// Compiled once. All patterns run on the LOWERCASED query; `regex` is Unicode-aware, so `\w`/`\b`
+// handle Polish diacritics. Diacritic-stripped PL variants are included (users type both).
+fn re_iso() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\b(\d{4})-(\d{2})-(\d{2})\b").expect("static regex"))
+}
+fn re_last_n_days() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"\b(?:last|past)\s+(\d{1,3})\s+days\b|\bostatni(?:e|ch)\s+(\d{1,3})\s+dni\b")
+            .expect("static regex")
+    })
+}
+fn re_weeks_ago() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+    Regex::new(
+        r"\b(\d{1,2}|one|two|three|four|five|jeden|dwa|trzy|cztery|pięć|piec)\s+(?:weeks?|tygodni(?:e|a)?|tygodnie)\s+(?:ago|temu)\b",
+    )
+    .expect("static regex")
+})
+}
+fn re_a_week_ago() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"\b(?:a\s+week\s+ago)\b|\btydzie[ńn]\s+temu\b").expect("static regex")
+    })
+}
+fn re_week_of() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+    Regex::new(
+        r"\bweek of (january|february|march|april|may|june|july|august|september|october|november|december)\s+(\d{1,2})\b",
+    )
+    .expect("static regex")
+})
+}
+fn re_first_week_of() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+    Regex::new(
+        r"\bfirst week of (january|february|march|april|may|june|july|august|september|october|november|december)\b|\bpierwsz\w*\s+(?:tydzień|tydzien|tygodniu|tygodnia)\s+(\w+)\b",
+    )
+    .expect("static regex")
+})
+}
+fn re_yesterday() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\byesterday\b|\bwczoraj\b").expect("static regex"))
+}
+fn re_today() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\btoday\b|\bdzisiaj\b|\bdziś\b|\bdzis\b").expect("static regex"))
+}
+fn re_last_week() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+    Regex::new(
+        r"\blast week\b|\b(?:zeszł|zeszl|poprzedni|ubiegł|ubiegl|ostatni)\w*\s+(?:tygodniu|tygodnia|tydzień|tydzien)\b",
+    )
+    .expect("static regex")
+})
+}
+fn re_this_week() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"\bthis week\b|\b(?:tym|bieżąc\w*|biezac\w*)\s+tygodniu\b|\btego tygodnia\b")
+            .expect("static regex")
+    })
+}
+fn re_last_month() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+    Regex::new(
+        r"\blast month\b|\b(?:zeszł|zeszl|poprzedni|ubiegł|ubiegl)\w*\s+(?:miesiącu|miesiacu|miesiąca|miesiaca)\b",
+    )
+    .expect("static regex")
+})
+}
+fn re_this_month() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(
+            r"\bthis month\b|\btym\s+(?:miesiącu|miesiacu)\b|\btego\s+(?:miesiąca|miesiaca)\b",
+        )
+        .expect("static regex")
+    })
+}
+
+/// Extract a calendar window from a natural-language PL/EN query, anchored at `today`.
+/// Returns `Some((from_inclusive, to_exclusive))` or `None` when the query names no time frame.
+///
+/// Precedence (first match wins): explicit ISO dates → "last/past N days" → "N weeks ago" →
+/// "week of <month> <day>" → "first week of <month>" → yesterday → today → last week →
+/// this week → last month → this month. Pure — no clock, no I/O.
+pub fn parse_temporal_constraint(query: &str, today: NaiveDate) -> Option<(NaiveDate, NaiveDate)> {
+    let q = query.to_lowercase();
+    let day = Days::new(1);
+    let week = Days::new(7);
+
+    // 1) Explicit ISO dates: one date = that day; two or more = the [min, max] range.
+    let mut iso: Vec<NaiveDate> = re_iso()
+        .captures_iter(&q)
+        .filter_map(|c| {
+            let y: i32 = c.get(1)?.as_str().parse().ok()?;
+            let m: u32 = c.get(2)?.as_str().parse().ok()?;
+            let d: u32 = c.get(3)?.as_str().parse().ok()?;
+            NaiveDate::from_ymd_opt(y, m, d)
+        })
+        .collect();
+    if !iso.is_empty() {
+        iso.sort_unstable();
+        let from = iso[0];
+        let to = iso[iso.len() - 1].checked_add_days(day)?;
+        return Some((from, to));
+    }
+
+    // 2) last/past N days · ostatnie N dni.
+    if let Some(c) = re_last_n_days().captures(&q) {
+        let n: u64 = c
+            .get(1)
+            .or_else(|| c.get(2))?
+            .as_str()
+            .parse()
+            .ok()
+            .filter(|n| *n > 0)?;
+        let from = today.checked_sub_days(Days::new(n))?;
+        return Some((from, today.checked_add_days(day)?));
+    }
+
+    // 3) N weeks ago · N tygodnie temu (the ISO week that many weeks back).
+    if let Some(c) = re_weeks_ago().captures(&q) {
+        let n = number_word(c.get(1)?.as_str()).filter(|n| *n > 0)?;
+        let from = monday_of(today).checked_sub_days(Days::new(7 * n))?;
+        return Some((from, from.checked_add_days(week)?));
+    }
+    if re_a_week_ago().is_match(&q) {
+        let from = monday_of(today).checked_sub_days(week)?;
+        return Some((from, from.checked_add_days(week)?));
+    }
+
+    // 4) week of <month> <day> (EN) — the ISO week containing that date, in today's year.
+    if let Some(c) = re_week_of().captures(&q) {
+        let whole = c.get(0)?;
+        // An explicit 4-digit year after the day ("week of June 15 2025") would be silently
+        // ignored and resolve to TODAY'S year — a WRONG window that hard-filters every leg
+        // is worse than no filter. Bail to None so the query runs unfiltered instead.
+        let rest = q[whole.end()..].trim_start_matches([' ', ',']);
+        if rest.len() >= 4 && rest.as_bytes()[..4].iter().all(u8::is_ascii_digit) {
+            return None;
+        }
+        let month = en_month_number(c.get(1)?.as_str())?;
+        let d: u32 = c.get(2)?.as_str().parse().ok()?;
+        let date = NaiveDate::from_ymd_opt(today.year(), month, d)?;
+        let from = monday_of(date);
+        return Some((from, from.checked_add_days(week)?));
+    }
+
+    // 5) first week of <month> — the ISO week containing the 1st of that month (today's year).
+    if let Some(c) = re_first_week_of().captures(&q) {
+        let month = c
+            .get(1)
+            .and_then(|m| en_month_number(m.as_str()))
+            .or_else(|| c.get(2).and_then(|m| pl_month_number(m.as_str())))?;
+        let first = NaiveDate::from_ymd_opt(today.year(), month, 1)?;
+        let from = monday_of(first);
+        return Some((from, from.checked_add_days(week)?));
+    }
+
+    // 6) yesterday · wczoraj.
+    if re_yesterday().is_match(&q) {
+        let from = today.checked_sub_days(day)?;
+        return Some((from, today));
+    }
+
+    // 7) today · dziś/dzisiaj.
+    if re_today().is_match(&q) {
+        return Some((today, today.checked_add_days(day)?));
+    }
+
+    // 8) last week · zeszłym tygodniu / zeszłego tygodnia / w zeszłym tygodniu / poprzednim / ubiegłym.
+    if re_last_week().is_match(&q) {
+        let from = monday_of(today).checked_sub_days(week)?;
+        return Some((from, from.checked_add_days(week)?));
+    }
+
+    // 9) this week · w tym tygodniu / tego tygodnia.
+    if re_this_week().is_match(&q) {
+        let from = monday_of(today);
+        return Some((from, from.checked_add_days(week)?));
+    }
+
+    // 10) last month · zeszłym miesiącu / zeszłego miesiąca / poprzednim miesiącu.
+    if re_last_month().is_match(&q) {
+        let this_start = month_start(today);
+        let prev_last_day = this_start.checked_sub_days(day)?;
+        return Some((month_start(prev_last_day), this_start));
+    }
+
+    // 11) this month · w tym miesiącu / tego miesiąca.
+    if re_this_month().is_match(&q) {
+        return Some((month_start(today), next_month_start(today)));
+    }
+
+    None
+}
+
+/// Format a parsed window as the `(from_iso, to_iso_exclusive)` string pair the DB readers bind
+/// (`m.started_at >= from AND m.started_at < to` — ISO-8601 strings compare lexicographically).
+pub fn date_filter_strings(range: (NaiveDate, NaiveDate)) -> (String, String) {
+    (
+        range.0.format("%Y-%m-%d").to_string(),
+        range.1.format("%Y-%m-%d").to_string(),
+    )
+}
+
+/// Convenience for the retrieval call sites: parse + format in one step.
+pub fn extract_date_filter(query: &str, today: NaiveDate) -> Option<(String, String)> {
+    parse_temporal_constraint(query, today).map(date_filter_strings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The eval corpus anchor — a Monday (2026-06-29).
+    fn anchor() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 29).unwrap()
+    }
+
+    fn d(y: i32, m: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, day).unwrap()
+    }
+
+    #[test]
+    fn no_temporal_phrase_yields_none() {
+        assert_eq!(
+            parse_temporal_constraint("Projekt Atlas budget review", anchor()),
+            None
+        );
+        assert_eq!(parse_temporal_constraint("", anchor()), None);
+        // "weekly" / "tygodniowy" must NOT trip the week matchers (word boundaries).
+        assert_eq!(
+            parse_temporal_constraint("weekly sync notes", anchor()),
+            None
+        );
+    }
+
+    #[test]
+    fn last_week_en_and_pl_declensions() {
+        // Anchor is Monday 2026-06-29 ⇒ last week = 2026-06-22 .. 2026-06-29 (exclusive).
+        let want = Some((d(2026, 6, 22), d(2026, 6, 29)));
+        assert_eq!(
+            parse_temporal_constraint("What did we discuss last week?", anchor()),
+            want
+        );
+        assert_eq!(
+            parse_temporal_constraint("Jakie wnioski z zeszłego tygodnia?", anchor()),
+            want
+        );
+        assert_eq!(
+            parse_temporal_constraint("co było w zeszłym tygodniu", anchor()),
+            want
+        );
+        assert_eq!(
+            parse_temporal_constraint("w poprzednim tygodniu", anchor()),
+            want
+        );
+        assert_eq!(
+            parse_temporal_constraint("ubiegłego tygodnia", anchor()),
+            want
+        );
+        // Mid-week anchor still resolves to the SAME Monday-anchored window.
+        let wed = d(2026, 7, 1);
+        assert_eq!(parse_temporal_constraint("last week", wed), want);
+    }
+
+    #[test]
+    fn this_week_and_months() {
+        assert_eq!(
+            parse_temporal_constraint("plans for this week", anchor()),
+            Some((d(2026, 6, 29), d(2026, 7, 6)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("co mamy w tym tygodniu", anchor()),
+            Some((d(2026, 6, 29), d(2026, 7, 6)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("what happened last month", anchor()),
+            Some((d(2026, 5, 1), d(2026, 6, 1)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("w zeszłym miesiącu", anchor()),
+            Some((d(2026, 5, 1), d(2026, 6, 1)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("spending this month", anchor()),
+            Some((d(2026, 6, 1), d(2026, 7, 1)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("wydatki w tym miesiącu", anchor()),
+            Some((d(2026, 6, 1), d(2026, 7, 1)))
+        );
+    }
+
+    #[test]
+    fn yesterday_today_and_last_n_days() {
+        assert_eq!(
+            parse_temporal_constraint("notes from yesterday", anchor()),
+            Some((d(2026, 6, 28), d(2026, 6, 29)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("co ustaliliśmy wczoraj", anchor()),
+            Some((d(2026, 6, 28), d(2026, 6, 29)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("agenda for today", anchor()),
+            Some((d(2026, 6, 29), d(2026, 6, 30)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("co mamy dziś", anchor()),
+            Some((d(2026, 6, 29), d(2026, 6, 30)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("decisions from the last 10 days", anchor()),
+            Some((d(2026, 6, 19), d(2026, 6, 30)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("ostatnie 3 dni", anchor()),
+            Some((d(2026, 6, 26), d(2026, 6, 30)))
+        );
+    }
+
+    #[test]
+    fn weeks_ago_and_week_of() {
+        // "two weeks ago" from Monday 2026-06-29 ⇒ week of 2026-06-15.
+        assert_eq!(
+            parse_temporal_constraint("What did we agree on two weeks ago?", anchor()),
+            Some((d(2026, 6, 15), d(2026, 6, 22)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("dwa tygodnie temu", anchor()),
+            Some((d(2026, 6, 15), d(2026, 6, 22)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("a week ago", anchor()),
+            Some((d(2026, 6, 22), d(2026, 6, 29)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("tydzień temu", anchor()),
+            Some((d(2026, 6, 22), d(2026, 6, 29)))
+        );
+        // "week of June 15" ⇒ the Monday-anchored week containing 2026-06-15.
+        assert_eq!(
+            parse_temporal_constraint(
+                "Which decisions were made in the week of June 15?",
+                anchor()
+            ),
+            Some((d(2026, 6, 15), d(2026, 6, 22)))
+        );
+        // An EXPLICIT year after the day must bail to None (today's-year resolution would build
+        // a WRONG window that hard-filters every leg — worse than no filter).
+        assert_eq!(
+            parse_temporal_constraint("week of June 15 2025", anchor()),
+            None
+        );
+        assert_eq!(
+            parse_temporal_constraint("week of June 15, 2025", anchor()),
+            None
+        );
+        // "first week of June" / PL "pierwszym tygodniu czerwca" ⇒ week of 2026-06-01 (a Monday).
+        assert_eq!(
+            parse_temporal_constraint("first week of June", anchor()),
+            Some((d(2026, 6, 1), d(2026, 6, 8)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("Co działo się w pierwszym tygodniu czerwca?", anchor()),
+            Some((d(2026, 6, 1), d(2026, 6, 8)))
+        );
+    }
+
+    #[test]
+    fn iso_dates_single_and_range() {
+        assert_eq!(
+            parse_temporal_constraint("what happened on 2026-05-11", anchor()),
+            Some((d(2026, 5, 11), d(2026, 5, 12)))
+        );
+        assert_eq!(
+            parse_temporal_constraint("between 2026-05-11 and 2026-05-20", anchor()),
+            Some((d(2026, 5, 11), d(2026, 5, 21)))
+        );
+        // Invalid calendar date is ignored (no panic, no bogus window).
+        assert_eq!(
+            parse_temporal_constraint("2026-13-45 nonsense", anchor()),
+            None
+        );
+    }
+
+    #[test]
+    fn date_filter_strings_are_half_open_iso() {
+        let f = extract_date_filter("last week", anchor()).unwrap();
+        assert_eq!(f, ("2026-06-22".to_string(), "2026-06-29".to_string()));
+    }
+}

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -59,11 +59,16 @@ pub fn build_vault_context_visible(
 ) -> Result<(String, Vec<VaultSource>)> {
     let budget = budget_for(provider_id);
 
+    // Brain v2 L1.5 — time-aware expansion: a temporal phrase in the question windows the
+    // candidate search on `started_at` (query-time `now` is the right anchor for a user query).
+    let date_filter =
+        crate::summarize::temporal::extract_date_filter(query, chrono::Utc::now().date_naive());
+
     // Relevance-first: VISIBLE search hits, else the most recent VISIBLE meetings. Both queries
     // apply the sealed-folder visibility clause against `unlocked`, so sealed-not-unlocked
     // meetings are filtered out of the candidate set before any content is read.
     let mut meetings: Vec<crate::storage::models::Meeting> = db
-        .search_visible(query, 40, unlocked)?
+        .search_visible_in_range(query, 40, unlocked, date_filter)?
         .into_iter()
         .map(|h| h.meeting)
         .collect();
@@ -96,13 +101,45 @@ pub fn build_vault_context_hybrid_visible(
     provider_id: &str,
     query_vec: &[f32],
     unlocked: &HashSet<String>,
+    reranker: Option<&dyn crate::rerank::Reranker>,
 ) -> Result<(String, Vec<VaultSource>)> {
     let budget = budget_for(provider_id);
-    let mut meetings: Vec<crate::storage::models::Meeting> = db
-        .search_hybrid_visible(query, query_vec, 40, unlocked)?
-        .into_iter()
-        .map(|h| h.meeting)
-        .collect();
+    // Brain v2 L1.5 — temporal window (all hybrid legs apply it; query-time `now` anchor).
+    let date_filter =
+        crate::summarize::temporal::extract_date_filter(query, chrono::Utc::now().date_naive());
+    let mut hits = db.search_hybrid_visible(query, query_vec, 40, unlocked, date_filter)?;
+
+    // Brain v2 L1.4 — the RERANKER seam (Ask-only): reorder the TOP-K fused candidates before
+    // packing. The reranker sees ONLY already-gated hits (id + title/snippet — content the caller
+    // may already pack into the prompt) and MUST degrade to input order on failure/timeout, so
+    // this can only reorder, never widen, the candidate set. `None` (no local model / cloud
+    // brain / non-Ask callers) = byte-identical to the un-reranked path.
+    if let Some(rr) = reranker {
+        let k = crate::rerank::RERANK_TOP_K.min(hits.len());
+        if k >= 2 {
+            let candidates: Vec<(String, String)> = hits[..k]
+                .iter()
+                .map(|h| {
+                    let title = h.meeting.title.clone().unwrap_or_default();
+                    (h.meeting.id.clone(), format!("{title}\n{}", h.snippet))
+                })
+                .collect();
+            let order = rr.rerank(query, &candidates, crate::rerank::RERANK_TIMEOUT_MS);
+            let mut head: Vec<crate::storage::models::SearchHit> = Vec::with_capacity(k);
+            let mut pool: Vec<crate::storage::models::SearchHit> = hits.drain(..k).collect();
+            for id in order {
+                if let Some(pos) = pool.iter().position(|h| h.meeting.id == id) {
+                    head.push(pool.remove(pos));
+                }
+            }
+            head.extend(pool); // degrade-safety: an id the reranker lost keeps its slot.
+            head.extend(hits);
+            hits = head;
+        }
+    }
+
+    let mut meetings: Vec<crate::storage::models::Meeting> =
+        hits.into_iter().map(|h| h.meeting).collect();
     if meetings.is_empty() {
         meetings = db.list_meetings_visible(30, unlocked)?;
     }
@@ -334,7 +371,8 @@ mod tests {
         // proving the READ-time gate (not just absence of an index row) excludes it.
         let emb = crate::embed::active_embedder();
         db.index_meeting_chunks("open", &[], emb.as_ref()).unwrap();
-        db.index_meeting_chunks("sealed", &[], emb.as_ref()).unwrap();
+        db.index_meeting_chunks("sealed", &[], emb.as_ref())
+            .unwrap();
         db.set_folder_locked("f-locked", true, None).unwrap();
 
         let qv = emb
@@ -344,7 +382,7 @@ mod tests {
 
         let nothing = HashSet::new();
         let (corpus, sources) =
-            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &nothing)
+            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &nothing, None)
                 .unwrap();
         assert!(
             corpus.contains("OPEN-SECRET"),
@@ -359,7 +397,7 @@ mod tests {
         let mut unlocked = HashSet::new();
         unlocked.insert("f-locked".to_string());
         let (corpus2, _) =
-            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &unlocked)
+            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &unlocked, None)
                 .unwrap();
         assert!(
             corpus2.contains("LOCKED-SECRET"),

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -73,7 +73,12 @@ impl AssistantScope {
             "get_open_commitments",
             "get_entity_dossier",
         ];
-        const CONNECTORS: [&str; 4] = ["web_search", "calendar_lookup", "jira_search", "slack_search"];
+        const CONNECTORS: [&str; 4] = [
+            "web_search",
+            "calendar_lookup",
+            "jira_search",
+            "slack_search",
+        ];
         match self {
             // Tier 1 reaches NEITHER vault reads NOR connectors — it answers from injected
             // current-meeting content only. (propose_note / writes still pass the tier gate; the
@@ -300,6 +305,12 @@ pub fn execute_tool(
     match call {
         ToolCall::SearchMeetings { query } => {
             let q = query.as_str();
+            // Brain v2 L1.5 — time-aware expansion: a temporal phrase in the query ("last week",
+            // "zeszłego tygodnia") becomes a `started_at` window on the meeting leg. The query
+            // text itself is NOT stripped (BM25 tolerates the extra tokens). Query-time `now` is
+            // the correct anchor here (the user means THEIR last week).
+            let date_filter =
+                crate::summarize::temporal::extract_date_filter(q, chrono::Utc::now().date_naive());
             // Documents/brain notes ride the SAME fan-out — the gated keyword (FTS/BM25) doc leg
             // works WITHOUT the e5 model, so ingested content is reachable through the primary
             // search tool on a default install. `search_doc_chunks_fts_visible` applies the SAME
@@ -307,7 +318,7 @@ pub fn execute_tool(
             let docs = db
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
                 .unwrap_or_default();
-            match db.search_visible(q, 20, unlocked) {
+            match db.search_visible_in_range(q, 20, unlocked, date_filter) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))
                 }
@@ -317,13 +328,17 @@ pub fn execute_tool(
         }
         ToolCall::SearchSemantic { query } => {
             let q = query.as_str();
+            // Brain v2 L1.5 — the same time-aware window as `search_meetings` (all legs of the
+            // hybrid query apply it).
+            let date_filter =
+                crate::summarize::temporal::extract_date_filter(q, chrono::Utc::now().date_naive());
             // GATE: the master flag lives in the (whole-DB-encrypted) settings table. When OFF,
             // DEGRADE HONESTLY to gated keyword (BM25) matching — never an ungated read, and no
             // `vec_chunks`/`doc_vec_chunks` row is ever touched (no stub-vector KNN). The output is
             // labelled as keyword matching so the model is never told a semantic search ran.
             if !config.semantic_search_enabled {
                 let hits = db
-                    .search_visible(q, 20, unlocked)
+                    .search_visible_in_range(q, 20, unlocked, date_filter)
                     .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
                 let docs = db
                     .search_doc_chunks_fts_visible(q, 20, unlocked)
@@ -357,7 +372,7 @@ pub fn execute_tool(
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
                 .unwrap_or_default();
             let docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
-            match db.search_hybrid_visible(q, &query_vec, 20, unlocked) {
+            match db.search_hybrid_visible(q, &query_vec, 20, unlocked, date_filter) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))
                 }
@@ -863,11 +878,15 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             },
             "jira_search" => match self.app {
                 Some(_) => block_on_tool(execute_jira_search(&s("query"), self.config)),
-                None => Err(AppError::InvalidArg("jira_search needs an AppHandle".into())),
+                None => Err(AppError::InvalidArg(
+                    "jira_search needs an AppHandle".into(),
+                )),
             },
             "slack_search" => match self.app {
                 Some(_) => block_on_tool(execute_slack_search(&s("query"), self.config)),
-                None => Err(AppError::InvalidArg("slack_search needs an AppHandle".into())),
+                None => Err(AppError::InvalidArg(
+                    "slack_search needs an AppHandle".into(),
+                )),
             },
             // ── PROPOSE (always-on, NO DB side effect): the model signals the user asked for a note.
             //    Records the draft in interior-mutable scratch; the caller threads it onto the result so
@@ -1075,7 +1094,9 @@ mod tests {
         let nothing = HashSet::new();
         let cfg = AppConfig::default();
         let res = execute_tool(
-            &ToolCall::JiraSearch { query: "login bug".into() },
+            &ToolCall::JiraSearch {
+                query: "login bug".into(),
+            },
             &db,
             &nothing,
             &cfg,
@@ -1092,7 +1113,10 @@ mod tests {
     fn jira_search_fail_closed_returns_sentinel_no_egress() {
         let cfg = AppConfig::default(); // jira disabled + unconsented
         let out = block_on(execute_jira_search("login bug", &cfg)).unwrap();
-        assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
+        assert!(
+            out.contains("not available"),
+            "fail-closed sentinel, no egress: {out}"
+        );
     }
 
     /// EGRESS GUARD: the synchronous, egress-free `execute_tool` MUST refuse a `SlackSearch` — like
@@ -1103,7 +1127,9 @@ mod tests {
         let nothing = HashSet::new();
         let cfg = AppConfig::default();
         let res = execute_tool(
-            &ToolCall::SlackSearch { query: "raport".into() },
+            &ToolCall::SlackSearch {
+                query: "raport".into(),
+            },
             &db,
             &nothing,
             &cfg,
@@ -1120,7 +1146,10 @@ mod tests {
     fn slack_search_fail_closed_returns_sentinel_no_egress() {
         let cfg = AppConfig::default(); // slack disabled + unconsented
         let out = block_on(execute_slack_search("raport", &cfg)).unwrap();
-        assert!(out.contains("not available"), "fail-closed sentinel, no egress: {out}");
+        assert!(
+            out.contains("not available"),
+            "fail-closed sentinel, no egress: {out}"
+        );
     }
 
     /// LOUD: calendar hits render with their `[calendar]` source label + the bounded context block,
@@ -1695,7 +1724,10 @@ mod tests {
         let cfg = AppConfig::default();
         let unlocked = Mutex::new(HashSet::new());
         let exec = exec_at(&db, &unlocked, &cfg, AssistantScope::CurrentMeeting);
-        let res = exec.run("search_meetings", &serde_json::json!({ "query": "anything" }));
+        let res = exec.run(
+            "search_meetings",
+            &serde_json::json!({ "query": "anything" }),
+        );
         assert!(
             matches!(res, Err(AppError::InvalidArg(_))),
             "Tier 1 must REFUSE search_meetings (structural, not prompt-trust): {res:?}"
@@ -1721,7 +1753,12 @@ mod tests {
             names.contains(&"search_meetings") && names.contains(&"get_meeting"),
             "Tier 2 advertises the owned-vault reads: {names:?}"
         );
-        for connector in ["web_search", "jira_search", "slack_search", "calendar_lookup"] {
+        for connector in [
+            "web_search",
+            "jira_search",
+            "slack_search",
+            "calendar_lookup",
+        ] {
             assert!(
                 !names.contains(&connector),
                 "Tier 2 must NOT advertise the connector {connector}: {names:?}"


### PR DESCRIPTION
Brain v2 PR 3 (plan: `docs/research/2026-07-09-brain-v2-architecture-spec.md` §L1.1–L1.5). First PR measured against the PR-2 eval gate.

## Eval gate — before → after (real e5, synthetic corpus, k=5)

| mode | recall@5 | ndcg@5 | mrr |
|---|---|---|---|
| fts | 0.2000 → **0.4500** | 0.2000 → **0.4500** | 0.2000 → **0.4500** |
| semantic | 0.8417 | 0.6834 → 0.7020 | 0.6563 → 0.6801 |
| hybrid | **0.8417 → 0.9000** | **0.6842 → 0.8250** | **0.6563 → 0.8146** |

Gate rule (hybrid recall@5 ≥ 0.8417): **PASS**. The verifier decomposed the gains: the fts jump is entirely the generic date-window mechanism (all five temporal queries 0→1.0), not fixture-shaped regexes (17 novel phrasings probed — all graceful). Artifact: `eval/results/rag-bakeoff-latest.md`; baseline untouched.

## What
- **L1.1** `embed::segment_topics` (lull ≥30s / speaker-flip / Jaccard <0.15) + additive `topic_chunks` + `topic_vec_chunks` + `fts_topic_chunks`; `index_meeting_topic_chunks` (gated, content-hash idempotent); startup backfill (batches of 20, real-model + `semantic_search_enabled` gated).
- **L1.2** `augment_chunk_text` — `title | date | attendees | facts` header on topic chunks + new `note_chunks.aug_text`; headers from visibility-gated readers, fail-closed for sealed content.
- **L1.3** `score_fuse` (min-max per leg, KNN distance inverted, 0.4/0.4/0.2) with `rrf_fuse` fallback; hybrid legs now include topic FTS + topic vectors.
- **L1.5** `summarize/temporal.rs` — pure PL+EN window parser (weeks/months/yesterday/N-days/N-weeks-ago/week-of/first-week-of/ISO) threaded as `date_filter` into every hybrid leg + a bounded temporal-window fallback (`matched_in: "temporal"`).
- **L1.4** `rerank.rs` — `Reranker` trait (degrade-to-input-order, never Err), `PromptedReranker` (pointwise on-device 1.7B, 3s deadline) + `StubReranker`; wired Ask-only; **cloud reasoners degrade to identity — rerank never egresses**.

## Verification
- **Adversarial-verifier: PASS** — re-ran the bake-off (byte-identical), surgical RED proofs (removed the purge → test fails; nulled the date clause → test fails), overfitting probe negative, score_fuse edge cases clean.
- **Lock-security-reviewer: PASS** — purge-on-seal covers all three choke points (rows+vectors+FTS tokens, test-proven incl. crash-reconcile), every new read on the canonical visibility predicate, no cross-meeting header contamination, no PII in logs, migrations additive-only.
- Reviewer findings closed pre-merge: **TOCTOU** (lock mid-embed) — in-tx sealed-at-rest re-check, session-independent, test `topic_index_refuses_write_when_sealed_at_rest_mid_flight`; **wrong-window year bug** ("week of June 15 2025" → today's year) — bails to None, tested; **backfill flag discipline** — respects `semantic_search_enabled`.
- `cargo test --lib`: 1219/0 (post-fixes). `scripts/ci.sh`: ✅ all gates green (after converting `LazyLock`→`OnceLock` accessors — MSRV 1.77; lesson recorded).

## Known limits
- `hybrid+rerank` row unmeasured (no local GGUF on disk at run time — runner prints an honest skip); reranker verified by unit tests, quality needs a Mac session with the brain model.
- Known LOW: KNN leg slightly stricter visibility arm than FTS (fail-closed recall asymmetry); AFM path ignores per-call timeout (on-device only).
- Real-vault numbers still unmeasured (synthetic = regression baseline).