### PR TITLE
feat(org): org shared notes in the Notes view + org picker + 2-min global auto-sync

### DIFF
--- a/e2e/notes/notes-org.spec.ts
+++ b/e2e/notes/notes-org.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Notes home — org (Shared Brain) surfacing. Confirms that with a mocked org
+ * (`org_list_statuses`) carrying a shared item (`list_org_items`), the Notes view:
+ *   1. renders the "Shared brains" rail section listing the org (name + role);
+ *   2. MERGES the org's shared item into the "All notes" content pane alongside
+ *      YOUR authored notes, with the ORG-NAME badge on the org card;
+ *   3. routes to the READ-ONLY `/org-item/:id` viewer when the org card is clicked
+ *      (your own notes still open the `/notes/:id` editor).
+ * All under the mocked IPC with NO console/page errors — the runtime check that
+ * catches NG0600 / ɵcmp / forwardRef / routerLink regressions a green build misses.
+ *
+ * The org command NAMES + camelCase DTOs match `ipc.service.ts` / `models.ts`:
+ *   org_refresh → void · org_list_statuses → OrgStatus[] · list_org_items →
+ *   OrgItemHeader[] · org_get_item → OrgItemDetail.
+ */
+
+/** The mocked org command overrides shared by every case in this file. */
+const ORG_MOCKS = {
+  org_refresh: () => null,
+  org_list_statuses: () => [
+    {
+      orgId: "org1",
+      name: "Siema",
+      role: "member",
+      memberCount: 3,
+      consented: true,
+      lastSeq: 5,
+      itemCount: 0,
+      receivedCount: 1,
+      pendingShares: 0,
+    },
+  ],
+  list_org_items: (args: { orgId: string }) =>
+    args.orgId === "org1"
+      ? [
+          {
+            itemId: "oi1",
+            title: "Team Roadmap Q3",
+            authorHint: "alice",
+            createdAt: "2026-07-09T10:00:00Z",
+            seq: 5,
+          },
+        ]
+      : [],
+  org_get_item: (args: { itemId: string }) => ({
+    itemId: args.itemId,
+    authorHint: "alice",
+    title: "Team Roadmap Q3",
+    createdAt: "2026-07-09T10:00:00Z",
+    rev: 1,
+    markdown: "# Team Roadmap Q3\n\nShip the org brain.",
+  }),
+};
+
+test("All notes merges org shared items (with org-name badge) + the rail lists the org", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, ORG_MOCKS);
+  await page.goto("/notes");
+
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // 1) The rail's "Shared brains" section lists the org (name + role hint).
+  await expect(page.locator(".folders-title", { hasText: "Shared brains" })).toBeVisible();
+  const orgRow = page.locator(".org-row");
+  await expect(orgRow).toHaveCount(1);
+  await expect(orgRow.locator(".folder-name")).toHaveText("Siema");
+  await expect(orgRow.locator(".org-role")).toHaveText("Member");
+
+  // 2) "All notes" shows YOUR authored note AND the org shared item, merged.
+  await expect(page.getByText("My First Note")).toBeVisible();
+  const orgCard = page.locator(".note-card--org");
+  await expect(orgCard).toHaveCount(1);
+  await expect(orgCard.getByText("Team Roadmap Q3")).toBeVisible();
+  // The org card carries the ORG-NAME badge + the author hint.
+  await expect(orgCard.locator(".org-badge")).toContainText("Siema");
+  await expect(orgCard.locator(".note-author")).toHaveText("alice");
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test("clicking an org shared item routes to the read-only /org-item viewer", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, ORG_MOCKS);
+  await page.goto("/notes");
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // Click the org card → the read-only org-item viewer route.
+  await page.locator(".note-card--org").click();
+  await expect(page).toHaveURL(/\/org-item\/oi1$/);
+  // The viewer rendered the decrypted org item body (read-only, no editor).
+  await expect(page.locator("app-org-item-viewer")).toBeVisible();
+  await expect(page.getByText("Ship the org brain.")).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test("selecting the org in the rail shows ONLY that org's items", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, ORG_MOCKS);
+  await page.goto("/notes");
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // Select the org in the rail → the pane scopes to its items only.
+  await page.locator(".org-row").click();
+  await expect(page.locator(".content-title")).toHaveText("Siema");
+  await expect(page.locator(".note-card--org")).toHaveCount(1);
+  // Your authored notes are NOT in the org-scoped view.
+  await expect(page.getByText("My First Note")).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -633,6 +633,24 @@ deferred it twice is now removed, so it's unblocked for the GA cut.
     },
   };
 
