### PR TITLE
feat(retrieval): query-adaptive empty-leg score fusion + real-vault eval

### DIFF
--- a/eval/results/rag-bakeoff-latest.md
+++ b/eval/results/rag-bakeoff-latest.md
@@ -1,7 +1,7 @@
 # RAG bake-off
 
 - date: 2026-07-10
-- commit: 3362d3c-dirty
+- commit: e862302-dirty
 - corpus: synthetic (eval::corpus, 16 seeded meetings, anchor 2026-06-29)
 - labeled set: src-tauri/src/eval/fixtures/rag-bakeoff-synthetic.json (20 queries, k=5)
 - config: score_fuse 0.4/0.4/0.2 + topic legs + temporal filter (RRF_K=60 fallback)

--- a/eval/results/rag-bakeoff-real-vault.md
+++ b/eval/results/rag-bakeoff-real-vault.md
@@ -1,0 +1,83 @@
+# RAG bake-off — REAL dev vault (2026-07-10, post query-adaptive fusion)
+
+- date: 2026-07-10
+- commit: e862302-dirty (+ query-adaptive empty-leg redistribution in `embed::score_fuse`)
+- corpus: the author's **real dev vault** — ~60 meetings (PL-dominant, noisy: many empty/test titles), WAL-copied, dev DEK
+- labeled set: **local only** (`~/Library/Application Support/MeetNotes-dev/eval/rag-bakeoff-real.json`) — 20 queries, deliberately **retrieval-hard**: 5 entity-anchored, 5 paraphrase (no lexical overlap), 5 cross-lingual PL↔EN, 5 temporal (absolute dates). NOT committed (real meeting titles = PII); reproduce with the env vars below.
+- embedder: multilingual-e5-small (REAL model)
+- reranker: prompted Qwen3-1.7B GGUF (REAL model, resident), `RERANK_TOP_K=10`, `RERANK_TIMEOUT_MS=3000`
+- config: RRF_K=60
+
+| mode | recall@5 | nDCG@5 | MRR |
+|---|---:|---:|---:|
+| fts | 0.1000 | 0.1000 | 0.1000 |
+| semantic | **0.9500** | 0.8991 | 0.8875 |
+| hybrid | 0.9000 | 0.8557 | 0.8500 |
+| hybrid+rerank | 0.9000 | 0.8557 | 0.8500 |
+
+## Result of the query-adaptive empty-leg redistribution: NO change on this set (honest negative)
+
+The fix does exactly what it was specified to do — a leg that returns ZERO candidates for a query
+contributes ZERO effective weight, its mass redistributing over the present legs — but on THIS
+real set it moves hybrid recall by **0.0000**. Hybrid stays 0.9000, still below semantic 0.9500.
+That is not a bug in the fix; it is a property of the fusion math that the original hypothesis
+missed. Two facts, both measured here, explain it:
+
+1. **18 / 20 of these queries have a genuinely EMPTY FTS leg** (diagnostic
+   `embed::tests::diag_count_empty_fts_legs_on_real_set`). `fts_meeting_scores` builds an
+   **implicit-AND** FTS5 match over all query terms (`fts_match_query`, `db.rs`), so a 4-word
+   paraphrase like *"Erste Bank advertising campaign motivational slogan"* matches no meeting
+   containing ALL four terms → the FTS candidate list is empty. Only 2 queries (Snowflake / Robert)
+   land a single AND-hit.
+
+2. **When a leg is empty, redistribution only RESCALES the surviving blend by a constant — it can
+   never reorder it.** With FTS empty the fused score of every id was already `0.4·knn + 0.2·graph`
+   (the empty leg added 0 to everyone); the fix makes it `0.667·knn + 0.333·graph`, i.e. the SAME
+   values × (1/0.6). The knn:graph ratio is unchanged (2:1 in both), so the top-k membership — and
+   therefore recall/nDCG/MRR — is byte-for-byte identical. Ranking-relevant weight changes require
+   the ratio BETWEEN present legs to change, which redistribution never does. This is pinned by
+   `score_fuse_fts_empty_redistributes_to_semantic_and_graph` (asserts the exact renormalized
+   scores) and `score_fuse_all_legs_present_identical_to_fixed_blend` (the no-regression pin).
+
+**So where does hybrid's 0.90 < semantic's 0.95 actually come from on this set?** NOT the FTS leg
+(empty on 18/20, contributes nothing). It is the **graph leg**: on the empty-FTS queries the fused
+order is `knn ⊕ graph`, and the entity-neighbourhood graph leg promotes a few co-mention meetings
+that semantic-alone would not surface, displacing a gold doc out of the top-5 on ~1 query. The
+redistribution *raises* graph's effective weight (0.2 → 0.333) on those queries, which is the
+opposite of what would help — but it happened not to change the top-5 membership here, hence the
+exact 0.9000 tie with the pre-change run.
+
+**Honest conclusion.** Query-adaptive empty-leg redistribution is the CORRECT, principled
+normalization (and it protects the all-legs-present keyword case exactly — see the synthetic gate
+below, still 0.90), but it is **not** the lever that recovers hybrid toward semantic on
+paraphrase/cross-lingual queries. The real levers, for a follow-up (NOT this change): (a) OR-match
+the FTS leg (`fts_match_query_any` already exists) so FTS returns ranked partial-overlap candidates
+instead of nothing — then its down-weighting would actually bite; and/or (b) make the GRAPH leg
+weight adaptive too, or gate it to entity-anchored queries, since it is graph noise (not FTS) that
+costs the ~1 gold doc here.
+
+## The reranker row is unchanged (still identical to hybrid) — see prior finding; a prompted 1.7B adds no measured value within the 3 s budget.
+
+## Reproduce
+
+```sh
+MURMUR_BAKEOFF_LIGHT_ID=qwen3-1.7b \
+MURMUR_BAKEOFF_DB=<wal-copy of the dev DB> \
+MURMUR_BAKEOFF_DEK=<dev DEK> \
+MURMUR_BAKEOFF_SET=<local labeled-set json> \
+MURMUR_BAKEOFF_K=5 \
+cargo test --lib run_bakeoff_over_real_db_from_env -- --ignored --nocapture
+
+# empty-FTS-leg diagnostic (same env, no reranker/model needed for the count):
+cargo test --lib diag_count_empty_fts_legs_on_real_set -- --ignored --nocapture
+```
+
+## Honest limits
+
+20 queries, one vault, PL-dominant, author-labeled, **deliberately skewed away from lexical
+overlap** — a signal, not a benchmark, and by construction the FTS leg is near-useless here (it
+would earn its weight on ordinary keyword queries, which this set has almost none of). The
+synthetic committed corpus (`rag-bakeoff-latest.md`, hybrid 0.90) remains the CI merge-gate
+baseline; this real-vault run is the reality check. The redistribution change is safe (no
+regression either place) and correct in principle; its measured recovery on THIS skewed set is
+zero, and this report says so rather than claiming a win.

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -825,10 +825,28 @@ pub fn augment_chunk_text(
 /// - `graph` — HIGHER-better (e.g. `1/rank` of the entity-neighbourhood ordering).
 ///
 /// Each leg is min-max normalized to `[0, 1]` independently (a constant/single-entry leg
-/// normalizes to all-1.0 — presence in a leg is signal), then blended
-/// `0.4·fts + 0.4·knn + 0.2·graph` ([`SCORE_FUSE_W_FTS`]/[`SCORE_FUSE_W_KNN`]/
-/// [`SCORE_FUSE_W_GRAPH`]). Returns `(id, fused)` sorted DESC, ties broken by id ASC (stable,
-/// deterministic). Pure — no DB, no model.
+/// normalizes to all-1.0 — presence in a leg is signal), then blended with QUERY-ADAPTIVE
+/// weights derived from the const source ratios `0.4·fts + 0.4·knn + 0.2·graph`
+/// ([`SCORE_FUSE_W_FTS`]/[`SCORE_FUSE_W_KNN`]/[`SCORE_FUSE_W_GRAPH`]).
+///
+/// **Empty-leg redistribution (Brain v2 L1.3, query-adaptive):** a leg that returned ZERO
+/// candidates for THIS query contributes ZERO effective weight; its weight mass redistributes
+/// proportionally across the legs that DID return results. Concretely, each present leg's
+/// effective weight is its base weight divided by the sum of the base weights of the *present*
+/// legs. So:
+/// - all three legs present ⇒ weights unchanged (`0.4/0.4/0.2`) — no regression where every
+///   leg earns its weight (the divisor is `1.0`);
+/// - FTS empty, KNN+graph present ⇒ `{0.4, 0.2}` renormalize to `{0.667, 0.333}` — the near-
+///   useless empty leg no longer drags hybrid below its live legs;
+/// - a single present leg ⇒ weight `1.0` (hybrid == that leg's order);
+/// - all empty ⇒ empty.
+///
+/// This is a monotonic rescale of the present legs (same divisor for all of them), so it NEVER
+/// reorders a fixed set of present legs — only the empty-leg mass moves. Score normalization and
+/// the ties→id-ASC ordering are unchanged.
+///
+/// Returns `(id, fused)` sorted DESC, ties broken by id ASC (stable, deterministic). Pure — no DB,
+/// no model.
 pub fn score_fuse(
     fts: &[(String, f64)],
     knn: &[(String, f64)],
@@ -861,14 +879,32 @@ pub fn score_fuse(
         .map(|(id, d)| (id.clone(), 1.0 / (1.0 + d.max(0.0))))
         .collect();
 
+    // Query-adaptive effective weights: only legs that returned candidates for THIS query keep
+    // their base weight mass; empty legs' mass redistributes proportionally over the present legs.
+    // The base weights are the SOURCE ratios; the divisor is the sum of the present ones.
+    let present_mass: f64 = [
+        (!fts.is_empty(), SCORE_FUSE_W_FTS),
+        (!knn_sim.is_empty(), SCORE_FUSE_W_KNN),
+        (!graph.is_empty(), SCORE_FUSE_W_GRAPH),
+    ]
+    .iter()
+    .filter(|(present, _)| *present)
+    .map(|(_, w)| *w)
+    .sum();
+
     let mut scores: HashMap<String, f64> = HashMap::new();
-    for (leg, w) in [
-        (minmax(fts), SCORE_FUSE_W_FTS),
-        (minmax(&knn_sim), SCORE_FUSE_W_KNN),
-        (minmax(graph), SCORE_FUSE_W_GRAPH),
-    ] {
-        for (id, s) in leg {
-            *scores.entry(id).or_insert(0.0) += w * s;
+    if present_mass > 0.0 {
+        for (leg, base_w) in [
+            (minmax(fts), SCORE_FUSE_W_FTS),
+            (minmax(&knn_sim), SCORE_FUSE_W_KNN),
+            (minmax(graph), SCORE_FUSE_W_GRAPH),
+        ] {
+            // Empty legs never enter this loop body (their `leg` is empty), so only present legs
+            // contribute — each at its base weight renormalized over the present mass.
+            let w = base_w / present_mass;
+            for (id, s) in leg {
+                *scores.entry(id).or_insert(0.0) += w * s;
+            }
         }
     }
     let mut fused: Vec<(String, f64)> = scores.into_iter().collect();
@@ -1481,8 +1517,9 @@ mod tests {
         let fused = score_fuse(&fts, &[], &[]);
         let ids: Vec<&str> = fused.iter().map(|(id, _)| id.as_str()).collect();
         assert_eq!(ids, vec!["a", "b", "c"]);
-        // Empty legs contribute nothing; the leg's best gets the full leg weight.
-        assert!((fused[0].1 - SCORE_FUSE_W_FTS).abs() < 1e-9);
+        // Query-adaptive redistribution: the two empty legs' mass moves onto the ONLY present
+        // leg, so it carries the full weight 1.0 — hybrid == that leg (its best normalizes to 1.0).
+        assert!((fused[0].1 - 1.0).abs() < 1e-9, "single present leg ⇒ weight 1.0: {fused:?}");
     }
 
     #[test]
@@ -1529,6 +1566,187 @@ mod tests {
         assert!(
             (fused[0].1 - fused[1].1).abs() < 1e-12,
             "constant leg ⇒ equal scores"
+        );
+    }
+
+    // Reference fixed-weight blend (the PRE-change math): min-max each leg, then
+    // `SCORE_FUSE_W_FTS·fts + SCORE_FUSE_W_KNN·knn_sim + SCORE_FUSE_W_GRAPH·graph`, empty legs
+    // contributing nothing and their mass simply LOST (no redistribution). Self-contained so the
+    // regression pin does not depend on the production `score_fuse` internals.
+    fn old_fixed_weight_blend(
+        fts: &[(String, f64)],
+        knn: &[(String, f64)],
+        graph: &[(String, f64)],
+    ) -> Vec<(String, f64)> {
+        fn minmax(leg: &[(String, f64)]) -> Vec<(String, f64)> {
+            if leg.is_empty() {
+                return Vec::new();
+            }
+            let min = leg.iter().map(|(_, s)| *s).fold(f64::INFINITY, f64::min);
+            let max = leg.iter().map(|(_, s)| *s).fold(f64::NEG_INFINITY, f64::max);
+            leg.iter()
+                .map(|(id, s)| {
+                    let norm = if max > min { (s - min) / (max - min) } else { 1.0 };
+                    (id.clone(), norm)
+                })
+                .collect()
+        }
+        let knn_sim: Vec<(String, f64)> = knn
+            .iter()
+            .map(|(id, d)| (id.clone(), 1.0 / (1.0 + d.max(0.0))))
+            .collect();
+        let mut scores: HashMap<String, f64> = HashMap::new();
+        for (leg, w) in [
+            (minmax(fts), SCORE_FUSE_W_FTS),
+            (minmax(&knn_sim), SCORE_FUSE_W_KNN),
+            (minmax(graph), SCORE_FUSE_W_GRAPH),
+        ] {
+            for (id, s) in leg {
+                *scores.entry(id).or_insert(0.0) += w * s;
+            }
+        }
+        let mut fused: Vec<(String, f64)> = scores.into_iter().collect();
+        fused.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        fused
+    }
+
+    // (1) REGRESSION PIN — all three legs present ⇒ effective weights == base weights (divisor
+    // 1.0), so the query-adaptive blend is BYTE-IDENTICAL (order AND scores) to the old fixed
+    // blend. This is the "no regression on keyword queries where every leg earns its weight" case.
+    #[test]
+    fn score_fuse_all_legs_present_identical_to_fixed_blend() {
+        let fts = vec![
+            ("m1".to_string(), 9.0),
+            ("m2".to_string(), 5.0),
+            ("x".to_string(), 1.0),
+        ];
+        let knn = vec![
+            ("m3".to_string(), 0.1),
+            ("m2".to_string(), 0.2),
+            ("y".to_string(), 2.0),
+        ];
+        let graph = vec![("m2".to_string(), 1.0), ("m4".to_string(), 0.5)];
+        let got = score_fuse(&fts, &knn, &graph);
+        let want = old_fixed_weight_blend(&fts, &knn, &graph);
+        assert_eq!(got.len(), want.len());
+        for ((gi, gs), (wi, ws)) in got.iter().zip(want.iter()) {
+            assert_eq!(gi, wi, "order diverged: {got:?} vs {want:?}");
+            assert!((gs - ws).abs() < 1e-12, "score diverged at {gi}: {gs} vs {ws}");
+        }
+    }
+
+    // (2) BUG FIX — FTS empty (paraphrase / cross-lingual query): the fused ranking must EQUAL the
+    // renormalized {knn, graph} blend (weights 0.4/0.2 → 0.667/0.333, summing to 1.0). RED against
+    // the old code, which applied the FTS 0.4 zero-mass and left {knn, graph} at raw 0.4/0.2.
+    #[test]
+    fn score_fuse_fts_empty_redistributes_to_semantic_and_graph() {
+        let knn = vec![
+            ("near".to_string(), 0.1),
+            ("mid".to_string(), 0.5),
+            ("far".to_string(), 2.0),
+        ];
+        let graph = vec![("mid".to_string(), 1.0), ("g2".to_string(), 0.5)];
+        let got = score_fuse(&[], &knn, &graph);
+
+        // Independently compute the renormalized {knn, graph} blend at 0.667/0.333.
+        let mass = SCORE_FUSE_W_KNN + SCORE_FUSE_W_GRAPH;
+        let wk = SCORE_FUSE_W_KNN / mass;
+        let wg = SCORE_FUSE_W_GRAPH / mass;
+        // knn min-max over sim = 1/(1+d): near=1/1.1, mid=1/1.5, far=1/3.0.
+        let knn_sim = [1.0 / 1.1_f64, 1.0 / 1.5_f64, 1.0 / 3.0_f64];
+        let (kmin, kmax) = (
+            knn_sim.iter().cloned().fold(f64::INFINITY, f64::min),
+            knn_sim.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+        );
+        let kn = |s: f64| (s - kmin) / (kmax - kmin);
+        // graph min-max: mid=1.0, g2=0.5 ⇒ mid→1.0, g2→0.0.
+        let mut want: HashMap<String, f64> = HashMap::new();
+        *want.entry("near".to_string()).or_insert(0.0) += wk * kn(1.0 / 1.1);
+        *want.entry("mid".to_string()).or_insert(0.0) += wk * kn(1.0 / 1.5);
+        *want.entry("far".to_string()).or_insert(0.0) += wk * kn(1.0 / 3.0);
+        *want.entry("mid".to_string()).or_insert(0.0) += wg * 1.0;
+        *want.entry("g2".to_string()).or_insert(0.0) += wg * 0.0;
+        for (id, gs) in &got {
+            let ws = want.get(id).copied().unwrap_or(f64::NAN);
+            assert!(
+                (gs - ws).abs() < 1e-12,
+                "fts-empty fused score for {id} = {gs}, expected renormalized {ws}"
+            );
+        }
+        // And RED-vs-old: the top score under redistribution (0.667·1.0) is strictly greater than
+        // the old zero-mass score (0.4·1.0) — the fix lifts the live legs into full weight.
+        assert!(
+            got[0].1 > SCORE_FUSE_W_KNN + 1e-9,
+            "redistributed top score {} must exceed the old raw 0.4 leg weight",
+            got[0].1
+        );
+    }
+
+    // (3) SINGLE LEG — one present leg ⇒ fused order == that leg's order, best score 1.0.
+    #[test]
+    fn score_fuse_single_present_leg_equals_that_leg() {
+        let knn = vec![
+            ("far".to_string(), 1.5),
+            ("near".to_string(), 0.1),
+            ("mid".to_string(), 0.6),
+        ];
+        let fused = score_fuse(&[], &knn, &[]);
+        let ids: Vec<&str> = fused.iter().map(|(id, _)| id.as_str()).collect();
+        // Smaller distance ⇒ higher sim ⇒ higher fused: near > mid > far.
+        assert_eq!(ids, vec!["near", "mid", "far"], "{fused:?}");
+        assert!((fused[0].1 - 1.0).abs() < 1e-9, "single leg best ⇒ 1.0: {fused:?}");
+    }
+
+    // (4) ALL EMPTY ⇒ empty (unchanged).
+    #[test]
+    fn score_fuse_all_empty_is_empty() {
+        assert!(score_fuse(&[], &[], &[]).is_empty());
+    }
+
+    // DIAGNOSTIC (not a gate): count how many labeled queries have a genuinely EMPTY FTS leg on
+    // the real vault — i.e. how many queries the empty-leg redistribution can even affect. Reuses
+    // the bake-off env vars. `#[ignore]`d; run manually with the same MURMUR_BAKEOFF_* env as the
+    // real-vault bake-off. Reports empty-FTS vs non-empty-FTS split so the ranking-impact of the
+    // redistribution is honest (redistribution when FTS is empty only RESCALES the {knn,graph}
+    // blend by a constant — it does NOT reorder — so it changes recall ONLY through the all-legs-
+    // present cases, never the fts-empty ones; this count quantifies that).
+    #[test]
+    #[ignore = "diagnostic: needs MURMUR_BAKEOFF_DB/DEK/SET env on a Mac"]
+    fn diag_count_empty_fts_legs_on_real_set() {
+        use std::collections::HashSet;
+        let db_path = std::env::var("MURMUR_BAKEOFF_DB").expect("MURMUR_BAKEOFF_DB");
+        let dek = std::env::var("MURMUR_BAKEOFF_DEK").expect("MURMUR_BAKEOFF_DEK");
+        let set_path = std::env::var("MURMUR_BAKEOFF_SET").expect("MURMUR_BAKEOFF_SET");
+        let db = crate::storage::Db::open_with_key(std::path::Path::new(&db_path), &dek).unwrap();
+        let set = crate::eval::LabeledSet::from_json(
+            &std::fs::read_to_string(&set_path).unwrap(),
+        )
+        .unwrap();
+        let today = chrono::Utc::now().date_naive();
+        let empties: HashSet<String> = HashSet::new();
+        let mut empty = 0usize;
+        let mut nonempty = 0usize;
+        for q in &set.0 {
+            let df = crate::summarize::temporal::extract_date_filter(&q.query, today);
+            let hits = db
+                .search_visible_in_range(&q.query, 40, &empties, df)
+                .unwrap();
+            if hits.is_empty() {
+                empty += 1;
+                println!("EMPTY-FTS: {}", q.query);
+            } else {
+                nonempty += 1;
+                println!("fts={:>2} hits: {}", hits.len(), q.query);
+            }
+        }
+        println!(
+            "\nFTS-empty legs: {empty}/{} ; non-empty (present, wrong-or-right): {nonempty}/{}",
+            set.0.len(),
+            set.0.len()
         );
     }
 

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -484,6 +484,7 @@ mod tests {
     fn local_reranker_or_note() -> Option<Box<dyn crate::rerank::Reranker>> {
         let cfg = crate::settings::AppConfig {
             brain_backend: crate::settings::BrainBackend::Local,
+            brain_model_id: std::env::var("MURMUR_BAKEOFF_LIGHT_ID").ok(),
             ..Default::default()
         };
         let reranker = crate::rerank::active_reranker(std::sync::Arc::from(

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -10,6 +10,16 @@
   background: var(--surface-base);
 }
 
+/* The single child of the fixed host — must itself be the flex column that
+   fills the window, otherwise the sticky header + scroll region below never
+   get a bounded height and the body overflows the viewport un-scrollably. */
+.editor {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 /* Transparent full-viewport backdrop that closes an open header menu on an
    outside click (a real focusable button for a11y; sits under the menus). */
 .menu-backdrop {
@@ -28,7 +38,10 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-4) var(--space-6) var(--space-3);
+  /* Extra left inset clears the overlay macOS traffic lights (trafficLightPosition
+     {32,30} in tauri.conf.json — this fixed drill-down covers the whole window,
+     so nothing else reserves room for them on this row). */
+  padding: var(--space-4) var(--space-6) var(--space-3) 84px;
   border-bottom: 1px solid var(--border-subtle);
 }
 .head-spacer {


### PR DESCRIPTION
## What

`score_fuse`: an empty retrieval leg now contributes zero effective weight; its mass redistributes over the present legs. All-legs-present is byte-identical to the old fixed blend (regression pin) — keyword queries unaffected. Adds the `MURMUR_BAKEOFF_LIGHT_ID` env hook (run the reranker bake-off on a real GGUF without code edits) + the real-vault findings artifact.

## Honest measured result

On the real dev vault (60 meetings, 20 retrieval-hard queries, real e5), the change moves hybrid recall by **0.0000** — 18/20 queries have an empty FTS leg, and redistribution only *rescales* the surviving blend, so it can't reorder top-5. The real `hybrid 0.90 < semantic 0.95` gap is the **graph leg** promoting co-mention noise, not FTS — a separate follow-up. The change is correct + regression-free (synthetic gate hybrid 0.90 ≥ baseline); the artifact says so rather than claiming a win.

Also: reranker finding — prompted Qwen3-1.7B adds zero measured value (10 candidates exhaust the 3 s deadline → identity); keep the trait seam, evaluate bge-reranker if ever wanted.

Rode along (parallel session, green): note-editor layout fix.

## How verified

lock-security + adversarial both **PASS** (RED-before-GREEN proven by reverting the fn; regression pin non-tautological); `cargo test --lib` **1413/0**; `scripts/ci.sh` ✅ green.