### PR TITLE
fix(brain): org key-grants key on server user_id, not email (live 404 fix)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12018,7 +12018,7 @@ async fn refresh_session(state: &AppState, stale_token: &str) -> Result<String, 
     // changed AND is now fresh, use it — do not spend our (now-stale) refresh token a second time.
     // The session (NOT the Keychain) is the source of truth for the current refresh token — see the
     // RAM-first rationale above; the identity fields ride along for the best-effort persist below.
-    let (refresh_token, device_id, email, account_id, generation) = {
+    let (refresh_token, device_id, email, account_id, server_user_id, generation) = {
         let g = state
             .account_session
             .lock()
@@ -12037,6 +12037,7 @@ async fn refresh_session(state: &AppState, stale_token: &str) -> Result<String, 
             s.device_id.clone(),
             s.email.clone(),
             s.account_id.clone(),
+            s.server_user_id.clone(),
             s.generation,
         )
     };
@@ -12127,6 +12128,7 @@ async fn refresh_session(state: &AppState, stale_token: &str) -> Result<String, 
         device_id,
         email,
         account_id,
+        server_user_id,
         generation,
         access_expires_at: Some(rotated.access_expires_at.clone()),
     }) {
@@ -12379,6 +12381,9 @@ pub async fn account_login(
         ));
     }
     let access_expires_at = finish.access_expires_at.clone();
+    // The account's stable server user id (UUID) — the client keys org grants on THIS, not the email.
+    // A pre-fix server omits it (`None`) ⇒ org sharing prompts a re-login once the server ships it.
+    let server_user_id = finish.user_id.clone();
     let (Some(access_token), Some(refresh_token), Some(device_id), Some(key_material)) = (
         finish.access_token,
         finish.refresh_token,
@@ -12401,6 +12406,7 @@ pub async fn account_login(
         device_id: device_id.clone(),
         email: acct_id.clone(),
         account_id: acct_id.clone(),
+        server_user_id: server_user_id.clone(),
         generation,
         access_expires_at: access_expires_at.clone(),
     })?;
