### PR TITLE
fix(dev): stop tauri-dev infinite rebuild loop on the brain sidecar

### DIFF
--- a/src-tauri/.taurignore
+++ b/src-tauri/.taurignore
@@ -1,0 +1,10 @@
+# Dev-watcher ignore list (gitignore syntax) — read by `tauri dev`'s file watcher.
+#
+# `binaries/` holds GENERATED sidecar artifacts (Swift helpers + the meetnotes-brain
+# child), staged into place by build.rs on every `cargo build`. They live inside the
+# watched `src-tauri/` tree, so without this ignore, build.rs re-staging one of them
+# (e.g. copying meetnotes-brain from target/) updates its mtime → the watcher fires
+# "Rebuilding application…" → build.rs re-stages it again → an INFINITE rebuild loop
+# that never boots the app. None of these are hand-edited source; they must not drive
+# an app rebuild. (Release `tauri build` ignores this file — it only affects dev.)
+binaries/

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -119,6 +119,11 @@ fn stage_brain_sidecar() {
     // debug fallback for a dev child build. First existing wins. This ONLY finds a HOST-ARCH child in
     // a normal `cargo build -p murmur-brain` dev build (a target-triple build writes under
     // `target/<triple>/…`, which the release path stages via `beforeBuildCommand`, not here).
+    // Require a NON-EMPTY file: a half-written / interrupted child build can leave a 0-byte
+    // `target/<profile>/meetnotes-brain`. A bare `is_file()` would treat that empty stub as a real
+    // child, then `fs::copy` it into `binaries/…` on EVERY build (since `already_real` — which also
+    // gates on `len() > 0` — never flips true for a 0-byte copy), re-arming the dev watcher into an
+    // infinite rebuild loop, and would emit a `BRAIN_BIN` pointing at an unspawnable empty binary.
     let built = target_dir.as_ref().and_then(|td| {
         [
             td.join("release").join(BIN),
@@ -126,7 +131,7 @@ fn stage_brain_sidecar() {
             td.join("debug").join(BIN),
         ]
         .into_iter()
-        .find(|p| p.is_file())
+        .find(|p| std::fs::metadata(p).map(|m| m.is_file() && m.len() > 0).unwrap_or(false))
     });
 
     match built {


### PR DESCRIPTION
## Problem

`npm run dev` was stuck rebuilding forever — `Info File src-tauri/binaries/meetnotes-brain changed. Rebuilding application…` on repeat — and never booted the app. Regression from the brain-sidecar merge (#238).

## Root cause (two compounding bugs)

1. `build.rs` `stage_brain_sidecar()` probed the target dir with `p.is_file()`, which is **true for a 0-byte file**. A stale/interrupted 0-byte `target/debug/meetnotes-brain` made it take the real-child branch and `fs::copy` that empty stub into `src-tauri/binaries/meetnotes-brain` on **every** build. Both stayed 0 bytes, so `already_real` (which gates on `len() > 0`) never flipped — it re-copied, bumping mtime, every pass.
2. There was **no `.taurignore`**, so Tauri's dev watcher watched `src-tauri/binaries/`. Each mtime bump → Rebuilding → build.rs copies again → an infinite loop that never finishes booting.

## Fix

- **`src-tauri/.taurignore`** (new) excludes `binaries/` — those are *generated* sidecar artifacts (Swift helpers + brain) staged by build.rs and must never drive an app rebuild. Canonical Tauri fix; breaks the loop on its own. Release `tauri build` ignores `.taurignore`, so signing/notarization is unaffected.
- **`build.rs`** — the child probe now requires a non-empty file (`m.is_file() && m.len() > 0`); a half-written 0-byte artifact is treated as not-built → no empty copies, no bogus `BRAIN_BIN` pointing at an unspawnable empty binary.

## Verification

Dev builds **once** (21s) and boots clean:
```
Finished dev profile ... Running target/debug/Murmur
MCP server listening on http://127.0.0.1:8765
embed model ready · rag backfill indexed=47 · update check complete
```
`Rebuilding application` count = **0** (was infinite), no panic/abort.

Note: in a plain dev run the brain sidecar isn't auto-built (only release's `beforeBuildCommand` lipos it), so the reasoner runs as the stub in dev — pre-existing behavior, unchanged. Building `-p murmur-brain` now stages it once without re-looping.