### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.8.0"
+version = "0.9.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 0.8.0 → 0.9.0 for the 0.9.0 release.

Payload since v0.8.0: the audit remediation (2 Notes data-loss/leak criticals, 3 seal-on-write gaps, org_leave replica purge + MCP consent-gate, SB-3/SB-2, TP-F1 voice wedge, MEM-1, timeline-loop, PK-F1 lock×shares, WT-F1) + the org-404/SB-1 fix + the resource-leak sweep + the notes-Brain "shorten" fix. All prior work already gate-verified on trunk.