### PR TITLE
chore(release): 0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.5"
+version = "0.9.6"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.6.

Rolls up since 0.9.5 (PRs #258–#264):
- #258 org author-editable cards + current titles + Back fix
- #259 Meetings view recordings-only (no org items)
- #260 Quiet Glass — minimalist Liquid Glass redesign + UX pass
- #261 prominent Org Brain CTA
- #262 generic Org Brain CTA + back-button spacing
- #263 Brain popover readability
- #264 note-assistant command menu (19 actions) + fix: EDIT-class note-assist actions (refine/grammar/shorten/expand/simplify/tone) now always match the selected passage's own language instead of forcing the global Notes-language setting (was forcing Polish output when shortening English text). Independently adversarial-verified: PASS.

scripts/ci.sh: all gates green (clippy -D warnings, cargo test --lib, cargo build, ng lint, ng build, headless E2E mic+system mixing).