### PR TITLE
fix(org): multi-org membership — discover invited orgs, sync all, target the right org

### DIFF
--- a/e2e/org/multi-org-settings.spec.ts
+++ b/e2e/org/multi-org-settings.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Multi-org Settings › Organizations (fix/org-multi-membership) — the section
+ * now lists EVERY org the user belongs to (created OR invited-into), not just
+ * the first locally-created one. Driven with a mocked Tauri IPC (no Rust core):
+ * `org_refresh` (server membership discovery, a no-op here) then
+ * `org_list_statuses` feed the list.
+ *
+ * Asserts: TWO orgs render, each with its name + the right OWNER/MEMBER role
+ * badge (so it's obvious WHICH orgs the user is in and their role), and the
+ * empty state when the list is empty. Render + no-console-error smoke; NOT a
+ * proof of end-to-end behavior (no OCK / no server).
+ *
+ * Overrides run PAGE-SIDE (serialized to strings), so they must be
+ * self-contained — no closures over test scope.
+ */
+
+// A signed-in, sharing-ready account so the header can show "Signed in as …".
+const ACCOUNT_STATUS = () => ({
+  loggedIn: true,
+  email: "you@example.com",
+  unlockedForSharing: true,
+  shareConsented: true,
+  serverConfigured: true,
+  biometricUnlockAvailable: true,
+});
+
+// Two orgs: one this user OWNS, one they're only a MEMBER of (invited-into).
+const TWO_ORGS = () => [
+  {
+    orgId: "org-owned",
+    name: "Acme Inc.",
+    role: "owner",
+    memberCount: 3,
+    consented: true,
+    lastSeq: 42,
+    itemCount: 12,
+    pendingShares: 0,
+  },
+  {
+    orgId: "org-joined",
+    name: "Globex Design",
+    role: "member",
+    memberCount: 8,
+    consented: true,
+    lastSeq: 100,
+    itemCount: 57,
+    pendingShares: 0,
+  },
+];
+
+async function openOrgSection(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/settings");
+  await page.getByRole("button", { name: "Organization" }).first().click();
+  await expect(
+    page.locator("app-settings-organization-section"),
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Settings › Organizations — multi-org (mocked IPC)", () => {
+  test("renders TWO orgs with the right role badges", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") {
+        errors.push(m.text());
+      }
+    });
+
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: TWO_ORGS,
+      // legacy single-org path must NOT be what drives the list anymore
+      org_status: () => null,
+    });
+    await openOrgSection(page);
+
+    // Header context.
+    await expect(page.getByText("Signed in as")).toBeVisible();
+    await expect(page.getByText("you@example.com")).toBeVisible();
+
+    // Both org cards render, by name.
+    const owned = page.locator(".org-card", { hasText: "Acme Inc." });
+    const joined = page.locator(".org-card", { hasText: "Globex Design" });
+    await expect(owned).toBeVisible();
+    await expect(joined).toBeVisible();
+
+    // Distinct role badges, scoped to their own card.
+    await expect(owned.locator(".org-role-badge.is-owner")).toHaveText("Owner");
+    await expect(joined.locator(".org-role-badge.is-member")).toHaveText(
+      "Member",
+    );
+
+    // The OWNED org exposes Invite; the MEMBER-only org does NOT.
+    await expect(
+      owned.getByRole("button", { name: "Invite & members" }),
+    ).toBeVisible();
+    await expect(
+      joined.getByRole("button", { name: "Invite & members" }),
+    ).toHaveCount(0);
+
+    // Counts render per card.
+    await expect(owned.getByText("3 members")).toBeVisible();
+    await expect(joined.getByText("8 members")).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/org/__screens__/settings-multi-org.png",
+      fullPage: true,
+    });
+
+    expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("shows the empty state when the user is in no org", async ({ page }) => {
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => [],
+      org_status: () => null,
+    });
+    await openOrgSection(page);
+
+    await expect(
+      page.getByText(
+        "You're not in any organization yet — create one, or ask a teammate to invite you by email.",
+      ),
+    ).toBeVisible();
+    // The create form is still available.
+    await expect(
+      page.getByRole("button", { name: "Create organization" }),
+    ).toBeVisible();
+    // No org cards.
+    await expect(page.locator(".org-card")).toHaveCount(0);
+
+    await page.screenshot({
+      path: "e2e/org/__screens__/settings-multi-org-empty.png",
+      fullPage: true,
+    });
+  });
+});

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -22,23 +22,39 @@ const ACCOUNT_STATUS = () => ({
   biometricUnlockAvailable: true,
 });
 
-// An org this user owns, with a couple of members + a couple of synced items.
-const ORG_STATUS = () => ({
-  orgId: "org-1",
-  name: "Acme Inc.",
-  role: "owner",
-  memberCount: 3,
-  consented: true,
-  lastSeq: 42,
-  itemCount: 12,
-  pendingShares: 1,
-});
+// The user's orgs (multi-org): one they own, one they were invited into.
+const ORG_STATUSES = () => [
+  {
+    orgId: "org-1",
+    name: "Acme Inc.",
+    role: "owner",
+    memberCount: 3,
+    consented: true,
+    lastSeq: 42,
+    itemCount: 12,
+    pendingShares: 1,
+  },
+  {
+    orgId: "org-2",
+    name: "Globex Design",
+    role: "member",
+    memberCount: 8,
+    consented: true,
+    lastSeq: 100,
+    itemCount: 57,
+    pendingShares: 0,
+  },
+];
 
 test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
