### PR TITLE
feat(org): unify Shared Brain across every assistant surface + per-instance org toggle

### DIFF
--- a/e2e/notes/brain-popover.spec.ts
+++ b/e2e/notes/brain-popover.spec.ts
@@ -84,3 +84,91 @@ test("selecting body text floats the bubble; Ask Brain → Refine → Accept upd
 
   expect(consoleErrors).toEqual([]);
 });
+
+/**
+ * A3 — `find_related` gains an org citation (`kind: "org"`, backed by
+ * `gather_note_enhance_citations`' new org-brain leg). Clicking it MUST route to
+ * the read-only `/org-item/:id` viewer (mirrors `library.component.ts`'s
+ * `orgItemLink`) — NOT the broken `/notes/<id>` fallback an unrecognized `kind`
+ * used to fall into. This is the regression test for BOTH the new org leg AND the
+ * incidental pre-existing `openCitation()` bug it made reachable.
+ */
+test("Find related: an org-kind citation routes to the read-only /org-item viewer, not /notes", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    note_assistant_action: (args: { req: { action: string } }) => ({
+      action: args.req.action,
+      shape: "info",
+      title: null,
+      suggestion: "2 related sources in your brain.",
+      citations: [
+        {
+          kind: "org",
+          id: "oi-launchcode",
+          title: "Anna's launchcode notes",
+          snippet: "the launchcode rollout plan",
+        },
+        {
+          kind: "note",
+          id: "n2",
+          title: "Weekly plan",
+          snippet: "Ship the notes feature",
+        },
+      ],
+      modelLabel: "Your brain (local search)",
+      mode: "local",
+      redacted: false,
+    }),
+    org_get_item: (args: { itemId: string }) => ({
+      itemId: args.itemId,
+      authorHint: "anna",
+      title: "Anna's launchcode notes",
+      createdAt: "2026-07-10T09:00:00Z",
+      rev: 1,
+      markdown: "# Anna's launchcode notes\n\nthe launchcode rollout plan",
+    }),
+  });
+  await page.goto("/notes/n1");
+
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    const start = el.value.indexOf("body text");
+    el.focus();
+    el.setSelectionRange(start, start + "body text".length);
+    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  });
+
+  const bubble = page.locator("app-note-selection-toolbar");
+  await expect(bubble).toBeVisible();
+  await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
+
+  const popover = page.locator("app-note-brain-popover");
+  await expect(popover).toBeVisible();
+  await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
+
+  await expect(popover.getByText("2 related sources in your brain.")).toBeVisible();
+  const orgCite = popover.locator(".pop-cite", { hasText: "Anna's launchcode notes" });
+  await expect(orgCite).toBeVisible();
+  await expect(orgCite.locator(".pop-cite-kind")).toHaveText("org");
+
+  await orgCite.dispatchEvent("click");
+
+  // The old bug: an unrecognized `kind` fell through to `/notes/<id>` — assert the
+  // FIX routes to the org-item viewer instead.
+  await expect(page).toHaveURL(/\/org-item\/oi-launchcode$/);
+  await expect(page).not.toHaveURL(/\/notes\/oi-launchcode$/);
+  await expect(page.locator("app-org-item-viewer")).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,9 +10,10 @@ use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BrainOverview, BuiltinRecipe, CalendarContext,
     CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, DocumentInfo,
