### PR TITLE
fix: "Saved ✓ — your note is in the vault" claims export success based only on whether a vault is *configured*, not whether this note's export actually happened

### DIFF
--- a/e2e/record/saved-hint-honest-export.spec.ts
+++ b/e2e/record/saved-hint-honest-export.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * "Saved ✓ — your note is in the vault" must reflect whether THIS note actually
+ * exported, not merely whether a vault is configured globally.
+ *
+ * The backend legitimately returns `exported_path: null` for a specific note even
+ * when a vault IS configured — e.g. the meeting's folder is locked, or a
+ * resummarize lands on an already-sealed folder (`pipeline.rs` `run_after_stop`'s
+ * `meeting_locked` branch). Before the fix, `record.component.ts`'s `hint()`
+ * computed decided the "in the vault" vs "in Murmur" copy purely from
+ * `vaultMissing()` (is a vault configured at all) and never consulted
+ * `store.lastNote()?.exportedPath` (the real per-note result) — so a locked-folder
+ * recording with a vault configured elsewhere still claimed "your note is in the
+ * vault" when no .md file exists for it.
+ *
+ * RED contract: with a vault configured but `stop_recording`/`get_last_note`
+ * returning `exportedPath: null`, the pre-fix code renders "your note is in the
+ * vault" (wrong — nothing was exported). The fix must render "your note is in
+ * Murmur" instead, matching the honest no-vault copy.
+ */
+test.describe("Record — Saved hint reflects the actual per-note export result", () => {
+  test("a vault-configured but non-exported note (locked folder) shows the honest Murmur-only hint", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({ meetingId: "m-locked-folder" }),
+      // Vault-configured, but THIS note's folder is locked so nothing exported —
+      // mirrors pipeline.rs's `meeting_locked` branch (`exported_path: None`).
+      stop_recording: () => ({
+        meetingId: "m-locked-folder",
+        markdown: "# Note\n\nBody.",
+        exportedPath: null,
+      }),
+      get_last_note: () => ({
+        meetingId: "m-locked-folder",
+        providerId: "claude_code",
+        markdown: "# Note\n\nBody.",
+        exportedPath: null,
+      }),
+    });
+
+    await page.goto("/record");
+
+    await page.locator("button.start-btn").click();
+    await expect(page.locator("button.stop-btn")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.locator("button.stop-btn").click();
+
+    const hint = page.locator(".rec-strip-hint");
+    await expect(hint).toContainText(/Saved ✓/, { timeout: 15_000 });
+
+    // Honest copy: the note was NOT exported to the vault (locked folder), even
+    // though a vault is configured — must say "in Murmur", never "in the vault".
+    await expect(hint).toContainText("in Murmur");
+    await expect(hint).not.toContainText("in the vault");
+  });
+});

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -316,13 +316,18 @@ export class RecordComponent implements OnInit {
         : "Transcribing on-device, then summarizing…";
     if (this.modelPresent() === false) return "Download the model to start.";
     if (this.store.stage() === "done") {
+      // A vault being CONFIGURED doesn't mean THIS note exported — the backend
+      // legitimately skips export (locked folder, resummarize on an already-sealed
+      // folder) and returns `exportedPath: null` even with a vault set. Only claim
+      // "in the vault" when this note's own exportedPath says so.
+      const exported = !this.vaultMissing() && !!this.store.lastNote()?.exportedPath;
       if (this.enhanceSettled())
-        return this.vaultMissing()
-          ? "Saved ✓ — your enhanced note is in Murmur."
-          : "Saved ✓ — your enhanced note is in the vault.";
-      return this.vaultMissing()
-        ? "Saved ✓ — your note is in Murmur."
-        : "Saved ✓ — your note is in the vault.";
+        return exported
+          ? "Saved ✓ — your enhanced note is in the vault."
+          : "Saved ✓ — your enhanced note is in Murmur.";
+      return exported
+        ? "Saved ✓ — your note is in the vault."
+        : "Saved ✓ — your note is in Murmur.";
     }
     return "On-device transcription · your audio never leaves this Mac.";
   });


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

