### PR TITLE
chore(release): 0.9.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.17"
+version = "0.9.18"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 0.9.18.

## What's in this release
Full note/org bug-fix batch (root-caused, not patched):
- Deleting a note/meeting shared to an org now revokes the org share instead of leaving a live ciphertext copy that resurrects on the author's own machine (delete cascade + a new delete-event fan-out that keeps tabs/lists in sync).
- A note's own author can now edit it from a second device — backfills `author_user_id` for org items synced before that column existed.
- Clickable `[[wikilinks]]`, a "Link to note" slash-command with autocomplete, and "Find related" reworked into an actionable insert-link picker.
- Fixed the real root cause of spurious "Save failed" errors (a missing SQLite busy_timeout under write contention) plus live tab-title sync independent of save completion, and closed a related silent-content-loss bug across every autosave call site sharing one debounce key.

CI: `scripts/ci.sh` green (clippy -D warnings, tests, ng lint, ng build, headless E2E core + mixing).