### PR TITLE
fix: list_meeting_org_shares_inner uses a narrower org-share state filter than the sibling functions fixed for the identical stuck-failed-row bug, causing Library's org-share badge to disappear while the note-share-panel's own CTA still shows shared

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24511,6 +24511,57 @@ mod lifecycle_tests {
         );
     }
 
+    /// STUCK-REPUBLISH FIX (Library badge/CTA parity): a share row whose MOST RECENT republish
+    /// attempt failed transiently but still carries a live server `item_id` (`set_org_share_failed`
+    /// never clears `item_id`) must still show the Library "shared into org" badge — mirroring the
+    /// same "live" definition `org_shares_for_source` already applies for the note-share-panel CTA
+    /// (`org_shares_for_source_includes_failed_rows_with_a_live_item_id`, storage/db.rs). Before the
+    /// fix, `list_meeting_org_shares_inner` used a hardcoded `state = 'uploaded'` filter that dropped
+    /// this exact reachable row, so the Library badge vanished while the share-panel CTA (reading the
+    /// already-fixed `org_shares_for_source`) still claimed the meeting was shared — a real two-surface
+    /// disagreement. A `failed` row that NEVER published (no `item_id`) must stay excluded (no live
+    /// item to badge).
+    #[test]
+    fn list_meeting_org_shares_includes_failed_rows_with_a_live_item_id() {
+        let state = build_state("list-meeting-org-shares-stuck-republish");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-open", "Open");
+
+        // Meeting m1: published once, then a REPUBLISH attempt failed transiently. item_id stays set
+        // (set_org_share_failed doesn't clear it) — this is a genuinely LIVE share.
+        seed_meeting(&state.db, "m-stuck", "# note", Some("f-open"));
+        state
+            .db
+            .insert_org_share(
+                "s-stuck", "org-1", Some("m-stuck"), None, "meeting", Some("Stuck"),
+                1, 1, &[11u8; 32], "2026-07-12T09:00:00Z",
+            )
+            .unwrap();
+        state.db.set_org_share_uploaded("s-stuck", "item-stuck", "2026-07-12T09:00:00Z").unwrap();
+        state.db.set_org_share_failed("s-stuck", "republish_upload_failed", "2026-07-12T09:05:00Z").unwrap();
+
+        // Meeting m2: failed on the INITIAL publish — never got an item_id. No live item to badge.
+        seed_meeting(&state.db, "m-never-live", "# note", Some("f-open"));
+        state
+            .db
+            .insert_org_share(
+                "s-never-live", "org-1", Some("m-never-live"), None, "meeting", Some("Never live"),
+                1, 1, &[12u8; 32], "2026-07-12T09:00:00Z",
+            )
+            .unwrap();
+        state.db.set_org_share_failed("s-never-live", "publish_failed", "2026-07-12T09:00:00Z").unwrap();
+
+        let rows = list_meeting_org_shares_inner(&state).unwrap();
+        assert!(
+            rows.iter().any(|r| r.meeting_id == "m-stuck"),
+            "a failed-with-item_id (stuck republish) row's badge must still be visible in Library"
+        );
+        assert!(
+            !rows.iter().any(|r| r.meeting_id == "m-never-live"),
+            "a failed row that never published (no item_id) stays excluded — no live item"
+        );
+    }
+
     /// FIX B (received-items COUNT): `OrgStatus.received_count` reflects the LOCAL replica (what
     /// colleagues shared IN), DISTINCT from `item_count` (the caller's OWN uploaded outbound shares).
     /// Seed org_items (received) + an outbound uploaded share and assert the two counts are independent.
