### PR TITLE
fix: Org-name badge on Notes rows hard-clips with no ellipsis, unlike sibling truncated elements in the same stylesheet

### DIFF
--- a/e2e/notes/notes-org.spec.ts
+++ b/e2e/notes/notes-org.spec.ts
@@ -206,3 +206,72 @@ test("selecting the org chip shows ONLY that org's items", async ({ page }) => {
 
   expect(consoleErrors).toEqual([]);
 });
+
+test("a long org name truncates with an ellipsis, not a hard clip (matches .title-text/.note-author)", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  // Overrides are serialized via `.toString()` and re-executed page-side
+  // (see `mockTauri`), so the literal MUST be inlined in the function body —
+  // a closure over an outer test-scope const would stringify to the bare
+  // identifier, not its value.
+  const LONG_NAME = "Globex Design With A Really Long Organization Name";
+  await mockNotes(page, {
+    ...ORG_MOCKS,
+    org_list_statuses: () => [
+      {
+        orgId: "org1",
+        name: "Globex Design With A Really Long Organization Name",
+        role: "member",
+        memberCount: 3,
+        consented: true,
+        lastSeq: 5,
+        itemCount: 0,
+        receivedCount: 1,
+        pendingShares: 0,
+        contextEnabled: true,
+      },
+    ],
+  });
+  await page.goto("/notes");
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  const orgRow = page.locator(".mur-table tbody tr", { hasText: "Team Roadmap Q3" });
+  const badge = orgRow.locator(".org-badge");
+  await expect(badge).toBeVisible();
+
+  // The badge's text content is fully in the DOM (not server-truncated) — the
+  // truncation must be purely visual via CSS, exactly like `.title-text` /
+  // `.note-author`. `title` carries the full name for the a11y/hover cue.
+  await expect(badge).toHaveAttribute("title", `Shared brain · ${LONG_NAME}`);
+
+  // The box is genuinely overflowing (content wider than the clipped max-width),
+  // so a REAL truncation cue is required — this is the regression guard: with
+  // `overflow: hidden` but no `text-overflow: ellipsis`, the box still clips
+  // visually (scrollWidth > clientWidth) but with no ellipsis glyph, which is
+  // indistinguishable from a broken layout. Assert the computed style pairs
+  // `overflow: hidden` with `text-overflow: ellipsis` + `white-space: nowrap`,
+  // the same triplet `.title-text`/`.note-author` use.
+  const style = await badge.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      overflow: cs.overflowX,
+      textOverflow: cs.textOverflow,
+      whiteSpace: cs.whiteSpace,
+      isOverflowing: el.scrollWidth > el.clientWidth,
+    };
+  });
+  expect(style.overflow).toBe("hidden");
+  expect(style.textOverflow).toBe("ellipsis");
+  expect(style.whiteSpace).toBe("nowrap");
+  expect(style.isOverflowing).toBe(true);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src/app/features/notes/notes-home/notes-home.component.scss
+++ b/src/app/features/notes/notes-home/notes-home.component.scss
@@ -199,6 +199,8 @@
   gap: var(--space-1);
   max-width: 14ch;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-secondary);
   background: var(--surface-raised);
   border: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

In notes-home.component.scss, .org-badge sets max-width: 14ch and overflow: hidden but omits text-overflow: ellipsis and white-space: nowrap, unlike its siblings .title-text (line ~175) and .note-author (line ~212) in the same file, which both correctly pair overflow: hidden with text-overflow: ellipsis and white-space: nowrap. A long org name gets hard-clipped mid-word/mid-character with no visual truncation cue, reading as a layout bug rather than intentional truncation.

**Repro:** Mock org_list_statuses with an org named 'Globex Design With A Really Long Organization Name'; open /notes and view the merged 'All notes' table row for an item shared from that org — the org-badge pill text is cut off abruptly at 14ch with no ellipsis character, while adjacent truncated text (title, author) shows the ellipsis correctly.

## Fix

Confirmed the bug exactly as described: in src/app/features/notes/notes-home/notes-home.component.scss, .org-badge (line ~195-207) paired max-width: 14ch + overflow: hidden without text-overflow: ellipsis or white-space: nowrap, unlike its siblings .title-text (line ~175-184) and .note-author (line ~212-219) in the same file, which both correctly pair all three. Since .org-badge's DOM content is an inline SVG glyph (flex: none) followed directly by the org-name text node (no wrapper span), adding text-overflow: ellipsis + white-space: nowrap directly on .org-badge is the correct minimal fix — it truncates the whole badge content with an ellipsis cue while the glyph (flex: none) stays unaffected, exactly matching the sibling pattern.

Fix: added `text-overflow: ellipsis;` and `white-space: nowrap;` to `.org-badge` in notes-home.component.scss (2 lines).

Test: added a new Playwright e2e case in e2e/notes/notes-org.spec.ts ("a long org name truncates with an ellipsis, not a hard clip") that mocks org_list_statuses with a long org name ("Globex Design With A Really Long Organization Name"), renders /notes, locates the merged org row's .org-badge, and asserts the computed style triplet (overflow: hidden, text-overflow: ellipsis, white-space: nowrap) plus that the box is genuinely overflowing (scrollWidth > clientWidth), matching the same assertion shape .title-text/.note-author would pass. RED-before-GREEN verified: reverted the scss fix via `git stash`, ran the new test — it failed with `Expected: "ellipsis", Received: "clip"` (the exact bug); restored the fix and reran — all 5 tests in the file passed. (Caught and fixed one bug in my own test along the way: mockTauri serializes override functions via `.toString()` and re-executes them page-side, so a closure over an outer test-scope `const LONG_NAME` stringified to the bare identifier rather than its value — inlined the literal string instead, per the existing mock-invoke.ts contract.)

Verification note: the default `npx playwright test` run at :4210 initially reused a STALE ng-serve process already running from the main (non-worktree) checkout directory (pre-existing, ~26 min old, unrelated to this task) via `reuseExistingServer: true`, so it didn't see this worktree's scss edit. I did not kill that process (could belong to a concurrent session per this repo's known worktree-collision trap) — instead ran an isolated scratch Playwright config on port 4299 with `reuseExistingServer: false` pointed at this worktree's `ng serve`, confirmed GREEN, then deleted the scratch config. This is worth flagging to the verifier: if they rerun `npx playwright test` from this worktree while another ng-serve on :4210 from a different directory is still alive, they'll see the same false stale-server result — same isolation workaround applies.

Gates: `npx ng lint` clean; `npx ng build` clean (notes-home-component chunk 35.27 kB, well within budget). Rust untouched — no `cargo test --lib` needed (pure Angular/scss + e2e test change). Committed as QueaT <kgm004a@gmail.com>, no Claude trailers, pushed to origin.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
