### PR TITLE
fix: Scheduled-briefs section never visually expands for a pending brief despite doc comment claiming it does

### DIFF
--- a/e2e/brain/briefs-pending-expanded.spec.ts
+++ b/e2e/brain/briefs-pending-expanded.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * RED-before-GREEN — "Scheduled briefs" section never visually expands for a
+ * pending brief despite `briefs.component.ts`'s doc comment claiming it does.
+ *
+ * `open` was a plain `signal(false)` never derived from `pendingCount()` — the
+ * template's `@if (open() || pendingCount() > 0)` let the pending-run action
+ * card peek through while the section header (`aria-expanded` + chevron
+ * rotation), both driven by `open()` alone, stayed visually collapsed. A user
+ * with a pending brief saw a lone Dismiss/Save-to-vault card floating under a
+ * header that still looked collapsed, with no cue the schedules list / create
+ * form exist underneath.
+ *
+ * RED contract: pre-fix, `aria-expanded` reads "false" and `.br-chevron` lacks
+ * `.is-open` even though the pending-run card is visible — this spec's first
+ * two assertions fail against the unpatched code. Post-fix, the header's
+ * `isExpanded()` mirrors the same `open() || pendingCount() > 0` condition
+ * that already gates the pending-run card, so the header visually agrees with
+ * what's rendered beneath it.
+ */
+test("Scheduled briefs: header visually expands when a brief is pending", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    list_brief_schedules: () => [
+      {
+        id: "sched-1",
+        label: "Monday kickoff",
+        dayOfWeek: 0,
+        hourLocal: 8,
+        minuteLocal: 30,
+        scopeDays: 7,
+        promptHint: null,
+        enabled: true,
+        lastRunAt: null,
+        createdAt: "2026-07-01T00:00:00Z",
+      },
+    ],
+    list_brief_runs: () => [
+      {
+        id: "run-1",
+        scheduleId: "sched-1",
+        status: "pending",
+        noteMd: "## Summary\nEverything is on track.",
+        meetingIds: ["m-1"],
+        proposedAt: "2026-07-12T08:30:00Z",
+        acceptedAt: null,
+      },
+    ],
+  });
+
+  await page.goto("/brain");
+
+  const section = page.locator("app-briefs");
+  await expect(section).toBeVisible();
+
+  // The pending-run card is visible without any click (existing behavior).
+  await expect(section.locator(".br-run")).toBeVisible();
+
+  // The header chrome must agree: expanded, chevron rotated open.
+  const toggle = section.locator(".br-toggle");
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(section.locator(".br-chevron")).toHaveClass(/is-open/);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src/app/features/briefs/briefs/briefs.component.html
+++ b/src/app/features/briefs/briefs/briefs.component.html
@@ -2,12 +2,12 @@
   <button
     type="button"
     class="br-toggle"
-    [attr.aria-expanded]="open()"
+    [attr.aria-expanded]="isExpanded()"
     (click)="open.set(!open())"
   >
     <svg
       class="br-chevron"
-      [class.is-open]="open()"
+      [class.is-open]="isExpanded()"
       viewBox="0 0 16 16"
       width="14"
       height="14"

--- a/src/app/features/briefs/briefs/briefs.component.ts
+++ b/src/app/features/briefs/briefs/briefs.component.ts
@@ -45,8 +45,17 @@ export class BriefsComponent {
   protected readonly store = inject(BriefsStore);
   private readonly toast = inject(ToastService);
 
-  /** Collapsed by default UNLESS a proposed brief is waiting (see template). */
+  /** The user's manual collapse/expand toggle (click on `.br-toggle`). */
   readonly open = signal(false);
+
+  /**
+   * Collapsed by default UNLESS a proposed brief is waiting: the pending-run
+   * card peeks through even while `open()` is false (see template), so the
+   * header chrome (aria-expanded + chevron rotation) must reflect that same
+   * condition — otherwise the header looks collapsed while content renders
+   * underneath it.
+   */
+  readonly isExpanded = computed(() => this.open() || this.pendingCount() > 0);
 
   // ── create form (signals-backed native inputs — no FormsModule) ─────────
   readonly formLabel = signal("");


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

briefs.component.ts's `open = signal(false)` carries the comment "Collapsed by default UNLESS a proposed brief is waiting (see template)", but `open` is never derived from `pendingCount()` anywhere (no effect/computed ties them together). The template's `@if (open() || pendingCount() > 0)` (briefs.component.html) only lets the pending-run action card peek through while the section header stays visually collapsed — `[attr.aria-expanded]="open()"` on `.br-toggle` stays `"false"` and the `.br-chevron.is-open` never rotates. Net effect: with a pending brief, the user sees a lone Dismiss/Save-to-vault card floating under a header that still looks collapsed and gives no cue that the full schedules list / create-schedule form exist underneath, until manually clicked.

**Repro:** Mock `list_brief_schedules` with >=1 schedule and `list_brief_runs` with 1 pending run, navigate to /brain, inspect 'Scheduled briefs': chevron points right and `page.locator('app-briefs .br-toggle').getAttribute('aria-expanded')` reads "false" immediately after render, even though the pending run's card is visible below it. Schedules stay hidden until the header is clicked manually.

## Fix

Confirmed the bug exactly as described in briefs.component.ts / briefs.component.html: `open` was a plain `signal(false)` never derived from `pendingCount()`, so the section header's `[attr.aria-expanded]` and `.br-chevron.is-open` class stayed tied only to the manual toggle, while the template separately let the pending-run card peek through via `@if (open() || pendingCount() > 0)`. Result: with a pending brief, the pending-run card renders but the header chrome (aria-expanded, chevron rotation) still visually reads collapsed.

Fix (minimal, scoped to this component): added a `readonly isExpanded = computed(() => this.open() || this.pendingCount() > 0)` to briefs.component.ts, and wired the header's `[attr.aria-expanded]` and `.br-chevron`'s `[class.is-open]` bindings to `isExpanded()` instead of raw `open()`. Left `open()` itself unchanged as the plain click-toggle signal (still drives the `@if (open())` schedules-list/create-form section, and the click handler `open.set(!open())` is untouched) — so manual expand/collapse behavior and the schedules/create-form gating are unaffected; only the header's visual-consistency bug is fixed.

Added e2e/brain/briefs-pending-expanded.spec.ts (Playwright FE harness, this repo's actual FE test convention — no Karma/Jasmine specs exist in src/app). Confirmed RED against pre-fix code (stashed the fix, ran the test: `aria-expanded` read "false", assertion failed as expected), then GREEN after restoring the fix (ran against an isolated worktree-scoped `ng serve` port to avoid colliding with another running dev-server process from the main checkout on the shared default test port 4210 — that temp config file was deleted after use, not committed).

Gates run: `npx ng lint` — clean. `npx ng build` — clean (brain-component chunk 94.84 kB, no style-budget violations). This is a frontend-only change (no src-tauri/ touch), so per the task instructions `cargo test --lib` was not required and not run.

Not independently re-verified — per repo convention the adversarial-verifier should still confirm before merge, though the RED-before-GREEN Playwright run plus green lint/build already demonstrate the fix live-reproduces correctly.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
