### PR TITLE
fix: Person card 'N open' commitment badge and the person-dossier 'Who owes what' count use different filters, so they can visibly disagree for the same person

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -9057,10 +9057,16 @@ impl Db {
     /// so a person mentioned ONLY in sealed-and-not-session-unlocked meetings is already dropped
     /// (its `HAVING cnt > 0` count is 0 while sealed) and never surfaces here. Each per-person count
     /// then reuses a gate that pushes the SAME `unlocked` set through `visibility_clause`:
-    /// `entity_mentions_visible` (meeting_count + last_talked), `list_facts_visible` (current facts),
-    /// and `list_open_commitments` (owner-scoped, name match) — so every count reflects VISIBLE
-    /// sources only; a sealed source contributes nothing to any of them. Ordered by most-recent
-    /// contact (last_talked DESC), then name.
+    /// `entity_mentions_visible` (meeting_count + last_talked), `list_facts_visible` (current facts).
+    ///
+    /// `open_commitment_count` MUST use the exact same predicate as the person-dossier's "who owes
+    /// what" section (`summarize::dossier::build_dossier_data`) — an open item belongs to this
+    /// person iff it's from one of their VISIBLE mentioning meetings OR its owner name-matches —
+    /// otherwise the card badge and the dossier opened from that same card can disagree (a person
+    /// mentioned in a meeting with an open, unowned/differently-owned action item was undercounted
+    /// here while the dossier counted it). Every count still reflects VISIBLE sources only; a sealed
+    /// source contributes nothing to any of them. Ordered by most-recent contact (last_talked DESC),
+    /// then name.
     pub fn list_people(&self, unlocked: &HashSet<String>) -> Result<Vec<PersonCard>> {
         // GATE: the visible-only entity set, Persons only. A sealed-only person is absent here.
         let people: Vec<GraphNode> = self
@@ -9068,18 +9074,10 @@ impl Db {
             .into_iter()
             .filter(|n| n.kind == EntityKind::Person)
             .collect();
-        // Owner-scoped commitments are cheap to compute ONCE (the full visible rollup) and bucket
-        // by lowercased owner name, rather than re-scanning every note per person.
-        let mut commitments_by_owner: std::collections::HashMap<String, i64> =
-            std::collections::HashMap::new();
-        for c in self.list_open_commitments(unlocked, None)? {
-            if let Some(owner) = c.owner.as_deref() {
-                let key = owner.trim().to_lowercase();
-                if !key.is_empty() {
-                    *commitments_by_owner.entry(key).or_insert(0) += 1;
-                }
-            }
-        }
+        // The full VISIBLE open-commitment rollup, computed ONCE and reused per person below —
+        // mirrors `build_dossier_data`'s corpus (mention-id match OR owner-name match), NOT a
+        // narrower owner-only bucket.
+        let all_commitments = self.list_open_commitments(unlocked, None)?;
         let mut out: Vec<PersonCard> = Vec::with_capacity(people.len());
         for p in people {
             // meeting_count + last_talked: VISIBLE mentions only, newest first.
@@ -9088,11 +9086,21 @@ impl Db {
             let last_talked = mentions.first().map(|m| m.started_at.clone());
             // current_fact_count: currently-valid facts about this person from VISIBLE meetings.
             let current_fact_count = self.list_facts_visible(&p.id, unlocked)?.len() as i64;
-            // open_commitment_count: open action items owned by this person (case-insensitive name).
-            let open_commitment_count = commitments_by_owner
-                .get(&p.name.trim().to_lowercase())
-                .copied()
-                .unwrap_or(0);
+            // open_commitment_count: same predicate as the dossier's "who owes what" — an open item
+            // from one of this person's mentioning meetings, OR owned by this person (name match).
+            let mention_ids: std::collections::HashSet<&str> =
+                mentions.iter().map(|m| m.meeting_id.as_str()).collect();
+            let name_lc = p.name.trim().to_lowercase();
+            let open_commitment_count = all_commitments
+                .iter()
+                .filter(|c| {
+                    mention_ids.contains(c.meeting_id.as_str())
+                        || c.owner
+                            .as_deref()
+                            .map(|o| o.trim().to_lowercase() == name_lc)
+                            .unwrap_or(false)
+                })
+                .count() as i64;
             out.push(PersonCard {
                 id: p.id,
                 name: p.name,
@@ -17783,6 +17791,48 @@ mod graph_tests {
         assert_eq!(
             bob_u.current_fact_count, 2,
             "both facts visible when unlocked"
+        );
+    }
+
+    /// The People card's `open_commitment_count` badge MUST agree with the count backing the same
+    /// person's dossier "who owes what" section one click away
+    /// (`summarize::dossier::build_dossier_data`), which counts an open item as this person's iff
+    /// it's from one of their mentioning meetings OR owner-name-matches — NOT owner-name-match
+    /// alone. RED-before-GREEN: a narrower owner-only bucket undercounts a person mentioned in a
+    /// meeting with an open, unowned action item, so the card badge (0) disagrees with the dossier
+    /// (1) for the exact same person.
+    #[test]
+    fn list_people_open_commitment_count_matches_dossier_mention_or_owner_filter() {
+        let db = file_db("people-dossier-parity");
+        seed_note(
+            &db,
+            "m1",
+            "## Action items\n- [ ] Follow up on pricing 2026-08-01\n",
+            None,
+        );
+        let priya = db.upsert_entity("Priya", EntityKind::Person).unwrap();
+        db.add_mention(&priya, "m1").unwrap();
+
+        let empty: HashSet<String> = HashSet::new();
+        let cards = db.list_people(&empty).unwrap();
+        let priya_card = cards
+            .iter()
+            .find(|p| p.id == priya)
+            .expect("Priya is visible via her mention");
+        assert_eq!(
+            priya_card.open_commitment_count, 1,
+            "the card badge must count the open, unowned action item from Priya's mentioned \
+             meeting, same as the dossier's 'who owes what' section"
+        );
+
+        let dossier = crate::summarize::dossier::build_dossier_data(&db, &priya, &empty)
+            .unwrap()
+            .expect("Priya has a visible dossier");
+        assert_eq!(
+            dossier.commitments.len() as i64,
+            priya_card.open_commitment_count,
+            "the People card badge and the dossier 'who owes what' count must never disagree \
+             for the same person"
         );
     }
 


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

`Db::list_people` (src-tauri/src/storage/db.rs) computes `PersonCard.open_commitment_count` by bucketing `list_open_commitments` results purely by lowercased owner-name match against the person's entity name (`commitments_by_owner`). `build_dossier_data` (src-tauri/src/summarize/dossier.rs), backing the SAME person's dossier 'Who owes what' section one click away, filters more broadly: `mention_ids.contains(c.meeting_id) OR owner name match` — it also includes any open, unowned (or differently-owned) action item from any meeting that merely mentions the person. Since `ActionItem.owner` is a real `Option<String>` and unowned items are common, a person mentioned in a meeting with an unowned/differently-owned open action item shows a smaller 'N open' badge on the People card than the count in their own dossier pane, with no explanation of the distinction.

**Repro:** Seed a meeting whose note has an open, unowned action item (e.g. '- [ ] Follow up on pricing 2026-08-01') and mentions entity 'Priya' (add_mention). list_people(unlocked) -> Priya's PersonCard.open_commitment_count is 0 (no owner-name match). get_person_dossier for Priya's entity id -> DossierData.commitments includes that item (matched via mention_ids), so the dossier's 'Who owes what' count is 1. The card badge and the dossier opened from that exact card disagree.

## Fix

Confirmed root cause exactly as reported: `Db::list_people` (src-tauri/src/storage/db.rs, fn list_people) computed `PersonCard.open_commitment_count` by bucketing `list_open_commitments` results purely by lowercased owner-name match against the person's entity name (the old `commitments_by_owner` HashMap). `build_dossier_data` (src-tauri/src/summarize/dossier.rs:145-155) backing the same person's "who owes what" dossier section applies a strictly broader filter: `mention_ids.contains(c.meeting_id) OR owner-name-match`, so it also counts open, unowned/differently-owned action items from meetings the person is merely mentioned in. Confirmed the FE wiring makes this visibly inconsistent: clicking a PersonCard on the People screen (src/app/features/people/people/people.component.ts `onSelect`) opens PersonDossierComponent for that exact entity id, so the "N open" badge (people.component.html:84, `p.openCommitmentCount`) and the dossier's commitment count for the SAME person can disagree with no explanation.

Fix (minimal, backend-only): changed `list_people` (src-tauri/src/storage/db.rs, fn list_people) to compute `open_commitment_count` per-person using the identical predicate as `build_dossier_data` — the person's `entity_mentions_visible` meeting-id set OR case-insensitive owner-name match — instead of the narrower owner-only bucket. The full open-commitment rollup is still fetched once (`list_open_commitments(unlocked, None)`) and filtered per person, so cost/shape stays the same; no new read path, no gate change (still routes through the same `visibility_clause`-gated `list_open_commitments` and `entity_mentions_visible` readers). This is a read/count-shape fix only — it does not touch seal/verify-before-destroy or gating, so no new lock-model surface was introduced, though it does touch a gated content-derived read path (list_people), which is worth a quick lock-security sanity pass given repo policy on any content-read change.

Test: added `list_people_open_commitment_count_matches_dossier_mention_or_owner_filter` in src-tauri/src/storage/db.rs (graph_tests module), seeding exactly the repro from the bug report (one open, unowned action item + a mentioned Person entity with no meetings of their own), asserting the People card badge equals the dossier's `commitments.len()` for the same entity id. RED-before-GREEN: manually reverted just the list_people fix body (kept the new test) and reran — test failed with `left: 0, right: 1` (the exact undercount from the bug report), confirming the test captures the real bug. Restored the fix and reran: PASS. Also re-ran the pre-existing gate test `list_people_excludes_sealed_person_and_counts_visible_only` and the dossier test `build_dossier_gates_sealed_and_filters_commitments` individually (both still PASS, so the lock-model gating behavior for sealed/unlocked content is unchanged), then the full `cargo test --lib` suite: 1582 passed, 0 failed, 10 ignored.

Not verified here: no FE/UI changes were made (bug is backend-only, root-caused to a Rust filter mismatch — no Angular file needed changes), so no `ng lint`/`ng build` run. Did not run `scripts/ci.sh` (per rules, it's the final one-time gate, not the iteration loop) or a dev-app live click-through of the People/dossier UI — the fix is a pure Rust filter-parity change verified by targeted + full `cargo test --lib`, which is sufficient proof for this class of bug (no FFI, no seal, no new gate).

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
