### PR TITLE
feat(transcribe): conditional turbo-q8_0 default + one-command power measurement protocol

### DIFF
--- a/scripts/measure-live-power.sh
+++ b/scripts/measure-live-power.sh
@@ -1,86 +1,223 @@
 #!/usr/bin/env bash
-# measure-live-power.sh — the powermetrics A/B protocol for Murmur's LIVE transcription loop
-# (T0.2 of docs/research/2026-07-09-transcription-performance.md).
+# measure-live-power.sh — the ONE-COMMAND live-power baseline for Murmur's LIVE transcription
+# loop (T0 of docs/research/2026-07-09-transcription-performance.md).
 #
-# WHAT IT MEASURES
-#   CPU / GPU / ANE package power + thermal pressure + per-process energy while Murmur records,
-#   sampled every 1 s. This is the ONLY ground truth for the heat work — every modeled number
-#   (VAD gate, audio_ctx, live pin, flash-attn, thermal governor) counts only once this script
-#   has measured it on a real Mac.
+# WHAT IT DOES
+#   Runs the headless duty-cycle simulation (`live_duty_cycle_sim_from_env` in
+#   src-tauri/src/transcribe/whisper.rs — mirrors live.rs semantics: 3 s ticks, 14 s window,
+#   Silero gate with 2-tick hangover, real wall-clock sleeps) three times while `powermetrics`
+#   samples CPU/GPU/ANE power, then writes the eval artifact
+#   eval/results/live-power-baseline.md. Needs NO running app and touches NO database.
 #
-# PROTOCOL (run the WHOLE thing twice — leg A vs leg B):
-#   1. Prepare a SCRIPTED ~10-minute meeting: play the same fixed PL/EN recording out loud (or
-#      a colleague reads the same script) so both legs hear identical audio.
-#   2. Leg A: set the live model to `small` (Settings, or config `live_model_pin=small`),
-#      start a Murmur recording, then run:
-#        sudo scripts/measure-live-power.sh --seconds 600 --out /tmp/live-power-small.txt
-#   3. Leg B: repeat the SAME scripted meeting with the live model pinned to `large-v3`
-#      (config `live_model_pin=large-v3`, model downloaded):
-#        sudo scripts/measure-live-power.sh --seconds 600 --out /tmp/live-power-large-v3.txt
-#   4. Pair each leg with Murmur's own per-tick decode telemetry: run the app with
-#        RUST_LOG=live_perf=info
-#      and keep the emitted `live decode tick` lines (decode_ms / window_s / model) next to the
-#      powermetrics file. Commit the two summaries as the eval artifact.
+# LEGS (one variable ladder, pre-fix worst case → shipped):
+#   A  large-v3  gate=0  audio_ctx=0    — the pre-fix worst case (decode every tick, full ctx)
+#   B  small     gate=0  audio_ctx=0    — the pre-fix default model
+#   C  small     gate=1  audio_ctx=832  — the shipped live loop (VAD gate + right-sized ctx)
+#
+# USAGE (root is needed for powermetrics ONLY — every cargo invocation runs as $SUDO_USER):
+#   sudo MURMUR_DUTY_WAV=/path/to/meeting-16k.wav bash scripts/measure-live-power.sh
+#
+# ENV KNOBS
+#   MURMUR_DUTY_WAV           REQUIRED — a 16 kHz mono WAV of real speech (looped + padded with
+#                             MURMUR_DUTY_SILENCE_SECS of silence to ~meeting speech density)
+#   MURMUR_DUTY_MINUTES       minutes of simulated wall-clock per leg (default 3)
+#   MURMUR_DUTY_SILENCE_SECS  injected silence between WAV loop-plays (default 240)
+#   MURMUR_DUTY_SMALL         path to ggml-small.bin        (default: app models dir)
+#   MURMUR_DUTY_LARGE         path to ggml-large-v3.bin     (default: app models dir)
+#   MURMUR_MODELS_DIR         override the app models dir
 #
 # NOTES
-#   * powermetrics REQUIRES sudo (it reads SMC/thermal counters).
 #   * Run on wall power, screen awake, no other heavy apps — or note the difference.
-#   * The same protocol A/Bs any other change: VAD gate on/off (`live_vad_gate`), flash-attn,
-#     audio_ctx, quants — one variable per pair of legs.
-#
-# USAGE
-#   sudo scripts/measure-live-power.sh [--seconds N] [--out FILE]
-#     --seconds N   sampling duration in seconds (default 600 = the 10-min scripted meeting)
-#     --out FILE    output file (default /tmp/murmur-live-power-<timestamp>.txt)
-#
-# SUMMARIZING (no jq needed — plain grep/awk over the plist-free text output):
-#   grep -E "GPU Power|CPU Power|ANE Power" "$OUT" \
-#     | awk -F': ' '{sum[$1]+=$2; n[$1]++} END {for (k in sum) printf "%s avg %.0f mW over %d samples\n", k, sum[k]/n[k], n[k]}'
-#   grep -E "pressure|Murmur" "$OUT" | sort | uniq -c | head        # thermal levels + process energy lines
+#   * The Silero VAD model (ggml-silero-v5.1.2.bin) must be in the models dir for leg C
+#     (the app downloads it on first Accurate run).
 
 set -euo pipefail
 
-SECONDS_TO_SAMPLE=600
-OUT="/tmp/murmur-live-power-$(date +%Y%m%d-%H%M%S).txt"
+usage() {
+  echo "USAGE: sudo MURMUR_DUTY_WAV=/path/to/meeting-16k.wav bash scripts/measure-live-power.sh" >&2
+  echo "       (root is for powermetrics only; cargo runs as \$SUDO_USER — see the header)" >&2
+}
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --seconds)
-      SECONDS_TO_SAMPLE="${2:?--seconds needs a value}"
-      shift 2
-      ;;
-    --out)
-      OUT="${2:?--out needs a path}"
-      shift 2
-      ;;
-    -h|--help)
-      sed -n '2,40p' "$0"
-      exit 0
-      ;;
-    *)
-      echo "unknown argument: $1 (see --help)" >&2
-      exit 2
-      ;;
-  esac
-done
-
+# ── Preflight: root for powermetrics, a REAL invoking user for cargo ──────────────────────────
 if [[ "$(id -u)" -ne 0 ]]; then
-  echo "powermetrics needs root — re-run with sudo." >&2
+  echo "ERROR: powermetrics needs root." >&2
+  usage
+  exit 1
+fi
+if [[ -z "${SUDO_USER:-}" || "${SUDO_USER:-}" == "root" ]]; then
+  echo "ERROR: SUDO_USER is empty — invoke via 'sudo bash scripts/measure-live-power.sh' from" >&2
+  echo "       a normal user shell, never from a root login. Every cargo invocation must run" >&2
+  echo "       as the real user (a root-owned target/ dir corrupts the build cache)." >&2
+  exit 1
+fi
+if [[ -z "${MURMUR_DUTY_WAV:-}" ]]; then
+  echo "ERROR: MURMUR_DUTY_WAV is required (a 16 kHz mono WAV of real speech)." >&2
+  usage
   exit 1
 fi
 
-SAMPLE_COUNT="$SECONDS_TO_SAMPLE" # -i 1000 ms ⇒ one sample per second.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+USER_HOME="$(dscl . -read "/Users/$SUDO_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+USER_HOME="${USER_HOME:-/Users/$SUDO_USER}"
 
