### PR TITLE
fix: Lock×shares dialog + bulk-revoke still miss a stuck failed-with-item_id org share (org_shares.state narrow-list not updated for the cd21b10 fix)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25970,6 +25970,70 @@ mod lifecycle_tests {
         assert!(active.iter().any(|(item, _)| item.is_none())); // the queued note share (no item yet)
     }
 
+    /// cd21b10 established that a `failed` row with a non-null `item_id` (a republish attempt failed
+    /// transiently but the PRIOR publish is still genuinely live on the server — `set_org_share_failed`
+    /// deliberately never clears `item_id`) counts as LIVE everywhere: `org_shares_for_source`,
+    /// `list_live_org_shares`, `OrgStatus.item_count`, `org_resolve_source_inner`. This proves
+    /// `active_org_shares_for_folder` and `active_org_share_ids_for_folder` (the lock×shares dialog +
+    /// bulk-revoke) also surface that shape — before the fix they used the pre-cd21b10 narrow
+    /// `state IN ('queued','uploaded','revoke_pending')` predicate, so a stuck failed-with-item_id share
+    /// was invisible to the dialog and never revoked when the folder was locked.
+    #[test]
+    fn active_org_shares_for_folder_includes_stuck_failed_republish_with_live_item_id() {
+        let state = build_state("org-active-folder-stuck-failed");
+        make_open_folder(&state.db, "f1", "Team");
+        state
+            .db
+            .insert_note("n1", "f1", "doc", "Doc", "# body", 1)
+            .unwrap();
+        let sha = vec![1u8; 32];
+        // Published once (item-stuck), then a republish-on-edit attempt failed transiently: state
+        // becomes 'failed' but item_id STAYS 'item-stuck' (the prior publish is still live).
+        state
+            .db
+            .insert_org_share("s-stuck", "org-1", None, Some("n1"), "note", Some("Doc"), 1, 1, &sha, "t")
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("s-stuck", "item-stuck", "t")
+            .unwrap();
+        state
+            .db
+            .set_org_share_failed("s-stuck", "republish_upload_failed", "t")
+            .unwrap();
+        // A never-published failed row (no item_id) must stay excluded — no live server item.
+        state
+            .db
+            .insert_note("n2", "f1", "doc", "Doc2", "# body2", 1)
+            .unwrap();
+        state
+            .db
+            .insert_org_share("s-dead", "org-1", None, Some("n2"), "note", Some("Doc2"), 1, 1, &sha, "t")
+            .unwrap();
+        state
+            .db
+            .set_org_share_failed("s-dead", "publish_failed", "t")
+            .unwrap();
+
+        let active = state.db.active_org_shares_for_folder("f1").unwrap();
+        assert_eq!(
+            active.len(),
+            1,
+            "the stuck failed-with-item_id share IS surfaced; the never-published failed row stays excluded: {active:?}"
+        );
+        assert_eq!(active[0].0.as_deref(), Some("item-stuck"));
+
+        // Same fix must apply to the bulk-revoke enumeration (`revoke_shares_for_folder`'s source).
+        let ids = state.db.active_org_share_ids_for_folder("f1").unwrap();
+        assert_eq!(
+            ids.len(),
+            1,
+            "bulk-revoke must also see the stuck failed-with-item_id share: {ids:?}"
+        );
+        assert_eq!(ids[0].0, "s-stuck");
+        assert_eq!(ids[0].1.as_deref(), Some("item-stuck"));
+    }
+
     /// Closes the pre-existing lock×shares HOLE: before `active_link_user_shares_for_folder`, a folder
     /// could be sealed with NO warning that its notes were still shared 1:1 (link/user). This proves
     /// the enumeration that `folder_active_shares` (→ the dialog) reads: it surfaces the folder's

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2297,9 +2297,18 @@ impl Db {
         Ok(out)
     }
 
