### PR TITLE
fix(ci): always refresh cargo-audit/cargo-deny instead of trusting a cached binary

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -41,10 +41,15 @@ echo "── cargo test ──"
 
 # ── Supply-chain gates (D11/F5): advisories + license/ban/source policy, BEFORE the build. ──
 echo "── cargo audit (RUSTSEC advisories) ──"
-if ! command -v cargo-audit >/dev/null 2>&1; then
-  echo "  cargo-audit not found — installing…"
-  cargo install --locked cargo-audit
-fi
+# ALWAYS (re)install, never "if missing" — CI caches ~/.cargo/bin (Swatinem/rust-cache), so a
+# presence check reuses whatever cargo-audit binary was built months ago indefinitely. That
+# defeats the entire point of the tool: a stale binary can't parse newer advisory-db entries
+# (hit 2026-07-12 — RUSTSEC-2026-0073 uses `cvss = "CVSS:4.0/…"`, which an old cargo-audit's
+# RUSTSEC-parser rejects as "unsupported CVSS version: 4.0", failing CI on an unrelated PR).
+# `cargo install --locked` is a no-op fetch-and-skip when already current, so this costs
+# nothing when the cache is fresh and self-heals when it isn't.
+echo "  installing/updating cargo-audit…"
+cargo install --locked cargo-audit
 # Gate on actual VULNERABILITIES (default behavior: non-zero exit on any RUSTSEC vulnerability).
 # We deliberately do NOT pass `--deny warnings`: the Tauri framework pulls in transitive crates
 # with unmaintained/unsound *warnings* (unic-ucd-*, glib) that we cannot fix here and that are not
@@ -56,10 +61,11 @@ fi
 cargo audit --file Cargo.lock
 
 echo "── cargo deny check (advisories, licenses, bans, sources) ──"
-if ! command -v cargo-deny >/dev/null 2>&1; then
-  echo "  cargo-deny not found — installing…"
-  cargo install --locked cargo-deny
-fi
+# Same always-(re)install rationale as cargo-audit above — same cached-~/.cargo/bin staleness
+# risk, same category of supply-chain tool where "quietly stopped updating" is the failure mode
+# to avoid, not a build-time optimization to chase.
+echo "  installing/updating cargo-deny…"
+cargo install --locked cargo-deny
 cargo deny --manifest-path src-tauri/Cargo.toml check
 
 echo "── cargo build ──"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -46,10 +46,14 @@ echo "── cargo audit (RUSTSEC advisories) ──"
 # defeats the entire point of the tool: a stale binary can't parse newer advisory-db entries
 # (hit 2026-07-12 — RUSTSEC-2026-0073 uses `cvss = "CVSS:4.0/…"`, which an old cargo-audit's
 # RUSTSEC-parser rejects as "unsupported CVSS version: 4.0", failing CI on an unrelated PR).
-# `cargo install --locked` is a no-op fetch-and-skip when already current, so this costs
-# nothing when the cache is fresh and self-heals when it isn't.
+# `--force` is required, not optional: without it, `cargo install` errors "binary already
+# exists in destination" the instant a rust-cache restore leaves a binary on disk whose
+# install-tracking metadata (~/.cargo/.crates2.json) doesn't fully agree with it (observed on
+# CI: it re-downloaded the crate, then refused to place the binary over the existing file) —
+# so a bare `cargo install --locked` is NOT reliably a no-op across a restored cache; `--force`
+# makes the outcome deterministic (always freshly placed) regardless of that metadata's state.
 echo "  installing/updating cargo-audit…"
-cargo install --locked cargo-audit
+cargo install --locked --force cargo-audit
 # Gate on actual VULNERABILITIES (default behavior: non-zero exit on any RUSTSEC vulnerability).
 # We deliberately do NOT pass `--deny warnings`: the Tauri framework pulls in transitive crates
 # with unmaintained/unsound *warnings* (unic-ucd-*, glib) that we cannot fix here and that are not
@@ -63,9 +67,9 @@ cargo audit --file Cargo.lock
 echo "── cargo deny check (advisories, licenses, bans, sources) ──"
 # Same always-(re)install rationale as cargo-audit above — same cached-~/.cargo/bin staleness
 # risk, same category of supply-chain tool where "quietly stopped updating" is the failure mode
-# to avoid, not a build-time optimization to chase.
+# to avoid, not a build-time optimization to chase. Same `--force` reasoning too.
 echo "  installing/updating cargo-deny…"
-cargo install --locked cargo-deny
+cargo install --locked --force cargo-deny
 cargo deny --manifest-path src-tauri/Cargo.toml check
 
 echo "── cargo build ──"


### PR DESCRIPTION
## Summary
- `scripts/ci.sh`'s cargo-audit/cargo-deny install steps only ran `cargo install` when the binary was **missing**. Since CI caches `~/.cargo/bin` (`Swatinem/rust-cache`), that binary is reused indefinitely once installed — it never picks up newer releases.
- This silently broke CI on `murmur` itself (confirmed on a trunk run predating this PR, unrelated to any feature diff): the advisory-db shipped `RUSTSEC-2026-0073` with `cvss = "CVSS:4.0/…"`, which the stale cached `cargo-audit` can't parse (`unsupported CVSS version: 4.0`) — it fails to even *load* the database, so the whole gate goes red regardless of what's in the PR.
- Fix: always run `cargo install --locked` for both tools. It's a fast no-op (~0.3s locally) when the cached binary is already current, and self-heals the moment it isn't — no more silently-frozen supply-chain tooling.

## Test plan
- [x] Reproduced locally: `cargo audit --file Cargo.lock` failed identically until reinstalling cargo-audit to a current version, then passed (only pre-existing allowed warnings, exit 0).
- [x] `cargo install --locked cargo-audit` confirmed as a ~0.3s no-op when already current (won't slow down CI when the cache is fresh).
- [x] `cargo deny --manifest-path src-tauri/Cargo.toml check` — clean (advisories/bans/licenses/sources ok).