### PR TITLE
chore(release): 0.9.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.14"
+version = "0.9.15"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.15.

Batch since 0.9.14: kernel memory-pressure signal, LocalSummarizerProvider heavy-inference gate, org-share stuck-failed-republish fix (+ 3 sibling instances found in a follow-up audit), a full-app UX/UI audit (20 fixes incl. a real sealed-meeting-data leak in Analytics and a HIGH-severity lock×shares revoke gap for Murmur↔Murmur person shares), and small UI polish (Settings sidebar fade, Library/Notes org-chip-row parity, tighter folder-tree hover).