### PR TITLE
feat(brain): L4 live brain — novelty gatekeeper, incremental bullets, boundary-timed surfacing

### DIFF
--- a/.claude/learnings/main-loop.md
+++ b/.claude/learnings/main-loop.md
@@ -98,3 +98,9 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
   SSL Full, but disable Rocket-Loader/Email-Obfuscation or they break the strict-CSP viewer).
 - **Status:** superseded by `2026-07-05 landing/API deploy` (final fix was CNAME + TXT +
   wait/poll; cert became `CERTIFICATE_STATUS_TYPE_VALID`)
+
+### [2026-07-10 brain-l4-live] Never run the MUTATING adversarial verifier concurrently with the READ-ONLY lock auditor
+- **Pattern:** both verifiers dispatched in parallel on the same uncommitted diff; the adversarial's mutation-probe (removing a purge site, then restoring byte-identical) overlapped the lock reviewer's audit window — the lock reviewer saw the mutated tree, reported a "blocking leak" for code that was present before and after, and burned a FAIL verdict + an investigation on a concurrency artifact.
+- **Caught by:** the lock reviewer's own tree-state warning (diff hunk count changed mid-audit) + a post-hoc grep/test on the settled tree.
+- **Lesson:** patch-and-restore verifiers get EXCLUSIVE tree access. Run adversarial first, lock-security after (or vice versa) — never both at once on a dirty tree. If parallelism matters, give the mutating verifier a worktree.
+- **Status:** journal

--- a/src-tauri/examples/e2e_core.rs
+++ b/src-tauri/examples/e2e_core.rs
@@ -71,6 +71,7 @@ async fn main() {
         vault_titles,
         related_context: None,
         user_notes: None,
+        live_bullets: None,
     };
 
     let provider = ClaudeCodeProvider::new();

