### PR TITLE
fix(wikilink): resolve_wikilink falls back to org (Shared Brain) items

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6181,10 +6181,12 @@ pub fn get_backlinks(
     state.db.backlinks_for_visible(kind, &target_id, &unlocked)
 }
 
-/// Resolve a clicked `[[Title]]` wikilink to a VISIBLE note/meeting to navigate to. Returns `None`
-/// when nothing matches OR the only match is a sealed-and-not-session-unlocked target (gated in
-/// `Db::resolve_wikilink`) — so a wikilink click never reveals or opens locked content. The FE
-/// routes on `kind`, or offers to create a note when `None`.
+/// Resolve a clicked `[[Title]]` wikilink to a VISIBLE note/meeting/org-item to navigate to.
+/// Returns `None` when nothing matches OR the only local match is a
+/// sealed-and-not-session-unlocked target (gated in `Db::resolve_wikilink`) — so a wikilink click
+/// never reveals or opens locked content. The org leg (2026-07-15) is gated by membership +
+/// per-instance-enabled, the same seam `list_link_candidates`/`search_org_brain_hits` use. The FE
+/// routes on `kind` (`"meeting"` | `"note"` | `"org"`), or offers to create a note when `None`.
 #[tauri::command]
 pub fn resolve_wikilink(
     state: State<'_, AppState>,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8505,11 +8505,19 @@ impl Db {
     }
 
     /// Resolve a `[[Title]]` wikilink to a VISIBLE navigation target — a standalone note (preferred,
