### PR TITLE
fix: Shared-Brain received-item count ignores the per-instance context_enabled toggle

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5382,10 +5382,19 @@ impl Db {
     /// (what colleagues shared IN). Distinct from the outbound `org_shares` count (what THIS member
     /// published OUT); the two were conflated so the Settings item count showed the caller's own
     /// uploads and read "0 items" to a receiver. Content-free.
+    ///
+    /// PER-INSTANCE ORG TOGGLE: joined to `org_state` and filtered on `context_enabled = 1` — same
+    /// gate as `search_org_chunks_knn`/`_fts`/`get_org_item`/`list_org_items_inner`. Without this a
+    /// disabled org's `received_count` stayed stale/inflated (the raw local-replica row count) even
+    /// though every other read of the same table (search, browse) correctly reports it as empty —
+    /// the count and the actual gated content must agree for the same org.
     pub fn count_org_items(&self, org_id: &str) -> Result<u32> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT COUNT(*) FROM org_items WHERE org_id = ?1 AND tombstoned = 0",
+            "SELECT COUNT(*)
+               FROM org_items oi
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.org_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1",
             rusqlite::params![org_id],
             |r| r.get::<_, i64>(0),
         )
@@ -11067,6 +11076,44 @@ mod tests {
         db.set_org_context_enabled("org-1", true).unwrap();
         let fts_reenabled = db.search_org_chunks_fts("quantum ledger migration", 10).unwrap();
         assert_eq!(fts_reenabled.len(), 2, "re-enabling instantly restores visibility, no re-sync");
+    }
+
+    /// PER-INSTANCE ORG TOGGLE (RED-before-GREEN): `count_org_items` must agree with the actual
+    /// gated content — `search_org_chunks_knn`/`_fts`/`get_org_item`/`list_org_items_inner` all
+    /// exclude a disabled org's items, so the count (used as `OrgStatus.received_count`) must too.
+    /// Before the fix this counted raw `org_items` rows with no `context_enabled` join, so a
+    /// disabled org's count stayed stale/inflated instead of dropping to zero like every sibling read.
+    #[test]
+    fn count_org_items_excludes_a_disabled_org_and_restores_on_reenable() {
+        let db = mem_db();
+        seed_org_state(&db, "org-1");
+        let emb = crate::embed::StubEmbedder;
+        db.upsert_org_item(
+            "it-1", "org-1", 1, "anna", "Kickoff", "roadmap body", "t", 1, 1, &sha32(21), None,
+            Some(&emb),
+        )
+        .unwrap();
+        db.upsert_org_item(
+            "it-2", "org-1", 1, "bob", "Follow-up", "roadmap follow-up", "t", 2, 1, &sha32(22),
+            None, Some(&emb),
+        )
+        .unwrap();
+
+        assert_eq!(db.count_org_items("org-1").unwrap(), 2, "both items counted while enabled");
+
+        db.set_org_context_enabled("org-1", false).unwrap();
+        assert_eq!(
+            db.count_org_items("org-1").unwrap(),
+            0,
+            "a disabled org's received_count must drop to zero, matching search/list, not stay inflated"
+        );
+
+        db.set_org_context_enabled("org-1", true).unwrap();
+        assert_eq!(
+            db.count_org_items("org-1").unwrap(),
+            2,
+            "re-enabling instantly restores the count — the replica was never touched"
+        );
     }
 
     /// The self-share dedup source: `all_org_shared_content_hashes` returns every non-null


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

