### PR TITLE
fix(perf): bound + RAM-gate the startup topic-chunk backfill

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -478,10 +478,24 @@ pub fn run() {
                     if !semantic_enabled || !crate::embed::embed_model_present() {
                         return;
                     }
+                    // 2026-07-13 launch-freeze incident: on a RAM-starved machine, defer the whole
+                    // backfill (incl. the lazy Candle/Metal embedder load) rather than starting it
+                    // at launch — it is content-hash idempotent, so a later, healthier launch just
+                    // picks up where this one left off.
+                    if !crate::transcribe::model::topic_backfill_ram_permits_now() {
+                        tracing::info!(target: "rag", "topic-chunk backfill skipped: low system RAM");
+                        return;
+                    }
+                    let started = std::time::Instant::now();
                     let embedder = crate::embed::active_embedder();
                     match db.backfill_topic_chunks_idempotent(embedder.as_ref()) {
                         Ok(indexed) if indexed > 0 => {
-                            tracing::info!(target: "rag", indexed, "topic-chunk backfill complete");
+                            tracing::info!(
+                                target: "rag",
+                                indexed,
+                                elapsed_ms = started.elapsed().as_millis() as u64,
+                                "topic-chunk backfill complete"
+                            );
                         }
                         Ok(_) => {}
                         Err(e) => {

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -555,16 +555,13 @@ async fn run_inner(
                 }
             }
         });
-        // Diarizer (best-effort): created once when models resolved — used on the system stream only.
-        let diarizer = diarize_models.and_then(|(seg, emb)| {
-            match crate::transcribe::diarize::Diarizer::load(&seg, &emb) {
-                Ok(d) => Some(d),
-                Err(e) => {
-                    tracing::warn!(target: "transcribe", error = %e, "diarizer load failed; single 'others' label");
-                    None
-                }
-            }
-        });
+        // NOTE: the diarizer is loaded further below, lazily, right before `d.diarize(&sys)` — NOT
+        // here. Loading it this early meant it sat resident through BOTH stream transcriptions, and
+        // (before the drop() below existed) Whisper stayed resident through diarization too — two
+        // heavy ML runtimes (whisper.cpp + sherpa-onnx/Pyannote) peaking RAM/CPU simultaneously
+        // (2026-07-13 RCA: matched a reported system freeze + macOS cpu_resource.diag hotspots
+        // through Diarizer::diarize). Their ASR/diarize work is inherently sequential — deferring
+        // the diarizer's load until Whisper is actually dropped costs nothing.
 
         // BATCH path → Accurate profile for BOTH streams, VAD-segmented so each speech region is a
         // FRESH decode (context reset across long gaps; never decode through silence). Live captions
