### PR TITLE
chore(release): 0.9.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.15"
+version = "0.9.16"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -832,6 +832,7 @@ mod tests {
                 parent_id: None,
                 locked: false,
                 unlocked: false,
+                is_root: false,
                 kind: "note".into(),
             },
             "2026-07-14T00:00:00Z",

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -14685,6 +14685,7 @@ mod tests {
                 parent_id: None,
                 locked: false,
                 unlocked: false,
+                is_root: false,
                 kind: "note".into(),
             },
             "2026-07-14T00:00:00Z",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.16 — Notes unlock-gate fix, locked-create message, unfiled-first notes (reserved always-open root), auto-title on close, org member emails (client; server live). All feature PRs (#321/#322/#326) already merged + verified.