### PR TITLE
feat(notes): clickable wikilinks + Link slash-command + fold Find related

### DIFF
--- a/e2e/notes/brain-popover.spec.ts
+++ b/e2e/notes/brain-popover.spec.ts
@@ -158,17 +158,93 @@ test("Find related: an org-kind citation routes to the read-only /org-item viewe
   await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
 
   await expect(popover.getByText("2 related sources in your brain.")).toBeVisible();
-  const orgCite = popover.locator(".pop-cite", { hasText: "Anna's launchcode notes" });
-  await expect(orgCite).toBeVisible();
-  await expect(orgCite.locator(".pop-cite-kind")).toHaveText("org");
+  // Fix 3 (2026-07-15): `find_related` rows are now ACTIONABLE — "Insert link" (primary)
+  // + "Open" (secondary), replacing the old single passive `.pop-cite` chip.
+  const orgRow = popover.locator(".pop-cite-row", { hasText: "Anna's launchcode notes" });
+  await expect(orgRow).toBeVisible();
+  await expect(orgRow.locator(".pop-cite-kind")).toHaveText("org");
 
-  await orgCite.dispatchEvent("click");
+  await orgRow.getByRole("button", { name: "Open" }).dispatchEvent("click");
 
   // The old bug: an unrecognized `kind` fell through to `/notes/<id>` — assert the
   // FIX routes to the org-item viewer instead.
   await expect(page).toHaveURL(/\/org-item\/oi-launchcode$/);
   await expect(page).not.toHaveURL(/\/notes\/oi-launchcode$/);
   await expect(page.locator("app-org-item-viewer")).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * Fix 3 — "Insert link" on a `find_related` citation row inserts a `[[Title]]`
+ * wikilink into the editor body (via the SAME wikilink-text builder the link
+ * picker/toolbar op uses) instead of navigating away, and "Open" is still present
+ * as the secondary action.
+ */
+test("Find related: Insert link drops a [[Title]] wikilink into the body instead of navigating", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    note_assistant_action: (args: { req: { action: string } }) => ({
+      action: args.req.action,
+      shape: "info",
+      title: null,
+      suggestion: "1 related source in your brain.",
+      citations: [
+        {
+          kind: "note",
+          id: "n2",
+          title: "Weekly plan",
+          snippet: "Ship the notes feature",
+        },
+      ],
+      modelLabel: "Your brain (local search)",
+      mode: "local",
+      redacted: false,
+    }),
+  });
+  await page.goto("/notes/n1");
+
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    const start = el.value.indexOf("body text");
+    el.focus();
+    el.setSelectionRange(start, start + "body text".length);
+    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  });
+
+  const bubble = page.locator("app-note-selection-toolbar");
+  await expect(bubble).toBeVisible();
+  await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
+
+  const popover = page.locator("app-note-brain-popover");
+  await expect(popover).toBeVisible();
+  await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
+  await expect(popover.getByText("1 related source in your brain.")).toBeVisible();
+
+  const row = popover.locator(".pop-cite-row", { hasText: "Weekly plan" });
+  await expect(row).toBeVisible();
+  // Both actions are present — Insert link (primary) AND Open (secondary), never
+  // removing the existing capability.
+  await expect(row.getByRole("button", { name: "Insert link" })).toBeVisible();
+  await expect(row.getByRole("button", { name: "Open" })).toBeVisible();
+
+  await row.getByRole("button", { name: "Insert link" }).dispatchEvent("click");
+
+  // The popover dismisses and the editor body now carries the wikilink — no navigation.
+  await expect(popover).toHaveCount(0);
+  await expect(body).toHaveValue(/\[\[Weekly plan\]\]/);
+  await expect(page).toHaveURL(/\/notes\/n1$/);
 
   expect(consoleErrors).toEqual([]);
 });

--- a/e2e/notes/link-picker.spec.ts
+++ b/e2e/notes/link-picker.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Fix 1 — a rendered `[[Wikilink]]` pill in Preview mode opens the resolved
+ * target through `TabsService` (a TRACKED TAB), not a raw `router.navigate` that
+ * looked like a no-op / left an orphaned untracked view (the same sibling-function
+ * bug already fixed for `NoteBrainPopoverComponent.openCitation`).
+ */
+test("clicking a rendered [[wikilink]] pill in Preview opens the target as a tracked tab", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    get_note: (args: { id: string }) => ({
+      id: args.id,
+      title: args.id === "n1" ? "My First Note" : "Weekly plan",
+      folderId: "nf1",
+      markdown: args.id === "n1" ? "See [[Weekly plan]] for details." : "The plan body.",
+      tags: [],
+      properties: {},
+      updatedAt: 1_720_000_000_000,
+      createdAt: 1_719_000_000_000,
+      exportedPath: null,
+      locked: false,
+      shared: false,
+    }),
+    resolve_wikilink: (args: { title: string }) =>
+      args.title === "Weekly plan" ? { kind: "note", id: "n2" } : null,
+  });
+  // Open the FIRST note through a real in-app action (the Notes list row click →
+  // `TabsService.openNote`) — a `page.goto` deep-link deliberately does NOT open a
+  // tab (matches real usage: only an in-app open action creates one), so opening
+  // via the list is what puts a first tab on the strip to compare against.
+  await page.goto("/notes");
+  await page.getByRole("button", { name: "My First Note" }).click();
+  await expect(page).toHaveURL(/\/notes\/n1$/);
+  await expect(page.locator(".tab-strip .tab-item")).toHaveCount(1);
+
+  // Switch to Preview to render the wikilink pill.
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  const pill = page.locator(".md-wikilink", { hasText: "Weekly plan" });
+  await expect(pill).toBeVisible();
+  await pill.click();
+
+  // Navigated to the resolved note AND registered as a SECOND tracked tab (the
+  // regression this fix closes — a raw router.navigate never added a tab).
+  await expect(page).toHaveURL(/\/notes\/n2$/);
+  await expect(page.locator(".tab-strip .tab-item")).toHaveCount(2);
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * Fix 2 — the slash-menu "Link to note" entry opens the SAME inline autocomplete
+ * as the raw `[[` keystroke trigger; picking a candidate inserts `[[Title]]` at
+ * the trigger position. Verifies BOTH trigger paths share one popover/codepath.
+ */
+test("slash menu 'Link to note' opens the autocomplete popover and inserts [[Title]] on pick", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    list_link_candidates: () => [
+      { kind: "note", id: "n2", title: "Weekly plan", snippet: "" },
+      { kind: "meeting", id: "m1", title: "Kickoff", snippet: "" },
+    ],
+  });
+  await page.goto("/notes/n1");
+
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+
+  // Move the caret to the end of a blank new line, then type `/`.
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("Enter");
+  await body.press("/");
+
+  const slashMenu = page.locator(".slash-menu");
+  await expect(slashMenu).toBeVisible();
+  await slashMenu.getByRole("option", { name: "Link to note" }).click();
+
+  // The link picker is now open (OPAQUE overlay, T3) with the mocked candidates.
+  const picker = page.locator("app-link-picker");
+  await expect(picker).toBeVisible();
+  await expect(picker.getByText("Weekly plan")).toBeVisible();
+  await expect(picker.getByText("Kickoff")).toBeVisible();
+
+  await picker.getByText("Weekly plan").click();
+
+  // The picker closes and the body now carries the wikilink (replacing the `[[` trigger).
+  await expect(picker).toHaveCount(0);
+  await expect(body).toHaveValue(/\[\[Weekly plan\]\]/);
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * Fix 2 (parity) — typing the raw `[[` keystroke ALSO opens the picker (not just
+ * the slash-menu entry), confirming the ONE shared trigger/component contract.
+ */
+test("typing [[ also opens the link-picker autocomplete", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    list_link_candidates: () => [
+      { kind: "note", id: "n2", title: "Weekly plan", snippet: "" },
+    ],
+  });
+  await page.goto("/notes/n1");
+
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("[");
+  await body.press("[");
+
+  const picker = page.locator("app-link-picker");
+  await expect(picker).toBeVisible();
+  await expect(picker.getByText("Weekly plan")).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6129,6 +6129,53 @@ pub fn resolve_wikilink(
     state.db.resolve_wikilink(&title, &unlocked)
 }
 