@@ -27948,6 +27999,14 @@ pub struct MeetingOrgShareRow {
 /// meetings, in one bulk call (avoids an N+1 `meeting_org_shares` fetch per Library row). Same
 /// disclosure class + gate as [`meeting_org_shares`]: a sealed-and-not-session-unlocked meeting's
 /// rows are dropped, exactly mirroring `mask_locked_meetings` for `list_meetings`.
+///
+/// STUCK-REPUBLISH FIX: uses `Db::list_live_org_shares` (not a hardcoded `state = 'uploaded'`
+/// filter) so a row whose most recent republish attempt failed transiently but still carries a
+/// live server `item_id` (`set_org_share_failed` never clears it) keeps showing the badge — the
+/// same "live" definition already applied by `org_shares_for_source` / `OrgStatus.item_count` /
+/// `org_resolve_source_inner`. Before this fix, that exact reachable state (edit → republish →
+/// transient network blip) made the Library badge vanish while the note-share-panel's own CTA
+/// (which reads `org_shares_for_source`) still showed the item as shared — two surfaces disagreed.
 #[tauri::command]
 pub fn list_meeting_org_shares(
     state: State<'_, AppState>,
@@ -27959,7 +28018,7 @@ pub fn list_meeting_org_shares(
 pub(crate) fn list_meeting_org_shares_inner(
     st: &AppState,
 ) -> Result<Vec<MeetingOrgShareRow>, AppError> {
-    let rows = st.db.list_org_shares_in_state("uploaded")?;
+    let rows = st.db.list_live_org_shares()?;
     let mut out = Vec::new();
     let mut org_names: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     let mut seen = std::collections::HashSet::new();

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2248,6 +2248,32 @@ impl Db {
         Ok(out)
     }
 
+    /// Every LIVE org share across ALL sources/orgs — the un-scoped twin of `org_shares_for_source`,
+    /// for callers that need the whole "is this live" set rather than one source (the Library bulk
+    /// share-badge listing). Same STUCK-REPUBLISH definition of "live" as `org_shares_for_source`:
+    /// `uploaded` rows AND `failed` rows that still carry a non-null `item_id` — a row whose MOST
+    /// RECENT republish attempt failed transiently but whose PRIOR publish is still genuinely live on
+    /// the server (`set_org_share_failed` deliberately never clears `item_id`; only the success path's
+    /// `reset_org_share_for_retry` does). A `queued`/never-published `failed` row (no `item_id`) or a
+    /// `revoked`/`revoke_pending` share is excluded. See `org_shares_for_source` for the full rationale.
+    pub fn list_live_org_shares(&self) -> Result<Vec<crate::storage::OrgShareRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {} FROM org_shares
+                   WHERE state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL)
+                   ORDER BY created_at ASC",
+                Self::ORG_SHARE_COLS
+            ))
+            .map_err(map_err)?;
+        let rows = stmt.query_map([], Self::map_org_share).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     /// Every org share for an org (the FE list). Newest first.
     pub fn list_org_shares_for_org(
         &self,


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

list_meeting_org_shares_inner (src-tauri/src/commands.rs, ~line 27962) calls st.db.list_org_shares_in_state("uploaded") — a hardcoded single-state filter (confirmed at db.rs:2230, `WHERE state = ?1`). This is the same bug shape independently fixed elsewhere in this feature area: org_shares_for_source (db.rs:2045) was deliberately widened to `WHERE (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))` (confirmed by reading the function) because a row whose most recent republish attempt failed transiently keeps its OLD, still-server-live item_id (set_org_share_failed never clears it; only the success path's reset_org_share_for_retry does) — so it represents a genuinely live share, not a dead one. OrgStatus.item_count and org_resolve_source_inner were independently fixed the same way (see the comment block and tests around commands.rs ~26690-26698, e.g. org_shares_for_source_includes_failed_rows_with_a_live_item_id at db.rs:11143). list_meeting_org_shares_inner was not updated to match. Its result backs OrgBrainService._myOrgShares, consumed by LibraryComponent's per-meeting 'shared into org X' badge. Both the note-edit path (update_note_doc_inner, commands.rs) and the meeting-record path call republish_org_shares_for_source, which can legitimately leave a row in this exact failed-with-item_id state after a transient network blip — so the state is reachable in production, not a theoretical corner case.

**Repro:** 1) Share a meeting (or note) into an org so its org_shares row reaches state='uploaded' with item_id set. 2) Edit the meeting/note so republish_org_shares_for_source is triggered, and have that specific republish attempt fail transiently (simulate a network blip during the blob/item publish call so set_org_share_failed is hit but item_id is retained). 3) Call list_meeting_org_shares (or view Library): the row is now state='failed' with item_id still set — org_shares_for_source/item_count/org_resolve_source_inner all still treat this as live, but list_org_shares_in_state('uploaded') excludes it, so the meeting silently loses its 'shared into org' badge in Library even though the note-share-panel's own 'In Org Brain' CTA (which uses the fixed org_shares_for_source) still shows it as shared — two UI surfaces disagree about whether the same item is shared.

## Fix

Confirmed the bug exactly as reported: `list_meeting_org_shares_inner` (src-tauri/src/commands.rs) called `st.db.list_org_shares_in_state("uploaded")` — a hardcoded single-state filter (src-tauri/src/storage/db.rs `list_org_shares_in_state`) — while the sibling `org_shares_for_source` (db.rs) was already deliberately widened to `WHERE (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))`, because `set_org_share_failed` never clears `item_id` on a republish failure, so a `failed` row with a live `item_id` still represents a genuinely live server share. `list_meeting_org_shares_inner` was the one caller in this feature area that hadn't been updated to match, so a meeting whose republish attempt failed transiently (reachable via `republish_org_shares_for_source`, called from both the note-edit and meeting-record paths) would silently lose its Library "shared into org" badge while the note-share-panel's own CTA (reading the already-fixed `org_shares_for_source`) still showed it as shared.

Fix (backend-only, src-tauri): added `Db::list_live_org_shares()` (src-tauri/src/storage/db.rs, next to `list_org_shares_in_state`) — an un-scoped twin of `org_shares_for_source` returning every `uploaded` row plus every `failed` row with a non-null `item_id`, across all sources/orgs. Switched `list_meeting_org_shares_inner` (src-tauri/src/commands.rs) to call it instead of the single-state filter. Did not touch `list_org_shares_in_state` itself — it's correctly used elsewhere for genuinely single-state queries (the launch sweep's `revoke_pending`/`queued`/`failed` retry loop, and tests asserting `failed` state directly), so widening it in place would have been the wrong fix shape.

Verified the FE needs no change: `OrgBrainService._myOrgShares` (src/app/services/org-brain.service.ts) just stores `ipc.listMeetingOrgShares()`'s result verbatim with no duplicate filtering, so the backend fix alone resolves the badge/CTA disagreement.

Test: added `list_meeting_org_shares_includes_failed_rows_with_a_live_item_id` (src-tauri/src/commands.rs, next to the existing `list_meeting_org_shares_drops_locked_meetings`) seeding a meeting whose share went uploaded→failed-with-item_id (must still badge) and a meeting whose share failed before ever publishing (item_id NULL, must stay excluded). Confirmed RED against the pre-fix single-state filter (assertion panic: "a failed-with-item_id (stuck republish) row's badge must still be visible in Library"), then GREEN after restoring the fix. Full `cargo test --lib`: 1582 passed, 0 failed, 10 ignored (unchanged ignore count — no regressions).

This is a plain gated-read narrowing fix, not a new read/export path or a new seal — `list_meeting_org_shares_inner` already ran every row through `meeting_is_unlocked` before and after this change, so the lock-model gate is untouched.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
