### PR TITLE
feat(notes): typed front-matter properties + folder Table/Board + query_database

### DIFF
--- a/e2e/notes/typed-properties.spec.ts
+++ b/e2e/notes/typed-properties.spec.ts
@@ -1,0 +1,240 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Feature C — typed note front-matter properties + folder Table/Board views.
+ *
+ * The schema/typed commands (`get_note_folder_schema` / `set_note_folder_schema`
+ * / `list_notes_typed`) are layered as per-spec `extra` overrides on top of the
+ * shared Notes mock. `nf1` ("Notes") gets a 3-field schema (a Select "Status", a
+ * Checkbox "Reviewed", a Date "Due"); the locked folder `nf2` returns `[]` from
+ * BOTH the schema + typed reads (backend-gated), so no typed view is offered.
+ *
+ * These are the runtime checks a green `ng build` can't make: the schema-driven
+ * WIDGET per property row (a checkbox renders `mur-toggle`, NOT a text input),
+ * the List/Table/Board switcher gated on a non-empty schema, the Table's
+ * column-per-field, the Board's group-by-Status, and — critically — that toggling
+ * a typed value re-serializes the note's front-matter unchanged in shape (the
+ * `properties` map stays `Record<string,string>`).
+ */
+
+/** The schema + typed-row overrides shared by these specs. */
+const TYPED_OVERRIDES = {
+  get_note_folder_schema: (args: { folderId: string }) => {
+    if (args.folderId === "nf1") {
+      return [
+        { key: "Status", kind: "select", options: ["Todo", "In progress", "Done"] },
+        { key: "Reviewed", kind: "checkbox", options: [] },
+        { key: "Due", kind: "date", options: [] },
+      ];
+    }
+    // nf2 is locked → gated to [] (no typed view).
+    return [];
+  },
+  set_note_folder_schema: () => null,
+  list_notes_typed: (args: { folderId: string }) => {
+    if (args.folderId === "nf1") {
+      return [
+        {
+          id: "n1",
+          title: "My First Note",
+          folderId: "nf1",
+          values: {
+            Status: { kind: "select", value: "In progress" },
+            Reviewed: { kind: "checkbox", value: true },
+            Due: { kind: "date", value: "2026-08-01" },
+          },
+          tags: ["idea"],
+          updatedAt: 1_720_000_000_000,
+        },
+        {
+          id: "n2",
+          title: "Weekly plan",
+          folderId: "nf1",
+          values: {
+            Status: { kind: "select", value: "Done" },
+            Reviewed: { kind: "checkbox", value: false },
+          },
+          tags: [],
+          updatedAt: 1_720_100_000_000,
+        },
+        {
+          id: "n3",
+          title: "Backlog idea",
+          folderId: "nf1",
+          values: { Status: { kind: "select", value: "Todo" } },
+          tags: [],
+          updatedAt: 1_720_200_000_000,
+        },
+      ];
+    }
+    return [];
+  },
+};
+
+/** A `get_note` for n1 carrying the three typed properties in its front-matter. */
+const NOTE_WITH_PROPS = {
+  get_note: (args: { id: string }) => ({
+    id: args.id,
+    title: "My First Note",
+    folderId: "nf1",
+    markdown:
+      "---\ntags: [idea]\nStatus: In progress\nReviewed: true\nDue: 2026-08-01\n---\n\n# Heading\n\nSome body text to select.",
+    tags: ["idea"],
+    properties: { Status: "In progress", Reviewed: "true", Due: "2026-08-01" },
+    updatedAt: 1_720_000_000_000,
+    createdAt: 1_719_000_000_000,
+    exportedPath: null,
+    locked: false,
+    shared: false,
+  }),
+};
+
+test("editor renders a SCHEMA-DRIVEN widget per property (checkbox → mur-toggle, select dropdown, date input) and toggling round-trips the front-matter", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  // Capture the exact markdown the editor sends to save_note_text so we can
+  // assert the front-matter round-trip stays byte-shaped.
+  await mockNotes(page, {
+    ...TYPED_OVERRIDES,
+    ...NOTE_WITH_PROPS,
+    save_note_text: (args: { id: string; title: string; markdown: string }) => {
+      (window as unknown as { __lastSave?: unknown }).__lastSave = args.markdown;
+      return 1_720_000_100_000;
+    },
+  });
+  await page.goto("/notes/n1");
+
+  // Title hydrated → the doc loaded.
+  await expect(page.locator(".note-title-input")).toHaveValue("My First Note");
+
+  // The properties bar auto-opens (it has props). Each row's KEY is present.
+  await expect(page.locator(".prop-key", { hasText: "Status" })).toBeVisible();
+  await expect(page.locator(".prop-key", { hasText: "Reviewed" })).toBeVisible();
+  await expect(page.locator(".prop-key", { hasText: "Due" })).toBeVisible();
+
+  // Checkbox → a mur-toggle (NOT a text input). Find the Reviewed row.
+  const reviewedRow = page.locator(".prop-row", { hasText: "Reviewed" });
+  await expect(reviewedRow.locator("mur-toggle")).toBeVisible();
+  await expect(reviewedRow.locator('input[type="text"]')).toHaveCount(0);
+  // Its switch reflects the true value.
+  await expect(reviewedRow.locator('input.switch')).toBeChecked();
+
+  // Select → a native <select> carrying the schema options + the current value.
+  const statusRow = page.locator(".prop-row", { hasText: "Status" });
+  await expect(statusRow.locator("select")).toBeVisible();
+  await expect(statusRow.locator("select")).toHaveValue("In progress");
+  await expect(statusRow.locator("select option", { hasText: "Done" })).toHaveCount(1);
+
+  // Date → an <input type="date"> with the ISO value.
+  const dueRow = page.locator(".prop-row", { hasText: "Due" });
+  await expect(dueRow.locator('input[type="date"]')).toHaveValue("2026-08-01");
+
+  // Toggle the checkbox OFF → the editor writes `Reviewed: false` back into the
+  // SAME front-matter block (round-trip: still `key: value` scalars, no shape drift).
+  await reviewedRow.locator("input.switch").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as { __lastSave?: string }).__lastSave ?? "",
+      ),
+    )
+    .toContain("Reviewed: false");
+  const saved = await page.evaluate(
+    () => (window as unknown as { __lastSave?: string }).__lastSave ?? "",
+  );
+  // The other typed properties survived unchanged (no data loss on a typed edit).
+  expect(saved).toContain("Status: In progress");
+  expect(saved).toContain("Due: 2026-08-01");
+  expect(saved).toContain("tags: [idea]");
+  // Still a single leading --- … --- YAML block (the byte-exact serializer path).
+  expect(saved.startsWith("---\n")).toBeTruthy();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test("notes home offers List/Table/Board only for a folder WITH a schema; Table shows a column per field; Board groups by Status", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, TYPED_OVERRIDES);
+  await page.goto("/notes");
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // "All notes" (no folder) → NO switcher.
+  await expect(page.locator(".view-switcher")).toHaveCount(0);
+
+  // Select the "Notes" (nf1) folder in the sidebar tree → its schema loads.
+  await page
+    .locator("app-notes-sidebar-tree mur-tree-row .row-label", { hasText: "Notes" })
+    .first()
+    .click();
+
+  // The switcher now appears (nf1 has a non-empty schema).
+  const switcher = page.locator(".view-switcher");
+  await expect(switcher).toBeVisible();
+  await expect(switcher.getByRole("button", { name: "Table" })).toBeVisible();
+  await expect(switcher.getByRole("button", { name: "Board" })).toBeVisible();
+
+  // Switch to TABLE → a column per schema field + Title + Updated.
+  await switcher.getByRole("button", { name: "Table" }).click();
+  const table = page.locator("app-notes-table-view");
+  await expect(table).toBeVisible();
+  await expect(table.locator("thead th", { hasText: "Title" })).toBeVisible();
+  await expect(table.locator("thead th", { hasText: "Status" })).toBeVisible();
+  await expect(table.locator("thead th", { hasText: "Reviewed" })).toBeVisible();
+  await expect(table.locator("thead th", { hasText: "Due" })).toBeVisible();
+  // A select value renders as a pill; a checkbox as a glyph (n1 Reviewed=true).
+  await expect(table.locator(".select-pill", { hasText: "In progress" })).toBeVisible();
+  await expect(table.locator(".check-glyph").first()).toBeVisible();
+
+  // Switch to BOARD → grouped by the Select field "Status": one column per option.
+  await switcher.getByRole("button", { name: "Board" }).click();
+  const board = page.locator("app-notes-board-view");
+  await expect(board).toBeVisible();
+  await expect(board.locator(".board-col-title", { hasText: "Todo" })).toBeVisible();
+  await expect(board.locator(".board-col-title", { hasText: "In progress" })).toBeVisible();
+  await expect(board.locator(".board-col-title", { hasText: "Done" })).toBeVisible();
+  // n1 (In progress) card is under the right column.
+  await expect(board.getByText("My First Note")).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test("a LOCKED folder (schema [] / rows []) offers NO typed view — only the lock gate / list", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, TYPED_OVERRIDES);
+  await page.goto("/notes");
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  // Select the locked "Work" folder (nf2) → schema gated to [].
+  await page
+    .locator("app-notes-sidebar-tree mur-tree-row .row-label", { hasText: "Work" })
+    .first()
+    .click();
+
+  // NO switcher (empty schema), NO table/board view.
+  await expect(page.locator(".view-switcher")).toHaveCount(0);
+  await expect(page.locator("app-notes-table-view")).toHaveCount(0);
+  await expect(page.locator("app-notes-board-view")).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,8 @@ use crate::storage::models::{
     EntityDetail, EntityDossierResult, Folder, FolderNode, GraphData, Meeting,
     MeetingActionSummary, MeetingStatus, MeetingTimeline, NoteAssistRequest, NoteAssistResult,
     NoteCitation, NoteDoc, NoteFolder, NoteRecord, NoteSummary, OrganizeMove, OrganizePlan,
-    PeopleList, PinResult, RecipeRecord, SavedView, SearchHit, TopicThread,
+    PeopleList, PinResult, PropertyKind, PropertySchemaField, RecipeRecord, SavedView, SearchHit,
+    TopicThread, TypedNoteRow,
 };
 use crate::summarize::all_providers;
 use crate::transcribe::types::Segment;
@@ -2841,6 +2842,147 @@ pub fn list_note_folders(state: State<'_, AppState>) -> Result<Vec<NoteFolder>, 
         f.unlocked = f.locked && unlocked.contains(&f.id);
     }
     Ok(folders)
