### PR TITLE
fix(org): auto-refresh shared-brain notes without a manual "Sync now"

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1479,12 +1479,21 @@ pub fn get_last_note(state: State<'_, AppState>) -> Result<Option<NoteDto>, AppE
 /// failure NEVER fails the save (`let _ = …`); the launch sweep retries a `failed` row.
 #[tauri::command]
 pub async fn update_note(
+    app: AppHandle,
     state: State<'_, AppState>,
     meeting_id: String,
     markdown: String,
 ) -> Result<NoteDto, AppError> {
     let dto = update_note_inner(state.inner(), &meeting_id, &markdown)?;
-    let _ = republish_org_shares_for_source(state.inner(), Some(&meeting_id), None).await;
+    // If the edit re-published ≥1 org copy, ping open org views (Notes list + Settings) so the fresh
+    // title/body shows without a manual "Sync now". Best-effort — a republish failure never fails the save.
+    if republish_org_shares_for_source(state.inner(), Some(&meeting_id), None)
+        .await
+        .unwrap_or(0)
+        > 0
+    {
+        crate::events::emit_org_feed_updated(&app, 1);
+    }
     Ok(dto)
 }
 
@@ -2472,13 +2481,21 @@ pub(crate) fn list_notes_inner(
 /// `save_note_text` autosave (OCK-seal + egress per keystroke is unacceptable) — only this commit path.
 #[tauri::command]
 pub async fn update_note_doc(
+    app: AppHandle,
     state: State<'_, AppState>,
     id: String,
     title: String,
     markdown: String,
 ) -> Result<NoteDoc, AppError> {
     let doc = update_note_doc_inner(state.inner(), &id, &title, &markdown)?;
-    let _ = republish_org_shares_for_source(state.inner(), None, Some(&id)).await;
+    // See `update_note`: ping open org views when the edit re-published ≥1 org copy. Best-effort.
+    if republish_org_shares_for_source(state.inner(), None, Some(&id))
+        .await
+        .unwrap_or(0)
+        > 0
+    {
+        crate::events::emit_org_feed_updated(&app, 1);
+    }
     Ok(doc)
 }
 
@@ -8340,8 +8357,15 @@ pub async fn resummarize(
     }
     let result = pipeline::resummarize_existing(&app, &state, &meeting_id).await?;
     // COMMIT BOUNDARY: a re-summarize rewrites the meeting's note → BEST-EFFORT re-publish any org
-    // shares of it so members see the fresh summary. Best-effort — never fails the re-summarize.
-    let _ = republish_org_shares_for_source(state.inner(), Some(&meeting_id), None).await;
+    // shares of it so members see the fresh summary. Best-effort — never fails the re-summarize. If
+    // ≥1 org copy was re-published, ping open org views so the fresh summary shows without a manual sync.
+    if republish_org_shares_for_source(state.inner(), Some(&meeting_id), None)
+        .await
+        .unwrap_or(0)
+        > 0
+    {
+        crate::events::emit_org_feed_updated(&app, 1);
+    }
     Ok(StopResult {
         meeting_id: result.meeting_id,
         markdown: result.note_markdown,
@@ -24200,6 +24224,54 @@ mod lifecycle_tests {
         );
     }
 
+    /// B1 (owner-live-refresh) — the OWNER's OWN first-time share must appear in `list_org_items`
+    /// IMMEDIATELY via the local `org_items` replica, not only after a later feed pull. RED before the
+    /// fix (`publish_org_body` published to the server but never upserted the local row → the shared
+    /// note was invisible in the Notes org view / Settings browse until a manual "Sync now"); GREEN
+    /// after: one owned/editable card resolves right away carrying the note's CURRENT title.
+    #[test]
+    fn initial_share_populates_local_org_items_replica_immediately() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-initial-share-replica");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-sh", "Team");
+        state
+            .db
+            .insert_note("n-sh", "f-sh", "plan", "Kickoff Plan", "# body to share", 1)
+            .unwrap();
+
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-sh".to_string()),
+            true,
+        ))
+        .expect("initial share should publish against the mock server");
+        assert_eq!(entry.item_id.as_deref(), Some("item-1"));
+
+        // The local replica must ALREADY hold the item — no feed pull has happened. This is exactly what
+        // makes the shared note show up without a manual "Sync now".
+        let items = list_org_items_inner(&state, "org-1").unwrap();
+        assert_eq!(
+            items.len(),
+            1,
+            "the owner's own share is in the local replica immediately (no pull needed)"
+        );
+        assert_eq!(items[0].item_id, "item-1");
+        // The caller authored it → resolved as an OWNED/editable card with the note's CURRENT title.
+        assert!(
+            items[0].owned_source.is_some(),
+            "the author's own item resolves to an owned/editable source"
+        );
+        assert_eq!(items[0].title, "Kickoff Plan");
+    }
+
     /// ITEM 1 — a republish MUST NOT tombstone-into-nothing. Lock the note's folder AFTER the share,
     /// then edit (the write itself is gated, but even the republish read-gate refuses): the org copy is
     /// left UNTOUCHED — no new publish, NO tombstone. Proves the `Locked` skip protects the org copy.
