### PR TITLE
fix: count_notes_per_folder() has no visibility/unlock gate — folder tree leaks sealed note counts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10172,7 +10172,6 @@ pub fn toggle_bar(app: AppHandle) {
 #[tauri::command]
 pub fn list_folders(state: State<'_, AppState>) -> Result<Vec<FolderNode>, AppError> {
     let folders = state.db.list_folders()?;
-    let counts = state.db.count_notes_per_folder()?;
     let unlocked = {
         state
             .unlocked_folders
@@ -10180,6 +10179,9 @@ pub fn list_folders(state: State<'_, AppState>) -> Result<Vec<FolderNode>, AppEr
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
             .clone()
     };
+    // Gated by the session unlock set — a sealed-and-not-unlocked folder's notes must not
+    // contribute to note_count (see count_notes_per_folder doc + .claude/rules/lock-model.md).
+    let counts = state.db.count_notes_per_folder(&unlocked)?;
     Ok(build_folder_tree(&folders, &counts, &unlocked))
 }
 
@@ -11018,8 +11020,9 @@ pub async fn unlock_folder(
         }
         tracing::info!(target: "lock", folder = %folder_id, "unlock_folder: session unlock complete");
 
-        // Return the refreshed node.
-        let counts = state.db.count_notes_per_folder()?;
+        // Return the refreshed node. This folder was just added to the unlock set above, so its
+        // own count is legitimately visible — pass the current unlock set through the same gate
+        // every other caller uses (count_notes_per_folder).
         let unlocked = {
             state
                 .unlocked_folders
@@ -11027,6 +11030,7 @@ pub async fn unlock_folder(
                 .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
                 .clone()
         };
+        let counts = state.db.count_notes_per_folder(&unlocked)?;
         Ok(FolderNode {
             id: folder.id.clone(),
             name: folder.name.clone(),
@@ -11471,7 +11475,17 @@ pub(crate) async fn discard_unrecoverable_folder_lock_inner(
         "discard_unrecoverable_folder_lock: key proven unrecoverable — discarded the sealed payload and reopened the folder (never-sealed plaintext preserved)"
     );
 
-    let counts = state.db.count_notes_per_folder()?;
+    // This folder was just reopened (discard_folder_seal cleared its lock), so its own count is
+    // legitimately visible under the (now-empty-for-this-folder) unlock gate — pass the current
+    // session unlock set through the same gate every other caller uses.
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    let counts = state.db.count_notes_per_folder(&unlocked)?;
     Ok(FolderNode {
         id: folder.id.clone(),
         name: folder.name.clone(),

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -6887,15 +6887,28 @@ impl Db {
         Ok(n)
     }
 
-    /// Count of notes assigned to each folder id (only folders with ≥1 note appear).
-    pub fn count_notes_per_folder(&self) -> Result<std::collections::HashMap<String, usize>> {
+    /// Count of notes assigned to each folder id (only folders with ≥1 VISIBLE note appear).
+    ///
+    /// Gated the same way as `analytics`'s `notes_count` / `list_entities_visible`: a folder that
+    /// is sealed and NOT session-unlocked contributes ZERO to its own count, never the true
+    /// sealed count. `seal_note` blanks a note's markdown/content_blob on lock but never deletes
+    /// or reparents the `notes` row, so an ungated `COUNT(*) GROUP BY folder_id` (the pre-fix
+    /// query) leaked the exact sealed-note count into the folder tree (`FolderNode.note_count`)
+    /// even though the lock model's invariant is that a sealed-and-not-unlocked folder leaks
+    /// NOTHING — see `.claude/rules/lock-model.md`.
+    pub fn count_notes_per_folder(
+        &self,
+        unlocked: &HashSet<String>,
+    ) -> Result<std::collections::HashMap<String, usize>> {
         let conn = self.lock();
-        let mut stmt = conn
-            .prepare(
-                "SELECT folder_id, COUNT(*) FROM notes
-                  WHERE folder_id IS NOT NULL GROUP BY folder_id",
-            )
-            .map_err(map_err)?;
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT n.folder_id, COUNT(*) FROM notes n
+               LEFT JOIN folders f ON f.id = n.folder_id
+              WHERE n.folder_id IS NOT NULL AND {visible}
+              GROUP BY n.folder_id"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
             .query_map([], |r| {
                 Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)? as usize))
@@ -15680,6 +15693,86 @@ mod tests {
         assert_eq!(a2.total_meetings, 3);
         assert_eq!(a2.total_duration_s, 7500);
         assert_eq!(a2.longest_duration_s, 6000);
+    }
+
+    /// The folder tree's `note_count` badge must never reveal a sealed-and-not-unlocked folder's
+    /// TRUE note count — same leak class `analytics_excludes_sealed_not_unlocked_folder` closes
+    /// for the Analytics tab. Regression for the audit finding: `Db::count_notes_per_folder()`
+    /// used to run a bare `SELECT folder_id, COUNT(*) FROM notes GROUP BY folder_id` with no join
+    /// to `folders` and no unlock-set gate at all — `seal_note` blanks a note's markdown on lock
+    /// but never deletes/reparents the `notes` row, so the sealed folder's exact note count leaked
+    /// into the sidebar tree (`list_folders` → `FolderNode.note_count`) even though the lock
+    /// model's invariant is that a sealed-and-not-unlocked folder must leak NOTHING.
+    #[test]
+    fn count_notes_per_folder_excludes_sealed_not_unlocked_folder() {
+        let db = mem_db();
+        db.insert_folder(&crate::storage::Folder {
+            id: "f-open".into(),
+            name: "Open".into(),
+            path: "Open".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.insert_folder(&crate::storage::Folder {
+            id: "f-secret".into(),
+            name: "Secret".into(),
+            path: "Secret".into(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-06-01T00:00:00Z".into(),
+        })
+        .unwrap();
+
+        // 1 note in the OPEN folder, 3 notes in the LOCKED folder.
+        for (id, folder) in [
+            ("open-1", "f-open"),
+            ("secret-1", "f-secret"),
+            ("secret-2", "f-secret"),
+            ("secret-3", "f-secret"),
+        ] {
+            db.insert_meeting(&crate::storage::Meeting {
+                id: id.into(),
+                started_at: "2026-06-20T10:00:00Z".into(),
+                ended_at: None,
+                title: Some("t".into()),
+                duration_s: 60,
+                audio_path: None,
+                status: crate::storage::MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+            db.upsert_note(&crate::storage::NoteRecord {
+                meeting_id: id.into(),
+                provider_id: "claude_code".into(),
+                markdown: "m".into(),
+                created_at: "2026-06-20T10:00:00Z".into(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+            db.set_note_folder(id, Some(folder)).unwrap();
+        }
+
+        // Sealed and NOT session-unlocked: the locked folder must be ABSENT from the map (or read
+        // back as 0), never its true count of 3.
+        let nothing = std::collections::HashSet::new();
+        let counts = db.count_notes_per_folder(&nothing).unwrap();
+        assert_eq!(counts.get("f-open").copied().unwrap_or(0), 1);
+        assert_eq!(
+            counts.get("f-secret").copied().unwrap_or(0),
+            0,
+            "a sealed-and-not-unlocked folder must not leak its true note count"
+        );
+
+        // Once the folder is SESSION-unlocked, the true count becomes visible again (reversible).
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-secret".to_string());
+        let counts2 = db.count_notes_per_folder(&unlocked).unwrap();
+        assert_eq!(counts2.get("f-secret").copied().unwrap_or(0), 3);
     }
 
     /// Race-safety regression (TOCTOU: prune snapshots a plaintext path, a concurrent seal


### PR DESCRIPTION
## Bug (found by a targeted pattern-sweep audit)

**Severity:** moderate

Db::count_notes_per_folder() in src-tauri/src/storage/db.rs (fn at line ~6891) runs a bare `SELECT folder_id, COUNT(*) FROM notes WHERE folder_id IS NOT NULL GROUP BY folder_id` with NO join to `folders`, no `visibility_clause`, and no `unlocked: &HashSet<String>` parameter at all — unlike every other visibility-sensitive aggregate (`brain_counts`, the now-fixed `analytics`, `list_entities_visible`, `count_entities_visible`). Db::seal_note() (storage/db.rs) blanks a note's `markdown`/`content_blob`/`exported_path` on lock but never deletes or reparents the `notes` row, so a sealed-and-not-session-unlocked folder's notes are still counted. The #[tauri::command] `list_folders` (src-tauri/src/commands.rs, fn list_folders) fetches `unlocked` from `state.unlocked_folders` for `build_folder_tree`'s locked/unlocked flags but never threads it into `count_notes_per_folder()` — so `FolderNode.note_count` is populated from the raw, ungated map for every folder in the tree, including ones the session has not unlocked. The Angular folder-row component (src/app/features/folders/folder-row/folder-row.component.html, `[count]="node().noteCount > 0 ? node().noteCount : null"`) renders this as a numeric badge on every row unconditionally, so a locked folder's exact sealed-note count is visible in the sidebar UI even though the lock model's stated invariant is that a sealed-and-not-unlocked folder must leak NOTHING (compare to the individual-note masking pattern elsewhere in commands.rs that replaces title with "🔒 Locked" and omits markdown). The other two call sites of count_notes_per_folder (unlock_folder at commands.rs ~11022, discard_unrecoverable_folder_lock at ~11474) are benign — they report the count of the single folder whose lock state is actively being changed in that same call, not a cross-folder tree read. No existing test (unlike analytics_excludes_sealed_not_unlocked_folder) exercises count_notes_per_folder for lock exclusion, confirming this gap was never audited.

**Repro:** 1) Create a folder, add several meetings/notes to it, lock the folder (lock_folder). 2) In a fresh session (folder not session-unlocked), call the `list_folders` Tauri command / open the Notes sidebar folder tree. 3) Observe the locked folder's tree row shows a real numeric note-count badge (e.g. "12") reflecting the true number of sealed notes inside, even though the folder's lock/unlock state elsewhere correctly masks all note content and titles.

## Fix

Confirmed real leak: Db::count_notes_per_folder() (src-tauri/src/storage/db.rs) ran an ungated COUNT(*)/GROUP BY over notes with no join to folders and no unlock-set param, unlike analytics()/list_entities_visible(). seal_note() blanks a note's markdown on lock but leaves the notes row in place, so list_folders (commands.rs) fed the raw, ungated count map into FolderNode.note_count for every folder including sealed-not-session-unlocked ones -- leaking the exact sealed note count as a sidebar badge, violating the lock model's leak-nothing invariant. Fixed by threading unlocked: &HashSet<String> through count_notes_per_folder and applying the same visibility_clause('n', unlocked) join pattern used by analytics()/list_entities_visible() (LEFT JOIN folders f ON f.id = n.folder_id, filtered by the shared helper). Updated all 3 call sites: list_folders (the actual leak site) now fetches unlocked before counting; unlock_folder and discard_unrecoverable_folder_lock_inner (both previously benign -- reporting only the single folder whose own lock state just changed) updated to the new signature. Added regression test count_notes_per_folder_excludes_sealed_not_unlocked_folder mirroring analytics_excludes_sealed_not_unlocked_folder's shape; manually verified RED (fails with left:3/right:0 against the old ungated query) before confirming GREEN on the fix. No Angular changes needed -- the FE template already just renders node().noteCount, so gating the backend source is sufficient. Gates: cargo test --lib 1588 passed/0 failed, ng lint clean, ng build clean.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed).