-    EntityDetail, Folder, FolderNode, GraphData, Meeting, MeetingStatus, MeetingTimeline,
-    NoteAssistRequest, NoteAssistResult, NoteCitation, NoteDoc, NoteFolder, NoteRecord, NoteSummary,
-    OrganizeMove, OrganizePlan, PersonCard, PinResult, RecipeRecord, SearchHit, TopicThread,
+    EntityDetail, EntityDossierResult, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
+    MeetingTimeline, NoteAssistRequest, NoteAssistResult, NoteCitation, NoteDoc, NoteFolder,
+    NoteRecord, NoteSummary, OrganizeMove, OrganizePlan, PersonCard, PinResult, RecipeRecord,
+    SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -3206,7 +3207,7 @@ async fn note_assistant_action_impl(
     //     with `mode="local"`, `redacted=false`. This never raises the local user-turn priority
     //     flag (no decode contends for Metal) and never calls a model → a privacy win.
     if action == "find_related" {
-        let citations = gather_note_enhance_citations(state, &req)?;
+        let citations = gather_note_enhance_citations(state, &config, &req)?;
         let suggestion = match citations.len() {
             0 => "No related sources found in your brain.".to_string(),
             1 => "1 related source in your brain.".to_string(),
@@ -3264,7 +3265,7 @@ async fn note_assistant_action_impl(
     //     `visibility_clause`, so a sealed source never grounds a result.
     let (citations, entity_names) = match retrieval {
         NoteAssistRetrieval::BrainCitations => {
-            (gather_note_enhance_citations(state, &req)?, Vec::new())
+            (gather_note_enhance_citations(state, &config, &req)?, Vec::new())
         }
         NoteAssistRetrieval::Entities => {
             let unlocked = unlocked_snapshot(state)?;
@@ -3381,6 +3382,7 @@ fn derive_artifact_title(action: &str, note_title: &str, body: &str) -> String {
 /// unlock set through `visibility_clause`), so a sealed source never grounds an enhancement.
 fn gather_note_enhance_citations(
     state: &AppState,
+    config: &AppConfig,
     req: &NoteAssistRequest,
 ) -> Result<Vec<NoteCitation>, AppError> {
     const MAX_CITATIONS: usize = 6;
@@ -3415,7 +3417,7 @@ fn gather_note_enhance_citations(
     // Other notes/documents (semantic when the e5 model is present, else FTS). EXCLUDE the current
     // note's own document id (never cite the note being edited).
     if out.len() < MAX_CITATIONS {
-        let doc_hits = if crate::embed::embed_model_present() {
+        let doc_hits = if config.semantic_search_enabled && crate::embed::embed_model_present() {
             let embedder = crate::embed::active_embedder();
             let qvecs = embedder.embed_query(std::slice::from_ref(&query))?;
             match qvecs.into_iter().next() {
@@ -3437,6 +3439,25 @@ fn gather_note_enhance_citations(
                 kind: "note".into(),
                 id: hit.document_id,
                 title: hit.name,
+                snippet: hit.snippet,
+            });
+            if out.len() >= MAX_CITATIONS {
+                break;
+            }
+        }
+    }
+
+    // Org shared brain (deliberately-disclosed colleague content — outside the folder-lock domain,
+    // gated on membership only via `org_brain_available`, same seam as the `org_brain_search` agent
+    // tool / MCP `org_search`). RETRIEVAL-ONLY: no provider call, no egress — this is a private,
+    // user-navigated discovery surface, matching `find_related`'s zero-provider-call invariant.
+    if out.len() < MAX_CITATIONS && crate::tools::org_brain_available(&state.db, config) {
+        let org_hits = crate::tools::search_org_brain_hits(&state.db, config, &query)?;
+        for hit in org_hits {
+            out.push(NoteCitation {
+                kind: "org".into(),
+                id: hit.item_id,
+                title: hit.title,
                 snippet: hit.snippet,
             });
             if out.len() >= MAX_CITATIONS {
@@ -5810,6 +5831,7 @@ fn ask_vault_agentic_attempt(
     let opts = crate::reason::GenOptions::ask_answer()
         .with_transcript_compaction(config.loop_transcript_compaction)
         .with_grammar_constraint(config.brain_heavy_grammar_enabled);
+    let org_available = crate::tools::org_brain_available(&state.db, &config);
     match ask_vault_loop(
         &*reasoner,
         &executor,
@@ -5819,6 +5841,7 @@ fn ask_vault_agentic_attempt(
         history,
         &memory_brief,
         &jit_listing,
+        org_available,
         Some(&sink as &dyn crate::agent::DeltaSink),
         opts,
     ) {
@@ -5843,7 +5866,10 @@ fn ask_vault_agentic_attempt(
 /// `jit_listing` (Brain v2 L3) is the compact gated meeting listing for JIT retrieval — `""` (the
 /// `ask_jit_retrieval`-off path) keeps the persona BYTE-IDENTICAL to the legacy agentic prompt
 /// (`agentic_system_jit`'s empty-listing contract). `opts` carries the caller's per-step
-/// generation bounds (the P0.3 ASK preset + the L3 compaction/grammar flags).
+/// generation bounds (the P0.3 ASK preset + the L3 compaction/grammar flags). `org_available` (A2)
+/// is threaded straight to `agentic_system_jit` — the caller passes the SAME `org_brain_available`
+/// predicate that gates the tool's own advertisement, so the hint and the actual tool availability
+/// can never diverge.
 #[allow(clippy::too_many_arguments)]
 fn ask_vault_loop(
     reasoner: &dyn crate::reason::LocalReasoner,
@@ -5854,10 +5880,12 @@ fn ask_vault_loop(
     history: &[ChatTurn],
     memory_brief: &str,
     jit_listing: &str,
+    org_available: bool,
     sink: Option<&dyn crate::agent::DeltaSink>,
     opts: crate::reason::GenOptions,
 ) -> Result<Option<AskVaultResult>, AppError> {
-    let system = crate::summarize::vault_chat::agentic_system_jit(memory_brief, jit_listing);
+    let system =
+        crate::summarize::vault_chat::agentic_system_jit(memory_brief, jit_listing, org_available);
     let user = crate::summarize::vault_chat::render_conversation(history, question);
     let Some(outcome) = crate::agent::run_agentic_loop(
         reasoner,
@@ -6219,6 +6247,7 @@ mod ask_vault_tests {
             &[],
             "",
             &listing,
+            false,
             None,
             crate::reason::GenOptions::ask_answer(),
         )
@@ -6399,6 +6428,7 @@ mod ask_vault_tests {
             &[],
             "",
             "",
+            false,
             None,
             crate::reason::GenOptions::ask_answer(),
         )
@@ -6447,6 +6477,7 @@ mod ask_vault_tests {
             &[],
             "",
             "",
+            false,
             None,
             crate::reason::GenOptions::ask_answer(),
         )
@@ -6482,6 +6513,7 @@ mod ask_vault_tests {
             &[],
             "",
             "",
+            false,
             None,
             crate::reason::GenOptions::ask_answer(),
         );
@@ -6623,6 +6655,7 @@ mod ask_vault_tests {
             &[],
             "",
             "",
+            false,
             None,
             crate::reason::GenOptions::ask_answer(),
         )
@@ -6677,14 +6710,20 @@ mod ask_vault_tests {
 /// assembled through the SAME visibility gate as Ask-My-Vault (sealed-not-unlocked meetings
 /// contribute nothing), then synthesized by the configured provider — so this is a CLOUD-egress
 /// path that goes through the redaction firewall + consent gate (E6/E7/E10) exactly like `ask_vault`.
+///
+/// B2 (Shared Brain, READ-ONLY): when the caller has joined an org, ALSO searches the org partition
+/// for this entity and folds `[org · author]`-labelled hits into the SYNTHESIS PROMPT ONLY as
+/// additional citable context — an entity with ZERO local facts/mentions can still resolve here
+/// purely from org content. This NEVER calls `build_and_persist_entities` and NEVER writes anything
+/// derived from org content into `entities`/`entity_mentions`/`facts` — those tables are untouched
+/// by this path. `has_org_context` on the response is the honest signal that org-sourced content
+/// contributed, so the caller never silently blends a colleague's claims with the user's own
+/// verified facts.
 #[tauri::command]
 pub async fn entity_dossier(
     state: State<'_, AppState>,
     entity: String,
-) -> Result<String, AppError> {
-    if entity.trim().is_empty() {
-        return Err(AppError::InvalidArg("entity is empty".into()));
-    }
+) -> Result<EntityDossierResult, AppError> {
     let config = {
         state
             .config
@@ -6695,20 +6734,343 @@ pub async fn entity_dossier(
     // Pass the LIVE session unlock set (E9): a folder the user has session-unlocked is included
     // again; sealed-and-NOT-unlocked content stays excluded by the same visibility predicate.
     let unlocked = unlocked_snapshot(state.inner())?;
-    let entity_id = crate::summarize::dossier::resolve_entity_id(&state.db, &entity, &unlocked)?
-        .ok_or_else(|| AppError::InvalidArg(format!("no visible entity matching \"{entity}\"")))?;
-    let data = crate::summarize::dossier::build_dossier_data(&state.db, &entity_id, &unlocked)?
-        .ok_or_else(|| AppError::InvalidArg(format!("no visible entity matching \"{entity}\"")))?;
+    let notes_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, &config)
+            .connection;
+    let (system, user, has_org_context) =
+        build_entity_dossier_prompt(&state.db, &entity, &unlocked, &config, &notes_conn)?;
     // Build the provider (firewall + consent gate) BEFORE synthesizing — the factory refuses a
     // cloud provider until the user has consented to egress. NOTES role (the dossier is a
     // written synthesis); the corpus budget keys on the same resolved connection.
     let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
-    let notes_conn =
-        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Notes, &config)
-            .connection;
-    let system = crate::summarize::dossier::dossier_system_prompt(&config.note_language);
-    let user = crate::summarize::dossier::render_dossier_user(&data, &notes_conn);
-    provider.complete(&system, &user).await
+    let markdown = provider.complete(&system, &user).await?;
+    Ok(EntityDossierResult {
+        markdown,
+        has_org_context,
+    })
+}
+
+/// The testable, SYNCHRONOUS core of [`entity_dossier`]: resolve the entity + gated local dossier
+/// data, ALSO run the READ-ONLY org leg (B2), and assemble the (system, user, has_org_context)
+/// synthesis-prompt triple — everything short of the actual `provider.complete` cloud call, so this
+/// can be tested without a real provider/network.
+///
+/// B2 (Shared Brain, READ-ONLY): when the caller has joined an org (`org_brain_available`), ALSO
+/// searches the org partition ONCE for this entity and folds `[org · author]`-labelled hits into
+/// the synthesis prompt ONLY — an entity with ZERO local facts/mentions can still resolve here
+/// purely from org content (`data` may be `None` while `org_context` is `Some`). This function NEVER
+/// calls `build_and_persist_entities` and NEVER writes to `entities`/`entity_mentions`/`facts` — it
+/// only reads. `has_org_context` is `true` iff org-sourced lines were folded in, so the caller can
+/// honestly signal that the dossier drew on colleague content.
+fn build_entity_dossier_prompt(
+    db: &crate::storage::Db,
+    entity: &str,
+    unlocked: &std::collections::HashSet<String>,
+    config: &AppConfig,
+    notes_conn: &str,
+) -> Result<(String, String, bool), AppError> {
+    if entity.trim().is_empty() {
+        return Err(AppError::InvalidArg("entity is empty".into()));
+    }
+    // B2: resolve the ORG leg once, up front — an entity that is ORG-ONLY (no local entity row at
+    // all) must still be resolvable, so the local-entity lookup below is allowed to miss as long as
+    // org content is present. Gated on the SAME `org_brain_available` predicate as every other org
+    // leg (A1/A2); one call, no per-query looping. READ-ONLY: `search_org_brain` never writes.
+    let org_query = entity.trim().to_string();
+    let org_context = if crate::tools::org_brain_available(db, config) {
+        match crate::tools::search_org_brain(db, config, &org_query) {
+            Ok(text) => {
+                let text = text.trim();
+                // `search_org_brain` degrades to a "No org-brain results …" sentinel (never an Err)
+                // when there is nothing to find — that carries no `- [org` line, so it is dropped
+                // here exactly like every other "nothing found" sentinel this codebase filters
+                // (`voice_action::is_empty_tool_result`). A real hit's text is passed THROUGH
+                // WHOLE (never re-split by line) — a snippet can legitimately wrap onto a second
+                // line that doesn't itself start with "- [org", and truncating there would silently
+                // drop cited content from the synthesis prompt.
+                if text.is_empty() || !text.contains("- [org") {
+                    None
+                } else {
+                    Some(text.to_string())
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    target: "dossier",
+                    error = %e,
+                    "entity dossier org-brain search failed; continuing without org context"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let entity_id = crate::summarize::dossier::resolve_entity_id(db, entity, unlocked)?;
+    let data = match entity_id {
+        Some(id) => crate::summarize::dossier::build_dossier_data(db, &id, unlocked)?,
+        None => None,
+    };
+    // Neither a local entity NOR any org context ⇒ genuinely unknown — the pre-org error semantics.
+    if data.is_none() && org_context.is_none() {
+        return Err(AppError::InvalidArg(format!(
+            "no visible entity matching \"{entity}\""
+        )));
+    }
+    let mut system = crate::summarize::dossier::dossier_system_prompt(&config.note_language);
+    let mut user = match &data {
+        Some(d) => crate::summarize::dossier::render_dossier_user(d, notes_conn),
+        // Org-only entity: no local dossier data at all — hand the model just the entity name so it
+        // has a subject to synthesize the org section against.
+        None => format!(
+            "ENTITY: {}\n(no local meetings/facts found for this entity)\n",
+            entity.trim()
+        ),
+    };
+    let has_org_context = if let Some(org_lines) = &org_context {
+        system.push_str(
+            " Additional context may include lines starting \"- [org ·\" — these are colleague-\
+             shared facts from your organization's Shared Brain, NOT the user's own verified data. \
+             Attribute any claim drawn from them by their \"[org · author]\" provenance, clearly \
+             distinguished from the user's own meetings/facts.",
+        );
+        user.push_str(&format!(
+            "\n\nADDITIONAL CONTEXT FROM YOUR ORGANIZATION'S SHARED BRAIN (colleague-shared, \
+             attribute by provenance):\n{org_lines}\n"
+        ));
+        true
+    } else {
+        false
+    };
+    Ok((system, user, has_org_context))
+}
+
+#[cfg(test)]
+mod entity_dossier_tests {
+    use super::*;
+    use crate::storage::models::{Meeting, MeetingStatus, NoteRecord};
+    use crate::storage::Db;
+    use std::collections::HashSet;
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn tmp_db() -> Db {
+        let p = crate::storage::db::unique_temp_path("murmur-dossier", "sqlite");
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn seed_note(db: &Db, id: &str, title: &str, markdown: &str) {
+        db.insert_meeting(&Meeting {
+            id: id.into(),
+            started_at: "2026-06-26T09:00:00Z".into(),
+            ended_at: None,
+            title: Some(title.into()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: id.into(),
+            provider_id: "claude_code".into(),
+            markdown: markdown.into(),
+            created_at: "2026-06-26T09:05:00Z".into(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+    }
+
+    /// Join org-1 for this session (mirrors `tools::tests::seed_org`).
+    fn seed_org(db: &Db) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: "org-1".to_string(),
+            name: "Acme".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-10T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+        })
+        .unwrap();
+    }
+
+    /// Ingest one org-brain item into the local replica (mirrors `tools::tests::ingest_org`).
+    fn ingest_org(db: &Db, item_id: &str, author: &str, title: &str, body: &str, sha: &[u8]) {
+        db.upsert_org_item(
+            item_id,
+            "org-1",
+            1,
+            author,
+            title,
+            body,
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            sha,
+            None,
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+    }
+
+    fn empty_unlocked() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    /// RED-before-GREEN (B2, the load-bearing leak/write-safety test): an entity that exists ONLY in
+    /// the org brain — ZERO local `entities`/`entity_mentions`/`facts` rows for it at all — must now
+    /// resolve via the dossier prompt builder with `[org · author]`-cited content, AND the local
+    /// `entities`/`entity_mentions` tables (proxied via `list_entities_visible` — row count + summed
+    /// visible mention count) must be BYTE-IDENTICAL (same COUNT) before and after the call, proving
+    /// the org leg is READ-ONLY and never calls `build_and_persist_entities` / writes derived rows.
+    /// Pre-fix, an org-only entity had NO local row at all and `resolve_entity_id` returned `None`
+    /// unconditionally ⇒ `InvalidArg("no visible entity matching …")` — RED.
+    #[test]
+    fn org_only_entity_resolves_via_dossier_and_writes_nothing_to_local_tables() {
+        let db = tmp_db();
+        seed_org(&db);
+        ingest_org(
+            &db,
+            "it-1",
+            "anna",
+            "Anna's roadmap",
+            "Project Apollo: the apollo migration ships friday, owned by anna",
+            &[3u8; 32],
+        );
+        let unlocked = empty_unlocked();
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+
+        // BASELINE row counts — a fresh DB with an org item but NO local entities/mentions at all.
+        let entities_before = db.list_entities_visible(&unlocked).unwrap();
+        let count_before = entities_before.len();
+        let mentions_before: i64 = entities_before.iter().map(|e| e.mention_count).sum();
+
+        // "Project Apollo" is ORG-ONLY — no local meeting/entity ever mentions it.
+        let (system, user, has_org_context) =
+            build_entity_dossier_prompt(&db, "Project Apollo", &unlocked, &cfg, "claude_code")
+                .expect("an org-only entity must now resolve (RED on the pre-fix hard miss)");
+
+        assert!(has_org_context, "has_org_context must be true when org content contributed");
+        assert!(
+            user.contains("[org · anna]") && user.contains("apollo migration"),
+            "the org-cited content must reach the synthesis USER prompt: {user}"
+        );
+        assert!(
+            system.contains("[org ·"),
+            "the synthesis SYSTEM prompt must instruct org-provenance attribution: {system}"
+        );
+
+        // THE LOAD-BEARING ASSERTION: local entities/entity_mentions rows are UNCHANGED — the org
+        // leg never persisted anything derived from org content.
+        let entities_after = db.list_entities_visible(&unlocked).unwrap();
+        let count_after = entities_after.len();
+        let mentions_after: i64 = entities_after.iter().map(|e| e.mention_count).sum();
+        assert_eq!(
+            count_before, count_after,
+            "entities row count must be UNCHANGED by a read-only org-context dossier call"
+        );
+        assert_eq!(
+            mentions_before, mentions_after,
+            "entity_mentions row count (proxied via summed visible mention_count) must be UNCHANGED"
+        );
+        assert!(
+            count_after == 0 && mentions_after == 0,
+            "an org-only entity must create NO local entity/mention row at all: entities={count_after} mentions={mentions_after}"
+        );
+    }
+
+    /// Companion: seed a REAL local entity (with its own mention + zero facts) so the baseline
+    /// tables are non-empty, then run a dossier call for a DIFFERENT org-only entity — the
+    /// pre-existing local entity's own facts (`list_facts_visible`) must stay untouched (still
+    /// empty), proving the org leg doesn't bleed into or mutate UNRELATED existing rows either.
+    #[test]
+    fn org_context_dossier_call_never_touches_an_unrelated_local_entitys_facts() {
+        let db = tmp_db();
+        seed_org(&db);
+        ingest_org(
+            &db,
+            "it-2",
+            "bob",
+            "Bob's plan",
+            "Project Zephyr: the zephyr rollout ships monday",
+            &[7u8; 32],
+        );
+        seed_note(&db, "m1", "Atlas Kickoff", "We discussed Atlas migration and pricing.");
+        let entity_id = db
+            .upsert_entity("Atlas", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&entity_id, "m1").unwrap();
+
+        let unlocked = empty_unlocked();
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let facts_before = db.list_facts_visible(&entity_id, &unlocked).unwrap().len();
+        assert_eq!(facts_before, 0, "seed self-check: no facts yet for the local entity");
+
+        // Dossier call for a DIFFERENT, org-only entity.
+        let (_, _, has_org_context) =
+            build_entity_dossier_prompt(&db, "Project Zephyr", &unlocked, &cfg, "claude_code")
+                .expect("org-only entity must resolve");
+        assert!(has_org_context);
+
+        // The pre-existing LOCAL entity's facts are untouched by the unrelated org-context call.
+        let facts_after = db.list_facts_visible(&entity_id, &unlocked).unwrap().len();
+        assert_eq!(
+            facts_after, 0,
+            "an unrelated local entity's facts must stay UNCHANGED by an org-context dossier call"
+        );
+        // And the local entity itself still resolves exactly as before (not clobbered/duplicated).
+        let entities = db.list_entities_visible(&unlocked).unwrap();
+        assert_eq!(
+            entities.iter().filter(|e| e.name == "Atlas").count(),
+            1,
+            "the pre-existing local entity must not be duplicated or removed"
+        );
+    }
+
+    /// A local-only entity (no org membership at all) keeps the EXACT pre-org behavior:
+    /// `has_org_context` is false and no org text reaches the prompt.
+    #[test]
+    fn local_only_entity_has_org_context_false_and_no_org_text_when_not_a_member() {
+        let db = tmp_db();
+        seed_note(&db, "m1", "Atlas Kickoff", "We discussed Atlas migration and pricing.");
+        let entity_id = db
+            .upsert_entity("Atlas", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&entity_id, "m1").unwrap();
+
+        let unlocked = empty_unlocked();
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let (system, user, has_org_context) =
+            build_entity_dossier_prompt(&db, "Atlas", &unlocked, &cfg, "claude_code").unwrap();
+        assert!(!has_org_context, "no org membership ⇒ has_org_context must be false");
+        assert!(!user.contains("[org ·") && !system.contains("[org ·"));
+    }
+
+    /// Neither a local entity NOR any org context ⇒ the pre-org `InvalidArg` error semantics are
+    /// preserved exactly (genuinely unknown entity).
+    #[test]
+    fn unknown_entity_with_no_org_context_still_errors() {
+        let db = tmp_db();
+        let unlocked = empty_unlocked();
+        let cfg = AppConfig::default();
+        let err = build_entity_dossier_prompt(&db, "Nonexistent Thing", &unlocked, &cfg, "claude_code")
+            .unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)));
+    }
 }
 
 /// Generate a Weekly Vault Digest synthesizing meetings from the last `days` days; writes it
@@ -19708,7 +20070,8 @@ mod lifecycle_tests {
             variant: None,
             instruction: None,
         };
-        let cites = gather_note_enhance_citations(&state, &req).unwrap();
+        let cfg = AppConfig::default();
+        let cites = gather_note_enhance_citations(&state, &cfg, &req).unwrap();
         let ids: Vec<&str> = cites.iter().map(|c| c.id.as_str()).collect();
         assert!(
             !ids.contains(&self_id.as_str()),
@@ -19721,6 +20084,122 @@ mod lifecycle_tests {
         assert!(
             ids.contains(&other_id.as_str()),
             "a different VISIBLE note that matches IS cited"
+        );
+    }
+
+    /// A3 (RED-before-GREEN): `gather_note_enhance_citations` gains a THIRD leg — the org shared
+    /// brain, via the same `search_org_brain_hits` seam as `org_brain_search`/MCP `org_search`. A
+    /// colleague's org item that matches the query must surface as a `kind: "org"` citation whose
+    /// `id` is the org item id (routed by the FE to `/org-item/:id`), title/snippet carried straight
+    /// through. Pre-fix, `gather_note_enhance_citations` only queried `search_visible` + doc chunks,
+    /// so an org-only match (zero local rows) was invisible — RED on the org leg simply not existing.
+    #[test]
+    fn enhance_retrieval_includes_org_leg_as_org_kind_citation() {
+        let state = build_state("note-enhance-retrieval-org");
+        state
+            .db
+            .upsert_org_state(&crate::storage::OrgState {
+                org_id: "org-1".to_string(),
+                name: "Acme".to_string(),
+                role: "member".to_string(),
+                joined_at: "2026-07-10T00:00:00Z".to_string(),
+                consented: true,
+                last_seq: 0,
+                generation: 1,
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_org_item(
+                "it-launchcode",
+                "org-1",
+                1,
+                "anna",
+                "Anna's launchcode notes",
+                "the launchcode rollout plan",
+                "2026-07-10T09:00:00Z",
+                1,
+                1,
+                &[9u8; 32],
+                None,
+                Some(&crate::embed::StubEmbedder),
+            )
+            .unwrap();
+
+        let fid = create_note_folder_inner(&state, "Work", None).unwrap().id;
+        let self_id = create_note_inner(&state, Some(&fid), "Self").unwrap();
+        update_note_doc_inner(&state, &self_id, "Self", "unrelated body").unwrap();
+
+        let req = NoteAssistRequest {
+            note_id: self_id.clone(),
+            action: "enhance".into(),
+            selection: "launchcode".into(),
+            before: None,
+            after: None,
+            variant: None,
+            instruction: None,
+        };
+        let cfg = AppConfig {
+            org_egress_consented: true,
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let cites = gather_note_enhance_citations(&state, &cfg, &req).unwrap();
+        let org_cite = cites
+            .iter()
+            .find(|c| c.kind == "org")
+            .expect("an org-brain match must surface as a kind:\"org\" citation");
+        assert_eq!(org_cite.id, "it-launchcode", "id is the org item id, for /org-item routing");
+        assert_eq!(org_cite.title, "Anna's launchcode notes");
+    }
+
+    /// A3 (RED-before-GREEN, leak guard): a NON-MEMBER (no `org_state` joined) must get ZERO org
+    /// citations even though a colleague's item sits in the local replica — the org leg is gated by
+    /// `org_brain_available` (membership), identical to `search_org_brain`'s own fail-closed gate.
+    #[test]
+    fn enhance_retrieval_org_leg_fails_closed_for_a_non_member() {
+        let state = build_state("note-enhance-retrieval-org-nonmember");
+        // Item is in the replica, but NO org joined for this session.
+        state
+            .db
+            .upsert_org_item(
+                "it-x",
+                "org-1",
+                1,
+                "anna",
+                "Anna's roadmap",
+                "the apollo migration ships friday",
+                "2026-07-10T09:00:00Z",
+                1,
+                1,
+                &[3u8; 32],
+                None,
+                Some(&crate::embed::StubEmbedder),
+            )
+            .unwrap();
+
+        let fid = create_note_folder_inner(&state, "Work", None).unwrap().id;
+        let self_id = create_note_inner(&state, Some(&fid), "Self").unwrap();
+        update_note_doc_inner(&state, &self_id, "Self", "unrelated body").unwrap();
+
+        let req = NoteAssistRequest {
+            note_id: self_id.clone(),
+            action: "enhance".into(),
+            selection: "apollo migration".into(),
+            before: None,
+            after: None,
+            variant: None,
+            instruction: None,
+        };
+        let cfg = AppConfig {
+            org_egress_consented: true,
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        let cites = gather_note_enhance_citations(&state, &cfg, &req).unwrap();
+        assert!(
+            !cites.iter().any(|c| c.kind == "org"),
+            "a non-member must get no org citations even with a populated replica: {cites:?}"
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6895,6 +6895,7 @@ mod entity_dossier_tests {
             consented: true,
             last_seq: 0,
             generation: 1,
+            context_enabled: true,
         })
         .unwrap();
     }
@@ -20106,6 +20107,7 @@ mod lifecycle_tests {
                 consented: true,
                 last_seq: 0,
                 generation: 1,
+                context_enabled: true,
             })
             .unwrap();
         state
@@ -24132,6 +24134,82 @@ mod lifecycle_tests {
         ));
     }
 
+    /// PER-INSTANCE ORG TOGGLE (RED-before-GREEN): a DISABLED org's `list_org_items_inner` returns
+    /// EMPTY — not an error (disabling is a deliberate, reversible local setting, not a membership
+    /// problem) — even though the local replica still has live items. Re-enabling instantly restores
+    /// the listing, proving the replica itself is untouched by the toggle.
+    #[test]
+    fn list_org_items_inner_is_empty_for_a_disabled_org_and_restores_on_reenable() {
+        let state = build_state("org-list-items-disabled");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .upsert_org_item("m1", "org-1", 1, "anna", "Kickoff", "body", "2026-07-11T09:00:00Z", 1, 1, &[1u8; 32], None, None)
+            .unwrap();
+
+        assert_eq!(list_org_items_inner(&state, "org-1").unwrap().len(), 1, "visible while enabled");
+
+        state.db.set_org_context_enabled("org-1", false).unwrap();
+        assert_eq!(
+            list_org_items_inner(&state, "org-1").unwrap(),
+            Vec::new(),
+            "a disabled org's item list must be EMPTY, not an error"
+        );
+
+        state.db.set_org_context_enabled("org-1", true).unwrap();
+        assert_eq!(
+            list_org_items_inner(&state, "org-1").unwrap().len(),
+            1,
+            "re-enabling instantly restores the listing — the replica was never touched"
+        );
+    }
+
+    /// `org_set_context_enabled_inner` (RED-before-GREEN): flips the per-instance toggle for a
+    /// MEMBER org, refuses a non-member (never lets a caller toggle an org it isn't in), and an
+    /// incoming `upsert_org_state` status refresh NEVER silently re-enables a locally-disabled org —
+    /// mirrors the existing `consented`/`last_seq` preservation contract.
+    #[test]
+    fn org_set_context_enabled_toggles_gates_non_members_and_survives_a_status_refresh() {
+        let state = build_state("org-set-context-enabled");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+
+        assert!(state.db.get_org_state("org-1").unwrap().unwrap().context_enabled);
+        org_set_context_enabled_inner(&state, "org-1", false).unwrap();
+        assert!(!state.db.get_org_state("org-1").unwrap().unwrap().context_enabled);
+
+        // Refuses a non-member — never toggles an org the caller isn't in.
+        assert!(matches!(
+            org_set_context_enabled_inner(&state, "org-not-mine", true),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // An incoming status refresh (e.g. `org_refresh`) must NOT silently re-enable the org the
+        // user explicitly disabled — mirrors the consent/cursor preservation contract.
+        state
+            .db
+            .upsert_org_state(&crate::storage::OrgState {
+                org_id: "org-1".to_string(),
+                name: "Acme Corp".to_string(), // the refresh DOES update name/role/generation...
+                role: "member".to_string(),
+                joined_at: "2026-07-10T00:00:00Z".to_string(),
+                consented: true,
+                last_seq: 0,
+                generation: 2,
+                context_enabled: true, // ...but this must be IGNORED, not applied.
+            })
+            .unwrap();
+        let row = state.db.get_org_state("org-1").unwrap().unwrap();
+        assert_eq!(row.name, "Acme Corp", "the refresh still updates name normally");
+        assert!(
+            !row.context_enabled,
+            "a status refresh must NEVER silently re-enable a locally-disabled org"
+        );
+
+        // Re-enable, explicit.
+        org_set_context_enabled_inner(&state, "org-1", true).unwrap();
+        assert!(state.db.get_org_state("org-1").unwrap().unwrap().context_enabled);
+    }
+
     /// `meeting_org_shares`: an OPEN meeting's active org shares are visible (org id + display
     /// name), and a SEALED-and-not-session-unlocked meeting's org-share status is MASKED to an empty
     /// list — exactly like `get_meeting_detail`'s `locked: true` masking. RED on any pre-gate version
@@ -24328,6 +24406,7 @@ mod lifecycle_tests {
                 consented: false,
                 last_seq: 0,
                 generation: 1,
+                context_enabled: true,
             })
             .unwrap();
         // Grant local consent + advance the cursor + bump the generation.
@@ -24346,6 +24425,7 @@ mod lifecycle_tests {
                 consented: false, // an incoming refresh's false must NOT clobber the local grant
                 last_seq: 0,      // …nor rewind the cursor
                 generation: 3,
+                context_enabled: true,
             })
             .unwrap();
         let row = state.db.get_org_state("org-1").unwrap().unwrap();
@@ -24373,6 +24453,7 @@ mod lifecycle_tests {
             consented: false,
             last_seq: 0,
             generation,
+            context_enabled: true,
         })
         .unwrap();
     }
@@ -24389,6 +24470,7 @@ mod lifecycle_tests {
             consented: false,
             last_seq: 0,
             generation: 1,
+            context_enabled: true,
         })
         .unwrap();
     }
@@ -25855,6 +25937,9 @@ pub struct OrgStatus {
     /// `received_count`, so the Settings count no longer lies "0 items" to a receiver.
     pub received_count: u32,
     pub pending_shares: u32,
+    /// PER-INSTANCE org toggle: whether this org contributes content (browsing + brain context) on
+    /// THIS Murmur install. `true` by default; flip via `org_set_context_enabled`.
+    pub context_enabled: bool,
 }
 
 /// One org member row for the FE (spec DTO `OrgMember`).
@@ -26142,6 +26227,7 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
         consented: false,
         last_seq: 0,
         generation: created.current_generation,
+        context_enabled: true,
     })?;
     {
         let mut cache = state
@@ -26165,6 +26251,7 @@ pub(crate) async fn org_create_inner(state: &AppState, name: String) -> Result<O
         item_count: 0,
         received_count: 0,
         pending_shares: 0,
+        context_enabled: true,
     }))
 }
 
@@ -26200,6 +26287,31 @@ pub(crate) async fn org_list_statuses_inner(state: &AppState) -> Result<Vec<OrgS
     Ok(out)
 }
 
+/// `org_set_context_enabled(org_id, enabled)` — the PER-INSTANCE org toggle (Settings →
+/// Organization): whether a JOINED org contributes content on THIS Murmur install. Membership-checked
+/// via [`resolve_org`] (refuses an org the caller isn't a local member of, exactly like every other
+/// per-org command); the actual gate lives in `Db::set_org_context_enabled` + the `context_enabled = 1`
+/// filter in `search_org_chunks_knn`/`_fts`/`list_org_items_inner` — this command only flips the flag.
+/// Disabling NEVER deletes the local replica (re-enabling is instant, no re-sync); NO egress, NO
+/// server call — purely local.
+#[tauri::command]
+pub fn org_set_context_enabled(
+    state: State<'_, AppState>,
+    org_id: String,
+    enabled: bool,
+) -> Result<(), AppError> {
+    org_set_context_enabled_inner(state.inner(), &org_id, enabled)
+}
+
+pub(crate) fn org_set_context_enabled_inner(
+    state: &AppState,
+    org_id: &str,
+    enabled: bool,
+) -> Result<(), AppError> {
+    resolve_org(state, org_id)?; // membership re-check
+    state.db.set_org_context_enabled(org_id, enabled)
+}
+
 /// Build the content-free [`OrgStatus`] for ONE locally-joined org. Refreshes name/role/generation +
 /// member_count from the server best-effort (offline / a per-org error falls back to the cached row),
 /// then reads pending/item counts from the local outbound `org_shares` and the GLOBAL egress consent.
@@ -26224,6 +26336,7 @@ async fn org_status_for(
                         consented: local.consented,
                         last_seq: local.last_seq,
                         generation: fresh.current_generation,
+                        context_enabled: true,
                     })?;
                     state.db.set_org_generation(&local.org_id, fresh.current_generation)?;
                     client
@@ -26269,6 +26382,7 @@ async fn org_status_for(
         item_count,
         received_count,
         pending_shares: pending,
+        context_enabled: refreshed.context_enabled,
     })
 }
 
@@ -26380,6 +26494,7 @@ fn reconcile_org_state_into_db(
             consented: false,
             last_seq: 0,
             generation: o.current_generation,
+            context_enabled: true,
         })?;
         if is_new {
             new_orgs.push((o.org_id.clone(), o.current_generation));
@@ -28250,6 +28365,13 @@ pub(crate) fn list_org_items_inner(
 ) -> Result<Vec<crate::storage::models::OrgItemHeader>, AppError> {
     // Membership re-check: refuse if the caller isn't a local member of this org.
     let org = resolve_org(st, org_id)?;
+    // PER-INSTANCE ORG TOGGLE: a disabled org is EMPTY here — not an error (it's a deliberate,
+    // reversible local setting, not a membership problem) — the local replica is never deleted, so
+    // this is silent and instant to reverse. Mirrors the `context_enabled = 1` SQL filter in
+    // `search_org_chunks_knn`/`_fts`; this is the direct-browse (Library "Shared brains") twin.
+    if !org.context_enabled {
+        return Ok(Vec::new());
+    }
     let mut items = st.db.list_org_items(&org.org_id)?;
     // OWNERSHIP ENRICHMENT (F-org-editable): for each replica the CALLER published, resolve its local
     // editable source + CURRENT title so the FE links straight to the editable original and never shows

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23862,6 +23862,7 @@ mod lifecycle_tests {
     #[test]
     fn org_get_item_returns_detail_and_none_for_tombstone() {
         let state = build_state("org-get-item");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
         state
             .db
             .upsert_org_item(
@@ -23891,6 +23892,47 @@ mod lifecycle_tests {
         assert!(state.db.get_org_item("it-g").unwrap().is_none());
         // Unknown id → None.
         assert!(state.db.get_org_item("nope").unwrap().is_none());
+    }
+
+    /// PER-INSTANCE ORG TOGGLE (RED-before-GREEN): `get_org_item` — the single-item read behind
+    /// `/org-item/:id` — must return `None` for a DISABLED org's item, closing the gap a stale
+    /// citation/bookmark/browser-history entry could otherwise exploit to read through the toggle
+    /// (this read has no org-id list-scoping to gate at, unlike `list_org_items_inner`). Re-enabling
+    /// instantly restores it — the item itself was never touched.
+    #[test]
+    fn org_get_item_returns_none_for_a_disabled_orgs_item_and_restores_on_reenable() {
+        let state = build_state("org-get-item-disabled");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .upsert_org_item(
+                "it-d",
+                "org-1",
+                1,
+                "anna",
+                "Weekly Sync",
+                "the roadmap for the platform team",
+                "2026-07-10T09:00:00Z",
+                1,
+                1,
+                &[6u8; 32],
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(state.db.get_org_item("it-d").unwrap().is_some(), "visible while enabled");
+
+        state.db.set_org_context_enabled("org-1", false).unwrap();
+        assert!(
+            state.db.get_org_item("it-d").unwrap().is_none(),
+            "a disabled org's item must NEVER be readable via a direct/stale link"
+        );
+
+        state.db.set_org_context_enabled("org-1", true).unwrap();
+        assert!(
+            state.db.get_org_item("it-d").unwrap().is_some(),
+            "re-enabling instantly restores it — the item itself was never touched"
+        );
     }
 
     /// FIX A (browsable org-items LIST): `db.list_org_items` returns the org's LIVE items as headers

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -346,7 +346,20 @@ impl Embedder for StubEmbedder {
 /// silently.) Cheap to construct (the stub is zero-sized; the candle backend defers the heavy load),
 /// so callers build one per operation. NEVER invoked when `semantic_search_enabled` is off (the gate
 /// short-circuits before this is called) — building the real embedder does NOT flip that flag.
+///
+/// TEST-BUILD SAFETY NET: `cargo test --lib` must never attempt a real Metal forward pass (see the
+/// header doc on `embed::candle_bert` — "NEVER runs a forward pass here"). That was previously true
+/// only incidentally (CI has no model on disk), so on a dev Mac that HAS downloaded the real e5 model,
+/// any ordinary test exercising a note/meeting index path (e.g. `update_note_doc_inner`) reaches this
+/// function, tries a real Metal forward pass inside the test binary, and can abort the process
+/// (observed: `MTLCompilerService` XPC failure). Force the stub under `cfg(test)` unless a caller has
+/// explicitly opted in via `MURMUR_TEST_REAL_EMBED=1` — only the manual, `#[ignore]`d bake-off tests
+/// (`eval::bakeoff`) set that var, since they are the one legitimate case that wants the real model.
 pub fn active_embedder() -> Box<dyn Embedder> {
+    #[cfg(test)]
+    if std::env::var_os("MURMUR_TEST_REAL_EMBED").is_none() {
+        return Box::new(StubEmbedder);
+    }
     let model = selected_embed_model();
     if embed_model_present() {
         let built = embed_model_dir().and_then(|dir| {

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -338,6 +338,9 @@ mod tests {
                  embedder and their numbers are NOT a quality signal. Download the model first."
             );
         }
+        // Opt out of the `cargo test --lib` real-Metal-forward-pass safety net (embed.rs
+        // `active_embedder`) — this is the one legitimate manual test that wants the real model.
+        std::env::set_var("MURMUR_TEST_REAL_EMBED", "1");
         let embedder = crate::embed::active_embedder();
         // Empty unlocked set = eval OPEN content only. To include a sealed folder, unlock it in the
         // app and copy the WAL'd DB, or extend this to accept a folder-id list.
@@ -390,6 +393,9 @@ mod tests {
                  embedder; only the fts row is a quality signal. Download the model and re-run."
             );
         }
+        // Opt out of the `cargo test --lib` real-Metal-forward-pass safety net (embed.rs
+        // `active_embedder`) — this is a legitimate manual test that wants the real model.
+        std::env::set_var("MURMUR_TEST_REAL_EMBED", "1");
         let embedder = crate::embed::active_embedder();
         let ids = crate::eval::corpus::seed_synthetic_corpus(&db, embedder.as_ref())
             .expect("seed synthetic corpus");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -205,6 +205,7 @@ pub fn run() {
             commands::org_create,
             commands::org_status,
             commands::org_list_statuses,
+            commands::org_set_context_enabled,
             commands::org_refresh,
             commands::org_invite_member,
             commands::org_list_members,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -236,7 +236,7 @@ fn tools_spec() -> Value {
     json!([
         {
             "name": "search_meetings",
-            "description": "Full-text search across your meeting titles, transcripts, notes, and imported documents/brain notes. Returns matching meetings and documents with snippets and ids.",
+            "description": "Full-text search across your meeting titles, transcripts, notes, and imported documents/brain notes. Returns matching meetings and documents with snippets and ids. If nothing relevant turns up and you have joined an org, also try org_search — a colleague may have already shared the answer.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         },
         {
@@ -251,7 +251,7 @@ fn tools_spec() -> Value {
         },
         {
             "name": "search_semantic",
-            "description": "Semantic (meaning-based) search across your meeting notes and imported documents/brain notes, fused with full-text search. Finds relevant content even without the exact words. When semantic search is disabled in Murmur settings it falls back to keyword-only matching (the result says so).",
+            "description": "Semantic (meaning-based) search across your meeting notes and imported documents/brain notes, fused with full-text search. Finds relevant content even without the exact words. When semantic search is disabled in Murmur settings it falls back to keyword-only matching (the result says so). If nothing relevant turns up and you have joined an org, also try org_search — a colleague may have already shared the answer.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         },
         {
@@ -266,7 +266,7 @@ fn tools_spec() -> Value {
         },
         {
             "name": "org_search",
-            "description": "Search the ORGANIZATION brain — notes your colleagues explicitly shared to the shared org brain (synced + decrypted locally; no data leaves this device). Results are attributed '[org · <author>]' and MUST be cited as coming from that colleague. Only meaningful when you have joined an org and consented to org sharing (otherwise returns no results). Use for 'what does the team / someone else know or decide about X' questions.",
+            "description": "Fallback for when search_meetings / search_semantic find nothing relevant in your OWN vault and you have joined an org: search the ORGANIZATION brain — notes your colleagues explicitly shared to the shared org brain (synced + decrypted locally; no data leaves this device). Results are attributed '[org · <author>]' and MUST be cited as coming from that colleague. Only meaningful when you have joined an org and consented to org sharing (otherwise returns no results). Use for 'what does the team / someone else know or decide about X' questions.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         }
     ])
@@ -424,6 +424,38 @@ mod tests {
         assert!(tools.iter().any(|t| t["name"] == "get_entity_dossier"));
         // Shared Brain — the org partition search tool is advertised.
         assert!(tools.iter().any(|t| t["name"] == "org_search"));
+    }
+
+    /// A4 (RED-before-GREEN): the MCP catalog must steer callers toward `org_search` as a FALLBACK
+    /// when `search_meetings`/`search_semantic` find nothing — and `org_search`'s own description
+    /// must lead with that fallback framing, not present itself as an unrelated alternative.
+    #[test]
+    fn tool_catalog_nudges_org_search_as_a_fallback() {
+        let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
+        let tools = r["result"]["tools"].as_array().unwrap();
+        let desc = |name: &str| -> String {
+            tools
+                .iter()
+                .find(|t| t["name"] == name)
+                .and_then(|t| t["description"].as_str())
+                .unwrap_or_default()
+                .to_string()
+        };
+        let search_meetings = desc("search_meetings");
+        let search_semantic = desc("search_semantic");
+        let org_search = desc("org_search");
+        assert!(
+            search_meetings.contains("org_search"),
+            "search_meetings must mention org_search as a fallback: {search_meetings}"
+        );
+        assert!(
+            search_semantic.contains("org_search"),
+            "search_semantic must mention org_search as a fallback: {search_semantic}"
+        );
+        assert!(
+            org_search.to_lowercase().starts_with("fallback"),
+            "org_search's own description must LEAD with the fallback framing: {org_search}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/prompts.rs
+++ b/src-tauri/src/prompts.rs
@@ -32,19 +32,29 @@ pub const TIER1_SUFFIX: &str = "SCOPE — CURRENT MEETING ONLY: Answer STRICTLY 
     EXACTLY this JSON and nothing else: {\"answer\":\"__ESCALATE__\"}. Otherwise answer normally.";
 
 /// Tier 2 — answer from the user's OWN VAULT (their saved meetings/notes) via the gated search tools;
-/// if the vault doesn't cover it, escalate.
+/// if the vault doesn't cover it, escalate. B1 (Shared Brain): the org/Shared Brain tool itself is
+/// NOT reachable at this tier (it is Tier-3/Connectors-class, `tools::AssistantScope::allows`), so the
+/// steering here is to escalate rather than give up — the ACTUAL "also try org" instruction lives in
+/// [`TIER3_SUFFIX`], the tier that can actually call it.
 pub const TIER2_SUFFIX: &str = "SCOPE — YOUR VAULT: Answer from the user's OWN saved meetings and notes, \
     using the gated vault search tools to ground your answer. Cite meetings by their [[Title]] \
     wikilink. If — and only if — the answer is NOT in the user's vault (it needs the web, Jira, \
-    Slack, or the calendar), reply with EXACTLY this JSON and nothing else: \
-    {\"answer\":\"__ESCALATE__\"}. Otherwise answer normally.";
+    Slack, the calendar, or your organization's Shared Brain), reply with EXACTLY this JSON and \
+    nothing else: {\"answer\":\"__ESCALATE__\"}. Otherwise answer normally.";
 
 /// Tier 3 — TERMINAL: reach the consent-gated connectors/web. If it still can't be answered, say so
-/// honestly — there is NO further tier, so NEVER emit the escalation sentinel here.
+/// honestly — there is NO further tier, so NEVER emit the escalation sentinel here. B1 (Shared Brain):
+/// explicitly steers the model to also try `org_brain_search` before concluding it doesn't know — the
+/// tool is already advertised at this tier (`AssistantScope::Connectors` allows `org_brain_search`,
+/// tools.rs) but a model that never CHOOSES to call it would otherwise silently skip a colleague's
+/// answer. No new tier/UI/badge — reuses the existing `[org · author]` citation format.
 pub const TIER3_SUFFIX: &str = "SCOPE — CONNECTORS & WEB (last resort): Use the consent-gated connector \
-    and web tools (and the vault tools for grounding) to answer. Loud-attribute external facts \
-    (\"(via web)\", \"(via Jira)\", \"(via Slack)\"). This is the LAST step — if you still cannot \
-    find the answer, say so plainly; do NOT emit any escalation marker.";
+    and web tools (and the vault tools for grounding) to answer. If the current meeting and your own \
+    vault don't answer this, ALSO try org_brain_search (your organization's Shared Brain) before \
+    concluding you don't know — a colleague may have already answered it. Loud-attribute external \
+    facts (\"(via web)\", \"(via Jira)\", \"(via Slack)\") and org facts by their \"[org · author]\" \
+    provenance. This is the LAST step — if you still cannot find the answer, say so plainly; do NOT \
+    emit any escalation marker.";
 
 // ── RECORDING-AWARENESS phrases (moved verbatim from `voice_action`) ─────────────────────────────
 // The THREE load-bearing substrings BOTH the cloud cascade prompt
@@ -104,6 +114,28 @@ mod tests {
         assert!(
             !TIER3_SUFFIX.contains(crate::agent::ESCALATE_SENTINEL),
             "the terminal tier must never be told to emit the sentinel"
+        );
+    }
+
+    /// B1 (Shared Brain, RED-before-GREEN): the TERMINAL Tier 3 suffix — the only tier that can
+    /// actually reach `org_brain_search` (`AssistantScope::Connectors`/`Full`) — must explicitly
+    /// steer the model to try it before concluding it doesn't know, mirroring the A2 fallback
+    /// sentence. Tier 2 must at least MENTION the Shared Brain as a reason to escalate rather than
+    /// give up. Pre-fix, neither suffix mentioned org/Shared Brain at all.
+    #[test]
+    fn tier3_suffix_steers_toward_org_brain_search_before_giving_up() {
+        assert!(
+            TIER3_SUFFIX.contains("org_brain_search"),
+            "the terminal tier must explicitly name org_brain_search as a fallback: {TIER3_SUFFIX}"
+        );
+        assert!(
+            TIER3_SUFFIX.to_lowercase().contains("shared brain")
+                || TIER3_SUFFIX.contains("[org ·"),
+            "the terminal tier must frame org search as the Shared Brain / attribute its provenance: {TIER3_SUFFIX}"
+        );
+        assert!(
+            TIER2_SUFFIX.to_lowercase().contains("shared brain"),
+            "Tier 2 must mention the Shared Brain as a reason to escalate, not just give up: {TIER2_SUFFIX}"
         );
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1390,7 +1390,11 @@ impl Db {
              CREATE INDEX IF NOT EXISTS idx_org_shares_state ON org_shares(state);
              CREATE INDEX IF NOT EXISTS idx_org_shares_item ON org_shares(item_id);",
         )
-        .map_err(map_err)
+        .map_err(map_err)?;
+        // Per-instance org toggle: which JOINED orgs actually contribute content on THIS install
+        // (Settings → Organization). Default enabled (1) so every existing membership stays active
+        // pre-upgrade. Guarded/additive per the migration rule.
+        Self::add_column_if_missing(conn, "org_state", "context_enabled", "INTEGER NOT NULL DEFAULT 1")
     }
 
     /// M6 Shared Brain (sync/ingest slice) — the local DECRYPTED REPLICA of the org feed + its
@@ -1721,13 +1725,14 @@ impl Db {
     // ── M6 Shared Brain: local org state + the outbound org-share state machine ──────────────────
 
     /// Upsert the locally-cached membership of an org (create/status). Preserves an existing row's
-    /// local `consented` flag and `last_seq` cursor (an incoming status refresh MUST NOT reset the
-    /// consent flag or rewind the sync cursor). NO content — membership metadata only.
+    /// local `consented` flag, `last_seq` cursor, AND `context_enabled` toggle (an incoming status
+    /// refresh MUST NOT reset the consent flag, rewind the sync cursor, or silently re-enable an org
+    /// the user disabled on this instance). NO content — membership metadata only.
     pub fn upsert_org_state(&self, o: &crate::storage::OrgState) -> Result<()> {
         let conn = self.lock();
         conn.execute(
-            "INSERT INTO org_state (org_id, name, role, joined_at, consented, last_seq, generation)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "INSERT INTO org_state (org_id, name, role, joined_at, consented, last_seq, generation, context_enabled)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(org_id) DO UPDATE SET
                name = excluded.name,
                role = excluded.role,
@@ -1739,7 +1744,8 @@ impl Db {
                 o.joined_at,
                 o.consented as i64,
                 o.last_seq,
-                o.generation as i64
+                o.generation as i64,
+                o.context_enabled as i64
             ],
         )
         .map_err(map_err)?;
@@ -1755,6 +1761,7 @@ impl Db {
             consented: r.get::<_, i64>(4)? != 0,
             last_seq: r.get(5)?,
             generation: r.get::<_, i64>(6)? as u32,
+            context_enabled: r.get::<_, i64>(7)? != 0,
         })
     }
 
@@ -1762,7 +1769,7 @@ impl Db {
     pub fn get_org_state(&self, org_id: &str) -> Result<Option<crate::storage::OrgState>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT org_id, name, role, joined_at, consented, last_seq, generation
+            "SELECT org_id, name, role, joined_at, consented, last_seq, generation, context_enabled
                FROM org_state WHERE org_id = ?1",
             rusqlite::params![org_id],
             Self::map_org_state,
@@ -1776,7 +1783,7 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT org_id, name, role, joined_at, consented, last_seq, generation
+                "SELECT org_id, name, role, joined_at, consented, last_seq, generation, context_enabled
                    FROM org_state ORDER BY joined_at ASC",
             )
             .map_err(map_err)?;
@@ -1797,6 +1804,21 @@ impl Db {
         conn.execute(
             "UPDATE org_state SET consented = ?2 WHERE org_id = ?1",
             rusqlite::params![org_id, consented as i64],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Set the PER-INSTANCE org context toggle (Settings → Organization): whether a JOINED org
+    /// contributes content on THIS Murmur install — browsing (`list_org_items`) AND brain/assistant
+    /// context (`search_org_chunks_knn`/`_fts`). The ONLY mutator (mirrors `set_org_consented`) — a
+    /// status/feed refresh (`upsert_org_state`) never touches this column. Disabling never deletes the
+    /// local replica; re-enabling is instant with no re-sync.
+    pub fn set_org_context_enabled(&self, org_id: &str, enabled: bool) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_state SET context_enabled = ?2 WHERE org_id = ?1",
+            rusqlite::params![org_id, enabled as i64],
         )
         .map_err(map_err)?;
         Ok(())
@@ -5097,13 +5119,18 @@ impl Db {
     /// the top-`k` nearest `org_vec_chunks` for the int8-quantized `query_vec`, joined to their
     /// (non-tombstoned) items, deduped to one hit per item (nearest). `query_vec` is the member's OWN
     /// f32 query embedding — it is int8-quantized here so it is comparable to the stored int8 vectors.
+    ///
+    /// PER-INSTANCE ORG TOGGLE: joined to `org_state` and filtered on `context_enabled = 1` — a
+    /// disabled org's chunks are EXCLUDED at the SQL level, never read into Rust at all. This is the
+    /// hard data-level gate (not a UI hide): a caller cannot accidentally surface a disabled org's
+    /// content by forgetting to filter it downstream.
     pub fn search_org_chunks_knn(&self, query_vec: &[f32], k: i64) -> Result<Vec<OrgChunkHit>> {
         if query_vec.is_empty() || k <= 0 {
             return Ok(Vec::new());
         }
         let conn = self.lock();
         // KNN isolated to the vec0 table in a CTE (a vec0 query allows a single MATCH+k); the item
-        // columns + the tombstone filter are joined OUTSIDE it.
+        // columns + the tombstone/context-enabled filters are joined OUTSIDE it.
         let sql = "WITH knn(chunk_id, distance) AS (
                  SELECT chunk_id, distance FROM org_vec_chunks
                   WHERE embedding MATCH vec_int8(?1) AND k = ?2
@@ -5113,7 +5140,8 @@ impl Db {
                FROM knn
                JOIN org_chunks oc ON oc.id = knn.chunk_id
                JOIN org_items oi ON oi.item_id = oc.item_id
-              WHERE oi.tombstoned = 0
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.tombstoned = 0 AND os.context_enabled = 1
               ORDER BY knn.distance ASC, oi.item_id ASC";
         let blob = crate::embed::vec_to_int8_blob(query_vec);
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
@@ -5133,6 +5161,7 @@ impl Db {
 
     /// KEYWORD (FTS5/BM25) leg over the org partition — the model-free twin of
     /// [`Db::search_org_chunks_knn`], so org text is reachable on a DEFAULT install (no e5 model).
+    /// Same `context_enabled = 1` per-instance org filter as the KNN leg — see its doc.
     ///
     /// CRITICAL (scale-spike finding #2): the `LIMIT` is PUSHED DOWN into the SQL (bm25-ordered),
     /// NOT applied in Rust after reading every match — the unbounded production reader hit an 8.8 s
@@ -5154,7 +5183,8 @@ impl Db {
                FROM fts_org_chunks
                JOIN org_chunks oc ON oc.id = fts_org_chunks.rowid
                JOIN org_items oi ON oi.item_id = oc.item_id
-              WHERE fts_org_chunks MATCH ?1 AND oi.tombstoned = 0
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE fts_org_chunks MATCH ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
               ORDER BY rank ASC, oi.item_id ASC
               LIMIT ?2";
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
@@ -10597,11 +10627,29 @@ mod tests {
         vec![tag; 32]
     }
 
+    /// Join `org_id` locally (enabled by default) — the retrieval legs INNER JOIN `org_state`
+    /// (per-instance org toggle), so any test that ingests `org_items` directly must seed this first,
+    /// mirroring how production content can never exist without a prior join.
+    fn seed_org_state(db: &Db, org_id: &str) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: org_id.to_string(),
+            name: "Acme".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-10T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled: true,
+        })
+        .unwrap();
+    }
+
     /// Ingest round-trip: upsert an org item WITH a real (stub) embedder → both the int8 KNN leg AND
     /// the FTS leg retrieve it back with the right author/title/snippet + content hash.
     #[test]
     fn org_ingest_round_trips_through_int8_knn_and_fts() {
         let db = mem_db();
+        seed_org_state(&db, "org-1");
         let emb = crate::embed::StubEmbedder;
         let sha = sha32(1);
         db.upsert_org_item(
@@ -10653,6 +10701,7 @@ mod tests {
     #[test]
     fn org_ingest_fts_only_when_no_embedder() {
         let db = mem_db();
+        seed_org_state(&db, "org-1");
         db.upsert_org_item(
             "it-x",
             "org-1",
@@ -10690,6 +10739,7 @@ mod tests {
     #[test]
     fn org_tombstone_evicts_from_retrieval_and_viewer() {
         let db = mem_db();
+        seed_org_state(&db, "org-1");
         let emb = crate::embed::StubEmbedder;
         db.upsert_org_item(
             "it-t",
@@ -10751,6 +10801,8 @@ mod tests {
     #[test]
     fn purge_org_replica_drops_the_whole_decrypted_replica() {
         let db = mem_db();
+        seed_org_state(&db, "org-1");
+        seed_org_state(&db, "org-2");
         let emb = crate::embed::StubEmbedder;
         db.upsert_org_item(
             "it-a", "org-1", 1, "anna", "Roadmap", "the falcon rollout plan alpha", "t", 1, 1,
@@ -10815,6 +10867,7 @@ mod tests {
     #[test]
     fn org_upsert_is_idempotent_and_replaces_on_rev_bump() {
         let db = mem_db();
+        seed_org_state(&db, "org-1");
         let emb = crate::embed::StubEmbedder;
         db.upsert_org_item(
             "it-r", "org-1", 1, "dan", "V1", "first version body alpha", "t", 1, 1, &sha32(4),
@@ -10838,6 +10891,63 @@ mod tests {
         let detail = db.get_org_item("it-r").unwrap().unwrap();
         assert_eq!(detail.rev, 2);
         assert_eq!(detail.title, "V2");
+    }
+
+    /// PER-INSTANCE ORG TOGGLE (RED-before-GREEN, the user's hard mandate: a disabled org's context
+    /// must NEVER leak through). Two orgs, BOTH with matching content; org-1 disabled, org-2 stays
+    /// enabled. The disabled org's item must be COMPLETELY absent from both retrieval legs — not
+    /// merely ranked lower — while the enabled org's item still surfaces normally. Proves the SQL
+    /// filter is a real exclusion, not a soft demotion.
+    #[test]
+    fn disabled_org_is_excluded_from_both_retrieval_legs_while_enabled_org_still_surfaces() {
+        let db = mem_db();
+        seed_org_state(&db, "org-1");
+        seed_org_state(&db, "org-2");
+        let emb = crate::embed::StubEmbedder;
+        db.upsert_org_item(
+            "it-disabled", "org-1", 1, "anna", "Disabled org note",
+            "the quantum ledger migration plan", "t", 1, 1, &sha32(11), None, Some(&emb),
+        )
+        .unwrap();
+        db.upsert_org_item(
+            "it-enabled", "org-2", 1, "bob", "Enabled org note",
+            "the quantum ledger migration rollout", "t", 1, 1, &sha32(12), None, Some(&emb),
+        )
+        .unwrap();
+
+        // Precondition: BOTH are reachable while both orgs are enabled.
+        let fts_before = db.search_org_chunks_fts("quantum ledger migration", 10).unwrap();
+        assert_eq!(fts_before.len(), 2, "both items reachable before any org is disabled");
+
+        db.set_org_context_enabled("org-1", false).unwrap();
+
+        let fts_after = db.search_org_chunks_fts("quantum ledger migration", 10).unwrap();
+        assert!(
+            fts_after.iter().all(|h| h.item_id != "it-disabled"),
+            "the disabled org's item must be ABSENT from FTS, not just re-ranked: {:?}",
+            fts_after.iter().map(|h| &h.item_id).collect::<Vec<_>>()
+        );
+        assert!(
+            fts_after.iter().any(|h| h.item_id == "it-enabled"),
+            "the STILL-enabled org's item must keep surfacing normally"
+        );
+
+        let qv = emb
+            .embed_query(&["quantum ledger migration".to_string()])
+            .unwrap()
+            .remove(0);
+        let knn_after = db.search_org_chunks_knn(&qv, 10).unwrap();
+        assert!(
+            knn_after.iter().all(|h| h.item_id != "it-disabled"),
+            "the disabled org's item must be ABSENT from KNN too: {:?}",
+            knn_after.iter().map(|h| &h.item_id).collect::<Vec<_>>()
+        );
+        assert!(knn_after.iter().any(|h| h.item_id == "it-enabled"));
+
+        // Re-enabling is instant — no re-sync/re-ingest needed, the replica was never touched.
+        db.set_org_context_enabled("org-1", true).unwrap();
+        let fts_reenabled = db.search_org_chunks_fts("quantum ledger migration", 10).unwrap();
+        assert_eq!(fts_reenabled.len(), 2, "re-enabling instantly restores visibility, no re-sync");
     }
 
     /// The self-share dedup source: `all_org_shared_content_hashes` returns every non-null

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5221,13 +5221,17 @@ impl Db {
         Ok(hits)
     }
 
-    /// The full decrypted org item (for the read-only FE viewer). `None` for an unknown or TOMBSTONED
-    /// item. No lock gate — org items are deliberately org-disclosed content.
+    /// The full decrypted org item (for the read-only FE viewer). `None` for an unknown, TOMBSTONED,
+    /// OR per-instance-DISABLED item's org (a stale citation/bookmark to `/org-item/:id` must not read
+    /// through the toggle — same `context_enabled = 1` gate as `search_org_chunks_knn`/`_fts`). No lock
+    /// gate otherwise — org items are deliberately org-disclosed content.
     pub fn get_org_item(&self, item_id: &str) -> Result<Option<crate::storage::models::OrgItemDetail>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT item_id, author_hint, title, created_at, rev, markdown
-               FROM org_items WHERE item_id = ?1 AND tombstoned = 0",
+            "SELECT oi.item_id, oi.author_hint, oi.title, oi.created_at, oi.rev, oi.markdown
+               FROM org_items oi
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1",
             rusqlite::params![item_id],
             |r| {
                 Ok(crate::storage::models::OrgItemDetail {

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -681,12 +681,15 @@ pub struct NoteAssistRequest {
     pub instruction: Option<String>,
 }
 
-/// One enhance-context provenance citation — the source note/meeting the additive passage drew on.
+/// One enhance-context provenance citation — the source note/meeting/org-item the additive passage
+/// drew on.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoteCitation {
-    /// `"meeting"` | `"note"`.
+    /// `"meeting"` | `"note"` | `"org"`.
     pub kind: String,
+    /// For `kind == "org"` this is the org item id (`OrgChunkHit::item_id`), routed by the FE to
+    /// `/org-item/:id` — never a local meeting/note id.
     pub id: String,
     pub title: String,
     pub snippet: String,
@@ -887,6 +890,19 @@ pub struct AskVaultResult {
 pub struct DigestResult {
     pub markdown: String,
     pub exported_path: Option<String>,
+}
+
+/// Result of the CLOUD-synthesized `entity_dossier` command (B2, Shared Brain). `has_org_context`
+/// is an HONEST signal: `true` iff the synthesis prompt included any `[org · author]`-attributed
+/// colleague content ALONGSIDE the user's own verified facts — so the FE/response never silently
+/// blends org-sourced claims into the dossier without a distinguishing signal. READ-ONLY: org
+/// content that contributes here is NEVER written into `entities`/`entity_mentions`/`facts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityDossierResult {
+    pub markdown: String,
+    #[serde(default)]
+    pub has_org_context: bool,
 }
 
 /// An upcoming Calendar event (best-effort; absent if Calendar access is denied).

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1023,6 +1023,13 @@ pub struct TopicThread {
 }
 
 /// M6 Shared Brain — a locally-joined org (row of `org_state`). Membership metadata only; no content.
+///
+/// `context_enabled` (per-instance org toggle): whether this JOINED org contributes content on THIS
+/// Murmur install — browsing (`list_org_items`) AND brain/assistant context
+/// (`search_org_chunks_knn`/`_fts`). Default `true` (every existing/new membership stays active).
+/// Distinct from `consented` (org EGRESS consent — sharing OUT); this gates READING IN. A disabled
+/// org's rows are NEVER deleted/purged — only excluded from every read path — so re-enabling is
+/// instant with no re-sync.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrgState {
     pub org_id: String,
@@ -1032,6 +1039,7 @@ pub struct OrgState {
     pub consented: bool,
     pub last_seq: i64,
     pub generation: u32,
+    pub context_enabled: bool,
 }
 
 /// M6 Shared Brain — one row of the outbound org-share state machine (`org_shares`). Anchors on a

--- a/src-tauri/src/summarize/vault_chat.rs
+++ b/src-tauri/src/summarize/vault_chat.rs
@@ -76,7 +76,13 @@ pub fn render_conversation(history: &[ChatTurn], question: &str) -> String {
 /// `memory_brief` is the gated cross-meeting USER MEMORY brief, injected identically to [`build`]:
 /// non-empty ⇒ a "WHAT YOU KNOW ABOUT THE USER" block; EMPTY ⇒ byte-identical to the pre-memory
 /// persona. Gated by the caller (VISIBLE facts only), rides the surface's existing egress.
-pub fn agentic_system(memory_brief: &str) -> String {
+///
+/// `org_available` (A2, Shared Brain): when `true`, appends one explicit fallback-steering sentence
+/// telling the model to ALSO try `org_brain_search` before concluding it doesn't know — the model
+/// already has the tool advertised (gated identically by `org_brain_available`, tools.rs) but may
+/// never CHOOSE to call it without this nudge. `false` ⇒ BYTE-IDENTICAL to the pre-org persona (the
+/// non-member / org-unavailable path is completely unchanged).
+pub fn agentic_system(memory_brief: &str, org_available: bool) -> String {
     format!(
         "You answer questions across a user's PAST MEETINGS, imported documents, and brain notes \
      (their private, on-device vault).\n\
@@ -90,9 +96,21 @@ pub fn agentic_system(memory_brief: &str) -> String {
      - Be concise and concrete.\n\
      - Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight \
      bullets or short `##` sections. A tasteful emoji in a section header is welcome (e.g. \
-     ## ✅ Decisions). Never output YAML or front-matter.{memory}",
+     ## ✅ Decisions). Never output YAML or front-matter.{org}{memory}",
+        org = org_fallback_suffix(org_available),
         memory = agentic_memory_suffix(memory_brief),
     )
+}
+
+/// The agentic persona's optional ORG FALLBACK sentence (A2). `false` ⇒ EMPTY string (byte-identical
+/// to the pre-org persona); `true` ⇒ one explicit steering sentence appended after the base rules.
+fn org_fallback_suffix(org_available: bool) -> String {
+    if !org_available {
+        return String::new();
+    }
+    "\n     - If the user's own vault doesn't answer this, ALSO try org_brain_search (the Shared \
+     Brain) before concluding you don't know."
+        .to_string()
 }
 
 /// Brain v2 L3 — the agentic persona WITH just-in-time retrieval seeding (behind the
@@ -103,8 +121,11 @@ pub fn agentic_system(memory_brief: &str) -> String {
 /// meetings it needs instead of a pre-stuffed corpus. EMPTY (the flag-off path and the
 /// nothing-visible vault) ⇒ BYTE-IDENTICAL to [`agentic_system`] — the flag-off legacy-prompt
 /// contract, pinned by `agentic_system_jit_empty_listing_is_byte_identical`.
-pub fn agentic_system_jit(memory_brief: &str, listing: &str) -> String {
-    let base = agentic_system(memory_brief);
+///
+/// `org_available` (A2) is threaded straight through to [`agentic_system`] — see its doc for the
+/// byte-identical-when-false contract.
+pub fn agentic_system_jit(memory_brief: &str, listing: &str, org_available: bool) -> String {
+    let base = agentic_system(memory_brief, org_available);
     let listing = listing.trim();
     if listing.is_empty() {
         return base;
@@ -179,11 +200,14 @@ mod tests {
     #[test]
     fn agentic_system_jit_empty_listing_is_byte_identical() {
         for brief in ["", "- You prefer: Polish replies"] {
-            assert_eq!(agentic_system_jit(brief, ""), agentic_system(brief));
-            assert_eq!(agentic_system_jit(brief, "   "), agentic_system(brief));
+            assert_eq!(agentic_system_jit(brief, "", false), agentic_system(brief, false));
+            assert_eq!(agentic_system_jit(brief, "   ", false), agentic_system(brief, false));
         }
-        let with = agentic_system_jit("", "- m1 | Standup | 2026-07-01");
-        assert!(with.starts_with(&agentic_system("")), "the base persona prefix is unchanged");
+        let with = agentic_system_jit("", "- m1 | Standup | 2026-07-01", false);
+        assert!(
+            with.starts_with(&agentic_system("", false)),
+            "the base persona prefix is unchanged"
+        );
         assert!(with.contains("MEETING LISTING"));
         assert!(with.contains("get_meeting"));
         assert!(with.contains("- m1 | Standup | 2026-07-01"));
@@ -193,12 +217,80 @@ mod tests {
     /// the labelled block appears.
     #[test]
     fn agentic_system_injects_memory_brief_and_empty_is_byte_identical() {
-        let base = agentic_system("");
-        assert_eq!(base, agentic_system("   "));
+        let base = agentic_system("", false);
+        assert_eq!(base, agentic_system("   ", false));
         assert!(!base.contains("WHAT YOU KNOW ABOUT THE USER"));
-        let with = agentic_system("- You prefer: Polish replies");
+        let with = agentic_system("- You prefer: Polish replies", false);
         assert!(with.contains("WHAT YOU KNOW ABOUT THE USER"));
         assert!(with.contains("Polish replies"));
         assert!(with.starts_with(&base), "the persona prefix is unchanged");
+    }
+
+    // ── A2 — org fallback steering ───────────────────────────────────────────────────────────────
+
+    /// RED-before-GREEN: `org_available=true` must append the explicit org_brain_search fallback
+    /// sentence to the agentic persona; `org_available=false` must produce a BYTE-IDENTICAL prompt to
+    /// today (no parameter at all, pre-fix). Mirrors the `agentic_system_jit_empty_listing_is_byte_
+    /// identical` pattern for this new parameter.
+    #[test]
+    fn agentic_system_org_hint_appears_only_when_available() {
+        for memory in ["", "- You prefer: Polish replies"] {
+            let off = agentic_system(memory, false);
+            assert!(
+                !off.contains("org_brain_search"),
+                "org_available=false must never mention org_brain_search: {off}"
+            );
+            let on = agentic_system(memory, true);
+            assert!(
+                on.contains("org_brain_search"),
+                "org_available=true must add the org fallback sentence: {on}"
+            );
+            // The base persona (everything before the memory suffix) must be UNCHANGED — the org
+            // sentence is inserted between the base rules and the memory block, never mutating
+            // either. Compare against the memory-off shape of each so insertion position doesn't
+            // trip up a direct substring/prefix check when a memory brief is also present.
+            let base = agentic_system("", false);
+            assert!(
+                on.starts_with(&base),
+                "the base persona prefix must be unchanged when org is available: {on}"
+            );
+            if !memory.trim().is_empty() {
+                assert!(
+                    on.contains("WHAT YOU KNOW ABOUT THE USER") && on.contains(memory),
+                    "the memory block must still be present when org is ALSO available: {on}"
+                );
+            }
+        }
+    }
+
+    /// `org_available=false` is BYTE-IDENTICAL to the pre-org-parameter persona (no `org` param at
+    /// all) — proven by pinning it against the exact historical rule text, so a future edit can't
+    /// silently start emitting the org sentence for `false`.
+    #[test]
+    fn agentic_system_org_unavailable_is_byte_identical_to_pre_org_persona() {
+        let historical = "You answer questions across a user's PAST MEETINGS, imported documents, and brain notes \
+     (their private, on-device vault).\n\
+     Rules:\n\
+     - Ground every claim in tool results — search before answering unless you already have \
+     enough grounding. If the answer isn't in the vault, say you don't know. Never invent \
+     facts, decisions, or attributions.\n\
+     - Cite the meetings you rely on inline using their [[Title]] exactly as the tools return \
+     it; attribute web facts as \"(via web)\".\n\
+     - When something evolved across meetings, trace it chronologically.\n\
+     - Be concise and concrete.\n\
+     - Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight \
+     bullets or short `##` sections. A tasteful emoji in a section header is welcome (e.g. \
+     ## ✅ Decisions). Never output YAML or front-matter.";
+        assert_eq!(agentic_system("", false), historical);
+    }
+
+    /// `agentic_system_jit` threads `org_available` through unchanged: false ⇒ no org sentence in
+    /// either the flag-off (empty listing) or flag-on (listing present) shapes.
+    #[test]
+    fn agentic_system_jit_org_hint_threads_through() {
+        let off = agentic_system_jit("", "- m1 | Standup | 2026-07-01", false);
+        assert!(!off.contains("org_brain_search"));
+        let on = agentic_system_jit("", "- m1 | Standup | 2026-07-01", true);
+        assert!(on.contains("org_brain_search"));
     }
 }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -856,8 +856,13 @@ fn format_web_hits_raw(hits: &[crate::connectors::ConnectorHit]) -> String {
 /// here. The egress/publish path keeps its own consent gate (`share_to_org_inner` step 2), unchanged.
 pub(crate) fn org_brain_available(db: &Db, config: &AppConfig) -> bool {
     let _ = config; // consent is a WRITE gate; reading the org brain needs only membership.
+    // PER-INSTANCE ORG TOGGLE: at least one JOINED org must also be ENABLED on this install — a
+    // member of orgs that are ALL disabled here must see the tool as unavailable, not attempt a
+    // search that the `context_enabled = 1` SQL filter would silently empty anyway. When SOME orgs
+    // are enabled and some disabled, this stays `true`; per-item filtering happens in
+    // `search_org_chunks_knn`/`_fts`.
     db.list_org_states()
-        .map(|orgs| !orgs.is_empty())
+        .map(|orgs| orgs.iter().any(|o| o.context_enabled))
         .unwrap_or(false)
 }
 
@@ -2494,6 +2499,7 @@ mod tests {
             consented: true,
             last_seq: 0,
             generation: 1,
+            context_enabled: true,
         })
         .unwrap();
     }
@@ -2671,6 +2677,113 @@ mod tests {
         assert!(org_brain_available(&db, &cfg), "joined member reads without publish consent");
         cfg.org_egress_consented = true;
         assert!(org_brain_available(&db, &cfg));
+    }
+
+    /// PER-INSTANCE ORG TOGGLE (RED-before-GREEN): a member of orgs that are ALL disabled on this
+    /// install must see the org brain as UNAVAILABLE — not just empty results, but the tool itself
+    /// stops being advertised/attempted. With a SECOND, still-enabled org, availability returns —
+    /// proves the check is "any enabled", not "any joined".
+    #[test]
+    fn org_brain_available_requires_at_least_one_enabled_org() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_org(&db); // org-1, enabled by default
+        assert!(org_brain_available(&db, &cfg));
+
+        db.set_org_context_enabled("org-1", false).unwrap();
+        assert!(
+            !org_brain_available(&db, &cfg),
+            "a member of only-disabled orgs must see the org brain as unavailable"
+        );
+
+        // A second, ENABLED org restores availability.
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: "org-2".to_string(),
+            name: "Beta".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-11T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled: true,
+        })
+        .unwrap();
+        assert!(
+            org_brain_available(&db, &cfg),
+            "a still-enabled second org keeps the brain available"
+        );
+    }
+
+    /// PER-INSTANCE ORG TOGGLE, end-to-end through the actual retrieval seam (RED-before-GREEN): with
+    /// TWO joined orgs, one disabled, `search_org_brain_hits`/`search_org_brain` must surface ONLY the
+    /// enabled org's content — the disabled org's item never reaches the rendered text or the
+    /// structured hits, even though it matches the query and would surface if both were enabled. This
+    /// is the user's hard mandate: a disabled org's context must NEVER leak through the brain seam.
+    #[test]
+    fn search_org_brain_excludes_a_disabled_org_while_surfacing_the_enabled_one() {
+        let db = tmp_db();
+        seed_org(&db); // org-1, enabled
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: "org-2".to_string(),
+            name: "Beta".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-11T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled: true,
+        })
+        .unwrap();
+        ingest_org(
+            &db,
+            "it-disabled",
+            "anna",
+            "Disabled org roadmap",
+            "the nebula pricing rollout plan",
+            &[21u8; 32],
+        );
+        db.upsert_org_item(
+            "it-enabled",
+            "org-2",
+            1,
+            "bob",
+            "Enabled org roadmap",
+            "the nebula pricing rollout timeline",
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &[22u8; 32],
+            None,
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+
+        db.set_org_context_enabled("org-1", false).unwrap();
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+
+        let hits = search_org_brain_hits(&db, &cfg, "nebula pricing rollout").unwrap();
+        assert!(
+            hits.iter().all(|h| h.item_id != "it-disabled"),
+            "the disabled org's item must never reach the structured hits: {:?}",
+            hits.iter().map(|h| &h.item_id).collect::<Vec<_>>()
+        );
+        assert!(
+            hits.iter().any(|h| h.item_id == "it-enabled"),
+            "the still-enabled org's item must keep surfacing"
+        );
+
+        let text = search_org_brain(&db, &cfg, "nebula pricing rollout").unwrap();
+        assert!(
+            !text.contains("Disabled org roadmap") && !text.contains("nebula pricing rollout plan"),
+            "the disabled org's content must never reach the rendered grounding text: {text}"
+        );
+        assert!(
+            text.contains("Enabled org roadmap"),
+            "the enabled org's content must still render: {text}"
+        );
     }
 
     /// A4 (RED-before-GREEN): the in-app agentic-loop catalog (`tool_specs`) must carry the SAME

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -204,7 +204,9 @@ pub fn tool_specs() -> Vec<ToolSpec> {
         ToolSpec {
             name: "search_meetings".into(),
             description: "Full-text search across the user's past meeting titles, notes, transcripts, \
-                          and imported documents/brain notes.".into(),
+                          and imported documents/brain notes. If nothing relevant turns up and the \
+                          user has joined an org, also try org_brain_search — a colleague may have \
+                          already shared the answer.".into(),
             parameters: str_arg("query", "Search terms, in the user's own language."),
             write: false,
         },
@@ -212,7 +214,9 @@ pub fn tool_specs() -> Vec<ToolSpec> {
             name: "search_semantic".into(),
             description: "Hybrid semantic + keyword search over meetings and imported documents/brain \
                           notes (finds related-by-meaning content). Falls back to keyword-only \
-                          matching when semantic search is disabled.".into(),
+                          matching when semantic search is disabled. If nothing relevant turns up and \
+                          the user has joined an org, also try org_brain_search — a colleague may have \
+                          already shared the answer.".into(),
             parameters: str_arg("query", "A natural-language description of what to find."),
             write: false,
         },
@@ -278,12 +282,14 @@ pub fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "org_brain_search".into(),
-            description: "Search the ORGANIZATION brain — notes your colleagues explicitly shared to \
-                          the shared org brain (synced + decrypted on this device, no data leaves). \
-                          Only available when you have joined an org and consented; results are \
-                          loud-attributed '[org · <author>]' and MUST be cited as coming from that \
-                          colleague. Use for 'what does the team / someone else know / decide about \
-                          X' questions that your own vault can't answer.".into(),
+            description: "Fallback for when search_meetings / search_semantic find nothing relevant in \
+                          the user's OWN vault and they have joined an org: search the ORGANIZATION \
+                          brain — notes your colleagues explicitly shared to the shared org brain \
+                          (synced + decrypted on this device, no data leaves). Only available when you \
+                          have joined an org and consented; results are loud-attributed \
+                          '[org · <author>]' and MUST be cited as coming from that colleague. Use for \
+                          'what does the team / someone else know / decide about X' questions that \
+                          your own vault can't answer.".into(),
             parameters: str_arg("query", "What to look for in the shared org brain, in the user's own language."),
             write: false,
         },
@@ -855,30 +861,35 @@ pub(crate) fn org_brain_available(db: &Db, config: &AppConfig) -> bool {
         .unwrap_or(false)
 }
 
-/// SHARED BRAIN — the single org retrieval + format seam used by BOTH `org_brain_search` (agent) and
-/// the MCP `org_search` tool. Runs the int8 vector KNN leg (with the member's OWN query embedding,
-/// skipped on the StubEmbedder / semantic-off path) + the keyword FTS leg (LIMIT-pushdown), RRF-fuses
-/// them, DROPS self-shared items (whose `content_sha256` matches a local `org_shares` row — a member
-/// never re-surfaces their own published note as an "org" result), formats each hit LOUDLY as
-/// `[org · <author>] <title> — <snippet>`, and FENCE-NEUTRALIZES the whole payload
-/// ([`neutralize_murmur_fences`]) so an UNTRUSTED org author cannot smuggle managed-block markers or
-/// a system-prompt override into the loop. The output is DATA for the loop — NEVER a system prompt.
-pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Result<String> {
-    // AVAILABILITY GATE (belt-and-braces, applied at the SEAM not just at advertisement): the org
-    // partition is searchable ONLY when the caller has JOINED an org. The AGENT tool gates this at
-    // `specs()` advertisement time, but the MCP `org_search` path reaches this seam DIRECTLY via
-    // `dispatch_tool` → `execute_tool` with NO advertisement filter — so without this in-seam check a
-    // departed member (whose replica hadn't yet been purged) could still search colleagues' content.
-    // FIX G: this is a READ gate = membership only; egress CONSENT gates PUBLISHING, not reading. Org
-    // items are disclosed content, so a joined-but-not-consented member reads legitimately; a departed
-    // member has no `org_state` (and a purged replica) so is excluded here. Fail-closed to an empty
-    // (never-a-leak) result.
+/// SHARED BRAIN — the single org retrieval seam used by BOTH `search_org_brain` (text-rendering, for
+/// `org_brain_search` (agent) and the MCP `org_search` tool) AND `gather_note_enhance_citations`
+/// (structured, for the Notes selection-assistant `find_related` action). Runs the int8 vector KNN
+/// leg (with the caller's OWN query embedding, skipped on the StubEmbedder / semantic-off path) + the
+/// keyword FTS leg (LIMIT-pushdown), RRF-fuses them, and DROPS self-shared items (whose
+/// `content_sha256` matches a local `org_shares` row — a member never re-surfaces their own published
+/// note as an "org" result). Returns the raw structured hits — callers decide how to render/gate them
+/// further; text-rendering + fence-neutralization lives in [`search_org_brain`], NOT here.
+///
+/// AVAILABILITY GATE (belt-and-braces, applied at the SEAM not just at advertisement): the org
+/// partition is searchable ONLY when the caller has JOINED an org. The AGENT tool gates this at
+/// `specs()` advertisement time, but the MCP `org_search` path reaches this seam DIRECTLY via
+/// `dispatch_tool` → `execute_tool` with NO advertisement filter — so without this in-seam check a
+/// departed member (whose replica hadn't yet been purged) could still search colleagues' content.
+/// FIX G: this is a READ gate = membership only; egress CONSENT gates PUBLISHING, not reading. Org
+/// items are disclosed content, so a joined-but-not-consented member reads legitimately; a departed
+/// member has no `org_state` (and a purged replica) so is excluded here. Fail-closed to an empty
+/// (never-a-leak) result.
+pub(crate) fn search_org_brain_hits(
+    db: &Db,
+    config: &AppConfig,
+    query: &str,
+) -> Result<Vec<crate::storage::models::OrgChunkHit>> {
     if !org_brain_available(db, config) {
-        return Ok("No org-brain results (not a member of an org).".to_string());
+        return Ok(Vec::new());
     }
     let q = query.trim();
     if q.is_empty() {
-        return Ok("No org-brain results for an empty query.".to_string());
+        return Ok(Vec::new());
     }
     // Vector leg: only with a real embedder + semantic on (mirrors the vault semantic gate). The
     // query is embedded with the e5 `query:` prefix, then int8-quantized inside the Db reader.
@@ -906,7 +917,23 @@ pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Resu
     if !mine.is_empty() {
         hits.retain(|h| h.content_sha256.is_empty() || !mine.contains(&h.content_sha256));
     }
+    Ok(hits)
+}
 
+/// SHARED BRAIN — thin text-rendering wrapper over [`search_org_brain_hits`], used by BOTH
+/// `org_brain_search` (agent) and the MCP `org_search` tool. Formats each hit LOUDLY as
+/// `[org · <author>] <title> — <snippet>`, and FENCE-NEUTRALIZES the whole payload
+/// ([`neutralize_murmur_fences`]) so an UNTRUSTED org author cannot smuggle managed-block markers or
+/// a system-prompt override into the loop. The output is DATA for the loop — NEVER a system prompt.
+pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Result<String> {
+    let q = query.trim();
+    if !org_brain_available(db, config) {
+        return Ok("No org-brain results (not a member of an org).".to_string());
+    }
+    if q.is_empty() {
+        return Ok("No org-brain results for an empty query.".to_string());
+    }
+    let hits = search_org_brain_hits(db, config, query)?;
     if hits.is_empty() {
         return Ok(format!("No org-brain results for \"{q}\"."));
     }
@@ -2644,6 +2671,37 @@ mod tests {
         assert!(org_brain_available(&db, &cfg), "joined member reads without publish consent");
         cfg.org_egress_consented = true;
         assert!(org_brain_available(&db, &cfg));
+    }
+
+    /// A4 (RED-before-GREEN): the in-app agentic-loop catalog (`tool_specs`) must carry the SAME
+    /// fallback-steering wording as the MCP catalog (`mcp.rs` `tools_spec`) — `search_meetings` /
+    /// `search_semantic` mention `org_brain_search` as a fallback, and `org_brain_search`'s own
+    /// description LEADS with that fallback framing rather than presenting an unrelated alternative.
+    #[test]
+    fn tool_specs_nudges_org_brain_search_as_a_fallback() {
+        let specs = tool_specs();
+        let desc = |name: &str| -> String {
+            specs
+                .iter()
+                .find(|s| s.name == name)
+                .map(|s| s.description.clone())
+                .unwrap_or_default()
+        };
+        let search_meetings = desc("search_meetings");
+        let search_semantic = desc("search_semantic");
+        let org_brain_search = desc("org_brain_search");
+        assert!(
+            search_meetings.contains("org_brain_search"),
+            "search_meetings must mention org_brain_search as a fallback: {search_meetings}"
+        );
+        assert!(
+            search_semantic.contains("org_brain_search"),
+            "search_semantic must mention org_brain_search as a fallback: {search_semantic}"
+        );
+        assert!(
+            org_brain_search.to_lowercase().starts_with("fallback"),
+            "org_brain_search's own description must LEAD with the fallback framing: {org_brain_search}"
+        );
     }
 
     /// The `org_brain_search` tool is CONNECTOR-CLASS: reachable ONLY at Tier 3 / Full, never at the

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -2975,6 +2975,7 @@ mod tests {
             consented: true,
             last_seq: 0,
             generation: 1,
+            context_enabled: true,
         })
         .unwrap();
     }
@@ -3131,6 +3132,92 @@ mod tests {
         assert!(
             res.citations.iter().all(|c| !c.contains("(org")),
             "a non-member must never surface an org citation: {:?}",
+            res.citations
+        );
+    }
+
+    /// PER-INSTANCE ORG TOGGLE, end-to-end through the deterministic floor (RED-before-GREEN, the
+    /// user's hard mandate — this is A1's original bug scenario, now with the toggle): a member of
+    /// TWO orgs who has disabled ONE of them on this install must NEVER see that org's content reach
+    /// the brain grounding — even though it matches the query and would surface if enabled. The
+    /// STILL-enabled org's content must keep working normally. Proves "disabled means truly gone",
+    /// not just deprioritized, at the actual consumer surface a real user hits.
+    #[test]
+    fn floor_never_folds_a_disabled_orgs_content_into_grounding_while_the_enabled_org_still_works() {
+        let db = tmp_db();
+        seed_org(&db); // org-1, enabled by default
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: "org-2".to_string(),
+            name: "Beta".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-11T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled: true,
+        })
+        .unwrap();
+        ingest_org(
+            &db,
+            "it-disabled",
+            "anna",
+            "Disabled org roadmap",
+            "the horizon launch plan for the beta release",
+            &[31u8; 32],
+        );
+        db.upsert_org_item(
+            "it-enabled",
+            "org-2",
+            1,
+            "carol",
+            "Enabled org roadmap",
+            "the horizon launch timeline for the beta release",
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &[32u8; 32],
+            None,
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        db.set_org_context_enabled("org-1", false).unwrap();
+
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "horizon launch".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig {
+                semantic_search_enabled: false,
+                ..AppConfig::default()
+            },
+            "live-mtg",
+            "",
+            "",
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        assert!(
+            !user.contains("Disabled org roadmap") && !user.contains("[org · anna]"),
+            "the disabled org's content must NEVER reach the brain input: {user}"
+        );
+        assert!(
+            user.contains("[org · carol]") && user.contains("Enabled org roadmap"),
+            "the still-enabled org's content must keep reaching the brain input: {user}"
+        );
+        assert!(
+            res.citations.iter().all(|c| !c.contains("anna")),
+            "the disabled org's author must never surface as a citation: {:?}",
+            res.citations
+        );
+        assert!(
+            res.citations.iter().any(|c| c.contains("(org · carol)")),
+            "the enabled org's citation must still surface: {:?}",
             res.citations
         );
     }

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -908,6 +908,50 @@ fn rag_answer(
             }
         }
     }
+    // ORG LEG (SHARED BRAIN): when the caller has JOINED an org, ALSO search the org partition and
+    // fold its LOUD, provenance-labelled hits into the grounding. Runs for BOTH `recall` and
+    // `research` (unlike the web leg, which is research-only) — a colleague's shared note is exactly
+    // the kind of fact "what do we know about X" (recall) should surface, not just open-ended
+    // research. ONE call (not looped per retrieval query) to avoid multiplying embedding calls, using
+    // the same `display_query` the other single-call legs (web/calendar) key off. The org text is
+    // UNTRUSTED multi-writer content but `search_org_brain` ALREADY fence-neutralizes it
+    // (`neutralize_murmur_fences`, tools.rs) before returning — treat the string as already-safe data,
+    // exactly like the web leg treats web results; do not re-neutralize or skip that step.
+    let mut org_lines: Vec<String> = Vec::new();
+    if crate::tools::org_brain_available(db, config) {
+        let org_query = if !display_query.is_empty() {
+            display_query.clone()
+        } else {
+            literal_command.trim().to_string()
+        };
+        if !org_query.is_empty() {
+            match crate::tools::search_org_brain(db, config, &org_query) {
+                Ok(text) => {
+                    let text = text.trim();
+                    if !text.is_empty() && !is_empty_tool_result(text) {
+                        // Capture the loud "[org · …]" lines for citations, and add to grounding.
+                        for line in text.lines() {
+                            if line.trim_start().starts_with("- [org") {
+                                org_lines.push(line.to_string());
+                            }
+                        }
+                        if !grounding.is_empty() {
+                            grounding.push_str("\n\n");
+                        }
+                        grounding.push_str(text);
+                        grounding.push_str("\n\n");
+                    }
+                }
+                // An org lookup failure is non-fatal — the vault (+ web/calendar) grounding still
+                // answers.
+                Err(e) => tracing::debug!(
+                    target: "voice",
+                    error = %e,
+                    "voice-action org-brain search failed; continuing with vault grounding"
+                ),
+            }
+        }
+    }
     let grounding = grounding.trim();
 
     // CURRENT-MEETING-FIRST (fixes the "describes other meetings" symptom on the local/reasoner-only
@@ -969,6 +1013,14 @@ fn rag_answer(
     // from the `[[Title]]` vault wikilinks and the "(web) …" web citations.
     for line in &calendar_lines {
         if let Some(c) = calendar_citation_from_line(line) {
+            push_cite(c);
+        }
+    }
+    // ORG citations: each loud "- [org · <author>] Title — snippet" line becomes a distinct
+    // "(org · <author>) Title" citation, so org-derived facts stay attributed to their untrusted
+    // colleague-provenance and are visibly distinguishable from the `[[Title]]` vault wikilinks.
+    for line in &org_lines {
+        if let Some(c) = org_citation_from_line(line) {
             push_cite(c);
         }
     }
@@ -1062,13 +1114,15 @@ fn rag_answer(
     };
     let system = format!(
         "You are an in-meeting assistant. Answer the user's request CONCISELY (2-4 sentences) using \
-         ONLY the provided context: the current meeting, the user's own meeting notes AND any WEB \
-         results (lines beginning \"[web\").{current_clause} Cite vault meetings by their [[Title]] \
-         wikilink and attribute web facts as \"(via web)\". If the context doesn't cover it, say so \
-         plainly. Do not invent facts. Write your final answer in the SAME language the USER actually \
-         wrote in — look at the user's OWN words in their request below, NOT at the language of these \
-         instructions or the surrounding context (which are in English). If the user wrote in Polish, \
-         answer in Polish; match the user's language exactly and NEVER default to English."
+         ONLY the provided context: the current meeting, the user's own meeting notes, any WEB results \
+         (lines beginning \"[web\") AND any org/Shared Brain results from colleagues (lines beginning \
+         \"- [org ·\").{current_clause} Cite vault meetings by their [[Title]] wikilink, attribute web \
+         facts as \"(via web)\", and attribute org facts by their \"[org · author]\" provenance so it's \
+         clear they came from a colleague, not the user's own notes. If the context doesn't cover it, \
+         say so plainly. Do not invent facts. Write your final answer in the SAME language the USER \
+         actually wrote in — look at the user's OWN words in their request below, NOT at the language \
+         of these instructions or the surrounding context (which are in English). If the user wrote in \
+         Polish, answer in Polish; match the user's language exactly and NEVER default to English."
     );
     // The user message leads with the user's ORIGINAL dictated words (so the model can match their
     // language even when `display_query` is a normalized/translated topic), then the CURRENT meeting's
@@ -1310,13 +1364,39 @@ fn web_citation_from_line(line: &str) -> Option<String> {
     })
 }
 
+/// Turn a loud org-brain grounding line `- [org · <author>] Title — snippet` into a compact citation
+/// `(org · <author>) Title`. Returns `None` for a non-org line. Deterministic, no regex. Kept distinct
+/// from [`web_citation_from_line`]/[`calendar_citation_from_line`] so org-derived facts stay
+/// attributed to their untrusted colleague-provenance, never blended with the user's own `[[Title]]`
+/// vault wikilinks.
+fn org_citation_from_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    let after_label = line.strip_prefix("- [org")?;
+    let close = after_label.find(']')?;
+    // `after_label` looks like " · <author>] Title — snippet" — the author sits between " · " and "]".
+    let author = after_label[..close]
+        .trim()
+        .trim_start_matches('·')
+        .trim();
+    let rest = after_label[close + 1..].trim();
+    let title = rest.split(" — ").next().unwrap_or(rest).trim();
+    if title.is_empty() {
+        return None;
+    }
+    if author.is_empty() {
+        Some(format!("(org) {title}"))
+    } else {
+        Some(format!("(org · {author}) {title}"))
+    }
+}
+
 /// Whether a tool result is a "nothing found" / "disabled" placeholder rather than real content,
 /// so it can be excluded from the brain grounding (an included placeholder would falsely count as
 /// grounding and trigger a brain call on an empty vault). Matches the deterministic prefixes
 /// `execute_tool` emits (`No meetings or documents match` — including `search_semantic`'s flag-off
 /// keyword-fallback variant — `No data`, `No open commitments`, `No visible entity`; the legacy
 /// `No meetings match` / `Semantic search is disabled` prefixes are kept so an old-shape sentinel
-/// can never miscount as grounding).
+/// can never miscount as grounding) plus `search_org_brain`'s own sentinels (`No org-brain results`).
 fn is_empty_tool_result(text: &str) -> bool {
     let t = text.trim_start();
     t.starts_with("No meetings match")
@@ -1330,6 +1410,7 @@ fn is_empty_tool_result(text: &str) -> bool {
         || t.starts_with("No Slack results")
         || t.starts_with("Slack search is not available")
         || t.starts_with("No calendar events")
+        || t.starts_with("No org-brain results")
 }
 
 /// Pull distinct `[[Title]]` wikilinks out of the gated tool grounding text, in first-seen order.
@@ -2880,5 +2961,177 @@ mod tests {
         assert_eq!(res.summary, NO_MODEL_ANSWER_NOTICE);
         assert_eq!(res.citations, vec!["[[Budget Review]]".to_string()]);
         assert_eq!(res.answered_from, Some(AnsweredFrom::CurrentMeeting));
+    }
+
+    // ── A1 — deterministic floor ORG LEG (Shared Brain) ─────────────────────────────────────────
+
+    /// Join org-1 for this session (mirrors `tools::tests::seed_org`).
+    fn seed_org(db: &Db) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: "org-1".to_string(),
+            name: "Acme".to_string(),
+            role: "member".to_string(),
+            joined_at: "2026-07-10T00:00:00Z".to_string(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+        })
+        .unwrap();
+    }
+
+    /// Ingest one org-brain item into the local replica (mirrors `tools::tests::ingest_org`).
+    fn ingest_org(db: &Db, item_id: &str, author: &str, title: &str, body: &str, sha: &[u8]) {
+        db.upsert_org_item(
+            item_id,
+            "org-1",
+            1,
+            author,
+            title,
+            body,
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            sha,
+            None,
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+    }
+
+    /// RED-before-GREEN (A1, the reported bug): the deterministic floor must fold ORG BRAIN results
+    /// into its grounding — an org item with NO vault match must still reach the brain input,
+    /// attributed with the `[org · author]` provenance line, and surface as a citation. Pre-fix,
+    /// `rag_answer` had no org leg at all, so a colleague's shared note (org-only, nothing in the
+    /// user's own vault) was silently omitted.
+    #[test]
+    fn floor_folds_org_brain_results_into_grounding_with_provenance() {
+        let db = tmp_db();
+        seed_org(&db);
+        // Semantic off so the test is embedder-independent (FTS leg only, mirrors tools.rs org tests).
+        ingest_org(
+            &db,
+            "it-1",
+            "anna",
+            "Anna's roadmap",
+            "the apollo migration ships friday",
+            &[3u8; 32],
+        );
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "apollo migration".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig {
+                semantic_search_enabled: false,
+                ..AppConfig::default()
+            },
+            "live-mtg",
+            "",
+            "",
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner
+            .last_user
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the brain MUST be called with org grounding present");
+        assert!(
+            user.contains("[org · anna]") && user.contains("Anna's roadmap"),
+            "org-only content (no vault match) must reach the brain input, attributed: {user}"
+        );
+        assert!(
+            res.citations.iter().any(|c| c.contains("(org · anna)")),
+            "the org hit must surface as a distinct '(org · author)' citation: {:?}",
+            res.citations
+        );
+        // The system prompt must also name org notes as a third context class.
+        let system = reasoner.last_system.lock().unwrap().clone().unwrap();
+        assert!(
+            system.contains("[org ·") || system.contains("org"),
+            "the system prompt must mention org-sourced context: {system}"
+        );
+    }
+
+    /// RED companion — recall must ALSO get the org leg (not just research, unlike the web leg).
+    #[test]
+    fn floor_folds_org_brain_results_for_recall_intent_too() {
+        let db = tmp_db();
+        seed_org(&db);
+        ingest_org(
+            &db,
+            "it-2",
+            "bob",
+            "Bob's plan",
+            "the siema onboarding checklist",
+            &[7u8; 32],
+        );
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Recall {
+                entity: "siema onboarding".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig {
+                semantic_search_enabled: false,
+                ..AppConfig::default()
+            },
+            "live-mtg",
+            "",
+            "",
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        assert!(
+            user.contains("[org · bob]") && user.contains("Bob's plan"),
+            "recall must ALSO fold in org grounding: {user}"
+        );
+    }
+
+    /// Fail-closed companion (mirrors `tools::tests::search_org_brain_seam_fails_closed_for_a_non_member`):
+    /// a caller who has NOT joined any org (`org_brain_available` false) never gets an org leg
+    /// attempted — the deterministic floor stays vault/web/calendar-only, byte-shape unchanged.
+    #[test]
+    fn floor_never_attempts_org_leg_for_a_non_member() {
+        let db = tmp_db();
+        seed_visible_and_sealed(&db); // vault grounding present, but NO org_state joined.
+        let reasoner = CaptureReasoner::new();
+        let res = handle_voice_action(
+            &VoiceIntent::Research {
+                topic: "Atlas".into(),
+            },
+            &reasoner,
+            &db,
+            &empty_unlocked(),
+            &AppConfig {
+                semantic_search_enabled: false,
+                ..AppConfig::default()
+            },
+            "live-mtg",
+            "",
+            "",
+            false,
+            None,
+        );
+        assert_eq!(res.status, "ok");
+        let user = reasoner.last_user.lock().unwrap().clone().unwrap();
+        assert!(
+            !user.contains("[org ·") && !user.contains("org-brain"),
+            "a non-member must NEVER get an org leg, even attempted: {user}"
+        );
+        assert!(
+            res.citations.iter().all(|c| !c.contains("(org")),
+            "a non-member must never surface an org citation: {:?}",
+            res.citations
+        );
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -553,6 +553,16 @@ export class IpcService {
   }
 
   /**
+   * PER-INSTANCE org toggle (Settings → Organization): flip whether a JOINED org
+   * contributes content — browsing + brain/assistant context — on THIS Murmur
+   * install. Membership-checked server-side; purely local, no egress. Disabling
+   * never deletes the local replica, so re-enabling is instant.
+   */
+  orgSetContextEnabled(orgId: string, enabled: boolean): Promise<void> {
+    return invoke<void>("org_set_context_enabled", { orgId, enabled });
+  }
+
+  /**
    * Pull the user's org MEMBERSHIP list from the server (`GET /v1/orgs`) and
    * reconcile the local `org_state` — this is what makes an org you were INVITED
    * to (and never created locally) appear. Best-effort: resolves even if the

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1755,7 +1755,8 @@ export interface NoteAssistRequest {
  * note/meeting.
  */
 export interface NoteCitation {
-  kind: "meeting" | "note" | "person" | "entity";
+  kind: "meeting" | "note" | "person" | "entity" | "org";
+  /** For `kind === "org"` this is the org item id, routed to `/org-item/:id` — never a local id. */
   id: string;
   title: string;
   snippet: string;

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1877,6 +1877,13 @@ export interface OrgStatus {
   receivedCount: number;
   /** Local outbound org shares still queued/failed (awaiting the launch sweep). */
   pendingShares: number;
+  /**
+   * PER-INSTANCE org toggle: whether this org contributes content (browsing +
+   * brain/assistant context) on THIS Murmur install. `true` by default; flip via
+   * {@link IpcService.orgSetContextEnabled}. Disabling never deletes the local
+   * replica — it is purely a local, reversible read gate.
+   */
+  contextEnabled: boolean;
 }
 
 /**

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -87,9 +87,28 @@
     @if (orgs().length > 0 || orgsLoading()) {
       <div class="folders-head org-head">
         <h3 class="folders-title">Shared brains</h3>
-        @if (orgsLoading()) {
-          <mur-spinner [size]="12" class="org-head-spinner" />
-        }
+        <span class="org-head-trailing">
+          @if (orgsLoading()) {
+            <mur-spinner [size]="12" class="org-head-spinner" />
+          }
+          <a
+            class="org-head-settings-link"
+            routerLink="/settings"
+            [queryParams]="{ section: 'organization' }"
+            title="Choose which organizations are active on this device"
+            aria-label="Manage organizations in Settings"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
+              <circle cx="8" cy="8" r="2.1" stroke="currentColor" stroke-width="1.3" />
+              <path
+                d="M8 2.2v1.4M8 12.4v1.4M13.8 8h-1.4M3.6 8H2.2M12.1 3.9l-1 1M4.9 11.1l-1 1M12.1 12.1l-1-1M4.9 4.9l-1-1"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-linecap="round"
+              />
+            </svg>
+          </a>
+        </span>
       </div>
       <nav class="folders-body org-body" aria-label="Shared brains">
         @for (org of orgs(); track org.orgId) {

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -163,10 +163,34 @@
   flex-direction: column;
   gap: 1px;
 }
-/* Trails the "Shared brains" heading while the org list/items are (re)loading. */
+/* Trailing group on the "Shared brains" heading: the loading spinner + the settings shortcut. */
+.org-head-trailing {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
 .org-head-spinner {
-  margin-left: auto;
   color: var(--text-muted);
+}
+/* Shortcut to Settings → Organization (which orgs are active on this device). */
+.org-head-settings-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+.org-head-settings-link:hover {
+  color: var(--text-secondary);
+  background: var(--surface-hover);
+}
+.org-head-settings-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
 }
 .folder-row {
   display: flex;

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -305,7 +305,14 @@ export class LibraryComponent implements OnInit {
       }
       let orgs: OrgStatus[];
       try {
-        orgs = await this.ipc.orgListStatuses();
+        // PER-INSTANCE ORG TOGGLE: the rail is a content BROWSER, not the management
+        // surface (that's Settings → Organization, which fetches its own UNFILTERED
+        // list so every joined org's toggle is reachable) — a disabled org must not
+        // appear as a pickable "Shared brains" entry here at all, matching the user's
+        // mental model ("F disabled ⇒ not used on this instance"). The actual content
+        // gate is already backend-enforced (list_org_items_inner returns empty for a
+        // disabled org); this filter just keeps the rail honest about what's usable.
+        orgs = (await this.ipc.orgListStatuses()).filter((o) => o.contextEnabled);
       } catch {
         return; // keep the last-known orgs on a transient failure
       }

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -486,9 +486,15 @@ export class NoteBrainPopoverComponent {
     }
   }
 
-  /** Open a citation's source note/meeting; dismiss the popover first. */
+  /** Open a citation's source note/meeting/org-item; dismiss the popover first. */
   openCitation(cite: NoteCitation): void {
     this.dismiss.emit();
+    // "org" routes to the read-only org-item viewer (mirrors library.component.ts orgItemLink) —
+    // it is NOT a local note/meeting id, so it must never fall into the "/notes" default below.
+    if (cite.kind === "org") {
+      void this.router.navigate(["/org-item", cite.id]);
+      return;
+    }
     const path =
       cite.kind === "meeting"
         ? "/meeting"

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -363,7 +363,11 @@ export class NotesHomeComponent implements OnInit {
       }
       let orgs: OrgStatus[];
       try {
-        orgs = await this.ipc.orgListStatuses();
+        // PER-INSTANCE ORG TOGGLE: this rail is a content BROWSER (mirrors
+        // library.component.ts) — a disabled org must not appear as a pickable
+        // "Shared brains" entry; the toggle itself lives only in Settings, which
+        // fetches its own unfiltered list.
+        orgs = (await this.ipc.orgListStatuses()).filter((o) => o.contextEnabled);
       } catch {
         return; // keep the last-known orgs on a transient failure
       }

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
@@ -62,6 +62,43 @@
                   }
                 </p>
 
+                <!-- Per-instance org toggle: which orgs contribute content (browsing + brain
+                     context) on THIS Murmur install. Purely local — never touches the synced
+                     replica, so re-enabling is instant. -->
+                <div class="context-toggle-row">
+                  @if (o.contextEnabled) {
+                    <span class="pill is-success signed-pill">
+                      <span class="pill-dot"></span>
+                      Active on this device
+                    </span>
+                  } @else {
+                    <span class="pill signed-pill context-disabled-pill">
+                      Disabled on this device
+                    </span>
+                  }
+                  <button
+                    type="button"
+                    class="btn btn-ghost mini-btn"
+                    (click)="toggleContextEnabled(o)"
+                    [disabled]="contextTogglingOrgId() !== null"
+                  >
+                    {{
+                      contextTogglingOrgId() === o.orgId
+                        ? "…"
+                        : o.contextEnabled
+                          ? "Disable here"
+                          : "Enable here"
+                    }}
+                  </button>
+                </div>
+                @if (!o.contextEnabled) {
+                  <p class="text-muted account-note context-disabled-note">
+                    Notes and recordings won't use this org's shared brain for
+                    context on this device — its content stays synced, just
+                    inactive here.
+                  </p>
+                }
+
                 <div class="org-actions">
                   <button
                     type="button"

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.scss
@@ -233,6 +233,22 @@
   align-self: flex-start;
 }
 
+/* ── Per-instance org toggle ── */
+.context-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.context-disabled-pill {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+}
+.context-disabled-note {
+  font-size: 0.8125rem;
+}
+
 /* Shared text input — mirrors the account section's input treatment via tokens. */
 .text-input {
   height: 38px;

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -69,6 +69,10 @@ export class SettingsOrganizationSectionComponent {
   private readonly _busyOrgId = signal<string | null>(null);
   readonly busyOrgId = this._busyOrgId.asReadonly();
 
+  /** The org id currently flipping its per-instance context toggle — locks that row's control. */
+  private readonly _contextTogglingOrgId = signal<string | null>(null);
+  readonly contextTogglingOrgId = this._contextTogglingOrgId.asReadonly();
+
   /** The signed-in account email (header context); `null` until loaded / logged out. */
   private readonly _email = signal<string | null>(null);
   readonly email = this._email.asReadonly();
@@ -390,6 +394,37 @@ export class SettingsOrganizationSectionComponent {
       this._error.set(String(e));
     } finally {
       this._busyOrgId.set(null);
+    }
+  }
+
+  // ── Per-org: active on this device (per-instance context toggle) ───────────────
+
+  /**
+   * Flip whether this org contributes content — browsing + brain/assistant
+   * context — on THIS Murmur install. Optimistic local flip (mirrors {@link
+   * toggleConsent}) with rollback on failure; purely local, no egress. Disabling
+   * never deletes the synced replica, so re-enabling is instant.
+   */
+  async toggleContextEnabled(org: OrgStatus): Promise<void> {
+    if (this._contextTogglingOrgId() !== null) {
+      return;
+    }
+    const next = !org.contextEnabled;
+    this._contextTogglingOrgId.set(org.orgId);
+    this._error.set(null);
+    this._orgs.update((list) =>
+      list.map((o) => (o.orgId === org.orgId ? { ...o, contextEnabled: next } : o)),
+    );
+    try {
+      await this.ipc.orgSetContextEnabled(org.orgId, next);
+    } catch (e) {
+      // Roll back the optimistic flip on failure.
+      this._orgs.update((list) =>
+        list.map((o) => (o.orgId === org.orgId ? { ...o, contextEnabled: !next } : o)),
+      );
+      this._error.set(String(e));
+    } finally {
+      this._contextTogglingOrgId.set(null);
     }
   }
 

--- a/src/app/features/settings/settings/settings.component.ts
+++ b/src/app/features/settings/settings/settings.component.ts
@@ -8,6 +8,7 @@ import {
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { ActivatedRoute } from "@angular/router";
 import { startWith } from "rxjs";
 import { NavHistoryService } from "../../../core/nav-history.service";
 import { MurSidebarComponent } from "../../../design-system/sidebar/sidebar.component";
@@ -115,6 +116,10 @@ export class SettingsComponent implements OnInit {
   /** Drill-down back navigation ("← Murmur" + Esc) — no settings state coupling. */
   readonly nav = inject(NavHistoryService);
 
+  /** Deep-link support: `?section=<id>` (e.g. from the Library "Shared brains" rail's
+   * settings shortcut) opens directly on that section instead of the Appearance default. */
+  private readonly route = inject(ActivatedRoute);
+
   /**
    * Esc while in settings. Backs out to where you came from — EXCEPT while you're
    * typing: in the search box the first Esc clears it (or blurs when empty), and
@@ -206,5 +211,11 @@ export class SettingsComponent implements OnInit {
     // Pre-split this was an async ngOnInit whose promise Angular ignored;
     // `void` keeps identical fire-and-forget semantics.
     void this.store.load();
+    // `?section=<id>` deep-link — only honored when it names a REAL section, so a stale/typo'd
+    // link falls back to the default (Appearance) instead of a blank right pane.
+    const requested = this.route.snapshot.queryParamMap.get("section");
+    if (requested && this.sections.some((s) => s.id === requested)) {
+      this.activeSection.set(requested);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Org-shared content ("Shared Brain") was previously invisible from several assistant surfaces even when visible in Notes — the deterministic voice-action floor, the Ask agentic persona, Notes "Find related", the MCP catalog, and the cloud-cascade terminal tier never searched/nudged toward the org partition. This PR treats shared org content as one unified knowledge base across every surface:

- **A1** (`voice_action.rs`) — the deterministic floor now folds org-brain results into grounding for both `recall` and `research`, fail-closed for non-members. This was the originally reported bug.
- **A2** (`vault_chat.rs`) — the Ask agentic persona gets an explicit fallback sentence nudging the model toward `org_brain_search`.
- **A3** (backend + FE) — Notes "Find related" gains an org leg; org citations route to the read-only `/org-item/:id` viewer.
- **A4** (`mcp.rs`) — the MCP tool catalog explicitly frames `org_search` as a fallback for `search_meetings`/`search_semantic`.
- **B1** (`prompts.rs`) — the cloud-cascade terminal tier (Tier 3) also tries org content before giving up.
- **B2** (entity dossier) — the dossier prompt reads org context too, read-only, no writes to local entity/fact tables.

**Also adds a per-instance org toggle**: a user can now choose, independently per Murmur install, which joined orgs actually contribute content (Settings → Organization). This is a **hard data-level gate**, not a UI hide:

- `search_org_chunks_knn`/`_fts` and `get_org_item` INNER JOIN `org_state` and filter on `context_enabled = 1` in SQL, so a disabled org's content is excluded before it ever reaches Rust — including a direct read via a stale citation/bookmark to `/org-item/:id`.
- `org_brain_available` requires at least one *enabled* org; `list_org_items_inner` returns empty (not an error) for a disabled org.
- The Library and Notes "Shared brains" rails filter disabled orgs out of the picker client-side (Settings keeps its own unfiltered fetch so every joined org's toggle stays reachable there — caught live in the running app: disabling an org left it still listed as pickable, fixed in the second commit).
- Toggling is local-only, membership-checked, and never touches the synced replica — re-enabling is instant.
- The Library "Shared brains" rail links straight to the per-org toggle via a new `Settings ?section=` deep link.

Also fixes a pre-existing, unrelated test-harness landmine surfaced while verifying this change: `cargo test --lib` could reach a real Metal forward pass (via the `embed_model_present().then(active_embedder)` idiom used at 9+ write-time indexing call sites) whenever the e5 model happens to be downloaded on the dev machine, aborting the process on a Metal-compiler-service XPC failure. `active_embedder()` now forces the stub under `cfg(test)` unless a caller opts in via `MURMUR_TEST_REAL_EMBED=1` (only the manual `#[ignore]`'d bake-off tests do). Confirmed via an old, unrelated test that crashed identically pre-fix and passed clean post-fix.

## Test plan

- [x] `cargo test --lib` — 1568 passed, 0 failed
- [x] `npx ng lint` — clean
- [x] `npx ng build` — clean
- [x] 8 new RED-before-GREEN tests for the per-instance org toggle (SQL retrieval legs, `org_brain_available`, `list_org_items_inner`, `get_org_item`, the toggle command itself, and an end-to-end proof through the deterministic voice-action floor) — one manually confirmed to fail without the SQL filter and pass with it restored
- [x] Live-verified in the running dev app (screenshots): the Settings toggle flips and persists correctly; caught the rail-still-listing-disabled-orgs gap live and fixed it
- [x] `npx playwright test e2e/notes/brain-popover.spec.ts` — both tests pass (the Notes citation-routing e2e for the A3 FE change)