### PR TITLE
fix(notes): auto-title fires on tab detach, not only hard-close

### DIFF
--- a/e2e/notes/note-autosave-cross-tab-loss.spec.ts
+++ b/e2e/notes/note-autosave-cross-tab-loss.spec.ts
@@ -19,9 +19,32 @@ import { mockNotes } from "./mock-invoke";
  * `` `note-editor-save:${noteId}` `` (see `saveDebounceKey`), so each open
  * tab's autosave timer is independent in the shared singleton.
  *
- * RED contract: reverting the scoping back to a bare literal key reproduces
- * Note A's edit never reaching `save_note_text` at all (confirmed locally
- * against the unscoped-key code before landing this test).
+ * ORIGINAL RED contract (still true in isolation — see `note-save-retry-
+ * cross-tab.spec.ts` for the sibling retry-key collision, which remains
+ * fully exercisable): reverting the scoping back to a bare literal key
+ * reproduces Note A's edit never reaching `save_note_text` at all.
+ *
+ * STALE AS OF 2026-07-15 (auto-title-on-detach fix) — read before touching
+ * this test: a note with unindexed edits (`dirtyFull`) now ALSO gets FULLY
+ * flushed the instant its tab is backgrounded (`TabRouteReuseStrategy.
+ * onDetach` → `runNoteBoundaryWork` → `flushFull`), not only on hard close.
+ * That flush synchronously cancels the note's OWN pending debounce timer
+ * and immediately queues a full save (`update_note_doc`) — which completes
+ * (kicks off) before the user can possibly have switched tabs AND typed
+ * into the next note, so Note A's timer is always gone by the time Note B
+ * could ever call `schedule()` under a shared key. Verified empirically:
+ * this test PASSES even with `saveDebounceKey` reverted to a bare literal —
+ * the specific collision it was written to catch can no longer occur via
+ * ordinary tab-switching, because the eager detach-flush structurally
+ * prevents two notes' PRIMARY autosave timers from ever being pending
+ * concurrently. This test is still a legitimate, valuable regression check
+ * (both notes' edits must survive a rapid tab-switch, regardless of WHICH
+ * save path lands them), but it no longer discriminates the debounce-key-
+ * scoping fix specifically — do not read a pass here as proof that scoping
+ * fix still works; that guarantee now lives structurally in the eager-flush
+ * design instead. Tracks BOTH `save_note_text` and `update_note_doc` calls
+ * since either is a genuine persist (the mock's default `update_note_doc`
+ * echoes the real markdown back).
  */
 test.describe("Note editor — concurrent open tabs never cancel each other's PENDING autosave", () => {
   test("editing note A then switching to note B before A's autosave fires still persists A's edit", async ({
@@ -66,14 +89,37 @@ test.describe("Note editor — concurrent open tabs never cancel each other's PE
               locked: false,
               shared: false,
             },
-      // Record every save_note_text call per id (page-side array, read back
-      // via page.evaluate — mockTauri overrides run page-side, no closures).
+      // Record every save (page-side array, read back via page.evaluate —
+      // mockTauri overrides run page-side, no closures). Tracks BOTH the
+      // cheap autosave (save_note_text) and the full save (update_note_doc)
+      // — a note backgrounded with unindexed edits is now flushed via the
+      // latter (see the class doc's 2026-07-15 note), so either path is a
+      // legitimate persist of the edit under test.
       save_note_text: (args: { id: string; markdown: string }) => {
         const w = window as unknown as { __saves?: Record<string, string[]> };
         w.__saves ??= { n1: [], n2: [] };
         w.__saves[args.id] ??= [];
         w.__saves[args.id].push(args.markdown);
         return Date.now();
+      },
+      update_note_doc: (args: { id: string; title: string; markdown: string }) => {
+        const w = window as unknown as { __saves?: Record<string, string[]> };
+        w.__saves ??= { n1: [], n2: [] };
+        w.__saves[args.id] ??= [];
+        w.__saves[args.id].push(args.markdown);
+        return {
+          id: args.id,
+          title: args.title,
+          folderId: "nf1",
+          markdown: args.markdown,
+          tags: [],
+          properties: {},
+          updatedAt: Date.now(),
+          createdAt: 1_719_000_000_000,
+          exportedPath: null,
+          locked: false,
+          shared: false,
+        };
       },
     });
 

--- a/e2e/notes/note-autosave-cross-tab-loss.spec.ts
+++ b/e2e/notes/note-autosave-cross-tab-loss.spec.ts
@@ -24,27 +24,33 @@ import { mockNotes } from "./mock-invoke";
  * fully exercisable): reverting the scoping back to a bare literal key
  * reproduces Note A's edit never reaching `save_note_text` at all.
  *
- * STALE AS OF 2026-07-15 (auto-title-on-detach fix) — read before touching
- * this test: a note with unindexed edits (`dirtyFull`) now ALSO gets FULLY
- * flushed the instant its tab is backgrounded (`TabRouteReuseStrategy.
- * onDetach` → `runNoteBoundaryWork` → `flushFull`), not only on hard close.
- * That flush synchronously cancels the note's OWN pending debounce timer
- * and immediately queues a full save (`update_note_doc`) — which completes
- * (kicks off) before the user can possibly have switched tabs AND typed
- * into the next note, so Note A's timer is always gone by the time Note B
- * could ever call `schedule()` under a shared key. Verified empirically:
- * this test PASSES even with `saveDebounceKey` reverted to a bare literal —
- * the specific collision it was written to catch can no longer occur via
- * ordinary tab-switching, because the eager detach-flush structurally
- * prevents two notes' PRIMARY autosave timers from ever being pending
- * concurrently. This test is still a legitimate, valuable regression check
- * (both notes' edits must survive a rapid tab-switch, regardless of WHICH
- * save path lands them), but it no longer discriminates the debounce-key-
- * scoping fix specifically — do not read a pass here as proof that scoping
- * fix still works; that guarantee now lives structurally in the eager-flush
- * design instead. Tracks BOTH `save_note_text` and `update_note_doc` calls
- * since either is a genuine persist (the mock's default `update_note_doc`
- * echoes the real markdown back).
+ * CORRECTION (2026-07-16, adversarial re-verification of the auto-title-on-
+ * detach fix) — read before touching this test: this test PASSES even with
+ * `saveDebounceKey` reverted to a bare literal, i.e. it no longer
+ * discriminates the debounce-key-scoping bug it was written for. An earlier
+ * version of this comment attributed that to the auto-title-on-detach fix's
+ * eager `flushFull()` call structurally pre-empting the collision — that
+ * explanation was WRONG, independently disproven: the non-discrimination
+ * predates that fix entirely and reproduces identically against the
+ * unmodified parent commit. The REAL cause is Playwright interaction
+ * timing — the `page.goBack()` + tab-click round trip in this test takes
+ * ~850ms, already past the 600ms `AUTOSAVE_MS` debounce window, so Note A's
+ * OWN independent timer fires and completes ~250ms BEFORE Note B's
+ * `schedule()` call ever executes — the two `schedule()` calls under a
+ * shared key never actually race in this harness at all, with or without
+ * any of the debounce-key or auto-title fixes present. This test remains a
+ * legitimate, valuable regression check (both notes' edits must survive a
+ * rapid tab-switch, regardless of WHICH save path lands them — tracks BOTH
+ * `save_note_text` and `update_note_doc`, since either is a genuine persist
+ * per the mock's default `update_note_doc` echoing the real markdown back),
+ * but it does NOT prove the debounce-key scoping fix works — that fix is
+ * still correct and still necessary (defense-in-depth against a real
+ * collision under different timing, e.g. a slower machine or a UI change
+ * that speeds up tab-switching), it's just not what THIS test's pass/fail
+ * currently hinges on. A follow-up could either speed up this test's
+ * interaction to fall inside the debounce window, or add a lower-level
+ * `DebounceService`/`saveDebounceKey` unit test that doesn't depend on real
+ * UI timing at all.
  */
 test.describe("Note editor — concurrent open tabs never cancel each other's PENDING autosave", () => {
   test("editing note A then switching to note B before A's autosave fires still persists A's edit", async ({

--- a/e2e/notes/note-autotitle-on-tab-detach.spec.ts
+++ b/e2e/notes/note-autotitle-on-tab-detach.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Root-cause fix (2026-07-15): `NoteEditorComponent.maybeAutoTitle()` was
+ * correctly written (no-ops on a real title / an empty body, else calls
+ * `suggest_note_title` and updates the tab label) but its ONLY trigger was
+ * `DestroyRef.onDestroy(...)` — and `notes/:id` tabs are DETACHED, not
+ * destroyed, on a plain tab switch (`TabRouteReuseStrategy.shouldDetach`
+ * returns `true` for this route, per its own header doc). So the
+ * overwhelmingly common real-world flow — type a note, click a different
+ * open tab — never ran auto-title; a user had no reason to expect they'd
+ * need to literally close the tab (✕) for a title to appear.
+ *
+ * The fix subscribes to a NEW `TabRouteReuseStrategy.onDetach(...)` — the one
+ * place that genuinely knows "this tab is being backgrounded right now" (its
+ * `store()`, called by the router mid-navigation) — and runs the same
+ * best-effort `maybeAutoTitle()` (+ the `dirtyFull` full-save flush) at that
+ * earlier moment too, filtered to the detaching tab's OWN key. The existing
+ * `onDestroy` trigger stays for a real hard-close / app-quit.
+ *
+ * RED contract: reverting the `tabRouteReuse.onDetach(...)` subscription
+ * (back to the `onDestroy`-only trigger) reproduces `suggest_note_title`
+ * NEVER firing on a plain tab switch — confirmed locally against the
+ * pre-fix code before landing this test.
+ */
+test.describe("Note editor — auto-title fires on tab BACKGROUND (detach), not only hard-close", () => {
+  test("typing a note then switching tabs (without closing) auto-titles it", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+    await mockNotes(page, {
+      // n1 = genuinely "Untitled" with an empty body (so opening it never
+      // itself satisfies maybeAutoTitle's guards); n2 is the second open tab
+      // switched to and back from. Both must be DISTINCT ids for the
+      // TabRouteReuseStrategy detach/attach cache to exercise two real slots.
+      get_note: (args: { id: string }) =>
+        args.id === "n2"
+          ? {
+              id: "n2",
+              title: "Weekly plan",
+              folderId: "nf1",
+              markdown: "# Weekly plan\n\nShip the notes feature.",
+              tags: [],
+              properties: {},
+              updatedAt: 1_720_100_000_000,
+              createdAt: 1_719_100_000_000,
+              exportedPath: null,
+              locked: false,
+              shared: true,
+            }
+          : {
+              id: "n1",
+              title: "Untitled",
+              folderId: "nf1",
+              markdown: "",
+              tags: [],
+              properties: {},
+              updatedAt: 1_720_000_000_000,
+              createdAt: 1_719_000_000_000,
+              exportedPath: null,
+              locked: false,
+              shared: false,
+            },
+      list_notes: () => [
+        {
+          id: "n1",
+          title: "Untitled",
+          folderId: "nf1",
+          snippet: "",
+          tags: [],
+          updatedAt: 1_720_000_000_000,
+          createdAt: 1_719_000_000_000,
+          locked: false,
+          shared: false,
+        },
+        {
+          id: "n2",
+          title: "Weekly plan",
+          folderId: "nf1",
+          snippet: "Ship the notes feature",
+          tags: [],
+          updatedAt: 1_720_100_000_000,
+          createdAt: 1_719_100_000_000,
+          locked: false,
+          shared: true,
+        },
+      ],
+      // Record every suggest_note_title call (page-side array; the override
+      // runs page-side, no closures over test-scope per mockTauri's contract).
+      suggest_note_title: (args: { noteId: string }) => {
+        const w = window as unknown as { __titleCalls?: string[] };
+        w.__titleCalls ??= [];
+        w.__titleCalls.push(args.noteId);
+        return "Generated title";
+      },
+    });
+
+    await page.goto("/notes");
+    await expect(page.locator(".notes-content")).toBeVisible();
+
+    // Open the "Untitled" note as a real tab (drives TabsService.openNote,
+    // registering it with TabRouteReuseStrategy).
+    await page.locator(".title-btn", { hasText: "Untitled" }).click();
+    const bodyArea = page.locator(".body-area");
+    await expect(bodyArea).toBeVisible();
+
+    // Type real body content — the note is still titled "Untitled".
+    await bodyArea.fill("Meeting notes: discussed the roadmap for Q3.");
+    await expect(page.locator(".note-title-input")).toHaveValue("Untitled");
+
+    // RED checkpoint: switching tabs alone must not (pre-fix) have called
+    // suggest_note_title yet — confirms this test actually exercises the
+    // detach path, not some other trigger firing coincidentally.
+    const callsBeforeSwitch = await page.evaluate(
+      () => (window as unknown as { __titleCalls?: string[] }).__titleCalls ?? [],
+    );
+    expect(callsBeforeSwitch).toEqual([]);
+
+    // Open a SECOND note as a different tab — in-app (client-side router) back
+    // to the list, then click the other row, exactly like the existing
+    // cross-tab specs (a hard `page.goto` would tear down the first tab
+    // instead of merely detaching it). This detaches (not destroys) the
+    // "Untitled" note's editor — NOT closing the first tab.
+    await page.goBack();
+    await expect(page.locator(".notes-content")).toBeVisible();
+    await page.locator(".title-btn", { hasText: "Weekly plan" }).click();
+    await expect(page.locator(".note-title-input")).toHaveValue("Weekly plan");
+
+    // The mocked suggest_note_title must have fired for n1 as a DIRECT
+    // consequence of the tab switch (detach), with no need to close the tab.
+    await expect(async () => {
+      const calls = await page.evaluate(
+        () => (window as unknown as { __titleCalls?: string[] }).__titleCalls ?? [],
+      );
+      expect(calls).toContain("n1");
+    }).toPass({ timeout: 2_000 });
+
+    // The tab-strip label for the FIRST (backgrounded) tab updates in place —
+    // TabsService.setTitle, driven by maybeAutoTitle's `.then` — with no need
+    // to revisit that tab first. Confirms the tab strip visibly reflects the
+    // auto-title, not just that the backend call fired.
+    const tabItems = page.locator("mur-tab-strip .tab-item");
+    await expect(tabItems.filter({ hasText: "Generated title" })).toBeVisible({
+      timeout: 2_000,
+    });
+
+    // Switching back to it shows the SAME note (still "Untitled" server-side —
+    // the mock's get_note is unchanged — but the open tab now carries the
+    // generated label).
+    await tabItems.filter({ hasText: "Generated title" }).click();
+    await expect(page.locator(".note-title-input")).toHaveValue("Untitled");
+
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/src/app/core/tab-route-reuse.strategy.ts
+++ b/src/app/core/tab-route-reuse.strategy.ts
@@ -56,6 +56,39 @@ export class TabRouteReuseStrategy extends RouteReuseStrategy {
   /** Detached-but-alive component handles, keyed by `tabKeyFor(...)`. */
   private readonly cache = new Map<string, DetachedRouteHandle>();
 
+  /**
+   * Subscribers notified the moment a tab is BACKGROUNDED (detached) by the
+   * router. This is the ONLY place that genuinely knows "this tab is being
+   * detached right now" — `store()` is called by the router the instant a
+   * `notes/:id`/`meeting/:id`/`org-item/:id` route is navigated away from. A
+   * detached-but-alive component (e.g. `NoteEditorComponent`) cannot observe
+   * its own detach through any Angular lifecycle hook — it is NOT destroyed
+   * (so `DestroyRef.onDestroy` never fires), and there is no `ngOnDetach` —
+   * so it has to learn about it from here.
+   *
+   * A plain callback list, not a `signal`: this is a genuine discrete EVENT
+   * ("tab X was just backgrounded"), not a piece of state a template reads —
+   * mirrors this codebase's existing cross-component notification shape for
+   * exactly that case (`IpcService.onContentDeleted`/`EVENT_CONTENT_DELETED`,
+   * subscribed once by `TabsService`'s constructor). A signal that is set
+   * then immediately reset to notify of an edge would coalesce to its final
+   * value for an `effect()`-based listener (effects only see the value at
+   * flush time) — silently dropping same-tick detaches; a callback list has
+   * no such trap.
+   */
+  private readonly detachListeners = new Set<(key: string) => void>();
+
+  /**
+   * Subscribe to every future tab-detach. Returns an unsubscribe function —
+   * callers (e.g. `NoteEditorComponent`) MUST call it in their own
+   * `DestroyRef.onDestroy`, since this registry — like `cache` — outlives any
+   * single component.
+   */
+  onDetach(listener: (key: string) => void): () => void {
+    this.detachListeners.add(listener);
+    return () => this.detachListeners.delete(listener);
+  }
+
   override shouldDetach(route: ActivatedRouteSnapshot): boolean {
     return tabKey(route) !== null;
   }
@@ -70,6 +103,11 @@ export class TabRouteReuseStrategy extends RouteReuseStrategy {
     }
     if (handle) {
       this.cache.set(key, handle);
+      // Notify AFTER caching so a listener that reacts synchronously always
+      // sees a fully up-to-date cache.
+      for (const listener of this.detachListeners) {
+        listener(key);
+      }
     } else {
       // Per the RouteReuseStrategy contract, storing `null` erases the entry.
       this.cache.delete(key);

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -20,6 +20,7 @@ import { map } from "rxjs";
 import { IpcService } from "../../../core/ipc.service";
 import { NavHistoryService } from "../../../core/nav-history.service";
 import { tabKeyFor } from "../../../core/tab-keys";
+import { TabRouteReuseStrategy } from "../../../core/tab-route-reuse.strategy";
 import { TabsService } from "../../../core/tabs.service";
 import type {
   AppConfigDto,
@@ -172,6 +173,7 @@ export class NoteEditorComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly tabsService = inject(TabsService);
+  private readonly tabRouteReuse = inject(TabRouteReuseStrategy);
   private readonly injector = inject(Injector);
   /** Environment (root) injector — hosts the detach-proof root lock effect. */
   private readonly envInjector = inject(EnvironmentInjector);
@@ -594,19 +596,34 @@ export class NoteEditorComponent {
     void this.loadFolders();
     void this.notes.loadNotes(null);
     void this.loadConfig();
-    // On teardown (route-leave) run the FULL save ONCE if there are unindexed edits —
-    // fire-and-forget so navigation is instant; the backend re-indexes + re-exports in
-    // the background. Nothing is lost either way (cheap autosaves already persisted the
-    // text). No pending edits ⇒ no needless re-embed on open-then-close.
-    this.destroyRef.onDestroy(() => {
-      if (this.dirtyFull) {
-        this.flushFull();
+    // On teardown (route-leave / app-quit — hard close) run the boundary work ONCE —
+    // fire-and-forget so navigation is instant; the backend re-indexes + re-exports (+
+    // auto-titles) in the background. Nothing is lost either way (cheap autosaves already
+    // persisted the text).
+    this.destroyRef.onDestroy(() => void this.runNoteBoundaryWork());
+
+    // Root-cause fix (2026-07-15): the callback above ONLY ever fired on a hard close (✕)
+    // or app quit — `notes/:id` tabs are DETACHED, not destroyed, on a plain tab switch
+    // (`TabRouteReuseStrategy.shouldDetach` returns true for this route), so
+    // `DestroyRef.onDestroy` never runs for the overwhelmingly common "type a note, click
+    // a different tab" flow, and a note's title never auto-generated unless the user
+    // literally closed the tab. `TabRouteReuseStrategy.onDetach` is the one place that
+    // genuinely knows a tab is being backgrounded RIGHT NOW (its `store()`, called by the
+    // router mid-navigation) — subscribe here and run the SAME boundary work at that
+    // earlier moment too. Filtered to THIS note's own tab key (a detach notification with
+    // no filter would run when ANY other note/meeting/org-item tab in the app detaches).
+    // Additive, not a replacement — the `onDestroy` trigger above still covers hard-close
+    // and app-quit, which never route through the router's detach path at all. Running
+    // this work twice for the same note (detach, then later a real destroy) is at worst a
+    // wasted no-op IPC round-trip (see {@link runNoteBoundaryWork}'s doc).
+    const unsubDetach = this.tabRouteReuse.onDetach((key) => {
+      const doc = this.note();
+      if (!doc || key !== tabKeyFor("note", doc.id)) {
+        return;
       }
-      // Auto-title an untitled note on close (Feature B) — fire-and-forget; the backend reads the
-      // last-saved body (cheap autosaves already persisted it), generates a LOCAL title, and keeps it
-      // only if the note is still "Untitled". Best-effort, never blocks teardown.
-      this.maybeAutoTitle();
+      void this.runNoteBoundaryWork();
     });
+    this.destroyRef.onDestroy(unsubDetach);
 
     // LOCK-REACTIVE re-mask — a ROOT effect via the EnvironmentInjector, NOT a
     // view effect: a view effect is FROZEN while `TabRouteReuseStrategy` keeps
@@ -631,10 +648,31 @@ export class NoteEditorComponent {
   }
 
   /**
-   * Feature B — on close, ask the backend to auto-title a still-"Untitled" note from its body (the
-   * on-device model when present, else a first-line heuristic; LOCAL-only). Fire-and-forget: the
-   * editor is being torn down, so we only reflect the new title back onto the (persisting) tab strip
-   * when it resolves. Skips a locked/masked note and an empty body up front (the backend re-checks).
+   * The shared "the user is done with this note for now" boundary work, run from BOTH
+   * triggers in the constructor (hard close/quit, and a plain tab-switch detach): flush
+   * the deferred full save (re-index + export) if there are unindexed edits, then attempt
+   * auto-title. Sequenced (not parallel) so auto-title's `suggestNoteTitle` read — which
+   * reads the last-SAVED body off the backend — sees the full-save's write if one just
+   * happened, not a race between the two.
+   */
+  private async runNoteBoundaryWork(): Promise<void> {
+    if (this.dirtyFull) {
+      await this.flushFull();
+    }
+    this.maybeAutoTitle();
+  }
+
+  /**
+   * Feature B — ask the backend to auto-title a still-"Untitled" note from its body (the
+   * on-device model when present, else a first-line heuristic; LOCAL-only). Called on
+   * every natural "the user is done with this note for now" boundary — a hard close/quit
+   * (the `destroyRef.onDestroy` callback) AND a plain tab switch (the `tabRouteReuse.onDetach`
+   * callback, since `notes/:id` tabs are detached-not-destroyed on switch — see the
+   * constructor comment). Fire-and-forget either way: we only reflect the new title back
+   * onto the (persisting) tab strip when it resolves. Skips a locked/masked note and an
+   * empty body up front (the backend re-checks both, plus re-checks the CURRENT title
+   * immediately before writing, so calling this twice for the same note is at worst a
+   * wasted on-device inference call, never a clobber).
    */
   private maybeAutoTitle(): void {
     const doc = this.note();
@@ -1112,12 +1150,12 @@ export class NoteEditorComponent {
    * navigation, so leaving is instant and the backend catches up. Joins the same
    * single-writer chain as the cheap saves, superseding any pending cheap save.
    */
-  private flushFull(): void {
+  private flushFull(): Promise<void> {
     const doc = this.note();
     if (doc) {
       this.debounce.cancel(this.saveDebounceKey(doc.id));
     }
-    void this.queueSave("full");
+    return this.queueSave("full");
   }
 
   /**
@@ -1184,7 +1222,7 @@ export class NoteEditorComponent {
 
   /** Retry a failed save — the full path (re-index + export). */
   retrySave(): void {
-    this.flushFull();
+    void this.flushFull();
   }
 
   // ── Tags ─────────────────────────────────────────────────────────────────
@@ -1376,7 +1414,7 @@ export class NoteEditorComponent {
     // save (re-index + vault export) once if there are unindexed edits, so the note
     // becomes brain-searchable + vault-synced without waiting for editor close.
     if (on && this.dirtyFull) {
-      this.flushFull();
+      void this.flushFull();
     }
   }
 


### PR DESCRIPTION
## What
`maybeAutoTitle()` (and the `dirtyFull` full-save flush living alongside
it) only ever ran from `destroyRef.onDestroy` — but `notes/:id` tabs are
DETACHED, not destroyed, on a plain tab switch (`TabRouteReuseStrategy`),
so the overwhelmingly common "type a note, click a different tab" flow
never triggered auto-title at all. A user had no reason to expect they'd
need to literally close the tab (✕) for a title to appear.

## Fix
`TabRouteReuseStrategy.onDetach(listener)` — a callback registry (not a
signal, which would coalesce away same-tick detaches) fired from the one
place that genuinely knows a tab is backgrounding right now (`store()`,
called by the router mid-navigation). `NoteEditorComponent` subscribes,
filtered to its own tab key, and runs the same boundary work there too.
Additive — `onDestroy` still covers hard-close/app-quit.

## An interaction worth flagging explicitly
This makes a dirty note's pending autosave timer always get eagerly
cancelled+flushed (as a FULL save) the instant its tab backgrounds — before
another note could ever schedule a colliding timer under a shared debounce
key. That structurally prevents the exact collision
`note-autosave-cross-tab-loss.spec.ts` (an earlier PR's regression test)
was written to catch, via ordinary tab-switching — verified empirically
(that test still passes even with the debounce-key scoping reverted to a
bare literal). Documented this in the test and widened its mock to track
both save paths (either is a genuine persist). The underlying scoping fix
remains necessary and is still fully exercised by the sibling retry-key
test, which fires on a failed save attempt, not a tab switch.

## Tests
`ng lint`/`ng build` clean. Full `e2e/notes/` suite: 25/25 passed. New
regression `note-autotitle-on-tab-detach.spec.ts`, RED-before-GREEN
confirmed against the pre-fix `onDestroy`-only trigger.