### PR TITLE
fix(ui): note editor header wrap + Settings shell height vs tab strip

### DIFF
--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -27,10 +27,23 @@
   cursor: default;
 }
 
-/* ===== Sticky header ===== */
+/* ===== Sticky header =====
+   Horizontal-only layout bug (confirmed — NOT a tab-strip desync): this is a
+   single flex row with `.head-spacer { flex: 1 1 auto }` and no wrap, so at a
+   narrow window the crumb/save-state/Edit-Preview/Share/⋯ cluster runs out of
+   room and jams together. `flex-wrap: wrap` (the `gap` shorthand already sets
+   BOTH row- and column-gap, so no separate `row-gap` override is needed —
+   adding one alongside the shorthand elsewhere folded the build's CSS
+   optimizer into an invalid empty `column-gap`) lets the cluster drop to a
+   second line instead of overlapping/clipping; `.head-spacer` shrinks to 0
+   (not just flex-basis 0 — an empty flex item still claims its content
+   min-width) so it never forces an early wrap by itself, and `.save-state`
+   (the least critical element — a hint, not an action) is de-prioritized via
+   `order` so wrapping affects it before the action buttons themselves. */
 .editor-head {
   flex: none;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-4) var(--space-6) var(--space-3);
@@ -38,6 +51,15 @@
 }
 .head-spacer {
   flex: 1 1 auto;
+  min-width: 0;
+}
+/* De-prioritized: the autosave hint (`.save-state`, styled below under
+   "Autosave indicator") wraps onto its own line before the action buttons
+   (Edit/Preview/Share/⋯) ever get cramped. */
+.head-seg,
+.head-btn,
+.head-more {
+  order: 2;
 }
 
 /* Breadcrumb / more triggers. */
@@ -150,11 +172,16 @@
   font-size: 0.82rem;
 }
 
-/* Autosave indicator. */
+/* Autosave indicator. `order: 1` (default is 0 for every other header child,
+   `.head-seg`/`.head-btn`/`.head-more` are explicitly 2) makes this the
+   FIRST thing to drop to a second line when `.editor-head` wraps at a narrow
+   width — it's a hint, not an action, so it's the least-critical element to
+   de-prioritize ahead of the Edit/Preview/Share/⋯ cluster. */
 .save-state {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+  order: 1;
   min-width: 70px;
   font-size: 0.78rem;
   color: var(--text-muted);

--- a/src/app/features/settings/settings/settings.component.scss
+++ b/src/app/features/settings/settings/settings.component.scss
@@ -17,12 +17,19 @@
   background: var(--surface-base);
 }
 
-/* ── Two-pane shell: floating section rail + scrolling content ── */
+/* ── Two-pane shell: floating section rail + scrolling content ──
+   `:host` already starts BELOW the tab strip (`top: var(--tabs-strip-height,
+   0px)` above), but this inner shell was still sized to the FULL viewport
+   height (`100vh`/`100dvh`) — so it overflowed the fixed `:host` box by
+   exactly the strip's height, spilling its bottom rows (the Light/Dark/
+   System toggle row, the sidebar's last nav item) past the bottom of the
+   viewport. Subtract the same offset here so the shell's height matches the
+   space `:host` actually reserves. */
 .settings-shell {
   display: grid;
   grid-template-columns: 246px minmax(0, 1fr);
-  height: 100vh;
-  height: 100dvh;
+  height: calc(100vh - var(--tabs-strip-height, 0px));
+  height: calc(100dvh - var(--tabs-strip-height, 0px));
 }
 
 /* Left rail — the shared floating liquid-glass panel (global .drill-rail


### PR DESCRIPTION
## What
Two separate layout overlap reports, two independent root causes:

1. **Note editor header cramped at narrow widths.** `.editor-head` was a
   single non-wrapping flex row (crumb / save-state / Edit / Preview /
   Share / ...) — at a narrow window the action-button cluster ran out
   of room and jammed together. Not a tab-strip issue at all (the strip
   is in-flow and pushes the editor down with no vertical overlap
   possible) — purely horizontal. Now wraps, with the save-state hint
   de-prioritized to drop to its own line first.
2. **Settings toggle row + sidebar visually overlapped by the tab strip.**
   `.settings-shell`'s `:host` already starts below the 48px tab strip
   (`top: var(--tabs-strip-height)`), but the shell itself was sized to
   the FULL `100vh`/`100dvh` viewport — overflowing the reserved space by
   exactly the strip's height. This pushed the Light/Dark/System toggle
   row into visual collision with the strip, and (same root cause) made
   the sidebar's scroll region + existing mask-fade land partly
   off-viewport, reading as a hard clip rather than the intended fade.

## Tests
`ng lint` clean. `ng build` clean. Full `e2e/notes/` suite: 24/24 passed, no regressions.