### PR TITLE
chore(eval): parakeet spike harness + measured ASR numbers + bake-off re-run

### DIFF
--- a/docs/research/2026-07-09-transcription-performance.md
+++ b/docs/research/2026-07-09-transcription-performance.md
@@ -113,6 +113,19 @@ Fixed-window re-decode is the documented anti-pattern. **LocalAgreement-2** (UFA
 - SpeechAnalyzer locale list on a live macOS 26 box (may grow in point releases).
 - whisper-rs maintenance cadence (GitHub archived → Codeberg; 0.16.0 is 2026-03) — a mild strategic argument for the sherpa-onnx/parakeet seam.
 
+## Measured results (2026-07-10 appendix — in-house, M-series dev Mac)
+
+First real numbers from the harnesses this report demanded (`asr_ab_harness_from_env` + `parakeet_spike_from_env`, both shipped as `#[ignore]` env-driven tests; 131 s synthesized PL→EN→PL WAV, macOS `say`/Zosia — clean TTS, NOT meeting audio; post-#230 tree, so flash-attn ON + VAD-segmented batch):
+
+| config | wall | RTF | Polish quality (same WAV, eyeballed diff) |
+|---|---:|---:|---|
+| small, Fast profile (today's live) | 0.77 s | ~170× | names garbled (Jakub→"jak ut", Łukasz→"półkarz", SQLCipher→"skłelcifer"), EN segment DROPPED, hallucination repeat-loops |
+| small, Accurate (today's batch default) | 2.75 s | ~48× | same error classes as Fast |
+| **large-v3-turbo-q8_0, Accurate** | **2.73 s** | ~48× | near-perfect PL (Jakub/Łukasz/Apple Silicon right), EN intact — **same batch wall as small, ~2.5× fewer errors** |
+| parakeet-tdt-0.6b-v3 int8, CPU ×4 (off Metal) | 10.0 s | ~13× | better than small (names right, zero loops, clean PL↔EN auto-LID), below turbo ("Apple śliczon", "modelu ISP") |
+
+Confirms the report's ladder (`small < parakeet < turbo`) and both engine recommendations: **(T2)** the turbo-q8_0 batch default costs the SAME wall as small on the VAD-segmented flash-attn batch path — the flip is now evidence-backed (cost: 874 MB download, ~1.2 GB RAM vs small's 470 MB); **(T3)** parakeet is a viable live-path engine at ~13× realtime on four CPU threads with Metal left entirely to the LLM, via the sherpa-onnx crate already in the lockfile (1.13.3 — no missing-words symptom on this WAV). Open: watts (T0 powermetrics protocol still pending, user-assisted), real-meeting audio, and PL WER on non-TTS speech.
+
 ## Sources
 
 **Repo (symbols):** `transcribe/live.rs` (`TICK`, `WINDOW_SECS`, tick body, `accumulate_live_caption`, `step_manual_capture`), `transcribe/whisper.rs` (`Transcriber::load`, `build_params`, `TranscribeQuality`, batch consts), `transcribe/vad.rs` (CPU-only rationale), `transcribe/model.rs` (`model_filename`, `ensure_model`), `audio/listener.rs` (`VoiceListener::start`), `commands.rs` (`live_model` pin, `restart_voice_listener`), `pipeline.rs` (`transcribe_stream`, `decode_windows`), `settings/config.rs` (`model_size`, `voice_trigger`), `Cargo.toml`/`Cargo.lock` (whisper-rs 0.16 / sherpa-onnx 1.13.3 / objc2-foundation); vendored: `whisper-rs-0.16.0/src/whisper_ctx.rs` (flash_attn default), `whisper-rs-sys-0.15.0/whisper.cpp` (1.8.3, FA default true; coreml build.rs), `sherpa-onnx-1.13.3/src/offline_asr.rs` (nemo_transducer example).

--- a/eval/results/rag-bakeoff-latest.md
+++ b/eval/results/rag-bakeoff-latest.md
@@ -1,7 +1,7 @@
 # RAG bake-off
 
 - date: 2026-07-10
-- commit: 2567226-dirty
+- commit: 3362d3c-dirty
 - corpus: synthetic (eval::corpus, 16 seeded meetings, anchor 2026-06-29)
 - labeled set: src-tauri/src/eval/fixtures/rag-bakeoff-synthetic.json (20 queries, k=5)
 - config: score_fuse 0.4/0.4/0.2 + topic legs + temporal filter (RRF_K=60 fallback)

--- a/src-tauri/src/transcribe/mod.rs
+++ b/src-tauri/src/transcribe/mod.rs
@@ -3,6 +3,8 @@ pub mod diarize;
 pub mod live;
 pub mod model;
 pub mod novelty;
+#[cfg(test)]
+mod parakeet_spike;
 pub mod types;
 pub mod vad;
 pub mod whisper;

--- a/src-tauri/src/transcribe/parakeet_spike.rs
+++ b/src-tauri/src/transcribe/parakeet_spike.rs
@@ -1,0 +1,72 @@
+//! T3 SPIKE HARNESS (2026-07-10, transcription research): NVIDIA parakeet-tdt-0.6b-v3 int8
+//! through the `sherpa-onnx` crate already in the dependency tree (the diarization crate) —
+//! the decision input for the Brain v2 live-ASR seam (whisper stays the batch authority; the
+//! question is whether parakeet takes the LIVE path off Metal at ≥ live-quality for Polish).
+//!
+//! NOT a shipping path: `#[cfg(test)]`-only, `#[ignore]`d, env-driven exactly like the whisper
+//! A/B harness (`asr_ab_harness_from_env`) so a human can compare both on the same WAV without
+//! recompiling. See docs/research/2026-07-09-transcription-performance.md (Phase T3):
+//!
+//! ```sh
+//! MURMUR_PARAKEET_DIR=~/models/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8 \
+//! MURMUR_ASR_AB_WAV=~/asr/meeting-16k.wav \
+//! cargo test --lib parakeet_spike_from_env -- --ignored --nocapture
+//! ```
+
+#[cfg(test)]
+mod tests {
+    /// Decodes `MURMUR_ASR_AB_WAV` (16 kHz mono) with the parakeet int8 transducer from
+    /// `MURMUR_PARAKEET_DIR` (encoder/decoder/joiner `.int8.onnx` + `tokens.txt`), on CPU via
+    /// the bundled static onnxruntime — deliberately OFF Metal, that is the whole point of the
+    /// spike. Prints model-load + decode wall-clock and writes the transcript to a temp file
+    /// for a side-by-side diff with the whisper A/B legs.
+    #[test]
+    #[ignore = "parakeet spike: needs MURMUR_PARAKEET_DIR + MURMUR_ASR_AB_WAV on a real Mac"]
+    fn parakeet_spike_from_env() {
+        let Ok(dir) = std::env::var("MURMUR_PARAKEET_DIR") else {
+            eprintln!("SKIP: set MURMUR_PARAKEET_DIR to the sherpa parakeet int8 model dir");
+            return;
+        };
+        let Ok(wav) = std::env::var("MURMUR_ASR_AB_WAV") else {
+            eprintln!("SKIP: set MURMUR_ASR_AB_WAV to a 16 kHz mono WAV path");
+            return;
+        };
+
+        let wave = sherpa_onnx::Wave::read(&wav).expect("read wave");
+        let audio_secs = wave.samples().len() as f64 / wave.sample_rate() as f64;
+
+        let mut config = sherpa_onnx::OfflineRecognizerConfig::default();
+        config.model_config.transducer = sherpa_onnx::OfflineTransducerModelConfig {
+            encoder: Some(format!("{dir}/encoder.int8.onnx")),
+            decoder: Some(format!("{dir}/decoder.int8.onnx")),
+            joiner: Some(format!("{dir}/joiner.int8.onnx")),
+        };
+        config.model_config.tokens = Some(format!("{dir}/tokens.txt"));
+        config.model_config.model_type = Some("nemo_transducer".into());
+        // Live-path shape: a handful of CPU threads, leaving the Metal GPU entirely to the
+        // brain LLM. 4 matches the E-core budget the live loop's QoS targets.
+        config.model_config.num_threads = 4;
+
+        let t_load = std::time::Instant::now();
+        let recognizer =
+            sherpa_onnx::OfflineRecognizer::create(&config).expect("create parakeet recognizer");
+        let load_s = t_load.elapsed().as_secs_f64();
+
+        let t = std::time::Instant::now();
+        let stream = recognizer.create_stream();
+        stream.accept_waveform(wave.sample_rate(), wave.samples());
+        recognizer.decode(&stream);
+        let result = stream.get_result().expect("parakeet result");
+        let wall = t.elapsed().as_secs_f64();
+
+        let out = std::env::temp_dir().join("murmur-parakeet-spike.txt");
+        std::fs::write(&out, &result.text).expect("write transcript");
+        println!(
+            "parakeet-v3 int8 (CPU x4): load {load_s:.2}s, decode {wall:.2}s for {audio_secs:.1}s \
+             audio ({rtf:.1}x realtime), {chars} chars -> {path}",
+            rtf = audio_secs / wall.max(1e-9),
+            chars = result.text.len(),
+            path = out.display()
+        );
+    }
+}


### PR DESCRIPTION
Test-only + docs + eval artifact:

- **parakeet spike harness** (`#[cfg(test)]`, `#[ignore]`, env-driven like the whisper A/B): parakeet-tdt-0.6b-v3 int8 via the in-tree sherpa-onnx crate, 4 CPU threads, Metal untouched. Measured **13.1× realtime**, clean PL↔EN auto language switch, quality between whisper small and turbo — the T3 live-ASR decision evidence.
- **Measured A/B** (131 s PL/EN/PL WAV, post-#230 flash-attn + VAD batch): `small` Accurate 2.75 s vs `large-v3-turbo-q8_0` Accurate **2.73 s — same batch wall**, near-perfect Polish on turbo (names right, EN intact) vs garbled names / dropped EN / hallucination loops on small. Appendix in the transcription research doc.
- **Bake-off re-run on the final tree** with the real e5: hybrid recall@5 **0.9000** / nDCG@5 **0.8250** — identical to L1, zero retrieval regression from L3/notes/lock fixes.

Verified: `cargo test --lib` (spike + harness both executed for real), `scripts/ci.sh` ✅ all gates green. Caveat: TTS-synthesized speech, not meeting audio; watts still need the user-assisted powermetrics session.