### PR TITLE
fix(perf): allow too_many_arguments on ask_vault_floor

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6073,6 +6073,7 @@ fn build_ask_vault_floor_prompt(
 /// completion, with the original error/consent semantics (`make_provider`'s fail-closed consent
 /// gate errors exactly as before). Runs on the local/off brain backend and whenever the agentic
 /// attempt did not converge or errored.
+#[allow(clippy::too_many_arguments)] // cohesive gated-Ask surface: corpus/consent state + the heavy-inference permit.
 async fn ask_vault_floor(
     db: &std::sync::Arc<crate::storage::Db>,
     config: &AppConfig,


### PR DESCRIPTION
## Summary
- Full `scripts/ci.sh` run on trunk after PR #292 + #293 caught what neither the build agent nor the adversarial-verifier could (both intentionally skip `clippy --all-targets` in their loop): PR #293's new `heavy: &Arc<Semaphore>` param pushed `ask_vault_floor` to 8 arguments, tripping clippy's `too_many_arguments` lint under `-D warnings`.
- Adds `#[allow(clippy::too_many_arguments)]` with a rationale comment — same established pattern already used at several sites in `commands.rs`/`pipeline.rs`/`voice_action.rs`/`e2ee/org.rs` for cohesive gated-state dispatch functions.

## Verification
- Full `bash scripts/ci.sh` green end-to-end on this fix: clippy `-D warnings` clean, `cargo test --lib` 1577 passed/0 failed/10 ignored, `ng lint` + `ng build` clean, both headless E2E (core note-gen + dual-stream mixing) PASS.

## Test plan
- [x] `bash scripts/ci.sh` — all gates green