### PR TITLE
chore(release): 0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.6"
+version = "0.9.7"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.7.

Rolls up since 0.9.6:
- #266 docs: agents point at ../murmur-server backend repo
- #267 org shared-brain notes auto-refresh without manual "Sync now"
- #268 stop duplicate org shares on re-click + block re-share + auto-clean dupes
- #269 shared meetings in Library (Shared Brain), separate from Notes — OrgEnvelope v2 wire format, backward-compatible; lock-security-reviewer PASS + adversarial-verifier PASS
- #270 README + landing page synced to current reality (was ~15 releases stale; fixed misleading "Coming soon" pricing claims for features already shipped free)

scripts/ci.sh: all gates green (clippy -D warnings, cargo test, cargo build, ng lint, ng build, headless E2E mic+system mixing).