### PR TITLE
fix: Onboarding model-presence probe has no stale-response guard on rapid language/quality changes

### DIFF
--- a/e2e/onboarding/model-presence-race.spec.ts
+++ b/e2e/onboarding/model-presence-race.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Regression test for the onboarding Model step's stale-response guard.
+ *
+ * `onLanguage`/`onModelSize` each call `refreshModelPresence()`, which does
+ * `modelPresent.set(null)` → `await persistConfig()` → `modelPresent.set(await
+ * ipc.modelPresent())`. Rapidly switching the Quality dropdown fires two
+ * overlapping calls; without a stale-result guard, whichever `model_present`
+ * IPC call resolves LAST wins, even if it belongs to an earlier, no-longer-
+ * selected quality. This test forces the FIRST call's `model_present`
+ * ("small", present) to resolve AFTER the second one ("medium", absent —
+ * opposite of call order) and asserts the final `modelPresent()` state
+ * matches the CURRENTLY selected quality ("medium", absent), not the stale
+ * first pick.
+ */
+test("rapid Quality switches don't leave a stale modelPresent state", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    // "small" resolves SLOW (present); "medium" resolves FAST (absent) — so
+    // if there is no stale-result guard, the slow "small" response lands
+    // LAST and overwrites the fast "medium" response, even though "medium"
+    // is the currently selected quality by the time both probes settle.
+    model_present: (args: any) => {
+      const w = window as any;
+      const size = (w.__demoConfig && w.__demoConfig.modelSize) || "";
+      const delayMs = size === "small" ? 400 : 50;
+      return new Promise((resolve) =>
+        setTimeout(() => resolve(size === "small"), delayMs),
+      );
+    },
+    save_config: (args: any) => {
+      const w = window as any;
+      w.__demoConfig = Object.assign({}, w.__demoConfig, args.config);
+      return null;
+    },
+  });
+
+  await page.goto("/onboarding");
+  await page.getByRole("button", { name: "Get started" }).click();
+
+  // Let the initial onEnterStep("model") probe (whatever the demo default
+  // quality is) settle into SOME terminal state before starting the race.
+  const qualitySelect = page.locator("select").nth(1);
+  await expect(
+    page.locator(".model-state .pill.is-success, .model-state button"),
+  ).toBeVisible({ timeout: 5_000 });
+
+  // Rapidly switch Quality small -> medium within the round-trip window: the
+  // "small" probe (slow, 400ms) is still in flight when "medium" (fast,
+  // 50ms) fires right after it.
+  await qualitySelect.selectOption("small");
+  await qualitySelect.selectOption("medium");
+
+  // Wait past BOTH probes' resolution windows (400ms slow + 50ms fast) so the
+  // late-resolving "small" response has had every chance to land and, on the
+  // unguarded code, overwrite the correct "medium" result.
+  await page.waitForTimeout(700);
+
+  // The CURRENT selection is "medium", which is NOT present on disk — the
+  // final state must reflect that (a "Download model" affordance), never the
+  // stale "small" response landing later and claiming the model is ready.
+  await expect(
+    page.getByRole("button", { name: /Download model/ }),
+  ).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Model ready")).not.toBeVisible();
+});

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -309,11 +309,26 @@ export class OnboardingComponent implements OnInit {
     await this.refreshModelPresence();
   }
 
