### PR TITLE
fix: remediate 2026-07-11 unreleased-audit findings (2 criticals + majors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 /playwright-report/
 /blob-report/
 /.playwright/
+# E2E-generated screenshot artifacts (verification output, never committed)
+e2e/**/__screens__/

--- a/docs/research/2026-07-11-remediation-plan.md
+++ b/docs/research/2026-07-11-remediation-plan.md
@@ -1,0 +1,222 @@
+# Remediation plan — unreleased audit v0.8.0..HEAD (2026-07-11)
+
+Source audit: `docs/research/2026-07-11-unreleased-audit-v0.8.0-HEAD.md`. Every item below has a
+root cause traced to a symbol, a concrete fix, a RED→GREEN verification, and the owning
+implementer + required verifier. Lock/crypto items are gated by `lock-security-reviewer`; every
+item's PASS/FAIL is owned by `adversarial-verifier`, never the implementer.
+
+Execution is autonomous, in dependency-ordered waves, on a feature branch → PR → merge to `murmur`.
+
+## Live repro added to scope — org creation 404 (`org-put-key-grants: rejected (404)`)
+
+**Root cause (traced end-to-end, = SB-1):** `org_create_inner` (commands.rs) sends the owner
+self-grant with `user_id: account_id.clone()`, and `account_id` is the **email**
+(`account_login`: `acct_id = email.trim()`). The server `put_key_grants` does
+`let target = parse_org_id(&g.user_id)?` where `parse_org_id = Uuid::parse_str(..).map_err(NotFound)`
+→ parsing an email as a UUID fails → uniform **404**. The server half is already fixed
+(`murmur-io/murmur-server` commit `b9b08a4`: `LoginFinishResponse.user_id` now returned) but (a)
+the client never consumes it and (b) the deployed Railway server may predate it. This is the same
+bug as SB-1 and is fixed together.
+
+---
+
+## Wave 1 — Lock / seal blockers (backend, `rust-tauri-dev`; gate: lock-security-reviewer + adversarial-verifier)
+
+All in `src-tauri/src/commands.rs` / `storage/db.rs`; serialized (same files).
+
+### NOTES-1 (CRITICAL) — `delete_note_folder` deletes authored notes; UI promises reparent
+- Fix: `delete_folder_inner` must reparent `documents(kind='note')` rows to the default note-folder
+  before folder deletion (mirror the `notes`-table reparent), OR the FE must stop promising a move.
+  Chosen: **reparent authored notes** (matches the UI copy + the notes.service doc) — move
+  `documents.folder_id` to `ensure_default_note_folder()` and rewrite `exported_path`, then delete
+  the empty folder. Never `DELETE FROM documents` on folder delete.
+- RED: unit test — create a note in folder F, `delete_note_folder(F)`, assert the note row still
+  exists under the default folder and its `.md` moved (not deleted).
+
+### NOTES-2 (CRITICAL) — note-folder move/rename strands `documents.exported_path` → plaintext `.md` survives lock
+- Fix: `reparent_note_folder_paths` / `Db::reparent_note_folder` must rewrite each contained
+  `documents.exported_path` to the new vault path (the physical `fs::rename` already moves the files;
+  the DB path must follow) so `lock_folder_inner`'s plaintext-`.md` cleanup deletes the REAL file.
+- RED: unit test — note in a locked-then-unlocked folder, move the folder, lock it, assert no
+  plaintext `.md` remains at either the old or new path and the DB `exported_path` matches disk.
+
+### NOTES-3 (MAJOR) — `Db::reparent_note_folder` byte-vs-char `substr` corrupts non-ASCII paths
+- Fix: stop passing Rust `old_path.len()+1` (bytes) into SQLite `substr` (chars). Either compute the
+  char count (`old_path.chars().count()+1`) or rewrite descendants with a bound-parameter
+  string-concat that doesn't rely on `substr` offsets. Prefer the char-count fix, guarded by a test.
+- RED: unit test — folder "Notes/Sprzedaż" with a child, rename parent, assert the child path is
+  `new || '/' || 'Child'` (leading slash intact), for a multi-byte name.
+
+### SEAM-F1 (MAJOR) — `generate_timeline` leaves plaintext timeline at rest after relock
+- Fix: bring `generate_timeline` under the #229/#234 seal discipline: acquire `lifecycle_guard`,
+  re-check the seal epoch across the provider `.await`, and if the folder is locked (session-unlocked)
+  seal the generated timeline under the folder CK via the existing `seal_timeline` path instead of a
+  bare `set_timeline_data`. If a seal landed mid-generation, discard the plaintext (don't persist).
+- RED: unit/integration test — session-unlock a locked folder, generate a timeline, relock, assert
+  the `timeline` row has an encrypted `data_blob` and no plaintext `data`.
+
+### SEAM-F2 (MAJOR) — `rename_speaker` edit destroyed on relock
+- Fix: route the renamed-timeline write through the seal-on-write helper (reseal under the cached CK
+  when the folder is session-unlocked-locked), mirroring `upsert_note_reseal_if_locked`.
+- RED: unit test — rename a speaker in a session-unlocked locked folder, relock, unlock, assert the
+  rename persisted (round-trips through the sealed blob).
+
+### LOCK-SHARE-INGEST-1 (MAJOR) — share accept into a locked folder writes plaintext that survives relock
+- Fix: `ingest_shared_note` must route its note write through `upsert_note_reseal_if_locked` (not the
+  raw `Db::upsert_note`) and under `lifecycle_guard`, and NOT write a plaintext `.md` into a
+  session-unlocked locked target — seal it like every other write path.
+- RED: unit test — accept a share into a session-unlocked locked folder, relock, assert no plaintext
+  note row/`.md` at rest (only the sealed blob).
+
+---
+
+## Wave 2 — Shared Brain crypto + server (backend + server; gate: lock-security-reviewer + adversarial-verifier)
+
+### SB-1 (MAJOR, = live 404) — key grants on the server `user_id`, not the email
+- Client fix (does NOT touch `account_id`, which stays the email for MK/identity AAD):
+  1. `LoginFinishResponse` (client DTO in `share/`) gains `user_id: Option<String>`.
+  2. `AccountSession` + `PersistedTokens` gain `server_user_id: String`; persisted to Keychain and
+     restored on biometric/restart (fallback: empty → forces a re-login before org ops, never the
+     email).
+  3. `account_login` stores `finish.user_id`; `require_session_mk` (or a new accessor) exposes it.
+  4. `org_create_inner`: grant `user_id` = `server_user_id`; wrap recipient + `grant_sig`
+     recipient_acct_id = `server_user_id`.
+  5. `acquire_org_ock`: match `g.user_id == server_user_id` and reconstruct the signed view with
+     recipient = `server_user_id` (+ correct generation).
+  6. `org_invite_member_inner`: confirm the grant target + signed recipient use the added member's
+     server `user_id` (AddMemberResponse.user_id, already a UUID) consistently with open.
+- Server: `b9b08a4` already returns `user_id`; **deploy it to Railway** (deploy-murmur-server skill)
+  and confirm `/v1/auth/login/finish` returns `userId`.
+- RED: (a) a client unit test asserting the KeyGrantInput.user_id is a UUID (server_user_id), not an
+  email; (b) a crypto round-trip test — owner wraps→PUT grant keyed on user_id, a second session
+  (same user_id, fresh MK-from-login) GETs + opens the OCK successfully.
+- MANUAL E2E (real server): create org "Test" succeeds (no 404); re-login recovers the OCK.
+
+### SB-3 (MAJOR) — `org_sweep_pending` retry row amplification
+- Fix: retry must reuse the existing queued/failed `org_shares` row (update in place / dedupe on the
+  logical share key) instead of `insert_org_share` minting a fresh row each attempt; only mark the
+  prior row revoked on success of a REPLACEMENT, not on every retry.
+- RED: unit test — a share whose upload fails N times yields exactly ONE row (state failed), and a
+  later success flips that row to uploaded without a duplicate publish.
+
+### SB-2 (MAJOR) — org provenance unwired (`SourceOrigin::org()` zero call sites)
+- Decision: SB-2 is a missing-feature, not a leak. Two honest options: (a) wire org origin into the
+  Ask `VaultSource` build so the chips reflect reality, or (b) remove the dead `SourceOrigin::org`/
+  `OrgItemSummary`/`Db::org_item_count` + the misleading docs. Choose (b) for this remediation
+  (smallest correct change; wiring real org provenance is a feature, deferred) — delete dead code +
+  fix the doc claims so nothing lies. Re-evaluate during Wave 2 with the code in front of us.
+
+### org_leave replica purge + MCP `org_search` gate (MAJOR-ish, leak/consent)
+- Fix: `org_leave` must purge the decrypted `org_items`/`org_chunks` replica (and vectors) for the
+  left org. MCP `org_search` + the `org_brain_search` agent tool must gate on `org_brain_available`
+  (membership + consent) so a departed/un-consented user can't search org content.
+- RED: unit test — after `org_leave`, `org_search`/`org_brain_search` return nothing and the replica
+  rows are gone.
+
+---
+
+## Wave 3 — Non-lock backend + red E2E + FE (parallel where disjoint)
+
+### TP-F1 (MAJOR, fresh-install regression) — turbo default arms voice-command with no live loop
+- Fix (backend): `begin_voice_command_inner` must refuse/duck-out when there is no live loop
+  (`live_model` is None and no live consumer), OR `start_recording`'s heavy-model arm must guarantee
+  a live consumer (spawn the pinned `small` live loop, not just `spawn_live_pin_download`). Prefer:
+  arm the voice command only when a live transcription consumer exists; otherwise surface a clean
+  "voice needs the live model" state (no wedge). Verify against the shipped fresh-install default
+  (`default_model_size_now` → turbo on ≥12 GB).
+- RED: unit test — fresh-install config (turbo heavy, no pinned small), start recording, assert the
+  voice-command path does not arm a consumer-less generation (no wedge / clean unavailable).
+
+### RED-E2E-1 — `timeline-defer.spec.ts` infinite loop (`deriveTimeline` unvalidated set)
+- Fix (FE): `deriveTimeline` / `loadTimeline` must treat a falsy/empty `generate_timeline` result as
+  a terminal state (set `timelineNeedsGeneration` or `timelineError`), never leave
+  `timeline==null && !error && !needsGeneration` which re-fires `_timelineOnAudioTab` forever. Also
+  add a one-shot latch so the Audio-tab effect cannot re-enter for the same meeting after a resolved
+  empty read.
+- RED: the existing `e2e/detail/timeline-defer.spec.ts` must go green (fires exactly once on Audio).
+
+### MEM-1 (MAJOR) — memory-import "delete to undo" leaves superseded facts closed
+- Fix (backend): either (a) `import_memories_inner` records the invalidated fact ids so
+  `delete_meeting` on the synthetic import can reopen them, or (b) scope the reconcile so a superseding
+  import does not permanently close facts anchored to other meetings (soft-supersede that delete
+  reverses). Prefer (a): stamp a reversible link (import meeting id ↔ invalidated fact ids) and reopen
+  on delete.
+- RED: unit test — import that supersedes an existing fact, delete the import meeting, assert the
+  pre-existing fact is reopened (open row restored).
+
+### PK-F1 (MAJOR) — Notes-section lock bypasses the lock×shares dialog
+- Fix (FE): `NotesHomeComponent.lockFolder` must run the same `folderActiveShares` probe +
+  warn/revoke flow as `FolderRowComponent.onLock` before calling `lockFolder` (extract the shared
+  flow so both call sites use it; don't duplicate). Fail-CLOSED on a probe error (warn, don't lock
+  silently) — also fixes minor F5.
+- RED: E2E — mock `folder_active_shares` to return a share; lock from the Notes section; assert the
+  warn/revoke dialog appears before `lock_folder` is invoked.
+
+### WT-F1 (MAJOR, working tree) — selection bubble re-floats after Accept; own e2e assertion fails
+- Fix (FE): suppress the programmatic `select` event that `replaceRange`'s `setSelectionRange`
+  queues — e.g. set a `suppressNextSelect` flag consumed by `onBodySelect`, or collapse the
+  selection after applying (place the caret at the end instead of selecting the inserted text). Keep
+  the new `brain-popover.spec.ts` assertion (`bubble toHaveCount(0)` after Accept) green.
+- Also fold in: restore reachability of `codeblock`/`divider` FormatOps (or delete the dead cases +
+  their enum arms so nothing is dead), and add Esc/outside-click dismissal for the bubble.
+- RED: `e2e/notes/brain-popover.spec.ts` green.
+
+### folder_active_shares gate (minor, downgraded) — mask titles for a sealed-not-unlocked folder
+- Fix (backend): gate `folder_active_shares` behind the folder-unlocked check (return an empty/masked
+  list for a sealed-not-unlocked folder) so org-share titles don't leak. Small, include in Wave 3 BE.
+
+---
+
+## Wave 4 — hygiene, gates, manual E2E, merge
+
+### Hygiene (must precede commit)
+- Remove the bare 64-hex `railway-verify=` token from `.claude/skills/deploy-murmur-server/SKILL.md`
+  (secret-scan will block the commit otherwise) — redact to a placeholder.
+- Add `e2e/org/__screens__/` (+ any generated PNGs) to `.gitignore` so verification artifacts don't
+  get committed; do not `git add` the stray `whisper-01.png`, `.agents/`, `.codex/`.
+- Decide `crates/murmur-brain` version alignment (cosmetic; note in the release runbook, not a code
+  blocker).
+
+### Minors folded in opportunistically (non-blocking, if low-risk)
+- `refreshOrgShared` stale-result guard (FE failure mode #4).
+- `note-brain-popover` component `setTimeout` → service-owned timer or `afterNextRender` (rule §5).
+- Hardcoded rgba scrims in new overlay scss → tokens.
+- Invalid two-easing animation shorthand (notes overlays) → valid single easing.
+- `AppConfig::default()` IO (`sysctl` + dir list) → memoize / lazy so a default ctor is pure.
+- Sidecar idle-exit zombie reap + `murmur-brain` crate into ci.sh (BS-4).
+- BS-1: document the serialize+reload trade explicitly and start the per-request deadline before the
+  lock wait so a queued request isn't unfairly timed out (no re-architecture this pass).
+
+### Gates
+- `cd src-tauri && cargo test --lib` green; `npx ng lint` + `npx ng build` green;
+  `npm run test:e2e` green (both currently-red specs fixed); finally `bash scripts/ci.sh`.
+
+### Manual E2E (dev app + local/real server + Playwright/browser) — verify, don't assume
+1. Boot the dev app (`MURMUR_DEV_DEK=… npm run dev`), clean boot no abort.
+2. **Org flow (the live bug):** with the deployed/local server, create org "Test" → succeeds (no
+   404); invite flow; consent/preview/share a note; a second session recovers the OCK.
+3. **Notes flow:** create note-folders, move/rename (incl. Polish name), delete a folder → notes
+   reparent (not deleted); lock a folder with notes → no plaintext `.md` at rest; lock from the Notes
+   section → shares dialog appears.
+4. **Timeline:** open a meeting, Audio tab → timeline generates once, no loop; locked meeting →
+   masked, and a session-unlock→relock leaves no plaintext timeline.
+5. **Selection Brain bubble:** select text → Refine → Accept → bubble dismisses (no re-float).
+6. **Voice/record:** fresh-install-like config → start recording → no voice-command wedge.
+   (Touch ID / screen-share auto-relock / real model decode = honestly flagged signed-build-only.)
+
+### Merge
+- Feature branch(es) off `murmur`; commits authored **only** by `QueaT <kgm004a@gmail.com>`, no
+  Claude trailers; `gh` account `JakubGawr`. PR → `gh pr merge`. Never direct-push to `murmur`.
+- Server fix: PR + merge in `murmur-io/murmur-server`, then Railway deploy via the skill.
+
+---
+
+## Ownership matrix
+
+| Item | Type | Implementer | Required verifier(s) |
+| --- | --- | --- | --- |
+| NOTES-1/2/3, SEAM-F1/F2, LOCK-SHARE-INGEST-1 | lock/crypto BE | rust-tauri-dev | lock-security-reviewer + adversarial-verifier |
+| SB-1, SB-2, SB-3, org_leave/MCP gate, folder_active_shares gate | lock/crypto BE + server | rust-tauri-dev | lock-security-reviewer + adversarial-verifier |
+| TP-F1, MEM-1 | BE | rust-tauri-dev | adversarial-verifier |
+| RED-E2E-1, PK-F1, WT-F1, FE minors | FE | angular-zoneless-dev | adversarial-verifier |
+| Hygiene, gates, manual E2E | main loop | — | main loop + adversarial-verifier final |

--- a/e2e/notes/lock-shares-dialog.spec.ts
+++ b/e2e/notes/lock-shares-dialog.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * PK-F1 — the Notes-section folder lock must run the SAME lock×shares flow as the
+ * meetings tree: probe `folder_active_shares` FIRST, and if the folder still has
+ * live shares open the warn/revoke dialog BEFORE calling `lock_folder`. Previously
+ * `NotesHomeComponent.lockFolder` called `FoldersService.lock` directly with no
+ * probe, so a shared note-folder was sealed without warning the owner.
+ *
+ * This spec pins the fix against the REAL FE bundle (only Tauri IPC mocked):
+ *  - `folder_active_shares` returns an active share for the folder;
+ *  - `lock_folder` records page-side WHETHER it was called;
+ * then locks the open "Notes" folder from the Notes rail and asserts:
+ *  1. the lock×shares dialog appears, and
+ *  2. `lock_folder` was NOT invoked until the user confirms (Lock anyway) in the dialog.
+ *
+ * RED contract: on the pre-fix code the Notes lock button calls `lock_folder`
+ * immediately (no dialog) → the dialog-visible assertion times out / `__lockCalled`
+ * is already true before any confirm.
+ */
+test.describe("Notes — folder lock runs the lock×shares dialog (PK-F1)", () => {
+  test("locking a shared note-folder shows the dialog BEFORE lock_folder is invoked", async ({
+    page,
+  }) => {
+    // Layer PK-F1 overrides into the SAME Notes mock call (a second mockTauri would
+    // re-install the base internals and wipe the Notes overrides).
+    await mockNotes(page, {
+      // The folder still has an active 1:1 user share → the flow must warn, not seal.
+      folder_active_shares: () => ({ links: 0, users: 1, org: [] }),
+      // Record page-side whether lock_folder ever ran (serialized override — no closures).
+      lock_folder: () => {
+        (window as unknown as { __lockCalled?: boolean }).__lockCalled = true;
+        return null;
+      },
+      revoke_shares_for_folder: () => null,
+    });
+
+    await page.goto("/notes");
+    await expect(page.locator(".notes-content")).toBeVisible();
+
+    // The open "Notes" folder has a Lock control on its row.
+    const lockBtn = page.getByRole("button", { name: "Lock folder" }).first();
+    await expect(lockBtn).toBeVisible();
+    await lockBtn.click();
+
+    // The lock×shares dialog appears (it was NOT sealed straight away).
+    const dialog = page.locator("app-lock-shares-dialog [role='dialog']");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(dialog.getByText("has active shares")).toBeVisible();
+
+    // Critically: lock_folder must NOT have been called yet — the dialog gates it.
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __lockCalled?: boolean }).__lockCalled ?? false,
+      ),
+    ).toBe(false);
+
+    // Confirm via "Lock anyway" → NOW lock_folder fires.
+    await dialog.getByRole("button", { name: "Lock anyway" }).click();
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __lockCalled?: boolean }).__lockCalled ??
+              false,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+
+    // The dialog dismisses once the lock lands.
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/e2e/notes/mock-invoke.ts
+++ b/e2e/notes/mock-invoke.ts
@@ -14,8 +14,16 @@ import { mockTauri } from "../settings-ai/mock-invoke";
  * self-contained, no closures over test-scope). Unknown commands fall through to
  * the demo mock's benign defaults, so the app always boots. `get_config` here
  * carries the note-assistant toggles ON so the editor's popover picker renders.
