### PR TITLE
fix: Settings Account section shows "Loading account…" forever with no sign-in button or error when accountStatus() resolves to null instead of throwing

### DIFF
--- a/e2e/settings-account/loading-state.spec.ts
+++ b/e2e/settings-account/loading-state.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Settings › Account — the "Loading account…" state must resolve, never hang.
+ *
+ * Bug: `SettingsAccountSectionComponent`'s template used to gate its entire
+ * signed-out/signed-in UI behind `@if (status(); as st) { … } @else { Loading
+ * account… }`. Angular's `@if(x; as y)` treats a resolved `null`/falsy value
+ * IDENTICALLY to "not yet resolved" — there was no signal distinguishing
+ * "still pending" from "settled, but falsy". A benign resolved-`null`
+ * `account_status` response (e.g. an unmocked command falling through to a
+ * generic default, as the demo/screenshot mock used to do) left the section
+ * stuck on "Loading account…" forever, with no sign-in button and no error.
+ *
+ * Fix: a dedicated `loaded` signal, set `true` in `reload()`'s `finally`
+ * block regardless of outcome — the template now gates "Loading account…" on
+ * `!loaded()`, so a settled-but-falsy status correctly falls through to the
+ * signed-out "Create or sign in to a sharing account" affordance.
+ *
+ * This test overrides `account_status` to resolve `null` directly (the exact
+ * settled-but-falsy shape the bug hinged on) — RED against the pre-fix
+ * template (stuck on "Loading account…", sign-in button never appears),
+ * GREEN after the fix.
+ */
+
+async function openAccountSection(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.goto("/settings");
+  await page.getByRole("button", { name: "Account" }).first().click();
+  await expect(
+    page.locator("app-settings-account-section"),
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Settings › Account — resolved-null status (mocked IPC)", () => {
+  test("shows the sign-in affordance, not a stuck 'Loading account…'", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") {
+        errors.push(m.text());
+      }
+    });
+
+    await mockTauri(page, {
+      // The exact settled-but-falsy shape that used to defeat the
+      // `@if (status(); as st)` truthiness gate.
+      account_status: () => null,
+    });
+    await openAccountSection(page);
+
+    const section = page.locator("app-settings-account-section");
+
+    // The permanent-spinner regression: "Loading account…" must NOT still be
+    // showing once the (resolved) IPC call has settled.
+    await expect(section.getByText("Loading account…")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    // The signed-out sign-in affordance must be visible instead.
+    await expect(
+      section.getByRole("button", {
+        name: "Create or sign in to a sharing account",
+      }),
+    ).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -762,6 +762,24 @@ scope to the GA-critical path only.
           redacted: true,
         };
 
+      // ── M3-CLIENT: sharing account (Settings → Account section) ──
+      // Signed-out shape (matches Rust `commands::AccountStatus`, camelCase over
+      // IPC): the demo world has no sharing-server account, so the section shows
+      // its normal signed-out "Create or sign in" affordance rather than falling
+      // through to the generic `default:` handler (a bare `account_status` name
+      // doesn't match the `list_`/`get_`/`has_`/`is_` fallback prefixes below, so
+      // an unhandled case would previously resolve `null` — which the FE now
+      // treats as a real signed-out status, never a permanent "Loading…" state).
+      case "account_status":
+        return {
+          loggedIn: false,
+          email: null,
+          unlockedForSharing: false,
+          shareConsented: false,
+          serverConfigured: false,
+          biometricUnlockAvailable: false,
+        };
+
       // ── Shared Brain (org) ──
       case "org_refresh": return null;
       case "org_list_statuses": return ORGS;

--- a/src/app/features/settings/sections/settings-account-section/settings-account-section.component.html
+++ b/src/app/features/settings/sections/settings-account-section/settings-account-section.component.html
@@ -44,100 +44,98 @@
       </div>
     </div>
 
