### PR TITLE
fix: Note/meeting Share panels use the legacy single-org org_status() instead of org_list_statuses(), so invite-only org members never see the Org Brain CTA

### DIFF
--- a/e2e/org/org-share-visible.spec.ts
+++ b/e2e/org/org-share-visible.spec.ts
@@ -230,4 +230,56 @@ test.describe("Org share — browse + picker (mocked IPC)", () => {
       fullPage: true,
     });
   });
+
+  test("invite-only member (not first in org_status) still sees the Add to Org Brain CTA", async ({
+    page,
+  }) => {
+    // Regression for the legacy-single-org bug: `SharePanelComponent` used to gate
+    // its "Add to Org Brain" section on `org_status` — which the backend documents
+    // as `list_org_states().into_iter().next()`, i.e. only the FIRST locally-joined
+    // org (kept for legacy callers). A user whose only membership came from an
+    // invite (never created an org locally) can have `org_status` resolve to null
+    // even though `org_list_statuses` correctly lists their org. Every other
+    // multi-org surface (Settings, the org-share sheet, the org-item viewer) reads
+    // `org_list_statuses`; the Share panels must too.
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      // Simulates the invite-only member: the legacy single-org lookup finds
+      // nothing (the joined org isn't first — or the local `next()` genuinely
+      // returns null for this membership shape), but the full list has it.
+      org_status: () => null,
+      org_list_statuses: () => [
+        {
+          orgId: "org-invited",
+          name: "Invited Co.",
+          role: "member",
+          memberCount: 6,
+          consented: true,
+          lastSeq: 12,
+          itemCount: 0,
+          receivedCount: 2,
+          pendingShares: 0,
+        },
+      ],
+      list_my_shares: () => [],
+      list_org_shares: () => [],
+      org_live_shares_for_source: () => [],
+    });
+
+    await page.goto("/library");
+    await page.locator("li.row-item a.row").first().click();
+    await page
+      .getByRole("tab", { name: /share/i })
+      .first()
+      .click()
+      .catch(async () => {
+        await page.getByText("Share", { exact: false }).first().click();
+      });
+
+    // The CTA must render even though `org_status` resolved to null — it should
+    // be driven by `org_list_statuses` like every other multi-org surface.
+    await expect(
+      page.getByRole("button", { name: "Add to Org Brain" }).first(),
+    ).toBeVisible({ timeout: 10_000 });
+  });
 });

