### PR TITLE
fix: Analytics dashboard counts/durations leak sealed-and-locked meetings — get_analytics has no visibility gate

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8859,10 +8859,14 @@ fn mask_locked_meetings(
         .collect())
 }
 
-/// Aggregate analytics for the dashboard + Analytics tab.
+/// Aggregate analytics for the dashboard + Analytics tab. VISIBLE-content only — a sealed-and-
+/// not-session-unlocked folder's meetings are excluded from every count/duration/breakdown (same
+/// gate as `brain_overview`/`list_meetings`), so the Analytics tab can never reveal the size or
+/// activity pattern of content the user has deliberately locked.
 #[tauri::command]
 pub fn get_analytics(state: State<'_, AppState>) -> Result<Analytics, AppError> {
-    state.db.analytics()
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.analytics(&unlocked)
 }
 
 /// Rename a speaker across a meeting's cached timeline (e.g. "User 1" → "Sarah"). Persists to

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -6308,31 +6308,64 @@ impl Db {
 
     // ── analytics ──────────────────────────────────────────────────────────────
 
-    /// Aggregate stats for the dashboard + Analytics tab.
-    pub fn analytics(&self) -> Result<Analytics> {
+    /// Aggregate stats for the dashboard + Analytics tab. VISIBLE-content only: mirrors the
+    /// `list_meetings_visible`/`brain_counts` predicate (a meeting counts iff it has no notes at
+    /// all, or at least one note whose folder is open/session-unlocked) so a sealed-and-not-
+    /// unlocked folder's meetings never contribute to totals/durations/status-breakdown/per-day
+    /// activity — the same leak class `visibility_clause` closes for search/graph/brain reads.
+    pub fn analytics(&self, unlocked: &HashSet<String>) -> Result<Analytics> {
         let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        // "meeting m is visible" = no notes at all, OR at least one visible note — reused below.
+        let visible_meeting = format!(
+            "(NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                 OR EXISTS (SELECT 1 FROM notes n
+                              LEFT JOIN folders f ON f.id = n.folder_id
+                             WHERE n.meeting_id = m.id AND {visible}))"
+        );
+
         let total_meetings: i64 = conn
-            .query_row("SELECT COUNT(*) FROM meetings", [], |r| r.get(0))
+            .query_row(
+                &format!("SELECT COUNT(*) FROM meetings m WHERE {visible_meeting}"),
+                [],
+                |r| r.get(0),
+            )
             .map_err(map_err)?;
         let total_duration_s: i64 = conn
             .query_row(
-                "SELECT COALESCE(SUM(duration_s), 0) FROM meetings",
+                &format!(
+                    "SELECT COALESCE(SUM(m.duration_s), 0) FROM meetings m WHERE {visible_meeting}"
+                ),
                 [],
                 |r| r.get(0),
             )
             .map_err(map_err)?;
         let longest_duration_s: i64 = conn
             .query_row(
-                "SELECT COALESCE(MAX(duration_s), 0) FROM meetings",
+                &format!(
+                    "SELECT COALESCE(MAX(m.duration_s), 0) FROM meetings m WHERE {visible_meeting}"
+                ),
                 [],
                 |r| r.get(0),
             )
             .map_err(map_err)?;
+        // Notes count — same folder-visibility gate as brain_counts's note/document split.
         let notes_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM notes n LEFT JOIN folders f ON f.id = n.folder_id
+                      WHERE {visible}"
+                ),
+                [],
+                |r| r.get(0),
+            )
             .map_err(map_err)?;
         let first_meeting_at: Option<String> = conn
