### PR TITLE
fix: Demo/screenshot mock's default org fixture omits contextEnabled, so the flagship demo org renders as "Disabled on this device" out of the box

### DIFF
--- a/e2e/org/multi-org-settings.spec.ts
+++ b/e2e/org/multi-org-settings.spec.ts
@@ -141,4 +141,23 @@ test.describe("Settings › Organizations — multi-org (mocked IPC)", () => {
       fullPage: true,
     });
   });
+
+  // Regression: the demo/screenshot mock's own default `ORGS` fixture
+  // ("Sonora", scripts/screenshots/mock-tauri.js) omitted `contextEnabled`,
+  // so the flagship demo org rendered as "Disabled on this device" out of
+  // the box. This test drives `org_list_statuses` with NO override — i.e.
+  // the real demo mock's default fixture — so it fails against the
+  // pre-fix fixture (missing field => falsy => "Disabled") and passes once
+  // the fixture carries `contextEnabled: true`.
+  test("the demo mock's own default org fixture is active on this device", async ({
+    page,
+  }) => {
+    await mockTauri(page, { account_status: ACCOUNT_STATUS });
+    await openOrgSection(page);
+
+    const sonora = page.locator(".org-card", { hasText: "Sonora" });
+    await expect(sonora).toBeVisible();
+    await expect(sonora.getByText("Active on this device")).toBeVisible();
+    await expect(sonora.getByText("Disabled on this device")).toHaveCount(0);
+  });
 });

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -544,6 +544,11 @@ scope to the GA-critical path only.
       itemCount: 4,
       receivedCount: 9,
       pendingShares: 0,
+      // Per-instance active/inactive toggle (origin/murmur#273 follow-up) —
+      // `true` by default on real orgs (see OrgStatus.contextEnabled in
+      // models.ts); a fixture missing this field renders the demo's own
+      // healthy example org as "Disabled on this device" out of the box.
+      contextEnabled: true,
     },
   ];
 


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

scripts/screenshots/mock-tauri.js's default `ORGS` fixture (org "Sonora", line ~536-547) has no `contextEnabled` field. Confirmed by inspection: the object has `orgId`, `name`, `role`, `memberCount`, `consented`, `lastSeq`, `itemCount`, `receivedCount`, `pendingShares` — no `contextEnabled`. `SettingsOrganizationSectionComponent`'s template does `@if (o.contextEnabled) { Active on this device } @else { Disabled on this device + Enable here }` (settings-organization-section.component.html:69-94) — with the field `undefined` it's falsy, so the demo's own primary/example org renders as inactive/disabled by default, with copy claiming its content 'stays synced, just inactive here'. This is the same class of bug already flagged in a code comment in e2e/org/org-editable-and-library.spec.ts about a fixture missing this field, but the demo mock's own org fixture was never updated to include `contextEnabled: true`. Not a production bug: the real Rust schema (src-tauri/src/storage/db.rs) added `context_enabled` via an additive migration with `DEFAULT 1`, so real users' orgs are active by default — this only affects the demo/screenshot mock's own rendered output.

**Repro:** 1. Load /settings → Organization section against the default (un-overridden) scripts/screenshots/mock-tauri.js demo world. 2. Observe: the "Sonora" org card shows a "Disabled on this device" pill and an "Enable here" button for what should be the demo's own healthy, fully-synced example org.

## Fix

Confirmed the bug exactly as reported: scripts/screenshots/mock-tauri.js's default `ORGS` fixture (the "Sonora" demo org) had no `contextEnabled` field, while `SettingsOrganizationSectionComponent`'s template (settings-organization-section.component.html) reads `o.contextEnabled` to decide between the "Active on this device" pill and the "Disabled on this device" pill + "Enable here" CTA. With the field `undefined`, it's falsy, so the demo's own flagship org rendered as inactive out of the box. models.ts documents `contextEnabled` as `true` by default on real orgs (OrgStatus.contextEnabled doc comment), and the real Rust schema defaults `context_enabled` to 1 (per the bug report) — this is purely a stale demo/screenshot fixture, not a production bug.

Fix: added `contextEnabled: true` to the ORGS fixture object in scripts/screenshots/mock-tauri.js, with a comment explaining why (mirrors the same fix pattern already applied to e2e/org/org-editable-and-library.spec.ts's own fixture, which had a comment flagging this exact class of bug but never touched the demo mock's own fixture).

Test: added a new Playwright e2e test to e2e/org/multi-org-settings.spec.ts ("the demo mock's own default org fixture is active on this device") that drives Settings > Organization via `mockTauri(page, { account_status: ACCOUNT_STATUS })` with NO override for `org_list_statuses` — i.e. it exercises the real demo mock's fixture verbatim (the same mechanism `e2e/settings-ai/mock-invoke.ts`'s `mockTauri` uses to load `scripts/screenshots/mock-tauri.js` as the base init script) — and asserts the "Sonora" org card shows "Active on this device" and never "Disabled on this device".

RED-before-GREEN verified manually: reverted only the fixture change (git checkout -- scripts/screenshots/mock-tauri.js) with the new test still in place → test failed with "element(s) not found" on `.org-card:has-text("Sonora") >> text=Active on this device`, confirming it reproduces the bug. Restored the fix → test passes. Ran the full e2e/org/ suite (13 tests) against a stable manually-kept-alive dev server on :4210 — all 13 pass, including 2 that flaked with ERR_CONNECTION_REFUSED under Playwright's own auto-managed webServer + 4 parallel workers (confirmed as pre-existing environmental flakiness unrelated to this change — they pass reliably once the server is stable, and they don't touch the ORGS/contextEnabled fixture at all).

Gates: `npx ng lint` — clean ("All files pass linting"). `npx ng build` — clean, all lazy chunks build fine, no style-budget or other errors. This is a frontend-only, non-Rust change (only a JS demo fixture + a Playwright e2e spec), so `cargo test --lib` was not run per the task's own scoping rule for FE-only changes.

Committed as QueaT <kgm004a@gmail.com> on branch fix/audit-demo-screenshot-mock-s-default-org-fixtu (commit 4f21557), no Claude trailers, and pushed to origin. Working tree is clean.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
