### PR TITLE
fix: Analytics: a real getAnalytics() failure silently renders as the 'no data yet' empty state

### DIFF
--- a/e2e/detail/analytics-error-state.spec.ts
+++ b/e2e/detail/analytics-error-state.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Analytics audit fix — a real `get_analytics` failure must NOT render as the
+ * "Nothing to measure yet" empty state.
+ *
+ * Pre-fix, `AnalyticsComponent.ngOnInit()` wrapped the `getAnalytics()` await in a
+ * bare `try { ... } finally { ... }` with no `catch`: a rejected promise left
+ * `data` at its initial `null`, `loading` still flipped to `false` in `finally`,
+ * and `isEmpty()` (`!a || a.totalMeetings === 0`) evaluated `true` — so a genuine
+ * backend error rendered byte-identical to a fresh, never-recorded vault, with no
+ * way to tell the two apart and no retry affordance.
+ *
+ * RED contract: on the pre-fix code, forcing `get_analytics` to throw still shows
+ * "Nothing to measure yet" (the `getByText(/Nothing to measure yet/)` expectation
+ * would pass and the "Couldn't load your analytics" / Retry assertions below would
+ * fail — there is no error branch at all).
+ */
+test.describe("Analytics — a real getAnalytics() failure surfaces as an error state (not empty)", () => {
+  test("shows an error card with Retry, not the empty-vault state", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // Count invocations PAGE-SIDE (the override is serialized — no test-scope closures).
+      get_analytics: () => {
+        const w = window as unknown as { __analyticsCalls?: number };
+        w.__analyticsCalls = (w.__analyticsCalls ?? 0) + 1;
+        throw new Error("db locked");
+      },
+    });
+
+    await page.goto("/analytics");
+
+    // The failed load must NOT render as the empty-vault state.
+    await expect(
+      page.getByText("Nothing to measure yet"),
+    ).not.toBeVisible();
+
+    // It must instead surface a distinct, honest error state with a retry affordance.
+    await expect(
+      page.getByText("Couldn’t load your analytics"),
+    ).toBeVisible({ timeout: 10_000 });
+    const retry = page.getByRole("button", { name: "Retry" });
+    await expect(retry).toBeVisible();
+
+    // Retry re-invokes the same IPC command.
+    await retry.click();
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __analyticsCalls?: number })
+                .__analyticsCalls ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/app/features/analytics/analytics/analytics.component.html
+++ b/src/app/features/analytics/analytics/analytics.component.html
@@ -10,6 +10,15 @@
     <div class="card state-card">
       <p class="empty">Loading…</p>
     </div>
