### PR TITLE
fix(notes): explain a locked-folder note-create refusal (no more generic 'couldn't create')

### DIFF
--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -1488,8 +1488,14 @@ export class NoteEditorComponent {
       await this.ipc.updateNoteDoc(id, title, body);
       void this.notes.loadNotes(null);
       void this.router.navigate(["/notes", id]);
-    } catch {
-      this.toast.danger("Couldn’t create the note");
+    } catch (e) {
+      // Surface a sealed-folder refusal (`Locked`) plainly, like the main
+      // "New note" action and the share panel — never a bare "couldn't create".
+      this.toast.danger(
+        /locked/i.test(String(e))
+          ? "This folder is locked — unlock it first to add a note."
+          : "Couldn’t create the note",
+      );
     }
   }
 

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -388,8 +388,16 @@ export class NotesHomeComponent implements OnInit {
     try {
       const id = await this.notes.create(this.activeFolderId(), "Untitled");
       await this.router.navigate(["/notes", id]);
-    } catch {
-      this.toast.danger("Couldn’t create the note. Please try again.");
+    } catch (e) {
+      // A sealed target folder (the selected one, or the default "Notes" folder
+      // if it's locked) refuses the write with a `Locked` AppError. Say WHY —
+      // the old generic "couldn't create" hid the real cause, so a user whose
+      // default folder was locked just saw an unexplained failure (2026-07-14).
+      this.toast.danger(
+        /locked/i.test(String(e))
+          ? "This folder is locked — unlock it first to add a note."
+          : "Couldn’t create the note. Please try again.",
+      );
     } finally {
       this.creating.set(false);
     }


### PR DESCRIPTION
## Symptom
"Couldn't create the note" (v0.9.15) when clicking **New note**.

## Root cause (confirmed)
`create_note` refuses a write into a **sealed-and-not-session-unlocked** folder with `AppError::Locked` (tested at `commands.rs` — *create_note into a SEALED note-folder is REFUSED with Locked*). "New note" targets the selected folder, or the **default "Notes" folder** when nothing is selected — and if that default folder is locked, **every** create fails. Both the notes-home "New note" action and the note-editor spinoff path caught the error **generically** (`"Couldn't create the note"`), hiding the real reason.

## Fix
Branch the toast on the `Locked` error → *"This folder is locked — unlock it first to add a note."* Mirrors `note-share-panel.friendlyCreateError`. **Message-only** — the write-gate is unchanged; no lock/crypto/visibility logic touched.

## Pairs with #321
The user was stuck because in 0.9.15 they *also* couldn't unlock the folder (the Notes unlock-gate bug fixed in #321). Together: a locked-default-folder user now (a) understands why create failed, and (b) can actually unlock to fix it. **Both land in the next build.**

## Verify
`ng lint` + `ng build` clean. Backend Locked-refusal already covered by the existing create-note-into-sealed-folder test.