-    @if (status(); as st) {
-      @if (st.loggedIn) {
-        <!-- (2a) Signed-in state. IDENTITY (who you are) is separated from
-             the SESSION share-key state (loaded this run or not) — the two
-             used to be conflated into a contradictory "signed in / sign in
-             to share". -->
-        <div class="account-section">
-          <span class="account-section-label text-muted">Signed in as</span>
-          <div class="signed-in-row">
-            <span class="pill is-success signed-pill">
-              <span class="pill-dot"></span>
-              {{ st.email ?? "Signed in" }}
-            </span>
-            <button
-              type="button"
-              class="btn btn-ghost"
-              (click)="logout()"
-              [disabled]="busy()"
-            >
-              Sign out
-            </button>
-          </div>
-          <p class="text-secondary account-note">
-            Your notes live on this Mac. Signing out only turns off sharing —
-            it never deletes, moves, or uploads a note.
-          </p>
-
-          <!-- SESSION share-key state — distinct from identity above. -->
-          @if (st.unlockedForSharing) {
-            <span class="pill is-success signed-pill">
-              <span class="pill-dot"></span>
-              Ready to share this session
-            </span>
-          } @else {
-            <p class="text-secondary account-note">
-              @if (canBiometricUnlock()) {
-                Sharing is locked this session — unlock with Touch ID to
-                share without re-entering your password.
-              } @else {
-                Sharing is locked this session — sign in again to load your
-                account key.
-              }
-            </p>
-            <div class="account-actions">
-              @if (canBiometricUnlock()) {
-                <button
-                  type="button"
-                  class="btn btn-primary"
-                  (click)="unlockWithBiometric()"
-                  [disabled]="unlocking()"
-                >
-                  {{ unlocking() ? "Unlocking…" : "Unlock with Touch ID" }}
-                </button>
-              } @else {
-                <button
-                  type="button"
-                  class="btn btn-primary"
-                  (click)="openFlow()"
-                >
-                  Sign in to share
-                </button>
-              }
-            </div>
-            @if (unlockError(); as uerr) {
-              <p class="text-secondary account-note" role="status">
-                {{ uerr }}
-              </p>
-            }
-          }
+    @if (!loaded()) {
+      <p class="text-muted account-note">Loading account…</p>
+    } @else if (isLoggedIn()) {
+      <!-- (2a) Signed-in state. IDENTITY (who you are) is separated from
+           the SESSION share-key state (loaded this run or not) — the two
+           used to be conflated into a contradictory "signed in / sign in
+           to share". -->
+      <div class="account-section">
+        <span class="account-section-label text-muted">Signed in as</span>
+        <div class="signed-in-row">
+          <span class="pill is-success signed-pill">
+            <span class="pill-dot"></span>
+            {{ status()?.email ?? "Signed in" }}
+          </span>
+          <button
+            type="button"
+            class="btn btn-ghost"
+            (click)="logout()"
+            [disabled]="busy()"
+          >
+            Sign out
+          </button>
         </div>
-      } @else {
-        <!-- (2b) Signed-out: ONE button opens the reusable flow -->
-        <div class="account-section">
-          <span class="account-section-label text-muted">Account</span>
+        <p class="text-secondary account-note">
+          Your notes live on this Mac. Signing out only turns off sharing —
+          it never deletes, moves, or uploads a note.
+        </p>
+
+        <!-- SESSION share-key state — distinct from identity above. -->
+        @if (status()?.unlockedForSharing) {
+          <span class="pill is-success signed-pill">
+            <span class="pill-dot"></span>
+            Ready to share this session
+          </span>
+        } @else {
           <p class="text-secondary account-note">
-            Create a sharing account or sign in to this Mac to start sharing
-            notes as end-to-end-encrypted links.
+            @if (canBiometricUnlock()) {
+              Sharing is locked this session — unlock with Touch ID to
+              share without re-entering your password.
+            } @else {
+              Sharing is locked this session — sign in again to load your
+              account key.
+            }
           </p>
           <div class="account-actions">
-            <button
-              type="button"
-              class="btn btn-primary"
-              (click)="openFlow()"
-            >
-              Create or sign in to a sharing account
-            </button>
+            @if (canBiometricUnlock()) {
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="unlockWithBiometric()"
+                [disabled]="unlocking()"
+              >
+                {{ unlocking() ? "Unlocking…" : "Unlock with Touch ID" }}
+              </button>
+            } @else {
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="openFlow()"
+              >
+                Sign in to share
+              </button>
+            }
           </div>
-          @if (accountError(); as aerr) {
-            <p class="text-danger account-note">{{ aerr }}</p>
+          @if (unlockError(); as uerr) {
+            <p class="text-secondary account-note" role="status">
+              {{ uerr }}
+            </p>
           }
-        </div>
-      }
+        }
+      </div>
     } @else {
-      <p class="text-muted account-note">Loading account…</p>
+      <!-- (2b) Signed-out: ONE button opens the reusable flow. Also the
+           fallback when `status()` settled but resolved falsy (e.g. an
+           unmocked `account_status` in the demo/screenshot world) — the
+           `loaded()` gate above guarantees this never means "still
+           pending" the way an `@if (status(); as st)` truthiness check did. -->
+      <div class="account-section">
+        <span class="account-section-label text-muted">Account</span>
+        <p class="text-secondary account-note">
+          Create a sharing account or sign in to this Mac to start sharing
+          notes as end-to-end-encrypted links.
+        </p>
+        <div class="account-actions">
+          <button type="button" class="btn btn-primary" (click)="openFlow()">
+            Create or sign in to a sharing account
+          </button>
+        </div>
+        @if (accountError(); as aerr) {
+          <p class="text-danger account-note">{{ aerr }}</p>
+        }
+      </div>
     }
   </div>
 

--- a/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
+++ b/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
@@ -56,6 +56,20 @@ export class SettingsAccountSectionComponent {
   private readonly _status = signal<AccountStatus | null>(null);
   readonly status = this._status.asReadonly();
 
+  /**
+   * True once the first `reload()` has settled (success OR failure). Distinct
+   * from `status()` itself: a resolved-but-falsy status (e.g. an unmocked
+   * `account_status` call in the demo/screenshot world falling through to a
+   * benign `null`) must NOT read as "still loading" forever — only render the
+   * "Loading account…" copy before the first settle, mirroring the
+   * `loaded`-signal shape in `settings-organization-section.component.ts`.
+   */
+  private readonly _loaded = signal(false);
+  readonly loaded = this._loaded.asReadonly();
+
+  /** Derived signed-in check the template gates on (post-`loaded()`). */
+  readonly isLoggedIn = computed(() => !!this._status()?.loggedIn);
+
   /** True while a logout IPC call is in flight (debounces the Sign out button). */
   private readonly _busy = signal(false);
   readonly busy = this._busy.asReadonly();
@@ -163,6 +177,8 @@ export class SettingsAccountSectionComponent {
       this._status.set(st);
     } catch (e) {
       this._accountError.set(String(e));
+    } finally {
+      this._loaded.set(true);
     }
     // Load the incoming-share inbox only when it's usable (signed in + a server).
     if (st?.loggedIn && st.serverConfigured) {


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

SettingsAccountSectionComponent's reload() does `st = await this.ipc.accountStatus(); this._status.set(st);` and the template gates its entire signed-out/signed-in UI behind `@if (status(); as st) { ... } @else { <p>Loading account…</p> }` (settings-account-section.component.html:139-140). Angular's `@if(x; as y)` treats a resolved `null` identically to "not yet resolved" — there is no distinct state for "resolved to null/falsy" vs "still pending". In the shipped app this is currently unreachable because the real `account_status` Tauri command always returns `Result<AccountStatus, AppError>` (never an Option), so a genuine failure throws and lands in the `catch(e)` branch that sets `_accountError` instead. It is a real, verified gap in the FE's own state model though: the demo/screenshot mock (scripts/screenshots/mock-tauri.js) has no case for `account_status` and falls through to its generic `default:` handler (returns a benign `null` so plugin/window calls don't crash boot) — so any screenshot or demo build taken against the default demo world shows the Account section permanently stuck on "Loading account…" with no sign-in affordance and no error.

**Repro:** 1. Load /settings → Account section against the shipped demo mock scripts/screenshots/mock-tauri.js (which has no case for `account_status`, falling through to `default:` → resolves null rather than throwing). 2. Observe: the Account section shows only header copy and "Loading account…" indefinitely — no "Sign in to share" button, no error message, despite the promise having already resolved.

## Fix

Confirmed root cause: SettingsAccountSectionComponent's template gated its entire signed-in/signed-out UI on `@if (status(); as st) { … } @else { Loading account… }`, and Angular's `@if(x; as y)` can't distinguish "not yet resolved" from "resolved to a falsy value" — a settled-but-null `account_status` left the section stuck on "Loading account…" forever with no sign-in button and no error. The concrete trigger is scripts/screenshots/mock-tauri.js, which had no `account_status` case and fell through to its generic `default:` handler (resolves `null`, since the command name doesn't match the list_/get_/has_/is_ fallback prefixes). Fixed by mirroring the exact same-app pattern already proven in settings-organization-section.component.ts: added a `_loaded`/`loaded` signal set true in reload()'s `finally` block (success or failure), added a derived `isLoggedIn` computed, and restructured the template to `@if (!loaded()) { Loading… } @else if (isLoggedIn()) { signed-in } @else { signed-out }` so a resolved-falsy status correctly falls into the signed-out affordance instead of hanging. Also added the missing `account_status` case to the demo mock so the concrete repro path is closed. Added e2e/settings-account/loading-state.spec.ts overriding `account_status` to resolve null directly; verified RED against pre-fix code (via git stash) and GREEN after restoring the fix. Re-ran e2e/org (12 tests) and e2e/settings-ai (23 tests) — all green, no regressions. `npx ng lint` and `npx ng build` both clean. Mid-task a stash-pop transiently pulled in an unrelated concurrent agent's analytics.component diff (shared-worktree stash collision, a known trap); caught via git diff --stat before committing, reverted the stray files, and recovered my own change from the correct stash entry — final commit contains only the four intended files.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