+  /**
+   * Stale-result guard for `refreshModelPresence` (mirrors
+   * `entity-detail.component.ts`'s `_load`): rapidly switching the language or
+   * quality dropdown fires two overlapping calls, each awaiting
+   * `persistConfig()` then `ipc.modelPresent()`; without a guard, whichever
+   * `modelPresent()` resolves LAST wins regardless of which selection is
+   * actually current. Bumped at the start of every call; a call only commits
+   * its own result if it is still the most recent one after each await.
+   */
+  private modelPresenceRequestId = 0;
+
   /** Persist the chosen language + size, then re-check what's on disk. */
   private async refreshModelPresence(): Promise<void> {
+    const requestId = ++this.modelPresenceRequestId;
     this.modelPresent.set(null);
     await this.persistConfig();
-    this.modelPresent.set(await this.ipc.modelPresent());
+    if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
+    const present = await this.ipc.modelPresent();
+    if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
+    this.modelPresent.set(present);
   }
 
   async downloadModel(): Promise<void> {


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** low

OnboardingComponent.onLanguage/onModelSize each call refreshModelPresence(), which does `modelPresent.set(null); await persistConfig(); modelPresent.set(await ipc.modelPresent())`. These are plain `(change)` event handlers, not an effect with a captured/compared input, and there is no request-id or 'is this still the current selection' check before the final `modelPresent.set(...)`. If a user changes the language or quality dropdown twice in quick succession, two overlapping `refreshModelPresence()` calls race; whichever `ipc.modelPresent()` resolves last wins, regardless of which dropdown value is actually selected at that time. Because `canAdvance()` for the 'model' step is gated purely on `modelPresent() === true`, this can transiently show the wrong ready/needs-download state for the currently-selected model (self-corrects on any further interaction, so severity is low, but it is the same 'unguarded async fetch that can write stale state' shape the codebase treats as a real bug class elsewhere, e.g. entity-detail.component.ts's documented stale-result guard).

**Repro:** In the onboarding Model step, rapidly switch the Quality dropdown between two sizes where one is present on disk and the other is not (e.g. an already-downloaded 'small' then 'large-v3' then back to 'small' within the round-trip time of the modelPresent() IPC call). Because refreshModelPresence() sets modelPresent to null then re-populates it with no guard against a newer selection having started in the meantime, the final displayed ready/needs-download state can correspond to a stale intermediate selection rather than the currently-selected modelSize()/language().

## Fix

Confirmed the bug as described: `OnboardingComponent.refreshModelPresence()` (src/app/features/onboarding/onboarding/onboarding.component.ts) did `modelPresent.set(null); await persistConfig(); modelPresent.set(await ipc.modelPresent())` with no stale-result guard, called from plain `(change)` handlers (onLanguage/onModelSize) rather than an effect tracking a captured input. Rapidly switching the Quality/Language dropdown fired two overlapping calls; whichever `ipc.modelPresent()` resolved last won, regardless of which selection was actually current — a real, reproducible race (I traced page-console logs showing exactly this: a slow "small" probe overwriting a fast "medium" probe's correct result).

Fix: added a monotonic `modelPresenceRequestId` counter, bumped at the start of every `refreshModelPresence()` call, checked after each `await` (persistConfig, then ipc.modelPresent()) before committing a write — a superseded call returns early instead of writing stale state. This mirrors the existing stale-result-guard shape used in `entity-detail.component.ts`'s `_load` effect (capture-then-compare-after-await), adapted to a non-effect call site since onLanguage/onModelSize are plain event handlers, not an effect tracking a signal input.

Added a Playwright e2e regression test (e2e/onboarding/model-presence-race.spec.ts) that mocks `model_present` to resolve "small" (present) SLOW (400ms) and "medium" (absent) FAST (50ms), rapidly switches the Quality dropdown small→medium, waits past both resolution windows, then asserts the final state reflects "medium" (Download-model affordance), never a stale "Model ready". Verified RED-before-GREEN by running this test on an isolated Playwright port (4291/4292, avoiding the shared :4210 dev-server port other concurrent agent sessions were using) against the pre-fix code (failed — showed "Model ready" i.e. the stale "small" result won) and against the fixed code (passed).

Gates run: `npx ng lint` — clean ("All files pass linting"). `npx ng build` — clean (Application bundle generation complete, onboarding-component chunk unaffected style-budget-wise). This is a frontend-only change so `cargo test --lib` was not required/run (no src-tauri touch). Not run: the full `npm run test:e2e` suite against the shared :4210 port, deliberately avoided due to multiple other concurrent agent sessions actively using that port in this shared worktree environment (per the repo's documented worktree-collision trap) — verified instead via an isolated dedicated port, which is an equivalent but non-colliding proof.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed where applicable).
