### PR TITLE
perf(transcribe): live-loop heat fix + notes save ordering

### DIFF
--- a/scripts/measure-live-power.sh
+++ b/scripts/measure-live-power.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# measure-live-power.sh — the powermetrics A/B protocol for Murmur's LIVE transcription loop
+# (T0.2 of docs/research/2026-07-09-transcription-performance.md).
+#
+# WHAT IT MEASURES
+#   CPU / GPU / ANE package power + thermal pressure + per-process energy while Murmur records,
+#   sampled every 1 s. This is the ONLY ground truth for the heat work — every modeled number
+#   (VAD gate, audio_ctx, live pin, flash-attn, thermal governor) counts only once this script
+#   has measured it on a real Mac.
+#
+# PROTOCOL (run the WHOLE thing twice — leg A vs leg B):
+#   1. Prepare a SCRIPTED ~10-minute meeting: play the same fixed PL/EN recording out loud (or
+#      a colleague reads the same script) so both legs hear identical audio.
+#   2. Leg A: set the live model to `small` (Settings, or config `live_model_pin=small`),
+#      start a Murmur recording, then run:
+#        sudo scripts/measure-live-power.sh --seconds 600 --out /tmp/live-power-small.txt
+#   3. Leg B: repeat the SAME scripted meeting with the live model pinned to `large-v3`
+#      (config `live_model_pin=large-v3`, model downloaded):
+#        sudo scripts/measure-live-power.sh --seconds 600 --out /tmp/live-power-large-v3.txt
+#   4. Pair each leg with Murmur's own per-tick decode telemetry: run the app with
+#        RUST_LOG=live_perf=info
+#      and keep the emitted `live decode tick` lines (decode_ms / window_s / model) next to the
+#      powermetrics file. Commit the two summaries as the eval artifact.
+#
+# NOTES
+#   * powermetrics REQUIRES sudo (it reads SMC/thermal counters).
+#   * Run on wall power, screen awake, no other heavy apps — or note the difference.
+#   * The same protocol A/Bs any other change: VAD gate on/off (`live_vad_gate`), flash-attn,
+#     audio_ctx, quants — one variable per pair of legs.
+#
+# USAGE
+#   sudo scripts/measure-live-power.sh [--seconds N] [--out FILE]
+#     --seconds N   sampling duration in seconds (default 600 = the 10-min scripted meeting)
+#     --out FILE    output file (default /tmp/murmur-live-power-<timestamp>.txt)
+#
+# SUMMARIZING (no jq needed — plain grep/awk over the plist-free text output):
+#   grep -E "GPU Power|CPU Power|ANE Power" "$OUT" \
+#     | awk -F': ' '{sum[$1]+=$2; n[$1]++} END {for (k in sum) printf "%s avg %.0f mW over %d samples\n", k, sum[k]/n[k], n[k]}'
+#   grep -E "pressure|Murmur" "$OUT" | sort | uniq -c | head        # thermal levels + process energy lines
+
+set -euo pipefail
+
+SECONDS_TO_SAMPLE=600
+OUT="/tmp/murmur-live-power-$(date +%Y%m%d-%H%M%S).txt"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --seconds)
+      SECONDS_TO_SAMPLE="${2:?--seconds needs a value}"
+      shift 2
+      ;;
+    --out)
+      OUT="${2:?--out needs a path}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,40p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1 (see --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "powermetrics needs root — re-run with sudo." >&2
+  exit 1
+fi
+
+SAMPLE_COUNT="$SECONDS_TO_SAMPLE" # -i 1000 ms ⇒ one sample per second.
+
+echo "Sampling cpu/gpu/ane power + thermal + per-process energy for ${SECONDS_TO_SAMPLE}s → ${OUT}"
+powermetrics \
+  -i 1000 \
+  -n "$SAMPLE_COUNT" \
+  --samplers cpu_power,gpu_power,ane_power,thermal \
+  --show-process-energy \
+  -o "$OUT"
+
+echo "Done → ${OUT}"
+echo "Quick summary:"
+grep -E "GPU Power|CPU Power|ANE Power" "$OUT" \
+  | awk -F': ' '{sum[$1]+=$2; n[$1]++} END {for (k in sum) printf "  %s avg %.0f mW over %d samples\n", k, sum[k]/n[k], n[k]}' \
+  || echo "  (no power lines found — check the samplers on this hardware)"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -156,7 +156,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 block2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSString", "NSError"] }
+# `NSProcessInfo` feature: the typed `thermalState` binding for the live-loop thermal governor
+# (`src/thermal.rs`) — a feature flip on an existing dep, no new crate.
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSProcessInfo"] }
 objc2-app-kit = { version = "0.3", features = ["NSScreen"] }
 objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGWindow"] }
 objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFDictionary", "CFString"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -609,23 +609,32 @@ pub async fn start_recording(
             .ok()
             .flatten()
         };