@@ -12414,6 +12420,7 @@ pub async fn account_login(
         *session = Some(crate::share::AccountSession {
             account_id: acct_id.clone(),
             email: acct_id.clone(),
+            server_user_id,
             device_id,
             mk: Zeroizing::new(*mk),
             generation,
@@ -12507,6 +12514,7 @@ pub async fn unlock_sharing_with_biometric(
         *session = Some(crate::share::AccountSession {
             account_id: tokens.account_id,
             email: tokens.email,
+            server_user_id: tokens.server_user_id,
             device_id: tokens.device_id,
             mk,
             generation: tokens.generation,
@@ -12977,6 +12985,24 @@ async fn require_session_mk(state: &AppState) -> Result<SessionMk, AppError> {
         zeroize::Zeroizing::new(*s.mk),
         access_token,
     ))
+}
+
+/// The account's stable SERVER USER ID (UUID) for org key-grants, from the live session. Errors with a
+/// clear re-login prompt when the session predates the `server_user_id` field (a login before the
+/// server started returning it on `LoginFinishResponse`). Org grants MUST key on this UUID — matching
+/// `org_members.user_id` — never the email `account_id` (the `parse_org_id` 404 root cause, 2026-07-11).
+fn session_server_user_id(state: &AppState) -> Result<String, AppError> {
+    let g = state
+        .account_session
+        .lock()
+        .map_err(|_| AppError::Storage("account-session mutex poisoned".into()))?;
+    let s = crate::share::require_login(&g)?;
+    s.server_user_id.clone().ok_or_else(|| {
+        AppError::Unavailable(
+            "sign out and sign back in to enable organization sharing (your saved session predates it)"
+                .into(),
+        )
+    })
 }
 
 /// The configured vault path (empty ⇒ `None`), read over `&AppState`.
@@ -15006,6 +15032,7 @@ mod lifecycle_tests {
         *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
             account_id: "acct-1".into(),
             email: "user@example.com".into(),
+            server_user_id: None,
             device_id: "dev-1".into(),
             mk: Zeroizing::new([7u8; 32]),
             generation: 1,
@@ -15056,6 +15083,7 @@ mod lifecycle_tests {
         *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
             account_id: "acct-1".into(),
             email: "user@example.com".into(),
+            server_user_id: None,
             device_id: "dev-1".into(),
             mk: Zeroizing::new([7u8; 32]),
             generation: 1,
@@ -21648,6 +21676,40 @@ mod lifecycle_tests {
         assert!(state.db.get_org_state("org-1").unwrap().is_none());
     }
 
+    /// REGRESSION (2026-07-11 live 404): org key-grants MUST key on the stable SERVER USER ID (a UUID),
+    /// never the email `account_id`. A login sets `account_id = email` (the mk-wrap AAD depends on it),
+    /// and `LoginFinishResponse` used to omit the user id, so the app sent the EMAIL as the grant
+    /// `user_id` → the server's `parse_org_id` rejected it 404 ("Start a shared brain" failed).
+    /// `session_server_user_id` now returns the UUID from the session, and fails CLOSED with a re-login
+    /// prompt (never the email) when a pre-fix session lacks it.
+    #[test]
+    fn org_identity_uses_server_user_id_not_email() {
+        let state = build_state("org-identity");
+        let uuid = "c534b6d2-02c1-4c2c-a256-3af8592b1567";
+        let set_session = |server_user_id: Option<String>| {
+            *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+                account_id: "user@example.com".into(), // the EMAIL — must NEVER be the grant key
+                email: "user@example.com".into(),
+                server_user_id,
+                device_id: "dev-1".into(),
+                mk: Zeroizing::new([7u8; 32]),
+                generation: 1,
+                access_token: "a".into(),
+                access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+                refresh_token: "r".into(),
+            });
+        };
+        // UUID present ⇒ org identity is the UUID, not the email.
+        set_session(Some(uuid.into()));
+        assert_eq!(session_server_user_id(&state).unwrap(), uuid);
+        // Absent (a session persisted before the fix) ⇒ a clear re-login prompt, never the email.
+        set_session(None);
+        assert!(matches!(
+            session_server_user_id(&state),
+            Err(AppError::Unavailable(_))
+        ));
+    }
+
     /// `active_org_shares_for_folder` returns the folder's ACTIVE (non-revoked/failed) org shares for
     /// the lock×shares dialog — meeting-anchored AND note-anchored — and excludes revoked ones.
     #[test]
@@ -21933,6 +21995,8 @@ async fn acquire_org_ock(
     // Miss → unwrap from the caller's server-relayed grant. Needs the MK session (to derive our
     // identity keypair) + a valid bearer.
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
+    // Grants are keyed by the server user id (UUID) — NOT the email `account_id`.
+    let server_user_id = session_server_user_id(state)?;
     let base = share_base_url(state)?;
     let client = crate::share::client::ShareClient::new(&base)?;
     let recipient = crate::e2ee::keys::derive_identity(&mk, &account_id, gen_id)?;
@@ -21943,7 +22007,7 @@ async fn acquire_org_ock(
     let grant = grants
         .grants
         .into_iter()
-        .find(|g| g.generation == generation && g.user_id == account_id)
+        .find(|g| g.generation == generation && g.user_id == server_user_id)
         .ok_or_else(|| {
             AppError::Unavailable(format!(
                 "no org key grant for generation {generation} — ask the owner to re-share the key"
@@ -22017,6 +22081,8 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
     }
     let base = share_base_url(state)?;
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
+    // The server DB key for grants (matches `org_members.user_id`) — a UUID, NOT the email `account_id`.
+    let server_user_id = session_server_user_id(state)?;
     let client = crate::share::client::ShareClient::new(&base)?;
 
     let created = client.org_create(&access_token, &name).await?;
@@ -22031,7 +22097,7 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
         &created.org_id,
         created.current_generation,
         &owner.pk_enc,
-        &account_id, // recipient acct id = our server user id (grants are keyed by user_id)
+        &owner_fp, // recipient_acct_id = our FINGERPRINT (the crypto binding `acquire_org_ock` opens with)
         &owner,
         &owner_fp,
         gen_id,
@@ -22041,7 +22107,8 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
             &access_token,
             &created.org_id,
             vec![crate::share::org_dto::KeyGrantInput {
-                user_id: account_id.clone(),
+                // DB key = the server user id (UUID), so the grant links to our `org_members` row.
+                user_id: server_user_id.clone(),
                 generation: created.current_generation,
                 wrapped_key: grant.wrapped_key,
                 grant_sig: grant.grant_sig,
@@ -22188,12 +22255,15 @@ pub(crate) async fn org_invite_member_inner(state: &AppState, email: String) -> 
     let ock = acquire_org_ock(state, &org.org_id, generation).await?;
     let owner = crate::e2ee::keys::derive_identity(&mk, &account_id, gen_id)?;
     let owner_fp = crate::e2ee::key_fingerprint(&owner.pk_enc, &owner.pk_sig);
+    // recipient_acct_id = the member's FINGERPRINT (the crypto binding THEY open with via `self_fp` in
+    // `acquire_org_ock`); the DB grant key stays their server user id (`added.user_id`).
+    let member_fp = crate::e2ee::key_fingerprint(&key.pk_enc, &key.pk_sig);
     let grant = crate::e2ee::org::wrap_ock_for_member(
         &ock,
         &org.org_id,
         generation,
         &key.pk_enc,
-        &added.user_id,
+        &member_fp,
         &owner,
         &owner_fp,
         gen_id,
@@ -22255,6 +22325,8 @@ pub(crate) async fn org_remove_member_inner(state: &AppState, user_id: String) -
     };
     let base = share_base_url(state)?;
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
+    // DB grant key = the owner's server user id (UUID), not the email `account_id`.
+    let server_user_id = session_server_user_id(state)?;
     let client = crate::share::client::ShareClient::new(&base)?;
 
     client
@@ -22282,7 +22354,7 @@ pub(crate) async fn org_remove_member_inner(state: &AppState, user_id: String) -
         &org.org_id,
         new_gen,
         &owner.pk_enc,
-        &account_id,
+        &owner_fp, // recipient_acct_id = our FINGERPRINT (matches `acquire_org_ock`'s open)
         &owner,
         &owner_fp,
         gen_id,
@@ -22292,7 +22364,7 @@ pub(crate) async fn org_remove_member_inner(state: &AppState, user_id: String) -
             &access_token,
             &org.org_id,
             vec![crate::share::org_dto::KeyGrantInput {
-                user_id: account_id.clone(),
+                user_id: server_user_id.clone(),
                 generation: new_gen,
                 wrapped_key: owner_grant.wrapped_key,
                 grant_sig: owner_grant.grant_sig,

--- a/src-tauri/src/share/mod.rs
+++ b/src-tauri/src/share/mod.rs
@@ -40,8 +40,15 @@ const KC_REFRESH_TOKEN: &str = "murmur_share_refresh_token";
 const KC_DEVICE_ID: &str = "murmur_share_device_id";
 /// Keychain account name for the account email (non-secret, but session-scoped; kept out of SQLite).
 const KC_ACCOUNT_EMAIL: &str = "murmur_share_account_email";
-/// Keychain account name for the account id (server user id).
+/// Keychain account name for the account id. NOTE: this is the account's EMAIL — it is baked into the
+/// `mk_wrap_pw` AAD + the identity-key derivation at signup, so it MUST stay the email (a login can't
+/// re-derive the MK otherwise). It is NOT the server user id despite the historical name.
 const KC_ACCOUNT_ID: &str = "murmur_share_account_id";
+/// Keychain account name for the account's stable SERVER USER ID (a UUID). Distinct from
+/// `KC_ACCOUNT_ID` (the email): org key-grants key on this UUID (matching `org_members.user_id`). A
+/// login learns it from `LoginFinishResponse.user_id`; absent for sessions persisted before this
+/// field existed ⇒ `None` ⇒ org sharing prompts a re-login to backfill it.
+const KC_SERVER_USER_ID: &str = "murmur_share_server_user_id";
 /// Keychain account name for the identity-key GENERATION (non-secret key-rotation counter). Persisted
 /// alongside the tokens so a biometric session restore can rebuild the identity-slot AAD without a
 /// re-login — the MK itself is cached separately + biometric-gated (see `secrets::keychain`).
@@ -71,6 +78,10 @@ pub struct PersistedTokens {
     pub device_id: String,
     pub email: String,
     pub account_id: String,
+    /// The account's stable server user id (UUID), from `LoginFinishResponse.user_id`. Org key-grants
+    /// key on it. `None` for a session persisted before this field existed ⇒ org sharing prompts a
+    /// re-login to backfill it (see `load_tokens`).
+    pub server_user_id: Option<String>,
     /// The identity-key generation at login (non-secret rotation counter). Needed to rebuild the
     /// `AccountSession` on a biometric restore; defaults to 1 for sessions persisted before this field
     /// existed (see `load_tokens`).
@@ -89,6 +100,11 @@ pub fn store_tokens(t: &PersistedTokens) -> Result<()> {
     crate::secrets::set_secret(KC_DEVICE_ID, &t.device_id)?;
     crate::secrets::set_secret(KC_ACCOUNT_EMAIL, &t.email)?;
     crate::secrets::set_secret(KC_ACCOUNT_ID, &t.account_id)?;
+    // The server user id (UUID) when known; otherwise DELETE any stale prior value.
+    match &t.server_user_id {
+        Some(uid) => crate::secrets::set_secret(KC_SERVER_USER_ID, uid)?,
+        None => crate::secrets::delete_secret(KC_SERVER_USER_ID)?,
+    }
     crate::secrets::set_secret(KC_GENERATION, &t.generation.to_string())?;
     // Write the expiry when known; otherwise DELETE any stale prior value so a refresh that omitted it
     // never leaves an old expiry behind (which would suppress the next proactive refresh).
@@ -120,12 +136,15 @@ pub fn load_tokens() -> Result<Option<PersistedTokens>> {
         .unwrap_or(1);
     // Absent for a session persisted before this field existed ⇒ `None` ⇒ refresh on the next share op.
     let access_expires_at = crate::secrets::get_secret(KC_ACCESS_EXPIRES_AT)?;
+    // `None` for a session persisted before this field existed ⇒ org sharing prompts a re-login.
+    let server_user_id = crate::secrets::get_secret(KC_SERVER_USER_ID)?;
     Ok(Some(PersistedTokens {
         access_token,
         refresh_token,
         device_id,
         email,
         account_id,
+        server_user_id,
         generation,
         access_expires_at,
     }))
@@ -143,6 +162,7 @@ pub fn clear_tokens() -> Result<()> {
     crate::secrets::delete_secret(KC_DEVICE_ID)?;
     crate::secrets::delete_secret(KC_ACCOUNT_EMAIL)?;
     crate::secrets::delete_secret(KC_ACCOUNT_ID)?;
+    crate::secrets::delete_secret(KC_SERVER_USER_ID)?;
     crate::secrets::delete_secret(KC_GENERATION)?;
     crate::secrets::delete_secret(KC_ACCESS_EXPIRES_AT)?;
     Ok(())
@@ -155,6 +175,9 @@ pub fn clear_tokens() -> Result<()> {
 pub struct AccountSession {
     pub account_id: String,
     pub email: String,
+    /// The account's stable server user id (UUID) for org key-grants. `None` for a session restored
+    /// from tokens persisted before this field existed ⇒ org sharing prompts a re-login to backfill it.
+    pub server_user_id: Option<String>,
     pub device_id: String,
     /// The account master key `MK`, unwrapped at login from the server's `mk_wrap_pw` via
     /// `keys::derive_kek_pw(export_key)`. Zeroized on drop.


### PR DESCRIPTION
## Fix: org key-grants keyed on the server user id, not the email (live 404 root cause)

Creating a shared brain failed live with `org-put-key-grants: rejected (404)`. Root cause, traced end-to-end (code + the live Railway DB):

- On **login**, the app sets `account_id = email` (the email is baked into the `mk_wrap_pw` AAD + the identity-key derivation, so it MUST stay the email), because `LoginFinishResponse` carried **no user id**.
- `org_create` then sent that **email** as the key-grant's `user_id`, and the server's `parse_org_id(&g.user_id)` — which expects a UUID and returns **404** on a parse miss — rejected it. The org + owner membership were created (the server derives membership from the *token*, a real UUID), but the grant never stored.
- A second, latent bug: `org_create`/`invite` wrapped the grant's `recipient_acct_id` with the email/UUID, while `acquire_org_ock` opens with the **fingerprint** — a binding mismatch that would have blocked the owner from opening their own grant even once the 404 was fixed.

This never surfaced in tests: the server integration test drives the API with a real UUID, and no headless test exercises the real OPAQUE-login → org-grant seam (the signed-build/live boundary flagged at merge).

### The fix (pairs with murmur-io/murmur-server#10, already merged)
- **Server (#10):** `LoginFinishResponse` now returns `user_id` (a UUID), populated in `issue_full_login`; the login test asserts every no-2FA login carries a UUID.
- **Client (this PR):**
  - A new **`server_user_id`** (the UUID) is threaded through `PersistedTokens` / `AccountSession` / store·load·clear·refresh·biometric-restore, set from `LoginFinishResponse.user_id`. Kept **distinct** from `account_id` (the email) so the MK-wrap AAD + identity derivation are untouched.
  - `session_server_user_id()` returns it, failing **closed** with a clear "sign out and back in" prompt for a session persisted before the fix (never falling back to the email).
  - **DB grant key** (`KeyGrantInput.user_id` + the `acquire_org_ock` find) now uses `server_user_id` (matches `org_members.user_id`).
  - **Crypto binding** (`wrap_ock_for_member`'s `recipient_acct_id`) now uses the recipient **fingerprint** in create/invite/remove — the exact value `acquire_org_ock` opens with — so a grant round-trips.

### Verified
- `cargo test --lib` green incl. the new regression `org_identity_uses_server_user_id_not_email` (org identity is the UUID, and a pre-fix session fails closed to a re-login, never the email). `scripts/ci.sh` green.
- **Needs the live redeploy + a rebuilt app to prove end-to-end** (real OPAQUE login → org create → grant stored → openable across two accounts) — the honest signed-build boundary. The server half is deployed; the app half ships with the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