+ *
+ * `extra` layers per-spec command overrides into the SAME `mockTauri` call (the base
+ * mock re-installs `window.__TAURI_INTERNALS__` from scratch, so a SECOND `mockTauri`
+ * call would wipe these Notes overrides — everything must go through one call). Keys
+ * in `extra` win over the Notes defaults.
  */
-export async function mockNotes(page: Page): Promise<void> {
+export async function mockNotes(
+  page: Page,
+  extra: Record<string, (args: any) => unknown> = {},
+): Promise<void> {
   await mockTauri(page, {
     // --- config (note-assistant toggles ON so the popover shows every action) ---
     get_config: () => ({
@@ -162,5 +170,8 @@ export async function mockNotes(page: Page): Promise<void> {
 
     // --- sharing (empty list; the editor warms this) ---
     list_my_shares: () => [],
+
+    // --- per-spec overrides win over the Notes defaults above ---
+    ...extra,
   });
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1083,21 +1083,52 @@ pub(crate) fn begin_voice_command_inner(
         .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?
         .as_ref()
         .map(|r| r.total_samples());
-    let Some(offset) = start_sample else {
-        return Ok(VoiceCommandArmResult {
+    let live_running = state
+        .live_running
+        .load(std::sync::atomic::Ordering::SeqCst);
+    match voice_command_arm_decision(start_sample, live_running) {
+        // A refusal (not recording / no live consumer) — arm NOTHING and return the reason.
+        Err(refusal) => Ok(refusal),
+        // Cleared to arm: latch the fresh capture the live loop consumes.
+        Ok(offset) => {
+            let mut guard = state.voice_command_capture.lock().map_err(|_| {
+                AppError::Other(anyhow::anyhow!("voice-command capture mutex poisoned"))
+            })?;
+            *guard = Some(crate::state::CaptureState::armed_from(offset));
+            Ok(VoiceCommandArmResult {
+                listening: true,
+                reason: None,
+            })
+        }
+    }
+}
+
+/// PURE arm decision for [`begin_voice_command_inner`] (no state, no locks → unit-testable without a
+/// real `Recorder`). `recording_offset` is `Some(total_samples)` while recording, `None` otherwise;
+/// `live_running` is whether the live-caption loop (the ONLY consumer of a voice capture) is running.
+///
+/// Returns `Ok(offset)` when the click may arm, else `Err(refusal)` carrying the FE-facing reason:
+/// - not recording ⇒ "not recording" (arm nothing — the live loop only runs during a recording);
+/// - TP-F1: recording but NO live consumer ⇒ "voice needs the live model" (the fresh-install
+///   heavy-turbo default spawns no live loop, so an armed capture would WEDGE with nothing to
+///   transcribe/dispatch it — refuse cleanly instead of arming a consumer-less generation).
+fn voice_command_arm_decision(
+    recording_offset: Option<usize>,
+    live_running: bool,
+) -> std::result::Result<usize, VoiceCommandArmResult> {
+    let Some(offset) = recording_offset else {
+        return Err(VoiceCommandArmResult {
             listening: false,
             reason: Some("not recording".into()),
         });
     };
-    let mut guard = state
-        .voice_command_capture
-        .lock()
-        .map_err(|_| AppError::Other(anyhow::anyhow!("voice-command capture mutex poisoned")))?;
-    *guard = Some(crate::state::CaptureState::armed_from(offset));
-    Ok(VoiceCommandArmResult {
-        listening: true,
-        reason: None,
-    })
+    if !live_running {
+        return Err(VoiceCommandArmResult {
+            listening: false,
+            reason: Some("voice needs the live model".into()),
+        });
+    }
+    Ok(offset)
 }
 
 /// STOP the MANUAL voice-command capture (CLICK-TO-STOP): the user clicked "stop" / "done", so the
@@ -3540,9 +3571,13 @@ pub(crate) fn import_memories_inner(
         status: crate::storage::models::MeetingStatus::Exported,
         folder_id: None,
     })?;
-    // 4) Stamp the anchor onto the Adds (gating + purge anchor) and apply atomically.
+    // 4) Stamp the anchor onto the Adds (gating + purge anchor) and apply atomically. MEM-1: use the
+    //    import-aware apply so every pre-existing fact this import SUPERSEDES (an Invalidate on a fact
+    //    anchored to another meeting) is linked to the synthetic import id — deleting the import then
+    //    REOPENS those facts, making "delete to undo" a FULL reversal instead of a partial one that
+    //    leaves prior memories permanently closed.
     crate::facts::set_meeting_id(&mut ops, &meeting_id);
-    db.apply_user_fact_ops(&ops)?;
+    db.apply_user_fact_ops_recording_import_supersedes(&ops, &meeting_id)?;
     tracing::info!(
         target: "user_memory",
         meeting_id = %meeting_id,
@@ -7903,7 +7938,12 @@ pub(crate) fn rename_speaker_inner(
     }
     let updated = serde_json::to_string(&tl)
         .map_err(|e| AppError::Storage(format!("serialize timeline: {e}")))?;
-    state.db.set_timeline_data(meeting_id, &updated)?;
+    // SEAM-F2 (2026-07-11 audit, edit lost): in a session-unlocked LOCKED folder the renamed timeline
+    // must be RE-SEALED under the folder CK at write time — the pre-fix bare `set_timeline_data`
+    // landed plaintext-only against the STALE sealed blob, so relock re-blanked the plaintext and the
+    // next unlock restored the OLD speaker labels (the rename was destroyed). Open/rootless meeting →
+    // the plain write inside the helper. Fail-closed on a missing session KEK.
+    set_timeline_data_reseal_if_locked(state, meeting_id, &updated)?;
 
     // ENROLL-ON-RENAME (Phase 2, opt-in): if the OLD label resolves to a diarized cluster (either a
     // raw `others-{n}` tag or, via the reconciliation above, the display label the FE lane showed) and
@@ -8224,8 +8264,20 @@ pub async fn generate_timeline(
     let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
     let timeline =
         crate::summarize::timeline::generate(provider.as_ref(), &segments, duration_s).await?;
+    // SEAM-F1 (2026-07-11 audit, plaintext-at-rest): the provider `.await` above can span a relock,
+    // so re-take the lifecycle guard and RE-GATE the meeting AFTER generation before persisting. Then
+    // route the write through the seal-on-write seam: a session-unlocked LOCKED folder SEALS the fresh
+    // timeline under the folder CK (never a bare plaintext `set_timeline_data`, which the pre-fix path
+    // left in the sealed row after relock — plaintext at rest). If a relock landed mid-generation
+    // (the meeting is now sealed-not-unlocked), do NOT persist plaintext at all — the generated
+    // timeline is discarded (the FE re-generates after the next unlock).
     if let Ok(json) = serde_json::to_string(&timeline) {
-        let _ = state.db.set_timeline_data(&meeting_id, &json);
+        let _lifecycle = lifecycle_guard(state.inner());
+        if !meeting_is_unlocked(state.inner(), &meeting_id)? {
+            return Ok(timeline); // relocked mid-generation → persist nothing plaintext behind the lock.
+        }
+        // Fail-closed on a missing session KEK for a locked folder (never write unsealed plaintext).
+        set_timeline_data_reseal_if_locked(state.inner(), &meeting_id, &json)?;
     }
     Ok(timeline)
 }
@@ -10665,6 +10717,13 @@ pub(crate) fn delete_folder_inner(state: &AppState, folder_id: String) -> Result
         }
     }
 
+    // NOTES-1 (2026-07-11 audit, CRITICAL data loss): AUTHORED notes (`documents(kind='note')`)
+    // must be REPARENTED to the default note-folder, NOT destroyed — the FE promises "delete folder"
+    // MOVES its notes to the default folder. The pre-fix path left them for `Db::delete_folder`'s
+    // blanket `DELETE FROM documents`, permanently deleting authored notes. `Db::delete_folder` now
+    // REFUSES if any authored note still references the folder, so this reparent MUST run first.
+    reparent_authored_notes_to_default(state, &folder_id)?;
+
     // Delete the folder row, then remove the (now note-free) vault subdir. Row first: a leftover
     // empty dir is harmless/reconcilable; a dangling row is not.
     state.db.delete_folder(&folder_id)?;
@@ -10720,6 +10779,121 @@ fn move_note_file_to_root(
             &dest.to_string_lossy(),
         )?;
     }
+    Ok(())
+}
+
+/// NOTES-1 (2026-07-11 audit, CRITICAL data loss) — reparent every AUTHORED note
+/// (`documents(kind='note')`) in a to-be-deleted folder to the DEFAULT note-folder ("Notes"), moving
+/// its plaintext `.md` into the default folder's vault subdir (copy-then-remove — never lose bytes)
+/// and rewriting `documents.exported_path`. The FE's "delete folder" promises its notes MOVE to the
+/// default folder; the pre-fix path left them for `Db::delete_folder`'s blanket `DELETE`, destroying
+/// them. Runs AFTER any sealed folder was unsealed back to plaintext (`remove_lock_inner`), so the
+/// notes here are plaintext. If the folder BEING deleted IS the default note-folder itself, its notes
+/// can't reparent to themselves — REFUSE rather than risk destroying them (the FE never offers to
+/// delete the root "Notes" folder). Best-effort FS move: a note's bytes live in the DB (canonical),
+/// so a failed `.md` move never loses content — but a missing target keeps the reparent (the row moves
+/// regardless). No PII in logs (ids only).
+fn reparent_authored_notes_to_default(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<(), AppError> {
+    let note_ids = state.db.note_ids_in_folder(folder_id)?;
+    if note_ids.is_empty() {
+        return Ok(());
+    }
+    let default_id = state.db.ensure_default_note_folder()?;
+    if default_id == folder_id {
+        // Deleting the default note-folder while it still holds authored notes: reparenting to
+        // itself is a no-op and the row-delete would then destroy them. Fail closed.
+        return Err(AppError::InvalidArg(
+            "cannot delete the default \"Notes\" folder while it holds notes — move them first".into(),
+        ));
+    }
+    let default_folder = state
+        .db
+        .note_folder_by_id(&default_id)?
+        .ok_or_else(|| AppError::Storage("default note-folder missing after ensure".into()))?;
+    for id in &note_ids {
+        // Reassign the row to the default note-folder (the gate/seal anchor). The default folder is
+        // OPEN (root "Notes" is never locked), so a plain reassign is correct — no reseal needed.
+        state.db.set_note_doc_folder(id, &default_id)?;
+        // Move the plaintext `.md` into the default folder's vault subdir + re-point exported_path.
+        if let Some(row) = state.db.get_note_row(id)? {
+            move_authored_note_md_to_folder(state, &row, &default_folder)?;
+        }
+    }
+    tracing::info!(
+        target: "notes",
+        folder_id = %folder_id,
+        moved = note_ids.len(),
+        "reparented authored notes to the default folder before folder delete"
+    );
+    Ok(())
+}
+
+/// Move ONE authored note's plaintext `.md` from its old export path into `target` note-folder's
+/// vault subdir (copy-then-remove — never lose bytes) and re-point `documents.exported_path`. A
+/// `&AppState`-only helper for the `_inner` delete path (which can't reach the `&State`-signature
+/// export helpers). No-op when there is no vault, no old export, or the source file is already gone
+/// (the DB row is the canonical copy; a re-export recreates the `.md`).
+fn move_authored_note_md_to_folder(
+    state: &AppState,
+    row: &crate::storage::db::NoteRow,
+    target: &NoteFolder,
+) -> Result<(), AppError> {
+    let Some(vault) = vault_path(state) else {
+        // No vault → nothing on disk to move; still clear the stale export path so a later lock
+        // never chases it.
+        state.db.set_note_doc_exported_path(&row.id, None)?;
+        return Ok(());
+    };
+    let vault_root = std::path::Path::new(&vault);
+    // Read the source bytes (if any). A missing source → nothing to move; clear the path.
+    let bytes = match row.exported_path.as_deref() {
+        Some(src_path) => match std::fs::read_to_string(src_path) {
+            Ok(b) => Some((src_path.to_string(), b)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(AppError::Export(format!("read note for move failed: {e}"))),
+        },
+        None => None,
+    };
+    let Some((src_path, content)) = bytes else {
+        // No on-disk file → just re-export from the (canonical) DB text into the new folder if we
+        // have text; otherwise clear the stale path.
+        if row.text.is_empty() {
+            state.db.set_note_doc_exported_path(&row.id, None)?;
+        } else if let Some(p) = write_note_to_vault(state, row)? {
+            let _ = p; // write_note_to_vault already re-points exported_path.
+        }
+        return Ok(());
+    };
+    // Compose the destination inside the target folder's vault subdir, D5-contained.
+    let file_name = std::path::Path::new(&src_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| AppError::Export("note path has no filename".into()))?;
+    let rel = std::path::Path::new(&target.path).join(file_name);
+    let dest = assert_in_vault(vault_root, &rel)?;
+    let src_canon = std::path::Path::new(&src_path)
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from(&src_path));
+    if dest == src_canon {
+        // Already at the destination (nothing to move) — just record the path.
+        state
+            .db
+            .set_note_doc_exported_path(&row.id, Some(&dest.to_string_lossy()))?;
+        return Ok(());
+    }
+    if let Some(dir) = dest.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| AppError::Export(format!("create move dir failed: {e}")))?;
+    }
+    // Write the destination atomically, THEN remove the source (never lose bytes).
+    crate::export::overwrite_note(&dest, &content)?;
+    let _ = std::fs::remove_file(&src_path);
+    state
+        .db
+        .set_note_doc_exported_path(&row.id, Some(&dest.to_string_lossy()))?;
     Ok(())
 }
 
@@ -11798,6 +11972,40 @@ pub(crate) fn set_manual_notes_reseal_with(
     }
     db.set_manual_notes_sealed(meeting_id, text, &blob)?;
     tracing::debug!(target: "lock", meeting_id = %meeting_id, "seal-on-write: typed notes re-sealed under the folder CK");
+    Ok(())
+}
+
+/// Persist a meeting's timeline JSON, RE-SEALING the fresh data into `data_blob` when the meeting's
+/// folder is LOCKED (session-unlocked, or the caller's gate already refused). Open/rootless meeting →
+/// the plain [`Db::set_timeline_data`]. Locked → encrypt under the folder CK with the SAME AAD the
+/// folder seal uses (`aad_content(.., "timeline")`), VERIFY byte-identical, then upsert plaintext +
+/// fresh blob atomically ([`Db::set_timeline_data_sealed`]) — so relock re-blanks to THIS timeline
+/// (never a stale copy), and a timeline GENERATED while session-unlocked is sealed FROM BIRTH (never
+/// a blob-less plaintext behind a lock). FAIL-CLOSED via [`session_folder_ck`]: no cached KEK ⇒
+/// `AppError::Locked` before any write. 2026-07-11 audit SEAM-F1 (generate_timeline) + SEAM-F2
+/// (rename_speaker).
+fn set_timeline_data_reseal_if_locked(
+    state: &AppState,
+    meeting_id: &str,
+    data: &str,
+) -> Result<(), AppError> {
+    let locked_folder = match state.db.folder_for_meeting(meeting_id)? {
+        Some(fid) => state.db.folder_by_id(&fid)?.filter(|f| f.locked),
+        None => None,
+    };
+    let Some(folder) = locked_folder else {
+        return state.db.set_timeline_data(meeting_id, data);
+    };
+    let ck = session_folder_ck(state, &folder.id)?;
+    let aad = aad_content(&folder.id, meeting_id, AAD_NO_PROVIDER, "timeline");
+    let blob = crate::crypto::encrypt(&ck, data.as_bytes(), &aad)?;
+    if crate::crypto::decrypt(&ck, &blob, &aad)? != data.as_bytes() {
+        return Err(AppError::Storage(
+            "timeline seal-on-write verification failed (blob mismatch)".into(),
+        ));
+    }
+    state.db.set_timeline_data_sealed(meeting_id, data, &blob)?;
+    tracing::debug!(target: "lock", meeting_id = %meeting_id, "seal-on-write: timeline re-sealed under the folder CK");
     Ok(())
 }
 
@@ -13793,6 +14001,9 @@ fn ingest_shared_note(
     sender_user_id: &str,
     share_id: &str,
 ) -> Result<AcceptedShare, AppError> {
+    // LOCK-SHARE-INGEST-1 (2026-07-11 audit, sealed-content leak): hold the lifecycle guard across the
+    // whole ingest so a relock cannot land between the meeting insert and the (sealed) note write.
+    let _lifecycle = lifecycle_guard(state);
     let meeting_id = uuid::Uuid::new_v4().to_string();
     let now = chrono::Utc::now().to_rfc3339();
     // A well-formed created_at (RFC3339) is kept; otherwise fall back to now (never trust the payload).
@@ -13828,21 +14039,41 @@ fn ingest_shared_note(
         folder_id: Some(target.id.clone()),
     })?;
 
-    // Atomic vault export (best-effort — a missing/invalid vault just leaves exported_path None; the
-    // note is still durable in the DB, the source of truth).
-    let exported_path = config_vault(state).and_then(|vault| {
-        crate::export::write_note(
-            std::path::Path::new(&vault),
-            Some(&target.path),
-            &title,
-            &started_at,
-            &full_md,
-        )
-        .ok()
-        .map(|p| p.to_string_lossy().to_string())
-    });
+    // LOCK-SHARE-INGEST-1: a session-unlocked LOCKED target must NOT receive a plaintext `.md` on
+    // disk NOR a plaintext note row — the pre-fix path wrote both via a RAW `upsert_note` + vault
+    // export, so the plaintext survived the next relock at rest (a sealed-content leak). When the
+    // target is locked, SEAL the note under the target folder CK from birth (verify-before-destroy
+    // inside `upsert_note_reseal_if_locked`) and write NO vault file. An open target keeps the plain
+    // write + export.
+    let target_locked = state
+        .db
+        .folder_by_id(&target.id)?
+        .map(|f| f.locked)
+        .unwrap_or(false);
 
-    state.db.upsert_note(&NoteRecord {
+    // Set the meeting's folder FIRST so `upsert_note_reseal_if_locked` resolves the (locked) folder
+    // via `folder_for_meeting`. It reads `notes.folder_id`, but there is no note row yet — so seed a
+    // folder association through a folder-set on the (about-to-be-written) note. We do this by writing
+    // the note with the folder resolved directly below instead of relying on a two-step.
+    let exported_path = if target_locked {
+        None // a locked folder has no on-disk export.
+    } else {
+        // Atomic vault export (best-effort — a missing/invalid vault just leaves exported_path None;
+        // the note is still durable in the DB, the source of truth).
+        config_vault(state).and_then(|vault| {
+            crate::export::write_note(
+                std::path::Path::new(&vault),
+                Some(&target.path),
+                &title,
+                &started_at,
+                &full_md,
+            )
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+        })
+    };
+
+    let note = NoteRecord {
         meeting_id: meeting_id.clone(),
         provider_id: "shared".to_string(),
         markdown: full_md,
@@ -13851,10 +14082,28 @@ fn ingest_shared_note(
         model_requested: None,
         model_served: None,
         gateway_host: None,
-    })?;
-    // The meeting's folder is resolved via `notes.folder_id` (`folder_for_meeting`) — set it so every
-    // gate (`meeting_is_unlocked`, `visibility_clause`) sees this note as living in the target folder.
-    state.db.set_note_folder(&meeting_id, Some(&target.id))?;
+    };
+    if target_locked {
+        // Seal under the TARGET folder CK from birth. `upsert_note_sealed` also writes the governing
+        // `folder_id`, so the gate + reblank lifecycle see this note as living in the target folder.
+        // Fail-closed on a missing session KEK (never unsealed plaintext behind a lock).
+        let ck = session_folder_ck(state, &target.id)?;
+        // SAME AAD the folder seal / `upsert_note_reseal_if_locked` use:
+        // aad_content(folder, meeting, provider, "note").
+        let aad = aad_content(&target.id, &note.meeting_id, &note.provider_id, "note");
+        let blob = crate::crypto::encrypt(&ck, note.markdown.as_bytes(), &aad)?;
+        if crate::crypto::decrypt(&ck, &blob, &aad)? != note.markdown.as_bytes() {
+            return Err(AppError::Storage(
+                "shared-note seal-on-ingest verification failed (blob mismatch)".into(),
+            ));
+        }
+        state.db.upsert_note_sealed(&note, &blob, &target.id)?;
+    } else {
+        state.db.upsert_note(&note)?;
+        // The meeting's folder is resolved via `notes.folder_id` (`folder_for_meeting`) — set it so
+        // every gate (`meeting_is_unlocked`, `visibility_clause`) sees this note in the target folder.
+        state.db.set_note_folder(&meeting_id, Some(&target.id))?;
+    }
 
     // Idempotency + provenance record (a re-accept of this share_id is INSERT-OR-IGNORE'd).
     state
@@ -14257,6 +14506,7 @@ mod lifecycle_tests {
             spill_writer: Mutex::new(None),
             voice_listener: Mutex::new(None),
             voice_command_capture: Mutex::new(None),
+            live_running: std::sync::atomic::AtomicBool::new(false),
             db,
             config: Arc::new(Mutex::new(AppConfig::default())),
             reasoner: crate::reason::ReasonerCell::fixed(Arc::new(crate::reason::StubReasoner)),
@@ -15627,6 +15877,52 @@ mod lifecycle_tests {
         );
     }
 
+    /// TP-F1 (RED-before-GREEN, fresh-install regression): the PURE arm decision. A RECORDING is in
+    /// progress (`Some(offset)`) but NO live loop is running (`live_running=false`) — the fresh-install
+    /// heavy-turbo default arm where `start_recording` sets `live_model=None` and spawns no live loop.
+    /// The decision must REFUSE cleanly ("voice needs the live model"), NOT arm — pre-fix the code saw
+    /// only the present recorder and armed a capture no consumer would ever transcribe, wedging the FE
+    /// in "listening…". This targets the extracted pure helper (a real `Recorder` can't be built
+    /// headless), covering all three arms: not-recording, recording-without-consumer, recording+consumer.
+    #[test]
+    fn voice_command_arm_refuses_without_a_live_consumer() {
+        // Not recording at all → "not recording", regardless of live_running.
+        assert_eq!(
+            voice_command_arm_decision(None, true).unwrap_err().reason.as_deref(),
+            Some("not recording")
+        );
+        assert_eq!(
+            voice_command_arm_decision(None, false).unwrap_err().reason.as_deref(),
+            Some("not recording")
+        );
+        // RECORDING but NO live consumer (the fresh-install wedge) → refuse cleanly, arm nothing.
+        let refusal = voice_command_arm_decision(Some(4800), false).unwrap_err();
+        assert!(!refusal.listening, "must not arm a consumer-less generation");
+        assert_eq!(
+            refusal.reason.as_deref(),
+            Some("voice needs the live model"),
+            "the wedge case must surface a clear reason, not arm"
+        );
+        // RECORDING + a live consumer → cleared to arm at the latched offset.
+        assert_eq!(
+            voice_command_arm_decision(Some(4800), true).unwrap(),
+            4800,
+            "with a live consumer, the click arms at the latched offset"
+        );
+    }
+
+    /// The inner integration for the not-recording path (no recorder ⇒ not recording), still exercising
+    /// `begin_voice_command_inner` end-to-end. The recording-present arms need a real audio device, so
+    /// the recording×consumer matrix is covered by the pure-decision test above.
+    #[test]
+    fn begin_voice_command_inner_not_recording_arms_nothing() {
+        let state = build_state("voicecmd-inner-notrec");
+        let res = begin_voice_command_inner(&state).unwrap();
+        assert!(!res.listening);
+        assert_eq!(res.reason.as_deref(), Some("not recording"));
+        assert!(state.voice_command_capture.lock().unwrap().is_none());
+    }
+
     /// MANUAL voice command: arming sets a fresh full-budget [`crate::state::CaptureState`] on the
     /// state (the live loop reads it). We exercise the arming half directly (a live `Recorder` needs
     /// a real audio device); the decision/dispatch half is unit-tested in `transcribe::live`.
@@ -16175,6 +16471,120 @@ mod lifecycle_tests {
         assert!(
             state.db.user_facts_all().unwrap().is_empty(),
             "deleting the synthetic meeting must undo the import"
+        );
+    }
+
+    /// MEM-1 (RED-before-GREEN): a memory import that SUPERSEDES a pre-existing user fact (anchored to
+    /// ANOTHER meeting) must be FULLY reversible — deleting the synthetic Memory-Import meeting must
+    /// REOPEN the superseded fact, not leave it permanently closed. Pre-fix, `set_meeting_id` stamped
+    /// only the Adds, so `delete_meeting`'s `purge_user_facts_tx` (WHERE meeting_id = import id)
+    /// deleted the import's Add but the pre-existing fact — closed by the reconcile's Invalidate —
+    /// stayed closed forever (a partial undo that silently lost the prior memory). This seeds the prior
+    /// fact under a REAL meeting, imports a colliding value (same subject/predicate, different object),
+    /// asserts the prior fact is now CLOSED + the new one OPEN, then deletes the import and asserts the
+    /// prior fact is REOPEN.
+    #[test]
+    fn import_supersede_is_reversible_delete_reopens_prior_fact() {
+        use crate::facts::{FactOp, NewFact};
+        let state = build_state("mem-import-reopen");
+        let none = HashSet::new();
+
+        // A REAL prior meeting the pre-existing user fact is anchored to (so it is visible + survives
+        // the import; deleting the IMPORT must not touch it beyond reopening).
+        state
+            .db
+            .insert_meeting(&crate::storage::models::Meeting {
+                id: "m-old".to_string(),
+                started_at: "2026-07-01T00:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Old chat".to_string()),
+                duration_s: 0,
+                audio_path: None,
+                status: crate::storage::models::MeetingStatus::Exported,
+                folder_id: None,
+            })
+            .unwrap();
+        // Pre-existing OPEN user fact keyed (You, "prefers") = "English replies", anchored to m-old.
+        // MockImportBrain emits {"prefers":"Polish replies"} → a same-key/DIFFERENT-object collision.
+        state
+            .db
+            .apply_user_fact_ops(&[FactOp::Add(NewFact {
+                entity_id: crate::user_memory::USER_SCOPE.to_string(),
+                subject: "You".to_string(),
+                predicate: "prefers".to_string(),
+                object: "English replies".to_string(),
+                valid_from: "2026-07-01T00:00:00Z".to_string(),
+                recorded_at: "2026-07-01T00:00:00Z".to_string(),
+                confidence: 1.0,
+                meeting_id: Some("m-old".to_string()),
+            })])
+            .unwrap();
+        let prior_id = state.db.user_facts_all().unwrap()[0].id.clone();
+        assert!(
+            state.db.user_facts_all().unwrap()[0].valid_to.is_none(),
+            "precondition: the prior fact is OPEN"
+        );
+
+        // IMPORT: supersedes "prefers" (English→Polish) and adds "works on".
+        let n = import_memories_inner(&state.db, &MockImportBrain, true, "export").unwrap();
+        assert_eq!(n, 2, "two Adds: the superseding 'prefers' + 'works on'");
+        // The prior fact is now CLOSED (superseded), and the new value is the visible one.
+        let prior_after = state
+            .db
+            .user_facts_all()
+            .unwrap()
+            .into_iter()
+            .find(|f| f.id == prior_id)
+            .unwrap();
+        assert!(
+            prior_after.valid_to.is_some(),
+            "the import superseded (closed) the prior fact"
+        );
+        let visible: Vec<_> = state
+            .db
+            .list_user_facts_visible(&none)
+            .unwrap()
+            .into_iter()
+            .filter(|f| f.predicate == "prefers")
+            .collect();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].object, "Polish replies", "the import's value is current");
+
+        // DELETE the synthetic import ⇒ the reconcile is REVERSED: the prior fact REOPENS, and the
+        // import's own Adds are gone.
+        let import_id = state
+            .db
+            .list_meetings(100)
+            .unwrap()
+            .into_iter()
+            .find(|m| m.id.starts_with("import-"))
+            .unwrap()
+            .id;
+        state.db.delete_meeting(&import_id).unwrap();
+
+        let prior_reopened = state
+            .db
+            .user_facts_all()
+            .unwrap()
+            .into_iter()
+            .find(|f| f.id == prior_id)
+            .expect("the prior fact must still exist (only the import's Adds were deleted)");
+        assert!(
+            prior_reopened.valid_to.is_none(),
+            "deleting the import must REOPEN the superseded prior fact (full undo)"
+        );
+        // And it is once again the visible current value.
+        let visible_after: Vec<_> = state
+            .db
+            .list_user_facts_visible(&none)
+            .unwrap()
+            .into_iter()
+            .filter(|f| f.predicate == "prefers")
+            .collect();
+        assert_eq!(visible_after.len(), 1, "exactly one open 'prefers' fact after undo");
+        assert_eq!(
+            visible_after[0].object, "English replies",
+            "the prior value is current again after undoing the import"
         );
     }
 
