### PR TITLE
fix: Notes settings "Summary style" <select> shows no visible selection when noteStyle holds a value outside the four hardcoded options, and its help text silently mislabels it as "standard"

### DIFF
--- a/e2e/settings-notes/summary-style-unknown-value.spec.ts
+++ b/e2e/settings-notes/summary-style-unknown-value.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * `note_style` is a free-form `String` on the Rust side (`AppConfigDto.note_style`,
+ * src-tauri/src/commands.rs) with NO enum validation — only an empty string is
+ * normalized (to "standard"); any other stored value passes through unvalidated.
+ * The demo mock (scripts/screenshots/mock-tauri.js) sets `noteStyle: "structured"`,
+ * a value outside the four hardcoded <option>s in
+ * settings-notes-section.component.html — so this is a real, live repro, not a
+ * contrived one.
+ *
+ * RED (pre-fix): the native <select> had no matching <option> for "structured" so
+ * it rendered with NOTHING visibly selected, while the help text's
+ * `@switch`/`@default` silently showed the "standard" balanced-summary copy —
+ * mislabeling the actual stored value with no indication anything was wrong.
+ *
+ * GREEN (post-fix): an extra <option> surfaces the raw unrecognized value so the
+ * select always shows a real selection, and the help text's `@default` says the
+ * value is unrecognized instead of lying that it's "standard".
+ */
+test.describe("Notes settings — Summary style select with an unrecognized stored value", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTauri(page);
+    await page.goto("/settings");
+    await page.getByText("Notes", { exact: true }).first().click();
+  });
+
+  test("the select shows a real visible selection, not blank", async ({
+    page,
+  }) => {
+    const select = page.locator('select[formcontrolname="noteStyle"]');
+    await expect(select).toBeVisible({ timeout: 10_000 });
+
+    // The demo mock's noteStyle is "structured" — confirm it actually loaded
+    // (guards the assertion below from passing vacuously against a stale form).
+    await expect
+      .poll(async () => select.inputValue())
+      .toBe("structured");
+
+    // The select must have a matching <option> for the current value — i.e. a
+    // real visible selection, not the browser's "no option selected" blank state.
+    const selectedOptionText = await select
+      .locator("option:checked")
+      .textContent();
+    expect(selectedOptionText).not.toBeNull();
+    expect(selectedOptionText!.trim().length).toBeGreaterThan(0);
+  });
+
+  test("the help text does not mislabel the unrecognized value as standard", async ({
+    page,
+  }) => {
+    const select = page.locator('select[formcontrolname="noteStyle"]');
+    await expect(select).toBeVisible({ timeout: 10_000 });
+    await expect.poll(async () => select.inputValue()).toBe("structured");
+
+    // Pre-fix this text appeared unconditionally for any unrecognized value.
+    await expect(
+      page.getByText(
+        "A balanced summary, key points and action items — good for most",
+      ),
+    ).not.toBeVisible();
+  });
+});

--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
@@ -15,6 +15,24 @@
                 <option value="brief">Brief (TL;DR + actions)</option>
                 <option value="detailed">Detailed (full depth)</option>
                 <option value="action">Action-focused</option>
+                @if (
+                  form.controls.noteStyle.value !== "standard" &&
+                  form.controls.noteStyle.value !== "brief" &&
+                  form.controls.noteStyle.value !== "detailed" &&
+                  form.controls.noteStyle.value !== "action"
+                ) {
+                  <!--
+                    note_style is a free-form String on the Rust side (commands.rs
+                    `AppConfigDto.note_style`) with no enum validation — a hand-edited
+                    config.json, legacy/removed style, or seed data can carry a value
+                    outside the four options above. Without this, the native <select>
+                    shows no visible selection at all. Surface the raw stored value as
+                    its own option instead of rendering blank.
+                  -->
+                  <option [value]="form.controls.noteStyle.value">
+                    {{ form.controls.noteStyle.value }} (custom)
+                  </option>
+                }
               </select>
               <span class="field-help text-muted">
                 @switch (form.controls.noteStyle.value) {
@@ -28,9 +46,13 @@
                   @case ("action") {
                     Front-loads who-does-what — owners, tasks and due dates first.
                   }
-                  @default {
+                  @case ("standard") {
                     A balanced summary, key points and action items — good for most
                     meetings.
+                  }
+                  @default {
+                    An unrecognized saved style — pick one of the options above to
+                    reset it to a supported style.
                   }
                 }
               </span>


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

The Notes settings section's `<select formControlName="noteStyle">` declares only four `<option>` values: `standard`, `brief`, `detailed`, `action` (settings-notes-section.component.html). The backing Rust config field `note_style` (src-tauri/src/commands.rs:179) is a free-form `String` with no enum/validation — empty string defaults to "standard" but any other string is passed through unvalidated. If the loaded config's `noteStyle` is any value outside the four options (a hand-edited config.json, a legacy/removed style, or demo/seed data — confirmed the shipped demo mock at scripts/screenshots/mock-tauri.js:362 sets `noteStyle: "structured"`, which is not one of the four valid values), the native `<select>` has no matching `<option>` and renders with nothing visibly selected. Simultaneously, the `@switch (form.controls.noteStyle.value)` driving the help text has no case for that value, falls to `@default`, and shows the "standard" description ("A balanced summary, key points and action items") — actively mislabeling the real stored value with no error or indication anything is wrong.

**Repro:** 1. Load /settings, open the Notes section, with the loaded config's `noteStyle` set to any string not in {standard, brief, detailed, action} — reproducible today via the shipped demo mock (scripts/screenshots/mock-tauri.js:362, `noteStyle: "structured"`) or a hand-edited config.json. 2. Observe: the "Summary style" <select> shows no visible selection (blank), while the help text below reads the "standard" description despite the actual stored value being different.

## Fix

Confirmed real bug: note_style is a free-form Rust String (AppConfigDto.note_style, src-tauri/src/commands.rs) with no enum validation — only empty string normalizes to "standard". The Notes settings Summary-style <select> hardcoded only 4 options (standard/brief/detailed/action); any other stored value (reproducible live via the shipped demo mock's noteStyle: "structured", scripts/screenshots/mock-tauri.js:362) has no matching <option> so the native select renders with nothing visibly selected, while the help text's @switch falls to @default and silently mislabels it "standard". Fixed in settings-notes-section.component.html only: added a conditional 5th <option> surfacing the raw unrecognized value (select always shows a real selection), and gave the help text an honest @case("standard")/@default split instead of the false default claim. Matches this file's existing idioms (form.controls.X.value direct reads, @switch/@if). Added e2e/settings-notes/summary-style-unknown-value.spec.ts using the existing Playwright harness (mockTauri) — confirmed RED against pre-fix code (select.inputValue() === "") and GREEN after the fix, on an isolated test port to route around a live port/stash collision with another concurrent agent sharing this multi-worktree environment. npx ng lint and npx ng build both clean (no style-budget violations). Frontend-only change; cargo test --lib not applicable (no Rust touched). Committed as QueaT <kgm004a@gmail.com>, no Claude trailers, pushed to origin.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
