### PR TITLE
fix: Analytics tab (and Topic-threads / Egress-ledger children) flash empty/Loading on every revisit — component-local signals not covered by TabRouteReuseStrategy

### DIFF
--- a/e2e/analytics/stale-while-revalidate.spec.ts
+++ b/e2e/analytics/stale-while-revalidate.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Analytics (+ its Topic-threads / Egress-ledger children) — a navigate-away
+ * -and-back to `/analytics` must show the LAST-KNOWN numbers INSTANTLY, not
+ * blank the whole dashboard to "Loading…" first. `/analytics` is not one of
+ * the three routes `TabRouteReuseStrategy` keeps alive (`meeting/:id` /
+ * `notes/:id` / `org-item/:id`), so `AnalyticsComponent` (and its
+ * `TopicThreadsComponent` / `EgressLedgerComponent` children) are genuinely
+ * destroyed and recreated on every visit — the stale-while-revalidate
+ * contract (`angular-zoneless.md` §8) is what must survive that, via the
+ * root-persisted `AnalyticsStore` / `TopicThreadsStore` / `EgressLedgerStore`.
+ *
+ * The IPC responses below carry an artificial delay so a REGRESSION (state
+ * wiped back to component-local signals) is observable: on the return visit
+ * the numbers would disappear behind "Loading…" until the delayed promise
+ * resolves. On the fix, the numbers stay on screen the whole time — the
+ * (still real, still unconditional) background refetch just replaces them
+ * silently once it resolves.
+ *
+ * RED contract: reverting the `AnalyticsStore`/`TopicThreadsStore`/
+ * `EgressLedgerStore` root services back to component-local `signal()`s (and
+ * the templates back to gating solely on `loading()`) makes this spec fail —
+ * the hero stat / thread label / egress tile assertions taken immediately
+ * after the second `page.goto("/analytics")` would find "Loading…" instead.
+ */
+test("Analytics dashboard shows cached data instantly on a return visit, not a Loading flash", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    // A deliberate delay on every relevant command so a wiped-state regression
+    // would show "Loading…" for a beat on the SECOND visit too.
+    get_analytics: () =>
+      new Promise((resolve) =>
+        setTimeout(
+          () =>
+            resolve({
+              totalMeetings: 47,
+              totalDurationS: 95880,
+              avgDurationS: 2040,
+              longestDurationS: 3720,
+              meetings7d: 9,
+              duration7dS: 17640,
+              notesCount: 44,
+              firstMeetingAt: new Date(
+                Date.now() - 58 * 86_400_000,
+              ).toISOString(),
+              byStatus: [{ status: "EXPORTED", count: 41 }],
+              perDay: [],
+            }),
+          400,
+        ),
+      ),
+    topic_threads: () =>
+      new Promise((resolve) =>
+        setTimeout(
+          () =>
+            resolve([
+              {
+                label: "Loopback blocker",
+                count: 3,
+                mentions: [
+                  {
+                    meetingId: "m-1",
+                    title: "Eng Sync",
+                    startedAt: new Date().toISOString(),
+                    startS: 12,
+                  },
+                ],
+              },
+            ]),
+          400,
+        ),
+      ),
+    get_egress_ledger: () =>
+      new Promise((resolve) =>
+        setTimeout(
+          () =>
+            resolve({
+              totalCalls: 12,
+              totalTokens: 48000,
+              byModel: [{ model: "claude-sonnet-4-6", tokens: 48000 }],
+              byDay: [],
+              totalRedactions: { email: 2, card: 0, phone: 1, name: 3 },
+              recent: [],
+            }),
+          400,
+        ),
+      ),
+  });
+
+  // First visit: the dashboard loads (spinner is fine — nothing cached yet).
+  // A full `page.goto` is fine here — it's the initial app boot either way.
+  await page.goto("/analytics");
+  await expect(page.getByText("Total meetings")).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByText("Loopback blocker")).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByText("Cloud calls")).toBeVisible({ timeout: 5_000 });
+
+  // Navigate away via an IN-APP router link (NOT `page.goto`, which forces a
+  // full browser navigation and reboots the whole Angular app — including
+  // the root services this fix relies on — defeating the very persistence
+  // being tested). This is a plain SPA route swap to a route NOT covered by
+  // `TabRouteReuseStrategy`, so `/analytics` and its children are genuinely
+  // destroyed.
+  await page.getByRole("link", { name: "Meetings", exact: true }).click();
+  await expect(page.getByText("Total meetings")).toBeHidden();
+
+  // Navigate BACK, again via the in-app link. The "Insights" sidebar
+  // section (which holds the Analytics link) auto-collapses once its route
+  // is no longer active, so expand it first.
+  const insightsToggle = page.getByRole("button", { name: "Expand Insights" });
+  if (await insightsToggle.isVisible()) {
+    await insightsToggle.click();
+  }
+  // Navigate BACK — the cached numbers/threads/ledger must render INSTANTLY,
+  // i.e. before the freshly-delayed IPC promises above have any chance to
+  // resolve (they take 400ms; assert well inside that window).
+  await page.getByRole("link", { name: "Analytics", exact: true }).click();
+  await expect(page.getByText("Total meetings")).toBeVisible({
+    timeout: 250,
+  });
+  await expect(page.locator(".stat-value", { hasText: "47" })).toBeVisible({
+    timeout: 250,
+  });
+  await expect(page.getByText("Loopback blocker")).toBeVisible({
+    timeout: 250,
+  });
+  await expect(page.getByText("Cloud calls")).toBeVisible({ timeout: 250 });
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src/app/features/analytics/analytics/analytics.component.html
+++ b/src/app/features/analytics/analytics/analytics.component.html
@@ -6,7 +6,7 @@
     }
   </header>
 
