### PR TITLE
fix(sharing): revoke org shares on delete + fan out delete events

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2286,13 +2286,32 @@ pub(crate) fn brain_overview_inner(state: &AppState) -> Result<BrainOverview, Ap
 /// Permanently delete a document and cascade-delete its chunks + vectors. GATED: a
 /// sealed-and-NOT-session-unlocked folder is refused (`AppError::Locked`) so the lock state can't be
 /// mutated from behind the gate (consistent with `import_document`'s write-gate).
+///
+/// DELETE-CASCADE FIX (2026-07-15): `delete_document` is generic over BOTH `kind='document'`
+/// (imported/ingested files) and `kind='note'` rows (`brain.component.ts`'s `removeItem` can reach
+/// either), so it needs the SAME org-share revoke cascade as [`delete_note`] before dropping the local
+/// row — a `kind='note'` document deleted through THIS surface must not resurrect via the org feed
+/// either. `async` (was sync) because the revoke is a network round-trip.
 #[tauri::command]
-pub fn delete_document(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
-    delete_document_inner(state.inner(), &id)
+pub async fn delete_document(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<(), AppError> {
+    // Only a `kind='note'` row is ever tab-tracked (a plain ingested `kind='document'` has no tab —
+    // see `TabKind` in `tab-keys.ts`), so only fire the delete-fan-out event for that case: emitting
+    // it for an id nothing tracks is harmless, but this stays precise about what was actually deleted.
+    let was_note = matches!(state.db.get_note_row(&id), Ok(Some(_)));
+    delete_document_inner(state.inner(), &id).await?;
+    if was_note {
+        crate::events::emit_content_deleted(&app, "note", &id);
+    }
+    Ok(())
 }
 
-/// Inner of [`delete_document`] taking `&AppState` (unit-testable gate).
-pub(crate) fn delete_document_inner(state: &AppState, id: &str) -> Result<(), AppError> {
+/// Inner of [`delete_document`] taking `&AppState` (unit-testable gate). `async` for the org-share
+/// revoke cascade (network round-trip); the gate + DB delete themselves stay synchronous internally.
+pub(crate) async fn delete_document_inner(state: &AppState, id: &str) -> Result<(), AppError> {
     let Some(folder_id) = state.db.folder_for_document(id)? else {
         return Ok(()); // unknown id → idempotent no-op.
     };
@@ -2301,6 +2320,11 @@ pub(crate) fn delete_document_inner(state: &AppState, id: &str) -> Result<(), Ap
             "this folder is locked — unlock it to delete a document".into(),
         ));
     }
+    // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact source
+    // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
+    // server item back into the local replica after the user asked to delete it. Fails LOUD: a revoke
+    // failure (e.g. offline) aborts the delete rather than silently leaving a dangling live share.
+    revoke_org_shares_for_source(state, None, Some(id)).await?;
     state.db.delete_document(id)?;
     tracing::info!(target: "documents", document_id = %id, "document deleted");
     Ok(())
@@ -2850,13 +2874,27 @@ fn remove_note_export_before_move(old_path: Option<&str>) -> Result<(), AppError
 
 /// Permanently delete a note (cascade its chunks + vectors + vault `.md`). GATED: a
 /// sealed-and-not-session-unlocked folder is refused. Reuses `delete_document` semantics.
+///
+/// DELETE-CASCADE FIX (2026-07-15): the local hard-delete used to leave any live org share of this
+/// note `uploaded` — the server ciphertext survived + the 60s background org-sync tick re-pulled it
+/// back into the local replica, resurrecting a "deleted" note. Now revokes every live org share of
+/// this exact note FIRST (fails loud on a revoke error — see `revoke_org_shares_for_source`), then
+/// fans out a content-free delete event so any other open surface (the tab-strip) can prune itself.
+/// `async` (was sync) because the revoke is a network round-trip.
 #[tauri::command]
-pub fn delete_note(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
-    delete_note_inner(state.inner(), &id)
+pub async fn delete_note(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<(), AppError> {
+    delete_note_inner(state.inner(), &id).await?;
+    crate::events::emit_content_deleted(&app, "note", &id);
+    Ok(())
 }
 
-/// Inner of [`delete_note`] taking `&AppState` (unit-testable gate).
-pub(crate) fn delete_note_inner(state: &AppState, id: &str) -> Result<(), AppError> {
+/// Inner of [`delete_note`] taking `&AppState` (unit-testable gate). `async` for the org-share revoke
+/// cascade (network round-trip); the gate + DB delete themselves stay synchronous internally.
+pub(crate) async fn delete_note_inner(state: &AppState, id: &str) -> Result<(), AppError> {
     let Some(row) = state.db.get_note_row(id)? else {
         return Ok(()); // unknown id → idempotent no-op.
     };
@@ -2865,6 +2903,11 @@ pub(crate) fn delete_note_inner(state: &AppState, id: &str) -> Result<(), AppErr
             "this folder is locked — unlock it to delete a note".into(),
         ));
     }
+    // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact note
+    // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
+    // server item back into the local replica after the user asked to delete it. Fails LOUD: a revoke
+    // failure (e.g. offline) aborts the delete rather than silently leaving a dangling live share.
+    revoke_org_shares_for_source(state, None, Some(id)).await?;
     // Remove the vault file first (best-effort), then cascade-delete the row + its chunks/vectors.
     if let Some(path) = &row.exported_path {
         let _ = std::fs::remove_file(path);
@@ -4452,23 +4495,45 @@ pub fn search_meetings(
 
 /// Permanently delete a meeting: its audio file, its exported vault note, and all DB rows
 /// (segments, notes, timeline cascade via FK). Irreversible.
+///
+/// DELETE-CASCADE FIX (2026-07-15): revokes every live org share of this meeting FIRST (see
+/// [`delete_meeting_inner`]), then fans out a content-free delete event so any other open surface
+/// (the tab-strip) can prune itself. `async` (was sync) because the revoke is a network round-trip.
 #[tauri::command]
-pub fn delete_meeting(state: State<'_, AppState>, meeting_id: String) -> Result<(), AppError> {
+pub async fn delete_meeting(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<(), AppError> {
+    delete_meeting_inner(state.inner(), &meeting_id).await?;
+    crate::events::emit_content_deleted(&app, "meeting", &meeting_id);
+    Ok(())
+}
+
+/// Inner of [`delete_meeting`] taking `&AppState` (unit-testable). `async` for the org-share revoke
+/// cascade (network round-trip); the file/DB cascade itself stays synchronous internally.
+pub(crate) async fn delete_meeting_inner(state: &AppState, meeting_id: &str) -> Result<(), AppError> {
+    // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact meeting
+    // BEFORE the local rows disappear, so the background org-sync tick can never re-pull a still-live
+    // server item back into the local replica after the user asked to delete it. Fails LOUD: a revoke
+    // failure (e.g. offline) aborts the delete rather than silently leaving a dangling live share.
+    revoke_org_shares_for_source(state, Some(meeting_id), None).await?;
+
     // Capture + remove on-disk files before the rows disappear (best-effort).
     // C4: the playback audio may exist as BOTH the plaintext WAV *and* its sealed `.enc` at once —
     // during a session-unlock, `session_unseal` decrypts the `.enc` to a plaintext WAV for playback
     // but KEEPS the `.enc`. So `audio_path` (plaintext form) alone would orphan the `.enc` on
     // record→lock→unlock→delete. Remove BOTH forms, exactly as the masters block below already does.
-    if let Some(m) = state.db.get_meeting(&meeting_id)? {
+    if let Some(m) = state.db.get_meeting(meeting_id)? {
         remove_meeting_audio_files(m.audio_path.as_deref());
     }
     // Masters too — a master path may be the plaintext WAV or its `.enc`; clear both forms.
-    if let Ok((mic, sys)) = state.db.get_meeting_master_paths(&meeting_id) {
+    if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
         for p in [mic, sys].into_iter().flatten() {
             remove_meeting_audio_files(Some(&p));
         }
     }
-    if let Some(note) = state.db.get_latest_note_for_meeting(&meeting_id)? {
+    if let Some(note) = state.db.get_latest_note_for_meeting(meeting_id)? {
         if let Some(path) = note.exported_path.as_deref() {
             let _ = std::fs::remove_file(path);
         }
@@ -4476,7 +4541,7 @@ pub fn delete_meeting(state: State<'_, AppState>, meeting_id: String) -> Result<
     // Brain v2 L2.1: the delete tx purges ALL memory rollups (they may paraphrase this meeting's
     // facts) and returns their exported vault paths — remove those files here, the same layer that
     // removed the note `.md`/audio above. Rollups regenerate from visible facts on the next pass.
-    let rollup_exports = state.db.delete_meeting(&meeting_id)?;
+    let rollup_exports = state.db.delete_meeting(meeting_id)?;
     remove_rollup_export_files(&rollup_exports);
     Ok(())
 }
@@ -17713,6 +17778,44 @@ mod lifecycle_tests {
         assert_eq!(now.audio_path.as_deref(), Some("/data/m-sealed.wav.enc"));
     }
 
+    /// DELETE-CASCADE FIX (Bug A) — deleting a meeting that has a LIVE org share must revoke it (never
+    /// leave a dangling `uploaded` row the background org-sync tick would resurrect). No live
+    /// server/session in this unit test, so the tombstone call fails closed — the row is still driven
+    /// to (at least) `revoke_pending` FIRST, and the delete itself fails loud + the local meeting
+    /// SURVIVES (never half-deleted-locally-with-a-dangling-server-copy). RED before the fix: the
+    /// unpatched `delete_meeting` never touched `org_shares`, so the meeting would vanish locally
+    /// while its share stayed `uploaded` (the resurrection bug).
+    #[test]
+    fn delete_meeting_revokes_a_live_org_share() {
+        let state = build_state("meeting-delete-org-revoke");
+        let db = &state.db;
+        make_open_folder(db, "f-open", "Standups");
+        seed_titled_meeting(db, "m1", "Shared standup", "/data/m1.wav", "f-open");
+
+        db.insert_org_share(
+            "share-meeting-1", "org-1", Some("m1"), None, "meeting", Some("Shared standup"), 1, 1,
+            &[5u8; 32], "2026-07-15T00:00:00Z",
+        )
+        .unwrap();
+        db.set_org_share_uploaded("share-meeting-1", "item-meeting-1", "2026-07-15T00:00:00Z")
+            .unwrap();
+
+        let err = block_on(delete_meeting_inner(&state, "m1")).unwrap_err();
+        assert!(
+            matches!(err, AppError::Unavailable(_)),
+            "delete fails loud when the revoke can't reach the server (no session), got {err:?}"
+        );
+        let row = db.get_org_share("share-meeting-1").unwrap().unwrap();
+        assert_ne!(
+            row.state, "uploaded",
+            "a live org share must be moved off `uploaded` before the delete gives up"
+        );
+        assert!(
+            db.get_meeting("m1").unwrap().is_some(),
+            "a failed (revoke-blocked) delete must not have removed the local meeting"
+        );
+    }
+
     /// Quiet-Glass verifier finding (2026-07-11): `list_meetings_by_tag` returned rows WITHOUT the
     /// backend mask — a sealed meeting's real AI title + `.enc` audio path crossed IPC whenever the
     /// Library was filtered by tag (the FE then leaked the title into the delete-confirm
@@ -19257,7 +19360,7 @@ mod lifecycle_tests {
             "sealed import must be Locked, got {err:?}"
         );
         // DELETE is refused with Locked too.
-        let derr = delete_document_inner(&state, &existing).unwrap_err();
+        let derr = block_on(delete_document_inner(&state, &existing)).unwrap_err();
         assert!(
             matches!(derr, AppError::Locked(_)),
             "sealed delete must be Locked, got {derr:?}"
@@ -19516,7 +19619,7 @@ mod lifecycle_tests {
         let id = import_document_inner(&state, md.to_str().unwrap(), "f-open").unwrap();
         assert_eq!(list_documents_inner(&state, "f-open").unwrap().len(), 1);
 
-        delete_document_inner(&state, &id).unwrap();
+        block_on(delete_document_inner(&state, &id)).unwrap();
         assert!(
             list_documents_inner(&state, "f-open").unwrap().is_empty(),
             "document deleted"
@@ -19525,6 +19628,48 @@ mod lifecycle_tests {
             state.db.doc_chunk_count(&id).unwrap(),
             0,
             "doc chunks cascade-deleted with the document"
+        );
+    }
+
+    /// DELETE-CASCADE FIX (Bug A) — deleting a document that has a LIVE org share must revoke it
+    /// (never leave a dangling `uploaded` row the background org-sync tick would resurrect). No live
+    /// server/session in this unit test, so the tombstone network call itself fails — the row is
+    /// still driven to `revoke_pending` FIRST (crash-safe: the launch sweep would finish a stuck one),
+    /// exactly mirroring `share_to_org_inner_collapses_existing_duplicates_keeping_the_earliest`'s
+    /// no-session assertion shape. RED before the fix: the unpatched `delete_document_inner` never
+    /// touches `org_shares` at all, so the row would still read `uploaded` after the delete.
+    #[test]
+    fn delete_document_revokes_a_live_org_share() {
+        let state = build_state("doc-delete-org-revoke");
+        make_open_folder(&state.db, "f-open", "Project");
+        let md = write_temp_doc("del-org", "md", "alpha bravo charlie");
+        let id = import_document_inner(&state, md.to_str().unwrap(), "f-open").unwrap();
+
+        state
+            .db
+            .insert_org_share(
+                "share-1", "org-1", None, Some(&id), "document", Some("A Doc"), 1, 1,
+                &[3u8; 32], "2026-07-15T00:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("share-1", "item-1", "2026-07-15T00:00:00Z")
+            .unwrap();
+        assert_eq!(
+            state.db.get_org_share("share-1").unwrap().unwrap().state,
+            "uploaded",
+            "sanity: the share starts live"
+        );
+
+        block_on(delete_document_inner(&state, &id)).unwrap_err();
+        // The delete FAILS LOUD here (no live session/server → the tombstone call errors), but the
+        // row must already have moved off `uploaded` — never left dangling as if nothing happened.
+        let row = state.db.get_org_share("share-1").unwrap().unwrap();
+        assert_ne!(
+            row.state, "uploaded",
+            "a live org share must be (at least) marked revoke_pending before the delete gives up, \
+             never left uploaded — that's the resurrection bug"
         );
     }
 
@@ -19563,6 +19708,50 @@ mod lifecycle_tests {
             state.db.list_note_folders().unwrap().len(),
             1,
             "the default note-folder is not duplicated"
+        );
+    }
+
+    /// DELETE-CASCADE FIX (Bug A) — deleting a note that has a LIVE org share must revoke it (never
+    /// leave a dangling `uploaded` row the background org-sync tick would resurrect on the SAME
+    /// machine). No live server/session in this unit test, so the tombstone network call itself fails
+    /// closed — the row is still driven to (at least) `revoke_pending` FIRST (crash-safe: the launch
+    /// sweep would finish a stuck one) BEFORE the delete gives up. RED before the fix: the unpatched
+    /// `delete_note_inner` never touches `org_shares` at all, so a live share would still read
+    /// `uploaded` and the local note row would ALSO already be gone (a strictly worse outcome — the
+    /// content deleted locally while its server copy stays live-and-undetectable).
+    #[test]
+    fn delete_note_revokes_a_live_org_share() {
+        let state = build_state("note-delete-org-revoke");
+        let id = create_note_inner(&state, None, "Shared note").unwrap();
+
+        state
+            .db
+            .insert_org_share(
+                "share-note-1", "org-1", None, Some(&id), "note", Some("Shared note"), 1, 1,
+                &[4u8; 32], "2026-07-15T00:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("share-note-1", "item-note-1", "2026-07-15T00:00:00Z")
+            .unwrap();
+
+        let err = block_on(delete_note_inner(&state, &id)).unwrap_err();
+        assert!(
+            matches!(err, AppError::Unavailable(_)),
+            "delete fails loud when the revoke can't reach the server (no session), got {err:?}"
+        );
+        let row = state.db.get_org_share("share-note-1").unwrap().unwrap();
+        assert_ne!(
+            row.state, "uploaded",
+            "a live org share must be moved off `uploaded` before the delete gives up — \
+             never left dangling live, that's the resurrection bug"
+        );
+        // The local note row must SURVIVE the failed delete — fail loud means fail WHOLE, not
+        // half-deleted-locally-with-a-dangling-server-copy.
+        assert!(
+            get_note_inner(&state, &id).is_ok(),
+            "a failed (revoke-blocked) delete must not have removed the local note"
         );
     }
 
@@ -29515,6 +29704,60 @@ pub async fn revoke_shares_for_folder(
             }
         };
         if let Err(e) = res {
+            first_err.get_or_insert(e);
+        }
+    }
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// DELETE-CASCADE FIX (2026-07-15): bulk-revoke every LIVE org share of ONE exact source
+/// (`meeting_id` XOR `document_id`), across ALL orgs it was shared into. This is the delete-time twin
+/// of [`revoke_shares_for_folder`] (which is folder-scoped, for the lock×shares dialog) — here the
+/// scope is a single note/meeting/document that is about to be permanently, locally deleted.
+///
+/// ROOT CAUSE this closes: `delete_note_inner`/`delete_meeting_inner`/`delete_document_inner` used to
+/// hard-delete the LOCAL rows (vault `.md`, WAV/`.enc`, DB rows) without ever touching `org_shares` —
+/// so a shared note/meeting's server ciphertext stayed `uploaded` and the 60s background org-sync tick
+/// (`org_background_sync_tick`) re-pulled the author's OWN still-live item back into the local
+/// `org_items` replica, resurrecting "deleted" content in Shared Brain / Ask / MCP on the SAME machine.
+///
+/// Reuses [`revoke_org_share_inner`]'s server-tombstone + local-`revoked` flip (never duplicated) —
+/// mirrors the `revoke_shares_for_folder` org loop exactly: an uploaded row is tombstoned on the
+/// server; a still-`queued`/never-uploaded row (no live server item) is simply cancelled LOCALLY so
+/// the launch sweep never egresses it after the source is gone.
+///
+/// BEST-EFFORT-BUT-LOUD: attempts EVERY live share even if one fails (never abandon a revoke sweep
+/// partway), then returns the FIRST error to the caller so a revoke failure (e.g. offline) is
+/// surfaced — the caller (delete) fails loud rather than silently deleting local content while a
+/// dangling live share survives on the server. Idempotent: an already-revoked row is excluded by
+/// `org_shares_for_source` (only `uploaded`/stuck-`failed` rows are live).
+pub(crate) async fn revoke_org_shares_for_source(
+    state: &AppState,
+    meeting_id: Option<&str>,
+    document_id: Option<&str>,
+) -> Result<(), AppError> {
+    let rows = state.db.org_shares_for_source(meeting_id, document_id)?;
+    let mut first_err: Option<AppError> = None;
+    for row in rows {
+        let res = match row.item_id {
+            Some(item_id) => revoke_org_share_inner(state, item_id).await,
+            None => {
+                // Never uploaded (a queued/stuck row with no live server item) — cancel locally so
+                // the launch sweep never tries to publish it for a source that no longer exists.
+                let now = chrono::Utc::now().to_rfc3339();
+                state.db.set_org_share_state(&row.id, "revoked", &now)
+            }
+        };
+        if let Err(e) = res {
+            tracing::warn!(
+                target: "org",
+                org_id = %row.org_id,
+                error = %brief_err(&e),
+                "delete-cascade: failed to revoke a live org share of the deleted source"
+            );
             first_err.get_or_insert(e);
         }
     }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -342,6 +342,44 @@ pub fn emit_org_feed_updated(app: &AppHandle, orgs_changed: u32) {
     }
 }
 
+/// DELETE FAN-OUT FIX (2026-07-15): emitted once a note/meeting delete has FULLY succeeded — local
+/// rows gone AND (per the org-share revoke-cascade fix) any live org shares of it already revoked.
+/// Root cause this closes: no delete flow ever told OTHER open consumers (most visibly the tab-strip,
+/// `TabsService`) that content vanished, so a stale tab opened from a different surface than the one
+/// that deleted it stayed open and clickable, landing on a 404/error state. Content-free: an id + a
+/// kind discriminator only — never a title or any other content.
+pub const EVENT_CONTENT_DELETED: &str = "murmur://content-deleted";
+
+/// Payload for [`EVENT_CONTENT_DELETED`]. `kind` is `"note"` | `"meeting"`; `id` is the deleted note's
+/// or meeting's id (an opaque identifier, not content).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentDeletedPayload {
+    /// `"note"` | `"meeting"`.
+    pub kind: &'static str,
+    /// The deleted note/meeting's id.
+    pub id: String,
+}
+
+/// Emit [`EVENT_CONTENT_DELETED`] to the FE (best-effort). Swallows the emit failure with a
+/// `tracing::warn!` so a failed emit can NEVER turn a successful delete into a reported failure. NO
+/// PII (id + kind only).
+pub fn emit_content_deleted(app: &AppHandle, kind: &'static str, id: &str) {
+    if let Err(e) = app.emit(
+        EVENT_CONTENT_DELETED,
+        ContentDeletedPayload {
+            kind,
+            id: id.to_string(),
+        },
+    ) {
+        tracing::warn!(
+            target: "notes",
+            error = %e,
+            "failed to emit content-deleted notice"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,6 +388,24 @@ mod tests {
     #[test]
     fn org_feed_updated_event_name_is_stable() {
         assert_eq!(EVENT_ORG_FEED_UPDATED, "murmur://org-feed-updated");
+    }
+
+    /// The FE listens on this exact event name; a rename silently drops the tab-strip fan-out.
+    #[test]
+    fn content_deleted_event_name_is_stable() {
+        assert_eq!(EVENT_CONTENT_DELETED, "murmur://content-deleted");
+    }
+
+    /// The payload must serialize as camelCase `{"kind":"note","id":"n1"}` (the FE contract) —
+    /// content-free (id + kind discriminator only).
+    #[test]
+    fn content_deleted_payload_is_camel_case_id_and_kind_only() {
+        let json = serde_json::to_string(&ContentDeletedPayload {
+            kind: "note",
+            id: "n1".to_string(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"kind":"note","id":"n1"}"#);
     }
 
     /// The payload must serialize `orgs_changed` as camelCase `orgsChanged` (the FE contract) and

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -104,6 +104,7 @@ import type {
   OrgSyncReport,
   OrgFeedUpdatedPayload,
   ActiveSharesReport,
+  ContentDeletedPayload,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
@@ -144,6 +145,9 @@ export const EVENT_BRIEF_PROPOSED = "murmur://brief-proposed";
 // Shared Brain — the background org-sync loop INGESTED/TOMBSTONED ≥1 org item this tick
 // (content-free "something changed, re-fetch" ping; drives the Notes org picker live refresh).
 export const EVENT_ORG_FEED_UPDATED = "murmur://org-feed-updated";
+// Delete fan-out fix — a note/meeting delete FULLY succeeded (local rows gone + any org shares
+// revoked); lets OTHER open surfaces (the tab-strip) prune themselves. Content-free (id + kind only).
+export const EVENT_CONTENT_DELETED = "murmur://content-deleted";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -2329,6 +2333,21 @@ export class IpcService {
     cb: (p: OrgFeedUpdatedPayload) => void,
   ): Promise<UnlistenFn> {
     return listen<OrgFeedUpdatedPayload>(EVENT_ORG_FEED_UPDATED, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /**
+   * Fires once a note/meeting delete has FULLY succeeded on the backend
+   * (delete-fan-out fix). Content-free — id + kind only; a subscriber prunes
+   * its OWN state for that id (the tab-strip closes a matching tab; a list
+   * store removes a matching row as a safety net for the case where the
+   * delete happened from a different surface than the one holding it).
+   */
+  onContentDeleted(
+    cb: (p: ContentDeletedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<ContentDeletedPayload>(EVENT_CONTENT_DELETED, (e) =>
       cb(e.payload),
     );
   }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -2218,6 +2218,22 @@ export interface OrgFeedUpdatedPayload {
 }
 
 /**
+ * Payload of the `murmur://content-deleted` event (`onContentDeleted`). Emitted
+ * once a note/meeting delete has FULLY succeeded on the backend (local rows
+ * gone AND any live org shares of it already revoked) — the delete-fan-out fix
+ * so OTHER open surfaces (most visibly the tab-strip) learn content vanished
+ * even when the delete happened from a different surface than the one showing
+ * a stale tab. Content-free: an id + a kind discriminator only, never a title.
+ * Mirrors the Rust `ContentDeletedPayload`.
+ */
+export interface ContentDeletedPayload {
+  /** `"note"` | `"meeting"`. */
+  kind: "note" | "meeting";
+  /** The deleted note's or meeting's id. */
+  id: string;
+}
+
+/**
  * The active-shares report for the lock×shares dialog (`folderActiveShares`),
  * gathered when the user tries to lock a folder that has outgoing shares. Titles
  * render only to the local owner (who can already read them) — content-free

--- a/src/app/core/tabs.service.ts
+++ b/src/app/core/tabs.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, effect, inject, signal } from "@angular/core";
+import { DestroyRef, Injectable, effect, inject, signal } from "@angular/core";
 import { type NavigationExtras, Router } from "@angular/router";
+import { IpcService } from "./ipc.service";
 import { NavHistoryService } from "./nav-history.service";
 import { TabRouteReuseStrategy } from "./tab-route-reuse.strategy";
 import { type TabKind, tabKeyFor } from "./tab-keys";
@@ -52,6 +53,8 @@ export class TabsService {
   private readonly router = inject(Router);
   private readonly tabRouteReuse = inject(TabRouteReuseStrategy);
   private readonly navHistory = inject(NavHistoryService);
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
 
   private readonly _tabs = signal<Tab[]>(this.restoreTabs());
   private readonly _activeTabId = signal<string | null>(this.restoreActiveTabId());
@@ -77,6 +80,40 @@ export class TabsService {
       // Private-mode / storage-disabled — tabs simply won't survive a restart.
     }
   });
+
+  /**
+   * DELETE FAN-OUT FIX (2026-07-15): subscribed ONCE here (a root singleton
+   * lives for the app's lifetime — mirrors `OrgBrainService`'s constructor
+   * subscription) so a note/meeting deleted from ANY surface closes its stale
+   * tab everywhere else too, instead of leaving a clickable tab that would
+   * later 404. Content-free payload (id + kind only); a no-op when no
+   * matching tab is open.
+   */
+  private feedUnlisten: (() => void) | null = null;
+  private feedDestroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      // A root service is never actually destroyed in practice (it outlives every
+      // component), but honor the contract in case a test harness tears it down.
+      this.feedDestroyed = true;
+      this.feedUnlisten?.();
+    });
+    void this.ipc
+      .onContentDeleted((p) => {
+        void this.closeTab(tabKeyFor(p.kind, p.id));
+      })
+      .then((un) => {
+        if (this.feedDestroyed) {
+          un();
+        } else {
+          this.feedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live fan-out */
+      });
+  }
 
   /** Open (or activate, if already open) a meeting tab and navigate to it. */
   async openMeeting(id: string, title = "Meeting"): Promise<void> {

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -741,7 +741,7 @@ export class NoteEditorComponent {
       this.hydrate(doc);
     } catch (e) {
       if (seq === this.requestSeq) {
-        this.error.set(String(e));
+        this.error.set(this.friendlyLoadError(e));
         this.note.set(null);
       }
     } finally {
@@ -749,6 +749,24 @@ export class NoteEditorComponent {
         this.loading.set(false);
       }
     }
+  }
+
+  /**
+   * A clean, non-technical message for the "couldn't open this note" state.
+   * `get_note` rejects with the raw backend `AppError` string (`"invalid
+   * argument: no note {id}"`) for an unknown id — normally the tab-strip's
+   * `content-deleted` fan-out (`TabsService`) closes a stale tab before this
+   * is ever reached, but a note opened a different way (a stale bookmark, a
+   * link from another surface not going through `TabsService`) can still land
+   * here after a delete, so this stays a friendly fallback rather than the raw
+   * technical string.
+   */
+  private friendlyLoadError(e: unknown): string {
+    const msg = String(e);
+    if (/no note /i.test(msg)) {
+      return "This note was deleted.";
+    }
+    return msg;
   }
 
   /** Apply a loaded/reconciled doc into the edit signals (no autosave feedback). */

--- a/src/app/services/meetings-list-store.service.ts
+++ b/src/app/services/meetings-list-store.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, signal } from "@angular/core";
+import { DestroyRef, Injectable, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
 import type { Meeting } from "../core/models";
 
 /**
@@ -17,10 +18,48 @@ import type { Meeting } from "../core/models";
  * drag-drop patches, delete pruning, the tree-reactive reload effect) — that
  * logic is unchanged, it now just reads/writes THESE signals instead of
  * component-local ones. See the pattern note in `angular-zoneless.md` §9.
+ *
+ * DELETE FAN-OUT FIX (2026-07-15) SAFETY NET: the ONE exception to "no methods
+ * of its own" is this passive constructor subscription (mirrors
+ * `OrgBrainService`) — a meeting deleted from a DIFFERENT surface than
+ * `LibraryComponent` (e.g. its own detail tab) still prunes THIS root-persisted
+ * list, since only a root singleton outlives that component's destroy+recreate
+ * cycle. It is pure pruning, not orchestration — `LibraryComponent`'s own
+ * `confirmDelete` pruning is unchanged and layered on top of this, not replaced.
  */
 @Injectable({ providedIn: "root" })
 export class MeetingsListStore {
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
+
   readonly meetings = signal<Meeting[]>([]);
   readonly loading = signal(true);
   readonly tags = signal<string[]>([]);
+
+  private feedUnlisten: (() => void) | null = null;
+  private feedDestroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.feedDestroyed = true;
+      this.feedUnlisten?.();
+    });
+    void this.ipc
+      .onContentDeleted((p) => {
+        if (p.kind !== "meeting") {
+          return;
+        }
+        this.meetings.update((list) => list.filter((m) => m.id !== p.id));
+      })
+      .then((un) => {
+        if (this.feedDestroyed) {
+          un();
+        } else {
+          this.feedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live fan-out */
+      });
+  }
 }

--- a/src/app/services/notes.service.ts
+++ b/src/app/services/notes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, signal } from "@angular/core";
+import { DestroyRef, Injectable, inject, signal } from "@angular/core";
 import { IpcService } from "../core/ipc.service";
 import type {
   NoteFolder,
@@ -23,6 +23,7 @@ import type {
 @Injectable({ providedIn: "root" })
 export class NotesService {
   private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
 
   private readonly _notes = signal<NoteSummary[]>([]);
   private readonly _noteFolders = signal<NoteFolder[]>([]);
@@ -70,6 +71,41 @@ export class NotesService {
   readonly schemaLoading = this._schemaLoading.asReadonly();
   /** True while the typed rows are (re)loading. */
   readonly typedLoading = this._typedLoading.asReadonly();
+
+  /**
+   * DELETE FAN-OUT FIX (2026-07-15) SAFETY NET: subscribed ONCE here (a root
+   * singleton lives for the app's lifetime — mirrors `OrgBrainService`'s
+   * constructor subscription) so a note deleted from a DIFFERENT surface than
+   * the one holding this list (e.g. the note's own editor tab, or the Brain
+   * page) still prunes it here. Layered on top of {@link remove}'s existing
+   * local pruning — never replaces it.
+   */
+  private feedUnlisten: (() => void) | null = null;
+  private feedDestroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.feedDestroyed = true;
+      this.feedUnlisten?.();
+    });
+    void this.ipc
+      .onContentDeleted((p) => {
+        if (p.kind !== "note") {
+          return;
+        }
+        this._notes.update((list) => list.filter((n) => n.id !== p.id));
+      })
+      .then((un) => {
+        if (this.feedDestroyed) {
+          un();
+        } else {
+          this.feedUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live fan-out */
+      });
+  }
 
   /**
    * Select a note-folder (or null for "All notes") as the shared sidebar/content


### PR DESCRIPTION
## Summary

Two related root-cause fixes (not symptom patches):

**Bug A — deleting a shared note/meeting/document left its server copy live.**
`delete_note_inner`/`delete_meeting_inner`/`delete_document_inner` hard-deleted
local rows (vault `.md`, WAV/`.enc`, DB rows) but never touched `org_shares`, so
a shared item's `org_shares` row stayed `uploaded` with a live server
ciphertext. The 60s background org-sync tick (`org_background_sync_tick`) then
re-pulled the author's own still-live item back into the local `org_items`
replica — the "deleted" note/meeting resurrected in Shared Brain / Ask / MCP on
the SAME machine.

Fix: a new `revoke_org_shares_for_source(state, meeting_id, document_id)`
helper (mirrors `revoke_shares_for_folder`'s org loop, reuses
`revoke_org_share_inner` — no duplicated tombstone/state-flip logic) is called
FIRST inside `delete_note_inner`, `delete_meeting_inner`, and
`delete_document_inner` (which is generic over `kind='document'` AND
`kind='note'` rows — `brain.component.ts`'s `removeItem` can delete either, so
it needed the same fix as a sibling instance of the bug). It attempts every
live share even if one fails, then returns the first error — **fails loud**:
a revoke failure (e.g. offline) aborts the whole delete rather than silently
leaving a dangling live share while the local content vanishes.

**Bug B — no delete-event fan-out, so other open surfaces went stale.**
Every delete flow only pruned its OWN local list; nothing told other open
consumers (most visibly the tab-strip) that content vanished. Added a typed
`murmur://content-deleted` event (`events.rs` `emit_content_deleted`,
content-free: `{ kind: "note"|"meeting", id }`) emitted from `delete_note`,
`delete_meeting`, and `delete_document` (only when the deleted row was
actually a note) once the delete (including the org-share revoke) has fully
succeeded. `IpcService.onContentDeleted` is the one typed FE listener;
`TabsService` subscribes once in its constructor (mirrors `OrgBrainService`'s
existing pattern) and closes any matching tab. `NotesService` and
`MeetingsListStore` also subscribe as a safety net so their root-persisted
lists self-prune even when the delete happened from a different surface than
the one holding a stale row — layered on top of, never replacing, each flow's
existing local pruning. `note-editor.component.ts`'s load-error branch now
shows "This note was deleted." instead of the raw backend error string for
the residual case where a note is opened a way that bypasses the tab-strip.

## Test plan
- [x] `cargo test --lib` — 1634 passed, 0 failed, 10 ignored (pre-existing
      hardware/network-gated tests, unrelated).
- [x] Three new RED-before-GREEN regression tests, one per delete path:
      `delete_note_revokes_a_live_org_share`,
      `delete_meeting_revokes_a_live_org_share`,
      `delete_document_revokes_a_live_org_share` — each asserts a live
      `org_shares` row is moved off `uploaded` (toward `revoke_pending`) and
      the local row survives when the revoke itself fails closed (no session
      in the unit test), and each was confirmed to FAIL against the pre-fix
      code (temporarily disabled the new `revoke_org_shares_for_source` call,
      reran, restored) before being left GREEN.
- [x] Two new event-contract tests in `events.rs`:
      `content_deleted_event_name_is_stable`,
      `content_deleted_payload_is_camel_case_id_and_kind_only`.
- [x] `npx ng lint` — clean.
- [x] `npx ng build` — clean (all chunk budgets included).

## Not verified here
- Live click-through in the running app (Playwright against `:1420` with a
  mocked Tauri IPC) — left for the adversarial-verifier per this repo's
  workflow rule (the implementer doesn't self-certify).
- The background org-sync tick's live re-pull behavior against a real
  `murmur-server` (needs a live account/session + server — the unit tests
  prove the revoke is ATTEMPTED and fails closed without one, not the full
  server round-trip).
- This touches the lock/sharing-adjacent security surface (org-share
  visibility after delete) — flagging for `lock-security-reviewer` per
  `.claude/rules/lock-model.md`'s spirit (content must not remain visible
  after the user asked to delete it), even though it isn't the folder-lock
  seal path itself.