### PR TITLE
feat(notes): clickable [[wikilinks]] + gated resolver (fixes red trunk)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6109,6 +6109,19 @@ pub fn get_backlinks(
     state.db.backlinks_for_visible(kind, &target_id, &unlocked)
 }
 
+/// Resolve a clicked `[[Title]]` wikilink to a VISIBLE note/meeting to navigate to. Returns `None`
+/// when nothing matches OR the only match is a sealed-and-not-session-unlocked target (gated in
+/// `Db::resolve_wikilink`) — so a wikilink click never reveals or opens locked content. The FE
+/// routes on `kind`, or offers to create a note when `None`.
+#[tauri::command]
+pub fn resolve_wikilink(
+    state: State<'_, AppState>,
+    title: String,
+) -> Result<Option<crate::storage::models::WikiTarget>, AppError> {
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.resolve_wikilink(&title, &unlocked)
+}
+
 /// Structured, GATED, egress-free person dossier for the `/people` detail pane. Unlike
 /// [`entity_dossier`] (which CLOUD-synthesizes a markdown String via the provider and discards the
 /// struct), this returns the STRUCTURED [`DossierData`](crate::summarize::dossier::DossierData) with

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,7 @@ pub fn run() {
             commands::get_graph,
             commands::get_entity_detail,
             commands::get_backlinks,
+            commands::resolve_wikilink,
             commands::get_person_dossier,
             commands::list_people,
             commands::ask_vault,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -832,6 +832,7 @@ mod tests {
                 parent_id: None,
                 locked: false,
                 unlocked: false,
+                is_root: false,
                 kind: "note".into(),
             },
             "2026-07-14T00:00:00Z",

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -18,7 +18,7 @@ use crate::storage::models::{
     NoteRecord, NoteSummary,
     OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertySchemaField,
     PropertyValue, RecipeRecord, SavedView, SearchHit,
-    SourceKind, TypedNoteRow,
+    SourceKind, TypedNoteRow, WikiTarget,
     StatusCount,
     VaultSource,
 };
@@ -8441,6 +8441,56 @@ impl Db {
             .transpose()
     }
 
+    /// Resolve a `[[Title]]` wikilink to a VISIBLE navigation target — a standalone note (preferred,
+    /// the more natural link target) else a meeting whose exact title matches. GATED by
+    /// `visibility_clause` on both legs: a sealed-and-not-session-unlocked note/meeting with that
+    /// title resolves to `None`, so clicking a wikilink can never reveal or navigate to locked
+    /// content. `None` also when nothing matches. Title match uses the note's display title
+    /// (`title`, falling back to `name`), matching how it is shown/exported.
+    pub fn resolve_wikilink(
+        &self,
+        title: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<WikiTarget>> {
+        let title = title.trim();
+        if title.is_empty() {
+            return Ok(None);
+        }
+        // Note leg first (a standalone note is the more natural wikilink target). VISIBLE notes only.
+        {
+            let conn = self.lock();
+            let visible = visibility_clause("f", unlocked);
+            let sql = format!(
+                "SELECT d.id
+                   FROM documents d
+                   JOIN folders f ON f.id = d.folder_id
+                  WHERE d.kind = 'note'
+                    AND COALESCE(NULLIF(TRIM(d.title), ''), d.name) = ?1
+                    AND {visible}
+                  ORDER BY d.updated_at DESC, d.id ASC
+                  LIMIT 1"
+            );
+            let note_id: Option<String> = conn
+                .query_row(&sql, rusqlite::params![title], |r| r.get(0))
+                .optional()
+                .map_err(map_err)?;
+            if let Some(id) = note_id {
+                return Ok(Some(WikiTarget {
+                    kind: SourceKind::Note,
+                    id,
+                }));
+            }
+        }
+        // Meeting leg — reuse the proven gated title resolver (acquires its own lock).
+        if let Some(m) = self.meeting_by_title_visible(title, unlocked)? {
+            return Ok(Some(WikiTarget {
+                kind: SourceKind::Meeting,
+                id: m.id,
+            }));
+        }
+        Ok(None)
+    }
+
     /// The latest visible note for a meeting (MCP `get_meeting`); `None` if the meeting's note
     /// is sealed-and-not-session-unlocked.
     pub fn get_note_if_visible(
@@ -13344,6 +13394,73 @@ mod tests {
         );
     }
 
+    /// `resolve_wikilink` prefers a standalone NOTE, falls back to a MEETING, and is `None` for a
+    /// title that matches nothing (or is blank).
+    #[test]
+    fn resolve_wikilink_prefers_note_then_meeting_else_none() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // A visible standalone note titled "Alpha".
+        db.insert_note("n-alpha", "f-open", "alpha", "Alpha", "body", 1_000)
+            .unwrap();
+        // A visible meeting titled "Beta" (its AI note lives in `notes`, not `documents`).
+        let mut beta = sample_meeting("m-beta", "2026-06-24T10:00:00Z");
+        beta.title = Some("Beta".to_string());
+        db.insert_meeting(&beta).unwrap();
+        note_for(&db, "m-beta", "claude_code", "beta note");
+        db.set_note_folder("m-beta", Some("f-open")).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let a = db
+            .resolve_wikilink("Alpha", &nothing)
+            .unwrap()
+            .expect("Alpha resolves");
+        assert_eq!(a.kind, SourceKind::Note);
+        assert_eq!(a.id, "n-alpha");
+
+        let b = db
+            .resolve_wikilink("Beta", &nothing)
+            .unwrap()
+            .expect("Beta resolves");
+        assert_eq!(b.kind, SourceKind::Meeting);
+        assert_eq!(b.id, "m-beta");
+
+        assert!(db.resolve_wikilink("Nope", &nothing).unwrap().is_none());
+        assert!(db.resolve_wikilink("   ", &nothing).unwrap().is_none());
+    }
+
+    /// GATED: a `[[Title]]` pointing at a SEALED-and-not-session-unlocked note resolves to `None`
+    /// (a wikilink click can never reveal/open locked content); session-unlock reverses it. RED
+    /// against an ungated title lookup.
+    #[test]
+    fn resolve_wikilink_hides_sealed_target() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // A sealed note titled "Secret" — plaintext still present, so the gate is the sole suppressor.
+        db.insert_note("n-secret", "f-locked", "secret", "Secret", "classified", 1_000)
+            .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        assert!(
+            db.resolve_wikilink("Secret", &nothing).unwrap().is_none(),
+            "a sealed note must not be resolvable/navigable from a wikilink"
+        );
+
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let t = db
+            .resolve_wikilink("Secret", &unlocked)
+            .unwrap()
+            .expect("unlocked target resolves");
+        assert_eq!(t.kind, SourceKind::Note);
+        assert_eq!(t.id, "n-secret");
+    }
+
     /// FAIL-CLOSED: a correction row with a NULL `meeting_id` (legacy/unattributed) is never returned
     /// by the gated reader, even with nothing locked.
     #[test]