+/// Live keystroke-prefix candidates for the inline `[[` / slash-menu link-insertion autocomplete
+/// (note-editor Fix 2). Distinct from [`resolve_wikilink`] (exact-title resolve on Enter/click) and
+/// from `note_assistant_action`'s `find_related` (SELECTION+semantic retrieval — the wrong shape
+/// for filtering on a short, growing keystroke prefix): this is a lightweight, gated title-prefix
+/// scan, capped at `MAX_LINK_CANDIDATES` total rows across notes + meetings + (when joined) the
+/// Shared Brain. GATED exactly like every other content read: notes/meetings go through
+/// `Db::list_link_candidates_visible` (`visibility_clause` on both legs, same as `resolve_wikilink`);
+/// org items go through `search_org_brain_hits`, the SAME retrieval-only, membership+enabled-gated,
+/// zero-egress reader `find_related` already uses (never a provider/egress call). Reuses
+/// [`crate::storage::models::NoteCitation`] — the popover renders it exactly like a `find_related`
+/// citation row, and `kind == "org"` carries an org item id (never a local id), matching that
+/// contract verbatim.
+#[tauri::command]
+pub fn list_link_candidates(
+    state: State<'_, AppState>,
+    prefix: String,
+) -> Result<Vec<crate::storage::models::NoteCitation>, AppError> {
+    const MAX_LINK_CANDIDATES: i64 = 8;
+    let unlocked = unlocked_snapshot(state.inner())?;
+    let mut out = state
+        .db
+        .list_link_candidates_visible(&prefix, MAX_LINK_CANDIDATES, &unlocked)?;
+    if (out.len() as i64) < MAX_LINK_CANDIDATES {
+        let config = {
+            state
+                .config
+                .lock()
+                .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+                .clone()
+        };
+        let q = prefix.trim();
+        if !q.is_empty() && crate::tools::org_brain_available(&state.db, &config) {
+            let remaining = (MAX_LINK_CANDIDATES - out.len() as i64).max(0) as usize;
+            let org_hits = crate::tools::search_org_brain_hits(&state.db, &config, q)?;
+            for hit in org_hits.into_iter().take(remaining) {
+                out.push(crate::storage::models::NoteCitation {
+                    kind: "org".into(),
+                    id: hit.item_id,
+                    title: hit.title,
+                    snippet: hit.snippet,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Structured, GATED, egress-free person dossier for the `/people` detail pane. Unlike
 /// [`entity_dossier`] (which CLOUD-synthesizes a markdown String via the provider and discards the
 /// struct), this returns the STRUCTURED [`DossierData`](crate::summarize::dossier::DossierData) with

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,7 @@ pub fn run() {
             commands::get_entity_detail,
             commands::get_backlinks,
             commands::resolve_wikilink,
+            commands::list_link_candidates,
             commands::get_person_dossier,
             commands::list_people,
             commands::ask_vault,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -14,7 +14,8 @@ use crate::storage::models::{
     CorrectionRecord, DayCount,
     DocChunkHit, DocumentInfo, DocumentSummary, EntityDetail, EntityKind, EntityNeighbor, Folder,
     GraphData,
-    GraphEdge, GraphEntity, GraphNode, Meeting, MeetingActionSummary, MeetingStatus, NoteFolder,
+    GraphEdge, GraphEntity, GraphNode, Meeting, MeetingActionSummary, MeetingStatus, NoteCitation,
+    NoteFolder,
     NoteRecord, NoteSummary,
     OrgChunkHit, PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertySchemaField,
     PropertyValue, RecipeRecord, SavedView, SearchHit,
@@ -8512,6 +8513,113 @@ impl Db {
         Ok(None)
     }
 
+    /// Live keystroke-prefix title match over VISIBLE notes + meetings, for the inline `[[` /
+    /// slash-menu link-insertion autocomplete (distinct from [`resolve_wikilink`]'s exact-title
+    /// resolve and from `gather_note_enhance_citations`'s SELECTION+semantic retrieval — this is a
+    /// lightweight `LIKE prefix%` title scan, the right shape for filtering-as-you-type). GATED
+    /// identically to every other title/content read: `visibility_clause` on both legs, so a
+    /// sealed-and-not-session-unlocked note/meeting never appears as a candidate. An empty/blank
+    /// `prefix` returns the most-recently-updated visible notes+meetings (so the popover has
+    /// something to show the instant it opens, before the user has typed anything). Capped at
+    /// `limit` total rows across BOTH kinds, notes first (mirrors `resolve_wikilink`'s note-first
+    /// preference), newest-updated first within each kind.
+    pub fn list_link_candidates_visible(
+        &self,
+        prefix: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<NoteCitation>> {
+        let prefix = prefix.trim();
+        let mut out: Vec<NoteCitation> = Vec::new();
+
+        // Notes leg.
+        {
+            let conn = self.lock();
+            let visible = visibility_clause("f", unlocked);
+            let like_pred = if prefix.is_empty() {
+                String::new()
+            } else {
+                " AND COALESCE(NULLIF(TRIM(d.title), ''), d.name) LIKE ?2 ESCAPE '\\'".to_string()
+            };
+            let sql = format!(
+                "SELECT d.id, COALESCE(NULLIF(TRIM(d.title), ''), d.name)
+                   FROM documents d
+                   JOIN folders f ON f.id = d.folder_id
+                  WHERE d.kind = 'note' AND {visible}{like_pred}
+                  ORDER BY d.updated_at DESC, d.id ASC
+                  LIMIT ?1"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+            let map_row = |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
+                Ok((r.get(0)?, r.get(1)?))
+            };
+            let rows = if prefix.is_empty() {
+                stmt.query_map(rusqlite::params![limit], map_row)
+            } else {
+                let pat = format!("{}%", escape_like(prefix));
+                stmt.query_map(rusqlite::params![limit, pat], map_row)
+            }
+            .map_err(map_err)?;
+            for r in rows {
+                let (id, title) = r.map_err(map_err)?;
+                out.push(NoteCitation {
+                    kind: "note".into(),
+                    id,
+                    title,
+                    snippet: String::new(),
+                });
+            }
+        }
+
+        // Meetings leg (only if the notes leg hasn't already filled the cap).
+        if (out.len() as i64) < limit {
+            let remaining = limit - out.len() as i64;
+            let conn = self.lock();
+            let visible = visibility_clause("n", unlocked);
+            let like_pred = if prefix.is_empty() {
+                String::new()
+            } else {
+                " AND m.title LIKE ?2 ESCAPE '\\'".to_string()
+            };
+            let sql = format!(
+                "SELECT m.id, m.title
+                   FROM meetings m
+                  WHERE m.title IS NOT NULL AND TRIM(m.title) != ''{like_pred}
+                    AND (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                      OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+                  ORDER BY m.started_at DESC, m.id DESC
+                  LIMIT ?1"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+            let map_row = |r: &Row<'_>| -> rusqlite::Result<(String, Option<String>)> {
+                Ok((r.get(0)?, r.get(1)?))
+            };
+            let rows = if prefix.is_empty() {
+                stmt.query_map(rusqlite::params![remaining], map_row)
+            } else {
+                let pat = format!("{}%", escape_like(prefix));
+                stmt.query_map(rusqlite::params![remaining, pat], map_row)
+            }
+            .map_err(map_err)?;
+            for r in rows {
+                let (id, title) = r.map_err(map_err)?;
+                out.push(NoteCitation {
+                    kind: "meeting".into(),
+                    id,
+                    title: title.unwrap_or_else(|| "Meeting".into()),
+                    snippet: String::new(),
+                });
+            }
+        }
+        Ok(out)
+    }
+
     /// The latest visible note for a meeting (MCP `get_meeting`); `None` if the meeting's note
     /// is sealed-and-not-session-unlocked.
     pub fn get_note_if_visible(
@@ -13480,6 +13588,100 @@ mod tests {
             .expect("unlocked target resolves");
         assert_eq!(t.kind, SourceKind::Note);
         assert_eq!(t.id, "n-secret");
+    }
+
+    /// `list_link_candidates_visible` prefix-filters (case-insensitively) over notes + meetings,
+    /// notes-first, and an empty prefix returns everything up to the cap (recency order).
+    #[test]
+    fn list_link_candidates_prefix_filters_notes_and_meetings() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        db.insert_note("n-alpha", "f-open", "alpha", "Alpha Project", "body", 1_000)
+            .unwrap();
+        db.insert_note("n-alt", "f-open", "alt", "Alternate Plan", "body", 2_000)
+            .unwrap();
+        let mut beta = sample_meeting("m-beta", "2026-06-24T10:00:00Z");
+        beta.title = Some("Alpine Standup".to_string());
+        db.insert_meeting(&beta).unwrap();
+        note_for(&db, "m-beta", "claude_code", "beta note");
+        db.set_note_folder("m-beta", Some("f-open")).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+
+        // "Alp" matches "Alpha Project" (note) and "Alpine Standup" (meeting), not "Alternate Plan".
+        let hits = db
+            .list_link_candidates_visible("Alp", 10, &nothing)
+            .unwrap();
+        let titles: Vec<&str> = hits.iter().map(|c| c.title.as_str()).collect();
+        assert!(titles.contains(&"Alpha Project"));
+        assert!(titles.contains(&"Alpine Standup"));
+        assert!(!titles.contains(&"Alternate Plan"));
+        // Notes leg is queried first (mirrors `resolve_wikilink`'s note-first preference).
+        assert_eq!(hits[0].kind, "note");
+
+        // Case-insensitive (SQLite LIKE is ASCII-case-insensitive by default, same as the
+        // existing `search_snippet`/path LIKE readers in this file).
+        let ci = db
+            .list_link_candidates_visible("alp", 10, &nothing)
+            .unwrap();
+        assert_eq!(ci.len(), hits.len());
+
+        // Empty prefix returns everything (capped), not nothing.
+        let all = db
+            .list_link_candidates_visible("", 10, &nothing)
+            .unwrap();
+        assert!(all.len() >= 3, "empty prefix should list existing candidates");
+
+        // A cap of 1 returns exactly 1 row (notes leg fills it before the meetings leg runs).
+        let capped = db
+            .list_link_candidates_visible("Alp", 1, &nothing)
+            .unwrap();
+        assert_eq!(capped.len(), 1);
+    }
+
+    /// GATED: a sealed-and-not-session-unlocked note/meeting never appears as a link candidate,
+    /// even when its title matches the prefix exactly — session-unlock reverses it. RED against an
+    /// ungated prefix scan (this is the same discipline `resolve_wikilink_hides_sealed_target`
+    /// enforces for the exact-title resolver).
+    #[test]
+    fn list_link_candidates_hides_sealed_sources() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        db.insert_note(
+            "n-secret",
+            "f-locked",
+            "secret",
+            "Secret Roadmap",
+            "classified",
+            1_000,
+        )
+        .unwrap();
+        let mut sealed_meeting = sample_meeting("m-secret", "2026-06-24T10:00:00Z");
+        sealed_meeting.title = Some("Secret Standup".to_string());
+        db.insert_meeting(&sealed_meeting).unwrap();
+        note_for(&db, "m-secret", "claude_code", "secret meeting note");
+        db.set_note_folder("m-secret", Some("f-locked")).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let hidden = db
+            .list_link_candidates_visible("Secret", 10, &nothing)
+            .unwrap();
+        assert!(
+            hidden.is_empty(),
+            "sealed-and-not-unlocked note/meeting must not be a link candidate"
+        );
+
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let visible = db
+            .list_link_candidates_visible("Secret", 10, &unlocked)
+            .unwrap();
+        assert_eq!(visible.len(), 2, "unlocking reveals both the note and the meeting");
     }
 
     /// FAIL-CLOSED: a correction row with a NULL `meeting_id` (legacy/unattributed) is never returned

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -57,6 +57,7 @@ import type {
   NoteFolder,
   NoteAssistRequest,
   NoteAssistResult,
+  NoteCitation,
   PropertySchemaField,
   TypedNoteRow,
   OrganizePlan,
@@ -1085,6 +1086,20 @@ export class IpcService {
    */
   resolveWikilink(title: string): Promise<WikiTarget | null> {
     return invoke<WikiTarget | null>("resolve_wikilink", { title });
+  }
+
+  /**
+   * Live keystroke-prefix candidates for the inline `[[` / slash-menu link-insertion
+   * autocomplete — a lightweight, GATED title-prefix scan over VISIBLE notes + meetings +
+   * (when joined) the Shared Brain, capped server-side. Distinct from {@link resolveWikilink}
+   * (exact-title resolve on Enter/click) and from `noteAssistantAction`'s `find_related`
+   * (SELECTION+semantic retrieval — the wrong shape for filtering on a short, growing
+   * prefix). Reuses the {@link NoteCitation} shape so the popover renders it exactly like a
+   * `find_related` row. An empty/blank `prefix` returns the most-recently-updated visible
+   * candidates (so the popover has something to show the instant it opens).
+   */
+  listLinkCandidates(prefix: string): Promise<NoteCitation[]> {
+    return invoke<NoteCitation[]>("list_link_candidates", { prefix });
   }
 
   /**

--- a/src/app/features/notes/link-picker/link-picker.component.html
+++ b/src/app/features/notes/link-picker/link-picker.component.html
@@ -1,0 +1,34 @@
+<!-- OPAQUE floating popover (T3): --surface-overlay + backdrop-filter:none.
+     Positioned in JS (afterNextRender) at the caret's anchor rect. Re-positions
+     on any scroll/resize via the shared directive (DestroyRef-cleaned listeners).
+     PRESENTATIONAL: the caret stays in the editor textarea (Obsidian parity) —
+     this renders the live candidate list only; the host owns query + keyboard nav. -->
+<div
+  #popover
+  class="link-pop"
+  appRepositionOnScroll
+  (reposition)="reposition()"
+  (mousedown)="$event.preventDefault()"
+  role="listbox"
+  aria-label="Link to note"
+>
+  @if (candidates().length > 0) {
+    @for (c of candidates(); track c.kind + c.id; let i = $index) {
+      <button
+        type="button"
+        class="link-pop-row"
+        role="option"
+        [class.is-active]="i === activeIndex()"
+        [attr.aria-selected]="i === activeIndex()"
+        (click)="pick(c)"
+      >
+        <span class="link-pop-kind">{{ c.kind }}</span>
+        <span class="link-pop-title">{{ c.title }}</span>
+      </button>
+    }
+  } @else if (loading()) {
+    <p class="link-pop-empty">Searching…</p>
+  } @else {
+    <p class="link-pop-empty">No matches. Keep typing to create a new note.</p>
+  }
+</div>

--- a/src/app/features/notes/link-picker/link-picker.component.scss
+++ b/src/app/features/notes/link-picker/link-picker.component.scss
@@ -1,0 +1,72 @@
+/* The link-insertion autocomplete floats OVER the editor body → OPAQUE overlay
+   (T3): --surface-overlay, --border-strong, --shadow-lg, backdrop-filter:none.
+   Never the frosted .card. Positioned in JS (top/left set from the caret rect). */
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none; /* only the popover box itself is interactive */
+}
+
+.link-pop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 280px;
+  max-width: calc(100vw - 2 * var(--space-3));
+  max-height: 240px;
+  overflow-y: auto;
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-1);
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+.link-pop-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+}
+.link-pop-row:hover,
+.link-pop-row.is-active {
+  background: var(--surface-hover);
+}
+.link-pop-kind {
+  flex: none;
+  font-size: 0.63rem;
+  font-weight: 660;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.link-pop-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.link-pop-empty {
+  margin: 0;
+  padding: var(--space-3) var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  text-align: center;
+}

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -1,0 +1,167 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { NoteCitation } from "../../../core/models";
+import { DebounceService } from "../../../services/debounce.service";
+import { RepositionOnScrollDirective } from "../note-brain-popover/reposition-on-scroll.directive";
+
+/** How long to wait after the last keystroke before re-querying the backend. */
+const QUERY_DEBOUNCE_MS = 150;
+/** The debounce-service key — only one picker is ever open at a time. */
+const DEBOUNCE_KEY = "link-picker-query";
+
+/**
+ * The inline `[[` / slash-menu "Link to note" autocomplete (note-editor Fix 2) —
+ * an Obsidian-style fuzzy-filterable popover of candidate note/meeting/org titles,
+ * anchored at the caret. Both trigger paths (typing `[[` and picking the slash-menu
+ * "Link to note" entry) share this ONE component, per the task's parity requirement.
+ *
+ * PURE PRESENTATIONAL + CONTROLLED — like Obsidian, the caret STAYS in the editor
+ * textarea while this is open (no focus steal): the HOST owns `query()` (derived
+ * from the text typed since the trigger) and `activeIndex()` (driven by the SAME
+ * textarea keydown handler that already runs the slash menu's ↑/↓/Enter/Esc), and
+ * this component only renders the live candidate list + does the debounced fetch.
+ * `NoteEditorComponent` owns the actual textarea splice on `picked` (this stays a
+ * dumb overlay, mirroring {@link import('../note-selection-toolbar/note-selection-toolbar.component').NoteSelectionToolbarComponent}).
+ *
+ * Live-filters via {@link IpcService.listLinkCandidates} (debounced through the
+ * sanctioned {@link DebounceService} — rule §5, never a bare `setTimeout`), with a
+ * stale-result guard (T1 discipline: an effect-orchestrated async fetch keyed on
+ * `query()`, dropping a late reply for a superseded query). The resolved
+ * `candidates()` is re-exposed via `candidatesChange` so the host's keyboard
+ * handler can navigate/pick without duplicating the fetch.
+ *
+ * OPAQUE overlay (T3): `--surface-overlay`, `--border-strong`, `--shadow-lg`,
+ * `backdrop-filter:none` — never the frosted `.card`, since this floats over the
+ * editor body. Positioned via `afterNextRender({injector})` at the caret rect the
+ * host supplies (no `setTimeout`/`rAF`), re-positioned on scroll/resize via the
+ * existing {@link RepositionOnScrollDirective}.
+ */
+@Component({
+  selector: "app-link-picker",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RepositionOnScrollDirective],
+  templateUrl: "./link-picker.component.html",
+  styleUrl: "./link-picker.component.scss",
+})
+export class LinkPickerComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly debounce = inject(DebounceService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** The caret's viewport anchor rect — a NEW object re-positions the popover. */
+  readonly anchorRect = input.required<{
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+  }>();
+  /** The live filter text, owned by the host (the text typed since the trigger). */
+  readonly query = input<string>("");
+  /** Which row is keyboard-highlighted, owned by the host. */
+  readonly activeIndex = input<number>(0);
+
+  /** A candidate was picked (click) — the host inserts `[[title]]` at the trigger position. */
+  readonly picked = output<NoteCitation>();
+  /** The resolved candidate list for the CURRENT query — the host's ↑/↓/Enter act on this. */
+  readonly candidatesChange = output<NoteCitation[]>();
+
+  /** The live candidate rows for the current query. */
+  readonly candidates = signal<NoteCitation[]>([]);
+  /** True while the (debounced) fetch for the CURRENT query is in flight. */
+  readonly loading = computed(() => this._loading());
+  private readonly _loading = signal(false);
+
+  private readonly popoverEl = viewChild<ElementRef<HTMLDivElement>>("popover");
+
+  /** Monotonic request token — a late reply for a superseded query is dropped (T1 stale-guard). */
+  private requestSeq = 0;
+
+  constructor() {
+    // Fetch on every query change (debounced) — a legitimate signal-writing effect
+    // (T1): async IPC orchestration keyed on the `query` INPUT, with a stale guard.
+    effect(() => {
+      const q = this.query();
+      this.debounce.schedule(
+        DEBOUNCE_KEY,
+        () => void this.fetch(q),
+        QUERY_DEBOUNCE_MS,
+      );
+    });
+    // Re-position whenever the anchor rect changes (a fresh caret position).
+    effect(() => {
+      this.anchorRect(); // track
+      this.reposition();
+    });
+    this.destroyRef.onDestroy(() => this.debounce.cancel(DEBOUNCE_KEY));
+  }
+
+  private async fetch(q: string): Promise<void> {
+    const seq = ++this.requestSeq;
+    this._loading.set(true);
+    try {
+      const rows = await this.ipc.listLinkCandidates(q);
+      if (seq !== this.requestSeq) {
+        return; // superseded by a newer query.
+      }
+      this.candidates.set(rows);
+      this.candidatesChange.emit(rows);
+    } catch {
+      if (seq === this.requestSeq) {
+        this.candidates.set([]);
+        this.candidatesChange.emit([]);
+      }
+    } finally {
+      if (seq === this.requestSeq) {
+        this._loading.set(false);
+      }
+    }
+  }
+
+  pick(candidate: NoteCitation): void {
+    this.picked.emit(candidate);
+  }
+
+  reposition(): void {
+    afterNextRender(
+      () => {
+        const el = this.popoverEl()?.nativeElement;
+        if (!el) {
+          return;
+        }
+        const rect = this.anchorRect();
+        const width = el.offsetWidth || 300;
+        const height = el.offsetHeight;
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+
+        let left = rect.left;
+        left = Math.max(8, Math.min(left, vw - width - 8));
+
+        // Prefer BELOW the caret; flip above when there isn't room below.
+        let top = rect.bottom + 4;
+        if (top + height > vh - 8) {
+          top = Math.max(8, rect.top - height - 4);
+        }
+
+        el.style.left = `${Math.round(left)}px`;
+        el.style.top = `${Math.round(top)}px`;
+      },
+      { injector: this.injector },
+    );
+  }
+}

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
@@ -315,27 +315,40 @@
               </div>
             }
 
-            <!-- info — read-only. `find_related` is a DISCOVERY aid (the citations ARE the payload —
-                 tap to open a source; nothing to insert). `fact_check`/`ask` produce a real answer
-                 you can copy or insert into the note. -->
+            <!-- info — read-only. `find_related` is an ACTIONABLE discovery aid: each row's
+                 PRIMARY action is "Insert link" (drops a [[Title]] wikilink into the note at
+                 the caret — the same wikilink text the link-picker/toolbar op builds), with
+                 "Open" kept as a secondary action (2026-07-15: this used to be a single passive
+                 "tap to open" row — direct user feedback called that confusing/low-value).
+                 `fact_check`/`ask` produce a real answer you can copy or insert into the note. -->
             @case ("info") {
               @if (res.action === "find_related") {
                 @if (res.citations.length > 0) {
                   <p class="pop-info-lead">{{ res.suggestion }}</p>
-                  <div class="pop-cites" aria-label="Related sources">
+                  <ul class="pop-cite-rows" aria-label="Related sources">
                     @for (cite of res.citations; track cite.id) {
-                      <button
-                        type="button"
-                        class="pop-cite"
-                        (click)="openCitation(cite)"
-                        [attr.title]="cite.snippet"
-                      >
+                      <li class="pop-cite-row" [attr.title]="cite.snippet">
                         <span class="pop-cite-kind">{{ cite.kind }}</span>
                         <span class="pop-cite-title">{{ cite.title }}</span>
-                      </button>
+                        <span class="pop-cite-actions">
+                          <button
+                            type="button"
+                            class="btn btn-primary pop-cite-btn"
+                            (click)="insertLinkFor(cite)"
+                          >
+                            Insert link
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-ghost pop-cite-btn"
+                            (click)="openCitation(cite)"
+                          >
+                            Open
+                          </button>
+                        </span>
+                      </li>
                     }
-                  </div>
-                  <p class="pop-hint">Tap a source to open it.</p>
+                  </ul>
                 } @else {
                   <div class="pop-info-answer">
                     Nothing related found in your brain yet.

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
@@ -517,6 +517,42 @@
   max-width: 180px;
 }
 
+/* --- find_related ACTIONABLE rows (Fix 3: Insert link primary + Open secondary,
+   replacing the old passive "tap the chip to open" pill) --- */
+.pop-cite-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.pop-cite-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-hover);
+}
+.pop-cite-row .pop-cite-title {
+  flex: 1;
+  min-width: 0;
+  max-width: none;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+}
+.pop-cite-actions {
+  display: flex;
+  flex: none;
+  gap: var(--space-1);
+}
+.pop-cite-btn {
+  padding: 3px var(--space-2);
+  font-size: 0.72rem;
+}
+
 .pop-redacted {
   margin: 0;
   font-size: 0.72rem;

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -50,16 +50,20 @@ export interface PopoverSelection {
 /**
  * One accepted assistant outcome, applied by the editor. Discriminated by `kind`
  * so the editor branches without re-deriving intent from the action:
- * - `replace` — replace the selection with `suggestion`.
- * - `insert`  — append `suggestion` after the selection (additive; also "Insert as note").
- * - `copy`    — copy `text` to the clipboard (draft follow-up / an info answer).
- * - `spinoff` — create a NEW note from `title` + `body` and open it.
+ * - `replace`    — replace the selection with `suggestion`.
+ * - `insert`     — append `suggestion` after the selection (additive; also "Insert as note").
+ * - `copy`       — copy `text` to the clipboard (draft follow-up / an info answer).
+ * - `spinoff`    — create a NEW note from `title` + `body` and open it.
+ * - `insertLink` — insert a `[[title]]` wikilink after the selection (Fix 3: the
+ *                  "Insert link" action on a `find_related` citation row, reusing
+ *                  the SAME wikilink text the link-picker/toolbar op builds).
  */
 export type AcceptedEdit =
   | { kind: "replace"; suggestion: string }
   | { kind: "insert"; suggestion: string }
   | { kind: "copy"; text: string }
-  | { kind: "spinoff"; title: string; body: string };
+  | { kind: "spinoff"; title: string; body: string }
+  | { kind: "insertLink"; title: string };
 
 /** One step in the animated progress tracker (mirrors the Ask trace-chip language). */
 interface FlowStep {
@@ -513,6 +517,18 @@ export class NoteBrainPopoverComponent {
       return;
     }
     void this.router.navigate(["/graph", cite.id]);
+  }
+
+  /**
+   * Insert a `[[Title]]` wikilink to this citation's source, then dismiss the
+   * popover (Fix 3 — the "Insert link" PRIMARY action alongside "Open" on every
+   * `find_related` citation row: reuses the SAME gated citation data, only the
+   * interaction changes). The editor applies it exactly like an `insert` outcome
+   * (appended after the selection), so this needs no new textarea-splice logic.
+   */
+  insertLinkFor(cite: NoteCitation): void {
+    this.accepted.emit({ kind: "insertLink", title: cite.title });
+    this.dismiss.emit();
   }
 
   // ── Positioning + teardown ───────────────────────────────────────────────

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -566,6 +566,21 @@
     }
   }
 
+  <!-- ===== Link picker (Fix 2) — Obsidian-style `[[` / "Link to note" autocomplete.
+       Opened by the raw `[[` keystroke OR the slash-menu "Link to note" entry (ONE
+       shared trigger signal, ONE component). Caret stays in the textarea (Obsidian
+       parity); this component is a pure presentational overlay, positioned at the
+       caret's viewport rect. ===== -->
+  @if (linkPickerTrigger(); as trigger) {
+    <app-link-picker
+      [anchorRect]="trigger.rect"
+      [query]="linkPickerQuery()"
+      [activeIndex]="linkPickerActiveIndex()"
+      (picked)="pickLinkCandidate($event)"
+      (candidatesChange)="onLinkPickerCandidates($event)"
+    />
+  }
+
   <!-- ===== Share modal (WP6) — link-share this note, opaque overlay (T3).
        Never shown for a locked note (share() no-ops + button is hidden). ===== -->
   @if (shareOpen()) {

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -25,6 +25,7 @@ import type {
   AppConfigDto,
   BacklinkSource,
   FolderNode,
+  NoteCitation,
   NoteDoc,
   NoteFolder,
 } from "../../../core/models";
@@ -34,6 +35,7 @@ import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
 import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { LinkPickerComponent } from "../link-picker/link-picker.component";
 import { NOTE_ASSIST_CATALOG } from "../note-brain-popover/note-assist-catalog";
 import {
   NoteBrainPopoverComponent,
@@ -72,12 +74,16 @@ export type FormatOp =
   | "wikilink"
   | "divider";
 
-/** One slash-menu block insertion. */
+/** One slash-menu block insertion, OR the special "Link to note" entry (no `snippet`). */
 interface SlashItem {
   id: string;
   label: string;
-  /** The markdown snippet inserted at the caret (with `$` marking the caret). */
-  snippet: string;
+  /**
+   * The markdown snippet inserted at the caret (with `$` marking the caret).
+   * Absent for `linkToNote` — that entry opens the link picker instead of
+   * inserting a static snippet (`pickSlash` branches on `id === "linkToNote"`).
+   */
+  snippet?: string;
 }
 
 const SLASH_ITEMS: readonly SlashItem[] = [
@@ -96,6 +102,10 @@ const SLASH_ITEMS: readonly SlashItem[] = [
   },
   { id: "divider", label: "Divider", snippet: "---\n$" },
   { id: "callout", label: "Callout", snippet: "> [!note]\n> $" },
+  // No `snippet` — opens the inline link-picker popover (Obsidian-style `[[` autocomplete)
+  // instead of inserting static markdown. Reuses the SAME picker as the raw `[[` keystroke
+  // trigger (one shared component/service, per the parity requirement).
+  { id: "linkToNote", label: "Link to note" },
 ];
 
 /** Up to this many chars of before/after context ship with an assistant request. */
@@ -142,6 +152,7 @@ const FULL_WIDTH_KEY = "murmur-note-full-width";
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     BacklinksComponent,
+    LinkPickerComponent,
     MarkdownComponent,
     NoteBrainPopoverComponent,
     NoteSelectionToolbarComponent,
@@ -252,6 +263,42 @@ export class NoteEditorComponent {
   // --- Slash menu ----------------------------------------------------------
   readonly slashOpen = signal(false);
   readonly slashIndex = signal(0);
+
+  // --- Link picker (Obsidian-style `[[` autocomplete, Fix 2) ----------------
+  /**
+   * The open link-picker's trigger span (`start`..caret in the body text to be
+   * REPLACED with `[[Title]]` on pick) + the caret's viewport anchor rect for
+   * positioning. `null` when the picker is closed. Set by BOTH trigger paths —
+   * the raw `[[` keystroke ({@link maybeOpenLinkPicker}) and the slash-menu
+   * "Link to note" entry ({@link pickSlash}) — so there is exactly ONE picker
+   * instance/codepath regardless of how it was opened (parity requirement).
+   */
+  readonly linkPickerTrigger = signal<{
+    start: number;
+    rect: { top: number; left: number; right: number; bottom: number };
+  } | null>(null);
+  /** Keyboard-highlighted row in the open picker (↑/↓, mirrors {@link slashIndex}). */
+  readonly linkPickerActiveIndex = signal(0);
+  /** The picker's live candidate list — updated via its `candidatesChange` output so
+   *  this component's ↑/↓/Enter handler (shared with the slash menu) can act on it
+   *  without duplicating the fetch. */
+  readonly linkPickerCandidates = signal<NoteCitation[]>([]);
+  /**
+   * The live filter text derived from what's been typed since the trigger.
+   * Tracks `body()` (a signal, so it re-runs on every keystroke) rather than
+   * reading `el.value` directly — a `computed()` only re-runs when a SIGNAL
+   * dependency changes, and raw DOM reads aren't one.
+   */
+  readonly linkPickerQuery = computed(() => {
+    const trigger = this.linkPickerTrigger();
+    const body = this.body();
+    const el = this.bodyArea()?.nativeElement;
+    if (!trigger || !el) {
+      return "";
+    }
+    const caret = Math.max(trigger.start, el.selectionStart);
+    return body.slice(trigger.start, caret);
+  });
 
   // --- Selection toolbar + Brain popover -----------------------------------
   /**
@@ -664,6 +711,7 @@ export class NoteEditorComponent {
         exportedPath: null,
       });
       this.clearSelection();
+      this.closeLinkPicker();
     }
     const seq = ++this.requestSeq;
     void this.fetchNote(doc.id, seq);
@@ -788,6 +836,7 @@ export class NoteEditorComponent {
     this.body.set(el.value);
     this.autoGrow();
     this.maybeOpenSlash(el);
+    this.maybeOpenLinkPicker(el);
     this.scheduleSave();
   }
 
@@ -1136,8 +1185,10 @@ export class NoteEditorComponent {
   setPreview(on: boolean): void {
     this.preview.set(on);
     if (on) {
-      // No textarea to select in Preview — drop the floating bubble / Brain popover.
+      // No textarea to select in Preview — drop the floating bubble / Brain popover
+      // and the link picker (its trigger position lives in the textarea).
       this.clearSelection();
+      this.closeLinkPicker();
     }
     // Switching to Preview is a natural "I'm reviewing" pause: run the deferred FULL
     // save (re-index + vault export) once if there are unindexed edits, so the note
@@ -1195,7 +1246,7 @@ export class NoteEditorComponent {
         caretEnd = caretStart + (selected || "text").length;
         break;
       case "wikilink":
-        replacement = `[[${selected || "Note"}]]`;
+        replacement = this.wikilinkText(selected || "Note");
         caretStart = start + 2;
         caretEnd = caretStart + (selected || "Note").length;
         break;
@@ -1226,6 +1277,15 @@ export class NoteEditorComponent {
     }
 
     this.replaceRange(el, start, end, replacement, caretStart, caretEnd);
+  }
+
+  /**
+   * The `[[Title]]` wikilink markdown for `title` — the ONE place this string is
+   * built, shared by the `wikilink` toolbar op (wraps a selection) and the link
+   * picker (Fix 2: replaces the `[[` trigger + typed query with a picked title).
+   */
+  private wikilinkText(title: string): string {
+    return `[[${title}]]`;
   }
 
   /**
@@ -1295,6 +1355,15 @@ export class NoteEditorComponent {
     const el = this.bodyArea()?.nativeElement;
     if (!el) {
       return;
+    }
+
+    // The link picker takes priority over everything else when open (mirrors
+    // the slash menu's own priority below) — Backspace back past the trigger
+    // closes it (handled in onBodyInput once the trigger text is gone).
+    if (this.linkPickerTrigger()) {
+      if (this.handleLinkPickerKey(event)) {
+        return;
+      }
     }
 
     // Slash menu navigation takes priority when open.
@@ -1436,7 +1505,11 @@ export class NoteEditorComponent {
     return false;
   }
 
-  /** Insert a slash-menu block, replacing the `/` trigger, caret at the `$`. */
+  /**
+   * Insert a slash-menu block, replacing the `/` trigger, caret at the `$` — OR,
+   * for the `linkToNote` entry (no `snippet`), open the SAME link picker the raw
+   * `[[` keystroke opens, anchored where the `/` trigger was (parity requirement).
+   */
   pickSlash(item: SlashItem): void {
     const el = this.bodyArea()?.nativeElement;
     if (!el) {
@@ -1445,12 +1518,131 @@ export class NoteEditorComponent {
     const value = el.value;
     const pos = el.selectionStart;
     const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+    this.slashOpen.set(false);
+    if (item.id === "linkToNote" || item.snippet === undefined) {
+      // Replace the `/` trigger with `[[` (the natural Obsidian trigger text),
+      // then open the picker anchored right after it.
+      const openBrackets = "[[";
+      this.replaceRange(
+        el,
+        lineStart,
+        pos,
+        openBrackets,
+        lineStart + openBrackets.length,
+        lineStart + openBrackets.length,
+      );
+      this.openLinkPickerAt(el, lineStart + openBrackets.length);
+      return;
+    }
     // Replace from the `/` (line start) through the caret with the snippet.
     const caretMarker = item.snippet.indexOf("$");
     const snippet = item.snippet.replace("$", "");
     const caret = lineStart + (caretMarker === -1 ? snippet.length : caretMarker);
-    this.slashOpen.set(false);
     this.replaceRange(el, lineStart, pos, snippet, caret, caret);
+  }
+
+  // ── Link picker (Obsidian-style `[[` autocomplete, Fix 2) ────────────────
+
+  /**
+   * Open the link picker when the two characters immediately before the caret
+   * are `[[` and it isn't already open — the raw-keystroke trigger path (the
+   * slash-menu path opens it directly via {@link openLinkPickerAt}). Closes it
+   * when the trigger text no longer starts with `[[` right before the caret
+   * (e.g. Backspace past it, or the caret moved away) or a newline/`]]` was typed.
+   */
+  private maybeOpenLinkPicker(el: HTMLTextAreaElement): void {
+    const trigger = this.linkPickerTrigger();
+    const pos = el.selectionStart;
+    const value = el.value;
+    if (!trigger) {
+      if (pos >= 2 && value.slice(pos - 2, pos) === "[[") {
+        this.openLinkPickerAt(el, pos);
+      }
+      return;
+    }
+    // Already open — close it if the caret backed up before the trigger start,
+    // a newline was typed since, or the query just got a closing `]]`.
+    const from = trigger.start;
+    if (
+      pos < from ||
+      value.slice(from - 2, from) !== "[[" ||
+      value.slice(from, pos).includes("\n") ||
+      value.slice(from, pos).includes("]]")
+    ) {
+      this.closeLinkPicker();
+    }
+  }
+
+  /** Open the picker with its trigger anchored at `start` (the text position right after `[[`). */
+  private openLinkPickerAt(el: HTMLTextAreaElement, start: number): void {
+    const rect = this.selectionRect(el, start, start);
+    if (!rect) {
+      return;
+    }
+    this.linkPickerActiveIndex.set(0);
+    this.linkPickerCandidates.set([]);
+    this.linkPickerTrigger.set({ start, rect });
+  }
+
+  /** ↑/↓/Enter/Esc while the picker is open. Returns true when consumed. */
+  private handleLinkPickerKey(event: KeyboardEvent): boolean {
+    const rows = this.linkPickerCandidates();
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.linkPickerActiveIndex.update((i) => (i + 1) % rows.length);
+        }
+        return true;
+      case "ArrowUp":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.linkPickerActiveIndex.update((i) => (i - 1 + rows.length) % rows.length);
+        }
+        return true;
+      case "Enter":
+      case "Tab":
+        if (rows.length > 0) {
+          event.preventDefault();
+          this.pickLinkCandidate(rows[this.linkPickerActiveIndex()]);
+        }
+        return true;
+      case "Escape":
+        event.preventDefault();
+        this.closeLinkPicker();
+        return true;
+    }
+    return false;
+  }
+
+  /** The picker's resolved candidates for the current query (drives keyboard nav). */
+  onLinkPickerCandidates(rows: NoteCitation[]): void {
+    this.linkPickerCandidates.set(rows);
+  }
+
+  /**
+   * A candidate was picked (click or Enter): replace the trigger span (`[[` +
+   * whatever was typed since) with the wikilink text via the SAME `wikilink`
+   * formatting op `format("wikilink")` builds (Fix 2 reuses it, never duplicates
+   * the `[[Title]]` construction), then collapse the caret after it.
+   */
+  pickLinkCandidate(candidate: NoteCitation): void {
+    const el = this.bodyArea()?.nativeElement;
+    const trigger = this.linkPickerTrigger();
+    if (!el || !trigger) {
+      return;
+    }
+    const link = this.wikilinkText(candidate.title);
+    const from = trigger.start - 2; // include the `[[` itself.
+    const to = el.selectionStart;
+    this.closeLinkPicker();
+    this.replaceRange(el, from, to, link, from + link.length, from + link.length);
+  }
+
+  /** Close the picker without inserting anything (Esc / outside click / caret moved away). */
+  closeLinkPicker(): void {
+    this.linkPickerTrigger.set(null);
+    this.linkPickerCandidates.set([]);
   }
 
   // ── Header: Move / ⋯ / Share / Export / Delete ──────────────────────────
@@ -1730,7 +1922,13 @@ export class NoteEditorComponent {
       }
       end = start + sel.text.length;
     }
-    if (edit.kind === "insert") {
+    if (edit.kind === "insertLink") {
+      // Fix 3 — insert a `[[Title]]` wikilink after the selection, on its own
+      // paragraph (same additive placement as `insert`), via the ONE shared
+      // wikilink-text builder (never re-duplicated).
+      const link = `\n\n${this.wikilinkText(edit.title)}\n`;
+      this.replaceRange(el, end, end, link, end + link.length, end + link.length);
+    } else if (edit.kind === "insert") {
       // Insert the additive passage after the selection on its own paragraph.
       const insert = `\n\n${edit.suggestion.trim()}\n`;
       this.replaceRange(el, end, end, insert, end + insert.length, end + insert.length);

--- a/src/app/shared/markdown/markdown.component.ts
+++ b/src/app/shared/markdown/markdown.component.ts
@@ -7,10 +7,10 @@ import {
   inject,
   input,
 } from "@angular/core";
-import { Router } from "@angular/router";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { IpcService } from "../../core/ipc.service";
+import { TabsService } from "../../core/tabs.service";
 import { ToastService } from "../../services/toast.service";
 
 /**
@@ -25,11 +25,23 @@ import { ToastService } from "../../services/toast.service";
  *   `<iframe>`/`<object>`/`<embed>`, and any other XSS vector BEFORE the string ever reaches the
  *   DOM. This is the primary sanitizer; we never call `bypassSecurityTrustHtml`, so Angular's
  *   built-in `[innerHTML]` sanitizer also runs as a second, redundant pass.
- * - `[[Wikilinks]]` become accent chips carrying a `data-wikilink` attribute (title HTML-escaped
- *   first, then DOMPurify keeps the `<span class="md-wikilink" data-wikilink=…>` because `span`/
- *   `class` are default-allowed and `data-wikilink`/`role`/`tabindex` are added to the allow-list).
+ * - `[[Wikilinks]]` become accent chips (`<span class="md-wikilink" role="link" tabindex="0">`).
+ *   ROOT-CAUSE FIX (2026-07-15, found while fixing the "clicking a wikilink pill does nothing"
+ *   bug): the chip used to carry the title in a `data-wikilink="…"` attribute, but Angular's OWN
+ *   `[innerHTML]` sanitizer (the second pass above) SILENTLY STRIPS unrecognized `data-*`
+ *   attributes even when DOMPurify's `ADD_ATTR` allow-lists them — DOMPurify only gates what
+ *   REACHES `[innerHTML]`, it doesn't control what Angular's sanitizer then does with it. So
+ *   `chip.getAttribute("data-wikilink")` always read `null` and the click silently no-opped —
+ *   independent of (and deeper than) the separate `router.navigate`-vs-`TabsService` bug fixed
+ *   alongside it. The fix: read the title from the chip's own `textContent` instead (the chip's
+ *   visible text ALREADY IS the escaped title — no extra attribute needed, so there's nothing
+ *   left for a sanitizer to strip).
  *   A host click/Enter handler resolves the title to a VISIBLE note/meeting (gated server-side)
- *   and navigates, or offers to create the note — so the chips are clickable like Obsidian links.
+ *   and opens it through {@link TabsService} (not a raw `router.navigate` — same sibling-function
+ *   fix as `NoteBrainPopoverComponent.openCitation`, 2026-07-12: a plain navigate never registers
+ *   the resulting view with the tab strip, so a wikilink click opened an orphaned, untracked view
+ *   and looked like a no-op), or offers to create the note — so the chips are clickable like
+ *   Obsidian links.
  * - A stray YAML front-matter block (some models leak one) is stripped defensively.
  *
  * Encapsulation is None with a `.md-body` scope so the styles reach the injected HTML.
@@ -46,8 +58,8 @@ import { ToastService } from "../../services/toast.service";
   },
 })
 export class MarkdownComponent {
-  private readonly router = inject(Router);
   private readonly ipc = inject(IpcService);
+  private readonly tabsService = inject(TabsService);
   private readonly toast = inject(ToastService);
 
   readonly markdown = input<string>("");
@@ -65,7 +77,7 @@ export class MarkdownComponent {
       return;
     }
     ev.preventDefault();
-    const title = chip.getAttribute("data-wikilink");
+    const title = this.chipTitle(chip);
     if (title) {
       void this.openWikilink(title);
     }
@@ -78,20 +90,34 @@ export class MarkdownComponent {
       return;
     }
     ev.preventDefault();
-    const title = chip.getAttribute("data-wikilink");
+    const title = this.chipTitle(chip);
     if (title) {
       void this.openWikilink(title);
     }
+  }
+
+  /**
+   * The wikilink title for a `.md-wikilink` chip — its OWN `textContent`, not a
+   * `data-*` attribute (see the class doc: Angular's `[innerHTML]` sanitizer
+   * silently strips those regardless of DOMPurify's allow-list, which is what
+   * made the chip look permanently unclickable).
+   */
+  private chipTitle(chip: HTMLElement): string | null {
+    const title = chip.textContent?.trim();
+    return title ? title : null;
   }
 
   private async openWikilink(title: string): Promise<void> {
     try {
       const target = await this.ipc.resolveWikilink(title);
       if (target) {
-        void this.router.navigate([
-          target.kind === "meeting" ? "/meeting" : "/notes",
-          target.id,
-        ]);
+        // Route through TabsService (not a raw `router.navigate`) so the opened
+        // note/meeting is a TRACKED TAB, matching every other open path in the app.
+        if (target.kind === "meeting") {
+          await this.tabsService.openMeeting(target.id, title);
+        } else {
+          await this.tabsService.openNote(target.id, title);
+        }
         return;
       }
       // No such note/meeting (or it is locked) — offer to create it, Obsidian-style.
@@ -107,7 +133,7 @@ export class MarkdownComponent {
   private async createAndOpen(title: string): Promise<void> {
     try {
       const id = await this.ipc.createNote(null, title);
-      void this.router.navigate(["/notes", id]);
+      await this.tabsService.openNote(id, title);
     } catch {
       this.toast.danger(`Nie udało się utworzyć „${title}"`);
     }
@@ -116,19 +142,21 @@ export class MarkdownComponent {
   private render(src: string): string {
     let text = this.stripFrontMatter(src);
     // [[Wikilink]] / [[Wikilink|alias]] → clickable accent chip (marked passes raw HTML through).
+    // The chip's TEXT is the title — no `data-*` attribute (Angular's `[innerHTML]` sanitizer
+    // strips those; see the class doc's ROOT-CAUSE FIX note), so `chipTitle()` reads `textContent`.
     text = text.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, (_m, t: string) => {
       const safe = this.escapeHtml(t.trim());
-      return `<span class="md-wikilink" data-wikilink="${safe}" role="link" tabindex="0">${safe}</span>`;
+      return `<span class="md-wikilink" role="link" tabindex="0">${safe}</span>`;
     });
     const out = marked.parse(text, { async: false, gfm: true, breaks: true });
     const raw = typeof out === "string" ? out : src;
     // Sanitize the parsed HTML before it is bound to [innerHTML]. The source is untrusted
     // (LLM output / transcript), so DOMPurify is the authoritative XSS gate — no
-    // bypassSecurityTrustHtml is ever applied. `data-wikilink`/`role`/`tabindex` are explicitly
-    // allow-listed so the clickable chip survives sanitization.
+    // bypassSecurityTrustHtml is ever applied. `role`/`tabindex` are explicitly allow-listed
+    // (both survive Angular's OWN sanitizer pass too, unlike a custom `data-*` attribute).
     return DOMPurify.sanitize(raw, {
       USE_PROFILES: { html: true },
-      ADD_ATTR: ["data-wikilink", "role", "tabindex"],
+      ADD_ATTR: ["role", "tabindex"],
     });
   }
 


### PR DESCRIPTION
## What
Three related note-linking fixes reported live-testing:

1. **Wikilink chips did nothing on click.** Two stacked root causes: Angular's own
   `[innerHTML]` sanitizer silently strips `data-*` attributes regardless of DOMPurify's
   allow-list (so the chip's title was always unreadable), and the open path used a raw
   `router.navigate` instead of `TabsService` — the exact sibling bug already fixed once
   in `NoteBrainPopoverComponent.openCitation` (2026-07-12) but never applied to
   wikilinks. Both fixed: title now read from the chip's own `textContent`; opens route
   through `TabsService.openNote`/`openMeeting` so the result is a tracked tab.
2. **No way to insert a link from the editor.** Added a "Link to note" slash-menu entry
   plus a `[[` keystroke trigger, both opening a new `LinkPickerComponent` (opaque
   overlay, not the frosted `.card`, per this app's floating-popover rule) backed by a
   new gated `list_link_candidates(prefix)` command — visibility-gated on notes/meetings,
   reusing the same membership+enabled-gated zero-egress org-brain reader `find_related`
   already uses for org items. Selecting inserts `[[Title]]` via the existing wikilink op.
3. **"Find related" was a confusing dead-end.** Folded it into the same actionable
   picker — each candidate row now offers "Insert link" alongside "Open".

## Tests
`cargo test --lib`: 1631 passed, 0 failed. `ng lint` clean. `ng build` clean.