### PR TITLE
fix(org): make org-shared notes visible to members + org picker on share

### DIFF
--- a/e2e/org/multi-org-settings.spec.ts
+++ b/e2e/org/multi-org-settings.spec.ts
@@ -37,6 +37,7 @@ const TWO_ORGS = () => [
     consented: true,
     lastSeq: 42,
     itemCount: 12,
+    receivedCount: 12,
     pendingShares: 0,
   },
   {
@@ -46,7 +47,8 @@ const TWO_ORGS = () => [
     memberCount: 8,
     consented: true,
     lastSeq: 100,
-    itemCount: 57,
+    itemCount: 0,
+    receivedCount: 57,
     pendingShares: 0,
   },
 ];

--- a/e2e/org/org-share-visible.spec.ts
+++ b/e2e/org/org-share-visible.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * feat/org-share-visible — the remediation for "a member can't see a note a
+ * colleague shared into their org". Two surfaces, driven against the extended
+ * spec DTO contract with a mocked Tauri IPC (no Rust core):
+ *
+ *  FIX A — Settings › Organization now BROWSES an org's shared brain: expanding
+ *          "Shared brain" lists `list_org_items(orgId)` (title + author + date),
+ *          each row a link to the /org-item/:id viewer. So a member finally has
+ *          somewhere to SEE what was shared in.
+ *
+ *  FIX C — the org-share sheet is a PICKER: it loads `org_list_statuses`, shows a
+ *          select of the user's orgs, and threads the CHOSEN orgId through
+ *          `share_document_to_org` (previously it shared to the FIRST org). We
+ *          record the invoke args page-side and assert the chosen orgId reaches
+ *          the command.
+ *
+ * Overrides run PAGE-SIDE (serialized to strings — self-contained, no closures).
+ * Render + arg-threading smoke; NOT proof of end-to-end behavior (no OCK / no
+ * server).
+ */
+
+const ACCOUNT_STATUS = () => ({
+  loggedIn: true,
+  email: "you@example.com",
+  unlockedForSharing: true,
+  shareConsented: true,
+  serverConfigured: true,
+  biometricUnlockAvailable: true,
+});
+
+// Two orgs the user belongs to (drives both the Settings list AND the picker).
+const TWO_ORGS = () => [
+  {
+    orgId: "org-owned",
+    name: "Acme Inc.",
+    role: "owner",
+    memberCount: 3,
+    consented: true,
+    lastSeq: 42,
+    itemCount: 2,
+    receivedCount: 5,
+    pendingShares: 0,
+  },
+  {
+    orgId: "org-siema",
+    name: "Siema",
+    role: "member",
+    memberCount: 4,
+    consented: true,
+    lastSeq: 100,
+    itemCount: 0,
+    receivedCount: 3,
+    pendingShares: 0,
+  },
+];
+
+test.describe("Org share — browse + picker (mocked IPC)", () => {
+  test("FIX A — Settings › Organization browses an org's shared items", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") {
+        errors.push(m.text());
+      }
+    });
+
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: TWO_ORGS,
+      org_status: () => null,
+      // One item shared INTO the "Siema" org — what a colleague published.
+      list_org_items: (args: { orgId: string }) =>
+        args.orgId === "org-siema"
+          ? [
+              {
+                itemId: "it-42",
+                title: "Q3 planning recap",
+                authorHint: "kasia",
+                createdAt: new Date("2026-07-10T09:00:00Z").toISOString(),
+                seq: 100,
+              },
+            ]
+          : [],
+    });
+
+    await page.goto("/settings");
+    await page.getByRole("button", { name: "Organization" }).first().click();
+    await expect(
+      page.locator("app-settings-organization-section"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // FIX B — the counts are labelled separately (kills the "0 items" lie): the
+    // member-only "Siema" org received items even though it uploaded none.
+    const siema = page.locator(".org-card", { hasText: "Siema" });
+    await expect(siema.getByText("3 in the org brain")).toBeVisible();
+    await expect(siema.getByText("0 shared by you")).toBeVisible();
+
+    // Expand the shared-brain browse list and see the colleague's item.
+    await siema.getByRole("button", { name: "Shared brain" }).click();
+    const itemLink = siema.locator(".org-item-link", {
+      hasText: "Q3 planning recap",
+    });
+    await expect(itemLink).toBeVisible();
+    await expect(itemLink.getByText("kasia", { exact: false })).toBeVisible();
+    // The row links to the read-only org-item viewer.
+    await expect(itemLink).toHaveAttribute("href", /\/org-item\/it-42/);
+
+    await page.screenshot({
+      path: "e2e/org/__screens__/settings-org-browse.png",
+      fullPage: true,
+    });
+
+    expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("FIX A — empty state when nothing is shared into the org", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: TWO_ORGS,
+      org_status: () => null,
+      list_org_items: () => [],
+    });
+    await page.goto("/settings");
+    await page.getByRole("button", { name: "Organization" }).first().click();
+    const acme = page.locator(".org-card", { hasText: "Acme Inc." });
+    await acme.getByRole("button", { name: "Shared brain" }).click();
+    await expect(
+      acme.getByText("Nothing shared into this org yet."),
+    ).toBeVisible();
+  });
+
+  test("FIX C — the share sheet picks an org and threads the chosen orgId", async ({
+    page,
+  }) => {
+    // Record share_meeting_to_org invocations page-side so we can assert the
+    // CHOSEN orgId reaches the command.
+    await page.addInitScript(() => {
+      (window as unknown as { __shareCalls: unknown[] }).__shareCalls = [];
+    });
+
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      // The picker loads the multi-org list.
+      org_list_statuses: TWO_ORGS,
+      // The share panel's gate section still reads the single-org status.
+      org_status: () => ({
+        orgId: "org-owned",
+        name: "Acme Inc.",
+        role: "owner",
+        memberCount: 3,
+        consented: true,
+        lastSeq: 42,
+        itemCount: 2,
+        receivedCount: 5,
+        pendingShares: 0,
+      }),
+      list_my_shares: () => [],
+      list_org_shares: () => [],
+      preview_org_share: () => ({
+        title: "Weekly sync",
+        markdown: "# Weekly sync\n\n- Shipped the org brain",
+        bytes: 64,
+        chunkCount: 1,
+        scrubbed: { emails: 0, phones: 0, cards: 0 },
+        scrub: true,
+      }),
+      share_meeting_to_org: (args: unknown) => {
+        (window as unknown as { __shareCalls: unknown[] }).__shareCalls.push(
+          args,
+        );
+        return null;
+      },
+    });
+
+    // Open a meeting, go to the Share tab → the Org Brain sheet.
+    await page.goto("/library");
+    await page.locator("a[href^='/meeting/']").first().click();
+    await page
+      .getByRole("tab", { name: /share/i })
+      .first()
+      .click()
+      .catch(async () => {
+        await page.getByText("Share", { exact: false }).first().click();
+      });
+
+    const addBtn = page
+      .getByRole("button", { name: "Add to Org Brain" })
+      .first();
+    await expect(addBtn).toBeVisible({ timeout: 10_000 });
+    await addBtn.click();
+
+    const dialog = page.locator("app-org-share-sheet [role='dialog']");
+    await expect(dialog).toBeVisible();
+
+    // The PICKER is present with BOTH orgs (2 options), defaulting to the first.
+    const select = dialog.locator("mur-select select");
+    await expect(select).toBeVisible();
+    await expect(select.locator("option")).toHaveCount(2);
+    await expect(select.locator("option").nth(0)).toHaveText("Acme Inc.");
+    await expect(select.locator("option").nth(1)).toHaveText("Siema");
+
+    // Choose "Siema" (org-siema) — the org the colleague couldn't see into.
+    await select.selectOption("org-siema");
+    // The audience line reflects the chosen org.
+    await expect(dialog.getByText("4 members of Siema")).toBeVisible();
+
+    // Confirm the publish; the CHOSEN orgId must reach share_document_to_org.
+    await dialog.getByRole("button", { name: "Add to Org Brain" }).click();
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __shareCalls: { orgId?: string }[] })
+              .__shareCalls,
+        ),
+      )
+      .toContainEqual(expect.objectContaining({ orgId: "org-siema" }));
+
+    await page.screenshot({
+      path: "e2e/org/__screens__/org-share-picker.png",
+      fullPage: true,
+    });
+  });
+});

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -32,6 +32,7 @@ const ORG_STATUSES = () => [
     consented: true,
     lastSeq: 42,
     itemCount: 12,
+    receivedCount: 12,
     pendingShares: 1,
   },
   {
@@ -41,7 +42,8 @@ const ORG_STATUSES = () => [
     memberCount: 8,
     consented: true,
     lastSeq: 100,
-    itemCount: 57,
+    itemCount: 0,
+    receivedCount: 57,
     pendingShares: 0,
   },
 ];
