### PR TITLE
fix(org): repair merge-skew compile break in upsert_org_item test call sites

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -13799,6 +13799,7 @@ mod tests {
             1,
             &sha32(9),
             None,
+            None,
             Some(&emb),
         )
         .unwrap();
@@ -13834,6 +13835,7 @@ mod tests {
             1,
             &sha32(10),
             None,
+            None,
             Some(&emb),
         )
         .unwrap();
@@ -13848,6 +13850,7 @@ mod tests {
             1,
             1,
             &sha32(11),
+            None,
             None,
             Some(&emb),
         )


### PR DESCRIPTION
## What
Trunk currently fails to compile: PR #337 and PR #340 were built
independently off an earlier common commit, so PR #340's
`upsert_org_item` signature change (12→13 args, new `author_user_id`
param) never saw PR #337's brand-new test call sites, which still passed
12 args. Each PR was individually green; GitHub doesn't re-run CI on the
merge result.

## Fix
Adds the missing `author_user_id: None` argument to the 3 affected test
call sites in `src-tauri/src/storage/db.rs` (these tests don't exercise
authorship, so `None` is correct).

## Tests
`cargo test --lib`: 1644 passed (1 pre-existing, environment-dependent
failure unrelated to this fix — `settings::ai_map::tests::
default_config_is_cloud_claude_with_inactive_reactions`). `ng lint`/
`ng build` clean. Full `e2e/notes/` suite: 27/27 passed.

Mechanical 3-line fix restoring a compile break on trunk — merging directly
given the urgency (trunk is currently broken) and the trivial, purely-
additive nature of the change (all logic/behavior is unchanged, only 3
test call sites gained the argument the rest of the codebase already has).