### PR TITLE
docs(agents): point CLAUDE.md/AGENTS.md at the ../murmur-server backend repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,28 @@ A **local-first macOS desktop app** that records meetings, transcribes on-device
 
 **Angular** (`src/app/features/`): `analytics`, `ask`, `bar`, `detail`, `folders`, `graph`, `library`, `onboarding`, `record`, `settings`. Services: `core/ipc.service.ts`, `services/{folders,toast,screen-share}.service.ts`, `core/models.ts`.
 
+## Backend server — a SEPARATE repo at `../murmur-server/`
+
+The accounts + sharing backend is **not in this repo** — it lives in the sibling checkout
+`../murmur-server/` (GitHub `murmur-io/murmur-server`). Murmur is local-first and fully usable with
+**no account**; this server is an **opt-in Tier 1** zero-knowledge relay that unlocks E2EE note +
+Org "Shared Brain" sharing. It stores only **ciphertext blobs, wrapped keys, and public keys** —
+never plaintext.
+
+**When a task touches the backend/server** — accounts (OPAQUE login), link-share, Murmur↔Murmur
+invites, Org sync, the sharing wire format, or anything the app calls over HTTPS — **read
+`../murmur-server/` for the real server-side implementation**; do not reason from the client alone.
+It is a Rust workspace:
+- `crates/murmur-protocol` — the shared E2EE envelope + wire format, **compiled into BOTH the Tauri
+  client (this repo) and the server**, so a format change must land in both or it's a compile error.
+  A client-side sharing change usually has a server-side counterpart here (`MIT OR Apache-2.0`).
+- `crates/murmur-server` — the axum + Postgres service (`AGPL-3.0`), deployed on **Railway**.
+
+Authoritative design spec lives in THIS repo:
+`docs/superpowers/specs/2026-07-04-murmur-server-spec.md` (accounts via OPAQUE, modes A/B, the
+threat matrix §1.1, the one-way two-domain rule §9). Deploy / redeploy / logs / env: follow the
+runbook `../murmur-server/DEPLOY.md` (Railway, GraphQL API not CLI) — never hand-roll ops.
+
 ## Common commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,28 @@ A **local-first macOS desktop app** that records meetings, transcribes on-device
 
 **Angular** (`src/app/features/`): `analytics`, `ask`, `bar`, `detail`, `folders`, `graph`, `library`, `onboarding`, `record`, `settings`. Services: `core/ipc.service.ts`, `services/{folders,toast,screen-share}.service.ts`, `core/models.ts`.
 
+## Backend server — a SEPARATE repo at `../murmur-server/`
+
+The accounts + sharing backend is **not in this repo** — it lives in the sibling checkout
+`../murmur-server/` (GitHub `murmur-io/murmur-server`). Murmur is local-first and fully usable with
+**no account**; this server is an **opt-in Tier 1** zero-knowledge relay that unlocks E2EE note +
+Org "Shared Brain" sharing. It stores only **ciphertext blobs, wrapped keys, and public keys** —
+never plaintext.
+
+**When a task touches the backend/server** — accounts (OPAQUE login), link-share, Murmur↔Murmur
+invites, Org sync, the sharing wire format, or anything the app calls over HTTPS — **read
+`../murmur-server/` for the real server-side implementation**; do not reason from the client alone.
+It is a Rust workspace:
+- `crates/murmur-protocol` — the shared E2EE envelope + wire format, **compiled into BOTH the Tauri
+  client (this repo) and the server**, so a format change must land in both or it's a compile error.
+  A client-side sharing change usually has a server-side counterpart here (`MIT OR Apache-2.0`).
+- `crates/murmur-server` — the axum + Postgres service (`AGPL-3.0`), deployed on **Railway**.
+
+Authoritative design spec lives in THIS repo:
+`docs/superpowers/specs/2026-07-04-murmur-server-spec.md` (accounts via OPAQUE, modes A/B, the
+threat matrix §1.1, the one-way two-domain rule §9). Deploy / redeploy / logs / env are owned by the
+**`deploy-murmur-server`** skill (runbook: `../murmur-server/DEPLOY.md`) — never hand-roll Railway ops.
+
 ## Common commands
 
 ```bash


### PR DESCRIPTION
Adds a **Backend server** section to `CLAUDE.md` (Claude Code) and `AGENTS.md` (Codex) so agents pull context from the separate `../murmur-server/` repo when a task touches the backend.

## Why
The accounts + E2EE sharing backend is a **separate repo** (`murmur-io/murmur-server`), not `src-tauri`. Agents were reasoning about sharing/Org/account work from the client alone. The new section tells them:
- **When** to consult it (accounts/OPAQUE, link-share, Murmur↔Murmur invites, Org sync, the sharing wire format, anything over HTTPS).
- The **key seam:** `crates/murmur-protocol` is compiled into BOTH the client and the server, so a wire-format change must land in both or it's a compile error.
- Where the **authoritative spec** lives (`docs/superpowers/specs/2026-07-04-murmur-server-spec.md`) and that deploy is owned by the `deploy-murmur-server` skill / `../murmur-server/DEPLOY.md`.

Docs-only; no code touched. A reciprocal `CLAUDE.md`/`AGENTS.md` pointing back at this client was also added in the `murmur-server` repo.