--- a/src/app/features/detail/share-panel/share-panel.component.ts
+++ b/src/app/features/detail/share-panel/share-panel.component.ts
@@ -291,9 +291,17 @@ export class SharePanelComponent {
   readonly verifyMode = signal<ShareVerifyMode | null>(null);
 
   // --- Org Brain (Shared Brain v1) ------------------------------------------
-  /** The user's org membership + sync state; `null` when in no org (hides the section). */
-  private readonly orgStatus = signal<OrgStatus | null>(null);
-  readonly org = this.orgStatus.asReadonly();
+  /**
+   * EVERY org this user actively belongs to (created OR invited-into) — drives
+   * whether the "Add to Org Brain" section renders at all. Uses `orgListStatuses`
+   * (not the legacy single-org `orgStatus`, which only ever returns the FIRST
+   * locally-joined org): an invite-only member whose org isn't first in the local
+   * list must still see the CTA. The actual org PICK happens inside
+   * `OrgShareSheetComponent`, which already loads this same full list.
+   */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  /** True while the user belongs to at least one org (gates the CTA section). */
+  readonly org = computed(() => this._orgs().length > 0);
   /** This user's outgoing org shares (drives the "In Org Brain" state for THIS meeting). */
   private readonly orgShares = signal<OrgShareEntry[]>([]);
   /**
@@ -390,15 +398,15 @@ export class SharePanelComponent {
     }
   }
 
-  /** Load the org status + this user's org shares (stale-guarded on the meeting id). */
+  /** Load every joined org + this user's org shares (stale-guarded on the meeting id). */
   private async refreshOrg(id: string): Promise<void> {
     try {
-      const status = await this.ipc.orgStatus();
+      const orgs = await this.ipc.orgListStatuses();
       if (this.meetingId() !== id) {
         return;
       }
-      this.orgStatus.set(status);
-      if (status) {
+      this._orgs.set(orgs);
+      if (orgs.length > 0) {
         const shares = await this.ipc.listOrgShares();
         if (this.meetingId() !== id) {
           return;
@@ -416,7 +424,7 @@ export class SharePanelComponent {
       }
     } catch {
       // Org unavailable (older backend / not joined) — hide the section.
-      this.orgStatus.set(null);
+      this._orgs.set([]);
       this.orgShares.set([]);
       this._orgSourceShares.set([]);
     }

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.ts
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.ts
@@ -199,9 +199,17 @@ export class NoteSharePanelComponent {
   readonly copiedRowId = signal<string | null>(null);
 
   // --- Org Brain (Shared Brain v1) ------------------------------------------
-  /** The user's org membership; `null` when in no org (hides the section). */
-  private readonly orgStatus = signal<OrgStatus | null>(null);
-  readonly org = this.orgStatus.asReadonly();
+  /**
+   * EVERY org this user actively belongs to (created OR invited-into) — drives
+   * whether the "Add to Org Brain" section renders at all. Uses `orgListStatuses`
+   * (not the legacy single-org `orgStatus`, which only ever returns the FIRST
+   * locally-joined org): an invite-only member whose org isn't first in the local
+   * list must still see the CTA. The actual org PICK happens inside
+   * `OrgShareSheetComponent`, which already loads this same full list.
+   */
+  private readonly _orgs = signal<OrgStatus[]>([]);
+  /** True while the user belongs to at least one org (gates the CTA section). */
+  readonly org = computed(() => this._orgs().length > 0);
   /**
    * Live (uploaded) org shares of THIS note specifically — powers the CTA "In Org
    * Brain ✓" state + blocks a duplicate re-share (edits sync automatically).
@@ -310,15 +318,15 @@ export class NoteSharePanelComponent {
     }
   }
 
-  /** Load the org status (stale-guarded on the note id). A failure hides the section. */
+  /** Load every joined org (stale-guarded on the note id). A failure hides the section. */
   private async refreshOrg(id: string): Promise<void> {
     try {
-      const status = await this.ipc.orgStatus();
+      const orgs = await this.ipc.orgListStatuses();
       if (this.noteId() !== id) {
         return;
       }
-      this.orgStatus.set(status);
-      if (status) {
+      this._orgs.set(orgs);
+      if (orgs.length > 0) {
         // Per-source live shares → the CTA "In Org Brain ✓" state + re-share block.
         const live = await this.ipc.orgLiveSharesForSource({ documentId: id });
         if (this.noteId() !== id) {
@@ -331,7 +339,7 @@ export class NoteSharePanelComponent {
         this._orgSourceShares.set([]);
       }
     } catch {
-      this.orgStatus.set(null);
+      this._orgs.set([]);
       this._orgSourceShares.set([]);
     }
   }


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** high

Both NoteSharePanelComponent.refreshOrg() (note-share-panel.component.ts) and the meeting SharePanelComponent (share-panel.component.ts) call this.ipc.orgStatus(), which wraps the backend command org_status → org_status_inner (src-tauri/src/commands.rs). org_status_inner is explicitly documented as legacy: `state.db.list_org_states()?.into_iter().next()` — 'the FIRST locally-joined org... kept for legacy FE callers that predate the multi-org list' (see the doc comment directly above org_status_inner and org_list_statuses_inner in commands.rs). It returns None for a user whose only org membership came from an invite rather than local creation, or more generally whenever the first-in-list org isn't the relevant one. Every other multi-org surface in the codebase (Settings > Organization's settings-organization-section.component.ts, org-share-sheet.component.ts, org-item-viewer.component.ts, and OrgBrainService) correctly calls ipc.orgListStatuses() instead, which enumerates every locally-joined org (owned AND invited). The two Share panels are the sole stragglers still on the legacy call, so their 'Add to Org Brain' CTA silently disappears for such users with no error and no fallback, even though Settings correctly shows org membership.

**Repro:** Mock org_status to return null and org_list_statuses to return one org with role 'member' (simulating a user who only joined via invite, never created one locally — i.e., that org isn't first in list_org_states()). Open a note (/notes/:id) or a meeting detail and click Share. The 'Add to Org Brain' CTA (<mur-org-brain-cta>) is absent — only the link-share 'Create a share link' section renders — while Settings > Organization (same mock data, using orgListStatuses) correctly lists the org.

## Fix

Confirmed the bug exactly as reported: NoteSharePanelComponent.refreshOrg() and SharePanelComponent.refreshOrg() called ipc.orgStatus() (backend org_status_inner = list_org_states().into_iter().next(), documented as legacy/first-org-only), instead of ipc.orgListStatuses() (every org the user actively belongs to). An invite-only member whose org isn't first in the local list gets org_status() -> null, silently hiding the "Add to Org Brain" CTA with no error, while Settings > Organization (already on orgListStatuses) shows the org fine.

Fix: in both note-share-panel.component.ts and share-panel.component.ts, replaced the private `orgStatus = signal<OrgStatus | null>(null)` with `_orgs = signal<OrgStatus[]>([])` fed by `ipc.orgListStatuses()`, and changed the public `org` signal to `computed(() => this._orgs().length > 0)`. This is safe/minimal because `org()` was only ever used as a boolean gate in both templates (`@if (org()) { <mur-org-brain-cta ...> }` and `@if (orgSheetOpen() && org())`) — the actual per-org selection already happens entirely inside OrgShareSheetComponent, which independently loads the same orgListStatuses() list for its picker. refreshOrg()'s downstream per-source-share lookups (orgLiveSharesForSource, listOrgShares) were updated to gate on `orgs.length > 0` instead of a single status object, with the same stale-guard and error-fallback shape preserved.

Added a Playwright regression to e2e/org/org-share-visible.spec.ts mirroring the file's existing style: mocks org_status -> null and org_list_statuses -> one org (role 'member', i.e. the invite-only shape), opens a meeting's Share tab, and asserts the "Add to Org Brain" button becomes visible. Verified RED-before-GREEN by stashing the component fix (test failed: button never appeared, 10s timeout) then restoring it (test + the other 3 tests in the file + all 17 tests across e2e/org and e2e/notes/notes-org.spec.ts passed). npx ng lint and npx ng build both clean. No src-tauri files touched, so cargo test --lib was not run (not applicable per the FE-only scope).

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