+  // Tauri v2 event-plugin internals: the `UnlistenFn` returned by
+  // `@tauri-apps/api` `listen()` calls `__TAURI_EVENT_PLUGIN_INTERNALS__
+  // .unregisterListener(event, eventId)` on teardown (event.js `_unlisten`).
+  // Without this, ANY component that unsubscribes a `listen()` on destroy (e.g.
+  // navigating away from a view holding an `onXxx` subscription) throws
+  // "Cannot read properties of undefined (reading 'unregisterListener')". We
+  // best-effort prune the maps the invoke router uses so a subscribe→unsubscribe
+  // round-trip is a clean no-op under the mock.
+  window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+    unregisterListener: (event, eventId) => {
+      const set = listeners.get(event);
+      if (set) {
+        set.delete(eventId);
+      }
+      callbacks.delete(eventId);
+    },
+  };
+
   // Legacy global some code paths probe.
   window.__TAURI__ = window.__TAURI__ || {};
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24840,7 +24840,7 @@ pub async fn revoke_shares_for_folder(
 /// first tick fires `ORG_SYNC_FIRST_DELAY_SECS` after launch (no startup contention); subsequent
 /// ticks every `ORG_SYNC_TICK_SECS`. Every tick is a cheap no-op while logged out / no org joined.
 pub const ORG_SYNC_FIRST_DELAY_SECS: u64 = 20;
-pub const ORG_SYNC_TICK_SECS: u64 = 300;
+pub const ORG_SYNC_TICK_SECS: u64 = 120;
 
 /// One background org-sync tick: drain the outbound share queue, then pull + ingest the inbound feed
 /// into the local int8 partition. This is what makes the org brain a REPLICATED brain — every
@@ -24848,7 +24848,13 @@ pub const ORG_SYNC_TICK_SECS: u64 = 300;
 /// warns-and-continues (a transient failure never kills the loop), and both inners gate to an early
 /// `Ok` when logged out / no org joined, so this is a no-op until a session is live. Logs only
 /// non-PII counts on a productive tick.
-pub(crate) async fn org_background_sync_tick(state: &AppState) {
+///
+/// Returns `true` when the inbound sync actually CHANGED the local replica this tick (≥1 ingest or
+/// tombstone) — the caller (`lib.rs` loop) uses this to fire a content-free
+/// [`crate::events::EVENT_ORG_FEED_UPDATED`] so an open FE view re-fetches WITHOUT polling. Returns
+/// `false` on a no-op / error tick. Emitting is done by the loop (which holds the `AppHandle`); the
+/// tick signature stays `&AppState`, unchanged for the other internal callers.
+pub(crate) async fn org_background_sync_tick(state: &AppState) -> bool {
     // Reconcile membership FIRST so a newly-invited org is present (and synced this same tick) and a
     // departed org is dropped before we pull its feed. Best-effort — a failure never blocks the sync.
     if let Err(e) = org_reconcile_memberships(state).await {
@@ -24858,14 +24864,20 @@ pub(crate) async fn org_background_sync_tick(state: &AppState) {
         tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
     }
     match org_sync_now_inner(state).await {
-        Ok(r) if r.ingested > 0 || r.tombstoned > 0 => tracing::info!(
-            target: "org",
-            ingested = r.ingested,
-            tombstoned = r.tombstoned,
-            "org feed synced"
-        ),
-        Ok(_) => {}
-        Err(e) => tracing::warn!(target: "org", error = %e, "org feed sync tick failed"),
+        Ok(r) if r.ingested > 0 || r.tombstoned > 0 => {
+            tracing::info!(
+                target: "org",
+                ingested = r.ingested,
+                tombstoned = r.tombstoned,
+                "org feed synced"
+            );
+            true
+        }
+        Ok(_) => false,
+        Err(e) => {
+            tracing::warn!(target: "org", error = %e, "org feed sync tick failed");
+            false
+        }
     }
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -312,3 +312,57 @@ pub fn emit_recording_capped(app: &AppHandle) {
         );
     }
 }
+
+/// Emitted after a background org-feed sync tick INGESTED or TOMBSTONED ≥1 item — i.e. the local
+/// org (Shared Brain) replica actually changed this tick. Lets an open FE view (the Notes org
+/// picker, the Settings shared-brain list) refresh WITHOUT polling. Counts only, NO PII (no item
+/// ids, titles, or content) — it is purely a "something changed, re-fetch" ping.
+pub const EVENT_ORG_FEED_UPDATED: &str = "murmur://org-feed-updated";
+
+/// Payload for [`EVENT_ORG_FEED_UPDATED`]. A single count only — NO PII. `orgsChanged` is the number
+/// of joined orgs whose feed produced ≥1 ingest/tombstone this tick (the all-orgs background tick
+/// aggregates across orgs). The FE treats any arrival as "re-fetch the org lists".
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgFeedUpdatedPayload {
+    /// Number of orgs whose replica changed this tick (≥1 when emitted).
+    pub orgs_changed: u32,
+}
+
+/// Emit [`EVENT_ORG_FEED_UPDATED`] to the FE (best-effort). Fired ONLY on a productive tick
+/// (≥1 ingest/tombstone). Swallows the emit failure with a `tracing::warn!` so a failed emit can
+/// NEVER break the background sync loop. NO PII (a count only).
+pub fn emit_org_feed_updated(app: &AppHandle, orgs_changed: u32) {
+    if let Err(e) = app.emit(EVENT_ORG_FEED_UPDATED, OrgFeedUpdatedPayload { orgs_changed }) {
+        tracing::warn!(
+            target: "org",
+            error = %e,
+            "failed to emit org-feed-updated notice"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The FE listens on this exact event name; a rename silently drops the live-refresh.
+    #[test]
+    fn org_feed_updated_event_name_is_stable() {
+        assert_eq!(EVENT_ORG_FEED_UPDATED, "murmur://org-feed-updated");
+    }
+
+    /// The payload must serialize `orgs_changed` as camelCase `orgsChanged` (the FE contract) and
+    /// carry NO PII field — a count only.
+    #[test]
+    fn org_feed_updated_payload_is_camel_case_count_only() {
+        let json = serde_json::to_string(&OrgFeedUpdatedPayload { orgs_changed: 3 }).unwrap();
+        assert_eq!(json, r#"{"orgsChanged":3}"#);
+    }
+
+    /// The global org auto-sync cadence is 2 minutes (guards the 300→120 change from regressing).
+    #[test]
+    fn org_sync_tick_cadence_is_two_minutes() {
+        assert_eq!(crate::commands::ORG_SYNC_TICK_SECS, 120);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,7 +544,14 @@ pub fn run() {
                     .await;
                     loop {
                         if let Some(state) = handle.try_state::<AppState>() {
-                            crate::commands::org_background_sync_tick(state.inner()).await;
+                            // On a PRODUCTIVE tick (≥1 ingest/tombstone) emit a content-free
+                            // `org-feed-updated` ping so an open FE view (Notes org picker /
+                            // Settings shared-brain list) re-fetches without polling. Best-effort:
+                            // a failed emit never breaks the loop. The count is aggregated across
+                            // orgs by the all-orgs tick, so we report `1` (≥1 org changed).
+                            if crate::commands::org_background_sync_tick(state.inner()).await {
+                                crate::events::emit_org_feed_updated(&handle, 1);
+                            }
                         }
                         tokio::time::sleep(std::time::Duration::from_secs(
                             crate::commands::ORG_SYNC_TICK_SECS,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -91,6 +91,7 @@ import type {
   OrgItemDetail,
   OrgItemHeader,
   OrgSyncReport,
+  OrgFeedUpdatedPayload,
   ActiveSharesReport,
 } from "./models";
 
@@ -129,6 +130,9 @@ export const EVENT_STORAGE_PRUNED = "murmur://storage-pruned";
 export const EVENT_RECORDING_CAPPED = "murmur://recording-capped";
 // Brain v2 L5 — a scheduled brief was STAGED (propose-accept; run id + label + size only).
 export const EVENT_BRIEF_PROPOSED = "murmur://brief-proposed";
+// Shared Brain — the background org-sync loop INGESTED/TOMBSTONED ≥1 org item this tick
+// (content-free "something changed, re-fetch" ping; drives the Notes org picker live refresh).
+export const EVENT_ORG_FEED_UPDATED = "murmur://org-feed-updated";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -2110,6 +2114,22 @@ export class IpcService {
   /** Fires with per-file progress for the in-flight PERSON-name NER model download. */
   onNerDownload(cb: (p: NerDownloadProgress) => void): Promise<UnlistenFn> {
     return listen<NerDownloadProgress>(EVENT_NER_DOWNLOAD, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires after the background org-sync loop INGESTED/TOMBSTONED ≥1 org (Shared
+   * Brain) item this tick — i.e. the local org replica actually changed. Lets an
+   * open view (the Notes org picker + merged All-notes list, the Settings
+   * shared-brain list) re-fetch its org items WITHOUT polling. Content-free — a
+   * count only, NO item ids / titles / content; treat any arrival as "re-fetch
+   * the org lists". Mirrors the {@link onBriefProposed} shape.
+   */
+  onOrgFeedUpdated(
+    cb: (p: OrgFeedUpdatedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<OrgFeedUpdatedPayload>(EVENT_ORG_FEED_UPDATED, (e) =>
       cb(e.payload),
     );
   }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1931,6 +1931,18 @@ export interface OrgSyncReport {
 }
 
 /**
+ * Payload of the `murmur://org-feed-updated` event (`onOrgFeedUpdated`). Emitted
+ * by the background org-sync loop ONLY on a PRODUCTIVE tick (≥1 ingest/tombstone
+ * changed the local org replica). Content-free — a single count, NO item ids /
+ * titles / content; the FE treats any arrival as "re-fetch the org lists".
+ * Mirrors the Rust `OrgFeedUpdatedPayload`.
+ */
+export interface OrgFeedUpdatedPayload {
+  /** Number of joined orgs whose replica changed this tick (≥1 when emitted). */
+  orgsChanged: number;
+}
+
+/**
  * The active-shares report for the lock×shares dialog (`folderActiveShares`),
  * gathered when the user tries to lock a folder that has outgoing shares. Titles
  * render only to the local owner (who can already read them) — content-free

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -217,6 +217,39 @@
         </form>
       }
     </nav>
+
+    <!-- ===== Shared brains (orgs) — read-only replicated org notes ===== -->
+    @if (orgs().length > 0) {
+      <div class="folders-head org-head">
+        <h3 class="folders-title">Shared brains</h3>
+      </div>
+      <nav class="folders-body org-body" aria-label="Shared brains">
+        @for (org of orgs(); track org.orgId) {
+          <button
+            type="button"
+            class="folder-row org-row"
+            [class.is-selected]="activeOrgId() === org.orgId"
+            [attr.aria-pressed]="activeOrgId() === org.orgId"
+            (click)="selectOrg(org.orgId)"
+          >
+            <span class="folder-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                <circle cx="5" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <circle cx="11" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <path
+                  d="M2 13c0-1.8 1.3-3 3-3s3 1.2 3 3M8 13c0-1.8 1.3-3 3-3s3 1.2 3 3"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </span>
+            <span class="folder-name">{{ org.name }}</span>
+            <span class="pill org-role" [title]="orgRoleLabel(org)">{{ orgRoleLabel(org) }}</span>
+          </button>
+        }
+      </nav>
+    }
   </mur-sidebar>
 
   <!-- ============ RIGHT PANE — note list ============ -->
@@ -278,112 +311,154 @@
             </button>
           }
         </div>
-      } @else if (loading()) {
+      } @else if (loading() || orgsLoading()) {
         <p class="notes-status">Loading notes…</p>
-      } @else if (noteList().length === 0) {
-        <div class="empty-state">
-          <h3 class="empty-title">No notes yet</h3>
-          <p class="empty-body">
-            Author a standalone note — it becomes first-class brain context, right
-            alongside your recordings.
-          </p>
-          <button
-            type="button"
-            class="btn btn-primary"
-            [disabled]="creating()"
-            (click)="newNote()"
-          >
-            New note
-          </button>
-        </div>
+      } @else if (listEmpty()) {
+        @if (activeOrg(); as org) {
+          <!-- An org is selected but its shared brain has no items yet. -->
+          <div class="empty-state">
+            <h3 class="empty-title">Nothing shared yet</h3>
+            <p class="empty-body">
+              No one has shared a note into “{{ org.name }}” yet. Shared notes
+              appear here automatically as they sync.
+            </p>
+          </div>
+        } @else {
+          <div class="empty-state">
+            <h3 class="empty-title">No notes yet</h3>
+            <p class="empty-body">
+              Author a standalone note — it becomes first-class brain context, right
+              alongside your recordings.
+            </p>
+            <button
+              type="button"
+              class="btn btn-primary"
+              [disabled]="creating()"
+              (click)="newNote()"
+            >
+              New note
+            </button>
+          </div>
+        }
       } @else {
         <ul class="note-list">
-          @for (note of noteList(); track note.id) {
+          @for (it of listItems(); track it.id) {
             <li class="note-item">
-              <div
-                class="card note-card"
-                [class.is-locked]="note.locked"
-                [class.menu-open]="movePopoverId() === note.id"
-              >
-                <button
-                  type="button"
-                  class="note-open"
-                  (click)="openNote(note.id, note.locked)"
-                >
-                  <div class="note-card-head">
-                    <span class="note-title">
-                      @if (note.locked) {
-                        <svg class="note-lock" viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
-                          <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
-                          <path d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-                        </svg>
-                      }
-                      {{ note.title }}
-                    </span>
-                    @if (note.shared) {
-                      <span class="pill is-accent note-shared" title="Shared">Shared</span>
-                    }
-                  </div>
-
-                  @if (note.snippet) {
-                    <p class="note-snippet">{{ note.snippet }}</p>
-                  }
-
-                  <div class="note-card-foot">
-                    @if (note.tags.length > 0) {
-                      <span class="note-tags">
-                        @for (tag of note.tags; track tag) {
-                          <span class="pill note-tag">{{ tag }}</span>
-                        }
-                      </span>
-                    }
-                    <span class="note-date">{{ formatDate(note.updatedAt) }}</span>
-                  </div>
-                </button>
-
-                <!-- Per-note "Move to…" affordance (hidden for masked rows). -->
-                @if (!note.locked) {
-                  <div class="note-move">
+              @switch (it.kind) {
+                @case ("note") {
+                  <div
+                    class="card note-card"
+                    [class.is-locked]="it.note.locked"
+                    [class.menu-open]="movePopoverId() === it.note.id"
+                  >
                     <button
                       type="button"
-                      class="note-move-btn"
-                      [attr.aria-expanded]="movePopoverId() === note.id"
-                      aria-label="Move note to a folder"
-                      title="Move to…"
-                      (click)="toggleMovePopover(note.id, $event)"
+                      class="note-open"
+                      (click)="openNote(it.note.id, it.note.locked)"
                     >
-                      <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
-                        <circle cx="8" cy="3.5" r="1.2" fill="currentColor" />
-                        <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                        <circle cx="8" cy="12.5" r="1.2" fill="currentColor" />
-                      </svg>
+                      <div class="note-card-head">
+                        <span class="note-title">
+                          @if (it.note.locked) {
+                            <svg class="note-lock" viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
+                              <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
+                              <path d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                            </svg>
+                          }
+                          {{ it.note.title }}
+                        </span>
+                        @if (it.note.shared) {
+                          <span class="pill is-accent note-shared" title="Shared">Shared</span>
+                        }
+                      </div>
+
+                      @if (it.note.snippet) {
+                        <p class="note-snippet">{{ it.note.snippet }}</p>
+                      }
+
+                      <div class="note-card-foot">
+                        @if (it.note.tags.length > 0) {
+                          <span class="note-tags">
+                            @for (tag of it.note.tags; track tag) {
+                              <span class="pill note-tag">{{ tag }}</span>
+                            }
+                          </span>
+                        }
+                        <span class="note-date">{{ formatDate(it.note.updatedAt) }}</span>
+                      </div>
                     </button>
 
-                    @if (movePopoverId() === note.id) {
-                      <!-- Opaque move menu (T3): --surface-overlay, no blur. -->
-                      <div class="menu move-menu" role="menu">
-                        <p class="menu-group-label">Move to folder</p>
-                        @for (folder of noteFolders(); track folder.id) {
-                          <button
-                            type="button"
-                            class="menu-item"
-                            role="menuitem"
-                            [disabled]="folder.id === note.folderId"
-                            (click)="moveNote(note.id, folder.id)"
-                          >
-                            {{ folder.name }}
-                            @if (folder.id === note.folderId) {
-                              <span class="menu-current text-muted">current</span>
+                    <!-- Per-note "Move to…" affordance (hidden for masked rows). -->
+                    @if (!it.note.locked) {
+                      <div class="note-move">
+                        <button
+                          type="button"
+                          class="note-move-btn"
+                          [attr.aria-expanded]="movePopoverId() === it.note.id"
+                          aria-label="Move note to a folder"
+                          title="Move to…"
+                          (click)="toggleMovePopover(it.note.id, $event)"
+                        >
+                          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+                            <circle cx="8" cy="3.5" r="1.2" fill="currentColor" />
+                            <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                            <circle cx="8" cy="12.5" r="1.2" fill="currentColor" />
+                          </svg>
+                        </button>
+
+                        @if (movePopoverId() === it.note.id) {
+                          <!-- Opaque move menu (T3): --surface-overlay, no blur. -->
+                          <div class="menu move-menu" role="menu">
+                            <p class="menu-group-label">Move to folder</p>
+                            @for (folder of noteFolders(); track folder.id) {
+                              <button
+                                type="button"
+                                class="menu-item"
+                                role="menuitem"
+                                [disabled]="folder.id === it.note.folderId"
+                                (click)="moveNote(it.note.id, folder.id)"
+                              >
+                                {{ folder.name }}
+                                @if (folder.id === it.note.folderId) {
+                                  <span class="menu-current text-muted">current</span>
+                                }
+                              </button>
+                            } @empty {
+                              <p class="menu-empty text-muted">No folders yet.</p>
                             }
-                          </button>
-                        } @empty {
-                          <p class="menu-empty text-muted">No folders yet.</p>
+                          </div>
                         }
                       </div>
                     }
                   </div>
                 }
-              </div>
+                @case ("org") {
+                  <!-- A READ-ONLY org (Shared Brain) replica — opens the /org-item viewer. -->
+                  <a
+                    class="card note-card note-card--org"
+                    [routerLink]="['/org-item', it.item.itemId]"
+                  >
+                    <div class="note-open note-open--org">
+                      <div class="note-card-head">
+                        <span class="note-title">{{ it.item.title }}</span>
+                        <span class="pill org-badge" [title]="'Shared brain · ' + it.orgName">
+                          <svg class="org-badge-glyph" viewBox="0 0 16 16" width="11" height="11" fill="none" aria-hidden="true">
+                            <circle cx="5" cy="6" r="1.6" stroke="currentColor" stroke-width="1.2" />
+                            <circle cx="11" cy="6" r="1.6" stroke="currentColor" stroke-width="1.2" />
+                            <path d="M2.5 12c0-1.5 1.1-2.5 2.5-2.5s2.5 1 2.5 2.5M8.5 12c0-1.5 1.1-2.5 2.5-2.5s2.5 1 2.5 2.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
+                          </svg>
+                          {{ it.orgName }}
+                        </span>
+                      </div>
+                      <div class="note-card-foot">
+                        @if (it.item.authorHint) {
+                          <span class="note-author text-muted">{{ it.item.authorHint }}</span>
+                        }
+                        <span class="note-date">{{ formatOrgDate(it.item.createdAt) }}</span>
+                      </div>
+                    </div>
+                  </a>
+                }
+              }
             </li>
           }
         </ul>

--- a/src/app/features/notes/notes-home/notes-home.component.scss
+++ b/src/app/features/notes/notes-home/notes-home.component.scss
@@ -145,6 +145,32 @@
   white-space: nowrap;
 }
 
+/* --- Rail: "Shared brains" (orgs) section --- */
+.org-head {
+  /* A quiet divider above the section so it reads as a distinct group. */
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+.org-body {
+  /* The org list sits under the folder list; it does not need its own scroll. */
+  flex: 0 0 auto;
+  overflow: visible;
+}
+.org-row {
+  cursor: pointer;
+}
+/* A quiet role hint (Owner / Member) trailing the org name. */
+.org-role {
+  flex: none;
+  margin-left: auto;
+  font-size: 0.62rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--surface-raised);
+}
+
 /* --- Right pane: note list --- */
 .notes-content {
   display: flex;
@@ -279,6 +305,48 @@
 }
 .note-shared {
   flex: none;
+}
+
+/* --- Org (Shared Brain) card: a read-only replica, styled as a note card --- */
+.note-card--org {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+.note-card--org:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+/* The org card has no floating move button, so it needs no right-side reserve. */
+.note-open--org {
+  padding-right: var(--space-4);
+  cursor: pointer;
+}
+/* The "shared brain" origin badge — distinct from the outbound "Shared" pill:
+   a neutral raised surface (not the accent fill) with the org's name + a glyph. */
+.org-badge {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  max-width: 14ch;
+  overflow: hidden;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+.org-badge-glyph {
+  flex: none;
+  color: var(--text-muted);
+}
+.note-author {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8rem;
 }
 
 .note-snippet {

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   Injector,
   OnInit,
@@ -10,9 +11,18 @@ import {
   signal,
   viewChild,
 } from "@angular/core";
-import { Router } from "@angular/router";
+import { Router, RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../../core/ipc.service";
 import { NavHistoryService } from "../../../core/nav-history.service";
-import type { NoteFolder, OrganizeMove, OrganizePlan } from "../../../core/models";
+import type {
+  NoteFolder,
+  NoteSummary,
+  OrganizeMove,
+  OrganizePlan,
+  OrgItemHeader,
+  OrgStatus,
+} from "../../../core/models";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
 import { FoldersService } from "../../../services/folders.service";
 import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
@@ -20,6 +30,31 @@ import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
 import { LockSharesDialogComponent } from "../../folders/lock-shares-dialog/lock-shares-dialog.component";
 import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.component";
+
+/**
+ * One row of the unified content list — a discriminated union over the two
+ * sources the pane merges. A `"note"` card is YOUR authored note (opens the
+ * editor); an `"org"` card is a READ-ONLY org (Shared Brain) replica (opens the
+ * `/org-item/:id` viewer, carries the origin org's name for its badge). Both
+ * expose an epoch-ms `sortAt` so the merged list orders by date desc regardless
+ * of source. `id` is namespaced (`note:`/`org:`) so the `@for` track key is
+ * stable + collision-free across the two id spaces.
+ */
+export type NotesListItem =
+  | {
+      kind: "note";
+      id: string;
+      sortAt: number;
+      note: NoteSummary;
+    }
+  | {
+      kind: "org";
+      id: string;
+      sortAt: number;
+      item: OrgItemHeader;
+      /** The origin org's display name (drives the "shared brain" badge label). */
+      orgName: string;
+    };
 
 /**
  * The Notes landing view — a Meetings-style drill-down `[note-folder rail |
@@ -43,6 +78,7 @@ import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.compone
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { "(document:keydown.escape)": "onEscape()" },
   imports: [
+    RouterLink,
     MurSidebarComponent,
     OrganizeSheetComponent,
     LockSharesDialogComponent,
@@ -53,9 +89,11 @@ import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.compone
 export class NotesHomeComponent implements OnInit {
   private readonly notes = inject(NotesService);
   private readonly folders = inject(FoldersService);
+  private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
   /**
    * Shared lock×shares flow (probe → warn/revoke dialog → lock). The SAME flow the
    * meetings tree runs, so locking a note-folder with live shares also warns before
@@ -78,6 +116,108 @@ export class NotesHomeComponent implements OnInit {
   /** True while a create-note IPC call is in flight (guards the "New note" button). */
   readonly creating = signal(false);
 
+  // --- Org (Shared Brain) shared-brain notes ------------------------------
+  /**
+   * Every org (Shared Brain) this user belongs to — the rail's "Shared brains"
+   * section + the source of merged org items in "All notes". Loaded stale-guarded
+   * on init, on the `org-feed-updated` event, and on window focus.
+   */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  readonly orgs = this._orgs.asReadonly();
+  /**
+   * The org's shared items keyed by orgId (`listOrgItems`). A flat parallel signal
+   * (not per-org sub-signals) so the merged `listItems` computed re-derives on any
+   * change. Populated alongside {@link _orgs} in {@link loadOrgs}.
+   */
+  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  /**
+   * Selected org id in the rail (null ⇒ not viewing a specific org). MUTUALLY
+   * exclusive with a note-folder selection: selecting an org clears
+   * {@link activeFolderId} back to the "All notes" root and vice-versa, so the
+   * content pane has exactly one active scope.
+   */
+  readonly activeOrgId = signal<string | null>(null);
+  /** True while the org list + items are (re)loading (rail hint only). */
+  readonly orgsLoading = signal(false);
+  /** The org whose items are shown when an org is rail-selected (null otherwise). */
+  readonly activeOrg = computed<OrgStatus | null>(() => {
+    const oid = this.activeOrgId();
+    return oid === null
+      ? null
+      : (this._orgs().find((o) => o.orgId === oid) ?? null);
+  });
+
+  /**
+   * The unified content list feeding the pane, sorted by date desc:
+   *  - a specific org rail-selected ⇒ ONLY that org's items;
+   *  - "All notes" (no folder, no org) ⇒ your authored notes MERGED with EVERY
+   *    org's shared items;
+   *  - a specific note-folder ⇒ only that folder's authored notes (no org items).
+   * Org items never carry a lock (they are deliberately-disclosed org content) —
+   * only authored notes can be masked.
+   */
+  readonly listItems = computed<NotesListItem[]>(() => {
+    const orgId = this.activeOrgId();
+    const orgItemsByOrg = this._orgItems();
+    const orgs = this._orgs();
+    const orgNameById = new Map(orgs.map((o) => [o.orgId, o.name]));
+
+    // A specific org selected: show ONLY that org's items.
+    if (orgId !== null) {
+      const name = orgNameById.get(orgId) ?? "";
+      return (orgItemsByOrg[orgId] ?? [])
+        .map((item) => this.toOrgCard(item, name))
+        .sort((a, b) => b.sortAt - a.sortAt);
+    }
+
+    const noteCards: NotesListItem[] = this.noteList().map((note) => ({
+      kind: "note" as const,
+      id: `note:${note.id}`,
+      sortAt: note.updatedAt,
+      note,
+    }));
+
+    // A specific note-folder is selected (not "All notes"): authored notes only.
+    if (this.activeFolderId() !== null) {
+      return noteCards.sort((a, b) => b.sortAt - a.sortAt);
+    }
+
+    // "All notes": merge YOUR notes with EVERY org's shared items.
+    const orgCards: NotesListItem[] = orgs.flatMap((o) =>
+      (orgItemsByOrg[o.orgId] ?? []).map((item) =>
+        this.toOrgCard(item, o.name),
+      ),
+    );
+    return [...noteCards, ...orgCards].sort((a, b) => b.sortAt - a.sortAt);
+  });
+
+  /** True when the unified list has zero rows (drives the empty state). */
+  readonly listEmpty = computed(() => this.listItems().length === 0);
+
+  /** Build an org card from a header + its origin org name. */
+  private toOrgCard(item: OrgItemHeader, orgName: string): NotesListItem {
+    const t = Date.parse(item.createdAt);
+    return {
+      kind: "org",
+      id: `org:${item.itemId}`,
+      sortAt: Number.isNaN(t) ? 0 : t,
+      item,
+      orgName,
+    };
+  }
+
+  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
+  private orgFeedUnlisten: UnlistenFn | null = null;
+  /** True once destroyed — so a `listen()` that resolves AFTER teardown releases immediately
+   * (distinct from `orgFeedUnlisten === null`, which also means "not yet resolved"). */
+  private orgFeedDestroyed = false;
+  /** Bumped per org load so a late (stale) reload result is dropped (T1 guard). */
+  private orgLoadSeq = 0;
+  /** Bound window-focus handler — re-loads org items when the view regains focus. */
+  private readonly onWindowFocus = (): void => {
+    void this.loadOrgs();
+  };
+
   /** The active folder node (null for the "All notes" root). */
   readonly activeFolder = computed<NoteFolder | null>(() => {
     const fid = this.activeFolderId();
@@ -86,8 +226,13 @@ export class NotesHomeComponent implements OnInit {
       : (this.noteFolders().find((f) => f.id === fid) ?? null);
   });
 
-  /** The active folder's display name, or "All notes" for the null selection. */
-  readonly listHeading = computed(() => this.activeFolder()?.name ?? "All notes");
+  /**
+   * The content-pane heading: the active org's name when an org is selected, else
+   * the active note-folder's name, else "All notes" for the root selection.
+   */
+  readonly listHeading = computed(
+    () => this.activeOrg()?.name ?? this.activeFolder()?.name ?? "All notes",
+  );
 
   /** True when the active folder is sealed (drives the locked-folder banner). */
   readonly activeFolderLocked = computed(() => !!this.activeFolder()?.locked);
@@ -132,12 +277,110 @@ export class NotesHomeComponent implements OnInit {
   readonly organizeOpen = computed(() => this.organizePlan() !== null);
 
   async ngOnInit(): Promise<void> {
-    // Load the note-folder rail + the (all-notes) list in parallel; settle each
-    // independently so a folder-load failure never blanks the note list.
+    // Live-refresh: the background org-sync loop fires `org-feed-updated` on a
+    // productive tick (≥1 ingest/tombstone). Subscribe ONCE (push straight into a
+    // reload — NEVER subscribe-into-a-field), and re-load org items when the view
+    // regains focus. Both cleaned up on destroy (release the UnlistenFn + the
+    // focus handler).
+    this.destroyRef.onDestroy(() => {
+      this.orgFeedDestroyed = true;
+      this.orgFeedUnlisten?.();
+      this.orgFeedUnlisten = null;
+      window.removeEventListener("focus", this.onWindowFocus);
+    });
+    window.addEventListener("focus", this.onWindowFocus);
+    void this.ipc
+      .onOrgFeedUpdated(() => void this.loadOrgs())
+      .then((un) => {
+        // If the view was already torn down before the listener resolved, release
+        // it immediately (never leak a subscription past destroy).
+        if (this.orgFeedDestroyed) {
+          un();
+        } else {
+          this.orgFeedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
+      });
+
+    // Load the note-folder rail + the (all-notes) list + the org list in parallel;
+    // settle each independently so one load's failure never blanks the others.
     await Promise.allSettled([
       this.notes.loadFolders(),
       this.notes.loadNotes(null),
+      this.loadOrgs(),
     ]);
+  }
+
+  /**
+   * (Re)load the org (Shared Brain) list + every org's shared items, stale-guarded
+   * on {@link orgLoadSeq} so a late reload (event / focus / init racing) never
+   * overwrites a newer result. Best-effort throughout: `orgRefresh` (server
+   * membership discovery) and each per-org `listOrgItems` swallow their own
+   * failures so a transient/offline error leaves the last-known list standing
+   * rather than blanking the pane. Never throws.
+   */
+  async loadOrgs(): Promise<void> {
+    const seq = ++this.orgLoadSeq;
+    this.orgsLoading.set(true);
+    try {
+      // Discover freshly-invited orgs before reading the local replica (best-effort).
+      try {
+        await this.ipc.orgRefresh();
+      } catch {
+        /* offline / no server → fall through to the local replica */
+      }
+      let orgs: OrgStatus[];
+      try {
+        orgs = await this.ipc.orgListStatuses();
+      } catch {
+        return; // keep the last-known orgs on a transient failure
+      }
+      if (seq !== this.orgLoadSeq) {
+        return; // a newer load superseded this one — drop the result
+      }
+      // Pull each org's browsable items in parallel; a per-org failure yields [].
+      const itemLists = await Promise.all(
+        orgs.map((o) =>
+          this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
+        ),
+      );
+      if (seq !== this.orgLoadSeq) {
+        return;
+      }
+      const byOrg: Record<string, OrgItemHeader[]> = {};
+      orgs.forEach((o, i) => {
+        byOrg[o.orgId] = itemLists[i];
+      });
+      this._orgs.set(orgs);
+      this._orgItems.set(byOrg);
+      // If the rail's selected org has since disappeared, fall back to "All notes".
+      const sel = this.activeOrgId();
+      if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
+        this.activeOrgId.set(null);
+      }
+    } finally {
+      if (seq === this.orgLoadSeq) {
+        this.orgsLoading.set(false);
+      }
+    }
+  }
+
+  /**
+   * Rail-select an org (Shared Brain): the pane shows ONLY that org's shared
+   * items. Mutually exclusive with a note-folder selection — clears
+   * {@link activeFolderId} back to the root + closes any open move popover.
+   */
+  selectOrg(orgId: string): void {
+    this.movePopoverId.set(null);
+    this.activeFolderId.set(null);
+    this.activeOrgId.set(orgId);
+  }
+
+  /** A friendly role hint for the rail ("Owner" / "Member"). */
+  orgRoleLabel(org: OrgStatus): string {
+    return org.role === "owner" ? "Owner" : "Member";
   }
 
   /** Esc backs out — but never mid-edit in a field, and it closes open transient UI first. */
@@ -162,12 +405,18 @@ export class NotesHomeComponent implements OnInit {
     this.nav.back();
   }
 
-  /** Select a note-folder (or null for "All notes") and reload its notes. */
+  /**
+   * Select a note-folder (or null for "All notes") and reload its notes. Clears
+   * any active org selection (the two rail scopes are mutually exclusive). A
+   * no-op re-select of the SAME folder while no org is active is skipped — but a
+   * re-select of "All notes" WHILE an org is active still runs, to drop the org.
+   */
   async selectFolder(folderId: string | null): Promise<void> {
     this.movePopoverId.set(null);
-    if (this.activeFolderId() === folderId) {
+    if (this.activeFolderId() === folderId && this.activeOrgId() === null) {
       return;
     }
+    this.activeOrgId.set(null);
     this.activeFolderId.set(folderId);
     await this.notes.loadNotes(folderId);
   }
@@ -457,6 +706,19 @@ export class NotesHomeComponent implements OnInit {
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+    });
+  }
+
+  /** Presentational only: an ISO timestamp (org item `createdAt`) → a friendly date. */
+  formatOrgDate(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) {
+      return "";
+    }
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
     });
   }
 }


### PR DESCRIPTION
Org shared-brain notes were only visible in Settings → Organization, and syncing was manual. This brings them into the main Notes view and makes sync automatic.

- **All notes**: your notes merged with every org's shared items (each org card badged with the org name, e.g. **Siema**); org items open the read-only \`/org-item\` viewer, your notes open the editor.
- **Org picker**: a "Shared brains" section in the Notes rail lists every org you belong to (Owner/Member); selecting one scopes the pane to that org.
- **Global auto-sync every 2 min**: \`ORG_SYNC_TICK_SECS\` 300 → 120 (the background loop already reconciles + pulls + ingests). A content-free \`org-feed-updated\` event fires after a productive tick so the open Notes view **live-refreshes** — no manual "Sync now".
- Guarded the live-refresh listener against the destroy-while-pending race (release the UnlistenFn if the view tore down before \`listen()\` resolved).

## Verification
- \`cargo test --lib\` **1513**; \`ng lint\`/\`ng build\` + Playwright e2e (\`notes-org\` merge/picker/routing) green; \`bash scripts/ci.sh\` green.
- **adversarial-verifier: PASS** — it FAILed once on a subscription leak on the destroy-while-pending race; this fixes it (RED→GREEN proven with an instrumented listen/release harness).