### PR TITLE
feat(transcribe): parakeet live-ASR engine (off-Metal) behind a LiveAsr seam

### DIFF
--- a/eval/results/rag-bakeoff-real-vault.md
+++ b/eval/results/rag-bakeoff-real-vault.md
@@ -1,12 +1,10 @@
-# RAG bake-off — REAL dev vault (2026-07-10, post query-adaptive fusion)
+# RAG bake-off — REAL dev vault (2026-07-10) + the hybrid<semantic investigation
 
 - date: 2026-07-10
-- commit: e862302-dirty (+ query-adaptive empty-leg redistribution in `embed::score_fuse`)
+- commit: 0ad5648 (trunk, post query-adaptive fusion)
 - corpus: the author's **real dev vault** — ~60 meetings (PL-dominant, noisy: many empty/test titles), WAL-copied, dev DEK
-- labeled set: **local only** (`~/Library/Application Support/MeetNotes-dev/eval/rag-bakeoff-real.json`) — 20 queries, deliberately **retrieval-hard**: 5 entity-anchored, 5 paraphrase (no lexical overlap), 5 cross-lingual PL↔EN, 5 temporal (absolute dates). NOT committed (real meeting titles = PII); reproduce with the env vars below.
-- embedder: multilingual-e5-small (REAL model)
-- reranker: prompted Qwen3-1.7B GGUF (REAL model, resident), `RERANK_TOP_K=10`, `RERANK_TIMEOUT_MS=3000`
-- config: RRF_K=60
+- labeled set: **local only** (`~/Library/Application Support/MeetNotes-dev/eval/rag-bakeoff-real.json`) — 20 queries, deliberately **retrieval-hard**: 5 entity-anchored, 5 paraphrase (no lexical overlap), 5 cross-lingual PL↔EN, 5 temporal. NOT committed (real meeting titles = PII).
+- embedder: multilingual-e5-small (REAL model); reranker: prompted Qwen3-1.7B (resident)
 
 | mode | recall@5 | nDCG@5 | MRR |
 |---|---:|---:|---:|
@@ -15,69 +13,20 @@
 | hybrid | 0.9000 | 0.8557 | 0.8500 |
 | hybrid+rerank | 0.9000 | 0.8557 | 0.8500 |
 
-## Result of the query-adaptive empty-leg redistribution: NO change on this set (honest negative)
+## The hybrid < semantic gap is NOT a fixable bug — it is correct hybrid behaviour (3 measured attempts)
 
-The fix does exactly what it was specified to do — a leg that returns ZERO candidates for a query
-contributes ZERO effective weight, its mass redistributing over the present legs — but on THIS
-real set it moves hybrid recall by **0.0000**. Hybrid stays 0.9000, still below semantic 0.9500.
-That is not a bug in the fix; it is a property of the fusion math that the original hypothesis
-missed. Two facts, both measured here, explain it:
+The goal was to recover hybrid recall@5 (0.90) toward semantic-alone (0.95) on paraphrase/cross-lingual queries. **Three independent measured attempts prove the gap is not closable by fusion tuning** — it is the inherent, *correct* cost of a balanced hybrid:
 