-    /// The ACTIVE (queued/uploaded/revoke_pending — not revoked/failed) org shares anchored to a
-    /// folder's meetings + notes, for the lock×shares warn/revoke dialog. Content-free enough for the
-    /// dialog (an `(item_id?, title?)` pair per share; titles render only to the local owner).
+    /// The ACTIVE-OR-STUCK-LIVE (queued/uploaded/revoke_pending, PLUS a `failed` row that still
+    /// carries a non-null `item_id`) org shares anchored to a folder's meetings + notes, for the
+    /// lock×shares warn/revoke dialog. Content-free enough for the dialog (an `(item_id?, title?)`
+    /// pair per share; titles render only to the local owner).
+    ///
+    /// The `failed AND item_id IS NOT NULL` clause mirrors the definition of "live" established by
+    /// `org_shares_for_source`/`list_live_org_shares` (see their doc comments): `set_org_share_failed`
+    /// deliberately never clears `item_id` on a republish failure, so such a row's PRIOR publish is
+    /// still genuinely live on the server even though the row's state says `failed`. Before this fix
+    /// that shape was invisible to the lock×shares dialog and to bulk-revoke
+    /// (`active_org_share_ids_for_folder`), so locking a folder with a stuck failed-republish share
+    /// never warned the user and never tombstoned the still-live server item.
     pub fn active_org_shares_for_folder(
         &self,
         folder_id: &str,
@@ -2311,7 +2320,8 @@ impl Db {
                    FROM org_shares s
                    LEFT JOIN notes n  ON n.meeting_id = s.meeting_id
                    LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE s.state IN ('queued','uploaded','revoke_pending')
+                  WHERE (s.state IN ('queued','uploaded','revoke_pending')
+                     OR (s.state = 'failed' AND s.item_id IS NOT NULL))
                     AND (n.folder_id = ?1 OR d.folder_id = ?1)",
             )
             .map_err(map_err)?;
@@ -2355,10 +2365,13 @@ impl Db {
         Ok(out)
     }
 
-    /// The folder's ACTIVE org shares as `(row_id, item_id?, title)` for bulk-revoke: an uploaded row
-    /// (item_id present) is tombstoned server-side; a still-`queued` row (no item_id) is cancelled
-    /// locally so the launch sweep never egresses it. Same folder join + state set as
-    /// [`Self::active_org_shares_for_folder`], but carries the local row id + item id for revocation.
+    /// The folder's ACTIVE-OR-STUCK-LIVE org shares as `(row_id, item_id?, title)` for bulk-revoke:
+    /// an uploaded row (item_id present) is tombstoned server-side; a still-`queued` row (no item_id)
+    /// is cancelled locally so the launch sweep never egresses it; a `failed` row with a non-null
+    /// `item_id` (a republish attempt failed but the PRIOR publish is still live — see
+    /// [`Self::active_org_shares_for_folder`]) is tombstoned server-side same as an uploaded row.
+    /// Same folder join + state set as [`Self::active_org_shares_for_folder`], but carries the local
+    /// row id + item id for revocation.
     pub fn active_org_share_ids_for_folder(
         &self,
         folder_id: &str,
@@ -2370,7 +2383,8 @@ impl Db {
                    FROM org_shares s
                    LEFT JOIN notes n     ON n.meeting_id = s.meeting_id
                    LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE s.state IN ('queued','uploaded','revoke_pending')
+                  WHERE (s.state IN ('queued','uploaded','revoke_pending')
+                     OR (s.state = 'failed' AND s.item_id IS NOT NULL))
                     AND (n.folder_id = ?1 OR d.folder_id = ?1)",
             )
             .map_err(map_err)?;


### PR DESCRIPTION
## Bug (found by a targeted pattern-sweep audit)

**Severity:** moderate

`Db::active_org_shares_for_folder` and `Db::active_org_share_ids_for_folder` (src-tauri/src/storage/db.rs) both filter `WHERE s.state IN ('queued','uploaded','revoke_pending')` — explicitly excluding `failed`. Commit cd21b10 established that a `failed` row with a non-null `item_id` (a republish that failed transiently, retaining the OLD still-server-live item_id since `set_org_share_failed` never clears it) is functionally LIVE and fixed every other read site (`org_shares_for_source`, `list_live_org_shares`, `OrgStatus.item_count`, `org_resolve_source_inner`) to the broadened predicate `state == 'uploaded' || (state == 'failed' && item_id.is_some())`. These two folder-scoped functions were not touched by that commit and still use the old narrow definition. They power `folder_active_shares_inner` (the lock×shares dialog's org-share list) and `revoke_shares_for_folder` (bulk-revoke before lock) — so a folder containing a note stuck in this exact shape shows no warning for that org share, and locking with 'Revoke & lock' never tombstones the still-live server item.

**Repro:** 1. Share a note into an org (state='uploaded', item-1). 2. Edit the note; let the republish attempt fail transiently (network blip during OCK acquire/seal/upload) — the row becomes state='failed' with item_id still Some('item-1') (per cd21b10's documented behavior of `set_org_share_failed`). 3. Lock the folder containing that note via the lock×shares dialog. Expected (per cd21b10's established 'live' definition, applied everywhere else): the dialog surfaces this org share and 'Revoke & lock' tombstones item-1. Actual: `active_org_shares_for_folder`/`active_org_share_ids_for_folder`'s `state IN ('queued','uploaded','revoke_pending')` excludes the failed row, so it's invisible to the dialog and never revoked — item-1 stays live in the org's shared brain after the user believes the folder is locked. Confirmed via `git show cd21b10 -- src-tauri/src/storage/db.rs`, which does not touch either function, and the only existing test (`active_org_shares_for_folder_lists_active_only`, commands.rs ~25908) only asserts revoked-exclusion, never exercising the stuck failed-with-item_id shape.

## Fix

Confirmed the bug exactly as reported. `Db::active_org_shares_for_folder` and `Db::active_org_share_ids_for_folder` (src-tauri/src/storage/db.rs, grep for those fn names — `commands.rs`/`db.rs` line numbers drift) filtered `WHERE s.state IN ('queued','uploaded','revoke_pending')`, which excludes a `failed` row that still carries a non-null `item_id`. `set_org_share_failed` (db.rs) never clears `item_id` on a republish failure, so such a row's PRIOR publish is still genuinely live server-side. Commit cd21b10 established the broadened "live" predicate `state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL)` and applied it to `org_shares_for_source`, `list_live_org_shares`, `OrgStatus.item_count`, and `org_resolve_source_inner` — but never touched these two folder-scoped functions, which power `folder_active_shares_inner` (the lock×shares dialog, commands.rs) and `revoke_shares_for_folder` (bulk-revoke before lock, commands.rs). Confirmed via `git show cd21b10 -- src-tauri/src/storage/db.rs` (neither function appears in that diff) and the only pre-existing test (`active_org_shares_for_folder_lists_active_only`) never exercises the failed-with-item_id shape.

What changed:
- src-tauri/src/storage/db.rs, `Db::active_org_shares_for_folder` — WHERE clause broadened to `(state IN ('queued','uploaded','revoke_pending') OR (state = 'failed' AND item_id IS NOT NULL))`, doc comment updated to explain the "stuck-live" shape (mirrors the cd21b10 doc-comment style on `org_shares_for_source`).
- src-tauri/src/storage/db.rs, `Db::active_org_share_ids_for_folder` — same predicate broadened; this is the function `revoke_shares_for_folder` reads to decide what to tombstone server-side.
- src-tauri/src/commands.rs — added test `active_org_shares_for_folder_includes_stuck_failed_republish_with_live_item_id` (in the `commands::lifecycle_tests` module, right after the existing `active_org_shares_for_folder_lists_active_only`), which builds a note with an org share that goes `insert_org_share` -> `set_org_share_uploaded("item-stuck")` -> `set_org_share_failed(...)` (the exact stuck sequence, mirroring the pattern already used by cd21b10's `org_shares_for_source_includes_failed_rows_with_a_live_item_id`), plus a sibling never-published failed row (no item_id) that must stay excluded. Asserts both `active_org_shares_for_folder` and `active_org_share_ids_for_folder` now surface the stuck row and only the stuck row.

Gating/seal/FFI proof: this is a read-gating fix, not a new read path — it does not weaken any gate. `folder_active_shares_inner` still checks `folder_is_unlocked(st, folder_id)?` before calling the now-broadened `active_org_share_ids_for_folder`, so a locked-not-unlocked folder still returns nothing (the existing gate is untouched, confirmed by reading commands.rs around `folder_active_shares_inner`). No new seal/at-rest-encrypt path is introduced. `revoke_org_share_inner` (the function `revoke_shares_for_folder` calls for each org row with an item_id) looks up the row by `item_id` via `org_share_by_item` and is state-agnostic, so it correctly tombstones a `failed`-with-item_id row exactly like an `uploaded` row — confirmed by reading its body, no change needed there.

Tests: added `commands::lifecycle_tests::active_org_shares_for_folder_includes_stuck_failed_republish_with_live_item_id`. RED-before-GREEN: ran it against the unfixed db.rs (git-stashed the db.rs change, kept the test) — failed with `assertion left == right failed: ... left: 0 right: 1` (the stuck row was invisible), confirming the test captures the real bug. Restored the fix and re-ran: `cargo test --lib` (from src-tauri/) → `test result: ok. 1588 passed; 0 failed; 10 ignored; 0 measured; 1599 filtered out` (1599 total incl. ignored) — full suite green, including the new test and the two pre-existing sibling tests (`active_org_shares_for_folder_lists_active_only`, `active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders`), both still passing (no regression).

Not verified here: this is a pure backend DB-predicate + unit-test change with no FFI/keychain/biometric/screen-share surface, so no signed-build-only behavior applies. Did not run `scripts/ci.sh` (clippy) per the rule against running it in the iterative loop; `cargo test --lib` is the mandated gate for this class of change and is green. Did not live-reproduce the lock×shares dialog in a running dev app (would need a real server-backed org share going through an actual failed republish) — the unit test reproduces the exact DB row shape cd21b10 documented as the real-world trigger.

Review needed: yes — this touches the lock-model's folder-scoped share visibility (feeds the lock×shares warn/revoke dialog and bulk-revoke-before-lock), so flag for `lock-security-reviewer` per the standing rule that any lock-touching change gets that second gate.

## Verification
Independently adversarial-verified PASS (gates re-run in an isolated worktree, RED-before-GREEN reconfirmed).