--- a/src-tauri/src/brain_reactions.rs
+++ b/src-tauri/src/brain_reactions.rs
@@ -140,7 +140,35 @@ fn extract_fact_candidates_capped(
 
 /// Chars of the live-transcript TAIL fed to one reactions scan — a bounded recent window (the far
 /// side's latest utterances), kept small so the light extraction stays a ~2–3-sentence task.
+/// LEGACY substrate: used only when the running bullets are empty/off (see [`reaction_window`]).
 const REACTION_WINDOW_CHARS: usize = 600;
+
+/// Chars of VERBATIM transcript tail appended after the running bullets in the L4 substrate —
+/// the bullets carry the meeting's accumulated context, so the verbatim part only needs the very
+/// latest utterance.
+const REACTION_VERBATIM_TAIL_CHARS: usize = 300;
+
+/// Brain v2 L4 — assemble the scan window (PURE): with non-empty running `bullets` the substrate
+/// is `bullets + the last `[`REACTION_VERBATIM_TAIL_CHARS`]` chars verbatim` (the bullets give the
+/// extraction the meeting's context, the tail gives it the fresh utterance); with bullets
+/// empty/off it is EXACTLY the legacy [`REACTION_WINDOW_CHARS`] tail — byte-identical behavior.
+///
+/// ACCEPTED POSTURE (lock-security nit, 2026-07-10): the `bullets` input is the UNGATED RAM read
+/// of `AppState::live_bullets` in [`reactions_scan`] — the same class as the pre-existing ungated
+/// `live_transcript` tail (the CURRENT recording's own captions, already on-screen). It feeds
+/// ONLY the on-device light engine (never a cloud call); the widened exposure is that a
+/// WhisperCard can QUOTE from the whole-meeting bullets digest (up to 4k chars) rather than the
+/// 600-char raw tail, and the boundary queue (≤30s max-hold + drain-on-stop) can emit such a card
+/// shortly after a mid-recording relock. Accepted because the substrate never leaves the device,
+/// the RAM buffer is cleared at recording start/Stop + the lock-surface idle hygiene, and every
+/// PERSISTED / prompt-injected read of the bullets IS gated (`gated_live_bullets`, fail-closed).
+pub(crate) fn reaction_window(bullets: &str, live: &str) -> String {
+    let b = bullets.trim();
+    if b.is_empty() {
+        return tail(live, REACTION_WINDOW_CHARS);
+    }
+    format!("{b}\n{}", tail(live, REACTION_VERBATIM_TAIL_CHARS))
+}
 
 /// The gated result of one live-loop reactions scan: the cards + whether they should be EMITTED (the
 /// contradiction sub-toggle is ON) or SHADOW-counted (OFF). Computed OFF the live tick thread.
@@ -151,10 +179,21 @@ pub struct ReactionScan {
 
 /// One Realtime-Reactions scan wired to the running app (spec §4). GATED: no cards unless Brain Live
 /// is ON and the LIGHT model is present (a stub reasoner yields nothing — feature degraded, NEVER a
-/// cloud call). Reads the live-transcript tail + gated entities and runs [`detect_reactions`] on the
-/// light engine. `emit` mirrors the `brain_contradiction_cards` sub-toggle (OFF ⇒ shadow: count,
+/// cloud call). Reads the scan substrate ([`reaction_window`] — running bullets + a short verbatim
+/// tail when the L4 bullets are on, the legacy raw tail otherwise) and runs [`detect_reactions`] on
+/// the light engine. `emit` mirrors the `brain_contradiction_cards` sub-toggle (OFF ⇒ shadow: count,
 /// don't show). IMPURE, Mac-verified inference path; the CALLER runs it OFF the live tick thread.
-pub fn reactions_scan(app: &tauri::AppHandle, now: &str) -> ReactionScan {
+///
+/// Brain v2 L4: `entities` is the caller's tick-thread [`crate::transcribe::novelty::RefreshableEntityCache`]
+/// snapshot (the gated `list_entities_visible` read, refreshed every ~60 ticks) — passed in so the
+/// scan stops re-fetching the list per scan. Staleness affects TRIGGER/candidate names only, never
+/// content: the fact reads inside [`detect_reactions`] re-check `list_facts_visible` against the
+/// FRESH unlocked set, so a mid-recording relock still surfaces nothing.
+pub fn reactions_scan(
+    app: &tauri::AppHandle,
+    now: &str,
+    entities: &[(String, String)],
+) -> ReactionScan {
     use tauri::Manager;
     let empty = ReactionScan {
         cards: Vec::new(),
@@ -185,24 +224,27 @@ pub fn reactions_scan(app: &tauri::AppHandle, now: &str) -> ReactionScan {
         .lock()
         .map(|u| u.clone())
         .unwrap_or_default();
-    let current = st
-        .current_meeting
+    // Brain v2 L4 substrate: running bullets (RAM — populated only when `live_bullets_enabled`
+    // AND a light model is present, so empty ⇒ the legacy raw tail, byte-identical behavior).
+    // Both inputs stay on-device: the window feeds ONLY the local light extraction below.
+    let bullets = st
+        .live_bullets
         .lock()
-        .ok()
-        .and_then(|m| m.map(|id| id.to_string()))
+        .map(|b| b.clone())
         .unwrap_or_default();
-    let window = st
+    let live = st
         .live_transcript
         .lock()
-        .map(|b| tail(&b, REACTION_WINDOW_CHARS))
+        .map(|b| b.clone())
         .unwrap_or_default();
+    let window = reaction_window(&bullets, &live);
     if window.trim().is_empty() {
         return ReactionScan {
             cards: Vec::new(),
             emit,
         };
     }
-    let entities = resolve_window_entities(&st.db, &unlocked, &current, &window);
+    let entities = filter_window_entities(entities, &window);
     let cards = detect_reactions(&*reasoner, &st.db, &unlocked, &entities, &window, now);
     // SESSION dedup (deep-review): a contradiction surfaces at most ONCE per recording — else the same
     // card re-emits every ~21 s scan and (in shadow mode) re-inflates the calibration count. Keyed on
@@ -238,25 +280,24 @@ fn tail(s: &str, n: usize) -> String {
     }
 }
 
-/// Resolve the VISIBLE entities whose name appears in the `window` (case-insensitive substring), for
-/// fact lookup. The current meeting is not special-cased: its facts aren't persisted mid-recording, so
-/// there is nothing of its own to surface. Gated: `list_entities_visible` already drops sealed-only
-/// entities. Best-effort — a failed read yields no entities (no cards), never a panic.
-fn resolve_window_entities(
-    db: &Db,
-    unlocked: &HashSet<String>,
-    _current_meeting_id: &str,
+/// Filter the caller-supplied VISIBLE entity list (the tick thread's shared cache — gated at fetch
+/// time by `list_entities_visible`) down to the entities whose name appears in the `window`
+/// (case-insensitive substring), for fact lookup. The current meeting is not special-cased: its
+/// facts aren't persisted mid-recording, so there is nothing of its own to surface. Pure —
+/// headless-testable; the content gate stays downstream (`list_facts_visible` on the FRESH
+/// unlocked set inside [`detect_reactions`]).
+pub(crate) fn filter_window_entities(
+    entities: &[(String, String)],
     window: &str,
 ) -> Vec<(String, String)> {
     let wl = window.to_lowercase();
-    db.list_entities_visible(unlocked)
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|n| {
-            let name = n.name.trim();
+    entities
+        .iter()
+        .filter(|(_, name)| {
+            let name = name.trim();
             !name.is_empty() && wl.contains(&name.to_lowercase())
         })
-        .map(|n| (n.id, n.name))
+        .cloned()
         .collect()
 }
 
@@ -336,6 +377,36 @@ mod tests {
         assert!(should_defer_scan(&flag), "user turn in flight: defer");
         flag.store(false, std::sync::atomic::Ordering::Relaxed);
         assert!(!should_defer_scan(&flag), "turn ended: the scan resumes");
+    }
+
+    /// Brain v2 L4 — the scan substrate: with bullets EMPTY the window is byte-identical to the
+    /// legacy 600-char tail; with bullets present it is `bullets + last-300-chars verbatim`.
+    #[test]
+    fn reaction_window_is_legacy_tail_without_bullets_and_bullets_plus_tail_with() {
+        let live = "x".repeat(1_000);
+        // Empty / whitespace bullets ⇒ EXACTLY the legacy tail.
+        assert_eq!(reaction_window("", &live), tail(&live, 600));
+        assert_eq!(reaction_window("   \n", &live), tail(&live, 600));
+        // Bullets present ⇒ bullets first, then only the short verbatim tail.
+        let w = reaction_window("- [deal]: pricing agreed", &live);
+        assert!(w.starts_with("- [deal]: pricing agreed\n"));
+        let verbatim = w.split_once('\n').unwrap().1;
+        assert_eq!(verbatim.chars().count(), 300, "verbatim tail bounded at 300");
+    }
+
+    /// Brain v2 L4 — the entity filter over the SHARED tick-thread cache: whole-window
+    /// case-insensitive containment, empty names dropped, non-mentioned entities dropped.
+    #[test]
+    fn filter_window_entities_matches_case_insensitively() {
+        let entities = vec![
+            ("e1".to_string(), "Atlas".to_string()),
+            ("e2".to_string(), "Kraken".to_string()),
+            ("e3".to_string(), "  ".to_string()),
+        ];
+        let hits = filter_window_entities(&entities, "wracamy do tematu atlas w przyszłym tygodniu");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, "e1");
+        assert!(filter_window_entities(&entities, "nic o nich").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -469,6 +469,9 @@ pub async fn start_recording(
     if let Ok(mut e) = state.reactions_emitted.lock() {
         e.clear();
     }
+    // Brain v2 L4: fresh recording ⇒ fresh running bullets (RAM buffer + delta tracker) — a stale
+    // previous meeting's bullets must never seed the new meeting's substrate or prompt inject.
+    crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
 
     let meeting_uuid = uuid::Uuid::new_v4();
     let meeting_id = meeting_uuid.to_string();
@@ -662,6 +665,10 @@ pub async fn stop_recording(
     // stale tail can never be injected into assistant prompts after Stop (nor keep egressing once
     // the just-recorded folder is sealed). The authoritative transcript is produced below.
     crate::transcribe::live::clear_live_transcript(&state.live_transcript);
+    // Brain v2 L4: clear the running-bullets RAM the same way. The crash-recovery `live_bullets`
+    // DB row deliberately SURVIVES this clear — the note pipeline below reads it as the
+    // "Live notes (auto)" Stage-1 input and consumes (clears) it after the note persists.
+    crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
 
     let meeting_uuid = {
         let mut current = state
@@ -5543,6 +5550,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         brain_heavy_grammar_enabled: current.brain_heavy_grammar_enabled,
         ask_jit_retrieval: current.ask_jit_retrieval,
         loop_transcript_compaction: current.loop_transcript_compaction,
+        // Brain v2 L4: the live-bullets flag is NOT carried on the settings DTO (no FE toggle
+        // yet) — PRESERVE the live value (same discipline as the L3 flags above); it round-trips
+        // through the dedicated K_LIVE_BULLETS_ENABLED load/save keys.
+        live_bullets_enabled: current.live_bullets_enabled,
         // Model-role keys ARE settable from the DTO (a future Settings UI owns the rows), like
         // `gateway_model` — plain strings, `""` = inherit legacy. An omitted key deserializes to
         // `""` (`#[serde(default)]`), so an older FE payload can never flip a role.
@@ -7905,6 +7916,12 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
 fn clear_stale_live_transcript(state: &AppState) {
     let recording = state.recorder.lock().map(|g| g.is_some()).unwrap_or(true);
     crate::transcribe::live::clear_live_transcript_if_idle(&state.live_transcript, recording);
+    // Brain v2 L4: the running-bullets RAM mirrors the live buffer — same idle-only hygiene
+    // (never wipe an in-flight recording's bullets; mid-recording correctness is owned by the
+    // `gated_live_bullets` visibility gate).
+    if !recording {
+        crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
+    }
 }
 
 /// SESSION-unlock a sealed folder: KEK → unwrap CK → decrypt each note's `content_blob` back into
@@ -11864,6 +11881,8 @@ mod lifecycle_tests {
             current_meeting: Mutex::new(None),
             focus_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
+            live_bullets: Mutex::new(String::new()),
+            live_bullets_tracker: Mutex::new(crate::transcribe::bullets::BulletsTracker::default()),
             capped_notified: std::sync::atomic::AtomicBool::new(false),
             reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
             reactions_emitted: Mutex::new(HashSet::new()),

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -974,6 +974,20 @@ async fn summarize_and_export(
     // resummarize is gated upstream by meeting_is_unlocked).
     let manual_notes = state.db.get_manual_notes(meeting_id).unwrap_or_default();
 
+    // Brain v2 L4 — the RUNNING LIVE BULLETS captured during the recording (the crash-recovery
+    // `live_bullets` row `transcribe::bullets::bullets_tick` maintained; the RAM buffer was
+    // already cleared at Stop). PRODUCER-side read like `manual_notes` above (ungated by design
+    // here — the pipeline produces this meeting's own note plaintext; a sealed meeting has no row
+    // anyway, purge-on-seal). Present ⇒ rendered as the "Live notes (auto)" section before the
+    // transcript (riding the RedactingProvider firewall like every other prompt field) and
+    // CONSUMED (row cleared) after the note persists below; absent (bullets off / stub /
+    // resummarize after the consume) ⇒ the prompt is byte-identical to before.
+    let live_bullets = state
+        .db
+        .get_live_bullets(meeting_id)
+        .unwrap_or_default()
+        .filter(|b| !b.trim().is_empty());
+
     let request = SummarizeRequest {
         // TIER 0: the SPEAKER-LABELED transcript (or the flat one for a solo-`me` meeting). It rides
         // `req.transcript`, so the RedactingProvider firewall scrubs any name in a `(speaker)` tag.
@@ -994,6 +1008,7 @@ async fn summarize_and_export(
         } else {
             None
         },
+        live_bullets: live_bullets.clone(),
     };
 
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;
@@ -1092,6 +1107,16 @@ async fn summarize_and_export(
         model_served: call_meta.model_served.clone(),
         gateway_host,
     })?;
+
+    // Brain v2 L4 — the live bullets are now folded into the persisted note: CONSUME the
+    // crash-recovery row (best-effort; a failed clear only means a later resummarize would see
+    // the same bullets again — never content loss). A summarize FAILURE above keeps the row, so
+    // a retry / crash-salvage re-run still gets its bullets.
+    if live_bullets.is_some() {
+        if let Err(e) = state.db.clear_live_bullets(meeting_id) {
+            tracing::debug!(target: "bullets", error = %e, "live-bullets consume (row clear) failed");
+        }
+    }
 
     // brain2 RAG Phase 2b — index the just-persisted note into the on-device vector layer, GATED by
     // the master flag AND the meeting's visibility (never index a sealed-not-unlocked folder's

--- a/src-tauri/src/prompts.rs
+++ b/src-tauri/src/prompts.rs
@@ -63,6 +63,33 @@ pub const MEETING_JUST_STARTED_PHRASE: &str = "meeting just started";
 pub const NO_SUBSTITUTE_OTHER_MEETINGS_PHRASE: &str =
     "do NOT search the vault for other saved meetings";
 
+// ── Brain v2 L4 — INCREMENTAL LIVE BULLETS (the running-notes prompt) ────────────────────────────
+// Used by `transcribe::bullets::update_bullets` on the LOCAL light reasoner only (never a cloud
+// call): previous bullets + the new transcript delta → at most 3 NEW bullets, or the literal
+// `NOTHING`. Prefix-prompted so the (KV-cached) previous bullets stay a stable prefix across calls.
+
+/// The literal token the bullets model must emit when the delta adds nothing noteworthy.
+/// `transcribe::bullets::update_bullets` treats it (case-insensitively) as "no new bullets".
+pub const LIVE_BULLETS_NOTHING: &str = "NOTHING";
+
+/// System prompt for the incremental live-bullets update (Brain v2 L4). Small-model-friendly:
+/// one narrow task, a fixed line format, and an explicit no-op token.
+pub const LIVE_BULLETS_SYSTEM: &str = "You maintain RUNNING NOTES for a meeting in progress. You \
+    are given the bullets so far and a NEW fragment of the live transcript. Output ONLY new \
+    bullets for genuinely NEW information in the fragment (decisions, facts, owners, dates, open \
+    questions) — never restate an existing bullet. Format: at most 3 lines, each exactly \
+    `- [topic]: point`, in the language of the transcript. If the fragment adds nothing \
+    noteworthy (filler, repetition, small talk), reply with EXACTLY the single word NOTHING and \
+    nothing else. No preamble, no commentary, no numbering.";
+
+/// The user message for one incremental bullets update: the bullets so far (may be empty) + the
+/// new transcript delta. Pure formatting — no I/O.
+pub fn live_bullets_user(previous_bullets: &str, delta: &str) -> String {
+    let prev = previous_bullets.trim();
+    let prev_block = if prev.is_empty() { "(none yet)" } else { prev };
+    format!("NOTES SO FAR:\n{prev_block}\n\nNEW TRANSCRIPT FRAGMENT:\n{}", delta.trim())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,6 +112,18 @@ mod tests {
     fn prompt_version_is_a_dated_stamp() {
         assert!(PROMPT_VERSION.starts_with('v'));
         assert!(PROMPT_VERSION.len() >= "v2026-01-01".len());
+    }
+
+    /// Brain v2 L4 — the bullets prompt carries the exact no-op token `update_bullets` detects,
+    /// and the user message renders both blocks (empty previous bullets get the "(none yet)"
+    /// placeholder so the prefix shape is stable).
+    #[test]
+    fn live_bullets_prompt_carries_nothing_token_and_renders_blocks() {
+        assert!(LIVE_BULLETS_SYSTEM.contains(LIVE_BULLETS_NOTHING));
+        let u = live_bullets_user("- [budget]: capped at 10k", "we also agreed Anna owns QA");
+        assert!(u.contains("NOTES SO FAR:\n- [budget]: capped at 10k"));
+        assert!(u.contains("NEW TRANSCRIPT FRAGMENT:\nwe also agreed Anna owns QA"));
+        assert!(live_bullets_user("", "delta").contains("(none yet)"));
     }
 
     /// The recording-awareness phrases stay the exact substrings the cascade prompt tests pin —

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -446,6 +446,15 @@ pub struct AppConfig {
     /// K_LOOP_TRANSCRIPT_COMPACTION.
     #[serde(default = "default_true")]
     pub loop_transcript_compaction: bool,
+    /// Brain v2 L4 — INCREMENTAL LIVE BULLETS: the reactions worker maintains running
+    /// `- [topic]: point` notes of the recording in progress on the LOCAL light engine
+    /// (`transcribe::bullets`, zero egress). Default ON — the worker itself no-ops to the legacy
+    /// behavior when no local light model is present (the stub guard), so ON is safe on every
+    /// install; OFF is the field escape hatch (legacy raw-tail reactions substrate, no bullets
+    /// row, legacy 6k live inject). ADDITIVE; not on the settings DTO; round-trips via
+    /// K_LIVE_BULLETS_ENABLED.
+    #[serde(default = "default_true")]
+    pub live_bullets_enabled: bool,
     /// Model-role override — the CONNECTION serving the **Notes** role (everything Murmur writes).
     /// `""` (the default, and every pre-role install) = inherit the legacy mapping EXACTLY — see
     /// [`crate::summarize::roles::resolve`]. Values: `claude_code`/`anthropic`/`ollama`/`gateway`
@@ -559,6 +568,7 @@ impl Default for AppConfig {
             brain_heavy_grammar_enabled: false,
             ask_jit_retrieval: false,
             loop_transcript_compaction: true,
+            live_bullets_enabled: true,
             role_notes_connection: String::new(),
             role_notes_model: String::new(),
             role_notes_effort: String::new(),
@@ -636,6 +646,7 @@ const K_GROUND_SUMMARY: &str = "ground_summary";
 const K_BRAIN_HEAVY_GRAMMAR_ENABLED: &str = "brain_heavy_grammar_enabled";
 const K_ASK_JIT_RETRIEVAL: &str = "ask_jit_retrieval";
 const K_LOOP_TRANSCRIPT_COMPACTION: &str = "loop_transcript_compaction";
+const K_LIVE_BULLETS_ENABLED: &str = "live_bullets_enabled";
 const K_ROLE_NOTES_CONNECTION: &str = "role_notes_connection";
 const K_ROLE_NOTES_MODEL: &str = "role_notes_model";
 const K_ROLE_NOTES_EFFORT: &str = "role_notes_effort";
@@ -850,6 +861,9 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_LOOP_TRANSCRIPT_COMPACTION)? {
             cfg.loop_transcript_compaction = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_LIVE_BULLETS_ENABLED)? {
+            cfg.live_bullets_enabled = v == "true";
         }
         // Model-role keys: `""` is a VALID value (= inherit legacy) and also the default, so the
         // stored value is taken verbatim (mirrors `provider_model`, not `anthropic_model`).
@@ -1148,6 +1162,14 @@ impl AppConfig {
         db.set_setting(
             K_LOOP_TRANSCRIPT_COMPACTION,
             if self.loop_transcript_compaction {
+                "true"
+            } else {
+                "false"
+            },
+        )?;
+        db.set_setting(
+            K_LIVE_BULLETS_ENABLED,
+            if self.live_bullets_enabled {
                 "true"
             } else {
                 "false"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -177,6 +177,19 @@ pub struct AppState {
     /// Prevents the same contradiction re-emitting every ~21 s scan (and re-inflating the shadow count)
     /// — the "does not resurface this session" contract (deep-review). Cleared at each `start_recording`.
     pub reactions_emitted: Mutex<std::collections::HashSet<String>>,
+    /// Brain v2 L4 — the RUNNING LIVE BULLETS of the recording IN PROGRESS (RAM, capped at
+    /// `transcribe::bullets::MAX_BULLETS_CHARS`, front-trimmed on line boundaries). Updated by the
+    /// reactions worker (`transcribe::bullets::bullets_tick`, behind `reactions_busy`); consumed
+    /// by the reactions substrate (`brain_reactions::reaction_window`), the gated live-question
+    /// inject (`transcribe::live::compose_live_inject`), and — via the crash-recovery
+    /// `live_bullets` DB row — the Stop-time note (`SummarizeRequest::live_bullets`). Cleared at
+    /// recording start + Stop + the lock-surface idle hygiene (mirrors `live_transcript`); prompt
+    /// reads are gated on the scope meeting's visibility (`gated_live_bullets`, fail-closed).
+    pub live_bullets: Mutex<String>,
+    /// Brain v2 L4 — the bullets' delta position over `live_transcript` (offset + anchor, see
+    /// `transcribe::bullets::BulletsTracker`), advanced by the WORKER at its own busy-gated pace
+    /// so a skipped scan's text reaches the next update. Reset with `live_bullets`.
+    pub live_bullets_tracker: Mutex<crate::transcribe::bullets::BulletsTracker>,
     /// Brain v2 P0.3 — per-meeting IN-FLIGHT assistant-turn counter: how many assistant turns are
     /// currently running for each scope meeting (key = the FE-sent meeting id, "" for the unscoped
     /// voice/wake path). `spawn_assistant_turn` DEDUPS on it: a second turn for the same key while one
@@ -292,6 +305,8 @@ impl AppState {
             current_meeting: Mutex::new(None),
             focus_meeting: Mutex::new(None),
             live_transcript: Mutex::new(String::new()),
+            live_bullets: Mutex::new(String::new()),
+            live_bullets_tracker: Mutex::new(crate::transcribe::bullets::BulletsTracker::default()),
             capped_notified: AtomicBool::new(false),
             reactions_shadow_count: AtomicU64::new(0),
             reactions_emitted: Mutex::new(std::collections::HashSet::new()),

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -365,6 +365,21 @@ impl Db {
              );
              CREATE INDEX IF NOT EXISTS idx_assistant_interactions_meeting
                ON assistant_interactions(meeting_id);
+             -- Brain v2 L4: CRASH-RECOVERY row for the incremental live bullets of a recording in
+             -- progress (`transcribe::bullets`). RAM (`AppState::live_bullets`) is authoritative
+             -- during the recording; this row lets a crash-salvaged meeting still feed its bullets
+             -- into the Stop-time note (`SummarizeRequest::live_bullets`). DERIVED meeting content
+             -- (the L2 lesson): PURGED on every seal path (`purge_chunks_for_meetings`,
+             -- `blank_sealed_notes_in_folders`, `reblank_locked_folders_at_rest`,
+             -- `discard_folder_seal`) and on `delete_meeting` (explicit + FK CASCADE); the write
+             -- refuses in-tx when the meeting is sealed at rest (`upsert_live_bullets`); consumed
+             -- + cleared by the note pipeline at Stop. Never read by an FE command.
+             CREATE TABLE IF NOT EXISTS live_bullets (
+               meeting_id TEXT PRIMARY KEY,
+               bullets_md TEXT NOT NULL,
+               updated_at TEXT NOT NULL,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
              -- brain2 R2: the BITEMPORAL FACTS layer. One row per entity·predicate·object
              -- assertion with TWO time axes: valid_from/valid_to (valid time — when the fact was
              -- true; valid_to NULL = currently valid, set when superseded) and recorded_at
@@ -2052,6 +2067,10 @@ impl Db {
         // purge_supersessions_tx). Their pre-images hold plaintext note bytes; a deleted meeting must
         // leave none behind.
         Self::purge_supersessions_tx(&tx, &[id.to_string()])?;
+        // Brain v2 L4: drop this meeting's live-bullets crash-recovery row EXPLICITLY in the same
+        // tx (the meetings FK CASCADE also covers it — the explicit delete keeps the purge visible
+        // and test-bound alongside the other derived artifacts).
+        Self::purge_live_bullets_tx(&tx, &[id.to_string()])?;
         // Brain v2 L2.2: purge this meeting's user facts EXPLICITLY (direct DELETE) rather than
         // relying on the meetings FK cascade alone — the direct DELETE reliably fires the
         // `fts_user_facts_ad` trigger, so the deleted facts' tokens leave the FTS index in this
@@ -2655,6 +2674,10 @@ impl Db {
         // Voice-assistant Q&A log is plaintext-derived convenience data mirroring sealed content —
         // drop it in the SAME seal tx (purge-on-seal, like corrections). Dropped by design.
         Self::purge_assistant_interactions_tx(&tx, meeting_ids)?;
+        // Brain v2 L4 LOCK-SAFETY: the live-bullets crash-recovery row is plaintext-derived
+        // running notes of the meeting — drop it in the SAME seal tx (purge-on-seal, like the
+        // assistant interactions above). Dropped by design; the transcript stays sealed+restorable.
+        Self::purge_live_bullets_tx(&tx, meeting_ids)?;
         // brain2 R2: bitemporal facts are DERIVED content tied to the meeting (plaintext at rest);
         // drop them in the SAME seal tx so a sealed meeting contributes no fact — same purge-on-seal
         // contract as corrections / chunks / assistant interactions.
@@ -4419,7 +4442,7 @@ impl Db {
     /// In one transaction, scoped to THIS folder's meetings + documents: NULL every sealed blob and
     /// blank the (already-empty) plaintext columns, purge every derived table that could hold
     /// sealed-content-derived data (chunks/vectors/facts/user-facts/correction-log/assistant-log/
-    /// voiceprints), then clear the folder's `wrapped_key` and set `locked = 0`. Returns the at-rest
+    /// voiceprints/live-bullets), then clear the folder's `wrapped_key` and set `locked = 0`. Returns the at-rest
     /// audio columns of the folder's meetings so the caller can delete the orphaned `.enc` files on
     /// disk (the DB layer stays pure-SQL). NEVER call this without the caller's non-recoverability
     /// proof — it is the one path that discards sealed content by design (and now provably only the
@@ -4542,6 +4565,11 @@ impl Db {
             "facts",
             "user_facts",
             "speaker_voiceprints",
+            // Brain v2 L4 (lock-security W3): the live-bullets crash-recovery row is the same
+            // derived-plaintext class — purge it with the rest (contract consistency; a reachable
+            // row at discard time only ever digests never-sealed plaintext, but the "purge every
+            // derived table" contract must not silently exclude one table).
+            "live_bullets",
         ] {
             tx.execute(
                 &format!("DELETE FROM {table} WHERE meeting_id IN ({FOLDER_MEETINGS})"),
@@ -4856,6 +4884,10 @@ impl Db {
             // (re-blanked / sealed) folders — an applied row's plaintext note pre-image must not
             // linger at rest for a sealed folder (same purge-on-seal contract as corrections above).
             Self::purge_supersessions_tx(&tx, &meeting_ids)?;
+            // Brain v2 L4 LOCK-SAFETY: drop the live-bullets crash-recovery rows of every meeting
+            // in these (re-blanked / sealed) folders in this SAME relock tx — running notes are
+            // plaintext derived from the transcript and must not survive a relock at rest.
+            Self::purge_live_bullets_tx(&tx, &meeting_ids)?;
             // NOTE: the typed-notes (`manual_notes`) re-blank does NOT live here — it is SEALED-AND-
             // RESTORED content (not a derived/purgeable artifact like chunks/corrections), so its
             // plaintext is re-blanked only WHERE the `manual_notes_blob` exists, by
@@ -4961,6 +4993,15 @@ impl Db {
         // a restart. Same purge-on-seal contract as the correction-log above.
         tx.execute(
             &format!("DELETE FROM assistant_interactions WHERE meeting_id IN ({LOCKED_MEETINGS})"),
+            [],
+        )
+        .map_err(map_err)?;
+        // Brain v2 L4 LOCK-SAFETY: purge the live-bullets crash-recovery rows for every meeting in
+        // a locked folder, in this same reconciliation transaction — so a crash mid-recording into
+        // a since-sealed folder cannot leave the plaintext running notes at rest after a restart.
+        // Same purge-on-seal contract as the assistant-interactions above.
+        tx.execute(
+            &format!("DELETE FROM live_bullets WHERE meeting_id IN ({LOCKED_MEETINGS})"),
             [],
         )
         .map_err(map_err)?;
@@ -5843,6 +5884,103 @@ impl Db {
         for mid in meeting_ids {
             tx.execute(
                 "DELETE FROM assistant_interactions WHERE meeting_id = ?1",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
+    // ── Brain v2 L4 — the `live_bullets` crash-recovery row (transcribe::bullets) ───────────────
+
+    /// Upsert the running live bullets for the recording in progress (crash recovery for the
+    /// Stop-time note input). Written by the reactions worker only while the meeting records;
+    /// consumed + cleared by the note pipeline at Stop.
+    ///
+    /// TOCTOU LOCK-SAFETY (lock-security W2, 2026-07-10 — the same shape as the in-tx re-check in
+    /// `index_meeting_topic_chunks`): a `lock_folder` can commit BETWEEN the worker's
+    /// `current_meeting` check and this write — its seal tx purged the row, and a plaintext
+    /// re-upsert would leave sealed-meeting running notes at rest until the next relock /
+    /// Stop-consume / startup reconcile. So the write re-checks the SESSION-INDEPENDENT DB-side
+    /// sealed-at-rest invariant (a `notes` row with `content_blob` present and blank `markdown`)
+    /// inside its own transaction and REFUSES silently (`Ok(())` — the worker is best-effort; the
+    /// RAM copy is cleared by the lock surface anyway).
+    pub fn upsert_live_bullets(
+        &self,
+        meeting_id: &str,
+        bullets_md: &str,
+        updated_at: &str,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let sealed_at_rest: bool = tx
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM notes
+                    WHERE meeting_id = ?1
+                      AND content_blob IS NOT NULL
+                      AND (markdown IS NULL OR markdown = '')
+                 )",
+                rusqlite::params![meeting_id],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if sealed_at_rest {
+            // Rollback via drop — nothing written. IDs only in the log (no bullet text — PII rule).
+            tracing::debug!(target: "bullets", meeting_id, "live-bullets upsert refused: meeting is sealed at rest");
+            return Ok(());
+        }
+        tx.execute(
+            "INSERT INTO live_bullets (meeting_id, bullets_md, updated_at)
+                  VALUES (?1, ?2, ?3)
+             ON CONFLICT(meeting_id) DO UPDATE
+                    SET bullets_md = excluded.bullets_md, updated_at = excluded.updated_at",
+            rusqlite::params![meeting_id, bullets_md, updated_at],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The stored live bullets for `meeting_id`, or `None`. INTERNAL PRODUCER READ ONLY — the note
+    /// pipeline consumes it while producing the meeting's own note plaintext (the same
+    /// ungated-by-design classification as `get_manual_notes` there); it must NEVER back an FE
+    /// command without a `meeting_is_unlocked` gate. A sealed meeting has no row anyway
+    /// (purge-on-seal — `purge_live_bullets_tx`), so this is defense-in-depth layering, not the
+    /// gate itself.
+    pub fn get_live_bullets(&self, meeting_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT bullets_md FROM live_bullets WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Drop the live-bullets row for `meeting_id` (the Stop-time consume). Idempotent.
+    pub fn clear_live_bullets(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM live_bullets WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// LOCK-SAFETY (the L2 lesson): delete every `live_bullets` row for `meeting_ids` within an
+    /// EXISTING transaction, so the purge lands in the SAME atomic unit as the plaintext blanking
+    /// on a seal (and on `delete_meeting` / the startup reconcile). Live bullets are
+    /// plaintext-DERIVED running notes mirroring the meeting's transcript; a sealed meeting must
+    /// surface NOTHING, so — exactly like `assistant_interactions` / `facts` / `note_chunks` — we
+    /// DELETE rather than key-seal. Dropped by design + not recoverable (never keyed); the
+    /// underlying transcript is still sealed + restorable.
+    fn purge_live_bullets_tx(tx: &rusqlite::Transaction<'_>, meeting_ids: &[String]) -> Result<()> {
+        for mid in meeting_ids {
+            tx.execute(
+                "DELETE FROM live_bullets WHERE meeting_id = ?1",
                 rusqlite::params![mid],
             )
             .map_err(map_err)?;
@@ -8764,6 +8902,176 @@ mod tests {
             interaction_count(&db, "m1"),
             0,
             "delete_meeting must purge the meeting's assistant_interactions rows"
+        );
+    }
+
+    // ── Brain v2 L4 — live_bullets: round-trip + purge on EVERY seal path (the L2 lesson) ──────
+
+    fn bullets_row(db: &Db, meeting_id: &str) -> Option<String> {
+        db.get_live_bullets(meeting_id).unwrap()
+    }
+
+    #[test]
+    fn live_bullets_round_trip_upsert_get_clear() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        assert_eq!(bullets_row(&db, "m1"), None, "no row before the first upsert");
+        db.upsert_live_bullets("m1", "- [a]: one", "2026-07-10T10:01:00Z")
+            .unwrap();
+        assert_eq!(bullets_row(&db, "m1").as_deref(), Some("- [a]: one"));
+        // Upsert REPLACES (one row per meeting — the RAM buffer is the accumulator).
+        db.upsert_live_bullets("m1", "- [a]: one\n- [b]: two", "2026-07-10T10:02:00Z")
+            .unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1").as_deref(),
+            Some("- [a]: one\n- [b]: two")
+        );
+        db.clear_live_bullets("m1").unwrap();
+        assert_eq!(bullets_row(&db, "m1"), None, "cleared (Stop-time consume)");
+        db.clear_live_bullets("m1").unwrap(); // idempotent
+    }
+
+    /// PURGE-ON-SEAL (RED-shaped: content seeded, seal, assert blank). Dropping the
+    /// `purge_live_bullets_tx` call from `purge_chunks_for_meetings` leaves the row at rest in a
+    /// locked folder and fails this.
+    #[test]
+    fn live_bullets_purged_on_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+        assert!(bullets_row(&db, "m1").is_some(), "row present before seal");
+
+        // The seal purge runs in the SAME tx that drops chunks + interactions for sealed meetings.
+        db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "live_bullets must be purged on seal (running notes are derived plaintext)"
+        );
+    }
+
+    /// PURGE-ON-RELOCK: the relock re-blank tx (`blank_sealed_notes_in_folders`) drops the row too
+    /// — a session-unlocked folder that recorded new bullets must not keep them at rest after
+    /// relock.
+    #[test]
+    fn live_bullets_purged_on_relock_reblank() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+
+        let mut folders = HashSet::new();
+        folders.insert("f-locked".to_string());
+        db.blank_sealed_notes_in_folders(&folders).unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "relock must purge the live-bullets row"
+        );
+    }
+
+    /// PURGE-AT-REST (startup reconcile): a crash mid-recording into a since-locked folder leaves
+    /// the row behind — `reblank_locked_folders_at_rest` must drop it like the Q&A log.
+    #[test]
+    fn live_bullets_purged_by_at_rest_reconcile() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.set_folder_locked("f-locked", true, None).unwrap();
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+
+        db.reblank_locked_folders_at_rest().unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "startup reconciliation must purge a locked folder's live-bullets row"
+        );
+    }
+
+    /// TOCTOU (lock-security W2, 2026-07-10 — mirrors
+    /// `topic_index_refuses_write_when_sealed_at_rest_mid_flight`): a `lock_folder` committing
+    /// BETWEEN the worker's `current_meeting` check and the row upsert purged the row and sealed
+    /// the note at rest (markdown blanked, `content_blob` kept) — the upsert's own in-tx
+    /// sealed-at-rest re-check must then REFUSE to re-write plaintext bullets for the sealed
+    /// meeting. RED before the fix: the plain upsert wrote the row unconditionally.
+    #[test]
+    fn live_bullets_upsert_refuses_when_sealed_at_rest_mid_flight() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.set_folder_locked("f-locked", true, None).unwrap();
+        // "lock_folder committed mid-model-call": note sealed at rest — exactly what
+        // `blank_sealed_notes_in_folders` leaves behind.
+        {
+            let conn = db.lock();
+            conn.execute(
+                "UPDATE notes SET markdown = '', content_blob = X'00' WHERE meeting_id = 'm1'",
+                [],
+            )
+            .unwrap();
+        }
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "the in-tx sealed-at-rest re-check must refuse re-upserting plaintext bullets"
+        );
+    }
+
+    /// PURGE-ON-DISCARD (lock-security W3, 2026-07-10): `discard_folder_seal` purges every other
+    /// derived table — the live-bullets row must go with them (contract consistency; RED before
+    /// `live_bullets` joined the discard purge list).
+    #[test]
+    fn live_bullets_purged_on_discard_folder_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-locked")).unwrap();
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        db.discard_folder_seal("f-locked").unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "discard_folder_seal must purge the live-bullets row like every other derived table"
+        );
+    }
+
+    /// PURGE-ON-DELETE: deleting a meeting removes its live-bullets row (explicit purge + FK).
+    #[test]
+    fn live_bullets_purged_on_delete_meeting() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m1", "2026-07-10T10:00:00Z"))
+            .unwrap();
+        db.upsert_live_bullets("m1", "- [deal]: pricing agreed", "2026-07-10T10:05:00Z")
+            .unwrap();
+        db.delete_meeting("m1").unwrap();
+        assert_eq!(
+            bullets_row(&db, "m1"),
+            None,
+            "delete_meeting must purge the live-bullets row"
         );
     }
 

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -45,6 +45,14 @@ pub struct SummarizeRequest {
     /// to the provider in the prompt — `RedactingProvider` MUST scrub it alongside the
     /// transcript (summarize/redact.rs) before egress. Today's append mode never egresses it.
     pub user_notes: Option<String>,
+    /// Brain v2 L4 — the RUNNING LIVE BULLETS captured during the recording
+    /// (`transcribe::bullets`), rendered by `render_user_content` as the "LIVE NOTES (auto)"
+    /// section BEFORE the transcript. `None`/blank (no recording bullets — the default, the
+    /// flag-off case, and every resummarize after the Stop-time consume) ⇒ the rendered prompt is
+    /// byte-identical to before this field existed (same contract as `user_notes`). SECURITY:
+    /// this string EGRESSES to the provider in the prompt — `RedactingProvider` MUST scrub it
+    /// alongside the transcript (summarize/redact.rs) before egress.
+    pub live_bullets: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -258,6 +266,7 @@ mod tests {
             vault_titles: vec![],
             related_context: None,
             user_notes: None,
+            live_bullets: None,
         };
         let (text, meta) = p.summarize_with_meta(&req).await.unwrap();
         assert_eq!(text, "note body");

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -549,8 +549,8 @@ impl SummarizerProvider for RedactingProvider {
     ///
     /// FIREWALL CONTRACT — every `SummarizeRequest` field that EGRESSES to the inner (cloud)
     /// provider is scrubbed here before the `req.clone()` is forwarded. The classification:
-    /// - `transcript`, `related_context`, `user_notes` — full firewall: regex (email/card/phone)
-    ///   via the shared map + the NER name layer, tokens restored in the reply.
+    /// - `transcript`, `related_context`, `user_notes`, `live_bullets` — full firewall: regex
+    ///   (email/card/phone) via the shared map + the NER name layer, tokens restored in the reply.
     /// - `template` (rides the SYSTEM prompt) and `meta.title_hint` (rides `render_user_content`) —
     ///   regex layer via the shared map, tokens restored in the reply (defense-in-depth; low-risk
     ///   instruction/label strings).
@@ -584,6 +584,13 @@ impl SummarizerProvider for RedactingProvider {
             .user_notes
             .as_ref()
             .map(|c| redact_into(c, &mut map, &mut rev));
+        // Brain v2 L4: the running live bullets ride the prompt as the "Live notes (auto)"
+        // section — scrub them through the SAME shared map as the transcript they were derived
+        // from, so a value redacted anywhere restores consistently in the reply.
+        let red_bullets = req
+            .live_bullets
+            .as_ref()
+            .map(|c| redact_into(c, &mut map, &mut rev));
         // Name layer (default no-op → text unchanged, `name_pairs` empty → byte-identical egress).
         let (red_transcript, mut name_pairs) = self.names.redact_names(&red_transcript);
         let red_related = red_related.map(|c| {
@@ -592,6 +599,11 @@ impl SummarizerProvider for RedactingProvider {
             c2
         });
         let red_notes = red_notes.map(|c| {
+            let (c2, more) = self.names.redact_names(&c);
+            name_pairs.extend(more);
+            c2
+        });
+        let red_bullets = red_bullets.map(|c| {
             let (c2, more) = self.names.redact_names(&c);
             name_pairs.extend(more);
             c2
@@ -657,11 +669,13 @@ impl SummarizerProvider for RedactingProvider {
         // Byte sizes of the REDACTED content (sizes, never the text itself).
         let user_bytes = red_transcript.len()
             + red_related.as_ref().map(|c| c.len()).unwrap_or(0)
-            + red_notes.as_ref().map(|c| c.len()).unwrap_or(0);
+            + red_notes.as_ref().map(|c| c.len()).unwrap_or(0)
+            + red_bullets.as_ref().map(|c| c.len()).unwrap_or(0);
         let mut r = req.clone();
         r.transcript = red_transcript;
         r.related_context = red_related;
         r.user_notes = red_notes;
+        r.live_bullets = red_bullets;
         r.template = red_template;
         r.meta.title_hint = red_title_hint;
         r.vault_titles = red_titles;
@@ -885,6 +899,7 @@ mod tests {
             vault_titles: Vec::new(),
             related_context: None,
             user_notes: None,
+            live_bullets: None,
         }
     }
 
@@ -1743,6 +1758,7 @@ mod tests {
             ],
             related_context: Some("s-related@leak.example".to_string()), // SCRUBBED (regex + NER)
             user_notes: Some("s-notes@leak.example".to_string()),        // SCRUBBED (regex + NER)
+            live_bullets: Some("s-bullets@leak.example".to_string()),    // SCRUBBED (regex + NER)
         };
         let inner = std::sync::Arc::new(CapturingInner(std::sync::Mutex::new(None)));
         let provider = RedactingProvider::new(inner.clone());
@@ -1756,6 +1772,7 @@ mod tests {
             "s-title@leak.example",
             "s-related@leak.example",
             "s-notes@leak.example",
+            "s-bullets@leak.example",
         ] {
             assert!(
                 !egress.contains(sentinel),

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -286,6 +286,24 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
         }
     }
 
+    // Brain v2 L4 — LIVE NOTES (auto): the running bullets captured during the recording, as a
+    // labeled grounding section BEFORE the transcript. The transcript stays authoritative — the
+    // bullets are a light-model digest and must never override it. Absent/blank ⇒ byte-identical
+    // output (the same contract as `user_notes` above).
+    if let Some(bullets) = &req.live_bullets {
+        if !bullets.trim().is_empty() {
+            out.push_str(
+                "\n## Live notes (auto)\n\
+                 Running bullets auto-captured during the meeting by the on-device assistant. \
+                 Use them as ADDITIONAL grounding for what mattered; the transcript below is \
+                 authoritative — never include a bullet the transcript does not support, and \
+                 never output a section titled `Live notes`.\n",
+            );
+            out.push_str(bullets.trim());
+            out.push('\n');
+        }
+    }
+
     out.push_str("\nTRANSCRIPT\n");
     out.push_str(&req.transcript);
     out.push('\n');
@@ -311,6 +329,7 @@ mod tests {
             vault_titles: vec!["Roadmap".to_string()],
             related_context: related,
             user_notes: None,
+            live_bullets: None,
         }
     }
 
@@ -446,6 +465,40 @@ mod tests {
         assert!(
             s.contains("Never output a section titled"),
             "forbids a My notes section"
+        );
+    }
+
+    /// Brain v2 L4: `live_bullets: None` (and blank) render byte-identical to the pre-field
+    /// prompt — the section only exists when a recording actually produced bullets.
+    #[test]
+    fn live_bullets_none_or_blank_renders_without_section() {
+        let base = render_user_content(&req(None));
+        assert!(!base.contains("Live notes (auto)"), "no section without bullets");
+        let mut blank = req(None);
+        blank.live_bullets = Some("  \n ".to_string());
+        assert_eq!(
+            render_user_content(&blank),
+            base,
+            "blank bullets must be byte-identical to None"
+        );
+    }
+
+    /// Brain v2 L4: the "Live notes (auto)" section lands BEFORE the transcript, carries the
+    /// bullets verbatim, and labels the transcript as authoritative.
+    #[test]
+    fn live_bullets_section_renders_before_transcript() {
+        let mut r = req(None);
+        r.live_bullets = Some("- [deal]: pricing agreed\n- [QA]: Anna owns testing".to_string());
+        let s = render_user_content(&r);
+        let bullets_at = s
+            .find("- [deal]: pricing agreed\n- [QA]: Anna owns testing")
+            .expect("bullets verbatim");
+        let transcript_at = s.find("\nTRANSCRIPT\n").expect("transcript section");
+        assert!(bullets_at < transcript_at, "live notes before transcript");
+        assert!(s.contains("## Live notes (auto)"), "labeled section");
+        assert!(
+            s.contains("the transcript below is authoritative"),
+            "transcript stays authoritative: {s}"
         );
     }
 

--- a/src-tauri/src/transcribe/bullets.rs
+++ b/src-tauri/src/transcribe/bullets.rs
@@ -1,0 +1,540 @@
+//! Brain v2 L4 — INCREMENTAL RUNNING BULLETS ("live notes"). While a recording is in progress the
+//! reactions worker (gated by the novelty gatekeeper + `reactions_busy`, see `transcribe::live`)
+//! feeds the NEW transcript delta plus the bullets-so-far to the LOCAL light reasoner and appends
+//! at most 3 new `- [topic]: point` lines. The bullets become:
+//! - the SUBSTRATE for reactions ([`crate::brain_reactions::reaction_window`]: bullets + a short
+//!   verbatim tail instead of the raw 600-char tail),
+//! - the tighter live-question inject (`transcribe::live::compose_live_inject`: 2k bullets + 2k
+//!   verbatim tail instead of the 6k raw tail), and
+//! - a Stage-1 note input at Stop (`SummarizeRequest::live_bullets`, rendered as the
+//!   "LIVE NOTES (auto)" section by `summarize::template::render_user_content`).
+//!
+//! ## Privacy / lock model
+//! The model call is the LOCAL light engine ONLY (`ReasonerCell::light` — local-or-stub, NEVER a
+//! cloud fallback): nothing egresses from this module. State lives in RAM
+//! (`AppState::live_bullets`, capped at [`MAX_BULLETS_CHARS`], cleared at recording start + Stop +
+//! the lock-surface idle hygiene) plus the additive `live_bullets` DB row (crash recovery for the
+//! Stop-time note input). The ROW is derived meeting content and follows the L2 lesson: PURGED on
+//! EVERY seal path (`lock_folder`/move-into-locked via `purge_chunks_for_meetings`, relock via
+//! `blank_sealed_notes_in_folders`, startup reblank via `reblank_locked_folders_at_rest`, the
+//! unrecoverable-key escape hatch via `discard_folder_seal`) and on `delete_meeting`; the row
+//! WRITE additionally refuses in-tx when the meeting is sealed at rest
+//! (`Db::upsert_live_bullets` — the mid-recording-lock TOCTOU); the only production read is the
+//! note pipeline (the plaintext PRODUCER — same
+//! ungated-by-design classification as `manual_notes` there) and the gated prompt inject
+//! (`gated_live_bullets`, fail-closed on `meeting_is_visible`). At Stop the row rides
+//! `SummarizeRequest.live_bullets` through the `RedactingProvider` firewall like every other
+//! prompt field. No PII in logs (counts + error strings only).
+//!
+//! Bullet QUALITY (does the light model produce useful lines? at what latency?) is real-Mac-only —
+//! `cargo test` proves the plumbing, never the model.
+
+use crate::reason::{GenOptions, LocalReasoner};
+
+/// Hard cap on the accumulated bullets (chars) — bounds RAM + the prompt injects over a multi-hour
+/// meeting; the OLDEST lines are trimmed from the front (the recent running notes matter most).
+pub const MAX_BULLETS_CHARS: usize = 4_000;
+
+/// Minimum transcript-delta size (chars) worth a model call — a shorter fragment (a word or two,
+/// e.g. a lull flush of a tiny remark) yields `None` without spinning the engine.
+pub const MIN_DELTA_CHARS: usize = 40;
+
+/// Max NEW bullet lines accepted from one update (the prompt asks for ≤3; this enforces it).
+pub const MAX_NEW_BULLETS: usize = 3;
+
+/// Token cap for one bullets update (≤3 short lines — spec §L4).
+const BULLETS_MAX_TOKENS: usize = 200;
+
+/// Low-variance sampling for the note-taking task (spec §L4).
+const BULLETS_TEMPERATURE: f64 = 0.2;
+
+/// Wall-clock bound on one background bullets generation (the live-path discipline — a hung
+/// update must degrade one tick, never wedge the worker).
+///
+/// CAVEAT (pre-existing class, shared with the reactions scan's own `GenOptions::light()`
+/// timeout): `GenOptions.timeout` is honored ONLY by the Mistral/GGUF backend's `reason_with`
+/// override — the `LocalReasoner` trait DEFAULT ignores the options and delegates to `reason`
+/// (`reason.rs`, `fn reason_with` default body). On a non-GGUF light backend a hung generation
+/// is therefore unbounded and wedges `reactions_busy` (no bullets AND no reaction scans) for the
+/// rest of the recording. Not fixed here — it is the same exposure the reactions scan already
+/// carries; a per-backend timeout belongs in `reason.rs`, not per call site.
+const BULLETS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Max chars of transcript delta folded into one bullets update (mirrors the gatekeeper's per-tick
+/// budget — the inner `novelty::TickDelta` already caps at the same figure, this is
+/// belt-and-braces for the prompt).
+const MAX_BULLETS_DELTA_CHARS: usize = 2_000;
+
+/// The bullets' OWN delta tracker over the live buffer (`AppState::live_bullets_tracker`) —
+/// separate from the gatekeeper's, because the WORKER consumes transcript at its own (busy-gated)
+/// pace: a skipped scan's text must reach the NEXT bullets update, not vanish. Same anchor
+/// discipline as `novelty::TickDelta` / `proactive::DeltaTracker`: survives the live buffer's
+/// front-trim at its 16k cap; degrades to a bounded recent-tail rescan when the anchor is gone.
+#[derive(Default)]
+pub struct BulletsTracker {
+    inner: crate::transcribe::novelty::TickDelta,
+}
+
+impl BulletsTracker {
+    /// The transcript text NEW since the last bullets update (most recent
+    /// ≤[`MAX_BULLETS_DELTA_CHARS`] of it), advancing the tracker.
+    pub fn take_delta(&mut self, live_buf: &str) -> String {
+        let delta = self.inner.take_delta(live_buf);
+        // The inner tracker caps at its own budget (2k) — enforce ours on a char boundary anyway.
+        let count = delta.chars().count();
+        if count <= MAX_BULLETS_DELTA_CHARS {
+            delta
+        } else {
+            delta.chars().skip(count - MAX_BULLETS_DELTA_CHARS).collect()
+        }
+    }
+}
+
+/// ONE incremental bullets update (pure over the injected reasoner): previous bullets + the new
+/// transcript `delta` → `Some(new bullet lines)` to APPEND, or `None` when there is nothing to add
+/// — on the stub reasoner (no local model ⇒ feature degraded, NEVER a cloud call), on a too-short
+/// delta, on a reasoner error/timeout, or when the model answered the literal
+/// [`crate::prompts::LIVE_BULLETS_NOTHING`]. The returned block is at most [`MAX_NEW_BULLETS`]
+/// `- `-prefixed lines, model prose stripped.
+pub fn update_bullets(
+    reasoner: &dyn LocalReasoner,
+    previous_bullets: &str,
+    delta: &str,
+) -> Option<String> {
+    if reasoner.id() == "stub" {
+        return None; // canonical stub guard — a missing model degrades, never egresses.
+    }
+    if delta.trim().chars().count() < MIN_DELTA_CHARS {
+        return None;
+    }
+    let user = crate::prompts::live_bullets_user(previous_bullets, delta);
+    let opts = GenOptions {
+        max_tokens: Some(BULLETS_MAX_TOKENS),
+        temperature: Some(BULLETS_TEMPERATURE),
+        enable_thinking: false,
+        timeout: Some(BULLETS_TIMEOUT),
+        ..GenOptions::default()
+    };
+    let out = match reasoner.reason_with(crate::prompts::LIVE_BULLETS_SYSTEM, &user, opts) {
+        Ok(o) => o,
+        Err(e) => {
+            // Best-effort background task: log (no PII — no transcript/bullet text) and skip.
+            tracing::debug!(target: "bullets", error = %e, "bullets update failed; skipping tick");
+            return None;
+        }
+    };
+    parse_new_bullets(&out)
+}
+
+/// Extract the accepted bullet lines from one model reply: `- `-prefixed lines only (prose /
+/// numbering / fences dropped), capped at [`MAX_NEW_BULLETS`]; the literal
+/// [`crate::prompts::LIVE_BULLETS_NOTHING`] (any case) or an empty / bullet-less reply ⇒ `None`.
+fn parse_new_bullets(out: &str) -> Option<String> {
+    let t = out.trim();
+    if t.is_empty() || t.eq_ignore_ascii_case(crate::prompts::LIVE_BULLETS_NOTHING) {
+        return None;
+    }
+    let lines: Vec<&str> = t
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("- ") && l.len() > 2)
+        .take(MAX_NEW_BULLETS)
+        .collect();
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines.join("\n"))
+}
+
+/// Append `new_lines` to the accumulated `existing` bullets, enforcing [`MAX_BULLETS_CHARS`] by
+/// dropping the OLDEST lines from the FRONT (whole lines — never a mid-line cut). Pure.
+pub fn append_bullets(existing: &str, new_lines: &str) -> String {
+    let mut merged = if existing.trim().is_empty() {
+        new_lines.trim().to_string()
+    } else {
+        format!("{}\n{}", existing.trim_end(), new_lines.trim())
+    };
+    while merged.chars().count() > MAX_BULLETS_CHARS {
+        match merged.find('\n') {
+            Some(nl) => merged = merged[nl + 1..].to_string(),
+            None => {
+                // A single line over the cap (degenerate) — keep the most recent tail.
+                let count = merged.chars().count();
+                merged = merged.chars().skip(count - MAX_BULLETS_CHARS).collect();
+                break;
+            }
+        }
+    }
+    merged
+}
+
+/// Clear the RAM bullets buffer + reset the delta tracker (recording start / Stop / the
+/// lock-surface idle hygiene). Best-effort: a poisoned lock is ignored — the buffer is re-cleared
+/// at the next recording start anyway. Logs a COUNT only (no bullet text — PII rule).
+pub fn clear_ram(
+    bullets: &std::sync::Mutex<String>,
+    tracker: &std::sync::Mutex<BulletsTracker>,
+) {
+    if let Ok(mut b) = bullets.lock() {
+        if !b.is_empty() {
+            tracing::debug!(target: "bullets", chars = b.chars().count(), "cleared live-bullets buffer");
+            b.clear();
+        }
+    }
+    if let Ok(mut t) = tracker.lock() {
+        *t = BulletsTracker::default();
+    }
+}
+
+/// ONE bullets tick, wired to the running app — runs on the reactions WORKER thread (behind
+/// `reactions_busy`, BEFORE `detect_reactions`), never the live tick thread. Flag- and
+/// stub-gated: `live_bullets_enabled` OFF or no local light model ⇒ a no-op (legacy behavior).
+/// The body lives in [`bullets_tick_with`] — the reasoner-injected seam headless tests drive.
+pub fn bullets_tick(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    let st = app.state::<crate::state::AppState>();
+    let enabled = st
+        .config
+        .lock()
+        .map(|c| c.live_bullets_enabled)
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+    let reasoner = st.reasoner.light();
+    if reasoner.id() == "stub" {
+        return; // no light model ⇒ feature degraded (never a cloud call).
+    }
+    bullets_tick_with(&st, &*reasoner);
+}
+
+/// The tick body with the light reasoner injected (production enters via [`bullets_tick`]; tests
+/// drive it with a fake reasoner + a headless `AppState`). Reads the live-buffer delta through
+/// `AppState::live_bullets_tracker`, runs ONE [`update_bullets`] model call, and COMMITS the
+/// result behind a FRESH `current_meeting` re-check taken AFTER the (≤30s) call — the SAME check
+/// gates BOTH the RAM write and the crash-recovery row write ([`commit_bullets_decision`]): a
+/// worker in flight across Stop(A)→Start(B) DISCARDS its result entirely (no RAM write, no row
+/// write), so meeting A's bullets can never contaminate meeting B's substrate / prompt inject /
+/// row / note. The RAM write happens while the `current_meeting` guard is still HELD (atomic with
+/// the check w.r.t. Stop/Start, which mutate `current_meeting` under the same mutex — only the
+/// String swap runs under the guard, never the DB write); the row write follows after the guard
+/// drops, its residual stale window backstopped by the sealed-at-rest refuse inside
+/// `Db::upsert_live_bullets` + the Stop-consume / purge-on-seal / at-rest-reconcile paths.
+///
+/// DISCARD POLICY on a stale worker (same as the NOTHING/error policy below): the tracker delta
+/// stays CONSUMED — the meeting switch already reset the tracker via the new recording's
+/// [`clear_ram`], so there is no stale text to re-feed and nothing to roll back. Best-effort +
+/// panic-free throughout (the worker's `BusyReset` guard is the outer safety net).
+pub(crate) fn bullets_tick_with(st: &crate::state::AppState, reasoner: &dyn LocalReasoner) {
+    // The meeting this tick belongs to — captured NOW, re-checked FRESH after the model call.
+    let Some(meeting_id) = st
+        .current_meeting
+        .lock()
+        .ok()
+        .and_then(|m| m.map(|id| id.to_string()))
+    else {
+        return; // not recording — nothing to note.
+    };
+    let buf = st
+        .live_transcript
+        .lock()
+        .map(|b| b.clone())
+        .unwrap_or_default();
+    let delta = match st.live_bullets_tracker.lock() {
+        Ok(mut t) => t.take_delta(&buf),
+        Err(_) => return,
+    };
+    let prev = st
+        .live_bullets
+        .lock()
+        .map(|b| b.clone())
+        .unwrap_or_default();
+    // NOTE: the tracker delta is CONSUMED even when the model answers NOTHING / errors — by
+    // design (the model judged the fragment noteless) / accepted degradation (one lost fragment
+    // beats re-feeding stale text forever).
+    let Some(new_lines) = update_bullets(reasoner, &prev, &delta) else {
+        return;
+    };
+    let merged = append_bullets(&prev, &new_lines);
+    // FRESH `current_meeting` snapshot AFTER the (≤30s) model call — the ONE check gating BOTH
+    // writes (adversarial CRITICAL, 2026-07-10: the RAM write used to run unconditionally, so a
+    // worker spanning Stop(A)→Start(B) re-populated B's RAM with A's bullets AFTER every
+    // clear_ram). The RAM write stays INSIDE the guard so Stop/Start (which mutate
+    // `current_meeting` under this same mutex) cannot interleave between check and write; only
+    // the in-RAM String swap runs under the guard — the DB write below never does.
+    let committed = {
+        let Ok(current) = st.current_meeting.lock() else {
+            return; // poisoned ⇒ discard (best-effort tick; next tick re-derives).
+        };
+        let current_id = current.map(|id| id.to_string());
+        let Some(m) = commit_bullets_decision(&meeting_id, current_id.as_deref(), merged) else {
+            return; // stale worker (stopped or switched meeting) — DISCARD entirely.
+        };
+        if let Ok(mut b) = st.live_bullets.lock() {
+            *b = m.clone();
+        }
+        m
+    };
+    // Crash-recovery row — behind the SAME fresh check as the RAM write above. The guard is
+    // dropped before this DB write; the microscopic residual (a Stop landing right here) can only
+    // re-write a row for a meeting that WAS recording a moment ago, and is backstopped by the
+    // sealed-at-rest refuse inside `upsert_live_bullets`, the Stop-time consume, and the
+    // purge-on-seal / at-rest-reconcile paths.
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Err(e) = st.db.upsert_live_bullets(&meeting_id, &committed, &now) {
+        tracing::debug!(target: "bullets", error = %e, "live-bullets row upsert failed; RAM copy unaffected");
+    }
+}
+
+/// PURE post-model commit decision (the headless-testable seam of the stale-worker guard): the
+/// worker's `merged` bullets are committed only while the CURRENT recording is still the worker's
+/// own meeting; `None` = DISCARD the result entirely (no RAM write, no row write).
+pub(crate) fn commit_bullets_decision(
+    worker_meeting: &str,
+    current_meeting: Option<&str>,
+    merged: String,
+) -> Option<String> {
+    (current_meeting == Some(worker_meeting)).then_some(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Result;
+    use serde_json::Value;
+
+    /// A test reasoner returning a fixed reply (id deliberately NOT "stub").
+    struct FixedReasoner(&'static str);
+    impl LocalReasoner for FixedReasoner {
+        fn id(&self) -> &str {
+            "fixed-test"
+        }
+        fn reason(&self, _system: &str, _user: &str) -> Result<String> {
+            Ok(self.0.to_string())
+        }
+        fn structured(&self, _system: &str, _user: &str, _schema: &Value) -> Result<Value> {
+            Ok(Value::Null)
+        }
+    }
+
+    const LONG_DELTA: &str = "omówiliśmy budżet projektu Atlas i ustaliliśmy, że Anna przejmuje \
+                              testy QA przed piątkowym wydaniem";
+
+    #[test]
+    fn stub_reasoner_yields_none() {
+        // The canonical stub guard: no local model ⇒ no bullets, never a cloud call.
+        let out = update_bullets(&crate::reason::StubReasoner, "", LONG_DELTA);
+        assert!(out.is_none(), "stub must yield None");
+    }
+
+    #[test]
+    fn nothing_reply_yields_none() {
+        let r = FixedReasoner("NOTHING");
+        assert!(update_bullets(&r, "- [x]: y", LONG_DELTA).is_none());
+        // Case-insensitive + whitespace-tolerant.
+        let r2 = FixedReasoner("  nothing \n");
+        assert!(update_bullets(&r2, "", LONG_DELTA).is_none());
+    }
+
+    #[test]
+    fn short_delta_yields_none_without_model_call() {
+        // A panicking reasoner proves the short-circuit happens BEFORE any model call.
+        struct PanicReasoner;
+        impl LocalReasoner for PanicReasoner {
+            fn id(&self) -> &str {
+                "panic-test"
+            }
+            fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+                panic!("must not be called for a short delta")
+            }
+            fn structured(&self, _s: &str, _u: &str, _j: &Value) -> Result<Value> {
+                panic!("never")
+            }
+        }
+        assert!(update_bullets(&PanicReasoner, "", "za krótko").is_none());
+    }
+
+    #[test]
+    fn bullets_are_parsed_capped_and_appended() {
+        // Model returns prose + 4 bullets → only the first 3 `- ` lines are accepted.
+        let r = FixedReasoner(
+            "Sure, here are the notes:\n- [budżet]: 10k zatwierdzone\n- [QA]: Anna przejmuje testy\n- [termin]: wydanie w piątek\n- [extra]: czwarta linia\nhope this helps",
+        );
+        let new = update_bullets(&r, "- [start]: kickoff", LONG_DELTA).expect("bullets parsed");
+        assert_eq!(new.lines().count(), MAX_NEW_BULLETS, "capped at {MAX_NEW_BULLETS}");
+        assert!(new.starts_with("- [budżet]:"));
+        assert!(!new.contains("czwarta linia"), "the 4th bullet is dropped");
+        assert!(!new.contains("Sure"), "prose stripped");
+        // Append keeps the existing bullets in front.
+        let merged = append_bullets("- [start]: kickoff", &new);
+        assert!(merged.starts_with("- [start]: kickoff\n- [budżet]:"));
+    }
+
+    #[test]
+    fn reply_with_no_bullet_lines_yields_none() {
+        let r = FixedReasoner("I could not find anything noteworthy in this fragment.");
+        assert!(update_bullets(&r, "", LONG_DELTA).is_none());
+    }
+
+    #[test]
+    fn append_enforces_char_cap_by_dropping_oldest_lines() {
+        // Build bullets just under the cap, then append — the OLDEST lines must fall off the
+        // front, the newest must survive, and the cap must hold.
+        let line = format!("- [t]: {}", "x".repeat(93)); // 100 chars per line
+        let existing = std::iter::repeat_with(|| line.clone())
+            .take(40) // 40 × ~101 ≈ 4040 chars > cap after append
+            .collect::<Vec<_>>()
+            .join("\n");
+        let merged = append_bullets(&existing, "- [new]: the freshest bullet");
+        assert!(
+            merged.chars().count() <= MAX_BULLETS_CHARS,
+            "cap enforced, got {}",
+            merged.chars().count()
+        );
+        assert!(merged.ends_with("- [new]: the freshest bullet"), "newest survives");
+        assert!(merged.starts_with("- "), "front-trim lands on a line boundary");
+    }
+
+    // ── bullets_tick_with: the stale-worker guard (adversarial CRITICAL, 2026-07-10) ────────────
+
+    /// Fixed at-rest DB key for the headless `AppState` (same shape as commands.rs lifecycle
+    /// tests — never the Keychain).
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn test_state(tag: &str) -> std::sync::Arc<crate::state::AppState> {
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-bullets-{tag}"), "sqlite");
+        let _ = std::fs::remove_file(&p);
+        std::sync::Arc::new(crate::state::AppState::init_at(&p, TEST_DEK).unwrap())
+    }
+
+    fn insert_meeting(st: &crate::state::AppState, id: &uuid::Uuid) {
+        st.db
+            .insert_meeting(&crate::storage::models::Meeting {
+                id: id.to_string(),
+                started_at: "2026-07-10T10:00:00Z".to_string(),
+                ended_at: None,
+                title: None,
+                duration_s: 0,
+                audio_path: None,
+                status: crate::storage::models::MeetingStatus::Recording,
+                folder_id: None,
+            })
+            .unwrap();
+    }
+
+    /// A reasoner that simulates Stop(A) → Start(B) landing INSIDE the (≤30s) model call: both
+    /// clear the RAM bullets (`clear_ram`), then the new recording takes `current_meeting` — the
+    /// exact interleaving of `stop_recording` + `start_recording` around a worker in flight.
+    struct StopStartReasoner {
+        st: std::sync::Arc<crate::state::AppState>,
+        next: uuid::Uuid,
+    }
+    impl LocalReasoner for StopStartReasoner {
+        fn id(&self) -> &str {
+            "switch-test"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+            clear_ram(&self.st.live_bullets, &self.st.live_bullets_tracker);
+            if let Ok(mut cur) = self.st.current_meeting.lock() {
+                *cur = Some(self.next);
+            }
+            Ok("- [stale]: meeting A leftovers".to_string())
+        }
+        fn structured(&self, _s: &str, _u: &str, _j: &Value) -> Result<Value> {
+            Ok(Value::Null)
+        }
+    }
+
+    /// THE CRITICAL (RED before the ordering fix): a worker whose model call spans
+    /// Stop(A)→Start(B) must DISCARD its result — pre-fix the RAM write ran unconditionally
+    /// BEFORE the `current_meeting` re-check, so meeting A's bullets landed in meeting B's RAM
+    /// (→ B's reaction substrate, prompt inject, row, and Stop-time note).
+    #[test]
+    fn stale_worker_discards_ram_and_row_when_meeting_switches_mid_call() {
+        let st = test_state("stale-switch");
+        let a = uuid::Uuid::new_v4();
+        let b = uuid::Uuid::new_v4();
+        insert_meeting(&st, &a);
+        insert_meeting(&st, &b);
+        *st.current_meeting.lock().unwrap() = Some(a);
+        *st.live_transcript.lock().unwrap() = LONG_DELTA.to_string();
+
+        let reasoner = StopStartReasoner {
+            st: std::sync::Arc::clone(&st),
+            next: b,
+        };
+        bullets_tick_with(&st, &reasoner);
+
+        assert_eq!(
+            st.live_bullets.lock().unwrap().as_str(),
+            "",
+            "stale worker's RAM write must be discarded (meeting switched mid-call)"
+        );
+        assert_eq!(
+            st.db.get_live_bullets(&a.to_string()).unwrap(),
+            None,
+            "no row resurrected for the stopped meeting A"
+        );
+        assert_eq!(
+            st.db.get_live_bullets(&b.to_string()).unwrap(),
+            None,
+            "meeting B must not inherit A's bullets row"
+        );
+    }
+
+    /// Happy path: the meeting is UNCHANGED across the model call → the same fresh check commits
+    /// BOTH writes (RAM + crash-recovery row).
+    #[test]
+    fn same_meeting_commits_ram_and_row() {
+        let st = test_state("happy-commit");
+        let a = uuid::Uuid::new_v4();
+        insert_meeting(&st, &a);
+        *st.current_meeting.lock().unwrap() = Some(a);
+        *st.live_transcript.lock().unwrap() = LONG_DELTA.to_string();
+
+        let r = FixedReasoner("- [budżet]: 10k zatwierdzone");
+        bullets_tick_with(&st, &r);
+
+        assert_eq!(
+            st.live_bullets.lock().unwrap().as_str(),
+            "- [budżet]: 10k zatwierdzone",
+            "RAM committed for the still-recording meeting"
+        );
+        assert_eq!(
+            st.db.get_live_bullets(&a.to_string()).unwrap().as_deref(),
+            Some("- [budżet]: 10k zatwierdzone"),
+            "crash-recovery row committed for the still-recording meeting"
+        );
+    }
+
+    #[test]
+    fn commit_decision_discards_on_meeting_switch_or_stop() {
+        assert_eq!(
+            commit_bullets_decision("A", Some("A"), "x".to_string()),
+            Some("x".to_string()),
+            "same meeting ⇒ commit"
+        );
+        assert_eq!(
+            commit_bullets_decision("A", Some("B"), "x".to_string()),
+            None,
+            "switched meeting ⇒ discard"
+        );
+        assert_eq!(
+            commit_bullets_decision("A", None, "x".to_string()),
+            None,
+            "stopped (no recording) ⇒ discard"
+        );
+    }
+
+    #[test]
+    fn tracker_survives_front_trim_and_caps_delta() {
+        let mut t = BulletsTracker::default();
+        let long: String = (0..40).map(|i| format!("word{i} ")).collect();
+        let _ = t.take_delta(&long);
+        // Front-trim (as the live buffer's 16k cap does) + genuinely-new tail.
+        let trimmed = format!("{} FRESH tail here", &long[60..].trim_end());
+        let delta = t.take_delta(&trimmed);
+        assert_eq!(delta.trim_start(), "FRESH tail here", "anchor relocation, got {delta:?}");
+        assert!(!delta.contains("word"), "no re-fed old text: {delta:?}");
+    }
+}

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -25,9 +25,9 @@ use crate::transcribe::Transcriber;
 
 /// How often to attempt a live caption.
 const TICK: Duration = Duration::from_millis(3000);
-/// How many ticks between Realtime-Reactions scans (~21 s at the 3 s TICK) — matches the light-engine
-/// min-interval so a slow extraction can't pile up (spec §4.2).
-const REACTIONS_SCAN_EVERY: u32 = 7;
+// NOTE (Brain v2 L4): the fixed `REACTIONS_SCAN_EVERY = 7` cadence was replaced by the
+// content-driven novelty gatekeeper (`crate::transcribe::novelty::NoveltyState`) — the hard
+// minimum interval lives there (`MIN_FIRE_INTERVAL_TICKS`, ~15 s).
 /// How many trailing seconds of audio to transcribe each tick (overlapping window).
 const WINDOW_SECS: usize = 14;
 
@@ -116,6 +116,13 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
     if let Ok(mut lt) = app.state::<AppState>().live_transcript.lock() {
         lt.clear();
     }
+    // Brain v2 L4: fresh bullets per recording too (belt-and-braces beside the
+    // `start_recording`/`stop_recording` clears) — stale running notes must never seed a new
+    // meeting's substrate or prompt inject.
+    {
+        let state = app.state::<AppState>();
+        crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
+    }
     let transcriber = match Transcriber::load(&model_path) {
         Ok(t) => t,
         Err(e) => {
@@ -133,10 +140,26 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
     let mut proactive = crate::proactive::ProactiveState::default();
 
     // REALTIME REACTIONS state — the light-engine contradiction scan runs OFF this tick thread (a
-    // 5–10 s extraction inline would stall captions), throttled + skip-if-busy so ASR stays the
-    // priority tenant (spec §4.2, review perf #7 / code-truth #11).
+    // 5–10 s extraction inline would stall captions), skip-if-busy so ASR stays the priority
+    // tenant (spec §4.2, review perf #7 / code-truth #11). Brain v2 L4: the fixed
+    // every-7-ticks cadence is replaced by the NOVELTY GATEKEEPER below.
     let reactions_busy = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let mut reactions_ticks: u32 = 0;
+
+    // Brain v2 L4 state — FRESH per recording:
+    // - `novelty` decides WHEN the reactions/bullets worker is worth spawning (new speech / a
+    //   question / a known-entity mention / a lull, under a hard ~15 s floor);
+    // - `entity_cache` is the visible-entity (id, name) list refreshed every ~60 ticks, shared
+    //   between the gatekeeper's entity-hit trigger and the worker's scan (which previously
+    //   re-fetched it per scan);
+    // - whisper cards + proactive hints QUEUE (`pending` + the worker→tick `mpsc`) and emit at a
+    //   conversational BOUNDARY (`boundary`), with drain-on-stop after the loop. Event names +
+    //   payloads are UNCHANGED — only the emit TIMING moved.
+    let mut novelty = crate::transcribe::novelty::NoveltyState::default();
+    let mut entity_cache = crate::transcribe::novelty::RefreshableEntityCache::default();
+    let mut boundary = crate::transcribe::novelty::BoundaryGate::default();
+    let (surface_tx, surface_rx) = std::sync::mpsc::channel::<QueuedSurface>();
+    let mut pending: Vec<QueuedSurface> = Vec::new();
+    let mut last_caption = String::new();
 
     loop {
         std::thread::sleep(TICK);
@@ -147,28 +170,59 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
         // K-th tick — only while `proactive_hints_enabled` is ON — the deterministic matcher scans
         // the NEW live-tail delta against the gated local substrates (entities / commitments /
         // facts / FTS) and surfaces AT MOST one recall card. Fully local: no provider, no consent,
-        // no egress. Best-effort — it can never disrupt the caption or the recording.
+        // no egress. Best-effort — it can never disrupt the caption or the recording. Brain v2 L4:
+        // the hint is QUEUED and emitted at the next conversational boundary (its own scan logic —
+        // throttle, dedup, scoring — is untouched; only the emit moved).
         if let Some(hint) = crate::proactive::scan_tick(&app, &mut proactive) {
-            // PII rule (§8): log the kind + score only — never the title or any content.
-            tracing::info!(
-                target: "proactive",
-                kind = %hint.kind,
-                score = hint.score,
-                "proactive hint emitted"
-            );
-            let _ = app.emit(crate::events::EVENT_PROACTIVE_HINT, hint);
+            pending.push(QueuedSurface::Hint(hint));
         }
 
-        // REALTIME REACTIONS (Brain Live): every REACTIONS_SCAN_EVERY ticks, if no scan is in flight,
-        // run the light-engine contradiction scan on a WORKER thread (never this tick thread) and emit
-        // the whisper cards — or, in shadow mode, count would-have-fired. Skip-if-busy: a slow scan
-        // drops this trigger; the recording never waits on the LLM.
-        reactions_ticks = reactions_ticks.wrapping_add(1);
-        if reactions_ticks % REACTIONS_SCAN_EVERY == 0
+        // NOVELTY GATEKEEPER (Brain v2 L4): the visible-entity cache ticks (a gated
+        // `list_entities_visible` read every ~60 ticks over the FRESH unlocked set — staleness
+        // affects trigger sensitivity only, never content; every downstream fact/content read
+        // re-gates itself), then the gatekeeper folds this tick's live-buffer delta into its
+        // pending triggers and decides whether the worker fires NOW.
+        let entities: Vec<(String, String)> = {
+            let state = app.state::<AppState>();
+            entity_cache
+                .on_tick(|| {
+                    let unlocked = state
+                        .unlocked_folders
+                        .lock()
+                        .map(|u| u.clone())
+                        .unwrap_or_default();
+                    state
+                        .db
+                        .list_entities_visible(&unlocked)
+                        .map(|v| v.into_iter().map(|n| (n.id, n.name)).collect())
+                        .unwrap_or_else(|e| {
+                            tracing::debug!(target: "live", error = %e, "entity cache refresh failed; keeping empty");
+                            Vec::new()
+                        })
+                })
+                .to_vec()
+        };
+        let live_buf = app
+            .state::<AppState>()
+            .live_transcript
+            .lock()
+            .map(|b| b.clone())
+            .unwrap_or_default();
+        let novelty_tick = novelty.on_tick(&live_buf, &entities);
+
+        // REALTIME REACTIONS + LIVE BULLETS (Brain Live / Brain v2 L4): when the gatekeeper fires
+        // and no scan is in flight, run the worker on its OWN thread (never this tick thread):
+        // FIRST the incremental bullets update (`bullets_tick` — flag- and stub-gated, it is the
+        // substrate the scan reads), THEN the light-engine contradiction scan. Cards are SENT back
+        // over the mpsc queue and emitted at a boundary — or, in shadow mode, counted. Skip-if-
+        // busy: a slow scan drops this trigger; the recording never waits on the LLM.
+        if novelty_tick.fire
             && !reactions_busy.swap(true, std::sync::atomic::Ordering::AcqRel)
         {
             let app2 = app.clone();
             let busy2 = std::sync::Arc::clone(&reactions_busy);
+            let tx2 = surface_tx.clone();
+            let entities2 = entities.clone();
             std::thread::spawn(move || {
                 // RAII: reset the busy flag on EVERY exit — including a panic inside reactions_scan.
                 // Without this, one panic would wedge the flag `true` and silently kill ALL further
@@ -180,12 +234,17 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                     }
                 }
                 let _reset = BusyReset(busy2);
+                // L4: bullets BEFORE the scan — the scan's window reads the just-updated bullets.
+                crate::transcribe::bullets::bullets_tick(&app2);
                 let now = chrono::Utc::now().to_rfc3339();
-                let scan = crate::brain_reactions::reactions_scan(&app2, &now);
+                let scan = crate::brain_reactions::reactions_scan(&app2, &now, &entities2);
                 let n = scan.cards.len() as u64;
                 if scan.emit {
                     for card in scan.cards {
-                        let _ = app2.emit(crate::events::EVENT_WHISPER_CARD, card);
+                        // Boundary-timed surfacing: queue to the tick thread. The send fails only
+                        // when the loop has ended (receiver dropped) — the card is then dropped
+                        // (the recording is over; a late card about it has no surface).
+                        let _ = tx2.send(QueuedSurface::Whisper(card));
                     }
                 } else if n > 0 {
                     // Shadow mode: count would-have-fired for user-local calibration; emit nothing.
@@ -194,6 +253,20 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                         .fetch_add(n, std::sync::atomic::Ordering::Relaxed);
                 }
             });
+        }
+
+        // BOUNDARY-TIMED SURFACING (Brain v2 L4): fold in any worker-queued cards, then emit the
+        // whole queue at a conversational boundary — a short lull, the (previous tick's) caption
+        // ending a sentence, or the 30 s max-hold force-emit. `last_caption` lags one tick by
+        // construction (this runs before this tick's transcription) — an accepted ~3 s skew on
+        // the sentence-final signal, not on the lull.
+        while let Ok(item) = surface_rx.try_recv() {
+            pending.push(item);
+        }
+        if boundary.on_tick(!pending.is_empty(), novelty_tick.new_chars > 0, &last_caption) {
+            for item in pending.drain(..) {
+                emit_surface(&app, item);
+            }
         }
 
         // Snapshot the recent tail; stop as soon as the recording is gone.
@@ -292,6 +365,9 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                 }
 
                 if !text.is_empty() {
+                    // Brain v2 L4: remember the latest caption for the NEXT tick's boundary check
+                    // (sentence-final punctuation = a good moment to surface queued cards).
+                    last_caption.clone_from(&text);
                     // In-meeting voice trigger (Phase A: DETECT + SURFACE only — NO action dispatch;
                     // that needs the local brain in a later phase). Best-effort + panic-free: the
                     // detection is a pure function and the emit error is ignored, so a wake miss/hit
@@ -350,6 +426,44 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                 }
             }
             Err(e) => tracing::debug!(target: "live", error = %e, "live transcribe tick failed"),
+        }
+    }
+
+    // DRAIN-ON-STOP (Brain v2 L4): the recording ended (recorder gone / poisoned lock) — emit
+    // everything still queued so a boundary-held card is never silently lost with the recording.
+    // A worker STILL in flight past this point sends to a dropped receiver and its cards are
+    // dropped (the recording is over; there is no live surface left for them).
+    while let Ok(item) = surface_rx.try_recv() {
+        pending.push(item);
+    }
+    for item in pending.drain(..) {
+        emit_surface(&app, item);
+    }
+}
+
+/// One queued live surface (Brain v2 L4 boundary-timed surfacing): a Realtime-Reactions whisper
+/// card or a proactive recall hint, held on the tick thread until a conversational boundary.
+/// Event names + payloads are the UNCHANGED existing contracts — only the emit timing moved.
+enum QueuedSurface {
+    Whisper(crate::brain_reactions::WhisperCard),
+    Hint(crate::events::ProactiveHintPayload),
+}
+
+/// Emit one queued surface on its ORIGINAL event channel (payloads unchanged — FE untouched).
+/// Best-effort; PII rule (§8): the hint log carries kind + score only, never title/content.
+fn emit_surface(app: &AppHandle, item: QueuedSurface) {
+    match item {
+        QueuedSurface::Whisper(card) => {
+            let _ = app.emit(crate::events::EVENT_WHISPER_CARD, card);
+        }
+        QueuedSurface::Hint(hint) => {
+            tracing::info!(
+                target: "proactive",
+                kind = %hint.kind,
+                score = hint.score,
+                "proactive hint emitted"
+            );
+            let _ = app.emit(crate::events::EVENT_PROACTIVE_HINT, hint);
         }
     }
 }
@@ -806,6 +920,11 @@ fn run_informational(
     // new egress class (it rides the same RedactingProvider + consent gate inside `handle_voice_action`).
     let (live, typed_notes) =
         gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
+    // Brain v2 L4: when running bullets exist (gated IDENTICALLY to the live buffer), the floor's
+    // current-meeting block becomes the tighter bullets+verbatim composition; with bullets empty
+    // this is byte-identical to before (compose is the identity then).
+    let bullets = gated_live_bullets(&state.db, &state.live_bullets, meeting_id, unlocked);
+    let live = compose_live_inject(&live, &bullets);
     let current_meeting_context = floor_current_context(&live, &typed_notes);
     let floor_intent = floor_intent_for(intent, command);
     crate::voice_action::handle_voice_action(
@@ -976,6 +1095,11 @@ fn run_cascade(
     // filtered against the user's CURRENT command (`command`, never the whole rendered conversation).
     let (live, typed_notes) =
         gated_live_context(&state.db, &state.live_transcript, meeting_id, unlocked);
+    // Brain v2 L4: the live-question inject becomes `2k bullets + 2k verbatim tail` when running
+    // bullets exist — gated IDENTICALLY to the live buffer (`gated_live_bullets` fail-closes on
+    // the same `meeting_is_visible` check), byte-identical to the legacy 6k tail when they don't.
+    let bullets = gated_live_bullets(&state.db, &state.live_bullets, meeting_id, unlocked);
+    let live = compose_live_inject(&live, &bullets);
     let memory_brief =
         gated_user_memory_brief(&state.db, unlocked, config.user_memory_enabled, command);
     let recording_in_progress = state.recorder.lock().map(|g| g.is_some()).unwrap_or(false);
@@ -1674,6 +1798,52 @@ fn gated_live_context(
         .unwrap_or_default();
     let typed = db.get_manual_notes(meeting_id).unwrap_or_default();
     (live, typed)
+}
+
+/// Brain v2 L4 — the RUNNING BULLETS of the recording in progress, GATED for prompt injection
+/// EXACTLY like [`gated_live_context`]: the RAM buffer only ever holds the CURRENT recording
+/// (cleared at recording start + Stop), and it is injected ONLY when the scope meeting is VISIBLE
+/// to the LIVE per-turn `unlocked` set — fail-closed: no scope meeting, a sealed-not-unlocked
+/// meeting, or a gate error yields "" (no injection, and [`compose_live_inject`] then degrades to
+/// the legacy behavior). Best-effort: a poisoned lock degrades to "".
+fn gated_live_bullets(
+    db: &crate::storage::Db,
+    live_bullets: &std::sync::Mutex<String>,
+    meeting_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+) -> String {
+    let visible =
+        !meeting_id.is_empty() && db.meeting_is_visible(meeting_id, unlocked).unwrap_or(false);
+    if !visible {
+        return String::new();
+    }
+    live_bullets.lock().map(|b| b.clone()).unwrap_or_default()
+}
+
+/// Chars of running bullets injected into the live-question prompt (Brain v2 L4).
+const LIVE_BULLETS_INJECT_CHARS: usize = 2_000;
+/// Chars of VERBATIM transcript tail injected ALONGSIDE the bullets (Brain v2 L4) — together a
+/// tighter 4k budget than the legacy 6k raw tail, better for small models.
+const LIVE_VERBATIM_INJECT_CHARS: usize = 2_000;
+
+/// Brain v2 L4 — compose the live-question inject (PURE): with running `bullets` present the
+/// injected "live transcript" becomes `≤2k bullets + ≤2k verbatim tail` (labeled sub-sections);
+/// with bullets empty (feature off / stub / not visible / nothing noted yet) OR an empty live
+/// buffer, the inject is EXACTLY the input `live` — byte-identical legacy behavior (the
+/// `assistant_system_prompt` 6k tail + its empty-buffer branches are untouched). Both inputs are
+/// already gated by the caller ([`gated_live_context`] / [`gated_live_bullets`]); the composed
+/// block rides the SAME redaction firewall + consent gate as the rest of the prompt.
+fn compose_live_inject(live: &str, bullets: &str) -> String {
+    let b = bullets.trim();
+    let l = live.trim();
+    if b.is_empty() || l.is_empty() {
+        return live.to_string();
+    }
+    format!(
+        "RUNNING NOTES (auto-generated from this meeting so far):\n{}\n\nMOST RECENT TRANSCRIPT (verbatim):\n{}",
+        tail_chars(b, LIVE_BULLETS_INJECT_CHARS),
+        tail_chars(l, LIVE_VERBATIM_INJECT_CHARS)
+    )
 }
 
 /// Phase 3 CROSS-MEETING USER MEMORY: synthesize the injectable memory brief from the CURRENTLY-
@@ -2571,6 +2741,74 @@ mod tests {
         })
         .unwrap();
         db.set_meeting_folder(mid, folder_id).unwrap();
+    }
+
+    #[test]
+    fn compose_live_inject_is_identity_without_bullets_and_composes_with() {
+        // Brain v2 L4 — no bullets (feature off / stub / nothing noted): the inject is EXACTLY the
+        // legacy live string, so every downstream prompt is byte-identical.
+        assert_eq!(compose_live_inject("live tail", ""), "live tail");
+        assert_eq!(compose_live_inject("live tail", "  \n"), "live tail");
+        // Empty live buffer: bullets alone must NOT flip the empty-buffer prompt branches.
+        assert_eq!(compose_live_inject("", "- [a]: b"), "");
+        // Both present: labeled bullets + verbatim tail, each bounded at its 2k budget.
+        let long_live = "w ".repeat(3_000); // 6k chars
+        let composed = compose_live_inject(&long_live, "- [deal]: pricing agreed");
+        assert!(composed.starts_with("RUNNING NOTES (auto-generated from this meeting so far):\n- [deal]: pricing agreed"));
+        let verbatim = composed
+            .split("MOST RECENT TRANSCRIPT (verbatim):\n")
+            .nth(1)
+            .expect("verbatim section present");
+        assert!(
+            verbatim.chars().count() <= LIVE_VERBATIM_INJECT_CHARS + 1, // + the '…' marker
+            "verbatim tail bounded at 2k, got {}",
+            verbatim.chars().count()
+        );
+        // The composed block stays under the prompt's own 6k tail budget → never re-truncated.
+        assert!(composed.chars().count() < LIVE_TRANSCRIPT_INJECT_CHARS);
+        // And it flows into the live prompt as the injected transcript section.
+        let prompt = assistant_system_prompt(&composed, "", "", true);
+        assert!(prompt.contains("RUNNING NOTES"));
+        assert!(prompt.contains("- [deal]: pricing agreed"));
+    }
+
+    /// Brain v2 L4 — the bullets prompt read is gated EXACTLY like the live buffer: a
+    /// sealed-not-unlocked scope meeting injects NO bullets (fail-closed), a session unlock
+    /// re-injects them, and the RAM buffer itself is never wiped by the gate.
+    #[test]
+    fn gated_live_bullets_masks_for_sealed_meeting_and_reinjects_on_unlock() {
+        let db = tmp_db("bullets-gate");
+        db.insert_folder(&crate::storage::Folder {
+            id: "f1".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed_meeting(&db, "m1", Some("f1"));
+        db.set_folder_locked("f1", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        let bullets = std::sync::Mutex::new("- [deal]: pricing agreed".to_string());
+        let unlocked = std::collections::HashSet::new();
+        assert!(
+            gated_live_bullets(&db, &bullets, "m1", &unlocked).is_empty(),
+            "sealed-not-unlocked meeting must inject NO bullets"
+        );
+        assert!(
+            gated_live_bullets(&db, &bullets, "", &unlocked).is_empty(),
+            "no scope meeting ⇒ no injection (fail-closed default)"
+        );
+        // Session unlock → the SAME buffer injects again (the gate is the live set, not a wipe).
+        let mut unlocked2 = std::collections::HashSet::new();
+        unlocked2.insert("f1".to_string());
+        assert_eq!(
+            gated_live_bullets(&db, &bullets, "m1", &unlocked2),
+            "- [deal]: pricing agreed"
+        );
+        assert_eq!(*bullets.lock().unwrap(), "- [deal]: pricing agreed");
     }
 
     #[test]

--- a/src-tauri/src/transcribe/mod.rs
+++ b/src-tauri/src/transcribe/mod.rs
@@ -1,6 +1,8 @@
+pub mod bullets;
 pub mod diarize;
 pub mod live;
 pub mod model;
+pub mod novelty;
 pub mod types;
 pub mod vad;
 pub mod whisper;

--- a/src-tauri/src/transcribe/novelty.rs
+++ b/src-tauri/src/transcribe/novelty.rs
@@ -1,0 +1,479 @@
+//! Brain v2 L4 — the LIVE-loop timing brains, all PURE and headless-testable:
+//!
+//! - [`NoveltyState`] — the NOVELTY GATEKEEPER that decides WHEN the reactions/bullets worker is
+//!   worth spawning. It replaces the fixed `% REACTIONS_SCAN_EVERY == 0` cadence in
+//!   `transcribe::live::run` with content-driven triggers (new speech, a question, a known-entity
+//!   mention, a lull) under a hard minimum interval, so the light on-device engine runs when there
+//!   is something to react to instead of on a blind clock.
+//! - [`RefreshableEntityCache`] — a tick-driven cache of the VISIBLE entity `(id, name)` list,
+//!   refreshed every [`ENTITY_CACHE_REFRESH_TICKS`] ticks and shared between the gatekeeper's
+//!   entity-hit trigger and `brain_reactions::reactions_scan` (which previously re-fetched the
+//!   gated list on every scan).
+//! - [`BoundaryGate`] — the BOUNDARY-TIMED SURFACING decision: queued whisper cards / proactive
+//!   hints are emitted at a conversational boundary (a short lull, or the caption ending on
+//!   sentence-final punctuation), with a hard max-hold force-emit so nothing waits forever.
+//!
+//! Nothing in this module does I/O, touches an `AppHandle`, or reads the DB — the cache takes a
+//! `fetch` closure so its refresh cadence is testable without a database. The wiring (worker
+//! spawn, mpsc queue, event emit) lives in `transcribe::live::run` and is real-Mac-verified only.
+//!
+//! GATING NOTE: the cached entity list is (at most [`ENTITY_CACHE_REFRESH_TICKS`] ticks) STALE
+//! against a mid-recording relock. That staleness affects only TRIGGER SENSITIVITY — a name match
+//! may fire a scan — never content: every fact/content read downstream
+//! (`Db::list_facts_visible`, `gated_live_context`) re-reads the LIVE unlocked set fresh, so a
+//! sealed meeting's content still surfaces nowhere. No PII lives here beyond the in-RAM names the
+//! gated fetch returned; nothing is logged.
+
+// ── Novelty-gatekeeper constants (spec §L4) ─────────────────────────────────────────────────────
+
+/// New chars accrued since the last fire that alone justify a scan (~a couple of sentences).
+pub const NOVELTY_NEW_CHARS: usize = 120;
+
+/// Ticks of TOTAL silence (zero new chars) after which pending text is scanned anyway —
+/// 14 ticks × ~3 s = ~42 s: the speaker paused, so react to what was said.
+pub const NOVELTY_LULL_TICKS: u32 = 14;
+
+/// HARD floor between two fires: never faster than 5 ticks (~15 s), whatever the triggers say —
+/// the light engine must never be re-spawned per tick on a chatty stream.
+pub const MIN_FIRE_INTERVAL_TICKS: u32 = 5;
+
+/// Ticks between refreshes of the visible-entity cache (~3 min at the 3 s tick).
+pub const ENTITY_CACHE_REFRESH_TICKS: u32 = 60;
+
+// ── Boundary-gate constants (spec §L4) ──────────────────────────────────────────────────────────
+
+/// Ticks with zero new transcript chars that count as a conversational lull (~8–9 s).
+pub const BOUNDARY_LULL_TICKS: u32 = 3;
+
+/// Hard cap on how many ticks a queued surface may be HELD waiting for a boundary (10 × 3 s =
+/// 30 s) — past it the queue force-emits mid-sentence rather than sitting on a stale card.
+pub const MAX_HOLD_TICKS: u32 = 10;
+
+/// Max chars of freshly-accumulated live text one gatekeeper tick inspects (mirrors the proactive
+/// scanner's per-scan budget — recency is what a live trigger is for).
+const MAX_DELTA_CHARS: usize = 2_000;
+
+/// Trailing chars remembered from the previous tick position, used to RE-LOCATE the scan point
+/// after the live buffer front-trims at its cap (mirrors `proactive::DeltaTracker` — once the
+/// buffer trims, plain offset arithmetic silently points at the WRONG text).
+const ANCHOR_CHARS: usize = 120;
+
+/// Anchor-disciplined per-tick delta over the (front-trimming) live buffer. A deliberate mirror of
+/// `proactive::DeltaTracker` (which stays private to its module and must not be touched — L4
+/// scope): offsets are in CHARS; on a front-trim the scan point is re-located by the remembered
+/// anchor text, and when even the anchor is gone it degrades to the bounded recent tail rather
+/// than ever slicing at a lying offset.
+#[derive(Default)]
+pub struct TickDelta {
+    /// Chars of the buffer already seen — valid only while the buffer is append-only.
+    offset: usize,
+    /// The last ≤[`ANCHOR_CHARS`] chars ending at `offset` at the previous tick.
+    anchor: String,
+}
+
+impl TickDelta {
+    /// The NEW text since the last tick (most recent ≤[`MAX_DELTA_CHARS`] of it), advancing the
+    /// tracker. Never returns stale text as "new" on a plain append; on a front-trim/rewrite it
+    /// degrades to a bounded recent-tail re-scan.
+    pub fn take_delta(&mut self, buf: &str) -> String {
+        let chars: Vec<char> = buf.chars().collect();
+        let total = chars.len();
+        let anchor: Vec<char> = self.anchor.chars().collect();
+        let anchored = self.offset <= total
+            && anchor.len() <= self.offset
+            && chars[self.offset - anchor.len()..self.offset] == anchor[..];
+        let start = if anchored {
+            self.offset
+        } else if !anchor.is_empty() {
+            match find_last_run(&chars, &anchor) {
+                Some(pos) => pos + anchor.len(),
+                None => total.saturating_sub(MAX_DELTA_CHARS),
+            }
+        } else {
+            0
+        };
+        let start = start.min(total).max(total.saturating_sub(MAX_DELTA_CHARS));
+        let delta: String = chars[start..].iter().collect();
+        self.offset = total;
+        self.anchor = chars[total.saturating_sub(ANCHOR_CHARS)..].iter().collect();
+        delta
+    }
+}
+
+/// Rightmost index where `needle` occurs in `hay` as a contiguous run of chars.
+fn find_last_run(hay: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > hay.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len())
+        .rev()
+        .find(|&i| hay[i..i + needle.len()] == needle[..])
+}
+
+/// What one gatekeeper tick decided. `new_chars` is the size of this tick's transcript delta
+/// (chars) — the boundary gate consumes it as its "was anything said" signal, so the loop computes
+/// the delta exactly once per tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoveltyTick {
+    /// Spawn the reactions/bullets worker THIS tick.
+    pub fire: bool,
+    /// Chars of genuinely-new transcript text this tick.
+    pub new_chars: usize,
+}
+
+/// The per-recording NOVELTY GATEKEEPER state. Created fresh by the live loop at every recording
+/// start (nothing leaks across recordings). Advanced once per tick via [`NoveltyState::on_tick`].
+#[derive(Default)]
+pub struct NoveltyState {
+    tracker: TickDelta,
+    /// Ticks since the last FIRE (saturating). Starts at 0, so the earliest possible first fire is
+    /// tick [`MIN_FIRE_INTERVAL_TICKS`] — the floor binds from recording start too.
+    ticks_since_fire: u32,
+    /// Consecutive ticks with ZERO new chars (the lull clock).
+    quiet_ticks: u32,
+    /// New chars accrued since the last fire.
+    pending_chars: usize,
+    /// A `?` appeared in the accrued delta since the last fire.
+    pending_question: bool,
+    /// A visible-entity name appeared in the accrued delta since the last fire.
+    pending_entity_hit: bool,
+}
+
+impl NoveltyState {
+    /// One live tick: take the buffer delta, fold it into the pending triggers, and decide whether
+    /// the worker fires now. Fires when ANY of (≥[`NOVELTY_NEW_CHARS`] pending chars / a `?` in the
+    /// pending delta / a visible-entity name in the pending delta / a [`NOVELTY_LULL_TICKS`] lull
+    /// with pending text) holds — but NEVER within [`MIN_FIRE_INTERVAL_TICKS`] of the previous
+    /// fire. On a fire the pending triggers reset; unspent triggers otherwise accrue.
+    pub fn on_tick(&mut self, live_buf: &str, entities: &[(String, String)]) -> NoveltyTick {
+        self.ticks_since_fire = self.ticks_since_fire.saturating_add(1);
+        let delta = self.tracker.take_delta(live_buf);
+        let new_chars = if delta.trim().is_empty() {
+            0
+        } else {
+            delta.chars().count()
+        };
+        if new_chars == 0 {
+            self.quiet_ticks = self.quiet_ticks.saturating_add(1);
+        } else {
+            self.quiet_ticks = 0;
+            self.pending_chars = self.pending_chars.saturating_add(new_chars);
+            if delta.contains('?') {
+                self.pending_question = true;
+            }
+            if entity_hit(&delta, entities) {
+                self.pending_entity_hit = true;
+            }
+        }
+        let has_pending = self.pending_chars > 0;
+        let trigger = self.pending_chars >= NOVELTY_NEW_CHARS
+            || self.pending_question
+            || self.pending_entity_hit
+            || (has_pending && self.quiet_ticks >= NOVELTY_LULL_TICKS);
+        let fire = trigger && self.ticks_since_fire >= MIN_FIRE_INTERVAL_TICKS;
+        if fire {
+            self.ticks_since_fire = 0;
+            self.pending_chars = 0;
+            self.pending_question = false;
+            self.pending_entity_hit = false;
+        }
+        NoveltyTick { fire, new_chars }
+    }
+}
+
+/// Case-insensitive substring match of any visible entity NAME in the delta (the same coarse
+/// containment `brain_reactions::filter_window_entities` uses — a trigger, not a gate; names ≤2
+/// chars are skipped as noise).
+fn entity_hit(delta: &str, entities: &[(String, String)]) -> bool {
+    let dl = delta.to_lowercase();
+    entities.iter().any(|(_, name)| {
+        let n = name.trim();
+        n.chars().count() >= 3 && dl.contains(&n.to_lowercase())
+    })
+}
+
+/// Tick-driven cache of the VISIBLE entity `(id, name)` list. The live loop calls
+/// [`Self::on_tick`] once per tick with a `fetch` closure (the gated `list_entities_visible` read
+/// over the FRESH unlocked set); the closure runs only on the first tick and then every
+/// [`ENTITY_CACHE_REFRESH_TICKS`] ticks. Pure over the injected closure — headless-testable.
+#[derive(Default)]
+pub struct RefreshableEntityCache {
+    entities: Vec<(String, String)>,
+    /// Ticks until the next refresh; 0 = refresh NOW (the default, so the first tick fetches).
+    ticks_until_refresh: u32,
+}
+
+impl RefreshableEntityCache {
+    /// Advance one tick, refreshing via `fetch` when due, and return the cached list.
+    pub fn on_tick(
+        &mut self,
+        fetch: impl FnOnce() -> Vec<(String, String)>,
+    ) -> &[(String, String)] {
+        if self.ticks_until_refresh == 0 {
+            self.entities = fetch();
+            self.ticks_until_refresh = ENTITY_CACHE_REFRESH_TICKS;
+        }
+        self.ticks_until_refresh -= 1;
+        &self.entities
+    }
+}
+
+/// Sentence-final punctuation the boundary gate treats as "the speaker finished a thought".
+fn ends_sentence(caption: &str) -> bool {
+    matches!(
+        caption.trim_end().chars().last(),
+        Some('.') | Some('!') | Some('?') | Some('…')
+    )
+}
+
+/// The BOUNDARY-TIMED SURFACING decision (pure). The live loop queues whisper cards / proactive
+/// hints and asks this gate once per tick whether NOW is a good moment to emit them: a
+/// conversational lull ([`BOUNDARY_LULL_TICKS`] ticks with no new transcript chars), the latest
+/// caption ending on sentence-final punctuation, or the [`MAX_HOLD_TICKS`] force-emit. Emitting
+/// mid-sentence interrupts the user's reading of the live caption — holding a stale card 30 s+
+/// makes it useless; this is the compromise the spec fixes. Drain-on-stop is the CALLER's job
+/// (the loop emits everything left when the recording ends).
+#[derive(Default)]
+pub struct BoundaryGate {
+    /// Consecutive ticks with zero new transcript chars.
+    quiet_ticks: u32,
+    /// Ticks the current pending batch has been held (0 while nothing is pending).
+    hold_ticks: u32,
+}
+
+impl BoundaryGate {
+    /// One live tick: `has_pending` = anything queued, `had_new_chars` = this tick's transcript
+    /// delta was non-empty, `last_caption` = the most recent caption text (for the sentence-final
+    /// check). Returns `true` when the caller should emit the whole queue now.
+    pub fn on_tick(&mut self, has_pending: bool, had_new_chars: bool, last_caption: &str) -> bool {
+        if had_new_chars {
+            self.quiet_ticks = 0;
+        } else {
+            self.quiet_ticks = self.quiet_ticks.saturating_add(1);
+        }
+        if !has_pending {
+            self.hold_ticks = 0;
+            return false;
+        }
+        self.hold_ticks = self.hold_ticks.saturating_add(1);
+        let emit = self.quiet_ticks >= BOUNDARY_LULL_TICKS
+            || ends_sentence(last_caption)
+            || self.hold_ticks >= MAX_HOLD_TICKS;
+        if emit {
+            self.hold_ticks = 0;
+        }
+        emit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ents(names: &[&str]) -> Vec<(String, String)> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (format!("e{i}"), n.to_string()))
+            .collect()
+    }
+
+    /// Feed `state` `n` silent ticks (unchanged buffer) asserting none fires.
+    fn silent_ticks(state: &mut NoveltyState, buf: &str, n: u32) {
+        for _ in 0..n {
+            assert!(!state.on_tick(buf, &[]).fire, "a silent tick must not fire");
+        }
+    }
+
+    // ── Novelty gatekeeper ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fires_on_enough_new_chars_and_resets_pending() {
+        let mut st = NoveltyState::default();
+        let mut buf = String::new();
+        // Small trickle: below the char threshold, no question, no entity → never fires.
+        buf.push_str("krótka wypowiedź");
+        assert!(!st.on_tick(&buf, &[]).fire);
+        silent_ticks(&mut st, &buf, 6);
+        // A burst of ≥120 new chars → fires (the floor of 5 ticks has long passed).
+        buf.push_str(&" omawiamy szczegóły harmonogramu wdrożenia oraz podział obowiązków w zespole na najbliższe dwa tygodnie sprintu produktowego".repeat(2));
+        let tick = st.on_tick(&buf, &[]);
+        assert!(tick.fire, "≥120 accrued new chars must fire");
+        assert!(tick.new_chars >= NOVELTY_NEW_CHARS);
+        // Pending reset: the very next silent tick does not re-fire.
+        assert!(!st.on_tick(&buf, &[]).fire);
+    }
+
+    #[test]
+    fn fires_on_question_mark_in_delta() {
+        let mut st = NoveltyState::default();
+        let mut buf = String::new();
+        silent_ticks(&mut st, &buf, 5); // clear the min-interval floor with silence
+        buf.push_str("a co z budżetem?");
+        assert!(
+            st.on_tick(&buf, &[]).fire,
+            "a '?' in the delta must fire even under the char threshold"
+        );
+    }
+
+    #[test]
+    fn fires_on_visible_entity_name_hit() {
+        let mut st = NoveltyState::default();
+        let entities = ents(&["Atlas", "Anna Kowalska"]);
+        let mut buf = String::new();
+        silent_ticks(&mut st, &buf, 5);
+        buf.push_str("wracamy do tematu atlas");
+        assert!(
+            st.on_tick(&buf, &entities).fire,
+            "a visible-entity name in the delta must fire"
+        );
+        // A too-short name (≤2 chars) never triggers.
+        let mut st2 = NoveltyState::default();
+        let noisy = ents(&["A"]);
+        let mut buf2 = String::new();
+        silent_ticks(&mut st2, &buf2, 5);
+        buf2.push_str("a tam cokolwiek");
+        assert!(!st2.on_tick(&buf2, &noisy).fire, "1-char names are noise, not a trigger");
+    }
+
+    #[test]
+    fn lull_fires_pending_text_after_fourteen_quiet_ticks() {
+        let mut st = NoveltyState::default();
+        let mut buf = String::new();
+        silent_ticks(&mut st, &buf, 5);
+        buf.push_str("krótka uwaga bez pytania"); // under every instant trigger
+        assert!(!st.on_tick(&buf, &[]).fire);
+        // 13 quiet ticks: still holding.
+        silent_ticks(&mut st, &buf, NOVELTY_LULL_TICKS - 1);
+        // The 14th quiet tick = the 42 s lull → fire on the pending text.
+        assert!(st.on_tick(&buf, &[]).fire, "the lull must flush pending text");
+        // With NOTHING pending, a lull alone never fires.
+        let mut idle = NoveltyState::default();
+        for _ in 0..40 {
+            assert!(!idle.on_tick("", &[]).fire, "an empty recording must never fire");
+        }
+    }
+
+    #[test]
+    fn min_interval_floor_binds_every_trigger() {
+        let mut st = NoveltyState::default();
+        // A question on tick 1: trigger present, but the 5-tick floor holds it.
+        let buf1 = "czy zdążymy?".to_string();
+        assert!(!st.on_tick(&buf1, &[]).fire, "tick 1 is inside the floor");
+        // Ticks 2–4 (unchanged buffer): trigger stays pending, floor still holds.
+        for _ in 0..3 {
+            assert!(!st.on_tick(&buf1, &[]).fire);
+        }
+        // Tick 5: floor cleared → the pending question fires.
+        assert!(st.on_tick(&buf1, &[]).fire, "the pending trigger fires at the floor");
+        // Immediately after a fire, a fresh question waits the full floor again.
+        let buf2 = format!("{buf1} no dobrze, a termin?");
+        assert!(!st.on_tick(&buf2, &[]).fire, "tick 1 after a fire is inside the floor");
+        for _ in 0..3 {
+            assert!(!st.on_tick(&buf2, &[]).fire);
+        }
+        assert!(st.on_tick(&buf2, &[]).fire);
+    }
+
+    /// The live buffer front-trims at its 16k cap: the tracker must re-locate via its anchor and
+    /// count ONLY the genuinely-new tail — never re-count already-seen text as new.
+    #[test]
+    fn tick_delta_survives_front_trim_via_anchor() {
+        let mut t = TickDelta::default();
+        let long: String = (0..40).map(|i| format!("word{i} ")).collect();
+        let _ = t.take_delta(&long);
+        let trimmed = format!("{} FRESH tail here", &long[60..].trim_end());
+        let delta = t.take_delta(&trimmed);
+        assert_eq!(delta.trim_start(), "FRESH tail here", "only the new tail, got {delta:?}");
+        assert!(!delta.contains("word"), "no already-seen text re-surfaced: {delta:?}");
+        // Anchor fully gone (buffer replaced) → bounded recent-tail rescan, never a lying slice.
+        let mut t2 = TickDelta::default();
+        let _ = t2.take_delta("completely original first buffer content");
+        assert_eq!(t2.take_delta("entirely different"), "entirely different");
+    }
+
+    // ── Entity cache ────────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn entity_cache_fetches_on_first_tick_then_every_sixty() {
+        let mut cache = RefreshableEntityCache::default();
+        let mut fetches = 0u32;
+        for tick in 1..=(ENTITY_CACHE_REFRESH_TICKS * 2 + 1) {
+            let got = cache
+                .on_tick(|| {
+                    fetches += 1;
+                    ents(&["Atlas"])
+                })
+                .len();
+            assert_eq!(got, 1, "cache always serves the list (tick {tick})");
+        }
+        // Tick 1 fetches, tick 61 fetches, tick 121 fetches: exactly 3 across 121 ticks.
+        assert_eq!(fetches, 3, "refresh exactly every {ENTITY_CACHE_REFRESH_TICKS} ticks");
+    }
+
+    // ── Boundary gate ───────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn holds_mid_sentence_while_speech_continues() {
+        let mut g = BoundaryGate::default();
+        for _ in 0..(MAX_HOLD_TICKS - 1) {
+            assert!(
+                !g.on_tick(true, true, "and then we decided to move the"),
+                "continuous speech mid-sentence must hold the queue"
+            );
+        }
+    }
+
+    #[test]
+    fn emits_on_lull() {
+        let mut g = BoundaryGate::default();
+        assert!(!g.on_tick(true, true, "mid sentence still going and"));
+        // 3 quiet ticks (~9 s of silence) → boundary.
+        assert!(!g.on_tick(true, false, "mid sentence still going and"));
+        assert!(!g.on_tick(true, false, "mid sentence still going and"));
+        assert!(
+            g.on_tick(true, false, "mid sentence still going and"),
+            "the {BOUNDARY_LULL_TICKS}-tick lull is a boundary"
+        );
+    }
+
+    #[test]
+    fn emits_on_sentence_final_punctuation() {
+        let mut g = BoundaryGate::default();
+        assert!(
+            g.on_tick(true, true, "so that is what we will do."),
+            "a sentence-final '.' is a boundary even while speech continues"
+        );
+        let mut g2 = BoundaryGate::default();
+        assert!(g2.on_tick(true, true, "czy na pewno zdążymy?"), "'?' ends a sentence");
+        let mut g3 = BoundaryGate::default();
+        assert!(g3.on_tick(true, true, "no i tyle…"), "'…' ends a sentence");
+    }
+
+    #[test]
+    fn max_hold_force_emits() {
+        let mut g = BoundaryGate::default();
+        let mut emitted_at = None;
+        for tick in 1..=MAX_HOLD_TICKS {
+            if g.on_tick(true, true, "endless run-on sentence that never terminates and") {
+                emitted_at = Some(tick);
+                break;
+            }
+        }
+        assert_eq!(
+            emitted_at,
+            Some(MAX_HOLD_TICKS),
+            "a queue held {MAX_HOLD_TICKS} ticks must force-emit"
+        );
+    }
+
+    #[test]
+    fn empty_queue_never_emits_and_resets_hold() {
+        let mut g = BoundaryGate::default();
+        for _ in 0..20 {
+            assert!(!g.on_tick(false, false, "done."), "no pending ⇒ nothing to emit");
+        }
+        // A fresh pending batch after a long idle emits on merit, not on stale hold ticks.
+        assert!(g.on_tick(true, false, "sentence over."), "sentence boundary applies");
+    }
+}


### PR DESCRIPTION
Brain v2 PR 6 (plan: `docs/research/2026-07-09-brain-v2-architecture-spec.md` §L4). Backend-only — FE events/payloads byte-unchanged.

## What
- **Novelty gatekeeper** (`transcribe/novelty.rs`) — reactions fire on signal (≥120 new chars / '?' / visible-entity hit / 42s lull; hard 15s floor) instead of the fixed every-21s cadence; shared 60-tick entity cache; anchor-based front-trim survival.
- **Incremental running bullets** (`transcribe/bullets.rs`) — prefix-prompted **local-only** light-reasoner call (≤3 new bullets or NOTHING, 200 tok, 30s timeout), RAM (4k cap) + crash-recovery row `live_bullets` (purged on **all five** seal paths incl. `discard_folder_seal` + `delete_meeting`; upsert refuses when sealed-at-rest — the L1 TOCTOU pattern). New substrates: reactions read `bullets + 300-char verbatim`; the live question inject becomes `2k bullets + 2k verbatim` (gated, fail-closed); at Stop the bullets land in `SummarizeRequest.live_bullets` → "## Live notes (auto)" before the transcript (redaction-scrubbed, sentinel-tested). Flag `live_bullets_enabled` (default true; stub/off ⇒ byte-identical legacy).
- **Boundary-timed surfacing** — whisper cards + proactive hints queue on the tick thread (mpsc from workers) and emit at a lull/sentence boundary (30s max-hold, drain-on-stop) instead of mid-utterance.

## Verification (two rounds, sequential verifiers)
- **Round 1: adversarial FAIL (CRITICAL)** — the RAM bullets write ran BEFORE the `current_meeting` re-check: a worker spanning Stop(A)→Start(B) would write meeting A's bullets into B's substrate, prompt and note. Lock-security flagged the row-upsert TOCTOU + the missing `discard_folder_seal` purge. (One lock finding was VOID — it audited during the adversarial's mutation window; process lesson recorded: mutating verifier gets exclusive tree access, reviews now run sequentially.)
- **Fixes:** fresh `current_meeting` snapshot after the model call gates BOTH writes (`commit_bullets_decision`, pure + test-bound; RAM swap under the mutex; row keyed by the worker's own meeting — cross-keying to B structurally impossible); sealed-at-rest refusal in `upsert_live_bullets`; `live_bullets` added to the discard purge contract.
- **Round 2: adversarial PASS** (guard mutation-killed two independent ways; lock ordering verified deadlock-free) **+ lock-security PASS** (all 5 purge paths tested green, checklist 9/9).
- `cargo test --lib`: 1309/0. `scripts/ci.sh`: ✅ (after adding the new `SummarizeRequest.live_bullets` field to the `e2e_core` example — examples compile only in the full gate).

## Known limitations
- Bullet quality/latency, boundary-timing UX, and the true 30s Stop/Start interleave need a real recording on a real Mac with the light model (headless proves plumbing/gating/purge only).
- Residual MINOR: a worker racing Stop's clear can leave the just-stopped meeting's OWN bullets in RAM until the next Start (same-meeting content, every read gated).
- `GenOptions.timeout` honored only on the GGUF path (trait default ignores it) — pre-existing class, documented.