### PR TITLE
feat(share): prominent Org Brain CTA at the top of the share surfaces

### DIFF
--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.html
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.html
@@ -1,0 +1,33 @@
+<div class="org-cta">
+  <div class="org-cta-head">
+    <span class="org-cta-mark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="8" r="3.2" />
+        <path d="M5 20a7 7 0 0 1 14 0" />
+        <circle cx="4.5" cy="10" r="2" />
+        <circle cx="19.5" cy="10" r="2" />
+      </svg>
+    </span>
+    <span class="org-cta-headings">
+      <span class="org-cta-title">Add to Org Brain</span>
+      <span class="org-cta-org">{{ orgName() }}</span>
+    </span>
+  </div>
+
+  <p class="org-cta-copy">
+    Share this note into <strong>{{ orgName() }}</strong>’s shared brain so your
+    {{ audience() }} can find it. End-to-end encrypted — the server can’t read it.
+  </p>
+
+  <button
+    type="button"
+    class="btn btn-primary org-cta-btn"
+    (click)="add.emit()"
+    [disabled]="disabled()"
+  >
+    <svg viewBox="0 0 16 16" width="15" height="15" fill="none" aria-hidden="true">
+      <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+    </svg>
+    Add to Org Brain
+  </button>
+</div>

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.scss
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.scss
@@ -1,0 +1,72 @@
+:host {
+  display: block;
+}
+
+/* Accent-tinted flagship card — stands apart from the quiet .panel-card blocks
+   so org sharing reads as the primary action at the top of the share surface. */
+.org-cta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--accent-ring);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, var(--accent-soft), transparent 70%),
+    var(--surface-raised);
+}
+
+.org-cta-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.org-cta-mark {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-md);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.org-cta-headings {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.org-cta-title {
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.org-cta-org {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.org-cta-copy {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.org-cta-copy strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.org-cta-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
@@ -1,0 +1,40 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from "@angular/core";
+
+/**
+ * Design System — `<mur-org-brain-cta>`: the prominent "Add to Org Brain" call
+ * to action shown at the TOP of the note / meeting share surfaces. Org sharing
+ * is the flagship action, so this is an accent-tinted card (not a quiet
+ * `.panel-card` with a ghost link) with the org mark, a one-line E2EE promise,
+ * and a primary button. Purely presentational — it emits `add` and the host
+ * panel opens the real `<app-org-share-sheet>`. Shared by `note-share-panel`
+ * and the meeting `share-panel` so the two stay identical.
+ */
+@Component({
+  selector: "mur-org-brain-cta",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./org-brain-cta.component.html",
+  styleUrl: "./org-brain-cta.component.scss",
+})
+export class MurOrgBrainCtaComponent {
+  /** The target org's display name. */
+  readonly orgName = input.required<string>();
+  /** Teammate count (drives the "N teammate(s)" copy). */
+  readonly memberCount = input.required<number>();
+  /** Disables the button (e.g. while the note is mid-edit). */
+  readonly disabled = input(false);
+
+  /** Fired when the user clicks the CTA — the host opens the org-share sheet. */
+  readonly add = output<void>();
+
+  /** "your N teammate" / "N teammates" — never a bare count. */
+  readonly audience = computed(() => {
+    const n = this.memberCount();
+    return `${n} ${n === 1 ? "teammate" : "teammates"}`;
+  });
+}

--- a/src/app/features/detail/share-panel/share-panel.component.html
+++ b/src/app/features/detail/share-panel/share-panel.component.html
@@ -44,6 +44,16 @@
       }
     </div>
   } @else {
+    <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org). -->
+    @if (org(); as orgStatus) {
+      <mur-org-brain-cta
+        [orgName]="orgStatus.name"
+        [memberCount]="orgStatus.memberCount"
+        [disabled]="editing()"
+        (add)="openOrgSheet()"
+      />
+    }
+
     <!-- ============================================================== -->
     <!-- CONFIGURE (2.3) — password FIRST → expires → open limit →       -->
     <!-- consent → Create link. Replaced by CREATED after a create.     -->
@@ -449,34 +459,6 @@
         </div>
       }
     </div>
-
-    <!-- ============================================================== -->
-    <!-- ORG BRAIN (Shared Brain v1) — publish this note to the org's    -->
-    <!-- shared brain. Only shown when the user is in an org.            -->
-    <!-- ============================================================== -->
-    @if (org(); as orgStatus) {
-      <div class="panel-card org">
-        <div class="manage-head">
-          <span class="section-label">Org Brain</span>
-          <span class="hint-inline">{{ orgStatus.name }}</span>
-        </div>
-        <p class="consent-copy">
-          Add this note to <strong>{{ orgStatus.name }}</strong>'s shared brain so
-          your
-          {{ orgStatus.memberCount }}
-          {{ orgStatus.memberCount === 1 ? "teammate" : "teammates" }} can find it.
-          It's end-to-end encrypted; the server can't read it.
-        </p>
-        <button
-          type="button"
-          class="btn btn-ghost org-btn"
-          (click)="openOrgSheet()"
-          [disabled]="editing()"
-        >
-          Add to Org Brain
-        </button>
-      </div>
-    }
 
     @if (verifyMode(); as mode) {
       <app-share-verify-sheet

--- a/src/app/features/detail/share-panel/share-panel.component.scss
+++ b/src/app/features/detail/share-panel/share-panel.component.scss
@@ -266,14 +266,10 @@
 
 /* --- 2.5 Manage --- */
 .manage,
-.person,
-.org {
+.person {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-}
-.org-btn {
-  align-self: flex-start;
 }
 .manage-head {
   display: flex;

--- a/src/app/features/detail/share-panel/share-panel.component.ts
+++ b/src/app/features/detail/share-panel/share-panel.component.ts
@@ -25,6 +25,7 @@ import {
   OrgShareSheetComponent,
   type OrgShareTarget,
 } from "../org-share-sheet/org-share-sheet.component";
+import { MurOrgBrainCtaComponent } from "../../../design-system/org-brain-cta/org-brain-cta.component";
 
 /** The step the in-flow "Share with a person" panel is showing. */
 export type PersonShareStep = "email" | "suggest-link" | "consent" | "result";
@@ -74,7 +75,11 @@ export interface LinkShareRow {
 @Component({
   selector: "app-share-panel",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ShareVerifySheetComponent, OrgShareSheetComponent],
+  imports: [
+    ShareVerifySheetComponent,
+    OrgShareSheetComponent,
+    MurOrgBrainCtaComponent,
+  ],
   templateUrl: "./share-panel.component.html",
   styleUrl: "./share-panel.component.scss",
 })

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.html
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.html
@@ -63,6 +63,15 @@
         }
       </div>
     } @else {
+      <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org). -->
+      @if (org(); as orgStatus) {
+        <mur-org-brain-cta
+          [orgName]="orgStatus.name"
+          [memberCount]="orgStatus.memberCount"
+          (add)="openOrgSheet()"
+        />
+      }
+
       <!-- CONFIGURE — password FIRST → expires → open limit → consent → Create. -->
       @if (step() === "configure") {
         <div class="panel-card create" role="group" aria-label="Create a share link">
@@ -354,25 +363,6 @@
         }
       </div>
 
-      <!-- ORG BRAIN — publish this note to the org's shared brain (only in an org). -->
-      @if (org(); as orgStatus) {
-        <div class="panel-card org">
-          <div class="manage-head">
-            <span class="section-label">Org Brain</span>
-            <span class="hint-inline">{{ orgStatus.name }}</span>
-          </div>
-          <p class="consent-copy">
-            Add this note to <strong>{{ orgStatus.name }}</strong>'s shared brain so
-            your
-            {{ orgStatus.memberCount }}
-            {{ orgStatus.memberCount === 1 ? "teammate" : "teammates" }} can find
-            it. It's end-to-end encrypted; the server can't read it.
-          </p>
-          <button type="button" class="btn btn-ghost" (click)="openOrgSheet()">
-            Add to Org Brain
-          </button>
-        </div>
-      }
     }
   </div>
 </div>

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.ts
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.ts
@@ -19,6 +19,7 @@ import {
   OrgShareSheetComponent,
   type OrgShareTarget,
 } from "../../detail/org-share-sheet/org-share-sheet.component";
+import { MurOrgBrainCtaComponent } from "../../../design-system/org-brain-cta/org-brain-cta.component";
 
 /** The link-share flow step (Manage always coexists as the list below). */
 type ShareStep = "configure" | "created";
@@ -65,7 +66,7 @@ interface LinkShareRow {
 @Component({
   selector: "app-note-share-panel",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [OrgShareSheetComponent],
+  imports: [OrgShareSheetComponent, MurOrgBrainCtaComponent],
   templateUrl: "./note-share-panel.component.html",
   styleUrl: "./note-share-panel.component.scss",
 })


### PR DESCRIPTION
## What

The "Add to Org Brain" entry was a quiet ghost-text button in a plain `panel-card` at the **bottom** of the note/meeting share sheets — easy to miss and it looked weak. Org sharing is the flagship action, so it's now surfaced **first** and looks the part.

**Before:** bottom, `section-label` + copy + ghost-text "Add to Org Brain".
**After:** top of the share body — an accent-tinted card (accent-ring border + soft accent gradient), org mark in an accent chip, bold title + org name, one-line E2EE copy, and a **primary** button with a `+` glyph.

## Changes

- **New shared design-system component** `mur-org-brain-cta` (its own directory, `mur-` prefix, tokens only). Presentational: inputs `orgName` / `memberCount` / `disabled`, output `add` — both share surfaces render the identical CTA.
- `note-share-panel` + meeting `share-panel`: render `<mur-org-brain-cta>` at the **top** of the share body (was a bottom `panel-card`); removed the old markup and now-dead `.org`/`.org-btn` scss.

## Verified

- `npx ng lint` + `npx ng build` green.
- **e2e/org + e2e/notes + e2e/detail 23/23** pass (incl. "Share panel shows the Org Brain flow" — the CTA still opens the org-share sheet).
- Visual confirmed via an isolated token-accurate render.

FE-only, no backend, no lock/crypto path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)