@@ -130,7 +132,8 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
   }) => {
     await mockTauri(page, {
       account_status: ACCOUNT_STATUS,
-      // The share panel still reads the single-org `org_status` (unchanged).
+      // The share panel's gate reads the single-org `org_status`; the sheet's
+      // picker reads the multi-org `org_list_statuses` (fix C).
       org_status: () => ({
         orgId: "org-1",
         name: "Acme Inc.",
@@ -139,8 +142,22 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
         consented: true,
         lastSeq: 42,
         itemCount: 12,
+        receivedCount: 12,
         pendingShares: 1,
       }),
+      org_list_statuses: () => [
+        {
+          orgId: "org-1",
+          name: "Acme Inc.",
+          role: "owner",
+          memberCount: 3,
+          consented: true,
+          lastSeq: 42,
+          itemCount: 12,
+          receivedCount: 12,
+          pendingShares: 1,
+        },
+      ],
       list_my_shares: () => [],
       list_org_shares: () => [],
       preview_org_share: () => ({
@@ -175,9 +192,12 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
     await expect(
       page.locator("app-org-share-sheet [role='dialog']"),
     ).toBeVisible();
-    // The exact outgoing markdown + the scrubbed-email count render.
+    // The exact outgoing markdown + the picker's single-org audience line render
+    // (one org ⇒ a label, not a redundant picker — fix C).
     await expect(page.getByText("Exactly what leaves your Mac")).toBeVisible();
-    await expect(page.getByText("Who can see this:")).toBeVisible();
+    await expect(
+      page.locator("app-org-share-sheet").getByText("3 members of Acme Inc."),
+    ).toBeVisible();
     await page.screenshot({
       path: "e2e/org/__screens__/org-share-sheet.png",
       fullPage: true,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22074,9 +22074,12 @@ mod lifecycle_tests {
     fn share_meeting_to_org_refuses_a_sealed_meeting() {
         let state = build_state("org-share-lockgate");
         seed_locked_meeting_with_note(&state, "f-lock", "m-locked");
+        // A real org so the target resolves — the read-gate + consent gate still fire FIRST.
+        seed_org(&state.db, "org-1", "Acme", "owner", 1);
         // NOT session-unlocked: unlocked_folders stays empty.
         let err = block_on(share_to_org_inner(
             &state,
+            "org-1",
             Some("m-locked".to_string()),
             None,
             true,
@@ -22095,6 +22098,7 @@ mod lifecycle_tests {
             .insert("f-lock".to_string());
         let err2 = block_on(share_to_org_inner(
             &state,
+            "org-1",
             Some("m-locked".to_string()),
             None,
             true,
@@ -22130,9 +22134,11 @@ mod lifecycle_tests {
             .db
             .set_folder_locked("f-note", true, Some(&b"wrapped"[..]))
             .unwrap();
+        seed_org(&state.db, "org-1", "Acme", "owner", 1);
 
         let err = block_on(share_to_org_inner(
             &state,
+            "org-1",
             None,
             Some("n1".to_string()),
             true,
@@ -22150,6 +22156,7 @@ mod lifecycle_tests {
             .insert("f-note".to_string());
         let err2 = block_on(share_to_org_inner(
             &state,
+            "org-1",
             None,
             Some("n1".to_string()),
             true,
@@ -22486,6 +22493,119 @@ mod lifecycle_tests {
         assert!(state.db.get_org_item("nope").unwrap().is_none());
     }
 
+    /// FIX A (browsable org-items LIST): `db.list_org_items` returns the org's LIVE items as headers
+    /// (newest `seq` first, no markdown body), and DROPS a tombstoned item + scopes to the org. This is
+    /// what lets a member SEE what colleagues shared IN — the root of the "A can't see B's note" bug (org
+    /// content was search-only). RED on a missing list (there was no browse path); GREEN with the list.
+    #[test]
+    fn list_org_items_returns_live_headers_newest_first_scoped_and_untombstoned() {
+        let state = build_state("org-list-items");
+        // Two items in org-1 at seq 1 and 2, plus an item in a DIFFERENT org, plus a tombstoned one.
+        state
+            .db
+            .upsert_org_item("a", "org-1", 1, "anna", "Kickoff", "the kickoff agenda", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("b", "org-1", 2, "bob", "Retro", "the sprint retro", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("z", "org-2", 9, "zed", "Other org", "not our org", "2026-07-11T09:00:00Z", 1, 1, &[3u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("d", "org-1", 3, "dan", "Dead", "revoked", "2026-07-11T10:00:00Z", 1, 1, &[4u8; 32], None)
+            .unwrap();
+        state.db.tombstone_org_item("d").unwrap();
+
+        let items = state.db.list_org_items("org-1").unwrap();
+        // Only the two LIVE org-1 items, newest seq first (b before a), no other org, no tombstone.
+        assert_eq!(items.len(), 2, "only live org-1 items: {items:?}");
+        assert_eq!(items[0].item_id, "b", "newest seq first");
+        assert_eq!(items[0].title, "Retro");
+        assert_eq!(items[0].author_hint, "bob");
+        assert_eq!(items[0].seq, 2);
+        assert_eq!(items[1].item_id, "a");
+        assert!(
+            !items.iter().any(|h| h.item_id == "z"),
+            "another org's item never appears"
+        );
+        assert!(
+            !items.iter().any(|h| h.item_id == "d"),
+            "a tombstoned item never appears"
+        );
+    }
+
+    /// FIX A (command gate): `list_org_items_inner` refuses an org the caller isn't a local member of
+    /// (membership-checked via `resolve_org`) — never leaking another org's list — and returns the list
+    /// for a member org.
+    #[test]
+    fn list_org_items_command_refuses_non_member_org() {
+        let state = build_state("org-list-items-gate");
+        seed_org(&state.db, "org-mine", "Mine", "owner", 1);
+        state
+            .db
+            .upsert_org_item("m1", "org-mine", 1, "anna", "Mine A", "body", "2026-07-11T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .unwrap();
+        // A member org resolves + returns the item.
+        let ok = list_org_items_inner(&state, "org-mine").unwrap();
+        assert_eq!(ok.len(), 1);
+        assert_eq!(ok[0].item_id, "m1");
+        // A non-member org is InvalidArg (never a leak of that org's list).
+        assert!(matches!(
+            list_org_items_inner(&state, "org-not-mine"),
+            Err(AppError::InvalidArg(_))
+        ));
+        // A blank id is refused too.
+        assert!(matches!(
+            list_org_items_inner(&state, "  "),
+            Err(AppError::InvalidArg(_))
+        ));
+    }
+
+    /// FIX B (received-items COUNT): `OrgStatus.received_count` reflects the LOCAL replica (what
+    /// colleagues shared IN), DISTINCT from `item_count` (the caller's OWN uploaded outbound shares).
+    /// Seed org_items (received) + an outbound uploaded share and assert the two counts are independent.
+    /// RED on the pre-fix code (only `item_count` existed → a receiving member saw "0 items").
+    #[test]
+    fn org_status_received_count_reflects_replica_distinct_from_outbound() {
+        let state = build_state("org-received-count");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        // TWO received items (from colleagues) in the local replica.
+        state
+            .db
+            .upsert_org_item("r1", "org-1", 1, "anna", "Doc A", "body a", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("r2", "org-1", 2, "bob", "Doc B", "body b", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None)
+            .unwrap();
+        // ONE of the caller's OWN outbound shares, state 'uploaded' (item_count = 1).
+        let now = "2026-07-11T12:00:00Z";
+        state
+            .db
+            .insert_org_share("s1", "org-1", Some("m-own"), None, "meeting", Some("My Share"), 1, 1, &[9u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_uploaded("s1", "srv-item-1", now).unwrap();
+
+        let status = block_on(org_status_for(
+            &state,
+            state.db.get_org_state("org-1").unwrap().unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(status.received_count, 2, "received_count = local replica items");
+        assert_eq!(status.item_count, 1, "item_count = the caller's OWN outbound uploads");
+        // A tombstoned received item drops out of received_count.
+        state.db.tombstone_org_item("r1").unwrap();
+        let status2 = block_on(org_status_for(
+            &state,
+            state.db.get_org_state("org-1").unwrap().unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(status2.received_count, 1, "a tombstoned received item is excluded");
+    }
+
     /// `org_state` upsert preserves the LOCAL consent + sync cursor across a status refresh (a refresh
     /// carrying role/name/generation must NOT reset consent or rewind last_seq), and the consent +
     /// generation + last_seq setters work as the single mutators.
@@ -22701,6 +22821,73 @@ mod lifecycle_tests {
         assert_eq!(state.db.get_org_state("org-b").unwrap().unwrap().last_seq, 20);
     }
 
+    /// FIX D (per-item sync robustness, RED→GREEN): a TERMINAL-bad item at seq N must NOT stall the
+    /// feed forever — the GOOD item at N+1 still ingests on the SAME sync. Pre-fix EVERY per-item
+    /// failure did `break 'pages`, so one poison cell blocked all newer items indefinitely. We serve a
+    /// synthetic one-page feed: item at seq 5 is a LIVE entry with NO blob (structurally terminal — it
+    /// can never open, detected before any key/network), and item at seq 6 is a TOMBSTONE (a "good"
+    /// action that applies with no key/blob). After the fix: seq 5 is skipped (error recorded, cursor
+    /// advanced), seq 6's tombstone APPLIES (`tombstoned == 1`) and the cursor advances to 6. RED on the
+    /// old break-all code: seq 5 breaks the loop → seq 6 never processed → `tombstoned == 0`, cursor
+    /// unchanged.
+    #[test]
+    fn org_sync_skips_a_terminal_item_and_ingests_the_next() {
+        use std::io::{Read, Write};
+        // One-shot local server answering exactly one `GET /v1/orgs/{id}/items` feed page.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf).unwrap();
+            // seq 5: LIVE (tombstoned:false) but blobId:null → TERMINAL missing-blob.
+            // seq 6: TOMBSTONE → applies without a key/blob (the "good" item behind the poison one).
+            let body = r#"{"items":[{"itemId":"poison","seq":5,"authorUserId":"u","rev":1,"generation":1,"createdAt":"2026-07-11T09:00:00Z","tombstoned":false,"blobId":null,"contentSha256":null},{"itemId":"good-tomb","seq":6,"authorUserId":"u","rev":1,"generation":1,"createdAt":"2026-07-11T09:01:00Z","tombstoned":true,"blobId":null,"contentSha256":null}],"nextSeq":6}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = sock.write_all(resp.as_bytes());
+        });
+
+        let state = build_state("org-sync-terminal-skip");
+        seed_org(&state.db, "org-x", "X", "member", 1);
+        state.db.set_org_last_seq("org-x", 4).unwrap(); // cursor starts at 4 (items 5,6 are new)
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}");
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "user@example.com".into(),
+            email: "user@example.com".into(),
+            server_user_id: Some("c534b6d2-02c1-4c2c-a256-3af8592b1567".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+
+        let report = block_on(org_sync_one_now_inner(&state, "org-x")).unwrap();
+        server.join().unwrap();
+
+        // Both items were pulled; the terminal one was recorded as an error, the good one APPLIED.
+        assert_eq!(report.pulled, 2, "both feed items were pulled");
+        assert_eq!(
+            report.tombstoned, 1,
+            "the GOOD item behind the poison one ingested (RED on break-all: this was 0)"
+        );
+        assert!(
+            report.errors.iter().any(|e| e.contains("poison") && e.contains("missing blob")),
+            "the terminal item is recorded as an error, not silently dropped: {:?}",
+            report.errors
+        );
+        // The cursor advanced PAST both the skipped terminal item and the applied tombstone.
+        assert_eq!(
+            state.db.get_org_state("org-x").unwrap().unwrap().last_seq,
+            6,
+            "cursor advanced past the terminal item AND the good one (RED on break-all: stayed at 4)"
+        );
+    }
+
     /// F1 (MULTI-ORG TARGETING, RED→GREEN for the `.next()` misroute): with TWO local orgs, the org
     /// commands must resolve the SPECIFIC org the FE passed, never the FIRST. `resolve_org` — the
     /// shared resolution seam every per-org command now uses — must return the SECOND org's row when
@@ -22734,6 +22921,79 @@ mod lifecycle_tests {
             resolve_org(&state, "org-not-mine"),
             Err(AppError::InvalidArg(_))
         ));
+    }
+
+    /// FIX C (org SHARE targets the SPECIFIED org, RED→GREEN for the `.next()` MISROUTE): with TWO
+    /// local orgs, `share_to_org_inner` must queue the outbound share under the org the FE PICKED, never
+    /// the FIRST (`.next()`). Seed a session + consent + an open (unlocked) meeting with a note, point
+    /// the client at a CLOSED loopback port (no real egress — the seal/upload fails), and share TARGETING
+    /// the SECOND org. Regardless of the network failure, the QUEUED row is persisted BEFORE any egress —
+    /// under `org-second`. RED on the pre-fix code (it `.next()`-picked `org-first` → the row landed under
+    /// org #1); GREEN after routing through `resolve_org`.
+    #[test]
+    fn share_to_org_queues_under_the_specified_org_not_the_first() {
+        let state = build_state("org-share-target");
+        // `org-first` joined EARLIER → the deterministic `.next()` (ORDER BY joined_at ASC) org a pre-fix
+        // share would have wrongly used. The FE picks `org-second`.
+        seed_org_at(&state.db, "org-first", "First", "owner", "2026-07-01T00:00:00Z");
+        seed_org_at(&state.db, "org-second", "Second", "member", "2026-07-11T00:00:00Z");
+
+        // An OPEN folder + a note so the read-gate + clean/scrub pass (no lock).
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-share".to_string(),
+                name: "Team".to_string(),
+                path: "Team".to_string(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-11T00:00:00Z".to_string(),
+            })
+            .unwrap();
+        state
+            .db
+            .insert_note("n-share", "f-share", "plan", "Q3 Plan", "# the Q3 roadmap", 1)
+            .unwrap();
+
+        // Consent granted + a closed loopback port (connection refused; NO real egress).
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = "http://127.0.0.1:9/".to_string();
+        // A live (non-expired) session so `require_session_mk` yields a bearer and the queue insert runs.
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "user@example.com".into(),
+            email: "user@example.com".into(),
+            server_user_id: Some("c534b6d2-02c1-4c2c-a256-3af8592b1567".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+
+        // Share TARGETING the SECOND org. The network egress fails (closed port), but the QUEUED row is
+        // written first — under the resolved target org.
+        let _ = block_on(share_to_org_inner(
+            &state,
+            "org-second",
+            None,
+            Some("n-share".to_string()),
+            true,
+        ));
+
+        // The row MUST be under org-second (the picked org), NOT org-first (the `.next()` org).
+        let second = state.db.list_org_shares_for_org("org-second").unwrap();
+        assert_eq!(
+            second.len(),
+            1,
+            "the outbound share was queued under the PICKED org (org-second)"
+        );
+        assert_eq!(second[0].document_id.as_deref(), Some("n-share"));
+        let first = state.db.list_org_shares_for_org("org-first").unwrap();
+        assert!(
+            first.is_empty(),
+            "no share landed under the FIRST org (RED on a .next() misroute — the row was under org-first)"
+        );
     }
 
     /// F1 (org_leave targets the SPECIFIED org's local state). `org_leave` deletes the local org row +
@@ -23308,7 +23568,12 @@ pub struct OrgStatus {
     pub member_count: u32,
     pub consented: bool,
     pub last_seq: i64,
+    /// The caller's OWN outbound uploads into this org (`org_shares` in state `uploaded`).
     pub item_count: u32,
+    /// RECEIVED items in the local org replica (`org_items`, non-tombstoned) — what colleagues shared
+    /// IN. Distinct from `item_count`: a member who only RECEIVES shows `item_count = 0` but a real
+    /// `received_count`, so the Settings count no longer lies "0 items" to a receiver.
+    pub received_count: u32,
     pub pending_shares: u32,
 }
 
@@ -23593,6 +23858,7 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
         consented: false,
         last_seq: 0,
         item_count: 0,
+        received_count: 0,
         pending_shares: 0,
     }))
 }
@@ -23679,6 +23945,9 @@ async fn org_status_for(
         .iter()
         .filter(|s| s.state == "uploaded")
         .count() as u32;
+    // RECEIVED items in the local replica (what colleagues shared IN) — distinct from item_count
+    // (the caller's OWN uploads). Fixes the "0 items" lie a receiving member saw.
+    let received_count = state.db.count_org_items(&refreshed.org_id)?;
     // Consent is the GLOBAL org-egress config flag (mirrors share_egress_consented).
     let consented = state
         .config
@@ -23693,6 +23962,7 @@ async fn org_status_for(
         consented,
         last_seq: refreshed.last_seq,
         item_count,
+        received_count,
         pending_shares: pending,
     })
 }
@@ -24209,30 +24479,35 @@ pub(crate) fn preview_org_share_inner(
     })
 }
 
-/// `share_meeting_to_org(meeting_id, scrub)` — the normative org share flow (spec gate order):
+/// `share_meeting_to_org(org_id, meeting_id, scrub)` — the normative org share flow (spec gate order):
 /// (1) read-gate, (2) consent fail-closed, (3) clean, (4) scrub, (5) seal under OCK + local
-/// open-verify, (6) upload blob + publish item, (7) content-free egress-ledger entry.
+/// open-verify, (6) upload blob + publish item, (7) content-free egress-ledger entry. `org_id` is the
+/// FE-picked target (membership-checked via `resolve_org`) — the multi-org fix for the `.next()`
+/// misroute that shared into the FIRST org, not the chosen one.
 #[tauri::command]
 pub async fn share_meeting_to_org(
     state: State<'_, AppState>,
+    org_id: String,
     meeting_id: String,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
-    share_to_org_inner(state.inner(), Some(meeting_id), None, scrub).await
+    share_to_org_inner(state.inner(), &org_id, Some(meeting_id), None, scrub).await
 }
 
-/// `share_document_to_org(document_id, scrub)` — the note twin of [`share_meeting_to_org`].
+/// `share_document_to_org(org_id, document_id, scrub)` — the note twin of [`share_meeting_to_org`].
 #[tauri::command]
 pub async fn share_document_to_org(
     state: State<'_, AppState>,
+    org_id: String,
     document_id: String,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
-    share_to_org_inner(state.inner(), None, Some(document_id), scrub).await
+    share_to_org_inner(state.inner(), &org_id, None, Some(document_id), scrub).await
 }
 
 pub(crate) async fn share_to_org_inner(
     state: &AppState,
+    org_id: &str,
     meeting_id: Option<String>,
     document_id: Option<String>,
     scrub: bool,
@@ -24258,23 +24533,11 @@ pub(crate) async fn share_to_org_inner(
         }
     }
 
-    // TODO(multi-org): let the user pick the target org — the FE does NOT yet pass an org_id to
-    // `share_meeting_to_org` / `share_document_to_org`, so this still resolves to the FIRST local org.
-    // For a single-org account that is correct; for a MULTI-org account this is a destructive EGRESS
-    // op picking org #1, so make the choice EXPLICIT (log which org — id only, no content) rather than
-    // silently choosing. When the FE gains an org picker, thread an `org_id` param through here (as
-    // `org_invite_member`/`org_leave` now do) and resolve via `resolve_org`.
-    let all_orgs = state.db.list_org_states()?;
-    let Some(org) = all_orgs.into_iter().next() else {
-        return Err(AppError::InvalidArg("not a member of any org".into()));
-    };
-    if state.db.list_org_states()?.len() > 1 {
-        tracing::warn!(
-            target: "org",
-            org_id = %org.org_id,
-            "org share targeting the first org on a multi-org account (no FE picker yet — TODO multi-org)"
-        );
-    }
+    // MULTI-ORG: share into the FE-PICKED org (membership-checked), never the first via `.next()`.
+    // This is a destructive EGRESS op — misrouting it to org #1 published a member's note into the
+    // WRONG org (the root of the "B shared into Siema but it went to org #1" bug). `resolve_org`
+    // refuses a blank id / an org the caller isn't a local member of.
+    let org = resolve_org(state, org_id)?;
     let base = share_base_url(state)?;
     let (_account_id, _gen_id, _mk, access_token) = require_session_mk(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
@@ -24654,6 +24917,9 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
             }
             let res = share_to_org_inner(
                 state,
+                // Re-publish targets the SAME org the row was queued under (never the first via
+                // `.next()`) — a multi-org account's sweep must re-share into the right org.
+                &row.org_id,
                 row.meeting_id.clone(),
                 row.document_id.clone(),
                 // A re-publish preserves the ORIGINAL scrub intent: if we can't know it, scrub ON
@@ -24798,12 +25064,27 @@ async fn org_sync_one(
     // ── ASYNC PULL PHASE — drain the feed, opening each cell; buffer decrypted items ──────────────
     // The embedder (`dyn Embedder`, !Send) is deliberately NOT constructed here: the whole async
     // section is Send-safe, and the synchronous INGEST phase below owns the embedder entirely (never
-    // held across an `.await`). A tombstone applies immediately (no key/blob needed). We STOP at the
-    // first un-openable LIVE item (never a silent skip-forward), so a transient key gap retries next
-    // sync — the cursor only advances past items we successfully ingested/tombstoned.
+    // held across an `.await`). A tombstone applies immediately (no key/blob needed).
+    //
+    // FIX D — per-item failures are classified TRANSIENT vs TERMINAL so one poison item never stalls
+    // the WHOLE feed forever (pre-fix: EVERY failure did `break 'pages`, so a single un-openable cell
+    // blocked all newer items indefinitely):
+    //   • TRANSIENT (OCK unavailable / blob fetch network error) → `break 'pages`, cursor NOT advanced:
+    //     the same item is retried next sync (correct — it may succeed once the key/network recovers).
+    //   • TERMINAL (missing blob / missing hash / envelope open failed / content-hash mismatch —
+    //     permanent for THAT cell) → record the error, `SkipTerminal` (advance the cursor PAST this
+    //     seq), and `continue` to the next item. It will NEVER ingest, so blocking newer items on it is
+    //     pure stall. The cursor only advances past a terminal item that appears BEFORE the first
+    //     transient stop (the loop processes items in seq order and breaks on the first transient), so
+    //     we never skip forward past a transient un-ingested item.
     enum FeedAction {
         Tombstone {
             item_id: String,
+            seq: u64,
+        },
+        /// A permanently un-ingestable item: advance the cursor past its seq (no DB write) so it never
+        /// stalls the feed. Recorded in `report.errors`.
+        SkipTerminal {
             seq: u64,
         },
         Ingest {
@@ -24837,22 +25118,27 @@ async fn org_sync_one(
             }
 
             let Some(blob_id) = item.blob_id.clone() else {
+                // TERMINAL: a live entry with no blob is structurally broken — it can never open. Skip
+                // past it (advance) rather than stall every newer item behind it.
                 report
                     .errors
                     .push(format!("item {}: live entry missing blob", item.item_id));
-                break 'pages;
+                actions.push(FeedAction::SkipTerminal { seq: item.seq });
+                continue;
             };
             // The AAD item nonce is hex(content_sha256) — the SAME value the publisher sealed under.
             let Some(sha) = item.content_sha256.clone() else {
+                // TERMINAL: no content hash ⇒ we can't derive the AAD nonce for this cell — permanent.
                 report
                     .errors
                     .push(format!("item {}: live entry missing content hash", item.item_id));
-                break 'pages;
+                actions.push(FeedAction::SkipTerminal { seq: item.seq });
+                continue;
             };
             let item_nonce = org_item_nonce(&sha);
 
             // Resolve the OCK for THIS item's generation (RAM cache / grant unwrap; gated on MK
-            // session). Unavailable ⇒ transient key gap → record + STOP (retried next sync).
+            // session). Unavailable ⇒ TRANSIENT key gap → record + STOP (retried next sync).
             let ock = match acquire_org_ock(state, &org.org_id, item.generation).await {
                 Ok(k) => k,
                 Err(e) => {
@@ -24865,6 +25151,7 @@ async fn org_sync_one(
             let ciphertext = match client.get_blob(access, &blob_id).await {
                 Ok(c) => c,
                 Err(e) => {
+                    // TRANSIENT: a network blob-fetch failure may succeed next sync → STOP, don't skip.
                     report
                         .errors
                         .push(format!("item {}: blob fetch failed ({})", item.item_id, brief_err(&e)));
@@ -24880,22 +25167,27 @@ async fn org_sync_one(
             ) {
                 Ok(e) => e,
                 Err(e) => {
+                    // TERMINAL: this exact ciphertext will never open under this key/AAD (a tampered or
+                    // corrupt cell is permanent for THAT seq). Skip past it rather than stall the feed.
                     report.errors.push(format!(
                         "item {}: envelope open failed ({})",
                         item.item_id,
                         brief_err(&e)
                     ));
-                    break 'pages;
+                    actions.push(FeedAction::SkipTerminal { seq: item.seq });
+                    continue;
                 }
             };
             // INTEGRITY: the opened plaintext's own hash must equal the feed-supplied one the AAD was
             // derived from (a successful AAD open already implies this, but assert so a server pairing
             // a valid cell with a lying feed hash is caught).
             if env.content_sha256() != sha {
+                // TERMINAL: the cell/hash pairing is permanently inconsistent for this seq.
                 report
                     .errors
                     .push(format!("item {}: content hash mismatch", item.item_id));
-                break 'pages;
+                actions.push(FeedAction::SkipTerminal { seq: item.seq });
+                continue;
             }
             actions.push(FeedAction::Ingest {
                 item_id: item.item_id.clone(),
@@ -24926,6 +25218,12 @@ async fn org_sync_one(
                 state.db.tombstone_org_item(&item_id)?;
                 report.tombstoned += 1;
                 applied = applied.max(seq);
+            }
+            // FIX D: a permanently un-ingestable item advances the cursor past its seq (no DB write),
+            // so it never stalls the feed — the good item behind it ingests on the SAME sync.
+            FeedAction::SkipTerminal { seq } => {
+                applied = applied.max(seq);
+                state.db.set_org_last_seq(&org.org_id, applied as i64)?;
             }
             FeedAction::Ingest {
                 item_id,
@@ -24981,6 +25279,32 @@ pub fn org_get_item(
     item_id: String,
 ) -> Result<Option<crate::storage::models::OrgItemDetail>, AppError> {
     state.inner().db.get_org_item(&item_id)
+}
+
+/// `list_org_items(org_id)` — the browsable LIST of one org's live items (headers only), so a member
+/// can SEE what colleagues shared into the org (the root of the "can't see B's note" bug: org content
+/// was search-only, with no browsable list). Resolves the FE-picked org membership-checked
+/// (`resolve_org`) — never the first via `.next()` — then returns newest-first headers. Org items are
+/// deliberately org-disclosed content (no folder lock gate applies); headers carry NO markdown body
+/// (that's `org_get_item`), keeping the list content-min. Not-a-member ⇒ `InvalidArg` (never a leak
+/// of another org's list).
+#[tauri::command]
+pub fn list_org_items(
+    state: State<'_, AppState>,
+    org_id: String,
+) -> Result<Vec<crate::storage::models::OrgItemHeader>, AppError> {
+    list_org_items_inner(state.inner(), &org_id)
+}
+
+/// Inner of [`list_org_items`] taking `&AppState` (unit-testable membership gate). Refuses an org the
+/// caller isn't a local member of; org items are org-disclosed content so no folder lock gate applies.
+pub(crate) fn list_org_items_inner(
+    st: &AppState,
+    org_id: &str,
+) -> Result<Vec<crate::storage::models::OrgItemHeader>, AppError> {
+    // Membership re-check: refuse if the caller isn't a local member of this org.
+    let org = resolve_org(st, org_id)?;
+    st.db.list_org_items(&org.org_id)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/e2ee/org.rs
+++ b/src-tauri/src/e2ee/org.rs
@@ -39,6 +39,21 @@ pub fn ock_grant_id(org_id: &str, generation: u32) -> String {
     format!("org:{org_id}:gen:{generation}")
 }
 
+/// The FIXED sender/granter IDENTITY generation an OCK grant is signed under, on BOTH wrap and unwrap.
+///
+/// LOCK-SECURITY (FIX F): the underlying [`ShareGrantSignedView`] signs a `sender_generation` field.
+/// For an OCK grant that field is AMBIGUOUS and adds nothing — the grant is ALREADY bound to the org +
+/// the ORG generation via [`ock_grant_id`] (the `share_id`/`rev`). The two sides disagreed on which
+/// generation to bind: `wrap_ock_for_member` bound the GRANTER's (owner's) identity generation, while
+/// `acquire_org_ock` unwrapped with the MEMBER's OWN identity generation. Today both are hard-wired to
+/// 1, so the signature verifies — but the moment identity generation rotation ships, an invited
+/// member's identity gen (2+) would no longer match the owner's (1) and EVERY invited-member unwrap
+/// would fail closed. Pinning BOTH sides to this constant removes the ambiguous field's mismatch (org
+/// authenticity still rests on the org-scoped grant id + the granter-key TOFU pin) while keeping the
+/// public signatures unchanged. The `*_generation` parameters below are therefore IGNORED for OCK
+/// grants.
+const OCK_GRANT_SENDER_GENERATION: u32 = 0;
+
 /// Generate a fresh random 32-byte OCK (org create + each rotation). Zeroizes on drop.
 pub fn generate_ock() -> Result<Key32> {
     crate::e2ee::random_key32()
@@ -52,6 +67,10 @@ pub fn generate_ock() -> Result<Key32> {
 /// `granter` is the owner's identity keypair (derived from their MK); `granter_acct_id` /
 /// `recipient_acct_id` are the stable account ids the two sides pin on (the caller passes the server
 /// user ids / fingerprints, exactly as mode-B does).
+///
+/// `granter_generation` is IGNORED (FIX F): the signed grant's `sender_generation` is pinned to the
+/// fixed [`OCK_GRANT_SENDER_GENERATION`] on BOTH wrap and unwrap, so an invited member's own identity
+/// generation never has to match the granter's for the unwrap to verify.
 #[allow(clippy::too_many_arguments)]
 pub fn wrap_ock_for_member(
     ock: &[u8; 32],
@@ -61,7 +80,7 @@ pub fn wrap_ock_for_member(
     recipient_acct_id: &str,
     granter: &IdentityKeypair,
     granter_acct_id: &str,
-    granter_generation: u32,
+    _granter_generation: u32,
 ) -> Result<OckGrant> {
     let grant_id = ock_grant_id(org_id, generation);
     // The signed grant binds a hash of the "content cell". For an OCK grant there is no separate
@@ -75,7 +94,9 @@ pub fn wrap_ock_for_member(
         recipient_acct_id,
         granter,
         granter_acct_id,
-        granter_generation,
+        // FIX F: pin the sender identity generation to a fixed constant (org+gen binding lives in the
+        // grant id; the identity generation is ambiguous across owner-vs-member and adds nothing).
+        OCK_GRANT_SENDER_GENERATION,
         &grant_id,
         generation,
     )?;
@@ -93,6 +114,10 @@ pub fn wrap_ock_for_member(
 ///
 /// `pinned_granter_acct_id` / `pinned_granter_pk_sig` are the TOFU-pinned granter identity the
 /// recipient stored on first contact (the org owner). `self_acct_id` is the caller's own account id.
+///
+/// `granter_generation` is IGNORED (FIX F): the reconstructed `sender_generation` is the fixed
+/// [`OCK_GRANT_SENDER_GENERATION`], matching the wrap side, so a member whose OWN identity generation
+/// differs from the granter's (post-rotation) still opens the grant.
 #[allow(clippy::too_many_arguments)]
 pub fn open_own_grant(
     wrapped_key: &[u8],
@@ -101,7 +126,7 @@ pub fn open_own_grant(
     recipient_acct_id: &str,
     self_acct_id: &str,
     granter_acct_id: &str,
-    granter_generation: u32,
+    _granter_generation: u32,
     pinned_granter_acct_id: &str,
     pinned_granter_pk_sig: &[u8],
     org_id: &str,
@@ -117,7 +142,8 @@ pub fn open_own_grant(
         recipient_acct_id,
         self_acct_id,
         granter_acct_id,
-        granter_generation,
+        // FIX F: pin the sender identity generation to the SAME fixed constant the wrap side used.
+        OCK_GRANT_SENDER_GENERATION,
         pinned_granter_acct_id,
         pinned_granter_pk_sig,
         &grant_id,
@@ -170,6 +196,53 @@ mod tests {
         )
         .unwrap();
         assert_eq!(*opened, *ock, "member recovers the exact OCK");
+    }
+
+    /// FIX F (identity-generation mismatch, RED→GREEN): the OWNER wraps the OCK under their own
+    /// identity generation (1), and the invited MEMBER unwraps under a DIFFERENT identity generation (2)
+    /// — as happens the moment identity rotation ships (the owner is gen 1, an invited member gen 2+).
+    /// The grant is bound to the ORG + org generation via the grant id, so the ambiguous IDENTITY
+    /// generation must NOT be part of what has to match: the unwrap still opens the exact OCK. RED on the
+    /// pre-fix code (wrap bound owner-gen=1, unwrap reconstructed member-gen=2 → signature mismatch →
+    /// Auth error); GREEN after both sides pin the fixed OCK sender generation.
+    #[test]
+    fn ock_open_succeeds_across_identity_generation_mismatch() {
+        let owner = generate_identity().unwrap();
+        let member = generate_identity().unwrap();
+        let ock = generate_ock().unwrap();
+
+        // Owner wraps under identity generation 1.
+        let grant = wrap_ock_for_member(
+            &ock,
+            ORG,
+            GEN,
+            &member.pk_enc,
+            MEMBER,
+            &owner,
+            OWNER,
+            1, // owner's identity generation at wrap
+        )
+        .unwrap();
+
+        // Member unwraps under identity generation 2 (post-rotation) — must STILL open.
+        let opened = open_own_grant(
+            &grant.wrapped_key,
+            &grant.grant_sig,
+            &member,
+            MEMBER,
+            MEMBER,
+            OWNER,
+            2, // member's OWN identity generation — DIFFERENT from the owner's
+            OWNER,
+            &owner.pk_sig,
+            ORG,
+            GEN,
+        )
+        .unwrap();
+        assert_eq!(
+            *opened, *ock,
+            "an invited member opens the OCK even when its identity generation differs from the granter's"
+        );
     }
 
     /// A grant wrapped for org-1 must NOT open as org-2 (cross-org replay blocked).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,6 +220,7 @@ pub fn run() {
             commands::org_sweep_pending,
             commands::org_sync_now,
             commands::org_get_item,
+            commands::list_org_items,
             commands::folder_active_shares,
             commands::revoke_shares_for_folder,
             commands::set_anthropic_key,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5055,6 +5055,57 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// The browsable LIST of one org's live (non-tombstoned) items — headers only (no `markdown`
+    /// body; that's [`Db::get_org_item`]). Newest-first by feed `seq`. This is what lets a member SEE
+    /// what colleagues shared into the org instead of only search-hitting it. Org items are
+    /// deliberately org-disclosed content (no folder lock gate applies); the COMMAND layer re-checks
+    /// the caller is a local member of `org_id` before calling this.
+    pub fn list_org_items(
+        &self,
+        org_id: &str,
+    ) -> Result<Vec<crate::storage::models::OrgItemHeader>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT item_id, title, author_hint, created_at, seq
+                   FROM org_items
+                  WHERE org_id = ?1 AND tombstoned = 0
+                  ORDER BY seq DESC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![org_id], |r| {
+                Ok(crate::storage::models::OrgItemHeader {
+                    item_id: r.get(0)?,
+                    title: r.get(1)?,
+                    author_hint: r.get(2)?,
+                    created_at: r.get(3)?,
+                    seq: r.get::<_, i64>(4)? as u64,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// COUNT of one org's live (non-tombstoned) RECEIVED items — the size of the local org replica
+    /// (what colleagues shared IN). Distinct from the outbound `org_shares` count (what THIS member
+    /// published OUT); the two were conflated so the Settings item count showed the caller's own
+    /// uploads and read "0 items" to a receiver. Content-free.
+    pub fn count_org_items(&self, org_id: &str) -> Result<u32> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM org_items WHERE org_id = ?1 AND tombstoned = 0",
+            rusqlite::params![org_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .map(|n| n as u32)
+        .map_err(map_err)
+    }
+
     /// Every non-null `content_sha256` from the local `org_shares` rows (across all orgs the user has
     /// shared into) — the SELF-SHARE dedup key set. A retrieval hit whose hash is in this set is the
     /// caller's OWN published item and is relabelled/dropped so a member never sees their own share

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -530,6 +530,21 @@ pub struct OrgItemDetail {
     pub markdown: String,
 }
 
+/// Shared Brain v1 — a LIST-row header for one live org item (the browsable org-items list, so a
+/// member can SEE what colleagues shared into the org instead of only search-hitting it). Headers
+/// ONLY — the `markdown` body is deliberately NOT here (that's `org_get_item`); org items are
+/// disclosed content so no per-note lock gate applies, but keeping the list content-min avoids
+/// shipping every body on a list read. Mirrors the FE `OrgItemHeader` (camelCase).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgItemHeader {
+    pub item_id: String,
+    pub title: String,
+    pub author_hint: String,
+    pub created_at: String,
+    pub seq: u64,
+}
+
 /// Shared Brain v1 — the content-free result of a manual `org_sync_now()` (counts + errors only).
 /// `fts_only` is true when the local member has no real embedder (StubEmbedder ⇒ the org partition
 /// is indexed FTS-only until a model appears + a re-embed runs). Mirrors the FE `OrgSyncReport`

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -836,17 +836,23 @@ fn format_web_hits_raw(hits: &[crate::connectors::ConnectorHit]) -> String {
         .join("\n")
 }
 
-/// SHARED BRAIN — is the org partition available as a tool for THIS session? True iff an org is
-/// joined AND org egress is consented (the same one-time consent that governs SHARING; a member who
-/// consented to publish into the org brain has opted into the org-brain surface). Fail-closed on any
-/// DB read error. This is the single advertisement predicate for BOTH the agent tool
-/// (`org_brain_search`) and the MCP tool (`org_search`).
+/// SHARED BRAIN — is the org partition available to READ/search for THIS session? True iff the caller
+/// has JOINED an org (`org_state` present). Fail-closed on any DB read error. This is the single
+/// advertisement predicate for BOTH the agent tool (`org_brain_search`) and the MCP tool
+/// (`org_search`).
+///
+/// FIX G — READ is decoupled from WRITE consent: `org_egress_consented` governs PUBLISHING INTO the
+/// org (the `share_*_to_org` egress path), NOT reading what colleagues shared. A joined member who has
+/// NOT consented to publish must still be able to SEE the org brain (the root of "A can't see B's
+/// shared note"). No leak: org items are DELIBERATELY-DISCLOSED content living in the dedicated `org_*`
+/// tables outside the folder-lock domain (personal notes stay lock-gated on their own read paths); and
+/// on `org_leave` the replica is purged, so a departed member (no `org_state`) is already excluded
+/// here. The egress/publish path keeps its own consent gate (`share_to_org_inner` step 2), unchanged.
 pub(crate) fn org_brain_available(db: &Db, config: &AppConfig) -> bool {
-    config.org_egress_consented
-        && db
-            .list_org_states()
-            .map(|orgs| !orgs.is_empty())
-            .unwrap_or(false)
+    let _ = config; // consent is a WRITE gate; reading the org brain needs only membership.
+    db.list_org_states()
+        .map(|orgs| !orgs.is_empty())
+        .unwrap_or(false)
 }
 
 /// SHARED BRAIN — the single org retrieval + format seam used by BOTH `org_brain_search` (agent) and
@@ -859,13 +865,16 @@ pub(crate) fn org_brain_available(db: &Db, config: &AppConfig) -> bool {
 /// a system-prompt override into the loop. The output is DATA for the loop — NEVER a system prompt.
 pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Result<String> {
     // AVAILABILITY GATE (belt-and-braces, applied at the SEAM not just at advertisement): the org
-    // partition is searchable ONLY when an org is joined AND org egress is consented. The AGENT tool
-    // gates this at `specs()` advertisement time, but the MCP `org_search` path reaches this seam
-    // DIRECTLY via `dispatch_tool` → `execute_tool` with NO advertisement filter — so without this
-    // in-seam check a departed member (whose replica hadn't yet been purged) or an un-consented user
-    // could still search colleagues' content. Fail-closed to an empty (never-a-leak) result.
+    // partition is searchable ONLY when the caller has JOINED an org. The AGENT tool gates this at
+    // `specs()` advertisement time, but the MCP `org_search` path reaches this seam DIRECTLY via
+    // `dispatch_tool` → `execute_tool` with NO advertisement filter — so without this in-seam check a
+    // departed member (whose replica hadn't yet been purged) could still search colleagues' content.
+    // FIX G: this is a READ gate = membership only; egress CONSENT gates PUBLISHING, not reading. Org
+    // items are disclosed content, so a joined-but-not-consented member reads legitimately; a departed
+    // member has no `org_state` (and a purged replica) so is excluded here. Fail-closed to an empty
+    // (never-a-leak) result.
     if !org_brain_available(db, config) {
-        return Ok("No org-brain results (not a member of a consented org).".to_string());
+        return Ok("No org-brain results (not a member of an org).".to_string());
     }
     let q = query.trim();
     if q.is_empty() {
@@ -2557,62 +2566,83 @@ mod tests {
     /// SEAM GATE (RED-before-GREEN, leak/consent): `search_org_brain` — the shared retrieval seam the
     /// MCP `org_search` reaches DIRECTLY (no advertisement filter) — must itself fail-closed when the
     /// org is not consented, even if the decrypted replica still holds a colleague's item. Pre-fix,
-    /// the seam returned the item (the "empty partition" assumption is false when a departed/
-    /// un-consented user still has the replica). RED on old code: the hit surfaced.
+    /// The seam fails closed for a NON-MEMBER (no `org_state`) even with a populated replica (as right
+    /// after a leave, before the replica purge lands). RED on a seam that trusts the replica alone: the
+    /// hit surfaces. FIX G: membership — not egress consent — is the read gate.
     #[test]
-    fn search_org_brain_seam_fails_closed_when_unconsented() {
+    fn search_org_brain_seam_fails_closed_for_a_non_member() {
         let db = tmp_db();
-        seed_org(&db); // joins org-1 (org_state present)
-        // A colleague's item IS in the local replica (as it would be right after a leave, before the
-        // replica purge lands / or for a user who ingested then revoked consent).
+        // A colleague's item IS in the local replica but the caller has NO org_state (departed member).
         ingest_org(&db, "it-x", "anna", "Anna's roadmap", "the apollo migration ships friday", &[3u8; 32]);
 
-        // Config: org egress NOT consented → the seam must return nothing.
-        let cfg_off = AppConfig {
-            org_egress_consented: false,
-            semantic_search_enabled: false,
-            ..AppConfig::default()
-        };
-        let out = search_org_brain(&db, &cfg_off, "apollo migration").unwrap();
-        assert!(
-            !out.contains("Anna's roadmap") && !out.contains("[org · anna]"),
-            "un-consented org search must leak NOTHING even with a populated replica: {out}"
-        );
-
-        // Sanity: WITH consent the same item is found (proving the gate — not a broken query — hid it).
-        let cfg_on = AppConfig {
+        // No org joined → the seam must return nothing (regardless of consent).
+        let cfg = AppConfig {
             org_egress_consented: true,
             semantic_search_enabled: false,
             ..AppConfig::default()
         };
-        let found = search_org_brain(&db, &cfg_on, "apollo migration").unwrap();
+        let out = search_org_brain(&db, &cfg, "apollo migration").unwrap();
+        assert!(
+            !out.contains("Anna's roadmap") && !out.contains("[org · anna]"),
+            "a non-member org search must leak NOTHING even with a populated replica: {out}"
+        );
+
+        // Sanity: once JOINED the same item is found (proving membership — not a broken query — gated it).
+        seed_org(&db);
+        let found = search_org_brain(&db, &cfg, "apollo migration").unwrap();
         assert!(
             found.contains("Anna's roadmap"),
-            "with consent the seam returns the item (gate, not query, hid it): {found}"
+            "a joined member's seam returns the item (gate, not query, hid it): {found}"
         );
     }
 
-    /// ADVERTISEMENT GATE: `org_brain_available` is true ONLY when an org is joined AND org egress is
-    /// consented — the single predicate both the agent tool and the MCP tool advertise on.
+    /// FIX G (READ decoupled from WRITE consent, RED→GREEN): a JOINED-but-NOT-CONSENTED member must be
+    /// able to READ/search the org brain — `org_egress_consented` governs PUBLISHING, not reading.
+    /// RED on the pre-fix consent-gated predicate (a joined member with consent=false got NOTHING, the
+    /// exact "A can't see B's shared note" bug); GREEN once the read gate is membership only.
     #[test]
-    fn org_brain_available_requires_join_and_consent() {
+    fn org_read_is_available_to_a_joined_but_unconsented_member() {
+        let db = tmp_db();
+        seed_org(&db); // JOINED org-1
+        ingest_org(&db, "it-y", "bob", "Bob's plan", "the siema onboarding checklist", &[7u8; 32]);
+
+        // Egress NOT consented (the member never opted to PUBLISH) — but they JOINED.
+        let cfg = AppConfig {
+            org_egress_consented: false,
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        // Available as a tool …
+        assert!(
+            org_brain_available(&db, &cfg),
+            "a joined member can READ the org brain without publish consent (RED on the consent gate)"
+        );
+        // … and actually returns the colleague's item.
+        let out = search_org_brain(&db, &cfg, "siema onboarding").unwrap();
+        assert!(
+            out.contains("Bob's plan") && out.contains("[org · bob]"),
+            "a joined-but-unconsented member SEES what colleagues shared: {out}"
+        );
+    }
+
+    /// ADVERTISEMENT GATE (FIX G): `org_brain_available` is true iff an org is JOINED — independent of
+    /// egress consent (a READ gate is membership; consent gates PUBLISHING).
+    #[test]
+    fn org_brain_available_requires_join_only() {
         let db = tmp_db();
         let mut cfg = AppConfig::default();
 
-        // No org, no consent → unavailable.
+        // No org → unavailable, regardless of consent (default egress = unconsented).
         assert!(!org_brain_available(&db, &cfg));
-
-        // Consent but no org → still unavailable.
         cfg.org_egress_consented = true;
         assert!(!org_brain_available(&db, &cfg));
 
-        // Org joined + consent → available.
+        // Org joined → available whether or not egress is consented.
         seed_org(&db);
-        assert!(org_brain_available(&db, &cfg));
-
-        // Org joined but consent revoked → unavailable (fail-closed).
         cfg.org_egress_consented = false;
-        assert!(!org_brain_available(&db, &cfg));
+        assert!(org_brain_available(&db, &cfg), "joined member reads without publish consent");
+        cfg.org_egress_consented = true;
+        assert!(org_brain_available(&db, &cfg));
     }
 
     /// The `org_brain_search` tool is CONNECTOR-CLASS: reachable ONLY at Tier 3 / Full, never at the

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -89,6 +89,7 @@ import type {
   OrgSharePreview,
   OrgShareEntry,
   OrgItemDetail,
+  OrgItemHeader,
   OrgSyncReport,
   ActiveSharesReport,
 } from "./models";
@@ -605,17 +606,41 @@ export class IpcService {
   }
 
   /**
+   * List a SPECIFIC org's browsable shared-brain items (`list_org_items`) — the
+   * synced+decrypted item headers (title + author hint + date), newest first.
+   * This is what makes org content BROWSABLE (previously it was search-only, so a
+   * member had nowhere to see a colleague's share). Content-lean per the org
+   * "no content-derived strings" discipline; the full body is fetched by
+   * {@link orgGetItem} in the viewer. `orgId` targets the org in a multi-org world.
+   */
+  listOrgItems(orgId: string): Promise<OrgItemHeader[]> {
+    return invoke<OrgItemHeader[]>("list_org_items", { orgId });
+  }
+
+  /**
    * Publish a MEETING to the org brain (seal under the OCK + upload). Gate order
    * backend-side: unlocked → consent → clean → scrub → seal → upload → ledger.
    * Refuses (`Locked`) a sealed meeting; requires org membership + consent.
    */
-  shareMeetingToOrg(meetingId: string, scrub: boolean): Promise<void> {
-    return invoke<void>("share_meeting_to_org", { meetingId, scrub });
+  shareMeetingToOrg(
+    meetingId: string,
+    orgId: string,
+    scrub: boolean,
+  ): Promise<void> {
+    return invoke<void>("share_meeting_to_org", { meetingId, orgId, scrub });
   }
 
-  /** Publish an authored NOTE to the org brain. Same gated pipeline as the meeting path. */
-  shareDocumentToOrg(documentId: string, scrub: boolean): Promise<void> {
-    return invoke<void>("share_document_to_org", { documentId, scrub });
+  /**
+   * Publish an authored NOTE to the org brain. Same gated pipeline as the meeting
+   * path. `orgId` targets the CHOSEN org (previously the backend shared to the
+   * FIRST org via `.next()`, which is why a share landed in the wrong org).
+   */
+  shareDocumentToOrg(
+    documentId: string,
+    orgId: string,
+    scrub: boolean,
+  ): Promise<void> {
+    return invoke<void>("share_document_to_org", { documentId, orgId, scrub });
   }
 
   /** This user's outgoing org shares (drives the "In Org Brain" state + per-item revoke). */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1801,10 +1801,40 @@ export interface OrgStatus {
   consented: boolean;
   /** Last synced feed sequence (drives the "N items synced" status). */
   lastSeq: number;
-  /** Number of decrypted org items in the local replica. */
+  /**
+   * Items YOU uploaded into this org (your own outbound shares). Distinct from
+   * {@link receivedCount} — labelling them separately kills the "0 items" lie
+   * where a member who received a colleague's share still saw `0` because this
+   * only counted the caller's OWN uploads.
+   */
   itemCount: number;
+  /**
+   * Items IN the org brain that THIS member has synced + ingested (everyone's
+   * shares, including received ones). This is the count of browsable org items —
+   * pair it with {@link itemCount} in the UI ("N in the org brain · M shared by
+   * you"). Mirrors the Rust `OrgStatus.receivedCount`.
+   */
+  receivedCount: number;
   /** Local outbound org shares still queued/failed (awaiting the launch sweep). */
   pendingShares: number;
+}
+
+/**
+ * One browsable row of an org's shared brain (`listOrgItems(orgId)`) — the
+ * header of a synced+decrypted org item, enough to render a list row that links
+ * to the read-only {@link OrgItemDetail} viewer (`/org-item/:id`). Content-lean:
+ * `title` + an author HINT (never a full identity) + the created date; the full
+ * body is fetched lazily by the viewer. `seq` is the item's feed sequence (stable
+ * order). Mirrors the Rust `OrgItemHeader`.
+ */
+export interface OrgItemHeader {
+  itemId: string;
+  title: string;
+  /** A short author hint (e.g. an email prefix) — never a full identity. */
+  authorHint: string;
+  createdAt: string;
+  /** The item's feed sequence — stable ordering key for the browse list. */
+  seq: number;
 }
 
 /**

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.html
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.html
@@ -11,9 +11,10 @@
     tabindex="-1"
     (keydown.escape)="cancel()"
   >
+    <!-- Compact header: mark + title + one-line copy. -->
     <div class="sheet-head">
       <span class="org-mark" aria-hidden="true">
-        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="8" r="3.2" />
           <path d="M5 20a7 7 0 0 1 14 0" />
           <circle cx="4.5" cy="10" r="2" />
@@ -23,25 +24,50 @@
       <div class="sheet-headings">
         <h2 id="org-share-title" class="sheet-title">Add to Org Brain</h2>
         <p class="sheet-copy">
-          Publishes an <strong>end-to-end-encrypted</strong> copy of this
-          {{ target().kind === "meeting" ? "meeting note" : "note" }} to your
-          org's shared brain. Every member's Murmur syncs and can search it — the
-          server can't read it.
+          An <strong>end-to-end-encrypted</strong> copy of this
+          {{ target().kind === "meeting" ? "meeting note" : "note" }} — every
+          member syncs and can search it; the server can't read it.
         </p>
       </div>
     </div>
 
-    <!-- Who can see this. -->
-    <p class="audience">
-      <span class="audience-mark" aria-hidden="true">👁</span>
-      <span>Who can see this: <strong>{{ audienceLabel() }}</strong></span>
-    </p>
+    <!-- Org PICKER (fix C): choose WHICH org to publish to; one org ⇒ a label. -->
+    <div class="org-pick">
+      <span class="section-label" id="org-pick-label">Publish to</span>
+      @if (orgsLoading()) {
+        <p class="pick-status text-muted">Loading your organizations…</p>
+      } @else if (orgsError(); as oerr) {
+        <p class="sheet-error" role="alert">{{ oerr }}</p>
+      } @else if (singleOrg()) {
+        @if (selectedOrg(); as org) {
+          <p class="pick-single">
+            <span class="pick-name">{{ org.name }}</span>
+            <span class="pick-members text-muted">{{ audienceLabel() }}</span>
+          </p>
+        }
+      } @else {
+        <mur-select
+          class="pick-select"
+          ariaLabel="Choose an organization"
+          [ngModel]="selectedOrgId()"
+          (ngModelChange)="selectedOrgId.set($event)"
+        >
+          @for (o of orgs(); track o.orgId) {
+            <option [value]="o.orgId">{{ o.name }}</option>
+          }
+        </mur-select>
+        @if (audienceLabel(); as label) {
+          <p class="pick-members text-muted">{{ label }}</p>
+        }
+      }
+    </div>
 
     @if (previewError(); as err) {
       <p class="sheet-error" role="alert">{{ err }}</p>
     }
 
-    <!-- The exact outgoing markdown (scrollable) + its size. -->
+    <!-- The exact outgoing markdown (scrollable) + its size. Honesty invariant:
+         the user sees EXACTLY what would leave the Mac before confirming. -->
     <div class="preview-block">
       <div class="preview-head">
         <span class="section-label">Exactly what leaves your Mac</span>
@@ -61,7 +87,7 @@
       }
     </div>
 
-    <!-- PII scrub toggle (default ON) + the scrubbed counts. -->
+    <!-- One-line scrub/consent note + toggle (default ON) + scrubbed counts. -->
     <div class="scrub-row">
       <label class="check">
         <input
@@ -113,7 +139,7 @@
         type="button"
         class="btn btn-primary"
         (click)="confirm()"
-        [disabled]="sharing() || loading() || !preview()"
+        [disabled]="sharing() || loading() || !preview() || !selectedOrgId()"
       >
         {{ sharing() ? "Adding…" : "Add to Org Brain" }}
       </button>

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.scss
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.scss
@@ -56,9 +56,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  min-width: 40px;
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
   border-radius: var(--radius-md);
   background: var(--accent-soft);
   border: 1px solid var(--border-subtle);
@@ -86,23 +86,39 @@
   color: var(--text-primary);
 }
 
-.audience {
+/* ── Org picker (fix C) ── */
+.org-pick {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-2);
-  margin: 0;
   padding: var(--space-3);
   border-radius: var(--radius-md);
   background: var(--surface-input);
   border: 1px solid var(--border-subtle);
-  color: var(--text-secondary);
-  font-size: 0.875rem;
 }
-.audience strong {
+.pick-status {
+  margin: 0;
+  font-size: 0.85rem;
+}
+.pick-select {
+  display: block;
+  max-width: 22rem;
+}
+.pick-single {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0;
+  flex-wrap: wrap;
+}
+.pick-name {
   color: var(--text-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
 }
-.audience-mark {
-  flex: 0 0 auto;
+.pick-members {
+  margin: 0;
+  font-size: 0.8125rem;
 }
 
 .section-label {

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
@@ -12,8 +12,10 @@ import {
   signal,
   viewChild,
 } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { IpcService } from "../../../core/ipc.service";
-import type { OrgSharePreview } from "../../../core/models";
+import type { OrgSharePreview, OrgStatus } from "../../../core/models";
+import { MurSelectComponent } from "../../../design-system/select/select.component";
 
 /**
  * Which local source this sheet is publishing to the org brain — a recorded
@@ -27,26 +29,34 @@ export interface OrgShareTarget {
 }
 
 /**
- * The "Add to Org Brain" PREVIEW SHEET (Shared Brain v1). A FLOATING overlay over
- * the note/detail, so it is OPAQUE `var(--surface-overlay)` + `backdrop-filter:
- * none` + a strong border + `--shadow-lg` — NEVER the frosted `.card` (trap T3),
- * which would bleed the content behind it through.
+ * The "Add to Org Brain" PREVIEW + PICKER SHEET (Shared Brain v1). A FLOATING
+ * overlay over the note/detail, so it is OPAQUE `var(--surface-overlay)` +
+ * `backdrop-filter: none` + a strong border + `--shadow-lg` — NEVER the frosted
+ * `.card` (trap T3), which would bleed the content behind it through.
  *
- * SELF-CONTAINED: it injects its own {@link IpcService} and owns the whole preview
- * sub-state. Given the `target` (a meeting or note id) + the org name/member count,
- * it fetches `previewOrgShare` and renders EXACTLY the outgoing markdown (scrollable),
- * its byte size + chunk count, the PII scrub toggle (default ON) with the scrubbed
- * counts, and a "who can see this" line (org name + member count). Confirm →
+ * SELF-CONTAINED: it injects its own {@link IpcService} and owns the whole
+ * preview + org-pick sub-state. It loads EVERY org the user belongs to
+ * (`orgListStatuses`) into a picker (`<mur-select>`, defaulting to the first) so
+ * the user chooses WHICH org to publish to — the CHOSEN `orgId` is threaded
+ * through `shareMeetingToOrg` / `shareDocumentToOrg` (fixing the old
+ * "shares to the FIRST org" bug). In exactly ONE org it shows the org as a
+ * label, no redundant picker.
+ *
+ * Given the `target` (a meeting or note id) it fetches `previewOrgShare` and
+ * renders EXACTLY the outgoing markdown (scrollable), its byte size + chunk
+ * count, the PII scrub toggle (default ON) with the scrubbed counts, and a
+ * "who can see this" line (chosen org name + member count). Confirm →
  * `shareMeetingToOrg` / `shareDocumentToOrg`; on success it emits `shared` so the
  * host can toast + refresh the badge. Cancel/backdrop/Escape emits `cancelled`.
  *
- * The scrub toggle re-runs `previewOrgShare` (the markdown + counts change with the
- * scrub setting) — the effect is stale-guarded on the current `(target, scrub)` so a
- * late response can't overwrite a newer one.
+ * The scrub toggle re-runs `previewOrgShare` (the markdown + counts change with
+ * the scrub setting) — the effect is stale-guarded on the current `(target,
+ * scrub)` so a late response can't overwrite a newer one.
  */
 @Component({
   selector: "app-org-share-sheet",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, MurSelectComponent],
   templateUrl: "./org-share-sheet.component.html",
   styleUrl: "./org-share-sheet.component.scss",
 })
@@ -56,10 +66,6 @@ export class OrgShareSheetComponent {
 
   /** The local source (meeting / note) being published. */
   readonly target = input.required<OrgShareTarget>();
-  /** The org name — shown in the "who can see this" line. */
-  readonly orgName = input.required<string>();
-  /** The org member count — shown in the "who can see this" line. */
-  readonly memberCount = input.required<number>();
 
   /** Emitted after a successful publish (host toasts + refreshes the badge). */
   readonly shared = output<void>();
@@ -67,6 +73,24 @@ export class OrgShareSheetComponent {
   readonly cancelled = output<void>();
 
   private readonly panel = viewChild<ElementRef<HTMLDivElement>>("panel");
+
+  // ── Org picker ──────────────────────────────────────────────────────────────
+  /** Every org the user belongs to; drives the picker + the audience line. */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  readonly orgs = this._orgs.asReadonly();
+  /** True while the org list is loading (before the picker can render). */
+  readonly orgsLoading = signal(true);
+  /** An org-list load error (e.g. offline) — surfaced inline. */
+  readonly orgsError = signal<string | null>(null);
+  /** The chosen org id (bound to `<mur-select>`); defaults to the first org. */
+  readonly selectedOrgId = signal("");
+
+  /** The full OrgStatus for the chosen org (null until the list loads). */
+  readonly selectedOrg = computed(
+    () => this._orgs().find((o) => o.orgId === this.selectedOrgId()) ?? null,
+  );
+  /** True when there's exactly one org (show it as a label, no picker). */
+  readonly singleOrg = computed(() => this._orgs().length === 1);
 
   /** Whether the regex PII scrub is on (default ON per the redaction policy). */
   readonly scrub = signal(true);
@@ -85,11 +109,15 @@ export class OrgShareSheetComponent {
   /** A share-confirm error to surface inline. */
   readonly shareError = signal<string | null>(null);
 
-  /** "who can see this" line: N members of the named org. */
-  readonly audienceLabel = computed(
-    () =>
-      `${this.memberCount()} ${this.memberCount() === 1 ? "member" : "members"} of ${this.orgName()}`,
-  );
+  /** "who can see this" line: N members of the chosen org. */
+  readonly audienceLabel = computed(() => {
+    const org = this.selectedOrg();
+    if (!org) {
+      return "";
+    }
+    const noun = org.memberCount === 1 ? "member" : "members";
+    return `${org.memberCount} ${noun} of ${org.name}`;
+  });
 
   /** True when the scrub removed anything at the current setting (drives the counts row). */
   readonly scrubbedAny = computed(() => {
@@ -98,6 +126,10 @@ export class OrgShareSheetComponent {
   });
 
   constructor() {
+    // Load every org the user belongs to → the picker. Default the selection to
+    // the first org so a single-org user is one click from sharing.
+    void this.loadOrgs();
+
     // Fetch (or re-fetch) the preview whenever the target or the scrub toggle
     // changes. Async IPC-on-signal-change effect (T1) — writes loading/error/
     // preview, stale-guarded on the captured (id, scrub) so a late response
@@ -115,6 +147,23 @@ export class OrgShareSheetComponent {
     afterNextRender(() => this.panel()?.nativeElement.focus(), {
       injector: this.injector,
     });
+  }
+
+  /** Load the user's orgs; default the picker to the first (stable order). */
+  private async loadOrgs(): Promise<void> {
+    this.orgsError.set(null);
+    this.orgsLoading.set(true);
+    try {
+      const list = await this.ipc.orgListStatuses();
+      this._orgs.set(list);
+      if (list.length && !list.some((o) => o.orgId === this.selectedOrgId())) {
+        this.selectedOrgId.set(list[0].orgId);
+      }
+    } catch (e) {
+      this.orgsError.set(String(e));
+    } finally {
+      this.orgsLoading.set(false);
+    }
   }
 
   /** Fetch the outgoing-share preview for `(target, scrub)`, stale-guarded. */
@@ -150,9 +199,13 @@ export class OrgShareSheetComponent {
     this.scrub.set((event.target as HTMLInputElement).checked);
   }
 
-  /** Confirm the publish. Routes to the meeting/note command; on success emits `shared`. */
+  /**
+   * Confirm the publish. Threads the CHOSEN org id through the meeting/note
+   * command; on success emits `shared`.
+   */
   async confirm(): Promise<void> {
-    if (this.sharing() || this.loading() || !this._preview()) {
+    const orgId = this.selectedOrgId();
+    if (this.sharing() || this.loading() || !this._preview() || !orgId) {
       return;
     }
     const t = this.target();
@@ -161,9 +214,9 @@ export class OrgShareSheetComponent {
     this.sharing.set(true);
     try {
       if (t.kind === "meeting") {
-        await this.ipc.shareMeetingToOrg(t.id, scrub);
+        await this.ipc.shareMeetingToOrg(t.id, orgId, scrub);
       } else {
-        await this.ipc.shareDocumentToOrg(t.id, scrub);
+        await this.ipc.shareDocumentToOrg(t.id, orgId, scrub);
       }
       this.shared.emit();
     } catch (e) {

--- a/src/app/features/detail/share-panel/share-panel.component.html
+++ b/src/app/features/detail/share-panel/share-panel.component.html
@@ -490,11 +490,9 @@
       />
     }
 
-    @if (orgSheetOpen() && org(); as orgStatus) {
+    @if (orgSheetOpen() && org()) {
       <app-org-share-sheet
         [target]="orgTarget()"
-        [orgName]="orgStatus.name"
-        [memberCount]="orgStatus.memberCount"
         (shared)="onOrgShared()"
         (cancelled)="closeOrgSheet()"
       />

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.html
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.html
@@ -377,11 +377,9 @@
   </div>
 </div>
 
-@if (orgSheetOpen() && org(); as orgStatus) {
+@if (orgSheetOpen() && org()) {
   <app-org-share-sheet
     [target]="orgTarget()"
-    [orgName]="orgStatus.name"
-    [memberCount]="orgStatus.memberCount"
     (shared)="onOrgShared()"
     (cancelled)="closeOrgSheet()"
   />

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
@@ -48,7 +48,8 @@
                   <span class="text-secondary org-counts">
                     {{ o.memberCount }}
                     {{ o.memberCount === 1 ? "member" : "members" }} ·
-                    {{ o.itemCount }} {{ o.itemCount === 1 ? "item" : "items" }}
+                    {{ o.receivedCount }} in the org brain ·
+                    {{ o.itemCount }} shared by you
                   </span>
                 </div>
 
@@ -62,6 +63,13 @@
                 </p>
 
                 <div class="org-actions">
+                  <button
+                    type="button"
+                    class="btn btn-ghost mini-btn"
+                    (click)="toggleBrowse(o)"
+                  >
+                    {{ browseOrgId() === o.orgId ? "Hide shared brain" : "Shared brain" }}
+                  </button>
                   @if (o.role === "owner") {
                     <button
                       type="button"
@@ -88,6 +96,41 @@
                     {{ busyOrgId() === o.orgId ? "Leaving…" : "Leave" }}
                   </button>
                 </div>
+
+                <!-- Shared brain browse list (fix A) — everything shared INTO
+                     this org, so a member can actually SEE a colleague's share.
+                     Each row links to the read-only /org-item/:id viewer. -->
+                @if (browseOrgId() === o.orgId) {
+                  <div class="org-browse">
+                    <span class="account-section-label text-muted">Shared brain</span>
+                    @if (itemsError(); as ierr) {
+                      <p class="text-danger account-note" role="alert">{{ ierr }}</p>
+                    }
+                    @if (itemsLoading()) {
+                      <p class="text-muted account-note">Loading shared items…</p>
+                    } @else {
+                      <ul class="org-item-list">
+                        @for (item of orgItems(); track item.itemId) {
+                          <li class="org-item-row">
+                            <a
+                              class="org-item-link"
+                              [routerLink]="['/org-item', item.itemId]"
+                            >
+                              <span class="org-item-title">{{ item.title }}</span>
+                              <span class="org-item-sub text-muted">
+                                {{ item.authorHint }} · {{ formatDate(item.createdAt) }}
+                              </span>
+                            </a>
+                          </li>
+                        } @empty {
+                          <li class="org-item-empty text-muted">
+                            Nothing shared into this org yet.
+                          </li>
+                        }
+                      </ul>
+                    }
+                  </div>
+                }
 
                 <!-- Member manager (owner only, expanded on demand). -->
                 @if (o.role === "owner" && expandedOrgId() === o.orgId) {

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
@@ -165,6 +165,60 @@
   border-top: 1px solid var(--border-subtle);
 }
 
+/* ── Shared brain browse list (fix A) ── */
+.org-browse {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+.org-item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.org-item-row {
+  border-top: 1px solid var(--border-subtle);
+}
+.org-item-row:first-child {
+  border-top: none;
+}
+.org-item-link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-3) 0;
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-sm);
+}
+.org-item-link:hover .org-item-title {
+  color: var(--accent);
+}
+.org-item-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.org-item-title {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 550;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.org-item-sub {
+  font-size: 0.78rem;
+}
+.org-item-empty {
+  padding: var(--space-3) 0;
+  font-size: 0.875rem;
+}
+
 .org-empty {
   font-size: 0.9rem;
 }

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -6,8 +6,14 @@ import {
   inject,
   signal,
 } from "@angular/core";
+import { RouterLink } from "@angular/router";
 import { IpcService } from "../../../../core/ipc.service";
-import type { OrgMember, OrgStatus } from "../../../../core/models";
+import { ToastService } from "../../../../services/toast.service";
+import type {
+  OrgItemHeader,
+  OrgMember,
+  OrgStatus,
+} from "../../../../core/models";
 
 /**
  * Settings → Organization section (Shared Brain v1, MULTI-ORG).
@@ -38,11 +44,13 @@ import type { OrgMember, OrgStatus } from "../../../../core/models";
 @Component({
   selector: "app-settings-organization-section",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
   templateUrl: "./settings-organization-section.component.html",
   styleUrl: "./settings-organization-section.component.scss",
 })
 export class SettingsOrganizationSectionComponent {
   private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
 
   /** Every org the user belongs to (created OR invited-into). Empty ⇒ empty state. */
   private readonly _orgs = signal<OrgStatus[]>([]);
@@ -110,6 +118,20 @@ export class SettingsOrganizationSectionComponent {
   private readonly _syncingOrgId = signal<string | null>(null);
   readonly syncingOrgId = this._syncingOrgId.asReadonly();
 
+  // ── Browse the shared brain (fix A) — per-org item list ──────────────────────
+  /** The org id whose "Shared brain" browse list is expanded (one at a time). */
+  private readonly _browseOrgId = signal<string | null>(null);
+  readonly browseOrgId = this._browseOrgId.asReadonly();
+  /** The expanded org's browsable items (`listOrgItems`). */
+  private readonly _orgItems = signal<OrgItemHeader[]>([]);
+  readonly orgItems = this._orgItems.asReadonly();
+  private readonly _itemsError = signal<string | null>(null);
+  readonly itemsError = this._itemsError.asReadonly();
+  private readonly _itemsLoading = signal(false);
+  readonly itemsLoading = this._itemsLoading.asReadonly();
+  /** Monotonic browse token — a resolved list writes only if it's still the latest. */
+  private _browseSeq = 0;
+
   constructor() {
     // On open: refresh membership from the server (so an invited-into org is
     // discovered) then load every org. Keyed on `_reloadTick` so create/leave/
@@ -161,12 +183,18 @@ export class SettingsOrganizationSectionComponent {
     this._reloadTick.update((n) => n + 1);
   }
 
-  /** Drop the expanded member manager if its org is gone from the fresh list. */
+  /** Drop the expanded member manager / browse list if their org is gone. */
   private reconcileExpanded(list: OrgStatus[]): void {
     const open = this._expandedOrgId();
     if (open && !list.some((o) => o.orgId === open)) {
       this._expandedOrgId.set(null);
       this._members.set([]);
+    }
+    const browse = this._browseOrgId();
+    if (browse && !list.some((o) => o.orgId === browse)) {
+      this._browseOrgId.set(null);
+      this._orgItems.set([]);
+      this._itemsError.set(null);
     }
   }
 
@@ -328,7 +356,13 @@ export class SettingsOrganizationSectionComponent {
 
   // ── Per-org: sync ──────────────────────────────────────────────────────────────
 
-  /** Pull + ingest one org's feed now, then reload the counts. */
+  /**
+   * Pull + ingest one org's feed now, inspect the report (fix E), then reload the
+   * counts. The report drives an honest toast: a partial/failed sync (errors, or
+   * pulled-but-nothing-ingested — the sync-stall symptom where a key isn't
+   * granted yet) shows a danger toast with the counts; a clean sync shows success.
+   * If the browse list for this org is open, refresh it too.
+   */
   async syncNow(org: OrgStatus): Promise<void> {
     if (this._syncingOrgId() !== null) {
       return;
@@ -336,12 +370,68 @@ export class SettingsOrganizationSectionComponent {
     this._syncingOrgId.set(org.orgId);
     this._error.set(null);
     try {
-      await this.ipc.orgSyncNow(org.orgId);
+      const report = await this.ipc.orgSyncNow(org.orgId);
+      const stalled = report.pulled > 0 && report.ingested === 0;
+      if (report.errors.length > 0 || stalled) {
+        this.toast.danger(
+          `${report.pulled} pulled, ${report.ingested} ingested, ` +
+            `${report.errors.length} error${report.errors.length === 1 ? "" : "s"} — ` +
+            `a key may not be granted yet.`,
+        );
+      } else {
+        this.toast.success(
+          report.ingested > 0
+            ? `Synced — ${report.ingested} new item${report.ingested === 1 ? "" : "s"}.`
+            : "Synced — up to date.",
+        );
+      }
       this.reload();
+      // Keep an open browse list fresh after a sync brings in new items.
+      if (this._browseOrgId() === org.orgId) {
+        void this.loadOrgItems(org.orgId);
+      }
     } catch (e) {
       this._error.set(String(e));
+      this.toast.danger(`Sync failed — ${String(e)}`);
     } finally {
       this._syncingOrgId.set(null);
+    }
+  }
+
+  // ── Browse the shared brain (fix A) ─────────────────────────────────────────
+
+  /** Toggle the "Shared brain" browse list for an org; loads its items lazily. */
+  async toggleBrowse(org: OrgStatus): Promise<void> {
+    if (this._browseOrgId() === org.orgId) {
+      this._browseOrgId.set(null);
+      this._orgItems.set([]);
+      this._itemsError.set(null);
+      return;
+    }
+    this._browseOrgId.set(org.orgId);
+    await this.loadOrgItems(org.orgId);
+  }
+
+  /** Load one org's browsable items (`listOrgItems`), stale-guarded on a token. */
+  private async loadOrgItems(orgId: string): Promise<void> {
+    const seq = ++this._browseSeq;
+    this._itemsError.set(null);
+    this._itemsLoading.set(true);
+    this._orgItems.set([]);
+    try {
+      const items = await this.ipc.listOrgItems(orgId);
+      if (seq !== this._browseSeq) {
+        return; // a newer browse/toggle superseded this one — drop the result
+      }
+      this._orgItems.set(items);
+    } catch (e) {
+      if (seq === this._browseSeq) {
+        this._itemsError.set(String(e));
+      }
+    } finally {
+      if (seq === this._browseSeq) {
+        this._itemsLoading.set(false);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes: a note a teammate shared into an org was **invisible** to other members, and there was **no way to choose which org** to share into.

## Root cause (traced; crypto for fresh accounts is fine)
1. **No browsable list** of an org's shared items — org content was search-only, so a member had nowhere to *see* the note.
2. **"Add to Org Brain" published to the first org**, not the chosen one (the FE passed no org_id), so the note could land in the wrong org entirely.
3. The Settings "N items" count showed **your own uploads**, not received items → a misleading "0 items".

## Fix
- **Org brain browse list**: `list_org_items(org_id)` (headers, membership-checked) + a "Shared brain" list per org in Settings, rows link to the org-item viewer.
- **Org picker on share** (the ask): `share_meeting_to_org` / `share_document_to_org` now take the target `org_id` (resolved via `resolve_org`, membership-checked); the shared org-share-sheet (meetings **and** notes) is a proper picker now, not an empty card.
- **Received-items count** shown separately from your own uploads.
- **Sync robustness**: a terminally-bad item no longer stalls the whole feed; the sync report surfaces pulled/ingested/errors as a toast.
- **Latent crypto fix**: the OCK grant's identity `sender_generation` is pinned to a constant on both wrap + unwrap (would break invited-member unwrap once identity rotation ships).
- **Decoupled org-brain READ from egress WRITE consent**: a joined member can read/search without having consented to publish.

## Verification
- Each fix **RED→GREEN**; `cargo test --lib` **1510**; `ng lint`/`ng build` + Playwright e2e (browse list + picker) green; `bash scripts/ci.sh` green.
- **lock-security-reviewer: PASS** + **adversarial-verifier: PASS** (it FAILed once on a clippy lint in a test — fixed).
- **Honest gap**: whether member A actually holds an OCK grant for the note's generation is the one thing only a **live 2-account round-trip on a signed build** can confirm; everything else is gate-proven headless.