+  } @else if (error(); as err) {
+    <div class="card empty-state">
+      <span class="empty-mark" aria-hidden="true"></span>
+      <p class="empty-title">Couldn’t load your analytics</p>
+      <p class="empty">{{ err }}</p>
+      <button type="button" class="btn btn-ghost" (click)="load()">
+        Retry
+      </button>
+    </div>
   } @else if (isEmpty()) {
     <div class="card empty-state">
       <span class="empty-mark" aria-hidden="true"></span>

--- a/src/app/features/analytics/analytics/analytics.component.ts
+++ b/src/app/features/analytics/analytics/analytics.component.ts
@@ -56,6 +56,7 @@ export class AnalyticsComponent implements OnInit {
 
   readonly data = signal<Analytics | null>(null);
   readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
 
   readonly isEmpty = computed(() => {
     const a = this.data();
@@ -188,8 +189,18 @@ export class AnalyticsComponent implements OnInit {
   });
 
   async ngOnInit(): Promise<void> {
+    await this.load();
+  }
+
+  /** (Re-)fetch analytics. Also the Retry button's handler on a load failure. */
+  async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
     try {
       this.data.set(await this.ipc.getAnalytics());
+    } catch (e) {
+      this.data.set(null);
+      this.error.set(String(e));
     } finally {
       this.loading.set(false);
     }


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** moderate

AnalyticsComponent.ngOnInit() (verified: `try { ... } finally { ... }` at lines 191/193, no catch block) wraps the `await this.ipc.getAnalytics()` call with no error handling. When the IPC call rejects (e.g. a locked/busy DB, a transient backend error), `data` stays null, `loading` flips to false in the finally block, and `isEmpty()` (`!a || a.totalMeetings === 0`) evaluates true — so the template shows the exact same 'Nothing to measure yet — Record your first meeting and your stats will appear here' empty-state card that a genuinely fresh vault would show. A user whose analytics failed to load because of a real backend error has no way to distinguish that from 'I haven't recorded anything yet,' and there's no retry affordance. The error does reach the browser console as an uncaught promise rejection, but nothing in the UI surfaces it.

**Repro:** Override the `get_analytics` Tauri command to throw (e.g. `() => { throw new Error('db locked'); }`), navigate to /analytics, wait for the promise to settle. The page renders `.empty-state` with 'Nothing to measure yet' instead of an error state, identical to the true-empty-vault case.

## Fix

Confirmed the bug: AnalyticsComponent.ngOnInit() (src/app/features/analytics/analytics/analytics.component.ts) wrapped `await this.ipc.getAnalytics()` in a bare try/finally with no catch. A rejected promise left `data` at its initial `null`; `loading` still flipped to `false` in `finally`; `isEmpty()` (`!a || a.totalMeetings === 0`) then evaluated true, so a real backend failure rendered identically to a genuinely empty vault, with no way to tell them apart and no retry.

Fix (minimal, mirrors two existing patterns already proven in this app):
- Added an `error` signal, mirroring `graph.component.ts`'s `_refetchOnLock`/`fetchGraph` shape (`error.set(null)` before the fetch, `catch` sets it, `finally` still clears `loading`).
- Renamed the load logic into a reusable `load()` method (called from `ngOnInit` and from the new Retry button), mirroring `meeting-recipes.component.ts`'s inline-error + Retry affordance.
- Added an error branch in the template between `loading()` and `isEmpty()`, using the same `.card.empty-state` / `.empty-mark` / `.empty-title` classes the existing empty-state and `graph.component.html`'s error branch already use (all global primitives from `src/app/design-system/primitives.css` — no new CSS, no token additions, scss file untouched).

Added `e2e/detail/analytics-error-state.spec.ts` (Playwright, mocked `window.__TAURI_INTERNALS__.invoke` via the existing `mockTauri` harness), which throws inside a `get_analytics` override and asserts the "Nothing to measure yet" text is NOT shown, "Couldn't load your analytics" + a Retry button ARE shown, and clicking Retry re-invokes `get_analytics`. Verified RED-before-GREEN: ran the test against the pre-fix component (temporarily reverted, then correctly reapplied by hand after a worktree stash mishap explained below) — it failed waiting for the error card, confirming it reproduces the bug; after the fix it passes.

Gates: `npx ng lint` — clean ("All files pass linting"). `npx ng build` — clean, `analytics-component` chunk 36.14 kB raw / 7.65 kB transfer, no style-budget violation. This is a frontend-only change so `cargo test --lib` was not run (no `src-tauri` files touched).

Operational note for the reviewer: this worktree shares a `git stash` stack with other concurrent worktrees on this machine. My `git stash push`/`pop` (used only to get a clean pre-fix baseline for the RED test) got interleaved with another worktree's concurrent stash activity and popped back an unrelated in-progress change to `src/app/features/ask/ask/ask.component.ts`/`.html` (an `AskTurn.id` stable-tracking fix, not mine). I did not create, stage, commit, or revert those files — they remain as local uncommitted modifications in this worktree, untouched, for whoever owns that other worktree to recover. My own analytics fix was lost from the stash in the same collision, so I reapplied it by hand from what I'd already written and re-verified end-to-end (RED test still reproduced on the reverted code, GREEN after reapplying). Also hit a second worktree-collision: Playwright's `webServer` on the shared port 4210 (`reuseExistingServer: true`) was briefly serving a stale bundle from a different worktree (`wf_fef76a58-b6b-65`) mid-run; a clean re-run against this worktree's own freshly-spawned server on the same port passed cleanly, and I did not modify the shared `playwright.config.ts`.

Committed as QueaT <kgm004a@gmail.com> on branch fix/audit-analytics-a-real-getanalytics-failure-si, no Claude trailers, pushed to origin.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
