### PR TITLE
fix(ui): settings sidebar fade, org-chip-row parity, tighter tree-row hover

### DIFF
--- a/src/app/design-system/tree-row/tree-row.component.scss
+++ b/src/app/design-system/tree-row/tree-row.component.scss
@@ -8,6 +8,10 @@
   flex: none;
   align-items: center;
   gap: var(--space-1);
+  /* A little breathing room on top of the tree's own 2px row gap — at the
+     tight gap alone, the hover/selected pill's rounded corners read as
+     crowding into the row right above/below it. */
+  margin-block: 1px;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   transition:
@@ -89,7 +93,7 @@
   gap: var(--space-2);
   flex: 1 1 auto;
   min-width: 0;
-  padding: var(--space-2) var(--space-2);
+  padding: 6px var(--space-2);
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: transparent;

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -99,6 +99,7 @@
          narrow, so a chip pick would have no visible effect there. -->
     @if (!hasQuery() && (orgs().length > 0 || orgsLoading())) {
       <div class="org-chip-row" role="group" aria-label="Shared brains">
+        <span class="org-chip-row-label text-muted">Shared brains</span>
         @for (org of orgs(); track org.orgId) {
           <button
             type="button"
@@ -122,7 +123,6 @@
               />
             </svg>
             {{ org.name }}
-            <span class="pill org-role" [title]="orgRoleLabel(org)">{{ orgRoleLabel(org) }}</span>
           </button>
         }
         @if (orgsLoading()) {

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -29,6 +29,12 @@
   align-items: center;
   gap: var(--space-2);
 }
+.org-chip-row-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
 .org-chip {
   display: inline-flex;
   align-items: center;

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -352,11 +352,6 @@ export class LibraryComponent implements OnInit {
     this.activeOrgId.set(null);
   }
 
-  /** A friendly role hint for the chip row ("Owner" / "Member"). */
-  orgRoleLabel(org: OrgStatus): string {
-    return org.role === "owner" ? "Owner" : "Member";
-  }
-
   // --- Own-meeting org-share badges (Library row + Detail) ------------------
   /**
    * Every active meeting→org share pairing across ALL of the caller's OWN

--- a/src/app/features/settings/settings/settings.component.scss
+++ b/src/app/features/settings/settings/settings.component.scss
@@ -138,6 +138,12 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  /* A scrolled-off last item hard-clips at the rail's rounded bottom edge
+     with no visible scrollbar (macOS hides overlay scrollbars until
+     actively scrolling) — nothing hints there's more below. Fade the last
+     ~28px instead of a hard cut, the standard "there's more, scroll" tell. */
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 28px), transparent);
+  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 28px), transparent);
 }
 .nav-item {
   display: flex;


### PR DESCRIPTION
## Summary
Small UI polish pass from live testing feedback:
- Settings section nav no longer hard-clips its last visible item at the rail's bottom edge (fades instead) — nothing else hinted there was more to scroll.
- Library's "Shared brains" chip row now matches Notes' (adds the row label, drops the nested Owner/Member role badge inside each chip).
- The shared `mur-tree-row` (both sidebar trees) hover/selected pill is smaller and better separated from neighboring rows.

## Verification
- `npx ng build` + `npx ng lint` clean.
- Visually confirmed via mocked-IPC Playwright screenshots (settings fade, chip-row match, tree-row before/after).

## Test plan
- [x] `ng build` / `ng lint`
- [x] Visual screenshot check against the mocked demo harness