### PR TITLE
fix(org): retry + resolve stuck failed-republish org shares

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24553,6 +24553,51 @@ mod lifecycle_tests {
         assert_eq!(status2.received_count, 1, "a tombstoned received item is excluded");
     }
 
+    /// STUCK-REPUBLISH FIX: `OrgStatus.item_count` also counts a `failed` row that still carries a
+    /// non-null `item_id` (a republish that failed transiently but whose OLD publish is still live on
+    /// the server — `set_org_share_failed` never clears `item_id`). Pre-fix this undercounted "N shared
+    /// by you" for exactly the rows the republish-failure bug got stuck. A `failed` row that never
+    /// published (`item_id` NULL) must still be excluded — no live item to count.
+    #[test]
+    fn org_status_item_count_includes_stuck_failed_rows_with_a_live_item_id() {
+        let state = build_state("org-item-count-stuck");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        let now = "2026-07-12T00:00:00Z";
+
+        // One cleanly-uploaded share.
+        state
+            .db
+            .insert_org_share("s-up", "org-1", None, Some("n-up"), "note", Some("T"), 1, 1, &[1u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_uploaded("s-up", "item-up", now).unwrap();
+
+        // One STUCK share: published once, then a republish attempt failed (item_id retained).
+        state
+            .db
+            .insert_org_share("s-stuck", "org-1", None, Some("n-stuck"), "note", Some("T"), 1, 1, &[2u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_uploaded("s-stuck", "item-stuck", now).unwrap();
+        state.db.set_org_share_failed("s-stuck", "republish_upload_failed", now).unwrap();
+
+        // One NEVER-published failed share (item_id NULL) — must stay excluded.
+        state
+            .db
+            .insert_org_share("s-dead", "org-1", None, Some("n-dead"), "note", Some("T"), 1, 1, &[3u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_failed("s-dead", "publish_failed", now).unwrap();
+
+        let status = block_on(org_status_for(
+            &state,
+            state.db.get_org_state("org-1").unwrap().unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(
+            status.item_count, 2,
+            "item_count includes the uploaded row AND the stuck failed-with-item_id row, \
+             excluding the never-published failed row"
+        );
+    }
+
     /// `org_state` upsert preserves the LOCAL consent + sync cursor across a status refresh (a refresh
     /// carrying role/name/generation must NOT reset consent or rewind last_seq), and the consent +
     /// generation + last_seq setters work as the single mutators.
@@ -25486,6 +25531,88 @@ mod lifecycle_tests {
         assert_eq!(log.tombstoned, vec!["item-1".to_string()]);
     }
 
+    /// STUCK-REPUBLISH FIX (the sweep side): `org_sweep_pending_inner` retries a `failed` row that
+    /// STILL carries an `item_id` (a republish that failed transiently, leaving the OLD publish live)
+    /// via `republish_org_shares_for_source` — which SUPERSEDES (new item, bumped rev, old tombstoned)
+    /// — rather than via `share_to_org_inner`, which would wrongly restart at `rev = 1` and mint a
+    /// DUPLICATE item alongside the still-live stuck one. Sequence: (1) share n-sw successfully
+    /// (item-1, rev 1); (2) evict the cached OCK so the NEXT OCK acquire 404s against the mock server
+    /// (no `/key-grants` route) — forcing a deterministic republish failure that lands the row in
+    /// `state='failed'` WITH `item_id` still `Some("item-1")`, exactly the stuck shape; (3) re-seed the
+    /// OCK (simulating the transient blip clearing) and run the sweep — assert it advances the row via
+    /// a NEW published item (rev 2, superseding item-1) rather than a second, independent rev-1 item.
+    #[test]
+    fn org_sweep_pending_retries_stuck_failed_rows_via_republish_not_fresh_share() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-sweep-stuck-republish");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-sw", "Team");
+        state
+            .db
+            .insert_note("n-sw", "f-sw", "plan", "Plan", "# original body", 1)
+            .unwrap();
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        // (1) Initial share succeeds: item-1, rev 1, one uploaded row.
+        let entry = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-sw".to_string()),
+            true,
+        ))
+        .expect("initial share should publish against the mock server");
+        assert_eq!(entry.item_id.as_deref(), Some("item-1"));
+        let row_id = state.db.list_org_shares_for_org("org-1").unwrap()[0].id.clone();
+
+        // Edit the note so the republish has new content to publish.
+        update_note_doc_inner(&state, "n-sw", "Plan", "# EDITED body").unwrap();
+
+        // (2) Evict the OCK cache so the republish's `acquire_org_ock` cache-misses and hits the
+        // (unmocked) key-grants endpoint, which 404s → deterministic republish failure.
+        state.org_ock_cache.lock().unwrap().clear();
+        let republished = block_on(republish_org_shares_for_source(&state, None, Some("n-sw"))).unwrap();
+        assert_eq!(republished, 0, "the forced OCK failure republished nothing this call");
+        let stuck = state.db.get_org_share(&row_id).unwrap().unwrap();
+        assert_eq!(stuck.state, "failed", "the row landed in failed state");
+        assert_eq!(
+            stuck.item_id.as_deref(),
+            Some("item-1"),
+            "the OLD, still-server-live item_id is retained (set_org_share_failed doesn't clear it)"
+        );
+        assert_eq!(stuck.rev, 1, "rev was NOT bumped — the republish attempt failed before publishing");
+
+        // (3) The transient blip clears (OCK re-seeded) — run the sweep.
+        seed_ock(&state, "org-1", 1);
+        let advanced = block_on(org_sweep_pending_inner(&state)).unwrap();
+        assert_eq!(advanced, 1, "the sweep advanced the stuck row");
+
+        let healed = state.db.get_org_share(&row_id).unwrap().unwrap();
+        assert_eq!(healed.state, "uploaded", "the row is live again after the sweep");
+        assert_eq!(healed.rev, 2, "republish bumped rev to 2 — NOT a fresh rev-1 share");
+        assert_eq!(
+            healed.item_id.as_deref(),
+            Some("item-2"),
+            "the row was repointed to a NEW item that SUPERSEDES item-1"
+        );
+        // Still exactly ONE org_shares row for this source — no duplicate row was minted.
+        let all_rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(all_rows.len(), 1, "no duplicate org_shares row for the source");
+
+        // The mock server saw item-1 published, then item-2 published, then item-1 tombstoned — the
+        // supersede sequence, NOT a second independent rev-1 publish with item-1 left live forever.
+        let log = mock.log.lock().unwrap();
+        assert_eq!(log.published, vec!["item-1".to_string(), "item-2".to_string()]);
+        assert_eq!(
+            log.tombstoned,
+            vec!["item-1".to_string()],
+            "the OLD stuck item was tombstoned once the new one superseded it"
+        );
+    }
+
     /// ITEM 2 — `org_resolve_source` maps an uploaded org item back to its LOCAL editable source, and
     /// returns `None` for an unknown item id (a colleague's item this device never published).
     #[test]
@@ -25519,6 +25646,46 @@ mod lifecycle_tests {
 
         // An unknown item (not published by THIS device) → None.
         assert!(org_resolve_source_inner(&state, "item-unknown").unwrap().is_none());
+    }
+
+    /// STUCK-REPUBLISH FIX: `org_resolve_source` still resolves a `failed` row whose LAST republish
+    /// attempt failed but which retained its OLD, still-server-live `item_id` (`set_org_share_failed`
+    /// never clears it — see `org_shares_for_source`'s doc). This is what makes the author's own note
+    /// open in the real editor instead of getting stuck in the read-only Org Brain viewer. A `revoked`
+    /// row (intentionally torn down) is the one state that must still return `None`.
+    #[test]
+    fn org_resolve_source_resolves_stuck_failed_rows_but_not_revoked() {
+        let state = build_state("org-resolve-source-stuck");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        let now = "2026-07-12T00:00:00Z";
+
+        // A row that published successfully once, then a REPUBLISH attempt failed — item_id retained.
+        state
+            .db
+            .insert_org_share("s-stuck", "org-1", None, Some("n-stuck"), "note", Some("T"), 1, 1, &[1u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_uploaded("s-stuck", "item-stuck", now).unwrap();
+        state.db.set_org_share_failed("s-stuck", "republish_upload_failed", now).unwrap();
+
+        let resolved = org_resolve_source_inner(&state, "item-stuck").unwrap();
+        assert_eq!(
+            resolved.map(|r| (r.kind, r.source_id)),
+            Some(("document".to_string(), "n-stuck".to_string())),
+            "a failed-with-item_id row still resolves to its real editable source"
+        );
+
+        // A row that was uploaded, then intentionally revoked — must NOT resolve.
+        state
+            .db
+            .insert_org_share("s-revoked", "org-1", None, Some("n-revoked"), "note", Some("T"), 1, 1, &[2u8; 32], now)
+            .unwrap();
+        state.db.set_org_share_uploaded("s-revoked", "item-revoked", now).unwrap();
+        state.db.set_org_share_state("s-revoked", "revoked", now).unwrap();
+
+        assert!(
+            org_resolve_source_inner(&state, "item-revoked").unwrap().is_none(),
+            "an intentionally revoked share must not resolve back to an editable source"
+        );
     }
 
     /// F1 (org_leave targets the SPECIFIED org's local state). `org_leave` deletes the local org row +
@@ -26520,11 +26687,15 @@ async fn org_status_for(
         .iter()
         .filter(|s| s.state == "queued" || s.state == "revoke_pending")
         .count() as u32;
+    // `item_count` also counts a `failed`-with-`item_id` row: `set_org_share_failed` never clears
+    // `item_id` on a republish failure, so such a row's PRIOR publish is still genuinely live on the
+    // server — excluding it undercounted "N shared by you" for exactly the rows stuck by the
+    // republish-failure bug (see `org_shares_for_source`'s doc for the full state-machine rationale).
     let item_count = state
         .db
         .list_org_shares_for_org(&refreshed.org_id)?
         .iter()
-        .filter(|s| s.state == "uploaded")
+        .filter(|s| s.state == "uploaded" || (s.state == "failed" && s.item_id.is_some()))
         .count() as u32;
     // RECEIVED items in the local replica (what colleagues shared IN) — distinct from item_count
     // (the caller's OWN uploads). Fixes the "0 items" lie a receiving member saw.
@@ -27897,7 +28068,13 @@ pub(crate) fn org_resolve_source_inner(
     let Some(row) = state.db.org_share_by_item(item_id)? else {
         return Ok(None);
     };
-    if row.state != "uploaded" {
+    // Only a `revoked` row is refused here — it was INTENTIONALLY torn down, so it must not redirect
+    // the author back into "editing" it. Every other state (including `failed` with a still-set
+    // `item_id` — a republish that failed transiently but whose PRIOR publish is still genuinely live
+    // on the server, see `org_shares_for_source`) falls through: the row's `document_id`/`meeting_id`
+    // (checked below) is what actually decides "nothing to route to", so a stuck-but-live row still
+    // resolves to the real editable source instead of the read-only Org Brain viewer.
+    if row.state == "revoked" {
         return Ok(None);
     }
     if let Some(document_id) = row.document_id {
@@ -28075,8 +28252,14 @@ pub(crate) async fn org_background_sync_tick(state: &AppState) -> bool {
 
 /// `org_sweep_pending()` — the on-launch org queue sweep (extends the mode-B `share_rewrap_pending`
 /// launch pattern). Idempotent + OFFLINE-TOLERANT: logged out / no server / a per-row failure leaves
-/// the row where it is for the next pass (never an error). Two queues:
-///   - `queued` (or `failed` retry) → re-seal under the current OCK + upload + publish → `uploaded`;
+/// the row where it is for the next pass (never an error). Three queues:
+///   - `queued`, or a `failed` row that NEVER published (`item_id` still `NULL`) → fresh publish via
+///     `share_to_org_inner` (re-seal under the current OCK + upload + publish → `uploaded`);
+///   - a `failed` row that WAS live before (`item_id` set — the row's LAST republish attempt failed,
+///     but `set_org_share_failed` never clears the OLD, still-server-live `item_id`) → retried via
+///     `republish_org_shares_for_source` instead, so it supersedes (bumps `rev`, tombstones the old
+///     item after the new one lands) rather than restarting at `rev = 1` and minting a duplicate item
+///     alongside the still-live stuck one;
 ///   - `revoke_pending` → tombstone the item server-side → `revoked`.
 /// Returns the number of rows ADVANCED. Reads ONLY the retained local rows' key/hash context — for a
 /// re-seal it re-reads the SOURCE note, so the per-row re-share still passes the READ-GATE (a source
@@ -28130,8 +28313,26 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
     //    queueing NEVER egresses (the read-gate refuses → the row stays `failed`).
     for state_label in ["queued", "failed"] {
         for row in state.db.list_org_shares_in_state(state_label)? {
-            // Skip rows already published (defensive — shouldn't be in these states with an item_id).
             if row.item_id.is_some() {
+                // Was live before: this row's LAST attempt was a REPUBLISH (not the initial publish)
+                // and it failed — `set_org_share_failed` deliberately retains the OLD, still-server-live
+                // `item_id` (only the success path's `reset_org_share_for_retry` clears it). The correct
+                // retry here is `republish_org_shares_for_source` (bumps `rev`, tombstones the OLD item
+                // only AFTER the new one lands) — `share_to_org_inner` would wrongly restart at `rev = 1`
+                // and mint a genuine DUPLICATE item since the old one is still live on the server.
+                // `org_shares_for_source` (the enumerator it reads through) now surfaces exactly this
+                // shape (`failed` + non-null `item_id`), so this retry can actually find the row.
+                let advanced_this_source = republish_org_shares_for_source(
+                    state,
+                    row.meeting_id.as_deref(),
+                    row.document_id.as_deref(),
+                )
+                .await
+                .map(|n| n > 0)
+                .unwrap_or(false);
+                if advanced_this_source {
+                    advanced += 1;
+                }
                 continue;
             }
             let res = share_to_org_inner(

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2026,13 +2026,22 @@ impl Db {
         .map_err(map_err)
     }
 
-    /// Every UPLOADED (live-on-server) org share anchored to a given source (`meeting_id` XOR
+    /// Every LIVE-OR-STUCK-LIVE org share anchored to a given source (`meeting_id` XOR
     /// `document_id`). Powers the re-publish-on-edit fix: one logical note may be shared into SEVERAL
-    /// orgs, so this returns rows ACROSS ALL of them (never restricted to the first). Only `uploaded`
-    /// rows are returned — a still-`queued`/`failed` row has no live server item to supersede yet (the
-    /// launch sweep publishes the current plaintext for it), and a `revoked`/`revoke_pending` share was
-    /// intentionally torn down (an edit must not resurrect it). Exactly one of `meeting_id`/`document_id`
-    /// must be `Some`; both-`None` returns an empty vec (no source ⇒ nothing to republish).
+    /// orgs, so this returns rows ACROSS ALL of them (never restricted to the first). Returns `uploaded`
+    /// rows AND `failed` rows that still carry a non-null `item_id` — the latter is a row whose MOST
+    /// RECENT republish attempt failed transiently (network blip during OCK acquire / seal / blob
+    /// upload / item publish) but whose PRIOR publish is still genuinely live on the server:
+    /// `set_org_share_failed` deliberately does not clear `item_id` on a republish failure (only the
+    /// SUCCESS path's `reset_org_share_for_retry` does), so such a row represents a live item whose
+    /// latest edit hasn't synced yet — not a dead row. Excluding it here (the pre-fix behavior) made it
+    /// permanently invisible to every caller keyed off this function (the edit-save republish path, the
+    /// re-share-block check, the Library share badge), so it could never self-heal and a manual re-share
+    /// would mint a genuine duplicate item. A `queued`/never-published `failed` row (no `item_id`, no
+    /// live server item to supersede yet — the launch sweep publishes the current plaintext for it) and
+    /// a `revoked`/`revoke_pending` share (intentionally torn down; an edit must not resurrect it) are
+    /// still excluded. Exactly one of `meeting_id`/`document_id` must be `Some`; both-`None` returns an
+    /// empty vec (no source ⇒ nothing to republish).
     pub fn org_shares_for_source(
         &self,
         meeting_id: Option<&str>,
@@ -2045,7 +2054,7 @@ impl Db {
         let mut stmt = conn
             .prepare(&format!(
                 "SELECT {} FROM org_shares
-                   WHERE state = 'uploaded'
+                   WHERE (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))
                      AND ((?1 IS NOT NULL AND meeting_id = ?1)
                        OR (?2 IS NOT NULL AND document_id = ?2))
                    ORDER BY created_at ASC",
@@ -11120,6 +11129,49 @@ mod tests {
         assert_eq!(mrows.len(), 1);
         assert_eq!(mrows[0].meeting_id.as_deref(), Some("m1"));
         assert!(db.org_shares_for_source(None, None).unwrap().is_empty());
+    }
+
+    /// STUCK-REPUBLISH FIX: `org_shares_for_source` also surfaces a `failed` row that still carries a
+    /// non-null `item_id` — the exact shape `set_org_share_failed` produces when a REPUBLISH (not the
+    /// initial publish) fails transiently, since that function never clears `item_id` (only the success
+    /// path's `reset_org_share_for_retry` does). Such a row's OLD item is still genuinely live on the
+    /// server, so it must stay visible (not silently excluded forever). A `failed` row that never
+    /// published at all (`item_id` still NULL, e.g. the initial publish itself failed) must stay
+    /// EXCLUDED — there is no live item to supersede yet; the launch sweep's fresh-share retry handles
+    /// that case instead.
+    #[test]
+    fn org_shares_for_source_includes_failed_rows_with_a_live_item_id() {
+        let db = mem_db();
+        let now = "2026-07-12T00:00:00Z";
+
+        // Row f1: published once (item-f1), THEN a republish attempt failed — mirrors the real sequence
+        // (insert → uploaded → failed-on-republish). `item_id` stays set (set_org_share_failed doesn't
+        // touch it).
+        db.insert_org_share("f1", "org-1", None, Some("d-stuck"), "note", Some("T"), 1, 1, &sha32(1), now)
+            .unwrap();
+        db.set_org_share_uploaded("f1", "item-f1", now).unwrap();
+        db.set_org_share_failed("f1", "republish_upload_failed", now).unwrap();
+
+        // Row f2: NEVER successfully published — failed before ever getting an item_id. Must stay
+        // excluded (no live server item to supersede).
+        db.insert_org_share("f2", "org-2", None, Some("d-never-live"), "note", Some("T"), 1, 1, &sha32(2), now)
+            .unwrap();
+        db.set_org_share_failed("f2", "publish_failed", now).unwrap();
+
+        let stuck_rows = db.org_shares_for_source(None, Some("d-stuck")).unwrap();
+        assert_eq!(
+            stuck_rows.len(),
+            1,
+            "a failed-with-item_id row (stuck republish) IS returned"
+        );
+        assert_eq!(stuck_rows[0].state, "failed");
+        assert_eq!(stuck_rows[0].item_id.as_deref(), Some("item-f1"));
+
+        let never_live_rows = db.org_shares_for_source(None, Some("d-never-live")).unwrap();
+        assert!(
+            never_live_rows.is_empty(),
+            "a failed row that never published (item_id NULL) stays excluded"
+        );
     }
 
     /// `uploaded_org_shares_for_source_in_org` is (org, source)-SCOPED and OLDEST-FIRST: only the


### PR DESCRIPTION
## Summary
User-reported bug: after editing an already-org-shared note, if that ONE republish attempt fails transiently (network blip during OCK acquire / seal / blob upload / item publish), the note becomes permanently stuck:
- The author can no longer edit it — clicking it opens a read-only "Org Brain" card instead of the real editor.
- Settings → Organization undercounts "N shared by you".

Root cause: `set_org_share_failed` sets `state='failed'` but deliberately leaves the row's `item_id` untouched (the old, still-server-live item — "never leave the org with no copy" is existing, correct design intent). But `org_shares_for_source`'s SQL hardcoded `WHERE state = 'uploaded'`, making the stuck row invisible to (a) future edit-triggered republish attempts, (b) the launch sweep — which explicitly *skips* any row with a set `item_id` to avoid minting a duplicate item via the wrong retry path.

## Fix (4 surgical changes, one root cause)
1. `Db::org_shares_for_source` — SQL broadened to also surface `state='failed' AND item_id IS NOT NULL` rows (still-live, stuck-retrying), not just `uploaded` ones.
2. `org_sweep_pending_inner` — a stuck `item_id`-having row now retries via `republish_org_shares_for_source` (correctly bumps rev, supersedes) instead of being skipped or wrongly restarted at rev=1 via `share_to_org_inner` (which would mint a duplicate item).
3. `org_resolve_source_inner` — gate loosened from `state != "uploaded"` to `state == "revoked"`, so the author can edit their own stuck-but-still-live share immediately, without waiting for a retry to land.
4. `org_status_for`'s `item_count` — count now includes stuck-but-live rows, fixing the undercount.

`uploaded_org_shares_for_source_in_org` and `collapse_org_share_dups_for_source` (dedup-keeper selection) are deliberately untouched.

## Verification
- `cargo test --lib`: 1577 → 1581 passed (exactly +4 new tests), 0 failed, 10 ignored.
- All 4 fixes independently proven RED-before-GREEN, TWICE — once by the implementer, once again independently by the adversarial-verifier (hand-reverted each hunk, confirmed the test fails, restored, confirmed it passes).
- **lock-security-reviewer: PASS** — `org_shares` confirmed local-only/single-device (never touched by the feed-ingest path `org_sync_one`, which writes only to the separate `org_items` replica table); every widened gate routes through the same unchanged read-gate + consent-check code; the resolve path is routing-only, downstream reads (`get_meeting_detail`) keep their own independent lock gates untouched.
- **adversarial-verifier: PASS** — confirmed the broadened SQL doesn't over-match (`queued`/`revoked`/`revoke_pending` rows all still correctly excluded, verified with a temporary probe test), confirmed the one-row-per-(org,source) invariant holds under the new retry path (no duplicate-item risk), confirmed no double-counting in the item_count fix.
- Two LOW-severity, non-blocking UX findings from the adversarial pass: the "Already added ✓ / nothing to add" copy in the org-share sheet and the meeting-detail "Shared with {org}" pill don't visually distinguish a stuck-but-healing share from a fully-synced one. Tracked as a fast follow-up candidate, not blocking this fix.

## Test plan
- [x] `cargo test --lib` (1581 passed, +4)
- [x] Independent adversarial-verifier PASS (RED-before-GREEN re-proven for all 4 fixes)
- [x] lock-security-reviewer PASS (no leak, no unauthorized write, no content loss)