### PR TITLE
fix(cleanup): reap capture helpers + calendar zombie, sweep .part/vault-tmp/.enc residue

### DIFF
--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -222,17 +222,29 @@ impl AecRecorder {
 
     /// SIGTERM the helper, wait, and return the WAV path if it captured anything. `Ok(None)` on any
     /// failure so the caller falls back to the raw cpal mic for ASR.
-    pub fn stop(mut self) -> Result<Option<PathBuf>> {
+    ///
+    /// `self` implements `Drop` (C1), so the teardown runs under [`std::mem::ManuallyDrop`] to
+    /// SUPPRESS the drop-guard's second teardown — a clean `stop` reaps the child exactly once (no
+    /// double-SIGTERM / recycled-pid risk). Fields are then dropped explicitly (no leak).
+    pub fn stop(self) -> Result<Option<PathBuf>> {
+        let mut this = std::mem::ManuallyDrop::new(self);
         let _ = Command::new("kill")
             .arg("-TERM")
-            .arg(self.child.id().to_string())
+            .arg(this.child.id().to_string())
             .status();
-        let status = self
-            .child
-            .wait()
-            .map_err(|e| AppError::Audio(format!("waiting on AEC helper: {e}")))?;
-        if status.success() && self.wav_path.exists() {
-            Ok(Some(self.wav_path))
+        let wait_res = this.child.wait();
+
+        // Move the fields out of the ManuallyDrop so they drop normally (the recorder's own `Drop`
+        // stays suppressed → the child is reaped exactly once above).
+        // SAFETY: each field is read exactly once and never touched again.
+        let wav_path = unsafe { std::ptr::read(&this.wav_path) };
+        let _child = unsafe { std::ptr::read(&this.child) };
+        let _started_at = unsafe { std::ptr::read(&this.started_at) };
+
+        let status =
+            wait_res.map_err(|e| AppError::Audio(format!("waiting on AEC helper: {e}")))?;
+        if status.success() && wav_path.exists() {
+            Ok(Some(wav_path))
         } else {
             tracing::warn!(
                 target: "audio",
@@ -241,6 +253,22 @@ impl AecRecorder {
             );
             Ok(None)
         }
+    }
+}
+
+/// C1 — best-effort teardown for an [`AecRecorder`] DROPPED without a clean [`AecRecorder::stop`]
+/// (app-quit mid-recording, a panic, a `take()` into a discard). A std [`Child`] only DETACHES on
+/// drop, so without this the VPIO helper reparents to launchd and keeps writing an unbounded scratch
+/// WAV until its 4h self-cap (the 91 GB incident). SIGTERM (not SIGKILL) so it flushes + closes the
+/// WAV exactly as `stop()` does, then `wait()` to reap. After a normal `stop(mut self)` (which
+/// CONSUMES self) this never runs on that value → no double-SIGTERM. Panic-free (`let _ =`).
+impl Drop for AecRecorder {
+    fn drop(&mut self) {
+        let _ = Command::new("kill")
+            .arg("-TERM")
+            .arg(self.child.id().to_string())
+            .status();
+        let _ = self.child.wait();
     }
 }
 
@@ -295,5 +323,45 @@ mod tests {
         assert!(parse_orphan_helpers("  412     1 /usr/libexec/somethingd").is_empty());
         assert!(parse_orphan_helpers("garbage\n\n123 abc def").is_empty());
         assert!(parse_orphan_helpers("").is_empty());
+    }
+
+    /// Whether `pid` still has a process-table entry (any state). None once fully reaped.
+    fn ps_present(pid: u32) -> bool {
+        std::process::Command::new("/bin/ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output()
+            .map(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty())
+            .unwrap_or(false)
+    }
+
+    /// C1 (RED-before-GREEN): an `AecRecorder` DROPPED without a clean `stop()` (app-quit
+    /// mid-recording) must SIGTERM + REAP its VPIO helper child. A std `Child` merely DETACHES on
+    /// drop — so before the added `impl Drop` the child would keep running (reparented to launchd,
+    /// growing an unbounded scratch WAV up to the 4h cap — the 91 GB incident) and never be reaped.
+    /// Proof: after the drop the pid has no process-table entry at all.
+    #[test]
+    fn drop_without_stop_reaps_the_aec_child() {
+        let child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a dummy long-lived child");
+        let pid = child.id();
+        let rec = AecRecorder {
+            child,
+            wav_path: PathBuf::from("/nonexistent/dummy.wav"),
+            started_at: Instant::now(),
+        };
+        assert!(ps_present(pid), "the dummy child is alive before drop");
+
+        drop(rec); // no stop() — the app-quit-mid-recording path.
+
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            !ps_present(pid),
+            "dropping without stop() must SIGTERM + reap the AEC helper — no orphan, no zombie"
+        );
     }
 }

--- a/src-tauri/src/audio/system.rs
+++ b/src-tauri/src/audio/system.rs
@@ -155,26 +155,40 @@ impl SystemAudioRecorder {
     /// SIGTERM the sidecar so it finalizes the WAV, wait for it, and return the WAV path
     /// if it captured anything. Returns `Ok(None)` on sidecar failure (e.g. permission
     /// denied → exit 3) so the caller proceeds mic-only rather than failing the recording.
-    pub fn stop(mut self) -> Result<Option<PathBuf>> {
+    ///
+    /// `self` implements `Drop` (C1), so we run the whole teardown under [`std::mem::ManuallyDrop`]
+    /// and SUPPRESS the drop-guard's second teardown — a clean `stop` reaps the child exactly once
+    /// (no double-SIGTERM, no recycled-pid risk). The fields are then dropped explicitly (no leak).
+    pub fn stop(self) -> Result<Option<PathBuf>> {
+        let mut this = std::mem::ManuallyDrop::new(self);
         // Use `/bin/kill -TERM` (not `Child::kill`, which is SIGKILL and would truncate
         // the WAV) so the sidecar's signal handler can flush + close the file.
         let _ = Command::new("kill")
             .arg("-TERM")
-            .arg(self.child.id().to_string())
+            .arg(this.child.id().to_string())
             .status();
 
-        let status = self
-            .child
-            .wait()
-            .map_err(|e| AppError::Audio(format!("waiting on system-audio sidecar: {e}")))?;
+        let wait_res = this.child.wait();
 
         // Join the stderr drainer (the child is gone, so its stderr is at EOF → the thread ends).
-        if let Some(handle) = self.stderr_reader.take() {
+        if let Some(handle) = this.stderr_reader.take() {
             let _ = handle.join();
         }
 
-        if status.success() && self.wav_path.exists() {
-            Ok(Some(self.wav_path))
+        // Take the fields out of the ManuallyDrop, then let them drop normally at end of scope —
+        // the recorder's `Drop` never runs (suppressed), so the child is reaped exactly once here.
+        // SAFETY: each field is read exactly once out of the ManuallyDrop and never used again.
+        let wav_path = unsafe { std::ptr::read(&this.wav_path) };
+        let _child = unsafe { std::ptr::read(&this.child) };
+        let _first_frame_at = unsafe { std::ptr::read(&this.first_frame_at) };
+        // `stderr_reader` was already `.take()`n above (now `None`); read + drop it too.
+        let _stderr_reader = unsafe { std::ptr::read(&this.stderr_reader) };
+
+        let status = wait_res
+            .map_err(|e| AppError::Audio(format!("waiting on system-audio sidecar: {e}")))?;
+
+        if status.success() && wav_path.exists() {
+            Ok(Some(wav_path))
         } else {
             tracing::warn!(
                 target: "audio",
@@ -186,9 +200,30 @@ impl SystemAudioRecorder {
     }
 }
 
+/// C1 — best-effort teardown for a recorder that is DROPPED without a clean [`SystemAudioRecorder::stop`]
+/// (app-quit mid-recording, a panic, a `take()` into a discard). A std [`Child`] merely DETACHES on
+/// drop — it does not kill or reap — so without this the Swift capture helper reparents to launchd and
+/// keeps writing to its temp WAV until its 4h self-cap. SIGTERM (not SIGKILL) so the helper flushes +
+/// closes its WAV exactly as `stop()` does, then `wait()` to reap the child (no `<defunct>` zombie).
+///
+/// After a normal `stop()` (which runs teardown under `ManuallyDrop` and suppresses this guard) this
+/// Drop never runs on that value, so there is no double-SIGTERM / recycled-pid risk. Panic-free:
+/// every step is `let _ =`.
+impl Drop for SystemAudioRecorder {
+    fn drop(&mut self) {
+        // SIGTERM via `/bin/kill` (matches `stop`) so the helper's signal handler finalizes the WAV.
+        let _ = Command::new("kill")
+            .arg("-TERM")
+            .arg(self.child.id().to_string())
+            .status();
+        // Reap the child so it does not linger as a zombie for the process lifetime.
+        let _ = self.child.wait();
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_first_frame_line;
+    use super::*;
 
     #[test]
     fn first_frame_line_is_recognized() {
@@ -199,5 +234,55 @@ mod tests {
             "audiocap: tap stuck silent — rebuilding (1)"
         ));
         assert!(!is_first_frame_line(""));
+    }
+
+    /// Whether `pid` still has a process-table entry (any state). None once fully reaped.
+    fn ps_present(pid: u32) -> bool {
+        std::process::Command::new("/bin/ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output()
+            .map(|o| !String::from_utf8_lossy(&o.stdout).trim().is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Build a `SystemAudioRecorder` around a real long-lived dummy child (`sleep`) WITHOUT going
+    /// through `start()` (which needs an AppHandle + a real sidecar). Mirrors the struct `start()`
+    /// produces: no stderr reader, spawn instant as the anchor.
+    fn recorder_over_dummy_child() -> (SystemAudioRecorder, u32) {
+        let child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a dummy long-lived child");
+        let pid = child.id();
+        let rec = SystemAudioRecorder {
+            child,
+            wav_path: std::path::PathBuf::from("/nonexistent/dummy.wav"),
+            started_at: std::time::Instant::now(),
+            first_frame_at: Arc::new(OnceLock::new()),
+            stderr_reader: None,
+        };
+        (rec, pid)
+    }
+
+    /// C1 (RED-before-GREEN): a `SystemAudioRecorder` DROPPED without a clean `stop()` (app-quit
+    /// mid-recording) must SIGTERM + REAP its capture-helper child. A std `Child` merely DETACHES on
+    /// drop — so before the added `impl Drop` the child would keep running (reparented to launchd)
+    /// and NEVER be reaped. Proof: after the drop the pid has no process-table entry at all.
+    #[test]
+    fn drop_without_stop_reaps_the_capture_child() {
+        let (rec, pid) = recorder_over_dummy_child();
+        assert!(ps_present(pid), "the dummy child is alive before drop");
+
+        drop(rec); // no stop() — exercises the app-quit-mid-recording path.
+
+        // Give the SIGTERM + wait() a moment to complete.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            !ps_present(pid),
+            "dropping without stop() must SIGTERM + reap the child — no orphan, no zombie"
+        );
     }
 }

--- a/src-tauri/src/calendar.rs
+++ b/src-tauri/src/calendar.rs
@@ -130,15 +130,16 @@ fn run_sidecar(bin: &PathBuf, back_minutes: u32, forward_minutes: u32) -> String
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
                     tracing::warn!(target: "calendar", "calendar sidecar timed out; killing");
-                    let _ = child.kill();
-                    let _ = child.wait();
+                    kill_and_reap(&mut child);
                     return String::new();
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
                 tracing::warn!(target: "calendar", error = %e, "calendar sidecar wait failed");
-                let _ = child.kill();
+                // C3: reap the SIGKILL'd child so it does not linger as a `<defunct>` zombie for the
+                // rest of the process lifetime (symmetric with the timeout arm two branches above).
+                kill_and_reap(&mut child);
                 return String::new();
             }
         }
@@ -148,6 +149,15 @@ fn run_sidecar(bin: &PathBuf, back_minutes: u32, forward_minutes: u32) -> String
         Ok(out) => String::from_utf8_lossy(&out.stdout).into_owned(),
         Err(_) => String::new(),
     }
+}
+
+/// C3 — SIGKILL a wedged/errored sidecar child THEN `wait()` to reap it, so it never lingers as a
+/// `<defunct>` zombie for the process lifetime. Used by BOTH the timeout and the `try_wait` error
+/// arms of [`run_sidecar`] (before the fix the error arm killed but never waited). Best-effort +
+/// panic-free — a kill/wait failure just means the child was already gone.
+fn kill_and_reap(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[cfg(test)]
@@ -214,5 +224,65 @@ mod tests {
         let events = parse_sidecar_output(s);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, "E");
+    }
+
+    /// C3 (RED-before-GREEN): the sidecar kill path must REAP the child, not leave a `<defunct>`
+    /// zombie for the process lifetime. The pre-fix `try_wait` error arm did `child.kill()` WITHOUT
+    /// `child.wait()`.
+    ///
+    /// The test proves BOTH sides against the kernel via `ps -o stat`:
+    ///   (a) the OLD behavior — a bare `kill()` with no reap — leaves the pid in state `Z` (zombie),
+    ///   (b) the FIX — `kill_and_reap` — leaves NO `ps` entry (the pid is fully reaped).
+    /// So this is genuinely RED on the old code shape and GREEN on the new one.
+    #[test]
+    fn kill_and_reap_leaves_no_zombie_unlike_bare_kill() {
+        use std::process::{Command, Stdio};
+
+        fn ps_stat(pid: u32) -> Option<String> {
+            let out = Command::new("/bin/ps")
+                .args(["-o", "stat=", "-p", &pid.to_string()])
+                .output()
+                .ok()?;
+            let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+
+        fn spawn_dummy() -> std::process::Child {
+            Command::new("/bin/sleep")
+                .arg("30")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn a dummy long-lived child")
+        }
+
+        // (a) OLD behavior: kill WITHOUT reap → the child becomes a zombie (`Z`).
+        let mut zombie = spawn_dummy();
+        let zpid = zombie.id();
+        let _ = zombie.kill();
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            ps_stat(zpid).as_deref().map(|s| s.starts_with('Z')),
+            Some(true),
+            "the pre-fix bare kill (no wait) strands a `<defunct>` zombie"
+        );
+        // Clean the fixture zombie up so the test leaves no residue.
+        let _ = zombie.wait();
+
+        // (b) THE FIX: kill AND reap → no `ps` entry at all (fully reaped, no zombie).
+        let mut reaped = spawn_dummy();
+        let rpid = reaped.id();
+        kill_and_reap(&mut reaped);
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            ps_stat(rpid),
+            None,
+            "kill_and_reap must fully reap the child — no zombie, no `ps` entry"
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3569,17 +3569,17 @@ pub fn search_meetings(
 #[tauri::command]
 pub fn delete_meeting(state: State<'_, AppState>, meeting_id: String) -> Result<(), AppError> {
     // Capture + remove on-disk files before the rows disappear (best-effort).
+    // C4: the playback audio may exist as BOTH the plaintext WAV *and* its sealed `.enc` at once —
+    // during a session-unlock, `session_unseal` decrypts the `.enc` to a plaintext WAV for playback
+    // but KEEPS the `.enc`. So `audio_path` (plaintext form) alone would orphan the `.enc` on
+    // record→lock→unlock→delete. Remove BOTH forms, exactly as the masters block below already does.
     if let Some(m) = state.db.get_meeting(&meeting_id)? {
-        if let Some(audio) = m.audio_path.as_deref() {
-            let _ = std::fs::remove_file(audio);
-        }
+        remove_meeting_audio_files(m.audio_path.as_deref());
     }
     // Masters too — a master path may be the plaintext WAV or its `.enc`; clear both forms.
     if let Ok((mic, sys)) = state.db.get_meeting_master_paths(&meeting_id) {
         for p in [mic, sys].into_iter().flatten() {
-            let _ = std::fs::remove_file(&p);
-            let _ = std::fs::remove_file(format!("{p}{ENC_SUFFIX}"));
-            let _ = std::fs::remove_file(p.trim_end_matches(ENC_SUFFIX));
+            remove_meeting_audio_files(Some(&p));
         }
     }
     if let Some(note) = state.db.get_latest_note_for_meeting(&meeting_id)? {
@@ -3604,6 +3604,20 @@ fn remove_rollup_export_files(paths: &[String]) {
     for p in paths {
         let _ = std::fs::remove_file(p);
     }
+}
+
+/// C4 — remove ALL on-disk forms of one at-rest audio path (best-effort). A path recorded in the DB
+/// may be the plaintext WAV OR its sealed `.enc`, and during a session-unlock BOTH coexist (the
+/// unseal decrypts the `.enc` to a playable WAV but keeps the `.enc`). So deleting a meeting must
+/// remove the path as-given, its `.enc` twin, and its plaintext twin — otherwise a
+/// record→lock→Touch-ID-unlock→delete leaves the `.enc` orphaned on disk. This is disk-residue
+/// cleanup, NOT a security gate (the plaintext WAV is removed regardless). Mirrors the masters block
+/// in `delete_meeting`. `None` is a no-op.
+fn remove_meeting_audio_files(audio_path: Option<&str>) {
+    let Some(p) = audio_path else { return };
+    let _ = std::fs::remove_file(p); // the path as recorded (plaintext WAV or the `.enc`).
+    let _ = std::fs::remove_file(format!("{p}{ENC_SUFFIX}")); // its sealed `.enc` twin.
+    let _ = std::fs::remove_file(p.trim_end_matches(ENC_SUFFIX)); // its plaintext twin.
 }
 
 /// Rename a meeting's title (in-app + Library list). Does not rename the vault file.
@@ -10048,6 +10062,56 @@ pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
     Ok(())
 }
 
+/// C1/C2 — best-effort in-process teardown of EVERY capture path on a true app exit
+/// (`RunEvent::ExitRequested`, via the `lib::relock_and_zeroize_on_lifecycle` hook). Without this,
+/// quitting mid-recording never runs any `stop()`, so the Swift capture helpers (system-audio /
+/// AEC) reparent to launchd and keep writing their temp WAVs until their 4h self-cap — the
+/// next-launch reaper (`aec::reap_orphaned_capture_helpers`) becomes the ONLY thing that reclaims
+/// them. Calling this on a clean exit finalizes + reaps them in-process, so the reaper is the true
+/// safety net rather than the primary path.
+///
+/// For each slot: `take()` it OUT of `AppState` under its own lock (deterministic — no `Drop`
+/// ordering ambiguity), then let the value's teardown run:
+///   - `system_recorder` / `aec_recorder`: `.stop()` SIGTERMs the helper so it flushes its WAV, then
+///     reaps it (their `Drop` would do the same, but the explicit `stop()` matches the clean-Stop
+///     path and consumes the value so the `Drop` no-ops).
+///   - `recorder` / `spill_writer`: just `take()` — their existing `Drop` handles teardown (the
+///     spill guard deletes the plaintext spill; the recorder stops its cpal stream) and runs
+///     deterministically at end of scope.
+///
+/// Panic-free: a POISONED slot mutex is skipped (`.lock().ok()`), a `stop()` error is ignored — this
+/// is a last-chance exit hook with no `Result` to surface. Never touches the DB / lock model. NOTE:
+/// call this ONLY on the true exit path, never on a mere window-hide (the app keeps recording in the
+/// tray then — see `lib::relock_and_zeroize_on_lifecycle`).
+pub(crate) fn stop_all_capture(state: &AppState) {
+    // System-audio sidecar: SIGTERM-flush + reap.
+    if let Some(rec) = state
+        .system_recorder
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take())
+    {
+        let _ = rec.stop();
+    }
+    // AEC (VPIO) helper: SIGTERM-flush + reap.
+    if let Some(rec) = state
+        .aec_recorder
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take())
+    {
+        let _ = rec.stop();
+    }
+    // The cpal mic recorder: `Drop` stops its stream — `take()` makes that deterministic here.
+    let _mic = state.recorder.lock().ok().and_then(|mut slot| slot.take());
+    // The crash-salvage spill writer: `Drop` stops the thread + deletes the plaintext spill.
+    let _spill = state
+        .spill_writer
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take());
+}
+
 /// PERMANENTLY remove a folder's lock: KEK → unwrap CK → decrypt each note back to plaintext
 /// markdown, clear `content_blob`, set `locked=0` + `wrapped_key=NULL`, and re-export each note's
 /// `.md` to the vault. The folder returns to the default OPEN state.
@@ -13864,6 +13928,64 @@ mod lock_read_gate_tests {
         );
     }
 
+    /// C4 (RED-before-GREEN): `delete_meeting` removed only the plaintext form of the primary
+    /// playback audio (`std::fs::remove_file(audio_path)`), but during a session-unlock the sealed
+    /// `.enc` coexists on disk (`session_unseal` decrypts to a plaintext WAV for playback yet KEEPS
+    /// the `.enc`). So record→lock→Touch-ID-unlock→delete left the `<file>.enc` orphaned. This is a
+    /// disk-residue leak, NOT a security leak (the plaintext IS removed). The fix routes the primary
+    /// audio through `remove_meeting_audio_files`, which clears both forms (matching the masters).
+    ///
+    /// RED: the assertion for the `.enc` fails under the OLD single-form removal (modeled inline
+    /// below to prove it). GREEN: `remove_meeting_audio_files` clears both.
+    #[test]
+    fn delete_meeting_removes_both_plaintext_and_enc_playback_audio() {
+        let base = std::env::temp_dir().join(format!(
+            "murmur-c4-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        // The session-unlock shape: audio_path points at the PLAINTEXT WAV, and its `.enc` twin
+        // (the durable sealed copy) coexists on disk.
+        let plaintext = format!("{}.wav", base.to_string_lossy());
+        let enc = format!("{plaintext}{ENC_SUFFIX}");
+        std::fs::write(&plaintext, b"PLAYBACK-WAV").unwrap();
+        std::fs::write(&enc, b"SEALED-ENC").unwrap();
+
+        // Proof of the OLD bug: removing ONLY the plaintext form (the pre-fix behavior) leaves the
+        // `.enc` orphaned — this is exactly the residue the fix eliminates.
+        let _ = std::fs::remove_file(&plaintext);
+        assert!(
+            std::path::Path::new(&enc).exists(),
+            "RED: the pre-fix single-form delete strands the sealed .enc"
+        );
+
+        // Re-create the plaintext to model the real pre-delete on-disk state, then run the FIX.
+        std::fs::write(&plaintext, b"PLAYBACK-WAV").unwrap();
+        remove_meeting_audio_files(Some(&plaintext));
+
+        assert!(
+            !std::path::Path::new(&plaintext).exists(),
+            "the plaintext playback WAV is removed"
+        );
+        assert!(
+            !std::path::Path::new(&enc).exists(),
+            "GREEN: the sealed .enc twin is ALSO removed (no orphan)"
+        );
+
+        // Symmetric: when audio_path is recorded as the `.enc` form, both twins are cleared too.
+        std::fs::write(&plaintext, b"PLAYBACK-WAV").unwrap();
+        std::fs::write(&enc, b"SEALED-ENC").unwrap();
+        remove_meeting_audio_files(Some(&enc));
+        assert!(!std::path::Path::new(&enc).exists(), ".enc form removes the .enc");
+        assert!(
+            !std::path::Path::new(&plaintext).exists(),
+            ".enc form also removes the plaintext twin"
+        );
+    }
+
     /// REGRESSION (audio asset-protocol leak): `get_meeting_detail`'s masked DTO for a sealed-and-
     /// not-session-unlocked meeting MUST null `audio_path`. The FE feeds `audio_path` straight into
     /// `convertFileSrc` (the Tauri `asset:` protocol, scoped to the audio dir) which serves the
@@ -14139,6 +14261,42 @@ mod lifecycle_tests {
             .build()
             .unwrap()
             .block_on(f)
+    }
+
+    /// C2 (lifecycle-helper contract): `stop_all_capture` must clear EVERY capture slot to `None`
+    /// (deterministic `take()`) and be panic-free on an empty state. Combined with the C1 Drop tests
+    /// (which prove a taken recorder finalizes + reaps its helper), this is the exit-hook safety net:
+    /// after it runs, no capture path is left owned by `AppState`. The real SIGTERM of the Swift
+    /// helper only truly verifies on a signed build, so this asserts the DETERMINISTIC slot-clearing —
+    /// the seam the exit hook depends on.
+    #[test]
+    fn stop_all_capture_clears_every_capture_slot() {
+        let state = build_state("stop-all-capture");
+        // Sanity: fresh state has no recorders (a real recording would populate these).
+        assert!(state.recorder.lock().unwrap().is_none());
+        assert!(state.system_recorder.lock().unwrap().is_none());
+        assert!(state.aec_recorder.lock().unwrap().is_none());
+        assert!(state.spill_writer.lock().unwrap().is_none());
+
+        // Must not panic, and must leave every slot None.
+        stop_all_capture(&state);
+
+        assert!(
+            state.recorder.lock().unwrap().is_none(),
+            "mic recorder slot cleared"
+        );
+        assert!(
+            state.system_recorder.lock().unwrap().is_none(),
+            "system-audio recorder slot cleared"
+        );
+        assert!(
+            state.aec_recorder.lock().unwrap().is_none(),
+            "AEC recorder slot cleared"
+        );
+        assert!(
+            state.spill_writer.lock().unwrap().is_none(),
+            "spill writer slot cleared"
+        );
     }
 
     /// PHASE-4 lock gate (RED-before-GREEN): `verify_note_sources` + `apply_note_verify_markers` on a

--- a/src-tauri/src/export/obsidian.rs
+++ b/src-tauri/src/export/obsidian.rs
@@ -142,7 +142,7 @@ pub fn write_note(
     // Atomic write: write to a hidden temp dotfile in the SAME directory (so the
     // rename is a same-filesystem atomic operation), fsync, then rename over the
     // final path. The temp name is unique to avoid clobbering a concurrent write.
-    let tmp_name = format!(".{}.{}.tmp", sanitize_for_tmp(&stem), std::process::id());
+    let tmp_name = format!(".{}.{}.murmur.tmp", sanitize_for_tmp(&stem), std::process::id());
     let tmp_path = target_dir.join(tmp_name);
 
     write_and_sync(&tmp_path, markdown).inspect_err(|_| {
@@ -328,7 +328,7 @@ pub fn overwrite_note(path: &Path, markdown: &str) -> Result<()> {
         .ok_or_else(|| AppError::Export("note path has no parent".into()))?;
     std::fs::create_dir_all(parent)
         .map_err(|e| AppError::Export(format!("create note dir failed: {e}")))?;
-    let tmp_path = parent.join(format!(".edit.{}.tmp", std::process::id()));
+    let tmp_path = parent.join(format!(".edit.{}.murmur.tmp", std::process::id()));
     write_and_sync(&tmp_path, markdown).inspect_err(|_| {
         let _ = std::fs::remove_file(&tmp_path);
     })?;
@@ -337,6 +337,125 @@ pub fn overwrite_note(path: &Path, markdown: &str) -> Result<()> {
         AppError::Export(format!("atomic rename failed: {e}"))
     })?;
     Ok(())
+}
+
+// ── Export temp-dotfile sweep ────────────────────────────────────────────────
+
+/// A `.tmp` export dotfile older than this cannot belong to a live export (both `write_note` and
+/// `overwrite_note` rename within a single synchronous call), so mtime is the fallback liveness
+/// signal when the embedded PID has been recycled onto an unrelated process.
+const STALE_EXPORT_TMP_AGE_SECS: u64 = 3600;
+
+/// R2 — best-effort startup sweep of orphaned export temp DOTFILES in the vault. `write_note` writes
+/// `.<stem>.<pid>.murmur.tmp` and `overwrite_note` writes `.edit.<pid>.murmur.tmp`, renaming
+/// atomically over the final `.md`; `remove_file` fires only on the ERROR branch, so a SIGKILL
+/// between the fsync and the rename orphans the dotfile in the user's vault (`collect_md_stems` skips
+/// dotfiles but never deletes them). This reclaims that residue. The `.murmur.tmp` marker makes the
+/// sweep provably OURS-only — a foreign third-party dotfile is never touched.
+///
+/// SAFE against a concurrent LIVE export: an entry is removed ONLY when its embedded PID is not a
+/// live process, OR its mtime is older than [`STALE_EXPORT_TMP_AGE_SECS`]. So a `.tmp` written by
+/// THIS still-running process (its own pid is live + mtime fresh) is never raced. Recurses into
+/// subfolders but SKIPS `.obsidian` / `.trash` (and every other dotfolder). No PII: logs a COUNT
+/// only — never a stem/path (they embed note titles).
+pub fn sweep_stale_export_tmp(vault_dir: &Path) {
+    let removed = sweep_export_tmp_dir(vault_dir, std::time::SystemTime::now());
+    if removed > 0 {
+        tracing::warn!(target: "export", removed, "swept orphaned export temp dotfiles at startup");
+    }
+}
+
+/// Recursive worker for [`sweep_stale_export_tmp`], with `now` injected so the age check is testable.
+/// Returns the count removed. Never errors (best-effort startup cleanup).
+fn sweep_export_tmp_dir(dir: &Path, now: std::time::SystemTime) -> u32 {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(OsStr::to_str) else {
+            continue;
+        };
+        let file_type = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if file_type.is_dir() {
+            // Never descend into Obsidian's config / trash (or any dotfolder) — they are not ours.
+            if name.starts_with('.') {
+                continue;
+            }
+            removed += sweep_export_tmp_dir(&path, now);
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        // Only OUR export temp shape: a dotfile ending `.tmp` whose penultimate `.`-segment is a PID.
+        let Some(pid) = export_tmp_pid(name) else {
+            continue;
+        };
+        // Remove only when the PID is dead OR the file is stale — never race a live export.
+        let pid_live = pid_is_live(pid);
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|age| age.as_secs() > STALE_EXPORT_TMP_AGE_SECS)
+            .unwrap_or(false);
+        if (!pid_live || stale) && std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+/// Parse the PID out of an export temp dotfile name, or `None` if it is not our shape. Matches both
+/// `write_note`'s `.<stem>.<pid>.tmp` and `overwrite_note`'s `.edit.<pid>.tmp`: a name that STARTS
+/// with `.`, ENDS with `.tmp`, and whose token immediately before `.tmp` parses as a u32 pid. A
+/// stem may itself contain dots, so we key off the LAST two dot-segments only.
+fn export_tmp_pid(name: &str) -> Option<u32> {
+    // Require the Murmur-specific `.murmur.tmp` marker so the sweep only ever reclaims OUR export
+    // temps — NEVER a foreign third-party dotfile of a similar `.<x>.<n>.tmp` shape in the vault
+    // (the theoretical over-delete both reviewers flagged). Only `write_note`/`overwrite_note`
+    // produce this marker.
+    if !name.starts_with('.') || !name.ends_with(".murmur.tmp") {
+        return None;
+    }
+    // Strip the `.murmur.tmp` marker, then the segment after the final '.' is the pid.
+    let without_marker = name.strip_suffix(".murmur.tmp")?;
+    let pid_seg = without_marker.rsplit('.').next()?;
+    // Guard against a missing pid (`.murmur.tmp` alone): require a non-empty numeric segment AND at
+    // least one more '.' before it (so `.<something>.<pid>.murmur.tmp`).
+    if pid_seg.is_empty() || !without_marker.contains('.') {
+        return None;
+    }
+    pid_seg.parse::<u32>().ok()
+}
+
+/// Whether `pid` is a currently-live process (best-effort, macOS-first). Uses `/bin/kill -0 <pid>`
+/// — signal 0 sends NO signal, it is the canonical liveness probe: exit 0 ⇒ the process exists (or
+/// exists but is owned by another user — still live), non-zero ⇒ gone (ESRCH). A dead pid means the
+/// export that wrote the temp file is gone, so its orphan is safe to reclaim. No new deps (mirrors
+/// the `/bin/kill -TERM` pattern the audio helpers already use); on a spawn failure we conservatively
+/// treat the pid as LIVE so a temp file is never mistakenly reclaimed (mtime staleness still catches
+/// it). NOTE: `kill -0` reports EPERM as a NON-zero exit on macOS, so we additionally fall back to
+/// the mtime staleness check at the call site — this probe only needs to avoid a false "dead".
+fn pid_is_live(pid: u32) -> bool {
+    std::process::Command::new("/bin/kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        // Conservative: if we can't even probe, assume LIVE (don't race a real export); the mtime
+        // staleness check at the call site still reclaims a genuinely-old orphan.
+        .unwrap_or(true)
 }
 
 // ── Deep links + pinned moments ─────────────────────────────────────────────
@@ -843,6 +962,107 @@ mod tests {
                 .unwrap_or(false)
         });
         assert!(!has_tmp, "temp dotfile must be renamed away");
+    }
+
+    /// R2 helper: does the dir still contain any `.tmp` dotfile?
+    fn dir_has_tmp(dir: &Path) -> bool {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .any(|e| e.unwrap().file_name().to_str().is_some_and(|n| n.ends_with(".tmp")))
+    }
+
+    /// R2 `export_tmp_pid` shape parser: matches BOTH `write_note` and `overwrite_note` temp shapes,
+    /// rejects non-ours names, and tolerates a stem that itself contains dots.
+    #[test]
+    fn export_tmp_pid_recognizes_our_shapes_only() {
+        // Our MARKED shapes parse:
+        assert_eq!(export_tmp_pid(".2026-06-24 1430 - Sync.99999.murmur.tmp"), Some(99999));
+        assert_eq!(export_tmp_pid(".edit.12345.murmur.tmp"), Some(12345));
+        assert_eq!(export_tmp_pid(".a.b.c.777.murmur.tmp"), Some(777)); // stem with dots
+        // Not our shape — REJECTED (the `.murmur.tmp` marker makes the sweep Murmur-only):
+        assert_eq!(export_tmp_pid(".2026-06-24 1430 - Sync.99999.tmp"), None); // no marker (old/foreign)
+        assert_eq!(export_tmp_pid(".foo.12345.tmp"), None); // a FOREIGN third-party temp — must NOT match
+        assert_eq!(export_tmp_pid("Sync.md"), None); // a real note
+        assert_eq!(export_tmp_pid(".hidden"), None); // dotfile, not a temp
+        assert_eq!(export_tmp_pid(".notapid.murmur.tmp"), None); // trailing seg not numeric
+        assert_eq!(export_tmp_pid(".murmur.tmp"), None); // no pid / no stem
+        assert_eq!(export_tmp_pid("noleadingdot.123.murmur.tmp"), None); // not a dotfile
+    }
+
+    /// R2 (RED-before-GREEN): a SIGKILL between fsync and the atomic rename orphans a `.tmp` dotfile
+    /// in the vault; `collect_md_stems` skips it but nothing deletes it. The startup sweep must
+    /// reclaim it — while leaving real `.md` files and never descending into `.obsidian`/`.trash`.
+    /// Mirrors the `no_temp_files_left_behind` / `has_tmp` assertion shape.
+    #[test]
+    fn sweep_removes_orphaned_export_tmp_keeps_md_and_skips_dotfolders() {
+        let dir = tmp_dir("sweep-tmp");
+
+        // A real exported note — must survive.
+        std::fs::write(dir.join("2026-06-24 1430 - Sync.md"), "# body").unwrap();
+
+        // Orphaned export temp dotfiles with a DEAD pid (99999 is not a live process) — must go.
+        let orphan_write = dir.join(".2026-06-24 1430 - Sync.99999.murmur.tmp");
+        std::fs::write(&orphan_write, "half-written").unwrap();
+        let orphan_edit = dir.join(".edit.99999.murmur.tmp");
+        std::fs::write(&orphan_edit, "half-edited").unwrap();
+
+        // A FOREIGN third-party dotfile of a similar shape but WITHOUT our `.murmur.tmp` marker,
+        // dead pid — the sweep must NEVER touch it (it is not ours).
+        let foreign = dir.join(".foo.99999.tmp");
+        std::fs::write(&foreign, "not ours").unwrap();
+
+        // A `.murmur.tmp` inside `.obsidian` — the sweep must NOT descend there (not ours).
+        std::fs::create_dir_all(dir.join(".obsidian")).unwrap();
+        let obsidian_tmp = dir.join(".obsidian").join(".foo.99999.murmur.tmp");
+        std::fs::write(&obsidian_tmp, "config-temp").unwrap();
+
+        // A temp whose pid is THIS live process + fresh mtime — must be spared (a live export).
+        let live_tmp = dir.join(format!(".edit.{}.murmur.tmp", std::process::id()));
+        std::fs::write(&live_tmp, "in-progress").unwrap();
+
+        sweep_stale_export_tmp(&dir);
+
+        assert!(!orphan_write.exists(), "dead-pid write_note temp orphan must be swept");
+        assert!(!orphan_edit.exists(), "dead-pid overwrite_note temp orphan must be swept");
+        assert!(
+            dir.join("2026-06-24 1430 - Sync.md").exists(),
+            "a real exported .md must never be touched"
+        );
+        assert!(
+            obsidian_tmp.exists(),
+            "the sweep must not descend into .obsidian"
+        );
+        assert!(
+            live_tmp.exists(),
+            "a live process's fresh export temp must not be raced/removed"
+        );
+        assert!(
+            foreign.exists(),
+            "a foreign dotfile WITHOUT our .murmur.tmp marker must never be swept"
+        );
+        // The live temp (and the untouched foreign file) remain at the top level; orphans are gone.
+        assert!(dir_has_tmp(&dir), "the live temp is intentionally left");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// R2 mtime fallback: an OLD `.tmp` whose embedded PID happens to be alive again (pid recycled)
+    /// is still reclaimed via the > 1 h staleness check, so a recycled pid can't strand residue
+    /// forever. Uses the injectable `now` on the private worker (age = 2 h).
+    #[test]
+    fn sweep_removes_stale_tmp_even_if_pid_recycled_live() {
+        let dir = tmp_dir("sweep-stale");
+        // A temp whose pid is THIS (live) process — but we age `now` forward 2 h so it counts stale.
+        let recycled = dir.join(format!(".edit.{}.murmur.tmp", std::process::id()));
+        std::fs::write(&recycled, "orphaned-but-pid-recycled").unwrap();
+
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2 * 3600);
+        let removed = sweep_export_tmp_dir(&dir, future);
+
+        assert_eq!(removed, 1, "a stale (> 1 h) temp is reclaimed even with a live pid");
+        assert!(!recycled.exists(), "the stale recycled-pid temp is removed");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -404,6 +404,23 @@ pub fn run() {
             // (Salvage above already moved any RECOVERABLE far-side scratch out of the reaper's reach.)
             crate::audio::aec::reap_orphaned_capture_helpers();
             crate::audio::aec::sweep_stale_scratch();
+            // R1: reclaim any STALE `*.part` model-download residue (a crash / force-quit / aborted
+            // model switch mid-download orphans up to ~3.1 GB). Only removes a `.part` older than 1 h
+            // so a live in-progress download is never raced. Best-effort; never fatal to launch.
+            if let Ok(models_dir) = crate::transcribe::model::models_dir() {
+                crate::transcribe::model::sweep_stale_model_parts(&models_dir);
+            }
+            // R2: reclaim any orphaned export temp DOTFILE (`.<stem>.<pid>.tmp` / `.edit.<pid>.tmp`)
+            // a SIGKILL between fsync + rename left in the user's Obsidian vault. Only removes a temp
+            // whose PID is dead OR whose mtime is > 1 h, and never descends into `.obsidian`/`.trash`,
+            // so a live export is never raced. Skipped entirely when no vault is configured.
+            {
+                let state = app.state::<AppState>();
+                let vault = state.config.lock().ok().and_then(|c| c.vault_path.clone());
+                if let Some(vault) = vault.filter(|v| !v.trim().is_empty()) {
+                    crate::export::obsidian::sweep_stale_export_tmp(std::path::Path::new(&vault));
+                }
+            }
 
             // STAGE 2 salvage worker (async, detached): now that the reaper has downed any orphan
             // helper, reconstruct + pipeline each claimed crashed recording. No-op when nothing crashed.
@@ -547,7 +564,8 @@ pub fn run() {
                 main.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                         api.prevent_close();
-                        relock_and_zeroize_on_lifecycle(&handle, "window-close");
+                        // Window-close only HIDES (recoverable from the tray) — do NOT stop capture.
+                        relock_and_zeroize_on_lifecycle(&handle, LIFECYCLE_CTX_WINDOW_CLOSE);
                         let _ = w.hide();
                     }
                 });
@@ -561,24 +579,43 @@ pub fn run() {
             // checkpoint+truncate the WAL so no plaintext lingers past the process. This is the
             // last-chance cleanup before the process tears down.
             if let tauri::RunEvent::ExitRequested { .. } = event {
-                relock_and_zeroize_on_lifecycle(handle, "app-exit");
-                // Kill the on-device brain sidecar so its multi-GB model RAM is reclaimed on quit
-                // (bounded reap — never hangs app-exit; a slow-dying child reparents to launchd and
-                // the startup reaper SIGTERMs it next launch).
+                // True exit — relock + stop_all_capture (C2) run FIRST inside the hook, THEN kill the
+                // brain sidecar so its multi-GB model RAM is reclaimed on quit (bounded reap — never
+                // hangs app-exit; a slow-dying child reparents to launchd and the startup reaper
+                // SIGTERMs it next launch).
+                relock_and_zeroize_on_lifecycle(handle, LIFECYCLE_CTX_APP_EXIT);
                 crate::reason::sidecar::kill_on_quit();
             }
         });
 }
 
+/// Lifecycle-hook context tags. `app-exit` is the TRUE quit (stop capture + relock); `window-close`
+/// merely hides the window while the app keeps running/recording in the tray (relock only, NEVER
+/// stop capture). Kept as named constants so the C2 exit-only gate can't drift on a typo.
+const LIFECYCLE_CTX_APP_EXIT: &str = "app-exit";
+const LIFECYCLE_CTX_WINDOW_CLOSE: &str = "window-close";
+
 /// Shared lifecycle cleanup (B12/C4): relock every session-unlocked folder (which re-blanks plaintext
 /// + zeroizes the cached master KEK) and checkpoint+truncate the WAL. Best-effort and panic-free —
 ///   invoked from both the window-close and app-exit paths, where there is no Result to surface. No-op
 ///   if AppState was never managed (the graceful-init failure path returns early without it).
+///
+/// C2: on the TRUE exit path (`ctx == "app-exit"`) we ALSO stop every capture path in-process
+/// (`stop_all_capture`) FIRST, so quitting mid-recording finalizes + reaps the Swift capture helpers
+/// instead of orphaning them to launchd until their 4h self-cap (the next-launch reaper then becomes
+/// the safety net, not the primary path). We deliberately do NOT stop capture on `ctx ==
+/// "window-close"`: closing the window only HIDES it and the app keeps recording in the tray — killing
+/// capture there would silently drop an active tray recording.
 fn relock_and_zeroize_on_lifecycle(handle: &tauri::AppHandle, ctx: &str) {
     use crate::state::AppState;
     let Some(state) = handle.try_state::<AppState>() else {
         return; // init failed / state not managed — nothing to clean up.
     };
+    // C2: FIRST, on the true exit path only, finalize + reap the capture helpers. Never on a mere
+    // window-hide (the tray recording must survive that).
+    if ctx == LIFECYCLE_CTX_APP_EXIT {
+        crate::commands::stop_all_capture(state.inner());
+    }
     // relock_all_inner clears the unlock set, zeroizes the cached KEK, re-blanks all sealed notes,
     // and (as of B12) checkpoints the WAL.
     if let Err(e) = crate::commands::relock_all_inner(state.inner()) {

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -529,6 +529,13 @@ where
     let total = resp.content_length();
 
     let part = dest.with_extension("part");
+    // R1: guard the `.part` so ANY early return below — a mid-stream body/write/flush error, a
+    // truncated (empty) body, or a task drop — removes the partial file instead of orphaning up to
+    // ~3.1 GB on disk. `disarm()`ed ONLY after the successful atomic rename (the part no longer
+    // exists then, so it's a no-op either way — but disarming keeps the log honest). The sync
+    // `std::fs::remove_file` in Drop is safe here (best-effort cleanup of a small metadata op).
+    let mut guard = PartFileGuard::new(part.clone());
+
     let mut file = tokio::fs::File::create(&part)
         .await
         .map_err(|e| AppError::Transcribe(format!("create model temp file: {e}")))?;
@@ -550,7 +557,7 @@ where
     drop(file);
 
     if downloaded == 0 {
-        let _ = tokio::fs::remove_file(&part).await;
+        // The guard removes the empty `.part` on the early return below.
         return Err(AppError::Transcribe(
             "model download returned empty body".into(),
         ));
@@ -558,6 +565,8 @@ where
     tokio::fs::rename(&part, dest)
         .await
         .map_err(|e| AppError::Transcribe(format!("rename model file: {e}")))?;
+    // Renamed successfully — the `.part` is gone; don't let the guard log/try to remove it.
+    guard.disarm();
 
     tracing::info!(
         target: "transcribe",
@@ -566,6 +575,72 @@ where
         "whisper model ready"
     );
     Ok(())
+}
+
+/// RAII guard that removes a partial `<model>.part` download file on drop unless [`disarm`]ed after
+/// the successful atomic rename (R1). Guarantees a mid-stream error / aborted model switch never
+/// leaves multi-GB residue: every `?` early return in [`download_model_streaming`] unwinds through
+/// this drop. Best-effort + panic-free (a failed remove is ignored — startup [`sweep_stale_model_parts`]
+/// is the crash/force-quit safety net). No PII: the `.part` path carries only a model filename.
+struct PartFileGuard {
+    part: PathBuf,
+    armed: bool,
+}
+
+impl PartFileGuard {
+    fn new(part: PathBuf) -> Self {
+        Self { part, armed: true }
+    }
+
+    /// Called after the successful rename (the `.part` no longer exists) so drop is a no-op.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PartFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.part);
+        }
+    }
+}
+
+/// Best-effort startup sweep: remove any STALE `*.part` download residue in `models_dir` left by a
+/// crash / force-quit / aborted model switch mid-download (up to ~3.1 GB per orphan). Only removes a
+/// `.part` whose mtime is OLDER than [`STALE_PART_AGE_SECS`] so it can NEVER race a live in-progress
+/// download (whose `.part` mtime stays fresh). This is the only thing that reclaims crash orphans —
+/// the in-process [`PartFileGuard`] covers only clean error returns. Panic-free; logs a COUNT only
+/// (no PII — a model `.part` name carries a whisper model id, nothing user-authored).
+pub fn sweep_stale_model_parts(models_dir: &Path) {
+    /// A `.part` older than 1 h cannot belong to a live download — the streaming writer touches its
+    /// file on every chunk, so a real in-progress fetch keeps the mtime fresh.
+    const STALE_PART_AGE_SECS: u64 = 3600;
+    let Ok(entries) = std::fs::read_dir(models_dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        // Match the `.part` EXTENSION (covers `ggml-tiny.part` from `with_extension("part")` and any
+        // `<name>.bin.part` shape). Never touch a real model file.
+        if entry.path().extension().and_then(|e| e.to_str()) != Some("part") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|age| age.as_secs() > STALE_PART_AGE_SECS)
+            .unwrap_or(false);
+        if stale && std::fs::remove_file(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::warn!(target: "transcribe", removed, "swept stale model .part download residue at startup");
+    }
 }
 
 /// Non-progress download for the VAD + diarization models (small, no UI progress bar). Delegates to
@@ -577,6 +652,151 @@ async fn download_model(url: &str, dest: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// R1 helper: make a unique temp dir for a `.part`/sweep fixture.
+    fn parts_tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-model-parts-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// R1 (RED-before-GREEN, mid-stream error path): a download that fails PART-WAY through the body
+    /// must leave NO `.part` residue. Before the fix the write/flush/body loop returned via `?` and
+    /// orphaned a multi-GB partial; the `PartFileGuard` now removes it on any early return.
+    ///
+    /// Drives the REAL `download_model_streaming` against a local socket that advertises a large
+    /// `Content-Length` but closes after a few bytes → `reqwest`'s `chunk()` errors mid-stream. On the
+    /// unpatched loop the `.part` survives (FAIL); with the guard it is gone (PASS).
+    #[tokio::test]
+    async fn download_removes_part_on_midstream_error() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Serve ONE connection: promise 1 MB, send 8 bytes, then drop the socket → truncated body.
+        let server = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf); // consume the request line/headers
+                let _ = sock.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\n",
+                );
+                let _ = sock.write_all(b"PARTIAL0");
+                let _ = sock.flush();
+                // Drop `sock` → connection closes with only 8/1000000 bytes delivered.
+            }
+        });
+
+        let dir = parts_tmp_dir("midstream");
+        let dest = dir.join("ggml-tiny.bin");
+        let url = format!("http://{addr}/model.bin");
+
+        let res = download_model_streaming(&url, &dest, |_, _| {}).await;
+        assert!(res.is_err(), "a truncated body must surface an error");
+
+        // `with_extension("part")` maps `ggml-tiny.bin` → `ggml-tiny.part`.
+        let part = dest.with_extension("part");
+        assert!(
+            !part.exists(),
+            "the partial `.part` must be removed on a mid-stream error (no multi-GB orphan)"
+        );
+        assert!(!dest.exists(), "no model file is produced from a failed download");
+
+        let _ = server.join();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// R1 unit: the `PartFileGuard` removes the `.part` on drop UNLESS disarmed after a successful
+    /// rename. This is the exact contract the mid-stream test above relies on.
+    #[test]
+    fn part_file_guard_removes_unless_disarmed() {
+        let dir = parts_tmp_dir("guard");
+        // (a) armed guard → drop removes the file.
+        let armed = dir.join("armed.part");
+        std::fs::write(&armed, b"partial").unwrap();
+        {
+            let _g = PartFileGuard::new(armed.clone());
+        }
+        assert!(!armed.exists(), "an armed guard removes the `.part` on drop");
+
+        // (b) disarmed guard → drop leaves the file (success path already renamed it away).
+        let kept = dir.join("kept.part");
+        std::fs::write(&kept, b"renamed-away").unwrap();
+        {
+            let mut g = PartFileGuard::new(kept.clone());
+            g.disarm();
+        }
+        assert!(kept.exists(), "a disarmed guard must NOT remove the file");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// R1 (RED-before-GREEN, crash-orphan path): the startup sweep reclaims a STALE `.part` (old
+    /// mtime — a crash/force-quit orphan) while leaving a real `.bin` model AND a FRESH `.part` (a
+    /// possibly-live download) untouched. Before the fix nothing ever reclaimed a crash orphan.
+    #[test]
+    fn sweep_removes_stale_part_keeps_bin_and_fresh_part() {
+        let dir = parts_tmp_dir("sweep");
+
+        // A stale orphan: old mtime (2 h) → must be swept.
+        let stale = dir.join("ggml-tiny.bin.part");
+        std::fs::write(&stale, b"orphaned-partial").unwrap();
+        let two_hours_ago =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(2 * 3600);
+        filetime_set(&stale, two_hours_ago);
+
+        // A fresh `.part` (possibly a live in-progress download) → must survive.
+        let fresh = dir.join("ggml-small.part");
+        std::fs::write(&fresh, b"in-progress").unwrap();
+
+        // A real model file → must survive.
+        let real = dir.join("ggml-tiny.bin");
+        std::fs::write(&real, b"MODEL-BYTES").unwrap();
+
+        sweep_stale_model_parts(&dir);
+
+        assert!(!stale.exists(), "a stale `.part` orphan must be swept");
+        assert!(fresh.exists(), "a fresh `.part` (possibly live) must NOT be raced/removed");
+        assert!(real.exists(), "a real model `.bin` must never be touched");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Set a file's mtime to `when` via a truncate-in-place touch fallback. `std::fs` has no mtime
+    /// setter, so we age the fixture with a no-dep `utimensat`-free trick: rewrite the file, then
+    /// use the FS's own timestamp by sleeping is too slow — instead we spawn `/usr/bin/touch -t`.
+    /// macOS-only test helper (this crate is macOS-first; tests run on the same platform).
+    fn filetime_set(path: &Path, when: std::time::SystemTime) {
+        let secs = when
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // `touch -t [[CC]YY]MMDDhhmm[.SS]` — format the aged timestamp in local-agnostic UTC via
+        // a simple civil-time breakdown is overkill; use `-d @epoch`-free `-t` with a computed
+        // value. Simplest robust path: `touch -A -<seconds>` is not portable, so use `-t`.
+        // Build the `-t` stamp from the epoch using `date -r`.
+        let stamp = std::process::Command::new("/bin/date")
+            .args(["-r", &secs.to_string(), "+%Y%m%d%H%M.%S"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .expect("date -r must format the aged mtime");
+        let ok = std::process::Command::new("/usr/bin/touch")
+            .args(["-t", &stamp])
+            .arg(path)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "touch -t must age the fixture mtime");
+    }
 
     #[test]
     fn english_resolves_en_only_build_for_small_sizes() {


### PR DESCRIPTION
## What

Six confirmed backend resource-lifecycle leaks from a whole-tree audit, following the brain-sidecar extraction (#238). All backend, no FE changes.

The audit was deliberately adversarial: of 9 suspected areas, **7 were adjudicated FALSE and dropped** — including the whisper `WhisperContext` residency (never cached in AppState; build-and-drop per run; stop-join-old-before-new — the OOM-class suspicion was clean), the FE `ipc.on*` per-component listeners (all release their `UnlistenFn` via `DestroyRef`), the SQLite vec0 prune (all delete paths purge in-tx) + WAL checkpoint, and a `settings.store` double-subscribe. Only the six below are real.

## The fixes

- **R1 ⭐ (highest value)** — a whisper/model download orphaned a multi-GB `.part` on ANY mid-stream error (up to ~3 GB, never reclaimed — no error-path cleanup, no sweep). A RAII `PartFileGuard` now removes it on every early return (`disarm()`ed only after the successful atomic rename), and a startup sweep reclaims crash/force-quit orphans (mtime > 1h so a live download is never raced). `transcribe/model.rs` + `lib.rs`.
- **C1** — `SystemAudioRecorder` / `AecRecorder` held a `Child` with no `Drop`, so a clean quit mid-recording detached the Swift capture helper (bounded only by its 4h self-cap + the next-launch reaper). Both now get a best-effort `Drop` (SIGTERM + reap); `stop()` runs under `ManuallyDrop` so a normal stop reaps exactly once (no second SIGTERM to a possibly-recycled pid). `audio/system.rs`, `audio/aec.rs`.
- **C2** — `relock_and_zeroize_on_lifecycle` now `stop_all_capture()`s on the TRUE app-exit only (gated on the `LIFECYCLE_CTX_APP_EXIT` constant); a window-hide that keeps the tray recording alive never stops capture. `lib.rs` + `commands.rs`.
- **C3** — the calendar sidecar's `try_wait` Err arm killed without `wait()` (zombie); it now reaps via a shared `kill_and_reap`, symmetric with the timeout arm. `calendar.rs`.
- **R2** — a SIGKILL between an Obsidian export's fsync and its atomic rename orphaned a temp dotfile in the vault. A startup sweep removes orphans whose pid is dead OR whose mtime > 1h (skips `.obsidian`/`.trash`, count-only logging). The temp is now namespaced `.<...>.<pid>.murmur.tmp` so the sweep is **provably Murmur-only** and can never touch a foreign third-party dotfile (the residual both reviewers flagged). `export/obsidian.rs` + `lib.rs`.
- **C4** — `delete_meeting` removed only the plaintext WAV, orphaning the `.enc` twin when the meeting was session-unlocked in a locked folder; it now removes both forms (matching the masters block). Disk-residue only — not a security leak (the plaintext was already removed). `commands.rs`.

All six are teardown / sweep / delete cleanup — no new read/export/seal path, no gate change.

## Verification

- `cargo test --lib` — green (~1477+ pass), **11 new RED-before-GREEN tests** (the reap/zombie ones proven against the kernel via `ps`/`kill`).
- `bash scripts/ci.sh` (E2E skipped) — all gates green (clippy `-D warnings` included).
- **adversarial-verifier: PASS** — RED-before-GREEN reproduced on 5/6; the two highest-risk items proven independently: **C1 `ManuallyDrop` soundness** (standalone Drop-counter replica: clean `stop()` → struct-Drop 0×, fields drop exactly once — no double-free / no second SIGTERM) and **C2 window-hide safety** (ctx constants, fails closed).
- **lock-security-reviewer: PASS** — R2 stats+unlinks only (never reads/serves dotfile content; live-export unraceable); C4 is this-meeting-scoped (uniquely-named `{meeting_id}.wav`/`.enc`, no over-delete; shared meetings carry no audio); the rebased `lib.rs` lifecycle still zeroizes the KEK + relocks + WAL-checkpoints on both paths; no seal/gate/crypto call site touched.
- Rebased onto the sidecar-merged trunk; the one `lib.rs` conflict (this batch's `stop_all_capture` vs the sidecar's `kill_on_quit` in `ExitRequested`) resolved to run relock + `stop_all_capture` FIRST, then `kill_on_quit()`.

### Needs a signed Mac (honest bar)
The real SIGTERM of the signed Swift capture helpers flushing their WAVs (C1/C2), the real EventKit calendar sidecar wedge (C3), and a real SIGKILL-between-fsync-and-rename orphan (R1/R2) verify only on a signed build — the tests use `/bin/sleep` stand-ins + fixtures (which DO prove the reap/sweep/slot-clear plumbing against the kernel).
