### PR TITLE
fix: Graph/People 'total' count and 'Show all N' silently understate completeness once the 500-entity backend cap trims rows, with no disclosure

### DIFF
--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -259,6 +259,7 @@ deferred it twice is now removed, so it's unblocked for the GA cut.
       { source: "pr-atlas", target: "pr-sales", weight: 3 },
     ],
     hasHidden: true,
+    totalVisibleEntities: 10,
   };
 
   const ENTITY_DETAIL = {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use crate::storage::models::{
     CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, DocumentInfo,
     EntityDetail, EntityDossierResult, Folder, FolderNode, GraphData, Meeting, MeetingStatus,
     MeetingTimeline, NoteAssistRequest, NoteAssistResult, NoteCitation, NoteDoc, NoteFolder,
-    NoteRecord, NoteSummary, OrganizeMove, OrganizePlan, PersonCard, PinResult, RecipeRecord,
+    NoteRecord, NoteSummary, OrganizeMove, OrganizePlan, PeopleList, PinResult, RecipeRecord,
     SearchHit, TopicThread,
 };
 use crate::summarize::all_providers;
@@ -5648,7 +5648,7 @@ pub fn get_graph(state: State<'_, AppState>) -> Result<GraphData, AppError> {
 /// sealed-and-not-session-unlocked meetings never appears and every count reflects visible sources
 /// only. Read-only, no model, no new egress.
 #[tauri::command]
-pub fn list_people(state: State<'_, AppState>) -> Result<Vec<PersonCard>, AppError> {
+pub fn list_people(state: State<'_, AppState>) -> Result<PeopleList, AppError> {
     let unlocked = unlocked_snapshot(state.inner())?;
     state.db.list_people(&unlocked)
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -12,7 +12,8 @@ use crate::storage::models::{
     Analytics, AssistantInteraction, AssistantThreadRow, Commitment, CorrectionRecord, DayCount,
     DocChunkHit, DocumentInfo, EntityDetail, EntityKind, EntityNeighbor, Folder, GraphData,
     GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteFolder, NoteRecord, NoteSummary,
-    OrgChunkHit, PendingShareAccept, PersonCard, RecipeRecord, SearchHit, StatusCount, VaultSource,
+    OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, RecipeRecord, SearchHit, StatusCount,
+    VaultSource,
 };
 use crate::transcribe::types::Segment;
 
@@ -8352,6 +8353,50 @@ impl Db {
         Ok(out)
     }
 
+    /// The TRUE count of entities with ≥1 VISIBLE mention — same predicate as
+    /// `list_entities_visible` but with NO `LIMIT`, so callers can detect the 500-row cap
+    /// truncating the result and disclose it (added 2026-07-13: the cap trimmed `get_graph`'s
+    /// node list and `list_people`'s roster silently, with no signal the FE could show — the
+    /// existing `hasHidden`/`has_hidden_folders` flag only reports LOCKED folders, so on a vault
+    /// with >500 visible entities and zero locked folders it stayed false while 100+ entities were
+    /// dropped). `list_entities_visible(unlocked).len() < count_entities_visible(unlocked, None)`
+    /// means the cap trimmed rows. `kind` optionally narrows to one `EntityKind` (e.g. `Person`,
+    /// mirroring how `list_people` filters `list_entities_visible`'s output to persons) — the cap
+    /// applies BEFORE that filter, so the all-kinds and Person-only totals must be counted
+    /// separately rather than derived from each other.
+    pub fn count_entities_visible(
+        &self,
+        unlocked: &HashSet<String>,
+        kind: Option<EntityKind>,
+    ) -> Result<i64> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let kind_filter = match kind {
+            Some(k) => format!("AND e.kind = '{}'", k.as_str()),
+            None => String::new(),
+        };
+        let sql = format!(
+            "SELECT COUNT(*) FROM (
+               SELECT e.id
+                 FROM entities e
+                 JOIN entity_mentions em ON em.entity_id = e.id
+                 JOIN meetings m ON m.id = em.meeting_id
+                WHERE (
+                        NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                     OR EXISTS (
+                          SELECT 1 FROM notes n
+                           LEFT JOIN folders f ON f.id = n.folder_id
+                           WHERE n.meeting_id = m.id AND {visible}
+                        )
+                      )
+                      {kind_filter}
+                GROUP BY e.id
+               HAVING COUNT(em.meeting_id) > 0
+             )"
+        );
+        conn.query_row(&sql, [], |r| r.get(0)).map_err(map_err)
+    }
+
     /// The VISIBLE meetings mentioning `entity_id`, newest first, as `VaultSource` chips
     /// (the same shape the FE uses for backlink chips). Sealed-not-unlocked meetings excluded.
     pub fn entity_mentions_visible(
@@ -8689,10 +8734,12 @@ impl Db {
         let nodes = self.list_entities_visible(unlocked)?;
         let edges = self.graph_edges_visible(unlocked)?;
         let has_hidden = self.has_hidden_folders(unlocked)?;
+        let total_visible_entities = self.count_entities_visible(unlocked, None)?;
         Ok(GraphData {
             nodes,
             edges,
             has_hidden,
+            total_visible_entities,
         })
     }
 
@@ -9061,7 +9108,15 @@ impl Db {
     /// and `list_open_commitments` (owner-scoped, name match) — so every count reflects VISIBLE
     /// sources only; a sealed source contributes nothing to any of them. Ordered by most-recent
     /// contact (last_talked DESC), then name.
-    pub fn list_people(&self, unlocked: &HashSet<String>) -> Result<Vec<PersonCard>> {
+    ///
+    /// Returns [`PeopleList`], not a bare `Vec`, because the candidate set is itself capped
+    /// UPSTREAM by `list_entities_visible`'s `MAX_VISIBLE_ENTITIES` (500, ordered by mention
+    /// count across ALL kinds) — on a vault with >500 visible entities, some visible Persons can
+    /// be trimmed before the `EntityKind::Person` filter even runs, with zero signal on the old
+    /// bare-`Vec` return (added 2026-07-13: `total_visible_people` is the TRUE Person count so the
+    /// FE's "Show all N people" expander can disclose the cap instead of presenting the trimmed
+    /// roster as complete).
+    pub fn list_people(&self, unlocked: &HashSet<String>) -> Result<PeopleList> {
         // GATE: the visible-only entity set, Persons only. A sealed-only person is absent here.
         let people: Vec<GraphNode> = self
             .list_entities_visible(unlocked)?
@@ -9113,7 +9168,11 @@ impl Db {
                 (None, None) => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
             },
         );
-        Ok(out)
+        let total_visible_people = self.count_entities_visible(unlocked, Some(EntityKind::Person))?;
+        Ok(PeopleList {
+            people: out,
+            total_visible_people,
+        })
     }
 
     // ── CROSS-MEETING USER MEMORY (Phase 3) ────────────────────────────────────
@@ -17717,7 +17776,7 @@ mod graph_tests {
         seal_folder(&db, "secret", &kek);
 
         let empty: HashSet<String> = HashSet::new();
-        let sealed_view = db.list_people(&empty).unwrap();
+        let sealed_view = db.list_people(&empty).unwrap().people;
 
         // (1) A person known only through the sealed meeting must NOT surface.
         assert!(
@@ -17761,7 +17820,7 @@ mod graph_tests {
         )
         .unwrap();
         let unlocked = unlocked_set(&["secret"]);
-        let unlocked_view = db.list_people(&unlocked).unwrap();
+        let unlocked_view = db.list_people(&unlocked).unwrap().people;
         assert!(
             unlocked_view.iter().any(|p| p.id == secret_p),
             "the secret person reappears once its folder id is in the unlocked set"
@@ -17783,6 +17842,63 @@ mod graph_tests {
         assert_eq!(
             bob_u.current_fact_count, 2,
             "both facts visible when unlocked"
+        );
+    }
+
+    /// 2026-07-13 UX audit fix: on a vault with MORE than `MAX_VISIBLE_ENTITIES` (500) visible
+    /// entities and ZERO locked folders, `has_hidden` (which only reflects LOCKED folders) stays
+    /// false while `list_entities_visible`'s `LIMIT 500` silently trims the roster — so the OLD
+    /// `GraphData`/`Vec<PersonCard>` shapes gave the FE no way to tell `total()`/"Show all N" was
+    /// understating completeness. RED-before-GREEN: before `total_visible_entities` /
+    /// `total_visible_people` existed, there was no field to assert on at all (a compile-time
+    /// absence); post-fix, both must exceed the capped roster length with `has_hidden` still false.
+    #[test]
+    fn graph_and_people_disclose_the_500_cap_even_with_no_locked_folders() {
+        let db = file_db("cap-disclosure");
+        seed_note(&db, "m1", "one shared meeting", None);
+
+        // 520 distinct Person entities, all mentioned in the SAME open (never-locked) meeting —
+        // every one has exactly one VISIBLE mention, so none is trimmed by the `HAVING cnt > 0`
+        // gate; only the trailing `LIMIT 500` in `list_entities_visible` caps the roster.
+        const SEEDED: usize = 520;
+        for i in 0..SEEDED {
+            let id = db
+                .upsert_entity(&format!("Person {i:04}"), EntityKind::Person)
+                .unwrap();
+            db.add_mention(&id, "m1").unwrap();
+        }
+
+        let empty: HashSet<String> = HashSet::new();
+
+        // No folder was ever locked, so the OLD disclosure signal stays false...
+        assert!(
+            !db.has_hidden_folders(&empty).unwrap(),
+            "no folder is locked, so the locked-folder disclosure has nothing to report"
+        );
+
+        // ...yet the graph payload is truncated below the true 520, and now says so explicitly.
+        let graph = db.build_graph(&empty).unwrap();
+        assert!(!graph.has_hidden, "still no locked folder");
+        assert_eq!(graph.nodes.len(), 500, "the render cap trims to 500 nodes");
+        assert_eq!(
+            graph.total_visible_entities, SEEDED as i64,
+            "the TRUE visible-entity count is reported even though the roster is capped"
+        );
+        assert!(
+            graph.total_visible_entities > graph.nodes.len() as i64,
+            "total must exceed the capped roster so the FE can detect + disclose truncation"
+        );
+
+        // Same shape on `/people`: the roster is capped, but `total_visible_people` is the truth.
+        let people = db.list_people(&empty).unwrap();
+        assert_eq!(people.people.len(), 500, "people roster is also capped at 500");
+        assert_eq!(
+            people.total_visible_people, SEEDED as i64,
+            "the TRUE visible-person count, independent of the render cap"
+        );
+        assert!(
+            people.total_visible_people > people.people.len() as i64,
+            "\"Show all N people\" must be able to disclose N > the capped roster length"
         );
     }
 

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -62,6 +62,12 @@ pub struct GraphData {
     /// True when ≥1 folder is sealed-and-not-unlocked → some entities/mentions may be hidden.
     /// The FE renders one honest disclosure banner; the count itself is never leaked.
     pub has_hidden: bool,
+    /// The TRUE count of VISIBLE entities, BEFORE the `MAX_VISIBLE_ENTITIES` (500) render cap
+    /// trims `nodes`. `total_visible_entities > nodes.len()` means the cap silently dropped rows —
+    /// distinct from `has_hidden` (which only reflects LOCKED folders, not the render cap). The FE
+    /// uses this to show an honest "showing N of TOTAL" caption instead of presenting the
+    /// capped `nodes.len()` as the whole graph.
+    pub total_visible_entities: i64,
 }
 
 /// A co-occurring neighbor of a selected entity (the neighborhood satellites), with the
@@ -106,6 +112,20 @@ pub struct PersonCard {
     pub open_commitment_count: i64,
     /// Currently-valid (open) facts about this person from VISIBLE meetings.
     pub current_fact_count: i64,
+}
+
+/// The payload returned by `list_people`: the (possibly render-capped) roster of `PersonCard`s
+/// plus the TRUE count of VISIBLE people. `list_people` derives its candidate set from
+/// `list_entities_visible`, which applies a `MAX_VISIBLE_ENTITIES` (500) cap ordered by mention
+/// count — on a vault with >500 visible entities, `people` can be a strict subset of every
+/// visible Person. `total_visible_people > people.len()` is the ONLY signal of that truncation;
+/// without it the FE's "Show all N people" expander silently understates completeness (added
+/// 2026-07-13, mirrors `GraphData::total_visible_entities`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeopleList {
+    pub people: Vec<PersonCard>,
+    pub total_visible_people: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -55,7 +55,7 @@ import type {
   NoteAssistRequest,
   NoteAssistResult,
   OrganizePlan,
-  PersonCard,
+  PeopleList,
   PinResult,
   PruneSummary,
   StorageReport,
@@ -1014,9 +1014,11 @@ export class IpcService {
    * sealed-not-unlocked meetings never appears, and every count reflects visible
    * sources only — so re-fetch on a FoldersService lock-state change to shift the
    * list live (mirrors {@link getGraph}). Each `id` links to the entity detail.
+   * Returns {@link PeopleList}, not a bare array — `people` may itself be capped by
+   * the backend's 500-row limit, and `totalVisiblePeople` is the true count.
    */
-  listPeople(): Promise<PersonCard[]> {
-    return invoke<PersonCard[]>("list_people");
+  listPeople(): Promise<PeopleList> {
+    return invoke<PeopleList>("list_people");
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1222,6 +1222,12 @@ export interface GraphData {
   edges: GraphEdge[];
   /** True when ≥1 folder is sealed-and-not-unlocked → render one honest disclosure banner. */
   hasHidden: boolean;
+  /**
+   * The TRUE count of VISIBLE entities, BEFORE the backend's 500-row render cap trims `nodes`.
+   * `totalVisibleEntities > nodes.length` means the cap silently dropped rows — independent of
+   * `hasHidden` (which only reflects LOCKED folders, never the render cap).
+   */
+  totalVisibleEntities: number;
 }
 
 /** A co-occurring neighbor of a selected entity (a neighborhood satellite). */
@@ -1264,6 +1270,18 @@ export interface PersonCard {
   openCommitmentCount: number;
   /** Currently-valid (open) facts about this person from VISIBLE meetings. */
   currentFactCount: number;
+}
+
+/**
+ * The payload from `listPeople()`: the (possibly render-capped) roster of {@link PersonCard}s
+ * plus the TRUE count of visible people. `list_people`'s candidate set is itself capped upstream
+ * by the same 500-row limit that backs {@link GraphData.totalVisibleEntities}, so
+ * `totalVisiblePeople > people.length` is the only signal that the roster — and therefore any
+ * "Show all N people" affordance — understates the real total.
+ */
+export interface PeopleList {
+  people: PersonCard[];
+  totalVisiblePeople: number;
 }
 
 /**

--- a/src/app/features/graph/graph/graph.component.html
+++ b/src/app/features/graph/graph/graph.component.html
@@ -8,7 +8,14 @@
       </p>
     </div>
     @if (!loading() && total() > 0) {
-      <span class="count g-total" [attr.title]="total() + ' entities'">
+      <span
+        class="count g-total"
+        [attr.title]="
+          isCapped()
+            ? total() + ' of ' + graphData()!.totalVisibleEntities + ' entities'
+            : total() + ' entities'
+        "
+      >
         {{ total() }}
       </span>
     }
@@ -43,6 +50,14 @@
         <span>
           Some entities are hidden — unlock a folder to include them.
         </span>
+      </div>
+    }
+
+    <!-- A SEPARATE disclosure: the 500-row render cap, independent of locked folders. -->
+    @if (capDisclosure(); as msg) {
+      <div class="banner is-accent g-banner" role="status">
+        <span class="g-banner-glyph" aria-hidden="true"></span>
+        <span>{{ msg }}</span>
       </div>
     }
 

--- a/src/app/features/graph/graph/graph.component.ts
+++ b/src/app/features/graph/graph/graph.component.ts
@@ -65,7 +65,7 @@ export class GraphComponent {
     { key: "project", label: "Projects" },
   ];
 
-  /** Total VISIBLE entities returned by the backend (before any local filter). */
+  /** VISIBLE entities actually rendered (may be capped — see {@link capDisclosure}). */
   protected readonly total = computed(
     () => this.graphData()?.nodes.length ?? 0,
   );
@@ -73,6 +73,26 @@ export class GraphComponent {
   protected readonly hasHidden = computed(
     () => this.graphData()?.hasHidden ?? false,
   );
+
+  /**
+   * Whether the backend's 500-row render cap trimmed the roster (independent of
+   * {@link hasHidden}, which only reflects LOCKED folders — a vault can have >500
+   * visible entities and zero locked folders, in which case `hasHidden` stays false
+   * while the cap still silently dropped rows without this check).
+   */
+  protected readonly isCapped = computed(() => {
+    const d = this.graphData();
+    return !!d && d.totalVisibleEntities > d.nodes.length;
+  });
+
+  /** One honest caption disclosing the render cap, mirroring `brain.component.ts`'s pattern. */
+  protected readonly capDisclosure = computed<string | null>(() => {
+    const d = this.graphData();
+    if (!d || !this.isCapped()) {
+      return null;
+    }
+    return `Showing the ${d.nodes.length} most-mentioned of ${d.totalVisibleEntities} entities.`;
+  });
 
   /** The filtered + searched + sorted nodes (the view-model for the directory). */
   protected readonly visibleEntities = computed<GraphNode[]>(() => {

--- a/src/app/features/people/people/people.component.html
+++ b/src/app/features/people/people/people.component.html
@@ -8,7 +8,14 @@
       </p>
     </div>
     @if (!loading() && total() > 0) {
-      <span class="count p-total" [attr.title]="total() + ' people'">
+      <span
+        class="count p-total"
+        [attr.title]="
+          backendCapped()
+            ? total() + ' of ' + totalVisiblePeople() + ' people'
+            : total() + ' people'
+        "
+      >
         {{ total() }}
       </span>
     }
@@ -118,6 +125,17 @@
         <button type="button" class="btn btn-ghost p-show-all" (click)="showAll()">
           Show all {{ total() }} people
         </button>
+      }
+
+      <!-- A SEPARATE disclosure: the BACKEND's 500-row cap, distinct from the client-side
+           RENDER_CAP expander above — "Show all N" only ever reveals up to N = total(),
+           which is itself already backend-capped, so this is the only signal that more
+           people exist beyond what "Show all" can ever surface. -->
+      @if (backendCapped()) {
+        <p class="p-cap-note">
+          Showing the {{ total() }} most-mentioned of
+          {{ totalVisiblePeople() }} people.
+        </p>
       }
 
       @if (selectedId(); as id) {

--- a/src/app/features/people/people/people.component.scss
+++ b/src/app/features/people/people/people.component.scss
@@ -162,4 +162,14 @@
   display: block;
   margin: var(--space-3) auto 0;
 }
+
+// The BACKEND 500-row cap disclosure — a distinct, honest caption (mirrors
+// brain.component.ts's MAP_NODE_CAP caption), separate from the client-side
+// RENDER_CAP expander above since "Show all" can never surface people past the cap.
+.p-cap-note {
+  margin: var(--space-2) auto 0;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
     

--- a/src/app/features/people/people/people.component.ts
+++ b/src/app/features/people/people/people.component.ts
@@ -42,10 +42,29 @@ export class PeopleComponent {
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
 
+  /**
+   * The TRUE count of VISIBLE people, from `listPeople()`'s `totalVisiblePeople` — may exceed
+   * `people().length` when the BACKEND's 500-row cap (`list_entities_visible`'s
+   * `MAX_VISIBLE_ENTITIES`, upstream of `list_people`) trimmed the roster before it ever reached
+   * this component. Defaults to 0 (matches `people`'s empty initial state).
+   */
+  readonly totalVisiblePeople = signal(0);
+
   /** The selected person id — opens the structured person-dossier pane. */
   readonly selectedId = signal<string | null>(null);
 
   protected readonly total = computed(() => this.people().length);
+
+  /**
+   * Whether the BACKEND capped the roster below the true visible-person count — independent of,
+   * and reported ALONGSIDE, the client-side `RENDER_CAP` expander below. 2026-07-13 UX audit: the
+   * old "Show all {{ total() }} people" button used `total()` (== `people().length`, the ALREADY
+   * backend-capped roster) as if it were the true count, so a 650-person vault silently showed
+   * "Show all 500 people" with 150 missing and no indication anything was cut.
+   */
+  protected readonly backendCapped = computed(
+    () => this.totalVisiblePeople() > this.people().length,
+  );
 
   /**
    * 2026-07-13 perf audit (LOW-MODERATE): `list_people` has no backend LIMIT, so a vault with
@@ -85,8 +104,9 @@ export class PeopleComponent {
   private async fetch(): Promise<void> {
     this.error.set(null);
     try {
-      const rows = await this.ipc.listPeople();
+      const { people: rows, totalVisiblePeople } = await this.ipc.listPeople();
       this.people.set(rows);
+      this.totalVisiblePeople.set(totalVisiblePeople);
       // If the selected person is no longer visible (e.g. their folder re-sealed),
       // close the detail panel so we never point at a vanished person.
       const sel = this.selectedId();
@@ -95,6 +115,7 @@ export class PeopleComponent {
       }
     } catch (e) {
       this.people.set([]);
+      this.totalVisiblePeople.set(0);
       this.error.set(String(e));
     } finally {
       this.loading.set(false);

--- a/src/app/features/record/brain-reveal-card/brain-reveal-card.component.ts
+++ b/src/app/features/record/brain-reveal-card/brain-reveal-card.component.ts
@@ -102,8 +102,11 @@ export class BrainRevealCardComponent {
 
   private async fetch(): Promise<void> {
     try {
-      const rows = await this.ipc.listPeople();
-      this._peopleCount.set(rows.length);
+      const { people: rows, totalVisiblePeople } = await this.ipc.listPeople();
+      // Use the TRUE visible-person count (not `rows.length`, which the backend's 500-row
+      // render cap can trim below it) so this "Murmur mapped N people" reveal never
+      // understates on a large vault.
+      this._peopleCount.set(totalVisiblePeople);
       this._commitmentCount.set(
         rows.reduce((n, p) => n + p.openCommitmentCount, 0),
       );


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

`Db::list_entities_visible` (src-tauri/src/storage/db.rs) applies `LIMIT MAX_VISIBLE_ENTITIES` (=500, ordered by mention count DESC) to fix an unbounded-render perf issue, and feeds both `get_graph` (GraphData.nodes) and `list_people` (PersonCard rollup). Graph's existing disclosure banner is unrelated: `GraphData.hasHidden` / `Db::has_hidden_folders` only queries `folders WHERE locked = 1`, so on a vault with >500 visible entities and zero locked folders, `hasHidden` stays false and `total()` (bound to `graphData()?.nodes.length`) silently reports the truncated count as the whole graph. People is worse: `PersonCard`/`list_people` carries no truncation signal at all, so `PeopleComponent.total()` and the 'Show all {{ total() }} people' expander button (people.component.html) present the 500-cap'd count as definitive — a 650-person vault shows '500' and 'Show all 500 people' with no indication 150 are missing. Contrast with the sibling `brain.component.ts` MAP_NODE_CAP pattern, which DOES render an explicit 'Showing the 60 most-connected of N entities' caption for the same shape of truncation.

**Repro:** Seed >500 distinct Person/Project entities each with >=1 visible mention, zero locked folders, then call get_graph / list_people. GraphData.hasHidden is false (has_hidden_folders only checks folders.locked) even though 100+ entities were dropped by LIMIT 500 in list_entities_visible; PersonCard has no field reflecting truncation; GraphComponent.total()/hasHidden() and PeopleComponent.total()/'Show all N people' both render the truncated number with no caveat.

## Fix

Confirmed root cause exactly as described: Db::list_entities_visible (src-tauri/src/storage/db.rs) applies `LIMIT MAX_VISIBLE_ENTITIES` (500) and feeds both get_graph and list_people, but the only truncation disclosure (GraphData.hasHidden / has_hidden_folders) checks LOCKED folders only — never the render cap. On a vault with >500 visible entities and zero locked folders, hasHidden stays false while entities silently drop, and list_people (a bare Vec<PersonCard>) had no truncation signal at all, so People's "Show all N people" understated N with zero indication.

Fix (backend): added `Db::count_entities_visible(unlocked, kind: Option<EntityKind>)` — the same visibility predicate as list_entities_visible but with no LIMIT, optionally filtered by EntityKind. `build_graph` now populates a new `GraphData.total_visible_entities` field. `list_people` now returns a new `PeopleList { people, total_visible_people }` wrapper instead of a bare `Vec<PersonCard>` (Person-filtered count), since the People roster can be trimmed by the 500-cap before the Person filter even runs.

Fix (frontend): `GraphComponent` gained an `isCapped`/`capDisclosure` computed rendering "Showing the N most-mentioned of TOTAL entities" (mirrors the existing `brain.component.ts` MAP_NODE_CAP pattern), shown as a separate banner from the existing locked-folder banner, plus an updated header-count tooltip. `PeopleComponent` gained `totalVisiblePeople`/`backendCapped` signals, a "Showing the N most-mentioned of TOTAL people" caption distinct from the pre-existing client-side RENDER_CAP "Show all N people" expander (which can never surface people past the backend cap), and an updated header tooltip. `BrainRevealCardComponent` (a third `listPeople()` consumer) now uses the true `totalVisiblePeople` instead of the capped `rows.length` for its "Murmur mapped N people" reveal.

Added a RED-before-GREEN regression test `graph_and_people_disclose_the_500_cap_even_with_no_locked_folders` in src-tauri/src/storage/db.rs: seeds 520 Person entities all mentioned in one never-locked meeting, asserts has_hidden_folders/hasHidden stays false, the capped roster is 500, and total_visible_entities/total_visible_people both report the true 520 (this field/return-shape did not exist pre-fix — proven by checking out original HEAD, which structurally could not express this assertion at all).

Gates: `cargo test --lib` 1582 passed / 0 failed / 10 ignored; `npx ng lint` clean; `npx ng build` clean (people-component chunk 22.79 kB, well within the 16 kB per-component *style* budget — total component including logic, not just styles).

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
