### PR TITLE
fix(share/notes): generic Org Brain CTA + back-button spacing

### DIFF
--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.html
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.html
@@ -10,13 +10,13 @@
     </span>
     <span class="org-cta-headings">
       <span class="org-cta-title">Add to Org Brain</span>
-      <span class="org-cta-org">{{ orgName() }}</span>
+      <span class="org-cta-org">End-to-end encrypted</span>
     </span>
   </div>
 
   <p class="org-cta-copy">
-    Share this note into <strong>{{ orgName() }}</strong>’s shared brain so your
-    {{ audience() }} can find it. End-to-end encrypted — the server can’t read it.
+    Share this note into a team’s <strong>shared brain</strong> so your teammates
+    can find it — you choose which organization next. The server can’t read it.
   </p>
 
   <button

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
   input,
   output,
 } from "@angular/core";
@@ -12,7 +11,9 @@ import {
  * is the flagship action, so this is an accent-tinted card (not a quiet
  * `.panel-card` with a ghost link) with the org mark, a one-line E2EE promise,
  * and a primary button. Purely presentational — it emits `add` and the host
- * panel opens the real `<app-org-share-sheet>`. Shared by `note-share-panel`
+ * panel opens the real `<app-org-share-sheet>`, where the user PICKS which
+ * organization to publish to (a member can belong to several), so this card is
+ * deliberately GENERIC and names no single org. Shared by `note-share-panel`
  * and the meeting `share-panel` so the two stay identical.
  */
 @Component({
@@ -22,19 +23,9 @@ import {
   styleUrl: "./org-brain-cta.component.scss",
 })
 export class MurOrgBrainCtaComponent {
-  /** The target org's display name. */
-  readonly orgName = input.required<string>();
-  /** Teammate count (drives the "N teammate(s)" copy). */
-  readonly memberCount = input.required<number>();
   /** Disables the button (e.g. while the note is mid-edit). */
   readonly disabled = input(false);
 
   /** Fired when the user clicks the CTA — the host opens the org-share sheet. */
   readonly add = output<void>();
-
-  /** "your N teammate" / "N teammates" — never a bare count. */
-  readonly audience = computed(() => {
-    const n = this.memberCount();
-    return `${n} ${n === 1 ? "teammate" : "teammates"}`;
-  });
 }

--- a/src/app/features/detail/share-panel/share-panel.component.html
+++ b/src/app/features/detail/share-panel/share-panel.component.html
@@ -44,14 +44,10 @@
       }
     </div>
   } @else {
-    <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org). -->
-    @if (org(); as orgStatus) {
-      <mur-org-brain-cta
-        [orgName]="orgStatus.name"
-        [memberCount]="orgStatus.memberCount"
-        [disabled]="editing()"
-        (add)="openOrgSheet()"
-      />
+    <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org).
+         Generic CTA: the org is PICKED in the sheet (a member can be in many). -->
+    @if (org()) {
+      <mur-org-brain-cta [disabled]="editing()" (add)="openOrgSheet()" />
     }
 
     <!-- ============================================================== -->

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -40,8 +40,9 @@
   gap: var(--space-2);
   /* Extra left inset clears the overlay macOS traffic lights (trafficLightPosition
      {32,30} in tauri.conf.json — this fixed drill-down covers the whole window,
-     so nothing else reserves room for them on this row). */
-  padding: var(--space-4) var(--space-6) var(--space-3) 84px;
+     so nothing else reserves room for them on this row). ~20px past the last dot
+     so the "‹ Notes" back button doesn't crowd the green light. */
+  padding: var(--space-4) var(--space-6) var(--space-3) 104px;
   border-bottom: 1px solid var(--border-subtle);
 }
 .head-spacer {

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.html
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.html
@@ -63,13 +63,10 @@
         }
       </div>
     } @else {
-      <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org). -->
-      @if (org(); as orgStatus) {
-        <mur-org-brain-cta
-          [orgName]="orgStatus.name"
-          [memberCount]="orgStatus.memberCount"
-          (add)="openOrgSheet()"
-        />
+      <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org).
+           Generic CTA: the org is PICKED in the sheet (a member can be in many). -->
+      @if (org()) {
+        <mur-org-brain-cta (add)="openOrgSheet()" />
       }
 
       <!-- CONFIGURE — password FIRST → expires → open limit → consent → Create. -->


### PR DESCRIPTION
Two small UI follow-ups from live testing.

**1. Org Brain CTA is generic (no hardcoded org name).** The card named a single org ("test") + "1 teammate", but a member can belong to several orgs and the target is **picked in the org-share sheet** — so naming one org up front was misleading. The card is now generic: subtitle "End-to-end encrypted", copy "Share this note into a team's shared brain … you choose which organization next." Dropped the `orgName`/`memberCount` inputs from `mur-org-brain-cta`; both panels render it under a plain `@if (org())` guard.

**2. Note-editor back button clearance.** The "‹ Notes" back button sat flush against the macOS traffic lights on the editor header row — bumped the header left inset 84px → 104px.

Verified: `ng lint` + `ng build` green; e2e/org + e2e/notes 21/21 pass; both changes eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)