### PR TITLE
fix(notes): make the selection Brain popover more readable

### DIFF
--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
@@ -10,15 +10,16 @@
   role="dialog"
   aria-label="Brain assistant"
 >
-  <!-- Header: the "Brain" identity + the mode chip (neutral until a result). -->
+  <!-- Header: the "Brain" identity + (once a result lands) the action name. The
+       model attribution moved to a quiet footer caption so the header stays clean. -->
   <div class="pop-head">
     <span class="pop-brand">
       <span class="pop-brand-glyph" aria-hidden="true"></span>
       Brain
     </span>
-    <span class="pop-mode" [class.is-resolved]="result() !== null">
-      {{ modeLabel() }}
-    </span>
+    @if (result(); as res) {
+      <span class="pop-head-action">{{ actionLabel(res.action) }}</span>
+    }
     <button
       type="button"
       class="pop-close"
@@ -93,12 +94,10 @@
     @case ("result") {
       @if (result(); as res) {
         <div class="pop-result">
-          <p class="pop-flow-title">{{ actionLabel(res.action) }}</p>
-
           @if (isEnhanceResult()) {
             <!-- Enhance is ADDITIVE: keep the selection, show the passage to insert. -->
             <div class="pop-diff">
-              <span class="pop-diff-tag">Keeps your text; adds</span>
+              <span class="pop-diff-tag is-add">Keeps your text · adds</span>
               <div class="pop-suggestion is-add">{{ res.suggestion }}</div>
             </div>
             @if (res.citations.length > 0) {
@@ -117,10 +116,18 @@
               </div>
             }
           } @else {
-            <!-- Refine/Shorten REPLACE: struck original vs accent suggestion. -->
+            <!-- Refine/Shorten REPLACE: original (muted) → suggestion (accent),
+                 each clearly labelled so the change reads at a glance. -->
             <div class="pop-diff">
-              <div class="pop-original">{{ original() }}</div>
-              <div class="pop-suggestion">{{ res.suggestion }}</div>
+              <div class="pop-diff-col">
+                <span class="pop-diff-tag">Original</span>
+                <div class="pop-original">{{ original() }}</div>
+              </div>
+              <span class="pop-diff-arrow" aria-hidden="true">↓</span>
+              <div class="pop-diff-col">
+                <span class="pop-diff-tag is-accent">Suggested</span>
+                <div class="pop-suggestion">{{ res.suggestion }}</div>
+              </div>
             </div>
           }
 
@@ -130,6 +137,8 @@
               Sensitive details were redacted before this left your Mac.
             </p>
           }
+
+          <p class="pop-model" [title]="res.modelLabel">{{ res.modelLabel }}</p>
 
           <div class="pop-buttons">
             <button

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
@@ -63,17 +63,17 @@
   background: var(--accent-gradient);
   box-shadow: 0 0 12px var(--accent-soft);
 }
-.pop-mode {
-  font-size: 0.7rem;
+/* The action name ("Shorten"…) sits quietly next to the brand once a result
+   lands; a subtle divider dot separates it from "Brain". */
+.pop-head-action {
+  font-size: 0.8125rem;
   font-weight: 550;
-  color: var(--text-muted);
-  padding: 2px var(--space-2);
-  border-radius: var(--radius-pill);
-  background: var(--surface-hover);
+  color: var(--text-secondary);
 }
-.pop-mode.is-resolved {
-  color: var(--accent-hover);
-  background: var(--accent-soft);
+.pop-head-action::before {
+  content: "·";
+  margin: 0 var(--space-1) 0 0;
+  color: var(--text-muted);
 }
 .pop-close {
   margin-left: auto;
@@ -240,26 +240,42 @@
 .pop-diff {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-1);
   max-height: 260px;
   overflow-y: auto;
 }
+.pop-diff-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 .pop-diff-tag {
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: 0.66rem;
+  font-weight: 650;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
+  color: var(--text-muted);
+}
+.pop-diff-tag.is-accent {
+  color: var(--accent-hover);
+}
+.pop-diff-tag.is-add {
+  color: var(--success);
+}
+/* The change direction between the two blocks (original → suggested). */
+.pop-diff-arrow {
+  align-self: center;
+  font-size: 0.8rem;
+  line-height: 1;
   color: var(--text-muted);
 }
 .pop-original {
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   background: var(--surface-hover);
-  color: var(--text-muted);
-  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
   line-height: 1.5;
-  text-decoration: line-through;
-  text-decoration-color: var(--text-muted);
 }
 .pop-suggestion {
   padding: var(--space-2) var(--space-3);
@@ -323,6 +339,16 @@
   display: flex;
   align-items: center;
   gap: var(--space-1);
+}
+
+/* Quiet model attribution — a single truncated line, out of the way. */
+.pop-model {
+  margin: 0;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* --- Buttons --------------------------------------------------------------- */

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -150,12 +150,6 @@ export class NoteBrainPopoverComponent {
     return t.refine || t.shorten || t.enhance;
   });
 
-  /** The mode chip label — the resolved model once a result lands, else neutral. */
-  readonly modeLabel = computed(() => {
-    const r = this.result();
-    return r ? `via ${r.modelLabel}` : "Brain";
-  });
-
   /** Whether the current result is the additive-enhance shape (insert, not replace). */
   readonly isEnhanceResult = computed(
     () => this.result()?.action === "enhance",


### PR DESCRIPTION
The selection Brain result popover was hard to read: a long model pill ("via the on-device model · qwen3-4b-instruct-2507") wrapped across the header and crowded the close button, and the original text was rendered fully **struck-through** (illegible).

**After:**
- Header shows just **"Brain · <action>"** (e.g. "Brain · Shorten") — clean, single line.
- The diff labels the two blocks **"Original" → "Suggested"** with a direction arrow; the original is now **muted (no strikethrough)** so it stays readable, the suggestion stays the prominent accent block.
- Model attribution moves to a **quiet, truncated one-line caption** at the bottom (full id on hover).

FE-only, no backend. `ng lint` + `ng build` green; **e2e/notes 9/9** pass (incl. `brain-popover`); visual confirmed via an isolated render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)