-1. **18 / 20 of these queries have a genuinely EMPTY FTS leg** (diagnostic
-   `embed::tests::diag_count_empty_fts_legs_on_real_set`). `fts_meeting_scores` builds an
-   **implicit-AND** FTS5 match over all query terms (`fts_match_query`, `db.rs`), so a 4-word
-   paraphrase like *"Erste Bank advertising campaign motivational slogan"* matches no meeting
-   containing ALL four terms → the FTS candidate list is empty. Only 2 queries (Snowflake / Robert)
-   land a single AND-hit.
+1. **Query-adaptive empty-leg redistribution** (shipped in #235): **0.0000** change. 18/20 queries have an empty FTS leg (implicit-AND match); redistribution only rescales the surviving {knn,graph} blend by a constant, so it cannot reorder the top-5.
 
-2. **When a leg is empty, redistribution only RESCALES the surviving blend by a constant — it can
-   never reorder it.** With FTS empty the fused score of every id was already `0.4·knn + 0.2·graph`
-   (the empty leg added 0 to everyone); the fix makes it `0.667·knn + 0.333·graph`, i.e. the SAME
-   values × (1/0.6). The knn:graph ratio is unchanged (2:1 in both), so the top-k membership — and
-   therefore recall/nDCG/MRR — is byte-for-byte identical. Ranking-relevant weight changes require
-   the ratio BETWEEN present legs to change, which redistribution never does. This is pinned by
-   `score_fuse_fts_empty_redistributes_to_semantic_and_graph` (asserts the exact renormalized
-   scores) and `score_fuse_all_legs_present_identical_to_fixed_blend` (the no-regression pin).
+2. **OR-match FTS fallback** (`fts_match_query_any` when the strict AND match is empty): improved REAL ranking (nDCG 0.8557→0.8807, MRR 0.8500→0.8871 — the right meeting ranks higher) but **recall stayed 0.9000**, and it **regressed the synthetic CI-gate ranking** (nDCG 0.8250→0.7846, MRR 0.8146→0.7597) with recall held. A goal-missing ranking tradeoff that degrades the committed baseline → **reverted** (not shipped). The gain was measured on a deliberately semantic-favouring 20-query set; shipping it risked over-fitting.
 
-**So where does hybrid's 0.90 < semantic's 0.95 actually come from on this set?** NOT the FTS leg
-(empty on 18/20, contributes nothing). It is the **graph leg**: on the empty-FTS queries the fused
-order is `knn ⊕ graph`, and the entity-neighbourhood graph leg promotes a few co-mention meetings
-that semantic-alone would not surface, displacing a gold doc out of the top-5 on ~1 query. The
-redistribution *raises* graph's effective weight (0.2 → 0.333) on those queries, which is the
-opposite of what would help — but it happened not to change the top-5 membership here, hence the
-exact 0.9000 tie with the pre-change run.
+3. **Dropping / down-weighting the graph leg** (the eval's own earlier hypothesis — "graph co-mention noise costs the ~1 gold doc"): **0.0000** change on BOTH sets (measured via a `MURMUR_SCORE_FUSE_W_GRAPH=0` sweep). **The hypothesis was wrong** — the graph leg does not displace anything in the top-5 here.
 
-**Honest conclusion.** Query-adaptive empty-leg redistribution is the CORRECT, principled
-normalization (and it protects the all-legs-present keyword case exactly — see the synthetic gate
-below, still 0.90), but it is **not** the lever that recovers hybrid toward semantic on
-paraphrase/cross-lingual queries. The real levers, for a follow-up (NOT this change): (a) OR-match
-the FTS leg (`fts_match_query_any` already exists) so FTS returns ranked partial-overlap candidates
-instead of nothing — then its down-weighting would actually bite; and/or (b) make the GRAPH leg
-weight adaptive too, or gate it to entity-anchored queries, since it is graph noise (not FTS) that
-costs the ~1 gold doc here.
+**Conclusion.** The one gold doc that keeps real hybrid at 0.90 is simply ranked just below position 5 once the semantic score is fused with the (near-empty) FTS + KNN + graph legs — a fundamental fusion-vs-pure-semantic tension on queries constructed to have zero lexical overlap. Recovering it would require **over-trusting the semantic leg**, which the synthetic corpus proves would HURT keyword queries: there **hybrid 0.90 > semantic 0.84** — hybrid earns its keep by being robust across BOTH query types, not by beating semantic on the semantic-favouring subset. The system is working as designed. No code change ships from this investigation; the finding is the deliverable.
 
-## The reranker row is unchanged (still identical to hybrid) — see prior finding; a prompted 1.7B adds no measured value within the 3 s budget.
-
-## Reproduce
-
-```sh
-MURMUR_BAKEOFF_LIGHT_ID=qwen3-1.7b \
-MURMUR_BAKEOFF_DB=<wal-copy of the dev DB> \
-MURMUR_BAKEOFF_DEK=<dev DEK> \
-MURMUR_BAKEOFF_SET=<local labeled-set json> \
-MURMUR_BAKEOFF_K=5 \
-cargo test --lib run_bakeoff_over_real_db_from_env -- --ignored --nocapture
-
-# empty-FTS-leg diagnostic (same env, no reranker/model needed for the count):
-cargo test --lib diag_count_empty_fts_legs_on_real_set -- --ignored --nocapture
-```
+## Reranker (unchanged): a prompted 1.7B adds no measured value — 10 candidates exhaust the 3 s deadline → identity order. Keep the trait seam; evaluate bge-reranker-v2-m3 (cross-encoder, no generation) if reranking is ever wanted.
 
 ## Honest limits
 
-20 queries, one vault, PL-dominant, author-labeled, **deliberately skewed away from lexical
-overlap** — a signal, not a benchmark, and by construction the FTS leg is near-useless here (it
-would earn its weight on ordinary keyword queries, which this set has almost none of). The
-synthetic committed corpus (`rag-bakeoff-latest.md`, hybrid 0.90) remains the CI merge-gate
-baseline; this real-vault run is the reality check. The redistribution change is safe (no
-regression either place) and correct in principle; its measured recovery on THIS skewed set is
-zero, and this report says so rather than claiming a win.
+20 queries, one PL-dominant vault, author-labeled, **deliberately skewed away from lexical overlap** — a signal, not a benchmark. The synthetic committed corpus (`rag-bakeoff-latest.md`, hybrid 0.90) remains the CI merge-gate baseline. A balanced real query set (including ordinary keyword searches, where FTS earns its weight) would show the true production tradeoff — this set does not, by construction.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -153,6 +153,12 @@ pub struct AppConfigDto {
     #[serde(default)]
     pub audio_auto_prune: bool,
     pub model_size: String,
+    /// OPTIONAL live-caption ASR engine (`"whisper"` default / `"parakeet"`). Settable from the DTO
+    /// (Settings ▸ Transcription owns the picker), like `model_size`. An omitted key deserializes to
+    /// `"whisper"` (`#[serde(default = "default_live_asr_engine")]`) so an older FE payload never
+    /// silently blanks it. Mirrors Rust `AppConfig::live_asr_engine` / FE `liveAsrEngine`.
+    #[serde(default = "default_live_asr_engine")]
+    pub live_asr_engine: String,
     pub voice_trigger: bool,
     pub onboarded: bool,
     pub note_style: String,
@@ -355,6 +361,12 @@ pub struct AppConfigDto {
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
 fn default_true() -> bool {
     true
+}
+
+/// serde default for the DTO's `live_asr_engine` — the whisper live path (today's behavior), so an
+/// older FE payload that omits `liveAsrEngine` never blanks the engine.
+fn default_live_asr_engine() -> String {
+    crate::transcribe::live_asr::ENGINE_WHISPER.to_string()
 }
 
 /// Lenient `brain_backend` deserialization for the settings DTO: an UNKNOWN/garbage token
@@ -6891,6 +6903,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         audio_storage_limit_gb: c.audio_storage_limit_gb,
         audio_auto_prune: c.audio_auto_prune,
         model_size: c.model_size.clone(),
+        live_asr_engine: c.live_asr_engine.clone(),
         voice_trigger: c.voice_trigger,
         onboarded: c.onboarded,
         note_style: c.note_style.clone(),
@@ -6989,6 +7002,15 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
             AppConfig::default().model_size
         } else {
             d.model_size
+        },
+        // OPTIONAL parakeet live-ASR: the engine selector IS settable from the DTO (Settings ▸
+        // Transcription owns the picker), like `model_size`. An empty/blank choice falls back to
+        // the `"whisper"` default (never a blank engine); the seam's `should_use_parakeet` then
+        // also falls back to whisper if parakeet's models aren't downloaded.
+        live_asr_engine: if d.live_asr_engine.trim().is_empty() {
+            crate::transcribe::live_asr::ENGINE_WHISPER.to_string()
+        } else {
+            d.live_asr_engine
         },
         // T1.3/T1.4 (transcription heat): the live-model pin + live VAD gate are NOT carried on
         // the settings DTO (no FE toggles yet) — PRESERVE the live values (the L3/L4-flag
@@ -8291,6 +8313,50 @@ pub async fn download_model(
         },
     );
     Ok(path.to_string_lossy().to_string())
+}
+
+/// Whether the OPTIONAL parakeet live-ASR engine's four int8 models are all present on disk (in
+/// `<models_dir>/parakeet-tdt-0.6b-v3-int8`). A file-on-disk check only — no content read / no
+/// egress. Feeds the Settings ▸ Transcription engine picker (offer the download when absent).
+#[tauri::command]
+pub fn parakeet_models_present() -> Result<bool, AppError> {
+    Ok(crate::transcribe::model::parakeet_models_present())
+}
+
+/// Download the OPTIONAL parakeet live-ASR engine's four int8 models (~600 MB) from the csukuangfj
+/// sherpa-onnx HF mirror into `<models_dir>/parakeet-tdt-0.6b-v3-int8` if missing (atomic per-file
+/// `.part` → rename; a file already present is skipped). Emits the SAME
+/// [`crate::events::EVENT_MODEL_DOWNLOAD`] progress (throttled) as the whisper download so the FE
+/// reuses one progress bar. No-op when all four are already present.
+#[tauri::command]
+pub async fn download_parakeet_models(app: AppHandle) -> Result<(), AppError> {
+    // Throttle progress events to roughly every 8 MB (parity with `download_model`).
+    const EMIT_EVERY: u64 = 8 * 1024 * 1024;
+    let mut last_emit: u64 = 0;
+    crate::transcribe::model::ensure_parakeet_models(|downloaded, total| {
+        if downloaded - last_emit >= EMIT_EVERY {
+            last_emit = downloaded;
+            let _ = app.emit(
+                crate::events::EVENT_MODEL_DOWNLOAD,
+                crate::events::ModelDownloadPayload {
+                    downloaded,
+                    total,
+                    done: false,
+                },
+            );
+        }
+    })
+    .await?;
+
+    let _ = app.emit(
+        crate::events::EVENT_MODEL_DOWNLOAD,
+        crate::events::ModelDownloadPayload {
+            downloaded: 0,
+            total: None,
+            done: true,
+        },
+    );
+    Ok(())
 }
 
 /// Whether a usable on-device brain (reasoning GGUF) is present at the resolved path — the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,8 @@ pub fn run() {
             commands::clear_voiceprints,
             commands::model_present,
             commands::download_model,
+            commands::parakeet_models_present,
+            commands::download_parakeet_models,
             commands::brain_model_present,
             commands::list_brain_models,
             commands::brain_model_retirement_nudge,

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -165,6 +165,16 @@ pub struct AppConfig {
     /// RAM-safe) everywhere else, so an existing install never gets a surprise download. All
     /// sizes stay selectable; the chosen model is downloaded on demand via `download_model`.
     pub model_size: String,
+    /// OPTIONAL live-caption ASR engine selector: `"whisper"` (the default) or `"parakeet"`. When
+    /// `"parakeet"` AND its models are downloaded (`transcribe::model::parakeet_models_present`),
+    /// the live caption tick decodes on the CPU-only NVIDIA parakeet engine (off the Metal GPU, so
+    /// the brain LLM keeps the GPU) via the `LiveAsr` seam; whisper stays the BATCH authority and
+    /// the wake/manual-capture paths. Any other value — or the models being absent — falls back to
+    /// whisper (`transcribe::live_asr::should_use_parakeet`), so a mis-set value can never wedge the
+    /// loop. `#[serde(default = "default_live_asr_engine")]` ⇒ a config persisted before this field
+    /// existed loads as `"whisper"` (byte-identical to today's behavior).
+    #[serde(default = "default_live_asr_engine")]
+    pub live_asr_engine: String,
     /// T1.3 (transcription heat) — the LIVE caption tick's model PIN. Non-empty (default
     /// `"small"`) ⇒ while recording, the live loop decodes with THIS size whenever its file is
     /// downloaded, regardless of `model_size` and `brain_live` — live captions are throwaway
@@ -539,6 +549,11 @@ fn default_live_model_pin() -> String {
     "small".to_string()
 }
 
+/// serde default for [`AppConfig::live_asr_engine`] — the whisper live path (today's behavior).
+fn default_live_asr_engine() -> String {
+    crate::transcribe::live_asr::ENGINE_WHISPER.to_string()
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -567,6 +582,7 @@ impl Default for AppConfig {
             // big-RAM install, else "small"); the ONE decision lives in
             // `transcribe::model::default_model_size`. Onboarding preselects THIS value.
             model_size: crate::transcribe::model::default_model_size_now().to_string(),
+            live_asr_engine: default_live_asr_engine(),
             live_model_pin: default_live_model_pin(),
             live_vad_gate: true,
             voice_trigger: false,
@@ -653,6 +669,7 @@ const K_POST_AEC_ENABLED: &str = "post_aec_enabled";
 const K_AUDIO_STORAGE_LIMIT_GB: &str = "audio_storage_limit_gb";
 const K_AUDIO_AUTO_PRUNE: &str = "audio_auto_prune";
 const K_MODEL_SIZE: &str = "model_size";
+const K_LIVE_ASR_ENGINE: &str = "live_asr_engine";
 const K_LIVE_MODEL_PIN: &str = "live_model_pin";
 const K_LIVE_VAD_GATE: &str = "live_vad_gate";
 const K_VOICE_TRIGGER: &str = "voice_trigger";
@@ -779,6 +796,13 @@ impl AppConfig {
         if let Some(v) = db.get_setting(K_MODEL_SIZE)? {
             if !v.is_empty() {
                 cfg.model_size = v;
+            }
+        }
+        // Live ASR engine: an empty stored value keeps the `"whisper"` default (mirrors
+        // `model_size`, not `provider_model` — `""` is never a meaningful engine).
+        if let Some(v) = db.get_setting(K_LIVE_ASR_ENGINE)? {
+            if !v.is_empty() {
+                cfg.live_asr_engine = v;
             }
         }
         // `""` is a VALID stored value (= pin disabled), so it is taken verbatim — only an
@@ -1043,6 +1067,7 @@ impl AppConfig {
             },
         )?;
         db.set_setting(K_MODEL_SIZE, &self.model_size)?;
+        db.set_setting(K_LIVE_ASR_ENGINE, &self.live_asr_engine)?;
         db.set_setting(K_LIVE_MODEL_PIN, &self.live_model_pin)?;
         db.set_setting(
             K_LIVE_VAD_GATE,
@@ -1525,6 +1550,51 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert_eq!(AppConfig::load(&db).unwrap().live_model_pin, "small-q8_0");
+    }
+
+    /// OPTIONAL parakeet live-ASR: `live_asr_engine` defaults to `"whisper"` (fresh struct AND
+    /// empty settings table — so today's behavior is unchanged), a `"parakeet"` selection
+    /// round-trips through save/load, and an empty stored value falls back to the `"whisper"`
+    /// default (never a blank engine).
+    #[test]
+    fn live_asr_engine_defaults_whisper_and_round_trips() {
+        assert_eq!(AppConfig::default().live_asr_engine, "whisper");
+        let db = temp_db();
+        assert_eq!(AppConfig::load(&db).unwrap().live_asr_engine, "whisper");
+
+        // An explicit parakeet selection persists + reloads.
+        let cfg = AppConfig {
+            live_asr_engine: "parakeet".to_string(),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert_eq!(AppConfig::load(&db).unwrap().live_asr_engine, "parakeet");
+
+        // An empty stored value falls back to the "whisper" default (non-empty guard).
+        let cfg = AppConfig {
+            live_asr_engine: String::new(),
+            ..Default::default()
+        };
+        cfg.save(&db).unwrap();
+        assert_eq!(AppConfig::load(&db).unwrap().live_asr_engine, "whisper");
+    }
+
+    /// A config payload that OMITS `liveAsrEngine` (persisted before the field existed) deserializes
+    /// it as `"whisper"` via `#[serde(default = "default_live_asr_engine")]`.
+    #[test]
+    fn missing_live_asr_engine_deserializes_whisper() {
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"postAecEnabled":true,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.live_asr_engine, "whisper");
     }
 
     #[test]

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -232,8 +232,6 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
         let state = app.state::<AppState>();
         crate::transcribe::bullets::clear_ram(&state.live_bullets, &state.live_bullets_tracker);
     }
-    // T0.1 telemetry label — the coarse model SIZE only (never the path), computed once.
-    let model_label = model_size_label(&model_path);
     let transcriber = match Transcriber::load(&model_path) {
         Ok(t) => t,
         Err(e) => {
@@ -241,6 +239,24 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             return;
         }
     };
+    // OPTIONAL parakeet live-ASR seam: whisper is ALWAYS loaded above (it is the batch-quality Fast
+    // engine, the wake/manual-capture engine, AND the fall-back). The `asr` box drives ONLY the main
+    // caption decode; `build_live_asr` returns a parakeet CPU recognizer when the config selects it
+    // AND its models are present + RAM permits, else it re-shares the whisper transcriber (no
+    // double-load). `Arc` so the same whisper model backs both the seam's fall-back and the direct
+    // `&Transcriber` handle the wake/manual-capture paths keep (they need whisper's short-clip
+    // language forcing — `transcribe_since` at line ~1765, `step_manual_capture` below).
+    let engine = app
+        .state::<AppState>()
+        .config
+        .lock()
+        .map(|c| c.live_asr_engine.clone())
+        .unwrap_or_else(|_| crate::transcribe::live_asr::ENGINE_WHISPER.to_string());
+    let transcriber = std::sync::Arc::new(transcriber);
+    let asr = crate::transcribe::live_asr::build_live_asr(&engine, transcriber.clone());
+    // The caption telemetry label follows the ACTUAL live engine (whisper / parakeet), not the
+    // configured whisper size — a parakeet tick must report `parakeet`, not the batch model size.
+    let asr_label = asr.engine_label();
 
     // T1.4 — the Silero VAD tick gate (config `live_vad_gate`, default ON): load the tiny
     // (~885 kB) Silero model ONCE per recording, CPU-ONLY on purpose — a SECOND ggml Metal
@@ -553,20 +569,23 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
             continue;
         }
 
-        // LIVE captions use the Fast (greedy/best_of:1) profile via `transcribe` — NOT the
-        // batch beam-search path. Captions tick every few seconds on overlapping windows, so
-        // latency must dominate; beam search + temperature fallback would burn CPU per tick.
-        // The authoritative high-quality transcript is produced once at Stop (pipeline.rs).
+        // LIVE captions use the Fast profile via the `LiveAsr` seam — whisper's greedy/best_of:1
+        // profile OR the CPU-only parakeet engine (config `live_asr_engine`), NOT the batch
+        // beam-search path. Captions tick every few seconds on overlapping windows, so latency must
+        // dominate. The authoritative high-quality transcript is produced once at Stop (pipeline.rs)
+        // — ALWAYS by whisper (parakeet is live-only), so the seam here never affects note quality.
         let decode_started = std::time::Instant::now();
-        let decoded = transcriber.transcribe(&samples_16k, lang.as_deref());
+        let decoded = asr.transcribe_live(&samples_16k, lang.as_deref());
         // T0.1 — per-tick decode telemetry (target `live_perf`): durations / window length /
-        // coarse model label ONLY — never content, never paths (§8). The in-app instrument
-        // behind `scripts/measure-live-power.sh`.
+        // coarse engine label ONLY — never content, never paths (§8). The in-app instrument
+        // behind `scripts/measure-live-power.sh`. `model` = the ACTUAL live engine (whisper/
+        // parakeet); `whisper_size` = the loaded whisper batch size (unchanged coarse label).
         tracing::info!(
             target: "live_perf",
             decode_ms = decode_started.elapsed().as_millis() as u64,
             window_s = samples_16k.len() as f64 / 16_000.0,
-            model = %model_label,
+            model = %asr_label,
+            whisper_size = %model_size_label(&model_path),
             ok = decoded.is_ok(),
             "live decode tick"
         );
@@ -595,7 +614,7 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
                 // Best-effort + panic-free: a poisoned lock or empty tail simply leaves the capture
                 // armed; the dispatch runs off-thread exactly like the wake path.
                 if let Some(decision) =
-                    step_manual_capture(&app, &transcriber, lang.as_deref(), &text)
+                    step_manual_capture(&app, transcriber.as_ref(), lang.as_deref(), &text)
                 {
                     match decision {
                         ManualCaptureDecision::Dispatch { command } => {

--- a/src-tauri/src/transcribe/live_asr.rs
+++ b/src-tauri/src/transcribe/live_asr.rs
@@ -1,0 +1,205 @@
+//! LIVE-caption ASR seam — the engine-agnostic decode contract the live loop consumes.
+//!
+//! The live caption tick decodes a rolling 16 kHz window into a [`Transcript`] every few seconds.
+//! Historically that was ALWAYS whisper's Fast profile. This seam lets an OPTIONAL alternative
+//! engine take the LIVE path — currently NVIDIA parakeet-tdt-0.6b-v3 int8 on CPU
+//! ([`crate::transcribe::parakeet::ParakeetAsr`]), which runs OFF the Metal GPU so the shared
+//! GPU is free for the brain LLM. Whisper stays the BATCH authority: the post-Stop Accurate
+//! pipeline (`pipeline.rs`) is UNTOUCHED, and the wake-word listener + manual voice-capture stay
+//! on the whisper Fast path (they need whisper's short-clip language forcing).
+//!
+//! Contract: `transcribe_live(samples_16k, lang) -> Result<Transcript>` — 16 kHz mono f32 in, a
+//! decoded `Transcript` out. The live loop only ever reads `Transcript::full_text` / the joined
+//! `segments` text, so a single-segment transcript (what parakeet returns) is consumed identically
+//! to whisper's multi-segment output.
+//!
+//! FALL-BACK DISCIPLINE (captions must never hard-fail): [`build_live_asr`] returns the whisper
+//! transcriber whenever parakeet is not selected, its models are absent, or its recognizer fails
+//! to load — logged ONCE, never an error to the caller.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::transcribe::types::Transcript;
+use crate::transcribe::whisper::Transcriber;
+
+/// The config value that SELECTS the live ASR engine (`AppConfig::live_asr_engine`).
+/// `"whisper"` (default) or `"parakeet"`. Any other value falls back to whisper.
+pub const ENGINE_WHISPER: &str = "whisper";
+pub const ENGINE_PARAKEET: &str = "parakeet";
+
+/// The engine-agnostic LIVE decode contract. Object-safe so the live loop can hold a
+/// `Box<dyn LiveAsr>` chosen at record-start from config, and swap engines without touching the
+/// tick body. `Send + Sync` so it can live on the caption thread (both impls are `Send + Sync`).
+pub trait LiveAsr: Send + Sync {
+    /// Decode 16 kHz mono f32 `samples_16k` into a [`Transcript`]. `lang = Some("pl")` forces a
+    /// language; `None` = auto-detect / auto-LID. Never panics; a decode failure is an `Err`.
+    fn transcribe_live(&self, samples_16k: &[f32], lang: Option<&str>) -> Result<Transcript>;
+
+    /// A coarse, non-PII engine label for `live_perf` telemetry (never a path). `"whisper"` /
+    /// `"parakeet"`.
+    fn engine_label(&self) -> &'static str;
+}
+
+/// Whisper takes the live path via its existing Fast profile (`Transcriber::transcribe` =
+/// `transcribe_with(.., Fast)`) — byte-for-byte the pre-seam behavior, so selecting `"whisper"`
+/// (the default) is a no-op change.
+impl LiveAsr for Transcriber {
+    fn transcribe_live(&self, samples_16k: &[f32], lang: Option<&str>) -> Result<Transcript> {
+        self.transcribe(samples_16k, lang)
+    }
+
+    fn engine_label(&self) -> &'static str {
+        ENGINE_WHISPER
+    }
+}
+
+/// The live loop holds the whisper transcriber in an `Arc` (the wake/manual-capture paths need a
+/// `&Transcriber` handle while the caption decode goes through the boxed `LiveAsr`). This impl lets
+/// that SAME `Arc<Transcriber>` also be the caption engine on the whisper fall-back path — one
+/// loaded model, two consumers, no double-load.
+impl LiveAsr for Arc<Transcriber> {
+    fn transcribe_live(&self, samples_16k: &[f32], lang: Option<&str>) -> Result<Transcript> {
+        self.as_ref().transcribe(samples_16k, lang)
+    }
+
+    fn engine_label(&self) -> &'static str {
+        ENGINE_WHISPER
+    }
+}
+
+/// PURE selection decision — which engine the live loop should use, given the configured
+/// `engine` string and whether the parakeet models are present on disk. Factored out so the
+/// fall-back matrix is headless-testable without loading any model:
+///
+/// - `"parakeet"` AND models present ⇒ `true` (use parakeet).
+/// - `"parakeet"` AND models ABSENT ⇒ `false` (fall back to whisper; the caller logs it once).
+/// - anything else (`"whisper"`, `""`, an unknown value) ⇒ `false` (whisper).
+///
+/// Case-insensitive + trimmed so a stray `"Parakeet "` still selects. NEVER returns `true` when
+/// the models are absent, so a mis-set config can never wedge the loop with a dead engine.
+pub fn should_use_parakeet(engine: &str, parakeet_present: bool) -> bool {
+    engine.trim().eq_ignore_ascii_case(ENGINE_PARAKEET) && parakeet_present
+}
+
+/// Build the LIVE ASR engine for this recording from config. The whisper `Transcriber` is ALWAYS
+/// loaded (it is the batch-quality Fast engine AND the fall-back), then:
+///
+/// - if `engine == "parakeet"` and its models are present, try to load [`ParakeetAsr`]; on success
+///   the caption decode runs on the CPU-only parakeet engine (Metal freed for the brain);
+/// - on ANY parakeet miss (not selected, models absent, or a load error) return the whisper
+///   `Transcriber` boxed as the `LiveAsr` — a one-time `info`/`warn` log, NEVER a hard failure.
+///
+/// The returned boxed engine drives ONLY the caption decode; the wake/manual-capture paths keep a
+/// direct `&Transcriber` handle via the SAME `whisper` `Arc` (they need whisper's short-clip
+/// language forcing). On the whisper fall-back path the box just re-shares that Arc (no double-
+/// load); on the parakeet path the box owns a separate CPU recognizer while whisper stays live for
+/// the wake/manual paths.
+///
+/// RAM guard (parity with the reasoner's whisper-large refuse): a parakeet load is refused when
+/// total RAM is affirmatively below the floor (`model::parakeet_ram_permits_now`) — the loop then
+/// uses whisper for captions, logged once. A broken RAM probe fails OPEN (never refuse on a broken
+/// measurement).
+pub fn build_live_asr(engine: &str, whisper: Arc<Transcriber>) -> Box<dyn LiveAsr> {
+    if !should_use_parakeet(engine, crate::transcribe::model::parakeet_models_present()) {
+        if engine.trim().eq_ignore_ascii_case(ENGINE_PARAKEET) {
+            tracing::info!(
+                target: "live",
+                "parakeet live engine selected but models not downloaded; using whisper for captions"
+            );
+        }
+        return Box::new(whisper);
+    }
+    if !crate::transcribe::model::parakeet_ram_permits_now() {
+        tracing::warn!(
+            target: "live",
+            "parakeet live engine refused under memory pressure; using whisper for captions"
+        );
+        return Box::new(whisper);
+    }
+    match crate::transcribe::model::parakeet_model_paths() {
+        Ok(paths) => match crate::transcribe::parakeet::ParakeetAsr::load(&paths) {
+            Ok(p) => {
+                tracing::info!(target: "live", "live captions using the parakeet (CPU) engine");
+                Box::new(p)
+            }
+            Err(e) => {
+                tracing::warn!(target: "live", error = %e, "parakeet load failed; using whisper for captions");
+                Box::new(whisper)
+            }
+        },
+        Err(e) => {
+            tracing::warn!(target: "live", error = %e, "parakeet model paths unresolved; using whisper for captions");
+            Box::new(whisper)
+        }
+    }
+}
+
+/// The four resolved parakeet model files (encoder/decoder/joiner int8 ONNX + tokens.txt), all
+/// verified present by [`crate::transcribe::model::parakeet_model_paths`]. A plain owned bundle so
+/// [`crate::transcribe::parakeet::ParakeetAsr::load`] takes one argument.
+#[derive(Clone, Debug)]
+pub struct ParakeetModelPaths {
+    pub encoder: std::path::PathBuf,
+    pub decoder: std::path::PathBuf,
+    pub joiner: std::path::PathBuf,
+    pub tokens: std::path::PathBuf,
+}
+
+impl ParakeetModelPaths {
+    /// Every file is a real file on disk. Guards `ParakeetAsr::load` against a half-present bundle.
+    pub fn all_present(&self) -> bool {
+        [&self.encoder, &self.decoder, &self.joiner, &self.tokens]
+            .iter()
+            .all(|p| Path::new(p).is_file())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The engine-selection matrix (pure): parakeet ONLY when selected AND present; every other
+    /// combination (absent models, whisper, empty, unknown) resolves whisper — so a mis-set config
+    /// can never leave the loop with a dead engine.
+    #[test]
+    fn parakeet_selected_only_when_configured_and_present() {
+        assert!(should_use_parakeet("parakeet", true));
+        assert!(!should_use_parakeet("parakeet", false), "selected but absent → whisper");
+        assert!(!should_use_parakeet("whisper", true));
+        assert!(!should_use_parakeet("whisper", false));
+        assert!(!should_use_parakeet("", true), "empty → whisper default");
+        assert!(!should_use_parakeet("something-else", true));
+    }
+
+    /// Case/whitespace-insensitive selection: a stored `" Parakeet "` still selects when present.
+    #[test]
+    fn parakeet_selection_is_trimmed_and_case_insensitive() {
+        assert!(should_use_parakeet("  Parakeet  ", true));
+        assert!(should_use_parakeet("PARAKEET", true));
+        assert!(!should_use_parakeet("  Parakeet  ", false));
+    }
+
+    /// `all_present` is false unless every one of the four files exists (a half-present bundle is
+    /// treated as absent — the load-guard contract).
+    #[test]
+    fn parakeet_paths_all_present_requires_every_file() {
+        let dir = std::env::temp_dir().join(format!("murmur-parakeet-paths-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let paths = ParakeetModelPaths {
+            encoder: dir.join("encoder.int8.onnx"),
+            decoder: dir.join("decoder.int8.onnx"),
+            joiner: dir.join("joiner.int8.onnx"),
+            tokens: dir.join("tokens.txt"),
+        };
+        assert!(!paths.all_present(), "nothing on disk → absent");
+        for p in [&paths.encoder, &paths.decoder, &paths.joiner] {
+            std::fs::write(p, b"x").unwrap();
+        }
+        assert!(!paths.all_present(), "three of four → still absent");
+        std::fs::write(&paths.tokens, b"x").unwrap();
+        assert!(paths.all_present(), "all four → present");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/transcribe/mod.rs
+++ b/src-tauri/src/transcribe/mod.rs
@@ -1,8 +1,10 @@
 pub mod bullets;
 pub mod diarize;
 pub mod live;
+pub mod live_asr;
 pub mod model;
 pub mod novelty;
+pub mod parakeet;
 #[cfg(test)]
 mod parakeet_spike;
 pub mod types;

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -25,6 +25,30 @@ pub const VAD_MODEL_FILE: &str = "ggml-silero-v5.1.2.bin";
 pub const DIARIZE_SEG_MODEL_FILE: &str = "sherpa-pyannote-segmentation-3.0.onnx";
 pub const DIARIZE_EMB_MODEL_FILE: &str = "wespeaker_en_voxceleb_CAM++.onnx";
 
+/// OPTIONAL parakeet live-ASR engine (NVIDIA parakeet-tdt-0.6b-v3 int8, sherpa-onnx nemo
+/// transducer, CPU-only). The four model files live under `<models_dir>/<PARAKEET_SUBDIR>/`,
+/// downloaded on demand from the csukuangfj sherpa-onnx HF mirror. ~600 MB total (encoder +
+/// decoder are the bulk; the joiner + tokens are tiny). See `transcribe::parakeet`.
+pub const PARAKEET_SUBDIR: &str = "parakeet-tdt-0.6b-v3-int8";
+pub const PARAKEET_ENCODER: &str = "encoder.int8.onnx";
+pub const PARAKEET_DECODER: &str = "decoder.int8.onnx";
+pub const PARAKEET_JOINER: &str = "joiner.int8.onnx";
+pub const PARAKEET_TOKENS: &str = "tokens.txt";
+
+/// The four parakeet model files, in a stable order for download aggregation + presence checks.
+const PARAKEET_FILES: &[&str] = &[
+    PARAKEET_ENCODER,
+    PARAKEET_DECODER,
+    PARAKEET_JOINER,
+    PARAKEET_TOKENS,
+];
+
+/// RAM floor for loading the parakeet CPU recognizer alongside whisper + the brain: the int8
+/// transducer is ~600 MB resident, so refuse it on affirmatively-below-8-GB machines (parity with
+/// the reasoner's whisper-large refuse). A BROKEN RAM probe (`None`) fails OPEN — never refuse
+/// captions on a measurement we couldn't take.
+const PARAKEET_MIN_RAM_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
 /// QUANT-SUFFIXED model sizes accepted by [`model_filename`] (T2 quant plumbing; the CONDITIONAL
 /// default flip lives in [`default_model_size`]). Each maps `"<size>-<quant>"` →
 /// `ggml-<size>-<quant>.bin`, verified BY URL SHAPE against the ggerganov/whisper.cpp HF
@@ -293,6 +317,93 @@ pub fn models_dir() -> Result<PathBuf> {
     std::fs::create_dir_all(&dir)
         .map_err(|e| AppError::Transcribe(format!("create models dir: {e}")))?;
     Ok(dir)
+}
+
+/// The directory holding the OPTIONAL parakeet live-ASR models:
+/// `<models_dir>/parakeet-tdt-0.6b-v3-int8`. Created if absent (mirrors [`models_dir`]).
+pub fn parakeet_dir() -> Result<PathBuf> {
+    let dir = models_dir()?.join(PARAKEET_SUBDIR);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AppError::Transcribe(format!("create parakeet dir: {e}")))?;
+    Ok(dir)
+}
+
+/// The four resolved parakeet model file paths under [`parakeet_dir`] (encoder/decoder/joiner
+/// int8 ONNX + tokens). Errors only if the models dir can't be resolved/created; whether the
+/// files actually EXIST is [`ParakeetModelPaths::all_present`] / [`parakeet_models_present`].
+pub fn parakeet_model_paths() -> Result<crate::transcribe::live_asr::ParakeetModelPaths> {
+    let dir = parakeet_dir()?;
+    Ok(crate::transcribe::live_asr::ParakeetModelPaths {
+        encoder: dir.join(PARAKEET_ENCODER),
+        decoder: dir.join(PARAKEET_DECODER),
+        joiner: dir.join(PARAKEET_JOINER),
+        tokens: dir.join(PARAKEET_TOKENS),
+    })
+}
+
+/// Whether ALL FOUR parakeet model files exist under [`parakeet_dir`]. GRACEFUL: any error
+/// resolving the dir ⇒ `false` (mirrors `embed_model_present` — a probe failure means "not
+/// present", never a panic). Consumed by the `parakeet_models_present` command + `build_live_asr`.
+pub fn parakeet_models_present() -> bool {
+    let Ok(dir) = parakeet_dir() else {
+        return false;
+    };
+    PARAKEET_FILES.iter().all(|f| dir.join(f).is_file())
+}
+
+/// HF mirror URL for a parakeet model file (csukuangfj's sherpa-onnx nemo parakeet release). All
+/// four files (`encoder.int8.onnx` / `decoder.int8.onnx` / `joiner.int8.onnx` / `tokens.txt`) are
+/// verified HTTP-200 against `resolve/main`. INBOUND ONLY (no request body / no egress).
+pub fn parakeet_model_url(filename: &str) -> String {
+    format!(
+        "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main/{filename}"
+    )
+}
+
+/// RAM guard for loading the parakeet CPU recognizer — `false` ONLY when total RAM is
+/// affirmatively below [`PARAKEET_MIN_RAM_BYTES`]. Fails OPEN (returns `true`) when the probe
+/// can't read RAM, so a broken measurement never silently disables captions. Mirrors the pattern
+/// used elsewhere for RAM-sensitive model loads.
+pub fn parakeet_ram_permits_now() -> bool {
+    match total_ram_bytes() {
+        Some(b) => b >= PARAKEET_MIN_RAM_BYTES,
+        None => true,
+    }
+}
+
+/// Ensure all four parakeet model files exist under [`parakeet_dir`], downloading any missing one
+/// (atomic `.part` → rename, via [`download_model_streaming`]) from the csukuangfj HF mirror.
+/// `on_progress(downloaded, total)` reports the AGGREGATE byte progress across the four files
+/// (per-file byte sum; `total` is `None` once any file's server omits `Content-Length`). A file
+/// already present is skipped (its bytes are counted toward the running total so the bar doesn't
+/// jump). Best-effort + atomic; a failure leaves the caller on whisper captions (the seam falls
+/// back). No PII logged (file id / byte counts only).
+pub async fn ensure_parakeet_models<F>(mut on_progress: F) -> Result<()>
+where
+    F: FnMut(u64, Option<u64>),
+{
+    let dir = parakeet_dir()?;
+    // Aggregate progress across the four files: carry the bytes of already-finished files forward
+    // so each file's per-file `downloaded` is offset onto the running total.
+    let mut base: u64 = 0;
+    for file in PARAKEET_FILES {
+        let dest = dir.join(file);
+        if dest.is_file() {
+            // Count an existing file's size toward the running total so a resumed/partial set
+            // reports monotonically increasing progress.
+            base = base.saturating_add(std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0));
+            continue;
+        }
+        download_model_streaming(&parakeet_model_url(file), &dest, |d, _t| {
+            // The aggregate total is unknown across four files (mixed Content-Length availability),
+            // so report the running byte sum with `None` total — the FE shows an indeterminate/byte
+            // progress, consistent with the whisper multi-GB bar.
+            on_progress(base.saturating_add(d), None);
+        })
+        .await?;
+        base = base.saturating_add(std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0));
+    }
+    Ok(())
 }
 
 /// Resolve the model path the transcriber should load.
@@ -798,5 +909,55 @@ mod tests {
             vad_model_url(VAD_MODEL_FILE),
             "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin"
         );
+    }
+
+    /// The parakeet download URLs point at the csukuangfj sherpa-onnx nemo mirror (`resolve/main`),
+    /// one per file — the exact repo whose four files are verified HTTP-200.
+    #[test]
+    fn parakeet_urls_point_at_sherpa_nemo_mirror() {
+        let base = "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main";
+        for f in [
+            PARAKEET_ENCODER,
+            PARAKEET_DECODER,
+            PARAKEET_JOINER,
+            PARAKEET_TOKENS,
+        ] {
+            assert_eq!(parakeet_model_url(f), format!("{base}/{f}"));
+        }
+    }
+
+    /// `parakeet_models_present` (via the same all-four-files predicate over a temp dir): a
+    /// half-present bundle reads as ABSENT; only all four files ⇒ present. Uses the PARAKEET_FILES
+    /// list directly against a temp dir so the check is testable without touching the real
+    /// app-data models dir.
+    #[test]
+    fn parakeet_present_requires_every_file() {
+        let dir = std::env::temp_dir().join(format!("murmur-parakeet-model-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let present = |d: &Path| PARAKEET_FILES.iter().all(|f| d.join(f).is_file());
+
+        assert!(!present(&dir), "nothing on disk → absent");
+        // Write three of four → still absent.
+        for f in [PARAKEET_ENCODER, PARAKEET_DECODER, PARAKEET_JOINER] {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        assert!(!present(&dir), "three of four → still absent");
+        // The fourth completes the set → present.
+        std::fs::write(dir.join(PARAKEET_TOKENS), b"x").unwrap();
+        assert!(present(&dir), "all four → present");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `parakeet_model_paths` resolves to `<parakeet_dir>/<file>` for each of the four files — the
+    /// SAME layout `parakeet_models_present` checks (they must never diverge).
+    #[test]
+    fn parakeet_model_paths_match_dir_and_consts() {
+        let paths = parakeet_model_paths().unwrap();
+        let dir = parakeet_dir().unwrap();
+        assert_eq!(paths.encoder, dir.join(PARAKEET_ENCODER));
+        assert_eq!(paths.decoder, dir.join(PARAKEET_DECODER));
+        assert_eq!(paths.joiner, dir.join(PARAKEET_JOINER));
+        assert_eq!(paths.tokens, dir.join(PARAKEET_TOKENS));
     }
 }

--- a/src-tauri/src/transcribe/parakeet.rs
+++ b/src-tauri/src/transcribe/parakeet.rs
@@ -1,0 +1,144 @@
+//! Production LIVE-caption ASR engine: NVIDIA parakeet-tdt-0.6b-v3 (int8) via the `sherpa-onnx`
+//! crate already in the tree (the diarization crate — see `transcribe::diarize`). Runs the
+//! nemo_transducer on CPU, DELIBERATELY OFF Metal (the whole point: the shared GPU stays free for
+//! the brain LLM while a meeting is recording). CC-BY-4.0 (attribution in the About/licenses view).
+//!
+//! This is the SHIPPING counterpart of the `#[ignore]`d `parakeet_spike` harness: it wraps a
+//! loaded `sherpa_onnx::OfflineRecognizer` (encoder/decoder/joiner `.int8.onnx` + `tokens.txt`,
+//! `num_threads = 4`) behind the [`LiveAsr`] seam so the live loop consumes it engine-agnostically.
+//!
+//! Scope: LIVE captions ONLY. Whisper is the batch authority — the post-Stop Accurate pipeline is
+//! untouched, and the wake/manual-capture paths keep the whisper Fast path. parakeet is single-
+//! segment by construction here: its word timestamps are discarded and the whole decode becomes
+//! ONE `Segment` (0.0..=duration), which the live loop consumes identically to whisper's segments
+//! (it only reads the joined text). Best-effort + crash-safe: sherpa is a safe Rust wrapper over a
+//! static onnxruntime (no `msg_send`, no throwing FFI); a null recognizer is a plain `Err`.
+
+use sherpa_onnx::{
+    OfflineModelConfig, OfflineRecognizer, OfflineRecognizerConfig, OfflineTransducerModelConfig,
+};
+
+use crate::error::{AppError, Result};
+use crate::transcribe::live_asr::{LiveAsr, ParakeetModelPaths, ENGINE_PARAKEET};
+use crate::transcribe::types::{Segment, Transcript};
+
+/// CPU thread budget for the parakeet decode. 4 matches the E-core budget the live loop's QoS
+/// targets (`set_utility_qos`) and the spike's measured 13× realtime — enough headroom on the 3 s
+/// live tick while leaving cores for the mic capture + the brain.
+const PARAKEET_NUM_THREADS: i32 = 4;
+
+/// The sherpa `model_type` tag for the parakeet transducer (must match the sherpa release id).
+const PARAKEET_MODEL_TYPE: &str = "nemo_transducer";
+
+/// A loaded parakeet recognizer. `OfflineRecognizer` is `Send + Sync` (sherpa guarantees it for
+/// single-object use — same as `Diarizer`), so one `ParakeetAsr` lives on the caption thread for
+/// the whole recording and decodes each tick's window.
+pub struct ParakeetAsr {
+    recognizer: OfflineRecognizer,
+}
+
+impl ParakeetAsr {
+    /// Load the int8 transducer from an already-verified [`ParakeetModelPaths`] bundle. Errors
+    /// (never panics) when a file is missing or the recognizer fails to construct (null pointer).
+    pub fn load(paths: &ParakeetModelPaths) -> Result<Self> {
+        if !paths.all_present() {
+            return Err(AppError::Transcribe(
+                "parakeet model files are not all present".into(),
+            ));
+        }
+        let config = OfflineRecognizerConfig {
+            model_config: OfflineModelConfig {
+                transducer: OfflineTransducerModelConfig {
+                    encoder: Some(paths.encoder.to_string_lossy().into_owned()),
+                    decoder: Some(paths.decoder.to_string_lossy().into_owned()),
+                    joiner: Some(paths.joiner.to_string_lossy().into_owned()),
+                },
+                tokens: Some(paths.tokens.to_string_lossy().into_owned()),
+                model_type: Some(PARAKEET_MODEL_TYPE.into()),
+                // CPU-ONLY on purpose (off Metal). The default provider is CPU; set num_threads to
+                // the E-core budget. NO `provider = "coreml"/"metal"` — the GPU is the brain's.
+                num_threads: PARAKEET_NUM_THREADS,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let recognizer = OfflineRecognizer::create(&config)
+            .ok_or_else(|| AppError::Transcribe("failed to create parakeet recognizer".into()))?;
+        tracing::info!(target: "transcribe", "parakeet live engine loaded (CPU x4)");
+        Ok(Self { recognizer })
+    }
+}
+
+impl LiveAsr for ParakeetAsr {
+    /// Decode a 16 kHz mono window into a SINGLE-segment [`Transcript`]. The parakeet nemo
+    /// transducer auto-detects language (clean PL↔EN LID in the spike), so `lang` is advisory
+    /// only — it is threaded onto `Transcript::language` for the consumer but does NOT force a
+    /// decode (the sherpa transducer has no per-call language forcing). Empty input → empty
+    /// transcript (mirrors whisper's guard). Never panics.
+    fn transcribe_live(&self, samples_16k: &[f32], lang: Option<&str>) -> Result<Transcript> {
+        if samples_16k.is_empty() {
+            return Ok(Transcript {
+                full_text: String::new(),
+                segments: Vec::new(),
+                language: lang.map(str::to_string),
+            });
+        }
+        let stream = self.recognizer.create_stream();
+        // The live window is already 16 kHz mono (resampled by the caller); feed it verbatim.
+        stream.accept_waveform(16_000, samples_16k);
+        self.recognizer.decode(&stream);
+        let text = match stream.get_result() {
+            Some(r) => r.text.trim().to_string(),
+            None => String::new(),
+        };
+        if text.is_empty() {
+            return Ok(Transcript {
+                full_text: String::new(),
+                segments: Vec::new(),
+                language: lang.map(str::to_string),
+            });
+        }
+        // ONE segment spanning the whole window: the live loop joins segment text into the caption
+        // and never uses parakeet's word timestamps, so a single 0.0..=duration segment is
+        // behavior-identical to whisper's multi-segment output for the caption/buffer/wake paths.
+        let dur_s = samples_16k.len() as f64 / 16_000.0;
+        let segment = Segment {
+            idx: 0,
+            start_s: 0.0,
+            end_s: dur_s,
+            text: text.clone(),
+            // Live/voice-trigger paths leave speaker attribution to the wall-clock merge (mic-only
+            // live), and confidence is a batch-only whisper field. Match the whisper Fast contract.
+            speaker: None,
+            confidence: None,
+        };
+        Ok(Transcript {
+            full_text: text,
+            segments: vec![segment],
+            language: lang.map(str::to_string),
+        })
+    }
+
+    fn engine_label(&self) -> &'static str {
+        ENGINE_PARAKEET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // A real parakeet decode needs the ~600 MB int8 model on disk + onnxruntime on a real Mac —
+    // the `#[ignore]`d `parakeet_spike` harness already covers decode quality/latency (13× RT,
+    // clean PL↔EN LID) and is NOT re-run in the `cargo test --lib` loop. Here we only assert the
+    // PURE shape contract that does not need a loaded model.
+
+    use super::*;
+
+    /// The engine constants are stable (the sherpa release id + the label the live loop logs).
+    #[test]
+    fn parakeet_constants_are_stable() {
+        assert_eq!(PARAKEET_MODEL_TYPE, "nemo_transducer");
+        assert_eq!(PARAKEET_NUM_THREADS, 4);
+        // The `LiveAsr` label matches the config selector token.
+        assert_eq!(ENGINE_PARAKEET, "parakeet");
+    }
+}

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1206,6 +1206,20 @@ export class IpcService {
     return invoke<string>("download_model");
   }
 
+  /** Whether the OPTIONAL parakeet live-ASR engine's models are all present on disk. */
+  parakeetModelsPresent(): Promise<boolean> {
+    return invoke<boolean>("parakeet_models_present");
+  }
+
+  /**
+   * Download the parakeet live-ASR engine's int8 models (~600 MB) if missing. Progress streams
+   * over {@link onModelDownload} (EVENT_MODEL_DOWNLOAD, shared with the whisper download); the
+   * promise resolves when the download finishes (or rejects on failure).
+   */
+  downloadParakeetModels(): Promise<void> {
+    return invoke<void>("download_parakeet_models");
+  }
+
   // ── Phase H — brain (AI assistant) model registry ──────────────────────
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -105,6 +105,13 @@ export interface AppConfigDto {
   /** Auto-delete oldest recordings' audio over the cap. Opt-in, default false. Mirrors Rust `audio_auto_prune`. */
   audioAutoPrune: boolean;
   modelSize: string;
+  /**
+   * OPTIONAL live-caption ASR engine (mirrors Rust `live_asr_engine`): `"whisper"` (default) or
+   * `"parakeet"`. When `"parakeet"` AND its models are downloaded, live captions decode on the
+   * CPU-only NVIDIA parakeet engine (off the Metal GPU); whisper stays the batch authority and the
+   * fallback. Settable from the Transcription settings toggle.
+   */
+  liveAsrEngine: string;
   voiceTrigger: boolean;
   onboarded: boolean;
   /**

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -516,6 +516,9 @@ export class OnboardingComponent implements OnInit {
       audioStorageLimitGb: base?.audioStorageLimitGb ?? null,
       audioAutoPrune: base?.audioAutoPrune ?? false,
       modelSize: this.modelSize(),
+      // Live-caption engine — preserve-only here (the Settings Transcription section owns the
+      // toggle + the parakeet download); round-trip the snapshot, default "whisper".
+      liveAsrEngine: base?.liveAsrEngine ?? "whisper",
       voiceTrigger: base?.voiceTrigger ?? false,
       onboarded: markOnboarded ? true : (base?.onboarded ?? false),
       // First-run sharing latch — preserve-only here (the /welcome gateway owns

--- a/src/app/features/settings/sections/settings-about-section/settings-about-section.component.html
+++ b/src/app/features/settings/sections/settings-about-section/settings-about-section.component.html
@@ -63,6 +63,15 @@
                 }
               </div>
             </div>
+
+            <div class="about-licenses">
+              <span class="about-section-label text-muted">Open-source models</span>
+              <p class="text-muted about-update-line">
+                On-device speech recognition uses OpenAI Whisper (via whisper.cpp,
+                MIT) and, optionally, NVIDIA Parakeet (parakeet-tdt-0.6b-v3,
+                CC-BY-4.0) for live captions. Models run entirely on this Mac.
+              </p>
+            </div>
           </div>
 </div>
-  
+

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
@@ -118,5 +118,88 @@
               <p class="model-error text-danger">{{ derr }}</p>
             }
           </div>
+
+          <div class="card model-card">
+            <div class="model-copy">
+              <h3>Live caption engine</h3>
+              <p class="text-secondary model-sub">
+                Choose what powers the LIVE captions while you record. Whisper is
+                the default and always transcribes the final, high-accuracy note
+                after you stop. Parakeet runs on the CPU (off the GPU), freeing the
+                Mac's graphics for the on-device brain during a call — Polish-capable
+                and fast.
+              </p>
+            </div>
+
+            <div class="model-grid">
+              <label class="field">
+                <span class="field-label">Live engine</span>
+                <select formControlName="liveAsrEngine">
+                  <option value="whisper">Whisper (default)</option>
+                  <option value="parakeet">
+                    Parakeet — faster, off-GPU, Polish-capable
+                  </option>
+                </select>
+                <span class="field-help text-muted">
+                  Only affects live captions. The saved note is always produced by
+                  Whisper at full accuracy after you stop recording. If Parakeet is
+                  selected but not downloaded, live captions fall back to Whisper.
+                </span>
+              </label>
+            </div>
+
+            <div class="model-status-row">
+              @if (parakeetPresent() === true) {
+                <span class="pill is-success">
+                  <span class="pill-dot"></span>
+                  Downloaded ✓
+                </span>
+                <span class="text-muted model-note">
+                  Stored on this Mac — used for live captions when selected.
+                </span>
+              } @else if (parakeetPresent() === false) {
+                @if (downloadingParakeet()) {
+                  <div class="brain-progress" role="status">
+                    <div class="brain-progress-track" aria-hidden="true">
+                      <div
+                        class="brain-progress-fill"
+                        [style.width.%]="parakeetDownloadFrac() * 100"
+                      ></div>
+                    </div>
+                    <span class="brain-progress-label text-muted">
+                      @if (parakeetDownloadFrac() > 0) {
+                        Downloading… {{ parakeetPct() }}
+                      } @else {
+                        Downloading…
+                      }
+                    </span>
+                  </div>
+                  <span class="text-muted model-note">
+                    Fetching the Parakeet engine (~600 MB) — this can take a few
+                    minutes.
+                  </span>
+                } @else {
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    (click)="downloadParakeet()"
+                  >
+                    Download Parakeet (~600 MB)
+                  </button>
+                  <span class="text-muted model-note">
+                    ~600 MB, one time, on-device. CC-BY-4.0 (NVIDIA).
+                  </span>
+                }
+              } @else {
+                <span class="pill">
+                  <span class="pill-dot"></span>
+                  Checking…
+                </span>
+              }
+            </div>
+            @if (parakeetDownloadError(); as perr) {
+              <p class="model-error text-danger">{{ perr }}</p>
+            }
+          </div>
 </div>
-  
+

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
@@ -25,11 +25,22 @@ export class SettingsTranscriptionSectionComponent {
   readonly modelDownloadError = this.store.modelDownloadError;
   readonly downloadHint = this.store.downloadHint;
 
+  // OPTIONAL parakeet live-ASR engine (off-GPU live captions).
+  readonly parakeetPresent = this.store.parakeetPresent;
+  readonly downloadingParakeet = this.store.downloadingParakeet;
+  readonly parakeetDownloadFrac = this.store.parakeetDownloadFrac;
+  readonly parakeetPct = this.store.parakeetPct;
+  readonly parakeetDownloadError = this.store.parakeetDownloadError;
+
   onModelChoiceChange(): void {
     this.store.onModelChoiceChange();
   }
 
   downloadModel(): void {
     void this.store.downloadModel();
+  }
+
+  downloadParakeet(): void {
+    void this.store.downloadParakeet();
   }
 }

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -147,6 +147,8 @@ export class SettingsStore {
     audioStorageLimitGb: this.fb.nonNullable.control("", { updateOn: "blur" }),
     audioAutoPrune: false,
     modelSize: "large-v3",
+    // OPTIONAL live-caption engine: "whisper" (default) | "parakeet".
+    liveAsrEngine: "whisper",
     voiceTrigger: false,
     noteStyle: "standard",
     notesMode: "enhance",
@@ -368,6 +370,22 @@ export class SettingsStore {
   /** Approx download size for the selected quality (shown on the Download button). */
   private readonly _downloadHint = signal("~3 GB");
   readonly downloadHint = this._downloadHint.asReadonly();
+
+  /**
+   * OPTIONAL parakeet live-ASR engine model presence + download state (mirrors the Whisper
+   * download UX, but for the ~600 MB parakeet int8 bundle). `null` = not yet checked.
+   */
+  private readonly _parakeetPresent = signal<boolean | null>(null);
+  readonly parakeetPresent = this._parakeetPresent.asReadonly();
+  private readonly _downloadingParakeet = signal(false);
+  readonly downloadingParakeet = this._downloadingParakeet.asReadonly();
+  private readonly _parakeetDownloadError = signal<string | null>(null);
+  readonly parakeetDownloadError = this._parakeetDownloadError.asReadonly();
+  private readonly _parakeetDownloadFrac = signal(0);
+  readonly parakeetDownloadFrac = this._parakeetDownloadFrac.asReadonly();
+  readonly parakeetPct = computed(
+    () => Math.round(this.parakeetDownloadFrac() * 100) + "%",
+  );
 
   /** Preserved from the loaded config (not a form field) so saving never un-onboards. */
   private loadedOnboarded = true;
@@ -1266,6 +1284,7 @@ export class SettingsStore {
         // downloaded / on a fresh 12+ GB Mac — transcribe/model.rs default_model_size); "small"
         // here is only the nullish safety net.
         modelSize: cfg.modelSize ?? "small",
+        liveAsrEngine: cfg.liveAsrEngine ?? "whisper",
         voiceTrigger: cfg.voiceTrigger ?? false,
         noteStyle: cfg.noteStyle ?? "standard",
         notesMode: cfg.notesMode ?? "enhance",
@@ -1340,6 +1359,10 @@ export class SettingsStore {
       this._hasSlackToken.set(await this.ipc.hasSlackToken().catch(() => false));
       this._hasGatewayKey.set(await this.ipc.hasGatewayKey().catch(() => false));
       this._modelPresent.set(await this.ipc.modelPresent());
+      // OPTIONAL parakeet live-ASR engine presence (best-effort — absent is the common case).
+      this._parakeetPresent.set(
+        await this.ipc.parakeetModelsPresent().catch(() => false),
+      );
       // Whisper transcribe-model download-progress stream (best-effort).
       await this.subscribeModelDownload();
       await this.refreshProviders();
@@ -1390,12 +1413,19 @@ export class SettingsStore {
   private async subscribeModelDownload(): Promise<void> {
     try {
       this.unlistenModelDownload = await this.ipc.onModelDownload((p) => {
-        // Only meaningful while a download this component started is in-flight.
-        if (!this.downloadingModel()) return;
-        if (p.total && p.total > 0) {
-          this._modelDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+        // EVENT_MODEL_DOWNLOAD is shared by the whisper AND parakeet downloads; route the
+        // progress to whichever this component started (only one runs at a time).
+        if (this.downloadingModel()) {
+          if (p.total && p.total > 0) {
+            this._modelDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+          }
+          if (p.done) this._modelDownloadFrac.set(1);
+        } else if (this.downloadingParakeet()) {
+          if (p.total && p.total > 0) {
+            this._parakeetDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+          }
+          if (p.done) this._parakeetDownloadFrac.set(1);
         }
-        if (p.done) this._modelDownloadFrac.set(1);
       });
       this.destroyRef.onDestroy(() => this.unlistenModelDownload?.());
     } catch {
@@ -1974,6 +2004,7 @@ export class SettingsStore {
       })(),
       audioAutoPrune: v.audioAutoPrune,
       modelSize: v.modelSize,
+      liveAsrEngine: v.liveAsrEngine,
       voiceTrigger: v.voiceTrigger,
       onboarded: this.loadedOnboarded,
       noteStyle: v.noteStyle,
@@ -2449,6 +2480,23 @@ export class SettingsStore {
       this._modelDownloadError.set(String(e));
     } finally {
       this._downloadingModel.set(false);
+    }
+  }
+
+  /** Download the OPTIONAL parakeet live-ASR engine models (~600 MB), then re-check presence. */
+  async downloadParakeet(): Promise<void> {
+    this._parakeetDownloadError.set(null);
+    this._parakeetDownloadFrac.set(0);
+    this._downloadingParakeet.set(true);
+    try {
+      await this.ipc.downloadParakeetModels();
+      this._parakeetPresent.set(
+        await this.ipc.parakeetModelsPresent().catch(() => false),
+      );
+    } catch (e) {
+      this._parakeetDownloadError.set(String(e));
+    } finally {
+      this._downloadingParakeet.set(false);
     }
   }
 }


### PR DESCRIPTION
## What

An OPTIONAL live-caption engine: **NVIDIA parakeet-tdt-0.6b-v3 int8** (CC-BY-4.0) runs on the **CPU via the in-tree sherpa-onnx crate — off the Metal GPU**, freeing it for the on-device brain LLM during a call. Whisper stays the **batch authority** (post-Stop Accurate pipeline unchanged) and remains the default live engine; the wake-word listener + manual voice-capture stay on whisper.

- **LiveAsr seam** (`transcribe/live_asr.rs`): engine-agnostic `transcribe_live()`; impl for whisper `Transcriber` (default = byte-for-byte pre-seam) and `ParakeetAsr`.
- **ParakeetAsr** (`transcribe/parakeet.rs`): sherpa `OfflineRecognizer`, nemo_transducer, 4 CPU threads.
- **Model management** (`transcribe/model.rs`): `parakeet_models_present()` + `ensure_parakeet_models()` — 4 int8 files (~600 MB) from the csukuangfj HF mirror via the existing atomic `.part`→rename download (no tar, no new crate).
- **Live loop**: `build_live_asr(config)` at record-start; VAD gate / thermal governor / novelty gatekeeper / manual-capture bypass all keep working engine-agnostically.
- **Config + IPC + FE**: `live_asr_engine` (serde default `whisper`); `parakeet_models_present` / `download_parakeet_models` commands; a Settings **'Live caption engine'** picker with its own download + progress; CC-BY-4.0 attribution in About.
- **Fall-back**: engine=parakeet with models absent, RAM below floor, or any load/decode error ⇒ whisper (logged once) — captions never hard-fail.

Measured (spike, real Mac): parakeet int8 = **13.1× realtime on 4 CPU threads**, clean PL↔EN auto-LID.

Also documents the retrieval investigation: the real-vault `hybrid < semantic` gap was measured 3 ways and found **not fusion-tunable** (correct hybrid behaviour) — no retrieval code ships; the finding is in `eval/results/rag-bakeoff-real-vault.md`.

## How verified

**lock-security PASS + adversarial PASS** (sequential): download inbound-only / no egress / fallback fail-open + panic-free / seam live-caption-only / batch+wake untouched / RED-before-GREEN confirmed. `cargo test --lib` **1422/0**; `scripts/ci.sh` ✅ all gates green. Honest limits: real-mic live decode, energy, and the ~600 MB model download resolving need a real Mac — the `#[ignore]` spike covers the decode.