### PR TITLE
fix: A failed voice-ask ("Ask AI") leaves a permanent orphaned "🎙 …" placeholder bubble in the notes/thread flow with no dismiss/retry

### DIFF
--- a/e2e/record/ask-ai-fail-no-orphan.spec.ts
+++ b/e2e/record/ask-ai-fail-no-orphan.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * A failed voice-ask ("Ask AI") must NOT leave a permanent orphaned "🎙 …"
+ * placeholder bubble in the notes/thread flow.
+ *
+ * `MeetingConversationStore.askNow()` optimistically pushes a fresh anchorless
+ * thread — text "🎙 …", `persisted: false` — BEFORE awaiting
+ * `ipc.beginVoiceCommand()`, so the listener orb can render immediately. When
+ * that IPC call REJECTS (e.g. the brain backend is unavailable), the listener
+ * never actually armed, so no voice-result event will ever land to backfill the
+ * placeholder's text. Before the fix, the catch block only reset the
+ * listening/in-flight signals and resolved the pending agent turn's error text
+ * ("Couldn't start the listener.") — it never removed the placeholder note/
+ * thread entry, so the raw "🎙 …" stayed rendered forever as the thread's first
+ * user bubble (a note-item with `!persisted` renders `n.text` as the anchor
+ * bubble) with no way to dismiss or retry it.
+ *
+ * RED contract: with `begin_voice_command` rejecting, the pre-fix code leaves
+ * the "🎙 …" bubble (and the whole orphaned thread) permanently in the flow —
+ * `toHaveCount(0)` on the mic-glyph bubble fails.
+ */
+test.describe("Record — a failed Ask AI leaves no orphaned mic bubble", () => {
+  test("begin_voice_command rejecting removes the placeholder thread instead of stranding it", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-rec",
+        startedAt: "2026-07-01T09:00:00Z",
+      }),
+      begin_voice_command: () => {
+        throw new Error("brain backend unavailable");
+      },
+    });
+
+    await page.goto("/record");
+
+    await page.locator("button.start-btn").click();
+    await expect(page.locator(".rec-strip.is-recording")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Click "Ask AI" — begin_voice_command rejects immediately.
+    await page.locator("button.ask-btn").click();
+
+    // The orb must NOT get stuck listening/processing.
+    await expect(page.locator("button.ask-btn.is-listening")).toHaveCount(0);
+
+    // No orphaned "🎙 …" bubble/thread should remain anywhere in the flow.
+    await expect(page.getByText("🎙 …", { exact: true })).toHaveCount(0);
+
+    // The flow stays in its pre-click state — no orphaned thread entry either.
+    await expect(page.locator("app-note-item")).toHaveCount(0);
+  });
+});

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -1069,7 +1069,13 @@ export class MeetingConversationStore {
   /**
    * Fire the manual "Ask AI" trigger: open a fresh anchorless thread to host the
    * voice turn, open the listener, and mark a manual ask in flight so the surface
-   * stays visible for the whole round-trip. Errors clear the in-flight flag.
+   * stays visible for the whole round-trip. When `begin_voice_command` itself
+   * REJECTS, the listener never armed and no {@link onResult} will ever land to
+   * backfill the "🎙 …" placeholder anchor — resolving its turn in place would
+   * strand an unlabeled mic bubble in the flow with no dismiss/retry for the rest
+   * of the session, so instead we DROP the whole placeholder thread (it never
+   * became a real note — `persisted: false`) and just clear the in-flight flag,
+   * leaving the flow exactly as it was before the click.
    */
   async askNow(): Promise<void> {
     this._manualAskInFlight.set(true);
@@ -1122,13 +1128,10 @@ export class MeetingConversationStore {
       this._manualAskInFlight.set(false);
       this._listening.set(false);
       this.voiceTargetNoteId = null;
-      this.resolveTurn(noteId, agentTurn.id, {
-        status: "error",
-        text: "Couldn't start the listener.",
-        citations: [],
-        proposedNote: null,
-        answeredFrom: null,
-      });
+      // The listener never started — there is nothing to resolve or retry, so
+      // remove the placeholder thread rather than leaving an orphaned "🎙 …"
+      // bubble permanently stuck in the flow.
+      this._notes.update((ns) => ns.filter((n) => n.id !== noteId));
       throw e;
     }
   }


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

MeetingConversationStore.askNow() (meeting-conversation.store.ts:1074-1134) immediately pushes a new note/thread entry with placeholder `text: "🎙 …"` (and `persisted: false`) before awaiting `ipc.beginVoiceCommand()`. When that call rejects (e.g. the brain backend is unavailable), the catch block resets `_manualAskInFlight`/`_listening` and resolves the AGENT turn via `resolveTurn` with the error text "Couldn't start the listener.", but never updates or clears the note's own `text` field (still "🎙 …") nor removes the note/thread entry from `_notes`. Because `persisted: false`, the "🎙 …" line itself isn't rendered as a note row, but IS rendered as the thread's first user bubble (note-item.component.html renders `n.text` for the anchor/first turn when `!n.persisted`), leaving a permanent, confusing thread in the conversation flow: a bare mic-emoji-and-ellipsis bubble above "Couldn't start the listener." with no way to tell what was being asked and no cleanup path for the rest of the session.

**Repro:** 1. Start a recording on /record. 2. Cause `begin_voice_command` to fail/reject (e.g. brain backend unavailable). 3. Click the Ask AI (mic) button in the recording strip. 4. Observe a new thread appears in the Notes flow with a floating "🎙 …" user bubble and an agent reply "Couldn't start the listener." — this orphaned thread stays visible in the flow for the rest of the session with no way to dismiss/retry it cleanly.

## Fix

Confirmed the bug exactly as reported: MeetingConversationStore.askNow() (src/app/core/meeting-conversation.store.ts) optimistically pushes a placeholder NoteItem (text "🎙 …", persisted: false) into the _notes signal BEFORE awaiting ipc.beginVoiceCommand(). When that IPC call rejects, the listener never actually armed, so the onResult event that normally backfills the placeholder's text (comparable pattern seen in the onResult handler) will never fire. The pre-fix catch block called resolveTurn() to set the pending agent turn's status/text to an error message, but left the note's own `text` field untouched at "🎙 …" and never removed the NoteItem from _notes. Because persisted is false, note-item.component.html (line ~74) renders n.text as the thread's first user bubble — so the raw "🎙 …" stayed visible forever with no dismiss/retry affordance anywhere in that component.

Fix (src/app/core/meeting-conversation.store.ts, askNow()): since a begin_voice_command rejection means the listener never started and no result will ever land to resolve the thread, the catch block now removes the whole placeholder NoteItem from the _notes signal (`this._notes.update((ns) => ns.filter((n) => n.id !== noteId))`) instead of resolving its turn in place. This restores the flow to exactly its pre-click state — no orphaned bubble, no dead thread. The existing rethrow (`throw e`) is preserved, so callers (record.component.ts toggleAsk, meeting-conversation.component.ts toggleAsk) keep swallowing the rejection exactly as before; only the store-side cleanup behavior changed.

Added e2e/record/ask-ai-fail-no-orphan.spec.ts (Playwright, the repo's actual FE test harness — there is no ng unit-test/.spec.ts convention in this codebase, confirmed by grep) mirroring e2e/record/stop-optimistic.spec.ts's shape: mocks start_recording + a rejecting begin_voice_command, starts a recording, clicks the "Ask AI" mic button, and asserts no "🎙 …" text and zero app-note-item elements remain. RED-before-GREEN was done manually: stashed only the store.ts fix, reran the test against pre-fix code -> failed exactly as expected (found 1 "🎙 …" element, expected 0); restored the fix, reran -> passed.

Gates run: `npx ng lint` clean, `npx ng build` clean (16kB style budget unaffected, no new component/style). No Rust files touched, so cargo test --lib was not run (per task scope for an FE-only fix). 

Process note for the verifier: this is a shared/concurrent worktree — mid-task, an unrelated concurrent agent's WIP (a ToastService-based persistNotes() error-toast change, unrelated to this bug) got interleaved into the same file via a stash race, and at one point even fully clobbered my askNow() edit back to HEAD content. I detected this via `git diff` showing more than my intended change, diagnosed it against `git stash show -p`, surgically reverted the foreign hunk, re-applied my fix, and immediately re-verified `git diff`/`git status` before committing. The final committed diff (verified via `git diff --cached` right before commit) contains ONLY the two-file change described above — no foreign content.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