-        // D1 (spec §4.3): while Realtime Reactions (Brain Live) is on, pin the LIVE tick to `small`
-        // when present — a large-v3 live tick alone can saturate the Metal GPU the light reasoner also
-        // needs. If `small` is NOT on disk, fall back to the configured model + warn (pinning to an
-        // absent file would kill the live loop). The post-call ACCURATE pass is unaffected.
-        let live_model = if cfg.brain_live {
-            match crate::transcribe::model::resolve_model_path(None, "small", lang) {
+        // T1.3 — the UNCONDITIONAL live-model pin (`live_model_pin`, default "small"): the LIVE
+        // caption tick decodes with the pinned SIZE whenever its file is downloaded, regardless
+        // of `model_size` — a `large-v3` live tick saturates the shared Metal GPU for the whole
+        // meeting (the heat complaint), while captions are throwaway (the post-Stop ACCURATE
+        // pass on the configured model is the authoritative transcript and is unaffected).
+        // `""` disables the pin → the configured model, with the LEGACY `brain_live` pin-to-small
+        // (D1, spec §4.3: the live tick must not starve the light reasoner) still applying — the
+        // full decision lives in `model::live_pin_size`. If the pinned model file is absent,
+        // fall back to the configured model + warn (pinning to an absent file would kill the
+        // live loop).
+        let live_model = match crate::transcribe::model::live_pin_size(
+            &cfg.live_model_pin,
+            cfg.brain_live,
+        ) {
+            Some(size) => match crate::transcribe::model::resolve_model_path(None, &size, lang) {
                 Ok(Some(p)) => Some(p),
                 _ => {
                     tracing::warn!(
                         target: "live",
-                        "reactions on but ggml-small absent; live tick uses the configured whisper model (may contend with the light reasoner)"
+                        pin = %size,
+                        "pinned live model absent; live tick uses the configured whisper model (may run hot / contend with the light reasoner)"
                     );
                     configured()
                 }
-            }
-        } else {
-            configured()
+            },
+            None => configured(),
         };
         if let Some(model_path) = live_model {
             crate::transcribe::live::spawn(app.clone(), model_path, cfg.language.clone());
@@ -6799,6 +6808,11 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         } else {
             d.model_size
         },
+        // T1.3/T1.4 (transcription heat): the live-model pin + live VAD gate are NOT carried on
+        // the settings DTO (no FE toggles yet) — PRESERVE the live values (the L3/L4-flag
+        // discipline), each round-tripping through its dedicated K_* load/save key.
+        live_model_pin: current.live_model_pin.clone(),
+        live_vad_gate: current.live_vad_gate,
         voice_trigger: d.voice_trigger,
         onboarded: d.onboarded,
         note_style: if d.note_style.trim().is_empty() {
@@ -11350,13 +11364,8 @@ pub fn restart_voice_listener(app: AppHandle) {
     if let Some(mut l) = state.voice_listener.lock().ok().and_then(|mut g| g.take()) {
         l.stop();
     }
-    let (enabled, configured, size, language) = match state.config.lock() {
-        Ok(c) => (
-            c.voice_trigger,
-            c.whisper_model_path.clone(),
-            c.model_size.clone(),
-            c.language.clone(),
-        ),
+    let (enabled, language) = match state.config.lock() {
+        Ok(c) => (c.voice_trigger, c.language.clone()),
         Err(_) => return,
     };
     if !enabled {
@@ -11366,16 +11375,24 @@ pub fn restart_voice_listener(app: AppHandle) {
     if state.recorder.lock().map(|g| g.is_some()).unwrap_or(false) {
         return;
     }
-    let p = configured.as_deref().map(std::path::Path::new);
-    match crate::transcribe::resolve_model_path(p, &size, language.as_deref().unwrap_or("")) {
-        Ok(Some(model_path)) => {
+    // T1.3 — the standby wake listener decodes a ~2.2 s mic window every few seconds for the
+    // WHOLE time it is armed, so it must run the SMALLEST downloaded model (tiny → base →
+    // small, first present), NEVER the configured model (a medium/large standby decode is a
+    // continuous heat + RAM source). Wake-phrase matching needs rough text only. With none of
+    // the three small sizes downloaded the listener does not start (download `tiny`/`base`/
+    // `small` to enable it) — it never silently escalates to a big model.
+    match crate::transcribe::model::smallest_wake_model(language.as_deref().unwrap_or("")) {
+        Some(model_path) => {
             let listener =
                 crate::audio::listener::VoiceListener::start(app.clone(), model_path, language);
             if let Ok(mut g) = state.voice_listener.lock() {
                 *g = Some(listener);
             }
         }
-        _ => tracing::warn!(target: "voice", "voice trigger enabled but no Whisper model present"),
+        None => tracing::warn!(
+            target: "voice",
+            "voice trigger enabled but no tiny/base/small whisper model downloaded; listener not started"
+        ),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub mod share;
 pub mod state;
 pub mod storage;
 pub mod summarize;
+pub mod thermal;
 pub mod tools;
 pub mod transcribe;
 pub mod update;

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -161,6 +161,26 @@ pub struct AppConfig {
     /// on 8 GB Macs, and onboarding already preselects `small`. All sizes (incl. `large-v3`, best
     /// for Polish) stay selectable; the chosen model is downloaded on demand via `download_model`.
     pub model_size: String,
+    /// T1.3 (transcription heat) — the LIVE caption tick's model PIN. Non-empty (default
+    /// `"small"`) ⇒ while recording, the live loop decodes with THIS size whenever its file is
+    /// downloaded, regardless of `model_size` and `brain_live` — live captions are throwaway
+    /// (the authoritative transcript is the post-Stop Accurate pass on the CONFIGURED model),
+    /// and a `large-v3` live tick saturates the shared Metal GPU for the whole meeting (the
+    /// heat complaint). `""` disables the pin → the configured model (today's pre-pin
+    /// behavior, incl. the legacy `brain_live` pin-to-small). If the pinned model file is
+    /// absent the loop falls back to the configured model (never a dead live loop).
+    /// `#[serde(default = "default_live_model_pin")]` ⇒ a config persisted before this field
+    /// existed loads as `"small"` (the fix applies to existing installs).
+    #[serde(default = "default_live_model_pin")]
+    pub live_model_pin: String,
+    /// T1.4 (transcription heat) — the Silero VAD TICK GATE for the live caption loop: run the
+    /// CPU-only Silero VAD on the newest ~3 s of each tick's window and SKIP the whisper decode
+    /// on silent ticks (with a 2-tick hangover). Default ON. Bypassed (always decode) while a
+    /// manual voice-capture is armed or a wake-suppression window is active, and disabled
+    /// automatically when the VAD model file is absent — so it can never eat a caption the
+    /// user's flows need. `#[serde(default = "default_true")]` ⇒ pre-existing configs load ON.
+    #[serde(default = "default_true")]
+    pub live_vad_gate: bool,
     /// Voice trigger: start recording when a wake phrase is heard. Default off.
     pub voice_trigger: bool,
     /// Whether the first-run onboarding has been completed.
@@ -510,6 +530,11 @@ fn default_true() -> bool {
     true
 }
 
+/// serde default for [`AppConfig::live_model_pin`] — pin the live tick to `small` (T1.3).
+fn default_live_model_pin() -> String {
+    "small".to_string()
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -535,6 +560,8 @@ impl Default for AppConfig {
             audio_storage_limit_gb: None,
             audio_auto_prune: false,
             model_size: "small".to_string(),
+            live_model_pin: default_live_model_pin(),
+            live_vad_gate: true,
             voice_trigger: false,
             onboarded: false,
             note_style: "standard".to_string(),
@@ -619,6 +646,8 @@ const K_POST_AEC_ENABLED: &str = "post_aec_enabled";
 const K_AUDIO_STORAGE_LIMIT_GB: &str = "audio_storage_limit_gb";
 const K_AUDIO_AUTO_PRUNE: &str = "audio_auto_prune";
 const K_MODEL_SIZE: &str = "model_size";
+const K_LIVE_MODEL_PIN: &str = "live_model_pin";
+const K_LIVE_VAD_GATE: &str = "live_vad_gate";
 const K_VOICE_TRIGGER: &str = "voice_trigger";
 const K_ONBOARDED: &str = "onboarded";
 const K_NOTE_STYLE: &str = "note_style";
@@ -744,6 +773,14 @@ impl AppConfig {
             if !v.is_empty() {
                 cfg.model_size = v;
             }
+        }
+        // `""` is a VALID stored value (= pin disabled), so it is taken verbatim — only an
+        // ABSENT key keeps the `"small"` default (mirrors `provider_model`, not `anthropic_model`).
+        if let Some(v) = db.get_setting(K_LIVE_MODEL_PIN)? {
+            cfg.live_model_pin = v;
+        }
+        if let Some(v) = db.get_setting(K_LIVE_VAD_GATE)? {
+            cfg.live_vad_gate = v == "true";
         }
         if let Some(v) = db.get_setting(K_VOICE_TRIGGER)? {
             cfg.voice_trigger = v == "true";
@@ -999,6 +1036,11 @@ impl AppConfig {
             },
         )?;
         db.set_setting(K_MODEL_SIZE, &self.model_size)?;
+        db.set_setting(K_LIVE_MODEL_PIN, &self.live_model_pin)?;
+        db.set_setting(
+            K_LIVE_VAD_GATE,
+            if self.live_vad_gate { "true" } else { "false" },
+        )?;
         db.set_setting(
             K_VOICE_TRIGGER,
             if self.voice_trigger { "true" } else { "false" },
@@ -1435,6 +1477,39 @@ mod tests {
         // Empty settings table loads the same default.
         let db = temp_db();
         assert_eq!(AppConfig::load(&db).unwrap().model_size, "small");
+    }
+
+    /// T1.3/T1.4 — the live-tick pin defaults to `small` and the VAD tick gate defaults ON
+    /// (both on a fresh config AND an empty settings table, so existing installs get the heat
+    /// fix), while the explicit opt-outs (`""` pin / gate OFF) persist + reload verbatim.
+    #[test]
+    fn live_pin_defaults_small_and_vad_gate_on_and_opt_outs_round_trip() {
+        assert_eq!(AppConfig::default().live_model_pin, "small");
+        assert!(AppConfig::default().live_vad_gate);
+        let db = temp_db();
+        let loaded = AppConfig::load(&db).unwrap();
+        assert_eq!(loaded.live_model_pin, "small");
+        assert!(loaded.live_vad_gate);
+
+        // The opt-outs are VALID stored values and must survive a save/load round-trip:
+        // `""` = pin disabled (NOT re-defaulted to "small"), `false` = gate off.
+        let cfg = AppConfig {
+            live_model_pin: String::new(),
+            live_vad_gate: false,
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        let reloaded = AppConfig::load(&db).unwrap();
+        assert_eq!(reloaded.live_model_pin, "");
+        assert!(!reloaded.live_vad_gate);
+
+        // And a quant pin round-trips verbatim too.
+        let cfg = AppConfig {
+            live_model_pin: "small-q8_0".to_string(),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert_eq!(AppConfig::load(&db).unwrap().live_model_pin, "small-q8_0");
     }
 
     #[test]

--- a/src-tauri/src/thermal.rs
+++ b/src-tauri/src/thermal.rs
@@ -1,0 +1,292 @@
+//! Thermal governor + QoS tagging for the LIVE transcription loop (T1.5 of the
+//! 2026-07-09 transcription-performance plan).
+//!
+//! The live caption loop re-decodes a rolling audio window on the Metal GPU it shares with
+//! the on-device LLM. Under sustained load the Mac heats up; macOS surfaces that as
+//! `NSProcessInfo.thermalState`. This module maps that state to a PURE back-off policy:
+//!
+//! | state    | live tick | reactions scans | live captions |
+//! |----------|-----------|-----------------|---------------|
+//! | Nominal  | 3 s       | run             | run           |
+//! | Fair     | 6 s       | run             | run           |
+//! | Serious  | 9 s       | **paused**      | run           |
+//! | Critical | 9 s       | paused          | **suspended** |
+//!
+//! The RECORDING and the post-Stop batch pipeline are NEVER touched by this governor — only
+//! the best-effort live loop backs off. Captions degrade; the authoritative transcript is
+//! produced at Stop regardless.
+//!
+//! FFI safety (rules §7): the thermal read uses the objc2-foundation TYPED
+//! `NSProcessInfo::processInfo().thermalState()` binding — a plain getter present since
+//! macOS 10.10.3 (our floor is 13.4), generated `extern_methods!` over a selector the class
+//! is documented to implement; it does not throw. Any doubt — an unknown/future enum value,
+//! a Rust-side panic — DEGRADES TO `Nominal` (today's behavior), never a crash. The QoS tag
+//! is a plain C function (`pthread_set_qos_class_self_np`) that returns an error code on
+//! failure — no exception path at all.
+
+use std::time::Duration;
+
+/// The live-loop tick period at each thermal level (see the module table).
+const TICK_NOMINAL: Duration = Duration::from_millis(3000);
+const TICK_FAIR: Duration = Duration::from_millis(6000);
+const TICK_SERIOUS: Duration = Duration::from_millis(9000);
+
+/// Consecutive BETTER thermal reads required before the governor recovers to a lighter
+/// level. Degrading is instant (protect the hardware fast); recovering is damped so a
+/// noisy Serious↔Fair boundary can't flap the tick period every read.
+const RECOVER_AFTER_READS: u8 = 2;
+
+/// Our own thermal ladder — decoupled from the ObjC enum so the POLICY is pure and
+/// headless-testable, and an unknown/future `NSProcessInfoThermalState` value maps to
+/// [`ThermalLevel::Nominal`] (degrade-to-today, never a wrong-side surprise).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ThermalLevel {
+    Nominal,
+    Fair,
+    Serious,
+    Critical,
+}
+
+/// The live loop's thermal back-off state machine. PURE (no FFI inside): the caller feeds it
+/// one [`ThermalLevel`] observation per tick (from [`read_thermal_level`]) and reads the
+/// policy. Hysteresis: degrade FAST (a worse read applies immediately), recover SLOW
+/// ([`RECOVER_AFTER_READS`] consecutive better reads) — no flapping at a boundary.
+#[derive(Debug, Default)]
+pub struct ThermalGovernor {
+    level: Option<ThermalLevel>,
+    /// Consecutive reads strictly BETTER than the current level (reset by an equal/worse read).
+    better_streak: u8,
+}
+
+impl ThermalGovernor {
+    /// The governed level (defaults to `Nominal` before the first observation).
+    fn level(&self) -> ThermalLevel {
+        self.level.unwrap_or(ThermalLevel::Nominal)
+    }
+
+    /// Fold one thermal observation in. Worse-or-equal ⇒ adopt immediately (degrade fast) and
+    /// reset the recovery streak; better ⇒ adopt only after [`RECOVER_AFTER_READS`] consecutive
+    /// better reads (recover slow), adopting the LATEST observed (better) level.
+    pub fn observe(&mut self, read: ThermalLevel) {
+        let current = self.level();
+        if read >= current {
+            self.level = Some(read);
+            self.better_streak = 0;
+            return;
+        }
+        self.better_streak = self.better_streak.saturating_add(1);
+        if self.better_streak >= RECOVER_AFTER_READS {
+            self.level = Some(read);
+            self.better_streak = 0;
+        }
+    }
+
+    /// The live-loop sleep for the governed level (see the module table). `Critical` keeps the
+    /// `Serious` tick — the loop still runs (recorder-gone detection, manual capture bypass),
+    /// it just skips the caption decode via [`Self::captions_suspended`].
+    pub fn effective_tick(&self) -> Duration {
+        match self.level() {
+            ThermalLevel::Nominal => TICK_NOMINAL,
+            ThermalLevel::Fair => TICK_FAIR,
+            ThermalLevel::Serious | ThermalLevel::Critical => TICK_SERIOUS,
+        }
+    }
+
+    /// Whether background Realtime-Reactions/bullets scans should be paused (`Serious`+).
+    pub fn reactions_paused(&self) -> bool {
+        self.level() >= ThermalLevel::Serious
+    }
+
+    /// Whether the live caption decode should be suspended entirely (`Critical` only).
+    /// The recording + the post-Stop batch pipeline are NEVER affected, and the live loop
+    /// exempts user-armed bypass flows (manual voice-capture / a just-fired wake) from the
+    /// suspend — a user-facing "listening" state must never freeze on thermal back-off.
+    pub fn captions_suspended(&self) -> bool {
+        self.level() >= ThermalLevel::Critical
+    }
+}
+
+/// USER-TURN DECODE DEFER (Brain v2 P0.3 companion): skip exactly ONE live decode tick per
+/// user-turn window while an assistant turn is in flight on the LOCAL GGUF brain — the worst
+/// Metal co-residency spike is the live whisper decode landing mid-generation. PURE state
+/// machine, headless-testable; mirrors the flag-read discipline of
+/// `brain_reactions::should_defer_scan` (advisory scheduling hint, `Relaxed` load upstream).
+#[derive(Debug, Default)]
+pub struct TurnDefer {
+    /// Whether the CURRENT contiguous turn window has already consumed its one skipped tick.
+    deferred_for_current: bool,
+}
+
+impl TurnDefer {
+    /// Decide whether THIS tick's decode should be skipped. Skips only when a user turn is in
+    /// flight AND the live path is local-GGUF-backed AND this turn window hasn't already been
+    /// deferred once. The window re-arms as soon as the turn flag clears.
+    pub fn should_skip(&mut self, user_turn_in_progress: bool, live_is_local_gguf: bool) -> bool {
+        if !user_turn_in_progress {
+            self.deferred_for_current = false;
+            return false;
+        }
+        if !live_is_local_gguf || self.deferred_for_current {
+            return false;
+        }
+        self.deferred_for_current = true;
+        true
+    }
+}
+
+/// Read the CURRENT process thermal state, degraded to [`ThermalLevel::Nominal`] on ANY doubt.
+///
+/// Uses the objc2-foundation TYPED `NSProcessInfo` binding (feature `NSProcessInfo`) — a plain
+/// documented getter (macOS 10.10.3+; our deployment floor is 13.4), so no
+/// unrecognized-selector risk (the `NSScreen.isCaptured` class of abort — rules §7). The raw
+/// `NSInteger` is matched by VALUE so an unknown/future state maps to `Nominal` (= today's
+/// behavior) rather than a wrong back-off. A Rust-side panic inside the call is contained by
+/// `catch_unwind` and likewise degrades to `Nominal` — this probe must NEVER take down the
+/// live loop, let alone the process.
+#[cfg(target_os = "macos")]
+pub fn read_thermal_level() -> ThermalLevel {
+    let read = std::panic::catch_unwind(|| {
+        let state = objc2_foundation::NSProcessInfo::processInfo().thermalState();
+        match state.0 {
+            1 => ThermalLevel::Fair,
+            2 => ThermalLevel::Serious,
+            3 => ThermalLevel::Critical,
+            // 0 = Nominal; anything unknown/future degrades to Nominal (no wrong-side back-off).
+            _ => ThermalLevel::Nominal,
+        }
+    });
+    read.unwrap_or(ThermalLevel::Nominal)
+}
+
+/// Non-macOS builds have no thermal probe — always `Nominal` (today's behavior).
+#[cfg(not(target_os = "macos"))]
+pub fn read_thermal_level() -> ThermalLevel {
+    ThermalLevel::Nominal
+}
+
+/// Tag the CALLING thread `QOS_CLASS_UTILITY` so macOS schedules the live caption tick and the
+/// reactions worker on efficiency cores under contention (Apple energy guidance: background
+/// inference belongs at utility-or-lower). Best-effort: `pthread_set_qos_class_self_np` is a
+/// plain C function (declared here directly — libc is only a transitive dep and this is its
+/// exact, ABI-stable signature) that returns a non-zero error code on failure — logged at
+/// debug, never fatal. No exception path exists (rules §7).
+#[cfg(target_os = "macos")]
+pub fn set_utility_qos() {
+    use std::os::raw::{c_int, c_uint};
+    /// `QOS_CLASS_UTILITY` from `<sys/qos.h>` (0x11) — the value libc's `qos_class_t` carries.
+    const QOS_CLASS_UTILITY: c_uint = 0x11;
+    extern "C" {
+        fn pthread_set_qos_class_self_np(qos_class: c_uint, relative_priority: c_int) -> c_int;
+    }
+    // SAFETY: plain C call with primitive args; documented to return an errno-style code.
+    let rc = unsafe { pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0) };
+    if rc != 0 {
+        tracing::debug!(target: "thermal", rc, "QoS utility tagging failed; thread stays at default QoS");
+    }
+}
+
+/// Non-macOS builds: no QoS API — no-op.
+#[cfg(not(target_os = "macos"))]
+pub fn set_utility_qos() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_maps_levels_to_ticks_and_pauses() {
+        let mut g = ThermalGovernor::default();
+        // Fresh governor = Nominal: 3 s tick, nothing paused.
+        assert_eq!(g.effective_tick(), Duration::from_millis(3000));
+        assert!(!g.reactions_paused());
+        assert!(!g.captions_suspended());
+
+        g.observe(ThermalLevel::Fair);
+        assert_eq!(g.effective_tick(), Duration::from_millis(6000));
+        assert!(!g.reactions_paused());
+        assert!(!g.captions_suspended());
+
+        g.observe(ThermalLevel::Serious);
+        assert_eq!(g.effective_tick(), Duration::from_millis(9000));
+        assert!(g.reactions_paused());
+        assert!(!g.captions_suspended());
+
+        g.observe(ThermalLevel::Critical);
+        assert_eq!(g.effective_tick(), Duration::from_millis(9000));
+        assert!(g.reactions_paused());
+        assert!(g.captions_suspended());
+    }
+
+    #[test]
+    fn degrades_fast_recovers_after_two_consecutive_better_reads() {
+        let mut g = ThermalGovernor::default();
+        // Degrade is INSTANT.
+        g.observe(ThermalLevel::Serious);
+        assert!(g.reactions_paused());
+
+        // ONE better read does not recover yet…
+        g.observe(ThermalLevel::Nominal);
+        assert!(g.reactions_paused(), "one better read must not recover");
+        // …the SECOND consecutive better read does — to the observed (better) level.
+        g.observe(ThermalLevel::Nominal);
+        assert!(!g.reactions_paused());
+        assert_eq!(g.effective_tick(), Duration::from_millis(3000));
+    }
+
+    #[test]
+    fn recovery_streak_resets_on_a_worse_or_equal_read_no_flapping() {
+        let mut g = ThermalGovernor::default();
+        g.observe(ThermalLevel::Serious);
+        // better, then equal-to-current: the streak resets, so a later single better read
+        // still isn't enough — the boundary can't flap the tick period.
+        g.observe(ThermalLevel::Fair);
+        g.observe(ThermalLevel::Serious);
+        g.observe(ThermalLevel::Fair);
+        assert!(
+            g.reactions_paused(),
+            "streak must reset on the worse read in between"
+        );
+        g.observe(ThermalLevel::Fair);
+        // Two consecutive Fair reads now ⇒ recover to Fair (6 s, reactions run again).
+        assert!(!g.reactions_paused());
+        assert_eq!(g.effective_tick(), Duration::from_millis(6000));
+    }
+
+    #[test]
+    fn turn_defer_skips_exactly_one_tick_per_turn_window() {
+        let mut d = TurnDefer::default();
+        // Idle: never skips.
+        assert!(!d.should_skip(false, true));
+        // Turn on local GGUF: skip the FIRST tick only…
+        assert!(d.should_skip(true, true));
+        assert!(!d.should_skip(true, true), "only one skip per turn window");
+        assert!(!d.should_skip(true, true));
+        // Turn ends → window re-arms → next local turn skips one tick again.
+        assert!(!d.should_skip(false, true));
+        assert!(d.should_skip(true, true));
+    }
+
+    #[test]
+    fn turn_defer_never_skips_on_cloud_backed_live_path() {
+        let mut d = TurnDefer::default();
+        // Cloud turn: no Metal co-residency ⇒ no defer, and it must not consume the window
+        // (a mid-turn switch to local would still get its one skip).
+        assert!(!d.should_skip(true, false));
+        assert!(d.should_skip(true, true));
+    }
+
+    #[test]
+    fn read_thermal_level_never_panics_and_qos_is_callable() {
+        // FFI smoke: on macOS this exercises the real NSProcessInfo getter + the QoS call;
+        // elsewhere the no-op stubs. Either way: no panic, a valid level.
+        let level = read_thermal_level();
+        assert!(matches!(
+            level,
+            ThermalLevel::Nominal
+                | ThermalLevel::Fair
+                | ThermalLevel::Serious
+                | ThermalLevel::Critical
+        ));
+        set_utility_qos();
+    }
+}

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -16,15 +16,18 @@
 //!   context reflect what YOU say during the call; the other side is folded in only after Stop.
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::state::AppState;
 use crate::transcribe::Transcriber;
 
-/// How often to attempt a live caption.
-const TICK: Duration = Duration::from_millis(3000);
+// NOTE (T1.5, 2026-07-09 transcription plan): the historical fixed `TICK = 3000 ms` sleep is
+// now THERMAL-GOVERNED — `crate::thermal::ThermalGovernor::effective_tick()` returns the same
+// 3 s at Nominal and stretches to 6 s / 9 s under Fair / Serious+ thermal pressure. Every
+// "tick"-counted window below (wake dedup, hangovers, backstop budgets) is counted in TICKS,
+// so under pressure those windows stretch in WALL-CLOCK terms with the tick — intended: the
+// whole live layer backs off together.
 // NOTE (Brain v2 L4): the fixed `REACTIONS_SCAN_EVERY = 7` cadence was replaced by the
 // content-driven novelty gatekeeper (`crate::transcribe::novelty::NoveltyState`) — the hard
 // minimum interval lives there (`MIN_FIRE_INTERVAL_TICKS`, ~15 s).
@@ -88,6 +91,109 @@ impl WakeDedup {
         self.cooldown = WAKE_DEDUP_TICKS;
         true
     }
+
+    /// Whether a wake-suppression window is currently ACTIVE (a wake just fired within the last
+    /// [`WAKE_DEDUP_TICKS`] ticks). The VAD tick gate BYPASSES itself while this is true: right
+    /// after a wake the user is mid-flow with the assistant, and a mis-gated tick there would be
+    /// user-visible in a way a silent-lull skip never is.
+    fn is_suppressing(&self) -> bool {
+        self.cooldown > 0
+    }
+}
+
+/// FLOOR on how many trailing seconds of the 16 kHz window the VAD gate scans for speech per
+/// tick (the historical fixed delta at the 3 s nominal tick). The ACTUAL span is
+/// [`vad_scan_span_secs`]: everything that arrived since the LAST VAD scan — the thermal
+/// governor stretches the tick to 6 s/9 s, and suspended/deferred/short-tail ticks skip the
+/// scan entirely, so a fixed 3 s would leave the rest of the new audio permanently unscanned
+/// (a short utterance there would scroll out of the window undecoded — a lost caption/wake).
+const VAD_DELTA_SECS: usize = 3;
+
+/// Extra seconds added on top of the measured since-last-scan span, covering loop-body time
+/// (decode latency, resample) between the wall-clock measurement and the audio snapshot.
+const VAD_SCAN_HEADROOM_SECS: usize = 2;
+
+/// Seconds of the freshest window audio the VAD gate scans THIS tick: the wall-clock span
+/// since the last scan (however the tick was stretched or how many ticks were skipped) plus
+/// [`VAD_SCAN_HEADROOM_SECS`], floored at [`VAD_DELTA_SECS`] and clamped to the rolling
+/// window itself. Guarantees the fail-open contract (speech ⇒ decode) holds under
+/// thermally-stretched ticks: no new audio is ever left un-scanned between scans.
+fn vad_scan_span_secs(secs_since_last_scan: f64) -> usize {
+    // `as usize` is a SATURATING float cast (NaN → 0, negative → 0, +∞ → usize::MAX), so every
+    // degenerate input lands safely between the floor and the window clamp below.
+    let elapsed = secs_since_last_scan.ceil() as usize;
+    elapsed
+        .saturating_add(VAD_SCAN_HEADROOM_SECS)
+        .clamp(VAD_DELTA_SECS, WINDOW_SECS)
+}
+
+/// How many extra ticks the gate keeps decoding after the LAST speech-positive tick. Bridges
+/// short mid-sentence pauses (a 2-tick hangover ≈ 6 s at the nominal tick) so a caption never
+/// cuts off on a breath; only a genuine lull stops the decode.
+const VAD_HANGOVER_TICKS: u8 = 2;
+
+/// T1.4 — the Silero VAD TICK GATE for the live loop: the PURE per-tick decision whether this
+/// tick's whisper decode should run. Today the loop decodes the rolling window UNCONDITIONALLY
+/// — even a fully silent meeting burns a full Metal encode every 3 s. The gate skips the decode
+/// on silent ticks; everything downstream (captions, live buffer, bullets, reactions, wake)
+/// consumes decoded TEXT, and silence produces none, so a skipped tick is behavior-identical to
+/// a decoded-empty tick — minus the GPU burn.
+///
+/// Inputs per tick:
+/// - `speech`: `Some(true/false)` = the CPU-only Silero verdict over the newest ~3 s delta;
+///   `None` = VAD unavailable this tick (model absent / load or inference failed) ⇒ FAIL-OPEN,
+///   decode (gate disabled = today's behavior — the gate may only ever REMOVE redundant work,
+///   never a caption someone needed).
+/// - `bypass`: manual voice-capture armed / wake-suppression window active ⇒ always decode
+///   (those flows consume every tick's transcript directly).
+///
+/// Pure + stateful (hangover), no I/O — headless-testable ([`live_vad_gate_decision_matrix`]).
+#[derive(Debug, Default)]
+struct LiveVadGate {
+    /// Remaining no-speech ticks that still decode after the last speech-positive tick.
+    hangover: u8,
+}
+
+impl LiveVadGate {
+    /// Decide whether THIS tick decodes. Speech re-arms the hangover; silence spends it;
+    /// silence with the hangover spent ⇒ skip. Bypass/VAD-unavailable ⇒ decode (fail-open),
+    /// leaving the hangover untouched.
+    fn should_decode(&mut self, speech: Option<bool>, bypass: bool) -> bool {
+        if bypass {
+            return true;
+        }
+        match speech {
+            None => true, // VAD unavailable ⇒ fail-open: today's decode-every-tick behavior.
+            Some(true) => {
+                self.hangover = VAD_HANGOVER_TICKS;
+                true
+            }
+            Some(false) => {
+                if self.hangover > 0 {
+                    self.hangover -= 1;
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+/// Coarse, non-PII MODEL-SIZE LABEL for the `live_perf` telemetry, derived from the ggml model
+/// FILENAME only (never the path — §8): `ggml-small.bin` → `small`, `ggml-large-v3-q5_0.bin` →
+/// `large-v3-q5_0`. A file that doesn't follow the ggml naming (an explicit
+/// `whisper_model_path` pointing at an arbitrary user file) yields `custom` — its name is
+/// deliberately NOT logged.
+fn model_size_label(model_path: &std::path::Path) -> String {
+    let stem = model_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    match stem.strip_prefix("ggml-") {
+        Some(rest) if !rest.is_empty() => rest.to_string(),
+        _ => "custom".to_string(),
+    }
 }
 
 /// Normalize a wake command for dedup comparison: lowercase, collapse whitespace, drop surrounding
@@ -111,6 +217,9 @@ pub fn spawn(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
 }
 
 fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
+    // T1.5 — QoS: the caption tick is background inference; tag this thread UTILITY so macOS
+    // schedules it onto efficiency cores under contention. Best-effort C call, never fatal.
+    crate::thermal::set_utility_qos();
     // Fresh transcript per recording: clear any leftover from a previous meeting so the in-meeting
     // assistant can never answer about a stale recording.
     if let Ok(mut lt) = app.state::<AppState>().live_transcript.lock() {
@@ -123,6 +232,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
         let state = app.state::<AppState>();
         crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
     }
+    // T0.1 telemetry label — the coarse model SIZE only (never the path), computed once.
+    let model_label = model_size_label(&model_path);
     let transcriber = match Transcriber::load(&model_path) {
         Ok(t) => t,
         Err(e) => {
@@ -130,6 +241,54 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             return;
         }
     };
+
+    // T1.4 — the Silero VAD tick gate (config `live_vad_gate`, default ON): load the tiny
+    // (~885 kB) Silero model ONCE per recording, CPU-ONLY on purpose — a SECOND ggml Metal
+    // context alongside the whisper context makes ggml's scheduler `ggml_abort` the process
+    // (see `transcribe::vad::VadSegmenter::load`). Flag off / model absent / load failure ⇒
+    // gate disabled (today's decode-every-tick behavior), logged ONCE here.
+    let vad_gate_enabled = app
+        .state::<AppState>()
+        .config
+        .lock()
+        .map(|c| c.live_vad_gate)
+        .unwrap_or(true);
+    let mut vad = if vad_gate_enabled {
+        match crate::transcribe::model::models_dir() {
+            Ok(dir) => {
+                let path = dir.join(crate::transcribe::model::VAD_MODEL_FILE);
+                if path.is_file() {
+                    match crate::transcribe::vad::VadSegmenter::load(&path) {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            tracing::warn!(target: "live", error = %e, "live VAD gate off (model load failed); decoding every tick");
+                            None
+                        }
+                    }
+                } else {
+                    tracing::info!(target: "live", "live VAD gate off (VAD model not downloaded); decoding every tick");
+                    None
+                }
+            }
+            Err(e) => {
+                tracing::debug!(target: "live", error = %e, "live VAD gate off (models dir unresolved); decoding every tick");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let mut vad_gate = LiveVadGate::default();
+    // Wall-clock cursor for the VAD scan span (see `vad_scan_span_secs`): advanced whenever a
+    // tick's fresh audio is either VAD-scanned or unconditionally decoded (bypass / no VAD).
+    // Ticks that skip both (thermal suspend, turn-defer, short tail, resample failure) leave
+    // it in place so the NEXT scan covers their accumulated audio too.
+    let mut last_vad_scan = std::time::Instant::now();
+
+    // T1.5 — thermal governor (tick-stretch + reactions pause + caption suspend under load) and
+    // the one-tick user-turn decode defer. Recording + the post-Stop batch are NEVER touched.
+    let mut governor = crate::thermal::ThermalGovernor::default();
+    let mut turn_defer = crate::thermal::TurnDefer::default();
 
     // DEDUP state for the wake trigger (#23): detect_wake now fires ANYWHERE in the overlapping tail,
     // so without this the same spoken wake re-fires every tick it stays visible. Lives across ticks.
@@ -162,7 +321,10 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
     let mut last_caption = String::new();
 
     loop {
-        std::thread::sleep(TICK);
+        // T1.5 — the sleep is thermal-governed: 3 s nominal (the historical TICK), stretching to
+        // 6 s / 9 s as the Mac heats up. One guarded FFI read per tick; degrade-to-Nominal.
+        std::thread::sleep(governor.effective_tick());
+        governor.observe(crate::thermal::read_thermal_level());
         // Age out an expired wake-suppression window once per tick (before this tick's wake check).
         wake_dedup.tick();
 
@@ -216,7 +378,10 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
         // substrate the scan reads), THEN the light-engine contradiction scan. Cards are SENT back
         // over the mpsc queue and emitted at a boundary — or, in shadow mode, counted. Skip-if-
         // busy: a slow scan drops this trigger; the recording never waits on the LLM.
+        // T1.5: under `Serious`+ thermal pressure the reactions/bullets worker is PAUSED
+        // (checked BEFORE the busy-flag swap so a paused tick can't wedge the flag).
         if novelty_tick.fire
+            && !governor.reactions_paused()
             && !reactions_busy.swap(true, std::sync::atomic::Ordering::AcqRel)
         {
             let app2 = app.clone();
@@ -224,6 +389,8 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             let tx2 = surface_tx.clone();
             let entities2 = entities.clone();
             std::thread::spawn(move || {
+                // T1.5 — QoS: the reactions worker is background inference too → UTILITY.
+                crate::thermal::set_utility_qos();
                 // RAII: reset the busy flag on EVERY exit — including a panic inside reactions_scan.
                 // Without this, one panic would wedge the flag `true` and silently kill ALL further
                 // reaction scans this recording (deep-review: worker-thread-panic stuck-busy).
@@ -291,6 +458,63 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             continue; // <1s captured so far — nothing worth transcribing yet
         }
 
+        // BYPASS (computed BEFORE the thermal suspend below): while a manual voice-capture is
+        // armed or a wake-suppression window is active, EVERY tick must decode — those flows
+        // consume the per-tick transcript directly (`step_manual_capture` accumulates it and
+        // owns the user's stop click + the backstop budget; a just-fired wake is mid-flow).
+        let bypass = {
+            let state = app.state::<AppState>();
+            let manual_armed = state
+                .voice_command_capture
+                .lock()
+                .map(|g| g.is_some())
+                .unwrap_or(false);
+            manual_armed || wake_dedup.is_suppressing()
+        };
+
+        // T1.5 — CRITICAL thermal: suspend the caption decode entirely (the recording and the
+        // post-Stop batch pipeline are untouched; the loop keeps ticking so recorder-gone
+        // still ends it). Checked AFTER the snapshot so self-termination is never delayed,
+        // BEFORE the resample so the skip costs ~nothing — but NEVER while a bypass flow is
+        // live: an armed click-to-stop capture must keep accumulating and stay stoppable
+        // (`step_manual_capture` is behind the decode), or the FE wedges in "listening" until
+        // thermal recovers. One in-flight utterance's worth of decodes is an acceptable
+        // thermal cost; freezing a user-armed flow is not.
+        if governor.captions_suspended() && !bypass {
+            tracing::debug!(target: "live", "critical thermal state; caption decode suspended this tick");
+            continue;
+        }
+
+        // TURN-DEFER (T1.5): while a user-initiated assistant turn runs on the LOCAL GGUF
+        // brain (the shared-Metal co-residency spike), skip ONE decode tick per turn window —
+        // the same flag-read discipline as `brain_reactions::should_defer_scan`. Evaluated
+        // ONLY on non-bypass ticks so a bypassed tick can't consume the turn window's single
+        // defer without an actual skip (and the resolve isn't computed needlessly). Trade-off:
+        // a turn window that both starts and ends entirely inside a bypass stretch leaves
+        // `deferred_for_current` armed, costing the NEXT local turn its one defer — fail-safe
+        // (fewer skips), never an extra skip.
+        if !bypass {
+            let user_turn = app
+                .state::<AppState>()
+                .user_turn_in_progress
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let live_local = user_turn
+                && app
+                    .state::<AppState>()
+                    .config
+                    .lock()
+                    .map(|c| {
+                        crate::summarize::roles::resolve(crate::summarize::roles::Role::Live, &c)
+                            .connection
+                            == crate::summarize::roles::CONN_LOCAL
+                    })
+                    .unwrap_or(false);
+            if turn_defer.should_skip(user_turn, live_local) {
+                tracing::debug!(target: "live", "user turn on the local brain; deferring one decode tick");
+                continue;
+            }
+        }
+
         let samples_16k = match crate::audio::resample_to_16k(&tail, rate) {
             Ok(s) => s,
             Err(e) => {
@@ -299,11 +523,54 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             }
         };
 
+        // VAD TICK GATE (T1.4): CPU-only Silero over EVERYTHING that arrived since the last
+        // scan (`vad_scan_span_secs` — the governed tick stretches to 6-9 s and skipped ticks
+        // accumulate, so a fixed 3 s delta would leave audio permanently unscanned). Silence
+        // with the hangover spent ⇒ skip the whisper decode; a VAD error fails OPEN (decode).
+        // Everything downstream consumes decoded TEXT — silence produces none — so a skipped
+        // tick changes no consumer's behavior, only the GPU burn.
+        let speech: Option<bool> = match vad.as_mut() {
+            Some(v) if !bypass => {
+                let span = vad_scan_span_secs(last_vad_scan.elapsed().as_secs_f64());
+                last_vad_scan = std::time::Instant::now();
+                let delta_start = samples_16k.len().saturating_sub(span * 16_000);
+                match v.speech_regions(&samples_16k[delta_start..]) {
+                    Ok(regions) => Some(!regions.is_empty()),
+                    Err(e) => {
+                        tracing::debug!(target: "live", error = %e, "live VAD tick failed; decoding");
+                        None
+                    }
+                }
+            }
+            _ => {
+                // Bypass or no VAD loaded: this tick decodes unconditionally (fail-open), so
+                // its fresh audio is consumed by the decode — advance the scan cursor too.
+                last_vad_scan = std::time::Instant::now();
+                None
+            }
+        };
+        if !vad_gate.should_decode(speech, bypass) {
+            continue;
+        }
+
         // LIVE captions use the Fast (greedy/best_of:1) profile via `transcribe` — NOT the
         // batch beam-search path. Captions tick every few seconds on overlapping windows, so
         // latency must dominate; beam search + temperature fallback would burn CPU per tick.
         // The authoritative high-quality transcript is produced once at Stop (pipeline.rs).
-        match transcriber.transcribe(&samples_16k, lang.as_deref()) {
+        let decode_started = std::time::Instant::now();
+        let decoded = transcriber.transcribe(&samples_16k, lang.as_deref());
+        // T0.1 — per-tick decode telemetry (target `live_perf`): durations / window length /
+        // coarse model label ONLY — never content, never paths (§8). The in-app instrument
+        // behind `scripts/measure-live-power.sh`.
+        tracing::info!(
+            target: "live_perf",
+            decode_ms = decode_started.elapsed().as_millis() as u64,
+            window_s = samples_16k.len() as f64 / 16_000.0,
+            model = %model_label,
+            ok = decoded.is_ok(),
+            "live decode tick"
+        );
+        match decoded {
             Ok(t) => {
                 let text = t
                     .segments
@@ -2011,6 +2278,107 @@ fn assistant_system_prompt(
 mod tests {
     use super::*;
     use crate::audio::wake::VoiceIntent;
+
+    // ── T1.4: the Silero VAD tick gate (pure decision matrix, stub-VAD) ──────────────────────────
+
+    /// The full gate matrix over stubbed VAD verdicts: speech decodes + re-arms the hangover;
+    /// silence spends the hangover then SKIPS; bypass (manual capture / wake window) always
+    /// decodes; VAD-unavailable (`None`) fails OPEN (today's decode-every-tick behavior).
+    #[test]
+    fn live_vad_gate_decision_matrix() {
+        // Speech ⇒ decode, hangover armed to 2.
+        let mut g = LiveVadGate::default();
+        assert!(g.should_decode(Some(true), false), "speech decodes");
+        // Two silent ticks ride the hangover, the THIRD is skipped.
+        assert!(g.should_decode(Some(false), false), "hangover tick 1 decodes");
+        assert!(g.should_decode(Some(false), false), "hangover tick 2 decodes");
+        assert!(
+            !g.should_decode(Some(false), false),
+            "silence with hangover spent SKIPS the decode"
+        );
+        assert!(
+            !g.should_decode(Some(false), false),
+            "continued silence keeps skipping"
+        );
+        // Speech returns ⇒ decode + hangover re-armed.
+        assert!(g.should_decode(Some(true), false), "speech resumes decoding");
+        assert!(g.should_decode(Some(false), false), "hangover re-armed");
+
+        // A FRESH gate (hangover 0) skips pure silence immediately…
+        let mut fresh = LiveVadGate::default();
+        assert!(
+            !fresh.should_decode(Some(false), false),
+            "a silent recording start is not decoded"
+        );
+        // …but BYPASS always decodes, without touching the hangover state…
+        assert!(fresh.should_decode(Some(false), true), "bypass always decodes");
+        assert!(
+            !fresh.should_decode(Some(false), false),
+            "bypass did not arm a hangover"
+        );
+        // …and VAD-unavailable fails OPEN.
+        assert!(
+            fresh.should_decode(None, false),
+            "no VAD verdict ⇒ gate disabled ⇒ decode (fail-open)"
+        );
+    }
+
+    /// T1.4/T1.5 fix-round — the VAD scan span tracks the wall clock since the last scan, so a
+    /// thermally-stretched tick (6 s Fair / 9 s Serious) or a run of skipped ticks (thermal
+    /// suspend, turn-defer, short tail) can never leave fresh audio permanently unscanned: a
+    /// wake phrase or short caption in that region is still caught by the next scan.
+    #[test]
+    fn vad_scan_span_scales_to_stretched_and_skipped_ticks() {
+        // Nominal 3 s tick: span = 3 s elapsed + 2 s headroom = 5 s (≥ the old fixed 3 s).
+        assert_eq!(vad_scan_span_secs(3.0), 5);
+        // Governed ticks: Fair 6 s → 8 s, Serious 9 s → 11 s — the whole stretched delta is
+        // scanned (the MAJOR finding: a fixed 3 s missed 3-6 s of each stretched tick).
+        assert_eq!(vad_scan_span_secs(6.0), 8);
+        assert_eq!(vad_scan_span_secs(9.0), 11);
+        // Sub-second loop-body drift still ceils up and keeps the headroom.
+        assert_eq!(vad_scan_span_secs(3.4), 6);
+        // Accumulated skipped ticks (thermal suspend / defer) clamp to the rolling window —
+        // the scan can never index past the audio that actually exists.
+        assert_eq!(vad_scan_span_secs(60.0), WINDOW_SECS);
+        // Degenerate inputs floor at the historical minimum, never underflow.
+        assert_eq!(vad_scan_span_secs(0.0), VAD_DELTA_SECS);
+        assert_eq!(vad_scan_span_secs(-1.0), VAD_DELTA_SECS);
+        assert_eq!(vad_scan_span_secs(f64::NAN), VAD_DELTA_SECS);
+        assert_eq!(vad_scan_span_secs(f64::INFINITY), WINDOW_SECS);
+    }
+
+    /// The wake-suppression window doubles as a VAD-gate bypass signal: active right after a
+    /// fire, expired after `WAKE_DEDUP_TICKS` tick() calls.
+    #[test]
+    fn wake_dedup_suppression_window_reports_active_then_expires() {
+        let mut d = WakeDedup::default();
+        assert!(!d.is_suppressing(), "fresh dedup: no window");
+        assert!(d.should_fire("zrób research o testach"));
+        assert!(d.is_suppressing(), "window armed by the fire");
+        for _ in 0..WAKE_DEDUP_TICKS {
+            d.tick();
+        }
+        assert!(!d.is_suppressing(), "window expired after WAKE_DEDUP_TICKS");
+    }
+
+    // ── T0.1: the telemetry model label (non-PII: ggml size token or "custom") ───────────────────
+
+    #[test]
+    fn model_size_label_extracts_ggml_size_or_custom() {
+        use std::path::Path;
+        assert_eq!(model_size_label(Path::new("/m/ggml-small.bin")), "small");
+        assert_eq!(
+            model_size_label(Path::new("/m/ggml-large-v3-turbo-q8_0.bin")),
+            "large-v3-turbo-q8_0"
+        );
+        assert_eq!(model_size_label(Path::new("/m/ggml-small.en.bin")), "small.en");
+        // A user-supplied arbitrary file name is NEVER echoed into logs.
+        assert_eq!(
+            model_size_label(Path::new("/Users/kim/my-meeting-model.bin")),
+            "custom"
+        );
+        assert_eq!(model_size_label(Path::new("")), "custom");
+    }
 
     // ── Brain v2 P0.3: in-flight assistant-turn dedup registry ────────────────────────────────────
 

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -25,16 +25,35 @@ pub const VAD_MODEL_FILE: &str = "ggml-silero-v5.1.2.bin";
 pub const DIARIZE_SEG_MODEL_FILE: &str = "sherpa-pyannote-segmentation-3.0.onnx";
 pub const DIARIZE_EMB_MODEL_FILE: &str = "wespeaker_en_voxceleb_CAM++.onnx";
 
+/// QUANT-SUFFIXED model sizes accepted by [`model_filename`] (T2 quant plumbing — NO default
+/// flip: `AppConfig::default().model_size` stays `"small"`). Each maps `"<size>-<quant>"` →
+/// `ggml-<size>-<quant>.bin`, verified BY URL SHAPE against the ggerganov/whisper.cpp HF
+/// mirror's file tree (which hosts `ggml-small-q8_0.bin`, `ggml-medium-q8_0.bin`,
+/// `ggml-large-v3-turbo.bin`, `ggml-large-v3-turbo-q8_0.bin`, `ggml-large-v3-q5_0.bin`).
+/// The mirror ALSO hosts `.en` quant builds (`ggml-small.en-q8_0.bin`, …) but we deliberately
+/// resolve quant selections to the MULTILINGUAL build only — the `.en` shortcut applies to the
+/// four plain small sizes exactly as before, never to a quant/large variant (the conservative
+/// URL-shape-only contract; the `.en` quant rows can be added later once someone actually
+/// wants them, with their own tests).
+pub const QUANT_MODEL_SIZES: &[&str] = &[
+    "small-q8_0",
+    "medium-q8_0",
+    "large-v3-turbo-q8_0",
+    "large-v3-q5_0",
+];
+
 /// Map a chosen size + language to a whisper.cpp GGML model filename.
 ///
 /// Supported sizes (all served by the ggerganov/whisper.cpp HF mirror):
-/// `tiny`, `base`, `small`, `medium`, `large-v3-turbo`, `large-v3`.
+/// `tiny`, `base`, `small`, `medium`, `large-v3-turbo`, `large-v3`, plus the quant-suffixed
+/// variants in [`QUANT_MODEL_SIZES`] (`small-q8_0`, `medium-q8_0`, `large-v3-turbo-q8_0`,
+/// `large-v3-q5_0`) — `"<size>-<quant>"` maps to `ggml-<size>-<quant>.bin`.
 ///
-/// English-only (`.en`) builds exist for tiny/base/small/medium — smaller + faster — and
+/// English-only (`.en`) builds exist for PLAIN tiny/base/small/medium — smaller + faster — and
 /// are used ONLY when the user explicitly selects English. Any other language (incl.
-/// Polish) or auto-detect needs the multilingual build. `large-v3` and `large-v3-turbo`
-/// are multilingual-only (no `.en` variant), so Polish always resolves the full
-/// multilingual `ggml-large-v3.bin`.
+/// Polish) or auto-detect needs the multilingual build. `large-v3` / `large-v3-turbo` and
+/// EVERY quant-suffixed size resolve multilingual-only (no `.en` is ever appended to a
+/// quant/large variant — see [`QUANT_MODEL_SIZES`]).
 ///
 /// An empty size falls back to the app default (`small`), matching
 /// `AppConfig::default().model_size` — a RAM-safe default so a config that bypasses onboarding
@@ -44,12 +63,67 @@ pub fn model_filename(size: &str, language: &str) -> String {
         "" => "small",
         s => s,
     };
+    // The `.en` shortcut applies ONLY to the four plain small sizes (exact match — a
+    // quant-suffixed size like `small-q8_0` deliberately does NOT match, so quants always
+    // resolve the multilingual `ggml-<size>-<quant>.bin`).
     let en_only = language == "en" && matches!(size, "tiny" | "base" | "small" | "medium");
     if en_only {
         format!("ggml-{size}.en.bin")
     } else {
         format!("ggml-{size}.bin")
     }
+}
+
+/// T1.3 — the LIVE-tick model-pin decision (pure; the file-presence resolution stays with the
+/// caller). Returns the SIZE the live loop should pin to, or `None` = use the configured model:
+///
+/// 1. A non-empty `live_model_pin` (config; serde-default `"small"`) pins UNCONDITIONALLY —
+///    live captions are throwaway (the authoritative transcript is the post-Stop Accurate
+///    pass) and a `large-v3` live tick alone can saturate the shared Metal GPU for the whole
+///    meeting (the heat complaint).
+/// 2. An EMPTY pin disables it → today's pre-pin behavior, which still includes the legacy
+///    `brain_live` pin-to-small (D1, spec §4.3: the live tick must not starve the light
+///    reasoner) — so turning the new pin off never regresses the Brain-Live guarantee.
+pub fn live_pin_size(live_model_pin: &str, brain_live: bool) -> Option<String> {
+    let pin = live_model_pin.trim();
+    if !pin.is_empty() {
+        return Some(pin.to_string());
+    }
+    if brain_live {
+        return Some("small".to_string());
+    }
+    None
+}
+
+/// T1.3 — resolve the SMALLEST downloaded whisper model for the WAKE listener
+/// (`audio/listener.rs`): tiny → base → small, first present in [`models_dir`], respecting the
+/// language-appropriate build ([`model_filename`]). NEVER medium/large — wake-phrase matching
+/// needs rough text only, and a large standby decode every ~2.2 s is a heat/RAM source.
+/// `None` = no suitable model downloaded (the caller does not start the listener).
+pub fn smallest_wake_model(language: &str) -> Option<PathBuf> {
+    let dir = models_dir().ok()?;
+    smallest_wake_model_in(&dir, language)
+}
+
+/// File-presence core of [`smallest_wake_model`], factored over an explicit `dir` so the
+/// tiny→base→small preference order is testable headless with a temp dir.
+pub fn smallest_wake_model_in(dir: &Path, language: &str) -> Option<PathBuf> {
+    for size in ["tiny", "base", "small"] {
+        let preferred = dir.join(model_filename(size, language));
+        if preferred.is_file() {
+            return Some(preferred);
+        }
+        // An English selection can also ride a downloaded MULTILINGUAL build of the same size
+        // (multilingual handles English fine; the reverse is not true, so a non-English
+        // language never falls back onto an `.en` build).
+        if language == "en" {
+            let multilingual = dir.join(model_filename(size, ""));
+            if multilingual.is_file() {
+                return Some(multilingual);
+            }
+        }
+    }
+    None
 }
 
 /// Hugging Face mirror of the official whisper.cpp GGML models (ggerganov/whisper.cpp).
@@ -294,6 +368,104 @@ mod tests {
         assert_eq!(model_filename("   ", "pl"), "ggml-small.bin");
         // large-v3 stays selectable when explicitly chosen.
         assert_eq!(model_filename("large-v3", ""), "ggml-large-v3.bin");
+    }
+
+    /// T2 — every supported quant-suffixed size maps `"<size>-<quant>"` →
+    /// `ggml-<size>-<quant>.bin`, for EVERY language (`.en` never applies to a quant/large
+    /// variant — URL-shape contract against the HF mirror).
+    #[test]
+    fn quant_sizes_map_to_quant_filenames_never_en() {
+        for size in QUANT_MODEL_SIZES {
+            let expected = format!("ggml-{size}.bin");
+            for lang in ["", "en", "pl"] {
+                assert_eq!(model_filename(size, lang), expected, "size={size} lang={lang}");
+            }
+        }
+        // The concrete rows, spelled out (the mirror's actual file names):
+        assert_eq!(model_filename("small-q8_0", "pl"), "ggml-small-q8_0.bin");
+        assert_eq!(model_filename("medium-q8_0", "en"), "ggml-medium-q8_0.bin");
+        assert_eq!(
+            model_filename("large-v3-turbo-q8_0", ""),
+            "ggml-large-v3-turbo-q8_0.bin"
+        );
+        assert_eq!(model_filename("large-v3-q5_0", "en"), "ggml-large-v3-q5_0.bin");
+    }
+
+    /// T2 — quant filenames ride the same HF mirror URL as the plain sizes.
+    #[test]
+    fn quant_url_points_at_whispercpp_hf_mirror() {
+        assert_eq!(
+            model_url(&model_filename("large-v3-turbo-q8_0", "pl")),
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q8_0.bin"
+        );
+    }
+
+    /// T1.3 — the live pin decision: a non-empty pin wins unconditionally; an empty pin falls
+    /// back to the legacy `brain_live` pin-to-small; neither ⇒ the configured model.
+    #[test]
+    fn live_pin_size_resolution() {
+        // Default config pin ("small") pins regardless of brain_live.
+        assert_eq!(live_pin_size("small", false).as_deref(), Some("small"));
+        assert_eq!(live_pin_size("small", true).as_deref(), Some("small"));
+        // Any explicit size (incl. a quant) pins.
+        assert_eq!(live_pin_size("base", false).as_deref(), Some("base"));
+        assert_eq!(
+            live_pin_size("small-q8_0", false).as_deref(),
+            Some("small-q8_0")
+        );
+        // Whitespace counts as empty.
+        assert_eq!(live_pin_size("  ", false), None);
+        // Empty pin = today's behavior: configured model, EXCEPT the legacy brain_live pin.
+        assert_eq!(live_pin_size("", false), None);
+        assert_eq!(live_pin_size("", true).as_deref(), Some("small"));
+    }
+
+    /// T1.3 — the wake listener resolves the SMALLEST downloaded model (tiny → base → small),
+    /// never medium/large, and honors the `.en` build for English.
+    #[test]
+    fn smallest_wake_model_prefers_tiny_and_never_medium_or_large() {
+        let dir = std::env::temp_dir().join(format!("murmur-wake-model-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Nothing downloaded → None (the listener does not start).
+        assert_eq!(smallest_wake_model_in(&dir, ""), None);
+
+        // Only medium/large present → STILL None (never a big standby model).
+        std::fs::write(dir.join("ggml-medium.bin"), b"x").unwrap();
+        std::fs::write(dir.join("ggml-large-v3.bin"), b"x").unwrap();
+        assert_eq!(smallest_wake_model_in(&dir, ""), None);
+
+        // small appears → picked; base appears → preferred; tiny appears → wins.
+        std::fs::write(dir.join("ggml-small.bin"), b"x").unwrap();
+        assert_eq!(
+            smallest_wake_model_in(&dir, "pl"),
+            Some(dir.join("ggml-small.bin"))
+        );
+        std::fs::write(dir.join("ggml-base.bin"), b"x").unwrap();
+        assert_eq!(
+            smallest_wake_model_in(&dir, ""),
+            Some(dir.join("ggml-base.bin"))
+        );
+        std::fs::write(dir.join("ggml-tiny.bin"), b"x").unwrap();
+        assert_eq!(
+            smallest_wake_model_in(&dir, ""),
+            Some(dir.join("ggml-tiny.bin"))
+        );
+
+        // English PREFERS the `.en` build of a size but falls back to the multilingual build
+        // of the SAME size (multilingual handles English; smallest-size still wins overall).
+        assert_eq!(
+            smallest_wake_model_in(&dir, "en"),
+            Some(dir.join("ggml-tiny.bin")),
+            "en falls back to the multilingual tiny when no .en build exists"
+        );
+        std::fs::write(dir.join("ggml-tiny.en.bin"), b"x").unwrap();
+        assert_eq!(
+            smallest_wake_model_in(&dir, "en"),
+            Some(dir.join("ggml-tiny.en.bin"))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -58,6 +58,36 @@ const BATCH_NO_SPEECH_THOLD: f32 = 0.6;
 /// whisper.cpp's own default; set explicitly to document that previous-text conditioning is ON.
 const BATCH_N_MAX_TEXT_CTX: i32 = 16384;
 
+// ── Fast (live) decoding constants ──
+
+/// Encoder audio context for the FAST (live) profile ONLY (T1.2). The live loop decodes a
+/// ~14 s rolling window, but whisper pads every input to a 30 s encoder pass (1500 frames) —
+/// pure waste. Right-size it: `(14/30)*1500 + 128 ≈ 828 → 832` (rounded UP to a multiple of
+/// 64 for Metal kernel alignment; > the 768 floor ggerganov calls quality-safe — his measured
+/// `(len/30)*1500+128` formula held WER on base.en at ~3.4× encoder speed). 832 frames cover
+/// ~16.6 s of audio per encoder pass, ≥ every Fast caller's window (live 14 s, voice-trigger
+/// ~2.2 s; a longer manual-capture window decodes in successive passes — whisper advances
+/// `seek` from the last decoded segment, so no audio is dropped). The ACCURATE batch profile
+/// MUST keep the full context (quality authority) — `audio_ctx_for` returns `None` there.
+/// CAVEAT (honest): Polish-neutrality of a reduced audio_ctx is only measured on base.en
+/// upstream — gate on the in-house A/B harness (`asr_ab_harness_from_env`).
+const LIVE_AUDIO_CTX: i32 = 832;
+
+// Compile-time invariants (clippy `assertions_on_constants` forbids these as runtime asserts):
+// a multiple of 64 (Metal kernel alignment) and above the 768 quality floor.
+const _: () = assert!(LIVE_AUDIO_CTX % 64 == 0 && LIVE_AUDIO_CTX > 768);
+
+/// Which encoder `audio_ctx` a [`TranscribeQuality`] profile sets: the Fast/live profile
+/// right-sizes to [`LIVE_AUDIO_CTX`]; the Accurate/batch profile sets NOTHING (whisper's full
+/// 30 s context — the quality authority is never truncated). Pure — the headless-testable seam
+/// for the profile contract (`FullParams` exposes no getter to assert on directly).
+fn audio_ctx_for(quality: TranscribeQuality) -> Option<i32> {
+    match quality {
+        TranscribeQuality::Fast => Some(LIVE_AUDIO_CTX),
+        TranscribeQuality::Accurate => None,
+    }
+}
+
 /// Wraps a loaded whisper.cpp model (Metal). Construct once; reuse per transcription.
 ///
 /// `WhisperContext` is `Send + Sync`, so a single `Transcriber` can live in shared state
@@ -96,7 +126,17 @@ impl Transcriber {
         // WhisperContext (and thus the Metal device).
         std::env::set_var("GGML_METAL_NO_RESIDENCY", "1");
 
-        let ctx = WhisperContext::new_with_params(path_str, WhisperContextParameters::default())
+        // FLASH ATTENTION ON (T1.1, 2026-07-09 transcription-performance plan): upstream
+        // whisper.cpp 1.8.3 defaults `flash_attn = true`; whisper-rs 0.16's Rust-side
+        // `WhisperContextParameters::default()` still carries the OLD `false` — silently
+        // overriding upstream. Measured upstream (PR #2152, M1 Pro Metal): encoder ~13–21%
+        // faster, decoder ~10–20%, at equal output on the tested sets. We don't use DTW token
+        // timestamps, so FA's DTW conflict is moot. CAVEAT (honest): one unconfirmed report of
+        // FA slightly changing Japanese output (whisper.cpp #3020) — Polish quality under FA is
+        // unpublished; gate any doubt on the in-house A/B harness (`asr_ab_harness_from_env`).
+        let mut ctx_params = WhisperContextParameters::default();
+        ctx_params.flash_attn(true);
+        let ctx = WhisperContext::new_with_params(path_str, ctx_params)
             .map_err(|e| AppError::Transcribe(format!("failed to load whisper model: {e}")))?;
 
         tracing::info!(target: "transcribe", model = %model_path.display(), "whisper model loaded");
@@ -253,8 +293,15 @@ fn build_params<'a>(quality: TranscribeQuality) -> FullParams<'a, 'a> {
         // overlapping windows every couple of seconds, so latency dominates — beam search +
         // a 6-rung temperature ladder would multiply the per-tick cost for output the user
         // only glances at. Quality is the batch path's job, NOT the live path's. Do NOT add
-        // beam search here.
-        TranscribeQuality::Fast => FullParams::new(SamplingStrategy::Greedy { best_of: 1 }),
+        // beam search here. `audio_ctx` is right-sized to the live window (see LIVE_AUDIO_CTX);
+        // the Accurate arm deliberately never sets it.
+        TranscribeQuality::Fast => {
+            let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+            if let Some(audio_ctx) = audio_ctx_for(quality) {
+                params.set_audio_ctx(audio_ctx);
+            }
+            params
+        }
 
         // BATCH (post-Stop authoritative transcript): the anti-hallucination + inflection
         // levers. Beam search explores multiple hypotheses (better wording/grammar — matters
@@ -363,5 +410,98 @@ mod tests {
         assert_eq!(BATCH_ENTROPY_THOLD, 2.4);
         assert_eq!(BATCH_LOGPROB_THOLD, -1.0);
         assert_eq!(BATCH_NO_SPEECH_THOLD, 0.6);
+    }
+
+    /// T1.2 — the profile contract: ONLY the Fast/live profile right-sizes the encoder
+    /// context; the Accurate batch authority keeps whisper's full 30 s context.
+    #[test]
+    fn fast_profile_sets_live_audio_ctx_accurate_does_not() {
+        assert_eq!(audio_ctx_for(TranscribeQuality::Fast), Some(832));
+        assert_eq!(audio_ctx_for(TranscribeQuality::Accurate), None);
+    }
+
+    /// T1.2 — the 832 derivation: `(14/30)*1500 + 128 ≈ 828`, rounded UP to a multiple of 64,
+    /// and above the 768 quality floor (ggerganov guidance).
+    #[test]
+    fn live_audio_ctx_is_aligned_and_above_the_quality_floor() {
+        // Alignment + quality-floor invariants live as a compile-time `const _: () = assert!(…)`
+        // beside LIVE_AUDIO_CTX (clippy assertions_on_constants). Here: the non-constant derivation.
+        let derived = (14.0_f64 / 30.0 * 1500.0 + 128.0).ceil() as i32; // 828
+        assert!(
+            LIVE_AUDIO_CTX >= derived && LIVE_AUDIO_CTX - derived < 64,
+            "832 is the next multiple of 64 above the derived {derived}"
+        );
+    }
+
+    /// T0.3 — env-driven A/B harness: decode the SAME WAV through TWO models at BOTH profiles
+    /// and print wall-clock per leg + write each transcript to a temp file for diffing. The
+    /// instrument behind every speed/Polish-quality claim of the 2026-07-09 transcription plan
+    /// (flash-attn, audio_ctx=832, quants, live pin): record a fixed ~10-min PL/EN WAV once,
+    /// then run e.g.
+    ///   MURMUR_ASR_AB_WAV=~/asr/meeting-16k.wav \
+    ///   MURMUR_ASR_AB_MODEL_A=~/Library/Application\ Support/MeetNotes/models/ggml-small.bin \
+    ///   MURMUR_ASR_AB_MODEL_B=.../ggml-large-v3-turbo-q8_0.bin \
+    ///   cargo test --lib asr_ab_harness_from_env -- --ignored --nocapture
+    /// PANICS NEVER: missing env / bad paths / decode failures print a message and return
+    /// (follows the `run_bakeoff_over_real_db_from_env` env-driven `#[ignore]` pattern, but
+    /// skip-soft). Needs a real Mac + loaded GGUFs — headless `cargo test` proves nothing here.
+    #[test]
+    #[ignore = "real A/B: needs MURMUR_ASR_AB_WAV + MURMUR_ASR_AB_MODEL_A/B on a Mac with Metal"]
+    fn asr_ab_harness_from_env() {
+        let Ok(wav) = std::env::var("MURMUR_ASR_AB_WAV") else {
+            eprintln!("SKIP: set MURMUR_ASR_AB_WAV to a 16 kHz mono WAV path");
+            return;
+        };
+        let Ok(model_a) = std::env::var("MURMUR_ASR_AB_MODEL_A") else {
+            eprintln!("SKIP: set MURMUR_ASR_AB_MODEL_A to a ggml model path");
+            return;
+        };
+        let Ok(model_b) = std::env::var("MURMUR_ASR_AB_MODEL_B") else {
+            eprintln!("SKIP: set MURMUR_ASR_AB_MODEL_B to a ggml model path");
+            return;
+        };
+        let lang = std::env::var("MURMUR_ASR_AB_LANG").ok();
+        let samples = match read_wav_16k_mono(Path::new(&wav)) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("SKIP: could not read WAV: {e}");
+                return;
+            }
+        };
+        eprintln!(
+            "A/B over {:.1}s of audio (lang={})",
+            samples.len() as f64 / 16_000.0,
+            lang.as_deref().unwrap_or("auto")
+        );
+        for (leg, model_path) in [("A", &model_a), ("B", &model_b)] {
+            let transcriber = match Transcriber::load(Path::new(model_path)) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("SKIP leg {leg}: model load failed: {e}");
+                    continue;
+                }
+            };
+            for quality in [TranscribeQuality::Fast, TranscribeQuality::Accurate] {
+                let started = std::time::Instant::now();
+                match transcriber.transcribe_with(&samples, lang.as_deref(), quality) {
+                    Ok(t) => {
+                        let wall = started.elapsed();
+                        let out = std::env::temp_dir()
+                            .join(format!("murmur-asr-ab-{leg}-{quality:?}.txt"));
+                        if let Err(e) = std::fs::write(&out, &t.full_text) {
+                            eprintln!("leg {leg} {quality:?}: transcript write failed: {e}");
+                        }
+                        eprintln!(
+                            "leg {leg} {quality:?}: wall {:.2}s, {} segments, {} chars → {}",
+                            wall.as_secs_f64(),
+                            t.segments.len(),
+                            t.full_text.chars().count(),
+                            out.display()
+                        );
+                    }
+                    Err(e) => eprintln!("leg {leg} {quality:?}: decode failed: {e}"),
+                }
+            }
+        }
     }
 }

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -201,6 +201,24 @@ export class NoteEditorComponent {
    */
   private dirtyFull = false;
 
+  // --- Single-writer save queue --------------------------------------------
+  /**
+   * The persistence chain — EVERY backend write for this note (cheap
+   * `saveNoteText` and full `updateNoteDoc`) is appended here, so writes reach
+   * the backend strictly in order. Without it the debounced cheap save and a
+   * boundary full save could be concurrently in flight with different payloads,
+   * and a stale older write could land after a newer one.
+   */
+  private saveChain: Promise<void> = Promise.resolve();
+  /**
+   * The single coalesced pending save (latest-wins): while a save is in flight,
+   * new requests only escalate/refresh this slot — they never stack. `"full"`
+   * supersedes `"text"` (the full save persists a superset). The payload is
+   * snapshotted from the signals when the queued save RUNS, so the newest text
+   * always wins.
+   */
+  private pendingSave: "text" | "full" | null = null;
+
   /** The rendered preview HTML source — a cached `computed` off title + doc markdown. */
   readonly previewMarkdown = computed(() =>
     serializeDoc(this.tags(), this.properties(), this.body()),
@@ -422,7 +440,45 @@ export class NoteEditorComponent {
     }
     this.dirtyFull = true;
     this.saveState.set("saving");
-    this.debounce.schedule("note-editor-save", () => void this.saveText(), AUTOSAVE_MS);
+    this.debounce.schedule(
+      "note-editor-save",
+      () => void this.queueSave("text"),
+      AUTOSAVE_MS,
+    );
+  }
+
+  /**
+   * Enqueue a save on the single-writer chain. If a save is already QUEUED (not
+   * yet started), the request only escalates/refreshes the pending slot —
+   * latest-payload-wins, since the payload is read from the signals when the
+   * save runs. If a save is IN FLIGHT, the queued one starts only after it
+   * settles, so writes reach the backend in order. Returns a promise that
+   * resolves once this request's save has landed (the chain never rejects —
+   * both save paths handle their own errors via `saveState`/toast).
+   */
+  private queueSave(kind: "text" | "full"): Promise<void> {
+    const alreadyQueued = this.pendingSave !== null;
+    this.pendingSave =
+      this.pendingSave === "full" || kind === "full" ? "full" : "text";
+    if (!alreadyQueued) {
+      this.saveChain = this.saveChain
+        .then(() => this.runPendingSave())
+        // Defensive: a rejected link would wedge the chain forever; both save
+        // paths already catch, so this only guards the truly unexpected.
+        .catch(() => undefined);
+    }
+    return this.saveChain;
+  }
+
+  /** Execute (and clear) the coalesced pending save. Runs on the chain only. */
+  private async runPendingSave(): Promise<void> {
+    const kind = this.pendingSave;
+    this.pendingSave = null;
+    if (kind === "full") {
+      await this.saveFull();
+    } else if (kind === "text") {
+      await this.saveText();
+    }
   }
 
   /** The current title + full markdown (front-matter re-emitted). */
@@ -437,6 +493,7 @@ export class NoteEditorComponent {
    * CHEAP persist — text only (no re-index, no export). Used by the frequent
    * autosave + blur so typing never triggers the e5 re-embed. The DB text is
    * canonical, so nothing is lost; the brain index catches up on the next full save.
+   * Runs ONLY via {@link runPendingSave} on the single-writer chain.
    */
   private async saveText(): Promise<void> {
     const doc = this.note();
@@ -459,48 +516,55 @@ export class NoteEditorComponent {
 
   /**
    * FULL save (fire-and-forget) — persist + RE-INDEX (brain) + vault re-export via
-   * `updateNoteDoc`. Runs ONLY on natural boundaries (Preview, editor close, retry) so
-   * the e5 re-embed never fires per keystroke-pause. NOT awaited by navigation, so
-   * leaving is instant and the backend catches up. Clears `dirtyFull` on success.
+   * `updateNoteDoc`. Requested ONLY on natural boundaries (Preview, editor close,
+   * retry) so the e5 re-embed never fires per keystroke-pause. NOT awaited by
+   * navigation, so leaving is instant and the backend catches up. Joins the same
+   * single-writer chain as the cheap saves, superseding any pending cheap save.
    */
   private flushFull(): void {
+    this.debounce.cancel("note-editor-save");
+    void this.queueSave("full");
+  }
+
+  /**
+   * The full-save body — persist + re-index + export, clearing `dirtyFull` on
+   * success. Runs ONLY via {@link runPendingSave} on the single-writer chain.
+   */
+  private async saveFull(): Promise<void> {
     const doc = this.note();
     if (!doc || doc.locked) {
       return;
     }
-    this.debounce.cancel("note-editor-save");
     const { title, markdown } = this.currentPayload();
     this.saveState.set("saving");
-    void this.ipc
-      .updateNoteDoc(doc.id, title, markdown)
-      .then((fresh) => {
-        this.dirtyFull = false;
-        this.note.update((cur) =>
-          cur
-            ? {
-                ...cur,
-                updatedAt: fresh.updatedAt,
-                exportedPath: fresh.exportedPath,
-                shared: fresh.shared,
-                locked: fresh.locked,
-              }
-            : cur,
-        );
-        this.saveState.set("saved");
-      })
-      .catch((e) => {
-        this.saveState.set("error");
-        if (String(e).includes("Locked")) {
-          this.toast.danger("This note is locked — unlock its folder to edit.");
-        }
-      });
+    try {
+      const fresh = await this.ipc.updateNoteDoc(doc.id, title, markdown);
+      this.dirtyFull = false;
+      this.note.update((cur) =>
+        cur
+          ? {
+              ...cur,
+              updatedAt: fresh.updatedAt,
+              exportedPath: fresh.exportedPath,
+              shared: fresh.shared,
+              locked: fresh.locked,
+            }
+          : cur,
+      );
+      this.saveState.set("saved");
+    } catch (e) {
+      this.saveState.set("error");
+      if (String(e).includes("Locked")) {
+        this.toast.danger("This note is locked — unlock its folder to edit.");
+      }
+    }
   }
 
   /** Blur handler (title / body) — flush the pending CHEAP save immediately. */
   onBlur(): void {
     if (this.saveState() === "saving") {
       this.debounce.cancel("note-editor-save");
-      void this.saveText();
+      void this.queueSave("text");
     }
   }
 
@@ -947,9 +1011,10 @@ export class NoteEditorComponent {
       return;
     }
     this.closeMenus();
-    // Persist the latest text first (cheap) so the exported file is current.
+    // Persist the latest text first (cheap) so the exported file is current —
+    // awaited through the single-writer chain so it lands after any in-flight save.
     this.debounce.cancel("note-editor-save");
-    await this.saveText();
+    await this.queueSave("text");
     try {
       const path = await this.ipc.exportNoteDoc(doc.id);
       this.note.update((cur) => (cur ? { ...cur, exportedPath: path } : cur));
@@ -971,9 +1036,10 @@ export class NoteEditorComponent {
     if (!doc || doc.locked) {
       return;
     }
-    // Persist the latest text (cheap) so the shared body is current.
+    // Persist the latest text (cheap, via the single-writer chain) so the
+    // shared body is current.
     this.debounce.cancel("note-editor-save");
-    void this.saveText();
+    void this.queueSave("text");
     this.shareOpen.set(true);
   }
 
@@ -1019,9 +1085,12 @@ export class NoteEditorComponent {
     if (!doc) {
       return;
     }
-    // Cancel a pending autosave + clear the dirty flag so the teardown full-save never
-    // resurrects the just-deleted note.
+    // Cancel a pending autosave, drop any queued-but-not-started save, and clear
+    // the dirty flag so neither the queue nor the teardown full-save resurrects
+    // the just-deleted note. (An already in-flight save cannot be recalled —
+    // same as before — but nothing new is started.)
     this.debounce.cancel("note-editor-save");
+    this.pendingSave = null;
     this.dirtyFull = false;
     try {
       await this.notes.remove(doc.id);

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
@@ -39,9 +39,18 @@
                   <option value="tiny">Tiny — fastest (~75 MB)</option>
                   <option value="base">Base (~150 MB)</option>
                   <option value="small">Small (~470 MB)</option>
+                  <option value="small-q8_0">
+                    Small (q8) — Small accuracy, less RAM (~270 MB)
+                  </option>
                   <option value="medium">Medium (~1.5 GB)</option>
+                  <option value="medium-q8_0">
+                    Medium (q8) — Medium accuracy, less RAM (~850 MB)
+                  </option>
                   <option value="large-v3-turbo">
                     Large v3 Turbo — fast &amp; accurate (~1.6 GB)
+                  </option>
+                  <option value="large-v3-turbo-q8_0">
+                    Large v3 Turbo (q8) — Turbo accuracy, less RAM (~875 MB)
                   </option>
                   <option value="large-v3">
                     Large v3 — best accuracy, recommended (~3 GB)
@@ -49,7 +58,9 @@
                 </select>
                 <span class="field-help text-muted">
                   Large v3 is the most accurate and the default — it’s a one-time ~3
-                  GB download. Turbo is nearly as good and much smaller.
+                  GB download. Turbo is nearly as good and much smaller. The (q8)
+                  variants are quantized: near-identical accuracy with a smaller
+                  download and less RAM while transcribing.
                 </span>
               </label>
             </div>

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -2376,8 +2376,11 @@ export class SettingsStore {
       tiny: "~75 MB",
       base: "~150 MB",
       small: "~470 MB",
+      "small-q8_0": "~270 MB",
       medium: "~1.5 GB",
+      "medium-q8_0": "~850 MB",
       "large-v3-turbo": "~1.6 GB",
+      "large-v3-turbo-q8_0": "~875 MB",
       "large-v3": "~3 GB",
     };
     this._downloadHint.set(hints[this.form.getRawValue().modelSize] ?? "");


### PR DESCRIPTION
## What

**Transcription heat fix (T1 of the transcription plan).** The live-caption loop re-decoded the last 14 s of audio every 3 s **unconditionally** (even silence), with the user-selected model (up to large-v3), on the Metal GPU shared with the local LLM — the reported laptop-heating cause. Research + duty-cycle model: `docs/research/2026-07-09-transcription-performance.md`.

- **Silero VAD tick gate** (`live_vad_gate`, default ON) — decode only when the fresh delta has speech (+2-tick hangover); wall-clock scan cursor guarantees stretched/skipped ticks never leave audio un-scanned; bypass while manual voice capture is armed / wake suppression active; fail-open without the VAD model. CPU-only (second ggml Metal context aborts).
- **flash_attn(true)** — whisper-rs's `false` default silently overrode upstream whisper.cpp 1.8.3's default-ON (~13–21% measured encoder gain on Metal).
- **audio_ctx=832 on the Fast/live profile only** (~1.8× encoder cut; batch keeps full context; compile-time invariants).
- **Unconditional live-model pin** (`live_model_pin`, default `small`) + wake listener resolves the smallest downloaded model.
- **Thermal governor** (`thermalState`, guarded FFI, hysteresis): Fair→6 s tick, Serious→9 s + reactions paused, Critical→captions suspended (recording + batch never touched); UTILITY QoS; one-tick ASR defer while a local user turn generates.
- **Quant plumbing**: `small-q8_0` / `medium-q8_0` / `large-v3-turbo(-q8_0)` selectable (default unchanged) + picker options with size hints.
- **T0 instrumentation**: `live_perf` telemetry, `scripts/measure-live-power.sh`, env-driven A/B harness.

**Notes FE**: single-writer save chain (latest-payload coalescing) — an older in-flight write can no longer land after a newer one.

## How verified

- Adversarial verifier per lane, sequential fix rounds: backend PASS after 1 round (caught a real VAD blind-spot under thermally-stretched ticks — fixed with a consume-cursor scan span, RED-proven); FE PASS with a **live Playwright RED→GREEN** (3 overlapping IPC writes + stale-payload-last on pre-fix code; strictly sequential after).
- `cargo test --lib` 1383/0; `ng lint`/`ng build` clean; `scripts/ci.sh` ✅ all gates green (exit captured directly).
- Honest gaps: watts, thermal transitions, Polish caption quality under gating and flash-attn need a real Mac + `sudo powermetrics` + a real bilingual meeting — the committed script + harness are the instrument (modeled expectation: ~6–8× live compute cut for small, ~25–50× for large-v3 users).