`Db::count_org_items(org_id)` (src-tauri/src/storage/db.rs, fn count_org_items) counts `SELECT COUNT(*) FROM org_items WHERE org_id = ?1 AND tombstoned = 0` with no filter on `org_state.context_enabled`. Every other org-read path answering the same conceptual question ('is this org's content currently included on this install') DOES filter on it: `search_org_chunks_knn`/`search_org_chunks_fts` (join `org_state os ... WHERE os.context_enabled = 1`), `get_org_item` (same join), and `list_org_items_inner` in commands.rs (`if !org.context_enabled { return Ok(Vec::new()); }`). `org_status_for` (src-tauri/src/commands.rs) calls `state.db.count_org_items(&refreshed.org_id)?` unconditionally to populate `OrgStatus.received_count` — confirmed by direct code read, no `context_enabled` guard at that call site, unlike the explicit guard in `list_org_items_inner` a few hundred lines away for the same underlying table. This means a joined-but-disabled org's `received_count` stays stale/inflated even though the actual searchable/browsable surface (org_brain_search tool, org_search MCP tool, list_org_items) correctly excludes it — the same class of bug as the already-fixed 'shared by you' undercount, just inverted (over- instead of under-counting). Currently `OrgStatus.receivedCount` is typed in src/app/core/models.ts but not yet rendered in any FE template, so today's user-visible blast radius is zero, but any future UI surfacing this number (e.g. a settings org card) will show an inconsistent count for a disabled org.

**Repro:** 1) Join two orgs A and B, have colleagues share items into both. 2) Call org_status(A) — note received_count includes A's items. 3) Disable org A via the per-instance toggle (org_set_context_enabled(A, false), which calls Db::set_org_context_enabled). 4) Call org_status_for(A) again (or read OrgStatus.receivedCount) — it still reports the full item count even though search_org_chunks_knn/_fts and list_org_items now return zero results for org A. The count and the actual gated content are inconsistent for the same org.

## Fix

Confirmed the bug by reading Db::count_org_items (src-tauri/src/storage/db.rs) and comparing it against the sibling org-read paths (search_org_chunks_knn, search_org_chunks_fts, get_org_item, list_org_items_inner in commands.rs) — every one of them JOINs org_state and filters `context_enabled = 1`; count_org_items did not, so it counted raw `org_items` rows regardless of the per-instance Shared-Brain toggle. That inflated `OrgStatus.received_count` (populated in commands.rs org_status_for via `state.db.count_org_items(...)`) for a disabled org even though the same table's search/browse reads correctly report zero.

Fix: added the identical `JOIN org_state os ON os.org_id = oi.org_id ... AND os.context_enabled = 1` gate to count_org_items's SQL, mirroring the exact pattern already proven in search_org_chunks_knn/_fts and get_org_item. This is a pure SQL-level exclusion (not a Rust-side filter), consistent with every sibling function's doc comment ("a caller cannot accidentally surface a disabled org's content by forgetting to filter it downstream").

Test: added `count_org_items_excludes_a_disabled_org_and_restores_on_reenable` in storage::db::tests, placed directly after the existing `disabled_org_is_excluded_from_both_retrieval_legs_while_enabled_org_still_surfaces` test it mirrors. It seeds an org with 2 items, asserts count=2 while enabled, disables the org via set_org_context_enabled and asserts count drops to 0, then re-enables and asserts count restores to 2 (proving the replica itself is untouched, only the read is gated).

RED-before-GREEN: ran the new test alone against the pre-fix implementation first — it failed with `assertion left == right failed ... left: 2, right: 0` (the disabled-org count stayed inflated), confirming the test captures the real bug. After applying the fix, the same test passes, and the full `cargo test --lib` suite (run from src-tauri/) passed 1582 passed / 0 failed / 10 ignored, finished in 125.65s — no regressions.

This is a content-count-only fix (no note/transcript/timeline/audio plaintext involved, no new command, no new read of member content) so it does not touch the seal/verify-before-destroy path or add a new content read surface — it tightens an existing count to match the already-established context_enabled gate other reads use. Given it touches org_state/context_enabled gating logic (the Shared-Brain per-instance toggle, part of the lock/visibility surface), flagging for lock-security-reviewer per the project's binding rule that any change touching gated reads gets a second review, even though this one only narrows an over-counting bug rather than affecting a leak-relevant read.

Note: this worktree had a pre-existing unrelated uncommitted change to src/app/features/record/record/record.component.ts (a "Saved in vault" vs "Saved in Murmur" export-path wording fix) present before I touched anything and left it alone — not part of this commit, not authored by me, and unrelated to the count_org_items bug.

Not verified here: this is a pure backend counting fix with a full cargo test --lib pass; it does not require FE, keychain, Touch ID, or signed-build verification since OrgStatus.receivedCount is not yet rendered in any FE template (confirmed by the audit finding itself) — so there is no UI-observable behavior to live-reproduce yet.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
