### PR TITLE
fix(org): author-editable org cards + current titles + Back fix

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22552,6 +22552,104 @@ mod lifecycle_tests {
         );
     }
 
+    /// F-org-editable: `list_org_items_inner` ENRICHES an item the caller published with an
+    /// `owned_source` ref plus the source's CURRENT title (so the author's own card links to the
+    /// editable original and never shows a stale publish-time snapshot), while an item shared by
+    /// SOMEONE ELSE (no local share) stays a bare read-only replica. RED before the enrichment
+    /// (owned_source always None, title frozen).
+    #[test]
+    fn list_org_items_enriches_owned_items_with_editable_source_and_current_title() {
+        let state = build_state("org-list-owned");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-own", "Team");
+        // The author's local note, retitled to "Jest tytul" AFTER it was shared as "Untitled".
+        state
+            .db
+            .insert_note("n-own", "f-own", "Untitled", "Jest tytul", "# body", 1)
+            .unwrap();
+        // The received replica (frozen at publish time = "Untitled") + the matching OUTBOUND share.
+        state
+            .db
+            .upsert_org_item("item-own", "org-1", 2, "kgm004a", "Untitled", "# body", "2026-07-11T09:00:00Z", 1, 1, &[9u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .insert_org_share("s-own", "org-1", None, Some("n-own"), "note", Some("Untitled"), 1, 1, &[9u8; 32], "2026-07-11T09:00:00Z")
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s-own", "item-own", "2026-07-11T09:00:00Z")
+            .unwrap();
+        // Someone ELSE's replica — no local share ⇒ stays read-only, title untouched.
+        state
+            .db
+            .upsert_org_item("item-other", "org-1", 1, "kgm004a+2", "Ich notatka", "body", "2026-07-10T09:00:00Z", 1, 1, &[7u8; 32], None)
+            .unwrap();
+
+        let items = list_org_items_inner(&state, "org-1").unwrap();
+        let own = items.iter().find(|i| i.item_id == "item-own").unwrap();
+        assert_eq!(
+            own.title, "Jest tytul",
+            "owned item shows the source's CURRENT title, not the stale snapshot"
+        );
+        let owned = own.owned_source.as_ref().expect("owned item carries a source ref");
+        assert_eq!(owned.kind, "document");
+        assert_eq!(owned.id, "n-own");
+
+        let other = items.iter().find(|i| i.item_id == "item-other").unwrap();
+        assert!(other.owned_source.is_none(), "a non-author's item is a read-only replica");
+        assert_eq!(other.title, "Ich notatka", "a non-owned title is left as-is");
+    }
+
+    /// F-org-editable GATE: an owned item whose source folder is LOCKED (not session-unlocked) is NOT
+    /// enriched — its current title must never leak through the org list, and it falls back to the
+    /// read-only replica (frozen snapshot title). RED before the `folder_is_unlocked` gate.
+    #[test]
+    fn list_org_items_does_not_leak_a_locked_owned_source_title() {
+        let state = build_state("org-list-owned-locked");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        // A LOCKED folder (never added to the session unlocked set).
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-lock".to_string(),
+                name: "Vault".to_string(),
+                path: "Vault".to_string(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-06-27T08:00:00Z".to_string(),
+            })
+            .unwrap();
+        state
+            .db
+            .insert_note("n-lock", "f-lock", "secret", "Secret Title", "# body", 1)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("item-lock", "org-1", 1, "kgm004a", "Old Snapshot", "# body", "2026-07-11T09:00:00Z", 1, 1, &[5u8; 32], None)
+            .unwrap();
+        state
+            .db
+            .insert_org_share("s-lock", "org-1", None, Some("n-lock"), "note", Some("Old Snapshot"), 1, 1, &[5u8; 32], "2026-07-11T09:00:00Z")
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s-lock", "item-lock", "2026-07-11T09:00:00Z")
+            .unwrap();
+
+        let items = list_org_items_inner(&state, "org-1").unwrap();
+        let it = items.iter().find(|i| i.item_id == "item-lock").unwrap();
+        assert!(
+            it.owned_source.is_none(),
+            "a locked owned source is not resolved (no editable link)"
+        );
+        assert_ne!(
+            it.title, "Secret Title",
+            "a locked source's current title must NOT leak into the org list"
+        );
+        assert_eq!(it.title, "Old Snapshot", "falls back to the frozen replica snapshot");
+    }
+
     /// FIX A (command gate): `list_org_items_inner` refuses an org the caller isn't a local member of
     /// (membership-checked via `resolve_org`) — never leaking another org's list — and returns the list
     /// for a member org.
@@ -25327,6 +25425,40 @@ pub(crate) async fn republish_org_shares_for_source(
             .set_org_share_uploaded(&row.id, &published.item_id, &now)?;
         crate::share::ledger_row(&state.db, &client.host(), "org_share_publish", content_sha.len());
 
+        // LOCAL REPLICA CONSISTENCY (F-org-editable): the author's OWN `org_items` replica would
+        // otherwise stay frozen on the OLD item_id until the next feed pull — so the just-repointed
+        // `org_shares` row no longer matches the replica the Notes list renders (`item_id` drift →
+        // the card falls back to a stale, read-only viewer). Upsert the NEW item + tombstone the OLD
+        // one LOCALLY now, so `list_org_items` immediately resolves this as an owned/editable card with
+        // the fresh title. FTS-only (`None` embedder) to keep this editor-close path light; the next
+        // real `org_sync_now` re-ingests authoritatively (idempotent upsert) and re-embeds. Best-effort:
+        // a local-replica error must never fail the save (the server copy is already live + correct).
+        if let Err(e) = state.db.upsert_org_item(
+            &published.item_id,
+            &org.org_id,
+            published.seq,
+            &env.author_hint,
+            &env.title,
+            &env.markdown,
+            &env.created_at,
+            new_rev,
+            generation,
+            &content_sha,
+            None,
+        ) {
+            tracing::warn!(target: "org", error = %e, "republish: local replica upsert failed (server copy live)");
+        }
+        if let Some(old_item) = row.item_id.as_deref() {
+            // Guard: only tombstone the OLD id if it truly differs from the freshly-published one —
+            // a defensive no-op if the server ever reused the item_id (it mints a new one per publish),
+            // so we never tombstone the replica we just upserted.
+            if old_item != published.item_id {
+                if let Err(e) = state.db.tombstone_org_item(old_item) {
+                    tracing::warn!(target: "org", error = %e, "republish: local old-item tombstone failed");
+                }
+            }
+        }
+
         // THEN tombstone the OLD item so members evict the stale copy. Publish-BEFORE-tombstone: a
         // crash here leaves a transient dup (recoverable), never a window with no org copy. A tombstone
         // failure is non-fatal — the new copy is already live; the stale one lingers until a revoke.
@@ -26029,7 +26161,76 @@ pub(crate) fn list_org_items_inner(
 ) -> Result<Vec<crate::storage::models::OrgItemHeader>, AppError> {
     // Membership re-check: refuse if the caller isn't a local member of this org.
     let org = resolve_org(st, org_id)?;
-    st.db.list_org_items(&org.org_id)
+    let mut items = st.db.list_org_items(&org.org_id)?;
+    // OWNERSHIP ENRICHMENT (F-org-editable): for each replica the CALLER published, resolve its local
+    // editable source + CURRENT title so the FE links straight to the editable original and never shows
+    // a stale publish-time snapshot. GATED — a locked-not-unlocked source resolves to `None` (its title
+    // must never leak through this org-disclosed list). A non-author's item has no local share ⇒ `None`
+    // ⇒ stays a read-only replica.
+    for item in &mut items {
+        if let Some(src) = resolve_owned_source(st, &item.item_id)? {
+            item.title = src.title;
+            item.owned_source = Some(src.owned);
+        }
+    }
+    Ok(items)
+}
+
+/// The caller's editable local source + its CURRENT title for an org item they published, if any. `None`
+/// when the item was shared by someone else (no local `org_shares` row), the source row is gone, or the
+/// source is locked-and-not-session-unlocked (never leak a sealed title through the org list). Powers the
+/// `OrgItemHeader.owned_source` enrichment; the gate mirrors the note/meeting content-read gates.
+struct OwnedSourceResolved {
+    title: String,
+    owned: crate::storage::models::OrgOwnedSource,
+}
+
+fn resolve_owned_source(
+    st: &AppState,
+    item_id: &str,
+) -> Result<Option<OwnedSourceResolved>, AppError> {
+    let Some(row) = st.db.org_share_by_item(item_id)? else {
+        return Ok(None);
+    };
+    if row.state != "uploaded" {
+        return Ok(None);
+    }
+    if let Some(document_id) = row.document_id {
+        let Some(note) = st.db.get_note_row(&document_id)? else {
+            return Ok(None);
+        };
+        // GATE: a sealed-not-unlocked note's title must not leak into the org list.
+        if !folder_is_unlocked(st, &note.folder_id)? {
+            return Ok(None);
+        }
+        return Ok(Some(OwnedSourceResolved {
+            title: note_display_title(&note),
+            owned: crate::storage::models::OrgOwnedSource {
+                kind: "document".to_string(),
+                id: document_id,
+            },
+        }));
+    }
+    if let Some(meeting_id) = row.meeting_id {
+        // GATE: a sealed-not-unlocked meeting refuses (masked title never leaks).
+        if !meeting_is_unlocked(st, &meeting_id)? {
+            return Ok(None);
+        }
+        let title = st
+            .db
+            .get_meeting(&meeting_id)?
+            .and_then(|m| m.title.clone())
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| "Shared note".to_string());
+        return Ok(Some(OwnedSourceResolved {
+            title,
+            owned: crate::storage::models::OrgOwnedSource {
+                kind: "meeting".to_string(),
+                id: meeting_id,
+            },
+        }));
+    }
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5132,6 +5132,9 @@ impl Db {
                     author_hint: r.get(2)?,
                     created_at: r.get(3)?,
                     seq: r.get::<_, i64>(4)? as u64,
+                    // Enriched in `list_org_items_inner` (needs `&AppState` for the unlock gate); the
+                    // raw DB row carries no ownership resolution.
+                    owned_source: None,
                 })
             })
             .map_err(map_err)?;

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -543,6 +543,24 @@ pub struct OrgItemHeader {
     pub author_hint: String,
     pub created_at: String,
     pub seq: u64,
+    /// The caller's OWN editable local source for this item, when THIS device published it (resolved
+    /// via `org_share_by_item` → the anchored note/meeting) AND that source is currently readable
+    /// (unlock-gated — a locked source resolves to `None`, never leaking its title). `None` for an
+    /// item shared by someone else (a read-only replica) or a locked own source. When present, the FE
+    /// links the row straight to the editable original (`/notes/:id` | `/meeting/:id`) and the header's
+    /// `title` is overridden to the source's CURRENT title — so the author's own card never shows a
+    /// stale publish-time snapshot and never routes through the read-only viewer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owned_source: Option<OrgOwnedSource>,
+}
+
+/// The caller's local editable source behind an org item they authored (see `OrgItemHeader.owned_source`).
+/// `kind` is `"document"` (a note → `/notes/:id`) or `"meeting"` (a recording → `/meeting/:id`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgOwnedSource {
+    pub kind: String,
+    pub id: String,
 }
 
 /// Shared Brain v1 — the content-free result of a manual `org_sync_now()` (counts + errors only).

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1835,6 +1835,15 @@ export interface OrgItemHeader {
   createdAt: string;
   /** The item's feed sequence — stable ordering key for the browse list. */
   seq: number;
+  /**
+   * When THIS user published the item AND their local source is readable, the
+   * editable original behind it (resolved backend-side, unlock-gated). Present ⇒
+   * the row links straight to `/notes/:id` | `/meeting/:id` and `title` is the
+   * source's CURRENT title (never a stale publish-time snapshot). Absent ⇒ a
+   * read-only replica shared by someone else (or a locked own source), opened via
+   * the `/org-item/:id` viewer. Mirrors the Rust `OrgItemHeader.owned_source`.
+   */
+  ownedSource?: { kind: "document" | "meeting"; id: string } | null;
 }
 
 /**

--- a/src/app/core/nav-history.service.ts
+++ b/src/app/core/nav-history.service.ts
@@ -21,7 +21,13 @@ export function isDrilldownRoute(url: string): boolean {
     url.startsWith("/settings") ||
     url.startsWith("/library") ||
     url.startsWith("/meeting") ||
-    url.startsWith("/notes")
+    url.startsWith("/notes") ||
+    // The org-item viewer is "inside" the Notes flow (reached from an org card; its
+    // own Back returns to /notes). Treating it as a drill-down (a) hides the primary
+    // rail so it owns the window like the note editor, and (b) keeps it OUT of
+    // `_lastAppRoute` so the Notes "← Murmur" affordance returns to the real prior
+    // app view (/record), not back into an org-item viewer.
+    url.startsWith("/org-item")
   );
 }
 

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -432,10 +432,14 @@
                   </div>
                 }
                 @case ("org") {
-                  <!-- A READ-ONLY org (Shared Brain) replica — opens the /org-item viewer. -->
+                  <!-- An org (Shared Brain) item. If the caller AUTHORED it
+                       (`ownedSource`), the row links straight to the EDITABLE
+                       original (/notes/:id | /meeting/:id) with the current title;
+                       otherwise it's a READ-ONLY replica → the /org-item viewer. -->
                   <a
                     class="card note-card note-card--org"
-                    [routerLink]="['/org-item', it.item.itemId]"
+                    [class.note-card--owned]="it.item.ownedSource"
+                    [routerLink]="orgItemLink(it.item)"
                   >
                     <div class="note-open note-open--org">
                       <div class="note-card-head">

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -182,17 +182,37 @@ export class NotesHomeComponent implements OnInit {
       return noteCards.sort((a, b) => b.sortAt - a.sortAt);
     }
 
-    // "All notes": merge YOUR notes with EVERY org's shared items.
+    // "All notes": merge YOUR notes with EVERY org's shared items — but DROP org
+    // replicas the caller authored (`ownedSource`): the editable original already
+    // appears (as a note card, or under Meetings), so showing the replica too would
+    // duplicate the row and surface a stale publish-time title. Replicas shared by
+    // OTHERS stay (that's the point of the merged view).
     const orgCards: NotesListItem[] = orgs.flatMap((o) =>
-      (orgItemsByOrg[o.orgId] ?? []).map((item) =>
-        this.toOrgCard(item, o.name),
-      ),
+      (orgItemsByOrg[o.orgId] ?? [])
+        .filter((item) => !item.ownedSource)
+        .map((item) => this.toOrgCard(item, o.name)),
     );
     return [...noteCards, ...orgCards].sort((a, b) => b.sortAt - a.sortAt);
   });
 
   /** True when the unified list has zero rows (drives the empty state). */
   readonly listEmpty = computed(() => this.listItems().length === 0);
