### PR TITLE
chore(release): 0.9.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.10"
+version = "0.9.11"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.11 — bundles the per-meeting embed batch-size + tokenizer-truncation fix (#281), a targeted follow-up after v0.9.10's launch-freeze fix didn't fully resolve the reported issue for a vault with a 1h+ recording.