### PR TITLE
fix: Ask conversation log uses banned `track $index` on a keyed, non-append-only turns array

### DIFF
--- a/e2e/ask/conversation-log-track.spec.ts
+++ b/e2e/ask/conversation-log-track.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Regression for the Ask conversation log's `@for` tracking. The turns array is
+ * NOT append-only: `retry()` (ask.component.ts) pops the dangling user turn and
+ * `send()` re-appends it, landing back at the same array INDEX it previously
+ * occupied. `AskTurn` carries a stable `id` (minted by a monotonic counter) and
+ * the template tracks `turn.id` — never `$index` — precisely so Angular mints a
+ * FRESH DOM node for the retried bubble instead of reusing the old one (which
+ * would silently skip its one-shot `bubble-in` entrance animation, the
+ * `.ask-row` CSS rule in ask.component.scss).
+ *
+ * The FIRST question succeeds so the log already has a settled turn at index 0
+ * BEFORE the one under test — this way `retry()`'s pop-then-reappend of the
+ * SECOND (failing) turn never drives the whole `@for` through an empty array
+ * (which would force a destroy/recreate regardless of tracking key and make
+ * the test tracking-key-insensitive). `ask_vault` is mocked to succeed on the
+ * first call, fail on the second, then succeed again on the retry.
+ */
+test("Ask conversation log mints a fresh DOM node for a retried turn (not an index-reused one)", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    list_meetings: () => [],
+    list_notes: () => [
+      {
+        id: "n1",
+        title: "A note",
+        folderId: null,
+        snippet: "",
+        tags: [],
+        updatedAt: 1_720_000_000_000,
+        createdAt: 1_719_000_000_000,
+        locked: false,
+        shared: false,
+      },
+    ],
+    // Overrides run PAGE-SIDE, re-parsed from a serialized string (see
+    // mockTauri) — no closures over outer scope, so the call counter is
+    // stashed on `window` instead.
+    ask_vault: () => {
+      const w = window as unknown as { __askVaultCalls?: number };
+      w.__askVaultCalls = (w.__askVaultCalls ?? 0) + 1;
+      if (w.__askVaultCalls === 2) {
+        throw new Error("simulated ask_vault failure");
+      }
+      return {
+        answer: "Answer #" + w.__askVaultCalls,
+        sources: [],
+        citations: [],
+      };
+    },
+  });
+
+  await page.goto("/ask");
+
+  const input = page.locator(".ask-input");
+  await expect(input).toBeVisible();
+
+  // Turn 1: succeeds — settles a turn at index 0/1 before the one under test.
+  await input.fill("First question");
+  await input.press("Enter");
+  await expect(
+    page.locator(".ask-row.is-assistant .ask-bubble").last(),
+  ).toContainText("Answer #1");
+
+  // Turn 2: fails — the user bubble for it lands at index 2 and stays put.
+  await input.fill("Second question that will fail");
+  await input.press("Enter");
+  const retryBtn = page.getByRole("button", { name: "Retry" });
+  await expect(retryBtn).toBeVisible();
+
+  const userRows = page.locator(".ask-row.is-user");
+  await expect(userRows).toHaveCount(2);
+  const failedUserRow = userRows.nth(1);
+  await expect(failedUserRow).toContainText("Second question that will fail");
+
+  // Stamp the failed turn's DOM node so we can tell whether Retry's
+  // pop-then-reappend reuses it (index-tracked bug) or replaces it
+  // (id-tracked fix). The array never goes empty across this retry (turn 0
+  // stays put), so `@for` only has the tracking key to decide reuse.
+  await failedUserRow.evaluate((el) => el.setAttribute("data-orig-node", "1"));
+
+  await retryBtn.click();
+
+  // Wait for the retry's async round-trip to fully land (the third
+  // ask_vault call succeeds) before inspecting the DOM — `retry()` pops the
+  // turn synchronously but `send()` re-appends + resolves asynchronously.
+  await expect(page.locator(".ask-row.is-assistant .ask-bubble").last()).toContainText(
+    "Answer #3",
+  );
+
+  // The retried turn lands back at the SAME array index (1) as the failed one.
+  await expect(page.locator(".ask-row.is-user").nth(1)).toContainText(
+    "Second question that will fail",
+  );
+
+  // Is the ORIGINAL stamped node (element identity, not just the attribute)
+  // still connected to the document? A correctly `turn.id`-tracked `@for`
+  // destroys the old node and creates a NEW one at the same slot — the
+  // original element must be DETACHED. Under the banned `track $index`, the
+  // very same element would be reused/kept connected.
+  const stillConnected = await page.evaluate(() => {
+    const el = document.querySelector('[data-orig-node="1"]');
+    return el !== null && el.isConnected;
+  });
+  expect(stillConnected).toBe(false);
+});