+
+  /**
+   * Router target for an org card. When the caller AUTHORED the item (`ownedSource`,
+   * resolved+gated backend-side) the row opens the EDITABLE original — a `/notes/:id`
+   * note or a `/meeting/:id` recording — so the author edits the real thing instead of
+   * a read-only replica. Otherwise it opens the read-only `/org-item/:id` viewer.
+   */
+  orgItemLink(item: OrgItemHeader): string[] {
+    const owned = item.ownedSource;
+    if (owned) {
+      return owned.kind === "meeting"
+        ? ["/meeting", owned.id]
+        : ["/notes", owned.id];
+    }
+    return ["/org-item", item.itemId];
+  }
 
   /** Build an org card from a header + its origin org name. */
   private toOrgCard(item: OrgItemHeader, orgName: string): NotesListItem {


### PR DESCRIPTION
## What

Fixes the three org-notes (Shared Brain) bugs reported from the Notes view. Root-caused against the **real dev DB** (inspected the encrypted `org_items` vs `org_shares` directly), not guessed.

| Bug | Cause | Fix |
| --- | --- | --- |
| Org card shows **"Untitled"** despite the note having a title | The org replica is frozen at share time (e.g. a note now titled *"Jest tytul"* whose share is stuck at `rev=1, "Untitled"`); `republish`-on-edit silently no-ops without a live session and nothing reconciled the author's own view | `list_org_items` now resolves each item the caller authored to its editable local source and overrides the card title with the source's **current** title — fully **unlock-gated** (a locked source never leaks its title) |
| Clicking an org item opens the **read-only viewer even for the author** | The card always routed through `/org-item/:id`, whose author-redirect relies on a fragile `item_id` match that drifts after a republish | New `OrgItemHeader.owned_source`: owned cards link straight to the editable original (`/notes/:id` \| `/meeting/:id`). Owned replicas are dropped from **All notes** (the original already appears) but kept in the org scope; non-owned stay read-only |
| **"← Murmur"** back button doesn't return to the main UI | `/org-item` wasn't a drill-down route, so it polluted the nav history and the Notes back button returned *into* an org-item viewer | `/org-item` added to `isDrilldownRoute` → hides the primary rail on the viewer and returns Back to `/record` |

**Hardening:** `republish_org_shares_for_source` now keeps the local replica consistent (upsert new + tombstone old, guarded against a same-`item_id` server response) so `item_id` never drifts on the author's own device.

## How verified

- Two new **RED→GREEN** backend tests: ownership enrichment shows the current title + editable ref; a **locked source's title is not leaked** into the org list (proven RED when the gate is removed).
- `scripts/ci.sh` green (clippy `-D warnings` + 1521 lib tests + `ng lint` + `ng build` + headless E2E).
- **adversarial-verifier**: PASS — full RED-before-GREEN on all three fixes + live browser probes (All-notes dedup, org-scope routing to `/notes`·`/meeting`·`/org-item`), zero console errors.
- **lock-security-reviewer**: PASS — the title-enrichment path is correctly gated (`folder_is_unlocked`/`meeting_is_unlocked`), `owned_source` never crosses to the server (`skip_serializing_if`), and the local-replica upsert is byte-identical to normal sync-ingest with no new at-rest exposure and no source-seal impact.

## Honest boundary

A full **2-account org round-trip** on a signed build (does a co-member evict the tombstoned copy / see the republished rev end-to-end) and Touch-ID lock-at-rest are **not** verifiable headless — the backend gate logic is unit-proven, the live server round-trip is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)