### PR TITLE
feat(brain): L2 memory — relevance-filtered brief, consolidation job, memory import

### DIFF
--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -140,3 +140,9 @@
 - **Caught by:** scripts/ci.sh clippy stage (and initially MASKED by piping ci.sh through `| tail` — the pipe's exit code hid the failure; always capture ci.sh exit directly).
 - **Lesson:** for lazy statics use the established repo pattern — `fn re_x() -> &'static Regex { static R: OnceLock<Regex> = OnceLock::new(); R.get_or_init(|| ...) }` (see redact.rs email_re). Check clippy.toml/Cargo.toml MSRV before reaching for newer std items.
 - **Status:** journal
+
+### [2026-07-10 brain-l2-memory] Derived artifacts EXPORTED OUTSIDE the DB need their own seal hooks
+- **Pattern:** memory rollups (LLM synthesis over facts) were written to `memory_rollups` AND exported as plaintext `.md` into the vault. Purge-on-seal covered the source facts but not the synthesis: "regenerates next pass" was false (weekly scopes never re-touched; entity scopes only on NEW facts — a seal removes facts and is invisible to that detector). Locking a folder left a plaintext paraphrase of its content in Obsidian forever.
+- **Caught by:** lock-security-reviewer + adversarial-verifier (both FAIL, independently reproduced end-to-end; builder's 1234 green tests never exercised seal-then-pass).
+- **Lesson:** any derived artifact that leaves the DB (vault export, cache file) must be (1) purged at EVERY seal path (rows in-tx, files at the command layer via recorded exported_path — same layering as sealed-note .md deletion, incl. screen-share relock + startup reconcile + delete_meeting), and (2) covered by a change-detector for regeneration (fact-set hash), never "new data arrived" heuristics — seals REMOVE data. Test shape: synthesize → export → seal → assert row AND file gone → later pass recreates nothing.
+- **Status:** journal

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2043,6 +2043,100 @@ pub(crate) fn clear_user_memory_inner(state: &AppState) -> Result<(), AppError> 
     Ok(())
 }
 
+/// Brain v2 L2.3 — IMPORT pasted memories from another AI assistant (a ChatGPT/Claude "what I
+/// remember about you" export) into the user-memory store. Returns the number of NEW facts added.
+///
+/// Flow: extract candidates on the ON-DEVICE light reasoner (`user_memory::extract_imported_memories`
+/// — stub ⇒ empty ⇒ 0) → deterministic `reconcile_facts` against ALL existing user facts (a
+/// re-import of the same text reconciles to NoOps ⇒ 0 new) → ONLY when there is ≥1 Add, create a
+/// SYNTHETIC anchor meeting (`import-<uuid>`, title "Memory Import", `Exported`, no audio, no
+/// folder — so its facts are VISIBLE via the no-note arm of the visibility predicate) → stamp +
+/// apply atomically. ORDER IS LOAD-BEARING: the meeting row is created only after reconcile found
+/// something to add, so a stub/duplicate import leaves NO synthetic meeting behind. Deleting that
+/// meeting undoes the whole import (`delete_meeting` purges its `user_facts` in-tx). ZERO egress:
+/// extraction runs on [`import_extraction_reasoner`] — LOCAL-or-stub, NEVER cloud (the FE copy
+/// promises on-device; a pasted third-party memory export must not ride the cloud Notes provider).
+/// No local model ⇒ 0 imported (the FE hints the model may be missing). Runs on a blocking worker
+/// (a local-model extraction can take seconds). Logs counts only.
+#[tauri::command]
+pub async fn import_memories(state: State<'_, AppState>, text: String) -> Result<usize, AppError> {
+    let db = state.db.clone();
+    let reasoner = import_extraction_reasoner(state.inner());
+    let enabled = user_memory_enabled(state.inner());
+    tauri::async_runtime::spawn_blocking(move || {
+        import_memories_inner(&db, reasoner.as_ref(), enabled, &text)
+    })
+    .await
+    .map_err(|e| AppError::Other(anyhow::anyhow!("import task join failed: {e}")))?
+}
+
+/// The reasoner the memory IMPORT extracts on: the LIGHT engine handle (`ReasonerCell::light`) —
+/// LOCAL-or-stub, NEVER cloud, regardless of Brain Live / role config / consent. The FE copy
+/// promises "extracts the durable facts on-device"; routing the pasted export through
+/// `extraction_reasoner()` (cloud-classified Notes provider under the default `brain_live=false`)
+/// would egress a content class users were told stays local (lock-security W2). Stub ⇒ the import
+/// extracts nothing (0 imported) — degrade, never egress.
+fn import_extraction_reasoner(state: &AppState) -> std::sync::Arc<dyn crate::reason::LocalReasoner> {
+    state.reasoner.light()
+}
+
+/// Inner of [`import_memories`] (unit-testable: Db + reasoner + flag injected).
+pub(crate) fn import_memories_inner(
+    db: &crate::storage::Db,
+    reasoner: &dyn crate::reason::LocalReasoner,
+    memory_enabled: bool,
+    text: &str,
+) -> Result<usize, AppError> {
+    if !memory_enabled {
+        return Err(AppError::InvalidArg(
+            "cross-meeting memory is turned off — enable it in Settings to import memories".into(),
+        ));
+    }
+    if text.trim().is_empty() {
+        return Err(AppError::InvalidArg("nothing to import — paste the memory text".into()));
+    }
+    // 1) Best-effort extraction (stub / decode failure ⇒ empty ⇒ 0 imported, nothing persisted).
+    let candidates = crate::user_memory::extract_imported_memories(reasoner, text);
+    if candidates.is_empty() {
+        return Ok(0);
+    }
+    // 2) Deterministic reconcile against ALL existing user facts — the dedup: re-importing the same
+    //    export yields NoOps only.
+    let existing = db.user_facts_all()?;
+    let at = chrono::Utc::now().to_rfc3339();
+    let mut ops = crate::facts::reconcile_facts(&existing, &candidates, &at);
+    let adds = ops
+        .iter()
+        .filter(|o| matches!(o, crate::facts::FactOp::Add(_)))
+        .count();
+    if adds == 0 {
+        return Ok(0); // pure dedup/no-op import — no synthetic meeting is created.
+    }
+    // 3) The synthetic anchor meeting — created ONLY now that something will be added, so deleting
+    //    it undoes the import and a no-op import leaves nothing behind.
+    let meeting_id = format!("import-{}", uuid::Uuid::new_v4());
+    db.insert_meeting(&crate::storage::models::Meeting {
+        id: meeting_id.clone(),
+        started_at: at.clone(),
+        ended_at: None,
+        title: Some("Memory Import".to_string()),
+        duration_s: 0,
+        audio_path: None,
+        status: crate::storage::models::MeetingStatus::Exported,
+        folder_id: None,
+    })?;
+    // 4) Stamp the anchor onto the Adds (gating + purge anchor) and apply atomically.
+    crate::facts::set_meeting_id(&mut ops, &meeting_id);
+    db.apply_user_fact_ops(&ops)?;
+    tracing::info!(
+        target: "user_memory",
+        meeting_id = %meeting_id,
+        added = adds,
+        "memories imported (anchored to a synthetic meeting)"
+    );
+    Ok(adds)
+}
+
 /// Full-text-ish search across meeting titles, transcripts, and notes (Library search).
 #[tauri::command]
 pub fn search_meetings(
@@ -2078,7 +2172,23 @@ pub fn delete_meeting(state: State<'_, AppState>, meeting_id: String) -> Result<
             let _ = std::fs::remove_file(path);
         }
     }
-    state.db.delete_meeting(&meeting_id)
+    // Brain v2 L2.1: the delete tx purges ALL memory rollups (they may paraphrase this meeting's
+    // facts) and returns their exported vault paths — remove those files here, the same layer that
+    // removed the note `.md`/audio above. Rollups regenerate from visible facts on the next pass.
+    let rollup_exports = state.db.delete_meeting(&meeting_id)?;
+    remove_rollup_export_files(&rollup_exports);
+    Ok(())
+}
+
+/// Brain v2 L2.1 LOCK-SAFETY (the filesystem half of `Db::purge_memory_rollups_tx`): best-effort
+/// removal of purged memory rollups' exported vault `.md`s. Only ever the paths the DB recorded at
+/// export time — never any other file; a missing file is fine (the DB rows are already gone, which
+/// is what the leak gate needs). Same layering as the sealed-note vault `.md` deletion: rows in the
+/// db-layer tx, files at the command layer.
+fn remove_rollup_export_files(paths: &[String]) {
+    for p in paths {
+        let _ = std::fs::remove_file(p);
+    }
 }
 
 /// Rename a meeting's title (in-app + Library list). Does not rename the vault file.
@@ -2139,7 +2249,7 @@ pub async fn chat_meeting(
     // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
     // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
     let unlocked = unlocked_snapshot(state.inner())?;
-    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked);
+    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked, &question);
     let (system, user) =
         crate::summarize::chat::build(&transcript, &history, &question, &memory_brief);
     provider.complete(&system, &user).await
@@ -3391,18 +3501,19 @@ fn gated_meeting_thread_turns(state: &AppState, meeting_id: &str) -> String {
 /// memory is disabled (config `user_memory_enabled == false`) it returns EMPTY, so the prompt is
 /// byte-identical to the pre-memory prompt. Rides the EXISTING redaction + consent egress of the
 /// surface it is injected into — no new egress class.
+///
+/// Brain v2 L2.2: `query` is the user's question when the surface has one in hand — the brief is
+/// then RELEVANCE-FILTERED (BM25 top-k over the SAME visible set, `build_memory_brief`); an empty
+/// query or zero hits falls back to the full-list brief (behavior-preserving).
 fn gated_memory_brief_for_injection(
     state: &AppState,
     unlocked: &std::collections::HashSet<String>,
+    query: &str,
 ) -> String {
     if !user_memory_enabled(state) {
         return String::new();
     }
-    let facts = state
-        .db
-        .list_user_facts_visible(unlocked)
-        .unwrap_or_default();
-    crate::user_memory::synthesize_brief(&facts)
+    crate::user_memory::build_memory_brief(&state.db, query, unlocked)
 }
 
 /// Resolve the people + projects in a meeting note → persist them to the encrypted DB graph
@@ -3565,7 +3676,8 @@ pub async fn ask_vault(
     let unlocked = unlocked_snapshot(state.inner())?;
     // Gated cross-meeting USER MEMORY brief (parity with the @brain loop): VISIBLE facts only under
     // this same unlock snapshot, empty when memory is disabled ⇒ the floor prompt is byte-identical.
-    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked);
+    // L2.2: relevance-filtered against the question (full-list fallback on zero hits).
+    let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked, &question);
     // Brain v2 L1.4 — the Ask-only reranker: resolve from the LIVE Ask-role reasoner.
     // `active_reranker` degrades stub/cloud reasoners to the identity StubReranker (rerank is
     // strictly on-device — a cloud reasoner would turn each pointwise judgment into egress).
@@ -3649,7 +3761,7 @@ fn ask_vault_agentic_attempt(
         .lock()
         .map(|g| g.clone())
         .unwrap_or_default();
-    let memory_brief = gated_memory_brief_for_injection(&state, &unlocked_now);
+    let memory_brief = gated_memory_brief_for_injection(&state, &unlocked_now, question);
     match ask_vault_loop(
         &*reasoner,
         &executor,
@@ -5183,6 +5295,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // toggle). An omitted value defaults ON (`default_true`), matching AppConfig::default — an
         // older FE payload can never silently turn memory off.
         user_memory_enabled: d.user_memory_enabled,
+        // Brain v2 L2.1: the consolidation-job flag is NOT carried on the settings DTO (no FE
+        // toggle yet) — PRESERVE the live value so a settings save can neither enable nor clear it;
+        // it round-trips through the dedicated K_MEMORY_CONSOLIDATION_ENABLED load/save keys.
+        memory_consolidation_enabled: current.memory_consolidation_enabled,
         // Tier 3b (B) grounding: NOT yet carried on the settings DTO (the FE toggle is a follow-up),
         // so PRESERVE the live value here — a normal settings save can neither enable nor clear it,
         // and it round-trips through the dedicated K_GROUND_SUMMARY load/save keys. Mirrors the
@@ -7339,10 +7455,13 @@ fn seal_moved_note(
     // The note's chunks/vectors are plaintext-derived and a dense embedding is invertible, so they
     // must NOT survive at rest for a meeting now sealed into a locked folder — same invariant the
     // lock_folder / relock / startup-reconcile paths enforce. Covers both the manual move-into-locked
-    // and the auto-file callers. (Re-indexed on unlock once indexing ships.)
-    state
+    // and the auto-file callers. (Re-indexed on unlock once indexing ships.) The same tx purges ALL
+    // memory rollups (cross-meeting synthesis that may paraphrase the just-sealed facts) — remove
+    // their exported vault `.md`s here, like the note `.md`s above.
+    let rollup_exports = state
         .db
         .purge_chunks_for_meetings(&[meeting_id.to_string()])?;
+    remove_rollup_export_files(&rollup_exports);
     Ok(())
 }
 
@@ -7516,7 +7635,11 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
     // lands a locked-then-unlocked folder is simply not semantically searchable (degraded, not
     // leaky).
     let sealed_meeting_ids = state.db.meeting_ids_in_folder(&folder_id)?;
-    state.db.purge_chunks_for_meetings(&sealed_meeting_ids)?;
+    // The purge tx also drops ALL memory rollups (cross-meeting synthesis that may paraphrase the
+    // just-sealed facts; regenerated from visible facts on the next hourly pass) and returns their
+    // exported vault paths — deleted below alongside the sealed notes' `.md`s.
+    let rollup_exports = state.db.purge_chunks_for_meetings(&sealed_meeting_ids)?;
+    remove_rollup_export_files(&rollup_exports);
     // Document ingestion LOCK-SAFETY: purge the (now-sealed) documents' plaintext-derived chunks +
     // their invertible vectors too — a doc vector is PII derived from the plaintext, so it must not
     // survive at rest in a locked folder. Re-embeddable on unlock (the text seal is restorable).
@@ -7778,7 +7901,10 @@ pub fn relock_folder(state: State<'_, AppState>, folder_id: String) -> Result<()
     }
     let mut one = std::collections::HashSet::new();
     one.insert(folder_id.clone());
-    state.db.blank_sealed_notes_in_folders(&one)?;
+    // The re-blank tx also purges ALL memory rollups (may paraphrase the re-sealed facts) and
+    // returns their exported vault paths — the files are removed here (command layer).
+    let rollup_exports = state.db.blank_sealed_notes_in_folders(&one)?;
+    remove_rollup_export_files(&rollup_exports);
     // Phase 0.5 — re-blank the transcript + timeline plaintext and drop the decrypted session WAV
     // (the .enc + the *_blob columns stay; the folder is still locked=1 on disk).
     reblank_folder_extras(state.inner(), &folder_id)?;
@@ -7820,10 +7946,12 @@ pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
             k.zeroize();
         }
     }
-    // Re-blank every sealed note across all locked folders.
+    // Re-blank every sealed note across all locked folders. The tx also purges ALL memory rollups
+    // (may paraphrase the re-sealed facts) — their exported vault `.md`s are removed here.
     let locked: std::collections::HashSet<String> =
         state.db.locked_folder_ids()?.into_iter().collect();
