### PR TITLE
feat(org): editable-by-author org items, re-publish on edit, richer viewer, Back fix, org in Meetings (0.9.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/e2e/org/org-editable-and-library.spec.ts
+++ b/e2e/org/org-editable-and-library.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * FE smoke for the "org-editable-and-fresh" work against the mocked Tauri IPC
+ * (no Rust core). Covers:
+ *   B1 — the org-item viewer Back button navigates to /notes (was a no-op).
+ *   F1 — org (Shared Brain) items appear in the Library: a "Shared brains" rail
+ *        section + merged in the all-meetings list; selecting an org shows only
+ *        its items.
+ *   F2 — the /org-item viewer resolves the local source and redirects the AUTHOR
+ *        (org_resolve_source → { kind:'document' }) to /notes/:id; a null resolve
+ *        renders the read-only view (F3) with the metadata strip.
+ * NOT proof of end-to-end behavior (no OCK / no server) — a render + routing +
+ * no-console-error smoke. Overrides run PAGE-SIDE (self-contained strings).
+ */
+
+const ORG_STATUSES = () => [
+  {
+    orgId: "org-1",
+    name: "Acme Inc.",
+    role: "owner",
+    memberCount: 3,
+    consented: true,
+    lastSeq: 42,
+    itemCount: 2,
+    receivedCount: 2,
+    pendingShares: 0,
+  },
+];
+
+const ORG_ITEMS = () => [
+  {
+    itemId: "it-1",
+    title: "Acme onboarding brief",
+    authorHint: "kasia",
+    createdAt: "2026-07-10T09:00:00Z",
+    seq: 2,
+  },
+  {
+    itemId: "it-2",
+    title: "Pricing rework notes",
+    authorHint: "alex",
+    createdAt: "2026-07-09T15:30:00Z",
+    seq: 1,
+  },
+];
+
+test.describe("org-editable + library unification (mocked IPC)", () => {
+  test("F1 — Library shows the Shared brains rail + merged org items", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      org_refresh: () => null,
+      org_list_statuses: ORG_STATUSES,
+      list_org_items: ORG_ITEMS,
+    });
+    await page.goto("/library");
+
+    // The rail "Shared brains" section + the org row render.
+    await expect(page.getByText("Shared brains")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator(".org-row", { hasText: "Acme Inc." })).toBeVisible();
+
+    // The all-meetings list MERGES org items — an org card links to /org-item/:id.
+    await expect(
+      page.locator("a[href='/org-item/it-1']"),
+    ).toBeVisible();
+    await expect(page.getByText("Acme onboarding brief")).toBeVisible();
+
+    // Selecting the org narrows to ONLY that org's items (heading = org name).
+    await page.locator(".org-row", { hasText: "Acme Inc." }).click();
+    await expect(
+      page.locator(".library-head h2", { hasText: "Acme Inc." }),
+    ).toBeVisible();
+    await expect(page.locator("a[href='/org-item/it-2']")).toBeVisible();
+  });
+
+  test("B1+F3 — read-only viewer (null resolve) renders + Back goes to /notes", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // Non-author: no local editable source → the read-only view.
+      org_resolve_source: () => null,
+      org_get_item: () => ({
+        itemId: "it-1",
+        authorHint: "kasia",
+        title: "Acme onboarding brief",
+        createdAt: "2026-07-10T09:00:00Z",
+        rev: 3,
+        markdown: "# Acme onboarding brief\n\n- Kickoff Monday\n- Owner: Kasia",
+      }),
+      org_refresh: () => null,
+      org_list_statuses: ORG_STATUSES,
+      list_org_items: ORG_ITEMS,
+    });
+    await page.goto("/org-item/it-1");
+
+    // The rich read-only view: title + Org Brain badge + revision + body.
+    await expect(page.locator(".oi-title")).toHaveText("Acme onboarding brief", {
+      timeout: 10_000,
+    });
+    await expect(page.getByText("Org Brain")).toBeVisible();
+    await expect(page.getByText("revision 3")).toBeVisible();
+    await expect(page.getByText("Shared by kasia")).toBeVisible();
+    // The org name resolves into the metadata strip (best-effort match).
+    await expect(page.locator(".oi-org-name")).toHaveText("Acme Inc.");
+
+    // Back → /notes (B1).
+    await page.getByRole("button", { name: /notes/i }).first().click();
+    await expect(page).toHaveURL(/\/notes$/, { timeout: 10_000 });
+  });
+
+  test("F2 — the AUTHOR is redirected to their editable note", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // Author: local source resolves → redirect to the editable /notes/:id.
+      org_resolve_source: () => ({ kind: "document", sourceId: "note-42" }),
+      // Note-editor load path (best-effort defaults for a smooth render).
+      get_note: () => ({
+        id: "note-42",
+        title: "Acme onboarding brief",
+        folderId: "f-notes-root",
+        markdown: "# Acme onboarding brief\n\nBody.",
+        tags: [],
+        properties: {},
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+        exportedPath: null,
+        locked: false,
+        shared: true,
+      }),
+      list_note_folders: () => [],
+      list_notes: () => [],
+    });
+    await page.goto("/org-item/it-1");
+
+    // The viewer redirects (replaceUrl) to the editable note editor.
+    await expect(page).toHaveURL(/\/notes\/note-42$/, { timeout: 10_000 });
+    await expect(page.locator("app-note-editor")).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.4"
+version = "0.9.5"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1468,13 +1468,19 @@ pub fn get_last_note(state: State<'_, AppState>) -> Result<Option<NoteDto>, AppE
 
 /// Replace a meeting note's markdown (in-app edit) and re-write the SAME vault file in
 /// place (no duplicate). Returns the updated note.
+///
+/// COMMIT BOUNDARY: after the local write succeeds, BEST-EFFORT re-publish any org shares of this
+/// meeting so a colleague sees the edit (never frozen at share time). Best-effort — a republish
+/// failure NEVER fails the save (`let _ = …`); the launch sweep retries a `failed` row.
 #[tauri::command]
-pub fn update_note(
+pub async fn update_note(
     state: State<'_, AppState>,
     meeting_id: String,
     markdown: String,
 ) -> Result<NoteDto, AppError> {
-    update_note_inner(state.inner(), &meeting_id, &markdown)
+    let dto = update_note_inner(state.inner(), &meeting_id, &markdown)?;
+    let _ = republish_org_shares_for_source(state.inner(), Some(&meeting_id), None).await;
+    Ok(dto)
 }
 
 /// Inner of [`update_note`] taking `&AppState` — the FULL command body (gate + lifecycle guard +
@@ -2455,14 +2461,20 @@ pub(crate) fn list_notes_inner(
 /// Update a note's title + markdown (write path). WRITE-GATED. Bumps `updated_at`, PURGES the old
 /// `doc_chunks` and re-chunks+re-embeds the new BODY (front-matter stripped) so the note stays a
 /// first-class brain source, then re-exports the vault `.md`. Returns the fresh DTO.
+///
+/// COMMIT BOUNDARY (authored-note full save): after the local write succeeds, BEST-EFFORT re-publish
+/// any org shares of this note (never freeze the org copy at share time). NOT the debounced
+/// `save_note_text` autosave (OCK-seal + egress per keystroke is unacceptable) — only this commit path.
 #[tauri::command]
-pub fn update_note_doc(
+pub async fn update_note_doc(
     state: State<'_, AppState>,
     id: String,
     title: String,
     markdown: String,
 ) -> Result<NoteDoc, AppError> {
-    update_note_doc_inner(state.inner(), &id, &title, &markdown)
+    let doc = update_note_doc_inner(state.inner(), &id, &title, &markdown)?;
+    let _ = republish_org_shares_for_source(state.inner(), None, Some(&id)).await;
+    Ok(doc)
 }
 
 /// Inner of [`update_note_doc`] taking `&AppState` (unit-testable gate).
@@ -7893,6 +7905,9 @@ pub async fn resummarize(
         ));
     }
     let result = pipeline::resummarize_existing(&app, &state, &meeting_id).await?;
+    // COMMIT BOUNDARY: a re-summarize rewrites the meeting's note → BEST-EFFORT re-publish any org
+    // shares of it so members see the fresh summary. Best-effort — never fails the re-summarize.
+    let _ = republish_org_shares_for_source(state.inner(), Some(&meeting_id), None).await;
     Ok(StopResult {
         meeting_id: result.meeting_id,
         markdown: result.note_markdown,
@@ -22996,6 +23011,413 @@ mod lifecycle_tests {
         );
     }
 
+    // ── RE-PUBLISH-ON-EDIT (the stale-org-copy fix) — end-to-end against a MOCK org server ─────────
+
+    /// What a `MockOrgServer` recorded across a test: the sequence of published item ids (one per
+    /// `POST …/items`) and the set of tombstoned item ids (one per `DELETE …/items/{id}`). Lets a
+    /// republish test assert BOTH the new-item-published AND the old-item-tombstoned sides.
+    #[derive(Default)]
+    struct MockOrgLog {
+        published: Vec<String>,
+        tombstoned: Vec<String>,
+    }
+
+    /// A minimal in-process org server (tiny_http) that answers the THREE routes the org publish/
+    /// republish flow hits — `POST /v1/blobs`, `POST /v1/orgs/{id}/items` (mints a fresh item id +
+    /// monotonic seq), `DELETE /v1/orgs/{id}/items/{id}` — so the full seal→upload→publish→tombstone
+    /// chain runs headless WITHOUT a real backend. The OCK is pre-seeded into `org_ock_cache` so
+    /// `acquire_org_ock` never needs the (unmocked) key-grants endpoint. Shuts down on drop.
+    struct MockOrgServer {
+        base: String,
+        log: Arc<Mutex<MockOrgLog>>,
+        shutdown: Arc<AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl MockOrgServer {
+        fn start() -> Self {
+            let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+            let addr = server.server_addr();
+            let base = format!("http://{}/", addr.to_ip().unwrap());
+            let log = Arc::new(Mutex::new(MockOrgLog::default()));
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let log_t = Arc::clone(&log);
+            let shutdown_t = Arc::clone(&shutdown);
+            let handle = std::thread::spawn(move || {
+                let mut seq: u64 = 0;
+                let mut counter: u64 = 0;
+                loop {
+                    if shutdown_t.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    match server.recv_timeout(std::time::Duration::from_millis(50)) {
+                        Ok(Some(req)) => {
+                            let method = req.method().clone();
+                            let url = req.url().to_string();
+                            let path = url.split('?').next().unwrap_or("").to_string();
+                            // POST /v1/blobs → {"blobId": "..."}
+                            if method == tiny_http::Method::Post && path == "/v1/blobs" {
+                                counter += 1;
+                                let body = format!("{{\"blobId\":\"blob-{counter}\"}}");
+                                let resp = tiny_http::Response::from_string(body).with_header(
+                                    "Content-Type: application/json".parse::<tiny_http::Header>().unwrap(),
+                                );
+                                let _ = req.respond(resp);
+                                continue;
+                            }
+                            // POST /v1/orgs/{id}/items → {"itemId": "...", "seq": N} (fresh id each call)
+                            if method == tiny_http::Method::Post
+                                && path.starts_with("/v1/orgs/")
+                                && path.ends_with("/items")
+                            {
+                                seq += 1;
+                                let item_id = format!("item-{seq}");
+                                log_t.lock().unwrap().published.push(item_id.clone());
+                                let body = format!("{{\"itemId\":\"{item_id}\",\"seq\":{seq}}}");
+                                let resp = tiny_http::Response::from_string(body).with_header(
+                                    "Content-Type: application/json".parse::<tiny_http::Header>().unwrap(),
+                                );
+                                let _ = req.respond(resp);
+                                continue;
+                            }
+                            // DELETE /v1/orgs/{id}/items/{itemId} → 200 (tombstone)
+                            if method == tiny_http::Method::Delete
+                                && path.contains("/items/")
+                                && !path.ends_with("/items")
+                            {
+                                if let Some(item) = path.rsplit('/').next() {
+                                    log_t.lock().unwrap().tombstoned.push(item.to_string());
+                                }
+                                let _ = req.respond(tiny_http::Response::empty(200));
+                                continue;
+                            }
+                            let _ = req.respond(tiny_http::Response::empty(404));
+                        }
+                        Ok(None) => continue,
+                        Err(_) => break,
+                    }
+                }
+            });
+            Self {
+                base,
+                log,
+                shutdown,
+                handle: Some(handle),
+            }
+        }
+    }
+
+    impl Drop for MockOrgServer {
+        fn drop(&mut self) {
+            self.shutdown.store(true, Ordering::SeqCst);
+            if let Some(h) = self.handle.take() {
+                let _ = h.join();
+            }
+        }
+    }
+
+    /// Seed a live (non-expiring) session so `require_session_mk` / `valid_access_token` yield a bearer
+    /// with NO network refresh — the mock server never sees an auth call.
+    fn seed_live_session(state: &AppState) {
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "user@example.com".into(),
+            email: "user@example.com".into(),
+            server_user_id: Some("c534b6d2-02c1-4c2c-a256-3af8592b1567".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+    }
+
+    /// Pre-seed the session OCK cache for `(org_id, generation)` so `acquire_org_ock` hits the cache
+    /// and never touches the (unmocked) key-grants endpoint.
+    fn seed_ock(state: &AppState, org_id: &str, generation: u32) {
+        state
+            .org_ock_cache
+            .lock()
+            .unwrap()
+            .insert((org_id.to_string(), generation), Zeroizing::new([9u8; 32]));
+    }
+
+    /// ITEM 1 — the core republish-on-edit assertion. Share a DOC to a mock org (item rev 1, one
+    /// `uploaded` `org_shares` row), then EDIT the note body → the edit re-publishes as a NEW item at
+    /// rev 2, the SAME single org_shares row is repointed (new item_id, rev==2, new content hash), the
+    /// OLD item is tombstoned, and the egress ledger carries a publish+revoke pair. RED on the old code
+    /// (no edit path re-published → org copy frozen at rev 1); GREEN after.
+    #[test]
+    fn republish_bumps_rev_and_tombstones_old_on_edit() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-republish-edit");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-rp", "Team");
+        state
+            .db
+            .insert_note("n-rp", "f-rp", "plan", "Q3 Plan", "# original body", 1)
+            .unwrap();
+
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        // Initial share → item-1, rev 1, one uploaded row.
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-rp".to_string()),
+            true,
+        ))
+        .expect("initial share should publish against the mock server");
+        assert_eq!(entry.rev, 1, "first share is rev 1");
+        assert_eq!(entry.item_id.as_deref(), Some("item-1"));
+        let rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(rows.len(), 1, "one uploaded share row after the initial share");
+        assert_eq!(rows[0].state, "uploaded");
+        assert_eq!(rows[0].item_id.as_deref(), Some("item-1"));
+        let sha_before = rows[0].content_sha256.clone();
+
+        // EDIT the note body through the COMMIT boundary. The async command wrapper is exactly
+        // `update_note_doc_inner(..)?` then `republish_org_shares_for_source(..).await` — replicate
+        // those two steps (a real `tauri::State` can't be constructed in a unit test).
+        update_note_doc_inner(&state, "n-rp", "Q3 Plan", "# EDITED body — the org copy must reflect this")
+            .unwrap();
+        block_on(republish_org_shares_for_source(&state, None, Some("n-rp"))).unwrap();
+
+        // The edit superseded the org item: a NEW item published, rev bumped, SAME row repointed.
+        let after = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "still ONE org_shares row after republish (no row amplification)"
+        );
+        assert_eq!(after[0].state, "uploaded");
+        assert_eq!(after[0].rev, 2, "rev bumped to 2 on the edit republish");
+        assert_eq!(
+            after[0].item_id.as_deref(),
+            Some("item-2"),
+            "the row was repointed to the NEW server item"
+        );
+        assert_ne!(
+            after[0].content_sha256, sha_before,
+            "content hash changed (the body was edited)"
+        );
+
+        // The mock server saw two publishes and the OLD item tombstoned.
+        let log = mock.log.lock().unwrap();
+        assert_eq!(log.published, vec!["item-1".to_string(), "item-2".to_string()]);
+        assert_eq!(
+            log.tombstoned,
+            vec!["item-1".to_string()],
+            "the OLD item (item-1) was tombstoned so members evict the stale copy"
+        );
+
+        // Egress ledger: two publishes + one revoke (all content-free).
+        assert_eq!(
+            state.db.count_share_egress_by_kind("org_share_publish").unwrap(),
+            2
+        );
+        assert_eq!(
+            state.db.count_share_egress_by_kind("org_share_revoke").unwrap(),
+            1
+        );
+    }
+
+    /// ITEM 1 — a republish MUST NOT tombstone-into-nothing. Lock the note's folder AFTER the share,
+    /// then edit (the write itself is gated, but even the republish read-gate refuses): the org copy is
+    /// left UNTOUCHED — no new publish, NO tombstone. Proves the `Locked` skip protects the org copy.
+    #[test]
+    fn republish_refuses_when_folder_locked() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-republish-locked");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-lk", "Team");
+        state
+            .db
+            .insert_note("n-lk", "f-lk", "plan", "Plan", "# body", 1)
+            .unwrap();
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-lk".to_string()),
+            true,
+        ))
+        .unwrap();
+
+        // Lock the folder (NOT session-unlocked) → the build_org_share_body read-gate refuses.
+        state
+            .db
+            .set_folder_locked("f-lk", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        // Republish directly (an edit would be gated too; here we exercise the republish skip path).
+        block_on(republish_org_shares_for_source(&state, None, Some("n-lk"))).unwrap();
+
+        let rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].rev, 1, "rev NOT bumped — republish skipped a locked source");
+        assert_eq!(
+            rows[0].item_id.as_deref(),
+            Some("item-1"),
+            "org copy left as-is (still item-1)"
+        );
+        let log = mock.log.lock().unwrap();
+        assert_eq!(log.published, vec!["item-1".to_string()], "no new publish");
+        assert!(log.tombstoned.is_empty(), "NEVER tombstone-into-nothing on a locked source");
+    }
+
+    /// ITEM 1 — unchanged content ⇒ NO egress. Re-save the IDENTICAL body → the content hash matches
+    /// the stored row → republish short-circuits: no new item, no tombstone, no egress ledger row.
+    #[test]
+    fn republish_noop_when_content_unchanged() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-republish-noop");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-nc", "Team");
+        state
+            .db
+            .insert_note("n-nc", "f-nc", "plan", "Plan", "# same body", 1)
+            .unwrap();
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-nc".to_string()),
+            true,
+        ))
+        .unwrap();
+        let publishes_before = state.db.count_share_egress_by_kind("org_share_publish").unwrap();
+
+        // Re-save the SAME body (title unchanged too) → identical envelope hash → no-op republish.
+        update_note_doc_inner(&state, "n-nc", "Plan", "# same body").unwrap();
+        block_on(republish_org_shares_for_source(&state, None, Some("n-nc"))).unwrap();
+
+        let rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(rows[0].rev, 1, "no rev bump on unchanged content");
+        assert_eq!(rows[0].item_id.as_deref(), Some("item-1"));
+        assert_eq!(
+            state.db.count_share_egress_by_kind("org_share_publish").unwrap(),
+            publishes_before,
+            "unchanged content ⇒ NO new publish egress"
+        );
+        let log = mock.log.lock().unwrap();
+        assert_eq!(log.published, vec!["item-1".to_string()], "no second publish");
+        assert!(log.tombstoned.is_empty(), "no tombstone on a no-op republish");
+    }
+
+    /// ITEM 6 — the MEETING arm: share a MEETING note → edit the meeting note via `update_note` → the
+    /// same supersede (new item rev 2, repointed row, old item tombstoned) fires for the meeting path.
+    #[test]
+    fn republish_meeting_note_bumps_rev_and_tombstones_old() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-republish-meeting");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-mtg", "Team");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-rp".to_string(),
+                started_at: "2026-07-10T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Board strategy".to_string()),
+                duration_s: 600,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: Some("f-mtg".to_string()),
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m-rp".to_string(),
+                provider_id: "claude_code".to_string(),
+                markdown: "# meeting note original".to_string(),
+                created_at: "2026-07-10T09:10:00Z".to_string(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state.db.set_note_folder("m-rp", Some("f-mtg")).unwrap();
+
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            Some("m-rp".to_string()),
+            None,
+            true,
+        ))
+        .unwrap();
+
+        // Edit the meeting note through the commit boundary (inner + republish, as the wrapper does).
+        update_note_inner(&state, "m-rp", "# meeting note EDITED").unwrap();
+        block_on(republish_org_shares_for_source(&state, Some("m-rp"), None)).unwrap();
+
+        let rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(rows.len(), 1, "one repointed row for the meeting share");
+        assert_eq!(rows[0].rev, 2, "meeting republish bumped rev to 2");
+        assert_eq!(rows[0].item_id.as_deref(), Some("item-2"));
+        assert_eq!(rows[0].meeting_id.as_deref(), Some("m-rp"));
+        let log = mock.log.lock().unwrap();
+        assert_eq!(log.published, vec!["item-1".to_string(), "item-2".to_string()]);
+        assert_eq!(log.tombstoned, vec!["item-1".to_string()]);
+    }
+
+    /// ITEM 2 — `org_resolve_source` maps an uploaded org item back to its LOCAL editable source, and
+    /// returns `None` for an unknown item id (a colleague's item this device never published).
+    #[test]
+    fn org_resolve_source_maps_item_to_local_source() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-resolve-source");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-rs", "Team");
+        state
+            .db
+            .insert_note("n-rs", "f-rs", "plan", "Plan", "# body", 1)
+            .unwrap();
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-rs".to_string()),
+            true,
+        ))
+        .unwrap();
+        let item_id = entry.item_id.unwrap();
+
+        let resolved = org_resolve_source_inner(&state, &item_id).unwrap().unwrap();
+        assert_eq!(resolved.kind, "document");
+        assert_eq!(resolved.source_id, "n-rs");
+
+        // An unknown item (not published by THIS device) → None.
+        assert!(org_resolve_source_inner(&state, "item-unknown").unwrap().is_none());
+    }
+
     /// F1 (org_leave targets the SPECIFIED org's local state). `org_leave` deletes the local org row +
     /// purges the replica for the org the FE picked. It first calls the server (unreachable here), so
     /// we drive the DB-side purge through the same helper `org_leave` uses (`delete_org_state`) against
