### PR TITLE
feat(org): shared meetings in Library, separate from Notes

### DIFF
--- a/e2e/notes/notes-org.spec.ts
+++ b/e2e/notes/notes-org.spec.ts
@@ -90,6 +90,57 @@ test("All notes merges org shared items (with org-name badge) + the rail lists t
   expect(consoleErrors).toEqual([]);
 });
 
+test("a kind:'meeting' org item is excluded from Notes (it belongs in Library's Shared brains rail)", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    ...ORG_MOCKS,
+    list_org_items: (args: { orgId: string }) =>
+      args.orgId === "org1"
+        ? [
+            {
+              itemId: "oi-doc",
+              title: "Team Roadmap Q3",
+              authorHint: "alice",
+              createdAt: "2026-07-09T10:00:00Z",
+              seq: 5,
+              kind: "document",
+            },
+            {
+              itemId: "oi-meeting",
+              title: "Weekly Sync Notes",
+              authorHint: "bob",
+              createdAt: "2026-07-10T10:00:00Z",
+              seq: 6,
+              kind: "meeting",
+            },
+          ]
+        : [],
+  });
+  await page.goto("/notes");
+
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // "All notes": the document-kind item shows, the meeting-kind one does NOT.
+  await expect(page.getByText("Team Roadmap Q3")).toBeVisible();
+  await expect(page.getByText("Weekly Sync Notes")).toHaveCount(0);
+
+  // Selecting the org in the rail: same exclusion applies to the org-scoped view.
+  await page.locator(".org-row").click();
+  await expect(page.getByText("Team Roadmap Q3")).toBeVisible();
+  await expect(page.getByText("Weekly Sync Notes")).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});
+
 test("clicking an org shared item routes to the read-only /org-item viewer", async ({
   page,
 }) => {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23308,7 +23308,9 @@ mod lifecycle_tests {
     /// row id), proving the two AADs match.
     #[test]
     fn org_envelope_aad_nonce_is_content_hash_so_cross_member_open_succeeds() {
-        use crate::share::org_envelope::{open_org_envelope, seal_org_envelope, OrgEnvelope, OrgItemKind};
+        use crate::share::org_envelope::{
+            open_org_envelope, seal_org_envelope, OrgEnvelope, OrgItemKind, OrgSourceKind,
+        };
 
         let ock = crate::crypto::random_key().unwrap();
         let env = OrgEnvelope::new(
@@ -23318,6 +23320,7 @@ mod lifecycle_tests {
             "anna",
             "2026-07-10T09:00:00Z",
             1,
+            OrgSourceKind::Meeting,
         );
         let content_sha = env.content_sha256();
 
@@ -23368,6 +23371,7 @@ mod lifecycle_tests {
                 1,
                 &[5u8; 32],
                 None,
+                None,
             )
             .unwrap();
         let got = state.db.get_org_item("it-g").unwrap().unwrap();
@@ -23394,19 +23398,19 @@ mod lifecycle_tests {
         // Two items in org-1 at seq 1 and 2, plus an item in a DIFFERENT org, plus a tombstoned one.
         state
             .db
-            .upsert_org_item("a", "org-1", 1, "anna", "Kickoff", "the kickoff agenda", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .upsert_org_item("a", "org-1", 1, "anna", "Kickoff", "the kickoff agenda", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None, None)
             .unwrap();
         state
             .db
-            .upsert_org_item("b", "org-1", 2, "bob", "Retro", "the sprint retro", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None)
+            .upsert_org_item("b", "org-1", 2, "bob", "Retro", "the sprint retro", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None, None)
             .unwrap();
         state
             .db
-            .upsert_org_item("z", "org-2", 9, "zed", "Other org", "not our org", "2026-07-11T09:00:00Z", 1, 1, &[3u8; 32], None)
+            .upsert_org_item("z", "org-2", 9, "zed", "Other org", "not our org", "2026-07-11T09:00:00Z", 1, 1, &[3u8; 32], None, None)
             .unwrap();
         state
             .db
-            .upsert_org_item("d", "org-1", 3, "dan", "Dead", "revoked", "2026-07-11T10:00:00Z", 1, 1, &[4u8; 32], None)
+            .upsert_org_item("d", "org-1", 3, "dan", "Dead", "revoked", "2026-07-11T10:00:00Z", 1, 1, &[4u8; 32], None, None)
             .unwrap();
         state.db.tombstone_org_item("d").unwrap();
 
@@ -23446,7 +23450,7 @@ mod lifecycle_tests {
         // The received replica (frozen at publish time = "Untitled") + the matching OUTBOUND share.
         state
             .db
-            .upsert_org_item("item-own", "org-1", 2, "kgm004a", "Untitled", "# body", "2026-07-11T09:00:00Z", 1, 1, &[9u8; 32], None)
+            .upsert_org_item("item-own", "org-1", 2, "kgm004a", "Untitled", "# body", "2026-07-11T09:00:00Z", 1, 1, &[9u8; 32], None, None)
             .unwrap();
         state
             .db
@@ -23459,7 +23463,7 @@ mod lifecycle_tests {
         // Someone ELSE's replica — no local share ⇒ stays read-only, title untouched.
         state
             .db
-            .upsert_org_item("item-other", "org-1", 1, "kgm004a+2", "Ich notatka", "body", "2026-07-10T09:00:00Z", 1, 1, &[7u8; 32], None)
+            .upsert_org_item("item-other", "org-1", 1, "kgm004a+2", "Ich notatka", "body", "2026-07-10T09:00:00Z", 1, 1, &[7u8; 32], None, None)
             .unwrap();
 
         let items = list_org_items_inner(&state, "org-1").unwrap();
@@ -23475,6 +23479,73 @@ mod lifecycle_tests {
         let other = items.iter().find(|i| i.item_id == "item-other").unwrap();
         assert!(other.owned_source.is_none(), "a non-author's item is a read-only replica");
         assert_eq!(other.title, "Ich notatka", "a non-owned title is left as-is");
+    }
+
+    /// `OrgItemHeader.kind` round-trips for BOTH an owned document-kind share and an owned
+    /// meeting-kind share, and stays `None` for a colleague's item that was upserted with no stored
+    /// `source_kind` (mirrors an item ingested off a v1 envelope / before this column existed — the
+    /// genuinely-unclassified case; a colleague's item ingested off a v2 envelope now DOES classify,
+    /// since `Db::list_org_items` SELECTs the stored `org_items.source_kind` column directly for
+    /// every item). For owned items, `kind` is resolved from `org_shares.document_id` / `meeting_id`
+    /// presence — metadata only, independent of the `owned_source` unlock gate.
+    #[test]
+    fn list_org_items_resolves_kind_for_document_and_meeting_owned_shares_and_none_for_others() {
+        let state = build_state("org-list-kind");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-own", "Team");
+
+        // Owned DOCUMENT (note) share.
+        state
+            .db
+            .insert_note("n-own", "f-own", "Untitled", "A Note", "# body", 1)
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("item-doc", "org-1", 3, "kgm004a", "A Note", "# body", "2026-07-11T09:00:00Z", 1, 1, &[9u8; 32], None, None)
+            .unwrap();
+        state
+            .db
+            .insert_org_share("s-doc", "org-1", None, Some("n-own"), "note", Some("A Note"), 1, 1, &[9u8; 32], "2026-07-11T09:00:00Z")
+            .unwrap();
+        state.db.set_org_share_uploaded("s-doc", "item-doc", "2026-07-11T09:00:00Z").unwrap();
+
+        // Owned MEETING share (unlocked meeting: no folder_id).
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-own".to_string(),
+                started_at: "2026-07-11T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Standup".to_string()),
+                duration_s: 60,
+                audio_path: None,
+                status: MeetingStatus::Exported,
+                folder_id: None,
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_org_item("item-meeting", "org-1", 2, "kgm004a", "Standup", "# body", "2026-07-11T09:00:00Z", 1, 1, &[8u8; 32], None, None)
+            .unwrap();
+        state
+            .db
+            .insert_org_share("s-meeting", "org-1", Some("m-own"), None, "meeting", Some("Standup"), 1, 1, &[8u8; 32], "2026-07-11T09:00:00Z")
+            .unwrap();
+        state.db.set_org_share_uploaded("s-meeting", "item-meeting", "2026-07-11T09:00:00Z").unwrap();
+
+        // A colleague's item — no local `org_shares` row.
+        state
+            .db
+            .upsert_org_item("item-other", "org-1", 1, "kgm004a+2", "Ich notatka", "body", "2026-07-10T09:00:00Z", 1, 1, &[7u8; 32], None, None)
+            .unwrap();
+
+        let items = list_org_items_inner(&state, "org-1").unwrap();
+        let doc = items.iter().find(|i| i.item_id == "item-doc").unwrap();
+        assert_eq!(doc.kind.as_deref(), Some("document"), "owned note share ⇒ kind=document");
+        let meeting = items.iter().find(|i| i.item_id == "item-meeting").unwrap();
+        assert_eq!(meeting.kind.as_deref(), Some("meeting"), "owned meeting share ⇒ kind=meeting");
+        let other = items.iter().find(|i| i.item_id == "item-other").unwrap();
+        assert!(other.kind.is_none(), "a colleague's item has no locally-knowable kind");
     }
 
     /// F-org-editable GATE: an owned item whose source folder is LOCKED (not session-unlocked) is NOT
@@ -23502,7 +23573,7 @@ mod lifecycle_tests {
             .unwrap();
         state
             .db
-            .upsert_org_item("item-lock", "org-1", 1, "kgm004a", "Old Snapshot", "# body", "2026-07-11T09:00:00Z", 1, 1, &[5u8; 32], None)
+            .upsert_org_item("item-lock", "org-1", 1, "kgm004a", "Old Snapshot", "# body", "2026-07-11T09:00:00Z", 1, 1, &[5u8; 32], None, None)
             .unwrap();
         state
             .db
@@ -23518,6 +23589,11 @@ mod lifecycle_tests {
         assert!(
             it.owned_source.is_none(),
             "a locked owned source is not resolved (no editable link)"
+        );
+        assert_eq!(
+            it.kind.as_deref(),
+            Some("document"),
+            "kind is METADATA (not content) — still resolved even when the owned source is locked"
         );
         assert_ne!(
             it.title, "Secret Title",
@@ -23535,7 +23611,7 @@ mod lifecycle_tests {
         seed_org(&state.db, "org-mine", "Mine", "owner", 1);
         state
             .db
-            .upsert_org_item("m1", "org-mine", 1, "anna", "Mine A", "body", "2026-07-11T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .upsert_org_item("m1", "org-mine", 1, "anna", "Mine A", "body", "2026-07-11T09:00:00Z", 1, 1, &[1u8; 32], None, None)
             .unwrap();
         // A member org resolves + returns the item.
         let ok = list_org_items_inner(&state, "org-mine").unwrap();
@@ -23553,6 +23629,144 @@ mod lifecycle_tests {
         ));
     }
 
+    /// `meeting_org_shares`: an OPEN meeting's active org shares are visible (org id + display
+    /// name), and a SEALED-and-not-session-unlocked meeting's org-share status is MASKED to an empty
+    /// list — exactly like `get_meeting_detail`'s `locked: true` masking. RED on any pre-gate version
+    /// that reads `org_shares_for_source` unconditionally (it would leak the org name for a locked
+    /// meeting even though every OTHER content channel on that meeting is closed).
+    #[test]
+    fn meeting_org_shares_gated_by_meeting_is_unlocked() {
+        let state = build_state("meeting-org-shares-gate");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+
+        // An OPEN meeting, actively shared into org-1.
+        make_open_folder(&state.db, "f-open", "Open");
+        seed_meeting(&state.db, "m-open", "# note", Some("f-open"));
+        state
+            .db
+            .insert_org_share(
+                "s-open", "org-1", Some("m-open"), None, "meeting", Some("Quarterly strategy"),
+                1, 1, &[7u8; 32], "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s-open", "item-open", "2026-07-11T09:00:00Z")
+            .unwrap();
+
+        let open_shares = meeting_org_shares_inner(&state, "m-open").unwrap();
+        assert_eq!(open_shares.len(), 1, "the open meeting's active org share is visible");
+        assert_eq!(open_shares[0].org_id, "org-1");
+        assert_eq!(open_shares[0].org_name, "Acme", "the org's display name resolves");
+
+        // A SEALED, NOT session-unlocked meeting, also actively shared into org-1.
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-sealed".to_string(),
+                name: "Sealed".to_string(),
+                path: "Sealed".to_string(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-06-27T08:00:00Z".to_string(),
+            })
+            .unwrap();
+        seed_meeting(&state.db, "m-sealed", "# note", Some("f-sealed"));
+        state
+            .db
+            .insert_org_share(
+                "s-sealed", "org-1", Some("m-sealed"), None, "meeting", Some("Confidential"),
+                1, 1, &[8u8; 32], "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s-sealed", "item-sealed", "2026-07-11T09:00:00Z")
+            .unwrap();
+
+        let sealed_shares = meeting_org_shares_inner(&state, "m-sealed").unwrap();
+        assert!(
+            sealed_shares.is_empty(),
+            "a sealed-and-not-session-unlocked meeting's org-share status must be masked, not leaked"
+        );
+
+        // Session-unlock the folder — the same meeting's org-share status becomes visible again.
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-sealed".to_string());
+        let unlocked_shares = meeting_org_shares_inner(&state, "m-sealed").unwrap();
+        assert_eq!(
+            unlocked_shares.len(),
+            1,
+            "a session-unlocked meeting's org-share status is visible again"
+        );
+        assert_eq!(unlocked_shares[0].org_id, "org-1");
+    }
+
+    /// `list_meeting_org_shares`: the BULK Library-row variant of `meeting_org_shares` — one row per
+    /// (meeting, org). An open meeting's active share is listed; a sealed-and-not-session-unlocked
+    /// meeting's row is DROPPED (never leaked in the bulk list either), and a document-anchored share
+    /// (no `meeting_id`) is skipped as not a Library concern.
+    #[test]
+    fn list_meeting_org_shares_drops_locked_meetings() {
+        let state = build_state("list-meeting-org-shares-gate");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+
+        make_open_folder(&state.db, "f-open", "Open");
+        seed_meeting(&state.db, "m-open", "# note", Some("f-open"));
+        state
+            .db
+            .insert_org_share(
+                "s-open", "org-1", Some("m-open"), None, "meeting", Some("Quarterly strategy"),
+                1, 1, &[7u8; 32], "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state.db.set_org_share_uploaded("s-open", "item-open", "2026-07-11T09:00:00Z").unwrap();
+
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-sealed".to_string(),
+                name: "Sealed".to_string(),
+                path: "Sealed".to_string(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-06-27T08:00:00Z".to_string(),
+            })
+            .unwrap();
+        seed_meeting(&state.db, "m-sealed", "# note", Some("f-sealed"));
+        state
+            .db
+            .insert_org_share(
+                "s-sealed", "org-1", Some("m-sealed"), None, "meeting", Some("Confidential"),
+                1, 1, &[8u8; 32], "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state.db.set_org_share_uploaded("s-sealed", "item-sealed", "2026-07-11T09:00:00Z").unwrap();
+
+        // A document-anchored share — not a meeting, must be skipped from the Library-scoped list.
+        state
+            .db
+            .insert_org_share(
+                "s-doc", "org-1", None, Some("n-doc"), "note", Some("A note"),
+                1, 1, &[9u8; 32], "2026-07-11T09:00:00Z",
+            )
+            .unwrap();
+        state.db.set_org_share_uploaded("s-doc", "item-doc", "2026-07-11T09:00:00Z").unwrap();
+
+        let rows = list_meeting_org_shares_inner(&state).unwrap();
+        assert_eq!(rows.len(), 1, "only the OPEN meeting's share is listed");
+        assert_eq!(rows[0].meeting_id, "m-open");
+        assert_eq!(rows[0].org_id, "org-1");
+        assert_eq!(rows[0].org_name, "Acme");
+        assert!(
+            !rows.iter().any(|r| r.meeting_id == "m-sealed"),
+            "a sealed-and-not-session-unlocked meeting's share must not appear in the bulk list"
+        );
+    }
+
     /// FIX B (received-items COUNT): `OrgStatus.received_count` reflects the LOCAL replica (what
     /// colleagues shared IN), DISTINCT from `item_count` (the caller's OWN uploaded outbound shares).
     /// Seed org_items (received) + an outbound uploaded share and assert the two counts are independent.
@@ -23564,11 +23778,11 @@ mod lifecycle_tests {
         // TWO received items (from colleagues) in the local replica.
         state
             .db
-            .upsert_org_item("r1", "org-1", 1, "anna", "Doc A", "body a", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None)
+            .upsert_org_item("r1", "org-1", 1, "anna", "Doc A", "body a", "2026-07-10T09:00:00Z", 1, 1, &[1u8; 32], None, None)
             .unwrap();
         state
             .db
-            .upsert_org_item("r2", "org-1", 2, "bob", "Doc B", "body b", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None)
+            .upsert_org_item("r2", "org-1", 2, "bob", "Doc B", "body b", "2026-07-11T09:00:00Z", 1, 1, &[2u8; 32], None, None)
             .unwrap();
         // ONE of the caller's OWN outbound shares, state 'uploaded' (item_count = 1).
         let now = "2026-07-11T12:00:00Z";
@@ -25948,6 +26162,14 @@ pub(crate) async fn publish_org_body(
         document_id.as_deref(),
         scrub,
     )?;
+    // `build_org_share_body` already enforces exactly one of meeting_id/document_id is `Some` (else it
+    // errors before this line is reached), so this mirrors that same exclusivity to stamp the wire
+    // envelope's SOURCE type (document vs meeting — a new axis, distinct from `kind`/content-shape).
+    let source_kind = if meeting_id.is_some() {
+        crate::share::org_envelope::OrgSourceKind::Meeting
+    } else {
+        crate::share::org_envelope::OrgSourceKind::Document
+    };
 
     // (2) consent fail-closed (the global one-time org-egress consent).
     {
@@ -25993,6 +26215,7 @@ pub(crate) async fn publish_org_body(
         author_hint,
         created_at,
         rev,
+        source_kind,
     );
     let content_sha = env.content_sha256();
     // SB-3 row-amplification fix: REUSE any existing retriable (`queued`/`failed`) row for this
@@ -26132,11 +26355,14 @@ pub(crate) async fn republish_org_shares_for_source(
     state: &AppState,
     meeting_id: Option<&str>,
     document_id: Option<&str>,
-) -> Result<(), AppError> {
+) -> Result<u32, AppError> {
     let rows = state.db.org_shares_for_source(meeting_id, document_id)?;
     if rows.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
+    // Count of rows that produced a NEW published rev this call — the caller emits `org-feed-updated`
+    // only when > 0 (a save that changed nothing / skipped every row must not ping the FE).
+    let mut republished = 0u32;
     let now = chrono::Utc::now().to_rfc3339();
     for row in rows {
         // Re-read the CURRENT plaintext THROUGH the read-gate. `build_org_share_body` also does the
@@ -26161,6 +26387,13 @@ pub(crate) async fn republish_org_shares_for_source(
                 tracing::warn!(target: "org", error = %e, "republish: could not re-read source; skipped");
                 continue;
             }
+        };
+        // `org_shares_for_source` rows always anchor exactly one of meeting_id/document_id (mirrors the
+        // exclusivity `build_org_share_body` already enforced when this row was first published).
+        let source_kind = if row.meeting_id.is_some() {
+            crate::share::org_envelope::OrgSourceKind::Meeting
+        } else {
+            crate::share::org_envelope::OrgSourceKind::Document
         };
 
         // Consent could have been withdrawn since the share → SKIP (never egress without consent).
@@ -26199,6 +26432,7 @@ pub(crate) async fn republish_org_shares_for_source(
             author_hint.clone(),
             created_at.clone(),
             row.rev,
+            source_kind,
         );
         if row.content_sha256.as_deref() == Some(cmp_env.content_sha256().as_slice()) {
             continue;
@@ -26212,6 +26446,7 @@ pub(crate) async fn republish_org_shares_for_source(
             author_hint,
             created_at,
             new_rev,
+            source_kind,
         );
         let content_sha = env.content_sha256();
 
@@ -26300,6 +26535,10 @@ pub(crate) async fn republish_org_shares_for_source(
             .db
             .set_org_share_uploaded(&row.id, &published.item_id, &now)?;
         crate::share::ledger_row(&state.db, &client.host(), "org_share_publish", content_sha.len());
+        // This row produced a NEW published rev this call — counted so the caller can decide whether
+        // to emit `org-feed-updated` (only when > 0; a save that changed nothing / skipped every row
+        // must not ping the FE).
+        republished += 1;
 
         // LOCAL REPLICA CONSISTENCY (F-org-editable): the author's OWN `org_items` replica would
         // otherwise stay frozen on the OLD item_id until the next feed pull — so the just-repointed
@@ -26320,6 +26559,7 @@ pub(crate) async fn republish_org_shares_for_source(
             new_rev,
             generation,
             &content_sha,
+            env.source_kind.map(crate::share::org_envelope::OrgSourceKind::as_str),
             None,
         ) {
             tracing::warn!(target: "org", error = %e, "republish: local replica upsert failed (server copy live)");
@@ -26354,7 +26594,7 @@ pub(crate) async fn republish_org_shares_for_source(
             }
         }
     }
-    Ok(())
+    Ok(republished)
 }
 
 /// `list_org_shares()` — the caller's outbound org shares (local rows; titles render only to the
@@ -26379,6 +26619,120 @@ pub fn list_org_shares(state: State<'_, AppState>) -> Result<Vec<OrgShareEntry>,
             state: r.state,
         })
         .collect())
+}
+
+/// One org this meeting is actively shared into (`meeting_org_shares`) — just enough for the
+/// Library row badge + the Detail "Shared with…" indicator. Content-free beyond the org's own
+/// display name (which the caller already sees everywhere else in the org UI).
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingOrgShareInfo {
+    pub org_id: String,
+    pub org_name: String,
+}
+
+/// `meeting_org_shares(meeting_id)` — every org THIS meeting is currently (actively) shared into,
+/// i.e. the `uploaded` `org_shares` rows anchored on it. Same disclosure class as `get_meeting_tags`
+/// (a metadata-only read of the user's OWN share state — never note/transcript content), but gated
+/// exactly like `get_meeting_detail`: a sealed-and-not-session-unlocked meeting returns an EMPTY
+/// list rather than leaking whether/where it's shared, mirroring `meeting_is_unlocked` at every
+/// other content read site. A meeting the caller never shared (or an unknown id) also returns `[]`.
+#[tauri::command]
+pub fn meeting_org_shares(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<MeetingOrgShareInfo>, AppError> {
+    meeting_org_shares_inner(state.inner(), &meeting_id)
+}
+
+/// Inner of [`meeting_org_shares`] taking `&AppState` (unit-testable read-gate). See the command doc
+/// for the disclosure-class rationale.
+pub(crate) fn meeting_org_shares_inner(
+    st: &AppState,
+    meeting_id: &str,
+) -> Result<Vec<MeetingOrgShareInfo>, AppError> {
+    if !meeting_is_unlocked(st, meeting_id)? {
+        return Ok(Vec::new());
+    }
+    let rows = st.db.org_shares_for_source(Some(meeting_id), None)?;
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for row in rows {
+        if !seen.insert(row.org_id.clone()) {
+            continue; // one badge per org even if somehow >1 uploaded row exists for it.
+        }
+        let name = st
+            .db
+            .get_org_state(&row.org_id)?
+            .map(|o| o.name)
+            .unwrap_or_else(|| "Shared brain".to_string());
+        out.push(MeetingOrgShareInfo {
+            org_id: row.org_id,
+            org_name: name,
+        });
+    }
+    Ok(out)
+}
+
+/// One row of [`list_meeting_org_shares`] — a single meeting-to-org share pairing (a meeting may
+/// have several rows, one per org it's shared into).
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingOrgShareRow {
+    pub meeting_id: String,
+    pub org_id: String,
+    pub org_name: String,
+}
+
+/// `list_meeting_org_shares()` — EVERY active meeting→org share pairing across ALL of the caller's
+/// meetings, in one bulk call (avoids an N+1 `meeting_org_shares` fetch per Library row). Same
+/// disclosure class + gate as [`meeting_org_shares`]: a sealed-and-not-session-unlocked meeting's
+/// rows are dropped, exactly mirroring `mask_locked_meetings` for `list_meetings`.
+#[tauri::command]
+pub fn list_meeting_org_shares(
+    state: State<'_, AppState>,
+) -> Result<Vec<MeetingOrgShareRow>, AppError> {
+    list_meeting_org_shares_inner(state.inner())
+}
+
+/// Inner of [`list_meeting_org_shares`] taking `&AppState` (unit-testable read-gate).
+pub(crate) fn list_meeting_org_shares_inner(
+    st: &AppState,
+) -> Result<Vec<MeetingOrgShareRow>, AppError> {
+    let rows = st.db.list_org_shares_in_state("uploaded")?;
+    let mut out = Vec::new();
+    let mut org_names: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut seen = std::collections::HashSet::new();
+    for row in rows {
+        let Some(meeting_id) = row.meeting_id else {
+            continue; // a document-anchored share — not a Library concern.
+        };
+        if !seen.insert((meeting_id.clone(), row.org_id.clone())) {
+            continue; // one badge per (meeting, org) even if somehow >1 uploaded row exists.
+        }
+        // GATE: a sealed-and-not-session-unlocked meeting's share status must not leak, exactly
+        // like every other content/metadata read on it (`meeting_is_unlocked`).
+        if !meeting_is_unlocked(st, &meeting_id)? {
+            continue;
+        }
+        let name = if let Some(n) = org_names.get(&row.org_id) {
+            n.clone()
+        } else {
+            let n = st
+                .db
+                .get_org_state(&row.org_id)?
+                .map(|o| o.name)
+                .unwrap_or_else(|| "Shared brain".to_string());
+            org_names.insert(row.org_id.clone(), n.clone());
+            n
+        };
+        out.push(MeetingOrgShareRow {
+            meeting_id,
+            org_id: row.org_id,
+            org_name: name,
+        });
+    }
+    Ok(out)
 }
 
 /// `revoke_org_share(item_id)` — tombstone a published org item (destroys its server ciphertext) and
@@ -26977,6 +27331,11 @@ async fn org_sync_one(
                     rev,
                     generation,
                     &sha,
+                    // Straight off the opened envelope: `Some("document"|"meeting")` for an item
+                    // published from a v2 wire envelope (this device's own publishes, or a peer already
+                    // on v2); `None` for one opened off an old v1 envelope (no wire signal) — honest
+                    // "unclassified", never guessed.
+                    env.source_kind.map(crate::share::org_envelope::OrgSourceKind::as_str),
                     embedder_ref,
                 )?;
                 report.ingested += 1;
@@ -27043,13 +27402,45 @@ pub(crate) fn list_org_items_inner(
     // a stale publish-time snapshot. GATED — a locked-not-unlocked source resolves to `None` (its title
     // must never leak through this org-disclosed list). A non-author's item has no local share ⇒ `None`
     // ⇒ stays a read-only replica.
+    //
+    // KIND (source-type) ENRICHMENT: separate from the above — `kind` is METADATA (meeting vs document),
+    // never content. `Db::list_org_items` now populates `item.kind` DIRECTLY from the stored
+    // `org_items.source_kind` column for EVERY item (opened off a v2 `OrgEnvelope` at ingest, so a
+    // colleague's item now classifies too). This local `org_shares`-anchored resolver is kept as a
+    // fallback/override ONLY for the CALLER'S OWN items — it stays correct (and UNGATED, unlike
+    // `owned_source`: a locked source still reports its kind) even if the stored column is somehow null
+    // for a row ingested before this column existed. It must NOT clobber a correctly-populated stored
+    // value for a colleague's item with `None`.
     for item in &mut items {
+        if let Some(own_kind) = resolve_own_item_kind(st, &item.item_id)? {
+            item.kind = Some(own_kind);
+        }
         if let Some(src) = resolve_owned_source(st, &item.item_id)? {
             item.title = src.title;
             item.owned_source = Some(src.owned);
         }
     }
     Ok(items)
+}
+
+/// The source kind (`"document"` | `"meeting"`) of an org item THIS device published, from the local
+/// `org_shares` anchor — metadata only (no title/body), so UNGATED (a locked source still reports its
+/// kind; only `owned_source`'s title is lock-gated). `None` when no local share row exists (an item
+/// published by a colleague) or the row anchors neither `meeting_id` nor `document_id` (shouldn't
+/// happen — `insert_org_share` always sets exactly one — but fails closed to `None` rather than guess).
+/// A fallback/override for the CALLER'S OWN items only — see the call site in `list_org_items_inner`;
+/// `Db::list_org_items` now populates `kind` for colleagues' items too, straight from storage.
+fn resolve_own_item_kind(st: &AppState, item_id: &str) -> Result<Option<String>, AppError> {
+    let Some(row) = st.db.org_share_by_item(item_id)? else {
+        return Ok(None);
+    };
+    if row.document_id.is_some() {
+        Ok(Some("document".to_string()))
+    } else if row.meeting_id.is_some() {
+        Ok(Some("meeting".to_string()))
+    } else {
+        Ok(None)
+    }
 }
 
 /// The caller's editable local source + its CURRENT title for an org item they published, if any. `None`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,8 @@ pub fn run() {
             commands::share_meeting_to_org,
             commands::share_document_to_org,
             commands::list_org_shares,
+            commands::meeting_org_shares,
+            commands::list_meeting_org_shares,
             commands::revoke_org_share,
             commands::org_sweep_pending,
             commands::org_sync_now,

--- a/src-tauri/src/share/org_envelope.rs
+++ b/src-tauri/src/share/org_envelope.rs
@@ -23,7 +23,19 @@ const ORG_ITEM_AAD_V1: &str = "murmur-org/v1|org-item";
 
 /// The envelope wire version. Bump only for a breaking canonical-format change (readers reject an
 /// unknown version fail-closed).
-pub const ORG_ENVELOPE_VERSION: u16 = 1;
+///
+/// v1 → v2 history: v2 APPENDS one `source_kind` tag byte after `created_at` (no other field moved).
+/// `from_canonical_bytes` accepts BOTH v1 (already-published envelopes sitting in real org feeds —
+/// parsed exactly as before, `source_kind: None`) and v2 (new envelopes, always constructed via
+/// `OrgEnvelope::new`) — an already-published v1 envelope MUST stay parseable forever; only an
+/// unrecognized version (anything but 1 or 2) fails closed. `to_canonical_bytes` also branches on
+/// `self.version` so re-serializing a PARSED v1 envelope reproduces byte-identical v1 bytes (never
+/// silently upgrades the wire form — that would shift `content_sha256` for existing dedup rows).
+pub const ORG_ENVELOPE_VERSION: u16 = 2;
+
+/// The PREVIOUS wire version, still accepted on read for backward compatibility with envelopes
+/// already published to org feeds before this device upgraded. See `ORG_ENVELOPE_VERSION` doc.
+const ORG_ENVELOPE_VERSION_V1: u16 = 1;
 
 /// The kind of authored content an org item carries. Serialized as a single tag byte in the canonical
 /// form (stable across versions).
@@ -58,7 +70,44 @@ impl OrgItemKind {
     }
 }
 
-/// The plaintext an org item carries (spec `OrgEnvelope v1`). `author_hint` is a display label only
+/// The SOURCE type an org item was published from — a DIFFERENT axis from [`OrgItemKind`] (which is
+/// content SHAPE, not source type; both `share_meeting_to_org` and `share_document_to_org` currently
+/// stamp every envelope `OrgItemKind::Note` regardless of source). Serialized as a single tag byte,
+/// present ONLY in a v2 envelope (v1 envelopes carry no source-type signal on the wire and parse to
+/// `OrgEnvelope.source_kind: None`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrgSourceKind {
+    /// Published from an authored standalone note/document.
+    Document,
+    /// Published from a meeting's note/summary.
+    Meeting,
+}
+
+impl OrgSourceKind {
+    fn tag(self) -> u8 {
+        match self {
+            OrgSourceKind::Document => 1,
+            OrgSourceKind::Meeting => 2,
+        }
+    }
+    fn from_tag(t: u8) -> Result<Self> {
+        match t {
+            1 => Ok(OrgSourceKind::Document),
+            2 => Ok(OrgSourceKind::Meeting),
+            _ => Err(AppError::InvalidArg("unknown org source kind tag".into())),
+        }
+    }
+    /// The lowercase wire label used by storage + FE DTOs (mirrors `OrgItemHeader.kind`'s existing
+    /// `"document"` / `"meeting"` strings from the owned-item resolver).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrgSourceKind::Document => "document",
+            OrgSourceKind::Meeting => "meeting",
+        }
+    }
+}
+
+/// The plaintext an org item carries (spec `OrgEnvelope v1`/`v2`). `author_hint` is a display label only
 /// (e.g. the author's email local-part / account short id) — it is deliberately NOT a note-content
 /// string, and is what the connector formatter renders as `[org · <author_hint>]` provenance.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -71,12 +120,18 @@ pub struct OrgEnvelope {
     pub created_at: String,
     /// The source revision of the local note/document at publish time (for later "update share").
     pub source_rev: u32,
+    /// The SOURCE type (document vs meeting) this envelope was published from. `Some(..)` for every
+    /// envelope THIS device constructs (`new()` always stamps v2 + a required source kind); `None`
+    /// ONLY for an envelope PARSED from already-published v1 wire bytes, which carry no such signal.
+    pub source_kind: Option<OrgSourceKind>,
 }
 
 impl OrgEnvelope {
-    /// Build a v1 envelope. Callers pass the ALREADY-CLEANED + scrubbed markdown (the seal layer does
-    /// no sanitization — that is the command's job, upstream, so the leak-safety transform is a
-    /// single well-tested seam).
+    /// Build a NEW envelope — always stamped the CURRENT wire version (`ORG_ENVELOPE_VERSION`, v2) with
+    /// a REQUIRED `source_kind`: every envelope this device constructs always knows its own source type,
+    /// so `source_kind: None` is reserved for envelopes parsed off old v1 wire data, never one built
+    /// here. Callers pass the ALREADY-CLEANED + scrubbed markdown (the seal layer does no sanitization —
+    /// that is the command's job, upstream, so the leak-safety transform is a single well-tested seam).
     pub fn new(
         kind: OrgItemKind,
         title: impl Into<String>,
@@ -84,6 +139,7 @@ impl OrgEnvelope {
         author_hint: impl Into<String>,
         created_at: impl Into<String>,
         source_rev: u32,
+        source_kind: OrgSourceKind,
     ) -> Self {
         Self {
             version: ORG_ENVELOPE_VERSION,
@@ -93,12 +149,17 @@ impl OrgEnvelope {
             author_hint: author_hint.into(),
             created_at: created_at.into(),
             source_rev,
+            source_kind: Some(source_kind),
         }
     }
 
-    /// Serialize to the CANONICAL byte form: `version(u16 LE) | kind_tag(u8) | source_rev(u32 LE) |
-    /// [len(u32 LE) || utf8]{title, markdown, author_hint, created_at}`. Fixed field order + explicit
-    /// length prefixes ⇒ two devices produce byte-identical bytes ⇒ a stable `content_sha256`.
+    /// Serialize to the CANONICAL byte form. v1 layout: `version(u16 LE) | kind_tag(u8) |
+    /// source_rev(u32 LE) | [len(u32 LE) || utf8]{title, markdown, author_hint, created_at}`. v2 layout
+    /// APPENDS one `source_kind_tag(u8)` after `created_at` — nothing before it moves, so a v1-shaped
+    /// value serialized here (i.e. `self.version == 1`, from a PARSED old envelope) reproduces the
+    /// EXACT v1 bytes, never silently upgrading the wire form (that would shift `content_sha256` for
+    /// existing dedup rows). Fixed field order + explicit length prefixes ⇒ two devices on the same
+    /// version produce byte-identical bytes ⇒ a stable `content_sha256`.
     pub fn to_canonical_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(
             2 + 1
@@ -107,7 +168,8 @@ impl OrgEnvelope {
                 + self.title.len()
                 + self.markdown.len()
                 + self.author_hint.len()
-                + self.created_at.len(),
+                + self.created_at.len()
+                + 1,
         );
         out.extend_from_slice(&self.version.to_le_bytes());
         out.push(self.kind.tag());
@@ -121,15 +183,27 @@ impl OrgEnvelope {
             out.extend_from_slice(&(field.len() as u32).to_le_bytes());
             out.extend_from_slice(field.as_bytes());
         }
+        if self.version >= ORG_ENVELOPE_VERSION {
+            // v2 (or later, should the format ever grow again): append the source-kind tag. `new()`
+            // guarantees `Some` here; a `None` on a v2-stamped value is an internal invariant violation
+            // (should never happen — nothing constructs one), so fail closed rather than write garbage.
+            let tag = self.source_kind.map(OrgSourceKind::tag).unwrap_or(0);
+            out.push(tag);
+        }
         out
     }
 
     /// Parse the canonical byte form. Fails closed (`InvalidArg`) on a truncated/oversized/malformed
     /// buffer or an unknown version — never panics, never reads out of bounds.
+    ///
+    /// BACKWARD COMPAT (binding): accepts BOTH `ORG_ENVELOPE_VERSION_V1` (already-published envelopes —
+    /// parsed exactly as the original v1 layout, `source_kind: None`) and `ORG_ENVELOPE_VERSION` (v2 —
+    /// the same 4 fields, then one extra source-kind tag byte). Any OTHER version fails closed exactly
+    /// as before. Never reject a v1 envelope — real users have v1 bytes live in org feeds today.
     pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self> {
         let mut cur = Cursor { b: bytes, i: 0 };
         let version = cur.take_u16()?;
-        if version != ORG_ENVELOPE_VERSION {
+        if version != ORG_ENVELOPE_VERSION_V1 && version != ORG_ENVELOPE_VERSION {
             return Err(AppError::InvalidArg(format!(
                 "unsupported org envelope version {version}"
             )));
@@ -140,6 +214,11 @@ impl OrgEnvelope {
         let markdown = cur.take_str()?;
         let author_hint = cur.take_str()?;
         let created_at = cur.take_str()?;
+        let source_kind = if version == ORG_ENVELOPE_VERSION {
+            Some(OrgSourceKind::from_tag(cur.take_u8()?)?)
+        } else {
+            None
+        };
         if cur.i != bytes.len() {
             return Err(AppError::InvalidArg(
                 "trailing bytes after org envelope".into(),
@@ -153,6 +232,7 @@ impl OrgEnvelope {
             author_hint,
             created_at,
             source_rev,
+            source_kind,
         })
     }
 
@@ -270,7 +350,22 @@ mod tests {
             "anna",
             "2026-07-10T10:00:00Z",
             3,
+            OrgSourceKind::Meeting,
         )
+    }
+
+    /// Hand-build a byte buffer in the OLD v1 wire layout (no trailing `source_kind` byte) — the exact
+    /// shape of an envelope already published to a real org feed before this device shipped v2. Mirrors
+    /// the manual byte-construction style of `malformed_canonical_bytes_fail_closed_no_panic`.
+    fn v1_bytes(title: &str, markdown: &str, author_hint: &str, created_at: &str, source_rev: u32) -> Vec<u8> {
+        let mut out = ORG_ENVELOPE_VERSION_V1.to_le_bytes().to_vec();
+        out.push(OrgItemKind::Note.tag());
+        out.extend_from_slice(&source_rev.to_le_bytes());
+        for field in [title, markdown, author_hint, created_at] {
+            out.extend_from_slice(&(field.len() as u32).to_le_bytes());
+            out.extend_from_slice(field.as_bytes());
+        }
+        out
     }
 
     #[test]
@@ -281,6 +376,65 @@ mod tests {
         assert_eq!(back, e);
         // Re-serializing the parsed value yields identical bytes (stable canonical form).
         assert_eq!(back.to_canonical_bytes(), bytes);
+    }
+
+    /// RED-BEFORE-GREEN (the load-bearing backward-compat regression): a byte buffer in the OLD v1
+    /// wire layout — no trailing `source_kind` tag byte, exactly what is sitting in real users' org
+    /// feeds today — MUST still parse successfully, yield `source_kind: None` (unclassified, not a
+    /// guess), and re-serialize back to the EXACT SAME v1 bytes (so `content_sha256`/dedup for
+    /// already-published v1 items never shifts). A naive "just require the new field always" fix fails
+    /// this test (either by rejecting the version-1 buffer outright, or by upgrading it to v2 bytes on
+    /// re-serialize); only correct version-branching in both `from_canonical_bytes` and
+    /// `to_canonical_bytes` passes.
+    #[test]
+    fn v1_wire_bytes_still_parse_and_reserialize_byte_identical() {
+        let old = v1_bytes(
+            "Weekly Sync",
+            "- decided on the roadmap\n- Anna owns follow-up",
+            "anna",
+            "2026-07-10T10:00:00Z",
+            3,
+        );
+        let parsed = OrgEnvelope::from_canonical_bytes(&old)
+            .expect("an already-published v1 envelope must remain parseable forever");
+        assert_eq!(parsed.version, ORG_ENVELOPE_VERSION_V1);
+        assert_eq!(
+            parsed.source_kind, None,
+            "a v1 envelope carries no source-type signal on the wire — unclassified, never guessed"
+        );
+        assert_eq!(parsed.title, "Weekly Sync");
+        assert_eq!(parsed.kind, OrgItemKind::Note);
+        // Re-serializing a PARSED v1 value must reproduce the EXACT v1 bytes — no silent upgrade to
+        // the v2 layout (that would shift content_sha256 for existing dedup rows).
+        assert_eq!(
+            parsed.to_canonical_bytes(),
+            old,
+            "re-serializing a parsed v1 envelope must not mutate the wire format of old data"
+        );
+    }
+
+    /// A v2 envelope (freshly constructed via `new()`, always required to carry a `source_kind`) round
+    /// trips both source kinds through the canonical byte form.
+    #[test]
+    fn v2_canonical_round_trips_both_source_kinds() {
+        for sk in [OrgSourceKind::Meeting, OrgSourceKind::Document] {
+            let e = OrgEnvelope::new(
+                OrgItemKind::Note,
+                "Standup",
+                "body",
+                "anna",
+                "2026-07-11T09:00:00Z",
+                1,
+                sk,
+            );
+            assert_eq!(e.version, ORG_ENVELOPE_VERSION);
+            let bytes = e.to_canonical_bytes();
+            let back = OrgEnvelope::from_canonical_bytes(&bytes).unwrap();
+            assert_eq!(back, e);
+            assert_eq!(back.source_kind, Some(sk));
+            // Stable re-serialization for v2 too.
+            assert_eq!(back.to_canonical_bytes(), bytes);
+        }
     }
 
     #[test]
@@ -354,6 +508,21 @@ mod tests {
         bad.extend_from_slice(&0u32.to_le_bytes()); // source_rev
         bad.extend_from_slice(&(9999u32).to_le_bytes()); // title len way past EOF
         assert!(OrgEnvelope::from_canonical_bytes(&bad).is_err());
+
+        // A v2 buffer missing its trailing source_kind tag byte (truncated exactly at the v1/v2
+        // boundary) must fail closed, not silently parse as v1.
+        let v2_missing_tag = v1_bytes("t", "m", "a", "c", 1); // v1-shaped bytes...
+        let mut v2_claimed = v2_missing_tag.clone();
+        v2_claimed[0] = ORG_ENVELOPE_VERSION.to_le_bytes()[0]; // ...but claims version 2
+        v2_claimed[1] = ORG_ENVELOPE_VERSION.to_le_bytes()[1];
+        assert!(OrgEnvelope::from_canonical_bytes(&v2_claimed).is_err());
+
+        // A v2 buffer with an unknown source_kind tag byte fails closed.
+        let mut v2_bad_tag = v1_bytes("t", "m", "a", "c", 1);
+        v2_bad_tag[0] = ORG_ENVELOPE_VERSION.to_le_bytes()[0];
+        v2_bad_tag[1] = ORG_ENVELOPE_VERSION.to_le_bytes()[1];
+        v2_bad_tag.push(0); // 0 is not a valid OrgSourceKind tag
+        assert!(OrgEnvelope::from_canonical_bytes(&v2_bad_tag).is_err());
     }
 
     #[test]
@@ -366,5 +535,41 @@ mod tests {
         assert!(OrgItemKind::from_tag(0).is_err());
         assert_eq!(OrgItemKind::Note.as_str(), "note");
         assert_eq!(OrgItemKind::Summary.as_str(), "summary");
+    }
+
+    #[test]
+    fn source_kind_tag_round_trips_and_labels() {
+        assert_eq!(
+            OrgSourceKind::from_tag(OrgSourceKind::Document.tag()).unwrap(),
+            OrgSourceKind::Document
+        );
+        assert_eq!(
+            OrgSourceKind::from_tag(OrgSourceKind::Meeting.tag()).unwrap(),
+            OrgSourceKind::Meeting
+        );
+        assert!(OrgSourceKind::from_tag(0).is_err());
+        assert_eq!(OrgSourceKind::Document.as_str(), "document");
+        assert_eq!(OrgSourceKind::Meeting.as_str(), "meeting");
+    }
+
+    /// The seal/open AEAD layer round-trips a v2 envelope end to end (models
+    /// `seal_open_round_trips_and_verifies_before_egress` for the new source_kind field).
+    #[test]
+    fn seal_open_round_trips_v2_envelope_with_source_kind() {
+        let ock = crypto::random_key().unwrap();
+        let e = OrgEnvelope::new(
+            OrgItemKind::Note,
+            "Doc share",
+            "authored note body",
+            "bob",
+            "2026-07-11T12:00:00Z",
+            1,
+            OrgSourceKind::Document,
+        );
+        let (ct, sha) = seal_org_envelope(&ock, &e, "org-1", "item-2").unwrap();
+        assert_eq!(sha, e.content_sha256());
+        let opened = open_org_envelope(&ock, &ct, "org-1", "item-2").unwrap();
+        assert_eq!(opened, e);
+        assert_eq!(opened.source_kind, Some(OrgSourceKind::Document));
     }
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1440,6 +1440,13 @@ impl Db {
              CREATE INDEX IF NOT EXISTS idx_org_chunks_item ON org_chunks(item_id);",
         )
         .map_err(map_err)?;
+        // ADDITIVE: `source_kind` (`"document"` | `"meeting"` | NULL) — the item's SOURCE type, opened
+        // straight off the `OrgEnvelope` wire field once a peer publishes on the v2 wire format (see
+        // `share::org_envelope::OrgSourceKind`). NULL for every row ingested before this column existed,
+        // and for any item still arriving from a peer on an old client (v1 envelope, no wire signal) —
+        // both are honestly "unclassified", never guessed. Guarded (`add_column_if_missing`) so an
+        // already-migrated DB just gets the new column with existing rows defaulting to NULL.
+        Self::add_column_if_missing(conn, "org_items", "source_kind", "TEXT")?;
         // vec0 int8 KNN table (width = EMBED_DIM; compile-time const, no user input). int8 per the
         // scale spike — see the doc comment. Values are inserted via `vec_int8(?)` (a raw i8 blob).
         conn.execute_batch(&format!(
@@ -4835,6 +4842,7 @@ impl Db {
         rev: u32,
         generation: u32,
         content_sha256: &[u8],
+        source_kind: Option<&str>,
         embedder: Option<&dyn Embedder>,
     ) -> Result<()> {
         // Chunk + embed OUTSIDE the write lock (embedding is CPU/Metal work). The header carries the
@@ -4853,13 +4861,13 @@ impl Db {
         tx.execute(
             "INSERT INTO org_items
                (item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation,
-                content_sha256, tombstoned)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,0)
+                content_sha256, source_kind, tombstoned)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,0)
              ON CONFLICT(item_id) DO UPDATE SET
                org_id=excluded.org_id, seq=excluded.seq, author_hint=excluded.author_hint,
                title=excluded.title, markdown=excluded.markdown, created_at=excluded.created_at,
                rev=excluded.rev, generation=excluded.generation,
-               content_sha256=excluded.content_sha256, tombstoned=0",
+               content_sha256=excluded.content_sha256, source_kind=excluded.source_kind, tombstoned=0",
             rusqlite::params![
                 item_id,
                 org_id,
@@ -4871,6 +4879,7 @@ impl Db {
                 rev as i64,
                 generation as i64,
                 content_sha256,
+                source_kind,
             ],
         )
         .map_err(map_err)?;
@@ -5111,6 +5120,13 @@ impl Db {
     /// what colleagues shared into the org instead of only search-hitting it. Org items are
     /// deliberately org-disclosed content (no folder lock gate applies); the COMMAND layer re-checks
     /// the caller is a local member of `org_id` before calling this.
+    ///
+    /// `kind` is now populated DIRECTLY from the stored `source_kind` column (opened off the item's
+    /// `OrgEnvelope` at ingest — see `upsert_org_item`) for EVERY item, not just ones this device
+    /// published: a v2-envelope item from a colleague now classifies correctly. Stays `None` for a row
+    /// ingested before this column existed, or from a peer still on an old v1-only client (honest
+    /// "unclassified", never guessed). `list_org_items_inner` may still override this with the
+    /// owned-item resolver for the caller's OWN items (correct even when the column is somehow null).
     pub fn list_org_items(
         &self,
         org_id: &str,
@@ -5118,7 +5134,7 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT item_id, title, author_hint, created_at, seq
+                "SELECT item_id, title, author_hint, created_at, seq, source_kind
                    FROM org_items
                   WHERE org_id = ?1 AND tombstoned = 0
                   ORDER BY seq DESC",
@@ -5132,8 +5148,9 @@ impl Db {
                     author_hint: r.get(2)?,
                     created_at: r.get(3)?,
                     seq: r.get::<_, i64>(4)? as u64,
-                    // Enriched in `list_org_items_inner` (needs `&AppState` for the unlock gate); the
-                    // raw DB row carries no ownership resolution.
+                    // Direct from storage now (see doc comment above); `list_org_items_inner` may still
+                    // enrich/override for the caller's own items via the local `org_shares` resolver.
+                    kind: r.get::<_, Option<String>>(5)?,
                     owned_source: None,
                 })
             })
@@ -10499,6 +10516,7 @@ mod tests {
             1,
             1,
             &sha,
+            None,
             Some(&emb),
         )
         .unwrap();
@@ -10547,6 +10565,7 @@ mod tests {
             1,
             1,
             &sha32(2),
+            None, // source_kind: unclassified in this test
             None, // no embedder → FTS-only
         )
         .unwrap();
@@ -10584,6 +10603,7 @@ mod tests {
             1,
             1,
             &sha32(3),
+            None,
             Some(&emb),
         )
         .unwrap();
@@ -10635,18 +10655,18 @@ mod tests {
         let emb = crate::embed::StubEmbedder;
         db.upsert_org_item(
             "it-a", "org-1", 1, "anna", "Roadmap", "the falcon rollout plan alpha", "t", 1, 1,
-            &sha32(6), Some(&emb),
+            &sha32(6), None, Some(&emb),
         )
         .unwrap();
         db.upsert_org_item(
             "it-b", "org-1", 2, "bob", "Budget", "the falcon rollout budget beta", "t", 1, 1,
-            &sha32(7), Some(&emb),
+            &sha32(7), None, Some(&emb),
         )
         .unwrap();
         // A DIFFERENT org's item must SURVIVE the scoped purge.
         db.upsert_org_item(
             "it-other", "org-2", 1, "carol", "Other", "unrelated other-org content", "t", 1, 1,
-            &sha32(8), Some(&emb),
+            &sha32(8), None, Some(&emb),
         )
         .unwrap();
 
@@ -10699,12 +10719,12 @@ mod tests {
         let emb = crate::embed::StubEmbedder;
         db.upsert_org_item(
             "it-r", "org-1", 1, "dan", "V1", "first version body alpha", "t", 1, 1, &sha32(4),
-            Some(&emb),
+            None, Some(&emb),
         )
         .unwrap();
         db.upsert_org_item(
             "it-r", "org-1", 2, "dan", "V2", "second version body bravo", "t", 2, 1, &sha32(5),
-            Some(&emb),
+            None, Some(&emb),
         )
         .unwrap();
         // Only the v2 body is chunked (no duplicate/stale chunks).

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -543,6 +543,20 @@ pub struct OrgItemHeader {
     pub author_hint: String,
     pub created_at: String,
     pub seq: u64,
+    /// The item's source kind — `"document"` (a shared authored note) or `"meeting"` (a shared
+    /// meeting note) — so the FE can filter a per-org list into "shared meetings" vs "shared notes"
+    /// (Library/Meetings vs Notes view). The `OrgEnvelope` wire format now carries this natively as of
+    /// `ORG_ENVELOPE_VERSION = 2` (`share::org_envelope::OrgSourceKind`), stored straight off the
+    /// opened envelope into `org_items.source_kind` at ingest — so a COLLEAGUE'S item now classifies
+    /// too, not just items THIS device published. For items THIS device published, an UNGATED local
+    /// `org_shares`-anchored resolver (`meeting_id` XOR `document_id`) can still override/fall back
+    /// (metadata only, never gated on unlock state, unlike `owned_source` below which also carries the
+    /// live title). `None` means genuinely unclassified: an item ingested off an old v1 envelope
+    /// (published before the peer/this device upgraded, or before this column existed) carries no
+    /// source-type signal on the wire — the FE MUST treat `None` as "unclassified", never
+    /// assume/default it to one bucket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     /// The caller's OWN editable local source for this item, when THIS device published it (resolved
     /// via `org_share_by_item` → the anchored note/meeting) AND that source is currently readable
     /// (unlock-gated — a locked source resolves to `None`, never leaking its title). `None` for an

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -2483,6 +2483,7 @@ mod tests {
             1,
             1,
             sha,
+            None,
             Some(&crate::embed::StubEmbedder),
         )
         .unwrap();

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -90,6 +90,8 @@ import type {
   OrgShareEntry,
   OrgItemDetail,
   OrgItemHeader,
+  MeetingOrgShareInfo,
+  MeetingOrgShareRow,
   OrgSourceRef,
   OrgSyncReport,
   OrgFeedUpdatedPayload,
@@ -651,6 +653,26 @@ export class IpcService {
   /** This user's outgoing org shares (drives the "In Org Brain" state + per-item revoke). */
   listOrgShares(): Promise<OrgShareEntry[]> {
     return invoke<OrgShareEntry[]>("list_org_shares");
+  }
+
+  /**
+   * Every org THIS meeting is actively shared into (org id + display name) — drives the
+   * "Shared with [org]" badge on the Library row + the Detail view. Gated exactly like
+   * `getMeetingDetail`: a sealed-and-not-session-unlocked meeting returns `[]`, never leaking
+   * its share status. Only the text note/summary is ever shared — the caller renders this
+   * alongside an explicit "audio never leaves the device" caption, never implying otherwise.
+   */
+  meetingOrgShares(meetingId: string): Promise<MeetingOrgShareInfo[]> {
+    return invoke<MeetingOrgShareInfo[]>("meeting_org_shares", { meetingId });
+  }
+
+  /**
+   * The BULK Library-row variant: every active meeting→org share pairing across ALL of the
+   * caller's meetings in one call — avoids fetching {@link meetingOrgShares} per row. Same gate
+   * (a sealed-and-not-session-unlocked meeting contributes no rows).
+   */
+  listMeetingOrgShares(): Promise<MeetingOrgShareRow[]> {
+    return invoke<MeetingOrgShareRow[]>("list_meeting_org_shares");
   }
 
   /** Revoke an org share: tombstone the feed item + drop the local ciphertext. Idempotent. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1895,6 +1895,18 @@ export interface OrgItemHeader {
   /** The item's feed sequence — stable ordering key for the browse list. */
   seq: number;
   /**
+   * The item's source kind — `"document"` (a shared authored note, for the Notes
+   * view) or `"meeting"` (a shared meeting note, for the Library/Meetings view) —
+   * so a per-org list can be filtered into "shared meetings" vs "shared notes".
+   * Populated backend-side (`Db::list_org_items` reads the stored `org_items
+   * .source_kind` column) for ANY item ingested off a v2 `OrgEnvelope` — including
+   * a colleague's item, not just one THIS device published. Still absent/`null`
+   * for an item ingested off an old v1 envelope (published before the source-kind
+   * wire field existed) — treat `null` as "unclassified", do NOT default it into
+   * either bucket. Mirrors the Rust `OrgItemHeader.kind`.
+   */
+  kind?: "document" | "meeting" | null;
+  /**
    * When THIS user published the item AND their local source is readable, the
    * editable original behind it (resolved backend-side, unlock-gated). Present ⇒
    * the row links straight to `/notes/:id` | `/meeting/:id` and `title` is the
@@ -1965,6 +1977,30 @@ export interface OrgShareEntry {
   sharedAt: string;
   rev: number;
   state: "queued" | "uploaded" | "failed" | "revoke_pending" | "revoked";
+}
+
+/**
+ * One org a meeting is ACTIVELY shared into (`meetingOrgShares`) — drives the "Shared with
+ * [org]" badge on the Library row + the Detail view. Content-free beyond the org's own display
+ * name. Gated exactly like `MeetingDetail`: a sealed-and-not-session-unlocked meeting resolves
+ * to `[]`, never leaking its share status. Only the text note/summary is ever shared through
+ * this path — the audio recording never leaves the device. Mirrors the Rust `MeetingOrgShareInfo`.
+ */
+export interface MeetingOrgShareInfo {
+  orgId: string;
+  orgName: string;
+}
+
+/**
+ * One row of `listMeetingOrgShares` — the BULK Library-row variant of
+ * {@link MeetingOrgShareInfo}: every active meeting→org share pairing across ALL of the
+ * caller's meetings in one call (avoids an N+1 per-row fetch). Same gate: a sealed-and-
+ * not-session-unlocked meeting contributes no rows. Mirrors the Rust `MeetingOrgShareRow`.
+ */
+export interface MeetingOrgShareRow {
+  meetingId: string;
+  orgId: string;
+  orgName: string;
 }
 
 /**

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -69,14 +69,21 @@
               {{ fb.name }}
             </span>
           }
-          <!-- "In Org Brain" badge — this meeting has an active org-brain share.
-               Hidden while locked (nothing to advertise on a masked note). -->
-          @if (orgShared() && !locked()) {
-            <span class="meta-sep" aria-hidden="true">·</span>
-            <span
-              class="pill is-accent"
-              title="This note is in your organization's shared brain"
-            >In Org Brain</span>
+          <!-- "Shared with [org]" badge(s) — this meeting has an active org-brain
+               share. Hidden while locked (nothing to advertise on a masked note).
+               ONE pill per org (a meeting may be shared into several); the
+               tooltip + caption below are explicit that only the TEXT note was
+               shared — the audio recording never leaves the device. -->
+          @if (!locked()) {
+            @for (share of orgShares(); track share.orgId) {
+              <span class="meta-sep" aria-hidden="true">·</span>
+              <span
+                class="pill is-accent org-share-pill"
+                [title]="
+                  'Shared with ' + share.orgName + ' — text note only, audio never leaves this device'
+                "
+              >Shared with {{ share.orgName }}</span>
+            }
           }
           <!-- ENHANCE-MY-NOTES: provenance badge — shown only when the backend
                stamped murmur_enhanced: true in the front-matter. Derives from
@@ -90,6 +97,15 @@
             >✨ Enhanced from your notes</span>
           }
         </div>
+
+        <!-- Explicit, unambiguous caption: org sharing carries the TEXT note
+             only — the audio recording never leaves the device. Shown whenever
+             the meeting is shared into at least one org. -->
+        @if (orgShared() && !locked()) {
+          <p class="org-share-caption">
+            Only the text note was shared — the audio recording stays on this device.
+          </p>
+        }
 
         <!-- TAG EDITOR: chips + inline add (persists via setMeetingTags).
              Hidden while locked — there is nothing to tag on a masked note. -->

--- a/src/app/features/detail/detail/detail.component.scss
+++ b/src/app/features/detail/detail/detail.component.scss
@@ -56,6 +56,19 @@
   font-size: 0.8125rem;
 }
 
+/* "Shared with [org]" pill(s) + the explicit audio-never-shared caption. */
+.org-share-pill {
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.org-share-caption {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
 /* --- Tag editor (chips + inline add) --- */
 .tag-editor {
   display: flex;

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -22,6 +22,7 @@ import type {
   FolderNode,
   GraphPayload,
   MeetingDetail,
+  MeetingOrgShareInfo,
   MeetingTimeline,
   SpeakerSuggestion,
 } from "../../../core/models";
@@ -203,16 +204,15 @@ export class DetailComponent implements OnInit {
 
   // --- Org Brain badge (Shared Brain v1) -----------------------------------
   /**
-   * True when THIS meeting is in the org brain — drives the "In Org Brain"
-   * header pill. Loaded best-effort from `list_org_shares` and refreshed when
-   * the share-panel reports a change.
-   *
-   * SEAM (Shared Brain v1): `list_org_shares` is content-free (item ids + titles,
-   * no `meetingId`), so we match by TITLE as the honest heuristic until the
-   * backend stamps an org-share row with the source meeting id. When it does,
-   * replace the title match in {@link refreshOrgShared} with a meeting-id join.
+   * Every org THIS meeting is actively shared into (`meetingOrgShares`, a real
+   * meeting-id join — supersedes the earlier title-match heuristic). Empty when
+   * never shared, OR when the meeting is locked (the backend gates this exactly
+   * like `getMeetingDetail`). Drives the "Shared with…" header pill(s); loaded
+   * best-effort and refreshed when the share-panel reports a change.
    */
-  readonly orgShared = signal(false);
+  readonly orgShares = signal<MeetingOrgShareInfo[]>([]);
+  /** True when this meeting is shared into at least one org — drives the pill's presence. */
+  readonly orgShared = computed(() => this.orgShares().length > 0);
 
   // --- Export Canvas (Obsidian .canvas board) ------------------------------
   /** True while an exportCanvas IPC call is in flight (disables the button). */
@@ -430,34 +430,30 @@ export class DetailComponent implements OnInit {
   }
 
   /**
-   * Refresh the "In Org Brain" header pill from `list_org_shares`. See the
-   * {@link orgShared} SEAM note: matched by title (the content-free share list
-   * carries no meeting id yet). Fails closed to `false` on any error / no org.
+   * Refresh the "Shared with…" header pill from `meetingOrgShares` — a real
+   * meeting-id join (gated backend-side exactly like `getMeetingDetail`), so a
+   * locked meeting always resolves to `[]`. Fails closed to `[]` on any error.
    *
-   * STALE-RESULT guard (FE failure mode #4): capture the meeting id at call time and,
-   * after the `list_org_shares` await, drop the result if the user navigated to another
-   * meeting mid-flight (`openRelated` reuses this component) — otherwise a late response
-   * could set the pill from the PREVIOUS meeting's title over the current one.
+   * STALE-RESULT guard (FE failure mode #4): capture the meeting id at call time
+   * and, after the await, drop the result if the user navigated to another
+   * meeting mid-flight (`openRelated` reuses this component) — otherwise a late
+   * response could paint the PREVIOUS meeting's org badges over the current one.
    */
   private async refreshOrgShared(): Promise<void> {
-    const meeting = this.detail()?.meeting;
-    const id = meeting?.id;
-    const title = meeting?.title;
-    if (!title) {
-      this.orgShared.set(false);
+    const id = this.detail()?.meeting.id;
+    if (!id) {
+      this.orgShares.set([]);
       return;
     }
     try {
-      const shares = await this.ipc.listOrgShares();
+      const shares = await this.ipc.meetingOrgShares(id);
       // Drop late responses for a meeting the user has since navigated away from.
       if (this.detail()?.meeting.id !== id) {
         return;
       }
-      this.orgShared.set(
-        shares.some((s) => s.state !== "revoked" && s.title === title),
-      );
+      this.orgShares.set(shares);
     } catch {
-      this.orgShared.set(false);
+      this.orgShares.set([]);
     }
   }
 

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -79,6 +79,45 @@
         />
       }
     </div>
+
+    <!-- ===== Shared brains (orgs) — read-only shared MEETING notes only.
+         "notes has notes, meetings has meetings": a `kind === "document"` org
+         item never appears here (Notes owns those); selecting an org shows a
+         DISTINCT list, never merged into "All meetings" (the bug #259 fixed). -->
+    @if (orgs().length > 0 || orgsLoading()) {
+      <div class="folders-head org-head">
+        <h3 class="folders-title">Shared brains</h3>
+        @if (orgsLoading()) {
+          <mur-spinner [size]="12" class="org-head-spinner" />
+        }
+      </div>
+      <nav class="folders-body org-body" aria-label="Shared brains">
+        @for (org of orgs(); track org.orgId) {
+          <button
+            type="button"
+            class="folder-row org-row"
+            [class.is-selected]="activeOrgId() === org.orgId"
+            [attr.aria-pressed]="activeOrgId() === org.orgId"
+            (click)="selectOrg(org.orgId)"
+          >
+            <span class="folder-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                <circle cx="5" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <circle cx="11" cy="6" r="2" stroke="currentColor" stroke-width="1.3" />
+                <path
+                  d="M2 13c0-1.8 1.3-3 3-3s3 1.2 3 3M8 13c0-1.8 1.3-3 3-3s3 1.2 3 3"
+                  stroke="currentColor"
+                  stroke-width="1.3"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </span>
+            <span class="folder-name">{{ org.name }}</span>
+            <span class="pill org-role" [title]="orgRoleLabel(org)">{{ orgRoleLabel(org) }}</span>
+          </button>
+        }
+      </nav>
+    }
   </mur-sidebar>
 
   <!-- ============ RIGHT PANE — search, filters, meeting list ============ -->
@@ -239,6 +278,71 @@
                   }
                 </span>
                 <span class="chevron" aria-hidden="true">›</span>
+              </a>
+            </li>
+          }
+        </ul>
+      }
+    } @else if (activeOrgId() !== null) {
+      <!-- ===================== SHARED BRAIN — org's meeting notes =====================
+           A DISTINCT list from "All meetings" (never merged — the bug #259 fixed):
+           read-only replicas of a colleague's shared meeting notes, or a straight
+           link to your OWN editable original when you authored the item. -->
+      <header class="library-head">
+        <h2>{{ listHeading() }}</h2>
+        @if (!orgsLoading() && !orgListEmpty()) {
+          <span class="count">{{ orgListItems().length }}</span>
+        }
+      </header>
+
+      @if (orgUnclassifiedCount() > 0) {
+        <p class="org-unclassified-note text-muted">
+          {{ orgUnclassifiedCount() }}
+          {{ orgUnclassifiedCount() === 1 ? "item" : "items" }} from this
+          shared brain couldn’t be classified as a meeting or a note (shared
+          before that distinction existed) — not shown here.
+        </p>
+      }
+
+      @if (orgsLoading()) {
+        <div class="card state-card">
+          <p class="empty">Loading…</p>
+        </div>
+      } @else if (orgListEmpty()) {
+        <div class="card empty-state">
+          <span class="empty-mark" aria-hidden="true"></span>
+          <p class="empty-title">Nothing shared here yet</p>
+          <p class="empty">
+            No one has shared a meeting note into “{{ listHeading() }}” yet.
+            Shared meeting notes appear here automatically as they sync.
+          </p>
+        </div>
+      } @else {
+        <ul class="list">
+          @for (it of orgListItems(); track it.id; let i = $index) {
+            <li>
+              <a
+                class="row"
+                [routerLink]="orgItemLink(it.item)"
+                [style.animation-delay.ms]="i * 35"
+              >
+                <span class="row-main">
+                  <span class="title">{{ it.item.title || "(untitled)" }}</span>
+                  <span class="meta">
+                    @if (it.item.authorHint) {
+                      <span class="date">{{ it.item.authorHint }}</span>
+                      <span class="dot" aria-hidden="true">·</span>
+                    }
+                    <span class="date">{{ formatDate(it.item.createdAt) }}</span>
+                  </span>
+                </span>
+                <span class="row-aside">
+                  <span
+                    class="pill org-badge"
+                    [title]="'Shared brain · ' + it.orgName"
+                  >{{ it.orgName }}</span>
+                  <span class="chevron" aria-hidden="true">›</span>
+                </span>
               </a>
             </li>
           }
@@ -433,6 +537,25 @@
                       }
                       <span class="folder-label-name">{{ fname }}</span>
                     </span>
+                  }
+
+                  <!-- "Shared with [org]" row badge — this OWN meeting has an
+                       active org-brain share. Text note only; audio never
+                       leaves the device (see the tooltip + the Detail caption). -->
+                  @if (orgSharesOf(m.id); as shares) {
+                    @if (shares.length > 0) {
+                      <span
+                        class="pill is-accent org-share-row-pill"
+                        [title]="
+                          'Shared with ' +
+                          shares[0].orgName +
+                          (shares.length > 1
+                            ? ' + ' + (shares.length - 1) + ' more'
+                            : '') +
+                          ' — text note only, audio never leaves this device'
+                        "
+                      >Shared{{ shares.length > 1 ? " ×" + shares.length : "" }}</span>
+                    }
                   }
 
                   <span class="pill" [class]="statusPillClass(m.status)">

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -150,6 +150,96 @@
   font-size: 0.8125rem;
 }
 
+/* --- Rail: "Shared brains" (orgs) section (mirrors notes-home's org rail) --- */
+.org-head {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+.org-body {
+  flex: 0 0 auto;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+/* Trails the "Shared brains" heading while the org list/items are (re)loading. */
+.org-head-spinner {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+.folder-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+.folder-row:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.folder-row:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.folder-row.is-selected {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+.folder-icon {
+  flex: none;
+  display: inline-flex;
+  color: var(--text-muted);
+}
+.folder-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.org-role {
+  flex: none;
+  margin-left: auto;
+  font-size: 0.62rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--surface-raised);
+}
+
+/* --- Shared-brain meeting list: the org-name badge + the row's own share pill --- */
+.org-badge {
+  flex: none;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.7rem;
+  font-weight: 600;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.org-share-row-pill {
+  flex: none;
+  font-size: 0.7rem;
+}
+.org-unclassified-note {
+  margin: 0;
+  font-size: 0.8125rem;
+}
+
 /* --- Right pane: stacks search, filters and the list ---
    Scrolls independently, with its own padding (no longer inside .app-main's
    padded column). Shares the rail's transform-only glide (40ms lag). */

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -10,13 +10,18 @@ import {
   viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { NavHistoryService } from "../../../core/nav-history.service";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import type {
   FolderNode,
   Meeting,
+  MeetingOrgShareRow,
   MeetingStatus,
+  OrgItemHeader,
+  OrgStatus,
   SearchHit,
 } from "../../../core/models";
 import {
@@ -52,6 +57,21 @@ export interface MeetingsListItem {
   meeting: Meeting;
 }
 
+/**
+ * One row of an org's "Shared Brains" meeting list (shown ONLY when an org is
+ * rail-selected — never merged into {@link MeetingsListItem}'s "All meetings").
+ * A READ-ONLY replica (opens `/org-item/:id`), UNLESS the caller authored it
+ * (`ownedSource`), in which case it routes straight to the editable original
+ * (`/meeting/:id`). `id` is `org:`-namespaced for a stable `@for` track key.
+ */
+export interface OrgMeetingListItem {
+  kind: "org";
+  id: string;
+  sortAt: number;
+  item: OrgItemHeader;
+  orgName: string;
+}
+
 @Component({
   selector: "app-library",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -67,6 +87,7 @@ export interface MeetingsListItem {
   },
   imports: [
     MurSidebarComponent,
+    MurSpinnerComponent,
     RouterLink,
     FolderTreeComponent,
     LockBadgeComponent,
@@ -166,6 +187,214 @@ export class LibraryComponent implements OnInit {
    */
   readonly activeFolderId = signal<string | null>(null);
 
+  // --- Org (Shared Brain) rail — "Shared Brains" meeting lists -------------
+  /**
+   * Every org (Shared Brain) this user belongs to — the rail's "Shared brains"
+   * section. Loaded stale-guarded on init, on the `org-feed-updated` event, and
+   * on window focus. Deliberately separate from Notes' own org state (each view
+   * loads independently; "notes has notes, meetings has meetings" — PR #259).
+   */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  readonly orgs = this._orgs.asReadonly();
+  /**
+   * Each org's shared items keyed by orgId (`listOrgItems`) — UNFILTERED (both
+   * kinds); {@link orgListItems} narrows to `kind === "meeting"` for display.
+   */
+  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  /**
+   * Selected org id in the rail (null ⇒ not viewing a specific org). MUTUALLY
+   * exclusive with a folder/tag selection: selecting an org clears both back to
+   * the "All meetings" root, and vice-versa — the content pane has exactly one
+   * active scope, and an org's items are NEVER merged into "All meetings" (the
+   * bug #259 fixed).
+   */
+  readonly activeOrgId = signal<string | null>(null);
+  /** True while the org list + items are (re)loading (rail hint only). */
+  readonly orgsLoading = signal(false);
+  /** The org whose items are shown when an org is rail-selected (null otherwise). */
+  readonly activeOrg = computed<OrgStatus | null>(() => {
+    const oid = this.activeOrgId();
+    return oid === null
+      ? null
+      : (this._orgs().find((o) => o.orgId === oid) ?? null);
+  });
+
+  /**
+   * The active org's items narrowed to `kind === "meeting"` — a DISTINCT list,
+   * never merged into {@link listItems} ("All meetings" stays exactly what
+   * #259 left it: the user's own recordings only). A `kind === "document"`
+   * item never appears here (it belongs in Notes); a `kind == null`
+   * (unclassified, pre-kind wire format) item is EXCLUDED from this
+   * confirmed-meetings list too — see {@link orgUnclassifiedCount}.
+   */
+  readonly orgListItems = computed<OrgMeetingListItem[]>(() => {
+    const org = this.activeOrg();
+    if (!org) {
+      return [];
+    }
+    const items = this._orgItems()[org.orgId] ?? [];
+    return items
+      .filter((item) => item.kind === "meeting")
+      .map((item) => this.toOrgMeetingCard(item, org.name))
+      .sort((a, b) => b.sortAt - a.sortAt);
+  });
+
+  /**
+   * Count of the active org's items that are neither a confirmed meeting nor a
+   * confirmed document (`kind == null` — shared under the pre-kind wire format).
+   * Surfaced as a small "N unclassified" note rather than silently folding them
+   * into the meeting list as if verified.
+   */
+  readonly orgUnclassifiedCount = computed(() => {
+    const org = this.activeOrg();
+    if (!org) {
+      return 0;
+    }
+    const items = this._orgItems()[org.orgId] ?? [];
+    return items.filter((item) => item.kind == null).length;
+  });
+
+  /** Router target for an org meeting card — the editable original for the author, else the read-only viewer. */
+  orgItemLink(item: OrgItemHeader): string[] {
+    const owned = item.ownedSource;
+    if (owned) {
+      return owned.kind === "meeting"
+        ? ["/meeting", owned.id]
+        : ["/notes", owned.id];
+    }
+    return ["/org-item", item.itemId];
+  }
+
+  /** Build an org meeting card from a header + its origin org name. */
+  private toOrgMeetingCard(item: OrgItemHeader, orgName: string): OrgMeetingListItem {
+    const t = Date.parse(item.createdAt);
+    return {
+      kind: "org",
+      id: `org:${item.itemId}`,
+      sortAt: Number.isNaN(t) ? 0 : t,
+      item,
+      orgName,
+    };
+  }
+
+  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
+  private orgFeedUnlisten: UnlistenFn | null = null;
+  /** True once destroyed — a `listen()` resolving AFTER teardown releases immediately. */
+  private orgFeedDestroyed = false;
+  /** Bumped per org load so a late (stale) reload result is dropped (T1 guard). */
+  private orgLoadSeq = 0;
+  /** Bound window-focus handler — re-loads org items when the view regains focus. */
+  private readonly onOrgWindowFocus = (): void => {
+    void this.loadOrgs();
+  };
+
+  /**
+   * (Re)load the org (Shared Brain) list + every org's shared items, stale-guarded
+   * on {@link orgLoadSeq}, and the bulk own-meeting org-share pairings (for the
+   * Library row badge). Best-effort throughout — a transient/offline error leaves
+   * the last-known state standing. Never throws.
+   */
+  async loadOrgs(): Promise<void> {
+    const seq = ++this.orgLoadSeq;
+    this.orgsLoading.set(true);
+    try {
+      try {
+        await this.ipc.orgRefresh();
+      } catch {
+        /* offline / no server → fall through to the local replica */
+      }
+      let orgs: OrgStatus[];
+      try {
+        orgs = await this.ipc.orgListStatuses();
+      } catch {
+        return; // keep the last-known orgs on a transient failure
+      }
+      if (seq !== this.orgLoadSeq) {
+        return;
+      }
+      const [itemLists, ownShares] = await Promise.all([
+        Promise.all(
+          orgs.map((o) =>
+            this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
+          ),
+        ),
+        this.ipc.listMeetingOrgShares().catch(() => [] as MeetingOrgShareRow[]),
+      ]);
+      if (seq !== this.orgLoadSeq) {
+        return;
+      }
+      const byOrg: Record<string, OrgItemHeader[]> = {};
+      orgs.forEach((o, i) => {
+        byOrg[o.orgId] = itemLists[i];
+      });
+      this._orgs.set(orgs);
+      this._orgItems.set(byOrg);
+      this._myOrgShares.set(ownShares);
+      // If the rail's selected org has since disappeared, fall back to "All meetings".
+      const sel = this.activeOrgId();
+      if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
+        this.activeOrgId.set(null);
+      }
+    } finally {
+      if (seq === this.orgLoadSeq) {
+        this.orgsLoading.set(false);
+      }
+    }
+  }
+
+  /**
+   * Rail-select an org (Shared Brain): the pane shows ONLY that org's shared
+   * meetings, in a list distinct from "All meetings". Mutually exclusive with a
+   * folder/tag selection — clears both back to the root + closes any open
+   * row menu / move popover / delete confirm.
+   */
+  selectOrg(orgId: string): void {
+    this.cancelDelete();
+    this.rowMenuId.set(null);
+    this.movePopoverId.set(null);
+    this.activeFolderId.set(null);
+    this.activeTag.set(null);
+    this.tagMeetings.set([]);
+    this.tagLoading.set(false);
+    this.activeOrgId.set(orgId);
+  }
+
+  /** Clear the org selection back to "All meetings" (mirrors `selectFolder(null)`). */
+  clearOrgSelection(): void {
+    this.activeOrgId.set(null);
+  }
+
+  /** A friendly role hint for the rail ("Owner" / "Member"). */
+  orgRoleLabel(org: OrgStatus): string {
+    return org.role === "owner" ? "Owner" : "Member";
+  }
+
+  // --- Own-meeting org-share badges (Library row + Detail) ------------------
+  /**
+   * Every active meeting→org share pairing across ALL of the caller's OWN
+   * meetings (`listMeetingOrgShares`, bulk — avoids an N+1 per-row fetch).
+   * Loaded alongside the org rail in {@link loadOrgs}; empty for a meeting
+   * never shared, or masked away server-side for a locked one.
+   */
+  private readonly _myOrgShares = signal<MeetingOrgShareRow[]>([]);
+  /** `meetingId` → the orgs it's shared into — O(1) lookup for the row badge. */
+  readonly orgSharesByMeetingId = computed(() => {
+    const map = new Map<string, MeetingOrgShareRow[]>();
+    for (const row of this._myOrgShares()) {
+      const list = map.get(row.meetingId);
+      if (list) {
+        list.push(row);
+      } else {
+        map.set(row.meetingId, [row]);
+      }
+    }
+    return map;
+  });
+  /** The orgs a meeting is shared into (empty when never shared). Drives the row badge. */
+  orgSharesOf(meetingId: string): MeetingOrgShareRow[] {
+    return this.orgSharesByMeetingId().get(meetingId) ?? [];
+  }
+
   /**
    * Every folder node keyed by id (flattened) — for O(1) exposure/mask lookups
    * keyed off a meeting's `folderId`. Recomputes whenever the tree reloads.
@@ -264,14 +493,21 @@ export class LibraryComponent implements OnInit {
     return this.tagLoading();
   });
 
-  /** Heading for the no-query list: folder name → tag → "Meetings". */
+  /** Heading for the no-query list: org name → folder name → tag → "Meetings". */
   readonly listHeading = computed(() => {
+    const org = this.activeOrg();
+    if (org !== null) {
+      return org.name;
+    }
     const fid = this.activeFolderId();
     if (fid !== null) {
       return this.folderById().get(fid)?.name ?? "Folder";
     }
     return this.activeTag() ?? "Meetings";
   });
+
+  /** True when an org is rail-selected and its meeting-kind list has zero rows. */
+  readonly orgListEmpty = computed(() => this.orgListItems().length === 0);
 
   /** Exposure of the active folder (for the header lock badge); null when none. */
   readonly activeFolderExposure = computed<FolderExposure | null>(() => {
@@ -343,11 +579,38 @@ export class LibraryComponent implements OnInit {
       }
     });
 
-    // Load the meetings list and the tag set in parallel; a tag-load failure
-    // must not break the meetings list, so settle each independently.
+    // Live-refresh: the background org-sync loop fires `org-feed-updated` on a
+    // productive tick. Subscribe ONCE (push straight into a reload — NEVER
+    // subscribe-into-a-field), and re-load on window focus too. Both cleaned up
+    // on destroy (release the UnlistenFn + the focus handler).
+    this.destroyRef.onDestroy(() => {
+      this.orgFeedDestroyed = true;
+      this.orgFeedUnlisten?.();
+      this.orgFeedUnlisten = null;
+      window.removeEventListener("focus", this.onOrgWindowFocus);
+    });
+    window.addEventListener("focus", this.onOrgWindowFocus);
+    void this.ipc
+      .onOrgFeedUpdated(() => void this.loadOrgs())
+      .then((un) => {
+        // If the view was already torn down before the listener resolved, release
+        // it immediately (never leak a subscription past destroy).
+        if (this.orgFeedDestroyed) {
+          un();
+        } else {
+          this.orgFeedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
+      });
+
+    // Load the meetings list, the tag set, and the org rail in parallel; any one
+    // failing must not break the others, so settle each independently.
     const [meetings] = await Promise.allSettled([
       this.ipc.listMeetings(),
       this.loadTags(),
+      this.loadOrgs(),
     ]);
     if (meetings.status === "fulfilled") {
       this.meetings.set(meetings.value);
@@ -381,10 +644,12 @@ export class LibraryComponent implements OnInit {
     this.rowMenuId.set(null);
     this.movePopoverId.set(null);
     // Tag + folder scopes are mutually exclusive: picking a tag clears any
-    // active folder so they never compose into an empty surprise.
+    // active folder so they never compose into an empty surprise. An org
+    // selection is a THIRD mutually-exclusive scope — picking a tag drops it.
     if (tag !== null) {
       this.activeFolderId.set(null);
     }
+    this.activeOrgId.set(null);
     this.activeTag.set(tag);
 
     if (tag === null) {
@@ -423,20 +688,23 @@ export class LibraryComponent implements OnInit {
    * race exists; the same idempotent-guard shape is kept for consistency.
    */
   selectFolder(folderId: string | null): void {
-    // A re-select of the SAME folder is a no-op.
-    if (this.activeFolderId() === folderId) {
+    // A re-select of the SAME folder while no org is active is a no-op — but a
+    // re-select of "All meetings" WHILE an org is active still runs, to drop it.
+    if (this.activeFolderId() === folderId && this.activeOrgId() === null) {
       return;
     }
     this.cancelDelete();
     this.rowMenuId.set(null);
     this.movePopoverId.set(null);
     // Folder + tag scopes are mutually exclusive — picking a folder clears the
-    // tag selection (and its fetched list) so they never compose.
+    // tag selection (and its fetched list) so they never compose. An org
+    // selection is a THIRD mutually-exclusive scope — always dropped here.
     if (folderId !== null) {
       this.activeTag.set(null);
       this.tagMeetings.set([]);
       this.tagLoading.set(false);
     }
+    this.activeOrgId.set(null);
     this.activeFolderId.set(folderId);
   }
 

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -219,9 +219,12 @@
     </nav>
 
     <!-- ===== Shared brains (orgs) — read-only replicated org notes ===== -->
-    @if (orgs().length > 0) {
+    @if (orgs().length > 0 || orgsLoading()) {
       <div class="folders-head org-head">
         <h3 class="folders-title">Shared brains</h3>
+        @if (orgsLoading()) {
+          <mur-spinner [size]="12" class="org-head-spinner" />
+        }
       </div>
       <nav class="folders-body org-body" aria-label="Shared brains">
         @for (org of orgs(); track org.orgId) {

--- a/src/app/features/notes/notes-home/notes-home.component.scss
+++ b/src/app/features/notes/notes-home/notes-home.component.scss
@@ -157,6 +157,11 @@
   flex: 0 0 auto;
   overflow: visible;
 }
+/* Trails the "Shared brains" heading while the org list/items are (re)loading. */
+.org-head-spinner {
+  margin-left: auto;
+  color: var(--text-muted);
+}
 .org-row {
   cursor: pointer;
 }

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -24,6 +24,7 @@ import type {
   OrgStatus,
 } from "../../../core/models";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { FoldersService } from "../../../services/folders.service";
 import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
 import { NotesService } from "../../../services/notes.service";
@@ -80,6 +81,7 @@ export type NotesListItem =
   imports: [
     RouterLink,
     MurSidebarComponent,
+    MurSpinnerComponent,
     OrganizeSheetComponent,
     LockSharesDialogComponent,
   ],
@@ -162,10 +164,15 @@ export class NotesHomeComponent implements OnInit {
     const orgs = this._orgs();
     const orgNameById = new Map(orgs.map((o) => [o.orgId, o.name]));
 
-    // A specific org selected: show ONLY that org's items.
+    // A specific org selected: show ONLY that org's items — EXCLUDING `kind === "meeting"`
+    // ones ("notes has notes, meetings has meetings": a shared meeting note belongs in the
+    // Library "Shared brains" rail, not here). An unclassified item (`kind` absent/`null` —
+    // shared under the pre-v2 wire format, before source-kind existed) stays visible here,
+    // same as it always has, since it can't be proven to be a meeting.
     if (orgId !== null) {
       const name = orgNameById.get(orgId) ?? "";
       return (orgItemsByOrg[orgId] ?? [])
+        .filter((item) => item.kind !== "meeting")
         .map((item) => this.toOrgCard(item, name))
         .sort((a, b) => b.sortAt - a.sortAt);
     }
@@ -186,10 +193,13 @@ export class NotesHomeComponent implements OnInit {
     // replicas the caller authored (`ownedSource`): the editable original already
     // appears (as a note card, or under Meetings), so showing the replica too would
     // duplicate the row and surface a stale publish-time title. Replicas shared by
-    // OTHERS stay (that's the point of the merged view).
+    // OTHERS stay (that's the point of the merged view). ALSO drop `kind === "meeting"`
+    // items — those now live exclusively in the Library "Shared brains" rail ("notes has
+    // notes, meetings has meetings"); an unclassified item (no `kind`, pre-v2 wire format)
+    // stays here, matching its historical behavior.
     const orgCards: NotesListItem[] = orgs.flatMap((o) =>
       (orgItemsByOrg[o.orgId] ?? [])
-        .filter((item) => !item.ownedSource)
+        .filter((item) => !item.ownedSource && item.kind !== "meeting")
         .map((item) => this.toOrgCard(item, o.name)),
     );
     return [...noteCards, ...orgCards].sort((a, b) => b.sortAt - a.sortAt);


### PR DESCRIPTION
## What

Meetings shared to an org (Shared Brain) were undiscoverable in Library after #259 (which correctly removed org *blending* from Meetings, but removed org visibility entirely as a side effect). This restores it — but per the explicit product requirement ("notes has notes, meetings has meetings") — as a separate, non-merging surface.

## Changes

- **`OrgEnvelope` wire format v1 → v2** (`src-tauri/src/share/org_envelope.rs`): adds a `source_kind` (document/meeting) tag. Additive + backward-compatible — v1 bytes still parse, `content_sha256` stays stable for already-published content (RED-before-GREEN: fails on a naive version-reject, passes on the real version-branching fix).
- New `org_items.source_kind` column (additive migration). `list_org_items` now classifies every item, including a colleague's.
- Two new gated commands: `meeting_org_shares` / `list_meeting_org_shares` — both route through `meeting_is_unlocked`.
- **Library**: a "Shared brains" rail. Selecting an org shows ONLY that org's `kind === "meeting"` items, distinct from "All meetings" (unchanged — recordings only, per #259). A per-meeting "Shared with \<org\>" badge (Library row + meeting detail) makes explicit that only the text note/summary is shared, never the audio.
- **Notes**: the merge/org view now excludes `kind === "meeting"` items symmetrically, so a shared meeting surfaces in exactly one place.
- Both rails show a loading indicator while org data (re)loads.
- Merged forward onto latest `murmur` (which picked up #267/#268 mid-flight) — resolved conflicts in `commands.rs`/`lib.rs`/`ipc.service.ts`/`models.ts` (all additive, non-overlapping capabilities from each side, kept both) plus one silent-merge compile gap (`upsert_org_item` call site missing the new `source_kind` arg) fixed and verified building clean from the committed state.

## Verified

- `cargo test --lib` (org-scoped + the 2 new commands): **90/90 green**, incl. the OrgEnvelope backward-compat RED→GREEN and the new commands' unlock-gate RED→GREEN.
- `npx ng lint` + `npx ng build`: clean (`library.component.scss` sits at 13.13kB — over the 12kB warn threshold, under the 16kB error budget).
- **lock-security-reviewer: PASS** on the `OrgEnvelope` v2 change (crypto-wire-format surface).
- **adversarial-verifier: PASS** on the full combined diff. One MAJOR finding (Notes wasn't excluding `kind === "meeting"` items) — fixed in this same branch before merge.
- Full unscoped `cargo test --lib` hit PRE-EXISTING, non-deterministic sandbox SIGABRTs (different unrelated tests each run — `ask_floor_preserves_no_consent_error_semantics`, `apply_organize_plan_creates_folder_and_moves_note`, etc.) — independently reproduced on unmodified trunk with this diff stashed out by the adversarial-verifier in this same session, confirmed environmental (local Keychain access instability), not a regression.

## Not verified here

New Playwright e2e case (`e2e/notes/notes-org.spec.ts`) could not run locally — a macOS Chromium launch failure (`mach_port_rendezvous`, unrelated to this diff) blocked the local run. CI runs in a clean environment and will execute it. Live 2-account org-sync round trip is unproven headless per this project's standing honesty bar for org sharing.