### PR TITLE
fix(perf): move reindex_embeddings off the async runtime + add stage timing

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4814,8 +4814,15 @@ pub async fn build_and_persist_entities(
             .clone()
     };
     let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let entities_started = std::time::Instant::now();
     let payload =
         crate::summarize::graph::extract_entities(provider.as_ref(), title, markdown).await?;
+    tracing::info!(
+        target: "perf",
+        stage = "extract_entities",
+        elapsed_ms = entities_started.elapsed().as_millis() as u64,
+        "pipeline stage complete"
+    );
 
     // Sink A — ALWAYS persist to the encrypted DB (the graph's source of truth). Collect the
     // resolved (entity_id, name) pairs so the bitemporal-facts pass below can extract + reconcile
@@ -4853,8 +4860,10 @@ pub async fn build_and_persist_entities(
     let title_owned = title.to_string();
     let markdown_owned = markdown.to_string();
     let entity_refs_owned = entity_refs.clone();
+    let facts_started = std::time::Instant::now();
     if let Err(e) = crate::perf::run_heavy(&state.heavy_inference, move || -> Result<(), AppError> {
         let state = app_for_facts.state::<AppState>();
+        let t0 = std::time::Instant::now();
         if let Err(e) = persist_facts_for_meeting(
             &state,
             &meeting_id_owned,
@@ -4864,17 +4873,26 @@ pub async fn build_and_persist_entities(
         ) {
             tracing::warn!(target: "facts", error = %e, "fact reconcile failed (note unaffected)");
         }
+        tracing::info!(target: "perf", stage = "persist_facts", elapsed_ms = t0.elapsed().as_millis() as u64, "pipeline stage complete");
+        let t1 = std::time::Instant::now();
         if let Err(e) =
             persist_user_facts_for_meeting(&state, &meeting_id_owned, &title_owned, &markdown_owned)
         {
             tracing::warn!(target: "user_memory", error = %e, "user-fact reconcile failed (note unaffected)");
         }
+        tracing::info!(target: "perf", stage = "persist_user_facts", elapsed_ms = t1.elapsed().as_millis() as u64, "pipeline stage complete");
         Ok(())
     })
     .await
     {
         tracing::warn!(target: "facts", error = %e, "facts/user-memory blocking task failed (note unaffected)");
     }
+    tracing::info!(
+        target: "perf",
+        stage = "facts_and_user_memory_total",
+        elapsed_ms = facts_started.elapsed().as_millis() as u64,
+        "pipeline stage complete"
+    );
 
     // Sink B — vault [[ ]] stubs, ONLY when a vault is configured AND the meeting's folder is
     // NOT sealed on disk. Disk-truth `locked` (not session `unlocked`): a session-unlock must
@@ -9894,18 +9912,36 @@ pub async fn reindex_embeddings(
         .map(|g| g.clone())
         .unwrap_or_default();
 
-    reindex_embeddings_inner(
-        &state.db,
-        &unlocked,
-        crate::embed::embed_model_present(),
-        crate::embed::active_embedder().as_ref(),
-        |done, total| {
-            let _ = app.emit(
-                crate::events::EVENT_REINDEX,
-                crate::events::ReindexPayload { done, total },
-            );
-        },
-    )
+    // 2026-07-13 perf audit (MODERATE): this ran `reindex_embeddings_inner` — a vault-wide loop
+    // (up to 100_000 meetings + every visible document) doing real Candle/Metal embed calls —
+    // INLINE on the async command's Tokio worker, the same shape as the original startup-freeze
+    // bug this whole investigation started from (now fixed there via a RAM floor + per-run cap;
+    // the per-meeting embed BATCH SIZE is already safe here too, since index_meeting_chunks/
+    // index_meeting_topic_chunks were sub-batched earlier today). This one is user-TRIGGERED (the
+    // Settings "Reindex" button), not automatic, so the risk is lower, but the fix is the same
+    // shape: move off the async runtime + gate on a RAM floor before starting.
+    if !crate::transcribe::model::topic_backfill_ram_permits_now() {
+        return Err(AppError::Unavailable(
+            "not enough free memory to reindex right now — close some apps and try again".into(),
+        ));
+    }
+    let db = state.db.clone();
+    let heavy_inference = state.heavy_inference.clone();
+    crate::perf::run_heavy(&heavy_inference, move || {
+        reindex_embeddings_inner(
+            &db,
+            &unlocked,
+            crate::embed::embed_model_present(),
+            crate::embed::active_embedder().as_ref(),
+            |done, total| {
+                let _ = app.emit(
+                    crate::events::EVENT_REINDEX,
+                    crate::events::ReindexPayload { done, total },
+                );
+            },
+        )
+    })
+    .await
 }
 
 /// "Powiązane wg znaczenia": the up-to-5 meetings most semantically similar to `meeting_id`.

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -545,6 +545,15 @@ async fn run_inner(
     // — this closure loads Whisper AND (further in) the diarizer, so it must serialize against any
     // OTHER heavy native-runtime call (embedder, NER, brain sidecar) running concurrently, not just
     // against itself.
+    //
+    // 2026-07-13 — per-stage wall-clock telemetry: a user reported a ~15min recording taking
+    // ~15min end-to-end (Stop → note ready) and force-quit thinking the app hung. Diagnosis
+    // couldn't pin the dominant cost without real numbers from the affected machine (candidates:
+    // Accurate-profile whisper decode of BOTH streams, diarization, note-gen, brain-sidecar fact
+    // extraction, embedding — all now strictly sequential through this same closure + the
+    // downstream summarize_and_export call). Logging elapsed_ms per stage (never audio/transcript
+    // content) so the NEXT report comes with a real breakdown instead of another guess.
+    let asr_diarize_started = std::time::Instant::now();
     let (merged_segments, echo_suppressed, cluster_voiceprints) = crate::perf::run_heavy(&state.heavy_inference, move || -> Result<(Vec<crate::transcribe::types::Segment>, usize, Vec<crate::transcribe::diarize::ClusterVoiceprint>)> {
         use crate::audio::merge::{merge_streams, StreamInput, SPEAKER_ME, SPEAKER_OTHERS};
 
@@ -644,6 +653,13 @@ async fn run_inner(
         Ok((merged, echo_suppressed, cluster_voiceprints))
     })
     .await?;
+    tracing::info!(
+        target: "perf",
+        stage = "asr_diarize",
+        elapsed_ms = asr_diarize_started.elapsed().as_millis() as u64,
+        duration_s,
+        "pipeline stage complete"
+    );
 
     // Persist the (opt-in) per-cluster voiceprints — one row per diarized "others" cluster, label
     // NULL until enrolled by rename. Best-effort: a persist failure is logged (no PII) and never
@@ -714,7 +730,8 @@ async fn run_inner(
     // ── 4 + 5. Summarize with the configured provider, then export ───────────
     // NOTE: no config is passed — the summarize step re-reads the LIVE config (consent may have
     // been revoked during the minutes of transcription above; see `resolve_summarize_egress`).
-    summarize_and_export(
+    let summarize_started = std::time::Instant::now();
+    let result = summarize_and_export(
         app,
         state,
         meeting_id,
@@ -724,7 +741,15 @@ async fn run_inner(
         &date_iso,
         &ended_at,
     )
-    .await
+    .await;
+    tracing::info!(
+        target: "perf",
+        stage = "summarize_and_export",
+        elapsed_ms = summarize_started.elapsed().as_millis() as u64,
+        ok = result.is_ok(),
+        "pipeline stage complete"
+    );
+    result
 }
 
 /// TIER 0 — the summarizer's transcript, in two forms.

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -374,12 +374,14 @@ pub fn parakeet_ram_permits_now() -> bool {
     }
 }
 
-/// RAM guard for the startup topic-chunk backfill (`Db::backfill_topic_chunks_idempotent`) —
-/// `false` ONLY when total RAM is affirmatively below [`TOPIC_BACKFILL_MIN_RAM_BYTES`]. Fails
-/// OPEN when the probe can't read RAM (a broken measurement never silently disables catch-up
-/// indexing). A genuinely RAM-starved machine defers the whole backfill rather than starting a
-/// Metal/Candle embed pass on launch — it catches up on a later, healthier launch since the
-/// backfill is content-hash idempotent. Mirrors [`parakeet_ram_permits_now`].
+/// RAM guard for any bulk Candle/Metal embed pass over the vault — the startup topic-chunk
+/// backfill (`Db::backfill_topic_chunks_idempotent`) and the user-triggered "Reindex" command
+/// (`commands::reindex_embeddings`) both gate on this before starting. `false` ONLY when total
+/// RAM is affirmatively below [`TOPIC_BACKFILL_MIN_RAM_BYTES`]. Fails OPEN when the probe can't
+/// read RAM (a broken measurement never silently disables catch-up indexing). A genuinely
+/// RAM-starved machine defers the whole pass rather than starting a Metal/Candle embed burst —
+/// both callers are safe to retry later (the backfill is content-hash idempotent; reindex is a
+/// user-initiated retry). Mirrors [`parakeet_ram_permits_now`].
 pub fn topic_backfill_ram_permits_now() -> bool {
     match total_ram_bytes() {
         Some(b) => b >= TOPIC_BACKFILL_MIN_RAM_BYTES,


### PR DESCRIPTION
## Summary
Continuing the perf-audit backlog:
- `reindex_embeddings` (Settings "Reindex" button) ran the vault-wide embed loop inline on the async runtime — same shape as the original startup-freeze bug. Moved to `spawn_blocking` + `perf::run_heavy`, gated on the existing RAM floor.
- Added per-stage wall-clock timing (`tracing::info!`, elapsed_ms only, no content) around ASR+diarize, summarize_and_export, extract_entities, and the two brain-sidecar fact-extraction calls — motivated by a live report (15min recording, ~15min processing) that couldn't be conclusively attributed without real numbers from the affected machine.

## Test plan
- [x] `cargo test --lib` — 1574 passed, 0 failed, 10 ignored
- [x] Adversarial-verifier: PASS (isolated worktree, RAM-gate ordering confirmed, no PII in new logs, byte-for-byte return-value preservation traced)