+}
+
+// ── Feature C — TYPED note front-matter properties (note-folder schemas + Table/Board substrate) ──
+
+/// Max property columns a note-folder schema may declare (a UI-scale bound, not a hard DB limit).
+const NOTE_SCHEMA_MAX_FIELDS: usize = 40;
+/// Max length of a schema property key.
+const NOTE_SCHEMA_MAX_KEY_LEN: usize = 60;
+
+/// Read a note-folder's typed property SCHEMA (Feature C). GATED (the SAFER choice): a
+/// sealed-and-not-session-unlocked folder returns `Ok(vec![])` — we deliberately do NOT expose a
+/// locked folder's schema (the schema is only needed to view/edit an UNLOCKED folder). `InvalidArg`
+/// when `folder_id` is not a note-folder.
+#[tauri::command]
+pub fn get_note_folder_schema(
+    state: State<'_, AppState>,
+    folder_id: String,
+) -> Result<Vec<PropertySchemaField>, AppError> {
+    get_note_folder_schema_inner(state.inner(), &folder_id)
+}
+
+/// Inner of [`get_note_folder_schema`] taking `&AppState` (unit-testable gate).
+pub(crate) fn get_note_folder_schema_inner(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<Vec<PropertySchemaField>, AppError> {
+    if state.db.note_folder_by_id(folder_id)?.is_none() {
+        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+    }
+    // GATE: a locked-and-not-session-unlocked folder's schema is NOT exposed (return empty).
+    if !folder_is_unlocked(state, folder_id)? {
+        return Ok(Vec::new());
+    }
+    state.db.get_note_folder_schema(folder_id)
+}
+
+/// Set a note-folder's typed property SCHEMA (Feature C). WRITE-GATED: a sealed-and-not-session-
+/// unlocked folder is refused (`AppError::Locked`) — never mutate metadata behind a lock. Validates:
+/// ≤40 fields, each `key` non-empty/trimmed/≤60 chars, case-insensitively UNIQUE, never the reserved
+/// `"tags"`, and every `Select` field carries ≥1 non-empty option.
+#[tauri::command]
+pub fn set_note_folder_schema(
+    state: State<'_, AppState>,
+    folder_id: String,
+    fields: Vec<PropertySchemaField>,
+) -> Result<(), AppError> {
+    set_note_folder_schema_inner(state.inner(), &folder_id, fields)
+}
+
+/// Inner of [`set_note_folder_schema`] taking `&AppState` (unit-testable gate + validation).
+pub(crate) fn set_note_folder_schema_inner(
+    state: &AppState,
+    folder_id: &str,
+    fields: Vec<PropertySchemaField>,
+) -> Result<(), AppError> {
+    if state.db.note_folder_by_id(folder_id)?.is_none() {
+        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+    }
+    // WRITE-GATE (before any validation or write): a sealed-not-unlocked folder is refused so a
+    // schema can never be edited behind a lock.
+    if !folder_is_unlocked(state, folder_id)? {
+        return Err(AppError::Locked(
+            "this folder is locked — unlock it to edit its properties".into(),
+        ));
+    }
+    if fields.len() > NOTE_SCHEMA_MAX_FIELDS {
+        return Err(AppError::InvalidArg(format!(
+            "too many properties (max {NOTE_SCHEMA_MAX_FIELDS})"
+        )));
+    }
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for f in &fields {
+        let key = f.key.trim();
+        if key.is_empty() {
+            return Err(AppError::InvalidArg("property key must not be empty".into()));
+        }
+        if key.len() > NOTE_SCHEMA_MAX_KEY_LEN {
+            return Err(AppError::InvalidArg(format!(
+                "property key too long (max {NOTE_SCHEMA_MAX_KEY_LEN} chars)"
+            )));
+        }
+        // `tags` is reserved for the front-matter tag list (parsed separately, never a property).
+        if key.eq_ignore_ascii_case("tags") {
+            return Err(AppError::InvalidArg(
+                "property key \"tags\" is reserved".into(),
+            ));
+        }
+        if !seen.insert(key.to_ascii_lowercase()) {
+            return Err(AppError::InvalidArg(format!(
+                "duplicate property key \"{key}\""
+            )));
+        }
+        if f.kind == PropertyKind::Select
+            && !f.options.iter().any(|o| !o.trim().is_empty())
+        {
+            return Err(AppError::InvalidArg(format!(
+                "select property \"{key}\" needs at least one option"
+            )));
+        }
+    }
+    // Persist the TRIMMED keys (so the read-time coercion keys match the front-matter keys exactly).
+    let normalized: Vec<PropertySchemaField> = fields
+        .into_iter()
+        .map(|f| PropertySchemaField {
+            key: f.key.trim().to_string(),
+            kind: f.kind,
+            options: f
+                .options
+                .into_iter()
+                .map(|o| o.trim().to_string())
+                .filter(|o| !o.is_empty())
+                .collect(),
+        })
+        .collect();
+    state.db.set_note_folder_schema(folder_id, &normalized)?;
+    tracing::info!(target: "notes", folder_id = %folder_id, fields = normalized.len(), "note-folder schema updated");
+    Ok(())
+}
+
+/// List a note-folder's notes projected through its typed schema (Feature C — the Table/Board
+/// substrate). GATED: a sealed-and-not-session-unlocked folder returns `[]` (no rows, never a masked
+/// row) via [`Db::list_notes_visible_typed`], which is built on the gated `list_notes_visible`.
+/// `InvalidArg` when `folder_id` is not a note-folder.
+#[tauri::command]
+pub fn list_notes_typed(
+    state: State<'_, AppState>,
+    folder_id: String,
+) -> Result<Vec<TypedNoteRow>, AppError> {
+    list_notes_typed_inner(state.inner(), &folder_id)
+}
+
+/// Inner of [`list_notes_typed`] taking `&AppState` (unit-testable gate).
+pub(crate) fn list_notes_typed_inner(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<Vec<TypedNoteRow>, AppError> {
+    if state.db.note_folder_by_id(folder_id)?.is_none() {
+        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+    }
+    let unlocked = unlocked_snapshot(state)?;
+    state.db.list_notes_visible_typed(folder_id, &unlocked)
 }
 
 /// Create a note-folder (`kind='note'`). `parent_id` must itself be a note-folder (or None = a
@@ -19234,6 +19376,178 @@ mod lifecycle_tests {
             state.db.get_note_row(&id).unwrap().unwrap().sealed,
             "a note created in a session-unlocked LOCKED folder is sealed from birth"
         );
+    }
+
+    /// Feature C (RED-before-GREEN): `set_note_folder_schema` on a SEALED-and-not-session-unlocked
+    /// folder MUST be refused with `AppError::Locked` and leave the schema UNCHANGED — an impl that
+    /// forgets the `folder_is_unlocked` gate would let a schema be edited behind a lock (this test is
+    /// RED against that). Session-unlock allows the edit.
+    #[test]
+    fn set_note_folder_schema_refuses_on_locked_folder() {
+        let state = build_state("schema-locked-refuse");
+        let fid = create_note_folder_inner(&state, "Secret", None).unwrap().id;
+        // Seed an initial schema WHILE the folder is open, then lock it.
+        let original = vec![PropertySchemaField {
+            key: "status".into(),
+            kind: PropertyKind::Text,
+            options: vec![],
+        }];
+        set_note_folder_schema_inner(&state, &fid, original.clone()).unwrap();
+        lock_folder_inner(&state, fid.clone()).unwrap();
+
+        // Attempt to overwrite the schema while sealed-not-unlocked → Locked refusal.
+        let attempt = vec![PropertySchemaField {
+            key: "owner".into(),
+            kind: PropertyKind::Text,
+            options: vec![],
+        }];
+        assert!(
+            matches!(
+                set_note_folder_schema_inner(&state, &fid, attempt.clone()).unwrap_err(),
+                AppError::Locked(_)
+            ),
+            "sealed-not-unlocked folder must refuse a schema write"
+        );
+        // The stored schema is UNCHANGED (read it directly — the command read gate returns [] when
+        // locked, so assert against the DB layer to prove the write was rejected, not just masked).
+        assert_eq!(
+            state.db.get_note_folder_schema(&fid).unwrap(),
+            original,
+            "the schema must be untouched after a refused write"
+        );
+
+        // Session-unlock ⇒ the write is allowed and takes effect.
+        let _ck = session_unlock(&state, &fid);
+        set_note_folder_schema_inner(&state, &fid, attempt.clone()).unwrap();
+        assert_eq!(state.db.get_note_folder_schema(&fid).unwrap(), attempt);
+    }
+
+    /// Feature C (RED-before-GREEN): `get_note_folder_schema` is GATED — a sealed-and-not-session-
+    /// unlocked folder returns `Ok(vec![])` (we deliberately do NOT expose a locked folder's schema);
+    /// session-unlock reveals the real schema. RED against an ungated read that would return the
+    /// schema while locked.
+    #[test]
+    fn get_note_folder_schema_gated_on_lock() {
+        let state = build_state("schema-read-gate");
+        let fid = create_note_folder_inner(&state, "Secret", None).unwrap().id;
+        let schema = vec![PropertySchemaField {
+            key: "status".into(),
+            kind: PropertyKind::Select,
+            options: vec!["Open".into(), "Done".into()],
+        }];
+        set_note_folder_schema_inner(&state, &fid, schema.clone()).unwrap();
+        lock_folder_inner(&state, fid.clone()).unwrap();
+
+        // Locked-not-unlocked → empty (schema not exposed), even though a row exists in the DB.
+        assert!(
+            get_note_folder_schema_inner(&state, &fid).unwrap().is_empty(),
+            "sealed-not-unlocked folder's schema must not be exposed"
+        );
+
+        // Session-unlock → the real schema.
+        let _ck = session_unlock(&state, &fid);
+        assert_eq!(get_note_folder_schema_inner(&state, &fid).unwrap(), schema);
+    }
+
+    /// Feature C: `list_notes_typed` returns `[]` for a sealed-and-not-session-unlocked folder (no
+    /// rows, never a masked row) and the real typed rows once session-unlocked.
+    #[test]
+    fn list_notes_typed_gated_on_lock() {
+        let state = build_state("typed-list-gate");
+        let fid = create_note_folder_inner(&state, "Tasks", None).unwrap().id;
+        set_note_folder_schema_inner(
+            &state,
+            &fid,
+            vec![PropertySchemaField {
+                key: "status".into(),
+                kind: PropertyKind::Select,
+                options: vec!["Open".into(), "Done".into()],
+            }],
+        )
+        .unwrap();
+        let id = create_note_inner(&state, Some(&fid), "Task A").unwrap();
+        update_note_doc_inner(&state, &id, "Task A", "---\nstatus: Done\n---\nbody").unwrap();
+        lock_folder_inner(&state, fid.clone()).unwrap();
+
+        // Locked → no rows.
+        assert!(
+            list_notes_typed_inner(&state, &fid).unwrap().is_empty(),
+            "sealed-not-unlocked folder must yield no typed rows"
+        );
+
+        // Session-unlock → the real typed row with the coerced Select value.
+        let _ck = session_unlock(&state, &fid);
+        let rows = list_notes_typed_inner(&state, &fid).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].title, "Task A");
+        assert_eq!(
+            rows[0].values.get("status"),
+            Some(&crate::storage::models::PropertyValue::Select("Done".into()))
+        );
+    }
+
+    /// Feature C: `set_note_folder_schema` validation — reserved `tags` key, duplicate keys,
+    /// empty-option Select, and the field-count cap all refuse with `InvalidArg`.
+    #[test]
+    fn set_note_folder_schema_validation() {
+        let state = build_state("schema-validate");
+        let fid = create_note_folder_inner(&state, "V", None).unwrap().id;
+
+        // Reserved key "tags".
+        assert!(matches!(
+            set_note_folder_schema_inner(
+                &state,
+                &fid,
+                vec![PropertySchemaField {
+                    key: "tags".into(),
+                    kind: PropertyKind::Text,
+                    options: vec![]
+                }]
+            )
+            .unwrap_err(),
+            AppError::InvalidArg(_)
+        ));
+
+        // Duplicate keys (case-insensitive).
+        assert!(matches!(
+            set_note_folder_schema_inner(
+                &state,
+                &fid,
+                vec![
+                    PropertySchemaField { key: "Owner".into(), kind: PropertyKind::Text, options: vec![] },
+                    PropertySchemaField { key: "owner".into(), kind: PropertyKind::Text, options: vec![] },
+                ]
+            )
+            .unwrap_err(),
+            AppError::InvalidArg(_)
+        ));
+
+        // Select with no non-empty option.
+        assert!(matches!(
+            set_note_folder_schema_inner(
+                &state,
+                &fid,
+                vec![PropertySchemaField {
+                    key: "status".into(),
+                    kind: PropertyKind::Select,
+                    options: vec!["  ".into()]
+                }]
+            )
+            .unwrap_err(),
+            AppError::InvalidArg(_)
+        ));
+
+        // A valid schema goes through.
+        set_note_folder_schema_inner(
+            &state,
+            &fid,
+            vec![PropertySchemaField {
+                key: "status".into(),
+                kind: PropertyKind::Select,
+                options: vec!["Open".into()],
+            }],
+        )
+        .unwrap();
     }
 
     /// WP0 gate — a note in a SEALED-and-not-session-unlocked folder MUST be MASKED: `get_note`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,6 +344,10 @@ pub fn run() {
             commands::rename_note_folder,
             commands::delete_note_folder,
             commands::move_note_folder,
+            // Feature C — typed note front-matter properties (note-folder schemas + Table/Board).
+            commands::get_note_folder_schema,
+            commands::set_note_folder_schema,
+            commands::list_notes_typed,
             // Notes — selection Brain-assistant (WP4) + auto-organize (WP5) + link sharing (WP6).
             commands::note_assistant_action,
             commands::plan_organize_notes,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -273,6 +273,11 @@ fn tools_spec() -> Value {
             "name": "org_search",
             "description": "Fallback for when search_meetings / search_semantic find nothing relevant in your OWN vault and you have joined an org: search the ORGANIZATION brain — notes your colleagues explicitly shared to the shared org brain (synced + decrypted locally; no data leaves this device). Results are attributed '[org · <author>]' and MUST be cited as coming from that colleague. Only meaningful when you have joined an org and consented to org sharing (otherwise returns no results). Use for 'what does the team / someone else know or decide about X' questions.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
+        },
+        {
+            "name": "query_database",
+            "description": "Query the TYPED PROPERTIES of a note-folder's notes as a small database (the folder's Table/Board columns: status, owner, due date, priority, etc.). Give the folder NAME (or id) and a filter: 'key op value' clauses joined by AND / OR, op ∈ = != > < >= <= or 'contains' (e.g. 'status=Done', 'openItems>3', 'owner contains ann', 'status=Open AND priority=High'). Empty filter = every row. Sealed-and-locked note folders are excluded. Use for 'which notes are still open', 'what does Anna own', 'high-priority items' questions over a note-folder's columns.",
+            "inputSchema": { "type": "object", "properties": { "folder": { "type": "string" }, "filter": { "type": "string" } }, "required": ["folder"] }
         }
     ])
 }
@@ -395,6 +400,23 @@ fn dispatch_tool(
                 .unwrap_or("")
                 .to_string(),
         },
+        // Feature C — TYPED note-folder database query. `folder` is required (name or id); `filter`
+        // is optional (empty = all rows). Gated by `list_notes_visible_typed` against `unlocked_set`,
+        // so a sealed-not-unlocked note folder yields no rows here.
+        "query_database" => {
+            let folder = args.get("folder").and_then(Value::as_str).unwrap_or("");
+            if folder.trim().is_empty() {
+                return Err((-32602, "missing required argument: folder".to_string()));
+            }
+            ToolCall::QueryDatabase {
+                folder: folder.to_string(),
+                filter: args
+                    .get("filter")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            }
+        }
         other => return Err((-32602, format!("unknown tool: {other}"))),
     };
     // The `semantic_search_enabled` flag lives in the whole-DB-encrypted settings table; load it from
@@ -432,10 +454,10 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_eight_tools() {
+    fn tools_list_has_nine_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 9);
         // The Phase 2b semantic tool is advertised.
         assert!(tools.iter().any(|t| t["name"] == "search_semantic"));
         // The Phase 5a open-commitments rollup tool is advertised.
@@ -448,6 +470,11 @@ mod tests {
         assert!(
             tools.iter().any(|t| t["name"] == "get_document"),
             "get_document must be advertised in the MCP tool catalog"
+        );
+        // Feature C — the typed note-folder database query tool is advertised (the 9th tool).
+        assert!(
+            tools.iter().any(|t| t["name"] == "query_database"),
+            "query_database must be advertised in the MCP tool catalog"
         );
     }
 
@@ -785,6 +812,73 @@ mod tests {
             !out3.contains("sign the contract"),
             "owner filter must drop Carol's item"
         );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// Feature C: `query_database` is visibility-gated exactly like the other read tools (mirror of
+    /// `get_open_commitments_is_visibility_gated`). A typed note in a sealed-and-not-unlocked
+    /// note-folder is INVISIBLE to the query (its title + typed values never surface), and reappears
+    /// once the folder is session-unlocked. RED if the tool bypasses `list_notes_visible_typed`.
+    #[test]
+    fn query_database_is_visibility_gated() {
+        use crate::storage::models::{NoteFolder, PropertyKind, PropertySchemaField};
+        let (db, p) = temp_db();
+        // A LOCKED note-folder with a typed `status` schema and one typed note.
+        db.insert_note_folder(
+            &NoteFolder {
+                id: "nf-lock".into(),
+                name: "Secret Tasks".into(),
+                path: "Notes/Secret Tasks".into(),
+                parent_id: None,
+                locked: false,
+                unlocked: false,
+                kind: "note".into(),
+            },
+            "2026-07-14T00:00:00Z",
+        )
+        .unwrap();
+        db.set_note_folder_schema(
+            "nf-lock",
+            &[PropertySchemaField {
+                key: "status".into(),
+                kind: PropertyKind::Select,
+                options: vec!["Open".into(), "Done".into()],
+            }],
+        )
+        .unwrap();
+        // Note title deliberately DISJOINT from the folder name so a substring test can't collide.
+        db.insert_note(
+            "n-secret",
+            "nf-lock",
+            "launch-plan",
+            "Launch Plan",
+            "---\nstatus: Open\n---\nbody",
+            1_000,
+        )
+        .unwrap();
+        db.set_folder_locked("nf-lock", true, Some(b"wrapped"))
+            .unwrap();
+
+        // Not unlocked → the sealed folder's typed row is invisible; the row's title never leaks.
+        let args = json!({ "folder": "Secret Tasks", "filter": "status=Open" });
+        let out = dispatch_tool(&db, "query_database", &args, &HashSet::new()).unwrap();
+        assert!(
+            !out.contains("Launch Plan"),
+            "sealed-not-unlocked note-folder's typed row leaked (gate violation): {out}"
+        );
+
+        // Session-unlock → the typed row reappears in the query result.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("nf-lock".to_string());
+        let out2 = dispatch_tool(&db, "query_database", &args, &unlocked).unwrap();
+        assert!(
+            out2.contains("[[Launch Plan]]"),
+            "unlocked typed row must reappear in query_database: {out2}"
+        );
+
+        // Missing required `folder` arg is an InvalidArg (JSON-RPC -32602), never a silent all-rows.
+        let bad = dispatch_tool(&db, "query_database", &json!({ "filter": "x=y" }), &unlocked);
+        assert!(bad.is_err(), "query_database requires a folder argument");
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -232,6 +232,8 @@ fn tool_label(call: &ToolCall) -> &'static str {
         // Shared Brain — org search is an EXPLICIT interactive tool, never auto-planned into note
         // generation (`map_to_tool_call` doesn't map it), so this label is only for completeness.
         ToolCall::OrgBrainSearch { .. } => "Org brain",
+        // Feature C — typed note-folder database query (explicit tool; label for completeness).
+        ToolCall::QueryDatabase { .. } => "Note database",
     }
 }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -16,8 +16,9 @@ use crate::storage::models::{
     GraphData,
     GraphEdge, GraphEntity, GraphNode, Meeting, MeetingActionSummary, MeetingStatus, NoteFolder,
     NoteRecord, NoteSummary,
-    OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, RecipeRecord, SavedView, SearchHit,
-    SourceKind,
+    OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertySchemaField,
+    PropertyValue, RecipeRecord, SavedView, SearchHit,
+    SourceKind, TypedNoteRow,
     StatusCount,
     VaultSource,
 };
@@ -355,6 +356,11 @@ impl Db {
                updated_at TEXT NOT NULL
              );
              CREATE INDEX IF NOT EXISTS idx_saved_views_scope ON saved_views(scope, sort_order);