@@ -21699,6 +22109,93 @@ mod lifecycle_tests {
         assert_eq!(failed[0].last_error.as_deref(), Some("upload_failed"));
     }
 
+    /// SB-3 ROW-AMPLIFICATION FIX (RED-before-GREEN): a share whose upload keeps FAILING must yield
+    /// EXACTLY ONE `org_shares` row (state `failed`) no matter how many sweep retries run, and a later
+    /// SUCCESS must flip that SAME row to `uploaded` with NO duplicate. This models the exact
+    /// row-management decision `share_to_org_inner` now makes — `find_reusable_org_share` →
+    /// `reset_org_share_for_retry` (reuse) instead of `insert_org_share` (mint) — using the real DB
+    /// helpers. Pre-fix `share_to_org_inner` unconditionally minted a fresh row every attempt while the
+    /// prior failed row survived, so N failures produced N rows and a recovery double-published. RED on
+    /// the old decision: `find_reusable_org_share` returned nothing (it didn't exist) → every attempt
+    /// would insert. This drives 3 failed attempts + 1 success and asserts a single row throughout.
+    #[test]
+    fn org_share_retry_reuses_one_row_no_amplification() {
+        let state = build_state("org-share-sb3");
+        let sha = vec![5u8; 32];
+        let org = "org-1";
+        let mid = Some("m-flaky");
+
+        // The share row decision `share_to_org_inner` performs, extracted so it can run without a
+        // server: reuse an existing retriable row, else insert a fresh one; return the row id.
+        let attempt_row_id = |title: &str, ts: &str| -> String {
+            match state
+                .db
+                .find_reusable_org_share(org, mid, None)
+                .unwrap()
+            {
+                Some(existing) => {
+                    state
+                        .db
+                        .reset_org_share_for_retry(&existing.id, Some(title), 1, 1, &sha, ts)
+                        .unwrap();
+                    existing.id
+                }
+                None => {
+                    let id = crate::share::new_share_id();
+                    state
+                        .db
+                        .insert_org_share(&id, org, mid, None, "note", Some(title), 1, 1, &sha, ts)
+                        .unwrap();
+                    id
+                }
+            }
+        };
+        let total_rows = || state.db.list_org_shares_for_org(org).unwrap().len();
+
+        // Attempt 1: insert, then upload FAILS.
+        let id1 = attempt_row_id("Flaky", "2026-07-11T10:00:00Z");
+        state.db.set_org_share_failed(&id1, "upload_failed", "2026-07-11T10:00:01Z").unwrap();
+        assert_eq!(total_rows(), 1, "first failed attempt = one row");
+
+        // Attempts 2 & 3 (sweep retries): REUSE the same row, fail again.
+        for (n, ts) in [(2, "2026-07-11T10:05:00Z"), (3, "2026-07-11T10:10:00Z")] {
+            let idn = attempt_row_id("Flaky", ts);
+            assert_eq!(idn, id1, "retry {n} must reuse the SAME row, not mint a new one");
+            state.db.set_org_share_failed(&idn, "upload_failed", ts).unwrap();
+            assert_eq!(total_rows(), 1, "after retry {n}, still exactly one row (no amplification)");
+        }
+        // Exactly one row, and it is FAILED (not a pile of stale queued/failed rows).
+        let failed = state.db.list_org_shares_in_state("failed").unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id, id1);
+
+        // Recovery: the next attempt reuses the row again and SUCCEEDS → the SAME row flips to
+        // uploaded, item_id recorded, with NO duplicate published row.
+        let id4 = attempt_row_id("Flaky", "2026-07-11T10:15:00Z");
+        assert_eq!(id4, id1, "recovery reuses the same row");
+        state.db.set_org_share_uploaded(&id4, "server-item-1", "2026-07-11T10:15:01Z").unwrap();
+        assert_eq!(total_rows(), 1, "success must not add a duplicate row");
+        let uploaded = state.db.get_org_share(&id1).unwrap().unwrap();
+        assert_eq!(uploaded.state, "uploaded");
+        assert_eq!(uploaded.item_id.as_deref(), Some("server-item-1"));
+        assert!(state.db.list_org_shares_in_state("failed").unwrap().is_empty());
+
+        // A DIFFERENT logical share (a different meeting) is its OWN row — reuse is per logical key.
+        let other = match state.db.find_reusable_org_share(org, Some("m-other"), None).unwrap() {
+            Some(_) => panic!("no reusable row should exist for a fresh meeting"),
+            None => {
+                let id = crate::share::new_share_id();
+                state
+                    .db
+                    .insert_org_share(&id, org, Some("m-other"), None, "note", Some("O"), 1, 1, &sha, "t")
+                    .unwrap();
+                id
+            }
+        };
+        assert_ne!(other, id1);
+        assert_eq!(total_rows(), 2, "a distinct share key gets its own row");
+    }
+
     /// CROSS-SLICE AAD FIX (RED-before-GREEN for the round-trip bug): the envelope AAD item nonce is
     /// `hex(content_sha256)`, which BOTH the publisher (from the envelope it seals) and every consumer
     /// (from the feed's `content_sha256`) derive identically — so a cross-member open SUCCEEDS. The
