### PR TITLE
fix(org): stop duplicate shares on re-click + block re-share + auto-clean dupes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23676,6 +23676,125 @@ mod lifecycle_tests {
         .unwrap();
     }
 
+    /// IDEMPOTENCY — the double-click / re-click DUPLICATE fix. `share_to_org_inner` for a source that is
+    /// ALREADY live (`uploaded`) in the org returns the EXISTING share WITHOUT publishing a second item:
+    /// no new `org_shares` row, no egress. RED before the guard: unpatched `share_to_org_inner` falls
+    /// straight into `publish_org_body`, which with no live session/consent in a unit test ERRORS instead
+    /// of returning the already-shared item. GREEN: the guard short-circuits BEFORE the publish path.
+    #[test]
+    fn share_to_org_inner_is_idempotent_for_an_already_uploaded_source() {
+        let state = build_state("org-share-idem");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        // The FIRST click already published ONE uploaded share of document n1 into org-1.
+        state
+            .db
+            .insert_org_share(
+                "s1", "org-1", None, Some("n1"), "note", Some("A Note"), 1, 1, &[9u8; 32],
+                "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s1", "item-1", "2026-07-11T09:00:00Z")
+            .unwrap();
+
+        let before = state.db.list_org_shares_for_org("org-1").unwrap().len();
+        // The SECOND share of the same source (the double-click) must NOT publish again.
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n1".to_string()),
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            entry.item_id.as_deref(),
+            Some("item-1"),
+            "returns the EXISTING item, not a fresh publish"
+        );
+        assert_eq!(entry.state, "uploaded");
+        let after = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(after.len(), before, "no new org_shares row was inserted (no duplicate)");
+        assert_eq!(
+            after.iter().filter(|r| r.state == "uploaded").count(),
+            1,
+            "still exactly one live share"
+        );
+    }
+
+    /// COLLAPSE — auto-clean of duplicates that already exist. `share_to_org_inner` on a source with
+    /// MULTIPLE live copies in one org returns the EARLIEST (the keeper) and marks the extras for teardown
+    /// (`revoke_pending`). The tombstone network call fails in a unit test (no session) but is
+    /// best-effort: `revoke_org_share_inner` marks the row `revoke_pending` FIRST (the launch sweep
+    /// finishes it), and the swallowed error never breaks the idempotent return.
+    #[test]
+    fn share_to_org_inner_collapses_existing_duplicates_keeping_the_earliest() {
+        let state = build_state("org-share-collapse");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        // Two accidental duplicates of (org-1, n1): earliest = keeper, later = the extra to tombstone.
+        state
+            .db
+            .insert_org_share(
+                "keep", "org-1", None, Some("n1"), "note", Some("A Note"), 1, 1, &[1u8; 32],
+                "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("keep", "item-keep", "2026-07-11T09:00:00Z")
+            .unwrap();
+        state
+            .db
+            .insert_org_share(
+                "dup", "org-1", None, Some("n1"), "note", Some("A Note"), 1, 1, &[2u8; 32],
+                "2026-07-11T09:05:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("dup", "item-dup", "2026-07-11T09:05:00Z")
+            .unwrap();
+        // A NOT-yet-uploaded sibling (a stuck pending retry) for the same source — redundant, cancelled.
+        state
+            .db
+            .insert_org_share(
+                "pending", "org-1", None, Some("n1"), "note", Some("A Note"), 1, 1, &[3u8; 32],
+                "2026-07-11T09:06:00Z",
+            )
+            .unwrap();
+
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n1".to_string()),
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            entry.item_id.as_deref(),
+            Some("item-keep"),
+            "the EARLIEST live copy is the keeper"
+        );
+        // Keeper stays uploaded; the duplicate is queued for tombstone. No new row was minted.
+        assert_eq!(
+            state.db.get_org_share("keep").unwrap().unwrap().state,
+            "uploaded",
+            "keeper untouched"
+        );
+        assert_eq!(
+            state.db.get_org_share("dup").unwrap().unwrap().state,
+            "revoke_pending",
+            "the duplicate is marked for tombstone (launch sweep finishes it)"
+        );
+        assert_eq!(
+            state.db.get_org_share("pending").unwrap().unwrap().state,
+            "revoked",
+            "a redundant not-yet-uploaded sibling is cancelled locally (no server item)"
+        );
+    }
+
     /// MULTI-ORG STATUS (RED→GREEN for the single-org `.next()` bug): `org_list_statuses` must return
     /// an `OrgStatus` for EVERY locally-joined org — the one I created AND the one I was invited to —
     /// not just the first. With no server configured (empty base URL) it stays offline: each status
@@ -25018,6 +25137,18 @@ pub struct OrgShareEntry {
     pub state: String,
 }
 
+/// Which org already holds a LIVE (`uploaded`) share of a given LOCAL source (meeting/note), so the FE
+/// can mark that org "Already added ✓" and BLOCK a re-share (the double-click duplicate fix). Content-
+/// free: only the org id + the server item id + rev — never a title or any other member's data. Powers
+/// `org_live_shares_for_source` (a READ, no egress).
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgSourceShareStatus {
+    pub org_id: String,
+    pub item_id: Option<String>,
+    pub rev: u32,
+}
+
 /// The LOCAL editable SOURCE behind an org item, if the CALLER is its author. `org_resolve_source`
 /// returns `Some` only when THIS device holds the `org_shares` row for the item (i.e. the caller
 /// published it) — so a member reading a colleague's org item gets `None` (no editable source). The
@@ -25921,9 +26052,79 @@ pub(crate) async fn share_to_org_inner(
     document_id: Option<String>,
     scrub: bool,
 ) -> Result<OrgShareEntry, AppError> {
-    // Initial share = rev 1. A re-publish-on-edit supersede bumps the rev (see
-    // `republish_org_shares_for_source`, which calls `publish_org_body` with `old_rev + 1`).
+    // IDEMPOTENCY (the double-click / re-click DUPLICATE fix). A user-initiated share of a source that
+    // is ALREADY live in this org must NOT mint a second feed item. The pre-fix hole: `publish_org_body`
+    // → `find_reusable_org_share` only reuses `queued`/`failed` rows, so a second click AFTER the first
+    // upload succeeded found no reusable row, inserted a fresh one, and published a DISTINCT item →
+    // the note appeared twice. Here we resolve the org (membership-checked) and look for an existing
+    // `uploaded` share of this exact (org, source): if one exists we COLLAPSE any accidental extras
+    // (keep the earliest, tombstone the rest — the user opted into auto-clean) and RETURN the survivor
+    // WITHOUT publishing. This is a READ + a dedup of the caller's OWN shares, NOT fresh content egress,
+    // so it runs BEFORE the org-egress consent gate — re-clicking an already-shared note never needs
+    // re-consent. Freshness on EDIT is `republish_org_shares_for_source`'s job, never this button's.
+    let org = resolve_org(state, org_id)?;
+    if let Some(keeper) = collapse_org_share_dups_for_source(
+        state,
+        &org.org_id,
+        meeting_id.as_deref(),
+        document_id.as_deref(),
+    )
+    .await?
+    {
+        return Ok(OrgShareEntry {
+            item_id: keeper.item_id,
+            kind: keeper.kind,
+            title: keeper.title,
+            shared_at: keeper.created_at,
+            rev: keeper.rev,
+            state: keeper.state,
+        });
+    }
+
+    // Not yet live in this org → the normal first share = rev 1. A re-publish-on-edit supersede bumps
+    // the rev (see `republish_org_shares_for_source`, which calls `publish_org_body` with `old_rev + 1`).
     publish_org_body(state, org_id, meeting_id, document_id, scrub, 1).await
+}
+
+/// Collapse accidental DUPLICATE live (`uploaded`) org items for ONE (org, source) down to the earliest,
+/// tombstoning the rest, and return the SURVIVOR (the earliest `uploaded` row) — or `None` when the
+/// source is not currently live in this org. The keeper = the oldest published item (the identity other
+/// members first synced); every later duplicate is revoked via `revoke_org_share_inner` (tombstone the
+/// server item + mark the local row revoked). BEST-EFFORT on each tombstone: a network failure leaves
+/// the extra `revoke_pending` (the launch sweep finishes it) and simply isn't cleaned this pass — it
+/// NEVER fails the idempotent share. No content is read or egressed here (only the caller's own share
+/// rows + a tombstone of a redundant copy), so it is safe to run before the egress-consent gate.
+async fn collapse_org_share_dups_for_source(
+    state: &AppState,
+    org_id: &str,
+    meeting_id: Option<&str>,
+    document_id: Option<&str>,
+) -> Result<Option<crate::storage::OrgShareRow>, AppError> {
+    // Oldest-first, so `remove(0)` is the canonical keeper and the remainder are the extras.
+    let mut rows =
+        state
+            .db
+            .uploaded_org_shares_for_source_in_org(org_id, meeting_id, document_id)?;
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    let keeper = rows.remove(0);
+    for extra in rows {
+        if let Some(item_id) = extra.item_id.clone() {
+            // Tombstone the redundant copy. Swallow errors — `revoke_org_share_inner` marks the row
+            // `revoke_pending` first, so an interrupted tombstone is completed by the launch sweep.
+            let _ = revoke_org_share_inner(state, item_id).await;
+        }
+    }
+    // Also cancel any NOT-yet-uploaded sibling (`queued`/`failed`) for this (org, source): the source is
+    // already live (the keeper), so a pending row is redundant and would otherwise linger as a stuck
+    // "pending" share that the launch sweep re-attempts every start. Local-only — these have no server
+    // item to tombstone. Best-effort (never fails the idempotent return).
+    let now = chrono::Utc::now().to_rfc3339();
+    let _ = state
+        .db
+        .cancel_pending_org_shares_for_source_in_org(org_id, meeting_id, document_id, &now);
+    Ok(Some(keeper))
 }
 
 /// The org publish CORE, shared by the FIRST share (`share_to_org_inner`, `rev = 1`) and the
@@ -26133,6 +26334,26 @@ pub(crate) async fn republish_org_shares_for_source(
     meeting_id: Option<&str>,
     document_id: Option<&str>,
 ) -> Result<(), AppError> {
+    // DEDUP FIRST (auto-clean, user-opted-in): collapse any accidental duplicate live items for this
+    // source — PER ORG — down to the earliest BEFORE republishing. Otherwise we'd republish (and keep
+    // alive) every duplicate; the survivor is what the edit then supersedes. Best-effort — a tombstone
+    // failure leaves the extra for the launch sweep's dedup pass and never blocks the save.
+    let dup_orgs: Vec<String> = {
+        let mut v: Vec<String> = state
+            .db
+            .org_shares_for_source(meeting_id, document_id)?
+            .into_iter()
+            .map(|r| r.org_id)
+            .collect();
+        v.sort();
+        v.dedup();
+        v
+    };
+    for org_id in &dup_orgs {
+        let _ =
+            collapse_org_share_dups_for_source(state, org_id, meeting_id, document_id).await;
+    }
+
     let rows = state.db.org_shares_for_source(meeting_id, document_id)?;
     if rows.is_empty() {
         return Ok(());
@@ -26381,6 +26602,31 @@ pub fn list_org_shares(state: State<'_, AppState>) -> Result<Vec<OrgShareEntry>,
         .collect())
 }
 
+/// `org_live_shares_for_source(meeting_id?, document_id?)` — which orgs already hold a LIVE (`uploaded`)
+/// share of THIS exact local source, so the FE can mark those orgs "Already added ✓" and BLOCK a
+/// re-share (the double-click duplicate fix). READ-ONLY, no egress. Content-free: only (org_id, item_id,
+/// rev) — never a title or another member's data. Exactly one of meeting_id/document_id is set; both-None
+/// ⇒ empty. Reuses `org_shares_for_source` (uploaded rows across ALL the caller's orgs).
+#[tauri::command]
+pub fn org_live_shares_for_source(
+    state: State<'_, AppState>,
+    meeting_id: Option<String>,
+    document_id: Option<String>,
+) -> Result<Vec<OrgSourceShareStatus>, AppError> {
+    let rows = state
+        .inner()
+        .db
+        .org_shares_for_source(meeting_id.as_deref(), document_id.as_deref())?;
+    Ok(rows
+        .into_iter()
+        .map(|r| OrgSourceShareStatus {
+            org_id: r.org_id,
+            item_id: r.item_id,
+            rev: r.rev,
+        })
+        .collect())
+}
+
 /// `revoke_org_share(item_id)` — tombstone a published org item (destroys its server ciphertext) and
 /// mark the local row revoked. Marks `revoke_pending` first (crash-safe: the launch sweep completes a
 /// `revoke_pending` if the tombstone call didn't land).
@@ -26625,6 +26871,21 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
         return Ok(0);
     }
     let mut advanced = 0u32;
+
+    // 0) DEDUP (auto-clean, user-opted-in): collapse accidental DUPLICATE live items — same org + same
+    //    source — down to the earliest, tombstoning the extras. Fixes duplicates created BEFORE the
+    //    idempotency guard existed (e.g. a double-click on Share), which self-healing needs a proactive
+    //    pass to reach (the FE now blocks re-share, so the share-time collapse never re-fires for them).
+    //    `duplicate_uploaded_org_shares` returns exactly the extras (never a keeper); each is torn down
+    //    via the crash-safe revoke path (marks `revoke_pending` first, so an interrupted tombstone is
+    //    completed by step 1 on the next pass). Best-effort — a network failure just retries next launch.
+    for extra in state.db.duplicate_uploaded_org_shares()? {
+        if let Some(item_id) = extra.item_id.clone() {
+            if revoke_org_share_inner(state, item_id).await.is_ok() {
+                advanced += 1;
+            }
+        }
+    }
 
     // 1) Finish any pending revokes (a tombstone that didn't land before a crash).
     for row in state.db.list_org_shares_in_state("revoke_pending")? {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             commands::share_meeting_to_org,
             commands::share_document_to_org,
             commands::list_org_shares,
+            commands::org_live_shares_for_source,
             commands::revoke_org_share,
             commands::org_sweep_pending,
             commands::org_sync_now,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1997,6 +1997,105 @@ impl Db {
         Ok(out)
     }
 
+    /// Every LIVE (`uploaded`) org share of ONE exact source (`meeting_id` XOR `document_id`) in ONE
+    /// org, OLDEST-FIRST (stable tie-break on `id`). The `(org, source)`-scoped twin of
+    /// `org_shares_for_source` (which spans all orgs): powers the share IDEMPOTENCY guard + the
+    /// duplicate collapse — `[0]` is the canonical KEEPER (earliest published, the identity other
+    /// members first saw), `[1..]` are accidental duplicates to tombstone. `state = 'uploaded'` only
+    /// (a queued/failed row has no live server item; a revoked one was intentionally torn down).
+    /// `meeting_id`/`document_id` matched NULL-safe via `IS`; both-None ⇒ empty (no source).
+    pub fn uploaded_org_shares_for_source_in_org(
+        &self,
+        org_id: &str,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<Vec<crate::storage::OrgShareRow>> {
+        if meeting_id.is_none() && document_id.is_none() {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {} FROM org_shares
+                   WHERE org_id = ?1 AND state = 'uploaded'
+                     AND meeting_id IS ?2 AND document_id IS ?3
+                   ORDER BY created_at ASC, id ASC",
+                Self::ORG_SHARE_COLS
+            ))
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![org_id, meeting_id, document_id],
+                Self::map_org_share,
+            )
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Every DUPLICATE live org share across the whole DB: an `uploaded` row that has an EARLIER
+    /// `uploaded` sibling for the same `(org_id, meeting_id, document_id)` — i.e. the extras to
+    /// tombstone, keeping only the earliest per group. Powers the on-launch dedup sweep that cleans
+    /// duplicates created before the idempotency guard existed (e.g. a double-click on Share). Tie-break
+    /// on `id` so two rows sharing a `created_at` still pick ONE deterministic keeper. NEVER returns a
+    /// keeper (the earliest of its group). `meeting_id`/`document_id` grouped NULL-safe via `IS`.
+    pub fn duplicate_uploaded_org_shares(&self) -> Result<Vec<crate::storage::OrgShareRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {} FROM org_shares o
+                   WHERE o.state = 'uploaded'
+                     AND EXISTS (
+                       SELECT 1 FROM org_shares e
+                        WHERE e.state = 'uploaded'
+                          AND e.org_id = o.org_id
+                          AND e.meeting_id IS o.meeting_id
+                          AND e.document_id IS o.document_id
+                          AND (e.created_at < o.created_at
+                            OR (e.created_at = o.created_at AND e.id < o.id)))
+                   ORDER BY o.created_at ASC, o.id ASC",
+                Self::ORG_SHARE_COLS
+            ))
+            .map_err(map_err)?;
+        let rows = stmt.query_map([], Self::map_org_share).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Cancel (mark `revoked`) any NOT-yet-uploaded (`queued`/`failed`) org share for a given
+    /// (org, source). Used after a collapse when a live `uploaded` keeper already exists for that
+    /// source: a pending sibling is redundant (the source is already live) and would otherwise linger
+    /// as a stuck "pending" row that the launch sweep re-attempts every start. These rows have NO server
+    /// `item_id`, so cancelling is LOCAL-ONLY (no tombstone). Returns the number of rows cancelled.
+    /// `meeting_id`/`document_id` matched NULL-safe via `IS`; both-None ⇒ 0 (no source).
+    pub fn cancel_pending_org_shares_for_source_in_org(
+        &self,
+        org_id: &str,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+        updated_at: &str,
+    ) -> Result<usize> {
+        if meeting_id.is_none() && document_id.is_none() {
+            return Ok(0);
+        }
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE org_shares SET state = 'revoked', updated_at = ?4
+                   WHERE org_id = ?1 AND state IN ('queued', 'failed')
+                     AND meeting_id IS ?2 AND document_id IS ?3",
+                rusqlite::params![org_id, meeting_id, document_id, updated_at],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
+
     /// SB-3 dedup: the EXISTING retriable (`queued`/`failed`) org-share row for a logical share key
     /// (org + meeting-or-document), if any. `share_to_org_inner` REUSES it on a re-publish instead of
     /// minting a fresh row every sweep tick — without this, each failed retry inserted a NEW row while
@@ -10781,6 +10880,128 @@ mod tests {
         assert_eq!(mrows.len(), 1);
         assert_eq!(mrows[0].meeting_id.as_deref(), Some("m1"));
         assert!(db.org_shares_for_source(None, None).unwrap().is_empty());
+    }
+
+    /// `uploaded_org_shares_for_source_in_org` is (org, source)-SCOPED and OLDEST-FIRST: only the
+    /// `uploaded` rows for the EXACT (org, source), earliest `created_at` first (so `[0]` is the dedup
+    /// keeper), excluding another org, another source, and any non-uploaded (queued / revoked) row.
+    #[test]
+    fn uploaded_org_shares_for_source_in_org_scopes_and_orders_oldest_first() {
+        let db = mem_db();
+        // (org-1, d1): three uploaded rows at increasing timestamps → all returned, oldest-first.
+        db.insert_org_share("u-b", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(2), "2026-07-11T00:02:00Z").unwrap();
+        db.set_org_share_uploaded("u-b", "item-b", "2026-07-11T00:02:00Z").unwrap();
+        db.insert_org_share("u-a", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(1), "2026-07-11T00:01:00Z").unwrap();
+        db.set_org_share_uploaded("u-a", "item-a", "2026-07-11T00:01:00Z").unwrap();
+        db.insert_org_share("u-c", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(3), "2026-07-11T00:03:00Z").unwrap();
+        db.set_org_share_uploaded("u-c", "item-c", "2026-07-11T00:03:00Z").unwrap();
+        // A still-`queued` row for the same (org, source) — EXCLUDED (no live server item).
+        db.insert_org_share("u-q", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(4), "2026-07-11T00:00:40Z").unwrap();
+        // A `revoked` row for the same (org, source) — EXCLUDED (intentionally torn down).
+        db.insert_org_share("u-r", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(5), "2026-07-11T00:00:30Z").unwrap();
+        db.set_org_share_uploaded("u-r", "item-r", "2026-07-11T00:00:30Z").unwrap();
+        db.set_org_share_state("u-r", "revoked", "2026-07-11T00:05:00Z").unwrap();
+        // Same source d1 in ANOTHER org — EXCLUDED (org-scoped).
+        db.insert_org_share("u-o2", "org-2", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(6), "2026-07-11T00:00:10Z").unwrap();
+        db.set_org_share_uploaded("u-o2", "item-o2", "2026-07-11T00:00:10Z").unwrap();
+        // ANOTHER source in org-1 — EXCLUDED.
+        db.insert_org_share("u-d2", "org-1", None, Some("d2"), "note", Some("T"), 1, 1, &sha32(7), "2026-07-11T00:00:20Z").unwrap();
+        db.set_org_share_uploaded("u-d2", "item-d2", "2026-07-11T00:00:20Z").unwrap();
+
+        let rows = db
+            .uploaded_org_shares_for_source_in_org("org-1", None, Some("d1"))
+            .unwrap();
+        let ids: Vec<_> = rows.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["u-a", "u-b", "u-c"], "only (org-1,d1) uploaded rows, oldest-first");
+        // The both-None guard returns empty (no source ⇒ nothing).
+        assert!(db
+            .uploaded_org_shares_for_source_in_org("org-1", None, None)
+            .unwrap()
+            .is_empty());
+    }
+
+    /// `duplicate_uploaded_org_shares` returns EXACTLY the extras (every `uploaded` row with an EARLIER
+    /// `uploaded` sibling in its (org, source) group) — never a keeper, never a single (non-dup) share,
+    /// never a revoked row. This is the on-launch dedup worklist.
+    #[test]
+    fn duplicate_uploaded_org_shares_returns_only_the_extras() {
+        let db = mem_db();
+        // Group A: (org-1, d1) has THREE uploaded rows → keeper = earliest (a1); extras = a2, a3.
+        db.insert_org_share("a1", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(1), "2026-07-11T00:01:00Z").unwrap();
+        db.set_org_share_uploaded("a1", "item-a1", "2026-07-11T00:01:00Z").unwrap();
+        db.insert_org_share("a2", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(2), "2026-07-11T00:02:00Z").unwrap();
+        db.set_org_share_uploaded("a2", "item-a2", "2026-07-11T00:02:00Z").unwrap();
+        db.insert_org_share("a3", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(3), "2026-07-11T00:03:00Z").unwrap();
+        db.set_org_share_uploaded("a3", "item-a3", "2026-07-11T00:03:00Z").unwrap();
+        // Group B: (org-1, m1) meeting has a SINGLE uploaded row → NOT a duplicate.
+        db.insert_org_share("b1", "org-1", Some("m1"), None, "note", Some("T"), 1, 1, &sha32(4), "2026-07-11T00:01:00Z").unwrap();
+        db.set_org_share_uploaded("b1", "item-b1", "2026-07-11T00:01:00Z").unwrap();
+        // Group C: (org-2, d1) SAME doc but DIFFERENT org → its own single-member group → NOT a duplicate.
+        db.insert_org_share("c1", "org-2", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(5), "2026-07-11T00:01:00Z").unwrap();
+        db.set_org_share_uploaded("c1", "item-c1", "2026-07-11T00:01:00Z").unwrap();
+        // A REVOKED extra in group A must NOT count (only live uploaded rows dedup).
+        db.insert_org_share("a-rev", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(6), "2026-07-11T00:04:00Z").unwrap();
+        db.set_org_share_uploaded("a-rev", "item-arev", "2026-07-11T00:04:00Z").unwrap();
+        db.set_org_share_state("a-rev", "revoked", "2026-07-11T00:05:00Z").unwrap();
+
+        let extras = db.duplicate_uploaded_org_shares().unwrap();
+        let ids: std::collections::HashSet<_> = extras.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            ["a2", "a3"].into_iter().collect(),
+            "only the later extras of group A (keep the earliest per group)"
+        );
+        assert!(!ids.contains("a1"), "the earliest (keeper) is never returned");
+        assert!(
+            !ids.contains("b1") && !ids.contains("c1"),
+            "single-share groups are not duplicates"
+        );
+        assert!(!ids.contains("a-rev"), "a revoked row is not a live duplicate");
+    }
+
+    /// `cancel_pending_org_shares_for_source_in_org` cancels ONLY the (org, source) `queued`/`failed`
+    /// rows, leaving `uploaded` keepers and other orgs/sources untouched.
+    #[test]
+    fn cancel_pending_org_shares_scopes_to_org_and_source() {
+        let db = mem_db();
+        // Target (org-1, d1): one queued + one failed → both cancelled.
+        db.insert_org_share("q", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(1), "2026-07-11T00:01:00Z").unwrap();
+        db.insert_org_share("f", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(2), "2026-07-11T00:02:00Z").unwrap();
+        db.set_org_share_failed("f", "boom", "2026-07-11T00:02:30Z").unwrap();
+        // An UPLOADED row for the same (org, source) — NOT cancelled.
+        db.insert_org_share("u", "org-1", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(3), "2026-07-11T00:00:30Z").unwrap();
+        db.set_org_share_uploaded("u", "item-u", "2026-07-11T00:00:30Z").unwrap();
+        // A queued row for ANOTHER source and ANOTHER org — NOT touched.
+        db.insert_org_share("q-d2", "org-1", None, Some("d2"), "note", Some("T"), 1, 1, &sha32(4), "2026-07-11T00:01:00Z").unwrap();
+        db.insert_org_share("q-o2", "org-2", None, Some("d1"), "note", Some("T"), 1, 1, &sha32(5), "2026-07-11T00:01:00Z").unwrap();
+
+        let n = db
+            .cancel_pending_org_shares_for_source_in_org("org-1", None, Some("d1"), "2026-07-11T01:00:00Z")
+            .unwrap();
+        assert_eq!(n, 2, "both the queued and failed (org-1,d1) rows are cancelled");
+        assert_eq!(db.get_org_share("q").unwrap().unwrap().state, "revoked");
+        assert_eq!(db.get_org_share("f").unwrap().unwrap().state, "revoked");
+        assert_eq!(
+            db.get_org_share("u").unwrap().unwrap().state,
+            "uploaded",
+            "the uploaded keeper is untouched"
+        );
+        assert_eq!(
+            db.get_org_share("q-d2").unwrap().unwrap().state,
+            "queued",
+            "another source is untouched"
+        );
+        assert_eq!(
+            db.get_org_share("q-o2").unwrap().unwrap().state,
+            "queued",
+            "another org is untouched"
+        );
+        // both-None guard → no-op.
+        assert_eq!(
+            db.cancel_pending_org_shares_for_source_in_org("org-1", None, None, "x")
+                .unwrap(),
+            0
+        );
     }
 
     /// NOTES feature — the additive columns exist after migrate() and re-migrating is a no-op

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -88,6 +88,7 @@ import type {
   OrgMember,
   OrgSharePreview,
   OrgShareEntry,
+  OrgSourceShareStatus,
   OrgItemDetail,
   OrgItemHeader,
   OrgSourceRef,
@@ -651,6 +652,21 @@ export class IpcService {
   /** This user's outgoing org shares (drives the "In Org Brain" state + per-item revoke). */
   listOrgShares(): Promise<OrgShareEntry[]> {
     return invoke<OrgShareEntry[]>("list_org_shares");
+  }
+
+  /**
+   * Which orgs already hold a LIVE (`uploaded`) share of THIS local source
+   * (meeting XOR note) — so the share sheet can mark those orgs "Already added ✓"
+   * and BLOCK a re-share (the double-click duplicate fix). Read-only, no egress.
+   */
+  orgLiveSharesForSource(args: {
+    meetingId?: string;
+    documentId?: string;
+  }): Promise<OrgSourceShareStatus[]> {
+    return invoke<OrgSourceShareStatus[]>("org_live_shares_for_source", {
+      meetingId: args.meetingId ?? null,
+      documentId: args.documentId ?? null,
+    });
   }
 
   /** Revoke an org share: tombstone the feed item + drop the local ciphertext. Idempotent. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1968,6 +1968,19 @@ export interface OrgShareEntry {
 }
 
 /**
+ * Which org already holds a LIVE (`uploaded`) share of a given LOCAL source
+ * (meeting/note), so the share sheet can mark that org "Already added ✓" and
+ * BLOCK a re-share (the double-click duplicate fix). Content-free: only the org
+ * id + server item id + rev. Populated by `orgLiveSharesForSource`. Mirrors the
+ * Rust `OrgSourceShareStatus`.
+ */
+export interface OrgSourceShareStatus {
+  orgId: string;
+  itemId: string | null;
+  rev: number;
+}
+
+/**
  * The full decrypted org item for the read-only viewer route (`orgGetItem`).
  * `markdown` is the plaintext envelope body — this is deliberately-disclosed org
  * content (no lock gate applies to org items), rendered read-only with an

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.html
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.html
@@ -1,4 +1,4 @@
-<div class="org-cta">
+<div class="org-cta" [class.is-shared]="shared()">
   <div class="org-cta-head">
     <span class="org-cta-mark" aria-hidden="true">
       <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
@@ -9,15 +9,22 @@
       </svg>
     </span>
     <span class="org-cta-headings">
-      <span class="org-cta-title">Add to Org Brain</span>
-      <span class="org-cta-org">End-to-end encrypted</span>
+      <span class="org-cta-title">{{ shared() ? "In Org Brain ✓" : "Add to Org Brain" }}</span>
+      <span class="org-cta-org">{{ shared() ? "Shared — edits sync automatically" : "End-to-end encrypted" }}</span>
     </span>
   </div>
 
-  <p class="org-cta-copy">
-    Share this note into a team’s <strong>shared brain</strong> so your teammates
-    can find it — you choose which organization next. The server can’t read it.
-  </p>
+  @if (shared()) {
+    <p class="org-cta-copy">
+      This note is in a team’s <strong>shared brain</strong>. Your edits sync
+      automatically — there’s no need to re-share. Open to see or manage where it’s shared.
+    </p>
+  } @else {
+    <p class="org-cta-copy">
+      Share this note into a team’s <strong>shared brain</strong> so your teammates
+      can find it — you choose which organization next. The server can’t read it.
+    </p>
+  }
 
   <button
     type="button"
@@ -26,8 +33,12 @@
     [disabled]="disabled()"
   >
     <svg viewBox="0 0 16 16" width="15" height="15" fill="none" aria-hidden="true">
-      <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+      @if (shared()) {
+        <path d="M3.5 8.5l3 3 6-7" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+      } @else {
+        <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+      }
     </svg>
-    Add to Org Brain
+    {{ shared() ? "Manage in Org Brain" : "Add to Org Brain" }}
   </button>
 </div>

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.scss
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.scss
@@ -70,3 +70,17 @@
   align-items: center;
   gap: 6px;
 }
+
+/* SHARED — a settled "done" state (a subtle success tint), not a call to action:
+   the note is already in the org brain, so the card reads as status. */
+.org-cta.is-shared {
+  border-color: var(--success-soft);
+  background:
+    linear-gradient(180deg, var(--success-soft), transparent 70%),
+    var(--surface-raised);
+}
+
+.org-cta.is-shared .org-cta-mark {
+  background: var(--success-soft);
+  color: var(--success);
+}

--- a/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
+++ b/src/app/design-system/org-brain-cta/org-brain-cta.component.ts
@@ -26,6 +26,13 @@ export class MurOrgBrainCtaComponent {
   /** Disables the button (e.g. while the note is mid-edit). */
   readonly disabled = input(false);
 
+  /**
+   * The source is ALREADY in the org brain (in ≥1 of the user's orgs). Flips the
+   * CTA to a calm "In Org Brain ✓ / Manage" state — edits sync automatically, so
+   * there is no re-share to make (the duplicate fix, surfaced before the sheet).
+   */
+  readonly shared = input(false);
+
   /** Fired when the user clicks the CTA — the host opens the org-share sheet. */
   readonly add = output<void>();
 }

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.html
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.html
@@ -53,7 +53,7 @@
           (ngModelChange)="selectedOrgId.set($event)"
         >
           @for (o of orgs(); track o.orgId) {
-            <option [value]="o.orgId">{{ o.name }}</option>
+            <option [value]="o.orgId">{{ o.name }}{{ sharedOrgIds().has(o.orgId) ? " · already added ✓" : "" }}</option>
           }
         </mur-select>
         @if (audienceLabel(); as label) {
@@ -131,17 +131,28 @@
       <p class="sheet-error" role="alert">{{ err }}</p>
     }
 
+    <!-- ALREADY-SHARED BLOCK (dup fix): the source is already live in the chosen
+         org, so re-adding would only duplicate it. Edits sync automatically via
+         re-publish-on-edit, so the confirm is disabled — nothing to add. -->
+    @if (alreadyShared()) {
+      <p class="pick-status text-muted" role="status">
+        This {{ target().kind === "meeting" ? "meeting note" : "note" }} is already in
+        {{ selectedOrg()?.name ?? "this organization" }}’s brain — your edits sync
+        automatically, so there’s nothing to add.
+      </p>
+    }
+
     <div class="sheet-actions">
       <button type="button" class="btn btn-ghost" (click)="cancel()" [disabled]="sharing()">
-        Cancel
+        {{ alreadyShared() ? "Close" : "Cancel" }}
       </button>
       <button
         type="button"
         class="btn btn-primary"
         (click)="confirm()"
-        [disabled]="sharing() || loading() || !preview() || !selectedOrgId()"
+        [disabled]="sharing() || loading() || !preview() || !selectedOrgId() || alreadyShared()"
       >
-        {{ sharing() ? "Adding…" : "Add to Org Brain" }}
+        {{ alreadyShared() ? "Already in Org Brain ✓" : (sharing() ? "Adding…" : "Add to Org Brain") }}
       </button>
     </div>
   </div>

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
@@ -14,7 +14,11 @@ import {
 } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { IpcService } from "../../../core/ipc.service";
-import type { OrgSharePreview, OrgStatus } from "../../../core/models";
+import type {
+  OrgSharePreview,
+  OrgSourceShareStatus,
+  OrgStatus,
+} from "../../../core/models";
 import { MurSelectComponent } from "../../../design-system/select/select.component";
 
 /**
@@ -92,6 +96,22 @@ export class OrgShareSheetComponent {
   /** True when there's exactly one org (show it as a label, no picker). */
   readonly singleOrg = computed(() => this._orgs().length === 1);
 
+  /**
+   * Orgs that ALREADY hold a live copy of this source (the double-click BLOCK).
+   * Loaded once per open via `orgLiveSharesForSource`; the confirm button is
+   * disabled — and the picker marks the org "Already added ✓" — for any org in
+   * this set, so a re-click can never publish a duplicate.
+   */
+  private readonly _liveShares = signal<OrgSourceShareStatus[]>([]);
+  /** Set of org ids that already hold a live share of this source. */
+  readonly sharedOrgIds = computed(
+    () => new Set(this._liveShares().map((s) => s.orgId)),
+  );
+  /** True when the CURRENTLY-selected org already holds this source. */
+  readonly alreadyShared = computed(() =>
+    this.sharedOrgIds().has(this.selectedOrgId()),
+  );
+
   /** Whether the regex PII scrub is on (default ON per the redaction policy). */
   readonly scrub = signal(true);
 
@@ -143,6 +163,16 @@ export class OrgShareSheetComponent {
       { injector: this.injector },
     );
 
+    // Load which orgs ALREADY hold this source → block a re-share (dup fix). Keyed
+    // on the target so it re-reads if the sheet is reused for another source.
+    effect(
+      () => {
+        const t = this.target();
+        void this.loadLiveShares(t);
+      },
+      { injector: this.injector },
+    );
+
     // Land focus in the sheet so Escape works + it's announced.
     afterNextRender(() => this.panel()?.nativeElement.focus(), {
       injector: this.injector,
@@ -163,6 +193,27 @@ export class OrgShareSheetComponent {
       this.orgsError.set(String(e));
     } finally {
       this.orgsLoading.set(false);
+    }
+  }
+
+  /**
+   * Load which orgs already hold a live copy of this source (the re-share block).
+   * Best-effort + stale-guarded on the target: a failure just leaves the set empty
+   * (never blocks sharing) — the backend idempotency guard is the real safety net.
+   */
+  private async loadLiveShares(t: OrgShareTarget): Promise<void> {
+    try {
+      const live = await this.ipc.orgLiveSharesForSource(
+        t.kind === "meeting" ? { meetingId: t.id } : { documentId: t.id },
+      );
+      if (this.target().id !== t.id) {
+        return; // stale — the target changed under us
+      }
+      this._liveShares.set(live);
+    } catch {
+      if (this.target().id === t.id) {
+        this._liveShares.set([]);
+      }
     }
   }
 
@@ -205,7 +256,16 @@ export class OrgShareSheetComponent {
    */
   async confirm(): Promise<void> {
     const orgId = this.selectedOrgId();
-    if (this.sharing() || this.loading() || !this._preview() || !orgId) {
+    if (
+      this.sharing() ||
+      this.loading() ||
+      !this._preview() ||
+      !orgId ||
+      this.alreadyShared()
+    ) {
+      // `alreadyShared` blocks a duplicate publish — the note is already in this
+      // org and edits sync automatically (re-publish-on-edit), so there is nothing
+      // to do. The backend guard is idempotent regardless, but we never even ask.
       return;
     }
     const t = this.target();

--- a/src/app/features/detail/share-panel/share-panel.component.html
+++ b/src/app/features/detail/share-panel/share-panel.component.html
@@ -47,7 +47,7 @@
     <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org).
          Generic CTA: the org is PICKED in the sheet (a member can be in many). -->
     @if (org()) {
-      <mur-org-brain-cta [disabled]="editing()" (add)="openOrgSheet()" />
+      <mur-org-brain-cta [disabled]="editing()" [shared]="sourceInOrg()" (add)="openOrgSheet()" />
     }
 
     <!-- ============================================================== -->

--- a/src/app/features/detail/share-panel/share-panel.component.ts
+++ b/src/app/features/detail/share-panel/share-panel.component.ts
@@ -14,6 +14,7 @@ import type {
   AccountStatus,
   MyShareEntry,
   OrgShareEntry,
+  OrgSourceShareStatus,
   OrgStatus,
   RecipientPreview,
 } from "../../../core/models";
@@ -295,6 +296,14 @@ export class SharePanelComponent {
   readonly org = this.orgStatus.asReadonly();
   /** This user's outgoing org shares (drives the "In Org Brain" state for THIS meeting). */
   private readonly orgShares = signal<OrgShareEntry[]>([]);
+  /**
+   * Live (uploaded) org shares of THIS meeting specifically — powers the CTA "In
+   * Org Brain ✓" state (a re-share is blocked; edits sync automatically). Joined to
+   * the meeting id backend-side, unlike the content-free `orgShares` list.
+   */
+  private readonly _orgSourceShares = signal<OrgSourceShareStatus[]>([]);
+  /** True when THIS meeting is already live in ≥1 org (flips the CTA to shared). */
+  readonly sourceInOrg = computed(() => this._orgSourceShares().length > 0);
   /** True while the org-share PREVIEW SHEET is open (the confirm flow). */
   readonly orgSheetOpen = signal(false);
 
@@ -395,13 +404,21 @@ export class SharePanelComponent {
           return;
         }
         this.orgShares.set(shares);
+        // Per-source live shares → the CTA "In Org Brain ✓" state + re-share block.
+        const live = await this.ipc.orgLiveSharesForSource({ meetingId: id });
+        if (this.meetingId() !== id) {
+          return;
+        }
+        this._orgSourceShares.set(live);
       } else {
         this.orgShares.set([]);
+        this._orgSourceShares.set([]);
       }
     } catch {
       // Org unavailable (older backend / not joined) — hide the section.
       this.orgStatus.set(null);
       this.orgShares.set([]);
+      this._orgSourceShares.set([]);
     }
   }
 

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.html
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.html
@@ -66,7 +66,7 @@
       <!-- ORG BRAIN — the flagship share action, surfaced FIRST (only in an org).
            Generic CTA: the org is PICKED in the sheet (a member can be in many). -->
       @if (org()) {
-        <mur-org-brain-cta (add)="openOrgSheet()" />
+        <mur-org-brain-cta [shared]="sourceInOrg()" (add)="openOrgSheet()" />
       }
 
       <!-- CONFIGURE — password FIRST → expires → open limit → consent → Create. -->

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.ts
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.ts
@@ -13,6 +13,7 @@ import { IpcService } from "../../../core/ipc.service";
 import type {
   AccountStatus,
   MyShareEntry,
+  OrgSourceShareStatus,
   OrgStatus,
 } from "../../../core/models";
 import {
@@ -201,6 +202,13 @@ export class NoteSharePanelComponent {
   /** The user's org membership; `null` when in no org (hides the section). */
   private readonly orgStatus = signal<OrgStatus | null>(null);
   readonly org = this.orgStatus.asReadonly();
+  /**
+   * Live (uploaded) org shares of THIS note specifically — powers the CTA "In Org
+   * Brain ✓" state + blocks a duplicate re-share (edits sync automatically).
+   */
+  private readonly _orgSourceShares = signal<OrgSourceShareStatus[]>([]);
+  /** True when THIS note is already live in ≥1 org (flips the CTA to shared). */
+  readonly sourceInOrg = computed(() => this._orgSourceShares().length > 0);
   /** True while the org-share preview sheet is open. */
   readonly orgSheetOpen = signal(false);
 
@@ -310,8 +318,19 @@ export class NoteSharePanelComponent {
         return;
       }
       this.orgStatus.set(status);
+      if (status) {
+        // Per-source live shares → the CTA "In Org Brain ✓" state + re-share block.
+        const live = await this.ipc.orgLiveSharesForSource({ documentId: id });
+        if (this.noteId() !== id) {
+          return;
+        }
+        this._orgSourceShares.set(live);
+      } else {
+        this._orgSourceShares.set([]);
+      }
     } catch {
       this.orgStatus.set(null);
+      this._orgSourceShares.set([]);
     }
   }
 


### PR DESCRIPTION
## Problem

Double-clicking **"Add to Org Brain"** published a note **twice** into the org feed (duplicate cards in the shared brain). Root cause: `find_reusable_org_share` only reuses `queued`/`failed` `org_shares` rows — a second share after the first upload succeeded minted a fresh row and published a distinct feed item. There was no `(org, source)` uniqueness, and the FE could not tell a note was already shared.

## Fix (defense in depth)

**Backend**
- `share_to_org_inner`: idempotency guard — if the source is already `uploaded` in the org, collapse any duplicates (keep the earliest, tombstone the rest) and return the existing share **without publishing**. Runs before the egress-consent gate (a re-click is a read, not fresh egress).
- Auto-clean existing duplicates (keep-earliest + tombstone) from three reachable places: the share guard, `republish_org_shares_for_source` (collapse-before-republish), and a new **step-0 in the launch sweep** (`org_sweep_pending`) so pre-existing dupes self-heal on next launch. Also cancels leftover `queued`/`failed` siblings so no stuck "pending" row lingers.
- New DB helpers: `uploaded_org_shares_for_source_in_org`, `duplicate_uploaded_org_shares`, `cancel_pending_org_shares_for_source_in_org`.
- New read-only command `org_live_shares_for_source` (+ `OrgSourceShareStatus` DTO).

**Frontend**
- The org-share sheet blocks re-share for already-shared orgs ("Already in Org Brain ✓", disabled confirm) and marks shared orgs in the picker.
- `mur-org-brain-cta` + both share panels reflect an "In Org Brain ✓ / Manage" state via the new command.

**Edits still keep the org copy fresh** — `republish_org_shares_for_source` (0.9.5) is unchanged in intent; it just gains a collapse pass.

## Verification

- `cargo test --lib`: **1538 passed / 0 failed** — 5 new RED→GREEN tests (idempotency, collapse-keeps-earliest, dedup selection, cancel-scoping).
- Full `scripts/ci.sh` gate green (clippy `-D warnings`, cargo audit, cargo deny, build, `ng lint`, `ng build`; audio E2E skipped — this change touches no audio/transcribe path, matching the per-PR CI gate).
- **lock-security-reviewer: PASS** — no leak/loss, keeper provably preserved, crash-safe `revoke_pending`-first tombstone, no PII in logs, no crypto/keychain touched.
- **adversarial-verifier: PASS** — RED-before-GREEN proven empirically; live browser repro of the re-share block (confirm disabled → "Already in Org Brain ✓", zero console errors); no leak/crash/loss.

## Honest gaps

Only a signed 2-account build against the live server can prove the tombstone actually evicts the duplicate from **other** members' feeds and that the launch-sweep dedup fires against the real server. Covered here by unit tests of the local state machine + the swallowed-error / `revoke_pending` recovery path.
