### PR TITLE
fix(brain): specific error when a model download reports success but the file isn't found

### DIFF
--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
@@ -143,11 +143,17 @@ export class BrainEnableCardComponent {
         this.enabled.emit();
       } else {
         // The store swallows download failures into its own signals — surface
-        // them so a failed download never looks like a silent no-op.
+        // them so a failed download never looks like a silent no-op. If NEITHER
+        // signal is set, the download command itself reported success but the
+        // presence probe still says missing — name which model and point at the
+        // likely cause (this is a resolve/disk-state mismatch, not a network
+        // failure, so "try again" alone is misleading).
+        const specific = this.store.brainError() ?? this.store.embedDownloadError();
         this.error.set(
-          this.store.brainError() ??
-            this.store.embedDownloadError() ??
-            "The download didn't finish. Please try again.",
+          specific ??
+            (!this.brainPresent()
+              ? "The brain model downloaded, but Murmur can't find it afterward. Check available disk space, then try again."
+              : "The embedding model downloaded, but Murmur can't find it afterward. Check available disk space, then try again."),
         );
         this.stage.set("idle");
       }


### PR DESCRIPTION
Live-found while testing v0.9.8: the generic "The download didn't finish. Please try again." fires only when BOTH download commands resolve WITHOUT throwing but the presence probe still says missing afterward — a disk-state mismatch, not a network failure, so the retry nudge was misleading. Now names which model (brain/embed) is missing and points at disk space.

## Test plan
- [x] `ng lint` clean
- [x] `ng build` clean
- [x] `cargo test --lib` — 1568 passed, 0 failed (untouched by this FE-only change, ran for completeness)