### PR TITLE
fix(ui+brain): batch of live-tested fixes + brain model selection

### DIFF
--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -195,6 +195,50 @@ prototype is the reference implementation). The concrete contract:
   event/interval streams into signals as in `recorder.store.ts`). Adding a UI
   kit, icon library, state library, charting lib, etc. is forbidden.
 
+## 8. List views — stale-while-revalidate (HARD)
+
+A **list route** (`/notes`, `/library`, any future "browse everything" view)
+is destroyed and recreated on every navigate-away-and-back (list routes are
+deliberately NOT in `TabRouteReuseStrategy`'s scope — see its doc — because a
+component that's kept alive can't be trusted to refetch on return; see the
+2026-07-12 incident below). Two rules make that reload invisible instead of a
+"reload flash":
+
+- **List-backing state lives in a `providedIn: 'root'` service, never a
+  component-local `signal()`.** A component-local signal is wiped to its
+  initial (usually empty) value on every destroy+recreate — the list has
+  nothing to show until the refetch resolves. A root service instance
+  outlives the component, so the SAME signal (and its last-known rows)
+  survives the remount; the component just re-injects it. Reference
+  implementations: `NotesService` (notes), `MeetingsListStore` (meetings),
+  `OrgBrainService` (the shared "Shared Brains" roster/items BOTH Notes and
+  Library merge in — was duplicated as two component-local copies before the
+  2026-07-12 fix, now the ONE source). A tiny signal-holder service (no
+  load()/CRUD methods of its own — the component keeps owning orchestration,
+  it just reads/writes the service's signals instead of local ones) is a
+  legitimate, minimal shape when the surrounding logic is non-trivial and
+  moving it wholesale would be riskier than worth it — see `MeetingsListStore`.
+- **A template's loading state must NEVER hide already-cached rows.** Gate the
+  "Loading…" branch on `listEmpty() && loading()`, not `loading()` alone —
+  `@if (listEmpty() && loading()) { <spinner> } @else if (listEmpty()) { <empty-state> } @else { <the list> }`.
+  The FIRST-ever visit still shows a spinner (nothing cached yet); every
+  RETURN visit shows the cached rows instantly while the (still real, still
+  unconditional) reload replaces them underneath — the reload itself is
+  UNCHANGED, only what the template does with `loading()` changes.
+
+**2026-07-12 incident:** `NotesHomeComponent`'s notes already persisted
+correctly (root `NotesService`), but its org-derived rows and
+`LibraryComponent`'s ENTIRE meetings list did not (component-local signals),
+and BOTH templates gated their whole list behind `loading()` regardless — so
+returning to either list always flashed empty/spinner even when data was one
+signal-read away. An earlier attempt to fix this by extending
+`TabRouteReuseStrategy` to also cover the list routes was reverted: keeping
+the component instance alive means `ngOnInit` never re-fires on return, so a
+genuinely NEW row (e.g. a meeting recorded while away) would need a bespoke
+"detect reactivation" hook to ever appear — the root-service approach needs
+no such hook, since the normal destroy+recreate cycle still reliably
+refetches every time.
+
 ## Banned → replacement
 
 | Banned | Use instead |

--- a/e2e/brain/brain-enable-card.spec.ts
+++ b/e2e/brain/brain-enable-card.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * RED-before-GREEN (live-found bug, v0.9.9): "Enable the brain" downloaded the heavy
+ * GGUF successfully but never SELECTED it — `brain_model_present` resolves via the
+ * persisted `brain_model_id`, which `download_brain_model` alone never writes. A fresh
+ * install (no prior selection) would download the file, then still report it "missing"
+ * forever, showing a misleading "download failed" banner — until something UNRELATED
+ * (e.g. a brain-posture preset) happened to persist `brain_model_id` as a side effect.
+ *
+ * This mock proves the fix: `brain_model_present` here is backed by whether
+ * `select_brain_model` was ever called (mirrors the real backend's `brain_model_id`
+ * read) — `download_brain_model` alone does NOT flip it. Pre-fix, `enable()` never
+ * calls `select_brain_model`, so this test fails (banner stays up forever). Post-fix,
+ * `enable()` explicitly selects the model it just downloaded.
+ */
+test("Enable the brain: a successful download is also SELECTED, not just fetched", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    list_brain_models: () => [
+      {
+        id: "qwen3-4b-instruct-2507",
+        name: "Qwen3 4B Instruct 2507 (heavy · multilingual)",
+        filename: "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+        url: "https://huggingface.co/example/model.gguf",
+        approxSizeBytes: 2_500_000_000,
+        minRamGb: 6,
+        languages: ["en", "multi", "pl"],
+        arch: "qwen3",
+        class: "heavy",
+        downloaded: false,
+        fitsRam: true,
+        selected: false,
+        selectedLight: false,
+        selectedHeavy: true,
+      },
+    ],
+    // The download command "succeeds" (mirrors the file already existing / a clean
+    // fetch) but — exactly like the real backend — does NOT itself persist a selection.
+    download_brain_model: () => null,
+    // Presence is gated on selection having happened, mirroring `brain_model_present`
+    // reading the persisted `brain_model_id` that ONLY `select_brain_model` writes.
+    brain_model_present: () => !!(window as unknown as { __brainSelected?: boolean }).__brainSelected,
+    select_brain_model: () => {
+      (window as unknown as { __brainSelected?: boolean }).__brainSelected = true;
+      return null;
+    },
+    embed_model_present: () => true, // isolate the test to the brain leg only
+  });
+
+  await page.goto("/brain");
+  const card = page.locator("app-brain-enable-card");
+  await expect(card).toBeVisible();
+
+  await card.getByRole("button", { name: "Enable the brain" }).click();
+
+  // The success path: no "download failed" banner, the card disappears (brainReady()).
+  await expect(page.getByText(/download|can't find/i)).toHaveCount(0, { timeout: 5000 });
+  await expect(card).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/notes/notes-org.spec.ts
+++ b/e2e/notes/notes-org.spec.ts
@@ -160,15 +160,24 @@ test("clicking an org shared item routes to the read-only /org-item viewer", asy
   await page.goto("/notes");
   await expect(page.locator(".notes-content")).toBeVisible();
 
-  // Click the org row's title link → the read-only org-item viewer route.
+  // Click the org row's title button → the read-only org-item viewer route
+  // (2026-07-12: now a <button> routed through TabsService, not a plain
+  // [routerLink] <a> — org items open as a tracked tab like a note/meeting).
   await page
     .locator(".mur-table tbody tr", { hasText: "Team Roadmap Q3" })
-    .locator(".title-link")
+    .locator(".title-btn")
     .click();
   await expect(page).toHaveURL(/\/org-item\/oi1$/);
   // The viewer rendered the decrypted org item body (read-only, no editor).
   await expect(page.locator("app-org-item-viewer")).toBeVisible();
   await expect(page.getByText("Ship the org brain.")).toBeVisible();
+
+  // RED-before-GREEN (live-found bug, 2026-07-12): an org item used to open
+  // as a full-page navigation with NO tab-strip entry, unlike an owned note —
+  // it must now register as a tracked, switchable tab exactly like one.
+  await expect(
+    page.locator(".tab-strip .tab-label", { hasText: "Team Roadmap Q3" }),
+  ).toBeVisible();
 
   expect(consoleErrors).toEqual([]);
 });

--- a/e2e/org/org-editable-and-library.spec.ts
+++ b/e2e/org/org-editable-and-library.spec.ts
@@ -94,18 +94,19 @@ test.describe("org-editable + library unification (mocked IPC)", () => {
     const orgChip = page.locator(".org-chip", { hasText: "Acme Inc." });
     await expect(orgChip).toHaveCount(1);
     // NO org rows/cards merged into the default "All meetings" list up front.
-    await expect(page.locator("a[href^='/org-item/']")).toHaveCount(0);
     await expect(page.getByText("Acme onboarding brief")).toHaveCount(0);
     await expect(page.getByText("Pricing rework notes")).toHaveCount(0);
 
-    // Selecting the org chip shows ITS scoped list — but both mocked items are
-    // unclassified (no `kind`), so NEITHER renders; the "couldn't be
-    // classified" note explains the two hidden items instead.
+    // Selecting the org chip shows ITS scoped list. Both mocked items are
+    // unclassified (no `kind` — the pre-v2 wire format) — live-found bug fix,
+    // 2026-07-12: these used to be silently EXCLUDED (a passive "couldn't be
+    // classified" note was the only hint they existed). Shared content must
+    // never just vanish, so they now render, each badged "unclassified"
+    // rather than shown as a confirmed meeting.
     await orgChip.click();
-    await expect(page.getByText(/couldn.t be classified/i)).toBeVisible();
-    await expect(page.getByText("Acme onboarding brief")).toHaveCount(0);
-    await expect(page.getByText("Pricing rework notes")).toHaveCount(0);
-    await expect(page.locator("a[href^='/org-item/']")).toHaveCount(0);
+    await expect(page.getByText("Acme onboarding brief")).toBeVisible();
+    await expect(page.getByText("Pricing rework notes")).toBeVisible();
+    await expect(page.locator(".unclassified-hint")).toHaveCount(2);
   });
 
   test("B1+F3 — read-only viewer (null resolve) renders + Back goes to /notes", async ({

--- a/src/app/core/tab-keys.ts
+++ b/src/app/core/tab-keys.ts
@@ -7,14 +7,24 @@
  * (`TabRouteReuseStrategy.evict`) with no translation step.
  */
 
-/** The two "document" tab kinds Murmur supports (browser-tab scope: meetings + notes). */
-export type TabKind = "meeting" | "note";
+/** The "document" tab kinds Murmur supports (browser-tab scope: meetings,
+ * notes, and read-only org (Shared Brain) items — added 2026-07-12: an
+ * org-shared note/meeting used to open in a full-page navigation instead of
+ * a tab, unlike its owned counterparts). */
+export type TabKind = "meeting" | "note" | "org-item";
 
 /**
- * The stable identity key for a meeting or note tab. Note the route-segment
- * asymmetry is intentional: meetings live at `/meeting/:id` (singular) and
- * notes at `/notes/:id` (plural) — the key mirrors each route's own path.
+ * The stable identity key for a meeting, note, or org-item tab. Note the
+ * route-segment asymmetry is intentional: meetings live at `/meeting/:id`
+ * (singular) and notes at `/notes/:id` (plural) — the key mirrors each
+ * route's own path. Org items live at `/org-item/:id`.
  */
 export function tabKeyFor(kind: TabKind, entityId: string): string {
-  return kind === "meeting" ? `meeting:${entityId}` : `notes:${entityId}`;
+  if (kind === "meeting") {
+    return `meeting:${entityId}`;
+  }
+  if (kind === "org-item") {
+    return `org-item:${entityId}`;
+  }
+  return `notes:${entityId}`;
 }

--- a/src/app/core/tab-route-reuse.strategy.ts
+++ b/src/app/core/tab-route-reuse.strategy.ts
@@ -9,18 +9,18 @@ import { tabKeyFor } from "./tab-keys";
 
 /**
  * The router-native tab cache for Murmur's "document" routes (`/meeting/:id`,
- * `/notes/:id`) — browser-style tabs (see `tabs.service.ts`) need each open
- * meeting/note to keep its own live component instance (scroll position,
- * in-progress edits, audio playback) while backgrounded, and to switch back to
- * it instantly. Angular's DEFAULT `RouteReuseStrategy` only compares
- * `routeConfig` (not params), so `/meeting/A` → `/meeting/B` already silently
- * REUSES the same component instance — which is also what forced
- * `DetailComponent` to carry a manual "reload in place" workaround before this
- * strategy existed.
+ * `/notes/:id`, `/org-item/:id`) — browser-style tabs (see `tabs.service.ts`)
+ * need each open meeting/note/org-item to keep its own live component
+ * instance (scroll position, in-progress edits, audio playback) while
+ * backgrounded, and to switch back to it instantly. Angular's DEFAULT
+ * `RouteReuseStrategy` only compares `routeConfig` (not params), so
+ * `/meeting/A` → `/meeting/B` already silently REUSES the same component
+ * instance — which is also what forced `DetailComponent` to carry a manual
+ * "reload in place" workaround before this strategy existed.
  *
- * Only `meeting/:id` and `notes/:id` are in scope — every other route falls
- * through to Angular's default `routeConfig`-only comparison, so unrelated
- * routes behave exactly as before.
+ * Only `meeting/:id`, `notes/:id`, and `org-item/:id` are in scope — every
+ * other route falls through to Angular's default `routeConfig`-only
+ * comparison, so unrelated routes behave exactly as before.
  *
  * DELIBERATELY OUT OF SCOPE: `notes/new`. It always transitions onward to a
  * real `/notes/:id` (via `NoteEditorComponent.createAndOpen`'s `replaceUrl`
@@ -43,6 +43,10 @@ function tabKey(route: ActivatedRouteSnapshot): string | null {
   if (path === "notes/:id") {
     const id = route.paramMap.get("id");
     return id ? tabKeyFor("note", id) : null;
+  }
+  if (path === "org-item/:id") {
+    const id = route.paramMap.get("id");
+    return id ? tabKeyFor("org-item", id) : null;
   }
   return null;
 }

--- a/src/app/core/tabs.service.ts
+++ b/src/app/core/tabs.service.ts
@@ -4,7 +4,7 @@ import { NavHistoryService } from "./nav-history.service";
 import { TabRouteReuseStrategy } from "./tab-route-reuse.strategy";
 import { type TabKind, tabKeyFor } from "./tab-keys";
 
-/** One open browser-style "document" tab (a meeting or a note). */
+/** One open browser-style "document" tab (a meeting, a note, or an org-shared item). */
 export interface Tab {
   /** Stable identity — SAME string as the `TabRouteReuseStrategy` cache key. */
   readonly id: string;
@@ -29,7 +29,7 @@ function isValidTab(v: unknown): v is Tab {
   const t = v as Record<string, unknown>;
   return (
     typeof t["id"] === "string" &&
-    (t["kind"] === "meeting" || t["kind"] === "note") &&
+    (t["kind"] === "meeting" || t["kind"] === "note" || t["kind"] === "org-item") &&
     typeof t["entityId"] === "string" &&
     typeof t["title"] === "string" &&
     Array.isArray(t["route"]) &&
@@ -95,6 +95,15 @@ export class TabsService {
     extra?: NavigationExtras,
   ): Promise<void> {
     await this.openTab("note", id, title, ["/notes", id], extra);
+  }
+
+  /**
+   * Open (or activate) a read-only org (Shared Brain) item's tab — added
+   * 2026-07-12: previously an org item had no tab at all and opened as a
+   * full-page navigation, unlike its owned meeting/note counterparts.
+   */
+  async openOrgItem(id: string, title = "Shared note"): Promise<void> {
+    await this.openTab("org-item", id, title, ["/org-item", id]);
   }
 
   private async openTab(

--- a/src/app/design-system/row-menu/row-menu.component.scss
+++ b/src/app/design-system/row-menu/row-menu.component.scss
@@ -48,10 +48,20 @@
 
 /* The panel floats OVER the tree — anchored to the trigger's bottom-right so
    it never runs off the sidebar's right edge. `.menu` (primitives.css)
-   supplies the opaque surface/border/shadow; this file only positions it. */
+   supplies the opaque surface/border/shadow; this file only positions it.
+   OVERRIDES `.menu`'s 240px min-width (live-found bug, 2026-07-12): that
+   width is sized for the note editor's multi-item "⋯" menu, but a nested
+   tree row can have very little room to the panel's LEFT (it's right-
+   anchored, so it grows leftward) before hitting the sidebar's own
+   `overflow: hidden` glass panel (`.drill-rail`, styles.css) — which clips
+   silently, no scrollbar, no visual cue (the "ename"/"elete" bug: the panel
+   was wide enough to lose "R"/"D" off its clipped left edge). This menu only
+   ever holds 2-3 short items (Rename/Lock/Delete), so a much narrower panel
+   comfortably fits even at deep indentation. */
 .row-menu-panel {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
   z-index: 30;
+  min-width: 140px;
 }

--- a/src/app/design-system/table/table.component.scss
+++ b/src/app/design-system/table/table.component.scss
@@ -57,10 +57,21 @@
   color: var(--text-muted);
 }
 /* Raise the row whose own overflow menu is open ABOVE a page-level click-away
-   scrim, so the (page-level, opaque T3) menu receives clicks instead of it. */
+   scrim, so the (page-level, opaque T3) menu receives clicks instead of it.
+   ALSO relax the cell's `overflow: hidden` (live-found bug, 2026-07-12): that
+   clipping enforces the fixed 44px row height for every OTHER row, but it
+   also clips a menu/popover projected into THIS row's action cell — the
+   dropdown opened fine, it was just invisible, clipped to the 44px box (the
+   "clicking … does nothing" bug). `overflow: visible` here does NOT break
+   the height constant: `height`/`max-height` on the cell still caps its
+   LAYOUT box; only whether overflowing content is clipped or allowed to
+   render past that box changes, and only for the one row with its menu open. */
 .mur-table tbody tr.is-menu-open {
   position: relative;
   z-index: 50;
+}
+.mur-table tbody tr.is-menu-open td {
+  overflow: visible;
 }
 
 /* Screen-reader-only header label (e.g. an icon-only actions column). */

--- a/src/app/design-system/tree-row/tree-row.component.html
+++ b/src/app/design-system/tree-row/tree-row.component.html
@@ -50,7 +50,7 @@
       }
     }
   </span>
-  <span class="row-label">{{ label() }}</span>
+  <span class="row-label" [title]="label()">{{ label() }}</span>
   @if (count() !== null && count()! > 0) {
     <span class="count row-count">{{ count() }}</span>
   }

--- a/src/app/features/ask/ask/ask.component.html
+++ b/src/app/features/ask/ask/ask.component.html
@@ -24,13 +24,13 @@
       <p class="empty">Loading…</p>
     </div>
   } @else if (isEmpty()) {
-    <!-- No meetings in the vault: nothing to ask about yet. -->
+    <!-- Nothing in the vault yet — neither a meeting nor a note. -->
     <div class="card empty-state">
       <span class="empty-mark" aria-hidden="true"></span>
-      <p class="empty-title">No meetings to ask about yet</p>
+      <p class="empty-title">Nothing to ask about yet</p>
       <p class="empty">
-        Record your first meeting and you can chat across your whole vault
-        here.
+        Record your first meeting or write a note, and you can chat across
+        your whole vault here.
       </p>
     </div>
   } @else {

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -116,15 +116,23 @@ export class AskComponent implements OnInit {
   );
 
   /**
-   * Probe whether there are any meetings to ask about. A failure here is not
-   * fatal — we still let the user try (the ask itself surfaces its own error),
-   * so we only flip to the empty state on a confirmed empty list.
+   * Probe whether there is ANYTHING to ask about — meetings OR notes (Ask
+   * chats across the whole vault, not just recordings; a vault with only
+   * standalone notes and zero meetings is very much askable — live-found bug,
+   * 2026-07-12: this used to check `listMeetings()` alone, so a notes-only
+   * vault wrongly showed "No meetings to ask about yet" and blocked the
+   * feature). A failure here is not fatal — we still let the user try (the
+   * ask itself surfaces its own error), so we only flip to the empty state
+   * when BOTH come back confirmed-empty.
    */
   async ngOnInit(): Promise<void> {
     void this.listenAskTool();
     try {
-      const meetings = await this.ipc.listMeetings();
-      this.isEmpty.set(meetings.length === 0);
+      const [meetings, notes] = await Promise.all([
+        this.ipc.listMeetings(),
+        this.ipc.listNotes(null),
+      ]);
+      this.isEmpty.set(meetings.length === 0 && notes.length === 0);
     } catch {
       this.isEmpty.set(false);
     } finally {

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
@@ -132,6 +132,15 @@ export class BrainEnableCardComponent {
         const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
         if (!heavy) throw new Error("no on-device model available");
         await this.store.downloadBrainModel(heavy.id);
+        // Downloading the GGUF is not the same as SELECTING it: `brain_model_present`
+        // resolves via the persisted `brain_model_id`, which download alone never
+        // writes — a fresh install with no prior selection would download the file
+        // successfully and then still report it "missing" forever (until something
+        // else, e.g. a posture preset, happened to set the id). "Enable the brain"
+        // means both fetch AND activate, so select explicitly here.
+        if (this.store.brainError() === null) {
+          await this.ipc.selectBrainModel(heavy.id);
+        }
       }
       if (this.embedPresent() !== true) {
         this.stage.set("embed");

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -243,16 +243,9 @@
         }
       </header>
 
-      @if (orgUnclassifiedCount() > 0) {
-        <p class="org-unclassified-note text-muted">
-          {{ orgUnclassifiedCount() }}
-          {{ orgUnclassifiedCount() === 1 ? "item" : "items" }} from this
-          shared brain couldn’t be classified as a meeting or a note (shared
-          before that distinction existed) — not shown here.
-        </p>
-      }
-
-      @if (orgsLoading()) {
+      @if (orgListEmpty() && orgsLoading()) {
+        <!-- Stale-while-revalidate: gate on loading ONLY when there's nothing
+             cached yet — see the pattern note in angular-zoneless.md §8. -->
         <div class="card state-card">
           <p class="empty">Loading…</p>
         </div>
@@ -271,7 +264,9 @@
             <li>
               <a
                 class="row"
-                [routerLink]="orgItemLink(it.item)"
+                tabindex="0"
+                (click)="openOrgCard($event, it.item)"
+                (keydown.enter)="openOrgCard($event, it.item)"
                 [style.animation-delay.ms]="i * 35"
               >
                 <span class="row-main">
@@ -282,6 +277,13 @@
                       <span class="dot" aria-hidden="true">·</span>
                     }
                     <span class="date">{{ formatDate(it.item.createdAt) }}</span>
+                    @if (it.unclassified) {
+                      <span class="dot" aria-hidden="true">·</span>
+                      <span
+                        class="unclassified-hint"
+                        title="Shared before Murmur could tell meetings and notes apart — shown here as a best guess."
+                      >unclassified</span>
+                    }
                   </span>
                 </span>
                 <span class="row-aside">
@@ -308,7 +310,9 @@
         }
       </header>
 
-      @if (listLoading()) {
+      @if (listEmpty() && listLoading()) {
+        <!-- Stale-while-revalidate: gate on loading ONLY when there's nothing
+             cached yet — see the pattern note in angular-zoneless.md §8. -->
         <div class="card state-card">
           <p class="empty">Loading…</p>
         </div>

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -102,9 +102,11 @@
   flex: none;
   font-size: 0.7rem;
 }
-.org-unclassified-note {
-  margin: 0;
-  font-size: 0.8125rem;
+/* Badges an org row shared before the meeting/document distinction existed —
+ * still shown (never silently dropped), just marked as a best guess. */
+.unclassified-hint {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .meetings-pane {

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -12,7 +12,6 @@ import {
   viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
-import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { TabsService } from "../../../core/tabs.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
@@ -29,6 +28,8 @@ import {
   FoldersService,
   type FolderExposure,
 } from "../../../services/folders.service";
+import { MeetingsListStore } from "../../../services/meetings-list-store.service";
+import { OrgBrainService } from "../../../services/org-brain.service";
 import { LockBadgeComponent } from "../../folders/lock-badge/lock-badge.component";
 import { MoveToMenuComponent } from "../../folders/move-to-menu/move-to-menu.component";
 import { NoteDragService } from "../../folders/note-drag.service";
@@ -70,6 +71,10 @@ export interface OrgMeetingListItem {
   sortAt: number;
   item: OrgItemHeader;
   orgName: string;
+  /** `item.kind` was `null`/absent (shared before the meeting/document distinction
+   * existed) — shown here anyway (never silently hidden), just badged so it reads
+   * as unverified rather than a confirmed meeting. See {@link orgListItems}. */
+  unclassified: boolean;
 }
 
 @Component({
@@ -101,6 +106,8 @@ export class LibraryComponent implements OnInit {
   private readonly drag = inject(NoteDragService);
   private readonly toast = inject(ToastService);
   private readonly tabsService = inject(TabsService);
+  private readonly meetingsStore = inject(MeetingsListStore);
+  private readonly orgBrain = inject(OrgBrainService);
 
   /**
    * Open a meeting as a browser-style tab (replaces the row's plain
@@ -170,9 +177,11 @@ export class LibraryComponent implements OnInit {
   private readonly searchInput =
     viewChild<ElementRef<HTMLInputElement>>("searchInput");
 
-  // --- No-query meetings list (unchanged behaviour) -----------------------
-  readonly meetings = signal<Meeting[]>([]);
-  readonly loading = signal(true);
+  // --- No-query meetings list (root-persisted — see MeetingsListStore's doc:
+  // survives a destroy+recreate so returning to /library shows the last-known
+  // rows instantly instead of a reload flash) --------------------------------
+  readonly meetings = this.meetingsStore.meetings;
+  readonly loading = this.meetingsStore.loading;
 
   // --- Folder filter ---------------------------------------------------
   // The folder TREE UI (create/rename/delete/lock/unlock/drag-drop, "Lock
@@ -216,19 +225,14 @@ export class LibraryComponent implements OnInit {
   });
 
   // --- Org (Shared Brain) chip row — "Shared Brains" meeting lists ---------
-  /**
-   * Every org (Shared Brain) this user belongs to — the content pane's
-   * "Shared brains" chip row. Loaded stale-guarded on init, on the `org-feed-updated` event, and
-   * on window focus. Deliberately separate from Notes' own org state (each view
-   * loads independently; "notes has notes, meetings has meetings" — PR #259).
-   */
-  private readonly _orgs = signal<OrgStatus[]>([]);
-  readonly orgs = this._orgs.asReadonly();
-  /**
-   * Each org's shared items keyed by orgId (`listOrgItems`) — UNFILTERED (both
-   * kinds); {@link orgListItems} narrows to `kind === "meeting"` for display.
-   */
-  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  // The RAW org roster/items/loading state lives in the shared, root-persisted
+  // OrgBrainService now (was: a component-local signal wiped to empty on every
+  // destroy+recreate — the stale-while-revalidate fix, 2026-07-12). This
+  // component keeps only its OWN derived view + chip-row selection.
+  /** Every org (Shared Brain) this user belongs to — the content pane's "Shared brains" chip row. */
+  readonly orgs = this.orgBrain.orgs;
+  /** True while the org list + items are (re)loading (chip-row hint only — never a render gate). */
+  readonly orgsLoading = this.orgBrain.loading;
   /**
    * Selected org id, chosen via the content pane's "Shared brains" chip row
    * (null ⇒ not viewing a specific org). MUTUALLY
@@ -238,60 +242,70 @@ export class LibraryComponent implements OnInit {
    * bug #259 fixed).
    */
   readonly activeOrgId = signal<string | null>(null);
-  /** True while the org list + items are (re)loading (chip-row hint only). */
-  readonly orgsLoading = signal(false);
   /** The org whose items are shown when an org chip is selected (null otherwise). */
   readonly activeOrg = computed<OrgStatus | null>(() => {
     const oid = this.activeOrgId();
     return oid === null
       ? null
-      : (this._orgs().find((o) => o.orgId === oid) ?? null);
+      : (this.orgBrain.orgs().find((o) => o.orgId === oid) ?? null);
+  });
+  /**
+   * If the chip row's selected org has since disappeared (left/no longer
+   * enabled here), fall back to "All meetings" — mirrors the reset the OLD
+   * per-component `loadOrgs()` used to do inline; now reactive over the
+   * SHARED roster since a load can land from either this view or Notes'.
+   */
+  private readonly _clearMissingActiveOrg = effect(() => {
+    const orgs = this.orgBrain.orgs();
+    const sel = this.activeOrgId();
+    if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
+      untracked(() => this.activeOrgId.set(null));
+    }
   });
 
   /**
-   * The active org's items narrowed to `kind === "meeting"` — a DISTINCT list,
-   * never merged into {@link listItems} ("All meetings" stays exactly what
-   * #259 left it: the user's own recordings only). A `kind === "document"`
-   * item never appears here (it belongs in Notes); a `kind == null`
-   * (unclassified, pre-kind wire format) item is EXCLUDED from this
-   * confirmed-meetings list too — see {@link orgUnclassifiedCount}.
+   * The active org's items narrowed to `kind === "meeting"` PLUS any
+   * unclassified item (`kind == null` — shared before the meeting/document
+   * distinction existed). Live-found bug (2026-07-12): a genuinely-shared
+   * meeting whose share predates `source_kind` was silently EXCLUDED here
+   * (only a passive "N items not shown" note hinted it existed) — shared
+   * content must never just vanish, so an unclassified item is now included
+   * and badged `unclassified: true` (the template shows it distinctly, never
+   * as a confirmed meeting) rather than hidden. A `kind === "document"` item
+   * still never appears here (it belongs in Notes).
    */
   readonly orgListItems = computed<OrgMeetingListItem[]>(() => {
     const org = this.activeOrg();
     if (!org) {
       return [];
     }
-    const items = this._orgItems()[org.orgId] ?? [];
+    const items = this.orgBrain.orgItems()[org.orgId] ?? [];
     return items
-      .filter((item) => item.kind === "meeting")
+      .filter((item) => item.kind === "meeting" || item.kind == null)
       .map((item) => this.toOrgMeetingCard(item, org.name))
       .sort((a, b) => b.sortAt - a.sortAt);
   });
 
   /**
-   * Count of the active org's items that are neither a confirmed meeting nor a
-   * confirmed document (`kind == null` — shared under the pre-kind wire format).
-   * Surfaced as a small "N unclassified" note rather than silently folding them
-   * into the meeting list as if verified.
+   * Open an org meeting card as a tracked tab — the editable original for the
+   * author, else the read-only `/org-item/:id` viewer tab. Live-found bug,
+   * 2026-07-12: this used to be a plain `[routerLink]`, so it never
+   * registered with {@link TabsService} (opened but never appeared in the tab
+   * strip, unlike an owned meeting). Mirrors `openMeeting`'s `<a>` +
+   * `event.preventDefault()` shape (and `NotesHomeComponent.openOrgCard`).
    */
-  readonly orgUnclassifiedCount = computed(() => {
-    const org = this.activeOrg();
-    if (!org) {
-      return 0;
-    }
-    const items = this._orgItems()[org.orgId] ?? [];
-    return items.filter((item) => item.kind == null).length;
-  });
-
-  /** Router target for an org meeting card — the editable original for the author, else the read-only viewer. */
-  orgItemLink(item: OrgItemHeader): string[] {
+  openOrgCard(event: Event, item: OrgItemHeader): void {
+    event.preventDefault();
     const owned = item.ownedSource;
     if (owned) {
-      return owned.kind === "meeting"
-        ? ["/meeting", owned.id]
-        : ["/notes", owned.id];
+      if (owned.kind === "meeting") {
+        void this.tabsService.openMeeting(owned.id, item.title || "Meeting");
+      } else {
+        void this.tabsService.openNote(owned.id, item.title || "Note");
+      }
+      return;
     }
-    return ["/org-item", item.itemId];
+    void this.tabsService.openOrgItem(item.itemId, item.title || "Shared note");
   }
 
   /** Build an org meeting card from a header + its origin org name. */
@@ -303,79 +317,13 @@ export class LibraryComponent implements OnInit {
       sortAt: Number.isNaN(t) ? 0 : t,
       item,
       orgName,
+      unclassified: item.kind == null,
     };
   }
 
-  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
-  private orgFeedUnlisten: UnlistenFn | null = null;
-  /** True once destroyed — a `listen()` resolving AFTER teardown releases immediately. */
-  private orgFeedDestroyed = false;
-  /** Bumped per org load so a late (stale) reload result is dropped (T1 guard). */
-  private orgLoadSeq = 0;
-  /** Bound window-focus handler — re-loads org items when the view regains focus. */
-  private readonly onOrgWindowFocus = (): void => {
-    void this.loadOrgs();
-  };
-
-  /**
-   * (Re)load the org (Shared Brain) list + every org's shared items, stale-guarded
-   * on {@link orgLoadSeq}, and the bulk own-meeting org-share pairings (for the
-   * Library row badge). Best-effort throughout — a transient/offline error leaves
-   * the last-known state standing. Never throws.
-   */
+  /** (Re)load the org roster + items — delegates to the shared {@link OrgBrainService}. */
   async loadOrgs(): Promise<void> {
-    const seq = ++this.orgLoadSeq;
-    this.orgsLoading.set(true);
-    try {
-      try {
-        await this.ipc.orgRefresh();
-      } catch {
-        /* offline / no server → fall through to the local replica */
-      }
-      let orgs: OrgStatus[];
-      try {
-        // PER-INSTANCE ORG TOGGLE: the rail is a content BROWSER, not the management
-        // surface (that's Settings → Organization, which fetches its own UNFILTERED
-        // list so every joined org's toggle is reachable) — a disabled org must not
-        // appear as a pickable "Shared brains" entry here at all, matching the user's
-        // mental model ("F disabled ⇒ not used on this instance"). The actual content
-        // gate is already backend-enforced (list_org_items_inner returns empty for a
-        // disabled org); this filter just keeps the rail honest about what's usable.
-        orgs = (await this.ipc.orgListStatuses()).filter((o) => o.contextEnabled);
-      } catch {
-        return; // keep the last-known orgs on a transient failure
-      }
-      if (seq !== this.orgLoadSeq) {
-        return;
-      }
-      const [itemLists, ownShares] = await Promise.all([
-        Promise.all(
-          orgs.map((o) =>
-            this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
-          ),
-        ),
-        this.ipc.listMeetingOrgShares().catch(() => [] as MeetingOrgShareRow[]),
-      ]);
-      if (seq !== this.orgLoadSeq) {
-        return;
-      }
-      const byOrg: Record<string, OrgItemHeader[]> = {};
-      orgs.forEach((o, i) => {
-        byOrg[o.orgId] = itemLists[i];
-      });
-      this._orgs.set(orgs);
-      this._orgItems.set(byOrg);
-      this._myOrgShares.set(ownShares);
-      // If the chip row's selected org has since disappeared, fall back to "All meetings".
-      const sel = this.activeOrgId();
-      if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
-        this.activeOrgId.set(null);
-      }
-    } finally {
-      if (seq === this.orgLoadSeq) {
-        this.orgsLoading.set(false);
-      }
-    }
+    await this.orgBrain.loadOrgs();
   }
 
   /**
@@ -413,14 +361,13 @@ export class LibraryComponent implements OnInit {
   /**
    * Every active meeting→org share pairing across ALL of the caller's OWN
    * meetings (`listMeetingOrgShares`, bulk — avoids an N+1 per-row fetch).
-   * Loaded alongside the org chip row in {@link loadOrgs}; empty for a meeting
-   * never shared, or masked away server-side for a locked one.
+   * Loaded alongside the org roster (shared {@link OrgBrainService}); empty
+   * for a meeting never shared, or masked away server-side for a locked one.
    */
-  private readonly _myOrgShares = signal<MeetingOrgShareRow[]>([]);
   /** `meetingId` → the orgs it's shared into — O(1) lookup for the row badge. */
   readonly orgSharesByMeetingId = computed(() => {
     const map = new Map<string, MeetingOrgShareRow[]>();
-    for (const row of this._myOrgShares()) {
+    for (const row of this.orgBrain.myOrgShares()) {
       const list = map.get(row.meetingId);
       if (list) {
         list.push(row);
@@ -471,8 +418,9 @@ export class LibraryComponent implements OnInit {
   });
 
   // --- Tag filter ----------------------------------------------------------
-  /** All distinct tags across meetings; empty → no filter bar is rendered. */
-  readonly tags = signal<string[]>([]);
+  /** All distinct tags across meetings; empty → no filter bar is rendered.
+   * Root-persisted (MeetingsListStore) for the same reason as {@link meetings}. */
+  readonly tags = this.meetingsStore.tags;
   /** Selected tag (null = "All", i.e. the full meetings list). */
   readonly activeTag = signal<string | null>(null);
   /** Meetings carrying the active tag (only used when a tag is selected). */
@@ -639,31 +587,8 @@ export class LibraryComponent implements OnInit {
       }
     });
 
-    // Live-refresh: the background org-sync loop fires `org-feed-updated` on a
-    // productive tick. Subscribe ONCE (push straight into a reload — NEVER
-    // subscribe-into-a-field), and re-load on window focus too. Both cleaned up
-    // on destroy (release the UnlistenFn + the focus handler).
-    this.destroyRef.onDestroy(() => {
-      this.orgFeedDestroyed = true;
-      this.orgFeedUnlisten?.();
-      this.orgFeedUnlisten = null;
-      window.removeEventListener("focus", this.onOrgWindowFocus);
-    });
-    window.addEventListener("focus", this.onOrgWindowFocus);
-    void this.ipc
-      .onOrgFeedUpdated(() => void this.loadOrgs())
-      .then((un) => {
-        // If the view was already torn down before the listener resolved, release
-        // it immediately (never leak a subscription past destroy).
-        if (this.orgFeedDestroyed) {
-          un();
-        } else {
-          this.orgFeedUnlisten = un;
-        }
-      })
-      .catch(() => {
-        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
-      });
+    // Live-refresh (org-feed-updated + window-focus) is subscribed ONCE, for the
+    // app's lifetime, by the shared OrgBrainService now — no per-mount wiring here.
 
     // Load the meetings list, the tag set, and the org chip row in parallel; any one
     // failing must not break the others, so settle each independently.

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -15,6 +15,7 @@ import {
 } from "@angular/core";
 import { Router } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
+import { TabsService } from "../../../core/tabs.service";
 import type {
   NoteAssistAction,
   NoteAssistResult,
@@ -116,6 +117,7 @@ export class NoteBrainPopoverComponent {
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
+  private readonly tabsService = inject(TabsService);
   /** Root-owned timer service — the sanctioned home for the step-animation tick (rule §5). */
   private readonly timers = inject(TimerService);
 
@@ -486,22 +488,31 @@ export class NoteBrainPopoverComponent {
     }
   }
 
-  /** Open a citation's source note/meeting/org-item; dismiss the popover first. */
+  /**
+   * Open a citation's source note/meeting/org-item; dismiss the popover
+   * first. A note/meeting/org-item opens as a TRACKED TAB (live-found bug,
+   * 2026-07-12: this used to be a plain `router.navigate`, so a citation
+   * click — for ANY kind, not just org — never registered with
+   * {@link TabsService}, unlike opening the same note/meeting from its own
+   * list row). `person`/`entity` still go to `/graph`, which isn't part of
+   * the tab system.
+   */
   openCitation(cite: NoteCitation): void {
     this.dismiss.emit();
-    // "org" routes to the read-only org-item viewer (mirrors library.component.ts orgItemLink) —
-    // it is NOT a local note/meeting id, so it must never fall into the "/notes" default below.
     if (cite.kind === "org") {
-      void this.router.navigate(["/org-item", cite.id]);
+      // NOT a local note/meeting id — the read-only org-item viewer tab.
+      void this.tabsService.openOrgItem(cite.id, cite.title || "Shared note");
       return;
     }
-    const path =
-      cite.kind === "meeting"
-        ? "/meeting"
-        : cite.kind === "person" || cite.kind === "entity"
-          ? "/graph"
-          : "/notes";
-    void this.router.navigate([path, cite.id]);
+    if (cite.kind === "meeting") {
+      void this.tabsService.openMeeting(cite.id, cite.title || "Meeting");
+      return;
+    }
+    if (cite.kind === "note") {
+      void this.tabsService.openNote(cite.id, cite.title || "Note");
+      return;
+    }
+    void this.router.navigate(["/graph", cite.id]);
   }
 
   // ── Positioning + teardown ───────────────────────────────────────────────

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -41,9 +41,13 @@
          A content-pane chip row (orgs aren't note-folders, so they don't live
          in the sidebar's folder tree). Picking a chip scopes the list to that
          org's shared items only; picking it again returns to the note-folder
-         scope. -->
+         scope. A leading "Shared brains" label + a Settings shortcut (mirrors
+         library.component.html — live-found gap, 2026-07-12: this row had
+         neither, so the chips read as generic unlabeled tags with no way to
+         reach the per-instance org toggle from here). -->
     @if (orgs().length > 0 || orgsLoading()) {
       <div class="org-chip-row" role="group" aria-label="Shared brains">
+        <span class="org-chip-row-label text-muted">Shared brains</span>
         @for (org of orgs(); track org.orgId) {
           <button
             type="button"
@@ -68,6 +72,24 @@
         @if (orgsLoading()) {
           <mur-spinner [size]="12" class="org-chip-spinner" />
         }
+        <!-- Manage which orgs are active on this device (per-instance toggle). -->
+        <a
+          class="org-chip-settings-link"
+          routerLink="/settings"
+          [queryParams]="{ section: 'organization' }"
+          title="Choose which organizations are active on this device"
+          aria-label="Manage organizations in Settings"
+        >
+          <svg viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="2.1" stroke="currentColor" stroke-width="1.3" />
+            <path
+              d="M8 2.2v1.4M8 12.4v1.4M13.8 8h-1.4M3.6 8H2.2M12.1 3.9l-1 1M4.9 11.1l-1 1M12.1 12.1l-1-1M4.9 4.9l-1-1"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+          </svg>
+        </a>
       </div>
     }
 
@@ -94,7 +116,12 @@
             </button>
           }
         </div>
-      } @else if (loading() || orgsLoading()) {
+      } @else if (listEmpty() && (loading() || orgsLoading())) {
+        <!-- Stale-while-revalidate: only gate on loading when there is NOTHING
+             cached to show yet (e.g. the very first visit). Once listItems()
+             has rows, a background reload (loading()/orgsLoading() flipping
+             true again on remount) must never hide them — see the pattern
+             note in angular-zoneless.md §8. -->
         <p class="notes-status">Loading notes…</p>
       } @else if (listEmpty()) {
         @if (activeOrg(); as org) {
@@ -171,7 +198,11 @@
                        (`ownedSource`), the row links straight to the EDITABLE
                        original (/notes/:id | /meeting/:id) with the current title;
                        otherwise it's a READ-ONLY replica → the /org-item viewer. -->
-                  <a class="title-btn title-link" [routerLink]="orgItemLink(row.item)">
+                  <button
+                    type="button"
+                    class="title-btn"
+                    (click)="openOrgCard(row.item)"
+                  >
                     <span class="title-text">{{ row.item.title }}</span>
                     <span class="pill org-badge" [title]="'Shared brain · ' + row.orgName">
                       <svg class="org-badge-glyph" viewBox="0 0 16 16" width="11" height="11" fill="none" aria-hidden="true">
@@ -184,7 +215,7 @@
                     @if (row.item.authorHint) {
                       <span class="note-author text-muted">{{ row.item.authorHint }}</span>
                     }
-                  </a>
+                  </button>
                 }
               }
             </ng-template>

--- a/src/app/features/notes/notes-home/notes-home.component.scss
+++ b/src/app/features/notes/notes-home/notes-home.component.scss
@@ -45,12 +45,21 @@
   gap: var(--space-2);
 }
 
-/* --- Shared brains (orgs) chip row --- */
+/* --- Shared brains (orgs) chip row (mirrors library.component.scss) --- */
 .org-chip-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-2);
   margin-bottom: var(--space-4);
+}
+/* A leading label so the chips read as "these are organizations", not
+   unlabeled generic tags (live-found feedback, 2026-07-12). */
+.org-chip-row-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 .org-chip {
   display: inline-flex;
@@ -82,6 +91,26 @@
 .org-chip-spinner {
   margin-left: var(--space-1);
   color: var(--text-muted);
+}
+/* Shortcut to Settings → Organization (which orgs are active on this device). */
+.org-chip-settings-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+.org-chip-settings-link:hover {
+  color: var(--text-secondary);
+  background: var(--surface-hover);
+}
+.org-chip-settings-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
 }
 
 .content-body {
@@ -161,11 +190,6 @@
   flex: none;
 }
 
-/* Org (Shared Brain) title link — same `.title-btn` shape, an `<a>` instead
-   of a `<button>` since it's a real navigation target. */
-.title-link {
-  cursor: pointer;
-}
 /* The "shared brain" origin badge — distinct from the outbound "Shared" pill:
    a neutral raised surface (not the accent fill) with the org's name + a glyph. */
 .org-badge {

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -1,16 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   OnInit,
   computed,
   effect,
   inject,
   signal,
+  untracked,
 } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
-import type { UnlistenFn } from "@tauri-apps/api/event";
-import { IpcService } from "../../../core/ipc.service";
 import { TabsService } from "../../../core/tabs.service";
 import type {
   NoteFolder,
@@ -25,6 +23,7 @@ import { MurTableComponent } from "../../../design-system/table/table.component"
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { FoldersService } from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
+import { OrgBrainService } from "../../../services/org-brain.service";
 import { ToastService } from "../../../services/toast.service";
 import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.component";
 
@@ -87,12 +86,11 @@ export type NotesListItem =
 })
 export class NotesHomeComponent implements OnInit {
   private readonly notes = inject(NotesService);
+  private readonly orgBrain = inject(OrgBrainService);
   private readonly folders = inject(FoldersService);
-  private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly tabsService = inject(TabsService);
-  private readonly destroyRef = inject(DestroyRef);
 
   /** The note list from the store (gated — masked rows carry no snippet/tags). */
   readonly noteList = this.notes.notes;
@@ -111,19 +109,14 @@ export class NotesHomeComponent implements OnInit {
   readonly creating = signal(false);
 
   // --- Org (Shared Brain) shared-brain notes ------------------------------
-  /**
-   * Every org (Shared Brain) this user belongs to — the content pane's "Shared
-   * brains" chip row + the source of merged org items in "All notes". Loaded
-   * stale-guarded on init, on the `org-feed-updated` event, and on window focus.
-   */
-  private readonly _orgs = signal<OrgStatus[]>([]);
-  readonly orgs = this._orgs.asReadonly();
-  /**
-   * The org's shared items keyed by orgId (`listOrgItems`). A flat parallel signal
-   * (not per-org sub-signals) so the merged `listItems` computed re-derives on any
-   * change. Populated alongside {@link _orgs} in {@link loadOrgs}.
-   */
-  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  // The RAW org roster/items/loading state lives in the shared, root-persisted
+  // OrgBrainService now (was: a component-local signal wiped to empty on every
+  // destroy+recreate — the stale-while-revalidate fix, 2026-07-12). This
+  // component keeps only its OWN derived view + chip-row selection.
+  /** Every org (Shared Brain) this user belongs to — the content pane's "Shared brains" chip row. */
+  readonly orgs = this.orgBrain.orgs;
+  /** True while the org list + items are (re)loading (chip-row hint only — never a render gate). */
+  readonly orgsLoading = this.orgBrain.loading;
   /**
    * Selected org id (null ⇒ not viewing a specific org), chosen via the content
    * pane's "Shared brains" chip row. Exiting to a DIFFERENT note-folder (picked
@@ -132,14 +125,25 @@ export class NotesHomeComponent implements OnInit {
    * one active scope.
    */
   readonly activeOrgId = signal<string | null>(null);
-  /** True while the org list + items are (re)loading (chip-row hint only). */
-  readonly orgsLoading = signal(false);
   /** The org whose items are shown when an org chip is selected (null otherwise). */
   readonly activeOrg = computed<OrgStatus | null>(() => {
     const oid = this.activeOrgId();
     return oid === null
       ? null
-      : (this._orgs().find((o) => o.orgId === oid) ?? null);
+      : (this.orgBrain.orgs().find((o) => o.orgId === oid) ?? null);
+  });
+  /**
+   * If the chip row's selected org has since disappeared (left/no longer
+   * enabled here), fall back to "All notes" — mirrors LibraryComponent's
+   * `_clearMissingActiveOrg`; reactive over the SHARED roster since a load can
+   * land from either this view or Library's.
+   */
+  private readonly _clearMissingActiveOrg = effect(() => {
+    const orgs = this.orgBrain.orgs();
+    const sel = this.activeOrgId();
+    if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
+      untracked(() => this.activeOrgId.set(null));
+    }
   });
 
   /**
@@ -153,8 +157,8 @@ export class NotesHomeComponent implements OnInit {
    */
   readonly listItems = computed<NotesListItem[]>(() => {
     const orgId = this.activeOrgId();
-    const orgItemsByOrg = this._orgItems();
-    const orgs = this._orgs();
+    const orgItemsByOrg = this.orgBrain.orgItems();
+    const orgs = this.orgBrain.orgs();
     const orgNameById = new Map(orgs.map((o) => [o.orgId, o.name]));
 
     // A specific org selected: show ONLY that org's items — EXCLUDING `kind === "meeting"`
@@ -217,19 +221,27 @@ export class NotesHomeComponent implements OnInit {
   });
 
   /**
-   * Router target for an org card. When the caller AUTHORED the item (`ownedSource`,
-   * resolved+gated backend-side) the row opens the EDITABLE original — a `/notes/:id`
-   * note or a `/meeting/:id` recording — so the author edits the real thing instead of
-   * a read-only replica. Otherwise it opens the read-only `/org-item/:id` viewer.
+   * Open an org card as a tracked tab. When the caller AUTHORED the item
+   * (`ownedSource`, resolved+gated backend-side) it opens the EDITABLE
+   * original — a note or meeting tab — so the author edits the real thing
+   * instead of a read-only replica; otherwise it opens the read-only
+   * `/org-item/:id` viewer tab. Live-found bug, 2026-07-12: this used to be a
+   * plain `[routerLink]`, so unlike an owned note/meeting it never registered
+   * with {@link TabsService} — it opened but never appeared in the tab strip
+   * and couldn't be switched back to. Routes through the SAME open* call an
+   * owned note/meeting card would use.
    */
-  orgItemLink(item: OrgItemHeader): string[] {
+  openOrgCard(item: OrgItemHeader): void {
     const owned = item.ownedSource;
     if (owned) {
-      return owned.kind === "meeting"
-        ? ["/meeting", owned.id]
-        : ["/notes", owned.id];
+      if (owned.kind === "meeting") {
+        void this.tabsService.openMeeting(owned.id, item.title || "Meeting");
+      } else {
+        void this.tabsService.openNote(owned.id, item.title || "Note");
+      }
+      return;
     }
-    return ["/org-item", item.itemId];
+    void this.tabsService.openOrgItem(item.itemId, item.title || "Shared note");
   }
 
   /** Build an org card from a header + its origin org name. */
@@ -243,18 +255,6 @@ export class NotesHomeComponent implements OnInit {
       orgName,
     };
   }
-
-  /** Released on destroy to detach the org-feed-updated live-refresh listener. */
-  private orgFeedUnlisten: UnlistenFn | null = null;
-  /** True once destroyed — so a `listen()` that resolves AFTER teardown releases immediately
-   * (distinct from `orgFeedUnlisten === null`, which also means "not yet resolved"). */
-  private orgFeedDestroyed = false;
-  /** Bumped per org load so a late (stale) reload result is dropped (T1 guard). */
-  private orgLoadSeq = 0;
-  /** Bound window-focus handler — re-loads org items when the view regains focus. */
-  private readonly onWindowFocus = (): void => {
-    void this.loadOrgs();
-  };
 
   /** The active folder node (null for the "All notes" root). */
   readonly activeFolder = computed<NoteFolder | null>(() => {
@@ -307,32 +307,8 @@ export class NotesHomeComponent implements OnInit {
   });
 
   async ngOnInit(): Promise<void> {
-    // Live-refresh: the background org-sync loop fires `org-feed-updated` on a
-    // productive tick (≥1 ingest/tombstone). Subscribe ONCE (push straight into a
-    // reload — NEVER subscribe-into-a-field), and re-load org items when the view
-    // regains focus. Both cleaned up on destroy (release the UnlistenFn + the
-    // focus handler).
-    this.destroyRef.onDestroy(() => {
-      this.orgFeedDestroyed = true;
-      this.orgFeedUnlisten?.();
-      this.orgFeedUnlisten = null;
-      window.removeEventListener("focus", this.onWindowFocus);
-    });
-    window.addEventListener("focus", this.onWindowFocus);
-    void this.ipc
-      .onOrgFeedUpdated(() => void this.loadOrgs())
-      .then((un) => {
-        // If the view was already torn down before the listener resolved, release
-        // it immediately (never leak a subscription past destroy).
-        if (this.orgFeedDestroyed) {
-          un();
-        } else {
-          this.orgFeedUnlisten = un;
-        }
-      })
-      .catch(() => {
-        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
-      });
+    // Live-refresh (org-feed-updated + window-focus) is subscribed ONCE, for the
+    // app's lifetime, by the shared OrgBrainService now — no per-mount wiring here.
 
     // Load the note-folder list (Move-to-folder menu + breadcrumb — the sidebar
     // tree also loads it independently, but this component may mount first),
@@ -347,62 +323,9 @@ export class NotesHomeComponent implements OnInit {
     ]);
   }
 
-  /**
-   * (Re)load the org (Shared Brain) list + every org's shared items, stale-guarded
-   * on {@link orgLoadSeq} so a late reload (event / focus / init racing) never
-   * overwrites a newer result. Best-effort throughout: `orgRefresh` (server
-   * membership discovery) and each per-org `listOrgItems` swallow their own
-   * failures so a transient/offline error leaves the last-known list standing
-   * rather than blanking the pane. Never throws.
-   */
+  /** (Re)load the org roster + items — delegates to the shared {@link OrgBrainService}. */
   async loadOrgs(): Promise<void> {
-    const seq = ++this.orgLoadSeq;
-    this.orgsLoading.set(true);
-    try {
-      // Discover freshly-invited orgs before reading the local replica (best-effort).
-      try {
-        await this.ipc.orgRefresh();
-      } catch {
-        /* offline / no server → fall through to the local replica */
-      }
-      let orgs: OrgStatus[];
-      try {
-        // PER-INSTANCE ORG TOGGLE: this rail is a content BROWSER (mirrors
-        // library.component.ts) — a disabled org must not appear as a pickable
-        // "Shared brains" entry; the toggle itself lives only in Settings, which
-        // fetches its own unfiltered list.
-        orgs = (await this.ipc.orgListStatuses()).filter((o) => o.contextEnabled);
-      } catch {
-        return; // keep the last-known orgs on a transient failure
-      }
-      if (seq !== this.orgLoadSeq) {
-        return; // a newer load superseded this one — drop the result
-      }
-      // Pull each org's browsable items in parallel; a per-org failure yields [].
-      const itemLists = await Promise.all(
-        orgs.map((o) =>
-          this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
-        ),
-      );
-      if (seq !== this.orgLoadSeq) {
-        return;
-      }
-      const byOrg: Record<string, OrgItemHeader[]> = {};
-      orgs.forEach((o, i) => {
-        byOrg[o.orgId] = itemLists[i];
-      });
-      this._orgs.set(orgs);
-      this._orgItems.set(byOrg);
-      // If the rail's selected org has since disappeared, fall back to "All notes".
-      const sel = this.activeOrgId();
-      if (sel !== null && !orgs.some((o) => o.orgId === sel)) {
-        this.activeOrgId.set(null);
-      }
-    } finally {
-      if (seq === this.orgLoadSeq) {
-        this.orgsLoading.set(false);
-      }
-    }
+    await this.orgBrain.loadOrgs();
   }
 
   /** A friendly role hint for the chip row ("Owner" / "Member"). */

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.scss
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.scss
@@ -67,25 +67,33 @@ mur-tree-row:focus-within .tree-actions {
   cursor: default;
 }
 
-/* Inline folder create / rename field + delete confirm. */
+/* Inline folder create / rename field + delete confirm. Polish pass
+   (2026-07-12, live-found "looks bad" feedback): the original cramped every
+   element to `--space-1` (4px) padding, so the input read as squashed next
+   to its own action buttons — breathing room + a border/shadow that matches
+   the rest of the sidebar's control language (mirrors `.tree-edit-input`'s
+   sibling `<mur-input>` sizing) fixes that without growing the sidebar. */
 .tree-edit,
 .tree-confirm {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-2);
+  padding: var(--space-3);
   border-radius: var(--radius-md);
   background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
 }
 .tree-edit-input {
   width: 100%;
-  padding: var(--space-1) var(--space-2);
+  height: 32px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   background: var(--surface-base);
   color: var(--text-primary);
   font: inherit;
   font-size: 0.84rem;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 .tree-edit-input:focus-visible {
   outline: none;
@@ -95,12 +103,14 @@ mur-tree-row:focus-within .tree-actions {
 .tree-edit-actions {
   display: flex;
   gap: var(--space-2);
+  justify-content: flex-end;
 }
 .tree-confirm-copy {
   font-size: 0.78rem;
   line-height: 1.4;
 }
 .btn-tiny {
-  padding: var(--space-1) var(--space-3);
+  height: 28px;
+  padding: 0 var(--space-3);
   font-size: 0.78rem;
 }

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -10,6 +10,8 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 import { IpcService } from "../../../core/ipc.service";
+import { TabsService } from "../../../core/tabs.service";
+import { tabKeyFor } from "../../../core/tab-keys";
 import type { OrgItemDetail } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 
@@ -43,6 +45,7 @@ export class OrgItemViewerComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly injector = inject(Injector);
+  private readonly tabsService = inject(TabsService);
 
   /** The `:id` route param as a signal (re-fetches when it changes in place). */
   private readonly itemId = toSignal(
@@ -125,6 +128,10 @@ export class OrgItemViewerComponent {
         return; // stale — the route moved on under us
       }
       this._item.set(item);
+      // Adopt the real title (mirrors note-editor's setTitle) — the caller
+      // already passes a best-known title when opening the tab, but this
+      // corrects it once the authoritative decrypted detail loads.
+      this.tabsService.setTitle(tabKeyFor("org-item", id), item.title || "Shared note");
       void this.resolveOrgName(id);
     } catch (e) {
       if (this.itemId() !== id) {

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -19,6 +19,9 @@ import { BrainRevealCardComponent } from "../brain-reveal-card/brain-reveal-card
 import { ReTruthCardComponent } from "../re-truth-card/re-truth-card.component";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
 
+/** localStorage key for the permanent "no vault set" notice dismissal. */
+const VAULT_NOTICE_DISMISSED_KEY = "murmur-vault-notice-dismissed";
+
 @Component({
   selector: "app-record",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -155,16 +158,30 @@ export class RecordComponent implements OnInit {
     return !c || !c.vaultPath || c.vaultPath.trim() === "";
   });
 
-  /** Dismissed for this session — the no-vault info notice stays hidden once closed. */
-  private readonly vaultNoticeDismissed = signal(false);
+  /**
+   * Dismissed permanently (localStorage — live-found bug, 2026-07-12: this used
+   * to be a plain component-local signal, so it "forgot" the dismissal on the
+   * very next remount, e.g. navigating away and back to /record within the
+   * same session — mirrors {@link BrainRevealCardComponent}'s one-time-seen
+   * pattern). Re-appears only if a vault gets configured then unset again.
+   */
+  private readonly vaultNoticeDismissed = signal(this.readVaultNoticeDismissed());
 
   /**
    * Show the calm, non-blocking "no vault set" info notice: only when no vault is configured
-   * and the user hasn't dismissed it this session. It never gates recording.
+   * and the user hasn't dismissed it. It never gates recording.
    */
   readonly showVaultNotice = computed(
     () => this.vaultMissing() && !this.vaultNoticeDismissed(),
   );
+
+  private readVaultNoticeDismissed(): boolean {
+    try {
+      return localStorage.getItem(VAULT_NOTICE_DISMISSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  }
 
   /**
    * True when the last failure was the backend's cloud-egress consent gate. We
@@ -405,9 +422,14 @@ export class RecordComponent implements OnInit {
     this.nudgeDismissed.set(true);
   }
 
-  /** No-vault info-notice dismiss — hide it for the rest of this session. */
+  /** No-vault info-notice dismiss — permanent (localStorage), not just this session. */
   dismissVaultNotice(): void {
     this.vaultNoticeDismissed.set(true);
+    try {
+      localStorage.setItem(VAULT_NOTICE_DISMISSED_KEY, "1");
+    } catch {
+      /* private-mode / storage-disabled — session-only dismissal is fine. */
+    }
   }
 
   /** ⌘R / Ctrl+R toggles recording. */

--- a/src/app/services/meetings-list-store.service.ts
+++ b/src/app/services/meetings-list-store.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal } from "@angular/core";
+import type { Meeting } from "../core/models";
+
+/**
+ * Root-persisted backing signals for {@link LibraryComponent}'s no-query
+ * meetings list — split out from the component itself so the DATA survives a
+ * destroy+recreate (e.g. leaving `/library` to open a meeting, then coming
+ * back): a component-local `signal<Meeting[]>([])` is wiped to empty on every
+ * remount, forcing a full reload-from-blank flash. A root service instance
+ * outlives the component, so the list renders with the LAST-KNOWN rows
+ * INSTANTLY on return while `LibraryComponent.ngOnInit`'s existing reload
+ * (unchanged — still a real refetch every visit, not a "skip if ever loaded"
+ * cache) quietly replaces it underneath.
+ *
+ * Deliberately a thin signal holder, NOT a service with its own load()/CRUD
+ * methods: `LibraryComponent` owns the orchestration (folder/tag filtering,
+ * drag-drop patches, delete pruning, the tree-reactive reload effect) — that
+ * logic is unchanged, it now just reads/writes THESE signals instead of
+ * component-local ones. See the pattern note in `angular-zoneless.md` §9.
+ */
+@Injectable({ providedIn: "root" })
+export class MeetingsListStore {
+  readonly meetings = signal<Meeting[]>([]);
+  readonly loading = signal(true);
+  readonly tags = signal<string[]>([]);
+}

--- a/src/app/services/org-brain.service.ts
+++ b/src/app/services/org-brain.service.ts
@@ -1,0 +1,133 @@
+import { DestroyRef, Injectable, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type {
+  MeetingOrgShareRow,
+  OrgItemHeader,
+  OrgStatus,
+} from "../core/models";
+
+/**
+ * Signal store for the raw "Shared Brains" (org) roster + items — the ONE
+ * source of `_orgs`/`_orgItems`/`_myOrgShares` that {@link NotesHomeComponent}
+ * and {@link LibraryComponent} both used to duplicate as component-local
+ * signals. `providedIn: 'root'` is the point: a component-local signal is
+ * WIPED to its initial empty value every time the component is destroyed and
+ * recreated (e.g. leaving `/notes` for a note, then coming back) — a root
+ * service instance outlives that, so the chip row / merged list render with
+ * the LAST-KNOWN org data INSTANTLY on return, while {@link loadOrgs} quietly
+ * re-fetches underneath (never gated behind a blocking "loading" state — see
+ * the pattern note in `angular-zoneless.md` §9).
+ *
+ * The live-refresh wiring (the `org-feed-updated` event + window-focus) is
+ * subscribed ONCE here, for the app's lifetime, instead of once per component
+ * mount — a strict improvement (was: re-subscribed/torn-down on every visit).
+ *
+ * Each consumer keeps its OWN derived view over the shared raw data (Library
+ * narrows to `kind === "meeting"`, Notes excludes it — "notes has notes,
+ * meetings has meetings", PR #259) and its OWN `activeOrgId` chip-row
+ * selection — those are legitimately per-view UI state, not shared.
+ */
+@Injectable({ providedIn: "root" })
+export class OrgBrainService {
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  private readonly _orgItems = signal<Record<string, OrgItemHeader[]>>({});
+  private readonly _myOrgShares = signal<MeetingOrgShareRow[]>([]);
+  private readonly _loading = signal(false);
+
+  /** Every org (Shared Brain) this user belongs to. */
+  readonly orgs = this._orgs.asReadonly();
+  /** Each org's shared items keyed by orgId (`listOrgItems`) — UNFILTERED (every kind). */
+  readonly orgItems = this._orgItems.asReadonly();
+  /** The caller's own outbound meeting org-shares (Library row badge). */
+  readonly myOrgShares = this._myOrgShares.asReadonly();
+  /** True while a (re)load is in flight — a HINT (e.g. the chip-row spinner), never a
+   * render gate: a consumer's template must keep showing {@link orgs}/{@link orgItems}
+   * while this is true, not hide them behind it. */
+  readonly loading = this._loading.asReadonly();
+
+  /** Bumped per load so a late (stale) reload result is dropped. */
+  private loadSeq = 0;
+  private feedUnlisten: (() => void) | null = null;
+  private feedDestroyed = false;
+  private readonly onWindowFocus = (): void => {
+    void this.loadOrgs();
+  };
+
+  constructor() {
+    window.addEventListener("focus", this.onWindowFocus);
+    this.destroyRef.onDestroy(() => {
+      // A root service is never actually destroyed in practice (it outlives every
+      // component), but honor the contract in case a test harness tears it down.
+      this.feedDestroyed = true;
+      this.feedUnlisten?.();
+      window.removeEventListener("focus", this.onWindowFocus);
+    });
+    void this.ipc
+      .onOrgFeedUpdated(() => void this.loadOrgs())
+      .then((un) => {
+        if (this.feedDestroyed) {
+          un();
+        } else {
+          this.feedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live refresh */
+      });
+  }
+
+  /**
+   * (Re)load the org roster + every org's shared items + the caller's own
+   * meeting org-shares. Stale-guarded on {@link loadSeq}; best-effort
+   * throughout — a transient/offline error leaves the last-known state
+   * standing (never blanks already-loaded data).
+   */
+  async loadOrgs(): Promise<void> {
+    const seq = ++this.loadSeq;
+    this._loading.set(true);
+    try {
+      try {
+        await this.ipc.orgRefresh();
+      } catch {
+        /* offline / no server → fall through to the local replica */
+      }
+      let orgs: OrgStatus[];
+      try {
+        // PER-INSTANCE ORG TOGGLE: a disabled org must not appear as a pickable
+        // "Shared brains" entry — Settings keeps its own unfiltered fetch so
+        // every joined org's toggle stays reachable there.
+        orgs = (await this.ipc.orgListStatuses()).filter((o) => o.contextEnabled);
+      } catch {
+        return; // keep the last-known orgs on a transient failure
+      }
+      if (seq !== this.loadSeq) {
+        return;
+      }
+      const [itemLists, ownShares] = await Promise.all([
+        Promise.all(
+          orgs.map((o) =>
+            this.ipc.listOrgItems(o.orgId).catch(() => [] as OrgItemHeader[]),
+          ),
+        ),
+        this.ipc.listMeetingOrgShares().catch(() => [] as MeetingOrgShareRow[]),
+      ]);
+      if (seq !== this.loadSeq) {
+        return;
+      }
+      const byOrg: Record<string, OrgItemHeader[]> = {};
+      orgs.forEach((o, i) => {
+        byOrg[o.orgId] = itemLists[i];
+      });
+      this._orgs.set(orgs);
+      this._orgItems.set(byOrg);
+      this._myOrgShares.set(ownShares);
+    } finally {
+      if (seq === this.loadSeq) {
+        this._loading.set(false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **Brain model selection**: "Enable the brain" now calls `select_brain_model` after the download succeeds — previously the selection never persisted, so a user who toggled Fully Local → Cloud → Fully Local again would silently reset. Better error messaging (names the model, suggests disk space) as a defensive second fix.
- **Stale-while-revalidate lists** (Notes + Meetings): navigating into a note/meeting and back no longer flashes a loading spinner over already-fetched data. List-backing state moved to root services (`OrgBrainService`, `MeetingsListStore`) that survive component destroy/recreate; loading gates changed to `listEmpty() && loading()`. Documented as the standing pattern in `angular-zoneless.md` §8.
- **Org-shared notes open as real tabs**: new `TabKind = "org-item"`, routed through `TabsService`/`TabRouteReuseStrategy` — previously a full-page navigation with no tab-strip entry.
- **Ask** no longer gates on meetings-only when notes exist.
- **"No Obsidian vault" notice** dismiss now persists (localStorage).
- **Unclassified org meetings** now show with a badge instead of silently vanishing from Library.
- **Row-menu popovers** ("...") no longer clipped by sidebar/table `overflow:hidden`.
- **Org chip row**: "Shared brains" label + settings shortcut in Notes (parity with Library).
- Folder-creation UI spacing + folder-name hover tooltip on truncation.

## Test plan
- [x] `cargo test --lib` — 1568 passed, 0 failed, 10 ignored
- [x] `npx ng lint` — clean
- [x] `npx ng build` — clean
- [x] `npx playwright test e2e/org/ e2e/notes/` — 23/23 passed
- [x] New e2e `e2e/brain/brain-enable-card.spec.ts` — RED-before-GREEN for the brain model selection fix