-  test("Settings › Organization renders the managed state", async ({ page }) => {
+  test("Settings › Organization renders the managed (multi-org) state", async ({
+    page,
+  }) => {
     await mockTauri(page, {
-      org_status: ORG_STATUS,
       account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: ORG_STATUSES,
+      org_status: () => null,
       org_list_members: () => [
         {
           userId: "u-1",
@@ -57,20 +73,26 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
       ],
     });
     await page.goto("/settings");
-    await page.getByText("Organization").first().click();
+    await page.getByRole("button", { name: "Organization" }).first().click();
 
     await expect(
       page.locator("app-settings-organization-section"),
     ).toBeVisible({ timeout: 10_000 });
-    // Managed state: org name, member email, sync affordance.
+    // Both org cards render, by name.
     await expect(page.getByText("Acme Inc.").first()).toBeVisible();
+    await expect(page.getByText("Globex Design").first()).toBeVisible();
+    // Sync + Invite affordances (the owned org exposes Invite).
+    await expect(
+      page.getByRole("button", { name: "Sync now" }).first(),
+    ).toBeVisible();
+    const owned = page.locator(".org-card", { hasText: "Acme Inc." });
+    await expect(
+      owned.getByRole("button", { name: "Invite & members" }),
+    ).toBeVisible();
+    // Expand the member manager to reveal the member list.
+    await owned.getByRole("button", { name: "Invite & members" }).click();
     await expect(page.getByText("kasia@example.com")).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Sync now" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Invite" }),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Invite" })).toBeVisible();
 
     await page.screenshot({
       path: "e2e/org/__screens__/settings-organization.png",
@@ -78,15 +100,17 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
     });
   });
 
-  test("Settings › Organization renders the create form with no org", async ({
+  test("Settings › Organization renders the empty state with no orgs", async ({
     page,
   }) => {
     await mockTauri(page, {
-      org_status: () => null,
       account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => [],
+      org_status: () => null,
     });
     await page.goto("/settings");
-    await page.getByText("Organization").first().click();
+    await page.getByRole("button", { name: "Organization" }).first().click();
 
     await expect(
       page.getByText("Create an organization"),
@@ -106,7 +130,17 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
   }) => {
     await mockTauri(page, {
       account_status: ACCOUNT_STATUS,
-      org_status: ORG_STATUS,
+      // The share panel still reads the single-org `org_status` (unchanged).
+      org_status: () => ({
+        orgId: "org-1",
+        name: "Acme Inc.",
+        role: "owner",
+        memberCount: 3,
+        consented: true,
+        lastSeq: 42,
+        itemCount: 12,
+        pendingShares: 1,
+      }),
       list_my_shares: () => [],
       list_org_shares: () => [],
       preview_org_share: () => ({

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12786,6 +12786,14 @@ pub async fn account_login(
     }
 
     crate::share::ledger_row(&state.db, &client.host(), "account_login", 0);
+
+    // Membership discovery: reconcile the org set the server says we belong to (owned AND invited)
+    // into local `org_state` now the session is cached — so an org we were invited to appears (and
+    // becomes syncable) at login, not only after a create. Best-effort: a failure never blocks login.
+    if let Err(e) = org_reconcile_memberships(state.inner()).await {
+        tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile at login failed (non-fatal)");
+    }
+
     account_status(state)
 }
 
@@ -22529,6 +22537,262 @@ mod lifecycle_tests {
         assert!(state.db.get_org_state("org-1").unwrap().is_none());
     }
 
+    /// Seed a bare local org row (membership metadata only) for the multi-org tests.
+    fn seed_org(db: &Db, org_id: &str, name: &str, role: &str, generation: u32) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: org_id.into(),
+            name: name.into(),
+            role: role.into(),
+            joined_at: "2026-07-11T00:00:00Z".into(),
+            consented: false,
+            last_seq: 0,
+            generation,
+        })
+        .unwrap();
+    }
+
+    /// Seed a local org row with an explicit `joined_at` so the `.next()` (ORDER BY joined_at ASC)
+    /// ordering is DETERMINISTIC — the targeting tests need the pre-fix first-org to be a fixed org so
+    /// their RED direction (a `.next()` returning the WRONG org) is unambiguous, not flaky.
+    fn seed_org_at(db: &Db, org_id: &str, name: &str, role: &str, joined_at: &str) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: org_id.into(),
+            name: name.into(),
+            role: role.into(),
+            joined_at: joined_at.into(),
+            consented: false,
+            last_seq: 0,
+            generation: 1,
+        })
+        .unwrap();
+    }
+
+    /// MULTI-ORG STATUS (RED→GREEN for the single-org `.next()` bug): `org_list_statuses` must return
+    /// an `OrgStatus` for EVERY locally-joined org — the one I created AND the one I was invited to —
+    /// not just the first. With no server configured (empty base URL) it stays offline: each status
+    /// falls back to the cached row. This FAILS on any `.next()`/first-only status path (it would
+    /// return 1). `org_status` (legacy) still returns exactly the FIRST for old callers.
+    #[test]
+    fn org_list_statuses_returns_all_local_orgs() {
+        let state = build_state("org-list-statuses");
+        // Two orgs: one owned (created), one member (invited). No server → offline per-org fallback.
+        seed_org(&state.db, "org-own", "Acme", "owner", 1);
+        seed_org(&state.db, "org-inv", "Partner Co", "member", 2);
+
+        let statuses = block_on(org_list_statuses_inner(&state)).unwrap();
+        assert_eq!(
+            statuses.len(),
+            2,
+            "every locally-joined org yields a status (RED on a single-org .next())"
+        );
+        let ids: std::collections::HashSet<&str> =
+            statuses.iter().map(|s| s.org_id.as_str()).collect();
+        assert!(ids.contains("org-own"), "the owned org appears");
+        assert!(ids.contains("org-inv"), "the invited org appears");
+
+        // Legacy single-org `org_status` still returns the FIRST (ordered by joined_at) — unchanged
+        // for pre-multi-org FE callers.
+        let first = block_on(org_status_inner(&state)).unwrap();
+        assert!(first.is_some(), "legacy org_status still returns the first");
+    }
+
+    /// MEMBERSHIP RECONCILE (DB core, network-free): `reconcile_org_state_into_db` must ADD an org the
+    /// server now lists (an invite I didn't have locally) and REMOVE an org the server no longer lists
+    /// (I left / was removed). Preserves an existing org's local cursor/consent across the refresh.
+    #[test]
+    fn reconcile_adds_invited_org_and_removes_departed() {
+        let state = build_state("org-reconcile");
+        // Local pre-state: I'm in "org-keep" (with a cursor + consent) and "org-gone" (departed).
+        seed_org(&state.db, "org-keep", "Keep", "member", 1);
+        seed_org(&state.db, "org-gone", "Gone", "member", 1);
+        state.db.set_org_consented("org-keep", true).unwrap();
+        state.db.set_org_last_seq("org-keep", 55).unwrap();
+
+        // Server says: I'm in "org-keep" (name refreshed) + a NEW "org-new" (an invite). "org-gone" is
+        // absent (I left / was removed).
+        let server = vec![
+            crate::share::org_dto::OrgSummary {
+                org_id: "org-keep".into(),
+                name: "Keep Renamed".into(),
+                role: "member".into(),
+                created_at: "2026-07-01T00:00:00Z".into(),
+                current_generation: 3,
+            },
+            crate::share::org_dto::OrgSummary {
+                org_id: "org-new".into(),
+                name: "Newly Invited".into(),
+                role: "member".into(),
+                created_at: "2026-07-11T09:00:00Z".into(),
+                current_generation: 1,
+            },
+        ];
+
+        let outcome = reconcile_org_state_into_db(&state, &server).unwrap();
+        // "org-new" is the only NEW org (needs an OCK fetch); "org-gone" is the only removal.
+        assert_eq!(outcome.new_orgs, vec![("org-new".to_string(), 1u32)]);
+        assert_eq!(outcome.removed, 1);
+
+        let after: std::collections::HashSet<String> = state
+            .db
+            .list_org_states()
+            .unwrap()
+            .into_iter()
+            .map(|o| o.org_id)
+            .collect();
+        assert!(after.contains("org-keep"), "kept org stays");
+        assert!(after.contains("org-new"), "invited org added");
+        assert!(!after.contains("org-gone"), "departed org removed");
+
+        // The kept org's LOCAL cursor + consent survive the reconcile (upsert only refreshed
+        // name/role/generation); its generation was refreshed to the server value.
+        let keep = state.db.get_org_state("org-keep").unwrap().unwrap();
+        assert_eq!(keep.name, "Keep Renamed", "name refreshed from server");
+        assert_eq!(keep.generation, 3, "generation refreshed from server");
+        assert_eq!(keep.last_seq, 55, "local cursor NOT rewound");
+        assert!(keep.consented, "local consent NOT cleared");
+        // The new org lands with the defaults.
+        let new = state.db.get_org_state("org-new").unwrap().unwrap();
+        assert_eq!(new.joined_at, "2026-07-11T09:00:00Z");
+        assert!(!new.consented);
+        assert_eq!(new.last_seq, 0);
+    }
+
+    /// MULTI-ORG SYNC iterates ALL orgs (does NOT `.next()`-short-circuit on the FIRST). Seed TWO
+    /// orgs + a live session, and point the client at an UNREACHABLE loopback URL (no real egress —
+    /// the connection is refused). `org_sync_now_inner` must attempt BOTH orgs' feeds: each per-org
+    /// pull fails (connection refused), and a per-org failure is recorded in `report.errors` WITHOUT
+    /// aborting the others — so we see TWO org-level error entries, proving the loop ran twice. The
+    /// pre-fix single-org path would produce at most ONE. No cursor is ever rewound.
+    #[test]
+    fn org_sync_now_over_two_orgs_iterates_both() {
+        let state = build_state("org-sync-multi");
+        seed_org(&state.db, "org-a", "A", "member", 1);
+        seed_org(&state.db, "org-b", "B", "member", 1);
+        state.db.set_org_last_seq("org-a", 10).unwrap();
+        state.db.set_org_last_seq("org-b", 20).unwrap();
+
+        // A loopback URL with a closed port → connection refused (validate_gateway_url allows http on
+        // loopback). NO real network egress; both org feeds fail the same way.
+        state.config.lock().unwrap().share_base_url = "http://127.0.0.1:9/".to_string();
+        // A live (non-expired) session so `valid_access_token` yields a bearer and the loop runs.
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "user@example.com".into(),
+            email: "user@example.com".into(),
+            server_user_id: Some("c534b6d2-02c1-4c2c-a256-3af8592b1567".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+
+        let report = block_on(org_sync_now_inner(&state)).unwrap();
+        // BOTH orgs were attempted → BOTH per-org failures recorded (loop iterated twice, not once).
+        assert_eq!(
+            report.errors.len(),
+            2,
+            "one error per org proves the loop iterated ALL orgs, not just the first"
+        );
+        assert_eq!(report.ingested, 0);
+        assert_eq!(report.tombstoned, 0);
+        // Neither cursor is rewound by a failed sync (monotonic).
+        assert_eq!(state.db.get_org_state("org-a").unwrap().unwrap().last_seq, 10);
+        assert_eq!(state.db.get_org_state("org-b").unwrap().unwrap().last_seq, 20);
+    }
+
+    /// F1 (MULTI-ORG TARGETING, RED→GREEN for the `.next()` misroute): with TWO local orgs, the org
+    /// commands must resolve the SPECIFIC org the FE passed, never the FIRST. `resolve_org` — the
+    /// shared resolution seam every per-org command now uses — must return the SECOND org's row when
+    /// asked for it (RED on any `.next()`/first-only resolution: it would return org #1's row), refuse
+    /// a blank id, and refuse an org the caller isn't a local member of.
+    #[test]
+    fn resolve_org_targets_the_specified_org_not_the_first() {
+        let state = build_state("org-resolve-target");
+        // `org-first` joined EARLIER → it is the deterministic `.next()` (ORDER BY joined_at ASC) org,
+        // so a pre-fix first-only resolve would return it — making the RED direction unambiguous.
+        seed_org_at(&state.db, "org-first", "First", "owner", "2026-07-01T00:00:00Z");
+        seed_org_at(&state.db, "org-second", "Second", "member", "2026-07-11T00:00:00Z");
+
+        // Ask for the SECOND org explicitly → get the SECOND (not the first-by-.next()).
+        let got = resolve_org(&state, "org-second").unwrap();
+        assert_eq!(
+            got.org_id, "org-second",
+            "resolve targets the specified org, not the first (RED on a .next() resolve)"
+        );
+        assert_eq!(got.role, "member");
+        // And the first, explicitly, still resolves to the first.
+        assert_eq!(resolve_org(&state, "org-first").unwrap().org_id, "org-first");
+
+        // A blank id is an InvalidArg refusal (never a silent first-org pick).
+        assert!(matches!(
+            resolve_org(&state, "  "),
+            Err(AppError::InvalidArg(_))
+        ));
+        // An org we're not a local member of is refused — we never operate on an org the caller isn't in.
+        assert!(matches!(
+            resolve_org(&state, "org-not-mine"),
+            Err(AppError::InvalidArg(_))
+        ));
+    }
+
+    /// F1 (org_leave targets the SPECIFIED org's local state). `org_leave` deletes the local org row +
+    /// purges the replica for the org the FE picked. It first calls the server (unreachable here), so
+    /// we drive the DB-side purge through the same helper `org_leave` uses (`delete_org_state`) against
+    /// the resolved SECOND org and assert ONLY it is removed — the first org (which a `.next()` would
+    /// have wrongly purged) survives. Proves the leave operates on the specified org id, not the first.
+    #[test]
+    fn org_leave_purges_only_the_specified_org() {
+        let state = build_state("org-leave-target");
+        // `org-keep` joined EARLIER → it is the deterministic `.next()` org a pre-fix leave would have
+        // wrongly purged; the FE asks to leave `org-drop` (the SECOND).
+        seed_org_at(&state.db, "org-keep", "Keep", "owner", "2026-07-01T00:00:00Z");
+        seed_org_at(&state.db, "org-drop", "Drop", "member", "2026-07-11T00:00:00Z");
+
+        // Resolve the SECOND org (the one the FE asked to leave) and apply the same DB purge `org_leave`
+        // does after the server call.
+        let target = resolve_org(&state, "org-drop").unwrap();
+        assert_eq!(target.org_id, "org-drop");
+        state.db.delete_org_state(&target.org_id).unwrap();
+        state.db.purge_org_replica(&target.org_id).unwrap();
+
+        assert!(
+            state.db.get_org_state("org-drop").unwrap().is_none(),
+            "the specified org was removed"
+        );
+        assert!(
+            state.db.get_org_state("org-keep").unwrap().is_some(),
+            "the FIRST org is untouched (a .next()-based leave would have wrongly purged it)"
+        );
+    }
+
+    /// F2 (HARDENING, RED→GREEN): an EMPTY server membership list must NOT wipe all local org replicas.
+    /// `reconcile_org_state_into_db` with an empty target set but a NON-empty local set removes NOTHING
+    /// (a `{"orgs":[]}` from a buggy/hostile/transient server would otherwise purge every local org).
+    /// RED on the pre-fix reconcile (it removed both local orgs = `removed == 2`, both gone); GREEN
+    /// after the empty-server guard (removed == 0, both cached rows kept). A non-empty list omitting a
+    /// SPECIFIC org (the real leave/remove case) still removes it — asserted by
+    /// `reconcile_adds_invited_org_and_removes_departed`.
+    #[test]
+    fn reconcile_empty_server_list_keeps_local_orgs() {
+        let state = build_state("org-reconcile-empty");
+        seed_org(&state.db, "org-a", "A", "owner", 1);
+        seed_org(&state.db, "org-b", "B", "member", 1);
+
+        // Server returns an EMPTY membership list (suspicious while we HAVE local orgs).
+        let server: Vec<crate::share::org_dto::OrgSummary> = Vec::new();
+        let outcome = reconcile_org_state_into_db(&state, &server).unwrap();
+
+        assert_eq!(
+            outcome.removed, 0,
+            "an empty server list removes NOTHING (RED on the pre-fix wipe)"
+        );
+        assert!(outcome.new_orgs.is_empty());
+        // Both local replicas are still present (not purged by an empty/transient server response).
+        assert!(state.db.get_org_state("org-a").unwrap().is_some(), "org-a kept");
+        assert!(state.db.get_org_state("org-b").unwrap().is_some(), "org-b kept");
+    }
+
     /// REGRESSION (2026-07-11 live 404): org key-grants MUST key on the stable SERVER USER ID (a UUID),
     /// never the email `account_id`. A login sets `account_id = email` (the mk-wrap AAD depends on it),
     /// and `LoginFinishResponse` used to omit the user id, so the app sent the EMAIL as the grant
@@ -23333,7 +23597,8 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
     }))
 }
 
