### PR TITLE
fix(perf): P0 batch from the Rust-perf research + codebase anti-pattern audit

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15443,6 +15443,7 @@ mod lifecycle_tests {
             lifecycle: Mutex::new(()),
             share_refresh_lock: tokio::sync::Mutex::new(()),
             seal_epoch: std::sync::atomic::AtomicU64::new(0),
+            heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
         }
     }
 

--- a/src-tauri/src/embed/candle_bert.rs
+++ b/src-tauri/src/embed/candle_bert.rs
@@ -231,30 +231,41 @@ impl Embedder for CandleBertEmbedder {
         let flat_ids: Vec<u32> = id_rows.into_iter().flatten().collect();
         let flat_mask: Vec<u32> = mask_rows.iter().flatten().copied().collect();
 
-        let input_ids = Tensor::from_vec(flat_ids, (batch, max_len), device)
-            .map_err(|e| AppError::Storage(format!("embed input tensor: {e}")))?;
-        let attention_mask = Tensor::from_vec(flat_mask.clone(), (batch, max_len), device)
-            .map_err(|e| AppError::Storage(format!("embed mask tensor: {e}")))?;
-        let token_type_ids = input_ids
-            .zeros_like()
-            .map_err(|e| AppError::Storage(format!("embed token-type tensor: {e}")))?;
+        // Metal's command buffers/encoders are Objective-C objects the Metal framework
+        // autoreleases internally; without an explicit pool, they only drain on the NEXT
+        // top-level pool pop (e.g. the WKWebView's run-loop pool), so repeated forward passes on
+        // a background thread with no run loop can accumulate autoreleased Metal objects for the
+        // life of the thread. Wrapping the whole tensor-build → forward → extract sequence closes
+        // this window per call — belt-and-suspenders alongside the known, still-open candle Metal
+        // leak (huggingface/candle#2271) this embedder is otherwise exposed to. `objc2` is already
+        // a workspace dependency (objc2-app-kit/-core-foundation/-core-audio), so this is a
+        // zero-new-crate fix.
+        let out: Vec<Vec<f32>> = objc2::rc::autoreleasepool(|_pool| -> Result<Vec<Vec<f32>>> {
+            let input_ids = Tensor::from_vec(flat_ids, (batch, max_len), device)
+                .map_err(|e| AppError::Storage(format!("embed input tensor: {e}")))?;
+            let attention_mask = Tensor::from_vec(flat_mask.clone(), (batch, max_len), device)
+                .map_err(|e| AppError::Storage(format!("embed mask tensor: {e}")))?;
+            let token_type_ids = input_ids
+                .zeros_like()
+                .map_err(|e| AppError::Storage(format!("embed token-type tensor: {e}")))?;
 
-        // [batch, seq, hidden]
-        let sequence = loaded
-            .model
-            .forward(&input_ids, &token_type_ids, Some(&attention_mask))
-            .map_err(|e| AppError::Storage(format!("embed forward failed: {e}")))?;
+            // [batch, seq, hidden]
+            let sequence = loaded
+                .model
+                .forward(&input_ids, &token_type_ids, Some(&attention_mask))
+                .map_err(|e| AppError::Storage(format!("embed forward failed: {e}")))?;
 
-        // MEAN-POOL over tokens with the attention mask (e5 requires mean-pooling, NOT the CLS token),
-        // then L2-normalize each row.
-        let pooled = mean_pool(&sequence, &attention_mask)
-            .map_err(|e| AppError::Storage(format!("embed mean-pool failed: {e}")))?;
-        let normed = l2_normalize(&pooled)
-            .map_err(|e| AppError::Storage(format!("embed normalize failed: {e}")))?;
+            // MEAN-POOL over tokens with the attention mask (e5 requires mean-pooling, NOT the CLS
+            // token), then L2-normalize each row.
+            let pooled = mean_pool(&sequence, &attention_mask)
+                .map_err(|e| AppError::Storage(format!("embed mean-pool failed: {e}")))?;
+            let normed = l2_normalize(&pooled)
+                .map_err(|e| AppError::Storage(format!("embed normalize failed: {e}")))?;
 
-        let out: Vec<Vec<f32>> = normed
-            .to_vec2::<f32>()
-            .map_err(|e| AppError::Storage(format!("embed extract vectors: {e}")))?;
+            normed
+                .to_vec2::<f32>()
+                .map_err(|e| AppError::Storage(format!("embed extract vectors: {e}")))
+        })?;
 
         // Width contract: every vector MUST be EMBED_DIM (the vec0 column width).
         for v in &out {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod facts;
 pub mod mcp;
 pub mod memory;
 pub mod orchestrate;
+pub mod perf;
 pub mod pipeline;
 pub mod proactive;
 pub mod prompts;

--- a/src-tauri/src/perf.rs
+++ b/src-tauri/src/perf.rs
@@ -1,0 +1,93 @@
+//! Shared "one heavy inference at a time" gate — see `AppState::heavy_inference`'s doc comment
+//! for the full rationale. `spawn_blocking` alone gets CPU-bound native work off the async
+//! runtime but is NOT a concurrency limiter (Tokio's own guidance: an unbounded blocking pool
+//! means nothing stops N heavy calls from running simultaneously and fighting each other for the
+//! same RAM/Metal context). Every native-runtime call site that loads/runs a heavy ML model
+//! (whisper ASR, the diarizer, the Candle embedder/NER, a brain-sidecar dispatch) should route
+//! through [`run_heavy`] instead of calling `tokio::task::spawn_blocking` directly.
+
+use std::sync::Arc;
+
+use crate::error::{AppError, Result};
+
+/// Acquire the ONE global heavy-inference permit (`AppState::heavy_inference`), then run `f` on
+/// the blocking thread pool. The permit is held for the duration of `f` and released when this
+/// future resolves (Ok or Err) — a second heavy call queues behind it rather than running
+/// concurrently. `f`'s own `Result<T>` (whatever `AppError` variant its domain uses) passes
+/// through unchanged; only the semaphore-closed / task-panicked cases surface as
+/// [`AppError::Other`]. Takes the semaphore directly (not the whole `AppState`) so it's
+/// independently unit-testable and so a caller that only has the `Arc` (not a full `&AppState`)
+/// can still route through it.
+pub async fn run_heavy<F, T>(semaphore: &Arc<tokio::sync::Semaphore>, f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let _permit = semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| AppError::Other(anyhow::anyhow!("heavy-inference semaphore closed")))?;
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| AppError::Other(anyhow::anyhow!("heavy inference task panicked: {e}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// The core contract: two `run_heavy` calls sharing ONE semaphore never overlap — the second
+    /// call's closure only starts once the first has fully finished, even though both are handed
+    /// to the blocking pool "concurrently" (a pool with >1 thread would otherwise happily run
+    /// them at the same time). Proves the serialization is real, not just "it compiles".
+    #[tokio::test]
+    async fn run_heavy_serializes_two_concurrent_calls() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let concurrent: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let max_concurrent: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+
+        let make_task = |sem: Arc<tokio::sync::Semaphore>,
+                          concurrent: Arc<AtomicUsize>,
+                          max_concurrent: Arc<AtomicUsize>| {
+            tokio::spawn(async move {
+                run_heavy(&sem, move || -> Result<()> {
+                    let now = concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_concurrent.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(50));
+                    concurrent.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+            })
+        };
+
+        let t1 = make_task(sem.clone(), concurrent.clone(), max_concurrent.clone());
+        let t2 = make_task(sem.clone(), concurrent.clone(), max_concurrent.clone());
+        t1.await.unwrap().unwrap();
+        t2.await.unwrap().unwrap();
+
+        assert_eq!(
+            max_concurrent.load(Ordering::SeqCst),
+            1,
+            "two run_heavy calls on the same semaphore must never overlap"
+        );
+    }
+
+    /// The permit must release even when `f` returns `Err` — a failed heavy op must not
+    /// permanently wedge every future heavy call behind a semaphore that never frees up.
+    #[tokio::test]
+    async fn run_heavy_releases_the_permit_on_error() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+
+        let first: Result<()> = run_heavy(&sem, || Err(AppError::Other(anyhow::anyhow!("boom")))).await;
+        assert!(first.is_err());
+
+        // A second call must still be able to acquire — proves the failed first call didn't leak
+        // its permit. Bounded by a timeout so a real leak fails the test instead of hanging it.
+        let second = tokio::time::timeout(Duration::from_secs(2), run_heavy(&sem, || Ok(42))).await;
+        assert_eq!(second.unwrap().unwrap(), 42, "the permit must be free again after an Err");
+    }
+}

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -541,7 +541,11 @@ async fn run_inner(
         None
     };
 
-    let (merged_segments, echo_suppressed, cluster_voiceprints) = tokio::task::spawn_blocking(move || -> Result<(Vec<crate::transcribe::types::Segment>, usize, Vec<crate::transcribe::diarize::ClusterVoiceprint>)> {
+    // Routed through the shared heavy-inference gate (perf::run_heavy), not a bare spawn_blocking
+    // — this closure loads Whisper AND (further in) the diarizer, so it must serialize against any
+    // OTHER heavy native-runtime call (embedder, NER, brain sidecar) running concurrently, not just
+    // against itself.
+    let (merged_segments, echo_suppressed, cluster_voiceprints) = crate::perf::run_heavy(&state.heavy_inference, move || -> Result<(Vec<crate::transcribe::types::Segment>, usize, Vec<crate::transcribe::diarize::ClusterVoiceprint>)> {
         use crate::audio::merge::{merge_streams, StreamInput, SPEAKER_ME, SPEAKER_OTHERS};
 
         let transcriber = Transcriber::load(&model_path_owned)?;
@@ -639,8 +643,7 @@ async fn run_inner(
             crate::audio::merge::suppress_cross_stream_echo(merge_streams(streams), leak.as_ref());
         Ok((merged, echo_suppressed, cluster_voiceprints))
     })
-    .await
-    .map_err(|e| AppError::Transcribe(format!("transcription task panicked: {e}")))??;
+    .await?;
 
     // Persist the (opt-in) per-cluster voiceprints — one row per diarized "others" cluster, label
     // NULL until enrolled by rename. Best-effort: a persist failure is logged (no PII) and never

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -269,6 +269,18 @@ pub struct AppState {
     /// resurrecting just-sealed content into a rollup (the pass-vs-seal TOCTOU). Content-free
     /// (a bare counter) — no PII, nothing to seal.
     pub seal_epoch: AtomicU64,
+    /// 2026-07-13 — GLOBAL "one heavy inference at a time" gate. A single permit shared across
+    /// every native-runtime call site that loads/runs a heavy ML model (whisper ASR, the
+    /// diarizer, the Candle embedder/NER, the brain sidecar dispatch). `spawn_blocking` alone gets
+    /// CPU-bound native work off the async runtime but is NOT a concurrency limiter — nothing
+    /// stops N heavy calls from landing on the blocking pool simultaneously and fighting each
+    /// other for the same RAM/Metal context (the exact mechanism behind the whisper/diarizer
+    /// co-residency bug fixed this session, generalized: per-call-site RAM checks alone can't
+    /// close the TOCTOU window between "checked headroom" and "actually allocated peak" the way a
+    /// semaphore does by construction). Acquire via [`crate::perf::run_heavy`] — do not bypass by
+    /// calling `spawn_blocking` directly for a heavy native call (same "one shared chokepoint"
+    /// discipline as `meeting_is_unlocked` for content reads).
+    pub heavy_inference: Arc<tokio::sync::Semaphore>,
 }
 
 impl AppState {
@@ -356,6 +368,7 @@ impl AppState {
             share_refresh_lock: tokio::sync::Mutex::new(()),
             lifecycle: Mutex::new(()),
             seal_epoch: AtomicU64::new(0),
+            heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
         })
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -125,6 +125,34 @@ fn chunk_hash(text: &str) -> u64 {
     h
 }
 
+/// Embed a batch of augmented chunk texts in small sub-batches instead of ONE call sized to the
+/// whole meeting/document/topic list. A long meeting or document can produce dozens of chunks
+/// (topic chunks merge to a 60s floor — a 1h+ recording can have 40-60; transcript chunks target
+/// ~1000 chars each — a 1h+ recording's transcript alone can produce a comparable or larger
+/// count), and `CandleBertEmbedder::embed` builds ONE rectangular Candle/Metal tensor per call
+/// sized to the whole input batch — so without this, one long meeting/document still drives an
+/// unbounded-size Metal burst regardless of any caller-side "how many ITEMS per run" cap
+/// (2026-07-13: the launch-freeze fix for topic chunks; the identical gap in transcript/note
+/// chunk indexing — the far more common path, since it runs on every recording Stop, not just
+/// the startup catch-up — is closed here too, both callers now sharing this one helper).
+fn embed_in_sub_batches(embedder: &dyn Embedder, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    const SUB_BATCH: usize = 8;
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    if texts.len() <= SUB_BATCH {
+        return embedder.embed_passage(texts);
+    }
+    let mut vectors = Vec::with_capacity(texts.len());
+    for (i, sub_batch) in texts.chunks(SUB_BATCH).enumerate() {
+        if i > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+        }
+        vectors.extend(embedder.embed_passage(sub_batch)?);
+    }
+    Ok(vectors)
+}
+
 fn register_vec_extension() {
     use std::sync::Once;
     static REGISTER: Once = Once::new();
@@ -3273,16 +3301,8 @@ impl Db {
         // Chunks are passages → e5 `passage:` prefix convention. The stub ignores the prefix; the real
         // CandleBertEmbedder needs it for retrieval recall. Embed each class only when non-empty —
         // on the AUGMENTED text (L1.2: the situating header rides the embedding AND the FTS legs).
-        let note_vectors = if note_aug.is_empty() {
-            Vec::new()
-        } else {
-            embedder.embed_passage(&note_aug)?
-        };
-        let transcript_vectors = if transcript_aug.is_empty() {
-            Vec::new()
-        } else {
-            embedder.embed_passage(&transcript_aug)?
-        };
+        let note_vectors = embed_in_sub_batches(embedder, &note_aug)?;
+        let transcript_vectors = embed_in_sub_batches(embedder, &transcript_aug)?;
 
         // Always purge this meeting's prior rows first (clean replace of BOTH classes), then insert the
         // fresh set in ONE transaction.
@@ -3528,29 +3548,14 @@ impl Db {
             }
         }
 
-        // Embed in small sub-batches rather than one call for the WHOLE meeting. Topic chunks are
-        // merged to >= TOPIC_MERGE_MIN_DURATION_S (60s), so a single long meeting (a 1h+ recording
-        // can easily produce 40-60 chunks) would otherwise build ONE rectangular Candle/Metal tensor
-        // sized (chunk_count, longest_chunk_tokens) in one blocking forward pass — a burst whose size
-        // scales with that ONE meeting's length, untouched by the per-run meeting-count cap above
-        // (2026-07-13: a reported launch freeze persisted after that cap because the freezing vault
-        // had a 1h+ recording — the cap bounds how many MEETINGS get re-embedded per run, not how
-        // much work one meeting's own embed call does).
-        const TOPIC_EMBED_SUB_BATCH: usize = 8;
-        let vectors = if augs.is_empty() {
-            Vec::new()
-        } else if augs.len() <= TOPIC_EMBED_SUB_BATCH {
-            embedder.embed_passage(&augs)?
-        } else {
-            let mut vectors = Vec::with_capacity(augs.len());
-            for (i, sub_batch) in augs.chunks(TOPIC_EMBED_SUB_BATCH).enumerate() {
-                if i > 0 {
-                    std::thread::sleep(std::time::Duration::from_millis(30));
-                }
-                vectors.extend(embedder.embed_passage(sub_batch)?);
-            }
-            vectors
-        };
+        // Embed in small sub-batches rather than one call for the WHOLE meeting — see
+        // `embed_in_sub_batches`'s doc comment. Topic chunks merge to >= TOPIC_MERGE_MIN_DURATION_S
+        // (60s), so a single long meeting (a 1h+ recording can easily produce 40-60 chunks) would
+        // otherwise build ONE rectangular Candle/Metal tensor sized (chunk_count,
+        // longest_chunk_tokens) in one blocking forward pass, untouched by the per-run
+        // meeting-count cap above (2026-07-13: a reported launch freeze persisted after that cap
+        // because the freezing vault had a 1h+ recording).
+        let vectors = embed_in_sub_batches(embedder, &augs)?;
 
         // PURGE-then-INSERT this meeting's topic rows in ONE transaction (clean replace).
         let mut conn = self.lock();
@@ -15080,7 +15085,7 @@ mod tests {
     /// call sized to the whole meeting — that burst scales with ONE meeting's length and is
     /// untouched by the per-run meeting-count cap (a freshly-Brain-enabled vault containing a long
     /// recording kept freezing on launch even after that cap shipped). Proves the embed calls are
-    /// sub-batched to TOPIC_EMBED_SUB_BATCH (8) at a time.
+    /// sub-batched (via the shared `embed_in_sub_batches` helper) 8 at a time.
     #[test]
     fn long_meeting_topic_chunks_are_embedded_in_small_sub_batches() {
         let db = mem_db();
@@ -15124,6 +15129,60 @@ mod tests {
         assert!(
             calls.len() > 1,
             "10 chunks over an 8-per-batch cap must take more than one embed call, got: {calls:?}"
+        );
+    }
+
+    /// 2026-07-13 launch-freeze fix (round 3): `index_meeting_chunks` (the REGULAR transcript/note
+    /// indexer, run on every meeting Stop — not just the startup catch-up) had the identical
+    /// unbounded-single-call bug as the topic-chunk indexer above. A long transcript (~1000
+    /// chars/chunk target) from a 1h+ recording can produce dozens of chunks; this proves BOTH the
+    /// note and transcript embed calls now share `embed_in_sub_batches` too.
+    #[test]
+    fn long_transcript_chunks_are_embedded_in_small_sub_batches() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-long-transcript", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        // 20 segments alternating speaker (chunk_transcript's turn-grouping only breaks a turn on
+        // a SPEAKER CHANGE, not a time gap — same-speaker segments merge into one turn and "a
+        // single oversized turn becomes its own chunk, never split mid-turn", so a same-speaker
+        // fixture would collapse to ONE chunk regardless of length). Alternating speakers forces
+        // 20 distinct turns totaling well over TRANSCRIPT_CHUNK_CHAR_TARGET(1000) x 8 chars, so
+        // the sliding window packs them into well more than 8 chunks.
+        let mut segs = Vec::new();
+        for i in 0..20i64 {
+            let body = format!("segment number {i} discusses a distinct agenda topic in detail. ")
+                .repeat(10);
+            let speaker = if i % 2 == 0 { "me" } else { "others" };
+            segs.push(Segment {
+                idx: i,
+                start_s: i as f64 * 20.0,
+                end_s: i as f64 * 20.0 + 18.0,
+                text: body,
+                speaker: Some(speaker.into()),
+                confidence: None,
+            });
+        }
+        db.insert_segments("m-long-transcript", &segs).unwrap();
+
+        let embedder = RecordingEmbedder {
+            call_sizes: std::sync::Mutex::new(Vec::new()),
+        };
+        db.index_meeting_chunks("m-long-transcript", &segs, &embedder)
+            .unwrap();
+
+        let calls = embedder.call_sizes.into_inner().unwrap();
+        assert!(
+            calls.iter().all(|&n| n <= 8),
+            "no single embed call may exceed the sub-batch size, got call sizes: {calls:?}"
+        );
+        assert!(
+            calls.len() > 1,
+            "a long transcript must take more than one embed call, got: {calls:?}"
+        );
+        assert_eq!(
+            chunk_count(&db, "m-long-transcript"),
+            calls.iter().sum::<usize>() as i64,
+            "every produced chunk (note + transcript classes) must be embedded exactly once across the sub-batches"
         );
     }
 

--- a/src-tauri/src/summarize/ner_deberta.rs
+++ b/src-tauri/src/summarize/ner_deberta.rs
@@ -190,24 +190,28 @@ impl DebertaNameRedactor {
         let special = encoding.get_special_tokens_mask(); // 1 for [CLS]/[SEP]/pad
 
         let seq = ids.len();
-        let input_ids = Tensor::from_vec(ids.to_vec(), (1, seq), device)
-            .map_err(|e| AppError::Storage(format!("ner input tensor: {e}")))?;
-        let attention_mask = Tensor::ones((1, seq), candle_core::DType::U32, device)
-            .map_err(|e| AppError::Storage(format!("ner mask tensor: {e}")))?;
+        // See the matching autoreleasepool wrap + rationale comment in embed/candle_bert.rs — same
+        // Metal-autorelease-drain concern, same zero-new-crate objc2 fix.
+        let label_ids: Vec<u32> = objc2::rc::autoreleasepool(|_pool| -> Result<Vec<u32>> {
+            let input_ids = Tensor::from_vec(ids.to_vec(), (1, seq), device)
+                .map_err(|e| AppError::Storage(format!("ner input tensor: {e}")))?;
+            let attention_mask = Tensor::ones((1, seq), candle_core::DType::U32, device)
+                .map_err(|e| AppError::Storage(format!("ner mask tensor: {e}")))?;
 
-        // logits: [1, seq, num_labels]
-        let logits = loaded
-            .model
-            .forward(&input_ids, None, Some(attention_mask))
-            .map_err(|e| AppError::Storage(format!("ner forward failed: {e}")))?;
-        let logits = logits
-            .to_dtype(candle_core::DType::F32)
-            .and_then(|t| t.squeeze(0)) // [seq, num_labels]
-            .map_err(|e| AppError::Storage(format!("ner logits reshape: {e}")))?;
-        let label_ids: Vec<u32> = logits
-            .argmax(candle_core::D::Minus1)
-            .and_then(|t| t.to_vec1::<u32>())
-            .map_err(|e| AppError::Storage(format!("ner argmax failed: {e}")))?;
+            // logits: [1, seq, num_labels]
+            let logits = loaded
+                .model
+                .forward(&input_ids, None, Some(attention_mask))
+                .map_err(|e| AppError::Storage(format!("ner forward failed: {e}")))?;
+            let logits = logits
+                .to_dtype(candle_core::DType::F32)
+                .and_then(|t| t.squeeze(0)) // [seq, num_labels]
+                .map_err(|e| AppError::Storage(format!("ner logits reshape: {e}")))?;
+            logits
+                .argmax(candle_core::D::Minus1)
+                .and_then(|t| t.to_vec1::<u32>())
+                .map_err(|e| AppError::Storage(format!("ner argmax failed: {e}")))
+        })?;
 
         // Decode BIO PERSON spans into char ranges, then map distinct names → stable tokens.
         let spans = decode_person_spans(&label_ids, offsets, special, &loaded.id2label);


### PR DESCRIPTION
## Summary
Follow-up to v0.9.10/v0.9.11's freeze fixes, driven by a two-workflow investigation (Rust/AI-app memory research + a 40-agent codebase anti-pattern audit, 33 confirmed findings). Ships the P0 items most directly relevant to the ongoing freeze investigation:

- **`Db::index_meeting_chunks`** had the identical unbounded-embed-batch bug already fixed in `index_meeting_topic_chunks_reporting` — but runs on EVERY meeting Stop, not just startup, so likely more impactful. Extracted a shared `embed_in_sub_batches` helper, deduplicating both indexers onto it.
- **`objc2::rc::autoreleasepool`** wraps around Candle Metal `.forward()` calls (embedder + NER) — closes exposure to the still-open, maintainer-confirmed `huggingface/candle#2271` leak. Zero new crate (`objc2` already a dependency).
- **Global "one heavy inference at a time" semaphore** (`AppState.heavy_inference` + `perf::run_heavy`) — `spawn_blocking` alone isn't a concurrency limiter. Wired into the whisper+diarizer closure. **Partial migration** — embedder/NER/brain-sidecar call sites aren't wired yet (tracked as follow-up), this closes the whisper+diarizer instance specifically.

## Test plan
- [x] `cargo test --lib` — 1573 passed, 0 failed, 10 ignored
- [x] New test `long_transcript_chunks_are_embedded_in_small_sub_batches` — RED-before-GREEN confirmed
- [x] New tests `run_heavy_serializes_two_concurrent_calls` + `run_heavy_releases_the_permit_on_error` — RED-before-GREEN confirmed on the serialization test (bumped to 2 permits, confirmed overlap, restored)
- [x] Adversarial-verifier: PASS — ordering correctness independently traced, autoreleasepool signature checked against vendored objc2 0.6.4 source, RAII permit-release confirmed structurally sound
- [ ] Live reproduction on the reporting user's low-RAM Mac — pending

## Follow-up (not in this PR)
Per the audit, HIGH-severity async-blocking findings remain open: `unlock_folder` runs its whole decrypt+re-embed restore synchronously on the async runtime, `build_and_persist_entities` runs an up-to-180s brain-sidecar dispatch the same way (twice per recording), `ask_vault_floor`'s local-reasoner path likewise. Plus 27 more MODERATE/LOW findings (missing DB indices, N+1 queries, unbounded FE lists, live-loop allocation churn). Tracked separately.