-echo "Sampling cpu/gpu/ane power + thermal + per-process energy for ${SECONDS_TO_SAMPLE}s → ${OUT}"
-powermetrics \
-  -i 1000 \
-  -n "$SAMPLE_COUNT" \
-  --samplers cpu_power,gpu_power,ane_power,thermal \
-  --show-process-energy \
-  -o "$OUT"
+MODELS_DIR="${MURMUR_MODELS_DIR:-$USER_HOME/Library/Application Support/MeetNotes/models}"
+SMALL_MODEL="${MURMUR_DUTY_SMALL:-$MODELS_DIR/ggml-small.bin}"
+LARGE_MODEL="${MURMUR_DUTY_LARGE:-$MODELS_DIR/ggml-large-v3.bin}"
+MINUTES="${MURMUR_DUTY_MINUTES:-3}"
+SILENCE_SECS="${MURMUR_DUTY_SILENCE_SECS:-240}"
 
-echo "Done → ${OUT}"
-echo "Quick summary:"
-grep -E "GPU Power|CPU Power|ANE Power" "$OUT" \
-  | awk -F': ' '{sum[$1]+=$2; n[$1]++} END {for (k in sum) printf "  %s avg %.0f mW over %d samples\n", k, sum[k]/n[k], n[k]}' \
-  || echo "  (no power lines found — check the samplers on this hardware)"
+for f in "$MURMUR_DUTY_WAV" "$SMALL_MODEL" "$LARGE_MODEL"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: missing file: $f" >&2
+    echo "       (models default to the app models dir; override via MURMUR_DUTY_SMALL/_LARGE)" >&2
+    exit 1
+  fi
+done
+
+OUT_DIR="$REPO_DIR/eval/results"
+mkdir -p "$OUT_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+# ── Crash/ctrl-c safety: powermetrics runs as ROOT in the background with NO sample limit — an
+# exit between spawn and kill (any set -e failure, SIGINT/TERM/HUP, closed terminal) would
+# otherwise orphan a root sampler writing into the repo FOREVER, and a failed run would leave
+# root-owned files inside eval/results/ (breaking the user's later writes there). The EXIT trap
+# always kills the current sampler and hands the output dir back to the real user.
+PM_PID=""
+cleanup() {
+  if [[ -n "$PM_PID" ]]; then
+    kill "$PM_PID" 2>/dev/null || true
+    wait "$PM_PID" 2>/dev/null || true
+    PM_PID=""
+  fi
+  chown -R "$SUDO_USER" "$OUT_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM HUP # signal → normal exit path → the EXIT trap fires
+
+# Every cargo command runs AS THE REAL USER (-H sets $HOME so ~/.cargo resolves) — the critical
+# detail: a single root-owned artifact in src-tauri/target corrupts the user's build cache.
+run_as_user() {
+  sudo -u "$SUDO_USER" -H env \
+    PATH="$USER_HOME/.cargo/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+    "$@"
+}
+
+echo "==> Pre-building the test binary as $SUDO_USER (kept OUT of the measured window)"
+run_as_user bash -c "cd '$REPO_DIR/src-tauri' && cargo test --lib --no-run" >/dev/null
+
+run_leg() {
+  local name="$1" model="$2" gate="$3" ctx="$4"
+  local pm_out="$OUT_DIR/live-power-leg-$name-$STAMP.powermetrics.txt"
+  local log_out="$OUT_DIR/live-power-leg-$name-$STAMP.log"
+
+  echo "==> Leg $name: model=$(basename "$model") gate=$gate audio_ctx=$ctx (${MINUTES} min)"
+  # PM_PID (script-global) so the EXIT trap can kill a sampler orphaned by a mid-leg failure.
+  powermetrics -i 1000 --samplers cpu_power,gpu_power,ane_power,thermal -o "$pm_out" &
+  PM_PID=$!
+  # Give powermetrics a moment to start sampling before the leg begins.
+  sleep 2
+
+  # 2>&1 is REQUIRED: cargo-test harness prints (incl. DUTY_RESULT) can land on stderr.
+  run_as_user env \
+    MURMUR_DUTY_WAV="$MURMUR_DUTY_WAV" \
+    MURMUR_DUTY_MODEL="$model" \
+    MURMUR_DUTY_MINUTES="$MINUTES" \
+    MURMUR_DUTY_GATE="$gate" \
+    MURMUR_DUTY_AUDIO_CTX="$ctx" \
+    MURMUR_DUTY_SILENCE_SECS="$SILENCE_SECS" \
+    bash -c "cd '$REPO_DIR/src-tauri' && cargo test --lib live_duty_cycle_sim_from_env -- --ignored --nocapture" \
+    >"$log_out" 2>&1 || true
+
+  kill "$PM_PID" 2>/dev/null || true
+  wait "$PM_PID" 2>/dev/null || true
+  PM_PID=""
+
+  local duty
+  duty="$(grep -h 'DUTY_RESULT' "$log_out" | tail -1 || true)"
+  if [[ -z "$duty" ]]; then
+    echo "WARN: leg $name produced no DUTY_RESULT line — see $log_out" >&2
+    duty="DUTY_RESULT (missing — see $(basename "$log_out"))"
+  fi
+  echo "    $duty"
+  DUTY_LINES+=("$name|$duty|$pm_out")
+}
+
+# Liberal powermetrics parser: field names vary by macOS version ("GPU Power: 123 mW",
+# "CPU Power: 456 mW", sometimes combined lines). Averages every "<label>: <n> mW" match for
+# the given label; prints n/a when nothing matched (the raw file stays in the artifact).
+avg_mw() {
+  local file="$1" label="$2"
+  awk -v lbl="$label" '
+    $0 ~ lbl && / mW/ {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^[0-9]+(\.[0-9]+)?$/ && $(i+1) ~ /^mW/) { sum += $i; n++ }
+      }
+    }
+    END { if (n > 0) printf "%.0f", sum / n; else printf "n/a" }
+  ' "$file" 2>/dev/null || printf "n/a"
+}
+
+DUTY_LINES=()
+run_leg "A" "$LARGE_MODEL" 0 0
+run_leg "B" "$SMALL_MODEL" 0 0
+run_leg "C" "$SMALL_MODEL" 1 832
+
+# ── Write the artifact ─────────────────────────────────────────────────────────────────────────
+ARTIFACT="$OUT_DIR/live-power-baseline.md"
+CHIP="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")"
+COMMIT="$(run_as_user git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+
+{
+  echo "# Live-loop power baseline (duty-cycle simulation)"
+  echo
+  echo "- Date: $(date '+%Y-%m-%d %H:%M %Z')"
+  echo "- Chip: $CHIP"
+  echo "- Commit: $COMMIT"
+  echo "- Simulated minutes per leg: $MINUTES (WAV looped + ${SILENCE_SECS}s injected silence)"
+  echo "- Harness: \`live_duty_cycle_sim_from_env\` (src-tauri/src/transcribe/whisper.rs) +"
+  echo "  \`powermetrics -i 1000 --samplers cpu_power,gpu_power,ane_power,thermal\`"
+  echo
+  echo "| Leg | Config | avg GPU mW | avg CPU mW | DUTY_RESULT |"
+  echo "|-----|--------|-----------:|-----------:|-------------|"
+  for entry in "${DUTY_LINES[@]}"; do
+    IFS='|' read -r name duty pm_file <<<"$entry"
+    case "$name" in
+      A) cfg="large-v3, gate=0, ctx=0 (pre-fix worst case)" ;;
+      B) cfg="small, gate=0, ctx=0 (pre-fix default)" ;;
+      C) cfg="small, gate=1, ctx=832 (shipped)" ;;
+      *) cfg="?" ;;
+    esac
+    gpu="$(avg_mw "$pm_file" "GPU Power")"
+    cpu="$(avg_mw "$pm_file" "CPU Power")"
+    echo "| $name | $cfg | $gpu | $cpu | \`$duty\` |"
+  done
+  echo
+  echo "Raw powermetrics files (per leg, same directory):"
+  for entry in "${DUTY_LINES[@]}"; do
+    IFS='|' read -r name _duty pm_file <<<"$entry"
+    echo "- Leg $name: \`$(basename "$pm_file")\`"
+  done
+  echo
+  echo "## Honest notes"
+  echo
+  echo "- The audio is a looped fixed WAV + injected silence (synthetic density ~35% speech),"
+  echo "  not a live meeting; TTS/recorded speech may VAD-gate slightly differently than a real"
+  echo "  far-end mix."
+  echo "- Flash attention is ON in ALL legs (baked into \`Transcriber::load\`), so the TRUE"
+  echo "  pre-fix baseline was WORSE than legs A/B measured here."
+  echo "- powermetrics wattages are Apple's modeled estimates, not shunt measurements."
+  echo "- The sim sleeps each tick's remainder, so the idle/busy pattern is real wall-clock;"
+  echo "  per-leg duty_pct comes from the DUTY_RESULT line, not from powermetrics."
+  echo "- The sim's VAD gate scans a FIXED newest-3 s delta each tick; the shipped live loop"
+  echo "  (live.rs \`vad_scan_span_secs\`) scans everything since the last scan + 2 s headroom,"
+  echo "  clamped [3, 14] s — at real (decode-stretched) tick spacing it scans MORE audio, so"
+  echo "  the sim slightly OVERSTATES gating (fewer boundary speech detections). Hangover"
+  echo "  (2 ticks), fail-open on VAD error, 3 s tick, 14 s window and the Fast/greedy decode"
+  echo "  profile do match the shipped loop."
+} >"$ARTIFACT"
+
+# powermetrics/artifact files are root-owned mid-run; the EXIT trap's cleanup hands $OUT_DIR
+# back to $SUDO_USER on EVERY exit path (success, failure, ctrl-c).
+
+echo "==> Artifact: $ARTIFACT"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -616,23 +616,55 @@ pub async fn start_recording(
         // pass on the configured model is the authoritative transcript and is unaffected).
         // `""` disables the pin → the configured model, with the LEGACY `brain_live` pin-to-small
         // (D1, spec §4.3: the live tick must not starve the light reasoner) still applying — the
-        // full decision lives in `model::live_pin_size`. If the pinned model file is absent,
-        // fall back to the configured model + warn (pinning to an absent file would kill the
-        // live loop).
+        // full decision lives in `model::live_pin_size`.
+        //
+        // ABSENT-FILE fallback (T2 default-flip follow-up — a fresh ≥12 GB install downloads
+        // ONLY `ggml-large-v3-turbo-q8_0.bin`, so the pinned `small` is absent on the flip's
+        // target machines): prefer the largest downloaded live-SAFE model (small → base →
+        // tiny); a live-safe CONFIGURED model still works as before; but a medium/large-class
+        // configured model is NEVER handed to the live tick — captions are skipped for THIS
+        // recording and the pinned size is downloaded in the background (single-flight,
+        // best-effort) so the next recording — and the wake listener, which reconciles via
+        // `restart_voice_listener` when this recording stops — has it.
         let live_model = match crate::transcribe::model::live_pin_size(
             &cfg.live_model_pin,
             cfg.brain_live,
         ) {
             Some(size) => match crate::transcribe::model::resolve_model_path(None, &size, lang) {
                 Ok(Some(p)) => Some(p),
-                _ => {
-                    tracing::warn!(
-                        target: "live",
-                        pin = %size,
-                        "pinned live model absent; live tick uses the configured whisper model (may run hot / contend with the light reasoner)"
-                    );
-                    configured()
-                }
+                _ => match crate::transcribe::model::live_fallback_model(lang) {
+                    Some(p) => {
+                        tracing::warn!(
+                            target: "live",
+                            pin = %size,
+                            "pinned live model absent; live tick uses the largest downloaded live-safe whisper model"
+                        );
+                        Some(p)
+                    }
+                    None => match configured() {
+                        Some(p) if !crate::transcribe::model::is_live_heavy_model_file(&p) => {
+                            tracing::warn!(
+                                target: "live",
+                                pin = %size,
+                                "pinned live model absent; live tick uses the configured whisper model (may contend with the light reasoner)"
+                            );
+                            Some(p)
+                        }
+                        Some(_) => {
+                            // Only medium/large-class models downloaded (e.g. the fresh
+                            // turbo-default install): NEVER run a large encoder on the 3 s
+                            // live tick (T1.3 heat).
+                            tracing::warn!(
+                                target: "live",
+                                pin = %size,
+                                "pinned live model absent and only medium/large models downloaded; live captions off for this recording; downloading the pinned model in the background"
+                            );
+                            spawn_live_pin_download(size, lang.to_string());
+                            None
+                        }
+                        None => None,
+                    },
+                },
             },
             None => configured(),
         };
@@ -651,6 +683,36 @@ pub async fn start_recording(
     );
 
     Ok(StartResult { meeting_id })
+}
+
+/// Best-effort BACKGROUND download of the pinned LIVE model (T2 default-flip follow-up): a
+/// fresh turbo-default install has no live-safe whisper model on disk, so the first record
+/// start fetches the pinned size (~487 MB `small`) off the recording path. Single-flight (an
+/// `AtomicBool` latch — consecutive record starts while a download is in flight must not race
+/// two writers onto the same `.part` file); failure is logged and re-armed (next record start
+/// retries). Deliberately does NOT spawn the live loop when the download lands mid-meeting:
+/// a belated `live::spawn` could race a NEXT recording's own live loop and clear its
+/// `live_transcript`. The model serves the next recording + the wake listener instead.
+fn spawn_live_pin_download(size: String, language: String) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+    if IN_FLIGHT
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        match crate::transcribe::model::ensure_model(None, &size, &language, |_, _| {}).await {
+            Ok(_) => {
+                tracing::info!(target: "live", pin = %size, "pinned live model downloaded; live captions available from the next recording")
+            }
+            Err(e) => {
+                tracing::warn!(target: "live", pin = %size, error = %e, "pinned live model download failed; will retry on a later record start")
+            }
+        }
+        IN_FLIGHT.store(false, Ordering::SeqCst);
+    });
 }
 
 /// Stop capture, then run the full pipeline (pipeline::run_after_stop). Returns the