-    /// the more natural link target) else a meeting whose exact title matches. GATED by
-    /// `visibility_clause` on both legs: a sealed-and-not-session-unlocked note/meeting with that
-    /// title resolves to `None`, so clicking a wikilink can never reveal or navigate to locked
-    /// content. `None` also when nothing matches. Title match uses the note's display title
-    /// (`title`, falling back to `name`), matching how it is shown/exported.
+    /// the more natural link target), else a meeting whose exact title matches, else (2026-07-15)
+    /// an org (Shared Brain) item whose exact title matches. GATED on all three legs: notes/meetings
+    /// via `visibility_clause` (a sealed-and-not-session-unlocked note/meeting with that title
+    /// resolves to `None`, so clicking a wikilink can never reveal or navigate to locked content);
+    /// the org leg via the SAME membership+per-instance-enabled gate `get_org_item`/
+    /// `search_org_chunks_knn`/`_fts` already use (`JOIN org_state ... WHERE context_enabled = 1`),
+    /// excluding tombstoned rows — never a laxer gate than the existing Shared Brain read path
+    /// (`crate::tools::org_brain_available`/`search_org_brain_hits`). `None` when nothing matches.
+    /// Title match uses the note's display title (`title`, falling back to `name`), matching how it
+    /// is shown/exported. This closes the sibling-gap left by the newer prefix-search picker
+    /// (`list_link_candidates_visible` + the org leg folded in at `commands::list_link_candidates`):
+    /// that picker already offered org items as autocomplete candidates, but this EXACT-title
+    /// resolver — used by both click-to-open and the "does this already exist" pre-check — did not.
     pub fn resolve_wikilink(
         &self,
         title: &str,
@@ -8539,7 +8547,7 @@ impl Db {
                 .map_err(map_err)?;
             if let Some(id) = note_id {
                 return Ok(Some(WikiTarget {
-                    kind: SourceKind::Note,
+                    kind: "note".to_string(),
                     id,
                 }));
             }
@@ -8547,9 +8555,39 @@ impl Db {
         // Meeting leg — reuse the proven gated title resolver (acquires its own lock).
         if let Some(m) = self.meeting_by_title_visible(title, unlocked)? {
             return Ok(Some(WikiTarget {
-                kind: SourceKind::Meeting,
+                kind: "meeting".to_string(),
                 id: m.id,
             }));
+        }
+        // Org (Shared Brain) leg — deliberately-disclosed content living OUTSIDE the folder-lock
+        // domain, so no `unlocked`/`visibility_clause` gate applies here; instead it is scoped to
+        // orgs the caller has actually JOINED and left ENABLED on this install, and excludes
+        // tombstoned items — the IDENTICAL gate `get_org_item` applies for the read-only viewer.
+        // Deliberately NOT the broader/unscoped `documents`/`meetings` query: this leg only ever
+        // touches `org_items`.
+        {
+            let conn = self.lock();
+            let org_id: Option<String> = conn
+                .query_row(
+                    "SELECT oi.item_id
+                       FROM org_items oi
+                       JOIN org_state os ON os.org_id = oi.org_id
+                      WHERE oi.tombstoned = 0
+                        AND os.context_enabled = 1
+                        AND oi.title = ?1
+                      ORDER BY oi.created_at DESC, oi.item_id ASC
+                      LIMIT 1",
+                    rusqlite::params![title],
+                    |r| r.get(0),
+                )
+                .optional()
+                .map_err(map_err)?;
+            if let Some(id) = org_id {
+                return Ok(Some(WikiTarget {
+                    kind: "org".to_string(),
+                    id,
+                }));
+            }
         }
         Ok(None)
     }
@@ -13586,14 +13624,14 @@ mod tests {
             .resolve_wikilink("Alpha", &nothing)
             .unwrap()
             .expect("Alpha resolves");
-        assert_eq!(a.kind, SourceKind::Note);
+        assert_eq!(a.kind, "note");
         assert_eq!(a.id, "n-alpha");
 
         let b = db
             .resolve_wikilink("Beta", &nothing)
             .unwrap()
             .expect("Beta resolves");
-        assert_eq!(b.kind, SourceKind::Meeting);
+        assert_eq!(b.kind, "meeting");
         assert_eq!(b.id, "m-beta");
 
         assert!(db.resolve_wikilink("Nope", &nothing).unwrap().is_none());
@@ -13627,8 +13665,108 @@ mod tests {
             .resolve_wikilink("Secret", &unlocked)
             .unwrap()
             .expect("unlocked target resolves");
-        assert_eq!(t.kind, SourceKind::Note);
+        assert_eq!(t.kind, "note");
         assert_eq!(t.id, "n-secret");
+    }
+
+    /// SIBLING-GAP FIX (2026-07-15): `resolve_wikilink` gained a THIRD leg over `org_items` — an
+    /// exact title match on a joined-and-enabled org's Shared Brain content must now resolve,
+    /// mirroring what the prefix-search picker (`list_link_candidates` folding in
+    /// `search_org_brain_hits`) already offered as an autocomplete candidate. RED against the
+    /// pre-fix code (which had only the note+meeting legs and returned `None` here).
+    #[test]
+    fn resolve_wikilink_falls_back_to_org_item_exact_title_match() {
+        let db = mem_db();
+        seed_org_state(&db, "org-1");
+        let emb = crate::embed::StubEmbedder;
+        db.upsert_org_item(
+            "it-shared",
+            "org-1",
+            1,
+            "anna",
+            "Nebula Rollout",
+            "the nebula rollout plan for q3",
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &sha32(9),
+            None,
+            Some(&emb),
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let t = db
+            .resolve_wikilink("Nebula Rollout", &nothing)
+            .unwrap()
+            .expect("an exact-title org item must resolve");
+        assert_eq!(t.kind, "org");
+        assert_eq!(t.id, "it-shared", "org leg must carry the ORG item id, never a local id");
+    }
+
+    /// NEGATIVE (mirrors `org_tombstone_evicts_from_retrieval_and_viewer` /
+    /// `org_brain_available_requires_at_least_one_enabled_org`): a TOMBSTONED org item, or one
+    /// whose org is joined but per-instance DISABLED, must NOT resolve — the new leg must not be any
+    /// laxer than the existing `get_org_item`/`search_org_brain_hits` gate.
+    #[test]
+    fn resolve_wikilink_excludes_tombstoned_and_disabled_org_items() {
+        let db = mem_db();
+        seed_org_state(&db, "org-1");
+        seed_org_state(&db, "org-2");
+        let emb = crate::embed::StubEmbedder;
+        db.upsert_org_item(
+            "it-gone",
+            "org-1",
+            1,
+            "anna",
+            "Ghost Doc",
+            "this item will be tombstoned",
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &sha32(10),
+            None,
+            Some(&emb),
+        )
+        .unwrap();
+        db.upsert_org_item(
+            "it-disabled",
+            "org-2",
+            1,
+            "bob",
+            "Disabled Org Doc",
+            "this org is disabled on this install",
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &sha32(11),
+            None,
+            Some(&emb),
+        )
+        .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        // Sanity: both resolve before we exclude them.
+        assert!(db.resolve_wikilink("Ghost Doc", &nothing).unwrap().is_some());
+        assert!(
+            db.resolve_wikilink("Disabled Org Doc", &nothing)
+                .unwrap()
+                .is_some()
+        );
+
+        db.tombstone_org_item("it-gone").unwrap();
+        assert!(
+            db.resolve_wikilink("Ghost Doc", &nothing).unwrap().is_none(),
+            "a tombstoned org item must not resolve as a wikilink target"
+        );
+
+        db.set_org_context_enabled("org-2", false).unwrap();
+        assert!(
+            db.resolve_wikilink("Disabled Org Doc", &nothing)
+                .unwrap()
+                .is_none(),
+            "a per-instance-disabled org's item must not resolve as a wikilink target"
+        );
     }
 
     /// `list_link_candidates_visible` prefix-filters (case-insensitively) over notes + meetings,

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1077,14 +1077,21 @@ pub struct BacklinkSource {
     pub timestamp: String,
 }
 
-/// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note or meeting whose exact title
-/// the link names, so the FE can route `/notes/:id` or `/meeting/:id`. Resolution is
-/// visibility-gated: a sealed-and-not-session-unlocked note/meeting with that title resolves to
-/// `None`, so clicking a wikilink can never reveal or navigate to locked content.
+/// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, or (2026-07-15)
+/// org (Shared Brain) item whose exact title the link names, so the FE can route `/notes/:id`,
+/// `/meeting/:id`, or `/org-item/:id`. Resolution is visibility-gated: a sealed-and-not-
+/// session-unlocked note/meeting with that title resolves to `None`, so clicking a wikilink can
+/// never reveal or navigate to locked content. `kind` is a raw string (`"meeting"` | `"note"` |
+/// `"org"`), NOT [`SourceKind`] — mirrors the convention [`NoteCitation`] already established for
+/// the identical tri-state (`SourceKind` stays a strict local meeting/note enum, used only for
+/// backlinks, which have no org leg). For `kind == "org"`, `id` is the org item id
+/// (`org_items.item_id`), never a local id — the FE routes it through
+/// `TabsService.openOrgItem`, exactly like `NoteCitation`'s org rows.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WikiTarget {
-    pub kind: SourceKind,
+    /// `"meeting"` | `"note"` | `"org"`.
+    pub kind: String,
     pub id: String,
 }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1218,13 +1218,17 @@ export interface BacklinkSource {
 }
 
 /**
- * A resolved `[[Title]]` wikilink navigation target — the VISIBLE note/meeting to
- * open (`resolveWikilink(title)`). `null` when nothing matches OR the only match is
- * sealed-and-not-session-unlocked (gated server-side, so a click can never reveal or
- * open locked content). Mirrors the Rust `WikiTarget` (serde camelCase).
+ * A resolved `[[Title]]` wikilink navigation target — the VISIBLE note/meeting/org
+ * (Shared Brain) item to open (`resolveWikilink(title)`). `null` when nothing matches
+ * OR the only local match is sealed-and-not-session-unlocked (gated server-side, so a
+ * click can never reveal or open locked content). `kind` is a raw string (NOT
+ * `SourceKind` — mirrors `NoteCitation`'s convention for the same tri-state, since
+ * `SourceKind` stays local-only for backlinks): `"org"` carries the org item's id,
+ * routed to `TabsService.openOrgItem`, never a local id. Mirrors the Rust `WikiTarget`
+ * (serde camelCase).
  */
 export interface WikiTarget {
-  kind: SourceKind;
+  kind: "meeting" | "note" | "org";
   id: string;
 }
 

--- a/src/app/shared/markdown/markdown.component.ts
+++ b/src/app/shared/markdown/markdown.component.ts
@@ -36,8 +36,9 @@ import { ToastService } from "../../services/toast.service";
  *   alongside it. The fix: read the title from the chip's own `textContent` instead (the chip's
  *   visible text ALREADY IS the escaped title — no extra attribute needed, so there's nothing
  *   left for a sanitizer to strip).
- *   A host click/Enter handler resolves the title to a VISIBLE note/meeting (gated server-side)
- *   and opens it through {@link TabsService} (not a raw `router.navigate` — same sibling-function
+ *   A host click/Enter handler resolves the title to a VISIBLE note/meeting/org-item (gated
+ *   server-side; the org leg added 2026-07-15) and opens it through {@link TabsService} (not a
+ *   raw `router.navigate` — same sibling-function
  *   fix as `NoteBrainPopoverComponent.openCitation`, 2026-07-12: a plain navigate never registers
  *   the resulting view with the tab strip, so a wikilink click opened an orphaned, untracked view
  *   and looked like a no-op), or offers to create the note — so the chips are clickable like
@@ -112,15 +113,19 @@ export class MarkdownComponent {
       const target = await this.ipc.resolveWikilink(title);
       if (target) {
         // Route through TabsService (not a raw `router.navigate`) so the opened
-        // note/meeting is a TRACKED TAB, matching every other open path in the app.
+        // note/meeting/org-item is a TRACKED TAB, matching every other open path in
+        // the app. "org" (2026-07-15) opens the read-only Shared Brain viewer — never
+        // offer to CREATE a note when an org item already matched the title.
         if (target.kind === "meeting") {
           await this.tabsService.openMeeting(target.id, title);
+        } else if (target.kind === "org") {
+          await this.tabsService.openOrgItem(target.id, title);
         } else {
           await this.tabsService.openNote(target.id, title);
         }
         return;
       }
-      // No such note/meeting (or it is locked) — offer to create it, Obsidian-style.
+      // No such note/meeting/org-item (or it is locked) — offer to create it, Obsidian-style.
       this.toast.push(`Notatka „${title}" jeszcze nie istnieje`, "info", 0, {
         label: "Utwórz",
         run: () => void this.createAndOpen(title),


### PR DESCRIPTION
## Summary
- `Db::resolve_wikilink` had only two legs — local `documents` (kind='note') and local `meetings` — so a `[[Title]]` matching a colleague's org-shared item (already visible everywhere else in the app: quick-search picker, notes/library merge, org brain search) fell through to `None`. The click-to-open path then offered "this note doesn't exist, create it?" instead of opening the existing Shared Brain item — a duplicate-note trap and a confusing dead end.
- Added a THIRD leg over `org_items`, gated with the exact same membership + per-instance-enabled + non-tombstoned predicate `Db::get_org_item`/`crate::tools::search_org_brain_hits` already use (`JOIN org_state ... WHERE tombstoned = 0 AND context_enabled = 1`) — no new, laxer gate introduced.
- `WikiTarget.kind` changed from the `SourceKind` enum (strictly local meeting/note, still used unchanged for backlinks) to a raw `String` (`"meeting"` | `"note"` | `"org"`), mirroring the convention `NoteCitation` already established for the identical tri-state used by `list_link_candidates`. For `kind == "org"`, `id` is the org item's id — never a local id.
- FE: `MarkdownComponent.openWikilink` now branches on `target.kind === "org"` and calls the already-existing `TabsService.openOrgItem(id, title)` (used elsewhere for the same read-only Shared Brain viewer). The "create new note?" toast only ever fires when `resolveWikilink` returns `null`, so it naturally stops firing once an org match resolves — no separate suppression logic needed.

## Files touched
- `src-tauri/src/storage/models.rs` — `WikiTarget.kind: SourceKind` → `String`, doc updated.
- `src-tauri/src/storage/db.rs` — `Db::resolve_wikilink` gains the org leg; updated 2 existing assertions (`SourceKind::Note`/`Meeting` → `"note"`/`"meeting"`); added 2 new regression tests.
- `src-tauri/src/commands.rs` — doc comment on the `resolve_wikilink` command updated for the new org leg (no logic change — straight passthrough to `Db::resolve_wikilink`).
- `src/app/core/models.ts` — `WikiTarget.kind` type updated to `"meeting" | "note" | "org"`.
- `src/app/shared/markdown/markdown.component.ts` — `openWikilink` org branch → `TabsService.openOrgItem`.

## Gating / leak-risk note
This is a content-resolution/visibility path. The new leg:
- Scopes ONLY to `org_items` (never falls back to a broader/unscoped `documents`/`meetings` query).
- Uses the IDENTICAL gate as the existing, already-shipped `get_org_item` viewer read and `search_org_brain_hits` retrieval seam — joined member + per-instance `context_enabled = 1` + `tombstoned = 0`.
- Org items are deliberately org-disclosed content living outside the folder-lock domain (per `lock-model.md` and the existing `org_items` doc comment in `db.rs`) — no folder-lock gate applies to them anywhere else in the codebase either, so this leg is consistent with every other org read path.
- Murmur is local-first with a physically separate DB per user, so there is no cross-user title-collision risk; the new leg never touches `documents`/`meetings` for a different user.

## Test plan
- [x] `cargo test --lib` — 1640 passed, 1 pre-existing unrelated failure (`settings::ai_map::tests::default_config_is_cloud_claude_with_inactive_reactions`, confirmed failing identically on `origin/murmur` HEAD before this change — a whisper-model-default assertion, unrelated to wikilinks/org items).
- [x] New tests: `resolve_wikilink_falls_back_to_org_item_exact_title_match` (RED on pre-fix code — confirmed by inspecting `origin/murmur`'s `resolve_wikilink`, which has no org leg and unconditionally returns `None` past the note/meeting legs), `resolve_wikilink_excludes_tombstoned_and_disabled_org_items` (mirrors `org_tombstone_evicts_from_retrieval_and_viewer` / `org_brain_available_requires_at_least_one_enabled_org`'s negative coverage).
- [x] Updated 2 existing `resolve_wikilink` assertions for the `kind: String` type change.
- [x] `npx ng lint` — clean.
- [x] `npx ng build` — clean.
- [ ] Live Playwright verification not run in this pass (would need a mocked IPC + org-item fixture); the FE branch is a 3-line mechanical addition to an already-tested pattern (`openMeeting`/`openNote`/`openOrgItem` all follow the identical `TabsService` shape).

## Review flags
- This touches a content-resolution/visibility path (not a lock/seal path directly) — worth an **adversarial-verifier** pass.
- Also worth a quick **lock-security-reviewer** look even though the investigation (and this PR) found no leak: org items are outside the folder-lock domain by design, and the new leg is scoped no more loosely than the existing, already-reviewed `get_org_item`/`search_org_brain_hits` gate.