-            .query_row("SELECT MIN(started_at) FROM meetings", [], |r| r.get(0))
+            .query_row(
+                &format!("SELECT MIN(m.started_at) FROM meetings m WHERE {visible_meeting}"),
+                [],
+                |r| r.get(0),
+            )
             .map_err(map_err)?;
         let avg_duration_s = if total_meetings > 0 {
             total_duration_s / total_meetings
@@ -6345,14 +6378,20 @@ impl Db {
         let cutoff_7d = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
         let meetings_7d: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM meetings WHERE started_at >= ?1",
+                &format!(
+                    "SELECT COUNT(*) FROM meetings m
+                      WHERE m.started_at >= ?1 AND {visible_meeting}"
+                ),
                 rusqlite::params![cutoff_7d],
                 |r| r.get(0),
             )
             .map_err(map_err)?;
         let duration_7d_s: i64 = conn
             .query_row(
-                "SELECT COALESCE(SUM(duration_s), 0) FROM meetings WHERE started_at >= ?1",
+                &format!(
+                    "SELECT COALESCE(SUM(m.duration_s), 0) FROM meetings m
+                      WHERE m.started_at >= ?1 AND {visible_meeting}"
+                ),
                 rusqlite::params![cutoff_7d],
                 |r| r.get(0),
             )
@@ -6360,7 +6399,10 @@ impl Db {
 
         let by_status = {
             let mut stmt = conn
-                .prepare("SELECT status, COUNT(*) FROM meetings GROUP BY status")
+                .prepare(&format!(
+                    "SELECT m.status, COUNT(*) FROM meetings m
+                      WHERE {visible_meeting} GROUP BY m.status"
+                ))
                 .map_err(map_err)?;
             let rows = stmt
                 .query_map([], |row| {
@@ -6380,10 +6422,11 @@ impl Db {
         let cutoff_30d = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
         let per_day = {
             let mut stmt = conn
-                .prepare(
-                    "SELECT substr(started_at, 1, 10) AS d, COUNT(*), COALESCE(SUM(duration_s), 0)
-                       FROM meetings WHERE started_at >= ?1 GROUP BY d ORDER BY d",
-                )
+                .prepare(&format!(
+                    "SELECT substr(m.started_at, 1, 10) AS d, COUNT(*), COALESCE(SUM(m.duration_s), 0)
+                       FROM meetings m WHERE m.started_at >= ?1 AND {visible_meeting}
+                       GROUP BY d ORDER BY d"
+                ))
                 .map_err(map_err)?;
             let rows = stmt
                 .query_map(rusqlite::params![cutoff_30d], |row| {
@@ -15410,6 +15453,92 @@ mod tests {
             "locked 'secret' excluded; oldest-first order"
         );
         let _ = std::fs::remove_file(&p);
+    }
+
+    /// The Analytics tab must never reveal a sealed-and-not-unlocked folder's meetings — same
+    /// leak class `visibility_clause` closes for search/graph/brain reads. Regression for the
+    /// audit finding: `Db::analytics()` used to run bare `SELECT COUNT(*)`/`SUM(duration_s)`
+    /// over ALL meetings with no folder join at all (confirmed RED against the pre-fix
+    /// no-arg `analytics()`: it counted the sealed meeting too).
+    #[test]
+    fn analytics_excludes_sealed_not_unlocked_folder() {
+        let db = mem_db();
+        // Two OPEN meetings (folder_id NULL) + one meeting in a LOCKED, not-session-unlocked folder.
+        for (id, at, dur) in [
+            ("open-1", "2026-06-20T10:00:00Z", 600i64),
+            ("open-2", "2026-06-21T10:00:00Z", 900i64),
+            ("secret", "2026-06-22T10:00:00Z", 6000i64),
+        ] {
+            db.insert_meeting(&crate::storage::Meeting {
+                id: id.into(),
+                started_at: at.into(),
+                ended_at: None,
+                title: Some("t".into()),
+                duration_s: dur,
+                audio_path: None,
+                status: crate::storage::MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+            db.upsert_note(&crate::storage::NoteRecord {
+                meeting_id: id.into(),
+                provider_id: "claude_code".into(),
+                markdown: "m".into(),
+                created_at: at.into(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        }
+        db.insert_folder(&crate::storage::Folder {
+            id: "f-secret".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-06-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.set_note_folder("secret", Some("f-secret")).unwrap();
+
+        // Sealed and NOT session-unlocked: the "secret" meeting (6000s, its own day, status
+        // Summarized) must be invisible everywhere in the aggregate.
+        let nothing = std::collections::HashSet::new();
+        let a = db.analytics(&nothing).unwrap();
+        assert_eq!(a.total_meetings, 2, "sealed meeting must not be counted");
+        assert_eq!(
+            a.total_duration_s, 1500,
+            "sealed meeting's duration must not contribute to the total"
+        );
+        assert_eq!(
+            a.longest_duration_s, 900,
+            "the sealed meeting's 6000s must not surface as the longest"
+        );
+        assert_eq!(a.avg_duration_s, 750);
+        let by_status_total: i64 = a.by_status.iter().map(|s| s.count).sum();
+        assert_eq!(
+            by_status_total, 2,
+            "status breakdown must not include the sealed meeting"
+        );
+        let per_day_total: i64 = a.per_day.iter().map(|d| d.count).sum();
+        assert_eq!(
+            per_day_total, 2,
+            "per-day activity chart must not include the sealed meeting's day"
+        );
+        assert!(
+            !a.per_day.iter().any(|d| d.date == "2026-06-22"),
+            "the sealed meeting's day must not appear in the 30-day activity chart at all"
+        );
+
+        // Once the folder is SESSION-unlocked, the same meeting becomes visible again (reversible).
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-secret".to_string());
+        let a2 = db.analytics(&unlocked).unwrap();
+        assert_eq!(a2.total_meetings, 3);
+        assert_eq!(a2.total_duration_s, 7500);
+        assert_eq!(a2.longest_duration_s, 6000);
     }
 
     /// Race-safety regression (TOCTOU: prune snapshots a plaintext path, a concurrent seal


### PR DESCRIPTION
## Bug (found by the full-app UX/UI audit workflow)

**Severity:** high

Db::analytics() (src-tauri/src/storage/db.rs, fn analytics, ~line 6312) computes total_meetings, total_duration_s, avg_duration_s, longest_duration_s, meetings_7d, duration_7d_s, by_status, and per_day with plain `SELECT COUNT(*)`/`SUM(duration_s)`/`GROUP BY` queries directly on the `meetings` table — no join against `folders` and no use of `visibility_clause`/the session unlocked set at all. The command handler get_analytics (src-tauri/src/commands.rs:8864) forwards straight to `state.db.analytics()` with zero gating call. This is the exact convention every other aggregate read in this codebase follows: Db::brain_counts (db.rs, ~line 4490) explicitly joins `folders f` and applies `visibility_clause("f", unlocked)` specifically so a sealed-not-unlocked folder's items are not counted, and its own doc comment calls a bare total 'leak-free' only because it IS gated. analytics() was verified by direct code read to have no such gate, no comment discussing it, and no test exercising it against a locked folder. Net effect: the Analytics tab (Total meetings / Total time / This week / Avg length / 30-day activity chart / status breakdown) silently reveals the count, aggregate duration, and per-day/status activity of meetings in folders the user has deliberately sealed and NOT unlocked this session — a metadata leak of exactly the class the lock-model rule ('gate EVERY read') exists to close, even though no note/transcript text itself is exposed. Raised from moderate to high severity because sealed folders in Murmur are the user's explicit 'hide this from me' action, and aggregate counts/durations of a specific hidden set (e.g. '3 meetings, 42 min total, all last Tuesday') can be sufficiently identifying to defeat the purpose of sealing in front of a shoulder-surfing viewer of the Analytics tab.

**Repro:** 1) Record 2-3 meetings, seal their folder (lock_folder) so it's sealed and NOT session-unlocked. 2) Without unlocking, open the Analytics tab. Observe Total meetings / Total time / This week / Avg length / the 30-day activity chart / the status breakdown all include the sealed meetings' counts and durations, even though Library/Brain correctly exclude them via list_meetings_visible / brain_counts's visibility_clause. Verified directly in code: Db::analytics() (db.rs fn analytics) issues bare `SELECT COUNT(*) FROM meetings` / `SUM(duration_s) FROM meetings` with no folders join, versus Db::brain_counts (db.rs fn brain_counts) which explicitly joins folders + visibility_clause; get_analytics (commands.rs:8864) calls state.db.analytics() directly with no meeting_is_unlocked/visibility gate in between.

## Fix

Confirmed the bug exactly as reported: Db::analytics() (src-tauri/src/storage/db.rs) ran bare `SELECT COUNT(*)`/`SUM(duration_s)`/`MAX(duration_s)`/`MIN(started_at)`/`GROUP BY status`/per-day queries directly against `meetings` with zero folder join or visibility gate, and get_analytics (src-tauri/src/commands.rs) forwarded to it with no gating call at all — while the sibling aggregate read Db::brain_counts explicitly joins `folders f` and applies `visibility_clause`.

Fix (backend-only, mirrors the proven pattern): changed `Db::analytics(&self)` to `Db::analytics(&self, unlocked: &HashSet<String>)`, built a reusable `visible_meeting` SQL predicate that is exactly the `list_meetings_visible`/`brain_counts` shape ("a meeting is visible iff it has no notes at all, or at least one note whose folder is open or in the session-unlocked set" via `visibility_clause`), and applied it to every query: total_meetings, total_duration_s, longest_duration_s, notes_count, first_meeting_at, meetings_7d, duration_7d_s, by_status, and per_day. Updated `get_analytics` in commands.rs to snapshot the session unlocked-folder set via the existing `unlocked_snapshot(state)` helper (the same helper `brain_overview_inner` uses) and pass it through — no new command, no lib.rs change needed (signature from the Tauri IPC boundary is unchanged, still just `state: State<'_, AppState>`).

Gating proof: every analytics query now routes through `visibility_clause("n", unlocked)` — the same db.rs-level gate that `list_meetings_visible`/`meeting_by_title_visible`/`get_note_if_visible`/`meeting_is_visible`/`brain_counts` use, per the lock-model rule ("db/MCP reads go through visibility_clause"). This is a read gate only — no seal/encrypt-at-rest path is touched, so verify-before-destroy is not applicable here.

RED-before-GREEN: reverted db.rs/commands.rs to pre-fix code, ran the new assertions against the OLD no-arg `analytics()` in a throwaway harness — it returned total_meetings=2 (leaking the sealed meeting) where the fixed behavior expects 1; confirmed FAILED. Reapplied the fix, reran: PASSED. Added a permanent regression test `analytics_excludes_sealed_not_unlocked_folder` (src-tauri/src/storage/db.rs, in `mod tests`, next to `prunable_candidates_are_oldest_first_and_exclude_locked_folders`) that seeds 2 open meetings + 1 meeting in a locked folder, asserts every field (total_meetings, total_duration_s, longest_duration_s, avg_duration_s, by_status sum, per_day sum, and that the sealed meeting's date never appears in the 30-day chart) excludes the sealed meeting when not session-unlocked, then asserts it reappears once the folder id is added to the unlocked set (proving reversibility).

Tests: `cargo test --lib` from src-tauri/ — 1582 passed, 0 failed, 10 ignored (full suite, includes the new test). Isolated run of `analytics_excludes_sealed_not_unlocked_folder` also passed standalone.

Not verified here: no FE change was needed (analytics.component.ts is a thin `await this.ipc.getAnalytics()` reader with no separate read path, confirmed by reading the file), so `npx ng lint`/`npx ng build` were not run for this backend-only fix. Real-Mac/signed-build behaviors (Touch ID, actual folder lock/unlock UI flow, screen-share auto-relock) are unrelated to this change and were not exercised — this fix is a pure SQL-gating change verified by unit test, not FFI/permission code.

Review needed: yes — this change touches the lock model (a content-visibility gate), so it should go through lock-security-reviewer per the binding rules, even though the change is minimal and mirrors an already-reviewed pattern (brain_counts).

## Verification
Independently adversarial-verified PASS, then a DEDICATED lock-security-reviewer pass (this touches the visibility-gate model) also returned PASS — confirmed the gate covers all 9 aggregate fields, confirmed reversibility on unlock, confirmed zero PII in logs, confirmed scope discipline (exactly 2 files touched).