--- a/src/app/features/ask/ask/ask.component.html
+++ b/src/app/features/ask/ask/ask.component.html
@@ -70,7 +70,7 @@
             </div>
           </div>
         } @else {
-          @for (turn of conversation(); track $index) {
+          @for (turn of conversation(); track turn.id) {
             <div
               class="ask-row"
               [class.is-user]="turn.role === 'user'"

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -27,6 +27,13 @@ import { SourcesComponent } from "../../../shared/sources/sources.component";
  * (rendered as chips that deep-link into each meeting).
  */
 interface AskTurn {
+  /**
+   * Stable id for `@for` tracking (never key a turn on $index) — the log is
+   * NOT append-only: `retry()` pops the dangling user turn and re-appends it,
+   * which would land back at the same index and fool an index-tracked `@for`
+   * into reusing the old DOM node (silently skipping its entrance animation).
+   */
+  id: number;
   role: "user" | "assistant";
   content: string;
   /** Present on assistant turns only — the meetings that grounded the answer. */
@@ -105,6 +112,8 @@ export class AskComponent implements OnInit {
   private activeAskId: string | null = null;
   /** Monotonic id source for trace chips (stable `@for` keys). */
   private nextTraceId = 1;
+  /** Monotonic id source for conversation turns (stable `@for` keys). */
+  private nextTurnId = 1;
   private unlistenAskTool: UnlistenFn | null = null;
 
   /** Starter prompts for the empty state. */
@@ -316,7 +325,7 @@ export class AskComponent implements OnInit {
     this.draft.set("");
     this.conversation.update((turns) => [
       ...turns,
-      { role: "user", content: question },
+      { id: this.nextTurnId++, role: "user", content: question },
     ]);
     this.pending.set(true);
     this.scrollToLatest();
@@ -330,6 +339,7 @@ export class AskComponent implements OnInit {
       this.conversation.update((turns) => [
         ...turns,
         {
+          id: this.nextTurnId++,
           role: "assistant",
           content: result.answer,
           sources: result.sources,


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

AskComponent's conversation log (src/app/features/ask/ask/ask.component.html:73, `@for (turn of conversation(); track $index)`) tracks by `$index`, which `.claude/rules/angular-zoneless.md` explicitly bans for keyed data. `AskTurn` (src/app/features/ask/ask/ask.component.ts:29) has no `id` field, so there's no stable identity to track by even if fixed. Confirmed non-append-only: `retry()` (ask.component.ts:260) does `this.conversation.set(turns.slice(0, -1))` then re-appends the same user turn via `send()`, landing at the same index it previously occupied — Angular reuses the existing DOM node instead of creating a new one. Each `.ask-bubble` has a one-shot CSS `animation: bubble-in 320ms …` (ask.component.scss:157/395) that silently does not replay on retry because the node is reused. Notably, a sibling type in the same file, `AskTraceStep` (ask.component.ts), already carries an explicit `id: number` field with the comment 'Stable id for `@for` tracking (never key a trace chip on $index)' — showing the codebase's own convention is violated by the `AskTurn` loop specifically.

**Repro:** 1) Open Ask, ask a question that errors (or triggers an ask_vault failure). 2) Click Retry. 3) Observe the re-appended user bubble does not play its bubble-in entrance animation the way a freshly-appended turn does, because @for reused the DOM node at the same index instead of creating a new element.

## Fix

Confirmed the bug exactly as described: AskComponent's conversation log (src/app/features/ask/ask/ask.component.html) tracked `@for (turn of conversation(); track $index)`, and AskTurn (ask.component.ts) had no stable id. retry() (ts) pops the dangling user turn (`conversation.set(turns.slice(0, -1))`) then re-appends it via send(), landing back at the same array index — an index-tracked @for reuses the old DOM node there instead of creating a fresh one, silently skipping the one-shot `bubble-in` CSS entrance animation defined on `.ask-row` (ask.component.scss).

Fix: gave AskTurn a stable `id: number` field (mirroring the existing AskTraceStep pattern, which already documents "never key a trace chip on $index"), added a monotonic `nextTurnId` counter, stamped both the optimistic user turn and the assistant reply with a fresh id on every send() call, and changed the template to `track turn.id`. Since retry() re-sends via send(), the re-appended turn always gets a brand-new id, so Angular's @for now correctly mints a new DOM node for it.

Verification: added e2e/ask/conversation-log-track.spec.ts (Playwright, mocked Tauri IPC) that drives a real failing-then-retried question and asserts, via DOM element identity (`Element.isConnected`), that the ORIGINAL failed-turn's DOM node is detached after a successful retry (not silently reused at the same slot). Confirmed genuine RED-before-GREEN by toggling the fix on/off against a freshly-started dev server: RED (unfixed, track $index) → `stillConnected === true` (bug reproduced, node reused); GREEN (fixed, track turn.id) → `stillConnected === false` (fresh node minted). Also verified `npx ng lint` and `npx ng build` clean on the final committed state.

One process note for the record: mid-session a stray `ng serve --port 4210` from an unrelated worktree was occupying the shared test port and served stale code for several iterations (misleading test results); killed it and used fresh dev-server restarts thereafter. Separately, a `git stash` on this shared-object-store repo briefly picked up an unrelated in-progress WIP change to settings-account-section.component.{ts,html} from a concurrent session; it was not touched further and was re-stashed with a clear "not my change" message (visible in `git stash list`) rather than discarded, so its owner can recover it. Final commit contains only the three ask-related files.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