-  @if (loading()) {
+  @if (isEmpty() && loading()) {
     <div class="card state-card">
       <p class="empty">Loading…</p>
     </div>

--- a/src/app/features/analytics/analytics/analytics.component.ts
+++ b/src/app/features/analytics/analytics/analytics.component.ts
@@ -4,10 +4,9 @@ import {
   OnInit,
   computed,
   inject,
-  signal,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
-import type { Analytics } from "../../../core/models";
+import { AnalyticsStore } from "../../../services/analytics-store.service";
 import { EgressLedgerComponent } from "../egress-ledger/egress-ledger.component";
 import { TopicThreadsComponent } from "../topic-threads/topic-threads.component";
 import { WeeklyDigestComponent } from "../weekly-digest/weekly-digest.component";
@@ -53,9 +52,14 @@ const STATUS_ORDER = [
 })
 export class AnalyticsComponent implements OnInit {
   private readonly ipc = inject(IpcService);
+  private readonly store = inject(AnalyticsStore);
 
-  readonly data = signal<Analytics | null>(null);
-  readonly loading = signal(true);
+  /**
+   * Root-persisted so a navigate-away-and-back shows the LAST-KNOWN numbers
+   * instantly instead of blanking to "Loading…" — see `AnalyticsStore`.
+   */
+  readonly data = this.store.data;
+  readonly loading = this.store.loading;
 
   readonly isEmpty = computed(() => {
     const a = this.data();

--- a/src/app/features/analytics/egress-ledger/egress-ledger.component.html
+++ b/src/app/features/analytics/egress-ledger/egress-ledger.component.html
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  @if (loading()) {
+  @if (!ledger() && loading()) {
     <p class="empty">Loading…</p>
   }
   @if (error(); as err) {

--- a/src/app/features/analytics/egress-ledger/egress-ledger.component.ts
+++ b/src/app/features/analytics/egress-ledger/egress-ledger.component.ts
@@ -4,10 +4,9 @@ import {
   computed,
   effect,
   inject,
-  signal,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
-import type { EgressLedger } from "../../../core/models";
+import { EgressLedgerStore } from "../../../services/egress-ledger-store.service";
 
 /** Selectable rolling-window lengths (in days). */
 const RANGES = [7, 30, 90] as const;
@@ -30,18 +29,24 @@ type Range = (typeof RANGES)[number];
 })
 export class EgressLedgerComponent {
   private readonly ipc = inject(IpcService);
+  private readonly store = inject(EgressLedgerStore);
 
   readonly ranges = RANGES;
 
-  /** The selected rolling window. Writing this signal re-triggers the load effect. */
-  readonly days = signal<Range>(30);
+  /**
+   * The selected rolling window. Writing this signal re-triggers the load
+   * effect. Root-persisted (see `EgressLedgerStore`) so a navigate-away-and
+   * -back keeps both the chosen window AND the last-known ledger instead of
+   * resetting to 30d + blanking to "Loading…".
+   */
+  readonly days = this.store.days;
 
-  private readonly _ledger = signal<EgressLedger | null>(null);
+  private readonly _ledger = this.store.ledger;
   /** The loaded ledger (null while loading or on error). */
   readonly ledger = this._ledger.asReadonly();
 
-  readonly loading = signal(false);
-  readonly error = signal<string | null>(null);
+  readonly loading = this.store.loading;
+  readonly error = this.store.error;
 
   /**
    * Per-model bars with their width % precomputed (denominator = the max model's tokens).
@@ -87,6 +92,17 @@ export class EgressLedgerComponent {
     return r.email + r.card + r.phone + r.name;
   });
 
+  /**
+   * The window this effect last fetched for, or `undefined` before the
+   * first run. NOT a signal — it's private bookkeeping the effect itself
+   * reads/writes to distinguish "the user just switched 7↔30↔90" (clear the
+   * stale bars before refetching) from "this component instance just
+   * (re)mounted onto an already-populated `EgressLedgerStore`" (keep the
+   * cached ledger on screen while the background refetch runs — the
+   * stale-while-revalidate contract in `angular-zoneless.md` §8).
+   */
+  private lastFetchedDays: Range | undefined;
+
   // This effect writes `loading` / `error` / `_ledger` (all signals) before and
   // after the async IPC call — signal writes in effects are allowed since Angular 19.
   private readonly _load = effect(
@@ -94,9 +110,18 @@ export class EgressLedgerComponent {
       const d = this.days();
       this.loading.set(true);
       this.error.set(null);
-      // Clear the previous window's data so the loading state doesn't render stale bars
-      // alongside the spinner during the refetch (clean transition on 7↔30↔90 toggles).
-      this._ledger.set(null);
+      // Clear the previous window's data on a REAL window switch, so the
+      // loading state doesn't render stale bars from a different window
+      // alongside the spinner (clean transition on 7↔30↔90 toggles) — but
+      // NOT on the effect's first run for this instance, so a cached ledger
+      // from a prior mount (same window) stays visible during the refetch.
+      if (
+        this.lastFetchedDays !== undefined &&
+        this.lastFetchedDays !== d
+      ) {
+        this._ledger.set(null);
+      }
+      this.lastFetchedDays = d;
       void this.fetch(d);
     },
   );

--- a/src/app/features/analytics/topic-threads/topic-threads.component.html
+++ b/src/app/features/analytics/topic-threads/topic-threads.component.html
@@ -6,7 +6,7 @@
     }
   </div>
 
-  @if (loading()) {
+  @if (threads().length === 0 && loading()) {
     <p class="empty">Loading…</p>
   } @else if (error()) {
     <div class="banner is-danger" role="alert">{{ error() }}</div>

--- a/src/app/features/analytics/topic-threads/topic-threads.component.ts
+++ b/src/app/features/analytics/topic-threads/topic-threads.component.ts
@@ -7,7 +7,7 @@ import {
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
-import type { TopicThread } from "../../../core/models";
+import { TopicThreadsStore } from "../../../services/topic-threads-store.service";
 
 /**
  * "Topic threads" — cross-meeting topic clusters surfaced on the Analytics
@@ -34,13 +34,19 @@ import type { TopicThread } from "../../../core/models";
 })
 export class TopicThreadsComponent implements OnInit {
   private readonly ipc = inject(IpcService);
+  private readonly store = inject(TopicThreadsStore);
 
-  /** All loaded threads, sorted multi-mention first (most-discussed topics up top). */
-  readonly threads = signal<TopicThread[]>([]);
+  /**
+   * All loaded threads, sorted multi-mention first (most-discussed topics up
+   * top). Root-persisted so a navigate-away-and-back shows the LAST-KNOWN
+   * threads instantly instead of blanking to "Loading…" — see
+   * `TopicThreadsStore`.
+   */
+  readonly threads = this.store.threads;
   /** True while {@link IpcService.topicThreads} is in flight. */
-  readonly loading = signal(true);
+  readonly loading = this.store.loading;
   /** Inline error message; null when clear. */
-  readonly error = signal<string | null>(null);
+  readonly error = this.store.error;
 
   /** Labels of the currently-expanded threads. */
   private readonly openLabels = signal<ReadonlySet<string>>(new Set());

--- a/src/app/services/analytics-store.service.ts
+++ b/src/app/services/analytics-store.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, signal } from "@angular/core";
+import type { Analytics } from "../core/models";
+
+/**
+ * Root-persisted backing signals for {@link AnalyticsComponent} — split out
+ * from the component itself so the DATA survives a destroy+recreate (leaving
+ * `/analytics` for another tab, then coming back): a component-local
+ * `signal<Analytics | null>(null)` is wiped to `null` on every remount,
+ * forcing a full "Loading…" flash even though the numbers barely changed.
+ * `/analytics` is NOT one of the three routes `TabRouteReuseStrategy` keeps
+ * alive (`meeting/:id` / `notes/:id` / `org-item/:id` — see its doc), so this
+ * component is genuinely destroyed and recreated on every navigate-away and
+ * back. A root service instance outlives the component, so the dashboard
+ * renders with the LAST-KNOWN numbers INSTANTLY on return while
+ * `AnalyticsComponent.ngOnInit`'s existing reload (unchanged — still a real
+ * refetch every visit) quietly replaces it underneath.
+ *
+ * Deliberately a thin signal holder, NOT a service with its own load()
+ * method: `AnalyticsComponent` keeps owning the fetch — it just reads/writes
+ * THESE signals instead of component-local ones. Mirrors `MeetingsListStore`
+ * (see `angular-zoneless.md` §8).
+ */
+@Injectable({ providedIn: "root" })
+export class AnalyticsStore {
+  readonly data = signal<Analytics | null>(null);
+  readonly loading = signal(true);
+}

--- a/src/app/services/egress-ledger-store.service.ts
+++ b/src/app/services/egress-ledger-store.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, signal } from "@angular/core";
+import type { EgressLedger } from "../core/models";
+
+/** Selectable rolling-window lengths (in days) — mirrors the component's own `RANGES`. */
+type Range = 7 | 30 | 90;
+
+/**
+ * Root-persisted backing signals for {@link EgressLedgerComponent} — split
+ * out from the component itself so the DATA survives a destroy+recreate
+ * (leaving `/analytics` for another tab, then coming back). `/analytics` is
+ * NOT covered by `TabRouteReuseStrategy` (only `meeting/:id` / `notes/:id` /
+ * `org-item/:id` are — see its doc), so this component — nested inside
+ * `AnalyticsComponent` — is genuinely destroyed and recreated on every
+ * navigate-away and back; component-local `signal<EgressLedger | null>(null)`
+ * + `signal<Range>(30)` would wipe to their initial values every time,
+ * forcing a "Loading…" flash and resetting the 7/30/90 toggle back to 30d. A
+ * root service instance outlives the component, so the ledger (and the
+ * user's chosen window) render with the LAST-KNOWN state INSTANTLY on
+ * return while the component's existing load effect (unchanged — still a
+ * real refetch every visit) quietly replaces the ledger underneath.
+ *
+ * Deliberately a thin signal holder, NOT a service with its own load()
+ * method: `EgressLedgerComponent` keeps owning the fetch (its `_load`
+ * effect) — it just reads/writes THESE signals instead of component-local
+ * ones. Mirrors `MeetingsListStore` (see `angular-zoneless.md` §8).
+ */
+@Injectable({ providedIn: "root" })
+export class EgressLedgerStore {
+  readonly days = signal<Range>(30);
+  readonly ledger = signal<EgressLedger | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+}

--- a/src/app/services/topic-threads-store.service.ts
+++ b/src/app/services/topic-threads-store.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, signal } from "@angular/core";
+import type { TopicThread } from "../core/models";
+
+/**
+ * Root-persisted backing signals for {@link TopicThreadsComponent} — split
+ * out from the component itself so the DATA survives a destroy+recreate
+ * (leaving `/analytics` for another tab, then coming back). `/analytics` is
+ * NOT covered by `TabRouteReuseStrategy` (only `meeting/:id` / `notes/:id` /
+ * `org-item/:id` are — see its doc), so this component — nested inside
+ * `AnalyticsComponent` — is genuinely destroyed and recreated on every
+ * navigate-away and back; a component-local `signal<TopicThread[]>([])`
+ * would wipe to empty every time, forcing a "Loading…" flash. A root
+ * service instance outlives the component, so the threads render with the
+ * LAST-KNOWN rows INSTANTLY on return while `ngOnInit`'s existing reload
+ * (unchanged — still a real refetch every visit) quietly replaces it
+ * underneath.
+ *
+ * Deliberately a thin signal holder, NOT a service with its own load()
+ * method: `TopicThreadsComponent` keeps owning the fetch — it just
+ * reads/writes THESE signals instead of component-local ones. Mirrors
+ * `MeetingsListStore` (see `angular-zoneless.md` §8).
+ */
+@Injectable({ providedIn: "root" })
+export class TopicThreadsStore {
+  readonly threads = signal<TopicThread[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+}


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

AnalyticsComponent's `data` signal, TopicThreadsComponent's `threads` signal, and EgressLedgerComponent's `_ledger` signal are all component-local `signal()`s populated once in ngOnInit/an effect, not backed by a `providedIn:'root'` service. `/analytics` is verified NOT one of the three routes (`meeting/:id`, `notes/:id`, `org-item/:id`) covered by TabRouteReuseStrategy (src/app/core/tab-route-reuse.strategy.ts's `tabKey()`), so every navigate-away-and-back destroys and recreates AnalyticsComponent (and its children) from scratch, wiping all three signals to their initial empty/null values. All three templates gate their entire content behind an unconditional `@if (loading())` (verified at analytics.component.html:9, topic-threads.component.html:9, egress-ledger.component.html:20) rather than `@if (isEmpty() && loading())`, so a RETURN visit to Analytics always shows a blank 'Loading…' flash before the (identical) data reappears — this is the same anti-pattern documented as the 2026-07-12 incident in `.claude/rules/angular-zoneless.md` §8 (NotesHomeComponent / LibraryComponent), not yet remediated on the Analytics surface.

**Repro:** 1) Open the app, navigate to Analytics (data loads and renders). 2) Navigate to any other tab, then back to Analytics. Observe the whole dashboard (hero stats, chart, topic threads, egress ledger) blanks to 'Loading…'/empty-state before repopulating with essentially the same numbers, instead of showing cached rows instantly while a background refetch runs underneath (stale-while-revalidate per angular-zoneless.md §8).

## Fix

Confirmed root cause: AnalyticsComponent.data/loading, TopicThreadsComponent.threads/loading/error, and EgressLedgerComponent's ledger/loading/error/days were component-local signal()s, wiped every time these components are destroyed+recreated (Analytics is not one of the three routes TabRouteReuseStrategy keeps alive). All three templates also gated their entire content behind an unconditional @if (loading()), so every return visit flashed empty/Loading before the same numbers reappeared -- the same anti-pattern already fixed for NotesHomeComponent/LibraryComponent per angular-zoneless.md §8.

Fix: added three providedIn:'root' signal-holder services (AnalyticsStore, TopicThreadsStore, EgressLedgerStore) mirroring the proven MeetingsListStore pattern; the three components now read/write these root-persisted signals instead of local ones (fetch orchestration unchanged -- still a real refetch every visit); templates now gate loading on emptiness (isEmpty() && loading(), threads().length===0 && loading(), !ledger() && loading()) so cached content renders instantly while the refetch runs underneath. Also fixed a second latent bug found while implementing: EgressLedgerComponent's load effect unconditionally nulled the ledger on every run including a fresh component mount, which would have silently defeated the store-persistence fix -- added non-signal bookkeeping (lastFetchedDays) so it only clears on a genuine window switch.

Added e2e/analytics/stale-while-revalidate.spec.ts and verified RED-before-GREEN: stashed the fix, confirmed the test fails against pre-fix code reproducing the exact reported symptom (cached content not visible immediately after navigating back), then restored the fix and confirmed it passes. npx ng lint and npx ng build both clean (frontend-only change, cargo test --lib not applicable/not run per task scope).

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