+             CREATE TABLE IF NOT EXISTS note_folder_schemas (
+               folder_id TEXT PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
+               schema_json TEXT NOT NULL DEFAULT '[]',
+               updated_at INTEGER NOT NULL
+             );
              CREATE TABLE IF NOT EXISTS folders (
                id TEXT PRIMARY KEY,
                name TEXT NOT NULL,
@@ -5908,6 +5914,125 @@ impl Db {
         Ok(out)
     }
 
+    // ── Feature C — TYPED note front-matter properties (note-folder schemas) ─────────────────────
+
+    /// Read a note-folder's declared property SCHEMA (Feature C). Returns the parsed field list, or
+    /// an EMPTY vec when the folder has no schema row. Content-free metadata: the schema declares
+    /// column names/types, never any note content. NOT lock-gated at this layer — the COMMAND layer
+    /// gates on the folder's session-unlock state (a locked folder's schema is deliberately not
+    /// exposed). A malformed `schema_json` (should never happen — we only ever write it via
+    /// [`Self::set_note_folder_schema`]) degrades to an empty vec rather than erroring the read.
+    pub fn get_note_folder_schema(&self, folder_id: &str) -> Result<Vec<PropertySchemaField>> {
+        let conn = self.lock();
+        let json: Option<String> = conn
+            .query_row(
+                "SELECT schema_json FROM note_folder_schemas WHERE folder_id = ?1",
+                rusqlite::params![folder_id],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        match json {
+            None => Ok(Vec::new()),
+            Some(s) => Ok(serde_json::from_str::<Vec<PropertySchemaField>>(&s).unwrap_or_default()),
+        }
+    }
+
+    /// UPSERT a note-folder's property schema (Feature C). Serializes `fields` to the `schema_json`
+    /// column, inserting a new row or replacing the existing one via `ON CONFLICT(folder_id)`. The
+    /// COMMAND layer validates the fields (count/key/options) and gates the write on the folder's
+    /// session-unlock state BEFORE calling this — this is the raw persistence.
+    pub fn set_note_folder_schema(
+        &self,
+        folder_id: &str,
+        fields: &[PropertySchemaField],
+    ) -> Result<()> {
+        let schema_json = serde_json::to_string(fields)
+            .map_err(|e| AppError::Storage(format!("schema serialize failed: {e}")))?;
+        let now = chrono::Utc::now().timestamp_millis();
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO note_folder_schemas (folder_id, schema_json, updated_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(folder_id) DO UPDATE SET schema_json = ?2, updated_at = ?3",
+            rusqlite::params![folder_id, schema_json, now],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// List a note-folder's VISIBLE notes projected through its typed schema (Feature C — the
+    /// Table/Board substrate). GATE: the visible rows come from the EXISTING gated
+    /// [`Self::list_notes_visible`] (`visibility_clause` against `unlocked`), so a sealed-and-not-
+    /// session-unlocked folder yields NO rows here (never a masked row) — a typed row can never carry
+    /// sealed content. Per visible row: re-read its markdown through the SAME visibility gate
+    /// (defense-in-depth — a row that somehow slipped the summary gate is still gated on the text
+    /// read), `parse_front_matter` the raw `Record<String,String>`, and coerce each schema key's raw
+    /// scalar via [`coerce_property_value`] against the folder schema. A `Select` value outside the
+    /// declared `options` is PRESERVED as `Text` (never dropped). The front-matter parsers are
+    /// untouched — typing is a pure read-time overlay.
+    pub fn list_notes_visible_typed(
+        &self,
+        folder_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<TypedNoteRow>> {
+        // The schema drives which keys are typed + how. Empty schema ⇒ rows carry no `values` (still
+        // their id/title/tags), never an error.
+        let schema = self.get_note_folder_schema(folder_id)?;
+        // GATE 1 — only VISIBLE notes for this folder (sealed-not-unlocked ⇒ absent).
+        let summaries = self.list_notes_visible(Some(folder_id), unlocked)?;
+        let mut out = Vec::with_capacity(summaries.len());
+        for s in summaries {
+            // GATE 2 (defense-in-depth) — re-read the markdown through the SAME visibility gate; a
+            // row that slipped the summary gate resolves to None and is dropped, never read plain.
+            let Some(markdown) = self.note_markdown_if_visible(&s.id, unlocked)? else {
+                continue;
+            };
+            let (tags, raw) = parse_front_matter(&markdown);
+            let mut values: std::collections::BTreeMap<String, PropertyValue> =
+                std::collections::BTreeMap::new();
+            for field in &schema {
+                if let Some(raw_val) = raw.get(&field.key) {
+                    values.insert(
+                        field.key.clone(),
+                        coerce_property_value(raw_val, field.kind, &field.options),
+                    );
+                }
+            }
+            out.push(TypedNoteRow {
+                id: s.id,
+                title: s.title,
+                folder_id: s.folder_id,
+                values,
+                tags,
+                updated_at: s.updated_at,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Read ONE note's raw markdown ONLY when its owning folder is VISIBLE (open or session-unlocked)
+    /// — the gated text read [`Self::list_notes_visible_typed`] uses per row. Applies the SAME
+    /// `visibility_clause` JOIN as [`Self::list_notes_visible`]: a note in a sealed-and-not-unlocked
+    /// folder resolves to `None` (never the stored/blanked text). `kind='note'` enforced.
+    pub fn note_markdown_if_visible(
+        &self,
+        note_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT COALESCE(d.text, '')
+               FROM documents d
+               JOIN folders f ON f.id = d.folder_id
+              WHERE d.id = ?1 AND d.kind = 'note' AND {visible}"
+        );
+        conn.query_row(&sql, rusqlite::params![note_id], |r| r.get::<_, String>(0))
+            .optional()
+            .map_err(map_err)
+    }
+
     // ── NOTE FOLDERS (`folders` with `kind='note'`) ──────────────────────────────────────────────
 
     /// Ensure the root note-folder exists (name "Notes", `kind='note'`, path "Notes") and return its
@@ -5984,6 +6109,24 @@ impl Db {
         )
         .optional()
         .map_err(map_err)
+    }
+
+    /// Resolve a note-folder by NAME (case-insensitive, over [`Self::list_note_folders`]) OR by exact
+    /// id (Feature C — the `query_database` brain tool's `folder` argument). Name match is tried
+    /// first (the FIRST match wins on a name collision); if no name matches, an exact id is tried.
+    /// `Ok(None)` when neither resolves — the tool turns that into a friendly "no note folder named X".
+    /// Note-folders only (`kind='note'`), so a meeting folder can never be driven through the tool.
+    pub fn note_folder_by_name_or_id(&self, folder: &str) -> Result<Option<NoteFolder>> {
+        let needle = folder.trim();
+        if needle.is_empty() {
+            return Ok(None);
+        }
+        for f in self.list_note_folders()? {
+            if f.name.eq_ignore_ascii_case(needle) {
+                return Ok(Some(f));
+            }
+        }
+        self.note_folder_by_id(needle)
     }
 
     /// The `kind` of a folder (or `None` if unknown). Lets the command layer reject cross-tree ops.
@@ -10842,6 +10985,83 @@ fn push_tag(tags: &mut Vec<String>, raw: &str) {
     }
 }
 
+/// Feature C — COERCE a raw front-matter scalar into a typed [`PropertyValue`] against a schema
+/// column's declared `kind`. PURE + unit-testable (no DB). NEVER drops a value: a raw string that
+/// cannot be coerced to the declared kind (a malformed number/date/bool, or a `Select` value not in
+/// `options`) is PRESERVED as [`PropertyValue::Text`] — the user's data survives even when it does
+/// not match the schema.
+///
+/// Coercion rules:
+/// - `Checkbox` — `true`/`1`/`yes` (case-insensitive) ⇒ `true`; `false`/`0`/`no` ⇒ `false`; else
+///   preserved as `Text`.
+/// - `Number` — a parseable `f64` ⇒ `Number`; else `Text`.
+/// - `Date` — an ISO-ish `YYYY-MM-DD` (optionally with a time suffix) ⇒ `Date`; else `Text`.
+/// - `Select` — the exact raw value when it is one of `options` (case-insensitive match, canonical
+///   option casing kept) ⇒ `Select`; otherwise the raw value PRESERVED as `Text`.
+/// - `Text` — the raw value verbatim.
+pub fn coerce_property_value(raw: &str, kind: PropertyKind, options: &[String]) -> PropertyValue {
+    let v = raw.trim();
+    match kind {
+        PropertyKind::Text => PropertyValue::Text(v.to_string()),
+        PropertyKind::Checkbox => match v.to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" => PropertyValue::Checkbox(true),
+            "false" | "0" | "no" => PropertyValue::Checkbox(false),
+            _ => PropertyValue::Text(v.to_string()), // not a bool → preserve, never drop.
+        },
+        PropertyKind::Number => match v.parse::<f64>() {
+            Ok(n) if n.is_finite() => PropertyValue::Number(n),
+            _ => PropertyValue::Text(v.to_string()),
+        },
+        PropertyKind::Date => {
+            if is_iso_ish_date(v) {
+                PropertyValue::Date(v.to_string())
+            } else {
+                PropertyValue::Text(v.to_string())
+            }
+        }
+        PropertyKind::Select => {
+            // A Select value not in the declared options is PRESERVED as Text (never dropped).
+            match options
+                .iter()
+                .find(|o| o.eq_ignore_ascii_case(v))
+            {
+                Some(canonical) => PropertyValue::Select(canonical.clone()),
+                None => PropertyValue::Text(v.to_string()),
+            }
+        }
+    }
+}
+
+/// Is `s` an ISO-ish date — `YYYY-MM-DD`, optionally followed by a `T`/space time (`YYYY-MM-DDThh…`)?
+/// Deliberately LENIENT on the time part (any suffix after the date is accepted) but STRICT on the
+/// `YYYY-MM-DD` head (4-2-2 digits, dash-separated, plausible month/day ranges) so a plain number or
+/// free text never coerces to Date.
+fn is_iso_ish_date(s: &str) -> bool {
+    // Split off any time/zone suffix at the first 'T' or space; validate the date head only.
+    let head = s
+        .split_once(['T', ' '])
+        .map(|(d, _)| d)
+        .unwrap_or(s);
+    let parts: Vec<&str> = head.split('-').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let (y, m, d) = (parts[0], parts[1], parts[2]);
+    if y.len() != 4 || m.len() != 2 || d.len() != 2 {
+        return false;
+    }
+    if !y.chars().all(|c| c.is_ascii_digit())
+        || !m.chars().all(|c| c.is_ascii_digit())
+        || !d.chars().all(|c| c.is_ascii_digit())
+    {
+        return false;
+    }
+    // Plausible ranges (no calendar-exact day count — the goal is "looks like a date", not validity).
+    let month: u8 = m.parse().unwrap_or(0);
+    let day: u8 = d.parse().unwrap_or(0);
+    (1..=12).contains(&month) && (1..=31).contains(&day)
+}
+
 /// Strip a single pair of matching surrounding quotes (`"…"` or `'…'`) from a YAML scalar.
 fn unquote(s: &str) -> String {
     let s = s.trim();
@@ -11368,6 +11588,29 @@ mod tests {
         assert!(
             has_saved_views(&db),
             "saved_views table missing after a second migrate (idempotency broken)"
+        );
+
+        // Feature C (typed properties): the additive `note_folder_schemas` table must exist after
+        // migrate and STILL exist idempotently after a re-migrate — additive, never destructive.
+        let has_schemas = |db: &Db| -> bool {
+            db.lock()
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'note_folder_schemas'",
+                    [],
+                    |_| Ok(()),
+                )
+                .optional()
+                .unwrap()
+                .is_some()
+        };
+        assert!(
+            has_schemas(&db),
+            "note_folder_schemas table missing after migrate"
+        );
+        db.migrate().unwrap();
+        assert!(
+            has_schemas(&db),
+            "note_folder_schemas table missing after a second migrate (idempotency broken)"
         );
     }
 
@@ -14315,6 +14558,200 @@ mod tests {
     }
 
     use crate::storage::models::Folder;
+
+    // ── Feature C — typed note front-matter properties ──────────────────────────────────────────
+
+    /// Seed a NOTE folder (`kind='note'`) at `id`/`name`, so `note_folder_by_id` / the schema fns
+    /// resolve it. Mirrors the command layer's `insert_note_folder`.
+    fn seed_note_folder(db: &Db, id: &str, name: &str) {
+        db.insert_note_folder(
+            &NoteFolder {
+                id: id.to_string(),
+                name: name.to_string(),
+                path: format!("Notes/{name}"),
+                parent_id: None,
+                locked: false,
+                unlocked: false,
+                kind: "note".into(),
+            },
+            "2026-07-14T00:00:00Z",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn note_folder_schema_round_trip() {
+        let db = mem_db();
+        seed_note_folder(&db, "nf1", "Tasks");
+
+        // No schema row yet → empty vec.
+        assert!(db.get_note_folder_schema("nf1").unwrap().is_empty());
+
+        let fields = vec![
+            PropertySchemaField {
+                key: "status".into(),
+                kind: PropertyKind::Select,
+                options: vec!["Open".into(), "Done".into()],
+            },
+            PropertySchemaField {
+                key: "due".into(),
+                kind: PropertyKind::Date,
+                options: vec![],
+            },
+            PropertySchemaField {
+                key: "priority".into(),
+                kind: PropertyKind::Number,
+                options: vec![],
+            },
+        ];
+        db.set_note_folder_schema("nf1", &fields).unwrap();
+        let got = db.get_note_folder_schema("nf1").unwrap();
+        assert_eq!(got, fields, "set→get must round-trip the schema");
+
+        // ON CONFLICT upsert: a second set REPLACES (never appends/duplicates).
+        let replaced = vec![PropertySchemaField {
+            key: "owner".into(),
+            kind: PropertyKind::Text,
+            options: vec![],
+        }];
+        db.set_note_folder_schema("nf1", &replaced).unwrap();
+        let got2 = db.get_note_folder_schema("nf1").unwrap();
+        assert_eq!(got2, replaced, "upsert must replace the whole schema");
+    }
+
+    #[test]
+    fn coerce_property_value_checkbox() {
+        // true-ish and false-ish forms coerce; anything else preserved as Text (never dropped).
+        for t in ["true", "1", "yes", "TRUE", "Yes"] {
+            assert_eq!(
+                coerce_property_value(t, PropertyKind::Checkbox, &[]),
+                PropertyValue::Checkbox(true),
+                "{t} → true"
+            );
+        }
+        for f in ["false", "0", "no", "NO"] {
+            assert_eq!(
+                coerce_property_value(f, PropertyKind::Checkbox, &[]),
+                PropertyValue::Checkbox(false),
+                "{f} → false"
+            );
+        }
+        // Malformed bool → preserved as Text, not dropped.
+        assert_eq!(
+            coerce_property_value("maybe", PropertyKind::Checkbox, &[]),
+            PropertyValue::Text("maybe".into())
+        );
+    }
+
+    #[test]
+    fn coerce_property_value_number() {
+        assert_eq!(
+            coerce_property_value("42", PropertyKind::Number, &[]),
+            PropertyValue::Number(42.0)
+        );
+        assert_eq!(
+            coerce_property_value("3.5", PropertyKind::Number, &[]),
+            PropertyValue::Number(3.5)
+        );
+        // Non-numeric → preserved as Text.
+        assert_eq!(
+            coerce_property_value("high", PropertyKind::Number, &[]),
+            PropertyValue::Text("high".into())
+        );
+        // NaN/inf strings must not become a Number.
+        assert_eq!(
+            coerce_property_value("NaN", PropertyKind::Number, &[]),
+            PropertyValue::Text("NaN".into())
+        );
+    }
+
+    #[test]
+    fn coerce_property_value_date() {
+        assert_eq!(
+            coerce_property_value("2026-07-14", PropertyKind::Date, &[]),
+            PropertyValue::Date("2026-07-14".into())
+        );
+        assert_eq!(
+            coerce_property_value("2026-07-14T09:30:00Z", PropertyKind::Date, &[]),
+            PropertyValue::Date("2026-07-14T09:30:00Z".into())
+        );
+        // Not a date → preserved as Text.
+        assert_eq!(
+            coerce_property_value("someday", PropertyKind::Date, &[]),
+            PropertyValue::Text("someday".into())
+        );
+        assert_eq!(
+            coerce_property_value("2026-13-40", PropertyKind::Date, &[]),
+            PropertyValue::Text("2026-13-40".into()),
+            "implausible month/day is not a date"
+        );
+    }
+
+    #[test]
+    fn coerce_property_value_select_out_of_options_preserved_as_text() {
+        let opts = vec!["Open".to_string(), "Done".to_string()];
+        // In-options (case-insensitive) → Select with the CANONICAL option casing.
+        assert_eq!(
+            coerce_property_value("done", PropertyKind::Select, &opts),
+            PropertyValue::Select("Done".into())
+        );
+        // Out-of-options value is PRESERVED as Text, never dropped.
+        assert_eq!(
+            coerce_property_value("Blocked", PropertyKind::Select, &opts),
+            PropertyValue::Text("Blocked".into())
+        );
+    }
+
+    /// GATE (RED against reading text_blob-derived plaintext without the gate): a typed note in a
+    /// LOCKED note-folder must yield NO rows via `list_notes_visible_typed` before session-unlock,
+    /// and the REAL typed row once the folder id is in the unlock set.
+    #[test]
+    fn list_notes_typed_empty_for_sealed_folder() {
+        let db = mem_db();
+        seed_note_folder(&db, "nf-lock", "Secret Tasks");
+        db.set_note_folder_schema(
+            "nf-lock",
+            &[PropertySchemaField {
+                key: "status".into(),
+                kind: PropertyKind::Select,
+                options: vec!["Open".into(), "Done".into()],
+            }],
+        )
+        .unwrap();
+        // A note whose front-matter carries the typed `status` property.
+        db.insert_note(
+            "n1",
+            "nf-lock",
+            "secret-task",
+            "Secret Task",
+            "---\nstatus: Done\n---\nbody",
+            1_000,
+        )
+        .unwrap();
+        // Seal the folder (locked=1). The plaintext `text` column is NOT blanked by this bare
+        // set_folder_locked, so the ONLY thing keeping it invisible is the visibility gate.
+        db.set_folder_locked("nf-lock", true, Some(b"wrapped")).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        assert!(
+            db.list_notes_visible_typed("nf-lock", &nothing)
+                .unwrap()
+                .is_empty(),
+            "sealed-not-unlocked note-folder must yield NO typed rows (gate violation)"
+        );
+
+        // Session-unlock → the real typed row (status coerced to Select Done) appears.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("nf-lock".to_string());
+        let rows = db.list_notes_visible_typed("nf-lock", &unlocked).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].title, "Secret Task");
+        assert_eq!(
+            rows[0].values.get("status"),
+            Some(&PropertyValue::Select("Done".into())),
+            "unlocked row must carry the coerced typed value"
+        );
+    }
 
     fn seed_folder(db: &Db, id: &str, name: &str) {
         db.insert_folder(&Folder {

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -722,6 +722,69 @@ pub struct NoteFolder {
     pub kind: String,
 }
 
+// ── Feature C — TYPED note front-matter properties + folder Table/Board substrate ────────────────
+//
+// A note-folder can declare a SCHEMA: an ordered list of typed property columns (Text/Select/Date/
+// Checkbox/Number) that overlay the note's YAML front-matter. The schema is content-free metadata
+// (like `saved_views`) stored in `note_folder_schemas`. Typing is a READ-TIME COERCION layer over
+// the SAME `Record<String,String>` YAML scalars `parse_front_matter` already yields — the owned-.md
+// byte round-trip and the `text_blob` seal path are UNAWARE of it (load-bearing: the front-matter
+// parsers are never touched). A `Select` value that is not in the declared `options` is PRESERVED as
+// `Text`, never dropped.
+
+/// The type of a note-folder schema property column. `snake_case` on the wire so the FE reads
+/// `"text"`/`"select"`/`"date"`/`"checkbox"`/`"number"`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PropertyKind {
+    Text,
+    Select,
+    Date,
+    Checkbox,
+    Number,
+}
+
+/// One declared property column in a note-folder's schema. `options` is meaningful ONLY for
+/// `Select` (the allowed values); empty for the other kinds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertySchemaField {
+    pub key: String,
+    pub kind: PropertyKind,
+    #[serde(default)]
+    pub options: Vec<String>,
+}
+
+/// A COERCED front-matter value — the typed reading of a raw YAML scalar against a schema column.
+/// ADJACENTLY-tagged: serialized as `{ "kind": "...", "value": ... }` so the FE gets both the type
+/// and the concrete value. A raw scalar that fails to coerce to the declared kind is preserved as
+/// `Text` (the value is never lost).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum PropertyValue {
+    Text(String),
+    Select(String),
+    Date(String),
+    Checkbox(bool),
+    Number(f64),
+}
+
+/// A note row projected through a folder's typed schema (the Table/Board substrate). `values` maps a
+/// schema `key` → its coerced [`PropertyValue`] (only keys present in BOTH the schema and the note's
+/// front-matter appear; a key not declared in the schema is not projected). `tags` is the raw
+/// front-matter tag list. Built ONLY from gated readers — a sealed-not-unlocked folder yields NO
+/// rows (never a masked row), so a typed row can never carry sealed content.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TypedNoteRow {
+    pub id: String,
+    pub title: String,
+    pub folder_id: String,
+    pub values: std::collections::BTreeMap<String, PropertyValue>,
+    pub tags: Vec<String>,
+    pub updated_at: i64,
+}
+
 /// The selection Brain-assistant request (WP4): the selected text + its surrounding context +
 /// which action. `before`/`after` are up to ~500 chars each around the selection.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -65,7 +65,7 @@ impl AssistantScope {
     /// and the connector tools are partitioned here; `propose_note` / write tools are governed by the
     /// surface flags, not the tier, so they are allowed through the tier gate and left to those flags.
     fn allows(self, tool: &str) -> bool {
-        const VAULT_READS: [&str; 7] = [
+        const VAULT_READS: [&str; 8] = [
             "search_meetings",
             "search_semantic",
             "get_meeting",
@@ -73,6 +73,8 @@ impl AssistantScope {
             "list_recent_meetings",
             "get_open_commitments",
             "get_entity_dossier",
+            // Feature C — the typed note-folder database query (an owned-vault read, egress-free).
+            "query_database",
         ];
         const CONNECTORS: [&str; 5] = [
             "web_search",
@@ -175,6 +177,13 @@ pub enum ToolCall {
     /// ([`neutralize_murmur_fences`]) before entering the loop, and NEVER injected into a system
     /// prompt.
     OrgBrainSearch { query: String },
+    /// Feature C — QUERY a note-folder's TYPED front-matter properties (the Table/Board substrate) as
+    /// a structured database. EGRESS-FREE: reads the LOCAL typed rows through the gated
+    /// [`Db::list_notes_visible_typed`] (a sealed-and-not-session-unlocked folder yields NO rows), then
+    /// applies a DETERMINISTIC, RUST-parsed filter grammar (`key op value`, `AND`/`OR`) — NEVER a second
+    /// LLM call, so there is no prompt-injection surface and nothing egresses. An unparseable filter
+    /// degrades to "no rows matched (could not parse)", NEVER all rows.
+    QueryDatabase { folder: String, filter: String },
 }
 
 /// Model-facing description of one tool the agentic brain may call. `parameters` is a JSON-schema
@@ -310,6 +319,27 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                           'what does the team / someone else know / decide about X' questions that \
                           your own vault can't answer.".into(),
             parameters: str_arg("query", "What to look for in the shared org brain, in the user's own language."),
+            write: false,
+        },
+        ToolSpec {
+            name: "query_database".into(),
+            description: "Query the TYPED PROPERTIES of the notes in a note-folder as a small \
+                          database (the folder's Table/Board columns: status, owner, due date, \
+                          priority, etc.). Give the folder NAME (or id) and a filter. The filter is a \
+                          simple grammar: 'key op value' clauses joined by AND / OR, where op is one \
+                          of = != > < >= <= or 'contains' (e.g. 'status=Done', 'openItems>3', \
+                          'owner contains ann', 'status=Open AND priority=High'). Leave the filter \
+                          empty to list every row. Use for 'which notes are still open', 'what does \
+                          Anna own', 'high-priority items' questions over a note-folder's columns."
+                .into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "folder": { "type": "string", "description": "The note-folder NAME (or id) to query." },
+                    "filter": { "type": "string", "description": "A 'key op value' filter (AND/OR); empty = all rows." }
+                },
+                "required": ["folder"]
+            }),
             write: false,
         },
         ToolSpec {
@@ -620,6 +650,37 @@ pub fn execute_tool(
             // at ADVERTISEMENT time; a call that reaches here on an unavailable org simply finds an
             // empty partition and returns "no results" (never an error, never a leak).
             search_org_brain(db, config, query)
+        }
+        ToolCall::QueryDatabase { folder, filter } => {
+            // Resolve the note-folder by NAME (case-insensitive) or exact id. Note-folders only, so a
+            // meeting folder can never be queried through here. An unresolvable name is a FRIENDLY
+            // sentinel (never an error) so the model can retry with a different name.
+            let target = match db.note_folder_by_name_or_id(folder) {
+                Ok(Some(f)) => f,
+                Ok(None) => return Ok(format!("No note folder named \"{}\".", folder.trim())),
+                Err(e) => return Err(AppError::Storage(format!("folder resolve failed: {e}"))),
+            };
+            // GATE: the typed rows come from `list_notes_visible_typed`, which is built on the gated
+            // `list_notes_visible` (`visibility_clause` against `unlocked`) — a sealed-and-not-session-
+            // unlocked folder yields NO rows here (never a masked row), so no sealed content can leak.
+            let rows = db
+                .list_notes_visible_typed(&target.id, unlocked)
+                .map_err(|e| AppError::Storage(format!("typed rows read failed: {e}")))?;
+            // DETERMINISTIC, RUST-PARSED filter (no second LLM call → egress-free, no injection
+            // surface). An UNPARSEABLE filter yields ZERO matches (never all rows).
+            let matched = filter_rows(&rows, filter);
+            if matched.is_empty() {
+                // Distinguish "parsed but nothing matched" from "could not parse the filter".
+                let f = filter.trim();
+                if !f.is_empty() && parse_filter(f).is_none() {
+                    return Ok(format!(
+                        "No rows matched in \"{}\" (could not parse the filter).",
+                        target.name
+                    ));
+                }
+                return Ok(format!("No rows matched in \"{}\".", target.name));
+            }
+            Ok(format_typed_rows(&target.name, &matched))
         }
     }
 }
@@ -1046,6 +1107,274 @@ fn format_commitments(items: &[crate::storage::models::Commitment]) -> String {
         .join("\n")
 }
 
+// ── Feature C — QUERY_DATABASE deterministic filter grammar (Rust-parsed; NEVER a second LLM call) ─
+//
+// The bounded grammar: `key op value` clauses joined by `AND` / `OR` (case-insensitive keywords).
+// `op` ∈ { =, !=, >, <, >=, <=, contains }. This is parsed ENTIRELY in Rust — no model call — so the
+// filter is deterministic, egress-free, and carries no prompt-injection surface. An UNPARSEABLE
+// filter yields `None` (the caller degrades to ZERO matches, never all rows). Comparisons run against
+// the note's TYPED property values (numeric when both sides parse as f64, else case-insensitive
+// string); a missing key never matches.
+
+/// One comparison operator in the filter grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterOp {
+    Eq,
+    Ne,
+    Gt,
+    Lt,
+    Ge,
+    Le,
+    Contains,
+}
+
+/// One `key op value` clause.
+#[derive(Debug, Clone, PartialEq)]
+struct FilterClause {
+    key: String,
+    op: FilterOp,
+    value: String,
+}
+
+/// How clauses combine. A single clause has no connective; a compound filter is UNIFORM (all `AND`
+/// or all `OR` — mixing is rejected as unparseable, keeping the grammar unambiguous without
+/// precedence rules).
+#[derive(Debug, Clone, PartialEq)]
+enum FilterExpr {
+    Clauses {
+        clauses: Vec<FilterClause>,
+        all: bool, // true = AND (every clause), false = OR (any clause)
+    },
+}
+
+/// Parse a filter string into a [`FilterExpr`], or `None` when it is unparseable (empty, a bad
+/// operator, a missing key/value, or a mix of `AND` and `OR`). Splitting on ` AND `/` OR ` FIRST
+/// (case-insensitive, space-padded so a `key`/`value` containing the substring "and" is safe), then
+/// each clause on its operator.
+fn parse_filter(filter: &str) -> Option<FilterExpr> {
+    let f = filter.trim();
+    if f.is_empty() {
+        return None;
+    }
+    // Detect the connective by scanning for space-padded AND/OR (case-insensitive). Mixed ⇒ reject.
+    let has_and = contains_connective(f, "and");
+    let has_or = contains_connective(f, "or");
+    if has_and && has_or {
+        return None; // ambiguous without precedence — reject.
+    }
+    let all = !has_or; // OR when an OR is present; AND otherwise (single clause is trivially AND).
+    let sep = if has_or { "or" } else { "and" };
+    let parts = split_on_connective(f, sep);
+    let mut clauses = Vec::new();
+    for part in parts {
+        clauses.push(parse_clause(part.trim())?);
+    }
+    if clauses.is_empty() {
+        return None;
+    }
+    Some(FilterExpr::Clauses { clauses, all })
+}
+
+/// Is a space-padded connective keyword (`and`/`or`, case-insensitive) present as a standalone token?
+fn contains_connective(s: &str, kw: &str) -> bool {
+    s.to_ascii_lowercase().contains(&format!(" {kw} "))
+}
+
+/// Split `s` on the space-padded, case-insensitive connective `kw` (` and `/` or `). Returns the
+/// segments (never splitting inside a word — the padding spaces guarantee token boundaries).
+fn split_on_connective(s: &str, kw: &str) -> Vec<String> {
+    let lower = s.to_ascii_lowercase();
+    let pad = format!(" {kw} ");
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut search = 0usize;
+    while let Some(rel) = lower[search..].find(&pad) {
+        let at = search + rel;
+        out.push(s[start..at].to_string());
+        start = at + pad.len();
+        search = start;
+    }
+    out.push(s[start..].to_string());
+    out
+}
+
+/// Parse one `key op value` clause. Tries the multi-char operators FIRST (so `>=` is not read as
+/// `>`), then the word operator `contains`. `None` on any malformed clause.
+fn parse_clause(clause: &str) -> Option<FilterClause> {
+    // Operator table, longest first so `>=`/`<=`/`!=` win over `>`/`<`, and `=` last.
+    for (sym, op) in [
+        (">=", FilterOp::Ge),
+        ("<=", FilterOp::Le),
+        ("!=", FilterOp::Ne),
+        (">", FilterOp::Gt),
+        ("<", FilterOp::Lt),
+        ("=", FilterOp::Eq),
+    ] {
+        if let Some((k, v)) = clause.split_once(sym) {
+            let key = k.trim();
+            let value = v.trim();
+            if key.is_empty() || value.is_empty() {
+                return None;
+            }
+            return Some(FilterClause {
+                key: key.to_string(),
+                op,
+                value: strip_quotes(value).to_string(),
+            });
+        }
+    }
+    // Word operator: `key contains value` (case-insensitive keyword, space-padded).
+    let lower = clause.to_ascii_lowercase();
+    if let Some(rel) = lower.find(" contains ") {
+        let key = clause[..rel].trim();
+        let value = clause[rel + " contains ".len()..].trim();
+        if key.is_empty() || value.is_empty() {
+            return None;
+        }
+        return Some(FilterClause {
+            key: key.to_string(),
+            op: FilterOp::Contains,
+            value: strip_quotes(value).to_string(),
+        });
+    }
+    None
+}
+
+/// Strip one layer of surrounding single or double quotes from a filter value.
+fn strip_quotes(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2 {
+        let b = s.as_bytes();
+        if (b[0] == b'"' && b[s.len() - 1] == b'"') || (b[0] == b'\'' && b[s.len() - 1] == b'\'') {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+/// Render one typed property value to a plain string for filter comparison / display. `Checkbox`
+/// renders `true`/`false`; `Number` renders without a trailing `.0` for whole numbers.
+fn property_value_str(v: &crate::storage::models::PropertyValue) -> String {
+    use crate::storage::models::PropertyValue as PV;
+    match v {
+        PV::Text(s) | PV::Select(s) | PV::Date(s) => s.clone(),
+        PV::Checkbox(b) => b.to_string(),
+        PV::Number(n) => {
+            if n.fract() == 0.0 && n.is_finite() {
+                format!("{}", *n as i64)
+            } else {
+                n.to_string()
+            }
+        }
+    }
+}
+
+/// Does one typed note row satisfy `clause`? A missing key never matches. Numeric comparison when
+/// BOTH the row value and the filter value parse as `f64`; otherwise case-insensitive string. The
+/// tag list is queryable via the reserved key `tags` (a `contains`/`=` over the row's tags).
+fn clause_matches(row: &crate::storage::models::TypedNoteRow, clause: &FilterClause) -> bool {
+    // The reserved `tags` key queries the front-matter tag list (any tag satisfies).
+    if clause.key.eq_ignore_ascii_case("tags") {
+        return row.tags.iter().any(|t| {
+            compare(t, &clause.value, clause.op)
+        });
+    }
+    // Otherwise a declared property value (case-insensitive key lookup over the BTreeMap).
+    let Some(val) = row
+        .values
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(&clause.key))
+        .map(|(_, v)| property_value_str(v))
+    else {
+        return false; // missing key never matches.
+    };
+    compare(&val, &clause.value, clause.op)
+}
+
+/// Compare a row's value string against the filter value under `op`. Numeric when both parse as
+/// f64; else case-insensitive string. `contains` is always a substring test.
+fn compare(row_val: &str, filter_val: &str, op: FilterOp) -> bool {
+    if op == FilterOp::Contains {
+        return row_val
+            .to_ascii_lowercase()
+            .contains(&filter_val.to_ascii_lowercase());
+    }
+    if let (Ok(a), Ok(b)) = (row_val.trim().parse::<f64>(), filter_val.trim().parse::<f64>()) {
+        return match op {
+            FilterOp::Eq => a == b,
+            FilterOp::Ne => a != b,
+            FilterOp::Gt => a > b,
+            FilterOp::Lt => a < b,
+            FilterOp::Ge => a >= b,
+            FilterOp::Le => a <= b,
+            FilterOp::Contains => unreachable!(),
+        };
+    }
+    // String comparison (case-insensitive). Ordering ops fall back to lexicographic.
+    let a = row_val.to_ascii_lowercase();
+    let b = filter_val.to_ascii_lowercase();
+    match op {
+        FilterOp::Eq => a == b,
+        FilterOp::Ne => a != b,
+        FilterOp::Gt => a > b,
+        FilterOp::Lt => a < b,
+        FilterOp::Ge => a >= b,
+        FilterOp::Le => a <= b,
+        FilterOp::Contains => unreachable!(),
+    }
+}
+
+/// Feature C — apply the DETERMINISTIC filter grammar to a set of typed rows, returning the matching
+/// rows (in input order). An UNPARSEABLE filter yields ZERO matches — NEVER all rows (the safe
+/// degrade: a filter the model wrote that we cannot parse must not silently return everything). An
+/// EMPTY/whitespace filter returns ALL rows (an explicit "no filter" = list the whole table).
+fn filter_rows<'a>(
+    rows: &'a [crate::storage::models::TypedNoteRow],
+    filter: &str,
+) -> Vec<&'a crate::storage::models::TypedNoteRow> {
+    if filter.trim().is_empty() {
+        return rows.iter().collect(); // no filter ⇒ the whole table.
+    }
+    let Some(FilterExpr::Clauses { clauses, all }) = parse_filter(filter) else {
+        return Vec::new(); // UNPARSEABLE ⇒ zero matches, never all rows.
+    };
+    rows.iter()
+        .filter(|row| {
+            if all {
+                clauses.iter().all(|c| clause_matches(row, c))
+            } else {
+                clauses.iter().any(|c| clause_matches(row, c))
+            }
+        })
+        .collect()
+}
+
+/// Feature C — render matched typed rows into the tool's text payload: a header, then one line per
+/// row: `- [[Title]] · key: value · key: value` (only the row's populated typed values + a `tags:`
+/// suffix when present). Egress-free, plain text; the model cites `[[Title]]`.
+fn format_typed_rows(
+    folder_name: &str,
+    rows: &[&crate::storage::models::TypedNoteRow],
+) -> String {
+    let mut out = format!("{} rows in \"{folder_name}\":", rows.len());
+    for row in rows {
+        let mut parts: Vec<String> = Vec::new();
+        for (k, v) in &row.values {
+            parts.push(format!("{k}: {}", property_value_str(v)));
+        }
+        if !row.tags.is_empty() {
+            parts.push(format!("tags: {}", row.tags.join(", ")));
+        }
+        let suffix = if parts.is_empty() {
+            String::new()
+        } else {
+            format!(" · {}", parts.join(" · "))
+        };
+        out.push_str(&format!("\n- [[{}]]{suffix}", row.title));
+    }
+    out
+}
+
 /// Feature D — render a meeting's transcript segments as a STRUCTURED, one-line-per-segment block:
 /// `[<start_s>–<end_s>] <Speaker>: <text>`. RAW SECONDS (never MM:SS) so a 2h+ meeting can never
 /// wrap/clip a minutes field. Speaker maps the cheap 2-way stream attribution
@@ -1355,6 +1684,18 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                 &unlocked,
                 self.config,
             ),
+            // Feature C — TYPED note-folder database query (owned-vault read, egress-free). Runs
+            // through the SAME gated `execute_tool`; `list_notes_visible_typed` gates every row on the
+            // re-read `unlocked` set, so a sealed-not-unlocked folder yields nothing.
+            "query_database" => execute_tool(
+                &ToolCall::QueryDatabase {
+                    folder: s("folder"),
+                    filter: s("filter"),
+                },
+                self.db,
+                &unlocked,
+                self.config,
+            ),
             // Shared Brain — egress-free LOCAL read of the org partition (the allowlist above already
             // proved it was advertised this turn: Tier 3/Full + org joined + consented). Runs through
             // the synchronous, egress-free `execute_tool`, which provenance-labels + fence-neutralizes
@@ -1549,6 +1890,82 @@ mod tests {
             .build()
             .unwrap()
             .block_on(f)
+    }
+
+    // ── Feature C — query_database filter grammar (Rust-parsed, deterministic) ───────────────────
+
+    fn typed_row(id: &str, title: &str, pairs: &[(&str, crate::storage::models::PropertyValue)]) -> crate::storage::models::TypedNoteRow {
+        crate::storage::models::TypedNoteRow {
+            id: id.into(),
+            title: title.into(),
+            folder_id: "nf".into(),
+            values: pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            tags: Vec::new(),
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn filter_rows_grammar() {
+        use crate::storage::models::PropertyValue as PV;
+        let rows = vec![
+            typed_row(
+                "a",
+                "Alpha",
+                &[
+                    ("status", PV::Select("Done".into())),
+                    ("openItems", PV::Number(5.0)),
+                    ("owner", PV::Text("Anna".into())),
+                ],
+            ),
+            typed_row(
+                "b",
+                "Beta",
+                &[
+                    ("status", PV::Select("Open".into())),
+                    ("openItems", PV::Number(2.0)),
+                    ("owner", PV::Text("Bob".into())),
+                ],
+            ),
+        ];
+        let ids = |v: Vec<&crate::storage::models::TypedNoteRow>| {
+            v.iter().map(|r| r.id.clone()).collect::<Vec<_>>()
+        };
+
+        // status=Done → case-insensitive equality picks Alpha only.
+        assert_eq!(ids(filter_rows(&rows, "status=Done")), vec!["a"]);
+        // openItems>3 → numeric comparison picks Alpha (5) not Beta (2).
+        assert_eq!(ids(filter_rows(&rows, "openItems>3")), vec!["a"]);
+        // owner contains ann → substring, case-insensitive → Anna only.
+        assert_eq!(ids(filter_rows(&rows, "owner contains ann")), vec!["a"]);
+        // A AND B → both clauses must hold.
+        assert_eq!(
+            ids(filter_rows(&rows, "status=Open AND openItems<3")),
+            vec!["b"]
+        );
+        // A OR B → either clause.
+        assert_eq!(
+            ids(filter_rows(&rows, "owner=Anna OR owner=Bob")).len(),
+            2
+        );
+        // Empty filter → ALL rows (explicit "no filter").
+        assert_eq!(ids(filter_rows(&rows, "")).len(), 2);
+        assert_eq!(ids(filter_rows(&rows, "   ")).len(), 2);
+        // UNPARSEABLE filter → ZERO matches, NEVER all rows.
+        assert!(
+            filter_rows(&rows, "this is not a filter").is_empty(),
+            "unparseable filter must match nothing, never all rows"
+        );
+        // Mixed AND/OR is ambiguous → unparseable → zero matches (never all rows).
+        assert!(
+            filter_rows(&rows, "status=Open AND owner=Bob OR owner=Anna").is_empty(),
+            "mixed AND/OR must be rejected as unparseable, not silently return all rows"
+        );
+        // A missing key never matches.
+        assert!(filter_rows(&rows, "nonexistent=x").is_empty());
     }
 
     /// EGRESS GUARD: the synchronous, egress-free `execute_tool` (the MCP surface's only entry) MUST

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -56,6 +56,8 @@ import type {
   NoteFolder,
   NoteAssistRequest,
   NoteAssistResult,
+  PropertySchemaField,
+  TypedNoteRow,
   OrganizePlan,
   PeopleList,
   PinResult,
@@ -1992,6 +1994,44 @@ export class IpcService {
    */
   applyOrganizePlan(plan: OrganizePlan): Promise<void> {
     return invoke<void>("apply_organize_plan", { plan });
+  }
+
+  // ── Feature C — typed note front-matter properties (folder-level schema +
+  // the typed notes list feeding the Table/Board views). All three are GATED
+  // backend-side on the folder unlock: a LOCKED folder returns `[]` from BOTH
+  // reads (empty schema + empty rows), so no typed view is offered for it and
+  // no sealed content leaks. `properties` (the plaintext front-matter map) is
+  // untouched — the schema is a NEW parallel layer describing how to render it.
+
+  /**
+   * The property SCHEMA for a note-folder: one {@link PropertySchemaField} per
+   * defined property (its key + kind + select options). Returns `[]` for a
+   * LOCKED (sealed-and-not-session-unlocked) folder — the backend gates it, so a
+   * locked folder never exposes a typed view.
+   */
+  getNoteFolderSchema(folderId: string): Promise<PropertySchemaField[]> {
+    return invoke<PropertySchemaField[]>("get_note_folder_schema", { folderId });
+  }
+
+  /**
+   * Persist a note-folder's property schema (replaces the whole field set).
+   * Gated — rejects (`Locked`) for a sealed-and-not-session-unlocked folder.
+   */
+  setNoteFolderSchema(
+    folderId: string,
+    fields: PropertySchemaField[],
+  ): Promise<void> {
+    return invoke<void>("set_note_folder_schema", { folderId, fields });
+  }
+
+  /**
+   * The TYPED notes list for a folder — one {@link TypedNoteRow} per note, each
+   * carrying its property key → {@link PropertyValue} map, tags, and updatedAt,
+   * for the folder's Table/Board views. GATED IN THE QUERY: a SEALED folder
+   * returns `[]` and a masked row carries no values/tags — never a per-row leak.
+   */
+  listNotesTyped(folderId: string): Promise<TypedNoteRow[]> {
+    return invoke<TypedNoteRow[]>("list_notes_typed", { folderId });
   }
 
   /** The note-kind folder list (`kind='note'` only). */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1881,6 +1881,60 @@ export interface NoteFolder {
   kind: string;
 }
 
+// ── Feature C — typed note front-matter properties (a NEW, PARALLEL layer over
+// the plaintext `NoteDoc.properties: Record<string,string>`, which is UNCHANGED).
+// A folder-level SCHEMA names each property's KIND so the note editor can render
+// the right widget and the folder Table/Board views can render typed cells; the
+// underlying front-matter string round-trip (`front-matter.ts`) is untouched.
+// The pure coercion helpers live beside the editor
+// (`features/notes/note-editor/property-field-types.ts`) and re-export these.
+
+/** The kind a note-folder's property schema assigns to a property (drives the widget). */
+export type PropertyKind = "text" | "select" | "date" | "checkbox" | "number";
+
+/**
+ * One field in a note-folder's property schema (`get_note_folder_schema` /
+ * `set_note_folder_schema`). Mirrors the Rust `PropertySchemaField`. `options`
+ * is only meaningful for `kind === "select"` (empty for the others). `key`
+ * matches the front-matter property key.
+ */
+export interface PropertySchemaField {
+  key: string;
+  kind: PropertyKind;
+  /** Allowed values for a `select`; empty for other kinds. */
+  options: string[];
+}
+
+/**
+ * A typed property value (mirrors the Rust `PropertyValue`, adjacently tagged
+ * `{ kind, value }`). The `value`'s runtime type follows the `kind`:
+ * checkbox → boolean, number → number, everything else → string.
+ */
+export type PropertyValue =
+  | { kind: "text"; value: string }
+  | { kind: "select"; value: string }
+  | { kind: "date"; value: string }
+  | { kind: "checkbox"; value: boolean }
+  | { kind: "number"; value: number };
+
+/**
+ * One row of the typed notes list (`list_notes_typed`). Mirrors the Rust
+ * `TypedNoteRow`. `values` is keyed by property key (an absent key = no value
+ * for that field). Leak-free: a sealed folder returns `[]` and a masked row
+ * carries no `values`/`tags` — the backend gates it, so a locked folder shows
+ * no typed view.
+ */
+export interface TypedNoteRow {
+  id: string;
+  title: string;
+  folderId: string;
+  /** Property key → its typed value (absent key = no value). */
+  values: Record<string, PropertyValue>;
+  tags: string[];
+  /** Epoch ms of the last edit. */
+  updatedAt: number;
+}
+
 // ── Shared Brain v1 — org-wide E2EE replicated brain (DTOs mirror the spec
 // contract `docs/superpowers/specs/2026-07-10-shared-brain-v1-spec.md`, Rust
 // `#[serde(rename_all = "camelCase")]`). Org items live OUTSIDE the folder-lock

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -309,18 +309,76 @@
                   </div>
                 </div>
 
-                <!-- Custom properties -->
+                <!-- Custom properties — SCHEMA-DRIVEN widget per row (Feature C).
+                     The underlying value is always the raw front-matter STRING;
+                     each widget coerces on read + writes a canonical string back,
+                     so serializeDoc's byte-exact round-trip is untouched. -->
                 @for (row of propertyRows(); track row.key) {
                   <div class="prop-row">
                     <span class="prop-key">{{ row.key }}</span>
-                    <input
-                      type="text"
-                      class="prop-input prop-value"
-                      [value]="row.value"
-                      [attr.aria-label]="row.key + ' value'"
-                      (input)="editProp(row.key, $event)"
-                      (blur)="onBlur()"
-                    />
+                    @switch (row.kind) {
+                      @case ("checkbox") {
+                        <span class="prop-value prop-value-toggle">
+                          <mur-toggle
+                            [ngModel]="checkboxValue(row.value)"
+                            (ngModelChange)="setCheckboxProp(row.key, $event)"
+                            [ariaLabel]="row.key + ' value'"
+                          />
+                        </span>
+                      }
+                      @case ("date") {
+                        <input
+                          type="date"
+                          class="prop-input prop-value"
+                          [value]="row.value"
+                          [attr.aria-label]="row.key + ' value'"
+                          (input)="editProp(row.key, row.kind, $event)"
+                          (blur)="onBlur()"
+                        />
+                      }
+                      @case ("number") {
+                        <input
+                          type="number"
+                          class="prop-input prop-value"
+                          [value]="row.value"
+                          [attr.aria-label]="row.key + ' value'"
+                          (input)="editProp(row.key, row.kind, $event)"
+                          (blur)="onBlur()"
+                        />
+                      }
+                      @case ("select") {
+                        <!-- OPAQUE dropdown (T3): the global <select> options paint
+                             var(--surface-overlay). An out-of-schema value is kept
+                             as an extra option so a passthrough value is never lost.
+                             `[selected]` on the option (not `[value]` on the select)
+                             so the current value is picked reliably even though the
+                             options render via @for (a bare `[value]` on <select>
+                             resets to "" when its option isn't in the DOM yet). -->
+                        <select
+                          class="prop-input prop-value prop-select"
+                          [attr.aria-label]="row.key + ' value'"
+                          (change)="editProp(row.key, row.kind, $event)"
+                        >
+                          <option value="" [selected]="row.value === ''">—</option>
+                          @if (selectValueIsOffSchema(row.value, row.options)) {
+                            <option [value]="row.value" [selected]="true">{{ row.value }}</option>
+                          }
+                          @for (opt of row.options; track opt) {
+                            <option [value]="opt" [selected]="opt === row.value">{{ opt }}</option>
+                          }
+                        </select>
+                      }
+                      @default {
+                        <input
+                          type="text"
+                          class="prop-input prop-value"
+                          [value]="row.value"
+                          [attr.aria-label]="row.key + ' value'"
+                          (input)="editProp(row.key, row.kind, $event)"
+                          (blur)="onBlur()"
+                        />
+                      }
+                    }
                     <button
                       type="button"
                       class="prop-remove"
@@ -332,46 +390,80 @@
                   </div>
                 }
 
-                <!-- Add property -->
+                <!-- Add property — the folder schema's DEFINED keys first (with a
+                     kind badge), then a "New property" escape hatch that prompts a
+                     kind + persists it to the folder schema. -->
                 @if (addingProp()) {
-                  <div class="prop-row prop-add">
-                    <input
-                      type="text"
-                      class="prop-input prop-add-key"
-                      placeholder="key"
-                      aria-label="Property key"
-                      [value]="propKeyDraft()"
-                      (input)="onPropKeyInput($event)"
-                    />
-                    <input
-                      type="text"
-                      class="prop-input prop-value"
-                      placeholder="value"
-                      aria-label="Property value"
-                      [value]="propValDraft()"
-                      (input)="onPropValInput($event)"
-                      (keydown.enter)="commitProp()"
-                    />
-                    <button type="button" class="btn btn-ghost prop-add-btn" (click)="commitProp()">
-                      Add
-                    </button>
-                    <button type="button" class="prop-remove" (click)="cancelAddProp()" aria-label="Cancel">
-                      ×
-                    </button>
+                  <div class="prop-add-panel">
+                    @if (definingProp()) {
+                      <!-- New-property sub-form: key + kind, persisted to the schema. -->
+                      <div class="prop-row prop-add">
+                        <input
+                          type="text"
+                          class="prop-input prop-add-key"
+                          placeholder="property name"
+                          aria-label="New property name"
+                          [value]="propKeyDraft()"
+                          (input)="onPropKeyInput($event)"
+                          (keydown.enter)="createSchemaProperty()"
+                        />
+                        <select
+                          class="prop-input prop-add-kind prop-select"
+                          aria-label="New property type"
+                          [value]="propKindDraft()"
+                          (change)="onPropKindInput($event)"
+                        >
+                          @for (k of propertyKindOptions; track k.kind) {
+                            <option [value]="k.kind">{{ k.label }}</option>
+                          }
+                        </select>
+                        <button type="button" class="btn btn-ghost prop-add-btn" (click)="createSchemaProperty()">
+                          Add
+                        </button>
+                        <button type="button" class="prop-remove" (click)="cancelAddProp()" aria-label="Cancel">
+                          ×
+                        </button>
+                      </div>
+                    } @else {
+                      <div class="menu prop-add-menu" role="menu" aria-label="Add property">
+                        @if (unusedSchemaFields().length > 0) {
+                          <p class="menu-group-label">Folder properties</p>
+                          @for (field of unusedSchemaFields(); track field.key) {
+                            <button
+                              type="button"
+                              class="menu-item prop-schema-item"
+                              role="menuitem"
+                              (click)="addSchemaProp(field)"
+                            >
+                              <span class="prop-schema-key">{{ field.key }}</span>
+                              <span class="pill prop-kind-badge">{{ field.kind }}</span>
+                            </button>
+                          }
+                          <div class="menu-group"></div>
+                        }
+                        <button
+                          type="button"
+                          class="menu-item prop-new-item"
+                          role="menuitem"
+                          (click)="startDefineProp()"
+                        >
+                          + New property…
+                        </button>
+                        <button
+                          type="button"
+                          class="menu-item prop-cancel-item"
+                          role="menuitem"
+                          (click)="cancelAddProp()"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    }
                   </div>
                 } @else {
                   <div class="prop-add-row">
                     <button type="button" class="prop-add-chip" (click)="startAddProp()">
                       + Add property
-                    </button>
-                    <button type="button" class="prop-add-chip is-quiet" (click)="addPropPreset('status')">
-                      status
-                    </button>
-                    <button type="button" class="prop-add-chip is-quiet" (click)="addPropPreset('date')">
-                      date
-                    </button>
-                    <button type="button" class="prop-add-chip is-quiet" (click)="addPropPreset('aliases')">
-                      aliases
                     </button>
                   </div>
                 }

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -400,6 +400,53 @@
   font-size: 0.78rem;
 }
 
+/* ── Typed properties (Feature C) ─────────────────────────────────────────── */
+
+/* Checkbox row: the mur-toggle sits where a text value would, left-aligned. */
+.prop-value-toggle {
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 auto;
+}
+
+/* Native select for a typed Select / the new-property kind — options paint
+   var(--surface-overlay) via the global `select option` primitive (T3). */
+.prop-select {
+  appearance: auto;
+  cursor: pointer;
+}
+.prop-add-kind {
+  flex: none;
+  min-width: 108px;
+}
+
+/* The Add-property picker: an OPAQUE menu (rides the global `.menu` primitive,
+   --surface-overlay, no blur — T3) floating below the last property row. */
+.prop-add-panel {
+  position: relative;
+}
+.prop-add-menu {
+  min-width: 220px;
+}
+.prop-schema-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.prop-schema-key {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+.prop-kind-badge {
+  font-size: 0.68rem;
+  text-transform: capitalize;
+  color: var(--text-muted);
+}
+.prop-cancel-item {
+  color: var(--text-muted);
+}
+
 /* Body textarea (document surface) with CSS auto-grow. */
 .body-wrap {
   position: relative;

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -14,6 +14,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
+import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 import { IpcService } from "../../../core/ipc.service";
@@ -41,7 +42,14 @@ import {
 } from "../note-brain-popover/note-brain-popover.component";
 import { NoteSharePanelComponent } from "../note-share-panel/note-share-panel.component";
 import { NoteSelectionToolbarComponent } from "../note-selection-toolbar/note-selection-toolbar.component";
+import { MurToggleComponent } from "../../../design-system/toggle/toggle.component";
 import { parseDoc, serializeDoc } from "./front-matter";
+import {
+  coerceForKind,
+  formatForYaml,
+  type PropertyKind,
+  type PropertySchemaField,
+} from "./property-field-types";
 
 /** The autosave indicator state. */
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -94,6 +102,15 @@ const SLASH_ITEMS: readonly SlashItem[] = [
 const CONTEXT_CHARS = 500;
 const AUTOSAVE_MS = 600;
 
+/** The property kinds offered when defining a NEW schema field (label + kind). */
+const PROPERTY_KIND_OPTIONS: readonly { kind: PropertyKind; label: string }[] = [
+  { kind: "text", label: "Text" },
+  { kind: "select", label: "Select" },
+  { kind: "date", label: "Date" },
+  { kind: "checkbox", label: "Checkbox" },
+  { kind: "number", label: "Number" },
+];
+
 /**
  * localStorage key for the "Full width" display preference: "1" = full width.
  * A GLOBAL preference (not per-note) — Notion persists this per-page, but that
@@ -129,6 +146,8 @@ const FULL_WIDTH_KEY = "murmur-note-full-width";
     NoteBrainPopoverComponent,
     NoteSelectionToolbarComponent,
     NoteSharePanelComponent,
+    MurToggleComponent,
+    FormsModule,
   ],
   templateUrl: "./note-editor.component.html",
   styleUrl: "./note-editor.component.scss",
@@ -203,10 +222,16 @@ export class NoteEditorComponent {
   readonly tagDraft = signal("");
   /** Which floating menu (if any) is open in the header. */
   readonly menu = signal<"none" | "move" | "more">("none");
-  /** Add-property form open. */
+  /** Add-property menu open (the DEFINED-keys picker + "New property" hatch). */
   readonly addingProp = signal(false);
+  /**
+   * The "New property" sub-form is open (a fresh key + kind that gets PERSISTED
+   * to the folder schema on commit). false = showing the defined-keys picker.
+   */
+  readonly definingProp = signal(false);
   readonly propKeyDraft = signal("");
-  readonly propValDraft = signal("");
+  /** The kind chosen for a brand-new schema property (defaults to text). */
+  readonly propKindDraft = signal<PropertyKind>("text");
   /** Two-step delete confirm. */
   readonly confirmingDelete = signal(false);
   /** True while the Share modal is open over the document. */
@@ -314,10 +339,57 @@ export class NoteEditorComponent {
       .slice(0, 6);
   });
 
-  /** Property rows for the properties bar (stable order). */
-  readonly propertyRows = computed(() =>
-    Object.entries(this.properties()).map(([key, value]) => ({ key, value })),
+  /**
+   * The property KIND options offered when defining a new schema field (template
+   * dropdown). Static — exposed as a field so the template can `@for` over it.
+   */
+  protected readonly propertyKindOptions = PROPERTY_KIND_OPTIONS;
+
+  /**
+   * The active note-folder's typed-property SCHEMA (Feature C) — read from the
+   * root {@link NotesService}, loaded reactively by {@link _loadSchema} when the
+   * note's folder changes. `[]` for a folder with no schema (or a locked folder,
+   * which the backend gates). Drives the SCHEMA-AWARE widget per property row and
+   * the Add-property menu's "defined keys first" list.
+   */
+  readonly folderSchema = computed<PropertySchemaField[]>(() =>
+    this.notes.folderSchema(),
   );
+
+  /** Fast key → schema-field lookup for resolving a row's widget kind. */
+  private readonly schemaByKey = computed<Map<string, PropertySchemaField>>(
+    () => new Map(this.folderSchema().map((f) => [f.key, f])),
+  );
+
+  /**
+   * Property rows for the properties bar (stable order), each ENRICHED with its
+   * schema-resolved widget `kind` + select `options`. A key with no schema entry
+   * defaults to `text` (unchanged behavior). The underlying value stays the raw
+   * front-matter STRING — the widget coerces on read + writes back a string via
+   * `formatForYaml`, so `serializeDoc`'s round-trip is untouched.
+   */
+  readonly propertyRows = computed(() => {
+    const byKey = this.schemaByKey();
+    return Object.entries(this.properties()).map(([key, value]) => {
+      const field = byKey.get(key);
+      return {
+        key,
+        value,
+        kind: (field?.kind ?? "text") as PropertyKind,
+        options: field?.options ?? [],
+      };
+    });
+  });
+
+  /**
+   * The schema keys NOT yet present on this note — the Add-property menu offers
+   * these DEFINED keys first (with their kind badge) before the "New property"
+   * escape hatch.
+   */
+  readonly unusedSchemaFields = computed<PropertySchemaField[]>(() => {
+    const present = new Set(Object.keys(this.properties()));
+    return this.folderSchema().filter((f) => !present.has(f.key));
+  });
 
   /**
    * The app config (loaded best-effort in the constructor), the source for the
@@ -413,6 +485,29 @@ export class NoteEditorComponent {
       }
     }
   }
+
+  /**
+   * The folder id whose schema the editor should load — null while the note is
+   * locked/masked (the backend gates it to `[]` anyway). A `computed` so the
+   * schema effect below only re-runs on a REAL folder/lock change, not on every
+   * autosave (which replaces the `note()` object reference with an unchanged
+   * `folderId`).
+   */
+  private readonly _schemaFolderId = computed<string | null>(() => {
+    const doc = this.note();
+    return doc && !doc.locked ? doc.folderId : null;
+  });
+
+  /**
+   * Load the active note-folder's typed-property SCHEMA when its id changes
+   * (Feature C). Delegated to the root {@link NotesService} so the schema is
+   * shared with the folder Table/Board views; best-effort (the service captures
+   * errors). Legitimate signal-writing effect via the service (T1) — async IPC
+   * keyed on a single input.
+   */
+  private readonly _loadSchema = effect(() => {
+    void this.notes.loadSchema(this._schemaFolderId());
+  });
 
   /** Persist the "Full width" preference whenever it changes (mirrors AppShellComponent). */
   private readonly _persistFullWidth = effect(() => {
@@ -845,47 +940,139 @@ export class NoteEditorComponent {
     this.propsOpen.update((v) => !v);
   }
 
-  // ── Properties ───────────────────────────────────────────────────────────
+  // ── Properties (schema-driven, Feature C) ─────────────────────────────────
+  // The `properties` signal stays Record<string,string>: every widget commit
+  // COERCES its raw value for the schema kind then stores the canonical STRING
+  // via `formatForYaml`, so `serializeDoc`'s byte-exact YAML round-trip is
+  // untouched. The Add-property menu offers the folder schema's DEFINED keys
+  // first, then a "New property" escape hatch that persists a new field to the
+  // folder schema (via `notes.saveSchema`) before adding it to this note.
 
+  /** Open the Add-property menu (defined-keys picker; not yet the new-property form). */
   startAddProp(): void {
     this.addingProp.set(true);
+    this.definingProp.set(false);
     this.propKeyDraft.set("");
-    this.propValDraft.set("");
+    this.propKindDraft.set("text");
+  }
+
+  /** Close the Add-property menu / new-property form. */
+  cancelAddProp(): void {
+    this.addingProp.set(false);
+    this.definingProp.set(false);
+  }
+
+  /**
+   * Add an already-DEFINED schema field to this note (menu item). Seeds a coerced
+   * default for its kind (a checkbox starts `false`, everything else empty) so the
+   * widget renders immediately, then autosaves. No-op for `tags` (its own row).
+   */
+  addSchemaProp(field: PropertySchemaField): void {
+    if (field.key.toLowerCase() === "tags") {
+      this.cancelAddProp();
+      return;
+    }
+    const seed = formatForYaml(coerceForKind("", field.kind));
+    this.properties.update((props) => ({ ...props, [field.key]: seed }));
+    this.cancelAddProp();
+    this.scheduleSave();
+  }
+
+  /** Open the "New property" sub-form (a fresh key + kind, persisted to the schema). */
+  startDefineProp(): void {
+    this.definingProp.set(true);
+    this.propKeyDraft.set("");
+    this.propKindDraft.set("text");
   }
 
   onPropKeyInput(event: Event): void {
     this.propKeyDraft.set((event.target as HTMLInputElement).value);
   }
-  onPropValInput(event: Event): void {
-    this.propValDraft.set((event.target as HTMLInputElement).value);
+  onPropKindInput(event: Event): void {
+    this.propKindDraft.set(
+      (event.target as HTMLSelectElement).value as PropertyKind,
+    );
   }
 
-  /** Pre-fill a common property key (status/date/aliases) into the add form. */
-  addPropPreset(key: string): void {
-    this.addingProp.set(true);
-    this.propKeyDraft.set(key);
-    this.propValDraft.set("");
-  }
-
-  commitProp(): void {
+  /**
+   * Commit a BRAND-NEW property: PERSIST its `{key, kind}` to the folder schema
+   * (so the widget + the Table/Board views all see the kind), then add it to this
+   * note with a coerced default. If the schema save fails the note property is
+   * NOT added (the value would render as bare text with no kind), and a toast
+   * surfaces the failure. A duplicate key just re-focuses (no-op on the schema).
+   */
+  async createSchemaProperty(): Promise<void> {
     const key = this.propKeyDraft().trim();
-    const value = this.propValDraft().trim();
-    if (!key || key.toLowerCase() === "tags") {
-      this.addingProp.set(false);
+    const kind = this.propKindDraft();
+    const doc = this.note();
+    if (!key || key.toLowerCase() === "tags" || !doc || doc.locked) {
+      this.cancelAddProp();
       return;
     }
-    this.properties.update((props) => ({ ...props, [key]: value }));
-    this.addingProp.set(false);
+    // Already a property on this note? Just close (no duplicate schema entry).
+    if (key in this.properties()) {
+      this.cancelAddProp();
+      return;
+    }
+    const existing = this.folderSchema().find((f) => f.key === key);
+    const nextSchema: PropertySchemaField[] = existing
+      ? this.folderSchema()
+      : [...this.folderSchema(), { key, kind, options: [] }];
+    try {
+      if (!existing) {
+        await this.notes.saveSchema(doc.folderId, nextSchema);
+      }
+      const seed = formatForYaml(coerceForKind("", existing?.kind ?? kind));
+      this.properties.update((props) => ({ ...props, [key]: seed }));
+      this.cancelAddProp();
+      this.scheduleSave();
+    } catch {
+      this.toast.danger("Couldn’t save the property. Please try again.");
+    }
+  }
+
+  /**
+   * Edit a TEXT/DATE/NUMBER/SELECT property from an `<input>`/`<select>` change.
+   * Coerces the raw value for the row's schema kind and stores the canonical
+   * string, so the YAML round-trip is untouched. `kind` comes from the row's
+   * resolved schema (`text` when undefined).
+   */
+  editProp(key: string, kind: PropertyKind, event: Event): void {
+    const raw = (event.target as HTMLInputElement | HTMLSelectElement).value;
+    this.setPropRaw(key, kind, raw);
+  }
+
+  /** Set a SELECT property from a picked option value (schema-aware coerce). */
+  setSelectProp(key: string, kind: PropertyKind, value: string): void {
+    this.setPropRaw(key, kind, value);
+  }
+
+  /** Toggle a CHECKBOX property (from `mur-toggle`'s ngModelChange-equivalent). */
+  setCheckboxProp(key: string, checked: boolean): void {
+    const raw = formatForYaml({ kind: "checkbox", value: checked });
+    this.properties.update((props) => ({ ...props, [key]: raw }));
     this.scheduleSave();
   }
 
-  cancelAddProp(): void {
-    this.addingProp.set(false);
+  /** Read a CHECKBOX property's current boolean (for `mur-toggle`'s [checked]-equivalent). */
+  checkboxValue(value: string): boolean {
+    const coerced = coerceForKind(value, "checkbox");
+    return coerced.kind === "checkbox" ? coerced.value : false;
   }
 
-  editProp(key: string, event: Event): void {
-    const value = (event.target as HTMLInputElement).value;
-    this.properties.update((props) => ({ ...props, [key]: value }));
+  /**
+   * Whether a SELECT row's current value is one of its schema options. When it is
+   * NOT, the value is an out-of-schema passthrough — the template keeps it visible
+   * as an extra option so it is never silently dropped.
+   */
+  selectValueIsOffSchema(value: string, options: string[]): boolean {
+    return value.trim().length > 0 && !options.includes(value);
+  }
+
+  /** Coerce `raw` for `kind`, store the canonical string, autosave. Shared writer. */
+  private setPropRaw(key: string, kind: PropertyKind, raw: string): void {
+    const canonical = formatForYaml(coerceForKind(raw, kind));
+    this.properties.update((props) => ({ ...props, [key]: canonical }));
     this.scheduleSave();
   }
 

--- a/src/app/features/notes/note-editor/property-field-types.spec.ts
+++ b/src/app/features/notes/note-editor/property-field-types.spec.ts
@@ -1,0 +1,123 @@
+import {
+  coerceForKind,
+  formatForYaml,
+  type PropertyKind,
+  type PropertyValue,
+} from "./property-field-types";
+
+/**
+ * Unit tests for the pure typed-property bridge (Feature C). These assert the
+ * `coerceForKind` → `formatForYaml` round-trip that keeps the underlying
+ * `properties` Record<string, string> (and therefore `serializeDoc`'s byte-exact
+ * YAML) unchanged — the critical invariant of this feature.
+ */
+describe("property-field-types", () => {
+  describe("coerceForKind", () => {
+    it("text keeps the raw string verbatim", () => {
+      expect(coerceForKind("hello world", "text")).toEqual({
+        kind: "text",
+        value: "hello world",
+      });
+    });
+
+    it("select keeps the value verbatim (in-options)", () => {
+      expect(coerceForKind("In progress", "select")).toEqual({
+        kind: "select",
+        value: "In progress",
+      });
+    });
+
+    it("select preserves an out-of-options value (passthrough)", () => {
+      expect(coerceForKind("Some legacy status", "select")).toEqual({
+        kind: "select",
+        value: "Some legacy status",
+      });
+    });
+
+    it("date keeps a YYYY-MM-DD string", () => {
+      expect(coerceForKind("2026-07-14", "date")).toEqual({
+        kind: "date",
+        value: "2026-07-14",
+      });
+    });
+
+    it("checkbox reads truthy spellings as true", () => {
+      for (const raw of ["true", "TRUE", "yes", "on", "1", "checked", "x"]) {
+        expect(coerceForKind(raw, "checkbox")).toEqual({
+          kind: "checkbox",
+          value: true,
+        });
+      }
+    });
+
+    it("checkbox reads anything else as false", () => {
+      for (const raw of ["false", "no", "0", "", "nope"]) {
+        expect(coerceForKind(raw, "checkbox")).toEqual({
+          kind: "checkbox",
+          value: false,
+        });
+      }
+    });
+
+    it("number parses a numeric string", () => {
+      expect(coerceForKind("42", "number")).toEqual({
+        kind: "number",
+        value: 42,
+      });
+      expect(coerceForKind("3.14", "number")).toEqual({
+        kind: "number",
+        value: 3.14,
+      });
+    });
+
+    it("number falls back to 0 for a non-numeric string", () => {
+      expect(coerceForKind("abc", "number")).toEqual({
+        kind: "number",
+        value: 0,
+      });
+      expect(coerceForKind("", "number")).toEqual({ kind: "number", value: 0 });
+    });
+  });
+
+  describe("formatForYaml", () => {
+    it("checkbox → true/false", () => {
+      expect(formatForYaml({ kind: "checkbox", value: true })).toBe("true");
+      expect(formatForYaml({ kind: "checkbox", value: false })).toBe("false");
+    });
+
+    it("number → its string form", () => {
+      expect(formatForYaml({ kind: "number", value: 42 })).toBe("42");
+    });
+
+    it("select → verbatim", () => {
+      expect(formatForYaml({ kind: "select", value: "Done" })).toBe("Done");
+    });
+
+    it("text/date → as-is", () => {
+      expect(formatForYaml({ kind: "text", value: "hi" })).toBe("hi");
+      expect(formatForYaml({ kind: "date", value: "2026-07-14" })).toBe(
+        "2026-07-14",
+      );
+    });
+  });
+
+  describe("round-trip: formatForYaml(coerceForKind(raw, kind))", () => {
+    const cases: { raw: string; kind: PropertyKind; expected: string }[] = [
+      { raw: "hello", kind: "text", expected: "hello" },
+      { raw: "In progress", kind: "select", expected: "In progress" },
+      { raw: "Legacy value", kind: "select", expected: "Legacy value" },
+      { raw: "2026-07-14", kind: "date", expected: "2026-07-14" },
+      { raw: "true", kind: "checkbox", expected: "true" },
+      { raw: "no", kind: "checkbox", expected: "false" },
+      { raw: "42", kind: "number", expected: "42" },
+      { raw: "oops", kind: "number", expected: "0" },
+    ];
+
+    for (const { raw, kind, expected } of cases) {
+      it(`${kind} "${raw}" → "${expected}"`, () => {
+        const value: PropertyValue = coerceForKind(raw, kind);
+        expect(formatForYaml(value)).toBe(expected);
+      });
+    }
+  });
+});

--- a/src/app/features/notes/note-editor/property-field-types.ts
+++ b/src/app/features/notes/note-editor/property-field-types.ts
@@ -1,0 +1,100 @@
+/**
+ * Typed note-property helpers — a NEW, PARALLEL layer sitting BESIDE the byte-exact
+ * YAML round-trip in `front-matter.ts` (Feature C). This file NEVER touches
+ * `parseDoc`/`serializeDoc`: the note's `properties` signal stays a plain
+ * `Record<string, string>`, and `serializeDoc` still emits it unchanged. The
+ * "typing" is purely a UI concern — a folder-level schema names each property's
+ * KIND (text / select / date / checkbox / number) so the editor can render the
+ * right widget, and this module is the pure bridge between a widget's raw string
+ * and a typed value (and back to the string the properties map + YAML store).
+ *
+ * Contract (fixed — the Rust backend implements the matching commands + DTOs):
+ *  - `PropertyKind`        — the five supported kinds.
+ *  - `PropertySchemaField` — one folder-schema entry: `{ key, kind, options }`.
+ *  - `PropertyValue`       — an adjacently-tagged `{ kind, value }` typed value.
+ *
+ * The three DTO types live canonically in `core/models.ts` (with every other IPC
+ * DTO); they are RE-EXPORTED here so a consumer of the helpers imports the type +
+ * its coercion from one place. The round-trip that matters:
+ * `formatForYaml(coerceForKind(raw, kind))` maps a widget's raw string to the
+ * canonical string stored in the `properties` map (and therefore the YAML). A
+ * `select` value that is NOT one of the schema's options is preserved VERBATIM
+ * (passthrough) so an out-of-schema value a note already carried is never dropped.
+ */
+
+import type {
+  PropertyKind,
+  PropertyValue,
+} from "../../../core/models";
+
+export type {
+  PropertyKind,
+  PropertySchemaField,
+  PropertyValue,
+  TypedNoteRow,
+} from "../../../core/models";
+
+/**
+ * Coerce a raw front-matter STRING into a typed {@link PropertyValue} for the
+ * given kind. Total + tolerant (never throws) — a value that doesn't fit its
+ * kind falls back sensibly so a widget always has something to render:
+ *  - `checkbox` — truthy YAML/Obsidian spellings (`true`/`yes`/`on`/`1`/`checked`,
+ *    case-insensitive) ⇒ `true`; anything else ⇒ `false`.
+ *  - `number`   — parsed with `Number(...)`; a non-numeric raw ⇒ `0`.
+ *  - `date`     — kept as the raw string (an `<input type="date">` reads/writes
+ *    `YYYY-MM-DD`; a non-conforming raw is preserved so it isn't lost).
+ *  - `select`   — kept VERBATIM (passthrough — the caller decides whether it's
+ *    one of the schema options; an out-of-schema value must survive).
+ *  - `text`     — the raw string unchanged.
+ */
+export function coerceForKind(raw: string, kind: PropertyKind): PropertyValue {
+  const trimmed = raw.trim();
+  switch (kind) {
+    case "checkbox":
+      return { kind: "checkbox", value: isTruthy(trimmed) };
+    case "number": {
+      const n = trimmed === "" ? Number.NaN : Number(trimmed);
+      return { kind: "number", value: Number.isFinite(n) ? n : 0 };
+    }
+    case "date":
+      return { kind: "date", value: trimmed };
+    case "select":
+      return { kind: "select", value: raw };
+    case "text":
+    default:
+      return { kind: "text", value: raw };
+  }
+}
+
+/**
+ * Collapse a typed {@link PropertyValue} back to the canonical STRING stored in
+ * the `properties` map (and therefore emitted by `serializeDoc` into the YAML
+ * front-matter). Inverse of {@link coerceForKind} for the round-trip:
+ *  - `checkbox` — `"true"` / `"false"` (lower-case, YAML-native booleans).
+ *  - `number`   — the number's `String(...)` form (`0` when non-finite).
+ *  - `date`     — the date string as-is.
+ *  - `select`   — the value VERBATIM (an out-of-options value is preserved).
+ *  - `text`     — the string as-is.
+ */
+export function formatForYaml(v: PropertyValue): string {
+  switch (v.kind) {
+    case "checkbox":
+      return v.value ? "true" : "false";
+    case "number":
+      return Number.isFinite(v.value) ? String(v.value) : "0";
+    case "date":
+      return v.value;
+    case "select":
+    case "text":
+    default:
+      return v.value;
+  }
+}
+
+/** The truthy string spellings a `checkbox` recognises (case-insensitive). */
+const TRUTHY = new Set(["true", "yes", "on", "1", "checked", "x", "☑", "done"]);
+
+/** Whether a raw string reads as a checked checkbox. */
+function isTruthy(raw: string): boolean {
+  return TRUTHY.has(raw.toLowerCase());
+}

--- a/src/app/features/notes/notes-board-view/notes-board-view.component.html
+++ b/src/app/features/notes/notes-board-view/notes-board-view.component.html
@@ -1,0 +1,40 @@
+@if (groupField(); as field) {
+  <div class="board" role="list">
+    @for (group of groups(); track trackByGroup(group)) {
+      <section class="board-col" role="listitem">
+        <header class="board-col-head">
+          <span class="board-col-title">{{ group.label }}</span>
+          <span class="count">{{ group.rows.length }}</span>
+        </header>
+        <div class="board-col-body">
+          @for (row of group.rows; track trackByRow(row)) {
+            <mur-card class="board-card">
+              <a class="board-card-link" [routerLink]="['/notes', row.id]">
+                <span class="board-card-title">{{ row.title || "(untitled)" }}</span>
+                @if (row.tags.length > 0) {
+                  <span class="board-card-tags">
+                    @for (tag of row.tags; track tag) {
+                      <span class="pill board-card-tag">{{ tag }}</span>
+                    }
+                  </span>
+                }
+              </a>
+            </mur-card>
+          } @empty {
+            <p class="board-col-empty text-muted">No notes</p>
+          }
+        </div>
+      </section>
+    }
+  </div>
+} @else {
+  <!-- No select-kind field to group by. -->
+  <div class="empty-state">
+    <h3 class="empty-title">No Select property to group by</h3>
+    <p class="empty-body">
+      The board groups notes by a Select property. Add one to this folder’s
+      schema (open a note, add a “Select” property) to organize notes into
+      columns.
+    </p>
+  </div>
+}

--- a/src/app/features/notes/notes-board-view/notes-board-view.component.scss
+++ b/src/app/features/notes/notes-board-view/notes-board-view.component.scss
@@ -1,0 +1,91 @@
+:host {
+  display: block;
+}
+
+.board {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  overflow-x: auto;
+  padding-bottom: var(--space-3);
+}
+
+.board-col {
+  flex: 0 0 300px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.board-col-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+.board-col-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+}
+
+.board-col-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.board-card {
+  padding: 0;
+  transition: transform var(--transition-fast);
+}
+.board-card:hover {
+  transform: translateY(-1px);
+}
+
+.board-card-link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-3);
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-lg);
+}
+.board-card-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
+.board-card-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.board-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.board-card-tag {
+  font-size: 0.7rem;
+}
+
+.board-col-empty {
+  padding: var(--space-3);
+  font-size: 0.875rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board-card {
+    transition: none;
+  }
+  .board-card:hover {
+    transform: none;
+  }
+}

--- a/src/app/features/notes/notes-board-view/notes-board-view.component.ts
+++ b/src/app/features/notes/notes-board-view/notes-board-view.component.ts
@@ -1,0 +1,95 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { MurCardComponent } from "../../../design-system/card/card.component";
+import type {
+  PropertySchemaField,
+  PropertyValue,
+  TypedNoteRow,
+} from "../../../core/models";
+
+/** One board column: a group value (a select option, or the "No value" bucket) + its rows. */
+interface BoardGroup {
+  key: string;
+  label: string;
+  rows: TypedNoteRow[];
+}
+
+/** The empty bucket label + key for rows whose group field has no value. */
+const NO_VALUE_KEY = "__none__";
+
+/**
+ * Feature C — the BOARD (kanban) view over a note-folder's TYPED notes. Groups
+ * the rows by the folder's FIRST `select`-kind field: one column per that
+ * field's schema option (plus a "No value" column for rows with none, and any
+ * out-of-schema values encountered). When the folder has NO select field there
+ * is nothing to group by, so it renders an empty-state prompting to add one.
+ * Presentation only — no data, no IPC; every card is a (backend-gated)
+ * {@link TypedNoteRow}, so a sealed folder shows nothing. Card title → the
+ * editor (routerLink `/notes/:id`).
+ */
+@Component({
+  selector: "app-notes-board-view",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, MurCardComponent],
+  templateUrl: "./notes-board-view.component.html",
+  styleUrl: "./notes-board-view.component.scss",
+})
+export class NotesBoardViewComponent {
+  readonly rows = input.required<TypedNoteRow[]>();
+  readonly schema = input.required<PropertySchemaField[]>();
+
+  /** The field the board groups by — the folder's first `select` field, or null. */
+  readonly groupField = computed<PropertySchemaField | null>(
+    () => this.schema().find((f) => f.kind === "select") ?? null,
+  );
+
+  /**
+   * The board columns: one per the group field's schema options (in order), a
+   * trailing "No value" bucket, and a column for any out-of-schema value found on
+   * a row (so a passthrough value is never hidden). Empty columns are kept so the
+   * board always shows the full option set. Null when there is no group field.
+   */
+  readonly groups = computed<BoardGroup[]>(() => {
+    const field = this.groupField();
+    if (!field) {
+      return [];
+    }
+    const rows = this.rows();
+    // Build the ordered set of group values: schema options first, then any
+    // extra (out-of-schema) value present on a row, then the empty bucket.
+    const order: string[] = [...field.options];
+    const seen = new Set(order);
+    for (const row of rows) {
+      const v = this.groupValue(row, field.key);
+      if (v !== "" && !seen.has(v)) {
+        seen.add(v);
+        order.push(v);
+      }
+    }
+    const columns: BoardGroup[] = order.map((opt) => ({
+      key: opt,
+      label: opt,
+      rows: rows.filter((r) => this.groupValue(r, field.key) === opt),
+    }));
+    columns.push({
+      key: NO_VALUE_KEY,
+      label: "No value",
+      rows: rows.filter((r) => this.groupValue(r, field.key) === ""),
+    });
+    return columns;
+  });
+
+  readonly trackByGroup = (g: BoardGroup): string => g.key;
+  readonly trackByRow = (row: TypedNoteRow): string => row.id;
+
+  /** The row's value for the group field as a plain string ("" when absent/off-kind). */
+  private groupValue(row: TypedNoteRow, key: string): string {
+    const v: PropertyValue | undefined = row.values[key];
+    return v && v.kind === "select" ? v.value : "";
+  }
+}

--- a/src/app/features/notes/notes-home/notes-home.component.html
+++ b/src/app/features/notes/notes-home/notes-home.component.html
@@ -6,6 +6,17 @@
     <header class="content-head">
       <h2 class="content-title">{{ listHeading() }}</h2>
       <div class="content-actions">
+        <!-- List / Table / Board switcher — only when the active folder has a
+             typed-property schema (Feature C). Persisted per-folder. -->
+        @if (typedViewsAvailable()) {
+          <mur-segmented
+            class="view-switcher"
+            [options]="viewModeOptions"
+            [value]="viewMode()"
+            (valueChange)="setViewMode($event)"
+            ariaLabel="Note view"
+          />
+        }
         <button
           type="button"
           class="btn btn-ghost organize-btn"
@@ -116,6 +127,12 @@
             </button>
           }
         </div>
+      } @else if (viewMode() === "table") {
+        <!-- Typed TABLE view (Feature C) — one column per folder-schema field. -->
+        <app-notes-table-view [rows]="typedRows()" [schema]="folderSchema()" />
+      } @else if (viewMode() === "board") {
+        <!-- Typed BOARD view (Feature C) — grouped by the first Select field. -->
+        <app-notes-board-view [rows]="typedRows()" [schema]="folderSchema()" />
       } @else if (listEmpty() && (loading() || orgsLoading())) {
         <!-- Stale-while-revalidate: only gate on loading when there is NOTHING
              cached to show yet (e.g. the very first visit). Once listItems()

--- a/src/app/features/notes/notes-home/notes-home.component.scss
+++ b/src/app/features/notes/notes-home/notes-home.component.scss
@@ -240,6 +240,9 @@
 .new-note-btn {
   gap: var(--space-2);
 }
+.view-switcher {
+  margin-right: var(--space-1);
+}
 
 /* --- Locked-folder gate --- */
 .lock-gate {

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -21,11 +21,17 @@ import type {
 import { MurTableColumnComponent } from "../../../design-system/table/table-column.component";
 import { MurTableComponent } from "../../../design-system/table/table.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import {
+  MurSegmentedComponent,
+  type SegmentOption,
+} from "../../../design-system/segmented/segmented.component";
 import { FoldersService } from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
 import { OrgBrainService } from "../../../services/org-brain.service";
 import { ToastService } from "../../../services/toast.service";
 import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.component";
+import { NotesTableViewComponent } from "../notes-table-view/notes-table-view.component";
+import { NotesBoardViewComponent } from "../notes-board-view/notes-board-view.component";
 
 /**
  * One row of the unified content list — a discriminated union over the two
@@ -51,6 +57,16 @@ export type NotesListItem =
       /** The origin org's display name (drives the "shared brain" badge label). */
       orgName: string;
     };
+
+/** The content-pane layout for a folder that has a typed-property schema (Feature C). */
+export type NotesViewMode = "list" | "table" | "board";
+
+/** The List / Table / Board segmented control options. */
+const VIEW_MODE_OPTIONS: readonly SegmentOption[] = [
+  { value: "list", label: "List" },
+  { value: "table", label: "Table" },
+  { value: "board", label: "Board" },
+];
 
 /**
  * The Notes landing view — NOW a normal in-flow route beside the ALWAYS-VISIBLE
@@ -80,6 +96,9 @@ export type NotesListItem =
     OrganizeSheetComponent,
     MurTableComponent,
     MurTableColumnComponent,
+    MurSegmentedComponent,
+    NotesTableViewComponent,
+    NotesBoardViewComponent,
   ],
   templateUrl: "./notes-home.component.html",
   styleUrl: "./notes-home.component.scss",
@@ -282,6 +301,77 @@ export class NotesHomeComponent implements OnInit {
   readonly activeFolderLocked = computed(() => {
     const f = this.activeFolder();
     return !!f?.locked && !f?.unlocked;
+  });
+
+  // --- Typed views (Feature C): List / Table / Board -----------------------
+  /** The current folder's property schema + typed rows (root-persisted in the store). */
+  readonly folderSchema = this.notes.folderSchema;
+  readonly typedRows = this.notes.typedRows;
+
+  readonly viewModeOptions = VIEW_MODE_OPTIONS;
+
+  /**
+   * The per-FOLDER view mode. A component-local Map is fine here (it's a
+   * transient UI preference, not list-backing data that must survive a remount —
+   * §8): a fresh mount defaults every folder to "list", which is exactly the
+   * unchanged existing rendering. Keyed by folder id; the null ("All notes")
+   * scope never gets the switcher.
+   */
+  private readonly viewModeByFolder = signal<Map<string, NotesViewMode>>(
+    new Map(),
+  );
+
+  /**
+   * True when the List/Table/Board switcher is OFFERED: a concrete folder is
+   * selected (not "All notes"), no org chip is active, the folder is unlocked,
+   * AND it has a non-empty typed-property schema. A locked folder yields an
+   * empty schema (backend-gated) → no switcher, no typed view.
+   */
+  readonly typedViewsAvailable = computed(
+    () =>
+      this.activeFolderId() !== null &&
+      this.activeOrgId() === null &&
+      !this.activeFolderLocked() &&
+      this.folderSchema().length > 0,
+  );
+
+  /**
+   * The resolved view mode for the active folder — "list" unless the user picked
+   * Table/Board for THIS folder AND the switcher is still available (a folder
+   * that lost its schema, or "All notes", always falls back to the list).
+   */
+  readonly viewMode = computed<NotesViewMode>(() => {
+    if (!this.typedViewsAvailable()) {
+      return "list";
+    }
+    const fid = this.activeFolderId();
+    return (fid && this.viewModeByFolder().get(fid)) || "list";
+  });
+
+  /** Set the active folder's view mode (List / Table / Board), persisted per-folder. */
+  setViewMode(mode: string): void {
+    const fid = this.activeFolderId();
+    if (fid === null) {
+      return;
+    }
+    this.viewModeByFolder.update((map) => {
+      const next = new Map(map);
+      next.set(fid, mode as NotesViewMode);
+      return next;
+    });
+  }
+
+  /**
+   * Load the active folder's typed-property SCHEMA + typed ROWS whenever the
+   * folder scope changes (Feature C). Skips (clears) for the null / org scope.
+   * Delegated to the root {@link NotesService} (stale-while-revalidate). A
+   * signal-writing effect via the service (T1) — async IPC keyed on one input.
+   * The typed views self-hide for a locked folder (the backend returns `[]`).
+   */
+  private readonly _loadTyped = effect(() => {
+    const fid = this.activeOrgId() === null ? this.activeFolderId() : null;
+    void this.notes.loadSchema(fid);
+    void this.notes.loadTypedRows(fid);
   });
 
   // --- Per-note "Move to…" popover ----------------------------------------

--- a/src/app/features/notes/notes-table-view/notes-table-view.component.html
+++ b/src/app/features/notes/notes-table-view/notes-table-view.component.html
@@ -1,0 +1,53 @@
+<mur-table [rows]="rows()" [trackBy]="trackByRow">
+  <!-- Title — links to the editor (routerLink /notes/:id). -->
+  <mur-table-column key="title" header="Title">
+    <ng-template let-row>
+      <a class="title-link" [routerLink]="['/notes', row.id]">{{
+        row.title || "(untitled)"
+      }}</a>
+    </ng-template>
+  </mur-table-column>
+
+  <!-- One column per folder-schema field; cell switches on the value kind. -->
+  @for (col of propColumns(); track col.key) {
+    <mur-table-column [key]="col.key" [header]="col.label" width="160px">
+      <ng-template let-row>
+        @let value = valueOf(row, col.key);
+        @switch (col.field.kind) {
+          @case ("checkbox") {
+            @if (isChecked(value)) {
+              <svg class="check-glyph" viewBox="0 0 16 16" width="15" height="15" fill="none" aria-hidden="true">
+                <path d="M3.5 8.5l3 3 6-7" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              <span class="sr-only">Yes</span>
+            } @else {
+              <span class="cell-muted" aria-hidden="true">—</span>
+              <span class="sr-only">No</span>
+            }
+          }
+          @case ("select") {
+            @if (displayValue(value); as v) {
+              <span class="pill select-pill">{{ v }}</span>
+            } @else {
+              <span class="cell-muted">—</span>
+            }
+          }
+          @default {
+            @if (displayValue(value); as v) {
+              <span class="cell-text">{{ v }}</span>
+            } @else {
+              <span class="cell-muted">—</span>
+            }
+          }
+        }
+      </ng-template>
+    </mur-table-column>
+  }
+
+  <!-- Updated timestamp. -->
+  <mur-table-column key="updatedAt" header="Updated" width="180px" [alignEnd]="true">
+    <ng-template let-row>
+      <span class="cell-muted">{{ formatDate(row.updatedAt) }}</span>
+    </ng-template>
+  </mur-table-column>
+</mur-table>

--- a/src/app/features/notes/notes-table-view/notes-table-view.component.scss
+++ b/src/app/features/notes/notes-table-view/notes-table-view.component.scss
@@ -1,0 +1,59 @@
+:host {
+  display: block;
+}
+
+.title-link {
+  color: var(--text-primary);
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  max-width: 100%;
+}
+.title-link:hover {
+  color: var(--accent);
+}
+.title-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+  border-radius: var(--radius-sm);
+}
+
+.cell-text {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.cell-muted {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.select-pill {
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.check-glyph {
+  color: var(--accent);
+  vertical-align: middle;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/src/app/features/notes/notes-table-view/notes-table-view.component.ts
+++ b/src/app/features/notes/notes-table-view/notes-table-view.component.ts
@@ -1,0 +1,96 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { MurTableComponent } from "../../../design-system/table/table.component";
+import { MurTableColumnComponent } from "../../../design-system/table/table-column.component";
+import type {
+  PropertySchemaField,
+  PropertyValue,
+  TypedNoteRow,
+} from "../../../core/models";
+
+/** One resolved property column: the schema field it renders. */
+interface PropColumn {
+  key: string;
+  label: string;
+  field: PropertySchemaField;
+}
+
+/**
+ * Feature C — the TABLE view over a note-folder's TYPED notes. A thin
+ * presentation layer over `<mur-table>`: it renders one column PER folder-schema
+ * field (cell switches on the row value's {@link PropertyValue} kind) plus a
+ * fixed Title column (routerLink `/notes/:id`) and an "Updated" column. It owns
+ * NO data + NO IPC — every row is a (backend-gated) {@link TypedNoteRow}; a
+ * sealed folder yields no rows, so a locked folder shows no typed view at all.
+ * No inline cell editing in v1 — the row's title links to the editor.
+ */
+@Component({
+  selector: "app-notes-table-view",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, MurTableComponent, MurTableColumnComponent],
+  templateUrl: "./notes-table-view.component.html",
+  styleUrl: "./notes-table-view.component.scss",
+})
+export class NotesTableViewComponent {
+  /** The typed rows for the active folder (each carries its property values). */
+  readonly rows = input.required<TypedNoteRow[]>();
+  /** The active folder's property schema — one column per field, in order. */
+  readonly schema = input.required<PropertySchemaField[]>();
+
+  /** One column per schema field (unknown value kinds fall back to text render). */
+  readonly propColumns = computed<PropColumn[]>(() =>
+    this.schema().map((field) => ({
+      key: field.key,
+      label: field.key,
+      field,
+    })),
+  );
+
+  /** `mur-table` track key — stable per note id. */
+  readonly trackByRow = (row: TypedNoteRow): string => row.id;
+
+  /** The typed value for a row's property key (undefined when the note has none). */
+  valueOf(row: TypedNoteRow, key: string): PropertyValue | undefined {
+    return row.values[key];
+  }
+
+  /** True when a checkbox value is checked (safe on a missing / off-kind value). */
+  isChecked(value: PropertyValue | undefined): boolean {
+    return value?.kind === "checkbox" && value.value === true;
+  }
+
+  /** The display string for a non-checkbox value (empty for a missing value). */
+  displayValue(value: PropertyValue | undefined): string {
+    if (!value) {
+      return "";
+    }
+    switch (value.kind) {
+      case "number":
+        return Number.isFinite(value.value) ? String(value.value) : "";
+      case "checkbox":
+        return value.value ? "Yes" : "No";
+      default:
+        return value.value;
+    }
+  }
+
+  /** Presentational only: epoch-ms → a friendly local date. */
+  formatDate(updatedAt: number): string {
+    const d = new Date(updatedAt);
+    if (Number.isNaN(d.getTime())) {
+      return "";
+    }
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+}

--- a/src/app/services/notes.service.ts
+++ b/src/app/services/notes.service.ts
@@ -5,6 +5,8 @@ import type {
   NoteSummary,
   OrganizeMove,
   OrganizePlan,
+  PropertySchemaField,
+  TypedNoteRow,
 } from "../core/models";
 
 /**
@@ -36,6 +38,17 @@ export class NotesService {
    */
   private readonly _activeFolderId = signal<string | null>(null);
 
+  // ── Feature C — typed note properties (folder schema + typed rows) ──────────
+  // Root-persisted (stale-while-revalidate, angular-zoneless.md §8): these outlive
+  // a component destroy+recreate so the Table/Board views show the last-known
+  // schema/rows instantly on remount while the reload replaces them underneath.
+  // Both are per-CURRENT-scope (whichever folder the caller last loaded); a
+  // LOCKED folder yields `[]` from the backend, so the typed views self-hide.
+  private readonly _folderSchema = signal<PropertySchemaField[]>([]);
+  private readonly _typedRows = signal<TypedNoteRow[]>([]);
+  private readonly _schemaLoading = signal(false);
+  private readonly _typedLoading = signal(false);
+
   /** The note list, as last returned by the backend (gated — masked rows included). */
   readonly notes = this._notes.asReadonly();
   /** The note-kind folder list (`kind='note'` only). */
@@ -48,6 +61,15 @@ export class NotesService {
   readonly error = this._error.asReadonly();
   /** The active note-folder scope (null = "All notes"). */
   readonly activeFolderId = this._activeFolderId.asReadonly();
+
+  /** The current folder's property schema (`[]` for a locked folder — gated backend-side). */
+  readonly folderSchema = this._folderSchema.asReadonly();
+  /** The current folder's typed rows for the Table/Board views (`[]` for a sealed folder). */
+  readonly typedRows = this._typedRows.asReadonly();
+  /** True while the folder schema is (re)loading. */
+  readonly schemaLoading = this._schemaLoading.asReadonly();
+  /** True while the typed rows are (re)loading. */
+  readonly typedLoading = this._typedLoading.asReadonly();
 
   /**
    * Select a note-folder (or null for "All notes") as the shared sidebar/content
@@ -235,5 +257,75 @@ export class NotesService {
       throw e;
     }
     await Promise.allSettled([this.loadFolders(), this.loadNotes()]);
+  }
+
+  // ── Feature C — typed properties (schema + typed rows) ─────────────────────
+
+  /**
+   * (Re)load the property SCHEMA for `folderId`. A LOCKED folder returns `[]`
+   * (the backend gates it), which correctly hides every typed view. `null` (the
+   * "All notes" scope) has no single folder schema → clears to `[]` without an
+   * IPC call. Error-tolerant: a failure captures into `error` and leaves the
+   * last-known schema untouched (stale-while-revalidate) rather than blanking it.
+   */
+  async loadSchema(folderId: string | null): Promise<void> {
+    if (folderId === null) {
+      this._folderSchema.set([]);
+      return;
+    }
+    this._schemaLoading.set(true);
+    this._error.set(null);
+    try {
+      this._folderSchema.set(await this.ipc.getNoteFolderSchema(folderId));
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._schemaLoading.set(false);
+    }
+  }
+
+  /**
+   * (Re)load the TYPED note rows for `folderId` (feeds the Table/Board views). A
+   * SEALED folder returns `[]` (gated in the query). `null` clears to `[]` (the
+   * typed views are only offered for a concrete folder). Error-tolerant like
+   * {@link loadSchema} — the stale rows self-heal on the next load.
+   */
+  async loadTypedRows(folderId: string | null): Promise<void> {
+    if (folderId === null) {
+      this._typedRows.set([]);
+      return;
+    }
+    this._typedLoading.set(true);
+    this._error.set(null);
+    try {
+      this._typedRows.set(await this.ipc.listNotesTyped(folderId));
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._typedLoading.set(false);
+    }
+  }
+
+  /**
+   * Persist a note-folder's property schema (replaces the whole field set), then
+   * refresh the local schema signal so the editor + views see it at once. The
+   * SAVE is the only failure that rejects (so the caller can surface it); the
+   * follow-on reload is best-effort (a refresh error is captured in `error`).
+   */
+  async saveSchema(
+    folderId: string,
+    fields: PropertySchemaField[],
+  ): Promise<void> {
+    this._error.set(null);
+    try {
+      await this.ipc.setNoteFolderSchema(folderId, fields);
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+    // Reflect the saved set locally at once (optimistic-but-verified: the SAVE
+    // already succeeded), then reconcile from the backend best-effort.
+    this._folderSchema.set([...fields]);
+    await this.loadSchema(folderId);
   }
 }


### PR DESCRIPTION
## What
Feature C of `docs/PLAN-obsidian-notion-parity.md` — the **structured-DB substrate** Murmur entirely lacked (the one Notion primitive with none of it), added **without breaking owned-`.md`**. A 'row' stays one `documents(kind='note')` `.md` with YAML front-matter; **typing is a read-time coercion layer** over the same `Record<String,String>`, so `split_front_matter`/`parse_front_matter` and the `text_blob` seal path are **untouched** (byte round-trip intact — `front-matter.ts` has an empty diff).

## Backend (additive, no destructive migration)
- `note_folder_schemas` table — content-free `{key,kind,options}` per note-folder.
- `PropertyKind`/`PropertySchemaField`/`PropertyValue` (`{kind,value}`)/`TypedNoteRow`; `coerce_property_value` (pure; an out-of-`options` Select / malformed number/date preserved as **Text, never dropped**).
- `list_notes_visible_typed` = the gated `list_notes_visible` + `note_markdown_if_visible` (both `visibility_clause`) + coercion. `get_note_folder_schema` (read **gated to `[]` on lock**), `set_note_folder_schema` (write **`Locked`-refused**), `list_notes_typed` (`[]` for a sealed folder).
- **`query_database` brain + MCP tool (9th):** resolves a note-folder, reads ONLY gated typed rows, filters via a **deterministic Rust grammar** (no 2nd LLM → **egress-free**, no prompt-injection; unparseable ⇒ zero rows, never all).

## Frontend (zoneless)
- `property-field-types` helpers; note-editor **schema-driven widgets** (Checkbox→`mur-toggle`, Date, Select opaque, Number, Text) writing coerced strings via `formatForYaml` so `serializeDoc` round-trip is untouched; notes-home **List/Table/Board switcher** (only when a folder has a schema); `notes-table-view` + `notes-board-view` over `mur-table`/`mur-card`.

## How verified
- `cargo test --lib`: **1620 passed** (+12). **RED-before-GREEN** on the lock-write gate, the `query_database` visibility gate, and the sealed-folder-empty read.
- `cargo clippy --lib -- -D warnings`: **clean**. `ng lint` + `ng build`: clean. E2E asserts the `.md` round-trip survives a typed edit + a locked folder shows no typed view.
- **lock-security-reviewer: PASS** (all typed reads gated; `query_database` egress-free; parsers/seal untouched; schema content-free). **adversarial-verifier: PASS** (coercion never drops a value; no leak through `query_database`/Table/Board).

## Not verified (honest)
Live WKWebView render of the new Table/Board (no browser MCP in the verifier session — covered by clean AOT build + E2E + code inspection). A minor non-blocking nit: `loadTypedRows` has no stale-result guard (a fast folder A→B switch could briefly flash A's rows; a locked folder still yields `[]`, so no leak) — cosmetic, deferred.