### PR TITLE
fix(notes,org): unlock gate + sidebar declutter + flush-left titles + edit own org notes anywhere

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2825,7 +2825,22 @@ fn index_note_body_chunks(
 /// List every note-folder (`kind='note'`). Lock state comes through unchanged from `folders.locked`.
 #[tauri::command]
 pub fn list_note_folders(state: State<'_, AppState>) -> Result<Vec<NoteFolder>, AppError> {
-    state.db.list_note_folders()
+    let mut folders = state.db.list_note_folders()?;
+    // Join the live session unlock set so a sealed-but-session-unlocked note folder reports
+    // `unlocked: true` — mirrors `list_folders` for the Meetings tree. Without this the Notes
+    // lock gate reads only the DB `locked` column (which never flips on session-unlock), so
+    // "Unlock folder" appeared to do nothing (the gate never lifted). (2026-07-14 fix.)
+    let unlocked = {
+        state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone()
+    };
+    for f in &mut folders {
+        f.unlocked = f.locked && unlocked.contains(&f.id);
+    }
+    Ok(folders)
 }
 
 /// Create a note-folder (`kind='note'`). `parent_id` must itself be a note-folder (or None = a
@@ -2882,6 +2897,8 @@ pub(crate) fn create_note_folder_inner(
         path: rel_path,
         parent_id: parent_id.map(|s| s.to_string()),
         locked: false,
+        // A freshly created folder is never sealed, so never session-unlocked.
+        unlocked: false,
         kind: "note".into(),
     };
     state
@@ -24167,6 +24184,130 @@ mod lifecycle_tests {
         assert_eq!(other.title, "Ich notatka", "a non-owned title is left as-is");
     }
 
+    /// F-org-editable-any-device storage: `set_org_item_author` stamps the author id and
+    /// `org_item_edit_ctx` reads it back (with org/rev/created_at/source_kind). An item that was never
+    /// stamped reports `author_user_id: None` — the fail-closed default the ownership gate relies on.
+    #[test]
+    fn org_item_edit_ctx_round_trips_author_and_meta() {
+        let state = build_state("org-edit-ctx");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .upsert_org_item("item-x", "org-1", 3, "anna", "T", "# body", "2026-07-11T09:00:00Z", 2, 1, &[9u8; 32], Some("document"), None)
+            .unwrap();
+
+        // Un-stamped ⇒ author is None (a member could never pass the ownership gate on it).
+        let ctx0 = state.db.org_item_edit_ctx("item-x").unwrap().unwrap();
+        assert_eq!(ctx0.author_user_id, None);
+        assert_eq!(ctx0.org_id, "org-1");
+        assert_eq!(ctx0.rev, 2);
+        assert_eq!(ctx0.created_at, "2026-07-11T09:00:00Z");
+        assert_eq!(ctx0.source_kind.as_deref(), Some("document"));
+
+        // After stamping, the exact author id reads back.
+        state.db.set_org_item_author("item-x", "author-uuid-123").unwrap();
+        let ctx1 = state.db.org_item_edit_ctx("item-x").unwrap().unwrap();
+        assert_eq!(ctx1.author_user_id.as_deref(), Some("author-uuid-123"));
+
+        // A survivor of ON CONFLICT re-upsert (feed re-pull) keeps the author (not in the SET list).
+        state
+            .db
+            .upsert_org_item("item-x", "org-1", 4, "anna", "T2", "# body2", "2026-07-11T09:00:00Z", 3, 1, &[8u8; 32], Some("document"), None)
+            .unwrap();
+        let ctx2 = state.db.org_item_edit_ctx("item-x").unwrap().unwrap();
+        assert_eq!(
+            ctx2.author_user_id.as_deref(),
+            Some("author-uuid-123"),
+            "a re-pull upsert must NOT wipe the stamped author"
+        );
+        assert_eq!(ctx2.rev, 3, "the re-pull DID update rev");
+    }
+
+    /// SECURITY GATE (F-org-editable): `org_update_own_item_inner` refuses to re-publish an item the
+    /// caller did NOT author — it returns `Auth` BEFORE any network egress. Seed a live session whose
+    /// `server_user_id` differs from the item's stamped author; the ownership check (step 0) must reject.
+    #[test]
+    fn org_update_own_item_refuses_a_non_author() {
+        let state = build_state("org-edit-not-author");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .upsert_org_item("item-theirs", "org-1", 1, "bob", "Bob's note", "# body", "2026-07-11T09:00:00Z", 1, 1, &[7u8; 32], Some("document"), None)
+            .unwrap();
+        // Authored by SOMEONE ELSE.
+        state.db.set_org_item_author("item-theirs", "bob-user-id").unwrap();
+        // Consent ON + a live session for a DIFFERENT user — proves the refusal is the OWNERSHIP gate,
+        // not a missing session or consent.
+        state.config.lock().unwrap().org_egress_consented = true;
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "me@example.com".into(),
+            email: "me@example.com".into(),
+            server_user_id: Some("me-user-id".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+
+        let err = block_on(org_update_own_item_inner(&state, "item-theirs", "hacked", "# pwned"))
+            .expect_err("a non-author must NOT be able to re-publish someone else's org item");
+        assert!(
+            matches!(err, AppError::Auth(_)),
+            "expected an Auth refusal, got {err:?}"
+        );
+        // The stored item is untouched (no local overwrite of the colleague's copy).
+        let detail = state.db.get_org_item("item-theirs").unwrap().unwrap();
+        assert_eq!(detail.title, "Bob's note");
+    }
+
+    /// FAIL-CLOSED CONSENT (F-org-editable): even the AUTHOR cannot re-publish an edit while org-egress
+    /// consent is OFF — `org_update_own_item_inner` returns `Unavailable` before any network egress.
+    #[test]
+    fn org_update_own_item_is_consent_fail_closed_for_the_author() {
+        let state = build_state("org-edit-consent");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .upsert_org_item("item-mine", "org-1", 1, "me", "Mine", "# body", "2026-07-11T09:00:00Z", 1, 1, &[9u8; 32], Some("document"), None)
+            .unwrap();
+        state.db.set_org_item_author("item-mine", "me-user-id").unwrap();
+        // The caller IS the author, but consent is OFF (the default).
+        assert!(!state.config.lock().unwrap().org_egress_consented);
+        *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+            account_id: "me@example.com".into(),
+            email: "me@example.com".into(),
+            server_user_id: Some("me-user-id".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([7u8; 32]),
+            generation: 1,
+            access_token: "a".into(),
+            access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+            refresh_token: "r".into(),
+        });
+
+        let err = block_on(org_update_own_item_inner(&state, "item-mine", "edit", "# edit"))
+            .expect_err("no egress while consent is off, even for the author");
+        assert!(
+            matches!(err, AppError::Unavailable(_)),
+            "expected an Unavailable (consent) refusal, got {err:?}"
+        );
+    }
+
+    /// A missing / tombstoned item id is an `InvalidArg`, resolved BEFORE any session or network work.
+    #[test]
+    fn org_update_own_item_rejects_an_unknown_item() {
+        let state = build_state("org-edit-unknown");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        let err = block_on(org_update_own_item_inner(&state, "does-not-exist", "t", "b"))
+            .expect_err("an unknown item id must be rejected");
+        assert!(
+            matches!(err, AppError::InvalidArg(_)),
+            "expected InvalidArg for an unknown item, got {err:?}"
+        );
+    }
+
     /// STUCK-REPUBLISH FIX (`resolve_owned_source`): `resolve_owned_source` must mirror
     /// `org_resolve_source_inner` (fixed in cd21b10) and NOT gate on `state == "uploaded"` — a
     /// republish that failed transiently leaves the row `state = "failed"` with its OLD,
@@ -28759,6 +28900,9 @@ async fn org_sync_one(
             generation: u32,
             env: crate::share::org_envelope::OrgEnvelope,
             sha: Vec<u8>,
+            /// The author's server account id, off the feed entry — stored on the local replica so the
+            /// author's OTHER machines can recognise + edit their own item (2026-07-14).
+            author_user_id: String,
         },
     }
     let mut actions: Vec<FeedAction> = Vec::new();