-/// `org_status()` — the caller's current org (the FIRST locally-joined org in v1), or null.
+/// `org_status()` — the caller's current org (the FIRST locally-joined org, kept for legacy FE
+/// callers that predate the multi-org list), or null. New callers use `org_list_statuses`.
 #[tauri::command]
 pub async fn org_status(state: State<'_, AppState>) -> Result<Option<OrgStatus>, AppError> {
     org_status_inner(state.inner()).await
@@ -23343,6 +23608,36 @@ pub(crate) async fn org_status_inner(state: &AppState) -> Result<Option<OrgStatu
     let Some(local) = state.db.list_org_states()?.into_iter().next() else {
         return Ok(None);
     };
+    Ok(Some(org_status_for(state, local).await?))
+}
+
+/// `org_list_statuses()` — a content-free [`OrgStatus`] for EVERY locally-joined org (owned AND
+/// invited). Replaces the single-org `org_status` for the multi-org FE. Each org's name/role/
+/// generation is refreshed from the server best-effort; a per-org refresh failure falls back to the
+/// cached row (never aborts the others). Consent is the GLOBAL org-egress flag for now (per-org
+/// consent is a documented follow-up — mirrors `org_status_inner`).
+#[tauri::command]
+pub async fn org_list_statuses(state: State<'_, AppState>) -> Result<Vec<OrgStatus>, AppError> {
+    org_list_statuses_inner(state.inner()).await
+}
+
+pub(crate) async fn org_list_statuses_inner(state: &AppState) -> Result<Vec<OrgStatus>, AppError> {
+    let mut out = Vec::new();
+    for local in state.db.list_org_states()? {
+        out.push(org_status_for(state, local).await?);
+    }
+    Ok(out)
+}
+
+/// Build the content-free [`OrgStatus`] for ONE locally-joined org. Refreshes name/role/generation +
+/// member_count from the server best-effort (offline / a per-org error falls back to the cached row),
+/// then reads pending/item counts from the local outbound `org_shares` and the GLOBAL egress consent.
+/// The single source of the per-org status body — `org_status_inner` (first) and `org_list_statuses`
+/// (all) both go through here so their per-org semantics can never drift.
+async fn org_status_for(
+    state: &AppState,
+    local: crate::storage::OrgState,
+) -> Result<OrgStatus, AppError> {
     // Refresh membership/generation from the server when logged in (best-effort — offline shows the
     // cached row).
     let member_count = match (share_base_url(state), valid_access_token(state).await) {
@@ -23390,7 +23685,7 @@ pub(crate) async fn org_status_inner(state: &AppState) -> Result<Option<OrgStatu
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?
         .org_egress_consented;
-    Ok(Some(OrgStatus {
+    Ok(OrgStatus {
         org_id: refreshed.org_id,
         name: refreshed.name,
         role: refreshed.role,
@@ -23399,27 +23694,197 @@ pub(crate) async fn org_status_inner(state: &AppState) -> Result<Option<OrgStatu
         last_seq: refreshed.last_seq,
         item_count,
         pending_shares: pending,
-    }))
+    })
 }
 
-/// `org_invite_member(email)` — owner adds a registered account, then wraps the CURRENT-generation
-/// OCK to them + PUTs the grant so they can decrypt the feed. Requires the OCK session.
+/// `org_refresh()` — pull the caller's org MEMBERSHIP from the server and reconcile it into local
+/// `org_state` (add invited orgs, drop departed ones). Best-effort; offline / logged-out = no-op. The
+/// FE triggers this on settings-open so an org you were just invited to appears without a re-login.
+#[tauri::command]
+pub async fn org_refresh(state: State<'_, AppState>) -> Result<(), AppError> {
+    org_reconcile_memberships(state.inner()).await
+}
+
+/// Reconcile the LOCAL `org_state` set against the server's authoritative membership list
+/// (`GET /v1/orgs`). Root fix for the single-org / no-membership-discovery bug: an org you were
+/// INVITED to (never one you CREATED) was invisible locally and never synced.
+///
+/// - ADD every server org: `upsert_org_state`. For an org already known locally, the upsert PRESERVES
+///   `joined_at`/`consented`/`last_seq` (its ON CONFLICT only refreshes name/role/generation) — so a
+///   reconcile never rewinds a cursor or clears consent. A NEW org is inserted with the server's
+///   `created_at` as `joined_at`, `consented=false`, `last_seq=0`, and its OCK is best-effort acquired
+///   so its feed can later decrypt (a missing grant is NOT fatal — logged + skipped).
+/// - REMOVE every local org NOT in the server list (you left / were removed) and PURGE its decrypted
+///   replica (`purge_org_replica`, same as `org_leave`) so a departed org's docs don't linger/leak.
+///   F2 GUARD: an EMPTY server list while local orgs exist is treated as suspicious (a hostile/buggy/
+///   transient `{"orgs":[]}`) and SKIPS all removals — one bad response must never wipe every replica.
+///
+/// Offline / not-logged-in = NO-OP: the cached rows are kept untouched (never destructive on a
+/// transient network failure). No PII in logs — ids/counts only.
+pub(crate) async fn org_reconcile_memberships(state: &AppState) -> Result<(), AppError> {
+    // Logged out / no server ⇒ keep the cached rows, do nothing (not an error).
+    let base = match share_base_url(state) {
+        Ok(b) if !b.trim().is_empty() => b,
+        _ => return Ok(()),
+    };
+    let access = match valid_access_token(state).await {
+        Ok(a) => a,
+        Err(_) => return Ok(()),
+    };
+    let client = crate::share::client::ShareClient::new(&base)?;
+    // A pull failure (network/5xx) is best-effort: keep the cached rows, retry next tick.
+    let server_orgs = match client.org_list(&access).await {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(target: "org", error = %brief_err(&e), "org membership pull failed — keeping cached rows");
+            return Ok(());
+        }
+    };
+
+    // Apply the ADD/REMOVE against the local DB (pure, testable without a network) and learn which
+    // orgs are NEW (so we can best-effort acquire their OCK) and which we dropped (to purge OCKs).
+    let outcome = reconcile_org_state_into_db(state, &server_orgs)?;
+
+    // Best-effort: acquire each newly-discovered org's OCK so its feed can later decrypt. A grant not
+    // yet issued (the owner hasn't PUT our wrapped key) must NOT fail the whole reconcile.
+    for (org_id, generation) in &outcome.new_orgs {
+        if let Err(e) = acquire_org_ock(state, org_id, *generation).await {
+            tracing::info!(
+                target: "org",
+                error = %brief_err(&e),
+                "org OCK not yet available for a newly-discovered org (will retry on sync)"
+            );
+        }
+    }
+
+    tracing::info!(
+        target: "org",
+        server = server_orgs.len(),
+        added = outcome.new_orgs.len(),
+        removed = outcome.removed,
+        "org membership reconciled"
+    );
+    Ok(())
+}
+
+/// The DB-side outcome of a membership reconcile: the NEW orgs (id + generation, needing an OCK
+/// fetch) and how many local orgs were REMOVED.
+struct ReconcileOutcome {
+    new_orgs: Vec<(String, u32)>,
+    removed: u32,
+}
+
+/// Apply the server's authoritative org set to the local `org_state` table — the PURE, network-free
+/// core of [`org_reconcile_memberships`] (so the add/remove/purge logic is unit-testable without a
+/// live server). ADD/refresh every server org (`upsert_org_state` preserves joined_at/consented/
+/// last_seq for a KNOWN org via its ON CONFLICT; a NEW org inserts with created_at/consented=false/
+/// last_seq=0), and REMOVE + `purge_org_replica` every local org the server no longer lists. Returns
+/// the NEW orgs (for OCK acquisition by the caller) + the removed count.
+fn reconcile_org_state_into_db(
+    state: &AppState,
+    server_orgs: &[crate::share::org_dto::OrgSummary],
+) -> Result<ReconcileOutcome, AppError> {
+    // Snapshot the known-local set BEFORE the upserts so "new org" detection is against the pre-state.
+    let known_before: std::collections::HashSet<String> = state
+        .db
+        .list_org_states()?
+        .into_iter()
+        .map(|o| o.org_id)
+        .collect();
+    let server_ids: std::collections::HashSet<String> =
+        server_orgs.iter().map(|o| o.org_id.clone()).collect();
+
+    let mut new_orgs = Vec::new();
+    for o in server_orgs {
+        let is_new = !known_before.contains(&o.org_id);
+        state.db.upsert_org_state(&crate::storage::OrgState {
+            org_id: o.org_id.clone(),
+            name: o.name.clone(),
+            role: o.role.clone(),
+            joined_at: o.created_at.clone(),
+            consented: false,
+            last_seq: 0,
+            generation: o.current_generation,
+        })?;
+        if is_new {
+            new_orgs.push((o.org_id.clone(), o.current_generation));
+        }
+    }
+
+    // F2 HARDENING — an EMPTY server list while we HAVE local orgs is SUSPICIOUS (a buggy/hostile
+    // server, or a transient `{"orgs":[]}` 200). Removing every local org on that signal would purge
+    // ALL replicas — an unrecoverable local wipe from a single bad response. SKIP the removals (keep
+    // the cached rows), log a warning (ids/counts only — no PII), and let the next reconcile with a
+    // real non-empty list do the honest cleanup. A NON-empty list that merely OMITS a specific org
+    // (the real leave/remove case) still removes that org below — only the all-empty case is guarded.
+    if server_orgs.is_empty() && !known_before.is_empty() {
+        tracing::warn!(
+            target: "org",
+            local = known_before.len(),
+            "server returned an EMPTY org membership list while local replicas exist — skipping removals (suspected transient/hostile empty response)"
+        );
+        return Ok(ReconcileOutcome {
+            new_orgs,
+            removed: 0,
+        });
+    }
+
+    // Remove local orgs the server no longer lists (left / removed) + purge their decrypted replica so
+    // a departed org's docs don't linger in the local retrieval partition (the same purge `org_leave`
+    // does — leak/consent invariant) + drop its cached OCKs.
+    let mut removed = 0u32;
+    for org_id in &known_before {
+        if !server_ids.contains(org_id) {
+            state.db.delete_org_state(org_id)?;
+            state.db.purge_org_replica(org_id)?;
+            if let Ok(mut cache) = state.org_ock_cache.lock() {
+                cache.retain(|(oid, _), _| oid != org_id);
+            }
+            removed += 1;
+        }
+    }
+
+    Ok(ReconcileOutcome { new_orgs, removed })
+}
+
+/// Resolve the TARGETED org by id, MEMBERSHIP-CHECKED against the local `org_state`. The multi-org
+/// fix: the FE passes the org the user picked, and every per-org command resolves THAT org (never the
+/// first via `.next()`, which misrouted a destructive/egress op to org #1 on a multi-org account). A
+/// blank id or an org we're not a local member of is an `InvalidArg` refusal — we never operate on an
+/// org the caller isn't in.
+fn resolve_org(state: &AppState, org_id: &str) -> Result<crate::storage::OrgState, AppError> {
+    let org_id = org_id.trim();
+    if org_id.is_empty() {
+        return Err(AppError::InvalidArg("org id required".into()));
+    }
+    state
+        .db
+        .get_org_state(org_id)?
+        .ok_or_else(|| AppError::InvalidArg("not a member of that org".into()))
+}
+
+/// `org_invite_member(org_id, email)` — owner adds a registered account into the TARGETED org, then
+/// wraps that org's CURRENT-generation OCK to them + PUTs the grant so they can decrypt the feed.
+/// Requires the OCK session for the targeted org.
 #[tauri::command]
 pub async fn org_invite_member(
     state: State<'_, AppState>,
+    org_id: String,
     email: String,
 ) -> Result<(), AppError> {
-    org_invite_member_inner(state.inner(), email).await
+    org_invite_member_inner(state.inner(), org_id, email).await
 }
 