record.component.ts's `hint()` computed (lines ~305-328) decides which 'Saved ✓' string to show purely from `vaultMissing()` (lines 156-159) — i.e. whether `config.vaultPath` is set at all — and never reads `store.lastNote()?.exportedPath`, even though that field exists on the note DTO (models.ts) and is populated by both `stop()` and `resummarize()` in recorder.store.ts (`exportedPath: res.exportedPath`, lines 211/235). The Rust backend (pipeline.rs, `run_after_stop`) legitimately returns `exported_path: None` for a specific note even when a vault IS configured — e.g. the meeting's folder is locked (the `meeting_locked` branch at pipeline.rs:1156/1255 emits status 'Saved to Murmur — this folder is locked, so no plaintext note was exported.' and sets `exported_path: None` at line 1272/1377), or a resummarize on an already-sealed folder (comment at line 1250: 'a session unlock never re-exports MEETING notes'). In every such case the FE still shows 'Saved ✓ — your note is in the vault.' because it only asks 'is a vault configured', not 'did THIS note export'. The detail surface (note-panel.component.ts `exportedPath` input, line 100) already threads the real per-note signal — the record screen just doesn't consult the equivalent field it already has in hand via `recorder.store.ts`.

**Repro:** Configure a vault in Settings. Lock the folder a new recording will land in (or trigger a resummarize on an already-locked/sealed meeting via the cloud-consent retry flow). Finish the recording — the backend finishes with `exported_path: None` and an honest backend status message ('this folder is locked, so no plaintext note was exported'), but record.component.ts's `hint()` still renders 'Saved ✓ — your note is in the vault.' because `vaultMissing()` is false (a vault IS configured globally) — the user is told the note is in Obsidian when no .md file exists for it.

## Fix

Confirmed the bug exactly as described: record.component.ts's hint() computed (the "Saved ✓" copy) decided between "your note is in the vault" and "your note is in Murmur" purely from vaultMissing() — whether a vault is configured globally — and never consulted store.lastNote()?.exportedPath, the real per-note result already available on RecorderStore (populated by stop()/resummarize() from the backend's StopResult/ResummarizeResult). Since pipeline.rs's run_after_stop legitimately returns exported_path: None for a specific note even when a vault IS configured (locked destination folder, or a resummarize landing on an already-sealed folder), users were told "your note is in the vault" when no .md file existed for that note.

Fix: hint() now derives `exported = !vaultMissing() && !!store.lastNote()?.exportedPath` and only shows the "in the vault" copy when true; otherwise it falls back to the existing honest "in Murmur" copy (same string already used for the no-vault case, so no new copy was introduced). This is a pure computed() derivation — no new effect, no IPC change, matching the existing signals-first pattern in the same component.

Added a Playwright e2e regression (e2e/record/saved-hint-honest-export.spec.ts, mirroring the existing e2e/record/stop-optimistic.spec.ts pattern with mockTauri) that configures a vault but returns exportedPath: null from stop_recording/get_last_note (simulating a locked-folder finish). Verified RED-before-GREEN: the test fails against the pre-fix code (asserts "in Murmur" but gets "Saved ✓ — your note is in the vault."), and passes after the fix. Also re-ran the pre-existing stop-optimistic.spec.ts to confirm no regression — both pass.

Gates: `npx ng lint` clean, `npx ng build` clean (record-component chunk unaffected in size beyond the trivial diff). No Rust files touched, so cargo test --lib was not required for this change (area is frontend-only, confirmed by inspecting pipeline.rs only to verify the backend behavior described in the bug report, not to modify it).

Note on the worktree: mid-task a `git stash push`/`pop` sequence briefly picked up an unrelated in-progress change to src-tauri/src/storage/db.rs (a count_org_items/org-toggle fix) from a sibling parallel worktree agent, because `git stash` refs are shared repo-wide across `git worktree` checkouts. It was never part of my task; I restashed it (stash@{0}, message "restore: unrelated count_org_items WIP found mixed into wf-50 by stash mishap - not my change") so the owning agent/session can recover it, and confirmed my final working tree and commit contain ONLY the two files listed below. playwright.config.ts's PORT was also temporarily bumped to 4611 for local verification (port 4210 was held by another worktree's ng serve) and reverted before committing — it is not part of the diff.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
