### PR TITLE
feat(notes): note↔note backlinks reader ('Linked mentions')

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5685,6 +5685,30 @@ pub fn get_entity_detail(
         .ok_or_else(|| AppError::InvalidArg(format!("no entity with id {entity_id}")))
 }
 
+/// "What links here" for a note or meeting: every VISIBLE meeting-note / standalone-note whose body
+/// carries a `[[<this row's title>]]` wikilink. GATE is folded into the DB builder
+/// (`Db::backlinks_for_visible`) exactly like [`get_entity_detail`] — no separate command-layer
+/// pre-check. Snapshots the LIVE session unlock set, so a sealed target yields `[]` (never reveals it
+/// HAS backlinks) and a sealed source never contributes. `target_kind` is `"meeting"` | `"note"`.
+#[tauri::command]
+pub fn get_backlinks(
+    state: State<'_, AppState>,
+    target_kind: String,
+    target_id: String,
+) -> Result<Vec<crate::storage::models::BacklinkSource>, AppError> {
+    let kind = match target_kind.as_str() {
+        "meeting" => crate::storage::models::SourceKind::Meeting,
+        "note" => crate::storage::models::SourceKind::Note,
+        other => {
+            return Err(AppError::InvalidArg(format!(
+                "unknown backlink target_kind {other:?} (expected \"meeting\" or \"note\")"
+            )))
+        }
+    };
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.backlinks_for_visible(kind, &target_id, &unlocked)
+}
+
 /// Structured, GATED, egress-free person dossier for the `/people` detail pane. Unlike
 /// [`entity_dossier`] (which CLOUD-synthesizes a markdown String via the provider and discards the
 /// struct), this returns the STRUCTURED [`DossierData`](crate::summarize::dossier::DossierData) with

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -274,6 +274,7 @@ pub fn run() {
             commands::link_meeting_entities,
             commands::get_graph,
             commands::get_entity_detail,
+            commands::get_backlinks,
             commands::get_person_dossier,
             commands::list_people,
             commands::ask_vault,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
+use regex::Regex;
 use rusqlite::{Connection, OptionalExtension, Row};
 
 use crate::error::{AppError, Result};
@@ -9,11 +10,13 @@ use std::collections::HashSet;
 
 use crate::embed::Embedder;
 use crate::storage::models::{
-    Analytics, AssistantInteraction, AssistantThreadRow, Commitment, CorrectionRecord, DayCount,
+    Analytics, AssistantInteraction, AssistantThreadRow, BacklinkSource, Commitment,
+    CorrectionRecord, DayCount,
     DocChunkHit, DocumentInfo, DocumentSummary, EntityDetail, EntityKind, EntityNeighbor, Folder,
     GraphData,
     GraphEdge, GraphEntity, GraphNode, Meeting, MeetingStatus, NoteFolder, NoteRecord, NoteSummary,
-    OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, RecipeRecord, SearchHit, StatusCount,
+    OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, RecipeRecord, SearchHit, SourceKind,
+    StatusCount,
     VaultSource,
 };
 use crate::transcribe::types::Segment;
@@ -8089,6 +8092,192 @@ impl Db {
         Ok(!has_notes || has_visible)
     }
 
+    /// "What links here" — every VISIBLE meeting note (`notes.markdown`) or standalone note
+    /// (`documents.text` where `kind='note'`) whose body carries a `[[<target's exact title>]]`
+    /// wikilink pointing AT the row identified by (`target_kind`, `target_id`). ON-DEMAND scan (no
+    /// index, no migration, no persisted table). Newest-first (meeting `started_at` / note
+    /// `updated_at`).
+    ///
+    /// FAIL-CLOSED, two gates:
+    /// 1. **TARGET GATE (first).** The target's own exact title is resolved through the SAME
+    ///    visibility predicate as [`Self::meeting_by_title_visible`] / [`Self::list_notes_visible`].
+    ///    An unknown target, or one whose folder is sealed-and-not-session-unlocked, returns
+    ///    `Ok(vec![])` BEFORE any source is scanned — so a locked target never even reveals that it
+    ///    HAS backlinks (no existence leak).
+    /// 2. **SOURCE GATE.** The candidate bodies come EXACTLY from the gated readers
+    ///    (`visibility_clause` on the meeting-note leg and the note leg), so a sealed-and-not-unlocked
+    ///    source can never contribute — its body is simply not in the scan set.
+    ///
+    /// Title collisions keep ALL same-titled matches (a dropped real backlink would be a silent false
+    /// negative). Logs IDs/counts only — never body text or titles.
+    pub fn backlinks_for_visible(
+        &self,
+        target_kind: SourceKind,
+        target_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<BacklinkSource>> {
+        // ── GATE 1: resolve the target's exact title THROUGH the visibility gate; empty on any miss. ──
+        let target_title = match self.resolve_visible_title(target_kind, target_id, unlocked)? {
+            Some(t) if !t.is_empty() => t,
+            // Unknown, sealed-not-unlocked, or empty-titled → nothing to link to. Fail closed.
+            _ => return Ok(Vec::new()),
+        };
+
+        let conn = self.lock();
+        // ── GATE 2, meeting-note leg: VISIBLE meeting notes only (same predicate as list_meetings_visible). ──
+        // Newest note per meeting; body = `notes.markdown`; timestamp = `meetings.started_at`.
+        let visible_notes = visibility_clause("n", unlocked);
+        let meeting_sql = format!(
+            "SELECT m.id, m.title, m.started_at, n.markdown
+               FROM meetings m
+               JOIN notes n ON n.meeting_id = m.id
+               LEFT JOIN folders f ON f.id = n.folder_id
+              WHERE {visible_notes}
+              ORDER BY m.started_at DESC, m.id DESC"
+        );
+        let mut stmt = conn.prepare(&meeting_sql).map_err(map_err)?;
+        let meeting_rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                ))
+            })
+            .map_err(map_err)?;
+
+        // A meeting can have several visible provider notes; scan EVERY visible note and include the
+        // meeting once as soon as ANY of its notes links the target — mark `seen` only on a MATCH, so
+        // a link that lives only in a non-first provider note is never missed. title/started_at are
+        // meeting-level (identical across the meeting's notes), so the matching row is representative.
+        let mut out: Vec<BacklinkSource> = Vec::new();
+        let mut seen_meetings: HashSet<String> = HashSet::new();
+        for row in meeting_rows {
+            let (id, title, started_at, body) = row.map_err(map_err)?;
+            if target_kind == SourceKind::Meeting && id == target_id {
+                continue; // never list the target itself.
+            }
+            if seen_meetings.contains(&id) {
+                continue; // already emitted this meeting.
+            }
+            if extract_wikilink_titles(&body).contains(&target_title) {
+                seen_meetings.insert(id.clone());
+                out.push(BacklinkSource {
+                    id,
+                    kind: SourceKind::Meeting,
+                    title,
+                    timestamp: started_at,
+                });
+            }
+        }
+        drop(stmt);
+
+        // ── GATE 2, note leg: VISIBLE standalone notes only (same predicate as list_notes_visible). ──
+        // Body = `documents.text`; title = `documents.title` (fallback `name`); timestamp = `updated_at`.
+        let visible_docs = visibility_clause("f", unlocked);
+        let doc_sql = format!(
+            "SELECT d.id, d.title, d.name, COALESCE(d.text, ''),
+                    COALESCE(d.updated_at, d.created_at)
+               FROM documents d
+               JOIN folders f ON f.id = d.folder_id
+              WHERE d.kind = 'note' AND {visible_docs}
+              ORDER BY COALESCE(d.updated_at, d.created_at) DESC, d.id ASC"
+        );
+        let mut doc_stmt = conn.prepare(&doc_sql).map_err(map_err)?;
+        let doc_rows = doc_stmt
+            .query_map([], |r| {
+                let id: String = r.get(0)?;
+                let title: Option<String> = r.get(1)?;
+                let name: String = r.get(2)?;
+                let text: String = r.get(3)?;
+                let ts: i64 = r.get(4)?;
+                Ok((id, title, name, text, ts))
+            })
+            .map_err(map_err)?;
+        let mut note_hits: Vec<BacklinkSource> = Vec::new();
+        for row in doc_rows {
+            let (id, title, name, text, ts) = row.map_err(map_err)?;
+            if target_kind == SourceKind::Note && id == target_id {
+                continue; // never list the target itself.
+            }
+            if extract_wikilink_titles(&text).contains(&target_title) {
+                note_hits.push(BacklinkSource {
+                    id,
+                    kind: SourceKind::Note,
+                    title: title.filter(|t| !t.is_empty()).unwrap_or(name),
+                    // Emit RFC3339 (like the meeting leg) so the wire `timestamp` is uniformly
+                    // ISO-8601 — the FE `new Date(iso)` renders it directly; a bare epoch-millis
+                    // string would parse to `Invalid Date` and show a blank chip date.
+                    timestamp: chrono::DateTime::from_timestamp_millis(ts)
+                        .map(|dt| dt.to_rfc3339())
+                        .unwrap_or_default(),
+                });
+            }
+        }
+        drop(doc_stmt);
+        drop(conn);
+
+        // Merge the two legs newest-first. Both legs now emit an RFC3339 `timestamp`, so
+        // `backlink_sort_key` parses a single format to a comparable epoch-millis key.
+        out.extend(note_hits);
+        out.sort_by_key(|b| std::cmp::Reverse(backlink_sort_key(b)));
+
+        tracing::debug!(
+            target: "backlinks",
+            count = out.len(),
+            "backlinks_for_visible resolved"
+        );
+        Ok(out)
+    }
+
+    /// Resolve the exact, current title of a backlink TARGET through the SAME visibility gate the
+    /// list readers use. `None` iff the target is unknown OR sealed-and-not-session-unlocked (the two
+    /// are indistinguishable to the caller — no existence leak). Meeting → gated `meetings.title`;
+    /// note → gated `documents.title`/`name` (`kind='note'`).
+    fn resolve_visible_title(
+        &self,
+        kind: SourceKind,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        match kind {
+            SourceKind::Meeting => {
+                // Visible iff the meeting has no notes OR at least one visible note (mirrors
+                // `meeting_by_title_visible` / `meeting_is_visible`).
+                if !self.meeting_is_visible(id, unlocked)? {
+                    return Ok(None);
+                }
+                let conn = self.lock();
+                conn.query_row(
+                    "SELECT COALESCE(title, '') FROM meetings WHERE id = ?1",
+                    rusqlite::params![id],
+                    |r| r.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(map_err)
+            }
+            SourceKind::Note => {
+                let conn = self.lock();
+                let visible = visibility_clause("f", unlocked);
+                let sql = format!(
+                    "SELECT d.title, d.name
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE d.id = ?1 AND d.kind = 'note' AND {visible}
+                      LIMIT 1"
+                );
+                conn.query_row(&sql, rusqlite::params![id], |r| {
+                    let title: Option<String> = r.get(0)?;
+                    let name: String = r.get(1)?;
+                    Ok(title.filter(|t| !t.is_empty()).unwrap_or(name))
+                })
+                .optional()
+                .map_err(map_err)
+            }
+        }
+    }
+
     /// Phase E (Flow B, `NoteAside`) — record a spoken aside against a meeting in the additive
     /// `notes_asides` store. PURELY ADDITIVE: it never touches the note `markdown`/`content_blob`,
     /// so it can never blank or clobber sealed content. The CALLER gates on the live unlocked set
@@ -10360,6 +10549,43 @@ pub struct Voiceprint {
 /// session-unlocked. `alias` is the notes-table alias (`n`); a sibling `folders f` join is
 /// assumed for the alias. The unlocked ids are inlined as quoted literals — safe because they
 /// are app-generated UUIDs, but we still escape single quotes defensively.
+/// Regex matching an Obsidian-native `[[wikilink]]` opener, capturing the raw TARGET up to the first
+/// `]`, `|` (alias), or `#` (heading anchor) — so `[[Title|alias]]` and `[[Title#heading]]` both
+/// degrade to the bare `Title`. Lazy `OnceLock` per the repo's static-regex convention (mirrors
+/// `summarize::redact::email_re`; NOT `LazyLock` — MSRV/clippy on ci.sh).
+fn wikilink_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\[\[([^\]\|#]+)").unwrap())
+}
+
+/// Extract the DISTINCT `[[Title]]` wikilink targets from a note/markdown body, in first-seen order.
+/// PURE (no DB). `[[Title|alias]]` and `[[Title#heading]]` yield the bare `Title`; each target is
+/// trimmed; duplicates are dropped keeping the first occurrence. An empty/no-match body yields `[]`.
+pub(crate) fn extract_wikilink_titles(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for cap in wikilink_re().captures_iter(text) {
+        // `cap[1]` is guaranteed by the single capture group in the pattern.
+        let title = cap[1].trim();
+        if title.is_empty() {
+            continue;
+        }
+        if !out.iter().any(|t| t == title) {
+            out.push(title.to_string());
+        }
+    }
+    out
+}
+
+/// A comparable newest-first sort key (epoch-millis) for a backlink chip. Both legs emit an RFC3339
+/// `timestamp` (meeting `started_at`, note `updated_at` rendered to RFC3339), so a single parse
+/// suffices. Unparseable → `i64::MIN` (sorts oldest), keeping the order total + deterministic
+/// without panicking.
+fn backlink_sort_key(b: &BacklinkSource) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(&b.timestamp)
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or(i64::MIN)
+}
+
 fn visibility_clause(_alias: &str, unlocked: &HashSet<String>) -> String {
     let mut clause = String::from("(f.locked IS NULL OR f.locked = 0");
     if !unlocked.is_empty() {
@@ -12367,6 +12593,241 @@ mod tests {
             both.len(),
             2,
             "session-unlocked meeting's correction must reappear"
+        );
+    }
+
+    // ── Feature A — note↔note backlinks reader ───────────────────────────────────────────────────
+
+    /// PURE parse: bare `[[T]]`, alias `[[T|a]]`→`T`, heading `[[T#h]]`→`T`, dedup first-seen, empty
+    /// on no match. RED before `wikilink_re`/`extract_wikilink_titles` existed.
+    #[test]
+    fn extract_wikilink_titles_covers_forms() {
+        assert_eq!(extract_wikilink_titles("see [[Alpha]] here"), vec!["Alpha"]);
+        assert_eq!(
+            extract_wikilink_titles("[[Alpha|the alias]]"),
+            vec!["Alpha"]
+        );
+        assert_eq!(extract_wikilink_titles("[[Alpha#Heading]]"), vec!["Alpha"]);
+        // Duplicates (across forms) dedup, first-seen order preserved.
+        assert_eq!(
+            extract_wikilink_titles("[[Beta]] then [[Alpha]] then [[Beta|x]]"),
+            vec!["Beta", "Alpha"]
+        );
+        // Surrounding whitespace inside the brackets is trimmed.
+        assert_eq!(extract_wikilink_titles("[[  Gamma  ]]"), vec!["Gamma"]);
+        // No wikilink → empty.
+        assert!(extract_wikilink_titles("plain text, no links").is_empty());
+        assert!(extract_wikilink_titles("").is_empty());
+    }
+
+    /// GATE 1 (target). A VISIBLE meeting note genuinely links `[[TargetTitle]]`, but the TARGET note
+    /// lives in a sealed-and-not-unlocked folder → the reader must return `[]` (never reveal the
+    /// locked target HAS backlinks). RED against a scan-then-filter impl that resolves the target's
+    /// title / lists backlinks BEFORE the visibility early-return.
+    #[test]
+    fn backlinks_sealed_target_hides_all() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // SOURCE: a visible meeting whose note body links to the target's title.
+        db.insert_meeting(&sample_meeting("m-src", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m-src", "claude_code", "recap — see [[TargetTitle]]");
+        db.set_note_folder("m-src", Some("f-open")).unwrap();
+
+        // TARGET: a standalone note titled exactly "TargetTitle", in the SEALED folder.
+        db.insert_note(
+            "n-target",
+            "f-locked",
+            "target",
+            "TargetTitle",
+            "the target body",
+            1_000,
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let got = db
+            .backlinks_for_visible(SourceKind::Note, "n-target", &nothing)
+            .unwrap();
+        assert!(
+            got.is_empty(),
+            "sealed target must not reveal it HAS backlinks; got {got:?}"
+        );
+    }
+
+    /// GATE 2 (source). A SEALED-and-not-unlocked SOURCE note links `[[VisibleTarget]]`. Querying the
+    /// visible target's backlinks must NOT include that sealed source. RED against an impl that scans
+    /// all note bodies ignoring `visibility_clause` on the source side.
+    #[test]
+    fn backlinks_sealed_source_never_contributes() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // TARGET: a VISIBLE meeting titled "VisibleTarget".
+        let mut target = sample_meeting("m-target", "2026-06-24T09:00:00Z");
+        target.title = Some("VisibleTarget".to_string());
+        db.insert_meeting(&target).unwrap();
+        note_for(&db, "m-target", "claude_code", "target note body");
+        db.set_note_folder("m-target", Some("f-open")).unwrap();
+
+        // A VISIBLE source that DOES link the target (the true positive that must appear).
+        db.insert_note(
+            "n-open-src",
+            "f-open",
+            "open-src",
+            "OpenSource",
+            "links [[VisibleTarget]] openly",
+            2_000,
+        )
+        .unwrap();
+
+        // A SEALED source that ALSO links the target — must NOT contribute while locked.
+        db.insert_note(
+            "n-sealed-src",
+            "f-locked",
+            "sealed-src",
+            "SealedSource",
+            "secretly links [[VisibleTarget]]",
+            3_000,
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let got = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-target", &nothing)
+            .unwrap();
+        let ids: Vec<&str> = got.iter().map(|b| b.id.as_str()).collect();
+        assert!(
+            ids.contains(&"n-open-src"),
+            "the visible source must be present; got {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"n-sealed-src"),
+            "sealed source leaked into backlinks; got {ids:?}"
+        );
+    }
+
+    /// Session-unlock reverses BOTH gates: the sealed TARGET now yields its backlink, and the sealed
+    /// SOURCE now contributes. Mirrors the entity/correction unlock-reappearance pattern.
+    #[test]
+    fn backlinks_unlock_reverses() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // A visible source linking a SEALED target (the gate-1 half).
+        db.insert_meeting(&sample_meeting("m-src", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m-src", "claude_code", "see [[TargetTitle]]");
+        db.set_note_folder("m-src", Some("f-open")).unwrap();
+        db.insert_note(
+            "n-target",
+            "f-locked",
+            "target",
+            "TargetTitle",
+            "target body",
+            1_000,
+        )
+        .unwrap();
+
+        // A SEALED source linking a VISIBLE target (the gate-2 half).
+        let mut vis_target = sample_meeting("m-vis-target", "2026-06-24T08:00:00Z");
+        vis_target.title = Some("VisibleTarget".to_string());
+        db.insert_meeting(&vis_target).unwrap();
+        note_for(&db, "m-vis-target", "claude_code", "vis target body");
+        db.set_note_folder("m-vis-target", Some("f-open")).unwrap();
+        db.insert_note(
+            "n-sealed-src",
+            "f-locked",
+            "sealed-src",
+            "SealedSource",
+            "links [[VisibleTarget]]",
+            3_000,
+        )
+        .unwrap();
+
+        // Locked: sealed target hides all; sealed source absent.
+        let nothing = std::collections::HashSet::new();
+        assert!(
+            db.backlinks_for_visible(SourceKind::Note, "n-target", &nothing)
+                .unwrap()
+                .is_empty(),
+            "sealed target still hidden while locked"
+        );
+        let vis_locked = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-vis-target", &nothing)
+            .unwrap();
+        assert!(
+            !vis_locked.iter().any(|b| b.id == "n-sealed-src"),
+            "sealed source must be absent while locked"
+        );
+
+        // Session-unlock the sealed folder → BOTH halves flip.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+
+        let target_now = db
+            .backlinks_for_visible(SourceKind::Note, "n-target", &unlocked)
+            .unwrap();
+        assert_eq!(
+            target_now.iter().map(|b| b.id.as_str()).collect::<Vec<_>>(),
+            vec!["m-src"],
+            "unlocked target must now surface its backlink"
+        );
+        assert_eq!(target_now[0].kind, SourceKind::Meeting);
+
+        let vis_now = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-vis-target", &unlocked)
+            .unwrap();
+        assert!(
+            vis_now.iter().any(|b| b.id == "n-sealed-src"),
+            "unlocked source must now contribute"
+        );
+    }
+
+    /// GATE 2 (meeting leg) COMPLETENESS: a meeting with SEVERAL provider notes must surface as a
+    /// backlink when ANY of its notes links the target — even if the first (newest-ordered) note does
+    /// NOT. RED against a dedup-before-check impl that keeps only the first provider note per meeting.
+    #[test]
+    fn backlinks_meeting_leg_scans_all_provider_notes() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // TARGET: a visible standalone note titled exactly "MultiTarget".
+        db.insert_note(
+            "n-multi-target",
+            "f-open",
+            "mt",
+            "MultiTarget",
+            "the target body",
+            1_000,
+        )
+        .unwrap();
+
+        // SOURCE: one meeting, TWO provider notes — only the SECOND provider links the target.
+        db.insert_meeting(&sample_meeting("m-multi", "2026-06-24T10:00:00Z"))
+            .unwrap();
+        note_for(&db, "m-multi", "claude_code", "recap with no link at all");
+        note_for(&db, "m-multi", "anthropic", "deep dive — see [[MultiTarget]]");
+        db.set_note_folder("m-multi", Some("f-open")).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let got = db
+            .backlinks_for_visible(SourceKind::Note, "n-multi-target", &nothing)
+            .unwrap();
+        let ids: Vec<&str> = got.iter().map(|b| b.id.as_str()).collect();
+        assert!(
+            ids.contains(&"m-multi"),
+            "a meeting whose link lives in a non-first provider note must still surface; got {ids:?}"
         );
     }
 

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -939,6 +939,30 @@ pub struct VaultSource {
     pub origin: Option<SourceOrigin>,
 }
 
+/// Which kind of owned-content row a backlink SOURCE (or target) is — a meeting (its AI note in
+/// `notes.markdown`) or a standalone note (`documents.text` where `kind='note'`). Serialized as a
+/// stable lowercase string so the FE can branch a chip icon/route without a second field.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Meeting,
+    Note,
+}
+
+/// A row whose body contains a `[[Title]]` wikilink pointing AT the queried target — a "what links
+/// here" backlink chip. `timestamp` is unified so the FE needs no kind-branch: the meeting's
+/// `started_at` for a meeting, the note's `updated_at` (rendered as a string) for a note. Only ever
+/// built from VISIBLE (session-unlocked) rows — a sealed source can never appear here, and a sealed
+/// target yields an empty list (never reveals it HAS backlinks).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinkSource {
+    pub id: String,
+    pub kind: SourceKind,
+    pub title: String,
+    pub timestamp: String,
+}
+
 /// Result of an Ask-My-Vault query: the grounded answer + the source meetings used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -7,6 +7,8 @@ import type {
   AiMapRow,
   Analytics,
   AppConfigDto,
+  BacklinkSource,
+  SourceKind,
   ContextHit,
   MyShareEntry,
   RecipientPreview,
@@ -1020,6 +1022,21 @@ export class IpcService {
   /** Detail for one entity: the entity + its visible backlinked meetings + top neighbors. */
   getEntityDetail(entityId: string): Promise<EntityDetail> {
     return invoke<EntityDetail>("get_entity_detail", { entityId });
+  }
+
+  /**
+   * Note↔note backlinks ("Linked mentions") — the VISIBLE inbound sources
+   * (meetings + authored notes) that mention/link the given target. GATED
+   * server-side like every content read: a sealed-and-not-session-unlocked
+   * source never appears, so the caller MUST skip the fetch entirely while the
+   * target itself is locked/masked (never surface backlinks behind a lock).
+   * Returns `[]` when nothing links to the target.
+   */
+  getBacklinks(
+    targetKind: SourceKind,
+    targetId: string,
+  ): Promise<BacklinkSource[]> {
+    return invoke<BacklinkSource[]>("get_backlinks", { targetKind, targetId });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1186,6 +1186,29 @@ export interface SourceOrigin {
   orgItemId?: string | null;
 }
 
+/**
+ * Note↔note backlinks ("Linked mentions") — the KIND of a local owned source
+ * that links to (mentions) the current target. `"meeting"` routes to
+ * `/meeting/:id`; `"note"` routes to `/notes/:id`. Mirrors the Rust
+ * `SourceKind` (serde camelCase / lowercase).
+ */
+export type SourceKind = "meeting" | "note";
+
+/**
+ * Note↔note backlinks — one INBOUND source that mentions the current target
+ * (`get_backlinks(targetKind, targetId)`). A chip in the "Linked mentions" row:
+ * `id` + `kind` decide the click-through route, `title` + `timestamp` (ISO-8601)
+ * render the chip. GATED server-side like every content read — a
+ * sealed-and-not-session-unlocked source never appears in the list. Mirrors the
+ * Rust `BacklinkSource` (serde camelCase).
+ */
+export interface BacklinkSource {
+  id: string;
+  kind: SourceKind;
+  title: string;
+  timestamp: string;
+}
+
 /** The two entity kinds the self-assembling graph resolves (Rust `EntityKind`, camelCase). */
 export type EntityKind = "person" | "project";
 

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -252,6 +252,7 @@
             [folderId]="d.meeting.folderId ?? null"
             [note]="note()"
             [interactions]="interactions()"
+            [backlinks]="backlinks()"
             [exportedPath]="d.note?.exportedPath ?? null"
             [provenanceLabel]="provenanceLabel()"
             [busy]="busy()"

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -23,6 +23,7 @@ import { TabsService } from "../../../core/tabs.service";
 import type {
   AppConfigDto,
   AssistantInteraction,
+  BacklinkSource,
   FolderNode,
   GraphPayload,
   MeetingDetail,
@@ -296,6 +297,53 @@ export class DetailComponent implements OnInit {
     const raw = this.detail()?.assistantInteractions ?? [];
     return raw.map((i, idx) => this.parseInteraction(i, idx));
   });
+
+  // --- Note↔note backlinks ("Linked mentions") ----------------------------
+  /**
+   * The VISIBLE inbound sources (meetings + authored notes) that link/mention
+   * THIS meeting. Fed to the note panel's "Linked mentions" chip row. Empty
+   * while the meeting is locked/masked (the fetch is skipped there — never
+   * surface backlinks behind a lock) and until the first fetch resolves.
+   */
+  readonly backlinks = signal<BacklinkSource[]>([]);
+  /**
+   * Monotonic request token — a late `getBacklinks` reply for a superseded
+   * meeting (openRelated reuses this component) is dropped (stale-result guard,
+   * FE failure mode #4).
+   */
+  private backlinksSeq = 0;
+
+  /**
+   * Load this meeting's backlinks whenever the loaded meeting id changes, and
+   * SKIP the fetch entirely while it is locked/masked (`locked()` derives from
+   * the backend's masked DTO). A legitimate signal-writing effect (T1): async
+   * IPC keyed on inputs with a stale-result guard. A late reply for a meeting
+   * the user has since navigated away from is dropped by the seq check.
+   */
+  private readonly _loadBacklinks = effect(() => {
+    const id = this.detail()?.meeting.id ?? null;
+    const locked = this.locked();
+    const seq = ++this.backlinksSeq;
+    if (!id || locked) {
+      this.backlinks.set([]);
+      return;
+    }
+    void this.fetchBacklinks(id, seq);
+  });
+
+  private async fetchBacklinks(id: string, seq: number): Promise<void> {
+    try {
+      const rows = await this.ipc.getBacklinks("meeting", id);
+      if (seq !== this.backlinksSeq) {
+        return; // superseded by a newer meeting / lock transition
+      }
+      this.backlinks.set(Array.isArray(rows) ? rows : []);
+    } catch {
+      if (seq === this.backlinksSeq) {
+        this.backlinks.set([]);
+      }
+    }
+  }
 
   // --- Phase 5 model-provenance badge -------------------------------------
   /**

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -321,6 +321,13 @@
     }
   </section>
 
+  <!-- LINKED MENTIONS — inbound note↔note backlinks (meetings + notes that link
+       this one). Only present when non-empty; the shell skips the gated fetch
+       while the meeting is locked, so nothing surfaces behind a lock. -->
+  @if (backlinks().length) {
+    <app-backlinks [sources]="backlinks()" />
+  }
+
   <!-- LIVE CONTEXT — enrich this note with fresh detail from connected tools (Jira / Slack / web).
        Sits right after the note summary; egress is on-demand + kept loud. Only rendered for an
        unlocked meeting (note-panel itself is under the detail view's `@else (!locked())`). Bubbles

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -8,9 +8,10 @@ import {
   signal,
   viewChild,
 } from "@angular/core";
-import type { GraphPayload } from "../../../core/models";
+import type { BacklinkSource, GraphPayload } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { AssistantSourcesComponent } from "../../../shared/assistant-sources/assistant-sources.component";
+import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
 import { MoveToMenuComponent } from "../../folders/move-to-menu/move-to-menu.component";
 import { MeetingActionsComponent } from "../meeting-actions/meeting-actions.component";
 import { MeetingChatComponent } from "../meeting-chat/meeting-chat.component";
@@ -78,6 +79,7 @@ export interface AssistantQa {
   imports: [
     MarkdownComponent,
     AssistantSourcesComponent,
+    BacklinksComponent,
     MoveToMenuComponent,
     MeetingActionsComponent,
     MeetingChatComponent,
@@ -96,6 +98,12 @@ export class NotePanelComponent {
   readonly note = input<ParsedNote | null>(null);
   /** The persisted in-meeting assistant Q&A. */
   readonly interactions = input<AssistantQa[]>([]);
+  /**
+   * Note↔note backlinks ("Linked mentions") — the VISIBLE inbound sources
+   * (meetings + notes) that link this meeting. Empty when the meeting is
+   * locked (the shell skips the gated fetch there). Rendered below the note body.
+   */
+  readonly backlinks = input<BacklinkSource[]>([]);
   /** The vault export path from the note DTO (Saved-to-vault line). */
   readonly exportedPath = input<string | null>(null);
   /** Model provenance for the ghost badge (null → hidden). */

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -379,6 +379,14 @@
             }
           </div>
 
+          <!-- LINKED MENTIONS — inbound note↔note backlinks (meetings + notes
+               that link this note). Under the properties bar, above the body.
+               Only present when non-empty; cleared on a live seal (the effect
+               skips + `onLockTreeChanged` blanks it) so nothing shows behind a lock. -->
+          @if (backlinks().length) {
+            <app-backlinks [sources]="backlinks()" />
+          }
+
           <!-- Body: preview (cached computed) OR the source-of-truth textarea.
                Formatting lives in the floating bubble on selection (below) +
                ⌘B/⌘I shortcuts + the `/` slash menu — no persistent toolbar. -->

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -22,6 +22,7 @@ import { tabKeyFor } from "../../../core/tab-keys";
 import { TabsService } from "../../../core/tabs.service";
 import type {
   AppConfigDto,
+  BacklinkSource,
   FolderNode,
   NoteDoc,
   NoteFolder,
@@ -30,6 +31,7 @@ import { DebounceService } from "../../../services/debounce.service";
 import { FoldersService } from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
+import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { NOTE_ASSIST_CATALOG } from "../note-brain-popover/note-assist-catalog";
 import {
@@ -122,6 +124,7 @@ const FULL_WIDTH_KEY = "murmur-note-full-width";
   selector: "app-note-editor",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    BacklinksComponent,
     MarkdownComponent,
     NoteBrainPopoverComponent,
     NoteSelectionToolbarComponent,
@@ -163,6 +166,21 @@ export class NoteEditorComponent {
   readonly note = signal<NoteDoc | null>(null);
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
+
+  // --- Note↔note backlinks ("Linked mentions") ----------------------------
+  /**
+   * The VISIBLE inbound sources (meetings + notes) that link/mention THIS note.
+   * Rendered under the properties bar. Empty until the first fetch resolves,
+   * while the note is locked/masked (the fetch is skipped — never surface
+   * backlinks behind a lock), and CLEARED in the `onLockTreeChanged` seal
+   * branch so a live seal drops stale chips immediately.
+   */
+  readonly backlinks = signal<BacklinkSource[]>([]);
+  /**
+   * Monotonic request token — a late `getBacklinks` reply for a superseded note
+   * id / lock transition is dropped (stale-result guard, trap #4).
+   */
+  private backlinksSeq = 0;
 
   // --- Editable surfaces (source state) -----------------------------------
   /** The title (borderless input). */
@@ -364,6 +382,38 @@ export class NoteEditorComponent {
     void this.fetchNote(id, seq);
   });
 
+  /**
+   * Load this note's backlinks whenever the loaded doc (id / lock state)
+   * changes, and SKIP the fetch entirely while it is locked/masked (never
+   * surface backlinks behind a lock — the same discipline as the seal branch's
+   * clear). A legitimate signal-writing effect (T1): async IPC keyed on inputs
+   * with a stale-result guard. A late reply for a superseded note id / lock
+   * transition is dropped by the seq check.
+   */
+  private readonly _loadBacklinks = effect(() => {
+    const doc = this.note();
+    const seq = ++this.backlinksSeq;
+    if (!doc || doc.locked) {
+      this.backlinks.set([]);
+      return;
+    }
+    void this.fetchBacklinks(doc.id, seq);
+  });
+
+  private async fetchBacklinks(id: string, seq: number): Promise<void> {
+    try {
+      const rows = await this.ipc.getBacklinks("note", id);
+      if (seq !== this.backlinksSeq) {
+        return; // superseded by a newer note / lock transition
+      }
+      this.backlinks.set(Array.isArray(rows) ? rows : []);
+    } catch {
+      if (seq === this.backlinksSeq) {
+        this.backlinks.set([]);
+      }
+    }
+  }
+
   /** Persist the "Full width" preference whenever it changes (mirrors AppShellComponent). */
   private readonly _persistFullWidth = effect(() => {
     const value = this.fullWidth();
@@ -459,6 +509,10 @@ export class NoteEditorComponent {
       this.debounce.cancel("note-editor-save");
       this.pendingSave = null;
       this.dirtyFull = false;
+      // Drop stale backlink chips immediately on a live seal (belt-and-braces
+      // with the `_loadBacklinks` effect's own skip-while-locked, so a detached
+      // tab holds no linked-mention titles behind the lock from this instant).
+      this.backlinks.set([]);
       this.hydrate({
         ...doc,
         locked: true,

--- a/src/app/shared/backlinks/backlinks.component.html
+++ b/src/app/shared/backlinks/backlinks.component.html
@@ -1,0 +1,25 @@
+@if (sources().length) {
+  <div class="bl">
+    <span class="bl-label">Linked mentions</span>
+    @for (s of visible(); track s.id) {
+      <a class="bl-chip" [routerLink]="routeFor(s)">
+        @if (s.kind === "meeting") {
+          <span class="bl-kind bl-kind--meeting" aria-hidden="true">meeting</span>
+        } @else {
+          <span class="bl-kind bl-kind--note" aria-hidden="true">note</span>
+        }
+        <span class="bl-title">{{ s.title }}</span>
+        <span class="bl-date">{{ fmt(s.timestamp) }}</span>
+      </a>
+    }
+    @if (sources().length > limit()) {
+      <button type="button" class="bl-more" (click)="toggle()">
+        {{
+          expanded()
+            ? "Show less"
+            : "+" + (sources().length - limit()) + " more"
+        }}
+      </button>
+    }
+  </div>
+}

--- a/src/app/shared/backlinks/backlinks.component.scss
+++ b/src/app/shared/backlinks/backlinks.component.scss
@@ -1,0 +1,83 @@
+:host {
+  display: block;
+}
+.bl {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+.bl-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-right: var(--space-1);
+}
+.bl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 22rem;
+  padding: 6px var(--space-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 13px;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+.bl-chip:hover {
+  border-color: var(--accent-ring);
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+/* Kind badge — a tiny pill so a meeting chip reads distinctly from a note. */
+.bl-kind {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.bl-kind--meeting {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.bl-kind--note {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+.bl-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.bl-date {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.bl-more {
+  padding: 6px var(--space-3);
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-pill);
+  color: var(--accent-hover);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+.bl-more:hover {
+  background: var(--accent-soft);
+}

--- a/src/app/shared/backlinks/backlinks.component.ts
+++ b/src/app/shared/backlinks/backlinks.component.ts
@@ -1,0 +1,54 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+
+import type { BacklinkSource } from "../../core/models";
+
+/**
+ * Note↔note backlinks reader ("Linked mentions"): a collapsible chip row of the
+ * VISIBLE inbound sources — meetings AND authored notes — that mention/link the
+ * current target. Modeled on {@link SourcesComponent}'s chip language, with the
+ * click-through route split by kind: a `"meeting"` chip routes to `/meeting/:id`,
+ * a `"note"` chip to `/notes/:id`. Shows the first `limit` chips with a
+ * "+N more" / "Show less" toggle. Presentational — the host owns the gated
+ * `get_backlinks` fetch (and MUST skip it while the target is locked/masked).
+ */
+@Component({
+  selector: "app-backlinks",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  templateUrl: "./backlinks.component.html",
+  styleUrl: "./backlinks.component.scss",
+})
+export class BacklinksComponent {
+  readonly sources = input<BacklinkSource[]>([]);
+  readonly limit = input(6);
+  readonly expanded = signal(false);
+
+  readonly visible = computed(() =>
+    this.expanded() ? this.sources() : this.sources().slice(0, this.limit()),
+  );
+
+  toggle(): void {
+    this.expanded.update((v) => !v);
+  }
+
+  /** The click-through route array for a source, split by its kind. */
+  routeFor(s: BacklinkSource): unknown[] {
+    return s.kind === "meeting"
+      ? ["/meeting", s.id]
+      : ["/notes", s.id];
+  }
+
+  fmt(iso: string): string {
+    const d = new Date(iso);
+    return isNaN(d.getTime())
+      ? ""
+      : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+}


### PR DESCRIPTION
## What
Closes the biggest 'feels like Obsidian' gap from `docs/PLAN-obsidian-notion-parity.md` (Feature A). Murmur already **writes** `[[Title]]` wikilinks into the vault but never **showed** them in-app — the only prior 'backlink' surface was entity co-occurrence, not note↔note links. This adds a **'Linked mentions'** chip row ("what links here") to the meeting-detail Note tab and the notes editor.

## Backend (on-demand, no migration)
- `extract_wikilink_titles` (pure, `OnceLock<Regex>`) + `backlinks_for_visible`:
  - **GATE 1 (target)** — resolves the target's own title through the visibility gate and **fail-closes to `[]`** for an unknown or sealed-and-not-session-unlocked target, *before* any scan (no 'this locked note HAS backlinks' existence leak).
  - **GATE 2 (source)** — scans only the bodies the **same `visibility_clause` predicates** as `list_meetings_visible` / `list_notes_visible` return, so a sealed source can never contribute.
  - meeting leg scans **all** provider notes (marks `seen` only on a match) → a link in a non-first provider note is never dropped; both legs emit **RFC3339** timestamps.
- `get_backlinks` command registered in `lib.rs`.

## Frontend (zoneless, signals)
- New `app-backlinks` chip row (tokens-only), wired into `detail` (container fetch) → `note-panel`, and into `note-editor`. Fetch **skipped while locked**, chips **cleared on live seal** (`onLockTreeChanged`), stale-result guard on the fetch effect. Chips route `/meeting/:id` vs `/notes/:id`.

## How verified
- `cargo test --lib`: **1606 passed** (+5). **RED-before-GREEN** on both leak gates (`backlinks_sealed_target_hides_all`, `backlinks_sealed_source_never_contributes`) + meeting-leg completeness + `unlock_reverses`.
- `ng lint` + `ng build`: clean. Mocked-invoke smoke: a **locked** meeting's Note tab issues **zero** `get_backlinks` calls; chips route correctly.
- **lock-security-reviewer: PASS** (both gates fail-closed, predicate parity, no content in DTO, no PII). **adversarial-verifier: PASS** — it first FAILed and caught 2 MINOR correctness bugs (blank note-chip date; meeting-leg false negative), both fixed and re-verified RED→GREEN.

## Not verified (honest)
Live WKWebView DOM render + click-through (no browser MCP available in the verifier session — covered by clean AOT build + real-parser node checks + static cycle/effect audit). Touch ID / lock-at-rest are signed-build-only and unaffected by this read-only feature.