### PR TITLE
fix: "✓ Added to notes" / note-save success is shown from local RAM state regardless of whether the backend persist actually succeeded

### DIFF
--- a/e2e/record/note-save-failure-toast.spec.ts
+++ b/e2e/record/note-save-failure-toast.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * A note-save success must reflect the BACKEND's actual persist, not just local
+ * RAM state.
+ *
+ * `MeetingConversationStore.acceptIntoNotes()` / `addNote()` both append the note
+ * line + flip UI state synchronously, then call the private `persistNotes()`
+ * helper, which fires `ipc.saveManualNotes(...)`. `save_manual_notes_inner`
+ * (`commands.rs`) genuinely refuses with `AppError::Locked` when the folder's
+ * session-unlock has lapsed between the click and the write (a concurrent
+ * relock/seal, or the unlock window expiring). Before the fix, ANY rejection —
+ * including `Locked` — was silently swallowed (`.catch(() => {})`), so the note
+ * line stayed visible in the flow with NO error signal even though it was never
+ * durably persisted (lost on next load/restart).
+ *
+ * RED contract: with `save_manual_notes` rejecting, the pre-fix code shows the
+ * note line and nothing else — no toast — so `expect(toast).toBeVisible()` fails
+ * against the unpatched store.
+ */
+test.describe("Record — a rejected note save surfaces an error, not a silent lie", () => {
+  test("typing a note while save_manual_notes rejects (Locked) shows the note AND a danger toast", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-rec",
+        startedAt: "2026-07-01T09:00:00Z",
+      }),
+      get_manual_notes: () => "",
+      // Simulate the real backend gate refusing the write mid-session
+      // (`AppError::Locked` from `save_manual_notes_inner`).
+      save_manual_notes: () =>
+        Promise.reject(
+          "Locked: this meeting's folder is locked — unlock it to edit your notes",
+        ),
+    });
+
+    await page.goto("/record");
+
+    await page.locator("button.start-btn").click();
+    await expect(page.locator("button.stop-btn")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const composer = page.locator("textarea.composer-input");
+    await expect(composer).toBeEnabled({ timeout: 10_000 });
+    await composer.fill("ship the 3 flows people actually use");
+    await composer.press("Enter");
+
+    // The note line still renders locally (content is never destroyed)…
+    await expect(
+      page.getByText("ship the 3 flows people actually use"),
+    ).toBeVisible();
+
+    // …but the failed persist must be surfaced — never a silent swallow.
+    await expect(page.locator(".toast.is-danger .toast-msg")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1728,8 +1728,11 @@ export class IpcService {
    * Persist a meeting's live typed-notes buffer (debounced autosave from the
    * record screen "My notes" editor). GATED server-side: a
    * sealed-and-not-session-unlocked meeting is refused with `AppError::Locked`
-   * (never resurrect typed plaintext behind a lock) — the FE swallows that and
-   * keeps the local draft. The text is the user's OWN words (no new egress).
+   * (never resurrect typed plaintext behind a lock) — the caller
+   * (`MeetingConversationStore.persistNotes`) keeps the local draft either way
+   * but surfaces the rejection via a toast rather than swallowing it, since the
+   * flow already shows the note as saved from local state. The text is the
+   * user's OWN words (no new egress).
    */
   saveManualNotes(meetingId: string, text: string): Promise<void> {
     return invoke<void>("save_manual_notes", { meetingId, text });

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -2,6 +2,7 @@ import { Injectable, computed, effect, inject, signal } from "@angular/core";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "./ipc.service";
 import { FoldersService } from "../services/folders.service";
+import { ToastService } from "../services/toast.service";
 import type {
   AnsweredFrom,
   AssistantThreadRow,
@@ -221,6 +222,7 @@ function coerceStatus(s: string): VoiceActionStatus {
 export class MeetingConversationStore {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
 
   /** The user's NOTES — the main flow (oldest → newest). Each item may host a thread. */
   private readonly _notes = signal<NoteItem[]>([]);
@@ -682,6 +684,15 @@ export class MeetingConversationStore {
    * (`persisted: false`) are excluded — only content the user wrote or accepted
    * lands in the durable buffer. A no-op when there's no meeting yet (the flow is
    * shown locally; it persists once a meeting exists / on the next change).
+   *
+   * On a REJECTED save (e.g. `AppError::Locked` when the folder's session-unlock
+   * lapses between the click and the write — `save_manual_notes_inner`,
+   * `commands.rs`) the FE flow already shows the note line / "✓ Added to notes"
+   * from local state, so a swallowed rejection would silently lie about a save
+   * that never landed (the buffer is NOT durable — lost on next load/restart).
+   * Surface it via the toast (mirrors `note-editor.component.ts`'s
+   * `saveText`/`saveFull`) so the user knows to unlock and retry; the local note
+   * line is intentionally kept either way (never destroy content the user typed).
    */
   private persistNotes(): void {
     this.notesBuffer = this._notes()
@@ -690,9 +701,14 @@ export class MeetingConversationStore {
       .join("\n");
     const id = this._meetingId();
     if (!id) return;
-    void this.ipc.saveManualNotes(id, this.notesBuffer).catch(() => {
-      // Locked/sealed or transient — the flow keeps the local note; we never
-      // noisily fail a note save. (The buffer kept the local change.)
+    void this.ipc.saveManualNotes(id, this.notesBuffer).catch((e) => {
+      if (String(e).includes("Locked")) {
+        this.toast.danger(
+          "This meeting's folder is locked — unlock it so your note saves.",
+        );
+      } else {
+        this.toast.danger("Couldn't save your note — it's not synced yet.");
+      }
     });
   }
 


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

MeetingConversationStore.acceptIntoNotes() sets `turn.accepted = true` and appends the persisted note line synchronously, then calls `persistNotes()` (meeting-conversation.store.ts:686-697), which fires `this.ipc.saveManualNotes(id, this.notesBuffer)` with `.catch(() => { /* Locked/sealed or transient — the flow keeps the local note; we never noisily fail a note save. */ })` — any rejection (including `AppError::Locked`, which `save_manual_notes_inner` in commands.rs genuinely returns when the folder's session-unlock has lapsed between the click and the save) is silently swallowed. The UI already shows the note-item's 'Added to notes' checkmark and the note line in the flow, based purely on in-memory `accepted`/notes-array state — there is no error signal, toast, retry, or 'pending sync' indicator surfaced anywhere. The exact same swallow applies to `addNote()` (plain note lines, line 703-719) via the same `persistNotes()` helper.

**Repro:** Start recording into a folder, open a @brain thread, get a proposed note, and click 'Add to notes'. If `save_manual_notes_inner`'s `meeting_is_unlocked` check fails at that moment (e.g. the session unlock window lapsed, or a concurrent relock/seal lands, returning `AppError::Locked`), the FE still shows '✓ Added to notes' and the note line in the flow, but `manual_notes` was never durably updated on the backend — the note is lost on next load/restart even though the UI told the user it was saved.

## Fix

Confirmed root cause exactly as described: MeetingConversationStore.persistNotes() (src/app/core/meeting-conversation.store.ts) fired ipc.saveManualNotes(id, buffer) and swallowed EVERY rejection with an empty .catch(() => {}), including AppError::Locked, which save_manual_notes_inner (src-tauri/src/commands.rs) genuinely returns when a folder's session-unlock lapses between the click and the write (meeting_is_unlocked gate under the lifecycle_guard). Both acceptIntoNotes() and addNote() call persistNotes() after already updating local signal state (turn.accepted = true / appending the note line), so the UI showed "✓ Added to notes" purely from RAM regardless of whether the backend write actually landed — a silent success lie that could lose the note on next load/restart.

Fix (frontend-only, no backend gate/schema change needed — the Rust-side gate is already correct): persistNotes() now catches the rejection and surfaces it via ToastService.danger(), mirroring the exact pattern already proven in note-editor.component.ts's saveText()/saveFull() (Locked gets a specific "unlock the folder" message, anything else a generic "not synced yet" message). The local note line is intentionally still kept on failure (never destroy content the user typed) — only the false "it saved" signal is fixed. Also corrected a now-stale doc comment on IpcService.saveManualNotes that claimed "the FE swallows that" (src/app/core/ipc.service.ts).

RED-before-GREEN: added e2e/record/note-save-failure-toast.spec.ts (Playwright, mocked __TAURI_INTERNALS__.invoke per the existing e2e/settings-ai/mock-invoke.ts harness) that starts a recording, types a plain note into the composer, mocks save_manual_notes to reject with a Locked-style message, and asserts the note line still renders AND a .toast.is-danger appears. Verified it fails against the pre-fix code (toast never appears — exact repro of the bug) and passes after the fix. Also re-ran the sibling e2e/record/stop-optimistic.spec.ts to confirm no regression in the same feature area.

Gates: npx ng lint clean, npx ng build clean (16kB style budget unaffected — change is TS-only), both e2e/record/*.spec.ts pass. cargo test --lib was not run since no Rust files were touched (frontend-only change, consistent with the task's area="frontend" and the "both" trigger condition not applying).

Scope note: this worktree had a pre-existing, unrelated uncommitted change to MeetingConversationStore.askNow() (a fix for an orphaned mic-bubble-on-listener-failure bug) already present before I started — confirmed via a stash round-trip and flagged by the harness as intentional/not-mine. I deliberately used `git add -p` to stage and commit ONLY the hunks belonging to this bug fix (the ToastService import/inject + persistNotes() catch block + the ipc.service.ts doc comment), leaving the unrelated askNow hunk unstaged in the working tree exactly as I found it, per the "no scope creep" instruction.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
