### PR TITLE
feat(notes,org): unfiled-first notes + auto-title on close + member emails (client)

### DIFF
--- a/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
+++ b/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
@@ -1,0 +1,118 @@
+# Notes UX: unfiled-first notes + auto-title on close — design
+
+**Date:** 2026-07-14 · **Status:** design (awaiting review) · **Target release:** 0.9.16 (with the
+already-merged #321 unlock-gate + #322 create-message fixes).
+
+## Problem
+
+Two related note-UX pain points, both surfaced live by the user on 0.9.15:
+
+1. **Redundant default folder + broken create.** "New note" from the Notes section defaults into a
+   nested folder literally named **"Notes"** — redundant with the "Notes" section itself ("you're in
+   Notes, and the note goes into Notes/Notes"). Worse: when that default folder is *locked*, create
+   fails with "Couldn't create the note". Root cause: `create_note(None)` →
+   `ensure_default_note_folder()` → the sealed "Notes" folder → the write-gate (`folder_is_unlocked`)
+   refuses.
+2. **Notes stay "Untitled".** New notes are created titled "Untitled" (`note-editor` line ~524,
+   `notes-home.newNote`) and users don't retitle them.
+
+## Feature A — unfiled-first notes (reserved always-open root)
+
+### The constraint that shapes the approach (grounded, not assumed)
+
+`documents.folder_id` is **`TEXT NOT NULL`** with `FOREIGN KEY (folder_id) REFERENCES folders(id) ON
+DELETE CASCADE` (`db.rs` `CREATE TABLE documents`). SQLite has no `ALTER COLUMN`, so making it
+nullable requires a **full table rebuild** (create-new → copy rows → drop → rename + recreate
+indexes/FTS/triggers). That violates the binding rule *"migrations ADDITIVE only, never DROP / rewrite
+user rows"* (`.claude/rules/rust-tauri.md` §4) and is risky given the FK, `text_blob`, and the notes
+FTS/index. **Rejected.**
+
+### Approach: a reserved, always-open "Notes root" folder
+
+"Unfiled" is realized as a **reserved note-folder that can never be locked** and is presented as the
+Notes section root — NOT as a nested folder. `folder_id` stays `NOT NULL` (satisfied by the root's
+id). No schema rebuild, no NULL edge cases in any gate.
+
+**Behavior:**
+- A reserved note-folder (`kind='note'`, marked as root via an additive `is_root INTEGER` column or a
+  reserved sentinel — see Open Questions) is ensured idempotently at startup. It is **always open** and
+  `lock_folder` / the lock×shares flow **refuse** to seal it (a guard).
+- `create_note(None)` targets the reserved root → **always succeeds** (the root is never locked).
+- **FE does NOT render the reserved root as a nested tree row** — it *is* the "Notes" / "All notes"
+  section. New notes are "unfiled" (they live at the root). Folders (e.g. "Tet") remain optional
+  organization + the lock unit.
+- **Privacy:** root/unfiled notes are open (plaintext) — the root can't be sealed. A subtle indicator
+  ("Unfiled · not sealed") + a hint ("notes are private only inside a locked folder — move this note
+  into one to seal it"). "Lock all" copy notes it does not cover unfiled notes. (User-approved: *"tak,
+  to jest akceptowalne, można dać info że tylko w folderze notki są prywatne"*.)
+
+**Existing "Notes" folder (legacy default):** left **untouched** — it becomes a normal, lockable
+folder that keeps its notes; the user can rename/delete it (after unlocking, if sealed). No migration
+of user rows. New reserved root is distinct from it. (For a fresh install there is no legacy "Notes"
+folder, so the tree is clean; existing users see a one-time redundant "Notes" folder they can remove.)
+
+### Backend
+- **Migration (additive):** `add_column_if_missing(folders, "is_root", "INTEGER")` (default 0), OR a
+  reserved id/path convention. `ensure_notes_root()` (idempotent) creates/returns the reserved root.
+- `create_note(None)` → the reserved root (replace the `ensure_default_note_folder` default).
+- `lock_folder` + the lock×shares probe: **refuse** to lock the reserved root (`AppError::InvalidArg`
+  / a friendly refusal). "Lock all" (`relock_all` is relock-only, unaffected) — but a *lock* of the
+  root must be impossible.
+- **Visibility: NO change** — the root is a normal, always-unlocked folder, so `folder_is_unlocked` /
+  `visibility_clause` already treat it correctly (this is the key win of the sentinel over nullable:
+  zero new NULL/edge handling in the security gates).
+- Vault export: reserved-root notes → `<vault>/Notes/<note>.md`; foldered notes unchanged.
+
+### Frontend
+- `notes-sidebar-tree`: filter the reserved root out of the rendered folder list (it's the section,
+  not a child).
+- `notes-home` / `note-editor`: show the folder name, or **"Unfiled"** for root notes; add a
+  "Remove from folder" (→ move to root) action to the move menu.
+- Privacy indicator + hint on unfiled notes.
+
+### Review
+- **lock-security review MANDATORY:** the reserved root is genuinely lock-refused; no gate is bypassed
+  or wrongly masks; the legacy "Notes" folder still seals/unseals; no note is orphaned; the root note's
+  openness is intended and cannot leak a *sealed* folder's content.
+
+## Feature B — auto-title an "Untitled" note on close
+
+### Trigger
+On note **close** (`note-editor` destroy / `onTabBackgrounded` / navigate-away), if the note's title
+is `"Untitled"` (or empty) **and** the body is non-empty → generate a title. (User: *"jak zamykasz
+notkę to się generuje tytuł jak jest Untitled"*.)
+
+### Model — local only
+Use the on-device brain sidecar (`meetnotes-brain`, mistralrs) with a short prompt ("a 3–6 word title
+for this note: <body excerpt>"). **Local-only, zero egress.**
+- **Fallback** when the brain model isn't downloaded / the sidecar isn't ready: derive a title from the
+  first non-empty line of the body (the `derive_artifact_title`-style heuristic already in the tree).
+  If the body is empty → leave "Untitled".
+- **Non-blocking:** fire on close in the background; the note may already be closed — update the DB row
+  + the notes list/tab title when the result lands.
+
+### Backend
+- New command `suggest_note_title(note_id)` (or reuse a `note_assistant_action` "title" action if one
+  already exists — verify during build): **gated** (a sealed-not-unlocked note refuses — read-gate),
+  reads the note text, calls the local brain (fallback to first-line), and `update_note`s the title
+  only if it is still "Untitled" (never clobber a user-set title — re-check under the write path).
+- Reuses the existing note write-gate + local-brain seam; no new egress.
+
+### Frontend
+- `note-editor`: on close, if `title() === "Untitled"` and body non-empty, fire-and-forget
+  `suggest_note_title`. Reflect the new title in the tab strip + notes list when it resolves.
+
+### Out of scope (both features)
+- Nullable `folder_id` / table rebuild (rejected above).
+- Migrating existing notes out of the legacy "Notes" folder.
+- Changing the per-folder lock model.
+- Cloud-based title generation; bulk-retitling existing "Untitled" notes.
+
+## Open questions for review
+1. **Reserved-root marker:** an additive `folders.is_root` column (clean, explicit) vs a reserved
+   id/path sentinel (no schema touch at all). Recommendation: `is_root` column — explicit + guardable.
+2. **Legacy "Notes" folder:** leave untouched (recommended — no risky migration) vs auto-promote an
+   *unlocked* legacy "Notes" folder to the reserved root (cleaner tree, more logic). Recommendation:
+   leave untouched for now.
+3. **Auto-title on a note in a locked folder:** the read-gate refuses → we simply skip (leave
+   "Untitled"). Acceptable? (Recommendation: yes — don't auto-unlock for a title.)

--- a/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
+++ b/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
@@ -112,9 +112,17 @@ for this note: <body excerpt>"). **Local-only, zero egress.**
 1. **Reserved-root marker:** additive **`folders.is_root INTEGER DEFAULT 0`** column — explicit +
    easy to guard (`lock_folder` refuses when `is_root=1`). `ensure_notes_root()` creates/returns the
    single `is_root=1` note-folder idempotently.
-2. **Legacy "Notes" folder:** **left untouched** — becomes a normal folder with its notes; the user
-   renames/deletes it manually (after unlocking if sealed). No migration of user rows. A one-time
-   redundant "Notes" folder remains for existing users; fresh installs are clean.
+2. **Legacy "Notes" folder + where the root lives** (refined after finding `folders.path` is
+   `NOT NULL UNIQUE`): `ensure_notes_root()` —
+   - an `is_root=1` folder already exists → return it;
+   - the path-`"Notes"` folder exists and is **unlocked** → set `is_root=1` on it (root lives at
+     "Notes"; a flag flip, no note movement, no risk) — covers most users;
+   - the path-`"Notes"` folder exists and is **locked** (this user) → can't repurpose (would expose
+     sealed content) and can't reuse the unique "Notes" path → create a **separate** always-open
+     root at path `"Inbox"` (first free of "Inbox", "Inbox 2", …); the locked "Notes" stays a normal
+     folder until the user unlocks/deletes it;
+   - no path-"Notes" folder (fresh install) → create the root at path "Notes".
+   Never moves user rows; never touches sealed content.
 3. **Auto-title on a note in a locked folder:** **skip** — the read-gate refuses, so the note stays
    "Untitled"; never auto-unlock just to title. (Rare in practice: new notes land in the always-open
    root, not a locked folder.)

--- a/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
+++ b/docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md
@@ -108,11 +108,13 @@ for this note: <body excerpt>"). **Local-only, zero egress.**
 - Changing the per-folder lock model.
 - Cloud-based title generation; bulk-retitling existing "Untitled" notes.
 
-## Open questions for review
-1. **Reserved-root marker:** an additive `folders.is_root` column (clean, explicit) vs a reserved
-   id/path sentinel (no schema touch at all). Recommendation: `is_root` column — explicit + guardable.
-2. **Legacy "Notes" folder:** leave untouched (recommended — no risky migration) vs auto-promote an
-   *unlocked* legacy "Notes" folder to the reserved root (cleaner tree, more logic). Recommendation:
-   leave untouched for now.
-3. **Auto-title on a note in a locked folder:** the read-gate refuses → we simply skip (leave
-   "Untitled"). Acceptable? (Recommendation: yes — don't auto-unlock for a title.)
+## Decisions (resolved 2026-07-14, user-approved)
+1. **Reserved-root marker:** additive **`folders.is_root INTEGER DEFAULT 0`** column — explicit +
+   easy to guard (`lock_folder` refuses when `is_root=1`). `ensure_notes_root()` creates/returns the
+   single `is_root=1` note-folder idempotently.
+2. **Legacy "Notes" folder:** **left untouched** — becomes a normal folder with its notes; the user
+   renames/deletes it manually (after unlocking if sealed). No migration of user rows. A one-time
+   redundant "Notes" folder remains for existing users; fresh installs are clean.
+3. **Auto-title on a note in a locked folder:** **skip** — the read-gate refuses, so the note stays
+   "Untitled"; never auto-unlock just to title. (Rare in practice: new notes land in the always-open
+   root, not a locked folder.)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24511,6 +24511,85 @@ mod lifecycle_tests {
         );
     }
 
+    /// Feature A (the primary bug fix, RED-before-GREEN): `create_note(None)` when the legacy "Notes"
+    /// folder is LOCKED must STILL succeed — it now anchors to the reserved always-open root, not the
+    /// sealed "Notes" (pre-fix it hit the write-gate and returned `Locked` — the "Couldn't create the
+    /// note" dead-end).
+    #[test]
+    fn create_note_with_a_locked_legacy_notes_still_succeeds_via_the_root() {
+        let state = build_state("create-note-locked-default");
+        let notes_id = state.db.ensure_default_note_folder().unwrap();
+        state
+            .db
+            .set_folder_locked(&notes_id, true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        let id = create_note_inner(&state, None, "Untitled").unwrap();
+        let row = state.db.get_note_row(&id).unwrap().unwrap();
+        assert_ne!(
+            row.folder_id, notes_id,
+            "a new note must NOT be created into the locked legacy Notes folder"
+        );
+        let root = state.db.note_root_id().unwrap().unwrap();
+        assert_eq!(row.folder_id, root, "it lands in the reserved always-open root");
+        assert!(
+            !state.db.folder_by_id(&root).unwrap().unwrap().locked,
+            "the root is always open"
+        );
+    }
+
+    /// Feature A: the reserved Notes root can NEVER be locked (unfiled notes are deliberately open;
+    /// sealing means filing into a lockable folder). `lock_folder_inner` refuses it.
+    #[test]
+    fn lock_folder_refuses_the_reserved_notes_root() {
+        let state = build_state("lock-refuses-root");
+        let root = state.db.ensure_notes_root().unwrap();
+        let err = lock_folder_inner(&state, root.clone())
+            .expect_err("locking the Notes root must be refused");
+        assert!(
+            matches!(err, AppError::InvalidArg(_)),
+            "expected InvalidArg refusing the root lock, got {err:?}"
+        );
+        assert!(
+            !state.db.folder_by_id(&root).unwrap().unwrap().locked,
+            "the root stays unlocked after a refused lock"
+        );
+    }
+
+    /// Feature A: `ensure_notes_root` repurposes an UNLOCKED legacy "Notes" in place (flag flip), but
+    /// creates a SEPARATE always-open root when the legacy "Notes" is LOCKED — never flagging the
+    /// locked folder as the root (the invariant "is_root ⟹ never sealed"). Idempotent.
+    #[test]
+    fn ensure_notes_root_repurposes_unlocked_but_separates_when_locked() {
+        // Fresh: creates "Notes" as an unlocked root; idempotent.
+        let fresh = build_state("root-fresh");
+        let r = fresh.db.ensure_notes_root().unwrap();
+        assert!(fresh.db.folder_is_root(&r).unwrap());
+        assert!(!fresh.db.folder_by_id(&r).unwrap().unwrap().locked);
+        assert_eq!(fresh.db.ensure_notes_root().unwrap(), r, "idempotent");
+
+        // Unlocked legacy "Notes" → repurposed in place (same id becomes the root).
+        let open = build_state("root-repurpose");
+        let notes = open.db.ensure_default_note_folder().unwrap();
+        assert_eq!(open.db.ensure_notes_root().unwrap(), notes);
+        assert!(open.db.folder_is_root(&notes).unwrap());
+
+        // Locked legacy "Notes" → a SEPARATE open root; the locked folder is never the root.
+        let locked = build_state("root-locked");
+        let notes3 = locked.db.ensure_default_note_folder().unwrap();
+        locked
+            .db
+            .set_folder_locked(&notes3, true, Some(&b"w"[..]))
+            .unwrap();
+        let r3 = locked.db.ensure_notes_root().unwrap();
+        assert_ne!(r3, notes3, "a locked legacy Notes is NOT repurposed");
+        assert!(
+            !locked.db.folder_is_root(&notes3).unwrap(),
+            "the locked Notes is never flagged is_root"
+        );
+        assert!(!locked.db.folder_by_id(&r3).unwrap().unwrap().locked);
+    }
+
     /// STUCK-REPUBLISH FIX (`resolve_owned_source`): `resolve_owned_source` must mirror
     /// `org_resolve_source_inner` (fixed in cd21b10) and NOT gate on `state == "uploaded"` — a
     /// republish that failed transiently leaves the row `state = "failed"` with its OLD,
@@ -27554,7 +27633,9 @@ pub async fn org_list_members(
         .into_iter()
         .map(|m| OrgMember {
             user_id: m.user_id,
-            email: None, // the server does not return member emails (content-min); FE shows the id
+            // The server now discloses member emails to fellow org members (2026-07-14) — the FE shows
+            // the email, falling back to the id when an older server omits it (`None`).
+            email: m.email,
             role: m.role,
             added_at: m.created_at,
             removed: false,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2382,7 +2382,10 @@ pub(crate) fn create_note_inner(
     // BLK-1 / TOCTOU (2026-07-10 audit F4): hold the lifecycle guard across gate+insert so a
     // concurrent lock/relock cannot land between the unlock check and the row insert.
     let _lifecycle = lifecycle_guard(state);
-    // Resolve the anchor note-folder (default when None). ensure_default_note_folder is idempotent.
+    // Resolve the anchor note-folder. A None/empty selection ⇒ the reserved always-open Notes ROOT
+    // (unfiled), NOT the old default "Notes" folder — so "New note" can NEVER fail because the default
+    // folder is sealed (the 2026-07-14 "Couldn't create the note" dead-end). `ensure_notes_root` is
+    // idempotent + never locked.
     let folder_id = match folder_id {
         Some(f) if !f.is_empty() => {
             // Must be a NOTE folder — never create a note inside a meeting folder.
@@ -2391,7 +2394,7 @@ pub(crate) fn create_note_inner(
             }
             f.to_string()
         }
-        _ => state.db.ensure_default_note_folder()?,
+        _ => state.db.ensure_notes_root()?,
     };
 
     // WRITE-GATE: a sealed-and-not-session-unlocked folder is refused.
@@ -2899,6 +2902,8 @@ pub(crate) fn create_note_folder_inner(
         locked: false,
         // A freshly created folder is never sealed, so never session-unlocked.
         unlocked: false,
+        // Only the reserved Notes root is `is_root`; a user-created folder never is.
+        is_root: false,
         kind: "note".into(),
     };
     state
@@ -10667,6 +10672,14 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
         .db
         .folder_by_id(&folder_id)?
         .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    // The reserved Notes root is the always-open home for unfiled notes — it can NEVER be sealed
+    // (unfiled notes are deliberately plaintext; sealing requires filing into a lockable folder). Refuse
+    // rather than silently no-op so the FE can guide the user (2026-07-14).
+    if state.db.folder_is_root(&folder_id)? {
+        return Err(AppError::InvalidArg(
+            "the Notes root can't be locked — move notes into a folder to seal them".into(),
+        ));
+    }
     if folder.locked {
         return Ok(()); // already sealed — idempotent.
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2436,6 +2436,146 @@ pub(crate) fn create_note_inner(
     Ok(id)
 }
 
+/// System prompt for the on-device auto-title (Feature B, 2026-07-14). Short + strict output so the
+/// result is a clean headline, not a sentence.
+const AUTO_TITLE_SYSTEM: &str = "You write a short, specific title (3 to 6 words) for a note. \
+Output ONLY the title text — no surrounding quotes, no trailing punctuation, no 'Title:' prefix.";
+
+/// The on-device summarizer for a LOCAL-ONLY, zero-egress title — `None` when the on-device model
+/// isn't downloaded (the caller then uses the first-line heuristic). NEVER the cloud: an auto-title
+/// must never egress the note. Mirrors the local-provider construction in `summarize::provider_for`.
+fn local_title_provider(
+    state: &AppState,
+) -> Option<std::sync::Arc<dyn crate::summarize::provider::SummarizerProvider>> {
+    let (configured_path, model_id, timeouts) = {
+        let config = state.config.lock().ok()?;
+        (
+            config.brain_model_path.clone(),
+            config.brain_model_id.clone(),
+            crate::reason::sidecar::SidecarTimeouts {
+                idle_secs: config.brain_idle_timeout_secs,
+                ready_secs: config.brain_ready_timeout_secs,
+                hard_cap_secs: config.brain_hard_cap_secs,
+            },
+        )
+    };
+    let configured = configured_path.as_deref().map(std::path::Path::new);
+    let path = crate::reason::resolve_brain_model(configured, model_id.as_deref()).ok()??;
+    let reasoner: std::sync::Arc<dyn crate::reason::LocalReasoner> =
+        std::sync::Arc::new(crate::reason::sidecar::SidecarReasoner::new(path, timeouts).ok()?);
+    Some(std::sync::Arc::new(
+        crate::summarize::local::LocalSummarizerProvider::new(
+            reasoner,
+            std::sync::Arc::clone(&state.heavy_inference),
+        ),
+    ))
+}
+
+/// Clean an LLM title suggestion into a single tidy line, or `None` if it collapsed to nothing.
+fn sanitize_title_suggestion(raw: &str) -> Option<String> {
+    let line = raw.trim().lines().next().unwrap_or("").trim();
+    let line = line
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim_start_matches('#')
+        .trim();
+    let line = line.trim_end_matches(['.', ':', '-']).trim();
+    if line.is_empty() {
+        return None;
+    }
+    Some(line.chars().take(80).collect())
+}
+
+/// Fallback title: the first non-empty line of the body, stripped of leading markdown, capped.
+fn first_line_title(body: &str) -> String {
+    let line = body
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let line = line.trim_start_matches(['#', '-', '*', '>', ' ']).trim();
+    let capped: String = line.chars().take(60).collect();
+    if capped.is_empty() {
+        "Untitled".to_string()
+    } else {
+        capped
+    }
+}
+
+/// `suggest_note_title(note_id)` — auto-title an "Untitled" note from its body (Feature B): the
+/// on-device model when present, else a first-line heuristic. LOCAL-ONLY (never egresses). Persists
+/// the new title ONLY if the note is still "Untitled" (never clobbers a user's title) and skips a note
+/// in a LOCKED folder (spec decision #3 — no auto-unlock / seal-on-write for a title). Returns the
+/// title (the current one unchanged when it skips). Called fire-and-forget by the editor on close.
+#[tauri::command]
+pub async fn suggest_note_title(
+    state: State<'_, AppState>,
+    note_id: String,
+) -> Result<String, AppError> {
+    suggest_note_title_inner(state.inner(), &note_id).await
+}
+
+pub(crate) async fn suggest_note_title_inner(
+    state: &AppState,
+    note_id: &str,
+) -> Result<String, AppError> {
+    let Some(row) = state.db.get_note_row(note_id)? else {
+        return Err(AppError::InvalidArg(format!("no note {note_id}")));
+    };
+    // `NoteRow.title` is Option<String> (NULL-able column) — treat a missing title as "".
+    let current = row.title.clone().unwrap_or_default();
+    // Only ever fill in an "Untitled" note — never overwrite a title the user chose.
+    let cur = current.trim();
+    if !cur.is_empty() && cur != "Untitled" {
+        return Ok(current);
+    }
+    // Skip a locked folder: new notes live in the always-open root, so this only skips the rare
+    // deliberately-filed-then-locked case; auto-titling it would need seal-on-write / an unlock.
+    let folder_locked = state
+        .db
+        .folder_by_id(&row.folder_id)?
+        .map(|f| f.locked)
+        .unwrap_or(false);
+    if folder_locked {
+        return Ok(current);
+    }
+    let body = row.text.trim();
+    if body.is_empty() {
+        return Ok(current);
+    }
+
+    // On-device first (zero egress); first-line heuristic otherwise / on failure.
+    let title = match local_title_provider(state) {
+        Some(provider) => {
+            let excerpt: String = body.chars().take(1200).collect();
+            match provider.complete(AUTO_TITLE_SYSTEM, &excerpt).await {
+                Ok(t) => sanitize_title_suggestion(&t).unwrap_or_else(|| first_line_title(body)),
+                Err(e) => {
+                    tracing::info!(target: "notes", error = %e, "auto-title: on-device failed, using first line");
+                    first_line_title(body)
+                }
+            }
+        }
+        None => first_line_title(body),
+    };
+    if title.trim().is_empty() || title == "Untitled" {
+        return Ok(current);
+    }
+
+    // Persist — re-read + re-check under the write so a title the user set meanwhile always wins.
+    if let Some(fresh) = state.db.get_note_row(note_id)? {
+        let fresh_title = fresh.title.clone().unwrap_or_default();
+        let ft = fresh_title.trim();
+        if ft.is_empty() || ft == "Untitled" {
+            let now = chrono::Utc::now().timestamp_millis();
+            state.db.update_note_row(note_id, &title, &fresh.text, now)?;
+            return Ok(title);
+        }
+        return Ok(fresh_title); // user titled it in the meantime
+    }
+    Ok(title)
+}
+
 /// Read ONE note (editor DTO). GATED: a sealed-and-not-session-unlocked note returns the MASKED DTO
 /// (title "🔒 Locked", no body/tags), never the stored text.
 #[tauri::command]
@@ -24318,6 +24458,56 @@ mod lifecycle_tests {
         assert!(
             matches!(err, AppError::InvalidArg(_)),
             "expected InvalidArg for an unknown item, got {err:?}"
+        );
+    }
+
+    /// Feature B (auto-title): a still-"Untitled" note gets a first-line title (no on-device model in
+    /// tests → the heuristic path), a user-titled note is NEVER overwritten, and an empty body stays
+    /// "Untitled". LOCAL-only; no egress in any branch.
+    #[test]
+    fn suggest_note_title_fills_untitled_and_never_clobbers() {
+        let state = build_state("auto-title");
+        make_open_folder(&state.db, "f", "Team");
+
+        // Untitled + body in an open folder → first non-empty line becomes the title, persisted.
+        state
+            .db
+            .insert_note("n1", "f", "n1", "Untitled", "# Kickoff planning\nmore body", 1)
+            .unwrap();
+        let t = block_on(suggest_note_title_inner(&state, "n1")).unwrap();
+        assert_eq!(t, "Kickoff planning");
+        assert_eq!(
+            state.db.get_note_row("n1").unwrap().unwrap().title.as_deref(),
+            Some("Kickoff planning"),
+            "the title is persisted"
+        );
+
+        // A user-set title is NEVER overwritten.
+        state
+            .db
+            .insert_note("n2", "f", "n2", "My Title", "some body", 1)
+            .unwrap();
+        assert_eq!(
+            block_on(suggest_note_title_inner(&state, "n2")).unwrap(),
+            "My Title"
+        );
+        assert_eq!(
+            state.db.get_note_row("n2").unwrap().unwrap().title.as_deref(),
+            Some("My Title")
+        );
+
+        // Untitled + EMPTY body → stays Untitled (nothing to title).
+        state
+            .db
+            .insert_note("n3", "f", "n3", "Untitled", "   \n  ", 1)
+            .unwrap();
+        assert_eq!(
+            block_on(suggest_note_title_inner(&state, "n3")).unwrap(),
+            "Untitled"
+        );
+        assert_eq!(
+            state.db.get_note_row("n3").unwrap().unwrap().title.as_deref(),
+            Some("Untitled")
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -326,6 +326,7 @@ pub fn run() {
             commands::move_note,
             // Notes feature — authored `documents(kind='note')` CRUD + note folders + vault export.
             commands::create_note,
+            commands::suggest_note_title,
             commands::get_note,
             commands::update_note_doc,
             commands::save_note_text,

--- a/src-tauri/src/share/org_dto.rs
+++ b/src-tauri/src/share/org_dto.rs
@@ -87,6 +87,10 @@ pub struct OrgMemberEntry {
     pub user_id: String,
     pub role: String,
     pub created_at: String,
+    /// The member's email, when the server discloses it (2026-07-14). `#[serde(default)]` keeps an
+    /// older server (which omits the field) deserializing cleanly — the FE then falls back to the id.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5925,15 +5925,13 @@ impl Db {
     }
 
     /// The ONE reserved, always-open note-folder that backs the "Notes" section root — the home for
-    /// UNFILED new notes (2026-07-14). Idempotent; returns the existing `is_root` folder, else:
-    ///   - the legacy path-`"Notes"` folder is UNLOCKED → flag it `is_root=1` in place (no note
-    ///     movement, no risk) and use it (root at "Notes" — the common/fresh case);
-    ///   - the legacy `"Notes"` is LOCKED → can't repurpose (would expose sealed content) and can't
-    ///     reuse the UNIQUE "Notes" path → create a SEPARATE always-open root at the first free
-    ///     "Inbox" path, leaving the locked "Notes" as an ordinary folder;
-    ///   - no `"Notes"` folder (fresh) → create the root at "Notes".
-    /// Never moves user rows, never touches sealed content. The root can never be locked
-    /// (`lock_folder` refuses `is_root`).
+    /// UNFILED new notes (2026-07-14). Idempotent; returns the existing `is_root` folder, else picks
+    /// one: an UNLOCKED legacy path-`"Notes"` is flagged `is_root=1` in place (no note movement — the
+    /// common/fresh case); a LOCKED legacy `"Notes"` can't be repurposed (would expose sealed content)
+    /// nor reuse the UNIQUE "Notes" path, so a SEPARATE always-open root is created at the first free
+    /// "Inbox" path (the locked "Notes" stays an ordinary folder); with no `"Notes"` folder at all
+    /// (fresh install) the root is created at "Notes". Never moves user rows, never touches sealed
+    /// content; the root can never be locked (`lock_folder` refuses `is_root`).
     pub fn ensure_notes_root(&self) -> Result<String> {
         if let Some(id) = self.note_root_id()? {
             return Ok(id);

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5977,11 +5977,13 @@ impl Db {
         .map_err(map_err)
     }
 
-    /// Flag an existing (unlocked) note-folder as the reserved root.
+    /// Flag an existing (unlocked) note-folder as the reserved root. The `AND locked = 0` makes
+    /// "is_root ⟹ never sealed" a SQL-enforced invariant even under a concurrent lock race — a locked
+    /// folder can NEVER become the always-open root (lock-security review, 2026-07-14).
     fn set_folder_is_root(&self, id: &str) -> Result<()> {
         let conn = self.lock();
         conn.execute(
-            "UPDATE folders SET is_root = 1 WHERE id = ?1",
+            "UPDATE folders SET is_root = 1 WHERE id = ?1 AND locked = 0",
             rusqlite::params![id],
         )
         .map_err(map_err)?;
@@ -6014,9 +6016,12 @@ impl Db {
             rusqlite::params![id, path, chrono::Utc::now().to_rfc3339()],
         )
         .map_err(map_err)?;
-        // Ensure is_root=1 even if a same-path row pre-existed (the OR IGNORE kept the old one).
+        // Ensure is_root=1 even if a same-path row pre-existed (the OR IGNORE kept the old one). The
+        // `AND locked = 0` keeps the "is_root ⟹ never sealed" invariant under a concurrent race where
+        // a LOCKED folder was created at this path between the free-path check and here.
         conn.execute(
-            "UPDATE folders SET is_root = 1 WHERE path = ?1",
+            "UPDATE folders SET is_root = 1 WHERE path = ?1 AND locked = 0 \
+               AND COALESCE(kind, 'meeting') = 'note'",
             rusqlite::params![path],
         )
         .map_err(map_err)?;

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -679,6 +679,11 @@ impl Db {
         // folders are created with kind='note'. Lock/seal/CK machinery is folder-id-keyed and
         // kind-agnostic → reused verbatim. Additive + guarded (idempotent).
         Self::add_column_if_missing(&conn, "folders", "kind", "TEXT NOT NULL DEFAULT 'meeting'")?;
+        // ADDITIVE (2026-07-14): `is_root` marks the ONE reserved always-open note-folder that backs
+        // the "Notes" section root — new UNFILED notes land there, it can never be locked, and the FE
+        // hides it from the folder tree (it IS the section, not a nested child). Exactly one row has
+        // is_root=1 (see `ensure_notes_root`). Guarded/idempotent; every existing folder defaults to 0.
+        Self::add_column_if_missing(&conn, "folders", "is_root", "INTEGER NOT NULL DEFAULT 0")?;
         // Phase 2b — content-free egress audit log. One row per cloud provider call written by
         // `DbEgressSink`. The table carries ONLY counts, ids, labels, byte sizes, and token counts —
         // NEVER transcript, prompt, scrubbed values, API keys, or any meeting content (§8: no PII
@@ -5919,6 +5924,110 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// The ONE reserved, always-open note-folder that backs the "Notes" section root — the home for
+    /// UNFILED new notes (2026-07-14). Idempotent; returns the existing `is_root` folder, else:
+    ///   - the legacy path-`"Notes"` folder is UNLOCKED → flag it `is_root=1` in place (no note
+    ///     movement, no risk) and use it (root at "Notes" — the common/fresh case);
+    ///   - the legacy `"Notes"` is LOCKED → can't repurpose (would expose sealed content) and can't
+    ///     reuse the UNIQUE "Notes" path → create a SEPARATE always-open root at the first free
+    ///     "Inbox" path, leaving the locked "Notes" as an ordinary folder;
+    ///   - no `"Notes"` folder (fresh) → create the root at "Notes".
+    /// Never moves user rows, never touches sealed content. The root can never be locked
+    /// (`lock_folder` refuses `is_root`).
+    pub fn ensure_notes_root(&self) -> Result<String> {
+        if let Some(id) = self.note_root_id()? {
+            return Ok(id);
+        }
+        match self.folder_by_path("Notes")? {
+            Some(f) if !f.locked => {
+                self.set_folder_is_root(&f.id)?;
+                Ok(f.id)
+            }
+            Some(_locked) => {
+                let path = self.first_free_note_root_path()?;
+                self.insert_note_root(&path)
+            }
+            None => self.insert_note_root("Notes"),
+        }
+    }
+
+    /// The id of the reserved note-root (`is_root=1`), or `None` if it hasn't been created yet.
+    pub fn note_root_id(&self) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id FROM folders WHERE is_root = 1 AND COALESCE(kind,'meeting') = 'note' LIMIT 1",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// True when this folder is the reserved always-open note-root (`is_root=1`). Drives the
+    /// `lock_folder` refusal so the root can never be sealed.
+    pub fn folder_is_root(&self, id: &str) -> Result<bool> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT COALESCE(is_root, 0) FROM folders WHERE id = ?1",
+            rusqlite::params![id],
+            |r| Ok(r.get::<_, i64>(0)? != 0),
+        )
+        .optional()
+        .map(|o| o.unwrap_or(false))
+        .map_err(map_err)
+    }
+
+    /// Flag an existing (unlocked) note-folder as the reserved root.
+    fn set_folder_is_root(&self, id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE folders SET is_root = 1 WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The first free "Inbox"-style path for a separate note-root (when the legacy "Notes" is locked).
+    fn first_free_note_root_path(&self) -> Result<String> {
+        for n in 0..1000 {
+            let path = if n == 0 {
+                "Inbox".to_string()
+            } else {
+                format!("Inbox {}", n + 1)
+            };
+            if self.folder_by_path(&path)?.is_none() {
+                return Ok(path);
+            }
+        }
+        Err(AppError::Storage("could not allocate a notes-root path".into()))
+    }
+
+    /// Insert a fresh reserved note-root at `path` (name = `path`, `is_root=1`, unlocked, no parent).
+    /// `INSERT OR IGNORE` on the UNIQUE path guards a race, then reads the id back.
+    fn insert_note_root(&self, path: &str) -> Result<String> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let conn = self.lock();
+        conn.execute(
+            "INSERT OR IGNORE INTO folders (id, name, path, parent_id, locked, wrapped_key, created_at, kind, is_root)
+             VALUES (?1, ?2, ?2, NULL, 0, NULL, ?3, 'note', 1)",
+            rusqlite::params![id, path, chrono::Utc::now().to_rfc3339()],
+        )
+        .map_err(map_err)?;
+        // Ensure is_root=1 even if a same-path row pre-existed (the OR IGNORE kept the old one).
+        conn.execute(
+            "UPDATE folders SET is_root = 1 WHERE path = ?1",
+            rusqlite::params![path],
+        )
+        .map_err(map_err)?;
+        conn.query_row(
+            "SELECT id FROM folders WHERE path = ?1",
+            rusqlite::params![path],
+            |r| r.get::<_, String>(0),
+        )
+        .map_err(map_err)
+    }
+
     /// Insert a note-folder (`kind='note'`). Mirrors [`Db::insert_folder`] but stamps the kind.
     pub fn insert_note_folder(&self, f: &NoteFolder, created_at: &str) -> Result<()> {
         let conn = self.lock();
@@ -5944,7 +6053,7 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, path, parent_id, locked, kind
+                "SELECT id, name, path, parent_id, locked, kind, COALESCE(is_root, 0)
                    FROM folders WHERE kind = 'note' ORDER BY created_at, name",
             )
             .map_err(map_err)?;
@@ -5961,7 +6070,7 @@ impl Db {
     pub fn note_folder_by_id(&self, id: &str) -> Result<Option<NoteFolder>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT id, name, path, parent_id, locked, kind
+            "SELECT id, name, path, parent_id, locked, kind, COALESCE(is_root, 0)
                FROM folders WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id],
             row_to_note_folder,
@@ -10931,6 +11040,7 @@ fn row_to_note_folder(row: &Row<'_>) -> rusqlite::Result<NoteFolder> {
         // fills this in from the live session set; every other reader gets `false` (safe default).
         unlocked: false,
         kind: row.get::<_, Option<String>>(5)?.unwrap_or_else(|| "note".into()),
+        is_root: row.get::<_, i64>(6)? != 0,
     })
 }
 

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -719,6 +719,10 @@ pub struct NoteFolder {
     /// always sets this `false`; the `list_note_folders` command overwrites it by joining the live
     /// `AppState::unlocked_folders` set (a sealed folder that is NOT session-unlocked stays `false`).
     pub unlocked: bool,
+    /// The reserved always-open note-root that backs the "Notes" section (2026-07-14). Exactly one
+    /// note-folder has this set; the FE HIDES it from the folder tree (it IS the section root, where
+    /// unfiled notes live) and it can never be locked. Everything else is `false`.
+    pub is_root: bool,
     pub kind: String,
 }
 

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1841,6 +1841,16 @@ export class IpcService {
   }
 
   /**
+   * Auto-title an "Untitled" note from its body — the on-device model when present,
+   * else a first-line heuristic. LOCAL-ONLY (never egresses). No-ops (returns the
+   * current title) when the note already has a title, is empty, or sits in a locked
+   * folder. Returns the resulting title. Called fire-and-forget when the editor closes.
+   */
+  suggestNoteTitle(noteId: string): Promise<string> {
+    return invoke<string>("suggest_note_title", { noteId });
+  }
+
+  /**
    * Read ONE note in full for the editor. GATED: a sealed-and-not-session-unlocked
    * note returns a MASKED {@link NoteDoc} (`locked: true`, title "🔒 Locked", empty
    * markdown/tags/properties) — render the lock gate, not the body.

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1855,6 +1855,12 @@ export interface NoteFolder {
    * the Notes lock gate (`locked && !unlocked`) so unlocking actually lifts it.
    */
   unlocked: boolean;
+  /**
+   * The reserved always-open note-root that backs the "Notes" section (2026-07-14).
+   * Exactly one note-folder has this set. The sidebar tree HIDES it (it IS the
+   * section root — where unfiled new notes live), and it can never be locked.
+   */
+  isRoot: boolean;
   kind: string;
 }
 

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -36,6 +36,14 @@
               <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
             </svg>
           </button>
+          <!-- Privacy hint: an unfiled note lives in the always-open root and is NOT sealed. -->
+          @if (isUnfiled()) {
+            <span
+              class="unfiled-hint"
+              title="Unfiled notes aren't encrypted. Move this note into a locked folder to seal it."
+              >not sealed</span
+            >
+          }
           @if (menu() === "move") {
             <div class="menu head-menu" role="menu" aria-label="Move to folder">
               <p class="menu-group-label">Move to…</p>
@@ -47,7 +55,7 @@
                   [disabled]="folder.id === doc.folderId"
                   (click)="moveTo(folder.id)"
                 >
-                  {{ folder.name }}
+                  {{ folder.isRoot ? "Unfiled" : folder.name }}
                   @if (folder.id === doc.folderId) {
                     <span class="menu-here">Here</span>
                   }

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -45,6 +45,21 @@
 .head-more {
   position: relative;
 }
+/* Privacy hint for an unfiled (always-open) note — subtle, muted, non-alarming. */
+.unfiled-hint {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-1);
+  padding: 0 var(--space-2);
+  height: 20px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: help;
+}
 .crumb-btn {
   display: inline-flex;
   align-items: center;

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -274,9 +274,20 @@ export class NoteEditorComponent {
     return this.noteFolders().find((f) => f.id === id) ?? null;
   });
 
-  /** Human breadcrumb: the folder's display path (Notes/… ) or "Notes". */
+  /**
+   * True when this note lives in the reserved always-open root — it's "unfiled"
+   * and therefore NOT sealable (unfiled notes are deliberately open plaintext;
+   * sealing requires filing into a lockable folder). Drives the breadcrumb label
+   * + the "not sealed" privacy hint (2026-07-14).
+   */
+  readonly isUnfiled = computed(() => this.currentFolder()?.isRoot ?? false);
+
+  /** Human breadcrumb: "Unfiled" for a root note, else the folder's name (or "Notes"). */
   readonly breadcrumb = computed(() => {
     const folder = this.currentFolder();
+    if (folder?.isRoot) {
+      return "Unfiled";
+    }
     return folder ? folder.name : "Notes";
   });
 
@@ -389,6 +400,10 @@ export class NoteEditorComponent {
       if (this.dirtyFull) {
         this.flushFull();
       }
+      // Auto-title an untitled note on close (Feature B) — fire-and-forget; the backend reads the
+      // last-saved body (cheap autosaves already persisted it), generates a LOCAL title, and keeps it
+      // only if the note is still "Untitled". Best-effort, never blocks teardown.
+      this.maybeAutoTitle();
     });
 
     // LOCK-REACTIVE re-mask — a ROOT effect via the EnvironmentInjector, NOT a
@@ -411,6 +426,37 @@ export class NoteEditorComponent {
       { injector: this.envInjector },
     );
     this.destroyRef.onDestroy(() => lockEffectRef.destroy());
+  }
+
+  /**
+   * Feature B — on close, ask the backend to auto-title a still-"Untitled" note from its body (the
+   * on-device model when present, else a first-line heuristic; LOCAL-only). Fire-and-forget: the
+   * editor is being torn down, so we only reflect the new title back onto the (persisting) tab strip
+   * when it resolves. Skips a locked/masked note and an empty body up front (the backend re-checks).
+   */
+  private maybeAutoTitle(): void {
+    const doc = this.note();
+    if (!doc || doc.locked) {
+      return;
+    }
+    const t = this.title().trim();
+    if (t !== "" && t.toLowerCase() !== "untitled") {
+      return; // the note already has a real title — never overwrite it
+    }
+    if (this.body().trim() === "") {
+      return; // nothing to title
+    }
+    const id = doc.id;
+    void this.ipc
+      .suggestNoteTitle(id)
+      .then((title) => {
+        if (title && title.toLowerCase() !== "untitled") {
+          this.tabsService.setTitle(tabKeyFor("note", id), title);
+        }
+      })
+      .catch(() => {
+        /* best-effort: an auto-title failure never surfaces */
+      });
   }
 
   /**

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.html
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.html
@@ -2,7 +2,7 @@
      consolidation — this component projects into it, see AppShellComponent).
      This template owns only the note-FOLDER list below it. -->
 <nav class="notes-tree" aria-label="Note folders">
-  @for (folder of noteFolders(); track folder.id) {
+  @for (folder of visibleFolders(); track folder.id) {
     @if (renamingId() === folder.id) {
       <form class="tree-edit" (submit)="confirmRename(folder.id, $event)">
         <input

--- a/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.ts
+++ b/src/app/features/notes/notes-sidebar-tree/notes-sidebar-tree.component.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   Injector,
   afterNextRender,
+  computed,
   inject,
   input,
   signal,
@@ -74,6 +75,16 @@ export class NotesSidebarTreeComponent {
 
   /** The note-kind folder list. */
   readonly noteFolders = this.notes.noteFolders;
+
+  /**
+   * The folders the tree RENDERS — everything except the reserved always-open
+   * root (2026-07-14): the root IS the "Notes" section itself (where unfiled new
+   * notes live), so showing it as a nested "Notes" row would just re-create the
+   * confusing "Notes-inside-Notes" redundancy the root was introduced to kill.
+   */
+  readonly visibleFolders = computed(() =>
+    this.noteFolders().filter((f) => !f.isRoot),
+  );
   /** The shared active-folder selection (null = "All notes"). */
   readonly activeFolderId = this.notes.activeFolderId;
 


### PR DESCRIPTION
Notes-UX batch for 0.9.16 (design spec: `docs/superpowers/specs/2026-07-14-notes-ux-unfiled-and-autotitle-design.md`). Both notes features passed **lock-security PASS + adversarial PASS**.

## Feature A — unfiled-first notes
New notes land in a reserved **always-open "Notes root"** (`folders.is_root`) instead of the old default "Notes" folder, so **"New note" can never fail because the default is sealed** (the "Couldn't create the note" dead-end), and the redundant "Notes-inside-Notes" tree row is gone.
- `ensure_notes_root()` repurposes an *unlocked* legacy "Notes" in place (flag flip), else a separate "Inbox" when it's locked, else creates "Notes" fresh — never moves rows, never touches sealed content.
- `lock_folder` refuses the root (SQL-enforced `is_root ⇒ locked=0`); FE hides the root from the tree; editor shows "Unfiled" + a "not sealed" privacy hint; the Move menu labels the root "Unfiled".

## Feature B — auto-title on close
On editor close, a still-"Untitled" note is titled from its body via the **on-device model** (mistralrs sidecar) or a first-line heuristic — **local-only, zero egress**; never clobbers a user title; skips a locked-folder note.

## #7 (client) — member emails
Deserializes the new `OrgMemberEntry.email` and maps it to `OrgMember` so the Organization member list shows emails instead of UUIDs (pairs with murmur-server PR #13; server-gated).

## Verification
- cargo test --lib **1605 pass** (incl. committed Feature A regressions: create-with-locked-default succeeds via root; lock refuses root; ensure_notes_root branches; + auto-title regression).
- ng lint + ng build clean.
- Independent lock-security + adversarial verifiers both PASS (findings: 2 LOW NITs, both hardened).
- Honest gap: on-device LLM title quality + Touch-ID/lock-at-rest need a signed Mac.