@@ -25895,23 +25967,35 @@ pub(crate) fn preview_org_share_inner(
 /// misroute that shared into the FIRST org, not the chosen one.
 #[tauri::command]
 pub async fn share_meeting_to_org(
+    app: AppHandle,
     state: State<'_, AppState>,
     org_id: String,
     meeting_id: String,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
-    share_to_org_inner(state.inner(), &org_id, Some(meeting_id), None, scrub).await
+    let entry = share_to_org_inner(state.inner(), &org_id, Some(meeting_id), None, scrub).await?;
+    // A successful share now lives in the local replica (`publish_org_body` upserts it) AND the server
+    // feed — ping every open org view (Notes list + Settings shared-brain) to re-fetch immediately, so
+    // the shared note appears without a manual "Sync now". Content-free count-only event; a best-effort
+    // emit never affects the share result.
+    crate::events::emit_org_feed_updated(&app, 1);
+    Ok(entry)
 }
 
 /// `share_document_to_org(org_id, document_id, scrub)` — the note twin of [`share_meeting_to_org`].
 #[tauri::command]
 pub async fn share_document_to_org(
+    app: AppHandle,
     state: State<'_, AppState>,
     org_id: String,
     document_id: String,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
-    share_to_org_inner(state.inner(), &org_id, None, Some(document_id), scrub).await
+    let entry = share_to_org_inner(state.inner(), &org_id, None, Some(document_id), scrub).await?;
+    // See `share_meeting_to_org`: ping open org views so the freshly-shared note appears without a
+    // manual "Sync now". Content-free; best-effort.
+    crate::events::emit_org_feed_updated(&app, 1);
+    Ok(entry)
 }
 
 pub(crate) async fn share_to_org_inner(
@@ -26086,6 +26170,29 @@ pub(crate) async fn publish_org_body(
         .db
         .set_org_share_uploaded(&row_id, &published.item_id, &now)?;
 
+    // LOCAL REPLICA CONSISTENCY (owner-live-refresh): the author's OWN `org_items` replica would
+    // otherwise stay EMPTY of this item until the next feed pull — so a note the owner just shared is
+    // invisible in `list_org_items` (the Notes org view + Settings browse) until a manual "Sync now".
+    // Upsert it LOCALLY now, mirroring the republish path, so `list_org_items` immediately resolves it
+    // as an owned/editable card. FTS-only (`None` embedder) to keep this share path light; the next real
+    // `org_sync_now` re-ingests authoritatively (idempotent upsert) and re-embeds. Best-effort: a local
+    // replica error must never fail the share (the server copy is already live + correct).
+    if let Err(e) = state.db.upsert_org_item(
+        &published.item_id,
+        &org.org_id,
+        published.seq,
+        &env.author_hint,
+        &env.title,
+        &env.markdown,
+        &env.created_at,
+        rev,
+        generation,
+        &content_sha,
+        None,
+    ) {
+        tracing::warn!(target: "org", error = %e, "share: local replica upsert failed (server copy live)");
+    }
+
     // (7) CONTENT-FREE egress ledger (host + ciphertext byte size). NEVER a title / note text / OCK.
     crate::share::ledger_row(
         &state.db,
@@ -26132,11 +26239,15 @@ pub(crate) async fn republish_org_shares_for_source(
     state: &AppState,
     meeting_id: Option<&str>,
     document_id: Option<&str>,
-) -> Result<(), AppError> {
+) -> Result<u32, AppError> {
     let rows = state.db.org_shares_for_source(meeting_id, document_id)?;
     if rows.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
+    // Count of rows that produced a NEW published rev this call — returned so the caller can emit
+    // `org-feed-updated` ONLY when > 0 (a save that changed nothing / skipped every row must not ping
+    // the FE).
+    let mut republished = 0u32;
     let now = chrono::Utc::now().to_rfc3339();
     for row in rows {
         // Re-read the CURRENT plaintext THROUGH the read-gate. `build_org_share_body` also does the
@@ -26353,8 +26464,10 @@ pub(crate) async fn republish_org_shares_for_source(
                 }
             }
         }
+        // This row published a NEW rev this call — count it so the caller emits `org-feed-updated`.
+        republished += 1;
     }
-    Ok(())
+    Ok(republished)
 }
 
 /// `list_org_shares()` — the caller's outbound org shares (local rows; titles render only to the
@@ -26560,8 +26673,11 @@ pub async fn revoke_shares_for_folder(
 /// Cadence of the background org-feed sync loop (M6 Shared Brain, spawned in `lib.rs` setup). The
 /// first tick fires `ORG_SYNC_FIRST_DELAY_SECS` after launch (no startup contention); subsequent
 /// ticks every `ORG_SYNC_TICK_SECS`. Every tick is a cheap no-op while logged out / no org joined.
+/// 60s (not 120s) so a member — who has no server push, only this pull — sees a colleague's newly
+/// shared/edited note within ~1 min without a manual "Sync now"; the owner's own shares refresh
+/// instantly via the `org-feed-updated` emit on the share/edit commands.
 pub const ORG_SYNC_FIRST_DELAY_SECS: u64 = 20;
-pub const ORG_SYNC_TICK_SECS: u64 = 120;
+pub const ORG_SYNC_TICK_SECS: u64 = 60;
 
 /// One background org-sync tick: drain the outbound share queue, then pull + ingest the inbound feed
 /// into the local int8 partition. This is what makes the org brain a REPLICATED brain — every

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -360,9 +360,10 @@ mod tests {
         assert_eq!(json, r#"{"orgsChanged":3}"#);
     }
 
-    /// The global org auto-sync cadence is 2 minutes (guards the 300→120 change from regressing).
+    /// The global org auto-sync cadence is 1 minute (guards the 120→60 change — members have no push,
+    /// only this pull, so it bounds a colleague's shared-note visibility to ~1 min).
     #[test]
-    fn org_sync_tick_cadence_is_two_minutes() {
-        assert_eq!(crate::commands::ORG_SYNC_TICK_SECS, 120);
+    fn org_sync_tick_cadence_is_one_minute() {
+        assert_eq!(crate::commands::ORG_SYNC_TICK_SECS, 60);
     }
 }

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   signal,
@@ -132,6 +133,14 @@ export class SettingsOrganizationSectionComponent {
   /** Monotonic browse token — a resolved list writes only if it's still the latest. */
   private _browseSeq = 0;
 
+  // ── Live refresh (org-feed-updated) ─────────────────────────────────────────
+  private readonly destroyRef = inject(DestroyRef);
+  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
+  private orgFeedUnlisten: (() => void) | null = null;
+  /** True once destroyed — so a `listen()` that resolves AFTER teardown releases immediately
+   * (distinct from `orgFeedUnlisten === null`, which also means "not yet resolved"). */
+  private orgFeedDestroyed = false;
+
   constructor() {
     // On open: refresh membership from the server (so an invited-into org is
     // discovered) then load every org. Keyed on `_reloadTick` so create/leave/
@@ -176,6 +185,36 @@ export class SettingsOrganizationSectionComponent {
         }
       })();
     });
+
+    // Live-refresh: the background org-sync loop AND the share/edit commands fire `org-feed-updated`
+    // whenever the org replica changes. Subscribe ONCE (push straight into a reload — never
+    // subscribe-into-a-field) so the counts + shared-brain browse list stay live WITHOUT a manual
+    // "Sync now"; released on destroy (never leak the subscription past teardown).
+    this.destroyRef.onDestroy(() => {
+      this.orgFeedDestroyed = true;
+      this.orgFeedUnlisten?.();
+      this.orgFeedUnlisten = null;
+    });
+    void this.ipc
+      .onOrgFeedUpdated(() => {
+        this.reload();
+        // Keep an open browse list fresh too (the reload only refreshes the org cards/counts).
+        const open = this._browseOrgId();
+        if (open !== null) {
+          void this.loadOrgItems(open);
+        }
+      })
+      .then((un) => {
+        // If the view was torn down before the listener resolved, release it immediately.
+        if (this.orgFeedDestroyed) {
+          un();
+        } else {
+          this.orgFeedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
+      });
   }
 
   /** Re-run the load effect (server discovery + list). */


### PR DESCRIPTION
## Problem
Org shared-brain notes didn't propagate or refresh on their own — a manual **Sync now** was required. As reported: the owner saves/shares a note but doesn't see it in the org automatically, and members getting a share also have to click manually. It should refresh by itself (~1 min).

Root cause was four gaps:
1. The **initial share** (`publish_org_body`) published to the server but never upserted the item into the **local `org_items` replica** — so the owner's own share was invisible in `list_org_items` until a later feed pull. (The republish-on-edit path already did this local upsert; the initial share didn't.)
2. Interactive share/edit **emitted no `org-feed-updated` event** — open views only refreshed on the 120 s background tick.
3. **Settings → Organization** (the exact view with the "Sync now" button) **didn't subscribe** to `org-feed-updated` — only `notes-home` did.
4. The background pull ran every **120 s**; members have no push (pull-only), so a colleague's note could take up to 2 min.

## Fix
- `publish_org_body` now `upsert_org_item(...)` on the initial share (FTS-only, best-effort), mirroring the republish path → the owner's own share shows **immediately**.
- `republish_org_shares_for_source` returns the count of re-published rows.
- `share_meeting_to_org` / `share_document_to_org` / `update_note` / `update_note_doc` / `resummarize` emit the **content-free** `org-feed-updated` event after a successful share / productive republish (count > 0 only — a save of a never-shared note emits nothing).
- `settings-organization-section` subscribes to `onOrgFeedUpdated` → reload (+ refresh an open browse list), with `DestroyRef` teardown — a byte-for-byte mirror of the proven `notes-home` subscription.
- `ORG_SYNC_TICK_SECS` **120 → 60**.

## How verified
- `cargo test --lib` — **1534 passed, 0 failed**. New RED→GREEN test `initial_share_populates_local_org_items_replica_immediately` (independently reproduced: **fails** `left: 0 right: 1` with the B1 upsert removed, **passes** restored). Cadence test updated to assert 60.
- `ng lint` clean · `ng build` clean (no budget failure).
- **lock-security-reviewer: PASS** — the local upsert sits after the full read-gate + consent fail-closed + OCK-seal + server-egress chain (identical to the existing republish upsert); `list_org_items_inner`/`resolve_owned_source` title-gating unchanged; the event payload is a count only; no PII/seal/migration/keychain changes.
- **adversarial-verifier: PASS** — no duplicate org card (author's own replica is filtered from "All notes" via `ownedSource`), idempotent item_id on later re-ingest, no spurious emit, no emit on a failed share, no subscription-teardown leak.

## Honest gaps (not headless-verifiable)
- The live 2-account round-trip (owner shares → a member sees it within ~1 min via the pull) and the owner's live FE refresh on the emit need a **signed build with two real accounts** against the deployed share server. The wiring is code-verified + gates green; the wall-clock behavior is not headless-observable.

## Note
Built in an **isolated worktree off clean `murmur`** to avoid colliding with concurrent uncommitted org-envelope-v2 (`source_kind`) WIP in the main tree. Expect a merge conflict in `commands.rs` (both touch the org share path) to resolve at merge time.