### PR TITLE
fix(perf): route LocalSummarizerProvider through the shared heavy-inference gate

### DIFF
--- a/src-tauri/src/brief_runner.rs
+++ b/src-tauri/src/brief_runner.rs
@@ -188,7 +188,11 @@ async fn run_one_brief(
 
     // Build the provider (consent gate + redaction firewall) BEFORE composing the prompt — an
     // unconsented cloud provider fails closed here and NOTHING egresses.
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(
+        crate::summarize::roles::Role::Notes,
+        &config,
+        &state.heavy_inference,
+    )?;
     let range_label = format!("the last {} days", schedule.scope_days.clamp(1, 90));
     let (system, mut user) = crate::summarize::digest::build_digest_prompt(
         &built.corpus,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3289,7 +3289,11 @@ async fn note_assistant_action_impl(
         build_note_assist_prompt(&action, &req, &citations, &entity_names, &config.note_language);
     let provider = match provider_override {
         Some(p) => p,
-        None => crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?,
+        None => crate::summarize::provider_for(
+            crate::summarize::roles::Role::Notes,
+            &config,
+            &state.heavy_inference,
+        )?,
     };
     let opts = crate::reason::GenOptions::edit_rewrite(note_edit_max_tokens(
         &action,
@@ -3867,7 +3871,7 @@ pub async fn plan_organize_notes(
         .map(|f| (f.id.clone(), f.name.clone()))
         .collect();
 
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
 
     let mut moves = Vec::new();
     for n in &notes {
@@ -4251,7 +4255,11 @@ pub async fn chat_meeting(
     };
     // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
     // default provider as before (the legacy chat path always ignored `brain_backend`).
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Ask, &config)?;
+    let provider = crate::summarize::provider_for(
+        crate::summarize::roles::Role::Ask,
+        &config,
+        &state.heavy_inference,
+    )?;
     // Inject the gated cross-meeting USER MEMORY brief (parity with the @brain agentic loop): derived
     // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
     // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
@@ -4516,7 +4524,7 @@ pub async fn run_recipe(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
     let (system, user) =
         crate::summarize::recipes::build_recipe_prompt(&transcript, &prompt, &config.note_language);
     provider.complete(&system, &user).await
@@ -4813,7 +4821,7 @@ pub async fn build_and_persist_entities(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
     let entities_started = std::time::Instant::now();
     let payload =
         crate::summarize::graph::extract_entities(provider.as_ref(), title, markdown).await?;
@@ -5767,6 +5775,7 @@ pub async fn ask_vault(
         &history,
         &memory_brief,
         Some(reranker),
+        &state.heavy_inference,
     )
     .await
 }
@@ -6072,6 +6081,7 @@ async fn ask_vault_floor(
     history: &[ChatTurn],
     memory_brief: &str,
     reranker: Option<Box<dyn crate::rerank::Reranker>>,
+    heavy: &std::sync::Arc<tokio::sync::Semaphore>,
 ) -> Result<AskVaultResult, AppError> {
     // `build_ask_vault_floor_prompt` does the LOCAL/on-device work — query embedding (Candle/
     // Metal) + hybrid FTS∪vector retrieval + reranker inference — synchronously. This is exactly
@@ -6111,7 +6121,7 @@ async fn ask_vault_floor(
             // ASK role. With role keys absent this builds the legacy default provider for EVERY
             // brain_backend (the pre-role floor ignored it) — original error/consent semantics.
             let provider =
-                crate::summarize::provider_for(crate::summarize::roles::Role::Ask, config)?;
+                crate::summarize::provider_for(crate::summarize::roles::Role::Ask, config, heavy)?;
             let answer = provider.complete(&system, &user).await?;
             Ok(AskVaultResult {
                 answer,
@@ -6455,6 +6465,7 @@ mod ask_vault_tests {
             &[],
             "",
             None,
+            &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
         ));
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),
@@ -6805,7 +6816,7 @@ pub async fn entity_dossier(
     // Build the provider (firewall + consent gate) BEFORE synthesizing — the factory refuses a
     // cloud provider until the user has consented to egress. NOTES role (the dossier is a
     // written synthesis); the corpus budget keys on the same resolved connection.
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
     let markdown = provider.complete(&system, &user).await?;
     Ok(EntityDossierResult {
         markdown,
@@ -7202,7 +7213,7 @@ pub async fn generate_digest(
         )));
     }
     let range_label = format!("the last {days} days");
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
     let (system, user) =
         crate::summarize::digest::build_digest_prompt(&corpus, &range_label, &config.note_language);
     let markdown = provider.complete(&system, &user).await?;
@@ -9231,7 +9242,7 @@ pub async fn generate_timeline(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         c.clone()
     };
-    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config)?;
+    let provider = crate::summarize::provider_for(crate::summarize::roles::Role::Notes, &config, &state.heavy_inference)?;
     let timeline =
         crate::summarize::timeline::generate(provider.as_ref(), &segments, duration_s).await?;
     // SEAM-F1 (2026-07-11 audit, plaintext-at-rest): the provider `.await` above can span a relock,
@@ -17688,7 +17699,8 @@ mod lifecycle_tests {
             brain_live: false,
             ..Default::default()
         }));
-        state.reasoner = crate::reason::ReasonerCell::new(Arc::clone(&cloud_cfg));
+        state.reasoner =
+            crate::reason::ReasonerCell::new(Arc::clone(&cloud_cfg), state.heavy_inference.clone());
 
         // PRECONDITION (the trap): this config cloud-routes the general extraction seam.
         assert!(

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -493,8 +493,11 @@ mod tests {
             brain_model_id: std::env::var("MURMUR_BAKEOFF_LIGHT_ID").ok(),
             ..Default::default()
         };
+        // Offline eval harness (not the live app runtime) — a fresh semaphore here is correct:
+        // there is no real concurrency to guard against in a standalone benchmark process.
+        let heavy = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
         let reranker = crate::rerank::active_reranker(std::sync::Arc::from(
-            crate::reason::active_reasoner(&cfg),
+            crate::reason::active_reasoner(&cfg, &heavy),
         ));
         if reranker.id() == "stub" {
             eprintln!(

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -884,7 +884,7 @@ fn resolve_summarize_egress(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         guard.clone()
     };
-    let provider = provider_for(Role::Notes, &config)?;
+    let provider = provider_for(Role::Notes, &config, &state.heavy_inference)?;
     Ok((config, provider))
 }
 
@@ -2004,7 +2004,7 @@ mod tests {
         // THE LEAK the fix closes (kept as the RED half): the stale Stop-time snapshot sails
         // PAST the gate — `InvalidArg` is the factory rejecting the bogus id, proving a real
         // provider id would have been built and egressed.
-        match provider_for(Role::Notes, &stop_snapshot) {
+        match provider_for(Role::Notes, &stop_snapshot, &state.heavy_inference) {
             Err(AppError::InvalidArg(_)) => {}
             Err(other) => panic!("stale snapshot should pass the gate (the leak), got {other:?}"),
             Ok(_) => panic!("bogus provider id must not construct"),

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -593,13 +593,19 @@ where
 /// - **`Local`** → the real `MistralReasoner` when a GGUF is present on disk ([`local_reasoner`]),
 ///   else the dependency-free `StubReasoner`.
 /// - **`Off`** → `StubReasoner` (the deterministic floor).
-pub fn active_reasoner(config: &AppConfig) -> Box<dyn LocalReasoner> {
+pub fn active_reasoner(
+    config: &AppConfig,
+    heavy: &Arc<tokio::sync::Semaphore>,
+) -> Box<dyn LocalReasoner> {
     match config.brain_backend {
         BrainBackend::Cloud => {
             // Cheap: just clones the config; the provider (+ consent gate + RedactingProvider) is
             // built per-call inside CloudReasoner via the same `make_provider` the summary uses.
             tracing::info!(target: "reason", "brain backend = cloud; reasoning via the summarizer-provider seam");
-            Box::new(CloudReasoner::new(Arc::new(Mutex::new(config.clone()))))
+            Box::new(CloudReasoner::new(
+                Arc::new(Mutex::new(config.clone())),
+                Arc::clone(heavy),
+            ))
         }
         BrainBackend::Local => local_reasoner(config),
         BrainBackend::Off => {
@@ -642,6 +648,9 @@ pub struct ReasonerCell {
     /// only when the resolved path changes — which also means a model downloaded or selected
     /// mid-session activates on the next call.
     local: Mutex<CachedLocalReasoner>,
+    /// The shared `AppState::heavy_inference` gate, threaded into every [`CloudReasoner`] this
+    /// cell builds — see `crate::perf::run_heavy`'s doc comment.
+    heavy: Arc<tokio::sync::Semaphore>,
     /// TEST-ONLY pinned reasoner (mirrors `CloudReasoner::provider_override`): `Some` makes
     /// `current()` always return this instance, so command tests keep a deterministic stub.
     /// `#[cfg(test)]` makes "no fixed reasoner in production" STRUCTURAL — the field does not
@@ -653,22 +662,26 @@ pub struct ReasonerCell {
 impl ReasonerCell {
     /// Build the live dispatch over the shared config handle. Cheap: nothing is resolved until the
     /// first [`current`](Self::current) call.
-    pub fn new(config: Arc<Mutex<AppConfig>>) -> Self {
+    pub fn new(config: Arc<Mutex<AppConfig>>, heavy: Arc<tokio::sync::Semaphore>) -> Self {
         Self {
             config,
             local: Mutex::new(None),
+            heavy,
             #[cfg(test)]
             fixed: None,
         }
     }
 
     /// TEST-ONLY: pin `current()` to a fixed reasoner instance (the old `Box<StubReasoner>` test
-    /// shape). Production dispatch always goes through [`new`] + live config resolution.
+    /// shape). Production dispatch always goes through [`new`] + live config resolution. `fixed()`
+    /// always short-circuits [`current_for`](Self::current_for) to the pinned reasoner and never
+    /// reaches the `CloudReasoner::for_role` arm, so the `heavy` field just needs SOME valid value.
     #[cfg(test)]
     pub(crate) fn fixed(reasoner: Arc<dyn LocalReasoner>) -> Self {
         Self {
             config: Arc::new(Mutex::new(AppConfig::default())),
             local: Mutex::new(None),
+            heavy: Arc::new(tokio::sync::Semaphore::new(1)),
             fixed: Some(reasoner),
         }
     }
@@ -710,7 +723,11 @@ impl ReasonerCell {
             roles::CONN_AFM => afm::afm_reasoner_arc(&cfg),
             // Cheap per call: the provider (+ consent gate) is built lazily inside, from a fresh
             // config read, so this instance can never pin a stale provider/consent state.
-            _ => Arc::new(CloudReasoner::for_role(Arc::clone(&self.config), role)),
+            _ => Arc::new(CloudReasoner::for_role(
+                Arc::clone(&self.config),
+                role,
+                Arc::clone(&self.heavy),
+            )),
         }
     }
 
@@ -1166,6 +1183,10 @@ pub struct CloudReasoner {
     /// The model ROLE this reasoner serves — `build_provider` resolves the provider FOR THIS ROLE
     /// (with role keys absent that is exactly the legacy default provider, byte-identical).
     role: Role,
+    /// The shared `AppState::heavy_inference` gate, threaded into every provider `build_provider`
+    /// resolves (in particular a `local`-connection role, which reaches `LocalSummarizerProvider`)
+    /// — see `crate::perf::run_heavy`'s doc comment.
+    heavy: Arc<tokio::sync::Semaphore>,
     /// TEST-ONLY injected provider. When `Some`, `build_provider` returns it instead of calling
     /// the factory, so the wiring/parse can be exercised with a mock — NO real Claude/network.
     /// `None` in every production path (the only constructors reachable in release are [`new`] /
@@ -1177,13 +1198,13 @@ impl CloudReasoner {
     /// Build the cloud brain over the shared live config handle for the legacy default role
     /// (Notes — whose fallback is the default provider triple). Cheap + infallible: the provider
     /// (and thus the consent gate) is constructed lazily, per call, from the config AS IT IS THEN.
-    pub fn new(config: Arc<Mutex<AppConfig>>) -> Self {
-        Self::for_role(config, Role::Notes)
+    pub fn new(config: Arc<Mutex<AppConfig>>, heavy: Arc<tokio::sync::Semaphore>) -> Self {
+        Self::for_role(config, Role::Notes, heavy)
     }
 
     /// Build the cloud brain serving `role`. The id names the connection the role RESOLVES to
     /// (`cloud:<connection>`) — under the legacy fallback that is `provider_id`, unchanged.
-    pub fn for_role(config: Arc<Mutex<AppConfig>>, role: Role) -> Self {
+    pub fn for_role(config: Arc<Mutex<AppConfig>>, role: Role, heavy: Arc<tokio::sync::Semaphore>) -> Self {
         let connection = config
             .lock()
             .map(|c| roles::provider_target(role, &c).connection)
@@ -1192,6 +1213,7 @@ impl CloudReasoner {
             id: format!("cloud:{connection}"),
             config,
             role,
+            heavy,
             provider_override: None,
         }
     }
@@ -1199,12 +1221,15 @@ impl CloudReasoner {
     /// TEST-ONLY: build a CloudReasoner that delegates to an injected provider instead of the real
     /// factory, so `reason`/`structured` can be asserted without a network/CLI call. NOT
     /// compiled in non-test builds, so production can never inject a provider that skips the gate.
+    /// `build_provider` always short-circuits to `provider_override` here, so `heavy` just needs
+    /// SOME valid value (never reaches the factory that would consume it).
     #[cfg(test)]
     fn with_provider(config: AppConfig, provider: Arc<dyn SummarizerProvider>) -> Self {
         Self {
             id: format!("cloud:{}", config.provider_id),
             config: Arc::new(Mutex::new(config)),
             role: Role::Notes,
+            heavy: Arc::new(tokio::sync::Semaphore::new(1)),
             provider_override: Some(provider),
         }
     }
@@ -1224,7 +1249,7 @@ impl CloudReasoner {
             .lock()
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone();
-        crate::summarize::provider_for(self.role, &cfg)
+        crate::summarize::provider_for(self.role, &cfg, &self.heavy)
     }
 }
 
@@ -1678,7 +1703,7 @@ mod tests {
             brain_model_id: None,
             ..Default::default()
         };
-        assert_eq!(active_reasoner(&cfg).id(), "stub");
+        assert_eq!(active_reasoner(&cfg, &Arc::new(tokio::sync::Semaphore::new(1))).id(), "stub");
     }
 
     // ---- CloudReasoner (the cloud brain) ----------------------------------------------------
@@ -1729,7 +1754,7 @@ mod tests {
             provider_id: "claude_code".to_string(),
             ..Default::default()
         };
-        assert_eq!(CloudReasoner::new(shared(cfg)).id(), "cloud:claude_code");
+        assert_eq!(CloudReasoner::new(shared(cfg), Arc::new(tokio::sync::Semaphore::new(1))).id(), "cloud:claude_code");
     }
 
     #[test]
@@ -1812,7 +1837,7 @@ mod tests {
             cloud_egress_consented: false,
             ..Default::default()
         };
-        let r = CloudReasoner::new(shared(cfg));
+        let r = CloudReasoner::new(shared(cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         match r.reason("s", "u") {
             Err(AppError::Unavailable(_)) => {}
             other => panic!("expected the make_provider consent gate to refuse, got {other:?}"),
@@ -1846,7 +1871,7 @@ mod tests {
     #[test]
     fn cloud_reasoner_sees_consent_granted_after_construction() {
         let cfg = shared(gate_probe_cfg(false));
-        let r = CloudReasoner::new(Arc::clone(&cfg));
+        let r = CloudReasoner::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         match r.reason("s", "u") {
             Err(AppError::Unavailable(_)) => {}
             other => panic!("pre-grant call must be refused by the consent gate, got {other:?}"),
@@ -1867,7 +1892,7 @@ mod tests {
     #[test]
     fn cloud_reasoner_refuses_next_call_after_consent_revoked() {
         let cfg = shared(gate_probe_cfg(true));
-        let r = CloudReasoner::new(Arc::clone(&cfg));
+        let r = CloudReasoner::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         match r.reason("s", "u") {
             Err(AppError::InvalidArg(_)) => {} // consented: past the gate
             other => panic!("pre-revoke call must pass the consent gate, got {other:?}"),
@@ -1890,7 +1915,7 @@ mod tests {
             brain_backend: BrainBackend::Off,
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         assert_eq!(
             cell.current().id(),
             "stub",
@@ -1920,7 +1945,7 @@ mod tests {
             provider_id: "claude_code".to_string(),
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         assert_eq!(cell.current().id(), "cloud:claude_code");
 
         cfg.lock().unwrap().provider_id = "anthropic".to_string();
@@ -1947,7 +1972,7 @@ mod tests {
             brain_model_id: None,
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         let a = cell.current();
         let b = cell.current();
         assert_eq!(
@@ -1997,7 +2022,7 @@ mod tests {
                 brain_model_id: None,
                 ..Default::default()
             });
-            let cell = ReasonerCell::new(Arc::clone(&cfg));
+            let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
             let legacy = cell.current().id().to_string();
             for role in [Role::Notes, Role::Ask, Role::Live] {
                 assert_eq!(
@@ -2024,7 +2049,7 @@ mod tests {
             role_ask_connection: "off".to_string(),
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         assert_eq!(
             cell.current_for(Role::Ask).id(),
             "stub",
@@ -2048,7 +2073,7 @@ mod tests {
             role_ask_connection: "anthropic".to_string(),
             ..Default::default()
         };
-        let r = CloudReasoner::for_role(shared(cfg), Role::Ask);
+        let r = CloudReasoner::for_role(shared(cfg), Role::Ask, Arc::new(tokio::sync::Semaphore::new(1)));
         assert_eq!(r.id(), "cloud:anthropic");
     }
 
@@ -2064,7 +2089,7 @@ mod tests {
             cloud_egress_consented: false,
             ..Default::default()
         });
-        let r = CloudReasoner::for_role(Arc::clone(&cfg), Role::Live);
+        let r = CloudReasoner::for_role(Arc::clone(&cfg), Role::Live, Arc::new(tokio::sync::Semaphore::new(1)));
         match r.reason("s", "u") {
             Err(AppError::Unavailable(_)) => {}
             other => panic!("role-keyed cloud call must be consent-gated, got {other:?}"),
@@ -2100,7 +2125,7 @@ mod tests {
             provider_id: "claude_code".to_string(),
             ..Default::default()
         };
-        assert_eq!(active_reasoner(&cfg).id(), "cloud:claude_code");
+        assert_eq!(active_reasoner(&cfg, &Arc::new(tokio::sync::Semaphore::new(1))).id(), "cloud:claude_code");
     }
 
     #[test]
@@ -2109,7 +2134,7 @@ mod tests {
             brain_backend: BrainBackend::Off,
             ..Default::default()
         };
-        assert_eq!(active_reasoner(&cfg).id(), "stub");
+        assert_eq!(active_reasoner(&cfg, &Arc::new(tokio::sync::Semaphore::new(1))).id(), "stub");
     }
 
     #[test]
@@ -2127,13 +2152,13 @@ mod tests {
             brain_model_id: None,
             ..Default::default()
         };
-        assert_eq!(active_reasoner(&cfg).id(), "stub");
+        assert_eq!(active_reasoner(&cfg, &Arc::new(tokio::sync::Semaphore::new(1))).id(), "stub");
     }
 
     /// Default config (the user's choice) selects the Cloud brain.
     #[test]
     fn active_reasoner_default_is_cloud() {
-        let id = active_reasoner(&AppConfig::default()).id().to_string();
+        let id = active_reasoner(&AppConfig::default(), &Arc::new(tokio::sync::Semaphore::new(1))).id().to_string();
         assert!(
             id.starts_with("cloud:"),
             "default brain must be cloud, got {id}"
@@ -2156,7 +2181,7 @@ mod tests {
             brain_backend: BrainBackend::AppleFoundation,
             ..Default::default()
         };
-        assert_eq!(active_reasoner(&cfg).id(), "stub");
+        assert_eq!(active_reasoner(&cfg, &Arc::new(tokio::sync::Semaphore::new(1))).id(), "stub");
     }
 
     /// ANTI-EGRESS ORDERING regression (the load-bearing `CONN_AFM`-before-`_` arm): a mid-session
@@ -2175,7 +2200,7 @@ mod tests {
             brain_backend: BrainBackend::Off,
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         assert_eq!(cell.current().id(), "stub", "Off dispatches the stub");
 
         cfg.lock().unwrap().brain_backend = BrainBackend::AppleFoundation;
@@ -2216,7 +2241,7 @@ mod tests {
             // default class ids (qwen3-1.7b / qwen3-4b-instruct-2507) — absent on disk in CI ⇒ stub.
             ..Default::default()
         });
-        let cell = ReasonerCell::new(Arc::clone(&cfg));
+        let cell = ReasonerCell::new(Arc::clone(&cfg), Arc::new(tokio::sync::Semaphore::new(1)));
         for id in [cell.light().id().to_string(), cell.heavy().id().to_string()] {
             assert!(
                 id == "stub" || id.starts_with("sidecar:"),
@@ -2240,7 +2265,7 @@ mod tests {
             ..Default::default()
         });
         assert!(
-            ReasonerCell::new(off).extraction_reasoner().id().starts_with("cloud:"),
+            ReasonerCell::new(off, Arc::new(tokio::sync::Semaphore::new(1))).extraction_reasoner().id().starts_with("cloud:"),
             "Brain Live OFF keeps the legacy cloud Notes extraction"
         );
         // ON ⇒ the local light engine (local-or-stub), never cloud — even with cloud consent.
@@ -2250,7 +2275,7 @@ mod tests {
             cloud_egress_consented: true,
             ..Default::default()
         });
-        let id = ReasonerCell::new(on).extraction_reasoner().id().to_string();
+        let id = ReasonerCell::new(on, Arc::new(tokio::sync::Semaphore::new(1))).extraction_reasoner().id().to_string();
         assert!(
             !id.starts_with("cloud:"),
             "Brain Live ON must route fact extraction LOCAL, never cloud (got {id})"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -323,11 +323,17 @@ impl AppState {
         let db = Arc::new(Db::open_with_key(db_path, dek)?);
         let config = Arc::new(Mutex::new(AppConfig::load(&db)?));
 
+        // GLOBAL "one heavy inference at a time" gate — constructed BEFORE the reasoner so it can
+        // be threaded into `ReasonerCell::new` (see the field's doc comment below for the full
+        // rationale).
+        let heavy_inference = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+
         // The live reasoner dispatch shares the config handle, so consent/provider/backend changes
         // written by the settings commands reach the very next reasoning call — no restart. Cheap +
         // panic-free: backends resolve lazily per call; a missing/failed local model degrades to
         // the StubReasoner.
-        let reasoner = crate::reason::ReasonerCell::new(Arc::clone(&config));
+        let reasoner =
+            crate::reason::ReasonerCell::new(Arc::clone(&config), Arc::clone(&heavy_inference));
 
         // SHOULD-FIX startup reconciliation: re-assert the at-rest sealed shape of every locked
         // folder. If the app crashed (or was force-quit) WHILE a folder was session-unlocked, the
@@ -368,7 +374,7 @@ impl AppState {
             share_refresh_lock: tokio::sync::Mutex::new(()),
             lifecycle: Mutex::new(()),
             seal_epoch: AtomicU64::new(0),
-            heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
+            heavy_inference,
         })
     }
 

--- a/src-tauri/src/summarize/local.rs
+++ b/src-tauri/src/summarize/local.rs
@@ -1,7 +1,9 @@
 //! The on-device HEAVY engine as a [`SummarizerProvider`] (spec §3.2, P3) — lets the Notes/Ask roles
 //! be served FULLY LOCALLY under the Fully-Local posture. Wraps a shared local [`LocalReasoner`]
 //! (whose weights live in the process-global mistral MODEL_CACHE, loaded once) and bridges the sync
-//! reasoner to the async trait via `spawn_blocking`.
+//! reasoner to the async trait via [`crate::perf::run_heavy`] — the shared "one heavy inference at
+//! a time" gate, not a bare `spawn_blocking` — so a local Notes/Ask generation can never run
+//! concurrently with an in-progress whisper transcription/diarization/embedding pass.
 //!
 //! ## Privacy (load-bearing)
 //! Built UNWRAPPED — no [`crate::summarize::redact::RedactingProvider`], no egress-ledger sink —
@@ -26,11 +28,16 @@ use crate::summarize::template;
 /// A [`SummarizerProvider`] backed by the on-device heavy reasoner.
 pub struct LocalSummarizerProvider {
     reasoner: Arc<dyn LocalReasoner>,
+    /// The shared `AppState::heavy_inference` gate — see `crate::perf::run_heavy`'s doc comment.
+    /// Every call into `reasoner.reason(...)` routes through it so a local Notes/Ask generation
+    /// can never run concurrently with an in-progress whisper transcription/diarization/embedding
+    /// pass on the same machine.
+    heavy: Arc<tokio::sync::Semaphore>,
 }
 
 impl LocalSummarizerProvider {
-    pub fn new(reasoner: Arc<dyn LocalReasoner>) -> Self {
-        Self { reasoner }
+    pub fn new(reasoner: Arc<dyn LocalReasoner>, heavy: Arc<tokio::sync::Semaphore>) -> Self {
+        Self { reasoner, heavy }
     }
 }
 
@@ -51,15 +58,17 @@ impl SummarizerProvider for LocalSummarizerProvider {
         // titles + transcript in one blob) — the on-device reasoner has one system+user channel.
         let prompt = template::render_prompt(req);
         let reasoner = Arc::clone(&self.reasoner);
-        let note = tokio::task::spawn_blocking(move || {
+        // Routed through the shared heavy-inference gate (perf::run_heavy), not a bare
+        // spawn_blocking — a local Notes generation must serialize against any OTHER heavy
+        // native-runtime call (whisper ASR, the diarizer, the embedder/NER) running concurrently.
+        let note = crate::perf::run_heavy(&self.heavy, move || {
             reasoner.reason(
                 "You are a meeting-notes writer. Produce clean Obsidian-ready Markdown; follow the \
                  instructions exactly.",
                 &prompt,
             )
         })
-        .await
-        .map_err(|e| AppError::Summarize(format!("local summarize task join failed: {e}")))??;
+        .await?;
         let note = note.trim_start_matches('\u{feff}').trim();
         if note.is_empty() {
             return Err(AppError::Summarize(
@@ -73,9 +82,7 @@ impl SummarizerProvider for LocalSummarizerProvider {
         let reasoner = Arc::clone(&self.reasoner);
         let system = system.to_string();
         let user = user.to_string();
-        let out = tokio::task::spawn_blocking(move || reasoner.reason(&system, &user))
-            .await
-            .map_err(|e| AppError::Summarize(format!("local complete task join failed: {e}")))??;
+        let out = crate::perf::run_heavy(&self.heavy, move || reasoner.reason(&system, &user)).await?;
         Ok(out.trim().to_string())
     }
 
@@ -92,9 +99,9 @@ impl SummarizerProvider for LocalSummarizerProvider {
         let reasoner = Arc::clone(&self.reasoner);
         let system = system.to_string();
         let user = user.to_string();
-        let out = tokio::task::spawn_blocking(move || reasoner.reason_with(&system, &user, opts))
-            .await
-            .map_err(|e| AppError::Summarize(format!("local complete task join failed: {e}")))??;
+        let out =
+            crate::perf::run_heavy(&self.heavy, move || reasoner.reason_with(&system, &user, opts))
+                .await?;
         Ok((
             out.trim().to_string(),
             crate::summarize::meta::CallMeta::default(),
@@ -106,10 +113,15 @@ impl SummarizerProvider for LocalSummarizerProvider {
 mod tests {
     use super::*;
     use crate::reason::StubReasoner;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     #[tokio::test]
     async fn id_is_local_and_available() {
-        let p = LocalSummarizerProvider::new(Arc::new(StubReasoner));
+        let p = LocalSummarizerProvider::new(
+            Arc::new(StubReasoner),
+            Arc::new(tokio::sync::Semaphore::new(1)),
+        );
         assert_eq!(p.id(), "local");
         assert!(matches!(p.availability().await, Availability::Available));
     }
@@ -118,8 +130,78 @@ mod tests {
     async fn complete_bridges_the_sync_reasoner() {
         // The stub echoes deterministically — proves the async↔sync spawn_blocking bridge works and
         // returns the reasoner's text (no network, no egress).
-        let p = LocalSummarizerProvider::new(Arc::new(StubReasoner));
+        let p = LocalSummarizerProvider::new(
+            Arc::new(StubReasoner),
+            Arc::new(tokio::sync::Semaphore::new(1)),
+        );
         let out = p.complete("sys", "user").await.unwrap();
         assert!(out.contains("stub-reason"), "got {out}");
+    }
+
+    /// A fake [`LocalReasoner`] whose `reason` call tracks max-concurrency via a shared
+    /// `AtomicUsize`, sleeping ~50ms mid-call so two overlapping calls would be observable if the
+    /// semaphore did NOT serialize them (mirrors `perf::run_heavy_serializes_two_concurrent_calls`).
+    struct ConcurrencyTrackingReasoner {
+        concurrent: Arc<AtomicUsize>,
+        max_concurrent: Arc<AtomicUsize>,
+    }
+
+    impl crate::reason::LocalReasoner for ConcurrencyTrackingReasoner {
+        fn id(&self) -> &str {
+            "concurrency-tracking-stub"
+        }
+
+        fn reason(&self, _system: &str, _user: &str) -> crate::error::Result<String> {
+            let now = self.concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_concurrent.fetch_max(now, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(50));
+            self.concurrent.fetch_sub(1, Ordering::SeqCst);
+            Ok("tracked".to_string())
+        }
+
+        fn structured(
+            &self,
+            _system: &str,
+            _user: &str,
+            _json_schema: &serde_json::Value,
+        ) -> crate::error::Result<serde_json::Value> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
+    /// The core contract this change adds: TWO separate `LocalSummarizerProvider` instances that
+    /// share ONE `heavy_inference` semaphore never run their reasoner calls concurrently — proving
+    /// the wiring is real, not just "it compiles". Without routing `complete` through
+    /// `perf::run_heavy`, two concurrent `tokio::spawn`ed calls would both land on the blocking
+    /// pool and race (max_concurrent would read 2).
+    #[tokio::test]
+    async fn two_providers_sharing_one_semaphore_never_run_concurrently() {
+        let heavy = Arc::new(tokio::sync::Semaphore::new(1));
+        let concurrent: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let max_concurrent: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+
+        let make_provider = |heavy: Arc<tokio::sync::Semaphore>| {
+            LocalSummarizerProvider::new(
+                Arc::new(ConcurrencyTrackingReasoner {
+                    concurrent: concurrent.clone(),
+                    max_concurrent: max_concurrent.clone(),
+                }),
+                heavy,
+            )
+        };
+        let p1 = make_provider(heavy.clone());
+        let p2 = make_provider(heavy.clone());
+
+        let t1 = tokio::spawn(async move { p1.complete("sys", "user").await });
+        let t2 = tokio::spawn(async move { p2.complete("sys", "user").await });
+        t1.await.unwrap().unwrap();
+        t2.await.unwrap().unwrap();
+
+        assert_eq!(
+            max_concurrent.load(Ordering::SeqCst),
+            1,
+            "two LocalSummarizerProvider instances sharing one heavy_inference semaphore must \
+             never run their reasoner calls concurrently"
+        );
     }
 }

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -95,6 +95,7 @@ pub(crate) fn egress_is_cloud(id: &str, config: &AppConfig) -> bool {
 pub fn make_provider(
     id: &str,
     config: &AppConfig,
+    heavy: &Arc<tokio::sync::Semaphore>,
 ) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
     // The legacy per-arm model semantics: only claude_code/anthropic ever read `provider_model`;
     // ollama/gateway resolve from ollama_model/gateway_model ("" = inherit below).
@@ -107,7 +108,7 @@ pub fn make_provider(
         model,
         effort: config.provider_effort.clone(),
     };
-    make_provider_resolved(&target, config)
+    make_provider_resolved(&target, config, heavy)
 }
 
 /// Build the `SummarizerProvider` serving `role`, resolved through the role layer
@@ -121,6 +122,7 @@ pub fn make_provider(
 pub fn provider_for(
     role: roles::Role,
     config: &AppConfig,
+    heavy: &Arc<tokio::sync::Semaphore>,
 ) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
     let target = roles::provider_target(role, config);
     // Refuse ONLY the targets that build no provider (off/apple). `local` now builds the on-device
@@ -133,7 +135,7 @@ pub fn provider_for(
             target.connection
         )));
     }
-    make_provider_resolved(&target, config)
+    make_provider_resolved(&target, config, heavy)
 }
 
 /// The EFFECTIVE model id a resolved target sends: the target's own model, or — when empty —
@@ -162,6 +164,7 @@ pub(crate) fn effective_model_requested(target: &roles::RoleTarget, config: &App
 fn make_provider_resolved(
     target: &roles::RoleTarget,
     config: &AppConfig,
+    heavy: &Arc<tokio::sync::Semaphore>,
 ) -> crate::error::Result<Arc<dyn SummarizerProvider>> {
     let id = target.connection.as_str();
     // E10 — fail-closed consent gate, now classification-aware: no cloud provider is built (so no
@@ -262,7 +265,10 @@ fn make_provider_resolved(
                     let reasoner: Arc<dyn crate::reason::LocalReasoner> = Arc::new(
                         crate::reason::sidecar::SidecarReasoner::new(path, timeouts)?,
                     );
-                    return Ok(Arc::new(local::LocalSummarizerProvider::new(reasoner)));
+                    return Ok(Arc::new(local::LocalSummarizerProvider::new(
+                        reasoner,
+                        heavy.clone(),
+                    )));
                 }
                 None => {
                     return Err(crate::error::AppError::Unavailable(
@@ -440,7 +446,7 @@ mod tests {
             cloud_egress_consented: false,
             ..AppConfig::default()
         };
-        let res = make_provider(PROVIDER_OLLAMA, &cfg);
+        let res = make_provider(PROVIDER_OLLAMA, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)));
         assert!(
             matches!(res, Err(crate::error::AppError::Unavailable(_))),
             "expected Unavailable for remote ollama without consent"
@@ -455,7 +461,7 @@ mod tests {
             ..AppConfig::default()
         };
         // local ollama must build without consent
-        assert!(make_provider(PROVIDER_OLLAMA, &cfg).is_ok());
+        assert!(make_provider(PROVIDER_OLLAMA, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).is_ok());
     }
 
     fn consented_config() -> AppConfig {
@@ -471,9 +477,9 @@ mod tests {
         // transparent to `id()`, so we assert construction succeeds (with consent granted) and
         // the wrapped provider reports the inner id.
         let cfg = consented_config();
-        let cc = make_provider(PROVIDER_CLAUDE_CODE, &cfg).unwrap();
+        let cc = make_provider(PROVIDER_CLAUDE_CODE, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).unwrap();
         assert_eq!(cc.id(), PROVIDER_CLAUDE_CODE);
-        let an = make_provider(PROVIDER_ANTHROPIC, &cfg).unwrap();
+        let an = make_provider(PROVIDER_ANTHROPIC, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).unwrap();
         assert_eq!(an.id(), PROVIDER_ANTHROPIC);
     }
 
@@ -483,7 +489,7 @@ mod tests {
         // A remote ollama_base_url is covered by remote_ollama_requires_consent.
         let cfg = AppConfig::default();
         assert!(!cfg.cloud_egress_consented);
-        let ol = make_provider(PROVIDER_OLLAMA, &cfg).unwrap();
+        let ol = make_provider(PROVIDER_OLLAMA, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).unwrap();
         assert_eq!(ol.id(), PROVIDER_OLLAMA);
     }
 
@@ -494,7 +500,7 @@ mod tests {
         let cfg = AppConfig::default(); // consent OFF
         for id in [PROVIDER_CLAUDE_CODE, PROVIDER_ANTHROPIC] {
             // `dyn SummarizerProvider` isn't Debug, so inspect the Result without `{:?}`.
-            let res = make_provider(id, &cfg);
+            let res = make_provider(id, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)));
             assert!(
                 matches!(res, Err(crate::error::AppError::Unavailable(_))),
                 "expected Unavailable for {id} without consent (got Ok or wrong error)"
@@ -517,12 +523,12 @@ mod tests {
         let mut cfg = AppConfig::load(&db).unwrap();
         cfg.grant_cloud_egress_consent(&db).unwrap();
         assert!(
-            make_provider(PROVIDER_CLAUDE_CODE, &cfg).is_ok(),
+            make_provider(PROVIDER_CLAUDE_CODE, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).is_ok(),
             "granted consent must build the cloud provider"
         );
         cfg.revoke_cloud_egress(&db).unwrap();
         for id in [PROVIDER_CLAUDE_CODE, PROVIDER_ANTHROPIC] {
-            let res = make_provider(id, &cfg);
+            let res = make_provider(id, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)));
             assert!(
                 matches!(res, Err(crate::error::AppError::Unavailable(_))),
                 "expected Unavailable for {id} after revoke (got Ok or wrong error)"
@@ -531,7 +537,7 @@ mod tests {
         for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
             assert!(
                 matches!(
-                    provider_for(role, &cfg),
+                    provider_for(role, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))),
                     Err(crate::error::AppError::Unavailable(_))
                 ),
                 "provider_for {role:?} must refuse after revoke"
@@ -551,7 +557,7 @@ mod tests {
             cloud_egress_consented: false,
             ..AppConfig::default()
         };
-        let err = make_provider(PROVIDER_GATEWAY, &c)
+        let err = make_provider(PROVIDER_GATEWAY, &c, &Arc::new(tokio::sync::Semaphore::new(1)))
             .map(|_| ())
             .expect_err("expected Err for gateway without consent");
         assert!(
@@ -573,7 +579,7 @@ mod tests {
         };
         // Must build without error — the make_provider consent gate + URL validation passed.
         assert!(
-            make_provider(PROVIDER_GATEWAY, &c).is_ok(),
+            make_provider(PROVIDER_GATEWAY, &c, &Arc::new(tokio::sync::Semaphore::new(1))).is_ok(),
             "consented localhost gateway must build successfully"
         );
     }
@@ -586,7 +592,7 @@ mod tests {
             cloud_egress_consented: true,
             ..AppConfig::default()
         };
-        let err = make_provider(PROVIDER_GATEWAY, &c)
+        let err = make_provider(PROVIDER_GATEWAY, &c, &Arc::new(tokio::sync::Semaphore::new(1)))
             .map(|_| ())
             .expect_err("expected Err for remote http gateway");
         assert!(
@@ -603,7 +609,7 @@ mod tests {
             cloud_egress_consented: true,
             ..AppConfig::default()
         };
-        let err = make_provider(PROVIDER_GATEWAY, &c)
+        let err = make_provider(PROVIDER_GATEWAY, &c, &Arc::new(tokio::sync::Semaphore::new(1)))
             .map(|_| ())
             .expect_err("expected Err for empty gateway URL");
         assert!(
@@ -629,7 +635,7 @@ mod tests {
                 ..AppConfig::default()
             };
             for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
-                let p = provider_for(role, &cfg)
+                let p = provider_for(role, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)))
                     .unwrap_or_else(|e| panic!("{role:?}/{backend:?} must build: {e}"));
                 assert_eq!(p.id(), PROVIDER_CLAUDE_CODE, "{role:?}/{backend:?}");
             }
@@ -646,7 +652,7 @@ mod tests {
         for role in [roles::Role::Notes, roles::Role::Ask, roles::Role::Live] {
             assert!(
                 matches!(
-                    provider_for(role, &cfg),
+                    provider_for(role, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))),
                     Err(crate::error::AppError::Unavailable(_))
                 ),
                 "fallback {role:?} must be consent-gated"
@@ -673,7 +679,7 @@ mod tests {
             extra(&mut cfg);
             assert!(
                 matches!(
-                    provider_for(roles::Role::Ask, &cfg),
+                    provider_for(roles::Role::Ask, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))),
                     Err(crate::error::AppError::Unavailable(_))
                 ),
                 "explicit Ask→{conn} must be consent-gated"
@@ -682,7 +688,7 @@ mod tests {
             // transparent to id(), which reports the inner connection — the wrap itself is proven
             // by the redact.rs tests, exactly like the legacy factory tests above).
             cfg.cloud_egress_consented = true;
-            let p = provider_for(roles::Role::Ask, &cfg)
+            let p = provider_for(roles::Role::Ask, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)))
                 .unwrap_or_else(|e| panic!("consented Ask→{conn} must build: {e}"));
             assert_eq!(p.id(), conn);
         }
@@ -698,7 +704,7 @@ mod tests {
             cloud_egress_consented: false,
             ..AppConfig::default()
         };
-        let p = provider_for(roles::Role::Ask, &cfg).expect("loopback ollama needs no consent");
+        let p = provider_for(roles::Role::Ask, &cfg, &Arc::new(tokio::sync::Semaphore::new(1))).expect("loopback ollama needs no consent");
         assert_eq!(p.id(), PROVIDER_OLLAMA);
     }
 
@@ -713,7 +719,7 @@ mod tests {
                 cloud_egress_consented: true,
                 ..AppConfig::default()
             };
-            let err = provider_for(roles::Role::Ask, &cfg)
+            let err = provider_for(roles::Role::Ask, &cfg, &Arc::new(tokio::sync::Semaphore::new(1)))
                 .map(|_| ())
                 .expect_err("explicit reasoner-only target must not build a provider");
             assert!(


### PR DESCRIPTION
## Summary
- Closes the last gap in this session's "one heavy native-runtime call at a time" gate (`AppState.heavy_inference`, `crate::perf::run_heavy`): `LocalSummarizerProvider` (the on-device brain-sidecar-backed `SummarizerProvider` for FullyLocal Notes/Ask) called `tokio::task::spawn_blocking` directly, unserialized against the ASR/diarize pipeline, entity/fact extraction, and embedding reindex — all of which already route through the shared semaphore.
- Threads `heavy: Arc<Semaphore>` as an explicit new parameter through the full construction chain: `LocalSummarizerProvider::new` → `make_provider`/`provider_for`/`make_provider_resolved` (`summarize/mod.rs`) → `CloudReasoner::new`/`for_role`/`build_provider` + `ReasonerCell::new`/`current_for` (`reason.rs`, the live in-app reasoner dispatch) → `AppState::init_at` (single construction point) → every production call site (9 in `commands.rs`, 1 each in `pipeline.rs`/`brief_runner.rs`).
- Deliberately explicit parameter-threading, not a global static — a process-global semaphore would make unrelated `cargo test --lib` tests (which run in parallel, each constructing its own `AppState`) contend on one real permit and flake/deadlock the suite.
- Cloud provider paths (Claude Code / Anthropic / Ollama / Gateway) are untouched — the semaphore is referenced only inside `make_provider_resolved`'s `CONN_LOCAL` arm.

## Verification
- `cargo build --lib` + `cargo test --lib` green in an isolated worktree: 1577 passed, 0 failed, 10 ignored (1 net new test).
- New test `two_providers_sharing_one_semaphore_never_run_concurrently` proves real serialization (two concurrent `LocalSummarizerProvider` calls sharing one semaphore, `max_concurrent == 1`) — the adversarial-verifier independently reverted the fix and confirmed this test goes RED (`max_concurrent == 2`) without it, then restored and reconfirmed GREEN.
- Adversarial-verifier PASS: enumerated all 48 `Semaphore::new(1)` occurrences repo-wide and confirmed exactly one production construction (`AppState::init_at`) with every other occurrence test-gated; confirmed no cross-semaphore drift between the `ReasonerCell` path and the direct-command path; confirmed cloud provider construction never touches the semaphore; confirmed zero lock/visibility/FFI surface touched, zero new logging.

## Test plan
- [x] `cargo test --lib` (1577 passed)
- [x] Independent adversarial-verifier pass, including a RED-before-GREEN revert of the actual fix (PASS, no findings)
- [ ] Real-machine confirmation that this prevents RAM/Metal contention during a live recording — inherently unverifiable headless; the unit test proves the serialization mechanism, not the real-world magnitude of the benefit (same honest-gap pattern as this session's other heavy-inference-gate PRs).