### PR TITLE
fix(perf): cap list_entities_visible + windowed People list render

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8296,6 +8296,12 @@ impl Db {
     pub fn list_entities_visible(&self, unlocked: &HashSet<String>) -> Result<Vec<GraphNode>> {
         let conn = self.lock();
         let visible = visibility_clause("n", unlocked);
+        // 2026-07-13 perf audit (MODERATE): this fed BOTH get_graph's node list and list_people
+        // with NO limit, unlike the sibling graph_edges_visible (MAX_GRAPH_EDGES=600, added for
+        // the same reason — see its own comment). Visibility is already enforced in WHERE; a
+        // trailing LIMIT trims magnitude only, ordered by mention count so the most-relevant
+        // entities/people survive the cut on a vault with many.
+        const MAX_VISIBLE_ENTITIES: usize = 500;
         let sql = format!(
             "SELECT e.id, e.name, e.kind, COUNT(em.meeting_id) AS cnt
                FROM entities e
@@ -8311,7 +8317,8 @@ impl Db {
                     )
               GROUP BY e.id, e.name, e.kind
              HAVING cnt > 0
-              ORDER BY cnt DESC, e.name COLLATE NOCASE ASC"
+              ORDER BY cnt DESC, e.name COLLATE NOCASE ASC
+              LIMIT {MAX_VISIBLE_ENTITIES}"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt

--- a/src/app/features/people/people/people.component.html
+++ b/src/app/features/people/people/people.component.html
@@ -36,7 +36,7 @@
   } @else {
     <div class="p-layout" [class.has-detail]="selectedId() !== null">
       <ul class="p-cards" role="list">
-        @for (p of people(); track p.id) {
+        @for (p of renderedPeople(); track p.id) {
           <li>
             <button
               type="button"
@@ -113,6 +113,12 @@
           </li>
         }
       </ul>
+
+      @if (hiddenCount() > 0) {
+        <button type="button" class="btn btn-ghost p-show-all" (click)="showAll()">
+          Show all {{ total() }} people
+        </button>
+      }
 
       @if (selectedId(); as id) {
         <app-person-dossier

--- a/src/app/features/people/people/people.component.scss
+++ b/src/app/features/people/people/people.component.scss
@@ -156,4 +156,10 @@
     transition: none;
   }
 }
+
+// "Show all N people" — the RENDER_CAP expander (mirrors audio-panel's .show-all).
+.p-show-all {
+  display: block;
+  margin: var(--space-3) auto 0;
+}
     

--- a/src/app/features/people/people/people.component.ts
+++ b/src/app/features/people/people/people.component.ts
@@ -48,6 +48,25 @@ export class PeopleComponent {
   protected readonly total = computed(() => this.people().length);
 
   /**
+   * 2026-07-13 perf audit (LOW-MODERATE): `list_people` has no backend LIMIT, so a vault with
+   * many people rendered every card unbounded — mirrors the pattern already established for the
+   * transcript (`audio-panel.component.ts` RENDER_CAP=80) and the brain entity map
+   * (`brain.component.ts` MAP_NODE_CAP=60), just not applied here yet.
+   */
+  private readonly RENDER_CAP = 100;
+  protected readonly expanded = signal(false);
+  protected readonly renderedPeople = computed<PersonCard[]>(() => {
+    const all = this.people();
+    if (this.expanded() || all.length <= this.RENDER_CAP) {
+      return all;
+    }
+    return all.slice(0, this.RENDER_CAP);
+  });
+  protected readonly hiddenCount = computed(
+    () => this.people().length - this.renderedPeople().length,
+  );
+
+  /**
    * Load the people list, and re-load whenever the folder lock-state changes.
    * Reading the folders `tree` signal registers this effect as its dependent, so
    * its initial value drives the first fetch (no separate `ngOnInit`), and a
@@ -89,6 +108,11 @@ export class PeopleComponent {
 
   clearSelection(): void {
     this.selectedId.set(null);
+  }
+
+  /** Reveal the full people list (drops the RENDER_CAP window). */
+  showAll(): void {
+    this.expanded.set(true);
   }
 
   /** The uppercase leading letter for the avatar (fallback "?" for empty names). */


### PR DESCRIPTION
## Summary
- `list_entities_visible` fed BOTH `get_graph`'s entity node list and `list_people` with no LIMIT. Added `MAX_VISIBLE_ENTITIES=500`, ordered by mention count (mirrors the sibling `graph_edges_visible`/`MAX_GRAPH_EDGES=600`).
- `PeopleComponent`'s `@for` had no RENDER_CAP window. Added the same pattern already used for the transcript (`audio-panel.component.ts`) and the brain entity map.

## Test plan
- [x] `cargo test --lib` — 1574 passed, 0 failed, 10 ignored
- [x] `ng build` + `ng lint` — clean
- [x] Adversarial-verifier: PASS — wrote its own RED/GREEN repro (520 seeded entities: unbounded pre-fix, capped at exactly 500 post-fix), confirmed visibility-gating clause byte-identical before/after (the LIMIT only trims an already-gated set)

Two non-blocking INFO notes from review: (1) on a vault with 500+ combined entities, low-mention People rows could be pushed below the cut by high-mention Projects — a narrow edge case; (2) the People "Show all" expanded state persists across refetches (judged reasonable UX, matches how a user's explicit "show more" choice should probably behave).