### PR TITLE
fix(perf): add kernel memory-pressure signal alongside the existing RAM floors

### DIFF
--- a/src-tauri/src/perf.rs
+++ b/src-tauri/src/perf.rs
@@ -33,11 +33,77 @@ where
         .map_err(|e| AppError::Other(anyhow::anyhow!("heavy inference task panicked: {e}")))?
 }
 
+/// macOS kernel memory-pressure level via `sysctl -n kern.memorystatus_vm_pressure_level` — the
+/// SAME no-new-crate/no-new-FFI shell-out convention as `total_ram_bytes`/`available_ram_bytes`
+/// (`transcribe/model.rs`, `reason/sidecar.rs`). `1` = normal, `2` = warn, `4` = critical.
+///
+/// This is a DIFFERENT signal than the existing `vm_stat`-derived free/inactive/speculative
+/// arithmetic: that answers "does THIS job's footprint fit the numbers we can see", this answers
+/// "does the KERNEL ITSELF already think the whole system is under pressure" (e.g. another app
+/// about to be jetsam-killed, or pressure that hasn't yet shown up as reduced free/inactive
+/// pages). Meant to be consulted ALONGSIDE an existing RAM-floor check, not instead of it — see
+/// [`heavy_op_permitted`].
+///
+/// Returns `None` on ANY parse/exec failure — callers must fail OPEN on `None`, matching every
+/// other RAM-probe convention in this codebase (a broken measurement must never silently refuse
+/// a legitimate task).
+fn kernel_memory_pressure_level() -> Option<u8> {
+    let out = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("kern.memorystatus_vm_pressure_level")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()?.trim().parse().ok()
+}
+
+/// Combine an existing RAM-floor verdict (`ram_floor_ok`, e.g. `topic_backfill_ram_permits_now()`
+/// or `parakeet_ram_permits_now()`) with the kernel's own pressure signal — refuses ONLY when the
+/// floor check already said no, OR the kernel reports CRITICAL (4) pressure. `WARN` (2) is common
+/// and deliberately NOT itself a refusal (per the research brief this codifies: blocking on WARN
+/// would be over-eager for a user-initiated action like starting a recording). Fails OPEN on a
+/// broken pressure probe — a `None` never adds a NEW refusal on top of an already-permitting floor
+/// check.
+pub fn heavy_op_permitted(ram_floor_ok: bool) -> bool {
+    if !ram_floor_ok {
+        return false;
+    }
+    kernel_memory_pressure_level().map_or(true, |level| level < 4)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+
+    /// The deterministic half of `heavy_op_permitted`'s logic: an already-failing RAM floor
+    /// short-circuits to `false` regardless of the kernel pressure signal (which we can't
+    /// deterministically mock — it shells out to the real `sysctl` on whatever machine runs this
+    /// test). This is the ONE branch fully testable without depending on real system state.
+    #[test]
+    fn heavy_op_permitted_short_circuits_on_a_failing_ram_floor() {
+        assert!(
+            !heavy_op_permitted(false),
+            "an already-failing RAM floor must refuse regardless of kernel pressure"
+        );
+    }
+
+    /// `kernel_memory_pressure_level` must never panic and must return a value in the documented
+    /// range (or None on a broken probe) — the one thing we CAN assert about the real machine
+    /// this test runs on, without asserting a specific pressure level (which is real system state,
+    /// not something this test controls).
+    #[test]
+    fn kernel_memory_pressure_level_never_panics() {
+        if let Some(level) = kernel_memory_pressure_level() {
+            assert!(
+                level == 1 || level == 2 || level == 4,
+                "unexpected kern.memorystatus_vm_pressure_level value: {level}"
+            );
+        }
+    }
 
     /// The core contract: two `run_heavy` calls sharing ONE semaphore never overlap — the second
     /// call's closure only starts once the first has fully finished, even though both are handed

--- a/src-tauri/src/reason/sidecar.rs
+++ b/src-tauri/src/reason/sidecar.rs
@@ -593,9 +593,13 @@ fn dispatch(
 
     // Spawn lazily on first use / after any kill. The RAM pre-check refuses-to-Cloud BEFORE paying a
     // spawn that would swap-death the machine (the child self-checks too; this avoids the fork).
+    // 2026-07-13: also consult the kernel's OWN pressure signal (crate::perf::heavy_op_permitted)
+    // alongside the vm_stat-derived floor — a different question ("does the kernel already think
+    // the whole system is under pressure") than "does this job's footprint fit the free/inactive
+    // arithmetic". Refuses only on CRITICAL kernel pressure; fails open on a broken probe either way.
     if !state.is_live() {
         if let Some(bytes) = model_disk_bytes(model_path) {
-            if !ram_permits_load(available_ram_bytes(), bytes) {
+            if !crate::perf::heavy_op_permitted(ram_permits_load(available_ram_bytes(), bytes)) {
                 let gb = bytes as f64 / 1_073_741_824.0;
                 tracing::warn!(
                     target: "reason",

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -383,10 +383,14 @@ pub fn parakeet_ram_permits_now() -> bool {
 /// both callers are safe to retry later (the backfill is content-hash idempotent; reindex is a
 /// user-initiated retry). Mirrors [`parakeet_ram_permits_now`].
 pub fn topic_backfill_ram_permits_now() -> bool {
-    match total_ram_bytes() {
+    let floor_ok = match total_ram_bytes() {
         Some(b) => b >= TOPIC_BACKFILL_MIN_RAM_BYTES,
         None => true,
-    }
+    };
+    // 2026-07-13: also consult the kernel's own pressure signal (crate::perf::heavy_op_permitted)
+    // alongside the total-RAM floor — see that function's doc comment for why this is a
+    // DIFFERENT, complementary signal, not a duplicate of the check above.
+    crate::perf::heavy_op_permitted(floor_ok)
 }
 
 /// Ensure all four parakeet model files exist under [`parakeet_dir`], downloading any missing one


### PR DESCRIPTION
## Summary
- Adds `perf::heavy_op_permitted(ram_floor_ok)` — combines an existing RAM-floor verdict with the kernel's own `kern.memorystatus_vm_pressure_level` signal (via `sysctl`, same shell-out convention as the existing RAM probes). Refuses only when the floor already said no, or the kernel reports CRITICAL (4) pressure; WARN (2) is deliberately not a refusal. Fails open on a broken probe.
- Wires it into the two existing heavy-op gates: `reason/sidecar.rs`'s brain-sidecar dispatch gate and `transcribe/model.rs`'s `topic_backfill_ram_permits_now()` (used by 3 callers: startup topic-chunk backfill, `reindex_embeddings`, and the internal RAM-floor check).
- Part of the ongoing perf-audit backlog (freeze-fix lineage 0.9.10–0.9.14): the kernel pressure signal is a second, independent line of defense — "does the KERNEL ITSELF already think the system is under pressure," not just "does this job's footprint fit the numbers we can see."

## Verification
- `cargo build --lib` + `cargo test --lib` green in an isolated detached worktree (1576 passed, 0 failed, 10 ignored — 2 new tests: `heavy_op_permitted_short_circuits_on_a_failing_ram_floor`, `kernel_memory_pressure_level_never_panics`).
- Independent adversarial-verifier PASS: hand-traced the combining truth table against every branch (floor-fail short-circuit, CRITICAL refuse, WARN/normal permit, broken-probe fail-open), confirmed MSRV safety (`map_or`, not `is_none_or` — repo pins `rust-version = "1.77"`), confirmed both existing call sites (`sidecar.rs`, `model.rs`) pass identical arguments and their pre-existing tests still pass unchanged, confirmed zero lock/crypto/visibility surface touched, zero FFI.
- `ng lint`/`ng build`: N/A — zero frontend files touched.

## Test plan
- [x] `cargo test --lib` (1576 passed)
- [x] Independent adversarial-verifier pass (PASS, no findings)
- [ ] Real-machine CRITICAL (level 4) kernel-pressure repro — not observed live this session (dev Mac stayed at level 1/normal); honestly out of reach without a genuinely pressured machine, same limitation the unit test comments already acknowledge.