-    state.db.blank_sealed_notes_in_folders(&locked)?;
+    let rollup_exports = state.db.blank_sealed_notes_in_folders(&locked)?;
+    remove_rollup_export_files(&rollup_exports);
     // Phase 0.5 — re-blank the transcript + timeline + drop the decrypted session WAVs for every
     // locked folder too (the .enc + *_blob columns stay).
     for fid in &locked {
@@ -12989,7 +13117,7 @@ mod lifecycle_tests {
 
         // OPEN folder: the fact is VISIBLE → the gated brief carries it → it reaches the Ask prompt.
         let open = unlocked_snapshot(&state).unwrap();
-        let brief_open = gated_memory_brief_for_injection(&state, &open);
+        let brief_open = gated_memory_brief_for_injection(&state, &open, "what did we ship?");
         assert!(
             brief_open.contains("Polish replies"),
             "an open-folder user fact must be in the brief"
@@ -13012,7 +13140,7 @@ mod lifecycle_tests {
             .set_folder_locked("f1", true, Some(&b"wrapped"[..]))
             .unwrap();
         let sealed = unlocked_snapshot(&state).unwrap();
-        let brief_sealed = gated_memory_brief_for_injection(&state, &sealed);
+        let brief_sealed = gated_memory_brief_for_injection(&state, &sealed, "what did we ship?");
         assert!(
             brief_sealed.is_empty(),
             "a sealed-source user fact must NOT be in the injected brief"
@@ -13037,14 +13165,14 @@ mod lifecycle_tests {
             .insert("f1".to_string());
         let unlocked = unlocked_snapshot(&state).unwrap();
         assert!(
-            gated_memory_brief_for_injection(&state, &unlocked).contains("Polish replies"),
+            gated_memory_brief_for_injection(&state, &unlocked, "what did we ship?").contains("Polish replies"),
             "a session unlock must re-admit the user fact to the Ask brief"
         );
 
         // FLAG OFF: even the visible fact must NOT be injected when memory is disabled.
         state.config.lock().unwrap().user_memory_enabled = false;
         assert!(
-            gated_memory_brief_for_injection(&state, &unlocked).is_empty(),
+            gated_memory_brief_for_injection(&state, &unlocked, "what did we ship?").is_empty(),
             "memory disabled must suppress the Ask brief even for a visible fact"
         );
         // And get_user_memory reports the explicit disabled marker (empty + disabled:true).
@@ -13057,6 +13185,201 @@ mod lifecycle_tests {
             mem.facts.is_empty() && mem.brief.is_empty(),
             "disabled ⇒ nothing surfaced"
         );
+    }
+
+    /// A deterministic "real" brain for the memory-import path: non-stub id, and `structured`
+    /// returns two fixed user-fact candidates regardless of prompt (the extraction seam is
+    /// exercised; the reconcile + anchoring are the deterministic core under test).
+    struct MockImportBrain;
+    impl crate::reason::LocalReasoner for MockImportBrain {
+        fn id(&self) -> &str {
+            "mock-import"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> Result<String, AppError> {
+            Ok(String::new())
+        }
+        fn structured(
+            &self,
+            _s: &str,
+            _u: &str,
+            _schema: &serde_json::Value,
+        ) -> Result<serde_json::Value, AppError> {
+            Ok(serde_json::json!({
+                "facts": [
+                    { "predicate": "prefers", "object": "Polish replies" },
+                    { "predicate": "works on", "object": "Project Atlas" }
+                ]
+            }))
+        }
+    }
+
+    /// Brain v2 L2.3 (RED-first): `import_memories` — the stub imports 0 and leaves NO synthetic
+    /// meeting behind; a real extraction anchors the Adds to ONE synthetic "Memory Import" meeting
+    /// whose facts are VISIBLE; a re-import of the same text reconciles to NoOps (0 new, and no
+    /// second synthetic meeting); deleting the synthetic meeting UNDOES the whole import. Fails
+    /// before L2.3: the command/inner did not exist.
+    #[test]
+    fn import_memories_dedups_anchors_and_delete_undoes() {
+        let state = build_state("mem-import");
+        let none = HashSet::new();
+        let count_import_meetings = |db: &Db| -> usize {
+            db.list_meetings(100)
+                .unwrap()
+                .iter()
+                .filter(|m| m.id.starts_with("import-"))
+                .count()
+        };
+
+        // Memory disabled ⇒ a loud refusal, nothing persisted.
+        assert!(matches!(
+            import_memories_inner(&state.db, &MockImportBrain, false, "x"),
+            Err(AppError::InvalidArg(_))
+        ));
+        // Empty text ⇒ a loud refusal.
+        assert!(matches!(
+            import_memories_inner(&state.db, &MockImportBrain, true, "   "),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // STUB (default install): 0 imported, NO synthetic meeting left behind.
+        let n = import_memories_inner(
+            &state.db,
+            &crate::reason::StubReasoner,
+            true,
+            "I like tea",
+        )
+        .unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(count_import_meetings(&state.db), 0, "stub must not create a meeting");
+        assert!(state.db.user_facts_all().unwrap().is_empty());
+
+        // REAL extraction: 2 added, anchored to ONE synthetic meeting, visible via the gated read.
+        let n = import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text")
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(count_import_meetings(&state.db), 1);
+        let visible = state.db.list_user_facts_visible(&none).unwrap();
+        assert_eq!(visible.len(), 2, "imported facts are visible (no-folder meeting)");
+        assert!(visible
+            .iter()
+            .all(|f| f.meeting_id.as_deref().unwrap().starts_with("import-")));
+
+        // RE-IMPORT of the same text: pure dedup — 0 new, and NO second synthetic meeting.
+        let n = import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text")
+            .unwrap();
+        assert_eq!(n, 0, "re-import must reconcile to NoOps");
+        assert_eq!(
+            count_import_meetings(&state.db),
+            1,
+            "a no-op import must not create another meeting"
+        );
+
+        // DELETE the synthetic meeting ⇒ the import is undone (facts + their scores gone).
+        let import_id = state
+            .db
+            .list_meetings(100)
+            .unwrap()
+            .into_iter()
+            .find(|m| m.id.starts_with("import-"))
+            .unwrap()
+            .id;
+        state.db.delete_meeting(&import_id).unwrap();
+        assert!(
+            state.db.user_facts_all().unwrap().is_empty(),
+            "deleting the synthetic meeting must undo the import"
+        );
+    }
+
+    /// FIX 2 (lock-security W2, RED-before-GREEN): the memory-IMPORT extraction reasoner is the
+    /// LIGHT local-or-stub handle — NEVER cloud, even under the exact config where the general
+    /// `extraction_reasoner()` goes cloud (default `brain_live=false` + cloud backend + consent).
+    /// RED on the pre-fix code: `import_memories` resolved `extraction_reasoner()`, whose id is
+    /// `cloud:*` under this config — the pasted third-party memory export would have egressed
+    /// while the FE copy promised on-device.
+    #[test]
+    fn import_extraction_reasoner_is_never_cloud() {
+        let mut state = build_state("import-reasoner");
+        let cloud_cfg = Arc::new(Mutex::new(AppConfig {
+            brain_backend: crate::settings::config::BrainBackend::Cloud,
+            cloud_egress_consented: true,
+            brain_live: false,
+            ..Default::default()
+        }));
+        state.reasoner = crate::reason::ReasonerCell::new(Arc::clone(&cloud_cfg));
+
+        // PRECONDITION (the trap): this config cloud-routes the general extraction seam.
+        assert!(
+            state
+                .reasoner
+                .extraction_reasoner()
+                .id()
+                .starts_with("cloud:"),
+            "precondition: the general extraction seam is cloud under this config"
+        );
+        // The import seam must stay local-or-stub regardless. On a machine WITH the light model
+        // installed this is the local engine (`mistralrs:*`); without it, the stub (⇒ 0 imported).
+        // Both are on-device — the binding invariant is NEVER `cloud:*`.
+        let id = import_extraction_reasoner(&state).id().to_string();
+        assert!(
+            !id.starts_with("cloud:"),
+            "memory import must NEVER extract on a cloud reasoner (got {id})"
+        );
+        assert!(
+            id == "stub" || id.starts_with("mistralrs:"),
+            "the import reasoner must be the LIGHT local-or-stub handle (got {id})"
+        );
+    }
+
+    /// FIX 1a (CRITICAL leak, both reviewers — RED-before-GREEN): SEALING purges every
+    /// memory-rollup row inside the seal tx AND deletes its exported vault `.md` at this (command)
+    /// layer — the reproduced leak was a rollup paraphrasing sealed facts persisting indefinitely
+    /// in `memory_rollups.content` + `<vault>/brain/memory/*.md` after `lock_folder`. Also covers
+    /// the relock path (`relock_all_inner`). Rollups are cheap re-derivable synthesis; the next
+    /// hourly pass regenerates them FROM VISIBLE FACTS ONLY.
+    #[test]
+    fn lock_and_relock_purge_memory_rollups_and_their_vault_exports() {
+        let vault = tmp_vault("rollup-seal");
+        let state = build_state_with_vault("rollup-seal", &vault);
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "# note", Some("f-lock"));
+
+        // A rollup exported to the vault, exactly as the hourly job leaves it.
+        let md = vault.join("brain").join("memory").join("weekly-2026-W28.md");
+        std::fs::create_dir_all(md.parent().unwrap()).unwrap();
+        std::fs::write(&md, "---\nmurmur: memory-rollup\n---\n\nsecret synthesis\n").unwrap();
+        state
+            .db
+            .upsert_memory_rollup("weekly:2026-W28", "secret synthesis", "h1", "2026-07-09T12:00:00Z")
+            .unwrap();
+        state
+            .db
+            .set_memory_rollup_exported("weekly:2026-W28", &md.to_string_lossy())
+            .unwrap();
+
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+
+        assert!(
+            state.db.list_memory_rollups().unwrap().is_empty(),
+            "seal must purge every memory-rollup row"
+        );
+        assert!(!md.exists(), "seal must delete the rollup's exported vault .md");
+
+        // RELOCK path: re-seed (the folder stays locked=1 on disk), then relock_all.
+        std::fs::write(&md, "stale synthesis").unwrap();
+        state
+            .db
+            .upsert_memory_rollup("weekly:2026-W28", "stale synthesis", "h2", "2026-07-09T13:00:00Z")
+            .unwrap();
+        state
+            .db
+            .set_memory_rollup_exported("weekly:2026-W28", &md.to_string_lossy())
+            .unwrap();
+        relock_all_inner(&state).unwrap();
+        assert!(
+            state.db.list_memory_rollups().unwrap().is_empty(),
+            "relock must purge rollup rows too"
+        );
+        assert!(!md.exists(), "relock must delete the exported .md too");
     }
 
     // ── VOICEPRINTS (Phase 2): matcher gating + enroll + management ───────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod events;
 pub mod export;
 pub mod facts;
 pub mod mcp;
+pub mod memory;
 pub mod orchestrate;
 pub mod pipeline;
 pub mod proactive;
@@ -144,6 +145,7 @@ pub fn run() {
             commands::get_user_memory,
             commands::forget_user_fact,
             commands::clear_user_memory,
+            commands::import_memories,
             // Re-Truth (the vault heals itself) — supersession review + one-tap stamp + undo.
             commands::preview_supersessions,
             commands::apply_supersessions,
@@ -397,6 +399,33 @@ pub fn run() {
                         Ok(_) => {}
                         Err(e) => {
                             tracing::warn!(target: "rag", error = %e, "topic-chunk backfill failed");
+                        }
+                    }
+                });
+            }
+            // Brain v2 L2.1 — the HOURLY memory consolidation/reflection job. Each tick re-resolves
+            // everything from the LIVE AppState (the `memory_consolidation_enabled` +
+            // `user_memory_enabled` flags, the LIGHT local-or-stub reasoner — NEVER cloud, so zero
+            // egress — and the vault path), runs one `run_consolidation_pass` on a BLOCKING worker
+            // (the local reasoner is synchronous; the DB lock is never held across an LLM call),
+            // and warns-and-continues on any failure — the loop never exits. First tick is a full
+            // interval after launch (no startup Metal contention); a stub/light-model-absent tick
+            // is a cheap no-op inside `consolidation_tick`.
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_secs(
+                            crate::memory::CONSOLIDATION_INTERVAL_SECS,
+                        ))
+                        .await;
+                        let tick_handle = handle.clone();
+                        let joined = tauri::async_runtime::spawn_blocking(move || {
+                            crate::memory::consolidation_tick(&tick_handle);
+                        })
+                        .await;
+                        if let Err(e) = joined {
+                            tracing::warn!(target: "memory", error = %e, "consolidation tick join failed");
                         }
                     }
                 });

--- a/src-tauri/src/memory.rs
+++ b/src-tauri/src/memory.rs
@@ -1,0 +1,1098 @@
+//! Brain v2 L2.1 — the MEMORY CONSOLIDATION / REFLECTION job (the generative-agents recipe,
+//! deterministic where it counts).
+//!
+//! An hourly background pass (spawned from `lib.rs` setup, mirroring the topic-chunk backfill
+//! block) that:
+//!   1. SCORES every open, VISIBLE user fact into `memory_scores` — deterministic
+//!      recency ([`compute_recency`], `0.995^hours`) blended with a batch-assessed importance
+//!      ([`composite_score`], weights 0.4/0.4/0.2). Importance is assigned in THIS job by the
+//!      LIGHT on-device reasoner (never at fact-write time — spec decision #7: zero pipeline
+//!      latency), defaulting to [`DEFAULT_IMPORTANCE`] when the reasoner is the stub or the reply
+//!      is unparseable. Steady-state passes are LLM-free: only never-scored facts are assessed.
+//!   2. REFLECTS: entity groups with ≥ [`ROLLUP_MIN_FACTS`] open visible facts OR any fact with
+//!      assessed importance ≥ [`IMPORTANT_FACT_MIN`] get a light-reasoner synthesis
+//!      (≤ [`REFLECTION_MAX_TOKENS`] tokens, wall-clock-bounded) upserted into `memory_rollups`
+//!      under scope `entity:<id>`; once per ISO week a `weekly:<YYYY-WNN>` rollup synthesizes the
+//!      user's own memory. EVERY existing rollup is re-checked each pass against its scope's
+//!      current visible fact set (`fact_set_hash`): ineligible ⇒ deleted (row + exported `.md`),
+//!      changed ⇒ re-reflected (weekly included). THE STUB NEVER WRITES A ROLLUP — stub "text" is
+//!      a debug echo, and rollups are exported to the user's vault, so a stub pass scores facts
+//!      (with the default importance) and produces ZERO rollups (tested); stub GC deletion still
+//!      runs (needs no LLM).
+//!   3. EXPORTS each un-exported rollup as an atomic `.md` under `<vault>/brain/memory/`
+//!      (frontmatter + the synthesis body, via the existing atomic overwrite helper).
+//!
+//! ## Lock model (the part the lock-security review audits)
+//! * Every fact read is GATED: the job reads through `list_user_facts_visible` /
+//!   `list_facts_visible` with the EMPTY unlock set — sealed-and-not-session-unlocked meetings are
+//!   excluded BY DESIGN (a background job must never see session-unlocked plaintext, let alone
+//!   sealed content).
+//! * `memory_scores` rows are CONTENT-FREE (fact ids + floats) and cascade off `user_facts`
+//!   (FK `ON DELETE CASCADE`), so the purge-on-seal / delete-meeting paths drop them transitively.
+//! * `memory_rollups` are CROSS-MEETING SYNTHESIS with no single source meeting, so they get TWO
+//!   protections: (1) EVERY seal path (`lock_folder` chain, relock, startup reconcile,
+//!   `delete_meeting`) purges ALL rollup rows inside the seal transaction
+//!   (`Db::purge_memory_rollups_tx`) and deletes their exported vault `.md`s — rollups are cheap
+//!   re-derivable synthesis that regenerates on the next hourly pass FROM VISIBLE FACTS ONLY;
+//!   (2) every pass GC's/REGENERATES each existing rollup against the CURRENT visible fact set
+//!   (`fact_set_hash`): a no-longer-eligible scope is DELETED (row + exported file), a changed set
+//!   is re-reflected + re-exported (weekly scopes included), so superseded/forgotten facts age out
+//!   even without a seal.
+//! * NO PII in logs: ids, scopes, counts, durations only.
+//!
+//! ## Egress
+//! ZERO. The job only ever calls the LIGHT engine handle (`ReasonerCell::light` — local-or-stub,
+//! NEVER a cloud fallback), so fact content never leaves the device from this path.
+//!
+//! ## Failure posture
+//! The hourly loop never exits: any per-pass / per-entity error is `tracing::warn` + continue.
+//! The DB lock is NEVER held across an LLM call — every read/write goes through short `Db`
+//! methods; the reasoner runs between them.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::Result;
+use crate::facts::Fact;
+use crate::reason::{GenOptions, LocalReasoner};
+use crate::storage::Db;
+
+/// Composite weight — recency component (spec L2.1: 0.4/0.4/0.2).
+pub const W_RECENCY: f64 = 0.4;
+/// Composite weight — importance component (importance is on a 1–10 scale, normalized inside).
+pub const W_IMPORTANCE: f64 = 0.4;
+/// Composite weight — relevance component. Relevance is a QUERY-TIME term; the job stores the
+/// baseline `0.0` (see [`run_consolidation_pass`]).
+pub const W_RELEVANCE: f64 = 0.2;
+
+/// Exponential recency decay per hour (generative-agents recipe): `0.995^hours`.
+pub const RECENCY_DECAY_PER_HOUR: f64 = 0.995;
+
+/// Importance assigned when the reasoner is the stub / absent or its reply is unparseable —
+/// the middle of the 1–10 scale (never blocks scoring on a missing model).
+pub const DEFAULT_IMPORTANCE: f64 = 5.0;
+
+/// Interval between consolidation passes (hourly).
+pub const CONSOLIDATION_INTERVAL_SECS: u64 = 3_600;
+
+/// An entity qualifies for a reflection rollup at this many OPEN visible facts.
+const ROLLUP_MIN_FACTS: usize = 3;
+
+/// Spec L2.1's second eligibility arm: an entity ALSO qualifies for a rollup when ANY of its open
+/// visible facts has an assessed importance at or above this (a single critical fact rolls up).
+const IMPORTANT_FACT_MIN: f64 = 7.0;
+
+/// Hard token cap on one reflection synthesis (spec L2.1).
+const REFLECTION_MAX_TOKENS: usize = 256;
+
+/// Hard token cap on one importance-assessment batch reply.
+const IMPORTANCE_MAX_TOKENS: usize = 256;
+
+/// Wall-clock bound on every reasoner call this job makes (a background job must never wedge the
+/// Metal queue; a timed-out call degrades to defaults / no rollup).
+const LLM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Max never-scored facts assessed in ONE importance batch call (bounds the prompt).
+const IMPORTANCE_BATCH: usize = 32;
+
+/// Max reflection (rollup) syntheses per pass — bounds per-pass Metal time; the rest catch up on
+/// later passes.
+const MAX_REFLECTIONS_PER_PASS: usize = 5;
+
+/// Max facts rendered into one reflection prompt (entity or weekly).
+const REFLECT_MAX_FACTS: usize = 40;
+
+/// What one pass did (counts only — safe to log).
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct PassStats {
+    /// Open visible user facts (re)scored into `memory_scores`.
+    pub scored: usize,
+    /// Rollups upserted (entity + weekly, new + re-reflected) this pass.
+    pub rollups: usize,
+    /// Rollup `.md` files exported to the vault this pass.
+    pub exported: usize,
+    /// Rollups GC'd this pass (scope no longer eligible — row + exported file deleted).
+    pub deleted: usize,
+}
+
+/// DETERMINISTIC recency: `0.995^hours_since(valid_from)`, clamped to `[0, 1]`. Pure (both instants
+/// injected). A `now` BEFORE `valid_from` clamps the age to 0 (recency 1.0). Unparseable timestamps
+/// degrade to a NEUTRAL `0.5` — never a panic, and neither buried nor artificially fresh.
+pub fn compute_recency(valid_from_iso: &str, now_iso: &str) -> f64 {
+    let (Ok(from), Ok(now)) = (
+        chrono::DateTime::parse_from_rfc3339(valid_from_iso),
+        chrono::DateTime::parse_from_rfc3339(now_iso),
+    ) else {
+        return 0.5;
+    };
+    let hours = (now - from).num_seconds().max(0) as f64 / 3_600.0;
+    RECENCY_DECAY_PER_HOUR.powf(hours).clamp(0.0, 1.0)
+}
+
+/// DETERMINISTIC composite: `0.4·recency + 0.4·(importance/10) + 0.2·relevance` (named weight
+/// consts). `importance` comes in on the 1–10 scale and is normalized here; every input is clamped
+/// to its valid range first so a junk model reply can never produce an out-of-range score.
+pub fn composite_score(recency: f64, importance: f64, relevance: f64) -> f64 {
+    let r = recency.clamp(0.0, 1.0);
+    let i = (importance.clamp(0.0, 10.0)) / 10.0;
+    let v = relevance.clamp(0.0, 1.0);
+    W_RECENCY * r + W_IMPORTANCE * i + W_RELEVANCE * v
+}
+
+/// DETERMINISTIC, dependency-free hash of a rollup's source fact set: FNV-1a 64 over the SORTED
+/// open-fact ids (with a record separator). Fact rows are append-only under the bitemporal model
+/// (a supersede CLOSES the old row and ADDS a new one; a seal DELETES rows), so the open-id set
+/// changes exactly when the content a rollup was synthesized from changes. Stored per rollup
+/// (`memory_rollups.fact_set_hash`) and compared each pass to decide re-reflection. Pure — no
+/// RandomState/DefaultHasher (stable across processes AND rustc versions; MSRV-1.77-safe).
+pub fn fact_set_hash(fact_ids: &[&str]) -> String {
+    let mut ids: Vec<&str> = fact_ids.to_vec();
+    ids.sort_unstable();
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = FNV_OFFSET;
+    for id in ids {
+        for b in id.as_bytes() {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        h ^= 0xff; // record separator — ["ab","c"] never collides with ["a","bc"].
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    format!("{h:016x}")
+}
+
+/// Spec L2.1 reflection eligibility for an entity group: ≥ [`ROLLUP_MIN_FACTS`] open visible facts
+/// OR any open fact with an assessed importance ≥ [`IMPORTANT_FACT_MIN`] (a single critical fact
+/// rolls up). `importance` is the persisted `facts.importance` map — an unassessed fact contributes
+/// nothing to the arm (fail-quiet, never invents importance).
+fn entity_group_eligible(open: &[&Fact], importance: &HashMap<String, f64>) -> bool {
+    open.len() >= ROLLUP_MIN_FACTS
+        || open
+            .iter()
+            .any(|f| importance.get(&f.id).copied().unwrap_or(0.0) >= IMPORTANT_FACT_MIN)
+}
+
+/// The ISO-week scope key for `now` (`weekly:<YYYY-WNN>`), or `None` when `now` is unparseable.
+fn weekly_scope(now_iso: &str) -> Option<String> {
+    let now = chrono::DateTime::parse_from_rfc3339(now_iso).ok()?;
+    let week = chrono::Datelike::iso_week(&now.date_naive());
+    Some(format!("weekly:{}-W{:02}", week.year(), week.week()))
+}
+
+const IMPORTANCE_SYSTEM: &str = "You rate how important each durable memory about the user is to \
+remember long-term, on a 1 (trivial) to 10 (critical) scale. Output STRICT JSON ONLY (no prose, \
+no code fences): {\"scores\":[{\"id\":\"<the given id>\",\"importance\":7}]}. Rate EVERY listed \
+memory, copy each id exactly, and output ONLY the JSON.";
+
+#[derive(Debug, Deserialize)]
+struct ImportanceReply {
+    #[serde(default)]
+    scores: Vec<RawImportance>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawImportance {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    importance: f64,
+}
+
+/// BEST-EFFORT batch importance assessment on the LIGHT reasoner (bounded tokens + wall clock).
+/// Stub / any failure ⇒ an EMPTY map — the caller falls back to [`DEFAULT_IMPORTANCE`]. Out-of-range
+/// replies are clamped by [`composite_score`] later; ids not in `facts` are ignored.
+fn assess_importance(reasoner: &dyn LocalReasoner, facts: &[&Fact]) -> HashMap<String, f64> {
+    if facts.is_empty() || reasoner.id() == "stub" {
+        return HashMap::new();
+    }
+    let lines = facts
+        .iter()
+        .take(IMPORTANCE_BATCH)
+        .map(|f| format!("- id={} | {} {}: {}", f.id, f.subject, f.predicate, f.object))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let user = format!("MEMORIES:\n{lines}");
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "scores": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "importance": { "type": "number" }
+                    },
+                    "required": ["id", "importance"]
+                }
+            }
+        },
+        "required": ["scores"]
+    });
+    let opts = GenOptions {
+        max_tokens: Some(IMPORTANCE_MAX_TOKENS),
+        temperature: Some(0.1),
+        enable_thinking: false,
+        timeout: Some(LLM_TIMEOUT),
+    };
+    let value = match reasoner.structured_with(IMPORTANCE_SYSTEM, &user, &schema, opts) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(target: "memory", error = %e, "importance assessment failed; using defaults");
+            return HashMap::new();
+        }
+    };
+    let reply: ImportanceReply = match serde_json::from_value(value) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(target: "memory", error = %e, "importance reply unparseable; using defaults");
+            return HashMap::new();
+        }
+    };
+    let known: HashSet<&str> = facts.iter().map(|f| f.id.as_str()).collect();
+    reply
+        .scores
+        .into_iter()
+        .filter(|s| known.contains(s.id.as_str()))
+        .map(|s| (s.id, s.importance))
+        .collect()
+}
+
+const REFLECT_SYSTEM: &str = "You are consolidating durable memory notes. Given a list of current \
+facts, write a SHORT synthesis (3-6 plain sentences or bullets) of the higher-level picture they \
+paint: patterns, roles, ongoing priorities. No preamble, no headings, no speculation beyond the \
+facts. Write in the language the facts are written in.";
+
+/// BEST-EFFORT reflection synthesis on the LIGHT reasoner. THE STUB NEVER PRODUCES A ROLLUP
+/// (its output is a debug echo and rollups are exported to the user's vault) — `None` on stub or
+/// any failure/empty reply.
+fn reflect(reasoner: &dyn LocalReasoner, label: &str, facts: &[&Fact]) -> Option<String> {
+    if reasoner.id() == "stub" || facts.is_empty() {
+        return None;
+    }
+    let lines = facts
+        .iter()
+        .take(REFLECT_MAX_FACTS)
+        .map(|f| format!("- {} {}: {}", f.subject, f.predicate, f.object))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let user = format!("SCOPE: {label}\n\nCURRENT FACTS:\n{lines}");
+    let opts = GenOptions {
+        max_tokens: Some(REFLECTION_MAX_TOKENS),
+        temperature: Some(0.3),
+        enable_thinking: false,
+        timeout: Some(LLM_TIMEOUT),
+    };
+    match reasoner.reason_with(REFLECT_SYSTEM, &user, opts) {
+        Ok(text) if !text.trim().is_empty() => Some(text.trim().to_string()),
+        Ok(_) => None,
+        Err(e) => {
+            tracing::warn!(target: "memory", error = %e, "reflection synthesis failed; no rollup this pass");
+            None
+        }
+    }
+}
+
+/// GC ONE no-longer-eligible rollup: delete the row and remove its exported vault `.md` — ONLY the
+/// path the row recorded at export time (never any other file; a missing file is fine). Best-effort:
+/// a DB error warns and leaves the row for the next pass. Logs the scope only (content-free).
+fn gc_rollup(db: &Db, scope: &str, stats: &mut PassStats) {
+    match db.delete_memory_rollup(scope) {
+        Ok(exported) => {
+            if let Some(p) = exported {
+                let _ = std::fs::remove_file(&p);
+            }
+            stats.deleted += 1;
+            tracing::debug!(target: "memory", scope = %scope, "rollup GC'd (scope no longer eligible)");
+        }
+        Err(e) => {
+            tracing::warn!(target: "memory", scope = %scope, error = %e, "rollup GC delete failed; retrying next pass");
+        }
+    }
+}
+
+/// Assess + persist (`facts.importance`) the importance of any never-assessed facts in `open` on
+/// the LIGHT reasoner — best-effort, batch, bounded. Only called for SMALL groups (the count arm
+/// already made a bigger group eligible), so the prompt stays tiny. Facts the model failed to rate
+/// persist [`DEFAULT_IMPORTANCE`] so steady-state passes stay LLM-free (the same contract as the
+/// user-fact scoring step). No-op on the stub.
+fn ensure_entity_importance(
+    db: &Db,
+    reasoner: &dyn LocalReasoner,
+    open: &[&Fact],
+    known: &mut HashMap<String, f64>,
+) {
+    if reasoner.id() == "stub" {
+        return;
+    }
+    let unassessed: Vec<&Fact> = open
+        .iter()
+        .filter(|f| !known.contains_key(&f.id))
+        .copied()
+        .collect();
+    if unassessed.is_empty() {
+        return;
+    }
+    let assessed = assess_importance(reasoner, &unassessed);
+    for f in unassessed {
+        let imp = assessed.get(&f.id).copied().unwrap_or(DEFAULT_IMPORTANCE);
+        match db.set_fact_importance(&f.id, imp) {
+            Ok(()) => {
+                known.insert(f.id.clone(), imp);
+            }
+            Err(e) => {
+                tracing::warn!(target: "memory", error = %e, "fact importance persist failed; retrying next pass");
+            }
+        }
+    }
+}
+
+/// The vault path a rollup exports to: `<vault>/brain/memory/<scope with ':' → '-'>.md`. The scope
+/// carries only ids / week keys (never fact text), so the FILENAME is content-free.
+fn rollup_export_path(vault_dir: &Path, scope: &str) -> PathBuf {
+    let name: String = scope
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect();
+    vault_dir.join("brain").join("memory").join(format!("{name}.md"))
+}
+
+/// Render one rollup `.md` (frontmatter + synthesis body).
+fn rollup_markdown(scope: &str, updated_at: &str, content: &str) -> String {
+    format!(
+        "---\nmurmur: memory-rollup\nscope: {scope}\nupdated: {updated_at}\n---\n\n{content}\n"
+    )
+}
+
+/// ONE consolidation pass — the testable orchestrator (no AppHandle, both the reasoner and `now`
+/// injected). Steps and their failure posture:
+///   1. sweep scores of CLOSED facts (forgotten/superseded);
+///   2. score every open VISIBLE user fact (empty unlock set — sealed excluded by design):
+///      recency from `valid_from`, importance from the batch assessment (only never-scored facts
+///      are assessed; stub/failure ⇒ [`DEFAULT_IMPORTANCE`]), stored relevance `0.0` (relevance is
+///      a query-time term — the stored composite is the query-independent baseline);
+///   3. GC + regenerate EVERY existing rollup against the CURRENT visible fact set
+///      ([`fact_set_hash`]): a no-longer-eligible scope is DELETED (row + exported `.md`), a
+///      changed set is re-reflected (weekly scopes included); then reflect NEW eligible entity
+///      groups (≥ [`ROLLUP_MIN_FACTS`] open visible facts OR any fact with importance ≥
+///      [`IMPORTANT_FACT_MIN`]) + the once-per-ISO-week user rollup — reflection NEVER on the stub
+///      (GC deletion still runs);
+///   4. export un-exported rollups to `<vault>/brain/memory/` (atomic write), when a vault is set.
+///
+/// Per-entity / per-file errors warn + continue; only a hard DB error on the scoring path errors
+/// the pass (the caller loop warns + retries next tick).
+pub fn run_consolidation_pass(
+    db: &Db,
+    reasoner: &dyn LocalReasoner,
+    vault_dir: Option<&Path>,
+    now: &str,
+) -> Result<PassStats> {
+    let mut stats = PassStats::default();
+    let no_unlocks: HashSet<String> = HashSet::new();
+
+    // 1. Closed facts keep no score rows (purged/deleted ones already cascaded off the FK).
+    if let Err(e) = db.delete_memory_scores_for_closed_facts() {
+        tracing::warn!(target: "memory", error = %e, "closed-fact score sweep failed; continuing");
+    }
+
+    // 2. Score the open, VISIBLE user facts.
+    let facts = db.list_user_facts_visible(&no_unlocks)?;
+    let known_importance = db.memory_importance_map()?;
+    let unscored: Vec<&Fact> = facts
+        .iter()
+        .filter(|f| !known_importance.contains_key(&f.id))
+        .collect();
+    // The ONLY LLM call of the scoring step — skipped entirely when nothing is new.
+    let assessed = assess_importance(reasoner, &unscored);
+    for f in &facts {
+        let importance = known_importance
+            .get(&f.id)
+            .or_else(|| assessed.get(&f.id))
+            .copied()
+            .unwrap_or(DEFAULT_IMPORTANCE);
+        let recency = compute_recency(&f.valid_from, now);
+        let relevance = 0.0; // query-time term — stored baseline (see the fn doc).
+        let composite = composite_score(recency, importance, relevance);
+        db.upsert_memory_score(&f.id, "user", recency, importance, relevance, composite, now)?;
+        stats.scored += 1;
+    }
+
+    // 3. Rollup GC + regeneration + creation. The GC half (deleting a no-longer-eligible scope's
+    //    row + exported file) runs under EVERY reasoner — deletion needs no LLM; (re-)reflection
+    //    is non-stub only (stub text must never reach the vault).
+    let entities = db.list_entities_visible(&no_unlocks).unwrap_or_default();
+    let entity_names: HashMap<String, String> = entities
+        .iter()
+        .map(|e| (e.id.clone(), e.name.clone()))
+        .collect();
+    let mut fact_importance = db.fact_importance_map().unwrap_or_default();
+    let existing = db.list_memory_rollups()?;
+    let existing_scopes: HashSet<String> = existing.iter().map(|r| r.scope.clone()).collect();
+    let user_ids: Vec<&str> = facts.iter().map(|f| f.id.as_str()).collect();
+    let user_hash = fact_set_hash(&user_ids);
+    let mut reflections = 0usize;
+
+    // 3a. EVERY existing rollup is re-derived against the CURRENT visible fact set: a scope that is
+    //     no longer eligible (entity invisible / below both eligibility arms / weekly with no facts)
+    //     is DELETED (row + exported vault `.md`); a scope whose fact set changed (`fact_set_hash`
+    //     mismatch — a supersede, forget, or new fact) is RE-REFLECTED + re-exported. Weekly scopes
+    //     INCLUDED — a frozen weekly rollup would preserve stale/superseded synthesis forever.
+    for r in &existing {
+        if let Some(entity_id) = r.scope.strip_prefix("entity:") {
+            let visible = entity_names.contains_key(entity_id);
+            let ent_facts = if visible {
+                match db.list_facts_visible(entity_id, &no_unlocks) {
+                    Ok(fs) => fs,
+                    Err(e) => {
+                        tracing::warn!(target: "memory", scope = %r.scope, error = %e, "entity fact read failed; leaving rollup for next pass");
+                        continue;
+                    }
+                }
+            } else {
+                Vec::new()
+            };
+            let open: Vec<&Fact> = ent_facts.iter().filter(|f| f.valid_to.is_none()).collect();
+            if open.len() < ROLLUP_MIN_FACTS {
+                ensure_entity_importance(db, reasoner, &open, &mut fact_importance);
+            }
+            if !visible || !entity_group_eligible(&open, &fact_importance) {
+                gc_rollup(db, &r.scope, &mut stats);
+                continue;
+            }
+            let ids: Vec<&str> = open.iter().map(|f| f.id.as_str()).collect();
+            let hash = fact_set_hash(&ids);
+            if r.fact_set_hash.as_deref() == Some(hash.as_str()) {
+                continue; // unchanged — nothing to redo.
+            }
+            if reasoner.id() == "stub" || reflections >= MAX_REFLECTIONS_PER_PASS {
+                continue; // stale but not re-reflectable this pass — caught next pass.
+            }
+            let label = entity_names.get(entity_id).cloned().unwrap_or_default();
+            if let Some(content) = reflect(reasoner, &label, &open) {
+                if let Err(e) = db.upsert_memory_rollup(&r.scope, &content, &hash, now) {
+                    tracing::warn!(target: "memory", scope = %r.scope, error = %e, "rollup re-reflect upsert failed; continuing");
+                    continue;
+                }
+                stats.rollups += 1;
+                reflections += 1;
+            }
+        } else if r.scope.starts_with("weekly:") {
+            // A weekly rollup synthesizes the user's WHOLE visible open fact set.
+            if facts.is_empty() {
+                gc_rollup(db, &r.scope, &mut stats);
+                continue;
+            }
+            if r.fact_set_hash.as_deref() == Some(user_hash.as_str())
+                || reasoner.id() == "stub"
+                || reflections >= MAX_REFLECTIONS_PER_PASS
+            {
+                continue;
+            }
+            let refs: Vec<&Fact> = facts.iter().collect();
+            if let Some(content) =
+                reflect(reasoner, "what the user is working on and prefers", &refs)
+            {
+                if let Err(e) = db.upsert_memory_rollup(&r.scope, &content, &user_hash, now) {
+                    tracing::warn!(target: "memory", scope = %r.scope, error = %e, "weekly re-reflect upsert failed; continuing");
+                    continue;
+                }
+                stats.rollups += 1;
+                reflections += 1;
+            }
+        }
+        // Unknown scope shapes are left untouched (forward-compat).
+    }
+
+    // 3b. NEW rollups — never on the stub (stub text must never reach the vault).
+    if reasoner.id() != "stub" {
+        // Entity groups without a rollup yet (gated reads, empty unlock set). Eligibility is
+        // ≥ ROLLUP_MIN_FACTS open facts OR any fact with importance ≥ IMPORTANT_FACT_MIN.
+        for ent in &entities {
+            if reflections >= MAX_REFLECTIONS_PER_PASS {
+                break;
+            }
+            let scope = format!("entity:{}", ent.id);
+            if existing_scopes.contains(&scope) {
+                continue; // regenerated (or GC'd as ineligible) in 3a.
+            }
+            let ent_facts = match db.list_facts_visible(&ent.id, &no_unlocks) {
+                Ok(fs) => fs,
+                Err(e) => {
+                    tracing::warn!(target: "memory", entity_id = %ent.id, error = %e, "entity fact read failed; skipping");
+                    continue;
+                }
+            };
+            let open: Vec<&Fact> = ent_facts.iter().filter(|f| f.valid_to.is_none()).collect();
+            if open.len() < ROLLUP_MIN_FACTS {
+                ensure_entity_importance(db, reasoner, &open, &mut fact_importance);
+            }
+            if !entity_group_eligible(&open, &fact_importance) {
+                continue;
+            }
+            let ids: Vec<&str> = open.iter().map(|f| f.id.as_str()).collect();
+            let hash = fact_set_hash(&ids);
+            if let Some(content) = reflect(reasoner, &ent.name, &open) {
+                if let Err(e) = db.upsert_memory_rollup(&scope, &content, &hash, now) {
+                    tracing::warn!(target: "memory", scope = %scope, error = %e, "rollup upsert failed; continuing");
+                    continue;
+                }
+                stats.rollups += 1;
+                reflections += 1;
+            }
+        }
+
+        // The weekly user rollup — created once per ISO week (then hash-regenerated in 3a).
+        if let Some(scope) = weekly_scope(now) {
+            if !existing_scopes.contains(&scope)
+                && !facts.is_empty()
+                && reflections < MAX_REFLECTIONS_PER_PASS
+            {
+                let refs: Vec<&Fact> = facts.iter().collect();
+                if let Some(content) =
+                    reflect(reasoner, "what the user is working on and prefers", &refs)
+                {
+                    if let Err(e) = db.upsert_memory_rollup(&scope, &content, &user_hash, now) {
+                        tracing::warn!(target: "memory", scope = %scope, error = %e, "weekly rollup upsert failed");
+                    } else {
+                        stats.rollups += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // 4. Export un-exported rollups to the vault (atomic write; best-effort per file).
+    if let Some(vault) = vault_dir {
+        for r in db.list_memory_rollups()? {
+            if r.exported_path.is_some() {
+                continue;
+            }
+            let path = rollup_export_path(vault, &r.scope);
+            let md = rollup_markdown(&r.scope, &r.updated_at, &r.content);
+            match crate::export::obsidian::overwrite_note(&path, &md) {
+                Ok(()) => {
+                    if let Err(e) =
+                        db.set_memory_rollup_exported(&r.scope, &path.to_string_lossy())
+                    {
+                        tracing::warn!(target: "memory", scope = %r.scope, error = %e, "rollup export stamp failed");
+                    } else {
+                        stats.exported += 1;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(target: "memory", scope = %r.scope, error = %e, "rollup vault export failed; will retry next pass");
+                }
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+/// ONE production tick: resolve everything from the LIVE `AppState` (flag, LIGHT reasoner, vault),
+/// then run [`run_consolidation_pass`]. Skips when the feature flag is off or the light engine is
+/// the stub (no model ⇒ importance defaults would be the only output — not worth an hourly wake;
+/// scores start accruing on the first tick after the user downloads a model). NEVER panics; every
+/// failure is a warn. Logs counts only.
+pub fn consolidation_tick(handle: &tauri::AppHandle) {
+    use tauri::Manager;
+    let Some(state) = handle.try_state::<crate::state::AppState>() else {
+        return; // init failed — nothing to consolidate.
+    };
+    let enabled = state
+        .config
+        .lock()
+        .map(|c| c.memory_consolidation_enabled && c.user_memory_enabled)
+        .unwrap_or(false); // poisoned config ⇒ skip this tick (fail quiet, retry next hour).
+    if !enabled {
+        return;
+    }
+    // LIGHT engine — local-or-stub, NEVER cloud (zero egress from this job by construction).
+    let reasoner = state.reasoner.light();
+    if reasoner.id() == "stub" {
+        tracing::debug!(target: "memory", "no local light model; skipping consolidation tick");
+        return;
+    }
+    let vault = state
+        .config
+        .lock()
+        .ok()
+        .and_then(|c| c.vault_path.clone())
+        .map(PathBuf::from);
+    let now = chrono::Utc::now().to_rfc3339();
+    match run_consolidation_pass(&state.db, reasoner.as_ref(), vault.as_deref(), &now) {
+        Ok(stats) => {
+            if stats.scored > 0 || stats.rollups > 0 || stats.exported > 0 {
+                tracing::info!(
+                    target: "memory",
+                    scored = stats.scored,
+                    rollups = stats.rollups,
+                    exported = stats.exported,
+                    "memory consolidation pass complete"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(target: "memory", error = %e, "memory consolidation pass failed; retrying next tick");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::{FactOp, NewFact};
+    use crate::reason::StubReasoner;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn file_db(label: &str) -> Db {
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-memory-{label}"), "sqlite");
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn temp_vault(label: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "murmur-memory-vault-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn seed_meeting(db: &Db, id: &str) {
+        db.insert_meeting(&Meeting {
+            id: id.to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some(format!("title-{id}")),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+    }
+
+    fn seed_user_fact(db: &Db, predicate: &str, object: &str, meeting_id: &str) {
+        db.apply_user_fact_ops(&[FactOp::Add(NewFact {
+            entity_id: crate::user_memory::USER_SCOPE.to_string(),
+            subject: "You".to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: "2026-07-01T09:00:00Z".to_string(),
+            recorded_at: "2026-07-01T09:00:00Z".to_string(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })])
+        .unwrap();
+    }
+
+    /// A deterministic mock "real" brain: a non-stub id, canned reflection text, and a canned
+    /// importance for every listed fact — so the reflection/rollup path is testable headless.
+    struct MockBrain;
+    impl LocalReasoner for MockBrain {
+        fn id(&self) -> &str {
+            "mock-brain"
+        }
+        fn reason(&self, _system: &str, _user: &str) -> Result<String> {
+            Ok("The user is heads-down on Project Atlas and prefers Polish replies.".to_string())
+        }
+        fn structured(
+            &self,
+            _system: &str,
+            user: &str,
+            _schema: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            // Rate every `id=<id>` line at 8.0.
+            let scores: Vec<serde_json::Value> = user
+                .lines()
+                .filter_map(|l| {
+                    let rest = l.split("id=").nth(1)?;
+                    let id = rest.split(' ').next()?.trim();
+                    Some(serde_json::json!({ "id": id, "importance": 8.0 }))
+                })
+                .collect();
+            Ok(serde_json::json!({ "scores": scores }))
+        }
+    }
+
+    /// 0 h old ⇒ recency 1.0 (no decay yet).
+    #[test]
+    fn recency_is_one_at_zero_hours() {
+        let r = compute_recency("2026-07-09T12:00:00Z", "2026-07-09T12:00:00Z");
+        assert!((r - 1.0).abs() < 1e-9, "got {r}");
+    }
+
+    /// 24 h old ⇒ 0.995^24 ≈ 0.887 (the generative-agents decay curve).
+    #[test]
+    fn recency_decays_to_0887_at_24_hours() {
+        let r = compute_recency("2026-07-08T12:00:00Z", "2026-07-09T12:00:00Z");
+        assert!((r - 0.887).abs() < 0.001, "got {r}");
+    }
+
+    /// Unparseable timestamps degrade to the neutral 0.5; a future valid_from clamps to fresh.
+    #[test]
+    fn recency_degrades_gracefully() {
+        assert!((compute_recency("garbage", "2026-07-09T12:00:00Z") - 0.5).abs() < 1e-9);
+        let future = compute_recency("2026-07-10T12:00:00Z", "2026-07-09T12:00:00Z");
+        assert!((future - 1.0).abs() < 1e-9, "future valid_from clamps to age 0");
+    }
+
+    /// The 0.4/0.4/0.2 blend, with importance normalized from the 1–10 scale and inputs clamped.
+    #[test]
+    fn composite_blends_weights() {
+        let c = composite_score(1.0, 10.0, 1.0);
+        assert!((c - 1.0).abs() < 1e-9, "max inputs ⇒ 1.0, got {c}");
+        let c = composite_score(0.5, 5.0, 0.0);
+        assert!((c - (0.4 * 0.5 + 0.4 * 0.5)).abs() < 1e-9, "got {c}");
+        // Junk model output is clamped, never out-of-range.
+        let c = composite_score(2.0, 99.0, -3.0);
+        assert!((0.0..=1.0).contains(&c));
+    }
+
+    /// STUB PASS (the default install): every open visible user fact gets a score with the DEFAULT
+    /// importance, and NO rollup is written (stub text must never reach the vault). RED-first for
+    /// the L2.1 store: fails before `memory_scores`/`run_consolidation_pass` existed.
+    #[test]
+    fn stub_pass_scores_defaults_and_writes_no_rollups() {
+        let db = file_db("stub-pass");
+        seed_meeting(&db, "m1");
+        seed_user_fact(&db, "prefer", "Polish replies", "m1");
+        seed_user_fact(&db, "works on", "Project Atlas", "m1");
+
+        let stats =
+            run_consolidation_pass(&db, &StubReasoner, None, "2026-07-09T12:00:00Z").unwrap();
+        assert_eq!(stats.scored, 2);
+        assert_eq!(stats.rollups, 0, "the stub must never produce a rollup");
+        assert_eq!(stats.exported, 0);
+
+        let scores = db.list_memory_scores().unwrap();
+        assert_eq!(scores.len(), 2);
+        for s in &scores {
+            assert!((s.importance - DEFAULT_IMPORTANCE).abs() < 1e-9);
+            assert!((0.0..=1.0).contains(&s.composite));
+        }
+        assert!(db.list_memory_rollups().unwrap().is_empty());
+    }
+
+    /// GATE: a sealed-and-not-unlocked meeting's user facts are NEVER scored (the job reads with
+    /// the EMPTY unlock set by design).
+    #[test]
+    fn pass_excludes_sealed_facts() {
+        let db = file_db("sealed-pass");
+        db.insert_folder(&Folder {
+            id: "f-lock".to_string(),
+            name: "Secret".to_string(),
+            path: "Secret".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m-sealed");
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m-sealed".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "secret".to_string(),
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder("m-sealed", Some("f-lock")).unwrap();
+        seed_user_fact(&db, "salary", "confidential", "m-sealed");
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let stats =
+            run_consolidation_pass(&db, &StubReasoner, None, "2026-07-09T12:00:00Z").unwrap();
+        assert_eq!(stats.scored, 0, "sealed facts must not be scored");
+        assert!(db.list_memory_scores().unwrap().is_empty());
+    }
+
+    /// REAL-BRAIN PASS: importance comes from the batch assessment, the weekly rollup is written
+    /// ONCE per ISO week (idempotent on re-run), and the rollup exports atomically to
+    /// `<vault>/brain/memory/`. Steady-state re-run makes no further LLM-derived changes.
+    #[test]
+    fn mock_brain_pass_scores_reflects_and_exports_once_per_week() {
+        let db = file_db("mock-pass");
+        let vault = temp_vault("mock-pass");
+        seed_meeting(&db, "m1");
+        seed_user_fact(&db, "prefer", "Polish replies", "m1");
+        seed_user_fact(&db, "works on", "Project Atlas", "m1");
+
+        let now = "2026-07-09T12:00:00Z";
+        let stats = run_consolidation_pass(&db, &MockBrain, Some(&vault), now).unwrap();
+        assert_eq!(stats.scored, 2);
+        assert_eq!(stats.rollups, 1, "the weekly rollup (no entity has ≥3 facts)");
+        assert_eq!(stats.exported, 1);
+
+        // Importance came from the mock assessment (8.0), not the default.
+        for s in db.list_memory_scores().unwrap() {
+            assert!((s.importance - 8.0).abs() < 1e-9, "got {}", s.importance);
+        }
+
+        // The rollup landed in the vault, under the content-free scope filename.
+        let rollups = db.list_memory_rollups().unwrap();
+        assert_eq!(rollups.len(), 1);
+        assert!(rollups[0].scope.starts_with("weekly:2026-W"));
+        let exported = rollups[0].exported_path.clone().unwrap();
+        let on_disk = std::fs::read_to_string(&exported).unwrap();
+        assert!(on_disk.contains("murmur: memory-rollup"));
+        assert!(on_disk.contains("Project Atlas"));
+
+        // SAME ISO WEEK re-run: no second weekly rollup, nothing re-exported.
+        let again = run_consolidation_pass(&db, &MockBrain, Some(&vault), now).unwrap();
+        assert_eq!(again.rollups, 0, "weekly rollup is once per ISO week");
+        assert_eq!(again.exported, 0);
+        assert_eq!(db.list_memory_rollups().unwrap().len(), 1);
+    }
+
+    /// Rollup upsert is idempotent PER SCOPE: a re-upsert replaces content (one row), keeps the
+    /// created_at, resets exported_path for re-export, and records the new fact-set hash.
+    #[test]
+    fn rollup_upsert_is_idempotent_per_scope() {
+        let db = file_db("rollup-upsert");
+        db.upsert_memory_rollup("entity:e1", "v1", "h1", "2026-07-09T12:00:00Z")
+            .unwrap();
+        db.set_memory_rollup_exported("entity:e1", "/vault/x.md")
+            .unwrap();
+        db.upsert_memory_rollup("entity:e1", "v2", "h2", "2026-07-09T13:00:00Z")
+            .unwrap();
+        let rollups = db.list_memory_rollups().unwrap();
+        assert_eq!(rollups.len(), 1, "one row per scope");
+        assert_eq!(rollups[0].content, "v2");
+        assert_eq!(rollups[0].created_at, "2026-07-09T12:00:00Z");
+        assert_eq!(rollups[0].updated_at, "2026-07-09T13:00:00Z");
+        assert!(rollups[0].exported_path.is_none(), "reset for re-export");
+        assert_eq!(rollups[0].fact_set_hash.as_deref(), Some("h2"));
+    }
+
+    /// The rollup change-detector: deterministic, order-insensitive over the id SET, and sensitive
+    /// to any membership change (a supersede closes one id and adds another ⇒ new hash).
+    #[test]
+    fn fact_set_hash_is_order_insensitive_and_membership_sensitive() {
+        let a = fact_set_hash(&["f1", "f2", "f3"]);
+        assert_eq!(a, fact_set_hash(&["f3", "f1", "f2"]), "order must not matter");
+        assert_ne!(a, fact_set_hash(&["f1", "f2"]), "membership change must change the hash");
+        assert_ne!(a, fact_set_hash(&["f1", "f2", "f4"]));
+        assert_ne!(fact_set_hash(&["ab", "c"]), fact_set_hash(&["a", "bc"]), "separator guards concat collisions");
+        assert_eq!(a, fact_set_hash(&["f2", "f3", "f1"]), "stable across calls");
+    }
+
+    /// FK/cascade decision test: purge-on-seal (direct DELETE) and delete_meeting both drop the
+    /// fact's score row via the `memory_scores` FK cascade.
+    #[test]
+    fn scores_cascade_with_fact_purge_and_meeting_delete() {
+        let db = file_db("score-cascade");
+        seed_meeting(&db, "m1");
+        seed_meeting(&db, "m2");
+        seed_user_fact(&db, "prefer", "Polish replies", "m1");
+        seed_user_fact(&db, "works on", "Project Atlas", "m2");
+        run_consolidation_pass(&db, &StubReasoner, None, "2026-07-09T12:00:00Z").unwrap();
+        assert_eq!(db.list_memory_scores().unwrap().len(), 2);
+
+        // Purge-on-seal path (direct DELETE inside the seal tx).
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(
+            db.list_memory_scores().unwrap().len(),
+            1,
+            "purged fact's score row must cascade away"
+        );
+
+        // delete_meeting path.
+        db.delete_meeting("m2").unwrap();
+        assert!(
+            db.list_memory_scores().unwrap().is_empty(),
+            "deleted meeting's fact score must cascade away"
+        );
+    }
+
+    /// A mock brain whose reflection ECHOES the fact lines it was given — so stale-vs-fresh rollup
+    /// content is assertable (the constant-text [`MockBrain`] cannot distinguish a re-reflection).
+    struct EchoBrain;
+    impl LocalReasoner for EchoBrain {
+        fn id(&self) -> &str {
+            "echo-brain"
+        }
+        fn reason(&self, _system: &str, user: &str) -> Result<String> {
+            Ok(user.to_string())
+        }
+        fn structured(
+            &self,
+            _system: &str,
+            user: &str,
+            _schema: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            let scores: Vec<serde_json::Value> = user
+                .lines()
+                .filter_map(|l| {
+                    let rest = l.split("id=").nth(1)?;
+                    let id = rest.split(' ').next()?.trim();
+                    Some(serde_json::json!({ "id": id, "importance": 8.0 }))
+                })
+                .collect();
+            Ok(serde_json::json!({ "scores": scores }))
+        }
+    }
+
+    fn seed_entity_fact(db: &Db, entity_id: &str, predicate: &str, object: &str, meeting_id: &str) {
+        db.apply_fact_ops(&[FactOp::Add(NewFact {
+            entity_id: entity_id.to_string(),
+            subject: "Atlas Corp".to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: "2026-07-01T09:00:00Z".to_string(),
+            recorded_at: "2026-07-01T09:00:00Z".to_string(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })])
+        .unwrap();
+    }
+
+    /// FIX 1b RED (adversarial finding 1, the non-seal half): a SUPERSEDED fact must age out of the
+    /// rollup — the next pass detects the fact-set change ([`fact_set_hash`]) and RE-REFLECTS +
+    /// re-exports (weekly scopes INCLUDED; the old "never re-touched after creation" freeze was the
+    /// bug). RED on the pre-fix code: the weekly rollup was created once per ISO week and never
+    /// regenerated, so the stale "Polish replies" synthesis persisted in the DB and the vault.
+    #[test]
+    fn superseded_fact_re_reflects_rollup_on_next_pass() {
+        let db = file_db("regen-supersede");
+        let vault = temp_vault("regen-supersede");
+        seed_meeting(&db, "m1");
+        seed_user_fact(&db, "prefer", "Polish replies", "m1");
+
+        let now = "2026-07-09T12:00:00Z";
+        let first = run_consolidation_pass(&db, &EchoBrain, Some(&vault), now).unwrap();
+        assert_eq!(first.rollups, 1, "the weekly rollup");
+        let rollup = &db.list_memory_rollups().unwrap()[0];
+        assert!(rollup.content.contains("Polish replies"));
+        let exported = rollup.exported_path.clone().unwrap();
+        assert!(std::fs::read_to_string(&exported).unwrap().contains("Polish replies"));
+
+        // Supersede the fact (bitemporal close + add) — NOT a seal.
+        let old = db.list_user_facts_visible(&HashSet::new()).unwrap();
+        db.apply_user_fact_ops(&[FactOp::Invalidate {
+            id: old[0].id.clone(),
+            valid_to: "2026-07-09T13:00:00Z".to_string(),
+        }])
+        .unwrap();
+        seed_user_fact(&db, "prefer", "English replies", "m1");
+
+        // Next pass (same ISO week): the hash changed ⇒ re-reflect + re-export, not a frozen copy.
+        let second =
+            run_consolidation_pass(&db, &EchoBrain, Some(&vault), "2026-07-09T14:00:00Z").unwrap();
+        assert_eq!(second.rollups, 1, "the weekly rollup must be RE-reflected");
+        assert_eq!(second.exported, 1, "and re-exported");
+        let rollup = &db.list_memory_rollups().unwrap()[0];
+        assert!(rollup.content.contains("English replies"));
+        assert!(
+            !rollup.content.contains("Polish replies"),
+            "the superseded fact must age out of the rollup: {}",
+            rollup.content
+        );
+        let on_disk = std::fs::read_to_string(&exported).unwrap();
+        assert!(on_disk.contains("English replies"));
+        assert!(!on_disk.contains("Polish replies"), "stale export must be overwritten");
+    }
+
+    /// FIX 1b GC: a rollup whose scope is NO LONGER ELIGIBLE (here: the entity's only source
+    /// meeting became invisible via a folder lock at the DB level) is DELETED — row AND exported
+    /// vault `.md` — on the next pass, even though nothing re-reflects it. RED on the pre-fix code:
+    /// the below-threshold group was skipped with `continue` and the row + file lingered forever.
+    #[test]
+    fn ineligible_scope_rollup_is_gcd_with_its_export() {
+        let db = file_db("gc-ineligible");
+        let vault = temp_vault("gc-ineligible");
+        db.insert_folder(&Folder {
+            id: "f-e".to_string(),
+            name: "Clients".to_string(),
+            path: "Clients".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m-e");
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m-e".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "note".to_string(),
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder("m-e", Some("f-e")).unwrap();
+        let eid = db
+            .upsert_entity("Atlas Corp", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&eid, "m-e").unwrap();
+        seed_entity_fact(&db, &eid, "ships", "ZenithSecret", "m-e");
+        seed_entity_fact(&db, &eid, "hq", "Warsaw", "m-e");
+        seed_entity_fact(&db, &eid, "owner", "Kim", "m-e");
+
+        let now = "2026-07-09T12:00:00Z";
+        let stats = run_consolidation_pass(&db, &MockBrain, Some(&vault), now).unwrap();
+        assert_eq!(stats.rollups, 1, "the entity rollup (no user facts ⇒ no weekly)");
+        let exported = db.list_memory_rollups().unwrap()[0]
+            .exported_path
+            .clone()
+            .unwrap();
+        assert!(std::path::Path::new(&exported).exists());
+
+        // The entity's only source meeting becomes invisible (DB-level lock flag — the command-layer
+        // seal purge is tested separately; this is the GC safety net).
+        db.set_folder_locked("f-e", true, None).unwrap();
+        let stats =
+            run_consolidation_pass(&db, &MockBrain, Some(&vault), "2026-07-09T13:00:00Z").unwrap();
+        assert_eq!(stats.deleted, 1, "the invisible scope must be GC'd");
+        assert!(db.list_memory_rollups().unwrap().is_empty(), "row deleted");
+        assert!(
+            !std::path::Path::new(&exported).exists(),
+            "the exported vault .md must be deleted with the row"
+        );
+    }
+
+    /// FIX 4 (spec L2.1): the SECOND eligibility arm — an entity group BELOW [`ROLLUP_MIN_FACTS`]
+    /// still rolls up when any fact's assessed importance is ≥ [`IMPORTANT_FACT_MIN`]. The mock
+    /// brain rates everything 8.0, so a 2-fact entity qualifies (RED before the arm existed: only
+    /// the ≥3-facts arm was implemented and this asserted zero rollups). The assessments persist to
+    /// `facts.importance` so the steady-state pass stays LLM-free.
+    #[test]
+    fn single_important_fact_entity_is_eligible_for_rollup() {
+        let db = file_db("importance-arm");
+        seed_meeting(&db, "m1");
+        let eid = db
+            .upsert_entity("Atlas Corp", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&eid, "m1").unwrap();
+        seed_entity_fact(&db, &eid, "ships", "Project Atlas", "m1");
+        seed_entity_fact(&db, &eid, "deadline", "Friday", "m1");
+
+        let stats =
+            run_consolidation_pass(&db, &MockBrain, None, "2026-07-09T12:00:00Z").unwrap();
+        assert_eq!(
+            stats.rollups, 1,
+            "2 facts with importance 8 ⇒ eligible via the importance arm"
+        );
+        let rollups = db.list_memory_rollups().unwrap();
+        assert_eq!(rollups[0].scope, format!("entity:{eid}"));
+        // Assessments persisted — the next pass needs no LLM to re-evaluate the arm.
+        let imp = db.fact_importance_map().unwrap();
+        assert_eq!(imp.len(), 2);
+        assert!(imp.values().all(|v| (*v - 8.0).abs() < 1e-9));
+    }
+}

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -400,6 +400,13 @@ pub struct AppConfig {
     /// this field existed loads as `true` (memory stays on for existing installs).
     #[serde(default = "default_true")]
     pub user_memory_enabled: bool,
+    /// Brain v2 L2.1 — the hourly memory CONSOLIDATION/REFLECTION job (`crate::memory`): scores
+    /// user facts, synthesizes entity/weekly rollups on the LIGHT local reasoner (never cloud) and
+    /// exports them to `<vault>/brain/memory/`. Default ON; effective only when `user_memory_enabled`
+    /// is also on AND a local light model is present (the stub tick is a no-op). ADDITIVE:
+    /// `#[serde(default = "default_true")]` ⇒ configs persisted before this field load as `true`.
+    #[serde(default = "default_true")]
+    pub memory_consolidation_enabled: bool,
     /// Tier 3b (B) anti-hallucination — DETERMINISTIC GROUNDING of the generated note. When ON, a
     /// pure, on-device, ZERO-EGRESS pass (`crate::summarize::grounding`) runs after summarization and
     /// annotates any summary bullet / action item / prose line whose content words are NOT supported
@@ -522,6 +529,7 @@ impl Default for AppConfig {
             share_base_url: "https://murmur-server-production-b9e8.up.railway.app".to_string(),
             proactive_hints_enabled: true,
             user_memory_enabled: true,
+            memory_consolidation_enabled: true,
             ground_summary: false,
             role_notes_connection: String::new(),
             role_notes_model: String::new(),
@@ -595,6 +603,7 @@ const K_GATEWAY_MODEL: &str = "gateway_model";
 const K_SHARE_BASE_URL: &str = "share_base_url";
 const K_PROACTIVE_HINTS_ENABLED: &str = "proactive_hints_enabled";
 const K_USER_MEMORY_ENABLED: &str = "user_memory_enabled";
+const K_MEMORY_CONSOLIDATION_ENABLED: &str = "memory_consolidation_enabled";
 const K_GROUND_SUMMARY: &str = "ground_summary";
 const K_ROLE_NOTES_CONNECTION: &str = "role_notes_connection";
 const K_ROLE_NOTES_MODEL: &str = "role_notes_model";
@@ -795,6 +804,9 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_USER_MEMORY_ENABLED)? {
             cfg.user_memory_enabled = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_MEMORY_CONSOLIDATION_ENABLED)? {
+            cfg.memory_consolidation_enabled = v == "true";
         }
         if let Some(v) = db.get_setting(K_GROUND_SUMMARY)? {
             cfg.ground_summary = v == "true";
@@ -1064,6 +1076,14 @@ impl AppConfig {
         db.set_setting(
             K_USER_MEMORY_ENABLED,
             if self.user_memory_enabled {
+                "true"
+            } else {
+                "false"
+            },
+        )?;
+        db.set_setting(
+            K_MEMORY_CONSOLIDATION_ENABLED,
+            if self.memory_consolidation_enabled {
                 "true"
             } else {
                 "false"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -332,13 +332,20 @@ impl AppState {
 /// there is no content key at startup). Best-effort and panic-free: every failure is logged, never
 /// fatal to launch.
 fn reconcile_locked_at_rest(db: &Db) {
-    let rows = match db.reblank_locked_folders_at_rest() {
+    let (rows, rollup_exports) = match db.reblank_locked_folders_at_rest() {
         Ok(a) => a,
         Err(e) => {
             tracing::warn!(target: "state", error = %e, "startup reconciliation: re-blank of locked folders failed");
             return;
         }
     };
+    // Brain v2 L2.1 LOCK-SAFETY (filesystem half): when any folder is locked, the reconcile tx
+    // purged EVERY memory-rollup row (a rollup may paraphrase sealed facts) — remove their exported
+    // vault `.md`s here. Only ever the recorded exported paths; a missing file is fine. The rollups
+    // regenerate from visible facts on the next hourly pass.
+    for p in &rollup_exports {
+        let _ = std::fs::remove_file(p);
+    }
     for row in rows {
         let crate::storage::LockedMeetingAudio {
             meeting_id,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -539,6 +539,16 @@ impl Db {
         // and ranking uses bm25(). SQLCipher is built with FTS5 compiled in (bundled-sqlcipher) —
         // ZERO new deps. Runs on the same locked connection as the rest of migrate().
         Self::migrate_fts(&conn)?;
+        // Brain v2 L2.2 — relevance-filtered memory brief: external-content FTS5 over `user_facts`
+        // (subject/predicate/object) kept in sync by the same _ai/_ad/_au trigger trio as the other
+        // FTS tables. Additive + guarded so migrate() stays idempotent. Lock model: the index only
+        // mirrors `user_facts`, which is PURGED on seal via a direct DELETE (`purge_user_facts_tx` /
+        // `reblank_locked_folders_at_rest`) — that DELETE fires the _ad trigger, so no sealed
+        // fact's tokens survive in the index; every READ goes through the gated
+        // `search_user_facts_visible` (same visibility predicate as `list_user_facts_visible`).
+        Self::migrate_user_facts_fts(&conn)?;
+        // Brain v2 L2.1 — memory consolidation tables (see `crate::memory`). Additive + guarded.
+        Self::migrate_memory(&conn)?;
         // Phase 2a — vector retrieval layer (note_chunks + the vec0 KNN table). Additive + guarded
         // (CREATE TABLE / CREATE VIRTUAL TABLE IF NOT EXISTS) so migrate() stays idempotent.
         Self::migrate_vector(&conn)?;
@@ -1072,6 +1082,125 @@ impl Db {
             )
             .map_err(map_err)?;
         }
+        Ok(())
+    }
+
+    /// Brain v2 L2.2 — idempotent FTS5 setup for `user_facts`: ONE external-content table over the
+    /// three content-bearing columns (`subject`/`predicate`/`object` — together the searchable
+    /// tokens of "<subject> <predicate>: <object>"), kept exact by the standard `_ai`/`_ad`/`_au`
+    /// trigger trio, plus a one-time backfill from existing rows. `user_facts` has a TEXT `id`
+    /// PRIMARY KEY, so it is a normal rowid table and `content_rowid='rowid'` mirrors it 1:1
+    /// (exactly like `fts_meetings`). Same Polish-safe tokenizer as the other FTS tables.
+    ///
+    /// LOCK MODEL: user facts are purged on seal via DIRECT `DELETE`s (`purge_user_facts_tx`,
+    /// `reblank_locked_folders_at_rest`) — those fire the `_ad` trigger, so a sealed meeting's fact
+    /// tokens are removed from the index in the SAME transaction. `delete_meeting` purges
+    /// explicitly too (not only via FK cascade) for the same trigger guarantee.
+    ///
+    /// CRASH SAFETY: the first-time CREATE (table + triggers) and the backfill run in ONE
+    /// transaction, so a crash mid-migration can never strand an EMPTY index that looks "already
+    /// built" — either everything lands (index complete) or nothing does (retried next launch).
+    fn migrate_user_facts_fts(conn: &Connection) -> Result<()> {
+        let already_built: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='fts_user_facts'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(map_err)?
+            .unwrap_or(false);
+
+        const CREATE: &str = "CREATE VIRTUAL TABLE IF NOT EXISTS fts_user_facts USING fts5(
+                 subject, predicate, object,
+                 content='user_facts',
+                 content_rowid='rowid',
+                 tokenize = 'unicode61 remove_diacritics 2'
+             );
+             CREATE TRIGGER IF NOT EXISTS fts_user_facts_ai AFTER INSERT ON user_facts BEGIN
+                 INSERT INTO fts_user_facts(rowid, subject, predicate, object)
+                   VALUES (new.rowid, new.subject, new.predicate, new.object);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_user_facts_ad AFTER DELETE ON user_facts BEGIN
+                 INSERT INTO fts_user_facts(fts_user_facts, rowid, subject, predicate, object)
+                   VALUES ('delete', old.rowid, old.subject, old.predicate, old.object);
+             END;
+             CREATE TRIGGER IF NOT EXISTS fts_user_facts_au AFTER UPDATE ON user_facts BEGIN
+                 INSERT INTO fts_user_facts(fts_user_facts, rowid, subject, predicate, object)
+                   VALUES ('delete', old.rowid, old.subject, old.predicate, old.object);
+                 INSERT INTO fts_user_facts(rowid, subject, predicate, object)
+                   VALUES (new.rowid, new.subject, new.predicate, new.object);
+             END;";
+
+        if already_built {
+            // Idempotent re-run: everything below IF-NOT-EXISTS no-ops; no backfill.
+            conn.execute_batch(CREATE).map_err(map_err)?;
+            return Ok(());
+        }
+        // First build: create + one-time backfill ATOMICALLY (rollback-on-drop guards a crash).
+        let tx = conn.unchecked_transaction().map_err(map_err)?;
+        tx.execute_batch(CREATE).map_err(map_err)?;
+        tx.execute_batch(
+            "INSERT INTO fts_user_facts(rowid, subject, predicate, object)
+               SELECT rowid, subject, predicate, object FROM user_facts;",
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Brain v2 L2.1 — memory-consolidation tables (see `crate::memory` for the job semantics).
+    ///
+    /// `memory_scores` — one row per OPEN user fact: the deterministic recency/importance/relevance
+    /// components + the composite. FK `ON DELETE CASCADE` to `user_facts(id)` so BOTH the
+    /// purge-on-seal (`purge_user_facts_tx`'s direct DELETE) and `delete_meeting`'s cascade drop the
+    /// score with its fact — a sealed/deleted meeting leaves no score row behind. (Scores are
+    /// CONTENT-FREE — floats + ids — but the cascade keeps the store consistent.)
+    ///
+    /// `memory_rollups` — one row per reflection scope (`entity:<id>` / `weekly:<YYYY-WNN>`):
+    /// cross-meeting SYNTHESIS text. LOCK MODEL (two layers, both required):
+    ///   1. PURGED on EVERY seal path — `purge_memory_rollups_tx` runs inside the seal transactions
+    ///      (`purge_chunks_for_meetings` / `blank_sealed_notes_in_folders` /
+    ///      `reblank_locked_folders_at_rest` / `delete_meeting`) and the CALLER deletes the exported
+    ///      vault `.md`s from the returned `exported_path`s. Rollups are cheap re-derivable synthesis;
+    ///      they regenerate on the next hourly pass FROM VISIBLE FACTS ONLY.
+    ///   2. Per-pass regeneration/GC — `fact_set_hash` records the SORTED visible-open-fact id set a
+    ///      rollup was synthesized from; the hourly pass deletes no-longer-eligible scopes and
+    ///      re-reflects any scope whose hash changed (superseded/forgotten facts age out even without
+    ///      a seal). See `crate::memory::run_consolidation_pass`.
+    ///
+    /// `scope` is UNIQUE so the upsert is idempotent per scope. `fact_set_hash` is added guarded
+    /// (`add_column_if_missing`) for DBs that ran the earlier shape of this migration.
+    ///
+    /// Also adds `facts.importance` (guarded, additive): the light reasoner's batch-assessed 1–10
+    /// importance of an ENTITY fact, persisted so steady-state passes stay LLM-free. It backs the
+    /// spec's "or any fact with importance ≥ 7" reflection-eligibility arm. Content-free (a float).
+    fn migrate_memory(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS memory_scores (
+               fact_id TEXT PRIMARY KEY,
+               scope TEXT NOT NULL DEFAULT 'user',
+               recency REAL NOT NULL,
+               importance REAL NOT NULL,
+               relevance REAL NOT NULL,
+               composite REAL NOT NULL,
+               scored_at TEXT NOT NULL,
+               FOREIGN KEY (fact_id) REFERENCES user_facts(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_memory_scores_composite
+               ON memory_scores(composite);
+             CREATE TABLE IF NOT EXISTS memory_rollups (
+               id TEXT PRIMARY KEY,
+               scope TEXT NOT NULL UNIQUE,
+               content TEXT NOT NULL,
+               created_at TEXT NOT NULL,
+               updated_at TEXT NOT NULL,
+               exported_path TEXT
+             );",
+        )
+        .map_err(map_err)?;
+        Self::add_column_if_missing(conn, "memory_rollups", "fact_set_hash", "TEXT")?;
+        Self::add_column_if_missing(conn, "facts", "importance", "REAL")?;
         Ok(())
     }
 
@@ -1904,7 +2033,11 @@ impl Db {
 
     /// Delete a meeting and (via ON DELETE CASCADE) its segments, notes, and timeline.
     /// Audio + vault files are removed by the caller before this.
-    pub fn delete_meeting(&self, id: &str) -> Result<()> {
+    ///
+    /// Returns the `exported_path`s of the memory rollups purged in the same transaction (a rollup
+    /// may paraphrase the deleted meeting's facts — see `purge_memory_rollups_tx`); the CALLER
+    /// deletes those vault `.md` files (same layering as the note/audio file removal above).
+    pub fn delete_meeting(&self, id: &str) -> Result<Vec<String>> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         // Drop derived chunks/vectors FIRST, in the same tx. `vec_chunks` is a vec0 virtual table
@@ -1919,10 +2052,20 @@ impl Db {
         // purge_supersessions_tx). Their pre-images hold plaintext note bytes; a deleted meeting must
         // leave none behind.
         Self::purge_supersessions_tx(&tx, &[id.to_string()])?;
+        // Brain v2 L2.2: purge this meeting's user facts EXPLICITLY (direct DELETE) rather than
+        // relying on the meetings FK cascade alone — the direct DELETE reliably fires the
+        // `fts_user_facts_ad` trigger, so the deleted facts' tokens leave the FTS index in this
+        // same tx (their `memory_scores` rows cascade off the user_facts FK). This also makes
+        // "delete the synthetic Memory Import meeting ⇒ the import is undone" structural.
+        Self::purge_user_facts_tx(&tx, &[id.to_string()])?;
+        // Brain v2 L2.1: purge ALL memory rollups in this same tx — a rollup may paraphrase the
+        // deleted meeting's (now-gone) facts; the survivors regenerate on the next hourly pass
+        // from the remaining visible facts only. The caller deletes the exported `.md`s.
+        let rollup_exports = Self::purge_memory_rollups_tx(&tx)?;
         tx.execute("DELETE FROM meetings WHERE id = ?1", rusqlite::params![id])
             .map_err(map_err)?;
         tx.commit().map_err(map_err)?;
-        Ok(())
+        Ok(rollup_exports)
     }
 
     pub fn get_meeting(&self, id: &str) -> Result<Option<Meeting>> {
@@ -2495,9 +2638,13 @@ impl Db {
     /// Purge (delete) every `note_chunks` + `vec_chunks` row for the given meetings. The vec0 row is
     /// deleted by its `chunk_id` (== note_chunks.id) BEFORE the note_chunks row, then the note_chunks
     /// rows go. Used standalone (lock_folder) and inside the relock transactions.
-    pub fn purge_chunks_for_meetings(&self, meeting_ids: &[String]) -> Result<()> {
+    ///
+    /// Returns the `exported_path`s of the memory rollups purged in the same transaction (see
+    /// `purge_memory_rollups_tx`) — the CALLER must delete those vault `.md` files (same layering
+    /// as the sealed-note `.md` deletion: DB rows in-tx here, filesystem at the command layer).
+    pub fn purge_chunks_for_meetings(&self, meeting_ids: &[String]) -> Result<Vec<String>> {
         if meeting_ids.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
@@ -2529,8 +2676,35 @@ impl Db {
         // sealed note content and returns (with the stamp) on unlock/remove-lock; only the undo
         // scratch is dropped.
         Self::purge_supersessions_tx(&tx, meeting_ids)?;
+        // Brain v2 L2.1 LOCK-SAFETY: memory ROLLUPS are cross-meeting synthesis that may paraphrase
+        // the just-sealed facts — purge ALL of them in this SAME seal tx (cheap, re-derivable: the
+        // next hourly pass regenerates from the still-VISIBLE facts only). The caller deletes the
+        // returned exported vault `.md`s.
+        let rollup_exports = Self::purge_memory_rollups_tx(&tx)?;
         tx.commit().map_err(map_err)?;
-        Ok(())
+        Ok(rollup_exports)
+    }
+
+    /// Brain v2 L2.1 LOCK-SAFETY: delete EVERY `memory_rollups` row within an EXISTING transaction
+    /// and return the recorded `exported_path`s so the CALLER can remove the exported vault `.md`s
+    /// (never any other file — only the paths this table recorded at export time; a missing file is
+    /// fine). ALL rollups go, not just the sealed scope's: a rollup is cross-meeting synthesis with
+    /// no single source meeting, so precision-purging is impossible — and rollups are cheap
+    /// re-derivable synthesis that the next hourly pass regenerates FROM VISIBLE FACTS ONLY.
+    fn purge_memory_rollups_tx(tx: &rusqlite::Transaction<'_>) -> Result<Vec<String>> {
+        let mut stmt = tx
+            .prepare("SELECT exported_path FROM memory_rollups WHERE exported_path IS NOT NULL")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut paths = Vec::new();
+        for r in rows {
+            paths.push(r.map_err(map_err)?);
+        }
+        drop(stmt);
+        tx.execute("DELETE FROM memory_rollups", []).map_err(map_err)?;
+        Ok(paths)
     }
 
     /// brain2 R2 LOCK-SAFETY: delete every `facts` row for `meeting_ids` within an EXISTING
@@ -4613,12 +4787,20 @@ impl Db {
 
     /// Re-blank the plaintext `markdown` of every note in `folder_ids` that still has a sealed
     /// `content_blob` (relock / relock-all). Idempotent; leaves the blob intact.
-    pub fn blank_sealed_notes_in_folders(&self, folder_ids: &HashSet<String>) -> Result<()> {
+    ///
+    /// Returns the `exported_path`s of the memory rollups purged in the same transaction
+    /// (`purge_memory_rollups_tx` — a relock re-asserts the sealed shape, so sealed-derived rollup
+    /// synthesis must not linger either); the CALLER deletes those vault `.md` files.
+    pub fn blank_sealed_notes_in_folders(
+        &self,
+        folder_ids: &HashSet<String>,
+    ) -> Result<Vec<String>> {
         if folder_ids.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        let rollup_exports;
         {
             let mut stmt = tx
                 .prepare(
@@ -4680,9 +4862,14 @@ impl Db {
             // `reblank_folder_extras` (relock) / `reblank_locked_folders_at_rest` (startup). Blanking
             // it here (unconditionally, with no CK to re-seal) would destroy the only copy of a
             // typed buffer that had not yet been sealed — the verify-before-destroy violation.
+
+            // Brain v2 L2.1 LOCK-SAFETY: purge ALL memory rollups in this SAME relock tx — a rollup
+            // may paraphrase the just-re-sealed facts. Cheap re-derivable synthesis; regenerates
+            // from VISIBLE facts on the next hourly pass. The caller deletes the exported `.md`s.
+            rollup_exports = Self::purge_memory_rollups_tx(&tx)?;
         }
         tx.commit().map_err(map_err)?;
-        Ok(())
+        Ok(rollup_exports)
     }
 
     /// SHOULD-FIX startup reconciliation: re-assert the at-rest sealed shape of EVERY `locked=1`
@@ -4700,7 +4887,12 @@ impl Db {
     /// (`mic_master_path` / `sys_master_path`). A crash-while-unlocked decrypts EVERY stream that
     /// was sealed, so re-pointing only `audio_path` would leave `{id}.mic.wav` / `{id}.sys.wav`
     /// plaintext on disk forever (B1) — the masters must be reconciled with the same logic.
-    pub fn reblank_locked_folders_at_rest(&self) -> Result<Vec<LockedMeetingAudio>> {
+    ///
+    /// The second tuple element is the `exported_path`s of the memory rollups purged in-tx when any
+    /// folder is locked (`purge_memory_rollups_tx`) — the caller deletes those vault `.md` files.
+    pub fn reblank_locked_folders_at_rest(
+        &self,
+    ) -> Result<(Vec<LockedMeetingAudio>, Vec<String>)> {
         const LOCKED_MEETINGS: &str = "SELECT DISTINCT meeting_id FROM notes \
              WHERE folder_id IN (SELECT id FROM folders WHERE locked = 1)";
         let mut conn = self.lock();
@@ -4882,8 +5074,25 @@ impl Db {
                 audio.push(r.map_err(map_err)?);
             }
         }
+        // Brain v2 L2.1 LOCK-SAFETY: when ANY folder is locked, purge ALL memory rollups in this
+        // same reconciliation transaction — a rollup synthesized before the seal (or during a
+        // crashed unlocked session) may paraphrase sealed facts. Skipped when nothing is locked
+        // (no sealed content ⇒ no leak ⇒ rollups survive restarts). The caller deletes the
+        // returned exported vault `.md`s.
+        let any_locked: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM folders WHERE locked = 1)",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        let rollup_exports = if any_locked {
+            Self::purge_memory_rollups_tx(&tx)?
+        } else {
+            Vec::new()
+        };
         tx.commit().map_err(map_err)?;
-        Ok(audio)
+        Ok((audio, rollup_exports))
     }
 
     /// Folder ids that are sealed (`locked=1`) — used to re-blank every sealed note on relock-all.
@@ -6675,6 +6884,275 @@ impl Db {
         Ok(out)
     }
 
+    /// Brain v2 L2.2 — GATED, RELEVANCE-FILTERED read: the top-`k` CURRENTLY-VALID (open) user
+    /// facts matching `query` (BM25 over `fts_user_facts`, best first), restricted by EXACTLY the
+    /// same visibility predicate as [`Self::list_user_facts_visible`] (source-meeting
+    /// `visibility_clause`; NULL `meeting_id` fail-closed via the INNER JOIN). The query is defused
+    /// through [`fts_match_query_any`] (an OR of quoted literal CONTENT terms — stopwords and
+    /// <3-char tokens are dropped, so a natural-language question must match a fact on a real
+    /// content word, never on "the"/"is"), so raw user text can never raise an FTS syntax error; an
+    /// empty / punctuation-only / all-stopword query returns NO hits (the caller falls back to the
+    /// full list). Only OPEN facts (`valid_to IS NULL`) are returned.
+    pub fn search_user_facts_visible(
+        &self,
+        query: &str,
+        k: usize,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<crate::facts::Fact>> {
+        let Some(match_expr) = fts_match_query_any(query) else {
+            return Ok(Vec::new());
+        };
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT uf.id, uf.subject, uf.predicate, uf.object, uf.valid_from, \
+                    uf.valid_to, uf.recorded_at, uf.meeting_id, uf.confidence \
+               FROM fts_user_facts \
+               JOIN user_facts uf ON uf.rowid = fts_user_facts.rowid \
+               JOIN meetings m ON m.id = uf.meeting_id \
+              WHERE fts_user_facts MATCH ?1 \
+                AND uf.valid_to IS NULL \
+                AND ( \
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id) \
+                   OR EXISTS ( \
+                        SELECT 1 FROM notes n \
+                         LEFT JOIN folders f ON f.id = n.folder_id \
+                         WHERE n.meeting_id = m.id AND {visible} \
+                      ) \
+                    ) \
+              ORDER BY bm25(fts_user_facts) ASC, uf.valid_from DESC, uf.id DESC \
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![match_expr, k as i64],
+                row_to_user_fact,
+            )
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    // ── Brain v2 L2.1 — memory consolidation store (see `crate::memory`) ─────────────────────────
+    //
+    // `memory_scores` rows are CONTENT-FREE (ids + floats) and cascade off `user_facts` (FK), so
+    // purge-on-seal / delete-meeting are transitive. `memory_rollups` carry SYNTHESIS text derived
+    // ONLY from VISIBLE facts (the job reads through the gated `list_user_facts_visible` /
+    // `list_facts_visible` with the empty unlock set); they are ALL PURGED inside every seal tx
+    // (`purge_memory_rollups_tx` — the caller deletes the exported `.md`s) AND hash-tracked
+    // (`fact_set_hash`) so the hourly pass re-reflects/GCs any rollup whose visible fact set changed.
+
+    /// Upsert ONE memory score row (idempotent per `fact_id` — the job re-scores every pass).
+    #[allow(clippy::too_many_arguments)] // a flat score row: id + scope + 4 floats + instant.
+    pub fn upsert_memory_score(
+        &self,
+        fact_id: &str,
+        scope: &str,
+        recency: f64,
+        importance: f64,
+        relevance: f64,
+        composite: f64,
+        scored_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO memory_scores \
+               (fact_id, scope, recency, importance, relevance, composite, scored_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+             ON CONFLICT(fact_id) DO UPDATE SET \
+               scope = excluded.scope, recency = excluded.recency, \
+               importance = excluded.importance, relevance = excluded.relevance, \
+               composite = excluded.composite, scored_at = excluded.scored_at",
+            rusqlite::params![fact_id, scope, recency, importance, relevance, composite, scored_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// All persisted memory scores as `(fact_id, importance)` — the job's "already assessed" set,
+    /// so the light-reasoner importance call runs ONLY for never-scored facts (steady-state passes
+    /// are LLM-free). Content-free read.
+    pub fn memory_importance_map(&self) -> Result<std::collections::HashMap<String, f64>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT fact_id, importance FROM memory_scores")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, f64>(1)?)))
+            .map_err(map_err)?;
+        let mut out = std::collections::HashMap::new();
+        for r in rows {
+            let (id, imp) = r.map_err(map_err)?;
+            out.insert(id, imp);
+        }
+        Ok(out)
+    }
+
+    /// Drop score rows whose fact is CLOSED (`valid_to` set — forgotten/superseded). Purged/deleted
+    /// facts cascade off the FK; closed facts are UPDATEs, so the job sweeps their scores here.
+    pub fn delete_memory_scores_for_closed_facts(&self) -> Result<usize> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "DELETE FROM memory_scores WHERE fact_id IN \
+                   (SELECT id FROM user_facts WHERE valid_to IS NOT NULL)",
+                [],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
+
+    /// Upsert ONE rollup by `scope` (idempotent — a re-reflection replaces the content, keeps the
+    /// row id + `created_at`, bumps `updated_at`, and resets `exported_path` until re-exported).
+    /// `fact_set_hash` is the deterministic hash of the SORTED visible-open-fact id set the content
+    /// was synthesized from (`crate::memory::fact_set_hash`) — the hourly pass compares it to decide
+    /// re-reflection.
+    pub fn upsert_memory_rollup(
+        &self,
+        scope: &str,
+        content: &str,
+        fact_set_hash: &str,
+        now: &str,
+    ) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO memory_rollups \
+               (id, scope, content, created_at, updated_at, exported_path, fact_set_hash) \
+             VALUES (?1, ?2, ?3, ?4, ?4, NULL, ?5) \
+             ON CONFLICT(scope) DO UPDATE SET \
+               content = excluded.content, updated_at = excluded.updated_at, \
+               exported_path = NULL, fact_set_hash = excluded.fact_set_hash",
+            rusqlite::params![id, scope, content, now, fact_set_hash],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Delete ONE rollup by `scope` (the hourly pass's GC of a no-longer-eligible scope), returning
+    /// its recorded `exported_path` so the caller can remove the exported vault `.md` (only ever
+    /// that recorded path). `Ok(None)` when the scope has no row or was never exported.
+    pub fn delete_memory_rollup(&self, scope: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        let path: Option<Option<String>> = conn
+            .query_row(
+                "SELECT exported_path FROM memory_rollups WHERE scope = ?1",
+                rusqlite::params![scope],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        conn.execute(
+            "DELETE FROM memory_rollups WHERE scope = ?1",
+            rusqlite::params![scope],
+        )
+        .map_err(map_err)?;
+        Ok(path.flatten())
+    }
+
+    /// The persisted `facts.importance` assessments as `(fact_id, importance)` — the reflection
+    /// job's "already assessed" set for ENTITY facts (only never-assessed facts hit the reasoner,
+    /// so steady-state passes are LLM-free). Content-free read (ids + floats).
+    pub fn fact_importance_map(&self) -> Result<std::collections::HashMap<String, f64>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT id, importance FROM facts WHERE importance IS NOT NULL")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, f64>(1)?)))
+            .map_err(map_err)?;
+        let mut out = std::collections::HashMap::new();
+        for r in rows {
+            let (id, imp) = r.map_err(map_err)?;
+            out.insert(id, imp);
+        }
+        Ok(out)
+    }
+
+    /// Persist the batch-assessed importance (1–10) of ONE entity fact (`facts.importance`).
+    pub fn set_fact_importance(&self, fact_id: &str, importance: f64) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE facts SET importance = ?2 WHERE id = ?1",
+            rusqlite::params![fact_id, importance],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Stamp the vault path a rollup was exported to (after the atomic `.md` write succeeded).
+    pub fn set_memory_rollup_exported(&self, scope: &str, path: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE memory_rollups SET exported_path = ?2 WHERE scope = ?1",
+            rusqlite::params![scope, path],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// All rollups, stable scope order (the export pass + tests).
+    pub fn list_memory_rollups(&self) -> Result<Vec<crate::storage::models::MemoryRollup>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, scope, content, created_at, updated_at, exported_path, fact_set_hash \
+                   FROM memory_rollups ORDER BY scope ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(crate::storage::models::MemoryRollup {
+                    id: r.get(0)?,
+                    scope: r.get(1)?,
+                    content: r.get(2)?,
+                    created_at: r.get(3)?,
+                    updated_at: r.get(4)?,
+                    exported_path: r.get(5)?,
+                    fact_set_hash: r.get(6)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// All memory scores (tests + diagnostics). Content-free rows.
+    pub fn list_memory_scores(&self) -> Result<Vec<crate::storage::models::MemoryScore>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT fact_id, scope, recency, importance, relevance, composite, scored_at \
+                   FROM memory_scores ORDER BY fact_id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(crate::storage::models::MemoryScore {
+                    fact_id: r.get(0)?,
+                    scope: r.get(1)?,
+                    recency: r.get(2)?,
+                    importance: r.get(3)?,
+                    relevance: r.get(4)?,
+                    composite: r.get(5)?,
+                    scored_at: r.get(6)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     /// Persist ONE voiceprint (opt-in voice biometric) for a diarized cluster of `meeting_id`.
     /// `embedding` is the L2-normalized CAM++ vector; it is stored as a little-endian f32 BLOB.
     /// `label` is NULL initially (bound later on enroll-by-rename). NO PII is logged (the embedding,
@@ -7123,6 +7601,51 @@ fn fts_match_query(q: &str) -> Option<String> {
             .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
             .collect::<Vec<_>>()
             .join(" "),
+    )
+}
+
+/// The OR-joined twin of [`fts_match_query`]: the same tokenize-and-quote defusal, but terms are
+/// joined with `OR` instead of implicit AND. Used for RELEVANCE filtering (Brain v2 L2.2), where the
+/// "query" is a whole natural-language question and a short fact row should match on ANY shared
+/// content word — an AND over the full question would almost never match a 5-word fact. BM25 still
+/// ranks multi-term matches above single-term ones.
+///
+/// CONTENT WORDS ONLY: stopwords (the shared EN+PL list, `related_context::is_stopword` — one
+/// source of truth) and tokens shorter than 3 chars are DROPPED before the OR is built. Without
+/// this, a question sharing only "the"/"co"/"is" with an irrelevant fact produces a non-empty hit
+/// set that DISPLACES the caller's full-list fallback (the reproduced brief-displacement bug —
+/// unicode61 has no stopword list and BM25 cannot rescue a hit set whose only members are stopword
+/// matches). Empty / punctuation-only / all-stopword input yields `None` — the caller's fallback
+/// owns that case.
+fn fts_match_query_any(q: &str) -> Option<String> {
+    let mut terms: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    for ch in q.chars() {
+        if ch.is_alphanumeric() {
+            cur.push(ch);
+        } else if !cur.is_empty() {
+            terms.push(std::mem::take(&mut cur));
+        }
+    }
+    if !cur.is_empty() {
+        terms.push(cur);
+    }
+    // Keep only content words: lowercase (FTS unicode61 case-folds anyway), then drop stopwords
+    // and <3-char tokens so a function-word overlap can never produce a "relevant" hit.
+    let terms: Vec<String> = terms
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .filter(|t| t.chars().count() >= 3 && !crate::summarize::related_context::is_stopword(t))
+        .collect();
+    if terms.is_empty() {
+        return None;
+    }
+    Some(
+        terms
+            .iter()
+            .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+            .collect::<Vec<_>>()
+            .join(" OR "),
     )
 }
 
@@ -12330,6 +12853,162 @@ mod lock_tests {
             db.user_facts_all().unwrap().is_empty(),
             "FK CASCADE drops user facts"
         );
+    }
+
+    /// Brain v2 L2.2 (RED-first): `search_user_facts_visible` is BM25-relevance-filtered AND runs
+    /// the SAME visibility gate as `list_user_facts_visible` — a sealed-not-unlocked source
+    /// meeting's fact never matches, a session unlock re-admits it, only OPEN facts return, and an
+    /// empty/punctuation-only query returns nothing (the caller's fallback owns that case).
+    #[test]
+    fn search_user_facts_visible_is_relevance_filtered_and_gated() {
+        let db = file_db("user-facts-search");
+        seed_folder(&db, "f-s", "Secret");
+        seed_note(&db, "m-open", "open note", None);
+        seed_note(&db, "m-priv", "private note", Some("f-s"));
+        db.apply_user_fact_ops(&[
+            user_add_op("works on", "Project Atlas", "2026-07-01T00:00:00Z", "m-open"),
+            user_add_op("prefer", "Polish replies", "2026-07-01T00:00:00Z", "m-open"),
+            user_add_op("salary", "Atlas bonus", "2026-07-01T00:00:00Z", "m-priv"),
+        ])
+        .unwrap();
+        let none = HashSet::new();
+
+        // Relevance: an "atlas" query matches the two Atlas facts, not the Polish-replies one.
+        let hits = db.search_user_facts_visible("what about atlas?", 8, &none).unwrap();
+        assert_eq!(hits.len(), 2, "both atlas facts match while all folders are open");
+        assert!(hits.iter().all(|f| f.object.contains("Atlas")));
+
+        // Empty / punctuation-only query ⇒ no hits (fallback belongs to the caller).
+        assert!(db.search_user_facts_visible("", 8, &none).unwrap().is_empty());
+        assert!(db
+            .search_user_facts_visible("?!():", 8, &none)
+            .unwrap()
+            .is_empty());
+        // FIX 3: a STOPWORD-ONLY query is no query at all — it must return zero hits (so the
+        // caller's full-list fallback owns it), never a stopword-overlap "match".
+        assert!(db
+            .search_user_facts_visible("what about the", 8, &none)
+            .unwrap()
+            .is_empty());
+
+        // GATE: seal the private folder — its fact drops out of the SAME query.
+        db.set_folder_locked("f-s", true, None).unwrap();
+        let hits = db.search_user_facts_visible("atlas", 8, &none).unwrap();
+        assert_eq!(hits.len(), 1, "the sealed source's fact must not match");
+        assert_eq!(hits[0].meeting_id.as_deref(), Some("m-open"));
+
+        // A session unlock re-admits it (reversible gate).
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-s".to_string());
+        assert_eq!(
+            db.search_user_facts_visible("atlas", 8, &unlocked).unwrap().len(),
+            2
+        );
+
+        // Only OPEN facts: forget the open-folder Atlas fact → it stops matching.
+        let open_fact_id = db
+            .list_user_facts_visible(&none)
+            .unwrap()
+            .into_iter()
+            .find(|f| f.object == "Project Atlas")
+            .unwrap()
+            .id;
+        db.forget_user_fact(&open_fact_id, "2026-07-02T00:00:00Z")
+            .unwrap();
+        assert!(
+            db.search_user_facts_visible("atlas", 8, &none).unwrap().is_empty(),
+            "a closed (forgotten) fact must not match"
+        );
+    }
+
+    /// Brain v2 L2.2 LOCK-AT-REST: the purge-on-seal DELETE and `delete_meeting` both remove the
+    /// fact's tokens from the `fts_user_facts` index (the `_ad` trigger fires on the direct
+    /// DELETE) — no sealed/deleted fact text survives as a searchable token. Mirrors
+    /// `sealed_tokens_purged_from_fts_after_blank` for the user-facts index.
+    #[test]
+    fn user_fact_tokens_purged_from_fts_on_seal_and_delete() {
+        let db = file_db("user-facts-fts-purge");
+        seed_note(&db, "m1", "note", None);
+        seed_note(&db, "m2", "note2", None);
+        db.apply_user_fact_ops(&[
+            user_add_op("codename", "Zenith", "2026-07-01T00:00:00Z", "m1"),
+            user_add_op("codename2", "Quasar", "2026-07-01T00:00:00Z", "m2"),
+        ])
+        .unwrap();
+        let fts_count = |term: &str| -> i64 {
+            let conn = db.lock();
+            conn.query_row(
+                "SELECT count(*) FROM fts_user_facts WHERE fts_user_facts MATCH ?1",
+                rusqlite::params![format!("\"{term}\"")],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(fts_count("zenith"), 1);
+        assert_eq!(fts_count("quasar"), 1);
+
+        // Purge-on-seal path (the direct DELETE inside the seal tx).
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(fts_count("zenith"), 0, "sealed fact tokens must leave the index");
+
+        // delete_meeting path (explicit purge in-tx).
+        db.delete_meeting("m2").unwrap();
+        assert_eq!(fts_count("quasar"), 0, "deleted fact tokens must leave the index");
+    }
+
+    /// FIX 1a (CRITICAL leak — the DB half): every seal/delete transaction purges ALL
+    /// `memory_rollups` rows and returns their `exported_path`s for the caller's file deletion —
+    /// `purge_chunks_for_meetings` (lock_folder / move-into-locked), `blank_sealed_notes_in_folders`
+    /// (relock), `reblank_locked_folders_at_rest` (startup reconcile — purges ONLY when a locked
+    /// folder exists, so an open-only DB keeps its rollups across restarts), and `delete_meeting`.
+    /// RED on the pre-fix code: none of these touched `memory_rollups`.
+    #[test]
+    fn seal_paths_purge_memory_rollup_rows_and_return_export_paths() {
+        let db = file_db("rollup-purge-paths");
+        seed_folder(&db, "f1", "Secret");
+        seed_note(&db, "m1", "note", Some("f1"));
+        let seed_rollup = |db: &Db| {
+            db.upsert_memory_rollup("entity:e1", "synth", "h", "2026-07-09T12:00:00Z")
+                .unwrap();
+            db.set_memory_rollup_exported("entity:e1", "/vault/brain/memory/entity-e1.md")
+                .unwrap();
+        };
+
+        // lock_folder / move-into-locked chain.
+        seed_rollup(&db);
+        let paths = db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(paths, vec!["/vault/brain/memory/entity-e1.md".to_string()]);
+        assert!(db.list_memory_rollups().unwrap().is_empty());
+
+        // relock chain.
+        seed_rollup(&db);
+        let mut folders = HashSet::new();
+        folders.insert("f1".to_string());
+        let paths = db.blank_sealed_notes_in_folders(&folders).unwrap();
+        assert_eq!(paths.len(), 1);
+        assert!(db.list_memory_rollups().unwrap().is_empty());
+
+        // Startup reconcile with NO locked folder ⇒ rollups SURVIVE (nothing sealed, no leak).
+        seed_rollup(&db);
+        let (_, paths) = db.reblank_locked_folders_at_rest().unwrap();
+        assert!(paths.is_empty());
+        assert_eq!(
+            db.list_memory_rollups().unwrap().len(),
+            1,
+            "an open-only DB keeps its rollups across restarts"
+        );
+
+        // Startup reconcile WITH a locked folder ⇒ purged.
+        db.set_folder_locked("f1", true, None).unwrap();
+        let (_, paths) = db.reblank_locked_folders_at_rest().unwrap();
+        assert_eq!(paths.len(), 1);
+        assert!(db.list_memory_rollups().unwrap().is_empty());
+
+        // delete_meeting.
+        seed_rollup(&db);
+        let paths = db.delete_meeting("m1").unwrap();
+        assert_eq!(paths.len(), 1);
+        assert!(db.list_memory_rollups().unwrap().is_empty());
     }
 
     // ── Voiceprints: at-rest storage + LOCK invariants (mirror the user_facts tests exactly) ──────

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -125,6 +125,41 @@ pub struct Meeting {
     pub folder_id: Option<String>,
 }
 
+/// Brain v2 L2.1 — one memory-consolidation rollup row (`memory_rollups`): cross-meeting synthesis
+/// for one reflection scope (`entity:<id>` or `weekly:<YYYY-WNN>`). Lock model: ALL rollup rows are
+/// purged inside every seal transaction (and their exported `.md`s deleted by the caller), and the
+/// hourly pass re-reflects/GCs any rollup whose VISIBLE fact set changed (`fact_set_hash`) — see
+/// `crate::memory`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryRollup {
+    pub id: String,
+    pub scope: String,
+    pub content: String,
+    pub created_at: String,
+    pub updated_at: String,
+    /// Absolute vault `.md` path this rollup was last exported to (`None` until exported).
+    pub exported_path: Option<String>,
+    /// Deterministic hash of the SORTED visible-open-fact id set the content was synthesized from
+    /// (`crate::memory::fact_set_hash`); `None` on rows written before the hash existed — treated
+    /// as "changed" so they re-reflect on the next pass.
+    pub fact_set_hash: Option<String>,
+}
+
+/// Brain v2 L2.1 — one memory score row (`memory_scores`): the deterministic components + the
+/// composite for one OPEN user fact. CONTENT-FREE (ids + floats); cascades off `user_facts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryScore {
+    pub fact_id: String,
+    pub scope: String,
+    pub recency: f64,
+    pub importance: f64,
+    pub relevance: f64,
+    pub composite: f64,
+    pub scored_at: String,
+}
+
 /// A vault folder Murmur tracks for organization + per-folder locking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -736,8 +736,8 @@ fn run_informational(
         // it and steps up. This is "deterministic escalation, model-driven retrieval": which tools are
         // reachable is code-enforced, retrieval within a tier stays model-driven.
         if let Some(result) = run_cascade(
-            app, state, config, unlocked, meeting_id, loop_user, intent, tool_event, thread_id,
-            &*reasoner,
+            app, state, config, unlocked, meeting_id, command, loop_user, intent, tool_event,
+            thread_id, &*reasoner,
         ) {
             return result;
         }
@@ -950,6 +950,7 @@ fn run_cascade(
     config: &crate::settings::AppConfig,
     unlocked: &std::collections::HashSet<String>,
     meeting_id: &str,
+    command: &str,
     loop_user: &str,
     intent: &crate::audio::wake::VoiceIntent,
     tool_event: &'static str,
@@ -959,10 +960,12 @@ fn run_cascade(
     // Shared per-turn injected context (gated). Tier 1 leans on the live buffer + typed notes for the
     // CURRENT meeting (read through `gated_live_context`, fail-closed on the LIVE unlocked set); the
     // memory brief + recording flag ride along exactly as before. NO new egress class — every segment
-    // goes through the same RedactingProvider + cloud-consent gate.
+    // goes through the same RedactingProvider + cloud-consent gate. L2.2: the brief is relevance-
+    // filtered against the user's CURRENT command (`command`, never the whole rendered conversation).
     let (live, typed_notes) =
         gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
-    let memory_brief = gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled);
+    let memory_brief =
+        gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled, command);
     let recording_in_progress = state.recorder.lock().map(|g| g.is_some()).unwrap_or(false);
     let base_system =
         assistant_system_prompt(&live, &typed_notes, &memory_brief, recording_in_progress);
@@ -1621,16 +1624,20 @@ fn gated_live_context(
 /// `enabled` is the config `user_memory_enabled` master gate: when FALSE the brief is EMPTY (no read,
 /// no injection) — so turning memory off suppresses injection into the @brain loop too, identically
 /// to Ask / per-meeting chat.
+///
+/// Brain v2 L2.2: `query` is the user's CURRENT command/question — the brief is RELEVANCE-FILTERED
+/// (BM25 top-k over the SAME visible set via `build_memory_brief`); an empty query or zero hits
+/// falls back to the full-list brief, byte-identical to the pre-L2.2 behavior.
 fn gated_user_memory_brief(
     db: &crate::storage::Db,
     unlocked: &std::collections::HashSet<String>,
     enabled: bool,
+    query: &str,
 ) -> String {
     if !enabled {
         return String::new();
     }
-    let facts = db.list_user_facts_visible(unlocked).unwrap_or_default();
-    crate::user_memory::synthesize_brief(&facts)
+    crate::user_memory::build_memory_brief(db, query, unlocked)
 }
 
 /// Clear the accumulated live-transcript buffer. Called when a recording STOPS
@@ -3174,7 +3181,7 @@ mod tests {
 
         // While the folder is OPEN the fact is visible → the brief contains it.
         let mut unlocked = std::collections::HashSet::new();
-        let brief_open = gated_user_memory_brief(&db, &unlocked, true);
+        let brief_open = gated_user_memory_brief(&db, &unlocked, true, "");
         assert!(
             brief_open.contains("Polish replies"),
             "an open-folder user fact must be in the brief"
@@ -3195,7 +3202,7 @@ mod tests {
             visible_sealed.is_empty(),
             "a sealed-not-unlocked meeting's user fact must be INVISIBLE to the gated reader"
         );
-        let brief_sealed = gated_user_memory_brief(&db, &unlocked, true);
+        let brief_sealed = gated_user_memory_brief(&db, &unlocked, true, "");
         assert!(
             brief_sealed.is_empty(),
             "sealed-source fact must NOT appear in the injected brief"
@@ -3213,14 +3220,14 @@ mod tests {
         // A SESSION UNLOCK re-admits it (reversible gate).
         unlocked.insert("f1".to_string());
         assert!(
-            gated_user_memory_brief(&db, &unlocked, true).contains("Polish replies"),
+            gated_user_memory_brief(&db, &unlocked, true, "").contains("Polish replies"),
             "a session unlock must re-inject the user fact"
         );
 
         // FLAG OFF: even a VISIBLE, open-folder fact must NOT be injected when memory is disabled —
         // the brief is empty regardless of visibility, so the @brain loop injects nothing.
         assert!(
-            gated_user_memory_brief(&db, &unlocked, false).is_empty(),
+            gated_user_memory_brief(&db, &unlocked, false, "").is_empty(),
             "memory disabled must suppress the brief even for a visible fact"
         );
     }

--- a/src-tauri/src/user_memory.rs
+++ b/src-tauri/src/user_memory.rs
@@ -141,6 +141,37 @@ pub fn synthesize_brief(facts: &[Fact]) -> String {
     brief
 }
 
+/// Brain v2 L2.2 — max user facts fed into a RELEVANCE-FILTERED brief (the FTS top-k). Smaller than
+/// [`MAX_BRIEF_FACTS`] on purpose: when a query is in hand, a tight, on-topic brief beats breadth.
+pub const RELEVANT_BRIEF_FACTS: usize = 8;
+
+/// Brain v2 L2.2 — the RELEVANCE-FILTERED memory brief: when a user `query` is in hand, rank the
+/// visible open user facts by BM25 against it (`Db::search_user_facts_visible` — the SAME
+/// visibility predicate as `list_user_facts_visible`, so a sealed-not-unlocked meeting's facts are
+/// NEVER read) and synthesize the brief from the top [`RELEVANT_BRIEF_FACTS`] hits.
+///
+/// BEHAVIOR-PRESERVING FALLBACK: an empty/punctuation-only query (the note-gen path), an FTS error,
+/// or ZERO hits all fall back to today's full-list `list_user_facts_visible` + [`synthesize_brief`]
+/// — so the brief is never emptier than the pre-L2.2 one just because relevance filtering found
+/// nothing. [`MEMORY_BRIEF_MAX_CHARS`] applies unchanged on both paths. Best-effort like the
+/// existing brief call sites: a DB read error degrades to an empty brief, never a failure. The
+/// CALLER still owns the `user_memory_enabled` flag check (this fn only assembles).
+pub fn build_memory_brief(
+    db: &crate::storage::Db,
+    query: &str,
+    unlocked: &std::collections::HashSet<String>,
+) -> String {
+    if !query.trim().is_empty() {
+        if let Ok(hits) = db.search_user_facts_visible(query, RELEVANT_BRIEF_FACTS, unlocked) {
+            if !hits.is_empty() {
+                return synthesize_brief(&hits);
+            }
+        }
+    }
+    let facts = db.list_user_facts_visible(unlocked).unwrap_or_default();
+    synthesize_brief(&facts)
+}
+
 /// The shape the reasoner must emit. Best-effort: parse failures degrade to no facts.
 #[derive(Debug, Deserialize)]
 struct UserFactsReply {
@@ -256,6 +287,73 @@ pub fn extract_user_fact_candidates(
         Ok(r) => r,
         Err(e) => {
             tracing::debug!(target: "user_memory", error = %e, "user-fact extraction reply unparseable; no candidates");
+            return Vec::new();
+        }
+    };
+    candidates_from_raw(reply.facts)
+}
+
+/// Brain v2 L2.3 — max chars of a pasted memory export fed to the import extractor (bounds the
+/// prompt / leak surface exactly like the note excerpt).
+const IMPORT_EXCERPT_CHARS: usize = 8_000;
+
+/// PURE + headless-testable assembly of the MEMORY-IMPORT user prompt (Brain v2 L2.3): the pasted
+/// text is labelled as pre-extracted memories from ANOTHER AI assistant (ChatGPT/Claude memory
+/// export), hard-bounded to [`IMPORT_EXCERPT_CHARS`]. Split out so the labelling + the bound can be
+/// unit-tested without a live model.
+fn build_import_user_prompt(text: &str) -> String {
+    let excerpt: String = text.chars().take(IMPORT_EXCERPT_CHARS).collect();
+    format!(
+        "PRE-EXTRACTED MEMORIES FROM ANOTHER AI ASSISTANT (the user pasted their memory export; \
+         each line is already a durable fact/preference about the user — convert them, do not \
+         re-summarize):\n{excerpt}"
+    )
+}
+
+/// Brain v2 L2.3 — BEST-EFFORT extraction of user-scoped fact candidates from a PASTED memory
+/// export (ChatGPT/Claude "what the assistant remembers" text). Reuses the [`EXTRACT_SYSTEM`]
+/// machinery (same schema, same [`candidates_from_raw`] scoping) with an import-specific user
+/// prompt. Same degradation contract as [`extract_user_fact_candidates`]: the stub reasoner / any
+/// decode or parse failure ⇒ an EMPTY vec — never an error, never a panic. ZERO egress: the
+/// command resolves the LIGHT local-or-stub reasoner (`import_extraction_reasoner` in commands.rs
+/// — NEVER cloud; the FE copy promises on-device, and a pasted third-party memory export must not
+/// ride the cloud Notes provider). No local model ⇒ nothing extracted ⇒ 0 imported.
+pub fn extract_imported_memories(
+    reasoner: &dyn LocalReasoner,
+    text: &str,
+) -> Vec<FactCandidate> {
+    if reasoner.id() == "stub" {
+        return Vec::new();
+    }
+    let user = build_import_user_prompt(text);
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "facts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "predicate": { "type": "string" },
+                        "object": { "type": "string" }
+                    },
+                    "required": ["predicate", "object"]
+                }
+            }
+        },
+        "required": ["facts"]
+    });
+    let value = match reasoner.structured(EXTRACT_SYSTEM, &user, &schema) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(target: "user_memory", error = %e, "memory import extraction failed; no candidates (best-effort)");
+            return Vec::new();
+        }
+    };
+    let reply: UserFactsReply = match serde_json::from_value(value) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(target: "user_memory", error = %e, "memory import reply unparseable; no candidates");
             return Vec::new();
         }
     };
@@ -382,6 +480,157 @@ mod tests {
         let prompt = build_extraction_user_prompt("Sync", "n", "", &huge);
         let z_count = prompt.chars().filter(|c| *c == 'z').count();
         assert!(z_count <= THREAD_TURNS_MAX_CHARS);
+    }
+
+    /// Brain v2 L2.2 (RED-first): with a QUERY in hand the brief is RELEVANCE-FILTERED — only the
+    /// BM25-matching fact appears; an EMPTY query falls back to the full list (behavior-preserving).
+    /// Zero FTS hits also fall back to the full list (the brief is never emptier than before).
+    /// RED before L2.2: `build_memory_brief`/`search_user_facts_visible` did not exist and every
+    /// surface injected the unfiltered full-list brief.
+    #[test]
+    fn build_memory_brief_filters_by_query_and_falls_back() {
+        use crate::facts::{FactOp, NewFact};
+        use crate::storage::models::{Meeting, MeetingStatus};
+        use crate::storage::Db;
+
+        let path = crate::storage::db::unique_temp_path("murmur-brief-filter", "sqlite");
+        let db = Db::open_with_key(
+            &path,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+        db.insert_meeting(&Meeting {
+            id: "m1".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Sync".to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        let add = |predicate: &str, object: &str| {
+            FactOp::Add(NewFact {
+                entity_id: USER_SCOPE.to_string(),
+                subject: "You".to_string(),
+                predicate: predicate.to_string(),
+                object: object.to_string(),
+                valid_from: "2026-07-01T09:00:00Z".to_string(),
+                recorded_at: "2026-07-01T09:00:00Z".to_string(),
+                confidence: 1.0,
+                meeting_id: Some("m1".to_string()),
+            })
+        };
+        db.apply_user_fact_ops(&[
+            add("prefer", "Polish replies"),
+            add("works on", "Project Atlas"),
+        ])
+        .unwrap();
+        let unlocked = std::collections::HashSet::new();
+
+        // Query matching ONE fact → the brief contains ONLY that fact.
+        let brief = build_memory_brief(&db, "what is the deadline for Atlas?", &unlocked);
+        assert!(brief.contains("Project Atlas"), "matching fact present: {brief}");
+        assert!(
+            !brief.contains("Polish replies"),
+            "non-matching fact filtered out: {brief}"
+        );
+
+        // Empty query → the full-list fallback (both facts, exactly the pre-L2.2 brief).
+        let brief_all = build_memory_brief(&db, "", &unlocked);
+        assert!(brief_all.contains("Project Atlas"));
+        assert!(brief_all.contains("Polish replies"));
+
+        // Zero hits → the full-list fallback too (never emptier than before).
+        let brief_nohit = build_memory_brief(&db, "qqqzzz nonexistent", &unlocked);
+        assert!(brief_nohit.contains("Project Atlas"));
+        assert!(brief_nohit.contains("Polish replies"));
+    }
+
+    /// FIX 3 RED (adversarial finding 2, reproduced): a query sharing ONLY STOPWORDS with an
+    /// irrelevant fact must NOT displace the full-list fallback. Facts {the darker theme / Polish
+    /// natively}; the question "what language should the assistant use?" shares only "the" with the
+    /// theme fact — on the pre-fix code the OR-joined FTS returned the theme fact as the whole
+    /// "relevant" set, so the brief contained ONLY the theme fact and the actually-relevant
+    /// language fact was DISPLACED. Post-fix: stopwords/<3-char tokens are dropped before the OR,
+    /// no content term matches, and the brief falls back to the FULL list — the language fact is
+    /// always present.
+    #[test]
+    fn stopword_only_overlap_never_displaces_the_full_list_fallback() {
+        use crate::facts::{FactOp, NewFact};
+        use crate::storage::models::{Meeting, MeetingStatus};
+        use crate::storage::Db;
+
+        let path = crate::storage::db::unique_temp_path("murmur-brief-stopword", "sqlite");
+        let db = Db::open_with_key(
+            &path,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+        db.insert_meeting(&Meeting {
+            id: "m1".to_string(),
+            started_at: "2026-07-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Sync".to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        let add = |predicate: &str, object: &str| {
+            FactOp::Add(NewFact {
+                entity_id: USER_SCOPE.to_string(),
+                subject: "You".to_string(),
+                predicate: predicate.to_string(),
+                object: object.to_string(),
+                valid_from: "2026-07-01T09:00:00Z".to_string(),
+                recorded_at: "2026-07-01T09:00:00Z".to_string(),
+                confidence: 1.0,
+                meeting_id: Some("m1".to_string()),
+            })
+        };
+        db.apply_user_fact_ops(&[
+            add("prefer", "the darker theme"),
+            add("speaks", "Polish natively"),
+        ])
+        .unwrap();
+        let unlocked = std::collections::HashSet::new();
+
+        // The adversarial repro query: only "the" overlaps (with the WRONG fact).
+        let brief = build_memory_brief(&db, "what language should the assistant use?", &unlocked);
+        assert!(
+            brief.contains("Polish natively"),
+            "the language fact must never be displaced by a stopword-only match: {brief}"
+        );
+        assert!(
+            brief.contains("darker theme"),
+            "zero content-word hits ⇒ the FULL-list fallback (both facts): {brief}"
+        );
+    }
+
+    /// L2.3 — the import prompt labels the pasted text as pre-extracted memories from another
+    /// assistant and hard-bounds it (bounds the prompt / leak surface).
+    #[test]
+    fn import_prompt_labels_source_and_bounds_text() {
+        let prompt = build_import_user_prompt("I prefer replies in Polish");
+        assert!(prompt.contains("ANOTHER AI ASSISTANT"));
+        assert!(prompt.contains("I prefer replies in Polish"));
+
+        // 'q' does not occur in the label text (unlike 'z' — "re-summarize"), so the count below
+        // measures ONLY the pasted excerpt.
+        let huge = "q".repeat(IMPORT_EXCERPT_CHARS * 3);
+        let bounded = build_import_user_prompt(&huge);
+        let q_count = bounded.chars().filter(|c| *c == 'q').count();
+        assert!(q_count <= IMPORT_EXCERPT_CHARS);
+    }
+
+    /// L2.3 — the stub reasoner (default install, no model) imports NOTHING, gracefully.
+    #[test]
+    fn extract_imported_memories_stub_is_empty() {
+        let out = extract_imported_memories(&crate::reason::StubReasoner, "remember: I like tea");
+        assert!(out.is_empty());
     }
 
     /// candidates_from_raw scopes every candidate to the user + drops empty pairs.

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -813,6 +813,21 @@ export class IpcService {
     return invoke<void>("clear_user_memory");
   }
 
+  /**
+   * Import pasted memories from another AI assistant (a ChatGPT/Claude "what I
+   * remember about you" export) into the user-memory store. Extraction runs
+   * STRICTLY on the on-device light brain model (local-or-stub, NEVER cloud —
+   * the pasted export never leaves the device); the candidates are reconciled
+   * (deduped) against the existing memory and anchored to one synthetic
+   * "Memory Import" meeting — deleting that meeting undoes the import.
+   * Resolves with the number of NEW facts added (0 on a duplicate re-import or
+   * when no on-device brain model is installed). Rejects with
+   * `AppError::InvalidArg` on empty text or when memory is disabled.
+   */
+  importMemories(text: string): Promise<number> {
+    return invoke<number>("import_memories", { text });
+  }
+
   // ── brain2 documents — expand the brain with imported .md/.txt files ────
 
   /**

--- a/src/app/features/brain/brain-memory/brain-memory.component.html
+++ b/src/app/features/brain/brain-memory/brain-memory.component.html
@@ -148,6 +148,12 @@
         </footer>
       </div>
     }
+
+    <!-- L2.3 — paste a ChatGPT/Claude memory export; hidden while memory is off/loading
+         (an import would be refused by the backend gate anyway). -->
+    @if (!loading() && !disabled()) {
+      <app-memory-import (imported)="onImported()" />
+    }
   }
 </section>
   

--- a/src/app/features/brain/brain-memory/brain-memory.component.ts
+++ b/src/app/features/brain/brain-memory/brain-memory.component.ts
@@ -11,6 +11,7 @@ import { IpcService } from "../../../core/ipc.service";
 import type { UserMemory, UserMemoryFact } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
 import { ToastService } from "../../../services/toast.service";
+import { MemoryImportComponent } from "../memory-import/memory-import.component";
 
 /**
  * "What the brain knows about you" — the user-memory audit section on the Brain
@@ -29,7 +30,7 @@ import { ToastService } from "../../../services/toast.service";
 @Component({
   selector: "app-brain-memory",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, MemoryImportComponent],
   templateUrl: "./brain-memory.component.html",
   styleUrl: "./brain-memory.component.scss",
 })
@@ -75,6 +76,11 @@ export class BrainMemoryComponent {
         void this.fetch();
       },
     );
+  }
+
+  /** Refetch after a memory import added new facts (L2.3 — the child emits `imported`). */
+  onImported(): void {
+    void this.fetch();
   }
 
   /** Render one fact as a plain sentence: "<subject> <predicate> <object>". */

--- a/src/app/features/brain/memory-import/memory-import.component.html
+++ b/src/app/features/brain/memory-import/memory-import.component.html
@@ -1,0 +1,62 @@
+<section class="mi">
+  <button
+    type="button"
+    class="mi-toggle"
+    [attr.aria-expanded]="open()"
+    (click)="open.set(!open())"
+  >
+    <svg
+      class="mi-chevron"
+      [class.is-open]="open()"
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M5.5 4l5 4-5 4"
+        stroke="currentColor"
+        stroke-width="1.7"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    Import memories from another assistant
+  </button>
+
+  @if (open()) {
+    <div class="mi-body">
+      <p class="mi-hint text-secondary">
+        Paste what ChatGPT or Claude remembers about you. Murmur extracts the
+        durable facts on-device, skips anything it already knows, and files the
+        import as one “Memory Import” entry you can delete to undo.
+      </p>
+      <textarea
+        class="mi-text"
+        rows="5"
+        [value]="text()"
+        (input)="onInput($event)"
+        [disabled]="importing()"
+        placeholder="Paste the exported memories here…"
+        aria-label="Memories to import"
+      ></textarea>
+      <div class="mi-actions">
+        @if (lastCount() === 0) {
+          <span class="mi-result text-secondary">
+            Nothing new to import — these memories are already known (or no
+            on-device model is available to read them).
+          </span>
+        }
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="runImport()"
+          [disabled]="!canImport()"
+        >
+          {{ importing() ? "Importing…" : "Import" }}
+        </button>
+      </div>
+    </div>
+  }
+</section>

--- a/src/app/features/brain/memory-import/memory-import.component.scss
+++ b/src/app/features/brain/memory-import/memory-import.component.scss
@@ -1,0 +1,80 @@
+:host {
+  display: block;
+}
+.mi {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Small collapsible affordance under the memory card (mirrors .mem-toggle, quieter). */
+.mi-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  align-self: flex-start;
+  padding: var(--space-1) 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+}
+.mi-toggle:hover {
+  color: var(--text-primary);
+}
+.mi-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+  border-radius: var(--radius-sm);
+}
+.mi-chevron {
+  flex: none;
+  transition: transform var(--transition);
+}
+.mi-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.mi-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.mi-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+.mi-text {
+  width: 100%;
+  resize: vertical;
+  min-height: 96px;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+.mi-text:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.mi-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.mi-result {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}

--- a/src/app/features/brain/memory-import/memory-import.component.ts
+++ b/src/app/features/brain/memory-import/memory-import.component.ts
@@ -1,0 +1,72 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import { ToastService } from "../../../services/toast.service";
+
+/**
+ * Brain v2 L2.3 — "Import memories from another assistant": paste a ChatGPT /
+ * Claude memory export, one Import button. The backend extracts STRICTLY on
+ * the on-device light reasoner (local-or-stub, never cloud — the pasted export
+ * never leaves the device), dedups against the existing memory (reconcile →
+ * NoOps on a re-import), and anchors the new facts to a synthetic "Memory
+ * Import" meeting — so the whole import is undoable by deleting that meeting.
+ * No local brain model ⇒ 0 imported (the empty-result hint mentions it). Emits
+ * `imported` with the added count so the parent audit list can refetch.
+ *
+ * Signals-first + OnPush; ZERO egress by construction.
+ */
+@Component({
+  selector: "app-memory-import",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./memory-import.component.html",
+  styleUrl: "./memory-import.component.scss",
+})
+export class MemoryImportComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
+
+  /** Fires after a successful import with the number of NEW facts added. */
+  readonly imported = output<number>();
+
+  /** Collapsed by default — an occasional migration affordance, not a headline. */
+  readonly open = signal(false);
+  readonly text = signal("");
+  readonly importing = signal(false);
+  /** The last import's added count (`null` until an import ran). */
+  readonly lastCount = signal<number | null>(null);
+
+  readonly canImport = computed(
+    () => !this.importing() && this.text().trim().length > 0,
+  );
+
+  onInput(event: Event): void {
+    this.text.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  async runImport(): Promise<void> {
+    if (!this.canImport()) return;
+    this.importing.set(true);
+    this.lastCount.set(null);
+    try {
+      const n = await this.ipc.importMemories(this.text());
+      this.lastCount.set(n);
+      if (n > 0) {
+        this.text.set("");
+        this.toast.info(
+          n === 1 ? "Imported 1 memory." : `Imported ${n} memories.`,
+        );
+        this.imported.emit(n);
+      }
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.importing.set(false);
+    }
+  }
+}


### PR DESCRIPTION
Brain v2 PR 4 (plan: `docs/research/2026-07-09-brain-v2-architecture-spec.md` §L2.1–L2.3).

## What
- **L2.2 Relevance-filtered memory brief:** `fts_user_facts` (external-content FTS5 + trigger trio) + gated `search_user_facts_visible` (byte-same visibility predicate) + `build_memory_brief` — the user-memory brief is now retrieved against the current question (top-8) instead of always injecting the full 2k block; empty/all-stopword queries keep today's full-list behavior. Threaded into `chat_meeting`, `ask_vault` (floor + agentic) and the live cascade.
- **L2.1 Consolidation/reflection job:** new `memory.rs` — deterministic scoring (recency `0.995^h` + importance + relevance, 0.4/0.4/0.2), batch importance on the **local** light reasoner, entity reflections (≥3 facts OR importance ≥7) + weekly rollup, exported as `.md` to `<vault>/brain/memory/` (content-free UUID filenames, atomic write). Hourly tokio loop, per-tick flag+stub checks, warn-and-continue, DB lock never held across an LLM call. New flag `memory_consolidation_enabled` (default true).
- **L2.3 Memory import (ClickUp-parity):** paste a ChatGPT/Claude memory export → `import_memories` extracts facts **on-device only** (`light()`, structurally never cloud — test-pinned), reconcile-dedups vs existing facts, anchors to a synthetic `Memory Import` meeting created only when something was added; deleting that meeting undoes the import. Minimal FE (`memory-import` component in the brain-memory view).

## Verification (two rounds)
- **Round 1: both reviewers FAIL** on the same reproduced blocker — *sealed-derived rollup synthesis persisted forever in `memory_rollups` + the exported vault `.md`* (weekly rollups never regenerated; entity rollups only on new facts). Adversarial also found stopword-only OR matches displacing the brief fallback.
- **Fixes:** seal-time purge of ALL rollup rows in every seal tx (`lock_folder`, move-into-locked, relock/relock-all incl. screen-share auto-relock, startup reconcile, `delete_meeting`) + deletion of the recorded exported files at the command layer (same layering as sealed-note `.md`s); per-pass GC/regeneration via `fact_set_hash` (weekly included); stopword/<3-char filter before the FTS OR-join; importance≥7 arm; single-tx FTS backfill; import routed `light()`-only.
- **Round 2: both PASS** — adversarial re-proved RED with 5 mutations (7 tests fail on old logic), re-ran its original end-to-end repro (rollup + `.md` gone at seal time; a week-later pass recreates nothing from sealed facts), cross-folder regeneration verified. Lock-security walked every seal path incl. the screenshare funnel.
- `cargo test --lib`: 1242/0. `ng lint` + `ng build`: green. `scripts/ci.sh`: ✅ (after 4 `doc_lazy_continuation` lint fixes).

## Known limitations (documented)
- **Pass-vs-seal TOCTOU (non-blocking, lock-reviewer):** a consolidation pass overlapping a `lock_folder` can write a rollup after the seal; triple-healed (next pass GCs it, any relock purges, startup reconcile purges), max ~1h exposure in a running session. Follow-up: seal-epoch counter.
- Past-week weekly rollups are dropped by purge-all and not recreated (derived synthesis only; privacy-over-convenience).
- Pre-existing flaky test noted (not this diff): `afm::probe_reports_available_through_a_fixture_sidecar` — env-var race under parallel tests; passed on re-run. Follow-up: parameterize the override instead of `env::set_var`.
- Real light-model reflection/importance quality + the live hourly tick need a Mac session with the brain model.