### PR TITLE
fix(perf): stop the meeting-timeline active-highlight eval storm

### DIFF
--- a/src/app/features/detail/meeting-timeline/meeting-timeline.component.html
+++ b/src/app/features/detail/meeting-timeline/meeting-timeline.component.html
@@ -197,7 +197,7 @@
                 <button
                   type="button"
                   class="tl-block"
-                  [class.is-active]="isActive(blk.startS, blk.endS)"
+                  [class.is-active]="activeBlockOrders().has(blk.order)"
                   [style.left.%]="blk.left"
                   [style.width.%]="blk.width"
                   [style.--i]="blk.order"
@@ -244,7 +244,7 @@
               type="button"
               class="tl-chapter"
               role="listitem"
-              [class.is-active]="isActiveChapter(ch.startS, ch.endS)"
+              [class.is-active]="activeTopicOrders().has(ch.order)"
               [style.--i]="ch.order"
               [attr.aria-label]="
                 'Chapter ' + ch.label + ', starts ' + fmt(ch.startS)
@@ -286,7 +286,7 @@
             <button
               type="button"
               class="tl-topic"
-              [class.is-active]="isActive(top.startS, top.endS)"
+              [class.is-active]="activeTopicOrders().has(top.order)"
               [style.left.%]="top.left"
               [style.width.%]="top.width"
               [style.--i]="top.order"

--- a/src/app/features/detail/meeting-timeline/meeting-timeline.component.ts
+++ b/src/app/features/detail/meeting-timeline/meeting-timeline.component.ts
@@ -314,6 +314,46 @@ export class MeetingTimelineComponent {
     })),
   );
 
+  /**
+   * The `order` of every speaker block whose [startS, endS) currently contains the playhead — a
+   * single `computed`, scanned ONCE per `currentTime` tick (O(n) over all blocks across all
+   * lanes); the template then does an O(1) `.has(blk.order)` per rendered block. Replaces the
+   * former `isActive(startS, endS)` METHOD binding, which Angular re-ran once per rendered block
+   * on EVERY change-detection pass — for a 1h+ meeting's timeline (proportional to meeting
+   * length, unlike the transcript's RENDER_CAP window) driven by `currentTime` writes on every
+   * native `timeupdate` (~4×/s during playback), this was the exact `isActiveSegment()`-class
+   * eval storm already fixed once in `audio-panel.component.ts`'s `activeSegKeys` — reintroduced
+   * here, unfixed (2026-07-13 perf follow-up).
+   */
+  readonly activeBlockOrders = computed<Set<number>>(() => {
+    const t = this.currentTime();
+    const out = new Set<number>();
+    for (const lane of this.lanes()) {
+      for (const blk of lane.blocks) {
+        if (t >= blk.startS && t < blk.endS) {
+          out.add(blk.order);
+        }
+      }
+    }
+    return out;
+  });
+
+  /**
+   * Same pattern as [`activeBlockOrders`] for the topic ribbon AND the chapter list — both derive
+   * their `order` from the same [`topics`] computed, so ONE Set covers both templates' `.has()`
+   * lookups.
+   */
+  readonly activeTopicOrders = computed<Set<number>>(() => {
+    const t = this.currentTime();
+    const out = new Set<number>();
+    for (const top of this.topics()) {
+      if (t >= top.startS && t < top.endS) {
+        out.add(top.order);
+      }
+    }
+    return out;
+  });
+
   /** True once we have at least one lane or topic to draw. */
   readonly ready = computed(
     () =>
@@ -366,12 +406,6 @@ export class MeetingTimelineComponent {
   protected readonly currentRounded = computed(() =>
     Math.round(clamp(this.currentTime(), 0, this.span())),
   );
-
-  /** True when playback is inside [startS, endS) — drives the live highlight. */
-  isActive(startS: number, endS: number): boolean {
-    const t = this.currentTime();
-    return t >= startS && t < endS;
-  }
 
   /** Click a block → request a seek to its start (parent decides if audio moves). */
   onBlock(event: MouseEvent, startS: number): void {
@@ -486,11 +520,6 @@ export class MeetingTimelineComponent {
       return;
     }
     this.renameSpeaker.emit({ oldLabel, newLabel });
-  }
-
-  /** True when the playhead sits inside a chapter — highlights its label. */
-  isActiveChapter(startS: number, endS: number): boolean {
-    return this.isActive(startS, endS);
   }
 
   /** Keyboard seeking on the focusable axis (← / → by 5s, Home/End). */


### PR DESCRIPTION
## Summary
User-reported follow-up after v0.9.12 fixed the launch freeze: opening the Audio tab of a 1h+ meeting still lags during playback.

Root cause: `isActive(startS, endS)`/`isActiveChapter(startS, endS)` were METHOD bindings called once per rendered speaker-block/topic-span/chapter, on every change-detection pass. `currentTime` updates on every native `<audio>` `timeupdate` (~4x/sec during playback), triggering OnPush CD that re-evaluates every one of those calls. Unlike the transcript (fixed-size RENDER_CAP=80), the timeline's block/topic count scales with meeting length — the same `isActiveSegment()` eval-storm class already fixed once for the transcript (`activeSegKeys`), reintroduced here unfixed.

Replaced both methods with `computed<Set<number>>` (`activeBlockOrders`, `activeTopicOrders`), each scanning its source list once per `currentTime` tick. Templates now do O(1) `Set.has(order)` per node instead of a method call re-evaluated per node per CD pass.

## Test plan
- [x] `ng build` + `ng lint` — clean
- [x] Adversarial-verifier: PASS — condition-logic equivalence confirmed character-by-character, `order` uniqueness traced through `lanes()`/`topics()`, no stale-Set risk (pure `computed()`), dead code fully removed
- [ ] No new e2e test — this component has no existing e2e coverage; reliably driving a native `<audio>` element's `currentTime` in Playwright without a real audio source was judged not worth the flakiness risk for a mechanical, directly-traceable refactor