-pub(crate) async fn org_invite_member_inner(state: &AppState, email: String) -> Result<(), AppError> {
+pub(crate) async fn org_invite_member_inner(
+    state: &AppState,
+    org_id: String,
+    email: String,
+) -> Result<(), AppError> {
     let email = email.trim().to_string();
     if email.is_empty() {
         return Err(AppError::InvalidArg("email required".into()));
     }
-    let Some(org) = state.db.list_org_states()?.into_iter().next() else {
-        return Err(AppError::InvalidArg("not a member of any org".into()));
-    };
+    let org = resolve_org(state, &org_id)?;
     let base = share_base_url(state)?;
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
@@ -23467,12 +23932,14 @@ pub(crate) async fn org_invite_member_inner(state: &AppState, email: String) -> 
     Ok(())
 }
 
-/// `org_list_members()` — the org's active members (content-free).
+/// `org_list_members(org_id)` — the TARGETED org's active members (content-free). Resolves the org the
+/// FE picked (membership-checked), never the first via `.next()`.
 #[tauri::command]
-pub async fn org_list_members(state: State<'_, AppState>) -> Result<Vec<OrgMember>, AppError> {
-    let Some(org) = state.inner().db.list_org_states()?.into_iter().next() else {
-        return Ok(Vec::new());
-    };
+pub async fn org_list_members(
+    state: State<'_, AppState>,
+    org_id: String,
+) -> Result<Vec<OrgMember>, AppError> {
+    let org = resolve_org(state.inner(), &org_id)?;
     let base = share_base_url(state.inner())?;
     let access = valid_access_token(state.inner()).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
@@ -23490,22 +23957,26 @@ pub async fn org_list_members(state: State<'_, AppState>) -> Result<Vec<OrgMembe
         .collect())
 }
 
-/// `org_remove_member(user_id)` — owner soft-removes a member, then ROTATES the OCK: generate gen
-/// N+1, wrap it to every REMAINING member, PUT the grants, and bump the server generation. The
-/// removed member keeps only the old-gen OCK (can't read anything sealed under N+1).
+/// `org_remove_member(org_id, user_id)` — owner soft-removes a member from the TARGETED org, then
+/// ROTATES that org's OCK: generate gen N+1, wrap it to every REMAINING member, PUT the grants, and
+/// bump the server generation. The removed member keeps only the old-gen OCK (can't read anything
+/// sealed under N+1). Resolves the FE-picked org (membership-checked), never the first via `.next()`.
 #[tauri::command]
 pub async fn org_remove_member(
     state: State<'_, AppState>,
+    org_id: String,
     user_id: String,
 ) -> Result<(), AppError> {
-    org_remove_member_inner(state.inner(), user_id).await
+    org_remove_member_inner(state.inner(), org_id, user_id).await
 }
 
-pub(crate) async fn org_remove_member_inner(state: &AppState, user_id: String) -> Result<(), AppError> {
+pub(crate) async fn org_remove_member_inner(
+    state: &AppState,
+    org_id: String,
+    user_id: String,
+) -> Result<(), AppError> {
     let user_id = user_id.trim().to_string();
-    let Some(org) = state.db.list_org_states()?.into_iter().next() else {
-        return Err(AppError::InvalidArg("not a member of any org".into()));
-    };
+    let org = resolve_org(state, &org_id)?;
     let base = share_base_url(state)?;
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
     // DB grant key = the owner's server user id (UUID), not the email `account_id`.
@@ -23570,14 +24041,13 @@ pub(crate) async fn org_remove_member_inner(state: &AppState, user_id: String) -
     Ok(())
 }
 
-/// `org_leave()` — the caller leaves the org (member self-removal). Drops the local org row + cached
-/// OCKs. Does NOT retroactively un-share the caller's already-published items (use `revoke_org_share`
-/// for that first if desired).
+/// `org_leave(org_id)` — the caller leaves the TARGETED org (member self-removal). Drops that org's
+/// local row + cached OCKs + decrypted replica. Does NOT retroactively un-share the caller's
+/// already-published items (use `revoke_org_share` for that first if desired). Resolves the FE-picked
+/// org (membership-checked), never the first via `.next()` — a leave must purge the RIGHT org.
 #[tauri::command]
-pub async fn org_leave(state: State<'_, AppState>) -> Result<(), AppError> {
-    let Some(org) = state.inner().db.list_org_states()?.into_iter().next() else {
-        return Ok(());
-    };
+pub async fn org_leave(state: State<'_, AppState>, org_id: String) -> Result<(), AppError> {
+    let org = resolve_org(state.inner(), &org_id)?;
     let base = share_base_url(state.inner())?;
     let access = valid_access_token(state.inner()).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
@@ -23788,9 +24258,23 @@ pub(crate) async fn share_to_org_inner(
         }
     }
 
-    let Some(org) = state.db.list_org_states()?.into_iter().next() else {
+    // TODO(multi-org): let the user pick the target org — the FE does NOT yet pass an org_id to
+    // `share_meeting_to_org` / `share_document_to_org`, so this still resolves to the FIRST local org.
+    // For a single-org account that is correct; for a MULTI-org account this is a destructive EGRESS
+    // op picking org #1, so make the choice EXPLICIT (log which org — id only, no content) rather than
+    // silently choosing. When the FE gains an org picker, thread an `org_id` param through here (as
+    // `org_invite_member`/`org_leave` now do) and resolve via `resolve_org`.
+    let all_orgs = state.db.list_org_states()?;
+    let Some(org) = all_orgs.into_iter().next() else {
         return Err(AppError::InvalidArg("not a member of any org".into()));
     };
+    if state.db.list_org_states()?.len() > 1 {
+        tracing::warn!(
+            target: "org",
+            org_id = %org.org_id,
+            "org share targeting the first org on a multi-org account (no FE picker yet — TODO multi-org)"
+        );
+    }
     let base = share_base_url(state)?;
     let (_account_id, _gen_id, _mk, access_token) = require_session_mk(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
@@ -23932,6 +24416,9 @@ pub(crate) async fn share_to_org_inner(
 /// local owner). Content-free enough for the FE list.
 #[tauri::command]
 pub fn list_org_shares(state: State<'_, AppState>) -> Result<Vec<OrgShareEntry>, AppError> {
+    // TODO(multi-org): let the user pick the target org — the FE does NOT yet pass an org_id here, so
+    // this read still lists the FIRST local org's shares. A READ (not destructive/egress), so a
+    // first-org default is acceptable until the FE gains an org picker; thread `org_id` through then.
     let Some(org) = state.inner().db.list_org_states()?.into_iter().next() else {
         return Ok(Vec::new());
     };
@@ -24099,6 +24586,11 @@ pub const ORG_SYNC_TICK_SECS: u64 = 300;
 /// `Ok` when logged out / no org joined, so this is a no-op until a session is live. Logs only
 /// non-PII counts on a productive tick.
 pub(crate) async fn org_background_sync_tick(state: &AppState) {
+    // Reconcile membership FIRST so a newly-invited org is present (and synced this same tick) and a
+    // departed org is dropped before we pull its feed. Best-effort — a failure never blocks the sync.
+    if let Err(e) = org_reconcile_memberships(state).await {
+        tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile tick failed");
+    }
     if let Err(e) = org_sweep_pending_inner(state).await {
         tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
     }
@@ -24183,22 +24675,66 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
     Ok(advanced)
 }
 
-/// `org_sync_now()` — pull the org feed from the last synced cursor, OPEN each ciphertext blob with
-/// the (RAM-cached / grant-unwrapped) OCK, and INGEST it into the local decrypted replica + int8
+/// `org_sync_now(org_id?)` — pull the org feed from the last synced cursor, OPEN each ciphertext blob
+/// with the (RAM-cached / grant-unwrapped) OCK, and INGEST it into the local decrypted replica + int8
 /// retrieval partition. A TOMBSTONE evicts the item's chunks/vectors/FTS. Returns a content-free
 /// [`OrgSyncReport`] (counts + `fts_only` + per-item error strings). Best-effort per item: a single
 /// item whose OCK is unavailable / whose blob won't open is SKIPPED (recorded in `errors`), never
 /// crashing the whole sync — the cursor still advances past a tombstone but STOPS at the first
 /// un-openable LIVE item so a transient key gap is retried next sync (no silent skip-forward).
+///
+/// `org_id`: `Some(id)` syncs ONLY that (FE-picked, membership-checked) org; `None` syncs ALL joined
+/// orgs (the background tick / internal callers). The tick's all-orgs iteration is unchanged.
 #[tauri::command]
 pub async fn org_sync_now(
     state: State<'_, AppState>,
+    org_id: Option<String>,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    org_sync_now_inner(state.inner()).await
+    // The FE passes a SPECIFIC org id (→ sync only that org); the background tick / internal callers
+    // pass `None` (→ sync ALL orgs, the tick's iteration is unchanged). This is the command-boundary
+    // dispatch of the multi-org fix: a user-triggered "Sync now" from a picked org must not sync (or
+    // report against) the wrong org.
+    match org_id {
+        Some(id) => org_sync_one_now_inner(state.inner(), &id).await,
+        None => org_sync_now_inner(state.inner()).await,
+    }
 }
 
 /// Server feed page size per `org_feed` request. The loop pages until the feed is drained.
 const ORG_FEED_PAGE: u32 = 200;
+
+/// Sync exactly ONE (FE-targeted) org's feed — the single-org boundary of [`org_sync_now`]. Resolves
+/// the org (membership-checked, never `.next()`), then runs the same per-org pull/ingest via
+/// `org_sync_one` used by the all-orgs loop. Offline / logged-out ⇒ an empty report (no-op), matching
+/// the all-orgs path.
+pub(crate) async fn org_sync_one_now_inner(
+    state: &AppState,
+    org_id: &str,
+) -> Result<crate::storage::models::OrgSyncReport, AppError> {
+    let mut report = crate::storage::models::OrgSyncReport::default();
+    let org = resolve_org(state, org_id)?;
+    let base = share_base_url(state)?;
+    if base.trim().is_empty() {
+        return Ok(report);
+    }
+    let access = match valid_access_token(state).await {
+        Ok(a) => a,
+        Err(_) => return Ok(report),
+    };
+    let client = crate::share::client::ShareClient::new(&base)?;
+    report.fts_only = !crate::embed::embed_model_present();
+    org_sync_one(state, &client, &access, &org, &mut report).await?;
+    tracing::info!(
+        target: "org",
+        pulled = report.pulled,
+        ingested = report.ingested,
+        tombstoned = report.tombstoned,
+        fts_only = report.fts_only,
+        errors = report.errors.len(),
+        "org feed sync (single org)"
+    );
+    Ok(report)
+}
 
 pub(crate) async fn org_sync_now_inner(
     state: &AppState,
@@ -24206,9 +24742,10 @@ pub(crate) async fn org_sync_now_inner(
     let mut report = crate::storage::models::OrgSyncReport::default();
 
     // No org joined ⇒ nothing to sync (not an error).
-    let Some(org) = state.db.list_org_states()?.into_iter().next() else {
+    let orgs = state.db.list_org_states()?;
+    if orgs.is_empty() {
         return Ok(report);
-    };
+    }
     let base = share_base_url(state)?;
     if base.trim().is_empty() {
         return Ok(report);
@@ -24224,6 +24761,40 @@ pub(crate) async fn org_sync_now_inner(
     // flag it so the FE can offer a re-embed once a model lands.
     report.fts_only = !crate::embed::embed_model_present();
 
+    // MULTI-ORG: sync EVERY locally-joined org (each with its own cursor via `org_last_seq_for`). A
+    // per-org failure must NOT abort the others — it's recorded in `report.errors` and the loop
+    // continues; `report.last_seq` reflects the LAST org synced (the field is per-org, but the counts
+    // aggregate). This is the fix for the single-org `.next()` that hid every invited org's feed.
+    for org in orgs {
+        if let Err(e) = org_sync_one(state, &client, &access, &org, &mut report).await {
+            report
+                .errors
+                .push(format!("org sync failed ({})", brief_err(&e)));
+        }
+    }
+
+    tracing::info!(
+        target: "org",
+        pulled = report.pulled,
+        ingested = report.ingested,
+        tombstoned = report.tombstoned,
+        fts_only = report.fts_only,
+        errors = report.errors.len(),
+        "org feed sync (multi-org)"
+    );
+    Ok(report)
+}
+
+/// Sync ONE org's append-only feed from its own cursor into the local decrypted replica + retrieval
+/// partition. Extracted from `org_sync_now_inner` so the multi-org loop can call it per org while the
+/// per-org pull/ingest logic stays byte-identical. Aggregates counts into the shared `report`.
+async fn org_sync_one(
+    state: &AppState,
+    client: &crate::share::client::ShareClient,
+    access: &str,
+    org: &crate::storage::OrgState,
+    report: &mut crate::storage::models::OrgSyncReport,
+) -> Result<(), AppError> {
     // ── ASYNC PULL PHASE — drain the feed, opening each cell; buffer decrypted items ──────────────
     // The embedder (`dyn Embedder`, !Send) is deliberately NOT constructed here: the whole async
     // section is Send-safe, and the synchronous INGEST phase below owns the embedder entirely (never
@@ -24249,7 +24820,7 @@ pub(crate) async fn org_sync_now_inner(
 
     'pages: loop {
         let feed = client
-            .org_feed(&access, &org.org_id, cursor, ORG_FEED_PAGE)
+            .org_feed(access, &org.org_id, cursor, ORG_FEED_PAGE)
             .await?;
         if feed.items.is_empty() {
             break;
@@ -24291,7 +24862,7 @@ pub(crate) async fn org_sync_now_inner(
                     break 'pages;
                 }
             };
-            let ciphertext = match client.get_blob(&access, &blob_id).await {
+            let ciphertext = match client.get_blob(access, &blob_id).await {
                 Ok(c) => c,
                 Err(e) => {
                     report
@@ -24385,17 +24956,9 @@ pub(crate) async fn org_sync_now_inner(
         state.db.set_org_last_seq(&org.org_id, applied as i64)?;
     }
 
+    // `report.last_seq` reflects the LAST org synced (per-org field on an aggregate report).
     report.last_seq = state.db.org_last_seq_for(&org.org_id)?;
-    tracing::info!(
-        target: "org",
-        pulled = report.pulled,
-        ingested = report.ingested,
-        tombstoned = report.tombstoned,
-        fts_only = report.fts_only,
-        errors = report.errors.len(),
-        "org feed sync"
-    );
-    Ok(report)
+    Ok(())
 }
 
 /// A short, PII-free rendering of an error for a sync report string (never note content — AppError

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,8 @@ pub fn run() {
             // M6 Shared Brain (Organizations): create/status/members + consent + preview + share.
             commands::org_create,
             commands::org_status,
+            commands::org_list_statuses,
+            commands::org_refresh,
             commands::org_invite_member,
             commands::org_list_members,
             commands::org_remove_member,

--- a/src-tauri/src/share/client.rs
+++ b/src-tauri/src/share/client.rs
@@ -466,6 +466,18 @@ impl ShareClient {
         .await
     }
 
+    /// `GET /v1/orgs` (bearer) — EVERY org the caller actively belongs to (owned OR invited-and-active).
+    /// This is the membership-discovery pull: without it an org you were INVITED to (never one you
+    /// CREATED) is invisible locally and its feed never syncs. Content-free (ids/roles/timestamps).
+    pub async fn org_list(
+        &self,
+        access_token: &str,
+    ) -> Result<Vec<super::org_dto::OrgSummary>> {
+        let resp: super::org_dto::OrgListResponse =
+            self.get_json("/v1/orgs", access_token, "org-list").await?;
+        Ok(resp.orgs)
+    }
+
     /// `GET /v1/orgs/{id}` (member-gated) — the caller's view of an org (name + role + generation).
     pub async fn org_status(
         &self,

--- a/src-tauri/src/share/org_dto.rs
+++ b/src-tauri/src/share/org_dto.rs
@@ -42,6 +42,30 @@ pub struct OrgResponse {
     pub current_generation: u32,
 }
 
+/// One org the caller actively belongs to, in `GET /v1/orgs` — the membership-discovery pull that
+/// makes an org you were INVITED to (not one you created) visible + syncable. Content-free: an opaque
+/// id, a role label, a timestamp, and the live generation. Mirrors [`OrgResponse`]'s field set (the
+/// server returns the same per-org shape in a list), tolerant of a server that omits `currentGeneration`.
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgSummary {
+    pub org_id: String,
+    pub name: String,
+    /// `owner` | `member`.
+    pub role: String,
+    pub created_at: String,
+    /// The org's live OCK generation (defaults to 1 for older servers that omit it).
+    #[serde(default = "one")]
+    pub current_generation: u32,
+}
+
+/// Response to `GET /v1/orgs` — every org the caller actively belongs to (owned OR invited-and-active).
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgListResponse {
+    pub orgs: Vec<OrgSummary>,
+}
+
 /// `POST /v1/orgs/{id}/members {email}` (owner-only).
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -253,5 +277,33 @@ mod tests {
         let json = r#"{"orgId":"o1","name":"Acme","role":"member","createdAt":"2026-07-10T00:00:00Z"}"#;
         let r: OrgResponse = serde_json::from_str(json).unwrap();
         assert_eq!(r.current_generation, 1);
+    }
+
+    /// `GET /v1/orgs` deserializes a MIXED list — an org I own + an org I was invited to (member),
+    /// one carrying a generation, one relying on the default. This is the membership-discovery shape.
+    #[test]
+    fn org_list_response_deserializes_owned_and_invited() {
+        let json = r#"{"orgs":[
+            {"orgId":"o-own","name":"Acme","role":"owner",
+             "createdAt":"2026-07-10T00:00:00Z","currentGeneration":3},
+            {"orgId":"o-inv","name":"Partner Co","role":"member",
+             "createdAt":"2026-07-11T00:00:00Z"}
+        ]}"#;
+        let r: OrgListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.orgs.len(), 2);
+        assert_eq!(r.orgs[0].org_id, "o-own");
+        assert_eq!(r.orgs[0].role, "owner");
+        assert_eq!(r.orgs[0].current_generation, 3);
+        assert_eq!(r.orgs[1].org_id, "o-inv");
+        assert_eq!(r.orgs[1].role, "member");
+        // Default generation for the invited org whose row omitted it.
+        assert_eq!(r.orgs[1].current_generation, 1);
+    }
+
+    /// An empty membership list (a fresh account belonging to nothing) round-trips to an empty vec.
+    #[test]
+    fn org_list_response_deserializes_empty() {
+        let r: OrgListResponse = serde_json::from_str(r#"{"orgs":[]}"#).unwrap();
+        assert!(r.orgs.is_empty());
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -532,24 +532,49 @@ export class IpcService {
     return invoke<OrgStatus | null>("org_status");
   }
 
-  /** Invite a member by email (owner only). Idempotent on an already-invited address. */
-  orgInviteMember(email: string): Promise<void> {
-    return invoke<void>("org_invite_member", { email });
+  /**
+   * EVERY org this user actively belongs to (created OR invited-into) — one
+   * {@link OrgStatus} per org. Supersedes the single-org {@link orgStatus} for
+   * the multi-org Settings surface. Call {@link orgRefresh} first so a freshly
+   * invited-into org (never created locally) is discovered before this reads the
+   * local replica. Content-free per org (counts + role only, no member emails).
+   */
+  orgListStatuses(): Promise<OrgStatus[]> {
+    return invoke<OrgStatus[]>("org_list_statuses");
   }
 
-  /** List the org's members (owner sees emails to manage; drives the member list). */
-  orgListMembers(): Promise<OrgMember[]> {
-    return invoke<OrgMember[]>("org_list_members");
+  /**
+   * Pull the user's org MEMBERSHIP list from the server (`GET /v1/orgs`) and
+   * reconcile the local `org_state` — this is what makes an org you were INVITED
+   * to (and never created locally) appear. Best-effort: resolves even if the
+   * server is unreachable (the last-known local state stands). Run it before
+   * {@link orgListStatuses} on open.
+   */
+  orgRefresh(): Promise<void> {
+    return invoke<void>("org_refresh");
   }
 
-  /** Remove a member (owner only) — drives the OCK generation rotation server-side. */
-  orgRemoveMember(userId: string): Promise<void> {
-    return invoke<void>("org_remove_member", { userId });
+  /**
+   * Invite a member by email into a SPECIFIC org (owner only). Idempotent on an
+   * already-invited address. `orgId` targets the org in a multi-org world.
+   */
+  orgInviteMember(orgId: string, email: string): Promise<void> {
+    return invoke<void>("org_invite_member", { orgId, email });
   }
 
-  /** Leave the org (self-removal). The local org replica is dropped. */
-  orgLeave(): Promise<void> {
-    return invoke<void>("org_leave");
+  /** List one org's members (owner sees emails to manage; drives the member list). */
+  orgListMembers(orgId: string): Promise<OrgMember[]> {
+    return invoke<OrgMember[]>("org_list_members", { orgId });
+  }
+
+  /** Remove a member from a SPECIFIC org (owner only) — drives the OCK generation rotation. */
+  orgRemoveMember(orgId: string, userId: string): Promise<void> {
+    return invoke<void>("org_remove_member", { orgId, userId });
+  }
+
+  /** Leave a SPECIFIC org (self-removal). The local org replica for that org is dropped. */
+  orgLeave(orgId: string): Promise<void> {
+    return invoke<void>("org_leave", { orgId });
   }
 
   /** Grant the one-time org-egress consent (mirrors `consentToShareEgress`). PRESERVE-ONLY config key. */
@@ -603,9 +628,9 @@ export class IpcService {
     return invoke<void>("revoke_org_share", { itemId });
   }
 
-  /** Manually pull + ingest the org feed now → the {@link OrgSyncReport} (counts + errors only). */
-  orgSyncNow(): Promise<OrgSyncReport> {
-    return invoke<OrgSyncReport>("org_sync_now");
+  /** Manually pull + ingest a SPECIFIC org's feed now → the {@link OrgSyncReport} (counts + errors only). */
+  orgSyncNow(orgId: string): Promise<OrgSyncReport> {
+    return invoke<OrgSyncReport>("org_sync_now", { orgId });
   }
 
   /** The full decrypted org item for the read-only viewer route. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1783,12 +1783,14 @@ export interface NoteFolder {
 export type OrgRole = "owner" | "member";
 
 /**
- * The org membership + sync state for the Settings › Organization section
- * (`orgStatus` / `orgCreate`). `null` from `orgStatus` ⇒ this user is in no org
- * yet (show the create form). `memberCount` + `itemCount` are counts only (no
- * names/content); `lastSeq` is the last synced feed sequence; `pendingShares`
- * is the count of queued/failed local outbound org shares awaiting the sweep.
- * Mirrors the Rust `OrgStatus`.
+ * The membership + sync state for ONE org (`orgCreate` returns one; `orgStatus`
+ * returns the legacy single-org view or `null`; `orgListStatuses` returns one
+ * per org the user belongs to — created OR invited-into). An empty
+ * `orgListStatuses` array ⇒ the user is in no org (show the empty state + create
+ * form). `memberCount` + `itemCount` are counts only (no names/content);
+ * `lastSeq` is the last synced feed sequence; `pendingShares` is the count of
+ * queued/failed local outbound org shares awaiting the sweep. Mirrors the Rust
+ * `OrgStatus`.
  */
 export interface OrgStatus {
   orgId: string;
@@ -1807,12 +1809,15 @@ export interface OrgStatus {
 
 /**
  * One org member row for the owner's member list (`orgListMembers`). Content-free:
- * an `email` the owner already knows + a role + join time. `removed` marks a
- * former member (rendered muted / historical). Mirrors the Rust `OrgMember`.
+ * a `role` + join time, and an `email` ONLY when the server discloses it — the
+ * server currently withholds member emails (content-minimization), so `email` is
+ * `null` and the row falls back to the opaque `userId`. `removed` marks a former
+ * member (rendered muted / historical). Mirrors the Rust `OrgMember`.
  */
 export interface OrgMember {
   userId: string;
-  email: string;
+  /** The member's email when the server discloses it; `null` otherwise (show `userId`). */
+  email: string | null;
   role: OrgRole;
   addedAt: string;
   removed: boolean;

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
@@ -2,7 +2,7 @@
   <div class="card account-card">
     <div class="account-head">
       <span class="account-mark" aria-hidden="true">
-        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" role="img" aria-label="Organization">
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" role="img" aria-label="Organizations">
           <circle cx="12" cy="8" r="3.2" fill="var(--accent-soft)" stroke="var(--accent-hover)" stroke-width="1.3" />
           <path d="M5.5 20a6.5 6.5 0 0 1 13 0" fill="none" stroke="var(--accent-hover)" stroke-width="1.3" stroke-linecap="round" />
           <circle cx="4.5" cy="10.5" r="1.8" fill="none" stroke="var(--accent-hover)" stroke-width="1.2" />
@@ -10,185 +10,200 @@
         </svg>
       </span>
       <div class="account-copy">
-        <h3>Organization</h3>
+        <h3>Organizations</h3>
         <p class="text-secondary account-sub">
-          Share notes into your org's <strong>shared brain</strong> — a
-          searchable knowledge base every member syncs on-device. It's
-          end-to-end encrypted; the server can't read it.
+          Share notes into an org's <strong>shared brain</strong> — a searchable
+          knowledge base every member syncs on-device. It's end-to-end
+          encrypted; the server can't read it. You can belong to several orgs.
         </p>
+        @if (email(); as e) {
+          <p class="text-muted account-note signed-as">Signed in as <strong>{{ e }}</strong></p>
+        }
       </div>
     </div>
 
     @if (!loaded()) {
-      <p class="text-muted account-note">Loading organization…</p>
-    } @else if (status(); as st) {
-      <!-- ── In an org: manage ── -->
-      <div class="account-section">
-        <span class="account-section-label text-muted">Your organization</span>
-        <div class="signed-in-row">
-          <span class="pill is-success signed-pill">
-            <span class="pill-dot"></span>
-            {{ st.name }}
-          </span>
-          <span class="org-role-chip">{{ st.role === "owner" ? "Owner" : "Member" }}</span>
-          <button
-            type="button"
-            class="btn btn-ghost"
-            (click)="leave()"
-            [disabled]="busy()"
-          >
-            Leave organization
-          </button>
-        </div>
-        <p class="text-secondary account-note">
-          {{ st.memberCount }}
-          {{ st.memberCount === 1 ? "member" : "members" }} ·
-          {{ st.itemCount }} shared
-          {{ st.itemCount === 1 ? "item" : "items" }} synced
-        </p>
-      </div>
-
-      <!-- Org-egress consent — a dedicated command (preserve-only config). -->
-      <div class="account-section">
-        <span class="account-section-label text-muted">Sharing to the org brain</span>
-        <div class="consent-row">
-          @if (consented()) {
-            <span class="pill is-success signed-pill">
-              <span class="pill-dot"></span>
-              Org sharing allowed
-            </span>
-            <button
-              type="button"
-              class="btn btn-ghost"
-              (click)="toggleConsent()"
-              [disabled]="consentBusy()"
-            >
-              {{ consentBusy() ? "…" : "Turn off" }}
-            </button>
-          } @else {
-            <p class="text-secondary account-note">
-              You haven't allowed org sharing yet. When you add an item, its
-              encrypted copy is uploaded to your org's feed.
-            </p>
-            <button
-              type="button"
-              class="btn btn-primary"
-              (click)="toggleConsent()"
-              [disabled]="consentBusy()"
-            >
-              {{ consentBusy() ? "…" : "Allow org sharing" }}
-            </button>
-          }
-        </div>
-      </div>
-
-      <!-- Sync status + Sync now. -->
-      <div class="account-section">
-        <span class="account-section-label text-muted">Sync</span>
-        <div class="signed-in-row">
-          <span class="text-secondary account-note">
-            Last synced sequence <strong>{{ st.lastSeq }}</strong> ·
-            {{ st.itemCount }} {{ st.itemCount === 1 ? "item" : "items" }} in your
-            local brain
-          </span>
-          <button
-            type="button"
-            class="btn btn-ghost"
-            (click)="syncNow()"
-            [disabled]="syncing()"
-          >
-            {{ syncing() ? "Syncing…" : "Sync now" }}
-          </button>
-        </div>
-        @if (st.pendingShares > 0) {
-          <p class="text-secondary account-note">
-            {{ st.pendingShares }}
-            {{ st.pendingShares === 1 ? "share" : "shares" }} still queued to
-            upload — they'll sync on the next launch.
-          </p>
-        }
-        @if (lastSync(); as report) {
-          <p class="text-secondary account-note" role="status">
-            Pulled {{ report.pulled }}, ingested {{ report.ingested }},
-            removed {{ report.tombstoned }}.
-            @if (report.ftsOnly) {
-              <span class="text-muted">
-                (Text-only search — download an embedding model in AI &amp;
-                Models for semantic search.)
-              </span>
-            }
-          </p>
-          @for (err of report.errors; track err) {
-            <p class="text-danger account-note">{{ err }}</p>
-          }
-        }
-      </div>
-
-      <!-- Members (owner only). -->
-      @if (isOwner()) {
+      <p class="text-muted account-note">Loading organizations…</p>
+    } @else {
+      <!-- ── Your organizations ── -->
+      @if (hasOrgs()) {
         <div class="account-section">
-          <span class="account-section-label text-muted">Members</span>
-          <div class="invite-row">
-            <input
-              type="email"
-              class="text-input invite-input"
-              [value]="inviteEmail()"
-              (input)="onInviteEmailInput($event)"
-              (keydown.enter)="invite()"
-              placeholder="colleague@example.com"
-              autocomplete="off"
-              spellcheck="false"
-              aria-label="Invite a member by email"
-              [disabled]="inviting()"
-            />
-            <button
-              type="button"
-              class="btn btn-primary"
-              (click)="invite()"
-              [disabled]="inviting() || !inviteEmail().trim()"
-            >
-              {{ inviting() ? "Inviting…" : "Invite" }}
-            </button>
-          </div>
-          @if (membersError(); as merr) {
-            <p class="text-danger account-note" role="alert">{{ merr }}</p>
-          }
-          <ul class="member-list">
-            @for (m of sortedMembers(); track m.userId) {
-              <li class="member-row" [class.is-removed]="m.removed">
-                <div class="member-meta">
-                  <span class="member-email">{{ m.email }}</span>
-                  <span class="member-sub text-muted">
-                    {{ m.role === "owner" ? "Owner" : "Member" }} ·
-                    joined {{ formatDate(m.addedAt) }}
-                    @if (m.removed) {
-                      · removed
-                    }
+          <span class="account-section-label text-muted">
+            Your organizations
+          </span>
+          <ul class="org-list">
+            @for (o of orgs(); track o.orgId) {
+              <li class="org-card">
+                <div class="org-card-head">
+                  <div class="org-identity">
+                    <span class="org-name">{{ o.name }}</span>
+                    <span
+                      class="org-role-badge"
+                      [class.is-owner]="o.role === 'owner'"
+                      [class.is-member]="o.role !== 'owner'"
+                    >
+                      {{ o.role === "owner" ? "Owner" : "Member" }}
+                    </span>
+                  </div>
+                  <span class="text-secondary org-counts">
+                    {{ o.memberCount }}
+                    {{ o.memberCount === 1 ? "member" : "members" }} ·
+                    {{ o.itemCount }} {{ o.itemCount === 1 ? "item" : "items" }}
                   </span>
                 </div>
-                @if (!m.removed && m.role !== "owner") {
+
+                <p class="text-muted account-note org-sync-line">
+                  Synced to sequence <strong>{{ o.lastSeq }}</strong>.
+                  @if (o.pendingShares > 0) {
+                    {{ o.pendingShares }}
+                    {{ o.pendingShares === 1 ? "share" : "shares" }} queued to
+                    upload.
+                  }
+                </p>
+
+                <div class="org-actions">
+                  @if (o.role === "owner") {
+                    <button
+                      type="button"
+                      class="btn btn-ghost mini-btn"
+                      (click)="toggleMembers(o)"
+                    >
+                      {{ expandedOrgId() === o.orgId ? "Hide members" : "Invite & members" }}
+                    </button>
+                  }
                   <button
                     type="button"
                     class="btn btn-ghost mini-btn"
-                    (click)="removeMember(m)"
-                    [disabled]="removingId() !== null"
+                    (click)="syncNow(o)"
+                    [disabled]="syncingOrgId() !== null"
                   >
-                    {{ removingId() === m.userId ? "Removing…" : "Remove" }}
+                    {{ syncingOrgId() === o.orgId ? "Syncing…" : "Sync now" }}
                   </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost mini-btn org-leave"
+                    (click)="leave(o)"
+                    [disabled]="busyOrgId() !== null"
+                  >
+                    {{ busyOrgId() === o.orgId ? "Leaving…" : "Leave" }}
+                  </button>
+                </div>
+
+                <!-- Member manager (owner only, expanded on demand). -->
+                @if (o.role === "owner" && expandedOrgId() === o.orgId) {
+                  <div class="org-members">
+                    <div class="invite-row">
+                      <input
+                        type="email"
+                        class="text-input invite-input"
+                        [value]="inviteEmail()"
+                        (input)="onInviteEmailInput($event)"
+                        (keydown.enter)="invite(o.orgId)"
+                        placeholder="colleague@example.com"
+                        autocomplete="off"
+                        spellcheck="false"
+                        aria-label="Invite a member by email"
+                        [disabled]="inviting()"
+                      />
+                      <button
+                        type="button"
+                        class="btn btn-primary"
+                        (click)="invite(o.orgId)"
+                        [disabled]="inviting() || !inviteEmail().trim()"
+                      >
+                        {{ inviting() ? "Inviting…" : "Invite" }}
+                      </button>
+                    </div>
+                    @if (membersError(); as merr) {
+                      <p class="text-danger account-note" role="alert">{{ merr }}</p>
+                    }
+                    @if (membersLoading()) {
+                      <p class="text-muted account-note">Loading members…</p>
+                    } @else {
+                      <ul class="member-list">
+                        @for (m of sortedMembers(); track m.userId) {
+                          <li class="member-row" [class.is-removed]="m.removed">
+                            <div class="member-meta">
+                              <span class="member-email">{{ m.email ?? m.userId }}</span>
+                              <span class="member-sub text-muted">
+                                {{ m.role === "owner" ? "Owner" : "Member" }} ·
+                                joined {{ formatDate(m.addedAt) }}
+                                @if (m.removed) {
+                                  · removed
+                                }
+                              </span>
+                            </div>
+                            @if (!m.removed && m.role !== "owner") {
+                              <button
+                                type="button"
+                                class="btn btn-ghost mini-btn"
+                                (click)="removeMember(o.orgId, m)"
+                                [disabled]="removingId() !== null"
+                              >
+                                {{ removingId() === m.userId ? "Removing…" : "Remove" }}
+                              </button>
+                            }
+                          </li>
+                        } @empty {
+                          <li class="member-empty text-muted">No other members yet — invite a colleague.</li>
+                        }
+                      </ul>
+                      <p class="text-muted account-note">
+                        Removing a member rotates the org's encryption key so they
+                        can no longer read new items.
+                      </p>
+                    }
+                  </div>
                 }
               </li>
-            } @empty {
-              <li class="member-empty text-muted">No other members yet — invite a colleague.</li>
             }
           </ul>
-          <p class="text-muted account-note">
-            Removing a member rotates the org's encryption key so they can no
-            longer read new items.
+        </div>
+
+        <!-- ONE global org-egress consent — not per-org (a follow-up). -->
+        <div class="account-section">
+          <span class="account-section-label text-muted">Sharing to your org brains</span>
+          <div class="consent-row">
+            @if (consented()) {
+              <span class="pill is-success signed-pill">
+                <span class="pill-dot"></span>
+                Org sharing allowed
+              </span>
+              <button
+                type="button"
+                class="btn btn-ghost"
+                (click)="toggleConsent()"
+                [disabled]="consentBusy()"
+              >
+                {{ consentBusy() ? "…" : "Turn off" }}
+              </button>
+            } @else {
+              <p class="text-secondary account-note">
+                Share my notes into my organizations. When you add an item, its
+                encrypted copy is uploaded to that org's feed.
+              </p>
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="toggleConsent()"
+                [disabled]="consentBusy()"
+              >
+                {{ consentBusy() ? "…" : "Allow org sharing" }}
+              </button>
+            }
+          </div>
+        </div>
+      } @else {
+        <!-- ── Empty state: in no org ── -->
+        <div class="account-section">
+          <p class="text-secondary account-note org-empty">
+            You're not in any organization yet — create one, or ask a teammate to
+            invite you by email.
           </p>
         </div>
       }
-    } @else {
-      <!-- ── No org: create ── -->
+
+      <!-- Create an org (always available — you can be in several). -->
       <div class="account-section">
         <span class="account-section-label text-muted">Create an organization</span>
         <p class="text-secondary account-note">

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
@@ -51,6 +51,12 @@
 .account-sub strong {
   color: var(--text-primary);
 }
+.signed-as {
+  margin-top: var(--space-1);
+}
+.signed-as strong {
+  color: var(--text-secondary);
+}
 
 .account-section {
   display: flex;
@@ -72,25 +78,95 @@
   color: var(--text-primary);
 }
 
-.signed-in-row {
+/* ── Org list of cards ── */
+.org-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.org-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+}
+.org-card-head {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-3);
   flex-wrap: wrap;
 }
-.signed-pill {
-  align-self: flex-start;
+.org-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
 }
-.org-role-chip {
+.org-name {
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.org-role-badge {
   padding: 2px var(--space-2);
   border-radius: var(--radius-pill);
-  background: var(--surface-input);
-  border: 1px solid var(--border-subtle);
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: 0.7rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
+  flex: none;
+}
+/* OWNER = filled accent (you manage this org). */
+.org-role-badge.is-owner {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border: 1px solid transparent;
+}
+/* MEMBER = neutral outline (you belong, someone else owns). */
+.org-role-badge.is-member {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+}
+.org-counts {
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+.org-sync-line {
+  font-size: 0.85rem;
+}
+
+.org-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.org-leave {
+  color: var(--text-secondary);
+}
+
+.org-members {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.org-empty {
+  font-size: 0.9rem;
 }
 
 .consent-row {
@@ -98,6 +174,9 @@
   align-items: center;
   gap: var(--space-3);
   flex-wrap: wrap;
+}
+.signed-pill {
+  align-self: flex-start;
 }
 
 /* Shared text input — mirrors the account section's input treatment via tokens. */

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -2,33 +2,38 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   signal,
 } from "@angular/core";
 import { IpcService } from "../../../../core/ipc.service";
-import type {
-  OrgMember,
-  OrgStatus,
-  OrgSyncReport,
-} from "../../../../core/models";
+import type { OrgMember, OrgStatus } from "../../../../core/models";
 
 /**
- * Settings → Organization section (Shared Brain v1). Manages the org behind the
- * org-wide E2EE shared brain. Mirrors the sibling `settings-account-section`
- * shape (`:host { display: contents }` + `.section-stack` + frosted `.card`,
- * global `.btn`/`.btn-primary`/`.btn-ghost`, `var(--token)`).
+ * Settings → Organization section (Shared Brain v1, MULTI-ORG).
  *
- * Two states, driven by `orgStatus`:
- *  - NO org → a create form (name → `orgCreate`).
- *  - IN an org → the org name/role, the member list (owner: invite by email +
- *    remove), Leave, the org-egress consent toggle, and the sync status
- *    (lastSeq / itemCount) with a "Sync now" (`orgSyncNow`).
+ * A user can belong to SEVERAL orgs — the ones they created AND the ones they
+ * were invited into. The old single-org surface only ever showed the FIRST
+ * locally-created org, so an invited-into org was invisible and never synced
+ * (root cause: `org_status_inner`/`org_sync_now_inner` took `…next()` and local
+ * `org_state` was only populated by create). This section now lists EVERY org
+ * the user actively belongs to.
  *
- * Everything talks to the Rust core through {@link IpcService}. `orgStatus` loads
- * once into a signal on construction; every mutation reloads it. The member list
- * loads only for the OWNER (the member management surface). The org-egress
- * consent is a dedicated command (`consentToOrgEgress` / `revokeOrgEgress`),
- * PRESERVE-ONLY config like the share-egress consent — never part of a config save.
+ * On open it refreshes membership from the server (`orgRefresh` = server
+ * discovery, so an invited-into org appears) then loads the full list
+ * (`orgListStatuses`) into `orgs`. Both run inside ONE tracked effect keyed on a
+ * `_reloadTick` trigger with a STALE-RESULT guard (a late response from a
+ * superseded reload is dropped — project failure mode #4).
+ *
+ * Each org renders as a card: name, a distinct OWNER/MEMBER role badge, member +
+ * item counts, and per-org actions — Invite (owner only; expands a member
+ * manager), Sync now, Leave. The CREATE-org form stays; creating refreshes the
+ * list. Consent is ONE GLOBAL control ("Share my notes into my organizations")
+ * bound to the existing global org-egress flag — NOT per-org (a follow-up).
+ *
+ * Everything talks to the Rust core through {@link IpcService}. The consent
+ * command pair (`consentToOrgEgress` / `revokeOrgEgress`) is PRESERVE-ONLY
+ * config, never part of a config save — mirrors the share-egress consent.
  */
 @Component({
   selector: "app-settings-organization-section",
@@ -39,33 +44,55 @@ import type {
 export class SettingsOrganizationSectionComponent {
   private readonly ipc = inject(IpcService);
 
-  /** The org membership + sync state; `null` = in no org (show the create form). */
-  private readonly _status = signal<OrgStatus | null>(null);
-  readonly status = this._status.asReadonly();
+  /** Every org the user belongs to (created OR invited-into). Empty ⇒ empty state. */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  readonly orgs = this._orgs.asReadonly();
 
-  /** True until the first `orgStatus` load resolves (avoids a create-form flash). */
+  /** True until the first list load resolves (avoids an empty-state flash). */
   private readonly _loaded = signal(false);
   readonly loaded = this._loaded.asReadonly();
 
-  /** A general org error (load / mutate failure). */
+  /** A general org error (list load / mutate failure). */
   private readonly _error = signal<string | null>(null);
   readonly error = this._error.asReadonly();
 
-  /** True during any in-flight mutation (debounces the buttons). */
-  private readonly _busy = signal(false);
-  readonly busy = this._busy.asReadonly();
+  /** True during any org-level mutation (Leave) — debounces those buttons. */
+  private readonly _busyOrgId = signal<string | null>(null);
+  readonly busyOrgId = this._busyOrgId.asReadonly();
 
-  readonly isOwner = computed(() => this._status()?.role === "owner");
+  /** The signed-in account email (header context); `null` until loaded / logged out. */
+  private readonly _email = signal<string | null>(null);
+  readonly email = this._email.asReadonly();
 
-  // ── Create form ───────────────────────────────────────────────────────────
+  /** True while at least one org is present. */
+  readonly hasOrgs = computed(() => this._orgs().length > 0);
+
+  /** True while the global org-egress consent is granted (any org's flag ⇒ global grant). */
+  private readonly _consented = signal(false);
+  readonly consented = this._consented.asReadonly();
+  readonly consentBusy = signal(false);
+
+  // ── Reload trigger + stale-result guard ─────────────────────────────────────
+  /** Bump to re-run the load effect (open, after create/leave/invite). */
+  private readonly _reloadTick = signal(0);
+  /** Monotonic load token — a resolved fetch writes only if it is still the latest. */
+  private _loadSeq = 0;
+
+  // ── Create form ─────────────────────────────────────────────────────────────
   readonly createName = signal("");
   readonly creating = signal(false);
 
-  // ── Members (owner only) ──────────────────────────────────────────────────
+  // ── Per-org member management (owner only) ──────────────────────────────────
+  /** The org id whose member manager is expanded (only one at a time). */
+  private readonly _expandedOrgId = signal<string | null>(null);
+  readonly expandedOrgId = this._expandedOrgId.asReadonly();
+  /** Members of the currently-expanded org (owner surface). */
   private readonly _members = signal<OrgMember[]>([]);
   readonly members = this._members.asReadonly();
   private readonly _membersError = signal<string | null>(null);
   readonly membersError = this._membersError.asReadonly();
+  private readonly _membersLoading = signal(false);
+  readonly membersLoading = this._membersLoading.asReadonly();
   /** The invite-by-email draft + in-flight flag. */
   readonly inviteEmail = signal("");
   readonly inviting = signal(false);
@@ -78,62 +105,78 @@ export class SettingsOrganizationSectionComponent {
     [...this._members()].sort((a, b) => Number(a.removed) - Number(b.removed)),
   );
 
-  // ── Consent ───────────────────────────────────────────────────────────────
-  readonly consented = computed(() => this._status()?.consented ?? false);
-  readonly consentBusy = signal(false);
-
-  // ── Sync ──────────────────────────────────────────────────────────────────
-  readonly syncing = signal(false);
-  private readonly _lastSync = signal<OrgSyncReport | null>(null);
-  readonly lastSync = this._lastSync.asReadonly();
+  // ── Sync (per-org) ──────────────────────────────────────────────────────────
+  /** The org id currently syncing (locks its Sync now button). */
+  private readonly _syncingOrgId = signal<string | null>(null);
+  readonly syncingOrgId = this._syncingOrgId.asReadonly();
 
   constructor() {
-    // Fire-and-forget one-shot load (no signal read → no effect needed).
-    void this.reload();
+    // On open: refresh membership from the server (so an invited-into org is
+    // discovered) then load every org. Keyed on `_reloadTick` so create/leave/
+    // invite can re-run it; a stale-result guard drops a superseded response.
+    effect(() => {
+      this._reloadTick(); // dependency: any bump re-runs the load
+      const seq = ++this._loadSeq;
+      this._error.set(null);
+      void (async () => {
+        // Account email (best-effort — a logged-out user still sees the section).
+        try {
+          const acct = await this.ipc.accountStatus();
+          if (seq === this._loadSeq) {
+            this._email.set(acct.email);
+          }
+        } catch {
+          // Non-fatal — the header just omits the email line.
+        }
+        // Server membership discovery is best-effort; a failure must not hide
+        // the locally-known orgs, so swallow it and still load the list.
+        try {
+          await this.ipc.orgRefresh();
+        } catch {
+          // Offline / no server → fall through to the local replica.
+        }
+        try {
+          const list = await this.ipc.orgListStatuses();
+          if (seq !== this._loadSeq) {
+            return; // a newer reload superseded this one — drop the result
+          }
+          this._orgs.set(list);
+          this._consented.set(list.some((o) => o.consented));
+          this.reconcileExpanded(list);
+        } catch (e) {
+          if (seq === this._loadSeq) {
+            this._error.set(String(e));
+          }
+        } finally {
+          if (seq === this._loadSeq) {
+            this._loaded.set(true);
+          }
+        }
+      })();
+    });
   }
 
-  /** Load the org status + (for an owner) the member list. */
-  private async reload(): Promise<void> {
-    try {
-      const st = await this.ipc.orgStatus();
-      this._status.set(st);
-      if (st?.role === "owner") {
-        await this.loadMembers();
-      } else {
-        this._members.set([]);
-      }
-      // On-open responsiveness: pull the org feed once (best-effort) so a freshly-joined member sees
-      // teammates' items right away instead of waiting for the next background sync tick. The periodic
-      // backend loop keeps it fresh thereafter; this only covers the "just opened Settings" moment.
-      if (st) {
-        void this.ipc
-          .orgSyncNow()
-          .then(async () => this._status.set(await this.ipc.orgStatus()))
-          .catch(() => undefined);
-      }
-    } catch (e) {
-      this._error.set(String(e));
-    } finally {
-      this._loaded.set(true);
+  /** Re-run the load effect (server discovery + list). */
+  private reload(): void {
+    this._reloadTick.update((n) => n + 1);
+  }
+
+  /** Drop the expanded member manager if its org is gone from the fresh list. */
+  private reconcileExpanded(list: OrgStatus[]): void {
+    const open = this._expandedOrgId();
+    if (open && !list.some((o) => o.orgId === open)) {
+      this._expandedOrgId.set(null);
+      this._members.set([]);
     }
   }
 
-  private async loadMembers(): Promise<void> {
-    this._membersError.set(null);
-    try {
-      this._members.set(await this.ipc.orgListMembers());
-    } catch (e) {
-      this._membersError.set(String(e));
-    }
-  }
-
-  // ── Create ─────────────────────────────────────────────────────────────────
+  // ── Create ───────────────────────────────────────────────────────────────────
 
   onCreateNameInput(event: Event): void {
     this.createName.set((event.target as HTMLInputElement).value);
   }
 
-  /** Create the org (this user becomes owner), then reload into the managed state. */
+  /** Create the org (this user becomes owner), then reload the full list. */
   async createOrg(): Promise<void> {
     const name = this.createName().trim();
     if (!name || this.creating()) {
@@ -142,12 +185,9 @@ export class SettingsOrganizationSectionComponent {
     this._error.set(null);
     this.creating.set(true);
     try {
-      const st = await this.ipc.orgCreate(name);
-      this._status.set(st);
+      await this.ipc.orgCreate(name);
       this.createName.set("");
-      if (st.role === "owner") {
-        await this.loadMembers();
-      }
+      this.reload();
     } catch (e) {
       this._error.set(String(e));
     } finally {
@@ -155,92 +195,27 @@ export class SettingsOrganizationSectionComponent {
     }
   }
 
-  // ── Members ────────────────────────────────────────────────────────────────
+  // ── Consent (ONE global control) ──────────────────────────────────────────────
 
-  onInviteEmailInput(event: Event): void {
-    this.inviteEmail.set((event.target as HTMLInputElement).value);
-  }
-
-  /** Invite a member by email (owner), then refresh the member list. */
-  async invite(): Promise<void> {
-    const email = this.inviteEmail().trim();
-    if (!email || this.inviting()) {
-      return;
-    }
-    this._membersError.set(null);
-    this.inviting.set(true);
-    try {
-      await this.ipc.orgInviteMember(email);
-      this.inviteEmail.set("");
-      await this.loadMembers();
-      await this.refreshStatusCounts();
-    } catch (e) {
-      this._membersError.set(String(e));
-    } finally {
-      this.inviting.set(false);
-    }
-  }
-
-  /** Remove a member (owner) — drives OCK rotation backend-side. Then refresh. */
-  async removeMember(member: OrgMember): Promise<void> {
-    if (this._removingId() !== null) {
-      return;
-    }
-    this._removingId.set(member.userId);
-    this._membersError.set(null);
-    try {
-      await this.ipc.orgRemoveMember(member.userId);
-      await this.loadMembers();
-      await this.refreshStatusCounts();
-    } catch (e) {
-      this._membersError.set(String(e));
-    } finally {
-      this._removingId.set(null);
-    }
-  }
-
-  // ── Leave ────────────────────────────────────────────────────────────────
-
-  /** Leave the org (self-removal); the section flips back to the create form. */
-  async leave(): Promise<void> {
-    if (this._busy()) {
-      return;
-    }
-    this._busy.set(true);
-    this._error.set(null);
-    try {
-      await this.ipc.orgLeave();
-      this._status.set(null);
-      this._members.set([]);
-      this._lastSync.set(null);
-    } catch (e) {
-      this._error.set(String(e));
-    } finally {
-      this._busy.set(false);
-    }
-  }
-
-  // ── Consent ────────────────────────────────────────────────────────────────
-
-  /** Toggle the one-time org-egress consent (dedicated command, preserve-only config). */
+  /** Toggle the one global org-egress consent (dedicated command, preserve-only config). */
   async toggleConsent(): Promise<void> {
     if (this.consentBusy()) {
       return;
     }
     this.consentBusy.set(true);
     this._error.set(null);
-    const grant = !this.consented();
+    const grant = !this._consented();
     try {
       if (grant) {
         await this.ipc.consentToOrgEgress();
       } else {
         await this.ipc.revokeOrgEgress();
       }
-      // Reflect locally so the UI flips without a full reload.
-      const st = this._status();
-      if (st) {
-        this._status.set({ ...st, consented: grant });
-      }
+      // Reflect locally without a full reload; mirror it onto every org row.
+      this._consented.set(grant);
+      this._orgs.update((list) =>
+        list.map((o) => ({ ...o, consented: grant })),
+      );
     } catch (e) {
       this._error.set(String(e));
     } finally {
@@ -248,33 +223,125 @@ export class SettingsOrganizationSectionComponent {
     }
   }
 
-  // ── Sync ─────────────────────────────────────────────────────────────────
+  // ── Per-org: expand member manager (owner) ────────────────────────────────────
 
-  /** Pull + ingest the org feed now; show the report + refresh the status counts. */
-  async syncNow(): Promise<void> {
-    if (this.syncing()) {
+  /** Toggle the member manager for an org (owner only); loads its members. */
+  async toggleMembers(org: OrgStatus): Promise<void> {
+    if (org.role !== "owner") {
       return;
     }
-    this.syncing.set(true);
-    this._error.set(null);
+    if (this._expandedOrgId() === org.orgId) {
+      this._expandedOrgId.set(null);
+      this._members.set([]);
+      return;
+    }
+    this._expandedOrgId.set(org.orgId);
+    this.inviteEmail.set("");
+    await this.loadMembers(org.orgId);
+  }
+
+  private async loadMembers(orgId: string): Promise<void> {
+    this._membersError.set(null);
+    this._membersLoading.set(true);
+    this._members.set([]);
     try {
-      const report = await this.ipc.orgSyncNow();
-      this._lastSync.set(report);
-      await this.refreshStatusCounts();
+      const members = await this.ipc.orgListMembers(orgId);
+      // Guard against a stale expand switch mid-flight.
+      if (this._expandedOrgId() === orgId) {
+        this._members.set(members);
+      }
     } catch (e) {
-      this._error.set(String(e));
+      if (this._expandedOrgId() === orgId) {
+        this._membersError.set(String(e));
+      }
     } finally {
-      this.syncing.set(false);
+      if (this._expandedOrgId() === orgId) {
+        this._membersLoading.set(false);
+      }
     }
   }
 
-  /** Re-read `orgStatus` to refresh the live counts (memberCount / lastSeq / itemCount). */
-  private async refreshStatusCounts(): Promise<void> {
+  onInviteEmailInput(event: Event): void {
+    this.inviteEmail.set((event.target as HTMLInputElement).value);
+  }
+
+  /** Invite a member by email into the expanded org (owner), then refresh. */
+  async invite(orgId: string): Promise<void> {
+    const email = this.inviteEmail().trim();
+    if (!email || this.inviting()) {
+      return;
+    }
+    this._membersError.set(null);
+    this.inviting.set(true);
     try {
-      const st = await this.ipc.orgStatus();
-      this._status.set(st);
-    } catch {
-      // Non-fatal — the last-known status stays.
+      await this.ipc.orgInviteMember(orgId, email);
+      this.inviteEmail.set("");
+      await this.loadMembers(orgId);
+      this.reload();
+    } catch (e) {
+      this._membersError.set(String(e));
+    } finally {
+      this.inviting.set(false);
+    }
+  }
+
+  /** Remove a member from the expanded org (owner) — rotates the OCK. Then refresh. */
+  async removeMember(orgId: string, member: OrgMember): Promise<void> {
+    if (this._removingId() !== null) {
+      return;
+    }
+    this._removingId.set(member.userId);
+    this._membersError.set(null);
+    try {
+      await this.ipc.orgRemoveMember(orgId, member.userId);
+      await this.loadMembers(orgId);
+      this.reload();
+    } catch (e) {
+      this._membersError.set(String(e));
+    } finally {
+      this._removingId.set(null);
+    }
+  }
+
+  // ── Per-org: leave ─────────────────────────────────────────────────────────────
+
+  /** Leave one org (self-removal). Reloads the list (the row drops out). */
+  async leave(org: OrgStatus): Promise<void> {
+    if (this._busyOrgId() !== null) {
+      return;
+    }
+    this._busyOrgId.set(org.orgId);
+    this._error.set(null);
+    try {
+      await this.ipc.orgLeave(org.orgId);
+      if (this._expandedOrgId() === org.orgId) {
+        this._expandedOrgId.set(null);
+        this._members.set([]);
+      }
+      this.reload();
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._busyOrgId.set(null);
+    }
+  }
+
+  // ── Per-org: sync ──────────────────────────────────────────────────────────────
+
+  /** Pull + ingest one org's feed now, then reload the counts. */
+  async syncNow(org: OrgStatus): Promise<void> {
+    if (this._syncingOrgId() !== null) {
+      return;
+    }
+    this._syncingOrgId.set(org.orgId);
+    this._error.set(null);
+    try {
+      await this.ipc.orgSyncNow(org.orgId);
+      this.reload();
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._syncingOrgId.set(null);
     }
   }
 


### PR DESCRIPTION
Fixes the reported bug: account A created org **Testowa** and B created **Siema** + invited A, but A couldn't see (or sync the documents of) the invited org.

## Root cause
The Shared Brain org subsystem was **single-org with no membership discovery**: \`org_status_inner\` and \`org_sync_now_inner\` both used \`list_org_states().next()\` (first local org only), and local \`org_state\` was populated **only on create** — so an org you were **invited** to was invisible and never synced.

## Fix (server already shipped + deployed)
- **Server** (\`murmur-server\`): new \`GET /v1/orgs\` → every org the caller actively belongs to (merged + live).
- **Discovery**: \`ShareClient::org_list\` + \`org_reconcile_memberships\` — add invited orgs, acquire their OCK, drop departed ones (+ purge their decrypted replica); wired into login, the sync tick, and a new \`org_refresh\`. An empty server list never wipes local replicas.
- **Multi-org sync**: \`org_sync_now_inner\` iterates ALL orgs (own cursor each); a per-org error never aborts the rest.
- **Multi-org status**: \`org_list_statuses\` → one status per org.
- **Per-org routing**: invite / list-members / remove-member / leave / sync now take the target \`org_id\` and resolve via \`resolve_org\` (membership-checked) — fixes an access-control misroute where those acted on the first org.
- **FE**: the Organization section lists **all** your orgs with an Owner/Member badge, counts, per-org actions, a "signed in as {email}" header, and an empty state.

## Verification
- Each fix **RED→GREEN**; \`cargo test --lib\` **1503**; \`ng lint\`/\`ng build\` + Playwright e2e (multi-org UI) green; \`bash scripts/ci.sh\` green (clippy \`-D warnings\`, audit, deny).
- **lock-security-reviewer: PASS** + **adversarial-verifier: PASS** (the adversarial pass caught, and this now fixes, the per-org routing + empty-list-wipe defects).
- **Honest gaps**: the real \`GET /v1/orgs\` round-trip + OCK acquisition for a newly-discovered org need a live login on a signed build. Follow-up: an org picker so \`org_share\` targets a chosen org on a multi-org account (today defaults to the first, warn-logged; content stays lock-gated).