@@ -28861,6 +29005,7 @@ async fn org_sync_one(
                 generation: item.generation,
                 env,
                 sha,
+                author_user_id: item.author_user_id.clone(),
             });
         }
         if (feed.items.len() as u32) < ORG_FEED_PAGE {
@@ -28897,6 +29042,7 @@ async fn org_sync_one(
                 generation,
                 env,
                 sha,
+                author_user_id,
             } => {
                 state.db.upsert_org_item(
                     &item_id,
@@ -28916,6 +29062,12 @@ async fn org_sync_one(
                     env.source_kind.map(crate::share::org_envelope::OrgSourceKind::as_str),
                     embedder_ref,
                 )?;
+                // Stamp the server-authoritative author id so the author's OTHER machines can edit
+                // their own item in-place (they have no local `org_shares` anchor). Server never sends
+                // an empty author id, but guard anyway — an empty stamp would just leave it unmatched.
+                if !author_user_id.is_empty() {
+                    state.db.set_org_item_author(&item_id, &author_user_id)?;
+                }
                 report.ingested += 1;
                 applied = applied.max(seq);
             }
@@ -28948,7 +29100,213 @@ pub fn org_get_item(
     state: State<'_, AppState>,
     item_id: String,
 ) -> Result<Option<crate::storage::models::OrgItemDetail>, AppError> {
-    state.inner().db.get_org_item(&item_id)
+    let st = state.inner();
+    let Some(mut detail) = st.db.get_org_item(&item_id)? else {
+        return Ok(None);
+    };
+    // EDITABLE (F-org-editable-any-device, 2026-07-14): the caller may edit this item in-place when
+    // they AUTHORED it — proven by the server-authoritative `author_user_id` stored at feed-ingest
+    // matching the caller's own `server_user_id`, NOT by a local `org_shares` anchor (which only exists
+    // on the machine that first shared it). On the origin machine the viewer redirects to the local
+    // source before this ever renders; a second machine has no anchor, so this is what unlocks editing
+    // there. Fail-closed: any missing piece (no stored author, no live session) ⇒ not editable.
+    if let Some(ctx) = st.db.org_item_edit_ctx(&item_id)? {
+        if let (Some(author), Ok(me)) =
+            (ctx.author_user_id.as_deref(), session_server_user_id(st))
+        {
+            detail.editable = author == me;
+        }
+    }
+    Ok(Some(detail))
+}
+
+/// `org_update_own_item(item_id, title, markdown)` — edit-in-place + re-publish for an org item the
+/// caller AUTHORED, from ANY of their machines (the "can't edit my own org note on my other Mac" fix).
+/// Same egress discipline as the share/republish paths (spec gate order): ownership gate → consent
+/// fail-closed → clean + scrub → seal under the OCK with LOCAL open-verify (verify-before-egress) →
+/// upload blob + publish the NEXT rev → tombstone the OLD item (publish-BEFORE-tombstone, so a crash
+/// leaves a recoverable transient dup, never a window with no org copy) → refresh the local replica.
+/// Returns the NEW server item id (the server mints one per publish) so the FE can navigate to it.
+///
+/// This deliberately does NOT touch any local vault note (Variant 1 — the user chose edit-in-place, not
+/// "adopt into this machine's vault"): the org item is edited as its own thing; nothing is materialised
+/// as a `documents` row here.
+#[tauri::command]
+pub async fn org_update_own_item(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    item_id: String,
+    title: String,
+    markdown: String,
+) -> Result<String, AppError> {
+    let new_item_id = org_update_own_item_inner(state.inner(), &item_id, &title, &markdown).await?;
+    // Ping every open org view (Notes list + Settings shared-brain) to re-fetch — the edit superseded
+    // the item (new id) + tombstoned the old. Content-free; best-effort (never affects the result).
+    crate::events::emit_org_feed_updated(&app, 1);
+    Ok(new_item_id)
+}
+
+pub(crate) async fn org_update_own_item_inner(
+    state: &AppState,
+    item_id: &str,
+    title: &str,
+    markdown: &str,
+) -> Result<String, AppError> {
+    // Resolve the item's edit context (org, current rev, original created_at/source_kind, author id).
+    let ctx = state
+        .db
+        .org_item_edit_ctx(item_id)?
+        .ok_or_else(|| AppError::InvalidArg("no such org item (or it was removed)".into()))?;
+
+    // (0) OWNERSHIP GATE — only the AUTHOR may re-publish. Server-authoritative id (stored at ingest),
+    // compared to this session's `server_user_id`. A missing stored author ⇒ refuse (fail-closed): we
+    // must never let a member overwrite a colleague's item.
+    let me = session_server_user_id(state)?;
+    if ctx.author_user_id.as_deref() != Some(me.as_str()) {
+        return Err(AppError::Auth(
+            "you can only edit org notes you authored".into(),
+        ));
+    }
+
+    // (2) CONSENT fail-closed (the same global one-time org-egress consent the share path checks).
+    {
+        let cfg = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        if !cfg.org_egress_consented {
+            return Err(AppError::Unavailable(
+                "org sharing not consented — confirm the one-time upload notice first".into(),
+            ));
+        }
+    }
+
+    // (3) CLEAN + (4) SCRUB the edited body — same leak-safe transform + PII scrub the share/republish
+    // paths apply (scrub ON: fail-safe toward LESS egress; an edit must never DOWNGRADE scrubbing).
+    let cleaned = crate::share::envelope::clean_note_body(markdown);
+    let (final_md, _counts) = scrub_org_markdown(&cleaned);
+
+    // Resolve the org (membership-checked) + a live session; seal at the org's CURRENT generation.
+    let org = resolve_org(state, &ctx.org_id)?;
+    let generation = org.generation;
+    let base = share_base_url(state)?;
+    let (_account_id, _gen_id, _mk, access_token) = require_session_mk(state).await?;
+    let client = crate::share::client::ShareClient::new(&base)?;
+
+    // Author hint = the account email local-part (display label; never note content) — recomputed from
+    // the session like the share path, not read from the (potentially stale) stored hint.
+    let author_hint = {
+        let g = state
+            .account_session
+            .lock()
+            .map_err(|_| AppError::Storage("account-session mutex poisoned".into()))?;
+        crate::share::require_login(&g)
+            .map(|s| org_author_hint(&s.email))
+            .unwrap_or_else(|_| "member".to_string())
+    };
+    let source_kind = match ctx.source_kind.as_deref() {
+        Some("meeting") => crate::share::org_envelope::OrgSourceKind::Meeting,
+        _ => crate::share::org_envelope::OrgSourceKind::Document,
+    };
+
+    let new_rev = ctx.rev.saturating_add(1);
+    let env = crate::share::org_envelope::OrgEnvelope::new(
+        crate::share::org_envelope::OrgItemKind::Note,
+        title.to_string(),
+        final_md,
+        author_hint,
+        ctx.created_at.clone(),
+        new_rev,
+        source_kind,
+    );
+    let content_sha = env.content_sha256();
+
+    // (5) SEAL under the OCK + LOCAL OPEN-VERIFY (verify-before-egress). AAD nonce = hex(content_sha256),
+    // deterministic + rides the feed so every member reconstructs it.
+    let ock = acquire_org_ock(state, &org.org_id, generation).await?;
+    let item_nonce = org_item_nonce(&content_sha);
+    let (ciphertext, _sha) =
+        crate::share::org_envelope::seal_org_envelope(&ock, &env, &org.org_id, &item_nonce)?;
+
+    // (6) upload → publish the NEXT rev. A failure here leaves the OLD item live (never tombstoned yet),
+    // so the org is never left with no copy.
+    let now = chrono::Utc::now().to_rfc3339();
+    let blob_id = client.put_blob(&access_token, ciphertext).await?;
+    let published = client
+        .org_publish_item(
+            &access_token,
+            &org.org_id,
+            crate::share::org_dto::PublishItemRequest {
+                blob_id,
+                content_sha256: content_sha.clone(),
+                rev: new_rev,
+                generation,
+            },
+        )
+        .await?;
+    crate::share::ledger_row(&state.db, &client.host(), "org_share_publish", content_sha.len());
+
+    // LOCAL REPLICA CONSISTENCY: upsert the NEW item (so the Notes list resolves it immediately) +
+    // re-stamp our authorship on it (so it stays editable here) + tombstone the OLD replica. FTS-only
+    // (`None` embedder) to keep the editor-close path light; the next `org_sync_now` re-ingests + embeds.
+    // Best-effort — a local-replica error must never fail the save (the server copy is already live).
+    if let Err(e) = state.db.upsert_org_item(
+        &published.item_id,
+        &org.org_id,
+        published.seq,
+        &env.author_hint,
+        &env.title,
+        &env.markdown,
+        &env.created_at,
+        new_rev,
+        generation,
+        &content_sha,
+        env.source_kind
+            .map(crate::share::org_envelope::OrgSourceKind::as_str),
+        None,
+    ) {
+        tracing::warn!(target: "org", error = %e, "org edit: local replica upsert failed (server copy live)");
+    }
+    let _ = state.db.set_org_item_author(&published.item_id, &me);
+    // Repoint any local `org_shares` anchor for the OLD id (usually none on a non-origin machine, but if
+    // this IS the origin machine keep the anchor pointing at the live item so the vault-note republish
+    // path stays consistent).
+    if let Ok(Some(row)) = state.db.org_share_by_item(item_id) {
+        let _ = state.db.reset_org_share_for_retry(
+            &row.id,
+            row.title.as_deref(),
+            new_rev,
+            generation,
+            &content_sha,
+            &now,
+        );
+        let _ = state.db.set_org_share_uploaded(&row.id, &published.item_id, &now);
+    }
+    if published.item_id != item_id {
+        if let Err(e) = state.db.tombstone_org_item(item_id) {
+            tracing::warn!(target: "org", error = %e, "org edit: local old-item tombstone failed");
+        }
+    }
+
+    // THEN tombstone the OLD item on the server so members evict the stale copy. Publish-BEFORE-tombstone
+    // (done above): a crash here leaves a transient dup (recoverable), never a window with no org copy. A
+    // tombstone failure is non-fatal — the new copy is already live; the stale one lingers until a sweep.
+    if published.item_id != item_id {
+        match client
+            .org_tombstone_item(&access_token, &org.org_id, item_id)
+            .await
+        {
+            Ok(()) => crate::share::ledger_row(&state.db, &client.host(), "org_share_revoke", 0),
+            Err(e) => tracing::warn!(
+                target: "org",
+                error = %e,
+                org_id = %org.org_id,
+                "org edit: superseded item published but old-item tombstone failed (transient dup)"
+            ),
+        }
+    }
+
+    Ok(published.item_id)
 }
 
 /// `list_org_items(org_id)` — the browsable LIST of one org's live items (headers only), so a member

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -225,6 +225,7 @@ pub fn run() {
             commands::org_sweep_pending,
             commands::org_sync_now,
             commands::org_get_item,
+            commands::org_update_own_item,
             commands::org_resolve_source,
             commands::list_org_items,
             commands::folder_active_shares,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1488,6 +1488,13 @@ impl Db {
         // both are honestly "unclassified", never guessed. Guarded (`add_column_if_missing`) so an
         // already-migrated DB just gets the new column with existing rows defaulting to NULL.
         Self::add_column_if_missing(conn, "org_items", "source_kind", "TEXT")?;
+        // ADDITIVE: `author_user_id` — the SERVER account id of the item's author, taken straight off the
+        // feed entry (`OrgItemEntry.author_user_id`) at ingest. Lets ANY of the author's own machines
+        // recognise their own item and offer edit-in-place, even one that never had the local `org_shares`
+        // anchor (the machine that first shared it). NULL for rows ingested before this column existed and
+        // for the local-replica upserts done at share/republish time (the next feed sync fills it in;
+        // those machines already edit via their local source). Guarded so a re-migrated DB is a no-op.
+        Self::add_column_if_missing(conn, "org_items", "author_user_id", "TEXT")?;
         // vec0 int8 KNN table (width = EMBED_DIM; compile-time const, no user input). int8 per the
         // scale spike — see the doc comment. Values are inserted via `vec_int8(?)` (a raw i8 blob).
         conn.execute_batch(&format!(
@@ -5370,6 +5377,48 @@ impl Db {
                     created_at: r.get(3)?,
                     rev: r.get::<_, i64>(4)? as u32,
                     markdown: r.get(5)?,
+                    // The DB layer has no session context — the `org_get_item` command computes the real
+                    // value by comparing the stored `author_user_id` with the caller's `server_user_id`.
+                    editable: false,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Stamp an org item's `author_user_id` (the server account id of its author, from the feed). Called
+    /// right after `upsert_org_item` at feed-ingest so a second machine can recognise its OWN items and
+    /// offer edit-in-place. Idempotent; a no-op for an unknown id. (2026-07-14.)
+    pub fn set_org_item_author(&self, item_id: &str, author_user_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_items SET author_user_id = ?2 WHERE item_id = ?1",
+            rusqlite::params![item_id, author_user_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The context the `org_update_own_item` egress command needs to re-publish an edited org item the
+    /// caller authored (org id, current rev, original created_at + source_kind, stored author id). `None`
+    /// for an unknown / tombstoned item. (2026-07-14.)
+    pub fn org_item_edit_ctx(
+        &self,
+        item_id: &str,
+    ) -> Result<Option<crate::storage::models::OrgItemEditCtx>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT org_id, rev, created_at, source_kind, author_user_id
+               FROM org_items WHERE item_id = ?1 AND tombstoned = 0",
+            rusqlite::params![item_id],
+            |r| {
+                Ok(crate::storage::models::OrgItemEditCtx {
+                    org_id: r.get(0)?,
+                    rev: r.get::<_, i64>(1)? as u32,
+                    created_at: r.get(2)?,
+                    source_kind: r.get::<_, Option<String>>(3)?,
+                    author_user_id: r.get::<_, Option<String>>(4)?,
                 })
             },
         )
@@ -10835,6 +10884,9 @@ fn row_to_note_folder(row: &Row<'_>) -> rusqlite::Result<NoteFolder> {
         path: row.get(2)?,
         parent_id: row.get(3)?,
         locked: row.get::<_, i64>(4)? != 0,
+        // DB-only view: the session-unlock state is not a column. The `list_note_folders` command
+        // fills this in from the live session set; every other reader gets `false` (safe default).
+        unlocked: false,
         kind: row.get::<_, Option<String>>(5)?.unwrap_or_else(|| "note".into()),
     })
 }

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -548,6 +548,26 @@ pub struct OrgItemDetail {
     pub created_at: String,
     pub rev: u32,
     pub markdown: String,
+    /// True when the CALLER authored this item (their `server_user_id` matches the item's stored
+    /// `author_user_id`) — so the viewer can offer edit-in-place on ANY of the author's machines, not
+    /// just the one that first shared it (the origin machine redirects to the local source instead;
+    /// a second machine has no local `org_shares` row, so this server-authoritative author check is
+    /// what unlocks editing there). Computed by the `org_get_item` command (needs the session);
+    /// `Db::get_org_item` always sets it `false`. 2026-07-14.
+    pub editable: bool,
+}
+
+/// Internal (not FE-facing) context the `org_update_own_item` egress command needs to re-publish an
+/// edited org item the caller authored: which org to publish into, the current rev (→ rev+1 supersede),
+/// the original `created_at` + `source_kind` to preserve on the wire, and the stored `author_user_id`
+/// for the ownership gate. Resolved by [`Db::org_item_edit_ctx`] for a LIVE (non-tombstoned) item.
+#[derive(Debug, Clone)]
+pub struct OrgItemEditCtx {
+    pub org_id: String,
+    pub rev: u32,
+    pub created_at: String,
+    pub source_kind: Option<String>,
+    pub author_user_id: Option<String>,
 }
 
 /// Shared Brain v1 — a LIST-row header for one live org item (the browsable org-items list, so a
@@ -670,7 +690,13 @@ pub struct NoteFolder {
     pub name: String,
     pub path: String,
     pub parent_id: Option<String>,
+    /// Sealed (encrypted) on disk — the DB `locked` column.
     pub locked: bool,
+    /// Sealed on disk BUT session-unlocked (decrypted for this session only). Mirrors
+    /// [`FolderNode::unlocked`] — the DB knows nothing about the session, so `row_to_note_folder`
+    /// always sets this `false`; the `list_note_folders` command overwrites it by joining the live
+    /// `AppState::unlocked_folders` set (a sealed folder that is NOT session-unlocked stays `false`).
+    pub unlocked: bool,
     pub kind: String,
 }
 

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -129,19 +129,25 @@
       </nav>
 
       <div class="sidebar-footer">
-        <!-- Session-privacy indicator: locked folders currently unlocked. -->
+        <!-- Session-privacy: the sidebar's SINGLE accent focal point + its only
+             "Lock all" action (2026-07-14 declutter — the former top-of-tree
+             pill was removed). Status (N unlocked) + action (Lock all now) in
+             one control; only shown while something is actually exposed. -->
         @if (unlockedCount() > 0) {
-          <span
+          <button
+            type="button"
             class="unlocked-pill"
-            role="status"
+            [disabled]="relockingAll()"
+            (click)="relockAll()"
             [attr.aria-label]="
+              'Re-seal all ' +
               unlockedCount() +
-              ' locked folder' +
+              ' unlocked folder' +
               (unlockedCount() === 1 ? '' : 's') +
-              ' unlocked this session'
+              ' now'
             "
             [attr.title]="
-              'These folders are decrypted into plaintext until you re-lock or a screen share starts.'
+              'These folders are decrypted into plaintext until you re-lock or a screen share starts. Click to re-seal all now.'
             "
           >
             <svg
@@ -157,7 +163,8 @@
             </svg>
             <span class="unlocked-count">{{ unlockedCount() }}</span>
             <span class="nav-label unlocked-label">unlocked</span>
-          </span>
+            <span class="nav-label unlocked-action">Lock all</span>
+          </button>
         }
 
         <a
@@ -258,18 +265,22 @@
       </a>
 
       @if (unlockedCount() > 0) {
-        <span
+        <button
+          type="button"
           class="pill-unlocked"
-          role="status"
-          [attr.aria-label]="unlockedCount() + ' unlocked this session'"
-          title="Locked folders decrypted for this session"
+          [disabled]="relockingAll()"
+          (click)="relockAll()"
+          [attr.aria-label]="
+            'Re-seal all ' + unlockedCount() + ' unlocked folders now'
+          "
+          title="Locked folders decrypted for this session — click to re-seal all now"
         >
           <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
             <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
             <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
           </svg>
           <span class="unlocked-count">{{ unlockedCount() }}</span>
-        </span>
+        </button>
       }
     </nav>
   }

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -336,8 +336,18 @@ export class AppShellComponent {
   /** Whether the ⌘K quick-search spotlight is open. */
   readonly searchOpen = signal(false);
 
-  /** How many locked folders are unlocked (plaintext-exposed) this session. */
+  /**
+   * How many locked folders are unlocked (plaintext-exposed) this session —
+   * drives the footer "N unlocked · Lock all" button. `FoldersService`'s tree
+   * comes from `list_folders`, which returns EVERY folder (meeting AND note —
+   * no `kind` filter in the SQL), each with its session `unlocked` flag, so this
+   * one count already covers both trees. (Do NOT add `NotesService`'s note-folder
+   * count on top — note folders are already in this tree, so that double-counts.)
+   */
   readonly unlockedCount = this.folders.unlockedCount;
+
+  /** True while the footer "Lock all" re-seal is in flight (guards double-clicks). */
+  readonly relockingAll = signal(false);
 
   /** The app-wide toast queue, rendered in the main-window viewport. */
   readonly toasts = this.toast.toasts;
@@ -503,6 +513,30 @@ export class AppShellComponent {
   newNote(): void {
     this.searchOpen.set(false);
     void this.router.navigate(["/notes/new"]);
+  }
+
+  /**
+   * The footer "N unlocked · Lock all" button (2026-07-14): re-seal EVERY
+   * session-unlocked folder now and zeroize the cached key — the sidebar's
+   * single privacy action (the former top-of-tree "Lock all" pill was removed).
+   * `FoldersService.relockAll` reloads the meetings tree; we then reload the
+   * Notes tree too so a re-sealed note-folder's per-row state updates as well
+   * (the backend `relock_all` re-seals both — folder ids share one session set).
+   */
+  async relockAll(): Promise<void> {
+    if (this.relockingAll()) {
+      return;
+    }
+    this.relockingAll.set(true);
+    try {
+      await this.folders.relockAll();
+      await this.notesService.loadFolders();
+      this.toast.success("All folders re-sealed");
+    } catch {
+      this.toast.danger("Couldn’t re-seal folders. Please try again.");
+    } finally {
+      this.relockingAll.set(false);
+    }
   }
 
   /**

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -717,6 +717,22 @@ export class IpcService {
   }
 
   /**
+   * Edit-in-place + re-publish an org item the caller AUTHORED (works from any of
+   * their machines, unlike the redirect-to-local-source path which only works on
+   * the machine that first shared it). Goes through the same consent + seal +
+   * verify-before-egress gates as sharing; supersedes the old item (rev+1) and
+   * returns the NEW server item id so the caller can navigate to it. Mirrors
+   * `org_update_own_item`.
+   */
+  orgUpdateOwnItem(
+    itemId: string,
+    title: string,
+    markdown: string,
+  ): Promise<string> {
+    return invoke<string>("org_update_own_item", { itemId, title, markdown });
+  }
+
+  /**
    * Resolve an org item back to THIS device's local editable source (the note or
    * meeting it was shared FROM), or `null` when the caller is NOT the author (no
    * local source). Lets the `/org-item/:id` viewer send an author straight to

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1846,7 +1846,15 @@ export interface NoteFolder {
   name: string;
   path: string;
   parentId: string | null;
+  /** Sealed (encrypted) on disk. */
   locked: boolean;
+  /**
+   * Sealed on disk BUT session-unlocked (decrypted for this session). Mirrors
+   * {@link FolderNode.unlocked} — the backend joins the live session set in
+   * `list_note_folders`. An open folder is `locked=false, unlocked=false`. Drives
+   * the Notes lock gate (`locked && !unlocked`) so unlocking actually lifts it.
+   */
+  unlocked: boolean;
   kind: string;
 }
 
@@ -2055,6 +2063,14 @@ export interface OrgItemDetail {
   createdAt: string;
   rev: number;
   markdown: string;
+  /**
+   * True when THIS user authored the item (server-authoritative author id) — the
+   * viewer then offers edit-in-place + re-publish (`orgUpdateOwnItem`) on ANY of
+   * the author's machines, even one that never held the local share anchor. On the
+   * origin machine the viewer redirects to the local source before this renders;
+   * a non-author always sees `false`. Mirrors the Rust `OrgItemDetail.editable`.
+   */
+  editable: boolean;
 }
 
 /**

--- a/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.html
+++ b/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.html
@@ -1,22 +1,9 @@
-@if (folders.unlockedCount() > 0) {
-  <button
-    type="button"
-    class="relock-pill"
-    [disabled]="relockingAll()"
-    [attr.aria-label]="
-      'Re-seal all ' + folders.unlockedCount() + ' unlocked folders now'
-    "
-    title="Re-seal every unlocked folder now"
-    (click)="relockAll()"
-  >
-    <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
-      <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.4" />
-      <path d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
-    </svg>
-    Lock all
-  </button>
-}
-
+<!-- The "Lock all" pill that used to sit here was REMOVED (2026-07-14, sidebar
+     declutter): it was one of three concurrent accent privacy signals (this
+     pill + the footer "N unlocked" pill + every folder row's lock glyph) all
+     firing for the ONE fact "a folder is decrypted right now". "Lock all" now
+     lives as the single footer button (see AppShellComponent) — one accent
+     focal point, and it doubles as the status indicator. -->
 @if (folders.loading()) {
   <p class="tree-state">Loading folders…</p>
 } @else {

--- a/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.scss
+++ b/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.scss
@@ -10,42 +10,9 @@
   margin-bottom: var(--space-1);
 }
 
-/* "Lock all" — quiet accent pill, only present when a folder is exposed. */
-.relock-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  align-self: flex-start;
-  height: 24px;
-  margin: 2px 0 var(--space-1);
-  padding: 0 var(--space-2);
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
-  color: var(--accent-hover);
-  font-family: inherit;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  transition:
-    filter var(--transition),
-    transform var(--transition-fast);
-}
-.relock-pill:hover:not(:disabled) {
-  filter: brightness(1.12);
-}
-.relock-pill:active:not(:disabled) {
-  transform: scale(0.95);
-}
-.relock-pill:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-.relock-pill:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+/* (The `.relock-pill` "Lock all" affordance was removed 2026-07-14 — see the
+   template comment; the single "Lock all" action now lives in the sidebar
+   footer, styled by `.unlocked-pill` in styles.css.) */
 
 .tree-state {
   margin: var(--space-1) var(--space-2);

--- a/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.ts
+++ b/src/app/features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component.ts
@@ -4,7 +4,6 @@ import {
   computed,
   inject,
   input,
-  signal,
   viewChild,
 } from "@angular/core";
 import { Router } from "@angular/router";
@@ -43,9 +42,6 @@ export class MeetingsSidebarTreeComponent {
 
   /** Shared folder store (tree data + the lock lifecycle FolderTreeComponent drives). */
   readonly folders = inject(FoldersService);
-
-  /** True while a "Lock all" op is in flight. */
-  readonly relockingAll = signal(false);
 
   /**
    * True while `/library`/`/meeting/:id` is the CURRENT route (bound from
@@ -132,22 +128,6 @@ export class MeetingsSidebarTreeComponent {
       this.toast.success(`Moved to ${name}`);
     } catch {
       this.toast.danger("Couldn’t move this note. Please try again.");
-    }
-  }
-
-  /** Re-seal every session-unlocked folder at once (privacy "panic" affordance). */
-  async relockAll(): Promise<void> {
-    if (this.relockingAll()) {
-      return;
-    }
-    this.relockingAll.set(true);
-    try {
-      await this.folders.relockAll();
-      this.toast.success("All folders re-sealed");
-    } catch {
-      this.toast.danger("Couldn’t re-seal folders. Please try again.");
-    } finally {
-      this.relockingAll.set(false);
     }
   }
 }

--- a/src/app/features/library/library/library.component.scss
+++ b/src/app/features/library/library/library.component.scss
@@ -130,14 +130,21 @@
   min-width: 0;
 }
 
-/* --- Drag grip (signals a row is draggable; reveals on row hover) ----- */
+/* --- Drag grip (signals a row is draggable; reveals on row hover) -----
+   ABSOLUTELY positioned in the row's left padding gutter so it never pushes
+   the title inward (2026-07-14: the title read as indented ~34px even while
+   the grip was invisible, because its 18px box + the row gap still reserved
+   flow width — user asked for titles flush-left). Now the title starts at the
+   row's own padding edge; the grip fades in over the gutter on hover only. */
 .grip {
+  position: absolute;
+  left: var(--space-1);
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: none;
-  width: 18px;
-  margin-left: calc(var(--space-2) * -1);
+  width: 14px;
   color: var(--text-muted);
   cursor: grab;
   opacity: 0;
@@ -428,6 +435,7 @@
   border-bottom: 1px solid var(--border-subtle);
 }
 .row {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -272,8 +272,17 @@ export class NotesHomeComponent implements OnInit {
     () => this.activeOrg()?.name ?? this.activeFolder()?.name ?? "All notes",
   );
 
-  /** True when the active folder is sealed (drives the locked-folder banner). */
-  readonly activeFolderLocked = computed(() => !!this.activeFolder()?.locked);
+  /**
+   * True when the active folder is sealed AND not session-unlocked (drives the
+   * locked-folder gate). Gating on `locked && !unlocked` — not `locked` alone —
+   * is what makes "Unlock folder" actually lift the gate: a session-unlock never
+   * flips the DB `locked` column, only the session `unlocked` flag, so the old
+   * `!!locked` check kept the gate up forever after unlocking (2026-07-14 fix).
+   */
+  readonly activeFolderLocked = computed(() => {
+    const f = this.activeFolder();
+    return !!f?.locked && !f?.unlocked;
+  });
 
   // --- Per-note "Move to…" popover ----------------------------------------
   /** The note id whose move popover is open (null = none). */

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.html
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.html
@@ -42,45 +42,67 @@
            action cluster below is this component's own. -->
       <mur-tree-row
         [label]="folder.name"
-        [icon]="folder.locked ? 'locked' : 'folder'"
+        [icon]="folder.locked && !folder.unlocked ? 'locked' : 'folder'"
         [selected]="sectionActive() && activeFolderId() === folder.id"
         (activate)="select(folder.id)"
       >
-        <div class="tree-actions">
-          <!-- Lock/unlock stays its own always-in-cluster control — this
-               tree's lock state was never a glanceable badge outside hover
-               to begin with (unlike Meetings' `.lock-toggle`), so folding it
-               into the shared dropdown below loses nothing. -->
-          @if (folder.locked) {
+        <!-- ONE lock control, three states (2026-07-14 — mirrors Meetings'
+             `.lock-toggle`): open → click to encrypt; locked → click to unlock
+             this session; session → accent + ALWAYS visible (plaintext exposed
+             right now), click to re-seal. It sits OUTSIDE the hover-revealed
+             `.tree-actions` cluster so the locked/session states stay glanceable
+             without hover; open stays hover-only (Direction A restraint). -->
+        @switch (exposureOf(folder)) {
+          @case ("open") {
             <button
               type="button"
-              class="tree-act"
-              [disabled]="lockBusyId() === folder.id"
-              (click)="unlockFolder(folder, $event)"
-              aria-label="Unlock folder"
-              title="Unlock"
-            >
-              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
-                <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
-                <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.6-0.9" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-              </svg>
-            </button>
-          } @else {
-            <button
-              type="button"
-              class="tree-act"
+              class="tree-lock"
               [disabled]="lockBusyId() === folder.id"
               (click)="lockFolder(folder, $event)"
               aria-label="Lock folder"
-              title="Lock"
+              title="Encrypt this folder"
             >
               <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
                 <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
-                <path d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
               </svg>
             </button>
           }
+          @case ("locked") {
+            <button
+              type="button"
+              class="tree-lock is-locked"
+              [disabled]="lockBusyId() === folder.id"
+              (click)="unlockFolder(folder, $event)"
+              aria-label="Unlock folder for this session"
+              title="Locked — click to unlock for this session"
+            >
+              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
+                <rect x="3.5" y="7" width="9" height="6" rx="1.4" fill="currentColor" stroke="currentColor" stroke-width="1.3" />
+                <path d="M5.5 7V5.4a2.5 2.5 0 0 1 5 0V7" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                <circle cx="8" cy="10" r="1" fill="var(--surface-base)" />
+              </svg>
+            </button>
+          }
+          @case ("session") {
+            <button
+              type="button"
+              class="tree-lock is-session"
+              [disabled]="lockBusyId() === folder.id"
+              (click)="relockFolder(folder, $event)"
+              aria-label="Re-seal folder"
+              title="Unlocked this session — click to re-seal now"
+            >
+              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
+                <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.4" />
+                <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+                <circle cx="8" cy="10" r="1.05" fill="currentColor" />
+              </svg>
+            </button>
+          }
+        }
 
+        <div class="tree-actions">
           <!-- Rename + Delete — behind the SAME shared `<mur-row-menu>` gear
                dropdown the Meetings tree renders (design-system,
                `row-menu.component.ts`). Same items, same order, so the two

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.scss
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.scss
@@ -67,6 +67,54 @@ mur-tree-row:focus-within .tree-actions {
   cursor: default;
 }
 
+/* The ONE per-row lock control (2026-07-14) — same box as `.tree-act` but it
+   lives OUTSIDE the hover-only cluster so locked/session stay glanceable.
+   `open` is hover-revealed (quiet); `locked` is always-visible grey; `session`
+   is always-visible accent (the one "plaintext exposed" cue on the row). */
+.tree-lock {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 21px;
+  height: 21px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+mur-tree-row:hover .tree-lock,
+mur-tree-row:focus-within .tree-lock {
+  opacity: 1;
+}
+.tree-lock.is-locked {
+  opacity: 1;
+  color: var(--text-secondary);
+}
+.tree-lock.is-session {
+  opacity: 1;
+  color: var(--accent-hover);
+}
+.tree-lock:hover:not(:disabled) {
+  background: var(--surface-raised);
+  color: var(--text-primary);
+}
+.tree-lock:focus-visible {
+  outline: none;
+  opacity: 1;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.tree-lock:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* Inline folder create / rename field + delete confirm. Polish pass
    (2026-07-12, live-found "looks bad" feedback): the original cramped every
    element to `--space-1` (4px) padding, so the input read as squashed next

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.ts
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.ts
@@ -14,7 +14,10 @@ import type { NoteFolder } from "../../../core/models";
 import { MurTreeRowComponent } from "../../../design-system/tree-row/tree-row.component";
 import { MurRowMenuComponent } from "../../../design-system/row-menu/row-menu.component";
 import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
-import { FoldersService } from "../../../services/folders.service";
+import {
+  FoldersService,
+  type FolderExposure,
+} from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
 
@@ -88,6 +91,21 @@ export class NotesSidebarTreeComponent {
 
   /** Id of the folder whose lock/unlock op is in flight. */
   readonly lockBusyId = signal<string | null>(null);
+
+  /**
+   * A note-folder's three-state privacy exposure (open / locked / session),
+   * derived from its lock flags — same model the Meetings tree uses. `session`
+   * (sealed on disk but decrypted for this session) is the only state that stays
+   * glanceable + accent-tinted; open/locked are quiet. Needs `NoteFolder.unlocked`
+   * (2026-07-14) — before that this tree only knew locked/open and could never
+   * show that a folder was session-unlocked.
+   */
+  exposureOf(folder: NoteFolder): FolderExposure {
+    if (!folder.locked) {
+      return "open";
+    }
+    return folder.unlocked ? "session" : "locked";
+  }
 
   // --- New-folder inline create -------------------------------------------
   readonly creatingFolder = signal(false);
@@ -237,6 +255,27 @@ export class NotesSidebarTreeComponent {
     } catch {
       // A cancelled/denied Touch ID prompt — stay masked, no scary toast.
       this.toast.danger("Couldn’t unlock this folder.");
+    } finally {
+      this.lockBusyId.set(null);
+    }
+  }
+
+  /**
+   * Re-seal a session-unlocked note-folder right now (drops the decrypted
+   * plaintext for this session; the `.enc`/blobs stay). Mirrors the Meetings
+   * tree's per-row re-seal — the action behind the `session` exposure state.
+   */
+  async relockFolder(folder: NoteFolder, event: Event): Promise<void> {
+    event.stopPropagation();
+    if (this.lockBusyId() !== null) {
+      return;
+    }
+    this.lockBusyId.set(folder.id);
+    try {
+      await this.folders.relock(folder.id);
+      await this.refreshAfterLockChange();
+    } catch {
+      this.toast.danger("Couldn’t re-seal this folder. Please try again.");
     } finally {
       this.lockBusyId.set(null);
     }

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.html
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.html
@@ -16,7 +16,53 @@
   } @else if (item(); as it) {
     <article class="card oi-card">
       <header class="oi-head">
-        <h1 class="oi-title">{{ it.title }}</h1>
+        <div class="oi-head-top">
+          @if (editing()) {
+            <input
+              class="oi-title-input"
+              type="text"
+              [value]="titleDraft()"
+              (input)="titleDraft.set($any($event.target).value)"
+              placeholder="Title"
+              aria-label="Note title"
+            />
+          } @else {
+            <h1 class="oi-title">{{ it.title }}</h1>
+          }
+
+          <!-- Edit-in-place (author only; works on any of the author's machines). -->
+          @if (it.editable) {
+            <div class="oi-actions">
+              @if (editing()) {
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  [disabled]="saving()"
+                  (click)="cancelEdit()"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  [disabled]="saving()"
+                  (click)="saveEdit()"
+                >
+                  {{ saving() ? "Saving…" : "Save" }}
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  (click)="startEdit()"
+                >
+                  Edit
+                </button>
+              }
+            </div>
+          }
+        </div>
+
         <div class="oi-meta">
           <span class="oi-org-chip">
             <span class="oi-org-dot" aria-hidden="true"></span>
@@ -37,7 +83,17 @@
         </div>
       </header>
       <div class="oi-body">
-        <app-markdown [markdown]="it.markdown" />
+        @if (editing()) {
+          <textarea
+            class="oi-editor"
+            [value]="markdownDraft()"
+            (input)="markdownDraft.set($any($event.target).value)"
+            aria-label="Note content (markdown)"
+            spellcheck="false"
+          ></textarea>
+        } @else {
+          <app-markdown [markdown]="it.markdown" />
+        }
       </div>
     </article>
   }

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.scss
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.scss
@@ -69,6 +69,13 @@
   padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--border-subtle);
 }
+/* Title row: the heading (or its edit input) + the author's edit/save actions. */
+.oi-head-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
 .oi-title {
   margin: 0;
   font-size: 1.55rem;
@@ -76,6 +83,51 @@
   letter-spacing: -0.01em;
   color: var(--text-primary);
   line-height: 1.25;
+}
+.oi-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+
+/* --- Edit-in-place (author only) ----------------------------------------- */
+.oi-title-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+.oi-title-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.oi-editor {
+  width: 100%;
+  min-height: 60vh;
+  padding: var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+.oi-editor:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
 }
 /* Metadata strip: Org Brain badge + org name + author + date + revision. */
 .oi-meta {

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -14,6 +14,7 @@ import { TabsService } from "../../../core/tabs.service";
 import { tabKeyFor } from "../../../core/tab-keys";
 import type { OrgItemDetail } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { ToastService } from "../../../services/toast.service";
 
 /**
  * Viewer for ONE org-brain item (`/org-item/:id`). Reached from an org-origin
@@ -46,6 +47,7 @@ export class OrgItemViewerComponent {
   private readonly router = inject(Router);
   private readonly injector = inject(Injector);
   private readonly tabsService = inject(TabsService);
+  private readonly toast = inject(ToastService);
 
   /** The `:id` route param as a signal (re-fetches when it changes in place). */
   private readonly itemId = toSignal(
@@ -64,6 +66,15 @@ export class OrgItemViewerComponent {
   readonly orgName = this._orgName.asReadonly();
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
+
+  // --- Edit-in-place (author only; F-org-editable-any-device) ---------------
+  /** True while the author is editing this item in place (drives the editor UI). */
+  readonly editing = signal(false);
+  /** Draft title/body bound to the inline editor while {@link editing}. */
+  readonly titleDraft = signal("");
+  readonly markdownDraft = signal("");
+  /** True while `orgUpdateOwnItem` (seal → publish → tombstone-old) is in flight. */
+  readonly saving = signal(false);
 
   constructor() {
     // Resolve + fetch the org item whenever the route id changes. Async IPC
@@ -97,6 +108,8 @@ export class OrgItemViewerComponent {
     this.error.set(null);
     this._item.set(null);
     this._orgName.set("");
+    // A route change (incl. the post-save redirect to the superseded item) always exits edit mode.
+    this.editing.set(false);
     try {
       const ref = await this.ipc.orgResolveSource(id);
       if (this.itemId() !== id) {
@@ -166,6 +179,54 @@ export class OrgItemViewerComponent {
       }
     } catch {
       /* best-effort: leave the org label empty */
+    }
+  }
+
+  /** Enter edit mode (author only), seeding the drafts from the loaded item. */
+  startEdit(): void {
+    const it = this._item();
+    if (!it || !it.editable) {
+      return;
+    }
+    this.titleDraft.set(it.title);
+    this.markdownDraft.set(it.markdown);
+    this.editing.set(true);
+  }
+
+  /** Leave edit mode without saving (ignored mid-save). */
+  cancelEdit(): void {
+    if (this.saving()) {
+      return;
+    }
+    this.editing.set(false);
+  }
+
+  /**
+   * Save the edit: re-publish the org item (rev+1) through the backend's consent +
+   * seal + verify-before-egress gates. The server mints a NEW item id (feed items
+   * are immutable), so on success we navigate to it (`replaceUrl`) — the route-id
+   * effect re-loads the fresh, still-editable item. A blank title/body or a
+   * no-change save is allowed (the backend short-circuits identical content).
+   */
+  async saveEdit(): Promise<void> {
+    const it = this._item();
+    if (!it || this.saving()) {
+      return;
+    }
+    const title = this.titleDraft().trim();
+    const markdown = this.markdownDraft();
+    this.saving.set(true);
+    try {
+      const newId = await this.ipc.orgUpdateOwnItem(it.itemId, title, markdown);
+      this.editing.set(false);
+      this.toast.success("Changes shared to the org");
+      // The superseded item has a new id — land on it so the viewer reloads fresh.
+      await this.router.navigate(["/org-item", newId], { replaceUrl: true });
+    } catch (e) {
+      this.toast.danger("Couldn’t save your changes. Please try again.");
+      console.error("org edit save failed", e);
+    } finally {
+      this.saving.set(false);
     }
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -380,11 +380,16 @@ mur-sidebar-section {
   border-top: 1px solid var(--border-subtle);
 }
 
-/* --- Session-privacy "N unlocked" indicator (footer) ----------------------- */
+/* --- Session-privacy "N unlocked · Lock all" button (footer) ---------------
+   The sidebar's SINGLE accent focal point AND its only "Lock all" action
+   (2026-07-14 declutter). Full-width so it reads as an action row like the
+   Settings/Collapse rows below it; status on the left, "Lock all" on the
+   right. Only rendered while a folder is actually exposed. */
 .unlocked-pill {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  width: 100%;
   height: 32px;
   margin-bottom: var(--space-1);
   padding: 0 var(--space-3);
@@ -392,15 +397,37 @@ mur-sidebar-section {
   border-radius: var(--radius-md);
   background: var(--accent-soft);
   color: var(--accent-hover);
+  font-family: inherit;
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1;
   white-space: nowrap;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    filter var(--transition),
+    background var(--transition);
+}
+.unlocked-pill:hover:not(:disabled) {
+  filter: brightness(1.12);
+}
+.unlocked-pill:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.unlocked-pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.unlocked-pill:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 .unlocked-glyph { display: block; flex: none; }
 .unlocked-count { font-variant-numeric: tabular-nums; }
 .unlocked-label { color: var(--accent-hover); opacity: 0.85; }
+/* The action half — pushed to the trailing edge, a touch bolder. */
+.unlocked-action { margin-left: auto; font-weight: 700; letter-spacing: 0; }
 
 /* --- Icon-rail collapse (Settings → Appearance → Sidebar → "Icon rail") ----
    The ALTERNATIVE collapsed chrome: the same floating glass panel, shrunk to
@@ -529,13 +556,28 @@ mur-sidebar-section {
   height: 28px;
   margin-left: 3px;
   padding: 0 var(--space-2);
+  border: 0;
   border-radius: var(--radius-pill);
   background: var(--accent-soft);
   color: var(--accent-hover);
+  font-family: inherit;
   font-size: 0.76rem;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
+  cursor: pointer;
+  transition: filter var(--transition);
+}
+.pill-unlocked:hover:not(:disabled) {
+  filter: brightness(1.12);
+}
+.pill-unlocked:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.pill-unlocked:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* --- Main column: [tab strip, app-main] stacked, beside the sidebar --------


### PR DESCRIPTION
Fixes four reported issues.

## 1. Dead "Unlock folder" button (P0)
The Notes lock gate read `NoteFolder.locked` — the DB column, which **never flips on a session-unlock** (only the in-memory session set changes). So clicking "Unlock folder" succeeded in the backend (the footer "N unlocked" pill proved it) but the gate never lifted. `list_note_folders` also never joined the session set, unlike `list_folders`.

- `NoteFolder` gains `unlocked: bool`, computed in the `list_note_folders` command (`unlocked = locked && session_set.contains(id)`, mirroring `list_folders`).
- FE gate is now `locked && !unlocked`.
- The Notes sidebar tree gets the same 3-state (open/locked/session) lock control as Meetings, so a session-unlocked note folder reflects it + re-seals on click.

## 2. Overwhelming sidebar lock UX (research-backed, Direction A)
Three concurrent accent signals fired for one fact ("a folder is decrypted now"): a top-of-tree "Lock all" pill + every folder-row lock glyph + a footer status pill. Best-in-class apps (Standard Notes, Bear, 1Password, Apple Notes, Obsidian) converge on *state = quiet glyph; "lock all" = one action off the tree; accent for the exposed state only*.

- Deleted the top-of-tree "Lock all" pill.
- The footer "N unlocked" pill is now the single **"Lock all" button** (it already counts every folder — `list_folders` returns note folders too, so no double-count).

## 3. Meeting titles indented
The drag grip reserved flow width even while invisible (~34px push). Pulled it out of flow (absolute, in the row's left gutter) so titles sit flush-left; it still fades in on hover. `.row-menu`/`.move-anchor` are unaffected (they anchor to `.row-item`).

## 4. Can't edit own org-shared notes from a second machine
Editability keyed off the device-local `org_shares` anchor, which only exists on the machine that shared. On a second machine (same account) a self-authored org note showed read-only.

- Store the server-authoritative `author_user_id` on `org_items` at feed ingest (additive migration).
- New `org_update_own_item` egress command: edit-in-place + re-publish (rev+1), gated **ownership → consent fail-closed → clean+scrub → seal with verify-before-egress → publish-before-tombstone** (mirrors `republish_org_shares_for_source`).
- The viewer shows an inline editor when `item().editable`. No local vault note is materialised (Variant 1, per product decision).

## Verification
- **cargo test --lib: 1593 passed / 0 failed** — incl. 4 new regression tests: ownership refusal (a member cannot overwrite a colleague's item), consent fail-closed for the author, unknown-item rejection, and author-survives-a-re-pull-upsert.
- **ng lint** clean, **ng build** clean.
- ⚠️ The independent adversarial-verifier + lock-security-reviewer agents hit an infra stream-watchdog stall and could not produce a final verdict; the adversarial agent DID surface one real bug before stalling (a footer double-count), which is fixed in this branch. The remaining review was done manually against the project's shipped failure modes. Recommend an independent `/code-review` / ultrareview pass on this PR.
- Needs a **signed build** to fully prove: Touch ID unlock, real cross-Mac org edit round-trip (seal→publish→tombstone over the network), and lock-at-rest. The added tests cover the security gates that reject *before* any egress.