@@ -585,6 +582,24 @@ async fn run_inner(
         if let (Some(sys), Some(sys_started)) = (sys_16k, system_started_at) {
             let mut sys_segments =
                 transcribe_stream(&transcriber, vad.as_mut(), &sys, lang_owned.as_deref())?;
+
+            // ASR is done for both streams — free Whisper (+ VAD, also unused from here on) BEFORE
+            // loading the diarizer, so the two heavy ML runtimes are never resident together.
+            drop(transcriber);
+            drop(vad);
+
+            // Diarizer (best-effort): loaded HERE, only once Whisper has been released, and only
+            // when there's actually a system stream to diarize.
+            let diarizer = diarize_models.and_then(|(seg, emb)| {
+                match crate::transcribe::diarize::Diarizer::load(&seg, &emb) {
+                    Ok(d) => Some(d),
+                    Err(e) => {
+                        tracing::warn!(target: "transcribe", error = %e, "diarizer load failed; single 'others' label");
+                        None
+                    }
+                }
+            });
+
             // N-way diarization on the "others" stream ONLY — relabel segments to others-0/1/2.
             if let Some(d) = &diarizer {
                 match d.diarize(&sys) {

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -3463,11 +3463,26 @@ impl Db {
         embedder: &dyn Embedder,
         unlocked: &HashSet<String>,
     ) -> Result<()> {
+        self.index_meeting_topic_chunks_reporting(meeting_id, segments, embedder, unlocked)
+            .map(|_wrote| ())
+    }
+
+    /// Same as [`Self::index_meeting_topic_chunks`] but reports whether it actually (re)wrote
+    /// chunks (`true`) vs. was a no-op — sealed/missing meeting, or the idempotency probe found
+    /// nothing changed (`false`). [`Self::backfill_topic_chunks_idempotent`] uses this to cap
+    /// how much REAL embedding work (not idempotent skips) one run performs.
+    fn index_meeting_topic_chunks_reporting(
+        &self,
+        meeting_id: &str,
+        segments: &[Segment],
+        embedder: &dyn Embedder,
+        unlocked: &HashSet<String>,
+    ) -> Result<bool> {
         if !self.meeting_is_visible(meeting_id, unlocked)? {
-            return Ok(()); // sealed-not-unlocked: never index its plaintext.
+            return Ok(false); // sealed-not-unlocked: never index its plaintext.
         }
         let Some(meeting) = self.get_meeting(meeting_id)? else {
-            return Ok(());
+            return Ok(false);
         };
         let title = meeting
             .title
@@ -3509,7 +3524,7 @@ impl Db {
                 existing.push(r.map_err(map_err)?.unwrap_or_default());
             }
             if existing == hashes {
-                return Ok(());
+                return Ok(false);
             }
         }
 
@@ -3542,7 +3557,7 @@ impl Db {
             )
             .map_err(map_err)?;
         if sealed_at_rest {
-            return Ok(());
+            return Ok(false);
         }
         tx.execute(
             "DELETE FROM topic_vec_chunks WHERE chunk_id IN
@@ -3597,7 +3612,7 @@ impl Db {
             topics = topics.len(),
             "topic chunks indexed"
         );
-        Ok(())
+        Ok(true)
     }
 
     /// Brain v2 L1.1 — STARTUP BACKFILL: index topic chunks for every VISIBLE meeting that has
@@ -3607,12 +3622,21 @@ impl Db {
     /// set (nothing is session-unlocked at startup; sealed meetings are skipped by the gate and
     /// their topic rows are re-derived on unlock via `reindex_meetings_after_unseal`). Returns how
     /// many meetings were (re)indexed. Per-meeting failures WARN (ids only, no PII) and continue.
+    ///
+    /// CAPPED at [`TOPIC_BACKFILL_MAX_REEMBED_PER_RUN`] REAL (re)embeds per call — a vault-wide
+    /// hash change (Brain freshly enabled, or a segmentation/augmentation version bump) would
+    /// otherwise re-embed the ENTIRE vault in one unthrottled pass on a single app launch, pegging
+    /// CPU/Metal for however long that takes before the user can do anything (the 2026-07-13
+    /// launch-freeze incident). The idempotency probe means the cap just defers the remainder to
+    /// the NEXT launch — no cursor needed, each run picks up wherever the hash still differs.
     pub fn backfill_topic_chunks_idempotent(&self, embedder: &dyn Embedder) -> Result<usize> {
         const TOPIC_BACKFILL_BATCH: usize = 20;
+        const TOPIC_BACKFILL_MAX_REEMBED_PER_RUN: usize = 50;
         let unlocked: HashSet<String> = HashSet::new();
         let meetings = self.list_meetings_visible(100_000, &unlocked)?;
         let mut indexed = 0usize;
-        for batch in meetings.chunks(TOPIC_BACKFILL_BATCH) {
+        let mut reembedded = 0usize;
+        'outer: for batch in meetings.chunks(TOPIC_BACKFILL_BATCH) {
             for m in batch {
                 let segments = match self.get_segments(&m.id) {
                     Ok(s) => s,
@@ -3624,11 +3648,30 @@ impl Db {
                 if segments.is_empty() {
                     continue;
                 }
-                match self.index_meeting_topic_chunks(&m.id, &segments, embedder, &unlocked) {
-                    Ok(()) => indexed += 1,
+                match self.index_meeting_topic_chunks_reporting(&m.id, &segments, embedder, &unlocked) {
+                    Ok(wrote) => {
+                        indexed += 1;
+                        if wrote {
+                            reembedded += 1;
+                            // Breathing room between REAL embeds specifically (idempotent no-ops
+                            // are free and stay unpaced) — a batch that's entirely fresh work
+                            // (e.g. Brain just enabled) would otherwise fire up to
+                            // TOPIC_BACKFILL_BATCH Candle/Metal calls back-to-back with zero
+                            // scheduler gap before the batch-level sleep below ever runs.
+                            std::thread::sleep(std::time::Duration::from_millis(50));
+                        }
+                    }
                     Err(e) => {
                         tracing::warn!(target: "rag", error = %e, "topic backfill: indexing one meeting failed (skipped)");
                     }
+                }
+                if reembedded >= TOPIC_BACKFILL_MAX_REEMBED_PER_RUN {
+                    tracing::info!(
+                        target: "rag",
+                        reembedded,
+                        "topic backfill: per-run cap reached, deferring remainder to next launch"
+                    );
+                    break 'outer;
                 }
             }
             std::thread::sleep(std::time::Duration::from_millis(25));
@@ -14943,6 +14986,57 @@ mod tests {
             "old topic text must be gone after the clean replace"
         );
         assert_eq!(topic_chunk_count(&db, "m1"), topic_vec_count(&db, "m1"));
+    }
+
+    /// 2026-07-13 launch-freeze fix: `backfill_topic_chunks_idempotent` bounds REAL (re)embeds to
+    /// a per-run cap — a vault where EVERY meeting genuinely needs (re)embedding (e.g. Brain
+    /// freshly enabled on this device) must not try to embed the whole vault in one unthrottled
+    /// pass on a single app launch. The cap is a no-op cost-wise: the idempotency probe means the
+    /// NEXT call just resumes past the meetings already done.
+    #[test]
+    fn topic_backfill_caps_real_reembeds_per_run_and_resumes_next_call() {
+        let db = mem_db();
+        const TOTAL: usize = 55;
+        const CAP: usize = 50; // mirrors TOPIC_BACKFILL_MAX_REEMBED_PER_RUN
+        for i in 0..TOTAL {
+            let id = format!("m{i}");
+            db.insert_meeting(&sample_meeting(&id, "2026-06-24T10:00:00Z"))
+                .unwrap();
+            db.insert_segments(&id, &[long_seg(0, 0.0, 60.0, "quarterly planning topic")])
+                .unwrap();
+        }
+
+        let first_pass = db
+            .backfill_topic_chunks_idempotent(&crate::embed::StubEmbedder)
+            .unwrap();
+        assert_eq!(
+            first_pass, CAP,
+            "the first run must stop at the per-run cap, not index the whole vault in one pass"
+        );
+        let indexed_after_first = (0..TOTAL)
+            .filter(|i| topic_chunk_count(&db, &format!("m{i}")) > 0)
+            .count();
+        assert_eq!(
+            indexed_after_first, CAP,
+            "exactly the capped count of meetings should have topic rows after the first run"
+        );
+
+        // Idempotent resume: the SECOND run skips the already-indexed meetings for free (their
+        // hash matches — no cursor needed, the hash probe IS the cursor) and reaches the rest.
+        let second_pass = db
+            .backfill_topic_chunks_idempotent(&crate::embed::StubEmbedder)
+            .unwrap();
+        assert_eq!(
+            second_pass, TOTAL,
+            "the second run must finish touching every remaining meeting"
+        );
+        let indexed_after_second = (0..TOTAL)
+            .filter(|i| topic_chunk_count(&db, &format!("m{i}")) > 0)
+            .count();
+        assert_eq!(
+            indexed_after_second, TOTAL,
+            "every meeting must be indexed after the second run"
+        );
     }
 
     /// L1.5 RED-contrast: WITHOUT a date filter an out-of-window meeting that matches lexically IS

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -48,6 +48,9 @@ const PARAKEET_FILES: &[&str] = &[
 /// the reasoner's whisper-large refuse). A BROKEN RAM probe (`None`) fails OPEN — never refuse
 /// captions on a measurement we couldn't take.
 const PARAKEET_MIN_RAM_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+/// Floor for the startup topic-chunk backfill — much lighter than parakeet (a small e5 embed
+/// pass, not real-time streaming ASR), so the floor is lower too.
+const TOPIC_BACKFILL_MIN_RAM_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
 /// QUANT-SUFFIXED model sizes accepted by [`model_filename`] (T2 quant plumbing; the CONDITIONAL
 /// default flip lives in [`default_model_size`]). Each maps `"<size>-<quant>"` →
@@ -367,6 +370,19 @@ pub fn parakeet_model_url(filename: &str) -> String {
 pub fn parakeet_ram_permits_now() -> bool {
     match total_ram_bytes() {
         Some(b) => b >= PARAKEET_MIN_RAM_BYTES,
+        None => true,
+    }
+}
+
+/// RAM guard for the startup topic-chunk backfill (`Db::backfill_topic_chunks_idempotent`) —
+/// `false` ONLY when total RAM is affirmatively below [`TOPIC_BACKFILL_MIN_RAM_BYTES`]. Fails
+/// OPEN when the probe can't read RAM (a broken measurement never silently disables catch-up
+/// indexing). A genuinely RAM-starved machine defers the whole backfill rather than starting a
+/// Metal/Candle embed pass on launch — it catches up on a later, healthier launch since the
+/// backfill is content-hash idempotent. Mirrors [`parakeet_ram_permits_now`].
+pub fn topic_backfill_ram_permits_now() -> bool {
+    match total_ram_bytes() {
+        Some(b) => b >= TOPIC_BACKFILL_MIN_RAM_BYTES,
         None => true,
     }
 }


### PR DESCRIPTION
## Summary
Two independent RAM/CPU-peak fixes from the same RCA (user-reported: launching Murmur on a lower-spec Mac freezes the whole system):

**1. Startup topic-chunk backfill (the confirmed root cause of the launch-freeze report)**
`lib.rs`'s startup hook unconditionally spawns `Db::backfill_topic_chunks_idempotent` on every launch once semantic search + the e5 model are present. It iterates every visible meeting and, if the content hash differs (e.g. Brain freshly enabled → the whole vault's history has never been embedded), does a real Candle/Metal embed pass — with no cap on total work and no RAM floor. Fixed: cap real re-embeds to 50/run (content-hash idempotency is the resume cursor), pause after each real embed, skip the whole backfill below 4GB total RAM.

**2. Whisper + Diarizer simultaneous residency (a separate, post-recording freeze mechanism)**
`pipeline.rs`'s offline transcribe+diarize closure held Whisper (up to ~3GB for large-v3) and the diarizer (sherpa-onnx/Pyannote) resident at the same time for the whole closure — the diarizer was even loaded before mic transcription started. Matches the RCA's macOS `cpu_resource.diag` hot stack through `Diarizer::diarize`. Fixed: `Diarizer::load` now happens only after both stream transcriptions finish and Whisper+VAD are explicitly dropped — pure reordering, zero behavior change (every downstream value built from identical inputs).

## Test plan
- [x] `cargo test --lib` — 1569 passed, 0 failed, 10 ignored (both fixes, run independently against this branch's clean trunk base)
- [x] Fix 1: new test `topic_backfill_caps_real_reembeds_per_run_and_resumes_next_call` — RED-before-GREEN confirmed
- [x] Fix 2: no dedicated unit test possible (`run_inner` needs real whisper.cpp/sherpa-onnx models CI doesn't have) — verified via the borrow checker enforcing the drop-before-load ordering (compiles clean) + full existing suite staying green
- [x] Independent adversarial-verifier pass on BOTH fixes: PASS
- [ ] Live reproduction on the actual reporting user's low-RAM Mac — pending; this PR ships both fixes + startup telemetry (`elapsed_ms`/`indexed`) so the next real launch tells us if fix 1 was enough

Honest caveat on fix 1 (carried from adversarial review): the cap+RAM-floor substantially reduces exposure but there's no thread-QoS throttling on this path, so a machine just above the 4GB floor could still see a shorter stall during the capped 50-embed catch-up.