@@ -23620,6 +24042,19 @@ pub struct OrgShareEntry {
     pub shared_at: String,
     pub rev: u32,
     pub state: String,
+}
+
+/// The LOCAL editable SOURCE behind an org item, if the CALLER is its author. `org_resolve_source`
+/// returns `Some` only when THIS device holds the `org_shares` row for the item (i.e. the caller
+/// published it) — so a member reading a colleague's org item gets `None` (no editable source). The
+/// FE uses it to route an org-item viewer to the real note/meeting editor for one's OWN shares.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgSourceRef {
+    /// `"document"` (an authored note) or `"meeting"` (a meeting note).
+    pub kind: String,
+    /// The local `documents.id` (for a note) or `meetings.id` (for a meeting).
+    pub source_id: String,
 }
 
 /// The org-scoped "grant author" identity id we pin the OCK granter on. For v1 (single-org, owner
@@ -24512,6 +24947,26 @@ pub(crate) async fn share_to_org_inner(
     document_id: Option<String>,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
+    // Initial share = rev 1. A re-publish-on-edit supersede bumps the rev (see
+    // `republish_org_shares_for_source`, which calls `publish_org_body` with `old_rev + 1`).
+    publish_org_body(state, org_id, meeting_id, document_id, scrub, 1).await
+}
+
+/// The org publish CORE, shared by the FIRST share (`share_to_org_inner`, `rev = 1`) and the
+/// re-publish-on-edit supersede (`republish_org_shares_for_source`, `rev = old_rev + 1`). It owns the
+/// FULL gate chain so a republish INHERITS it rather than re-implementing (the leak-safety single
+/// seam): (1) read-gate + (3) clean + (4) scrub via `build_org_share_body`, (2) org-egress consent
+/// fail-closed, (5) OCK seal + LOCAL open-verify-before-publish, (6) blob upload + publish item,
+/// (7) content-free egress ledger. `rev` is stamped into BOTH the `OrgEnvelope` (source_rev) and the
+/// `PublishItemRequest` so members see the supersede.
+pub(crate) async fn publish_org_body(
+    state: &AppState,
+    org_id: &str,
+    meeting_id: Option<String>,
+    document_id: Option<String>,
+    scrub: bool,
+    rev: u32,
+) -> Result<OrgShareEntry, AppError> {
     // (1) READ-GATE + (3) clean + (4) scrub — all inside `build_org_share_body` (read-gate FIRST).
     let (title, markdown, created_at, _counts, kind) = build_org_share_body(
         state,
@@ -24563,7 +25018,7 @@ pub(crate) async fn share_to_org_inner(
         markdown,
         author_hint,
         created_at,
-        1,
+        rev,
     );
     let content_sha = env.content_sha256();
     // SB-3 row-amplification fix: REUSE any existing retriable (`queued`/`failed`) row for this
@@ -24581,7 +25036,7 @@ pub(crate) async fn share_to_org_inner(
             state.db.reset_org_share_for_retry(
                 &existing.id,
                 Some(&title),
-                1,
+                rev,
                 generation,
                 &content_sha,
                 &now,
@@ -24597,7 +25052,7 @@ pub(crate) async fn share_to_org_inner(
                 document_id.as_deref(),
                 kind.as_str(),
                 Some(&title),
-                1,
+                rev,
                 generation,
                 &content_sha,
                 &now,
@@ -24641,7 +25096,7 @@ pub(crate) async fn share_to_org_inner(
             crate::share::org_dto::PublishItemRequest {
                 blob_id,
                 content_sha256: content_sha.clone(),
-                rev: 1,
+                rev,
                 generation,
             },
         )
@@ -24670,9 +25125,228 @@ pub(crate) async fn share_to_org_inner(
         kind: kind.as_str().to_string(),
         title: Some(title),
         shared_at: now,
-        rev: 1,
+        rev,
         state: "uploaded".to_string(),
     })
+}
+
+/// RE-PUBLISH-ON-EDIT (the stale-org-copy fix). When the author edits a note/meeting they have
+/// already shared into one or more orgs, the org copy would otherwise stay FROZEN at share time (the
+/// blob is written ONCE by the initial share; nothing re-publishes; the feed has no in-place update —
+/// `org_publish_item` mints a NEW server item_id every call and members key on item_id). The only
+/// correct supersede is TOMBSTONE-OLD + PUBLISH-NEW-REV, done for EVERY org this source was shared to.
+///
+/// BEST-EFFORT: called AFTER a local write already succeeded. It NEVER fails the save — a network /
+/// transient failure marks the row `failed` so the existing launch sweep re-publishes it later (the
+/// intent is not lost), and the whole helper swallows its own error at the call site (`let _ = …`).
+///
+/// Per uploaded row (across ALL orgs — a note may be shared to several):
+///  - Re-read the CURRENT plaintext THROUGH the read-gate (`build_org_share_body`). If it now refuses
+///    (`Locked` — the folder/meeting got locked since the share) → SKIP (never tombstone-into-nothing;
+///    leave the org copy as-is). Same skip if org-egress consent was withdrawn.
+///  - Short-circuit: if the fresh body's `content_sha256` == the row's stored hash → NO egress, skip.
+///  - Seal a fresh OCK envelope at the item's current generation with local open-verify (the egress
+///    verify-before-destroy) → `put_blob` → `org_publish_item(rev = old_rev + 1)` → REPOINT THE SAME
+///    ROW to the new item_id (`set_org_share_uploaded`, bumping rev + hash — no row amplification) →
+///    THEN tombstone the OLD item so members evict the stale copy. ORDER IS LOAD-BEARING: publish-new
+///    BEFORE tombstone-old (a crash between = a transient dup, recoverable; the reverse risks a window
+///    with NO org copy). Both are ledgered content-free.
+///  - SCRUB INTENT: `org_shares` does not persist the original scrub flag, so republish defaults scrub
+///    ON (fail-safe toward LESS egress — matches the launch sweep's documented default). An edit must
+///    never silently DOWNGRADE scrubbing.
+pub(crate) async fn republish_org_shares_for_source(
+    state: &AppState,
+    meeting_id: Option<&str>,
+    document_id: Option<&str>,
+) -> Result<(), AppError> {
+    let rows = state.db.org_shares_for_source(meeting_id, document_id)?;
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let now = chrono::Utc::now().to_rfc3339();
+    for row in rows {
+        // Re-read the CURRENT plaintext THROUGH the read-gate. `build_org_share_body` also does the
+        // clean+scrub (scrub ON by default — fail-safe toward LESS egress). A `Locked` refusal (the
+        // source got locked since the share) → SKIP without tombstone.
+        let (title, markdown, created_at, _counts, kind) = match build_org_share_body(
+            state,
+            row.meeting_id.as_deref(),
+            row.document_id.as_deref(),
+            true,
+        ) {
+            Ok(v) => v,
+            Err(AppError::Locked(_)) => {
+                tracing::info!(
+                    target: "org",
+                    org_id = %row.org_id,
+                    "republish skipped: source is locked (org copy left as-is)"
+                );
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(target: "org", error = %e, "republish: could not re-read source; skipped");
+                continue;
+            }
+        };
+
+        // Consent could have been withdrawn since the share → SKIP (never egress without consent).
+        {
+            let consented = state
+                .config
+                .lock()
+                .map(|c| c.org_egress_consented)
+                .unwrap_or(false);
+            if !consented {
+                tracing::info!(target: "org", org_id = %row.org_id, "republish skipped: org egress consent withdrawn");
+                continue;
+            }
+        }
+
+        // Author hint = the account's email local-part (a display label, never note content).
+        let author_hint = {
+            let g = match state.account_session.lock() {
+                Ok(g) => g,
+                Err(_) => continue,
+            };
+            crate::share::require_login(&g)
+                .map(|s| org_author_hint(&s.email))
+                .unwrap_or_else(|_| "member".to_string())
+        };
+
+        // Short-circuit: unchanged content ⇒ NO new item, NO egress. `content_sha256` folds
+        // `source_rev` into the canonical bytes, so the stored hash (computed at `row.rev`) must be
+        // compared against a hash at the SAME rev — else every republish would look "changed" purely
+        // because the rev bumped. Build the comparison envelope at `row.rev`; only the PUBLISH envelope
+        // uses `new_rev`.
+        let cmp_env = crate::share::org_envelope::OrgEnvelope::new(
+            kind,
+            title.clone(),
+            markdown.clone(),
+            author_hint.clone(),
+            created_at.clone(),
+            row.rev,
+        );
+        if row.content_sha256.as_deref() == Some(cmp_env.content_sha256().as_slice()) {
+            continue;
+        }
+
+        let new_rev = row.rev.saturating_add(1);
+        let env = crate::share::org_envelope::OrgEnvelope::new(
+            kind,
+            title,
+            markdown,
+            author_hint,
+            created_at,
+            new_rev,
+        );
+        let content_sha = env.content_sha256();
+
+        // Resolve the org + a live session (best-effort: a resolve/session failure just skips this row;
+        // the note is already saved locally). `generation` = the item's CURRENT live generation.
+        let org = match resolve_org(state, &row.org_id) {
+            Ok(o) => o,
+            Err(_) => continue,
+        };
+        let generation = org.generation;
+        let base = match share_base_url(state) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let access_token = match require_session_mk(state).await {
+            Ok((_, _, _, t)) => t,
+            Err(_) => {
+                // No live session → leave the row uploaded (stale); a later save with a session
+                // republishes. NOT a failure (never blocks the save).
+                continue;
+            }
+        };
+        let client = match crate::share::client::ShareClient::new(&base) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        // (5) Seal under the OCK + LOCAL OPEN-VERIFY (egress verify-before-destroy). AAD nonce =
+        // hex(content_sha256) — deterministic + rides the feed so every member reconstructs it.
+        let ock = match acquire_org_ock(state, &org.org_id, generation).await {
+            Ok(k) => k,
+            Err(_) => {
+                state.db.set_org_share_failed(&row.id, "republish_ock_failed", &now)?;
+                continue;
+            }
+        };
+        let item_nonce = org_item_nonce(&content_sha);
+        let ciphertext =
+            match crate::share::org_envelope::seal_org_envelope(&ock, &env, &org.org_id, &item_nonce) {
+                Ok((ct, _)) => ct,
+                Err(_) => {
+                    state.db.set_org_share_failed(&row.id, "republish_seal_failed", &now)?;
+                    continue;
+                }
+            };
+
+        // (6) upload → publish the NEW rev. On failure, mark the row `failed` (the launch sweep retries)
+        // but do NOT tombstone (the OLD copy stays live — never leave the org with no copy).
+        let blob_id = match client.put_blob(&access_token, ciphertext).await {
+            Ok(id) => id,
+            Err(_) => {
+                state.db.set_org_share_failed(&row.id, "republish_upload_failed", &now)?;
+                continue;
+            }
+        };
+        let published = match client
+            .org_publish_item(
+                &access_token,
+                &org.org_id,
+                crate::share::org_dto::PublishItemRequest {
+                    blob_id,
+                    content_sha256: content_sha.clone(),
+                    rev: new_rev,
+                    generation,
+                },
+            )
+            .await
+        {
+            Ok(p) => p,
+            Err(_) => {
+                state.db.set_org_share_failed(&row.id, "republish_publish_failed", &now)?;
+                continue;
+            }
+        };
+
+        // REPOINT THE SAME ROW to the new item (new item_id + bumped rev + fresh hash) — no new row.
+        state.db.reset_org_share_for_retry(
+            &row.id,
+            row.title.as_deref(),
+            new_rev,
+            generation,
+            &content_sha,
+            &now,
+        )?;
+        state
+            .db
+            .set_org_share_uploaded(&row.id, &published.item_id, &now)?;
+        crate::share::ledger_row(&state.db, &client.host(), "org_share_publish", content_sha.len());
+
+        // THEN tombstone the OLD item so members evict the stale copy. Publish-BEFORE-tombstone: a
+        // crash here leaves a transient dup (recoverable), never a window with no org copy. A tombstone
+        // failure is non-fatal — the new copy is already live; the stale one lingers until a revoke.
+        if let Some(old_item) = row.item_id.as_deref() {
+            match client.org_tombstone_item(&access_token, &org.org_id, old_item).await {
+                Ok(()) => {
+                    crate::share::ledger_row(&state.db, &client.host(), "org_share_revoke", 0);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "org",
+                        error = %e,
+                        org_id = %org.org_id,
+                        "republish: superseded item published but old-item tombstone failed (transient dup)"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// `list_org_shares()` — the caller's outbound org shares (local rows; titles render only to the
@@ -24724,6 +25398,45 @@ pub(crate) async fn revoke_org_share_inner(state: &AppState, item_id: String) ->
     state.db.set_org_share_state(&row.id, "revoked", &now)?;
     crate::share::ledger_row(&state.db, &client.host(), "org_share_revoke", 0);
     Ok(())
+}
+
+/// `org_resolve_source(item_id)` — resolve an org item back to the LOCAL editable source (note or
+/// meeting) IF the caller authored it. Only the author's device holds the `org_shares` row for the
+/// item, so a `Some(...)` result means the caller can edit the underlying note/meeting; a member
+/// reading a colleague's shared item gets `None`. READ-ONLY (a local row lookup; no egress, no
+/// content). The FE routes its own shares from the org-item viewer into the real editor.
+#[tauri::command]
+pub fn org_resolve_source(
+    state: State<'_, AppState>,
+    item_id: String,
+) -> Result<Option<OrgSourceRef>, AppError> {
+    org_resolve_source_inner(state.inner(), &item_id)
+}
+
+pub(crate) fn org_resolve_source_inner(
+    state: &AppState,
+    item_id: &str,
+) -> Result<Option<OrgSourceRef>, AppError> {
+    let item_id = item_id.trim();
+    let Some(row) = state.db.org_share_by_item(item_id)? else {
+        return Ok(None);
+    };
+    if row.state != "uploaded" {
+        return Ok(None);
+    }
+    if let Some(document_id) = row.document_id {
+        return Ok(Some(OrgSourceRef {
+            kind: "document".to_string(),
+            source_id: document_id,
+        }));
+    }
+    if let Some(meeting_id) = row.meeting_id {
+        return Ok(Some(OrgSourceRef {
+            kind: "meeting".to_string(),
+            source_id: meeting_id,
+        }));
+    }
+    Ok(None)
 }
 
 /// One org-brain item still live for a folder (lock×shares dialog). `item_id` is the server item id

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,6 +220,7 @@ pub fn run() {
             commands::org_sweep_pending,
             commands::org_sync_now,
             commands::org_get_item,
+            commands::org_resolve_source,
             commands::list_org_items,
             commands::folder_active_shares,
             commands::revoke_shares_for_folder,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1696,6 +1696,21 @@ impl Db {
         Ok(())
     }
 
+    /// Count content-free egress-ledger rows of a given `kind` (e.g. `org_share_publish` /
+    /// `org_share_revoke`). Content-free (a count, never a body); used by the re-publish tests to
+    /// assert a publish+revoke pair was ledgered on an edit-supersede.
+    pub fn count_share_egress_by_kind(&self, kind: &str) -> Result<u64> {
+        let conn = self.lock();
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM share_egress_log WHERE kind = ?1",
+                rusqlite::params![kind],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(n as u64)
+    }
+
     // ── M6 Shared Brain: local org state + the outbound org-share state machine ──────────────────
 
     /// Upsert the locally-cached membership of an org (create/status). Preserves an existing row's
@@ -1944,6 +1959,42 @@ impl Db {
         )
         .optional()
         .map_err(map_err)
+    }
+
+    /// Every UPLOADED (live-on-server) org share anchored to a given source (`meeting_id` XOR
+    /// `document_id`). Powers the re-publish-on-edit fix: one logical note may be shared into SEVERAL
+    /// orgs, so this returns rows ACROSS ALL of them (never restricted to the first). Only `uploaded`
+    /// rows are returned — a still-`queued`/`failed` row has no live server item to supersede yet (the
+    /// launch sweep publishes the current plaintext for it), and a `revoked`/`revoke_pending` share was
+    /// intentionally torn down (an edit must not resurrect it). Exactly one of `meeting_id`/`document_id`
+    /// must be `Some`; both-`None` returns an empty vec (no source ⇒ nothing to republish).
+    pub fn org_shares_for_source(
+        &self,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<Vec<crate::storage::OrgShareRow>> {
+        if meeting_id.is_none() && document_id.is_none() {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {} FROM org_shares
+                   WHERE state = 'uploaded'
+                     AND ((?1 IS NOT NULL AND meeting_id = ?1)
+                       OR (?2 IS NOT NULL AND document_id = ?2))
+                   ORDER BY created_at ASC",
+                Self::ORG_SHARE_COLS
+            ))
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id, document_id], Self::map_org_share)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
     }
 
     /// SB-3 dedup: the EXISTING retriable (`queued`/`failed`) org-share row for a logical share key
@@ -10684,6 +10735,49 @@ mod tests {
         let hashes = db.all_org_shared_content_hashes().unwrap();
         assert!(hashes.contains(&sha32(7)));
         assert!(hashes.contains(&sha32(8)));
+    }
+
+    /// `org_shares_for_source` (the re-publish-on-edit enumerator) returns EVERY uploaded row for a
+    /// source ACROSS ALL orgs (a note may be shared to several), and ONLY `uploaded` rows — a
+    /// `queued`/`failed`/`revoked` row is excluded (no live server item to supersede). A `None`/`None`
+    /// call returns empty.
+    #[test]
+    fn org_shares_for_source_returns_uploaded_rows_across_all_orgs() {
+        let db = mem_db();
+        let now = "2026-07-11T00:00:00Z";
+        // Document d1 shared to TWO orgs, both uploaded.
+        db.insert_org_share("a", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(1), now)
+            .unwrap();
+        db.set_org_share_uploaded("a", "item-a", now).unwrap();
+        db.insert_org_share("b", "org-2", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(2), now)
+            .unwrap();
+        db.set_org_share_uploaded("b", "item-b", now).unwrap();
+        // A THIRD row for d1 still `queued` (not uploaded) — must be EXCLUDED.
+        db.insert_org_share("c", "org-3", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(3), now)
+            .unwrap();
+        // An unrelated document's uploaded row — must NOT be returned for d1.
+        db.insert_org_share("d", "org-1", None, Some("d2"), "note", Some("T"), 1, 1, &sha32(4), now)
+            .unwrap();
+        db.set_org_share_uploaded("d", "item-d", now).unwrap();
+
+        let rows = db.org_shares_for_source(None, Some("d1")).unwrap();
+        assert_eq!(rows.len(), 2, "both uploaded org rows for d1 (across orgs) returned");
+        let orgs: std::collections::HashSet<_> =
+            rows.iter().map(|r| r.org_id.as_str()).collect();
+        assert!(orgs.contains("org-1") && orgs.contains("org-2"));
+        assert!(
+            rows.iter().all(|r| r.state == "uploaded"),
+            "only uploaded rows (the queued org-3 row is excluded)"
+        );
+
+        // Meeting arm + the both-None guard.
+        db.insert_org_share("e", "org-1", Some("m1"), None, "note", Some("T"), 1, 1, &sha32(5), now)
+            .unwrap();
+        db.set_org_share_uploaded("e", "item-e", now).unwrap();
+        let mrows = db.org_shares_for_source(Some("m1"), None).unwrap();
+        assert_eq!(mrows.len(), 1);
+        assert_eq!(mrows[0].meeting_id.as_deref(), Some("m1"));
+        assert!(db.org_shares_for_source(None, None).unwrap().is_empty());
     }
 
     /// NOTES feature — the additive columns exist after migrate() and re-migrating is a no-op

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -90,6 +90,7 @@ import type {
   OrgShareEntry,
   OrgItemDetail,
   OrgItemHeader,
+  OrgSourceRef,
   OrgSyncReport,
   OrgFeedUpdatedPayload,
   ActiveSharesReport,
@@ -665,6 +666,18 @@ export class IpcService {
   /** The full decrypted org item for the read-only viewer route. */
   orgGetItem(itemId: string): Promise<OrgItemDetail> {
     return invoke<OrgItemDetail>("org_get_item", { itemId });
+  }
+
+  /**
+   * Resolve an org item back to THIS device's local editable source (the note or
+   * meeting it was shared FROM), or `null` when the caller is NOT the author (no
+   * local source). Lets the `/org-item/:id` viewer send an author straight to
+   * their editable original (`/notes/:id` or `/meeting/:id`, whose edits
+   * re-publish) while a non-author gets the read-only replica view. Mirrors
+   * `org_resolve_source`.
+   */
+  orgResolveSource(itemId: string): Promise<OrgSourceRef | null> {
+    return invoke<OrgSourceRef | null>("org_resolve_source", { itemId });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1915,6 +1915,20 @@ export interface OrgItemDetail {
 }
 
 /**
+ * The LOCAL source of an org item — resolved by `org_resolve_source` so the
+ * viewer can route the AUTHOR straight to their editable original (a `/notes/:id`
+ * note or a `/meeting/:id` detail) instead of the read-only replica, while a
+ * non-author (no local source) still gets the read-only viewer. `kind` selects
+ * the route family; `sourceId` is the local document/meeting id. Mirrors the Rust
+ * `OrgSourceRef`. A `null` result (from `orgResolveSource`) ⇒ this user is NOT the
+ * author (no local source) → render the read-only viewer.
+ */
+export interface OrgSourceRef {
+  kind: "document" | "meeting";
+  sourceId: string;
+}
+
+/**
  * The result of a manual `orgSyncNow()` — counts + errors only, no content.
  * `ftsOnly` is true when the local member has no real embedder (StubEmbedder ⇒
  * the org partition is FTS-only until a model appears + a re-embed runs).

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -79,6 +79,41 @@
         />
       }
     </div>
+
+    <!-- ===== Shared brains (orgs) — read-only replicated org items ===== -->
+    @if (orgs().length > 0) {
+      <div class="folders-head org-head">
+        <h3 class="folders-title">Shared brains</h3>
+      </div>
+      <nav class="folders-body org-body" aria-label="Shared brains">
+        @for (org of orgs(); track org.orgId) {
+          <button
+            type="button"
+            class="org-row"
+            [class.is-selected]="activeOrgId() === org.orgId"
+            [attr.aria-pressed]="activeOrgId() === org.orgId"
+            (click)="selectOrg(org.orgId)"
+          >
+            <span class="org-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                <circle cx="5" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <circle cx="11" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <path
+                  d="M2 13c0-1.8 1.3-3 3-3s3 1.2 3 3M8 13c0-1.8 1.3-3 3-3s3 1.2 3 3"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </span>
+            <span class="org-name">{{ org.name }}</span>
+            <span class="pill org-role" [title]="orgRoleLabel(org)">{{
+              orgRoleLabel(org)
+            }}</span>
+          </button>
+        }
+      </nav>
+    }
   </mur-sidebar>
 
   <!-- ============ RIGHT PANE — search, filters, meeting list ============ -->
@@ -237,8 +272,8 @@
         @if (activeFolderExposure(); as exp) {
           <app-lock-badge [exposure]="exp" />
         }
-        @if (!listLoading() && displayedMeetings().length > 0) {
-          <span class="count">{{ displayedMeetings().length }}</span>
+        @if (!listLoading() && !listEmpty()) {
+          <span class="count">{{ listItems().length }}</span>
         }
         @if (storageReport(); as sr) {
           @if (sr.limitBytes !== null) {
@@ -263,9 +298,17 @@
         <div class="card state-card">
           <p class="empty">Loading…</p>
         </div>
-      } @else if (displayedMeetings().length === 0) {
+      } @else if (listEmpty()) {
         <div class="card empty-state">
-          @if (activeFolderId() !== null) {
+          @if (activeOrg(); as org) {
+            <!-- An org is selected but its shared brain has no items yet. -->
+            <span class="empty-mark" aria-hidden="true"></span>
+            <p class="empty-title">Nothing shared yet</p>
+            <p class="empty">
+              No one has shared into “{{ org.name }}” yet. Shared items appear
+              here automatically as they sync.
+            </p>
+          } @else if (activeFolderId() !== null) {
             <!-- ACTIONABLE empty folder: on-brand "drop here" illustration
                  plus the two concrete ways to file a note. -->
             <span class="empty-illo" aria-hidden="true">
@@ -357,13 +400,16 @@
         </div>
       } @else {
         <ul class="list card">
-          @for (m of displayedMeetings(); track m.id; let i = $index) {
-            <li
-              class="row-item"
-              [class.is-confirming]="pendingDeleteId() === m.id"
-              [class.is-dragging]="draggingId() === m.id"
-              [class.is-menu-open]="movePopoverId() === m.id"
-            >
+          @for (it of listItems(); track it.id; let i = $index) {
+            @switch (it.kind) {
+              @case ("meeting") {
+                @let m = it.meeting;
+                <li
+                  class="row-item"
+                  [class.is-confirming]="pendingDeleteId() === m.id"
+                  [class.is-dragging]="draggingId() === m.id"
+                  [class.is-menu-open]="movePopoverId() === m.id"
+                >
               <a
                 class="row"
                 [routerLink]="['/meeting', m.id]"
@@ -574,6 +620,75 @@
                 </div>
               }
             </li>
+              }
+              @case ("org") {
+                <!-- A READ-ONLY org (Shared Brain) replica — opens the /org-item
+                     viewer (which routes the AUTHOR to their editable source).
+                     No folder-chip / delete / drag / lock affordances. -->
+                <li class="row-item row-item--org">
+                  <a
+                    class="row row--org"
+                    [routerLink]="['/org-item', it.item.itemId]"
+                    [style.animation-delay.ms]="i * 45"
+                  >
+                    <span class="row-main">
+                      <span class="title-row">
+                        <span class="title">{{
+                          it.item.title || "(untitled)"
+                        }}</span>
+                      </span>
+                      <span class="meta">
+                        @if (it.item.authorHint) {
+                          <span class="date">Shared by {{ it.item.authorHint }}</span>
+                          <span class="dot" aria-hidden="true">·</span>
+                        }
+                        <span class="date">{{
+                          formatOrgDate(it.item.createdAt)
+                        }}</span>
+                      </span>
+                    </span>
+                    <span class="row-aside">
+                      <span
+                        class="pill org-badge"
+                        [title]="'Shared brain · ' + it.orgName"
+                      >
+                        <svg
+                          class="org-badge-glyph"
+                          viewBox="0 0 16 16"
+                          width="11"
+                          height="11"
+                          fill="none"
+                          aria-hidden="true"
+                        >
+                          <circle
+                            cx="5"
+                            cy="6"
+                            r="1.6"
+                            stroke="currentColor"
+                            stroke-width="1.2"
+                          />
+                          <circle
+                            cx="11"
+                            cy="6"
+                            r="1.6"
+                            stroke="currentColor"
+                            stroke-width="1.2"
+                          />
+                          <path
+                            d="M2.5 12c0-1.5 1.1-2.5 2.5-2.5s2.5 1 2.5 2.5M8.5 12c0-1.5 1.1-2.5 2.5-2.5s2.5 1 2.5 2.5"
+                            stroke="currentColor"
+                            stroke-width="1.2"
+                            stroke-linecap="round"
+                          />
+                        </svg>
+                        {{ it.orgName }}
+                      </span>
+                      <span class="chevron" aria-hidden="true">›</span>
+                    </span>
+                  </a>
+                </li>
+              }
+            }
           }
         </ul>
       }

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -779,6 +779,94 @@
   }
 }
 
+/* --- Rail: "Shared brains" (orgs) section --- */
+/* A quiet divider above the section so it reads as a distinct group. */
+.org-head {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+/* Sits under the folder tree; no own scroll. */
+.org-body {
+  flex: 0 0 auto;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.org-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.org-row:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.org-row:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.org-row.is-selected {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+.org-icon {
+  flex: none;
+  display: inline-flex;
+  color: var(--text-muted);
+}
+.org-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* A quiet role hint (Owner / Member) trailing the org name. */
+.org-role {
+  flex: none;
+  margin-left: auto;
+  font-size: 0.62rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--surface-raised);
+}
+
+/* --- List: org (Shared Brain) row --- */
+/* The org row has no delete button → no right-side reserve; the "shared brain"
+   origin badge is a neutral raised surface with the org name. */
+.row-item--org .row--org {
+  padding-right: var(--space-4);
+}
+.org-badge {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  max-width: 16ch;
+  overflow: hidden;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+.org-badge-glyph {
+  flex: none;
+  color: var(--text-muted);
+}
+
 /* Honor reduced-motion everywhere: no rail slide / content stagger (the
    surface is opaque from frame 1, so entry is instant with no flash), and
    no in-flow rise on the popover / empty illustration. */

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { NavHistoryService } from "../../../core/nav-history.service";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
@@ -17,6 +18,8 @@ import type {
   FolderNode,
   Meeting,
   MeetingStatus,
+  OrgItemHeader,
+  OrgStatus,
   SearchHit,
   StorageReport,
 } from "../../../core/models";
@@ -38,6 +41,33 @@ interface SnippetPart {
   text: string;
   hit: boolean;
 }
+
+/**
+ * One row of the unified no-query list — a discriminated union over the two
+ * sources the list merges. A `"meeting"` row is a local recording (opens
+ * `/meeting/:id`, keeps its folder-chip / delete / drag / lock affordances); an
+ * `"org"` row is a READ-ONLY org (Shared Brain) replica (opens the
+ * `/org-item/:id` viewer, carries the origin org's name for its badge, no
+ * folder/delete/drag affordances). Both expose an epoch-ms `sortAt` so the
+ * merged list orders by date desc regardless of source. `id` is namespaced
+ * (`meeting:`/`org:`) so the `@for` track key is stable + collision-free across
+ * the two id spaces.
+ */
+export type MeetingsListItem =
+  | {
+      kind: "meeting";
+      id: string;
+      sortAt: number;
+      meeting: Meeting;
+    }
+  | {
+      kind: "org";
+      id: string;
+      sortAt: number;
+      item: OrgItemHeader;
+      /** The origin org's display name (drives the "shared brain" badge label). */
+      orgName: string;
+    };
 
 @Component({
   selector: "app-library",
@@ -174,13 +204,13 @@ export class LibraryComponent implements OnInit {
   readonly tagLoading = signal(false);
 
   /**
-   * The list to render when not searching, in strict precedence (search is
-   * handled separately via `hasQuery()`):
+   * The MEETINGS (recordings) to render when not searching, in strict precedence
+   * (search is handled separately via `hasQuery()`):
    *   folder selected → folder-filtered;
    *   else tag selected → tag-filtered;
    *   else → the full list.
-   * No existing branch is removed — the folder branch sits ABOVE the tag/all
-   * branches the screen already had.
+   * This is the meeting SOURCE the unified {@link listItems} merges with org
+   * items; an org selection is handled in `listItems` (it shows only org items).
    */
   readonly displayedMeetings = computed(() => {
     if (this.activeFolderId() !== null) {
@@ -188,18 +218,95 @@ export class LibraryComponent implements OnInit {
     }
     return this.activeTag() === null ? this.meetings() : this.tagMeetings();
   });
-  /** Loading state for the visible no-query list (initial load or a tag fetch). */
+
+  /**
+   * The unified no-query list feeding the pane, sorted by date desc:
+   *  - a specific org rail-selected ⇒ ONLY that org's items;
+   *  - "Meetings" (no folder, no tag, no org) ⇒ your recordings MERGED with EVERY
+   *    org's shared items;
+   *  - a specific folder OR tag ⇒ only those meetings (no org items).
+   * Org items never carry a lock (they are deliberately-disclosed org content) —
+   * only recordings can be masked (folder-sealed).
+   */
+  readonly listItems = computed<MeetingsListItem[]>(() => {
+    const orgId = this.activeOrgId();
+    const orgItemsByOrg = this._orgItems();
+    const orgs = this._orgs();
+
+    // A specific org selected: show ONLY that org's items.
+    if (orgId !== null) {
+      const name = orgs.find((o) => o.orgId === orgId)?.name ?? "";
+      return (orgItemsByOrg[orgId] ?? [])
+        .map((item) => this.toOrgCard(item, name))
+        .sort((a, b) => b.sortAt - a.sortAt);
+    }
+
+    const meetingCards: MeetingsListItem[] = this.displayedMeetings().map(
+      (meeting) => ({
+        kind: "meeting" as const,
+        id: `meeting:${meeting.id}`,
+        sortAt: this.meetingSortAt(meeting),
+        meeting,
+      }),
+    );
+
+    // A specific folder OR tag is selected (not the "Meetings" root): meetings only.
+    if (this.activeFolderId() !== null || this.activeTag() !== null) {
+      return meetingCards.sort((a, b) => b.sortAt - a.sortAt);
+    }
+
+    // "Meetings" (all): merge YOUR recordings with EVERY org's shared items.
+    const orgCards: MeetingsListItem[] = orgs.flatMap((o) =>
+      (orgItemsByOrg[o.orgId] ?? []).map((item) => this.toOrgCard(item, o.name)),
+    );
+    return [...meetingCards, ...orgCards].sort((a, b) => b.sortAt - a.sortAt);
+  });
+
+  /** True when the unified no-query list has zero rows (drives the empty state). */
+  readonly listEmpty = computed(() => this.listItems().length === 0);
+
+  /** Build an org card from a header + its origin org name. */
+  private toOrgCard(item: OrgItemHeader, orgName: string): MeetingsListItem {
+    const t = Date.parse(item.createdAt);
+    return {
+      kind: "org",
+      id: `org:${item.itemId}`,
+      sortAt: Number.isNaN(t) ? 0 : t,
+      item,
+      orgName,
+    };
+  }
+
+  /** Epoch-ms sort key for a meeting (its start time; 0 when unparseable). */
+  private meetingSortAt(m: Meeting): number {
+    const t = Date.parse(m.startedAt);
+    return Number.isNaN(t) ? 0 : t;
+  }
+
+  /** Loading state for the visible no-query list (initial load, tag fetch, or org load). */
   readonly listLoading = computed(() => {
+    if (this.activeOrgId() !== null) {
+      // An org scope: the org items are client-side; share the org-load flag.
+      return this.orgsLoading();
+    }
     if (this.activeFolderId() !== null) {
       // Folder filtering is client-side over `meetings`, so it shares the
       // initial-load flag (and the tree's own loading shows in the left pane).
       return this.loading();
     }
-    return this.activeTag() === null ? this.loading() : this.tagLoading();
+    // The "Meetings" root merges org items, so its load also depends on the org load.
+    if (this.activeTag() === null) {
+      return this.loading() || this.orgsLoading();
+    }
+    return this.tagLoading();
   });
 
-  /** Heading for the no-query list: folder name → tag → "Meetings". */
+  /** Heading for the no-query list: org name → folder name → tag → "Meetings". */
   readonly listHeading = computed(() => {
+    const org = this.activeOrg();
+    if (org) {
+      return org.name;
+    }
     const fid = this.activeFolderId();
     if (fid !== null) {
       return this.folderById().get(fid)?.name ?? "Folder";
@@ -216,6 +323,52 @@ export class LibraryComponent implements OnInit {
     const node = this.folderById().get(fid);
     return node ? this.folders.exposureOf(node) : null;
   });
+
+  // --- Org (Shared Brain) shared-brain items ------------------------------
+  /**
+   * Every org (Shared Brain) this user belongs to — the rail's "Shared brains"
+   * section + the source of merged org items in the "Meetings" (all) list. Loaded
+   * stale-guarded on init, on the `org-feed-updated` event, and on window focus.
+   * Mirrors the notes-home org integration (0.9.4).
+   */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  readonly orgs = this._orgs.asReadonly();
+  /**
+   * The org's shared items keyed by orgId (`listOrgItems`). A flat parallel signal
+   * (not per-org sub-signals) so the merged list computed re-derives on any change.
+   */
+  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  /**
+   * Selected org id in the rail (null ⇒ not viewing a specific org). MUTUALLY
+   * exclusive with a folder OR tag selection: selecting an org clears both
+   * {@link activeFolderId} and {@link activeTag}, and selecting a folder/tag clears
+   * this — so the content pane has exactly one active scope.
+   */
+  readonly activeOrgId = signal<string | null>(null);
+  /** True while the org list + items are (re)loading (rail hint only). */
+  readonly orgsLoading = signal(false);
+  /** The org whose items are shown when an org is rail-selected (null otherwise). */
+  readonly activeOrg = computed<OrgStatus | null>(() => {
+    const oid = this.activeOrgId();
+    return oid === null
+      ? null
+      : (this._orgs().find((o) => o.orgId === oid) ?? null);
+  });
+
+  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
+  private orgFeedUnlisten: UnlistenFn | null = null;
+  /**
+   * True once destroyed — so a `listen()` that resolves AFTER teardown releases
+   * immediately (distinct from `orgFeedUnlisten === null`, which also means "not
+   * yet resolved").
+   */
+  private orgFeedDestroyed = false;
+  /** Bumped per org load so a late (stale) reload result is dropped (T1 guard). */
+  private orgLoadSeq = 0;
+  /** Bound window-focus handler — re-loads org items when the view regains focus. */
+  private readonly onWindowFocus = (): void => {
+    void this.loadOrgs();
+  };
 
   // --- Delete affordance (in-app, signal-driven confirm) ------------------
   /** Id of the meeting whose inline confirm panel is open (null = none). */
@@ -240,18 +393,45 @@ export class LibraryComponent implements OnInit {
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
 
   async ngOnInit(): Promise<void> {
-    // Clean up any in-flight debounce timer when the view is torn down.
+    // Clean up any in-flight debounce timer + the org live-refresh listener +
+    // the focus handler when the view is torn down.
     this.destroyRef.onDestroy(() => {
       if (this.searchTimer) {
         clearTimeout(this.searchTimer);
       }
+      this.orgFeedDestroyed = true;
+      this.orgFeedUnlisten?.();
+      this.orgFeedUnlisten = null;
+      window.removeEventListener("focus", this.onWindowFocus);
     });
 
-    // Load the meetings list and the tag set in parallel; a tag-load failure
-    // must not break the list, so settle each independently.
+    // Live-refresh the org items: the background org-sync loop fires
+    // `org-feed-updated` on a productive tick (≥1 ingest/tombstone). Subscribe
+    // ONCE (push straight into a reload — never subscribe-into-a-field), and
+    // re-load org items when the view regains focus. Mirrors notes-home.
+    window.addEventListener("focus", this.onWindowFocus);
+    void this.ipc
+      .onOrgFeedUpdated(() => void this.loadOrgs())
+      .then((un) => {
+        // If the view was already torn down before the listener resolved, release
+        // it immediately (never leak a subscription past destroy).
+        if (this.orgFeedDestroyed) {
+          un();
+        } else {
+          this.orgFeedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
+      });
+
+    // Load the meetings list, the tag set, and the org list in parallel; a
+    // tag/org-load failure must not break the meetings list, so settle each
+    // independently.
     const [meetings] = await Promise.allSettled([
       this.ipc.listMeetings(),
       this.loadTags(),
+      this.loadOrgs(),
     ]);
     if (meetings.status === "fulfilled") {
       this.meetings.set(meetings.value);
@@ -264,6 +444,94 @@ export class LibraryComponent implements OnInit {
       .catch(() => {
         /* best-effort: no cap set / backend unavailable → the chip stays hidden */
       });
+  }
+
+  /**
+   * (Re)load the org (Shared Brain) list + every org's shared items, stale-guarded
+   * on {@link orgLoadSeq} so a late reload (event / focus / init racing) never
+   * overwrites a newer result. Best-effort throughout: `orgRefresh` (server
+   * membership discovery) and each per-org `listOrgItems` swallow their own
+   * failures so a transient/offline error leaves the last-known list standing
+   * rather than blanking the pane. Never throws. Mirrors notes-home `loadOrgs`.
+   */
+  async loadOrgs(): Promise<void> {
+    const seq = ++this.orgLoadSeq;
+    this.orgsLoading.set(true);
+    try {
+      // Discover freshly-invited orgs before reading the local replica (best-effort).
+      try {
+        await this.ipc.orgRefresh();
+      } catch {
+        /* offline / no server → fall through to the local replica */
+      }
+      let orgs: OrgStatus[];
+      try {
+        orgs = await this.ipc.orgListStatuses();
+      } catch {
+        return; // keep the last-known orgs on a transient failure
+      }
+      if (seq !== this.orgLoadSeq) {
+        return; // a newer load superseded this one — drop the result
+      }
+      // Pull each org's browsable items in parallel; a per-org failure yields [].
+      const itemLists = await Promise.all(
+        orgs.map((o) =>
+          this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
+        ),
+      );
+      if (seq !== this.orgLoadSeq) {
+        return;
+      }
+      const byOrg: Record<string, OrgItemHeader[]> = {};
+      orgs.forEach((o, i) => {
+        byOrg[o.orgId] = itemLists[i];
+      });
+      this._orgs.set(orgs);
+      this._orgItems.set(byOrg);
+      // If the rail's selected org has since disappeared, fall back to "Meetings".
+      const sel = this.activeOrgId();
+      if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
+        this.activeOrgId.set(null);
+      }
+    } finally {
+      if (seq === this.orgLoadSeq) {
+        this.orgsLoading.set(false);
+      }
+    }
+  }
+
+  /**
+   * Rail-select an org (Shared Brain): the pane shows ONLY that org's shared
+   * items. Mutually exclusive with a folder OR tag selection — clears both
+   * {@link activeFolderId} and {@link activeTag} (and its fetched list) + closes
+   * any open transient UI.
+   */
+  selectOrg(orgId: string): void {
+    this.cancelDelete();
+    this.closeMovePopover();
+    this.activeFolderId.set(null);
+    this.activeTag.set(null);
+    this.tagMeetings.set([]);
+    this.tagLoading.set(false);
+    this.activeOrgId.set(orgId);
+  }
+
+  /** A friendly role hint for the rail ("Owner" / "Member"). */
+  orgRoleLabel(org: OrgStatus): string {
+    return org.role === "owner" ? "Owner" : "Member";
+  }
+
+  /** Presentational only: an ISO timestamp (org item `createdAt`) → a friendly date. */
+  formatOrgDate(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) {
+      return "";
+    }
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
   }
 
   /** Fetch the distinct tag set; on failure leave `tags` empty (no filter bar). */
@@ -289,11 +557,12 @@ export class LibraryComponent implements OnInit {
     // Switching the view dismisses any open delete confirm to avoid a dangling
     // panel pointing at a row that may not be in the new list.
     this.cancelDelete();
-    // Tag + folder filters are mutually exclusive: picking a tag clears any
-    // active folder selection so the two never compose into an empty surprise.
+    // Tag + folder + org scopes are mutually exclusive: picking a tag clears any
+    // active folder AND org selection so they never compose into an empty surprise.
     if (tag !== null) {
       this.activeFolderId.set(null);
     }
+    this.activeOrgId.set(null);
     this.activeTag.set(tag);
 
     if (tag === null) {
@@ -332,17 +601,22 @@ export class LibraryComponent implements OnInit {
    * race exists; the same idempotent-guard shape is kept for consistency.
    */
   selectFolder(folderId: string | null): void {
-    if (this.activeFolderId() === folderId) {
+    // A re-select of the SAME folder while no org is active is a no-op — but a
+    // re-select of "All notes" (null) WHILE an org is active still runs, to drop
+    // the org scope.
+    if (this.activeFolderId() === folderId && this.activeOrgId() === null) {
       return;
     }
     this.cancelDelete();
-    // Folder + tag filters are mutually exclusive — picking a folder clears the
-    // tag selection (and its fetched list) so they never compose.
+    // Folder + tag + org scopes are mutually exclusive — picking a folder clears
+    // the tag selection (and its fetched list) AND any org selection so they
+    // never compose.
     if (folderId !== null) {
       this.activeTag.set(null);
       this.tagMeetings.set([]);
       this.tagLoading.set(false);
     }
+    this.activeOrgId.set(null);
     this.activeFolderId.set(folderId);
   }
 
@@ -510,14 +784,18 @@ export class LibraryComponent implements OnInit {
       return;
     }
 
-    // Search takes precedence over BOTH the tag and folder filters: reset to
-    // the full list so clearing the search returns to "All" (the chip bar is
-    // hidden while searching). Per-row delete still works against `meetings`.
+    // Search takes precedence over the tag, folder AND org scopes: reset to the
+    // full list so clearing the search returns to "All" (the chip bar is hidden
+    // while searching). Search stays meetings-only — org items appear only in the
+    // no-query list branch. Per-row delete still works against `meetings`.
     if (this.activeTag() !== null) {
       void this.selectTag(null);
     }
     if (this.activeFolderId() !== null) {
       this.activeFolderId.set(null);
+    }
+    if (this.activeOrgId() !== null) {
+      this.activeOrgId.set(null);
     }
 
     this.searching.set(true);

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.html
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.html
@@ -1,7 +1,7 @@
 <section class="org-item">
-  <button type="button" class="back" (click)="nav.back()">
+  <button type="button" class="back" (click)="back()">
     <span class="back-arrow" aria-hidden="true">←</span>
-    <span>Back</span>
+    <span>Notes</span>
   </button>
 
   @if (loading()) {
@@ -16,15 +16,25 @@
   } @else if (item(); as it) {
     <article class="card oi-card">
       <header class="oi-head">
-        <span class="oi-org-chip">
-          <span class="oi-org-dot" aria-hidden="true"></span>
-          Org Brain
-        </span>
         <h1 class="oi-title">{{ it.title }}</h1>
-        <p class="oi-meta">
-          Shared by <strong>{{ it.authorHint }}</strong>
-          · {{ formatDate(it.createdAt) }}
-        </p>
+        <div class="oi-meta">
+          <span class="oi-org-chip">
+            <span class="oi-org-dot" aria-hidden="true"></span>
+            Org Brain
+          </span>
+          @if (orgName(); as name) {
+            <span class="oi-meta-sep" aria-hidden="true">·</span>
+            <span class="oi-org-name">{{ name }}</span>
+          }
+          @if (it.authorHint) {
+            <span class="oi-meta-sep" aria-hidden="true">·</span>
+            <span class="oi-author">Shared by {{ it.authorHint }}</span>
+          }
+          <span class="oi-meta-sep" aria-hidden="true">·</span>
+          <span class="oi-date">{{ formatDate(it.createdAt) }}</span>
+          <span class="oi-meta-sep" aria-hidden="true">·</span>
+          <span class="oi-rev">revision {{ it.rev }}</span>
+        </div>
       </header>
       <div class="oi-body">
         <app-markdown [markdown]="it.markdown" />

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.scss
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.scss
@@ -69,17 +69,34 @@
   padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--border-subtle);
 }
+.oi-title {
+  margin: 0;
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  line-height: 1.25;
+}
+/* Metadata strip: Org Brain badge + org name + author + date + revision. */
+.oi-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
 .oi-org-chip {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  align-self: flex-start;
-  padding: 3px var(--space-3);
+  padding: 2px var(--space-3);
   border-radius: var(--radius-pill);
   background: var(--accent-soft);
   border: 1px solid var(--accent-ring);
   color: var(--accent-hover);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   font-weight: 650;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -90,20 +107,15 @@
   border-radius: var(--radius-pill);
   background: var(--accent);
 }
-.oi-title {
-  margin: 0;
-  font-size: 1.4rem;
-  font-weight: 680;
-  color: var(--text-primary);
-  line-height: 1.3;
-}
-.oi-meta {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.875rem;
-}
-.oi-meta strong {
+.oi-org-name {
   color: var(--text-secondary);
+  font-weight: 600;
+}
+.oi-author {
+  color: var(--text-secondary);
+}
+.oi-meta-sep {
+  color: var(--border-strong);
 }
 .oi-body {
   color: var(--text-secondary);

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -7,24 +7,29 @@ import {
   signal,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 import { IpcService } from "../../../core/ipc.service";
-import { NavHistoryService } from "../../../core/nav-history.service";
 import type { OrgItemDetail } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 
 /**
- * Read-only viewer for ONE org-brain item (`/org-item/:id`). Reached from an
- * org-origin source chip in the Ask `SourcesComponent`. Renders the decrypted
- * `OrgItemDetail.markdown` with an author + date header. Org items are
- * deliberately-disclosed org content (no lock gate applies), so this is a plain
- * read-only render — there is no edit/share affordance here.
+ * Viewer for ONE org-brain item (`/org-item/:id`). Reached from an org-origin
+ * source chip (Ask) or an org card in the Notes / Meetings list.
+ *
+ * On entry the viewer FIRST resolves the item back to THIS device's local
+ * editable source (`org_resolve_source`, F2): if the caller is the AUTHOR it
+ * redirects (replaceUrl) to their editable original — a `/notes/:id` note or a
+ * `/meeting/:id` detail (whose edits re-publish) — so they land on the thing they
+ * can change, not a read-only replica. A non-author (no local source ⇒ `null`)
+ * falls through to the rich READ-ONLY document view: an "Org Brain" badge + the
+ * org name + author hint + date + revision, the decrypted `OrgItemDetail.markdown`
+ * rendered inside a frosted document card. Org items are deliberately-disclosed
+ * org content (no lock gate applies), so the read view has no edit/share affordance.
  *
  * The route param drives the load via an IPC-on-signal-change effect (T1) with a
  * stale-result guard, so navigating between org items in place re-fetches
- * correctly. The back-affordance uses {@link NavHistoryService} to return to
- * wherever the user came from (Ask, most commonly).
+ * correctly. Back returns to the Notes home (mirrors the note-editor `back()`).
  */
 @Component({
   selector: "app-org-item-viewer",
@@ -36,8 +41,8 @@ import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 export class OrgItemViewerComponent {
   private readonly ipc = inject(IpcService);
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly injector = inject(Injector);
-  readonly nav = inject(NavHistoryService);
 
   /** The `:id` route param as a signal (re-fetches when it changes in place). */
   private readonly itemId = toSignal(
@@ -47,22 +52,39 @@ export class OrgItemViewerComponent {
 
   private readonly _item = signal<OrgItemDetail | null>(null);
   readonly item = this._item.asReadonly();
+  /**
+   * The origin org's display name (drives the metadata strip's org label).
+   * Best-effort: resolved by matching the item against each org's browsable
+   * items; empty when it can't be determined (offline / already-tombstoned).
+   */
+  private readonly _orgName = signal("");
+  readonly orgName = this._orgName.asReadonly();
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
 
   constructor() {
-    // Fetch the org item whenever the route id changes. Async IPC effect (T1) —
-    // writes loading/error/item, stale-guarded on the captured id.
+    // Resolve + fetch the org item whenever the route id changes. Async IPC
+    // effect (T1) — first resolves the local editable source and (for the author)
+    // redirects; otherwise loads the read-only detail. Stale-guarded on the
+    // captured id so an in-place route change drops the late reply.
     effect(
       () => {
         const id = this.itemId();
-        void this.load(id);
+        void this.resolveThenLoad(id);
       },
       { injector: this.injector },
     );
   }
 
-  private async load(id: string | null): Promise<void> {
+  /**
+   * F2 — author-editable routing. Resolve the item's LOCAL editable source; if
+   * this user authored it (a non-null ref) redirect to the editable original
+   * (`replaceUrl` so Back doesn't bounce into the redirect). Otherwise render the
+   * read-only view. The resolve is best-effort: any failure (no Tauri host, an
+   * unknown command on an older backend, a transient error) falls through to the
+   * read-only load rather than blocking the view. Stale-guarded on `id`.
+   */
+  private async resolveThenLoad(id: string | null): Promise<void> {
     if (!id) {
       this.loading.set(false);
       this.error.set("No item id.");
@@ -70,12 +92,40 @@ export class OrgItemViewerComponent {
     }
     this.loading.set(true);
     this.error.set(null);
+    this._item.set(null);
+    this._orgName.set("");
+    try {
+      const ref = await this.ipc.orgResolveSource(id);
+      if (this.itemId() !== id) {
+        return; // stale — the route moved on under us
+      }
+      if (ref) {
+        // The author's editable original — replace so Back skips the redirect.
+        const path =
+          ref.kind === "document"
+            ? ["/notes", ref.sourceId]
+            : ["/meeting", ref.sourceId];
+        await this.router.navigate(path, { replaceUrl: true });
+        return;
+      }
+    } catch {
+      // Best-effort: fall through to the read-only load on any resolve failure.
+      if (this.itemId() !== id) {
+        return;
+      }
+    }
+    await this.load(id);
+  }
+
+  /** Load the read-only detail (+ best-effort org name) for a non-author. Stale-guarded. */
+  private async load(id: string): Promise<void> {
     try {
       const item = await this.ipc.orgGetItem(id);
       if (this.itemId() !== id) {
         return; // stale — the route moved on under us
       }
       this._item.set(item);
+      void this.resolveOrgName(id);
     } catch (e) {
       if (this.itemId() !== id) {
         return;
@@ -87,6 +137,34 @@ export class OrgItemViewerComponent {
         this.loading.set(false);
       }
     }
+  }
+
+  /**
+   * Best-effort org name for the metadata strip: the viewer route carries no org
+   * context and `OrgItemDetail` has no `orgId`, so we discover the origin org by
+   * matching the item id against each org's browsable items. Never throws; leaves
+   * the label empty when it can't be resolved. Stale-guarded on `id`.
+   */
+  private async resolveOrgName(id: string): Promise<void> {
+    try {
+      const orgs = await this.ipc.orgListStatuses();
+      for (const org of orgs) {
+        const items = await this.ipc.listOrgItems(org.orgId).catch(() => []);
+        if (items.some((it) => it.itemId === id)) {
+          if (this.itemId() === id) {
+            this._orgName.set(org.name);
+          }
+          return;
+        }
+      }
+    } catch {
+      /* best-effort: leave the org label empty */
+    }
+  }
+
+  /** Back returns to the Notes home (mirrors the note-editor `back()`, B1). */
+  back(): void {
+    void this.router.navigate(["/notes"]);
   }
 
   /** Presentational: an ISO timestamp → a friendly local date. */


### PR DESCRIPTION
## What

Org shared items now stay **fresh** and are **first-class in both the Notes and Meetings views**. Fixes the two reported bugs (stale org copy after edit; broken Back) plus three UX gaps.

### The stale fix (highest value) — re-publish on edit
Editing or resummarizing an org-shared note/meeting now re-publishes a new revision to **every org** it was shared to. The feed has no in-place update, so this is **tombstone-old + publish-new-rev**, and it re-runs the **full egress gate chain** — read-gate (a locked source is skipped, never tombstone-into-nothing), `org_egress_consented` fail-closed, `clean_note_body` + `scrub_org_markdown` (default-on), OCK seal with **local open-verify before publish**, **publish-before-tombstone** ordering, content-free egress ledger, and a **same-row repoint** (no row amplification). Wired best-effort on commit boundaries (`update_note` / `update_note_doc` / `resummarize`) — **never** per-keystroke autosave. `Sync now`/the launch sweep retry any queued republish.

### Author-editable + richer viewer
- `org_resolve_source` maps an org item back to the author's local source row; the viewer redirects the **author** to their **editable** `/notes/:id` or `/meeting/:id`. Non-authors get a rich read-only view.
- Rebuilt `org-item-viewer` (title header + document surface + metadata strip: Org Brain badge, org name, author, date, revision).
- **Back** now returns to `/notes` (was a no-op — `/org-item` wasn't a drill-down route).

### Org in Meetings
Library now mirrors the 0.9.4 Notes-view org integration: a merged meetings + org-items stream and a per-org **Shared brains** rail; org selection is mutually exclusive with folder + tag; search stays meetings-only.

## How verified
- `cargo test --lib` **1519 passed / 0 failed** — 6 new tests, **RED→GREEN proven three ways**, multi-org republish proven (2 orgs → 4 publishes / 2 tombstones).
- `ng lint` clean, `ng build` ok, 3/3 org e2e green, full `scripts/ci.sh` **all gates green**.
- **lock-security-reviewer PASS** (all 8 egress invariants hold) + **adversarial-verifier PASS**.

## Honest gaps (signed-build / live only)
A real 2-account server round-trip (member sees the fresh revision after the author's edit) needs a signed build on two Macs; Touch ID / lock-at-rest are untouched by this change.