@@ -6896,9 +6958,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         audio_storage_limit_gb: d.audio_storage_limit_gb,
         audio_auto_prune: d.audio_auto_prune,
         model_size: if d.model_size.trim().is_empty() {
-            // Mirror AppConfig::default().model_size — an empty/blank choice from the FE must
-            // fall back to the multilingual large-v3 default (best Polish quality), NOT a
-            // smaller model that would silently downgrade transcription.
+            // Mirror AppConfig::default().model_size — an empty/blank choice from the FE
+            // resolves the machine-conditional T2 default (`model::default_model_size_now`:
+            // turbo-q8_0 when already downloaded / fresh ≥12 GB install, else `small`), the
+            // same ONE decision every other blank-size path takes.
             AppConfig::default().model_size
         } else {
             d.model_size

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -157,9 +157,13 @@ pub struct AppConfig {
     #[serde(default)]
     pub audio_auto_prune: bool,
     /// Whisper model size: "tiny" | "base" | "small" | "medium" | "large-v3-turbo" |
-    /// "large-v3". Default "small" (~466 MB) — a RAM-safe default: `large-v3` is ~3 GB and swaps
-    /// on 8 GB Macs, and onboarding already preselects `small`. All sizes (incl. `large-v3`, best
-    /// for Polish) stay selectable; the chosen model is downloaded on demand via `download_model`.
+    /// "large-v3" | the quant variants (e.g. "large-v3-turbo-q8_0"). The DEFAULT is the
+    /// machine-conditional T2 flip (`transcribe::model::default_model_size_now`):
+    /// `large-v3-turbo-q8_0` when it is already downloaded OR on a FRESH install (no whisper
+    /// model on disk) with ≥ 12 GB RAM — measured same batch wall-clock as `small` at far better
+    /// Polish (docs/research/2026-07-09-transcription-performance.md); `small` (~470 MB,
+    /// RAM-safe) everywhere else, so an existing install never gets a surprise download. All
+    /// sizes stay selectable; the chosen model is downloaded on demand via `download_model`.
     pub model_size: String,
     /// T1.3 (transcription heat) — the LIVE caption tick's model PIN. Non-empty (default
     /// `"small"`) ⇒ while recording, the live loop decodes with THIS size whenever its file is
@@ -559,7 +563,10 @@ impl Default for AppConfig {
             post_aec_enabled: false,
             audio_storage_limit_gb: None,
             audio_auto_prune: false,
-            model_size: "small".to_string(),
+            // T2 DEFAULT FLIP — machine-conditional (turbo-q8_0 when already downloaded / fresh
+            // big-RAM install, else "small"); the ONE decision lives in
+            // `transcribe::model::default_model_size`. Onboarding preselects THIS value.
+            model_size: crate::transcribe::model::default_model_size_now().to_string(),
             live_model_pin: default_live_model_pin(),
             live_vad_gate: true,
             voice_trigger: false,
@@ -1468,15 +1475,23 @@ mod tests {
         assert!(!AppConfig::load(&db).unwrap().capture_system_audio);
     }
 
-    /// A2 — the app default whisper model is `small` (RAM-safe; `large-v3` is ~3 GB and swaps on
-    /// 8 GB Macs). Must match `transcribe::model_filename("", _)`'s empty-size fallback so a config
-    /// that bypasses onboarding no longer lands on `large-v3`. All sizes stay selectable.
+    /// A2 + T2 flip — the app default whisper model is the MACHINE-CONDITIONAL resolver's pick
+    /// (`transcribe::model::default_model_size_now`): turbo-q8_0 when already downloaded or on a
+    /// fresh big-RAM install, `small` (RAM-safe) otherwise. Machine-dependent BY DESIGN, so
+    /// assert consistency with the resolver (the ONE decision) rather than a literal, plus the
+    /// closed set of sanctioned defaults. `large-v3` (~3 GB) is never a default.
     #[test]
-    fn model_size_defaults_to_small() {
-        assert_eq!(AppConfig::default().model_size, "small");
+    fn model_size_default_matches_conditional_resolver() {
+        let expected = crate::transcribe::model::default_model_size_now();
+        assert_eq!(AppConfig::default().model_size, expected);
         // Empty settings table loads the same default.
         let db = temp_db();
-        assert_eq!(AppConfig::load(&db).unwrap().model_size, "small");
+        assert_eq!(AppConfig::load(&db).unwrap().model_size, expected);
+        // Whatever the machine, the default is one of the two sanctioned sizes.
+        assert!(
+            expected == "small" || expected == crate::transcribe::model::TURBO_DEFAULT_SIZE,
+            "unsanctioned default: {expected}"
+        );
     }
 
     /// T1.3/T1.4 — the live-tick pin defaults to `small` and the VAD tick gate defaults ON

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -25,8 +25,8 @@ pub const VAD_MODEL_FILE: &str = "ggml-silero-v5.1.2.bin";
 pub const DIARIZE_SEG_MODEL_FILE: &str = "sherpa-pyannote-segmentation-3.0.onnx";
 pub const DIARIZE_EMB_MODEL_FILE: &str = "wespeaker_en_voxceleb_CAM++.onnx";
 
-/// QUANT-SUFFIXED model sizes accepted by [`model_filename`] (T2 quant plumbing — NO default
-/// flip: `AppConfig::default().model_size` stays `"small"`). Each maps `"<size>-<quant>"` →
+/// QUANT-SUFFIXED model sizes accepted by [`model_filename`] (T2 quant plumbing; the CONDITIONAL
+/// default flip lives in [`default_model_size`]). Each maps `"<size>-<quant>"` →
 /// `ggml-<size>-<quant>.bin`, verified BY URL SHAPE against the ggerganov/whisper.cpp HF
 /// mirror's file tree (which hosts `ggml-small-q8_0.bin`, `ggml-medium-q8_0.bin`,
 /// `ggml-large-v3-turbo.bin`, `ggml-large-v3-turbo-q8_0.bin`, `ggml-large-v3-q5_0.bin`).
@@ -42,6 +42,103 @@ pub const QUANT_MODEL_SIZES: &[&str] = &[
     "large-v3-q5_0",
 ];
 
+/// T2 DEFAULT FLIP (the SAFE shape) — the size a NO-CHOICE config defaults to when the machine
+/// qualifies. Measured evidence (docs/research/2026-07-09-transcription-performance.md,
+/// "Measured results"): the turbo q8_0 quant runs an Accurate batch in the same wall-clock as
+/// `small` with near-perfect Polish, at ~875 MB download. Only [`default_model_size`] decides
+/// WHO gets it — existing installs and low-RAM machines stay on `small`.
+pub const TURBO_DEFAULT_SIZE: &str = "large-v3-turbo-q8_0";
+
+/// On-disk filename of [`TURBO_DEFAULT_SIZE`]'s (multilingual-only) build — must equal
+/// `model_filename(TURBO_DEFAULT_SIZE, _)` (test: `turbo_default_file_matches_model_filename`).
+const TURBO_DEFAULT_FILE: &str = "ggml-large-v3-turbo-q8_0.bin";
+
+/// RAM floor for defaulting a FRESH install to the turbo quant: the ~1 GB-resident turbo is a
+/// safe default on ≥ 12 GB machines; 8 GB Macs stay on `small` (the A2 RAM-safety rationale).
+const TURBO_DEFAULT_MIN_RAM_BYTES: u64 = 12 * 1024 * 1024 * 1024;
+
+/// T2 DEFAULT FLIP — the ONE place that decides what an EMPTY `model_size` means. PURE over the
+/// models-dir file names + total RAM so every branch is headless-testable:
+///
+/// 1. `ggml-large-v3-turbo-q8_0.bin` already downloaded → `large-v3-turbo-q8_0` (the user
+///    already paid the download; same wall-clock as `small`, much better Polish).
+/// 2. NO whisper `ggml-*.bin` at all (fresh install — onboarding will download whatever we
+///    return) AND total RAM ≥ 12 GB → `large-v3-turbo-q8_0`.
+/// 3. Otherwise → `small`. An EXISTING install (any whisper model on disk, e.g. `small`) NEVER
+///    gets a surprise 874 MB download or a behavior change, and unknown RAM (`None`) never
+///    triggers one either (fail-SMALL, not fail-open — the opposite of the reasoner's RAM guard,
+///    because "open" here would mean a large unrequested download).
+///
+/// The VAD model (`ggml-silero-v5.1.2.bin`) is a `ggml-*.bin` but NOT a whisper model — its
+/// presence alone still counts as a fresh install. `.part` partials never count (no `.bin`
+/// suffix). The LIVE pin (`live_model_pin`, default `small`) is deliberately untouched — turbo
+/// is a BATCH default only, ENFORCED at the record-start pin resolution: when the pinned file
+/// is absent the live tick falls back to [`live_fallback_model`] (live-safe sizes only) and
+/// NEVER to a medium/large configured model ([`is_live_heavy_model_file`]).
+pub fn default_model_size<S: AsRef<str>>(
+    models_dir_files: &[S],
+    total_ram_bytes: Option<u64>,
+) -> &'static str {
+    if models_dir_files
+        .iter()
+        .any(|f| f.as_ref() == TURBO_DEFAULT_FILE)
+    {
+        return TURBO_DEFAULT_SIZE;
+    }
+    let any_whisper_model = models_dir_files.iter().any(|f| {
+        let name = f.as_ref();
+        name.starts_with("ggml-") && name.ends_with(".bin") && name != VAD_MODEL_FILE
+    });
+    if !any_whisper_model && total_ram_bytes.is_some_and(|b| b >= TURBO_DEFAULT_MIN_RAM_BYTES) {
+        return TURBO_DEFAULT_SIZE;
+    }
+    "small"
+}
+
+/// [`default_model_size`] over the REAL machine: lists [`models_dir`] + reads total RAM via
+/// `sysctl -n hw.memsize` (the same no-new-dep pattern as `commands.rs::total_ram_gb`). Any
+/// probe/listing failure resolves `small` — a broken probe must never trigger a large download.
+/// Called by `AppConfig::default()` (the onboarding preselect) and by [`effective_model_size`].
+pub fn default_model_size_now() -> &'static str {
+    let Ok(dir) = models_dir() else {
+        return "small";
+    };
+    let Ok(read) = std::fs::read_dir(&dir) else {
+        return "small";
+    };
+    let files: Vec<String> = read
+        .filter_map(|e| e.ok().and_then(|e| e.file_name().into_string().ok()))
+        .collect();
+    default_model_size(&files, total_ram_bytes())
+}
+
+/// Resolve a possibly-empty configured `model_size` to the size that should actually load:
+/// non-empty passes through verbatim; empty/blank resolves the machine-conditional default
+/// ([`default_model_size_now`]). [`resolve_model_path`] / [`ensure_model`] route through this so
+/// a legacy config that persisted `""` follows the same ONE decision as a fresh default.
+pub fn effective_model_size(size: &str) -> String {
+    let s = size.trim();
+    if s.is_empty() {
+        default_model_size_now().to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// macOS total physical RAM in bytes via `sysctl -n hw.memsize` — mirrors
+/// `commands.rs::total_ram_gb` (no new FFI/crate). `None` on any failure.
+fn total_ram_bytes() -> Option<u64> {
+    let out = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.memsize")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()?.trim().parse().ok()
+}
+
 /// Map a chosen size + language to a whisper.cpp GGML model filename.
 ///
 /// Supported sizes (all served by the ggerganov/whisper.cpp HF mirror):
@@ -55,9 +152,11 @@ pub const QUANT_MODEL_SIZES: &[&str] = &[
 /// EVERY quant-suffixed size resolve multilingual-only (no `.en` is ever appended to a
 /// quant/large variant — see [`QUANT_MODEL_SIZES`]).
 ///
-/// An empty size falls back to the app default (`small`), matching
-/// `AppConfig::default().model_size` — a RAM-safe default so a config that bypasses onboarding
-/// no longer lands on the ~3 GB `large-v3`. All sizes (incl. `large-v3`) stay selectable.
+/// An empty size falls back to `small` here as a STATIC safety net only — the real
+/// machine-conditional default (T2 flip: turbo when already downloaded / fresh big-RAM install)
+/// is applied BEFORE this function by [`effective_model_size`] inside [`resolve_model_path`] /
+/// [`ensure_model`], and by `AppConfig::default()` via [`default_model_size_now`]. All sizes
+/// (incl. `large-v3`) stay selectable.
 pub fn model_filename(size: &str, language: &str) -> String {
     let size = match size.trim() {
         "" => "small",
@@ -108,14 +207,37 @@ pub fn smallest_wake_model(language: &str) -> Option<PathBuf> {
 /// File-presence core of [`smallest_wake_model`], factored over an explicit `dir` so the
 /// tiny→base→small preference order is testable headless with a temp dir.
 pub fn smallest_wake_model_in(dir: &Path, language: &str) -> Option<PathBuf> {
-    for size in ["tiny", "base", "small"] {
+    first_present_model_in(dir, &["tiny", "base", "small"], language)
+}
+
+/// T2 default-flip follow-up — the LIVE-pin ABSENT-FILE fallback: the pinned live model
+/// (default `small`) is not on disk, so pick the LARGEST downloaded live-SAFE model instead
+/// (small → small-q8_0 → base → tiny; captions want the best of the safe sizes). NEVER
+/// medium/large — falling through to a large-class configured model is exactly the T1.3
+/// "large live tick saturates the shared Metal GPU" heat scenario the pin exists to prevent,
+/// and on a fresh turbo-default install (ONLY `ggml-large-v3-turbo-q8_0.bin` downloaded) it
+/// would be the DEFAULT experience. `None` = nothing live-safe downloaded (the caller skips
+/// captions and may background-download the pinned size).
+pub fn live_fallback_model(language: &str) -> Option<PathBuf> {
+    let dir = models_dir().ok()?;
+    live_fallback_model_in(&dir, language)
+}
+
+/// File-presence core of [`live_fallback_model`], testable headless with a temp dir.
+pub fn live_fallback_model_in(dir: &Path, language: &str) -> Option<PathBuf> {
+    first_present_model_in(dir, &["small", "small-q8_0", "base", "tiny"], language)
+}
+
+/// First size in `sizes` whose model file exists in `dir`, honoring the language-appropriate
+/// build ([`model_filename`]). An English selection can also ride a downloaded MULTILINGUAL
+/// build of the same size (multilingual handles English fine; the reverse is not true, so a
+/// non-English language never falls back onto an `.en` build).
+fn first_present_model_in(dir: &Path, sizes: &[&str], language: &str) -> Option<PathBuf> {
+    for size in sizes {
         let preferred = dir.join(model_filename(size, language));
         if preferred.is_file() {
             return Some(preferred);
         }
-        // An English selection can also ride a downloaded MULTILINGUAL build of the same size
-        // (multilingual handles English fine; the reverse is not true, so a non-English
-        // language never falls back onto an `.en` build).
         if language == "en" {
             let multilingual = dir.join(model_filename(size, ""));
             if multilingual.is_file() {
@@ -124,6 +246,20 @@ pub fn smallest_wake_model_in(dir: &Path, language: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Whether a whisper model FILE is too heavy for the 3 s LIVE tick (medium/large class, incl.
+/// every large-v3 / turbo / quant variant — the name-based check covers `ggml-large-v3.bin`,
+/// `ggml-large-v3-turbo-q8_0.bin`, `ggml-medium.en.bin`, …). Best-effort by design: an
+/// unrecognizable custom filename classifies NOT-heavy, which preserves the pre-pin behavior
+/// for explicit `whisper_model_path` users.
+pub fn is_live_heavy_model_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| {
+            let n = n.to_ascii_lowercase();
+            n.contains("large") || n.contains("medium")
+        })
 }
 
 /// Hugging Face mirror of the official whisper.cpp GGML models (ggerganov/whisper.cpp).
@@ -179,7 +315,9 @@ pub fn resolve_model_path(
             return Ok(Some(p.to_path_buf()));
         }
     }
-    let derived = models_dir()?.join(model_filename(size, language));
+    // An empty configured size resolves the machine-conditional default (T2 flip) so a legacy
+    // `""` config follows the same ONE decision as `AppConfig::default()`.
+    let derived = models_dir()?.join(model_filename(&effective_model_size(size), language));
     if derived.is_file() {
         return Ok(Some(derived));
     }
@@ -204,12 +342,15 @@ pub async fn ensure_model<F>(
 where
     F: FnMut(u64, Option<u64>),
 {
-    if let Some(found) = resolve_model_path(configured, size, language)? {
+    // Resolve the effective size ONCE so the presence check and the download name can't diverge
+    // (an empty size resolves the machine-conditional default — see `effective_model_size`).
+    let size = effective_model_size(size);
+    if let Some(found) = resolve_model_path(configured, &size, language)? {
         return Ok(found);
     }
 
     let dir = models_dir()?;
-    let file = model_filename(size, language);
+    let file = model_filename(&size, language);
     let dest = dir.join(&file);
     download_model_streaming(&model_url(&file), &dest, on_progress).await?;
     Ok(dest)
@@ -391,6 +532,92 @@ mod tests {
         assert_eq!(model_filename("large-v3-q5_0", "en"), "ggml-large-v3-q5_0.bin");
     }
 
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    /// T2 DEFAULT FLIP branch 1 — turbo already downloaded wins regardless of RAM (even
+    /// unknown/low): the user already paid the 874 MB.
+    #[test]
+    fn default_model_size_prefers_downloaded_turbo() {
+        let files = ["ggml-large-v3-turbo-q8_0.bin", "ggml-small.bin"];
+        assert_eq!(default_model_size(&files, None), TURBO_DEFAULT_SIZE);
+        assert_eq!(default_model_size(&files, Some(8 * GIB)), TURBO_DEFAULT_SIZE);
+        assert_eq!(
+            default_model_size(&["ggml-large-v3-turbo-q8_0.bin"], Some(64 * GIB)),
+            TURBO_DEFAULT_SIZE
+        );
+    }
+
+    /// T2 DEFAULT FLIP branch 2 — a FRESH install (no whisper model on disk) with ≥ 12 GB RAM
+    /// defaults to turbo; the VAD ggml file / onnx sidecars / `.part` partials do NOT make an
+    /// install "existing".
+    #[test]
+    fn default_model_size_fresh_install_big_ram_gets_turbo() {
+        let none: [&str; 0] = [];
+        assert_eq!(default_model_size(&none, Some(16 * GIB)), TURBO_DEFAULT_SIZE);
+        // The floor is inclusive.
+        assert_eq!(default_model_size(&none, Some(12 * GIB)), TURBO_DEFAULT_SIZE);
+        // Non-whisper residents of the models dir still count as fresh.
+        let sidecars = [
+            VAD_MODEL_FILE,
+            DIARIZE_SEG_MODEL_FILE,
+            DIARIZE_EMB_MODEL_FILE,
+            "ggml-small.bin.part",
+        ];
+        assert_eq!(default_model_size(&sidecars, Some(16 * GIB)), TURBO_DEFAULT_SIZE);
+    }
+
+    /// T2 DEFAULT FLIP branch 3a — low or UNKNOWN RAM stays on `small` (a broken RAM probe must
+    /// never trigger an 874 MB download: fail-SMALL, not fail-open).
+    #[test]
+    fn default_model_size_low_or_unknown_ram_stays_small() {
+        let none: [&str; 0] = [];
+        assert_eq!(default_model_size(&none, Some(8 * GIB)), "small");
+        assert_eq!(default_model_size(&none, Some(12 * GIB - 1)), "small");
+        assert_eq!(default_model_size(&none, None), "small");
+    }
+
+    /// T2 DEFAULT FLIP branch 3b — the existing-install-no-surprise PROPERTY: ANY whisper model
+    /// already on disk (and no turbo) keeps the default at `small`, however big the RAM. An
+    /// install that chose `small` never gets a surprise download or behavior change.
+    #[test]
+    fn default_model_size_existing_install_never_surprised() {
+        for present in [
+            "ggml-tiny.bin",
+            "ggml-base.bin",
+            "ggml-small.bin",
+            "ggml-small.en.bin",
+            "ggml-medium-q8_0.bin",
+            "ggml-large-v3.bin",
+        ] {
+            assert_eq!(
+                default_model_size(&[present], Some(64 * GIB)),
+                "small",
+                "existing install with {present} must stay on small"
+            );
+        }
+    }
+
+    /// T2 DEFAULT FLIP — the constant pair stays coherent with `model_filename` for every
+    /// language (turbo is multilingual-only).
+    #[test]
+    fn turbo_default_file_matches_model_filename() {
+        for lang in ["", "en", "pl"] {
+            assert_eq!(model_filename(TURBO_DEFAULT_SIZE, lang), TURBO_DEFAULT_FILE);
+        }
+    }
+
+    /// T2 DEFAULT FLIP — `effective_model_size`: non-empty passes through verbatim; blank
+    /// resolves the same value as the machine-conditional resolver (ONE decision).
+    #[test]
+    fn effective_model_size_passthrough_and_blank_resolution() {
+        assert_eq!(effective_model_size("small"), "small");
+        assert_eq!(effective_model_size(" large-v3 "), "large-v3");
+        let resolved = default_model_size_now();
+        assert_eq!(effective_model_size(""), resolved);
+        assert_eq!(effective_model_size("   "), resolved);
+        assert!(resolved == "small" || resolved == TURBO_DEFAULT_SIZE);
+    }
+
     /// T2 — quant filenames ride the same HF mirror URL as the plain sizes.
     #[test]
     fn quant_url_points_at_whispercpp_hf_mirror() {
@@ -466,6 +693,95 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// T2 default-flip follow-up — the live-pin ABSENT-FILE fallback picks the LARGEST
+    /// downloaded live-SAFE model (small → small-q8_0 → base → tiny) and NEVER medium/large:
+    /// a fresh turbo-only install (the flip's target machines) must resolve `None` so the
+    /// live tick never decodes a large-v3 encoder.
+    #[test]
+    fn live_fallback_never_picks_medium_or_large() {
+        let dir = std::env::temp_dir().join(format!("murmur-live-fb-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Fresh turbo-default install: ONLY the turbo file (+ VAD) on disk → None.
+        std::fs::write(dir.join("ggml-large-v3-turbo-q8_0.bin"), b"x").unwrap();
+        std::fs::write(dir.join(VAD_MODEL_FILE), b"x").unwrap();
+        assert_eq!(live_fallback_model_in(&dir, ""), None);
+        assert_eq!(live_fallback_model_in(&dir, "pl"), None);
+
+        // medium/large additions still resolve None.
+        std::fs::write(dir.join("ggml-medium.bin"), b"x").unwrap();
+        std::fs::write(dir.join("ggml-large-v3.bin"), b"x").unwrap();
+        assert_eq!(live_fallback_model_in(&dir, ""), None);
+
+        // tiny appears → picked; base → preferred; small-q8_0 → preferred; small wins.
+        std::fs::write(dir.join("ggml-tiny.bin"), b"x").unwrap();
+        assert_eq!(
+            live_fallback_model_in(&dir, "pl"),
+            Some(dir.join("ggml-tiny.bin"))
+        );
+        std::fs::write(dir.join("ggml-base.bin"), b"x").unwrap();
+        assert_eq!(
+            live_fallback_model_in(&dir, ""),
+            Some(dir.join("ggml-base.bin"))
+        );
+        std::fs::write(dir.join("ggml-small-q8_0.bin"), b"x").unwrap();
+        assert_eq!(
+            live_fallback_model_in(&dir, ""),
+            Some(dir.join("ggml-small-q8_0.bin"))
+        );
+        std::fs::write(dir.join("ggml-small.bin"), b"x").unwrap();
+        assert_eq!(
+            live_fallback_model_in(&dir, ""),
+            Some(dir.join("ggml-small.bin"))
+        );
+
+        // English prefers the `.en` build but rides a multilingual of the same size.
+        assert_eq!(
+            live_fallback_model_in(&dir, "en"),
+            Some(dir.join("ggml-small.bin"))
+        );
+        std::fs::write(dir.join("ggml-small.en.bin"), b"x").unwrap();
+        assert_eq!(
+            live_fallback_model_in(&dir, "en"),
+            Some(dir.join("ggml-small.en.bin"))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// T2 default-flip follow-up — the heavy-file classifier: every medium/large-class name
+    /// (incl. turbo + quants + `.en`) is heavy; live-safe sizes and unrecognizable custom
+    /// names are not (custom `whisper_model_path` keeps its pre-pin fallback behavior).
+    #[test]
+    fn live_heavy_classifier_flags_medium_and_large_class_files() {
+        for heavy in [
+            "ggml-large-v3.bin",
+            "ggml-large-v3-turbo.bin",
+            "ggml-large-v3-turbo-q8_0.bin",
+            "ggml-large-v3-q5_0.bin",
+            "ggml-medium.bin",
+            "ggml-medium.en.bin",
+            "ggml-medium-q8_0.bin",
+        ] {
+            assert!(
+                is_live_heavy_model_file(Path::new(heavy)),
+                "{heavy} must classify heavy"
+            );
+        }
+        for safe in [
+            "ggml-tiny.bin",
+            "ggml-base.en.bin",
+            "ggml-small.bin",
+            "ggml-small-q8_0.bin",
+            "my-custom-model.bin",
+        ] {
+            assert!(
+                !is_live_heavy_model_file(Path::new(safe)),
+                "{safe} must classify live-safe"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -433,6 +433,216 @@ mod tests {
         );
     }
 
+    /// `u64` env knob with a default — shared by the env-driven `#[ignore]` harnesses below.
+    fn env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(default)
+    }
+
+    /// Greedy (Fast-profile) decode with an EXPLICIT `audio_ctx` override for the duty-cycle
+    /// sim: `0` = leave whisper's full 30 s encoder context (the PRE-fix behavior),
+    /// `n > 0` = right-size it (e.g. 832 = the shipped `LIVE_AUDIO_CTX`). Mirrors
+    /// `build_params(Fast)` + the print-silencing in `transcribe_with`, but returns only the
+    /// segment count — the sim measures TIME, not text.
+    fn duty_decode(t: &Transcriber, samples_16k: &[f32], audio_ctx: i32) -> Result<usize> {
+        let mut state = t
+            .ctx
+            .create_state()
+            .map_err(|e| AppError::Transcribe(format!("create whisper state: {e}")))?;
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        if audio_ctx > 0 {
+            params.set_audio_ctx(audio_ctx);
+        }
+        params.set_language(None);
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+        state
+            .full(params, samples_16k)
+            .map_err(|e| AppError::Transcribe(format!("whisper inference failed: {e}")))?;
+        Ok(state.full_n_segments().max(0) as usize)
+    }
+
+    /// T0 — LIVE DUTY-CYCLE simulation (env-driven `#[ignore]`, the instrument behind the
+    /// live-power baseline in `scripts/measure-live-power.sh`). MIRRORS `live.rs` SEMANTICS,
+    /// not its code: a virtual clock advances in 3 s ticks over an endless
+    /// `[WAV + injected silence]` loop; each tick snapshots the trailing 14 s window; the
+    /// optional Silero gate (same newest-3 s-delta scan + 2-tick hangover as the live loop)
+    /// decides decode-or-skip; a decode runs the Fast/greedy profile with the `audio_ctx`
+    /// override; then the tick SLEEPS its wall-clock remainder so the idle/busy pattern is
+    /// REAL — `powermetrics` sampling alongside sees the true duty cycle.
+    ///
+    /// Envs: MURMUR_DUTY_WAV (16 kHz mono), MURMUR_DUTY_MODEL (ggml path),
+    /// MURMUR_DUTY_MINUTES (default 3), MURMUR_DUTY_GATE (1 = Silero gate, default 1; the VAD
+    /// model must be in the app models dir), MURMUR_DUTY_AUDIO_CTX (0 = full context, else e.g.
+    /// 832), MURMUR_DUTY_SILENCE_SECS (default 240 — zeros injected between WAV loop-plays so
+    /// speech density approximates a real meeting's mic share, ~35% with the 2-min A/B WAV).
+    ///
+    /// Prints ONE machine-greppable line at the end:
+    ///   DUTY_RESULT model=<name> gate=<0/1> audio_ctx=<n> ticks=<n> decodes=<n>
+    ///   decode_ms_total=<n> wall_s=<n> duty_pct=<n.n>
+    /// PANICS NEVER — missing env / bad paths skip-soft (the `asr_ab_harness_from_env`
+    /// pattern). Needs a real Mac + a loaded GGUF; headless `cargo test` proves nothing here.
+    #[test]
+    #[ignore = "real duty-cycle sim: needs MURMUR_DUTY_WAV + MURMUR_DUTY_MODEL on a Mac with Metal"]
+    fn live_duty_cycle_sim_from_env() {
+        /// Nominal live tick (live.rs `TICK`), seconds.
+        const TICK_SECS: usize = 3;
+        /// Rolling window the live loop decodes (live.rs `WINDOW_SECS`), seconds.
+        const WINDOW_SECS: usize = 14;
+        /// Post-speech decode hangover (live.rs `VAD_HANGOVER_TICKS`), ticks.
+        const HANGOVER_TICKS: u8 = 2;
+        const RATE: usize = 16_000;
+
+        let Ok(wav) = std::env::var("MURMUR_DUTY_WAV") else {
+            eprintln!("SKIP: set MURMUR_DUTY_WAV to a 16 kHz mono WAV path");
+            return;
+        };
+        let Ok(model) = std::env::var("MURMUR_DUTY_MODEL") else {
+            eprintln!("SKIP: set MURMUR_DUTY_MODEL to a ggml model path");
+            return;
+        };
+        let minutes = env_u64("MURMUR_DUTY_MINUTES", 3);
+        let gate = env_u64("MURMUR_DUTY_GATE", 1) != 0;
+        let audio_ctx = env_u64("MURMUR_DUTY_AUDIO_CTX", 0) as i32;
+        let silence_secs = env_u64("MURMUR_DUTY_SILENCE_SECS", 240) as usize;
+
+        let speech = match read_wav_16k_mono(Path::new(&wav)) {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => {
+                eprintln!("SKIP: MURMUR_DUTY_WAV is empty");
+                return;
+            }
+            Err(e) => {
+                eprintln!("SKIP: could not read WAV: {e}");
+                return;
+            }
+        };
+        let transcriber = match Transcriber::load(Path::new(&model)) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("SKIP: model load failed: {e}");
+                return;
+            }
+        };
+        // Silero gate (CPU-only — see transcribe::vad): resolved from the shared app models
+        // dir, exactly the file the live loop uses.
+        let mut vad = if gate {
+            let vad_path = match crate::transcribe::model::models_dir() {
+                Ok(d) => d.join(crate::transcribe::model::VAD_MODEL_FILE),
+                Err(e) => {
+                    eprintln!("SKIP: models dir unresolvable for the VAD model: {e}");
+                    return;
+                }
+            };
+            match crate::transcribe::vad::VadSegmenter::load(&vad_path) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    eprintln!("SKIP: gate=1 but Silero VAD model not loadable: {e}");
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+
+        // The endless [speech + silence] virtual stream: position p maps into the loop period.
+        let period = speech.len() + silence_secs * RATE;
+        let sample_at = |p: usize| -> f32 {
+            let i = p % period;
+            if i < speech.len() {
+                speech[i]
+            } else {
+                0.0
+            }
+        };
+
+        let ticks_total = ((minutes as usize) * 60 / TICK_SECS).max(1);
+        let window_len = WINDOW_SECS * RATE;
+        let delta_len = TICK_SECS * RATE;
+        eprintln!(
+            "duty sim: {ticks_total} ticks of {TICK_SECS}s, speech {:.1}s / period {:.1}s (~{:.0}% density), gate={gate}, audio_ctx={audio_ctx}",
+            speech.len() as f64 / RATE as f64,
+            period as f64 / RATE as f64,
+            100.0 * speech.len() as f64 / period as f64,
+        );
+
+        let mut cursor = 0usize; // virtual samples elapsed
+        let mut hangover = 0u8;
+        let mut decodes = 0usize;
+        let mut decode_ms_total = 0u128;
+        let run_started = std::time::Instant::now();
+        for tick in 0..ticks_total {
+            let tick_started = std::time::Instant::now();
+            cursor += delta_len;
+            let start = cursor.saturating_sub(window_len);
+            let window: Vec<f32> = (start..cursor).map(sample_at).collect();
+
+            // Gate: Silero over the newest 3 s delta; speech re-arms the hangover, silence
+            // spends it, spent hangover ⇒ skip. A VAD error fails OPEN (decode) — the live
+            // loop's contract.
+            let do_decode = match vad.as_mut() {
+                None => true,
+                Some(v) => {
+                    let delta = &window[window.len().saturating_sub(delta_len)..];
+                    let has_speech = match v.speech_regions(delta) {
+                        Ok(regions) => !regions.is_empty(),
+                        Err(e) => {
+                            eprintln!("tick {tick}: VAD failed ({e}); decoding (fail-open)");
+                            true
+                        }
+                    };
+                    if has_speech {
+                        hangover = HANGOVER_TICKS;
+                        true
+                    } else if hangover > 0 {
+                        hangover -= 1;
+                        true
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if do_decode {
+                let started = std::time::Instant::now();
+                if let Err(e) = duty_decode(&transcriber, &window, audio_ctx) {
+                    eprintln!("tick {tick}: decode failed: {e}");
+                }
+                decode_ms_total += started.elapsed().as_millis();
+                decodes += 1;
+            }
+
+            // Sleep the tick remainder so the WALL-CLOCK duty cycle is real (powermetrics
+            // samples the true idle/busy pattern). An overrunning decode stretches the tick,
+            // exactly like the live loop under load.
+            let spent = tick_started.elapsed();
+            let tick_dur = std::time::Duration::from_secs(TICK_SECS as u64);
+            if spent < tick_dur {
+                std::thread::sleep(tick_dur - spent);
+            }
+        }
+
+        let wall_s = run_started.elapsed().as_secs_f64();
+        let duty_pct = if wall_s > 0.0 {
+            (decode_ms_total as f64 / 1000.0) / wall_s * 100.0
+        } else {
+            0.0
+        };
+        // Model NAME only (a ggml filename), never the path — §8.
+        let model_name = Path::new(&model)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("custom");
+        println!(
+            "DUTY_RESULT model={model_name} gate={} audio_ctx={audio_ctx} ticks={ticks_total} decodes={decodes} decode_ms_total={decode_ms_total} wall_s={wall_s:.0} duty_pct={duty_pct:.1}",
+            u8::from(gate)
+        );
+    }
+
     /// T0.3 — env-driven A/B harness: decode the SAME WAV through TWO models at BOTH profiles
     /// and print wall-clock per leg + write each transcript to a temp file for diffing. The
     /// instrument behind every speed/Polish-quality claim of the 2026-07-09 transcription plan

--- a/src/app/features/onboarding/onboarding/onboarding.component.html
+++ b/src/app/features/onboarding/onboarding/onboarding.component.html
@@ -90,7 +90,10 @@
               >
                 <option value="tiny">Tiny — fastest (~75 MB)</option>
                 <option value="base">Base (~150 MB)</option>
-                <option value="small">Small — recommended (~470 MB)</option>
+                <option value="small">Small — light (~470 MB)</option>
+                <option value="large-v3-turbo-q8_0">
+                  Large v3 Turbo (q8) — recommended on 12+ GB Macs (~875 MB)
+                </option>
                 <option value="medium">Medium — accurate (~1.5 GB)</option>
                 <option value="large-v3">Large — best (~3 GB)</option>
               </select>

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -63,6 +63,7 @@ const SIZE_HINTS: Record<string, string> = {
   tiny: "~75 MB",
   base: "~150 MB",
   small: "~470 MB",
+  "large-v3-turbo-q8_0": "~875 MB",
   medium: "~1.5 GB",
   "large-v3": "~3 GB",
 };

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
@@ -50,17 +50,18 @@
                     Large v3 Turbo — fast &amp; accurate (~1.6 GB)
                   </option>
                   <option value="large-v3-turbo-q8_0">
-                    Large v3 Turbo (q8) — Turbo accuracy, less RAM (~875 MB)
+                    Large v3 Turbo (q8) — recommended: Turbo accuracy, less RAM (~875 MB)
                   </option>
                   <option value="large-v3">
-                    Large v3 — best accuracy, recommended (~3 GB)
+                    Large v3 — best accuracy, largest (~3 GB)
                   </option>
                 </select>
                 <span class="field-help text-muted">
-                  Large v3 is the most accurate and the default — it’s a one-time ~3
-                  GB download. Turbo is nearly as good and much smaller. The (q8)
-                  variants are quantized: near-identical accuracy with a smaller
-                  download and less RAM while transcribing.
+                  Large v3 Turbo (q8) is the recommended default on Macs with 12 GB+
+                  RAM — near-Large accuracy at a one-time ~875 MB download. Small is
+                  the fallback default on smaller machines. The (q8) variants are
+                  quantized: near-identical accuracy with a smaller download and less
+                  RAM while transcribing.
                 </span>
               </label>
             </div>

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -1262,7 +1262,9 @@ export class SettingsStore {
         audioStorageLimitGb:
           cfg.audioStorageLimitGb != null ? String(cfg.audioStorageLimitGb) : "",
         audioAutoPrune: cfg.audioAutoPrune ?? false,
-        // Mirrors backend default model_size = "small" (settings/config.rs, AppConfig::default).
+        // The backend default is machine-conditional (small, or large-v3-turbo-q8_0 when already
+        // downloaded / on a fresh 12+ GB Mac — transcribe/model.rs default_model_size); "small"
+        // here is only the nullish safety net.
         modelSize: cfg.modelSize ?? "small",
         voiceTrigger: cfg.voiceTrigger ?? false,
         noteStyle: cfg.noteStyle ?? "standard",


### PR DESCRIPTION
## What

**T2 — evidence-backed default flip, safe shape.** Measured on the committed A/B harness: `large-v3-turbo-q8_0` Accurate = **same batch wall as `small`** (2.73 vs 2.75 s / 131 s WAV) with near-perfect Polish vs small's garbled names + dropped English + hallucination loops.

- ONE decision point: turbo-q8_0 becomes the default only when **already downloaded** or on a **fresh install with ≥12 GB RAM**; existing installs with small never see a surprise 874 MB download (every empty-size resolution path enumerated by the verifier routes through it).
- **Turbo stays batch-only, enforced**: live fallback ladder is live-safe-only (small→small-q8_0→base→tiny) + heavy-model classifier — a fresh turbo-only install cannot run the caption tick on turbo (round-1 adversarial MAJOR, fixed).
- Onboarding + Settings copy updated truthfully (turbo-q8 recommended; large-v3 no longer claims default).

**T0 — the measurement protocol as one command**: `live_duty_cycle_sim_from_env` (env-driven live-loop simulation with real tick sleeps + live-semantics Silero gate; smoke gate=0→duty 6.9%, gate=1→3.6%) + `scripts/measure-live-power.sh` (sudo only for powermetrics, every cargo call drops to `SUDO_USER`, EXIT/INT/TERM trap kills the sampler, writes `eval/results/live-power-baseline.md`).

## How verified

Adversarial PASS after 1 fix round (2 real MAJORs caught + fixed); `cargo test --lib` **1398/0**; `ng lint`/`ng build` clean; `scripts/ci.sh` ✅ all gates green. Honest gaps: the real sudo powermetrics run (user-assisted, next step), fresh-install end-to-end needs a fresh-profile Mac.