@@ -14685,6 +14802,7 @@ mod tests {
                 parent_id: None,
                 locked: false,
                 unlocked: false,
+                is_root: false,
                 kind: "note".into(),
             },
             "2026-07-14T00:00:00Z",

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1066,6 +1066,17 @@ pub struct BacklinkSource {
     pub timestamp: String,
 }
 
+/// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note or meeting whose exact title
+/// the link names, so the FE can route `/notes/:id` or `/meeting/:id`. Resolution is
+/// visibility-gated: a sealed-and-not-session-unlocked note/meeting with that title resolves to
+/// `None`, so clicking a wikilink can never reveal or navigate to locked content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikiTarget {
+    pub kind: SourceKind,
+    pub id: String,
+}
+
 /// Result of an Ask-My-Vault query: the grounded answer + the source meetings used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -8,6 +8,7 @@ import type {
   Analytics,
   AppConfigDto,
   BacklinkSource,
+  WikiTarget,
   SourceKind,
   ContextHit,
   MyShareEntry,
@@ -1072,6 +1073,15 @@ export class IpcService {
     targetId: string,
   ): Promise<BacklinkSource[]> {
     return invoke<BacklinkSource[]>("get_backlinks", { targetKind, targetId });
+  }
+
+  /**
+   * Resolve a clicked `[[Title]]` wikilink to the VISIBLE note/meeting to navigate to,
+   * or `null` when nothing matches / the only match is sealed-and-not-session-unlocked
+   * (gated server-side). The caller routes on `kind` or offers to create a note.
+   */
+  resolveWikilink(title: string): Promise<WikiTarget | null> {
+    return invoke<WikiTarget | null>("resolve_wikilink", { title });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1209,6 +1209,17 @@ export interface BacklinkSource {
   timestamp: string;
 }
 
+/**
+ * A resolved `[[Title]]` wikilink navigation target — the VISIBLE note/meeting to
+ * open (`resolveWikilink(title)`). `null` when nothing matches OR the only match is
+ * sealed-and-not-session-unlocked (gated server-side, so a click can never reveal or
+ * open locked content). Mirrors the Rust `WikiTarget` (serde camelCase).
+ */
+export interface WikiTarget {
+  kind: SourceKind;
+  id: string;
+}
+
 /** The two entity kinds the self-assembling graph resolves (Rust `EntityKind`, camelCase). */
 export type EntityKind = "person" | "project";
 

--- a/src/app/shared/markdown/markdown.component.scss
+++ b/src/app/shared/markdown/markdown.component.scss
@@ -150,6 +150,16 @@
   font-size: 0.9em;
   font-weight: 500;
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+.md-wikilink:hover,
+.md-wikilink:focus-visible {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  outline: none;
 }
 .md-wikilink::before {
   content: "🔗";

--- a/src/app/shared/markdown/markdown.component.ts
+++ b/src/app/shared/markdown/markdown.component.ts
@@ -4,10 +4,14 @@ import {
   ViewEncapsulation,
   booleanAttribute,
   computed,
+  inject,
   input,
 } from "@angular/core";
+import { Router } from "@angular/router";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
+import { IpcService } from "../../core/ipc.service";
+import { ToastService } from "../../services/toast.service";
 
 /**
  * Renders LLM / markdown text (transcript text AND model output) as beautifully formatted,
@@ -21,8 +25,11 @@ import DOMPurify from "dompurify";
  *   `<iframe>`/`<object>`/`<embed>`, and any other XSS vector BEFORE the string ever reaches the
  *   DOM. This is the primary sanitizer; we never call `bypassSecurityTrustHtml`, so Angular's
  *   built-in `[innerHTML]` sanitizer also runs as a second, redundant pass.
- * - `[[Wikilinks]]` become accent chips (the label is HTML-escaped first, then DOMPurify keeps
- *   the `<span class="md-wikilink">` wrapper because `span`/`class` are on its default allow-list).
+ * - `[[Wikilinks]]` become accent chips carrying a `data-wikilink` attribute (title HTML-escaped
+ *   first, then DOMPurify keeps the `<span class="md-wikilink" data-wikilink=…>` because `span`/
+ *   `class` are default-allowed and `data-wikilink`/`role`/`tabindex` are added to the allow-list).
+ *   A host click/Enter handler resolves the title to a VISIBLE note/meeting (gated server-side)
+ *   and navigates, or offers to create the note — so the chips are clickable like Obsidian links.
  * - A stray YAML front-matter block (some models leak one) is stripped defensively.
  *
  * Encapsulation is None with a `.md-body` scope so the styles reach the injected HTML.
@@ -33,26 +40,102 @@ import DOMPurify from "dompurify";
   encapsulation: ViewEncapsulation.None,
   templateUrl: "./markdown.component.html",
   styleUrl: "./markdown.component.scss",
+  host: {
+    "(click)": "onClick($event)",
+    "(keydown.enter)": "onEnter($event)",
+  },
 })
 export class MarkdownComponent {
+  private readonly router = inject(Router);
+  private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
+
   readonly markdown = input<string>("");
   readonly compact = input(false, { transform: booleanAttribute });
 
   readonly html = computed(() => this.render(this.markdown() ?? ""));
 
+  /** Click anywhere in the rendered markdown — act only when a `.md-wikilink` chip was hit. */
+  onClick(ev: Event): void {
+    const chip = (ev.target as HTMLElement | null)?.closest?.(".md-wikilink") as
+      | HTMLElement
+      | null
+      | undefined;
+    if (!chip) {
+      return;
+    }
+    ev.preventDefault();
+    const title = chip.getAttribute("data-wikilink");
+    if (title) {
+      void this.openWikilink(title);
+    }
+  }
+
+  /** Enter on a focused wikilink chip (it carries `tabindex="0"`) opens it — keyboard parity. */
+  onEnter(ev: Event): void {
+    const chip = ev.target as HTMLElement | null;
+    if (!chip?.classList?.contains("md-wikilink")) {
+      return;
+    }
+    ev.preventDefault();
+    const title = chip.getAttribute("data-wikilink");
+    if (title) {
+      void this.openWikilink(title);
+    }
+  }
+
+  private async openWikilink(title: string): Promise<void> {
+    try {
+      const target = await this.ipc.resolveWikilink(title);
+      if (target) {
+        void this.router.navigate([
+          target.kind === "meeting" ? "/meeting" : "/notes",
+          target.id,
+        ]);
+        return;
+      }
+      // No such note/meeting (or it is locked) — offer to create it, Obsidian-style.
+      this.toast.push(`Notatka „${title}" jeszcze nie istnieje`, "info", 0, {
+        label: "Utwórz",
+        run: () => void this.createAndOpen(title),
+      });
+    } catch {
+      this.toast.danger(`Nie udało się otworzyć „${title}"`);
+    }
+  }
+
+  private async createAndOpen(title: string): Promise<void> {
+    try {
+      const id = await this.ipc.createNote(null, title);
+      void this.router.navigate(["/notes", id]);
+    } catch {
+      this.toast.danger(`Nie udało się utworzyć „${title}"`);
+    }
+  }
+
   private render(src: string): string {
     let text = this.stripFrontMatter(src);
-    // [[Wikilink]] / [[Wikilink|alias]] → safe accent chip (marked passes raw HTML through).
+    // [[Wikilink]] / [[Wikilink|alias]] → clickable accent chip (marked passes raw HTML through).
     text = text.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, (_m, t: string) => {
-      const label = t.trim().replace(/[<>]/g, "");
-      return `<span class="md-wikilink">${label}</span>`;
+      const safe = this.escapeHtml(t.trim());
+      return `<span class="md-wikilink" data-wikilink="${safe}" role="link" tabindex="0">${safe}</span>`;
     });
     const out = marked.parse(text, { async: false, gfm: true, breaks: true });
     const raw = typeof out === "string" ? out : src;
     // Sanitize the parsed HTML before it is bound to [innerHTML]. The source is untrusted
     // (LLM output / transcript), so DOMPurify is the authoritative XSS gate — no
-    // bypassSecurityTrustHtml is ever applied to this string.
-    return DOMPurify.sanitize(raw, { USE_PROFILES: { html: true } });
+    // bypassSecurityTrustHtml is ever applied. `data-wikilink`/`role`/`tabindex` are explicitly
+    // allow-listed so the clickable chip survives sanitization.
+    return DOMPurify.sanitize(raw, {
+      USE_PROFILES: { html: true },
+      ADD_ATTR: ["data-wikilink", "role", "tabindex"],
+    });
+  }
+
+  private escapeHtml(s: string): string {
+    return s.replace(/[&<>"]/g, (c) =>
+      c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&quot;",
+    );
   }
 
   private stripFrontMatter(src: string): string {


### PR DESCRIPTION
## What
The `[[Title]]` chips the markdown renderer already drew were **dead** (a styled `<span>`, no click). This wires them to navigation — everywhere app markdown renders (notes, meeting notes, brain answers). Follow-up to Feature A (which added the *reverse* direction, "Linked mentions").

- **Backend:** gated `Db::resolve_wikilink` — note leg uses the same `visibility_clause` predicate as `list_notes_visible`; meeting leg reuses `meeting_by_title_visible`. Returns `WikiTarget{kind,id}`, or **`None` for a sealed-and-not-session-unlocked target** (the `AND {visible}` is in the `WHERE` *before* `ORDER BY … LIMIT 1`, so a sealed same-title row can't win the slot) → a click can never reveal or open locked content. `resolve_wikilink` command + `lib.rs`.
- **Frontend:** `MarkdownComponent` renders `<span class="md-wikilink" data-wikilink=…>` (title HTML-escaped; `data-wikilink`/`role`/`tabindex` added to the DOMPurify allow-list) + a host `(click)`/`(keydown.enter)` handler → `resolveWikilink` → `router.navigate(['/notes'|'/meeting', id])`, or a toast offering to **create** the note (`createNote(null, title)` → open), Obsidian-style. `cursor: pointer` + hover.
- **Trunk fix (bundled):** adds `is_root: false` to two Feature-C `NoteFolder` **test** seeds that stopped compiling after a concurrent PR added the `is_root` field — a per-PR-green / **merge-broken** race that left `cargo test --lib` **red on trunk**. Now green.

## How verified
- `cargo test --lib`: **1626 passed** (+2). **RED-before-GREEN** on `resolve_wikilink_hides_sealed_target` (a sealed note is not resolvable; unlock reverses).
- `cargo clippy --lib -- -D warnings`: **clean**. `ng lint` + `ng build`: clean.
- **lock-security-reviewer: PASS** — both legs gated, masked-`None`, no order-then-filter leak, no content in the DTO, `is_root` test-fix safe.
- **adversarial-verifier: PASS** — the untrusted-title (LLM/transcript) XSS surface is closed, **RED-before-GREEN proven in real Chromium** with the app's actual DOMPurify+marked (`" onmouseover=…` breakout blocked; `ADD_ATTR` doesn't re-enable scripts/`on*`); routing/contract/create-flow correct.

## Not verified (honest)
True in-app click→navigate on the packaged WKWebView + a real Touch-ID-locked target — signed-build only. A minor robustness try/catch was added to `openWikilink` post-review (IPC-reject → toast instead of unhandled rejection).