### PR TITLE
chore(release): 0.9.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.16"
+version = "0.9.17"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 0.9.16 → 0.9.17 for the Notes/Meetings consistency release (#330): folder-leak fix, Board removal, Saved Views ported to Notes. This PR's CI also validates the merged trunk (#329 wikilinks + #330) before the release DMG is cut from it.