### PR TITLE
fix: Lock×shares dialog + bulk-revoke never sees a mode-B (Murmur↔Murmur person) share — state='active' excludes every real row

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25974,6 +25974,15 @@ mod lifecycle_tests {
     /// could be sealed with NO warning that its notes were still shared 1:1 (link/user). This proves
     /// the enumeration that `folder_active_shares` (→ the dialog) reads: it surfaces the folder's
     /// ACTIVE link + user shares, and excludes revoked shares AND shares in other folders.
+    ///
+    /// The mode-B (Murmur↔Murmur USER) fixture is seeded via the REAL production helper
+    /// (`insert_outbound_user_share`, called from `share_note_to_user_inner`) rather than
+    /// `insert_outbound_share` (which hardcodes `state='active'` and is only ever used for mode-A LINK
+    /// shares) — `insert_outbound_user_share` never writes `'active'`, only `'sent'`/`'awaiting_key'`.
+    /// A prior version of this test seeded its "user"-mode row via `insert_outbound_share`, which gave
+    /// false confidence: it never exercised the state values a genuine mode-B row actually carries, so
+    /// it didn't catch `active_link_user_shares_for_folder`'s `WHERE state = 'active'` excluding every
+    /// real 1:1-person share (100%-reproducible, not an edge case).
     #[test]
     fn active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders() {
         let state = build_state("folder-1to1-shares");
@@ -26010,23 +26019,50 @@ mod lifecycle_tests {
         };
         mk_note("m1", "f1", "Sync");
         mk_note("m2", "f2", "Elsewhere");
-        // f1/m1: an active LINK + active USER share, plus a REVOKED link that must be excluded.
+        // f1/m1: an active LINK share, a REVOKED link that must be excluded, a mode-B USER share
+        // already 'sent' (registered recipient), and a mode-B USER share still 'awaiting_key'
+        // (unregistered recipient, pending re-wrap) — both are LIVE and must surface.
         state.db.insert_outbound_share("lnk", "m1", "link", 1, "t").unwrap();
-        state.db.insert_outbound_share("usr", "m1", "user", 1, "t").unwrap();
         state.db.insert_outbound_share("old", "m1", "link", 1, "t").unwrap();
         state.db.set_outbound_share_state("old", "revoked").unwrap();
+        state
+            .db
+            .insert_outbound_user_share("usr-sent", "m1", 1, "t", "sent", b"nk", "acct-1", "a@x.com", b"hash")
+            .unwrap();
+        state
+            .db
+            .insert_outbound_user_share(
+                "usr-pending",
+                "m1",
+                1,
+                "t",
+                "awaiting_key",
+                b"nk",
+                "acct-2",
+                "b@x.com",
+                b"hash",
+            )
+            .unwrap();
         // f2/m2: a share in ANOTHER folder must not leak into f1's report.
         state.db.insert_outbound_share("f2lnk", "m2", "link", 1, "t").unwrap();
 
         let shares = state.db.active_link_user_shares_for_folder("f1").unwrap();
         assert_eq!(
             shares.len(),
-            2,
-            "two active 1:1 shares in f1 (revoked + other-folder excluded): {shares:?}"
+            3,
+            "one active LINK + two live USER shares (sent + awaiting_key) in f1, revoked + other-folder excluded: {shares:?}"
         );
         let links = shares.iter().filter(|(_, m)| m == "link").count();
         let users = shares.iter().filter(|(_, m)| m == "user").count();
-        assert_eq!((links, users), (1, 1), "one link + one user share");
+        assert_eq!((links, users), (1, 2), "one link + two user shares (sent + awaiting_key)");
+        assert!(
+            shares.iter().any(|(id, _)| id == "usr-sent"),
+            "a 'sent' mode-B share must surface: {shares:?}"
+        );
+        assert!(
+            shares.iter().any(|(id, _)| id == "usr-pending"),
+            "an 'awaiting_key' mode-B share must surface: {shares:?}"
+        );
         assert!(
             shares.iter().all(|(id, _)| id != "old" && id != "f2lnk"),
             "revoked + other-folder shares excluded"

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2330,7 +2330,12 @@ impl Db {
     /// The folder's ACTIVE 1:1 shares (LINK + Murmur↔Murmur USER) as `(share_id, mode)`, joined to
     /// the folder through the shared meeting/document. Powers the lock×shares dialog + bulk-revoke —
     /// closing the pre-existing hole where `lock_folder` never surfaced live 1:1 shares. Mirrors
-    /// [`Self::active_org_shares_for_folder`]. `state = 'active'` only (revoked rows excluded).
+    /// [`Self::active_org_shares_for_folder`]. Mode-A LINK shares use `state = 'active'`
+    /// ([`Self::insert_outbound_share`] / [`Self::insert_outbound_note_share`]); mode-B Murmur↔Murmur
+    /// USER shares NEVER carry `'active'` — [`Self::insert_outbound_user_share`] writes `'sent'`
+    /// (recipient already registered) or `'awaiting_key'` (pending, later flipped to `'sent'` by
+    /// `share_rewrap_pending`) — so all three live states must match or every real mode-B row is
+    /// silently excluded. `'revoked'` (terminal, [`Self::set_outbound_share_state`]) stays excluded.
     pub fn active_link_user_shares_for_folder(&self, folder_id: &str) -> Result<Vec<(String, String)>> {
         let conn = self.lock();
         let mut stmt = conn
@@ -2339,7 +2344,7 @@ impl Db {
                    FROM outbound_shares s
                    LEFT JOIN notes n     ON n.meeting_id = s.meeting_id
                    LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE s.state = 'active'
+                  WHERE s.state IN ('active', 'sent', 'awaiting_key')
                     AND (n.folder_id = ?1 OR d.folder_id = ?1)",
             )
             .map_err(map_err)?;


### PR DESCRIPTION
## Bug (found by a targeted pattern-sweep audit) - HIGH severity

`Db::active_link_user_shares_for_folder` (src-tauri/src/storage/db.rs, doc says it powers the lock×shares warn/revoke dialog for 'LINK + Murmur↔Murmur USER' shares) filters `WHERE s.state = 'active'`. But every real mode-B share row is inserted by `Db::insert_outbound_user_share` (called from `share_note_to_user_inner`, commands.rs ~14491/14512) with `state = "sent"` (recipient already registered) or `state = "awaiting_key"` (recipient not yet registered, later flipped to `"sent"` by `share_rewrap_pending`, commands.rs:14667) — NEVER `"active"`. `insert_outbound_user_share`'s own INSERT statement doesn't even accept a `state` literal of 'active'; only the separate `insert_outbound_share`/`insert_outbound_note_share` helpers (used for mode-A LINK shares) hardcode `'active'`. So `active_link_user_shares_for_folder` structurally can never match a genuine mode-B row — not an edge case, a 100%-reproducible category exclusion. Downstream: `folder_active_shares_inner` (commands.rs) uses this to build the lock-dialog's `users` count (`src/app/features/folders/lock-shares-dialog/`), and `revoke_shares_for_folder` (commands.rs) uses the SAME query to decide which 1:1 shares to bulk-revoke before/with a folder lock. Both silently ignore every mode-B share: the user gets no warning a colleague still holds live/pending access, and 'Revoke & lock' does not revoke it.

**Repro:** 1. Record a meeting, get a note. 2. Share it with a colleague via 'Share with a person' (`share_note_to_user`) — if the colleague is a registered Murmur account this lands in state 'sent'; if not, 'awaiting_key'. 3. Open the folder containing that meeting and lock it via the lock×shares dialog. Expected: the dialog warns about the live 1:1 share and 'Revoke & lock' tombstones it server-side. Actual: `report().users` is 0 (query only matches state='active'), no warning shown, and 'Revoke & lock' never calls `revoke_share_inner` for that share — the colleague's access/copy remains live after the user believes the folder is locked/protected. Confirmed by reading `insert_outbound_user_share`'s INSERT (src-tauri/src/storage/db.rs ~2438-2470, no 'active' literal anywhere) against `active_link_user_shares_for_folder`'s `WHERE s.state = 'active'` (db.rs ~2334-2356), and the only existing test for that function (`active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders`, commands.rs ~25978) seeds its 'user'-mode fixture via the WRONG helper (`insert_outbound_share`, which hardcodes 'active'), never exercising the real 'sent'/'awaiting_key' values a genuine mode-B row carries — so the test gives false confidence and never caught this.

## Fix

Confirmed real bug, fixed minimally, RED-before-GREEN verified.

WHAT CHANGED
- src-tauri/src/storage/db.rs (fn active_link_user_shares_for_folder, ~line 2334): the query's `WHERE s.state = 'active'` clause is broadened to `WHERE s.state IN ('active', 'sent', 'awaiting_key')`. Doc comment updated to record why: mode-A LINK shares (Db::insert_outbound_share / insert_outbound_note_share) hardcode `state='active'`, but mode-B Murmur<->Murmur USER shares (Db::insert_outbound_user_share, called from share_note_to_user_inner in commands.rs) only ever write `'sent'` (recipient already registered) or `'awaiting_key'` (pending, later flipped to `'sent'` by share_rewrap_pending) — confirmed by reading insert_outbound_user_share's own INSERT statement, which has no `'active'` literal anywhere. So `active_link_user_shares_for_folder` structurally could never match a real mode-B row.
- src-tauri/src/commands.rs (test active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders, ~line 25978): replaced the misleading fixture (which seeded its "user"-mode row via insert_outbound_share, the wrong helper that hardcodes 'active' and never exercised the real bug) with two rows seeded via the actual production helper insert_outbound_user_share — one in state 'sent', one in 'awaiting_key' — plus kept the existing active LINK + revoked LINK + other-folder LINK cases. Asserts both live mode-B shares now surface, revoked/other-folder stay excluded.

GATING/SEAL/FFI PROOF
This is a READ-gating bug within the already-content-free 1:1-share enumeration used by folder_active_shares_inner (commands.rs) — the query only returns `(share_id, mode)`, no note/transcript content — and folder_active_shares_inner already gates the WHOLE report behind folder_is_unlocked before this function is even called, so the lock-model's "gate every content read" invariant was never at risk here; the bug was a category-exclusion bug in what counts as "active", not a missing gate. No new read path was added, no seal/encrypt-at-rest path touched, no FFI touched. The fix only widens a `state IN (...)` filter to match the real state machine of the same table; `'revoked'` (the terminal state written by revoke_share_inner / set_outbound_share_state) is still excluded, so a genuinely revoked share still does not resurface.

TESTS
- Updated: commands::lifecycle_tests::active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders — now seeds real mode-B rows via insert_outbound_user_share (states 'sent' and 'awaiting_key') alongside an active LINK share, a revoked LINK share, and an other-folder LINK share; asserts 3 total shares in f1 (1 link + 2 user), both mode-B share_ids present, revoked/other-folder excluded.
- RED-before-GREEN performed manually: temporarily reverted the db.rs WHERE clause back to `= 'active'` and reran — test failed with `left: 1, right: 3` (only the LINK share surfaced; both mode-B USER shares were silently excluded, exactly matching the reported bug). Restored the fix and reran — passes.
- Full gate: `cargo test --lib` from src-tauri/ — 1587 passed, 0 failed, 10 ignored (the usual #[ignore] dev-DB inspection tests), 0 filtered.

NOT VERIFIED HERE
- No FE/UI change was needed or made (lock-shares-dialog.component.ts / folder-lock-flow.service.ts consume folder_active_shares_inner's already-existing counts/report shape unchanged — this was a pure backend data-correctness fix, so `npx ng lint`/`ng build` were not run; nothing in src/app changed).
- Did not live-launch the dev app / drive the actual lock×shares dialog in a running Murmur instance (no signed build, no real Murmur↔Murmur account pair available in this environment) — the fix and regression test are verified at the Db-query level via cargo test, which is the correct level for this bug (a SQL state-filter category bug), but the end-to-end FE dialog render + "Revoke & lock" network call to a real murmur-server instance was not observed live.
- Did not run `cargo clippy` / `scripts/ci.sh` per the rules (never run clippy --all-targets in the loop); `cargo test --lib` is the mandated inner gate and is green.

REVIEW NEEDED
This touches the lock×shares dialog / bulk-revoke data source, which is part of the lock model's share-visibility surface (though not a content-read gate). Given CLAUDE.md's binding rule that lock-touching changes get a lock-security-reviewer pass, flagging this for that review before merge, even though the change is a narrow SQL state-filter widening with no gate weakening, no new read path, and no seal/verify-before-destroy change.

## Verification
The workflow's automated verify-fix step failed to return a verdict (a transient API error, not a rejection), so this went through TWO dedicated, independent reviews before merge:
- **adversarial-verifier: PASS** - independently reproduced RED-before-GREEN, exhaustively enumerated every write to outbound_shares.state across the whole tree (confirmed the state universe is exactly {active, sent, awaiting_key, revoked}), confirmed revoke_shares_for_folder handles newly-visible mode-B rows through the same generic, mode-agnostic revoke path as mode-A rows, agreed HIGH severity is justified (a security/trust promise - "Revoke and lock" - silently failed to revoke real access for an entire share class).
- **lock-security-reviewer: PASS** - same exhaustive state-machine enumeration independently, confirmed revoke_shares_for_folder's server-side DELETE call is uniform across share modes, confirmed the dialog's folder_is_unlocked gate is untouched and still fail-closed, confirmed no PII in logs. Flagged one OUT-OF-SCOPE adjacent cosmetic issue for a future fix: note_has_active_share/notes_with_active_share have the same 'active'-only blind spot, so the note-list "shared" badge doesn't show for mode-B-only shares (not a security control, just an under-informative badge).

## Test plan
- [x] cargo test --lib (1587 passed, 0 failed, 10 ignored)
- [x] Independent adversarial-verifier PASS (RED-before-GREEN re-proven)
- [x] Independent lock-security-reviewer PASS
