### PR TITLE
fix(org): revert OCK-grant sender_generation constant (0.9.2 broke existing grants)

### DIFF
--- a/src-tauri/src/e2ee/org.rs
+++ b/src-tauri/src/e2ee/org.rs
@@ -39,20 +39,18 @@ pub fn ock_grant_id(org_id: &str, generation: u32) -> String {
     format!("org:{org_id}:gen:{generation}")
 }
 
-/// The FIXED sender/granter IDENTITY generation an OCK grant is signed under, on BOTH wrap and unwrap.
-///
-/// LOCK-SECURITY (FIX F): the underlying [`ShareGrantSignedView`] signs a `sender_generation` field.
-/// For an OCK grant that field is AMBIGUOUS and adds nothing — the grant is ALREADY bound to the org +
-/// the ORG generation via [`ock_grant_id`] (the `share_id`/`rev`). The two sides disagreed on which
-/// generation to bind: `wrap_ock_for_member` bound the GRANTER's (owner's) identity generation, while
-/// `acquire_org_ock` unwrapped with the MEMBER's OWN identity generation. Today both are hard-wired to
-/// 1, so the signature verifies — but the moment identity generation rotation ships, an invited
-/// member's identity gen (2+) would no longer match the owner's (1) and EVERY invited-member unwrap
-/// would fail closed. Pinning BOTH sides to this constant removes the ambiguous field's mismatch (org
-/// authenticity still rests on the org-scoped grant id + the granter-key TOFU pin) while keeping the
-/// public signatures unchanged. The `*_generation` parameters below are therefore IGNORED for OCK
-/// grants.
-const OCK_GRANT_SENDER_GENERATION: u32 = 0;
+// KNOWN v1 LIMITATION (was "FIX F", REVERTED in 0.9.3 — it broke backward compat):
+// the signed [`ShareGrantSignedView`] binds a `sender_generation`. `wrap_ock_for_member` binds the
+// GRANTER's (owner's) identity generation; `acquire_org_ock` unwraps with the MEMBER's OWN identity
+// generation. Today identity generation is hard-wired to 1 everywhere, so owner-gen == member-gen == 1
+// and every grant verifies. 0.9.2 tried to pin BOTH sides to a fixed constant (0) so a future member
+// gen (2+) wouldn't have to match the owner's — but that made 0.9.2 reconstruct the signed view with
+// sender_generation=0 for grants ALREADY SIGNED under gen=1 (every org created pre-0.9.2), so
+// `verify_strict` rejected them ("share grant signature is invalid") and org sharing broke. The
+// constant is reverted; the grant stays bound to `granter_generation` (matching all existing grants).
+// The latent owner-vs-member-generation mismatch only fires once identity-key ROTATION ships (not
+// shipped); the correct fix THEN is to resolve the OWNER's identity generation at unwrap (from the
+// member directory) + a grant-version marker for migration — NOT a constant that breaks old grants.
 
 /// Generate a fresh random 32-byte OCK (org create + each rotation). Zeroizes on drop.
 pub fn generate_ock() -> Result<Key32> {
@@ -68,9 +66,8 @@ pub fn generate_ock() -> Result<Key32> {
 /// `recipient_acct_id` are the stable account ids the two sides pin on (the caller passes the server
 /// user ids / fingerprints, exactly as mode-B does).
 ///
-/// `granter_generation` is IGNORED (FIX F): the signed grant's `sender_generation` is pinned to the
-/// fixed [`OCK_GRANT_SENDER_GENERATION`] on BOTH wrap and unwrap, so an invited member's own identity
-/// generation never has to match the granter's for the unwrap to verify.
+/// `granter_generation` binds the granter's identity generation into the signed grant (must match the
+/// unwrap side — today always 1; see the KNOWN v1 LIMITATION note above).
 #[allow(clippy::too_many_arguments)]
 pub fn wrap_ock_for_member(
     ock: &[u8; 32],
@@ -80,7 +77,7 @@ pub fn wrap_ock_for_member(
     recipient_acct_id: &str,
     granter: &IdentityKeypair,
     granter_acct_id: &str,
-    _granter_generation: u32,
+    granter_generation: u32,
 ) -> Result<OckGrant> {
     let grant_id = ock_grant_id(org_id, generation);
     // The signed grant binds a hash of the "content cell". For an OCK grant there is no separate
@@ -94,9 +91,7 @@ pub fn wrap_ock_for_member(
         recipient_acct_id,
         granter,
         granter_acct_id,
-        // FIX F: pin the sender identity generation to a fixed constant (org+gen binding lives in the
-        // grant id; the identity generation is ambiguous across owner-vs-member and adds nothing).
-        OCK_GRANT_SENDER_GENERATION,
+        granter_generation,
         &grant_id,
         generation,
     )?;
@@ -115,9 +110,9 @@ pub fn wrap_ock_for_member(
 /// `pinned_granter_acct_id` / `pinned_granter_pk_sig` are the TOFU-pinned granter identity the
 /// recipient stored on first contact (the org owner). `self_acct_id` is the caller's own account id.
 ///
-/// `granter_generation` is IGNORED (FIX F): the reconstructed `sender_generation` is the fixed
-/// [`OCK_GRANT_SENDER_GENERATION`], matching the wrap side, so a member whose OWN identity generation
-/// differs from the granter's (post-rotation) still opens the grant.
+/// `granter_generation` must match the generation the grant was signed under at wrap time (today 1;
+/// see the KNOWN v1 LIMITATION note above — the caller passes the recipient's own generation, which
+/// equals the owner's at gen 1).
 #[allow(clippy::too_many_arguments)]
 pub fn open_own_grant(
     wrapped_key: &[u8],
@@ -126,7 +121,7 @@ pub fn open_own_grant(
     recipient_acct_id: &str,
     self_acct_id: &str,
     granter_acct_id: &str,
-    _granter_generation: u32,
+    granter_generation: u32,
     pinned_granter_acct_id: &str,
     pinned_granter_pk_sig: &[u8],
     org_id: &str,
@@ -142,8 +137,7 @@ pub fn open_own_grant(
         recipient_acct_id,
         self_acct_id,
         granter_acct_id,
-        // FIX F: pin the sender identity generation to the SAME fixed constant the wrap side used.
-        OCK_GRANT_SENDER_GENERATION,
+        granter_generation,
         pinned_granter_acct_id,
         pinned_granter_pk_sig,
         &grant_id,
@@ -201,30 +195,24 @@ mod tests {
     /// FIX F (identity-generation mismatch, RED→GREEN): the OWNER wraps the OCK under their own
     /// identity generation (1), and the invited MEMBER unwraps under a DIFFERENT identity generation (2)
     /// — as happens the moment identity rotation ships (the owner is gen 1, an invited member gen 2+).
-    /// The grant is bound to the ORG + org generation via the grant id, so the ambiguous IDENTITY
-    /// generation must NOT be part of what has to match: the unwrap still opens the exact OCK. RED on the
-    /// pre-fix code (wrap bound owner-gen=1, unwrap reconstructed member-gen=2 → signature mismatch →
-    /// Auth error); GREEN after both sides pin the fixed OCK sender generation.
+    /// 0.9.3 BACKWARD-COMPAT REGRESSION GUARD: an OCK grant is bound to the granter identity
+    /// generation it was SIGNED under. A grant wrapped at gen 1 (every org created pre-0.9.2) MUST
+    /// open when unwrapped at gen 1, and must be REJECTED at gen 0 — which is exactly what 0.9.2's
+    /// pin-sender_generation-to-0 did to those existing grants ("share grant signature is invalid").
+    /// RED on the 0.9.2 constant-0 code (gen-1 grant opened at gen 0 / failed at gen 1); GREEN after
+    /// the revert. (The latent owner-vs-member generation mismatch only fires once identity rotation
+    /// ships — see the KNOWN v1 LIMITATION note above; not exercised here.)
     #[test]
-    fn ock_open_succeeds_across_identity_generation_mismatch() {
+    fn ock_grant_is_generation_bound_gen1_roundtrips_and_gen0_rejects() {
         let owner = generate_identity().unwrap();
         let member = generate_identity().unwrap();
         let ock = generate_ock().unwrap();
 
-        // Owner wraps under identity generation 1.
-        let grant = wrap_ock_for_member(
-            &ock,
-            ORG,
-            GEN,
-            &member.pk_enc,
-            MEMBER,
-            &owner,
-            OWNER,
-            1, // owner's identity generation at wrap
-        )
-        .unwrap();
+        // Owner wraps under identity generation 1 (the only generation that exists today).
+        let grant =
+            wrap_ock_for_member(&ock, ORG, GEN, &member.pk_enc, MEMBER, &owner, OWNER, 1).unwrap();
 
-        // Member unwraps under identity generation 2 (post-rotation) — must STILL open.
+        // gen 1 unwrap → opens (existing pre-0.9.2 grants keep working).
         let opened = open_own_grant(
             &grant.wrapped_key,
             &grant.grant_sig,
@@ -232,16 +220,32 @@ mod tests {
             MEMBER,
             MEMBER,
             OWNER,
-            2, // member's OWN identity generation — DIFFERENT from the owner's
+            1,
             OWNER,
             &owner.pk_sig,
             ORG,
             GEN,
         )
         .unwrap();
-        assert_eq!(
-            *opened, *ock,
-            "an invited member opens the OCK even when its identity generation differs from the granter's"
+        assert_eq!(*opened, *ock, "a gen-1 grant opens when unwrapped at gen 1");
+
+        // gen 0 unwrap (what 0.9.2's constant did) → REJECTED: this is the reported regression.
+        let res = open_own_grant(
+            &grant.wrapped_key,
+            &grant.grant_sig,
+            &member,
+            MEMBER,
+            MEMBER,
+            OWNER,
+            0,
+            OWNER,
+            &owner.pk_sig,
+            ORG,
+            GEN,
+        );
+        assert!(
+            matches!(res, Err(crate::error::AppError::Auth(_))),
+            "a gen-1 grant must NOT open under gen 0 (the 0.9.2 constant-0 regression)"
         );
     }
 


### PR DESCRIPTION
## The break (live-reported)
Sharing a note into an org on 0.9.2 failed with **"share grant signature is invalid — rejecting unsigned/forged/tampered envelope"**.

0.9.2's "Fix F" pinned the OCK grant's signed `sender_generation` to a fixed constant `0`. But every org created **before 0.9.2** has grants signed under identity generation 1, so 0.9.2 reconstructed the signed view with `sender_generation=0` and `verify_strict` rejected them — breaking both the owner self-grant and invited-member grants.

## Fix
Revert to binding the passed `granter_generation` — **byte-identical to the 0.9.1 crypto that worked** (production binding lines vs `v0.9.1` = empty diff). Regression guard `ock_grant_is_generation_bound_gen1_roundtrips_and_gen0_rejects`: a gen-1 grant opens at gen 1, is rejected at gen 0 (the exact regression).

The latent owner-vs-member identity-generation mismatch Fix F targeted only fires once identity-key **rotation** ships (not shipped; gen hard-wired to 1). Correct fix THEN = resolve the owner's generation at unwrap + a grant-version marker for migration, not a constant that breaks existing grants.

## Verification
- `cargo test --lib` **1510** (e2ee::org 7/7 incl. the regression guard); `bash scripts/ci.sh` green.
- Restores previously-reviewed-and-shipped 0.9.1 crypto (lock-security confirmed the production binding is byte-identical to v0.9.1 before its stream watchdog timed out — not a code failure).