@@ -21996,6 +22493,336 @@ mod lifecycle_tests {
         assert!(
             shares.iter().all(|(id, _)| id != "old" && id != "f2lnk"),
             "revoked + other-folder shares excluded"
+        );
+    }
+
+    // ── 2026-07-11 audit remediation: NOTES-1/2/3, SEAM-F1/F2, LOCK-SHARE-INGEST-1, gate ─────────────
+
+    /// NOTES-1 (CRITICAL data loss, RED-before-GREEN): deleting a note-folder must REPARENT its
+    /// authored notes (`documents(kind='note')`) to the default "Notes" folder — never DELETE them.
+    /// Pre-fix `delete_folder_inner` demoted only MEETING notes, then `Db::delete_folder`'s blanket
+    /// `DELETE FROM documents WHERE folder_id` permanently destroyed every authored note (the FE
+    /// promises they MOVE to the default folder). This asserts the row SURVIVES under the default
+    /// folder with its `.md` moved + `exported_path` re-pointed.
+    #[test]
+    fn delete_note_folder_reparents_authored_notes_never_deletes_them() {
+        let vault = tmp_vault("notes1-del");
+        let state = build_state_with_vault("notes1-del", &vault);
+        state.db.ensure_default_note_folder().unwrap();
+        let fid = create_note_folder_inner(&state, "Sprint", None).unwrap().id;
+        let id = create_note_inner(&state, Some(&fid), "Roadmap").unwrap();
+        // Give it a body so it exports a real `.md`.
+        update_note_doc_inner(&state, &id, "Roadmap", "the plan lives here").unwrap();
+        let old_path = state
+            .db
+            .get_note_row(&id)
+            .unwrap()
+            .unwrap()
+            .exported_path
+            .expect("note exported to the vault");
+        assert!(std::path::Path::new(&old_path).exists(), "old .md exists");
+
+        delete_folder_inner(&state, fid.clone()).unwrap();
+
+        // The folder row is gone…
+        assert!(
+            state.db.note_folder_by_id(&fid).unwrap().is_none(),
+            "folder row deleted"
+        );
+        // …but the AUTHORED NOTE ROW SURVIVES (the pre-fix bug DELETED it) under the default folder.
+        let row = state
+            .db
+            .get_note_row(&id)
+            .unwrap()
+            .expect("authored note row MUST still exist after folder delete (never destroyed)");
+        assert_eq!(row.text, "the plan lives here", "note content never lost");
+        let default_id = state.db.ensure_default_note_folder().unwrap();
+        assert_eq!(row.folder_id, default_id, "note reparented to the default folder");
+        // Its `.md` moved into the default folder's vault subdir and `exported_path` re-points to it.
+        let new_path = row.exported_path.expect("exported_path re-pointed to the moved .md");
+        assert!(std::path::Path::new(&new_path).exists(), "moved .md exists at the new path");
+        assert!(new_path.contains("Notes"), "moved under the default Notes subdir: {new_path}");
+        assert!(
+            new_path != old_path,
+            "exported_path was actually re-pointed (not left stale)"
+        );
+
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// NOTES-2 (CRITICAL sealed-content leak, RED-before-GREEN): moving a note-folder physically
+    /// `fs::rename`s its vault dir, so `documents.exported_path` MUST be rewritten to the new on-disk
+    /// path — otherwise a later `lock_folder` deletes NOTHING at the stale path and the real plaintext
+    /// `.md` survives on disk in a sealed folder. This asserts the path is rewritten to the moved file
+    /// AND that a subsequent lock leaves NO plaintext `.md` at either the old or new path.
+    #[test]
+    fn move_note_folder_rewrites_exported_path_so_lock_deletes_the_real_md() {
+        let vault = tmp_vault("notes2-move");
+        let state = build_state_with_vault("notes2-move", &vault);
+        state.db.ensure_default_note_folder().unwrap();
+        // Notes/Parent and Notes/Dest; the note lives in Parent, we move Parent under Dest.
+        let parent = create_note_folder_inner(&state, "Parent", None).unwrap().id;
+        let dest = create_note_folder_inner(&state, "Dest", None).unwrap().id;
+        let id = create_note_inner(&state, Some(&parent), "Secret plan").unwrap();
+        update_note_doc_inner(&state, &id, "Secret plan", "top secret body").unwrap();
+        let old_path = state
+            .db
+            .get_note_row(&id)
+            .unwrap()
+            .unwrap()
+            .exported_path
+            .expect("exported to the vault");
+        assert!(std::path::Path::new(&old_path).exists(), "old .md present pre-move");
+
+        // Move Parent under Dest → the on-disk dir moves; exported_path must follow.
+        move_note_folder_inner(&state, &parent, Some(&dest)).unwrap();
+
+        let new_path = state
+            .db
+            .get_note_row(&id)
+            .unwrap()
+            .unwrap()
+            .exported_path
+            .expect("exported_path present after move");
+        assert!(
+            new_path != old_path,
+            "exported_path REWRITTEN to the moved location (pre-fix it stayed stale)"
+        );
+        assert!(
+            new_path.contains("Dest"),
+            "exported_path reflects the new vault path under Dest: {new_path}"
+        );
+        assert!(
+            std::path::Path::new(&new_path).exists(),
+            "the real .md is at the rewritten path"
+        );
+
+        // Now LOCK the moved folder (Parent, now under Dest). It must delete the REAL `.md` — so no
+        // plaintext `.md` survives at EITHER path in the sealed folder.
+        lock_folder_inner(&state, parent.clone()).unwrap();
+        assert!(
+            !std::path::Path::new(&new_path).exists(),
+            "lock deleted the REAL plaintext .md (the leak the stale path caused)"
+        );
+        assert!(
+            !std::path::Path::new(&old_path).exists(),
+            "no plaintext .md left at the old path either"
+        );
+
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// NOTES-3 (MAJOR, RED-before-GREEN): the descendant-path rewrite in `Db::reparent_note_folder`
+    /// (triggered by MOVING a note-folder) fed the Rust BYTE length into SQLite `substr()` (which
+    /// counts CHARACTERS), corrupting descendant paths for a multi-byte (Polish) folder name. Move a
+    /// multi-byte parent under a new destination and assert the child path = `<new>/Sprzedaż/Q3` with
+    /// the leading slash intact (no mid-path slice / dropped separator).
+    #[test]
+    fn move_multibyte_note_folder_keeps_descendant_paths_intact() {
+        let state = build_state("notes3-multibyte");
+        state.db.ensure_default_note_folder().unwrap();
+        // "Sprzedaż" has a multi-byte 'ż' → BYTE length (15 for "Notes/Sprzedaż") != CHAR length (14),
+        // so a byte-length `substr()` offset drops the '/' after the prefix and corrupts descendants.
+        let parent = create_note_folder_inner(&state, "Sprzedaż", None).unwrap().id;
+        let child = create_note_folder_inner(&state, "Q3", Some(&parent))
+            .unwrap()
+            .id;
+        let dest = create_note_folder_inner(&state, "Klienci", None).unwrap().id;
+        assert_eq!(
+            state.db.note_folder_by_id(&child).unwrap().unwrap().path,
+            "Notes/Sprzedaż/Q3"
+        );
+
+        // MOVE the multi-byte parent under "Notes/Klienci" → parent becomes "Notes/Klienci/Sprzedaż";
+        // the child MUST follow to "Notes/Klienci/Sprzedaż/Q3" with the leading slash intact.
+        move_note_folder_inner(&state, &parent, Some(&dest)).unwrap();
+
+        let child_path = state.db.note_folder_by_id(&child).unwrap().unwrap().path;
+        assert_eq!(
+            child_path, "Notes/Klienci/Sprzedaż/Q3",
+            "multi-byte parent move must not corrupt the descendant path (byte vs char substr)"
+        );
+    }
+
+    /// SEAM-F1 (MAJOR plaintext-at-rest, RED-before-GREEN): a timeline persisted while a locked folder
+    /// is session-unlocked must be SEALED under the folder CK — the pre-fix bare `set_timeline_data`
+    /// left a plaintext timeline in the sealed row that survived relock at rest. This drives the
+    /// seal-on-write helper `generate_timeline` now uses and asserts the row has an encrypted
+    /// `data_blob` and NO plaintext `data` at rest after relock.
+    #[test]
+    fn timeline_written_while_unlocked_is_sealed_at_rest() {
+        let state = build_state("seam-f1-timeline");
+        make_open_folder(&state.db, "f", "Vault");
+        seed_meeting(&state.db, "m", "# note", Some("f"));
+        lock_folder_inner(&state, "f".to_string()).unwrap();
+        let ck = session_unlock(&state, "f");
+
+        // The write path `generate_timeline` uses after re-gating.
+        let json = "{\"topics\":[{\"title\":\"Budget\"}],\"speakers\":[]}";
+        set_timeline_data_reseal_if_locked(&state, "m", json).unwrap();
+
+        // At the session it is plaintext-visible AND carries a blob.
+        let raw = state.db.raw_timeline("m").unwrap().unwrap();
+        assert_eq!(raw.data, json, "plaintext visible in-session");
+        assert!(raw.data_blob.is_some(), "sealed blob written at write time");
+
+        // RELOCK: plaintext re-blanked, blob kept.
+        state.unlocked_folders.lock().unwrap().remove("f");
+        reblank_folder_extras(&state, "f").unwrap();
+        let at_rest = state.db.raw_timeline("m").unwrap().unwrap();
+        assert_eq!(at_rest.data, "", "NO plaintext timeline at rest after relock");
+        assert!(at_rest.data_blob.is_some(), "encrypted data_blob kept at rest");
+
+        // UNLOCK: byte-identical restore of the generated timeline.
+        unseal_folder_extras(&state, "f", &ck, None).unwrap();
+        assert_eq!(
+            state.db.raw_timeline("m").unwrap().unwrap().data,
+            json,
+            "the sealed timeline restores byte-identical"
+        );
+    }
+
+    /// SEAM-F2 (MAJOR edit lost, RED-before-GREEN): a speaker rename in a session-unlocked locked
+    /// folder plaintext-upserted the renamed timeline over the sealed blob, so relock destroyed the
+    /// rename (reblank restored the OLD sealed labels). This asserts the rename ROUND-TRIPS through
+    /// the sealed blob across a relock→unlock cycle.
+    #[test]
+    fn rename_speaker_in_unlocked_locked_folder_survives_relock() {
+        let state = build_state("seam-f2-rename");
+        make_open_folder(&state.db, "f", "Vault");
+        seed_meeting(&state.db, "m", "# note", Some("f"));
+        // Seed a timeline with a speaker turn we can rename.
+        let tl0 = "{\"topics\":[],\"speakers\":[{\"speaker\":\"others-0\",\"start_s\":0.0,\"end_s\":1.0}]}";
+        state.db.set_timeline_data("m", tl0).unwrap();
+        lock_folder_inner(&state, "f".to_string()).unwrap();
+        let ck = session_unlock(&state, "f");
+
+        rename_speaker_inner(&state, "m", "others-0", "Alice").unwrap();
+
+        // In-session the rename is visible AND sealed.
+        let raw = state.db.raw_timeline("m").unwrap().unwrap();
+        assert!(raw.data.contains("Alice"), "rename visible in-session");
+        assert!(raw.data_blob.is_some(), "renamed timeline sealed at write time");
+
+        // RELOCK then UNLOCK: the rename must persist through the sealed blob.
+        state.unlocked_folders.lock().unwrap().remove("f");
+        reblank_folder_extras(&state, "f").unwrap();
+        assert_eq!(
+            state.db.raw_timeline("m").unwrap().unwrap().data,
+            "",
+            "plaintext re-blanked at rest"
+        );
+        unseal_folder_extras(&state, "f", &ck, None).unwrap();
+        let restored = state.db.raw_timeline("m").unwrap().unwrap().data;
+        assert!(
+            restored.contains("Alice") && !restored.contains("others-0"),
+            "the speaker rename survives the relock round-trip (was destroyed pre-fix): {restored}"
+        );
+    }
+
+    /// LOCK-SHARE-INGEST-1 (MAJOR sealed-content leak, RED-before-GREEN): accepting a share into a
+    /// session-unlocked LOCKED folder wrote a RAW plaintext note row + a plaintext `.md`, both of
+    /// which survived the next relock at rest. This asserts the ingested note is SEALED from birth
+    /// (blob present, no plaintext row at rest after relock) and no plaintext `.md` is written.
+    #[test]
+    fn ingest_shared_note_into_unlocked_locked_folder_seals_at_rest() {
+        let vault = tmp_vault("share-ingest");
+        let state = build_state_with_vault("share-ingest", &vault);
+        make_open_folder(&state.db, "f", "Shared");
+        std::fs::create_dir_all(vault.join("Shared")).unwrap();
+        lock_folder_inner(&state, "f".to_string()).unwrap();
+        let ck = session_unlock(&state, "f");
+        let target = state.db.folder_by_id("f").unwrap().unwrap();
+
+        let env = murmur_protocol::envelope::ShareEnvelope::new(
+            "Confidential deal",
+            "the secret terms",
+            "2026-07-04T10:00:00Z",
+        );
+        let accepted =
+            ingest_shared_note(&state, &target, &env, "SENDERFP", "sender-uuid", "share-lk").unwrap();
+        let mid = accepted.meeting_id;
+
+        // The note row must be SEALED (blob present) — never a raw plaintext note behind the lock.
+        let sealed = &state.db.sealable_notes_for_meeting(&mid).unwrap()[0];
+        assert!(
+            sealed.content_blob.is_some(),
+            "shared note sealed from birth (blob present)"
+        );
+        // No plaintext `.md` was written into the locked folder.
+        let shared_dir = vault.join("Shared");
+        let md_files: Vec<_> = std::fs::read_dir(&shared_dir)
+            .map(|rd| {
+                rd.filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("md"))
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            md_files.is_empty(),
+            "no plaintext .md written into the locked target: {md_files:?}"
+        );
+
+        // RELOCK (command-layer shape): blank the sealed meeting-note markdown + reblank the extras.
+        state.unlocked_folders.lock().unwrap().remove("f");
+        let mut one = std::collections::HashSet::new();
+        one.insert("f".to_string());
+        state.db.blank_sealed_notes_in_folders(&one).unwrap();
+        reblank_folder_extras(&state, "f").unwrap();
+        let n = &state.db.sealable_notes_for_meeting(&mid).unwrap()[0];
+        assert_eq!(n.markdown, "", "no plaintext note markdown at rest after relock");
+        assert!(n.content_blob.is_some(), "sealed blob kept at rest");
+
+        // UNLOCK: the shared note comes back with its provenance + body.
+        // (unlock restores note markdown via the folder unlock path; here we assert the blob decrypts.)
+        let aad = aad_content("f", &mid, "shared", "note");
+        let pt = crate::crypto::decrypt(&ck, n.content_blob.as_ref().unwrap(), &aad).unwrap();
+        let restored = String::from_utf8(pt).unwrap();
+        assert!(
+            restored.contains("the secret terms") && restored.contains("share-id: share-lk"),
+            "sealed shared note decrypts to the ingested content + provenance"
+        );
+
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// folder_active_shares gate (RED-before-GREEN): the report returned org-share TITLES (plaintext)
+    /// for ANY folder including a sealed-and-not-session-unlocked one. This asserts a locked-not-
+    /// unlocked folder returns an EMPTY report (no title leak).
+    #[test]
+    fn folder_active_shares_masks_a_sealed_not_unlocked_folder() {
+        let state = build_state("active-shares-gate");
+        make_open_folder(&state.db, "f", "Secret");
+        seed_meeting(&state.db, "m", "# note", Some("f"));
+        // Seed an org share carrying a plaintext title anchored to this folder's meeting.
+        state
+            .db
+            .insert_org_share(
+                "os-1",
+                "org-1",
+                Some("m"),
+                None,
+                "note",
+                Some("TOP SECRET acquisition"),
+                1,
+                1,
+                &[0u8; 32],
+                "2026-07-11T00:00:00Z",
+            )
+            .unwrap();
+        // Sanity: while OPEN, the title is surfaced.
+        let open = folder_active_shares_inner(&state, "f").unwrap();
+        assert_eq!(open.org.len(), 1, "open folder surfaces the org share");
+
+        // Lock (NOT session-unlocked) → the report MUST be empty (no title leak).
+        lock_folder_inner(&state, "f".to_string()).unwrap();
+        let masked = folder_active_shares_inner(&state, "f").unwrap();
+        assert_eq!(masked.links, 0);
+        assert_eq!(masked.users, 0);
+        assert!(
+            masked.org.is_empty(),
+            "a sealed-not-unlocked folder leaks NO org share titles: {:?}",
+            masked.org
         );
     }
 }
@@ -22558,6 +23385,12 @@ pub async fn org_leave(state: State<'_, AppState>) -> Result<(), AppError> {
     let client = crate::share::client::ShareClient::new(&base)?;
     client.org_leave(&access, &org.org_id).await?;
     state.inner().db.delete_org_state(&org.org_id)?;
+    // LEAVE = full consent withdrawal: PURGE the decrypted org replica (items/chunks/vectors/FTS) so
+    // a departed member keeps NO searchable copy of colleagues' shared content. Without this the
+    // plaintext replica lingered forever and `org_search` / the `org_brain_search` tool would still
+    // return it (leak/consent invariant). Belt-and-braces beside the `org_brain_available` gate on
+    // the retrieval seam (a purged replica is empty either way).
+    state.inner().db.purge_org_replica(&org.org_id)?;
     // Drop every cached OCK for this org.
     {
         let mut cache = state
@@ -22777,8 +23610,7 @@ pub(crate) async fn share_to_org_inner(
     };
 
     // Persist a queued row FIRST (so a crash between seal + publish is recoverable by the launch
-    // sweep). The row id doubles as the envelope's item nonce (fresh per publish).
-    let row_id = crate::share::new_share_id();
+    // sweep).
     let now = chrono::Utc::now().to_rfc3339();
     let env = crate::share::org_envelope::OrgEnvelope::new(
         kind,
@@ -22789,18 +23621,45 @@ pub(crate) async fn share_to_org_inner(
         1,
     );
     let content_sha = env.content_sha256();
-    state.db.insert_org_share(
-        &row_id,
+    // SB-3 row-amplification fix: REUSE any existing retriable (`queued`/`failed`) row for this
+    // logical share key (org + meeting-or-document) instead of minting a fresh row on every sweep
+    // attempt. Pre-fix each retry inserted a NEW row while the old survived → unbounded row growth +
+    // a duplicate publish on eventual recovery. On reuse we re-arm the SAME row (state → queued,
+    // item_id/last_error cleared, per-attempt fields refreshed); a later success flips THAT one row to
+    // uploaded. Only a truly-new share (no reusable row) inserts.
+    let row_id = match state.db.find_reusable_org_share(
         &org.org_id,
         meeting_id.as_deref(),
         document_id.as_deref(),
-        kind.as_str(),
-        Some(&title),
-        1,
-        generation,
-        &content_sha,
-        &now,
-    )?;
+    )? {
+        Some(existing) => {
+            state.db.reset_org_share_for_retry(
+                &existing.id,
+                Some(&title),
+                1,
+                generation,
+                &content_sha,
+                &now,
+            )?;
+            existing.id
+        }
+        None => {
+            let row_id = crate::share::new_share_id();
+            state.db.insert_org_share(
+                &row_id,
+                &org.org_id,
+                meeting_id.as_deref(),
+                document_id.as_deref(),
+                kind.as_str(),
+                Some(&title),
+                1,
+                generation,
+                &content_sha,
+                &now,
+            )?;
+            row_id
+        }
+    };
 
     // (5) Seal under the OCK + LOCAL OPEN-VERIFY (the egress verify-before-destroy — publish only a
     // blob we just proved we can decrypt back).
@@ -22950,9 +23809,28 @@ pub fn folder_active_shares(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<ActiveSharesReport, AppError> {
-    let st = state.inner();
+    folder_active_shares_inner(state.inner(), &folder_id)
+}
+
+/// Inner of [`folder_active_shares`] taking `&AppState` (unit-testable gate).
+pub(crate) fn folder_active_shares_inner(
+    st: &AppState,
+    folder_id: &str,
+) -> Result<ActiveSharesReport, AppError> {
+    // GATE (2026-07-11 audit): a sealed-and-not-session-unlocked folder surfaces NOTHING here — org
+    // shares carry plaintext `title`s (stored un-sealed), which this command returned ungated for ANY
+    // folder, leaking a locked folder's note titles. Mirror the `folder_is_unlocked` read gate: a
+    // locked-not-unlocked folder returns an empty report (the FE shows the unlock affordance, never
+    // the share list). An open / session-unlocked folder proceeds normally.
+    if !folder_is_unlocked(st, folder_id)? {
+        return Ok(ActiveSharesReport {
+            links: 0,
+            users: 0,
+            org: Vec::new(),
+        });
+    }
     let (mut links, mut users) = (0u32, 0u32);
-    for (_share_id, mode) in st.db.active_link_user_shares_for_folder(&folder_id)? {
+    for (_share_id, mode) in st.db.active_link_user_shares_for_folder(folder_id)? {
         match mode.as_str() {
             "link" => links += 1,
             "user" => users += 1,
@@ -22961,7 +23839,7 @@ pub fn folder_active_shares(
     }
     let org = st
         .db
-        .active_org_share_ids_for_folder(&folder_id)?
+        .active_org_share_ids_for_folder(folder_id)?
         .into_iter()
         .map(|(row_id, item_id, title)| OrgActiveShare {
             item_id: item_id.unwrap_or(row_id),
@@ -23095,10 +23973,10 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
             )
             .await;
             if res.is_ok() {
-                // The new share created a fresh row; drop the stale queued/failed row so it doesn't
-                // re-fire. (A superseded queue entry — the retry replaced it.)
-                let now = chrono::Utc::now().to_rfc3339();
-                let _ = state.db.set_org_share_state(&row.id, "revoked", &now);
+                // SB-3: `share_to_org_inner` REUSED this same row (dedup on the logical key) and
+                // flipped it to `uploaded` on success — so there is NO stale row to revoke here (the
+                // pre-fix code minted a fresh row per attempt and revoked the old one, which is
+                // exactly the amplification we removed). Just count the advance.
                 advanced += 1;
             }
         }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -123,6 +123,15 @@ pub struct AppState {
     /// SAME gated `handle_voice_action` path as the wake trigger. Opt-in PER CLICK — independent of
     /// the `realtime_reactions` toggle.
     pub voice_command_capture: Mutex<Option<CaptureState>>,
+    /// TP-F1 — `true` while the LIVE-caption loop (`transcribe::live::run`) is actually running: the
+    /// ONLY consumer of a [`voice_command_capture`](Self::voice_command_capture). Set at the loop's
+    /// entry, cleared on EVERY exit (RAII guard) incl. an early model-load failure. The recorder being
+    /// present is NOT sufficient — on the fresh-install heavy-model default (`large-v3-turbo-q8_0`,
+    /// pinned `small` absent) `start_recording` sets `live_model = None` and spawns NO live loop, so a
+    /// voice command armed against a live-less recording would WEDGE with no consumer/backstop.
+    /// `begin_voice_command_inner` gates on THIS (not just the recorder) so it refuses cleanly
+    /// ("voice needs the live model") instead of arming a stuck capture. No PII (a bare flag).
+    pub live_running: AtomicBool,
     /// Db is internally Send+Sync (Mutex<Connection>). Held in an `Arc` so the egress-ledger
     /// sink (`DbEgressSink`) can hold a cheaply-cloned handle without requiring a second keychain
     /// access or separate connection (the ledger writes go through the same locked `Mutex<Conn>`).
@@ -325,6 +334,7 @@ impl AppState {
             spill_writer: Mutex::new(None),
             voice_listener: Mutex::new(None),
             voice_command_capture: Mutex::new(None),
+            live_running: AtomicBool::new(false),
             db,
             config,
             reasoner,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -436,6 +436,25 @@ impl Db {
              );
              CREATE INDEX IF NOT EXISTS idx_user_facts_meeting ON user_facts(meeting_id);
 
+             -- MEM-1 reversible memory-import supersede. When an import_memories run reconciles a
+             -- pasted export against EXISTING user facts and a same-key/different-object collision
+             -- CLOSES a pre-existing OPEN fact anchored to ANOTHER meeting, we record the link here so
+             -- deleting the synthetic Memory-Import meeting (the undo affordance) can REOPEN those
+             -- facts. Without it, delete_meeting purge_user_facts_tx deletes only the import's
+             -- OWN Adds (meeting_id = import_id) and the superseded pre-existing facts stay closed
+             -- FOREVER — a partial undo that silently loses prior memories. `superseded_valid_to` is
+             -- the exact `valid_to` we stamped, so the reopen only reverts OUR closure (idempotent /
+             -- conflict-safe). No FK on `superseded_fact_id` (the fact row survives — only its
+             -- valid_to changed); the import_meeting_id side is cleaned by `delete_meeting`.
+             CREATE TABLE IF NOT EXISTS user_fact_import_supersedes (
+               import_meeting_id  TEXT NOT NULL,
+               superseded_fact_id TEXT NOT NULL,
+               superseded_valid_to TEXT NOT NULL,
+               PRIMARY KEY (import_meeting_id, superseded_fact_id)
+             );
+             CREATE INDEX IF NOT EXISTS idx_ufis_import
+               ON user_fact_import_supersedes(import_meeting_id);
+
              -- On-device VOICE BIOMETRICS for diarized remote speakers (opt-in, default off). One row
              -- per diarized others-{cluster_index} cluster of a meeting: the L2-normalized CAM++
              -- speaker embedding (little-endian f32 BLOB), plus the bound person `label` once the user
@@ -1927,6 +1946,62 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// SB-3 dedup: the EXISTING retriable (`queued`/`failed`) org-share row for a logical share key
+    /// (org + meeting-or-document), if any. `share_to_org_inner` REUSES it on a re-publish instead of
+    /// minting a fresh row every sweep tick — without this, each failed retry inserted a NEW row while
+    /// the old one survived, so a persistently-failing share amplified rows unboundedly and a later
+    /// recovery double-published. Newest-created first (a stable pick if somehow >1 exists). Uploaded/
+    /// revoked/revoke_pending rows are NOT reused (an uploaded share is a distinct published item; a
+    /// revoked one is intentionally torn down). `meeting_id`/`document_id` are matched exactly (both
+    /// NULL-safe via `IS`).
+    pub fn find_reusable_org_share(
+        &self,
+        org_id: &str,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<Option<crate::storage::OrgShareRow>> {
+        let conn = self.lock();
+        conn.query_row(
+            &format!(
+                "SELECT {} FROM org_shares
+                   WHERE org_id = ?1
+                     AND meeting_id IS ?2 AND document_id IS ?3
+                     AND state IN ('queued', 'failed')
+                   ORDER BY created_at DESC LIMIT 1",
+                Self::ORG_SHARE_COLS
+            ),
+            rusqlite::params![org_id, meeting_id, document_id],
+            Self::map_org_share,
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// SB-3 retry re-arm: reset an EXISTING org-share row back to `queued` for a fresh publish attempt,
+    /// refreshing the per-attempt fields (title/content hash/generation/timestamps) and CLEARING any
+    /// item_id + last_error. Used by `share_to_org_inner` when it reuses a `find_reusable_org_share`
+    /// row instead of inserting a new one — so N failed attempts stay ONE row, and a later success
+    /// flips that same row to uploaded (no duplicate). Idempotent on the row id.
+    pub fn reset_org_share_for_retry(
+        &self,
+        id: &str,
+        title: Option<&str>,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        updated_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_shares SET state = 'queued', item_id = NULL, last_error = NULL,
+               title = ?2, rev = ?3, generation = ?4, content_sha256 = ?5, updated_at = ?6
+             WHERE id = ?1",
+            rusqlite::params![id, title, rev as i64, generation as i64, content_sha256, updated_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     /// All org shares in a given `state` (the launch sweep pulls `queued` + `revoke_pending`).
     pub fn list_org_shares_in_state(
         &self,
@@ -2788,6 +2863,13 @@ impl Db {
         // tx (the meetings FK CASCADE also covers it — the explicit delete keeps the purge visible
         // and test-bound alongside the other derived artifacts).
         Self::purge_live_bullets_tx(&tx, &[id.to_string()])?;
+        // MEM-1 (reversible import supersede): BEFORE purging this meeting's own facts, REOPEN every
+        // pre-existing fact that a synthetic Memory-Import superseded (set valid_to back to NULL) and
+        // drop the link rows — so "delete the import ⇒ undo" restores prior memories instead of
+        // leaving them permanently closed. A non-import meeting has no link rows ⇒ a no-op. Runs
+        // before `purge_user_facts_tx` so the reopen targets facts that survive (the import's OWN
+        // Adds are then deleted below); the two never touch the same rows.
+        Self::reopen_import_superseded_facts_tx(&tx, id)?;
         // Brain v2 L2.2: purge this meeting's user facts EXPLICITLY (direct DELETE) rather than
         // relying on the meetings FK cascade alone — the direct DELETE reliably fires the
         // `fts_user_facts_ad` trigger, so the deleted facts' tokens leave the FTS index in this
@@ -4485,18 +4567,46 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         // Descendants first: rewrite every `<old_path>/…` prefix to `<new_path>/…`.
+        // NOTES-3 (2026-07-11 audit): SQLite `substr()` counts CHARACTERS, not bytes, so the
+        // suffix offset MUST be the char count of `old_path` (+1 for the following '/'), never the
+        // Rust byte length — a multi-byte prefix (Polish "Sprzedaż") would otherwise slice mid-path
+        // and corrupt every descendant. `char_length(old_path) + 1` picks up at the '/' after the
+        // old prefix, so the leading slash survives into the rewritten path.
         let like = format!("{}/%", old_path.replace('!', "!!").replace('%', "!%").replace('_', "!_"));
         tx.execute(
             "UPDATE folders
                 SET path = ?1 || substr(path, ?2)
               WHERE kind = 'note' AND path LIKE ?3 ESCAPE '!'",
-            rusqlite::params![new_path, (old_path.len() + 1) as i64, like],
+            rusqlite::params![new_path, (old_path.chars().count() + 1) as i64, like],
         )
         .map_err(map_err)?;
         // Then the folder itself: its own path + parent link.
         tx.execute(
             "UPDATE folders SET path = ?2, parent_id = ?3 WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id, new_path, parent_id],
+        )
+        .map_err(map_err)?;
+        // NOTES-2 (2026-07-11 audit): rewrite every affected authored note's `documents.exported_path`
+        // so it reflects the NEW on-disk vault path (the FS `.md` was physically moved by
+        // `reparent_note_folder_paths`). Without this the path stays STALE and a later `lock_folder`
+        // deletes nothing at that stale path — leaving the real plaintext `.md` on disk in a sealed
+        // folder (a sealed-content leak). We replace the OLD path prefix with the NEW one for the moved
+        // folder AND its descendants. `replace()` is byte-safe (substring, not offset) and multi-byte
+        // safe. Scoped to notes whose folder is now under the new path (folders were rewritten above).
+        tx.execute(
+            "UPDATE documents
+                SET exported_path = replace(exported_path, ?1, ?2)
+              WHERE kind = 'note' AND exported_path IS NOT NULL
+                AND instr(exported_path, ?1) > 0
+                AND folder_id IN (
+                    SELECT id FROM folders
+                     WHERE kind = 'note' AND (path = ?2 OR path LIKE ?3 ESCAPE '!')
+                )",
+            rusqlite::params![
+                old_path,
+                new_path,
+                format!("{}/%", new_path.replace('!', "!!").replace('%', "!%").replace('_', "!_")),
+            ],
         )
         .map_err(map_err)?;
         tx.commit().map_err(map_err)?;
@@ -4756,6 +4866,46 @@ impl Db {
         Ok(())
     }
 
+    /// LEAVE-A-ORG CONSENT PURGE: drop the ENTIRE decrypted replica of one org — every `org_items`
+    /// row plus its derived `org_chunks` / `org_vec_chunks` / `fts_org_chunks` tokens — in ONE atomic
+    /// tx. Called by `org_leave` so a departed member keeps NO searchable copy of colleagues' shared
+    /// content (leak/consent invariant): the OCK cache is dropped and `org_state` deleted at the
+    /// command layer, but WITHOUT this the plaintext replica lingered forever and `org_search` could
+    /// still return it. Order: vec0 first (its FK-less rowid mirrors `org_chunks.id`), then
+    /// `org_chunks` (whose DELETE fires the `fts_org_chunks_ad` trigger, purging the keyword tokens),
+    /// then the `org_items` header rows. Idempotent; an unknown org id is a no-op. Content-free log
+    /// (org id + counts, never titles/bodies).
+    pub fn purge_org_replica(&self, org_id: &str) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        // vec0 KNN rows for every chunk of every item in this org (the FK-less mirror table).
+        tx.execute(
+            "DELETE FROM org_vec_chunks WHERE chunk_id IN
+               (SELECT oc.id FROM org_chunks oc
+                  JOIN org_items oi ON oi.item_id = oc.item_id
+                 WHERE oi.org_id = ?1)",
+            rusqlite::params![org_id],
+        )
+        .map_err(map_err)?;
+        // Source chunks (their DELETE fires the FTS `_ad` trigger → keyword tokens purged).
+        tx.execute(
+            "DELETE FROM org_chunks WHERE item_id IN
+               (SELECT item_id FROM org_items WHERE org_id = ?1)",
+            rusqlite::params![org_id],
+        )
+        .map_err(map_err)?;
+        // Finally the item headers (the decrypted markdown/title replica).
+        let items = tx
+            .execute(
+                "DELETE FROM org_items WHERE org_id = ?1",
+                rusqlite::params![org_id],
+            )
+            .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        tracing::info!(target: "org", items, "purged org replica on leave");
+        Ok(())
+    }
+
     /// Delete an org item's `org_chunks` + `org_vec_chunks` rows within an EXISTING tx. vec0 first
     /// (its FK-less rowid mirrors `org_chunks.id`), then the source rows (whose DELETE fires the FTS
     /// `_ad` trigger, purging the tokens). Mirrors [`Db::purge_doc_chunks_tx`].
@@ -4903,19 +5053,6 @@ impl Db {
         )
         .optional()
         .map_err(map_err)
-    }
-
-    /// Count of LIVE (non-tombstoned) org items for an org — the `OrgStatus.itemCount` source.
-    pub fn org_item_count(&self, org_id: &str) -> Result<u64> {
-        let conn = self.lock();
-        let n: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM org_items WHERE org_id = ?1 AND tombstoned = 0",
-                rusqlite::params![org_id],
-                |r| r.get(0),
-            )
-            .map_err(map_err)?;
-        Ok(n.max(0) as u64)
     }
 
     /// Every non-null `content_sha256` from the local `org_shares` rows (across all orgs the user has
@@ -5633,6 +5770,31 @@ impl Db {
         Ok(())
     }
 
+    /// SEAL-ON-WRITE twin of [`Db::set_timeline_data`] for a meeting in a session-unlocked LOCKED
+    /// folder (2026-07-11 audit SEAM-F1/F2): upsert the fresh plaintext (session-visible) AND its
+    /// freshly-encrypted `data_blob` in ONE atomic statement, so relock/at-rest reblank restores THIS
+    /// timeline — never a stale lock-time copy, and a timeline GENERATED while unlocked is sealed from
+    /// birth (never a blob-less plaintext behind a lock). The CALLER must have verified the blob
+    /// decrypts back byte-identical BEFORE calling this (verify-before-destroy) — exactly like
+    /// [`Db::seal_timeline`]. INSERT-or-update (a freshly generated timeline has no row yet).
+    pub fn set_timeline_data_sealed(
+        &self,
+        meeting_id: &str,
+        data: &str,
+        data_blob: &[u8],
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO timelines (meeting_id, data, data_blob) VALUES (?1, ?2, ?3)
+             ON CONFLICT(meeting_id) DO UPDATE SET
+               data = excluded.data,
+               data_blob = excluded.data_blob",
+            rusqlite::params![meeting_id, data, data_blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     // ── meeting tags ─────────────────────────────────────────────────────────
 
     /// Replace all tags for a meeting with `tags` (trimmed, blanks dropped).
@@ -6259,9 +6421,30 @@ impl Db {
     pub fn delete_folder(&self, id: &str) -> Result<usize> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        // NOTES-1 (2026-07-11 audit, CRITICAL data loss): AUTHORED notes (`documents(kind='note')`)
+        // must have been REPARENTED to the default note-folder by the command layer BEFORE we get
+        // here — the FE promises "delete folder" MOVES its notes, never destroys them. If any authored
+        // note STILL references this folder, REFUSE (never blanket-DELETE an authored note). The
+        // pre-fix `DELETE FROM documents WHERE folder_id` permanently destroyed every authored note in
+        // the folder. Uploaded/ingested documents (`kind != 'note'`) — which are DERIVED brain sources,
+        // not user-authored primary content — are still cleaned up here as before.
+        let authored_remaining: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM documents WHERE folder_id = ?1 AND kind = 'note'",
+                rusqlite::params![id],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        if authored_remaining > 0 {
+            return Err(AppError::Storage(format!(
+                "refusing to delete folder {id}: {authored_remaining} authored note(s) still assigned \
+                 — reparent them first (never destroy authored notes on folder delete)"
+            )));
+        }
+        // Only DERIVED (uploaded/ingested) documents remain — purge their chunks + rows.
         let document_ids: Vec<String> = {
             let mut stmt = tx
-                .prepare("SELECT id FROM documents WHERE folder_id = ?1")
+                .prepare("SELECT id FROM documents WHERE folder_id = ?1 AND kind != 'note'")
                 .map_err(map_err)?;
             let rows = stmt
                 .query_map(rusqlite::params![id], |r| r.get::<_, String>(0))
@@ -6273,9 +6456,10 @@ impl Db {
             out
         };
         Self::purge_doc_chunks_tx(&tx, &document_ids)?;
-        // Explicit (rather than FK-cascade) so the delete is deterministic and trigger-visible.
+        // Explicit (rather than FK-cascade) so the delete is deterministic and trigger-visible. Scoped
+        // to non-authored documents — authored notes were reparented out above (and refused if not).
         tx.execute(
-            "DELETE FROM documents WHERE folder_id = ?1",
+            "DELETE FROM documents WHERE folder_id = ?1 AND kind != 'note'",
             rusqlite::params![id],
         )
         .map_err(map_err)?;
@@ -8625,6 +8809,29 @@ impl Db {
     /// and is NOT persisted (there is no entity column). The whole batch commits or rolls back
     /// together, so a crash mid-apply never leaves a half-reconciled store.
     pub fn apply_user_fact_ops(&self, ops: &[crate::facts::FactOp]) -> Result<()> {
+        self.apply_user_fact_ops_inner(ops, None)
+    }
+
+    /// MEM-1: apply the reconcile ops AND, in the SAME atomic tx, record every `Invalidate`d
+    /// pre-existing fact under `import_meeting_id` (into `user_fact_import_supersedes`) so deleting the
+    /// synthetic Memory-Import meeting can REOPEN them. Used ONLY by `import_memories` — a normal
+    /// meeting's fact extraction anchors its Adds to the meeting itself and needs no reversible link
+    /// (deleting that meeting purges its Adds; it does not supersede OTHER meetings' facts). Recording
+    /// the closure link atomically with the closure means a crash can never leave a closed-but-unlinked
+    /// (permanently-lost-on-undo) fact.
+    pub fn apply_user_fact_ops_recording_import_supersedes(
+        &self,
+        ops: &[crate::facts::FactOp],
+        import_meeting_id: &str,
+    ) -> Result<()> {
+        self.apply_user_fact_ops_inner(ops, Some(import_meeting_id))
+    }
+
+    fn apply_user_fact_ops_inner(
+        &self,
+        ops: &[crate::facts::FactOp],
+        import_meeting_id: Option<&str>,
+    ) -> Result<()> {
         use crate::facts::FactOp;
         if ops.is_empty() {
             return Ok(());
@@ -8654,16 +8861,62 @@ impl Db {
                     .map_err(map_err)?;
                 }
                 FactOp::Invalidate { id, valid_to } => {
-                    tx.execute(
-                        "UPDATE user_facts SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
-                        rusqlite::params![id, valid_to],
-                    )
-                    .map_err(map_err)?;
+                    let closed = tx
+                        .execute(
+                            "UPDATE user_facts SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
+                            rusqlite::params![id, valid_to],
+                        )
+                        .map_err(map_err)?;
+                    // MEM-1: only record the reversible link when WE actually closed the row (the
+                    // `AND valid_to IS NULL` guard) AND this is an import run — so the undo reopens
+                    // exactly the facts THIS import superseded, nothing else.
+                    if closed > 0 {
+                        if let Some(imid) = import_meeting_id {
+                            tx.execute(
+                                "INSERT OR IGNORE INTO user_fact_import_supersedes
+                                   (import_meeting_id, superseded_fact_id, superseded_valid_to)
+                                 VALUES (?1, ?2, ?3)",
+                                rusqlite::params![imid, id, valid_to],
+                            )
+                            .map_err(map_err)?;
+                        }
+                    }
                 }
                 FactOp::NoOp => {}
             }
         }
         tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// MEM-1 reversible-supersede UNDO (in an EXISTING tx, called from `delete_meeting`): when the
+    /// deleted meeting is a synthetic Memory-Import, REOPEN every pre-existing fact that import closed
+    /// (set `valid_to` back to NULL) — but ONLY where the row is still closed at the EXACT `valid_to`
+    /// we stamped (so a later legitimate re-supersession by a DIFFERENT meeting is never clobbered) —
+    /// then drop the link rows. Then the caller's `purge_user_facts_tx` deletes the import's OWN Adds.
+    /// A non-import meeting has no link rows ⇒ a no-op. This makes "delete the import ⇒ full undo"
+    /// restore the pre-existing memories instead of leaving them permanently closed.
+    fn reopen_import_superseded_facts_tx(
+        tx: &rusqlite::Transaction<'_>,
+        import_meeting_id: &str,
+    ) -> Result<()> {
+        // Reopen each still-matching superseded fact (guarded on the recorded valid_to).
+        tx.execute(
+            "UPDATE user_facts
+                SET valid_to = NULL
+              WHERE id IN (SELECT superseded_fact_id FROM user_fact_import_supersedes
+                            WHERE import_meeting_id = ?1)
+                AND valid_to = (SELECT superseded_valid_to FROM user_fact_import_supersedes s
+                                 WHERE s.import_meeting_id = ?1 AND s.superseded_fact_id = user_facts.id)",
+            rusqlite::params![import_meeting_id],
+        )
+        .map_err(map_err)?;
+        // Drop the link rows (the import is being deleted).
+        tx.execute(
+            "DELETE FROM user_fact_import_supersedes WHERE import_meeting_id = ?1",
+            rusqlite::params![import_meeting_id],
+        )
+        .map_err(map_err)?;
         Ok(())
     }
 
@@ -10264,6 +10517,73 @@ mod tests {
         assert_eq!(n, 0, "org_chunks purged on tombstone");
         // Idempotent re-tombstone.
         db.tombstone_org_item("it-t").unwrap();
+    }
+
+    /// LEAVE PURGE (RED-before-GREEN, leak/consent): `purge_org_replica` drops the WHOLE decrypted
+    /// replica of an org — every `org_items` header, its `org_chunks`/`org_vec_chunks`, and the
+    /// `fts_org_chunks` tokens — so `org_leave` leaves NO searchable copy of colleagues' content.
+    /// Pre-fix `org_leave` deleted only `org_state`, so the replica lingered forever and `org_search`
+    /// could still return it. Idempotent; scoped to the named org (a second org survives).
+    #[test]
+    fn purge_org_replica_drops_the_whole_decrypted_replica() {
+        let db = mem_db();
+        let emb = crate::embed::StubEmbedder;
+        db.upsert_org_item(
+            "it-a", "org-1", 1, "anna", "Roadmap", "the falcon rollout plan alpha", "t", 1, 1,
+            &sha32(6), Some(&emb),
+        )
+        .unwrap();
+        db.upsert_org_item(
+            "it-b", "org-1", 2, "bob", "Budget", "the falcon rollout budget beta", "t", 1, 1,
+            &sha32(7), Some(&emb),
+        )
+        .unwrap();
+        // A DIFFERENT org's item must SURVIVE the scoped purge.
+        db.upsert_org_item(
+            "it-other", "org-2", 1, "carol", "Other", "unrelated other-org content", "t", 1, 1,
+            &sha32(8), Some(&emb),
+        )
+        .unwrap();
+
+        // Precondition: org-1 items are retrievable.
+        assert_eq!(db.search_org_chunks_fts("falcon rollout", 10).unwrap().len(), 2);
+
+        db.purge_org_replica("org-1").unwrap();
+
+        // FTS + KNN + the viewer + the raw rows all show org-1 gone.
+        assert!(
+            db.search_org_chunks_fts("falcon rollout", 10).unwrap().is_empty(),
+            "org-1 replica must vanish from FTS after leave-purge"
+        );
+        // KNN: no org-1 item survives (the surviving org-2 item may still appear — StubEmbedder
+        // vectors are text-independent — so assert org-1's ids are GONE, not that KNN is empty).
+        let qv = emb.embed_query(&["falcon rollout".to_string()]).unwrap().remove(0);
+        let knn = db.search_org_chunks_knn(&qv, 10).unwrap();
+        assert!(
+            knn.iter().all(|h| h.item_id != "it-a" && h.item_id != "it-b"),
+            "no org-1 item may survive in KNN after leave-purge: {:?}",
+            knn.iter().map(|h| &h.item_id).collect::<Vec<_>>()
+        );
+        assert!(db.get_org_item("it-a").unwrap().is_none());
+        assert!(db.get_org_item("it-b").unwrap().is_none());
+        let n_items: i64 = db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM org_items WHERE org_id='org-1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_items, 0, "org_items header rows for org-1 are gone");
+        let n_chunks: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM org_chunks WHERE item_id IN ('it-a','it-b')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n_chunks, 0, "org_chunks for org-1 items are gone");
+
+        // The OTHER org is untouched, and the purge is idempotent.
+        assert!(db.get_org_item("it-other").unwrap().is_some(), "org-2 survives the scoped purge");
+        db.purge_org_replica("org-1").unwrap(); // idempotent no-op
     }
 
     /// Re-pull idempotency: upserting the SAME item id twice REPLACES (never duplicates) its chunks —

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -500,10 +500,11 @@ pub struct DocChunkHit {
 
 /// Shared Brain v1 — one ORG-partition retrieval hit: the nearest/best chunk's snippet + the
 /// source org item's id, `author_hint`, and title. The parallel of [`DocChunkHit`] for the org
-/// leg; the retrieval fusion turns it into a [`VaultSource`] with `origin = SourceOrigin::org(..)`
-/// so the FE renders the `[org · <author>]` provenance chip. `content_sha256` rides along so the
-/// self-share dedup (drop a hit whose plaintext hash matches a local `org_shares` row) is applied
-/// at the fusion layer without a second DB read.
+/// leg. The `org_search` / `org_brain_search` TOOL renders each hit as a LOUD `[org · <author>]`
+/// text line (`crate::tools::format_org_hits`); the structured `VaultSource` provenance chip on the
+/// Ask surface is NOT wired to org hits (`origin` is always `None`). `content_sha256` rides along
+/// so the self-share dedup (drop a hit whose plaintext hash matches a local `org_shares` row) is
+/// applied without a second DB read.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrgChunkHit {
     pub item_id: String,
@@ -527,18 +528,6 @@ pub struct OrgItemDetail {
     pub created_at: String,
     pub rev: u32,
     pub markdown: String,
-}
-
-/// Shared Brain v1 — a summary row of a synced org item (feed replica). Mirrors the FE
-/// `OrgItemSummary` (camelCase).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct OrgItemSummary {
-    pub item_id: String,
-    pub author_hint: String,
-    pub title: String,
-    pub created_at: String,
-    pub rev: u32,
 }
 
 /// Shared Brain v1 — the content-free result of a manual `org_sync_now()` (counts + errors only).
@@ -779,6 +768,11 @@ pub struct PinResult {
 /// org hit, `author` is the item's `author_hint` label and `org_item_id` is the id the read-only
 /// org-item viewer loads via `org_get_item`. Mirrors the FE `SourceOrigin` (camelCase). CONTENT-FREE
 /// beyond the author label the local user is already allowed to see.
+///
+/// NOTE (2026-07-11 SB-2): the STRUCTURED chip is not yet wired — every [`VaultSource`] currently
+/// sets `origin: None`; org retrieval provenance is surfaced only as the LOUD `[org · <author>]`
+/// TEXT line the `org_search` / `org_brain_search` tool emits (`crate::tools::format_org_hits`).
+/// This DTO exists for the (unimplemented) chip surface; do not document a fusion that does not run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceOrigin {
@@ -790,17 +784,6 @@ pub struct SourceOrigin {
     pub org_item_id: Option<String>,
 }
 
-impl SourceOrigin {
-    /// The provenance of an ORG-brain hit (renders the `[org · <author>]` chip → the viewer route).
-    pub fn org(author: impl Into<String>, org_item_id: impl Into<String>) -> Self {
-        Self {
-            kind: "org".to_string(),
-            author: Some(author.into()),
-            org_item_id: Some(org_item_id.into()),
-        }
-    }
-}
-
 /// A meeting referenced as a source in an Ask-My-Vault answer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -808,9 +791,10 @@ pub struct VaultSource {
     pub meeting_id: String,
     pub title: String,
     pub started_at: String,
-    /// Shared Brain v1 — absent/null for a plain LOCAL owned-content source; present with
-    /// `kind:"org"` for an org-brain hit synced from a colleague. Lets the FE render an org-origin
-    /// chip (author + date) routing to the read-only org-item viewer.
+    /// Shared Brain v1 — always `None` today (SB-2): the structured org-origin chip is NOT wired, so
+    /// every source is a plain LOCAL owned-content reference. Kept as an ADDITIVE, FE-optional field
+    /// (`skip_serializing_if`) for the eventual chip surface; org provenance rides the tool's text
+    /// `[org · <author>]` line instead. See [`SourceOrigin`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin: Option<SourceOrigin>,
 }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -858,6 +858,15 @@ pub(crate) fn org_brain_available(db: &Db, config: &AppConfig) -> bool {
 /// ([`neutralize_murmur_fences`]) so an UNTRUSTED org author cannot smuggle managed-block markers or
 /// a system-prompt override into the loop. The output is DATA for the loop — NEVER a system prompt.
 pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Result<String> {
+    // AVAILABILITY GATE (belt-and-braces, applied at the SEAM not just at advertisement): the org
+    // partition is searchable ONLY when an org is joined AND org egress is consented. The AGENT tool
+    // gates this at `specs()` advertisement time, but the MCP `org_search` path reaches this seam
+    // DIRECTLY via `dispatch_tool` → `execute_tool` with NO advertisement filter — so without this
+    // in-seam check a departed member (whose replica hadn't yet been purged) or an un-consented user
+    // could still search colleagues' content. Fail-closed to an empty (never-a-leak) result.
+    if !org_brain_available(db, config) {
+        return Ok("No org-brain results (not a member of a consented org).".to_string());
+    }
     let q = query.trim();
     if q.is_empty() {
         return Ok("No org-brain results for an empty query.".to_string());
@@ -2542,6 +2551,44 @@ mod tests {
         assert!(
             out.contains("Anna's note") && out.contains("[org · anna]"),
             "a colleague's item must still surface: {out}"
+        );
+    }
+
+    /// SEAM GATE (RED-before-GREEN, leak/consent): `search_org_brain` — the shared retrieval seam the
+    /// MCP `org_search` reaches DIRECTLY (no advertisement filter) — must itself fail-closed when the
+    /// org is not consented, even if the decrypted replica still holds a colleague's item. Pre-fix,
+    /// the seam returned the item (the "empty partition" assumption is false when a departed/
+    /// un-consented user still has the replica). RED on old code: the hit surfaced.
+    #[test]
+    fn search_org_brain_seam_fails_closed_when_unconsented() {
+        let db = tmp_db();
+        seed_org(&db); // joins org-1 (org_state present)
+        // A colleague's item IS in the local replica (as it would be right after a leave, before the
+        // replica purge lands / or for a user who ingested then revoked consent).
+        ingest_org(&db, "it-x", "anna", "Anna's roadmap", "the apollo migration ships friday", &[3u8; 32]);
+
+        // Config: org egress NOT consented → the seam must return nothing.
+        let cfg_off = AppConfig {
+            org_egress_consented: false,
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let out = search_org_brain(&db, &cfg_off, "apollo migration").unwrap();
+        assert!(
+            !out.contains("Anna's roadmap") && !out.contains("[org · anna]"),
+            "un-consented org search must leak NOTHING even with a populated replica: {out}"
+        );
+
+        // Sanity: WITH consent the same item is found (proving the gate — not a broken query — hid it).
+        let cfg_on = AppConfig {
+            org_egress_consented: true,
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let found = search_org_brain(&db, &cfg_on, "apollo migration").unwrap();
+        assert!(
+            found.contains("Anna's roadmap"),
+            "with consent the seam returns the item (gate, not query, hid it): {found}"
         );
     }
 

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -220,6 +220,23 @@ fn run(app: AppHandle, model_path: PathBuf, lang: Option<String>) {
     // T1.5 — QoS: the caption tick is background inference; tag this thread UTILITY so macOS
     // schedules it onto efficiency cores under contention. Best-effort C call, never fatal.
     crate::thermal::set_utility_qos();
+    // TP-F1 — advertise the live-loop as RUNNING while this thread lives (the only consumer of a
+    // manual voice-command capture). Set here at entry and cleared on EVERY exit (incl. the early
+    // model-load-failure returns below and a panic) via the RAII guard, so `begin_voice_command_inner`
+    // knows a consumer exists. Registered BEFORE `Transcriber::load` so a load failure still clears it.
+    struct LiveRunningGuard(AppHandle);
+    impl Drop for LiveRunningGuard {
+        fn drop(&mut self) {
+            self.0
+                .state::<AppState>()
+                .live_running
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    app.state::<AppState>()
+        .live_running
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let _live_running_guard = LiveRunningGuard(app.clone());
     // Fresh transcript per recording: clear any leftover from a previous meeting so the in-meeting
     // assistant can never answer about a stale recording.
     if let Ok(mut lt) = app.state::<AppState>().live_transcript.lock() {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1865,19 +1865,6 @@ export interface OrgShareEntry {
 }
 
 /**
- * A summary row of a synced org item (feed replica). Content-free beyond the
- * title/author-hint the local user is allowed to see. Mirrors the Rust
- * `OrgItemSummary`.
- */
-export interface OrgItemSummary {
-  itemId: string;
-  authorHint: string;
-  title: string;
-  createdAt: string;
-  rev: number;
-}
-
-/**
  * The full decrypted org item for the read-only viewer route (`orgGetItem`).
  * `markdown` is the plaintext envelope body — this is deliberately-disclosed org
  * content (no lock gate applies to org items), rendered read-only with an

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -289,35 +289,50 @@ export class DetailComponent implements OnInit {
   readonly timelineLoading = signal(false);
 
   /**
+   * One-shot latch for the Audio-tab effect: the meeting id whose Audio-tab timeline read has
+   * already been attempted (and resolved) this open. Set the moment `loadTimeline` starts, so the
+   * effect can NEVER re-enter for the same meeting — even if the read resolves to an empty/falsy
+   * backend timeline that leaves no terminal signal set (the #234 infinite-loop root cause: a
+   * `get_timeline`/`generate_timeline` returning `{speakers:[],topics:[]}`/null left
+   * `timeline==null && !error && !needsGeneration`, so the effect re-fired forever). Cleared per
+   * meeting in `loadMeeting`. The explicit Retry / Generate clicks call `loadTimeline`/`generateTimeline`
+   * directly (not via the effect), so a deliberate re-run is unaffected.
+   */
+  private readonly _timelineAttempted = signal<string | null>(null);
+
+  /**
    * PERF/OOM (P0.1): generate the timeline LAZILY — only when the Audio tab (the only surface that
    * renders it) is first opened for an unlocked meeting and it isn't already loaded / in flight.
    * `loadMeeting`/`unlock` no longer kick it off on open, so a plain Note-tab open never triggers the
-   * multi-GB on-device LLM pass that OOM-killed the Mac. `allowSignalWrites` because `loadTimeline`
-   * writes `timelineLoading` (which this effect reads) — the `!timelineLoading()` guard makes the
-   * re-run a no-op, so there is no loop. See docs/research/2026-07-07-perf-memory-audit.md.
+   * multi-GB on-device LLM pass that OOM-killed the Mac. Signal writes in the invoked `loadTimeline`
+   * are fine in v22 (no flag) — the `_timelineAttempted` latch below makes the effect fire at most
+   * once per meeting-open, so there is no loop. See docs/research/2026-07-07-perf-memory-audit.md.
    */
-  private readonly _timelineOnAudioTab = effect(
-    () => {
-      if (
-        this.activeTab() === "audio" &&
-        this.detail() &&
-        !this.locked() &&
-        !this.timeline() &&
-        !this.timelineLoading() &&
-        // Do NOT auto-retry after a failure: a persistent error would otherwise re-fire this effect
-        // every time `timelineLoading` flips back to false → an infinite retry loop. A failed load
-        // surfaces the Retry button, which clears `timelineError` and re-calls `loadTimeline`.
-        !this.timelineError() &&
-        // Do NOT re-fire once we've surfaced the "Generate" affordance (on-device, no cache): the
-        // read leaves `timeline` null + `timelineLoading` false, so without this guard the effect
-        // would loop calling `loadTimeline` forever. Cleared only by the user's Generate click.
-        !this.timelineNeedsGeneration()
-      ) {
-        void this.loadTimeline();
-      }
-    },
-    { allowSignalWrites: true },
-  );
+  private readonly _timelineOnAudioTab = effect(() => {
+    const d = this.detail();
+    const id = d?.meeting.id ?? null;
+    if (
+      this.activeTab() === "audio" &&
+      d &&
+      id &&
+      !this.locked() &&
+      !this.timeline() &&
+      !this.timelineLoading() &&
+      // Do NOT auto-retry after a failure: a persistent error would otherwise re-fire this effect
+      // every time `timelineLoading` flips back to false → an infinite retry loop. A failed load
+      // surfaces the Retry button, which clears `timelineError` and re-calls `loadTimeline`.
+      !this.timelineError() &&
+      // Do NOT re-fire once we've surfaced the "Generate" affordance (on-device, no cache): the
+      // read leaves `timeline` null + `timelineLoading` false, so without this guard the effect
+      // would loop calling `loadTimeline` forever. Cleared only by the user's Generate click.
+      !this.timelineNeedsGeneration() &&
+      // ONE-SHOT LATCH (#234): never re-attempt the Audio-tab read for a meeting id already tried
+      // this open — an empty/falsy backend result that sets no terminal signal must NOT re-loop.
+      this._timelineAttempted() !== id
+    ) {
+      void this.loadTimeline();
+    }
+  });
   readonly timelineError = signal(false);
   /**
    * PERF/OOM: true when deriving THIS install's timeline would load a residency-bound on-device
@@ -418,15 +433,26 @@ export class DetailComponent implements OnInit {
    * Refresh the "In Org Brain" header pill from `list_org_shares`. See the
    * {@link orgShared} SEAM note: matched by title (the content-free share list
    * carries no meeting id yet). Fails closed to `false` on any error / no org.
+   *
+   * STALE-RESULT guard (FE failure mode #4): capture the meeting id at call time and,
+   * after the `list_org_shares` await, drop the result if the user navigated to another
+   * meeting mid-flight (`openRelated` reuses this component) — otherwise a late response
+   * could set the pill from the PREVIOUS meeting's title over the current one.
    */
   private async refreshOrgShared(): Promise<void> {
-    const title = this.detail()?.meeting.title;
+    const meeting = this.detail()?.meeting;
+    const id = meeting?.id;
+    const title = meeting?.title;
     if (!title) {
       this.orgShared.set(false);
       return;
     }
     try {
       const shares = await this.ipc.listOrgShares();
+      // Drop late responses for a meeting the user has since navigated away from.
+      if (this.detail()?.meeting.id !== id) {
+        return;
+      }
       this.orgShared.set(
         shares.some((s) => s.state !== "revoked" && s.title === title),
       );
@@ -453,6 +479,8 @@ export class DetailComponent implements OnInit {
     this.timeline.set(null);
     this.timelineError.set(false);
     this.timelineNeedsGeneration.set(false);
+    // Reset the Audio-tab one-shot latch so the next meeting-open may attempt its timeline read once.
+    this._timelineAttempted.set(null);
     this.speakerSuggestions.set([]);
     this.tags.set([]);
     this.graph.set(null);
@@ -656,6 +684,11 @@ export class DetailComponent implements OnInit {
     if (!id || this.timelineLoading()) {
       return;
     }
+    // ONE-SHOT LATCH (#234): record that this meeting's Audio-tab timeline read has been attempted,
+    // so the `_timelineOnAudioTab` effect can never re-enter for it even when the read resolves to
+    // an empty/falsy timeline that sets no terminal signal. A deliberate Retry clears the terminal
+    // signals and re-calls this method directly; the latch is not consulted there.
+    this._timelineAttempted.set(id);
     this.timelineError.set(false);
     this.timelineNeedsGeneration.set(false);
     this.timelineLoading.set(true);
@@ -666,7 +699,7 @@ export class DetailComponent implements OnInit {
       if (this.detail()?.meeting.id !== id) {
         return;
       }
-      if (cached.speakers.length > 0 || cached.topics.length > 0) {
+      if (cached && (cached.speakers.length > 0 || cached.topics.length > 0)) {
         this.timeline.set(cached);
       } else if (this.timelineOnDevice()) {
         // Heavy on-device generation is user-initiated only — show the Generate affordance.
@@ -720,7 +753,16 @@ export class DetailComponent implements OnInit {
       if (this.detail()?.meeting.id !== id) {
         return; // stale — the user moved on
       }
-      this.timeline.set(tl);
+      // TERMINAL-STATE guard (#234): a falsy/empty generate_timeline result must NOT leave
+      // `timeline==null && !error && !needsGeneration` — that combination re-fired the Audio-tab
+      // effect forever. An empty derivation is a resolved failure to produce content → surface the
+      // Retry affordance (timelineError) rather than a silent, effect-re-triggering blank.
+      if (tl && (tl.speakers.length > 0 || tl.topics.length > 0)) {
+        this.timeline.set(tl);
+      } else {
+        this.timeline.set(null);
+        this.timelineError.set(true);
+      }
     } catch {
       if (this.detail()?.meeting.id === id) {
         this.timeline.set(null);

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.scss
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-5);
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--scrim);
 }
 
 /* Floating overlay → OPAQUE (trap T3): never the frosted .card, or the note

--- a/src/app/features/detail/share-verify-sheet/share-verify-sheet.component.scss
+++ b/src/app/features/detail/share-verify-sheet/share-verify-sheet.component.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-5);
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--scrim);
 }
 /* Floating overlay → OPAQUE (trap T3): never the frosted .card, or the
    meeting note behind it bleeds through. */

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.ts
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.ts
@@ -64,16 +64,13 @@ export class Stage2PanelComponent {
    * state. Paired with a per-op stale-id guard in `fetchContext`/`addToNote`/`clearContext` below
    * (belt-and-braces: the reset clears the UI; the guard blocks a write racing a mid-flight nav).
    */
-  private readonly _resetOnMeetingChange = effect(
-    () => {
-      this.meetingId(); // track
-      this.hits.set(null);
-      this.applied.set(false);
-      this.cleared.set(false);
-      this.error.set(null);
-    },
-    { allowSignalWrites: true },
-  );
+  private readonly _resetOnMeetingChange = effect(() => {
+    this.meetingId(); // track
+    this.hits.set(null);
+    this.applied.set(false);
+    this.cleared.set(false);
+    this.error.set(null);
+  });
 
   /**
    * The EGRESS moment: fetch live context from the consented connectors.

--- a/src/app/features/folders/folder-row/folder-row.component.html
+++ b/src/app/features/folders/folder-row/folder-row.component.html
@@ -362,15 +362,17 @@
 }
 
 <!-- Lock×shares blocking dialog — shown when locking a folder that still has
-     active shares (Shared Brain v1). OPAQUE overlay (trap T3). -->
-@if (sharesReport(); as report) {
+     active shares (or when the share probe failed; Shared Brain v1 + PK-F1).
+     Owned by the shared FolderLockFlowService. OPAQUE overlay (trap T3). -->
+@if (showLockDialog()) {
   <app-lock-shares-dialog
     [folderName]="node().name"
-    [report]="report"
-    [busy]="revokingShares()"
-    (revokeAndLock)="onRevokeAndLock()"
-    (lockAnyway)="onLockAnyway()"
-    (cancelled)="onCancelLockShares()"
+    [report]="lockFlow.report()"
+    [probeFailed]="lockFlow.pending()?.probeFailed ?? false"
+    [busy]="lockFlow.busy()"
+    (revokeAndLock)="lockFlow.revokeAndLock()"
+    (lockAnyway)="lockFlow.lockAnyway()"
+    (cancelled)="lockFlow.cancel()"
   />
 }
   

--- a/src/app/features/folders/folder-row/folder-row.component.ts
+++ b/src/app/features/folders/folder-row/folder-row.component.ts
@@ -16,9 +16,9 @@ import {
   FoldersService,
   type FolderExposure,
 } from "../../../services/folders.service";
+import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
 import { ToastService } from "../../../services/toast.service";
-import { IpcService } from "../../../core/ipc.service";
-import type { ActiveSharesReport, FolderNode } from "../../../core/models";
+import type { FolderNode } from "../../../core/models";
 import { FolderTreeComponent } from "../folder-tree/folder-tree.component";
 import { FolderDropDirective } from "../folder-drop.directive";
 import { LockSharesDialogComponent } from "../lock-shares-dialog/lock-shares-dialog.component";
@@ -69,8 +69,9 @@ import { LockSharesDialogComponent } from "../lock-shares-dialog/lock-shares-dia
 export class FolderRowComponent {
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
-  private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  /** Shared lock×shares flow (probe → warn/revoke dialog → lock), reused by the Notes rail too. */
+  readonly lockFlow = inject(FolderLockFlowService);
 
   /** This row's folder node. */
   readonly node = input.required<FolderNode>();
@@ -94,13 +95,14 @@ export class FolderRowComponent {
 
   // --- Lock×shares dialog (Shared Brain v1) --------------------------------
   /**
-   * The active-shares report when a lock is blocked by live shares (null = the
-   * dialog is closed). When set, the blocking dialog is shown: Revoke & lock /
-   * Lock anyway / Cancel.
+   * The blocking lock×shares dialog is owned by the shared {@link FolderLockFlowService}
+   * (a root singleton, one pending request at a time). Render it for THIS row only when
+   * the pending request targets this folder id, so a dialog opened for one row doesn't
+   * appear under every row.
    */
-  readonly sharesReport = signal<ActiveSharesReport | null>(null);
-  /** True while the Revoke-&-lock (revoke + lock) sequence is in flight. */
-  readonly revokingShares = signal(false);
+  readonly showLockDialog = computed(
+    () => this.lockFlow.pending()?.folderId === this.node().id,
+  );
 
   // --- ⋯ folder-actions menu + inline rename + delete confirm ---------------
   /** Whether the ⋯ actions menu popover is open. */
@@ -162,63 +164,28 @@ export class FolderRowComponent {
   }
 
   /**
-   * Seal this folder. Shared Brain v1: FIRST check for active shares (link /
-   * user / org) via `folder_active_shares`. If any exist, open the blocking
+   * Seal this folder. Delegates to the shared {@link FolderLockFlowService}, which
+   * FIRST probes active shares (link / user / org) via `folder_active_shares`. If any
+   * exist — OR the probe itself fails (FAIL-CLOSED, F5) — it opens the blocking
    * lock×shares dialog instead of locking straight away; the dialog's actions
-   * (Revoke & lock / Lock anyway / Cancel) drive the real lock. With no active
-   * shares (or if the check itself fails — fail-open to the plain lock, the old
-   * behavior), lock directly.
+   * (Revoke & lock / Lock anyway / Cancel) drive the real lock. With no shares and a
+   * clean probe it locks directly. The tree reloads on lock, so this row re-renders
+   * reactively — no host refresh needed.
    */
   async onLock(): Promise<void> {
-    if (this.busy() || this.revokingShares()) {
+    if (this.busy() || this.lockFlow.busy()) {
       return;
     }
     this.lockError.set(null);
-    let report: ActiveSharesReport | null;
+    // Direct-lock (no shares) rejections surface as this row's inline lock error, matching the
+    // previous per-row behavior; the dialog path reports its own error via the shared service.
     try {
-      report = await this.ipc.folderActiveShares(this.node().id);
+      await this.lockFlow.requestLock(this.node().id, this.node().name, () => {
+        /* tree reload (inside FoldersService.lock) re-renders this row reactively */
+      });
     } catch {
-      // The check failed (older backend / no sharing) — fall through to a plain
-      // lock. Never block locking on the share probe.
-      report = null;
+      this.lockError.set("Couldn’t change this folder’s lock. Try again.");
     }
-    if (report && report.links + report.users + report.org.length > 0) {
-      this.sharesReport.set(report);
-      return;
-    }
-    await this.run(() => this.folders.lock(this.node().id));
-  }
-
-  /** Dialog: Revoke every share, then lock. */
-  async onRevokeAndLock(): Promise<void> {
-    if (this.revokingShares()) {
-      return;
-    }
-    this.revokingShares.set(true);
-    this.lockError.set(null);
-    try {
-      await this.ipc.revokeSharesForFolder(this.node().id);
-      await this.folders.lock(this.node().id);
-      this.sharesReport.set(null);
-    } catch {
-      this.lockError.set("Couldn’t revoke the shares and lock. Try again.");
-    } finally {
-      this.revokingShares.set(false);
-    }
-  }
-
-  /** Dialog: Lock while leaving the shares live. */
-  async onLockAnyway(): Promise<void> {
-    if (this.revokingShares()) {
-      return;
-    }
-    this.sharesReport.set(null);
-    await this.run(() => this.folders.lock(this.node().id));
-  }
-
-  /** Dialog: Cancel — do nothing. */
-  onCancelLockShares(): void {
-    this.sharesReport.set(null);
   }
 
   /** Session-unlock this folder. */

--- a/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.html
+++ b/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.html
@@ -12,16 +12,30 @@
     (keydown.escape)="cancelled.emit()"
   >
     <h2 id="lock-shares-title" class="sheet-title">
-      “{{ folderName() }}” has active shares
+      @if (probeFailed()) {
+        Couldn’t check “{{ folderName() }}” for active shares
+      } @else {
+        “{{ folderName() }}” has active shares
+      }
     </h2>
 
-    <p class="sheet-copy">
-      {{ totalCount() }} {{ totalCount() === 1 ? "item is" : "items are" }} shared
-      @if (orgCount() > 0) {
-        ({{ orgCount() }} in Org Brain)
-      }. Locking this folder encrypts its notes, but does
-      <strong>not</strong> take back shares that already left this Mac.
-    </p>
+    @if (probeFailed()) {
+      <!-- FAIL-CLOSED (F5): the share probe errored, so we can't confirm this folder has no
+           live shares. Warn + let the user decide rather than silently locking. -->
+      <p class="sheet-copy">
+        We couldn’t verify whether this folder still has active shares. Locking
+        encrypts its notes, but does <strong>not</strong> take back any shares
+        that already left this Mac. Revoke first to be safe, or lock anyway.
+      </p>
+    } @else {
+      <p class="sheet-copy">
+        {{ totalCount() }} {{ totalCount() === 1 ? "item is" : "items are" }} shared
+        @if (orgCount() > 0) {
+          ({{ orgCount() }} in Org Brain)
+        }. Locking this folder encrypts its notes, but does
+        <strong>not</strong> take back shares that already left this Mac.
+      </p>
+    }
 
     <!-- Breakdown of the active shares. -->
     <ul class="share-breakdown">

--- a/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.scss
+++ b/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-5);
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--scrim);
 }
 
 /* Floating overlay → OPAQUE (trap T3): never the frosted .card. */

--- a/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.ts
+++ b/src/app/features/folders/lock-shares-dialog/lock-shares-dialog.component.ts
@@ -41,6 +41,13 @@ export class LockSharesDialogComponent {
   readonly report = input.required<ActiveSharesReport>();
   /** True while the parent's revoke/lock call is in flight. */
   readonly busy = input(false);
+  /**
+   * True when the active-shares PROBE itself failed (fail-closed, F5): the report is
+   * all-zero but we can't be sure the folder has no shares, so the dialog warns the
+   * user to decide explicitly instead of the app silently locking a possibly-shared
+   * folder. Swaps the copy to the "couldn't check shares" message.
+   */
+  readonly probeFailed = input(false);
 
   /** Revoke every share, then lock (default when org shares exist). */
   readonly revokeAndLock = output<void>();

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
@@ -25,7 +25,9 @@
   box-shadow: var(--shadow-lg);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
-  animation: pop-in var(--transition) var(--ease-spring) both;
+  /* Duration-only token: --transition already carries an easing, so pairing it with
+     --ease-spring made TWO timing-functions → an invalid shorthand the browser dropped. */
+  animation: pop-in var(--transition-dur) var(--ease-spring) both;
 }
 
 @keyframes pop-in {

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -20,6 +20,7 @@ import type {
   NoteAssistResult,
   NoteCitation,
 } from "../../../core/models";
+import { TimerService } from "../../../services/timer.service";
 import { RepositionOnScrollDirective } from "./reposition-on-scroll.directive";
 
 /** The live text selection the popover acts on, plus its viewport anchor rect. */
@@ -95,6 +96,8 @@ export class NoteBrainPopoverComponent {
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
+  /** Root-owned timer service — the sanctioned home for the step-animation tick (rule §5). */
+  private readonly timers = inject(TimerService);
 
   /** The note being edited (for the assistant request). */
   readonly noteId = input.required<string>();
@@ -133,8 +136,8 @@ export class NoteBrainPopoverComponent {
    * resolution time (stale-result guard, trap #4).
    */
   private requestSeq = 0;
-  /** The step-animation timers to clear on teardown / supersede (no leak). */
-  private stepTimers: ReturnType<typeof setTimeout>[] = [];
+  /** The step-animation timer HANDLE IDS (from TimerService) to clear on teardown / supersede. */
+  private stepTimers: number[] = [];
   /** Monotonic id source for stable step `@for` keys. */
   private nextStepId = 1;
 
@@ -263,16 +266,16 @@ export class NoteBrainPopoverComponent {
   /**
    * Optimistically walk the step tracker forward while the IPC is in flight:
    * every ~520ms mark the running step done and start the next, stopping one
-   * short of the last so it stays "running" until the real result lands. Tracked
-   * timers cleared on supersede/teardown (no bare component setTimeout leak; the
-   * handles are owned + cleared here, the sanctioned tracked pattern).
+   * short of the last so it stays "running" until the real result lands. The tick
+   * is scheduled through the root {@link TimerService} (rule §5 — no bare component
+   * setTimeout); the returned handle ids are tracked + cleared on supersede/teardown.
    */
   private animateSteps(seq: number, count: number): void {
     const advance = (index: number): void => {
       if (seq !== this.requestSeq || index >= count - 1) {
         return;
       }
-      const handle = setTimeout(() => {
+      const handle = this.timers.after(520, () => {
         if (seq !== this.requestSeq) {
           return;
         }
@@ -288,7 +291,7 @@ export class NoteBrainPopoverComponent {
           }),
         );
         advance(index + 1);
-      }, 520);
+      });
       this.stepTimers.push(handle);
     };
     advance(0);
@@ -356,10 +359,10 @@ export class NoteBrainPopoverComponent {
     );
   }
 
-  /** Clear + forget every pending step-animation timer. */
+  /** Clear + forget every pending step-animation timer (through the TimerService). */
   private clearStepTimers(): void {
     for (const handle of this.stepTimers) {
-      clearTimeout(handle);
+      this.timers.clear(handle);
     }
     this.stepTimers = [];
   }

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -1250,7 +1250,19 @@ export class NoteEditorComponent {
       const insert = `\n\n${edit.suggestion.trim()}\n`;
       this.replaceRange(el, end, end, insert, end + insert.length, end + insert.length);
     } else {
-      this.replaceRange(el, start, end, edit.suggestion, start, start + edit.suggestion.length);
+      // COLLAPSE the caret to the END of the inserted suggestion (WT-F1 fix). Re-SELECTING the
+      // suggestion (start..start+len) makes `setSelectionRange` queue a `select` event that fires
+      // AFTER `clearSelection()` below — with a live non-empty selection but a null `sel()`, so the
+      // unchanged-selection guard in `onBodySelect` can't fire and the bubble RE-FLOATS after Accept.
+      // A collapsed caret leaves no selection → the queued `select` closes cleanly → bubble stays gone.
+      this.replaceRange(
+        el,
+        start,
+        end,
+        edit.suggestion,
+        start + edit.suggestion.length,
+        start + edit.suggestion.length,
+      );
     }
     this.clearSelection();
   }

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.scss
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.scss
@@ -41,7 +41,9 @@
   box-shadow: var(--shadow-lg);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
-  animation: modal-in var(--transition) var(--ease-spring) both;
+  /* Duration-only token here: --transition already carries an easing, so pairing it with
+     --ease-spring made TWO timing-functions → an invalid shorthand the browser dropped. */
+  animation: modal-in var(--transition-dur) var(--ease-spring) both;
   overflow: hidden;
 }
 @keyframes modal-in {

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -410,4 +410,19 @@
       (cancelled)="closeOrganize()"
     />
   }
+
+  <!-- Lock×shares blocking dialog (PK-F1): the SAME flow the meetings tree runs —
+       shown when locking a note-folder that still has active shares (or when the
+       share probe failed). Owned by the shared FolderLockFlowService. OPAQUE (T3). -->
+  @if (lockFlow.pending(); as pending) {
+    <app-lock-shares-dialog
+      [folderName]="pending.folderName"
+      [report]="lockFlow.report()"
+      [probeFailed]="pending.probeFailed"
+      [busy]="lockFlow.busy()"
+      (revokeAndLock)="lockFlow.revokeAndLock()"
+      (lockAnyway)="lockFlow.lockAnyway()"
+      (cancelled)="lockFlow.cancel()"
+    />
+  }
 </section>

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -15,8 +15,10 @@ import { NavHistoryService } from "../../../core/nav-history.service";
 import type { NoteFolder, OrganizeMove, OrganizePlan } from "../../../core/models";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
 import { FoldersService } from "../../../services/folders.service";
+import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
 import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
+import { LockSharesDialogComponent } from "../../folders/lock-shares-dialog/lock-shares-dialog.component";
 import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.component";
 
 /**
@@ -40,7 +42,11 @@ import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.compone
   selector: "app-notes-home",
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { "(document:keydown.escape)": "onEscape()" },
-  imports: [MurSidebarComponent, OrganizeSheetComponent],
+  imports: [
+    MurSidebarComponent,
+    OrganizeSheetComponent,
+    LockSharesDialogComponent,
+  ],
   templateUrl: "./notes-home.component.html",
   styleUrl: "./notes-home.component.scss",
 })
@@ -50,6 +56,12 @@ export class NotesHomeComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly injector = inject(Injector);
+  /**
+   * Shared lock×shares flow (probe → warn/revoke dialog → lock). The SAME flow the
+   * meetings tree runs, so locking a note-folder with live shares also warns before
+   * sealing (PK-F1). Public so the template can bind the dialog + its actions.
+   */
+  readonly lockFlow = inject(FolderLockFlowService);
 
   /** Drill-down back navigation ("← Murmur" + Esc). */
   readonly nav = inject(NavHistoryService);
@@ -317,20 +329,26 @@ export class NotesHomeComponent implements OnInit {
   // --- Folder lock / unlock -----------------------------------------------
 
   /**
-   * Lock a note-folder (seal its notes). Reuses the shared folder lock command
-   * via `FoldersService`; on success we refresh the NOTE lists so the rail badge
-   * + masked rows reflect the new sealed state.
+   * Lock a note-folder (seal its notes) THROUGH the shared lock×shares flow (PK-F1):
+   * the flow FIRST probes `folder_active_shares` and — if the folder still has live
+   * shares, or the probe itself fails (FAIL-CLOSED, F5) — opens the warn/revoke dialog
+   * instead of sealing straight away. Previously this called `FoldersService.lock`
+   * directly and BYPASSED that dialog, so a shared note-folder could be sealed without
+   * the owner deciding what happens to the outstanding shares. The `onLocked` callback
+   * refreshes the NOTE lists once a lock actually lands (from any path) so the rail
+   * badge + masked rows reflect the new sealed state.
    */
   async lockFolder(folder: NoteFolder, event: Event): Promise<void> {
     event.stopPropagation();
-    if (this.lockBusyId() !== null) {
+    if (this.lockBusyId() !== null || this.lockFlow.busy()) {
       return;
     }
     this.lockBusyId.set(folder.id);
     try {
-      await this.folders.lock(folder.id);
-      await this.refreshAfterLockChange();
-      this.toast.success(`Locked “${folder.name}”`);
+      await this.lockFlow.requestLock(folder.id, folder.name, async () => {
+        await this.refreshAfterLockChange();
+        this.toast.success(`Locked “${folder.name}”`);
+      });
     } catch {
       this.toast.danger("Couldn’t lock this folder. Please try again.");
     } finally {

--- a/src/app/features/notes/organize-sheet/organize-sheet.component.scss
+++ b/src/app/features/notes/organize-sheet/organize-sheet.component.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-5);
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--scrim);
 }
 
 /* Floating modal → OPAQUE (trap T3): never the frosted .card, or the note list

--- a/src/app/services/folder-lock-flow.service.ts
+++ b/src/app/services/folder-lock-flow.service.ts
@@ -1,0 +1,151 @@
+import { Injectable, computed, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type { ActiveSharesReport } from "../core/models";
+import { FoldersService } from "./folders.service";
+
+/**
+ * A folder-lock request that is BLOCKED pending the lock×shares dialog: the folder
+ * being locked plus the probe outcome. `report` is null when the share PROBE itself
+ * failed — in that case the dialog is shown FAIL-CLOSED (warn, never lock silently).
+ */
+export interface PendingFolderLock {
+  folderId: string;
+  folderName: string;
+  /** The active-shares report, or null when the probe errored (fail-closed warn). */
+  report: ActiveSharesReport | null;
+  /** True when the probe itself failed (older backend / sharing off / transient). */
+  probeFailed: boolean;
+  /** Host-supplied refresh, run after a lock actually lands (revoke&lock / lock anyway). */
+  onLocked: () => Promise<void> | void;
+}
+
+/**
+ * Shared lock×shares flow (Shared Brain v1 + PK-F1 remediation).
+ *
+ * BOTH the meetings tree ({@link FolderRowComponent}) and the Notes rail
+ * ({@link NotesHomeComponent}) must run the SAME "probe active shares → warn/revoke
+ * dialog → then lock" flow before sealing a folder, so a folder with live shares is
+ * never sealed without the owner deciding what happens to those shares. Previously
+ * only the tree ran it; the Notes rail called `FoldersService.lock` directly and
+ * bypassed the dialog (PK-F1). This root singleton owns the flow ONCE so neither
+ * call site duplicates (or diverges on) the probe/revoke/lock orchestration.
+ *
+ * FAIL-CLOSED (fixes F5): if `folder_active_shares` ERRORS we do NOT lock silently —
+ * we surface the dialog (probeFailed) so the user explicitly chooses, rather than the
+ * old fail-open behavior that could seal a shared folder on a transient probe error.
+ *
+ * The service holds only the flow STATE + the async orchestration; each host renders
+ * the reusable {@link LockSharesDialogComponent} bound to these signals and wires its
+ * button outputs to {@link revokeAndLock} / {@link lockAnyway} / {@link cancel}, then
+ * runs its own view refresh via the `onLocked` callback it passed to {@link requestLock}.
+ * A lock is only ever performed through {@link FoldersService.lock}, so the backend
+ * stays the single source of truth for lock state.
+ */
+@Injectable({ providedIn: "root" })
+export class FolderLockFlowService {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+
+  private readonly _pending = signal<PendingFolderLock | null>(null);
+  private readonly _busy = signal(false);
+  private readonly _error = signal<string | null>(null);
+
+  /** The blocked lock request while the dialog is open (null = no dialog). */
+  readonly pending = this._pending.asReadonly();
+  /** True while a revoke/lock sequence driven by the dialog is in flight. */
+  readonly busy = this._busy.asReadonly();
+  /** Non-null when the last dialog-driven revoke/lock failed (cleared on the next action). */
+  readonly error = this._error.asReadonly();
+
+  /** The active-shares report to render, safe even when the probe failed (all-zero). */
+  readonly report = computed<ActiveSharesReport>(
+    () => this._pending()?.report ?? { links: 0, users: 0, org: [] },
+  );
+
+  /**
+   * Begin locking `folderId`. Probes active shares FIRST:
+   *  - shares exist → open the dialog (Revoke & lock / Lock anyway / Cancel); DON'T lock yet.
+   *  - probe ERRORS → open the dialog FAIL-CLOSED (probeFailed); DON'T lock silently.
+   *  - no shares → lock directly via {@link FoldersService.lock} + run `onLocked`.
+   *
+   * `onLocked` runs the HOST's own post-lock refresh (the tree re-renders reactively; the
+   * Notes rail must reload its note lists). Rejections from the direct lock propagate so the
+   * caller can surface a host-appropriate error.
+   */
+  async requestLock(
+    folderId: string,
+    folderName: string,
+    onLocked: () => Promise<void> | void,
+  ): Promise<void> {
+    if (this._busy() || this._pending()) {
+      return;
+    }
+    this._error.set(null);
+    let report: ActiveSharesReport | null;
+    let probeFailed = false;
+    try {
+      report = await this.ipc.folderActiveShares(folderId);
+    } catch {
+      // FAIL-CLOSED (F5): a failed probe must NOT lock silently — warn via the dialog instead.
+      report = null;
+      probeFailed = true;
+    }
+    const hasShares =
+      !!report && report.links + report.users + report.org.length > 0;
+    if (hasShares || probeFailed) {
+      this._pending.set({ folderId, folderName, report, probeFailed, onLocked });
+      return;
+    }
+    // No shares and a clean probe → lock straight away.
+    await this.folders.lock(folderId);
+    await onLocked();
+  }
+
+  /** Dialog: revoke EVERY share for the folder, then lock. Then run the host refresh. */
+  async revokeAndLock(): Promise<void> {
+    const pending = this._pending();
+    if (!pending || this._busy()) {
+      return;
+    }
+    this._busy.set(true);
+    this._error.set(null);
+    try {
+      await this.ipc.revokeSharesForFolder(pending.folderId);
+      await this.folders.lock(pending.folderId);
+      await pending.onLocked();
+      this._pending.set(null);
+    } catch {
+      this._error.set("Couldn’t revoke the shares and lock. Try again.");
+    } finally {
+      this._busy.set(false);
+    }
+  }
+
+  /** Dialog: lock while leaving the shares live. Then run the host refresh. */
+  async lockAnyway(): Promise<void> {
+    const pending = this._pending();
+    if (!pending || this._busy()) {
+      return;
+    }
+    this._busy.set(true);
+    this._error.set(null);
+    try {
+      await this.folders.lock(pending.folderId);
+      await pending.onLocked();
+      this._pending.set(null);
+    } catch {
+      this._error.set("Couldn’t lock this folder. Try again.");
+    } finally {
+      this._busy.set(false);
+    }
+  }
+
+  /** Dialog: cancel — dismiss without locking. */
+  cancel(): void {
+    if (this._busy()) {
+      return;
+    }
+    this._pending.set(null);
+    this._error.set(null);
+  }
+}

--- a/src/app/services/timer.service.ts
+++ b/src/app/services/timer.service.ts
@@ -1,0 +1,59 @@
+import { DestroyRef, Injectable, inject } from "@angular/core";
+
+/**
+ * A minimal root-owned timer service — the ONLY sanctioned home for `setTimeout`
+ * (rule §5: a bare `setTimeout`/`requestAnimationFrame` in a COMPONENT is banned;
+ * only a `providedIn:"root"` service may hold tracked timers, mirroring
+ * {@link ToastService}). Components that need a delayed tick (e.g. a step
+ * animation that can't be expressed with the one-shot `afterNextRender`) schedule
+ * through here so the raw timer lives in a service, is tracked, and is cleared on
+ * root teardown — never orphaned.
+ *
+ * Each scheduled callback gets a monotonic handle id; the caller cancels a single
+ * pending tick with {@link clear}, and every outstanding tick is cleared on
+ * `DestroyRef.onDestroy`. The callback auto-forgets its own handle when it fires.
+ */
+@Injectable({ providedIn: "root" })
+export class TimerService {
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Active timeouts, keyed by our monotonic handle id, so we can cancel them. */
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+  private nextId = 1;
+
+  constructor() {
+    // Clear every pending tick on teardown — no orphaned timers (HMR-safe).
+    this.destroyRef.onDestroy(() => this.clearAll());
+  }
+
+  /**
+   * Run `fn` after `ms`. Returns a handle id for {@link clear}. The handle is
+   * forgotten automatically once `fn` fires.
+   */
+  after(ms: number, fn: () => void): number {
+    const id = this.nextId++;
+    const handle = setTimeout(() => {
+      this.timers.delete(id);
+      fn();
+    }, ms);
+    this.timers.set(id, handle);
+    return id;
+  }
+
+  /** Cancel a single pending tick by its handle id (a no-op if already fired). */
+  clear(id: number): void {
+    const handle = this.timers.get(id);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      this.timers.delete(id);
+    }
+  }
+
+  /** Cancel every outstanding tick (used on host teardown / supersede). */
+  clearAll(): void {
+    for (const handle of this.timers.values()) {
+      clearTimeout(handle);
+    }
+    this.timers.clear();
+  }
+}

--- a/src/design-tokens/colors.css
+++ b/src/design-tokens/colors.css
@@ -7,6 +7,7 @@
   --surface-input: rgba(255, 255, 255, 0.035);  /* form wells (glassy)         */
   --surface-solid: #111118;      /* when a true opaque surface is needed       */
   --surface-hover: rgba(255, 255, 255, 0.06);   /* hover wash on rows/ghosts   */
+  --scrim: rgba(0, 0, 0, 0.5);   /* dimming backdrop behind a floating modal   */
 
   /* --- Text --------------------------------------------------------------- */
   --text-primary: #f6f6fa;

--- a/src/design-tokens/layout.css
+++ b/src/design-tokens/layout.css
@@ -27,6 +27,12 @@
   --transition: 200ms cubic-bezier(0.32, 0.72, 0, 1);
   --transition-fast: 130ms cubic-bezier(0.32, 0.72, 0, 1);
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Duration-only companions — use when composing an `animation` shorthand with an
+     explicit easing (e.g. --ease-spring). Pairing a duration with --transition (which
+     ALREADY carries its own easing) yields TWO timing-functions → an INVALID shorthand
+     the browser drops silently. Compose as `<name> var(--transition-dur) var(--ease-spring)`. */
+  --transition-dur: 200ms;
+  --transition-fast-dur: 130ms;
 
   /* --- Layout ------------------------------------------------------------- */
   --content-max: 840px;

--- a/src/design-tokens/theme-light.css
+++ b/src/design-tokens/theme-light.css
@@ -9,6 +9,9 @@
    ============================================================================ */
 :root[data-theme="light"] {
   color-scheme: light;
+  /* --scrim is intentionally INHERITED from :root (rgba(0,0,0,0.5)) — a modal scrim
+     DIMS the content behind it, so it stays dark in both themes (a light scrim would
+     wash out instead of dim). Same rationale as radius/spacing/motion inheritance. */
   --surface-base: #f3f3f8;
   --surface-raised: rgba(255, 255, 255, 0.72);
   --surface-overlay: #ffffff;


### PR DESCRIPTION
Remediates the still-open findings from the 2026-07-11 unreleased-changes audit
(`docs/research/2026-07-11-unreleased-audit-v0.8.0-HEAD.md`), re-baselined against the
concurrently-advanced trunk. The org-404 / SB-1 fix (#243) and the resource-leak sweep
(#242) were already merged and are **not** re-done here.

## Backend — lock / seal (verify-before-destroy, gate every read)
- **NOTES-1 (CRITICAL, data loss):** `delete_note_folder` reparents authored notes to the
  default folder instead of `DELETE FROM documents` (the UI promised a move; notes were
  being destroyed).
- **NOTES-2 (CRITICAL, sealed leak):** note-folder move/rename rewrites
  `documents.exported_path` so a later lock deletes the real plaintext `.md` (it was left
  on disk in a sealed folder).
- **NOTES-3:** `reparent_note_folder` uses char count, not byte length, in SQLite `substr`
  (Polish/multi-byte descendant paths were corrupted).
- **SEAM-F1:** `generate_timeline` seals the timeline under the folder CK and re-gates after
  the provider await (plaintext timeline was left at rest after relock).
- **SEAM-F2:** `rename_speaker` reseals the timeline write (the rename was destroyed on relock).
- **LOCK-SHARE-INGEST-1:** `ingest_shared_note` seals from birth under the lifecycle guard and
  writes no plaintext `.md` into a locked folder (it was surviving relock).
- **folder_active_shares** is gated for a sealed-not-unlocked folder (it was leaking org-share titles).

## Backend — shared brain + misc
- **org_leave** purges the decrypted org replica; **MCP `org_search` / `org_brain_search`**
  fail-close on membership + consent (a departed/un-consented user could still search).
- **SB-3:** `org_sweep_pending` reuses the queued/failed row on retry (was minting a fresh
  `org_shares` row every tick → row amplification + duplicate publishes).
- **SB-2:** remove the dead, unwired `SourceOrigin::org` / `OrgItemSummary` / `org_item_count`.
- **TP-F1:** `begin_voice_command` refuses without a live consumer (a fresh turbo-default install
  armed the voice flow with no live loop → wedge).
- **MEM-1:** memory-import supersede is reversible — deleting the import reopens the facts it
  closed (`user_fact_import_supersedes`, additive migration).

## Frontend
- **RED-E2E-1:** the detail timeline treats an empty `get_timeline`/`generate_timeline` result as
  terminal + a per-meeting one-shot latch, so the Audio-tab effect can't loop forever (infinite
  `get_timeline` from #234).
- **PK-F1:** a new root `FolderLockFlowService` runs the probe → warn/revoke dialog → lock flow for
  BOTH the meetings tree and the Notes rail (the Notes rail bypassed the dialog); fail-closed on a
  probe error.
- **WT-F1:** the note-editor selection bubble collapses the caret after Accept so the queued
  textarea `select` event can't re-float it (the `brain-popover` spec was red on trunk).
- minors: `refreshOrgShared` stale-result guard; `note-brain-popover` step timer via a root
  `TimerService`; drop the deprecated `allowSignalWrites` no-op; `--scrim` + `--transition-dur`
  tokens (rgba scrims + an invalid two-easing animation shorthand).

## Verification
- Each fix is RED→GREEN (a test that fails on the pre-fix code, passes after).
- `cargo test --lib` **1491 passed / 0 failed**; `npx ng lint` + `npx ng build` clean;
  Playwright E2E **36 passed**; `bash scripts/ci.sh` green (clippy `-D warnings`, cargo audit,
  cargo deny). E2E skipped inside ci.sh only because it was run independently.
- Independent verifiers own the verdict: **lock-security-reviewer: PASS**, **adversarial-verifier:
  PASS**.
- **Honest gaps (need a signed build / real Mac / logged-in session):** Touch ID KEK release,
  real screen-share auto-relock, on-disk lock-at-rest bytes, live-recording wedge-avoidance, the
  org-create click-through against the live server (server confirmed live: routes return 401, not
  404).