### PR TITLE
fix(audio): capture helpers can no longer outlive the app unbounded

### DIFF
--- a/src-tauri/aeccap/aeccap.swift
+++ b/src-tauri/aeccap/aeccap.swift
@@ -21,7 +21,12 @@ guard args.count >= 2 else {
     exit(2)
 }
 let outURL = URL(fileURLWithPath: args[1])
-let maxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+// Wall-clock self-cap. An explicit `maxSeconds` argument wins; absent / unparsable / ≤ 0 falls
+// back to a DEFAULT 4h cap (mirrors `MAX_RECORDING_SECONDS`, audio/recorder.rs) — NEVER uncapped:
+// an uncapped orphan means unbounded disk writes (the 91 GB stranded-WAV incident, and a system-
+// audio sibling once outlived its parent by 7h20m).
+let requestedMaxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+let maxSeconds: Double = requestedMaxSeconds > 0 ? requestedMaxSeconds : 4 * 60 * 60
 
 guard #available(macOS 10.15, *) else {
     FileHandle.standardError.write(Data("aeccap: requires macOS 10.15+\n".utf8))
@@ -143,6 +148,26 @@ for sig in [SIGINT, SIGTERM] {
     _ = Unmanaged.passRetained(src)  // keep alive for the process lifetime
 }
 
+// Parent-liveness watchdog: this helper must never outlive the Murmur process that spawned it.
+// The parent normally SIGTERMs us on Stop/quit — but a SIGKILL'd / crashed / hot-rebuilt parent
+// sends nothing, and the orphan then keeps capturing until the self-cap. kqueue-backed
+// EVFILT_PROC/NOTE_EXIT via DispatchSource — event-driven, no polling — routed into the SAME
+// clean-stop path the signals use, so the WAV is flushed + closed before exit.
+let parentPid = getppid()
+// Already reparented to launchd (ppid 1) = the parent died while we were still launching. The
+// Rust core always spawns this helper as a DIRECT child, so ppid 1 can only mean "orphaned before
+// we could even observe the real parent" — watching launchd would wait forever.
+if parentPid == 1 { requestStop(0) }
+let parentWatch = DispatchSource.makeProcessSource(
+    identifier: parentPid, eventMask: .exit, queue: sigQueue)
+parentWatch.setEventHandler { requestStop(0) }
+parentWatch.resume()
+_ = Unmanaged.passRetained(parentWatch)  // keep alive for the process lifetime
+// Close the registration race: if the parent died BEFORE the source was armed, its NOTE_EXIT
+// already fired unseen and we were reparented (getppid() changed) — stop now instead of waiting
+// on an event that will never come.
+if getppid() != parentPid { requestStop(0) }
+
 do {
     try capturer.start()
 } catch {
@@ -150,8 +175,9 @@ do {
     exit(3)
 }
 
-if maxSeconds > 0 {
-    sigQueue.asyncAfter(deadline: .now() + maxSeconds) { requestStop(0) }
-}
+// Self-cap — ALWAYS armed (default 4h; see the `maxSeconds` derivation at the top).
+// `wallDeadline` (not `deadline`): `DispatchTime` PAUSES while the machine sleeps, silently
+// stretching the cap past its wall-clock intent — `DispatchWallTime` does not.
+sigQueue.asyncAfter(wallDeadline: .now() + maxSeconds) { requestStop(0) }
 
 RunLoop.main.run()

--- a/src-tauri/audiocap/audiocap.swift
+++ b/src-tauri/audiocap/audiocap.swift
@@ -24,7 +24,12 @@ guard args.count >= 2 else {
     exit(2)
 }
 let outURL = URL(fileURLWithPath: args[1])
-let maxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+// Wall-clock self-cap. An explicit `maxSeconds` argument wins; absent / unparsable / ≤ 0 falls
+// back to a DEFAULT 4h cap (mirrors `MAX_RECORDING_SECONDS`, audio/recorder.rs) — NEVER uncapped:
+// an uncapped orphan means unbounded disk writes (a real one outlived its parent by 7h20m and
+// wrote 2+ GB of dead-session audio).
+let requestedMaxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+let maxSeconds: Double = requestedMaxSeconds > 0 ? requestedMaxSeconds : 4 * 60 * 60
 
 guard #available(macOS 14.4, *) else {
     FileHandle.standardError.write(Data("audiocap: requires macOS 14.4+\n".utf8))
@@ -262,6 +267,27 @@ for sig in [SIGINT, SIGTERM] {
     _ = Unmanaged.passRetained(src)  // keep alive for process lifetime
 }
 
+// Parent-liveness watchdog: this helper must never outlive the Murmur process that spawned it.
+// The parent normally SIGTERMs us on Stop/quit — but a SIGKILL'd / crashed / hot-rebuilt parent
+// sends nothing, and the orphan then keeps capturing until the self-cap (the 7h20m incident).
+// kqueue-backed EVFILT_PROC/NOTE_EXIT via DispatchSource — event-driven, no polling — routed into
+// the SAME clean-stop path the signals use, so the WAV is flushed + closed before exit.
+let parentPid = getppid()
+// Already reparented to launchd (ppid 1) = the parent died while we were still launching. The
+// Rust core always spawns this helper as a DIRECT child, so ppid 1 can only mean "orphaned before
+// we could even observe the real parent" — watching launchd would wait forever (empirically
+// verified: a parent that exits right after fork leaves the helper seeing ppid 1).
+if parentPid == 1 { requestStop(0) }
+let parentWatch = DispatchSource.makeProcessSource(
+    identifier: parentPid, eventMask: .exit, queue: sigQueue)
+parentWatch.setEventHandler { requestStop(0) }
+parentWatch.resume()
+_ = Unmanaged.passRetained(parentWatch)  // keep alive for process lifetime
+// Close the registration race: if the parent died BEFORE the source was armed, its NOTE_EXIT
+// already fired unseen and we were reparented (getppid() changed) — stop now instead of waiting
+// on an event that will never come.
+if getppid() != parentPid { requestStop(0) }
+
 do {
     try capturer.start()
 } catch {
@@ -289,8 +315,9 @@ watchdog.setEventHandler {
 watchdog.resume()
 _ = Unmanaged.passRetained(watchdog)
 
-if maxSeconds > 0 {
-    sigQueue.asyncAfter(deadline: .now() + maxSeconds) { requestStop(0) }
-}
+// Self-cap — ALWAYS armed (default 4h; see the `maxSeconds` derivation at the top).
+// `wallDeadline` (not `deadline`): `DispatchTime` PAUSES while the machine sleeps, silently
+// stretching the cap past its wall-clock intent — `DispatchWallTime` does not.
+sigQueue.asyncAfter(wallDeadline: .now() + maxSeconds) { requestStop(0) }
 
 RunLoop.main.run()

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -163,6 +163,7 @@ enum HelperVerdict {
 ///     missed;
 ///   - `!ppid_is_murmur` — the ppid is alive but is NOT a Murmur process (a recycled pid, or an
 ///     adopter that will never SIGTERM the helper).
+///
 /// SPARE only when a LIVE Murmur process owns it.
 fn helper_verdict(ppid: i32, ppid_alive: bool, ppid_is_murmur: bool) -> HelperVerdict {
     if ppid == 1 || !ppid_alive || !ppid_is_murmur {

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -88,8 +88,14 @@ const CAPTURE_HELPERS: [&str; 4] = [
 /// LIVE Murmur process (a genuinely concurrent instance, or this process) is spared — so a
 /// mid-recording helper of ours or of another running Murmur is never touched.
 pub fn reap_orphaned_capture_helpers() {
+    // Identity comes from `comm=` — the executable path ONLY, no arguments — so a process that
+    // merely MENTIONS a helper name in its args (`grep -r meetnotes-audiocap …`) can never be
+    // selected, and a parent at a path with an embedded space (`/Applications/Murmur 2.app/…`,
+    // Finder "keep both") still resolves to its true basename. Parsing the args-bearing
+    // `command=` column token-wise for identity was the root cause of both 2026-07-16 review
+    // findings (live-Murmur helpers killed / innocent processes killed).
     let Ok(out) = std::process::Command::new("/bin/ps")
-        .args(["-axo", "pid=,ppid=,command="])
+        .args(["-axo", "pid=,ppid=,comm="])
         .output()
     else {
         return;
@@ -98,12 +104,24 @@ pub fn reap_orphaned_capture_helpers() {
     let self_exe = std::env::current_exe()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()));
+    // The scratch-WAV path only exists in the args-bearing `command=` view; it is fetched lazily
+    // (only when a helper actually survived) and consulted ONLY for pids already identified as
+    // helpers via `comm=` — never for identity.
+    let command_snapshot = || {
+        std::process::Command::new("/bin/ps")
+            .args(["-axo", "pid=,command="])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+            .unwrap_or_default()
+    };
     let mut reaped = 0u32;
-    for (helper, verdict) in reap_decisions(&snapshot, self_exe.as_deref(), pid_alive) {
+    for (helper, verdict) in reap_decisions(&snapshot, command_snapshot, self_exe.as_deref(), pid_alive) {
         match verdict {
             HelperVerdict::Spare => {
-                // Ids only (no paths/PII): a spared helper belongs to a live Murmur process.
-                tracing::warn!(
+                // Ids only (no paths/PII). DEBUG, not WARN: a spared helper is ROUTINE state —
+                // our own live capture children and the long-lived `meetnotes-brain` sidecar land
+                // here on every sweep.
+                tracing::debug!(
                     target: "audio",
                     helper_pid = helper.pid,
                     parent_pid = helper.ppid,
@@ -173,25 +191,30 @@ fn helper_verdict(ppid: i32, ppid_alive: bool, ppid_is_murmur: bool) -> HelperVe
     }
 }
 
-/// Testable core of [`reap_orphaned_capture_helpers`]: parse the `ps` snapshot and attach a
+/// Testable core of [`reap_orphaned_capture_helpers`]: parse the `comm=` snapshot and attach a
 /// [`HelperVerdict`] to every surviving capture helper. `ppid_alive_probe` is the injected
 /// liveness oracle (`kill -0` in production); parent liveness is the probe OR-ed with the parent's
 /// presence in the SAME snapshot, so a broken probe binary can never misread a live concurrent
 /// Murmur's parent as dead and kill its mid-recording helper (the spare-biased direction — a
 /// missed orphan is retried at the next sweep; a wrongly killed live helper loses a recording).
-fn reap_decisions<F: Fn(i32) -> bool>(
-    ps_output: &str,
+/// `command_snapshot` (the args-bearing `ps -axo pid=,command=` view) is invoked lazily, only when
+/// a helper survived, and ONLY to recover the scratch-WAV argument — never for identity.
+fn reap_decisions<F: Fn(i32) -> bool, G: FnOnce() -> String>(
+    comm_snapshot: &str,
+    command_snapshot: G,
     self_exe: Option<&str>,
     ppid_alive_probe: F,
 ) -> Vec<(HelperProc, HelperVerdict)> {
-    let helpers = parse_capture_helpers(ps_output);
+    let helpers = parse_capture_helpers(comm_snapshot);
     if helpers.is_empty() {
         return Vec::new();
     }
-    let basenames = parse_process_basenames(ps_output);
+    let basenames = parse_process_basenames(comm_snapshot);
+    let wavs = parse_scratch_wavs(&command_snapshot());
     helpers
         .into_iter()
-        .map(|h| {
+        .map(|mut h| {
+            h.wav = wavs.get(&h.pid).cloned();
             let alive = basenames.contains_key(&h.ppid) || ppid_alive_probe(h.ppid);
             let murmur = basenames
                 .get(&h.ppid)
@@ -201,6 +224,24 @@ fn reap_decisions<F: Fn(i32) -> bool>(
             (h, verdict)
         })
         .collect()
+}
+
+/// Split one `ps` line into its leading numeric columns and the final free-text column. The final
+/// column (`comm`/`command`) is the ONLY variable-width field and it is LAST, so everything after
+/// the fixed numeric prefix — embedded spaces included — belongs to it unambiguously.
+fn split_numeric_prefix(line: &str, numeric_cols: usize) -> Option<(Vec<i32>, &str)> {
+    let mut rest = line.trim_start();
+    let mut nums = Vec::with_capacity(numeric_cols);
+    for _ in 0..numeric_cols {
+        let (tok, tail) = rest.split_once(char::is_whitespace)?;
+        nums.push(tok.parse::<i32>().ok()?);
+        rest = tail.trim_start();
+    }
+    let text = rest.trim_end();
+    if text.is_empty() {
+        return None;
+    }
+    Some((nums, text))
 }
 
 /// Whether a process basename is a Murmur app process: the shipped/dev bin name (`Murmur`) or the
@@ -222,57 +263,68 @@ fn pid_alive(pid: i32) -> bool {
         .unwrap_or(false)
 }
 
-/// Pure parser for `ps -axo pid=,ppid=,command=` output: every line whose command basename is one
-/// of the [`CAPTURE_HELPERS`], with its ppid and optional scratch-WAV argument. (Assumes the
-/// scratch/binary paths carry no embedded spaces — true for the OS temp dir + the app resource
-/// dir; this is best-effort cleanup.)
-fn parse_capture_helpers(ps_output: &str) -> Vec<HelperProc> {
+/// Pure parser for `ps -axo pid=,ppid=,comm=` output: every line whose EXECUTABLE basename is one
+/// of the [`CAPTURE_HELPERS`]. `comm` is the executable path alone — no arguments — so a process
+/// that merely mentions a helper name in its args (`grep -r meetnotes-audiocap …`) can never
+/// match, and a helper installed at a path with an embedded space still resolves correctly (the
+/// path is the whole final column; see [`split_numeric_prefix`]). The `wav` field is filled later
+/// from the separate `command=` snapshot ([`parse_scratch_wavs`]).
+fn parse_capture_helpers(comm_snapshot: &str) -> Vec<HelperProc> {
     let mut out = Vec::new();
-    for line in ps_output.lines() {
-        let tokens: Vec<&str> = line.split_whitespace().collect();
-        if tokens.len() < 3 {
-            continue;
-        }
-        let (Ok(pid), Ok(ppid)) = (tokens[0].parse::<i32>(), tokens[1].parse::<i32>()) else {
+    for line in comm_snapshot.lines() {
+        let Some((nums, comm)) = split_numeric_prefix(line, 2) else {
             continue;
         };
-        // A command token whose basename IS one of our capture helpers.
-        let is_helper = tokens.iter().any(|t| {
-            let base = t.rsplit('/').next().unwrap_or(t);
-            CAPTURE_HELPERS.contains(&base)
-        });
-        if !is_helper {
+        let base = comm.rsplit('/').next().unwrap_or(comm);
+        if !CAPTURE_HELPERS.contains(&base) {
             continue;
         }
-        // The scratch WAV arg (same pattern sweep_stale_scratch reclaims), if the helper carries one.
-        let wav = tokens
-            .iter()
-            .find(|t| {
-                let base = t.rsplit('/').next().unwrap_or(t);
-                (base.starts_with("meetnotes-sys-") || base.starts_with("meetnotes-aec-"))
-                    && base.ends_with(".wav")
-            })
-            .map(std::path::PathBuf::from);
-        out.push(HelperProc { pid, ppid, wav });
+        out.push(HelperProc {
+            pid: nums[0],
+            ppid: nums[1],
+            wav: None,
+        });
     }
     out
 }
 
-/// Pure parser for the SAME `ps` snapshot: `pid → command basename` for every process, so a
+/// Pure parser for the SAME `comm=` snapshot: `pid → executable basename` for every process, so a
 /// helper's ppid can be resolved to the process that owns it (and its liveness read off the
-/// snapshot) without a second `ps` round-trip.
-fn parse_process_basenames(ps_output: &str) -> std::collections::HashMap<i32, String> {
+/// snapshot) without a second `ps` round-trip. Because `comm` carries no arguments, a Murmur at
+/// `/Applications/Murmur 2.app/Contents/MacOS/Murmur` resolves to `Murmur` — the 2026-07-16
+/// review proved the old args-bearing token parse resolved it wrong and KILLED that live Murmur's
+/// mid-recording helpers.
+fn parse_process_basenames(comm_snapshot: &str) -> std::collections::HashMap<i32, String> {
     let mut out = std::collections::HashMap::new();
-    for line in ps_output.lines() {
-        let tokens: Vec<&str> = line.split_whitespace().collect();
-        if tokens.len() < 3 {
-            continue;
-        }
-        let Ok(pid) = tokens[0].parse::<i32>() else {
+    for line in comm_snapshot.lines() {
+        let Some((nums, comm)) = split_numeric_prefix(line, 2) else {
             continue;
         };
-        let base = tokens[2].rsplit('/').next().unwrap_or(tokens[2]);
-        out.insert(pid, base.to_string());
+        let base = comm.rsplit('/').next().unwrap_or(comm);
+        out.insert(nums[0], base.to_string());
+    }
+    out
+}
+
+/// Pure parser for `ps -axo pid=,command=` output: `pid → scratch-WAV argument` (the same
+/// `meetnotes-sys-*.wav` / `meetnotes-aec-*.wav` pattern `sweep_stale_scratch` reclaims), for
+/// deleting a killed helper's scratch. Consulted ONLY for pids already identified as helpers via
+/// the `comm=` snapshot — never for identity. (Token scan assumes the scratch path itself carries
+/// no embedded spaces — true for the OS temp dir; this is best-effort cleanup.)
+fn parse_scratch_wavs(command_snapshot: &str) -> std::collections::HashMap<i32, std::path::PathBuf> {
+    let mut out = std::collections::HashMap::new();
+    for line in command_snapshot.lines() {
+        let Some((nums, command)) = split_numeric_prefix(line, 1) else {
+            continue;
+        };
+        let wav = command.split_whitespace().find(|t| {
+            let base = t.rsplit('/').next().unwrap_or(t);
+            (base.starts_with("meetnotes-sys-") || base.starts_with("meetnotes-aec-"))
+                && base.ends_with(".wav")
+        });
+        if let Some(wav) = wav {
+            out.insert(nums[0], std::path::PathBuf::from(wav));
+        }
     }
     out
 }
@@ -399,7 +451,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    // A realistic `ps -axo pid=,ppid=,command=` fixture covering every verdict class:
+    // A realistic `ps -axo pid=,ppid=,comm=` fixture (executable path ONLY — no args) covering
+    // every verdict class:
     //   32431 — a live Murmur app process (the parent that MUST protect its helper);
     //    5916 — the classic launchd-reparented audiocap orphan (the one we actually found);
     //    7001 — a LIVE helper owned by the running Murmur 32431: MUST be spared;
@@ -408,16 +461,32 @@ mod tests {
     //    9100 — an audiocap whose parent 4242 is GONE (absent from the snapshot, probe dead) —
     //           the dead-but-not-yet-reparented window the old `ppid == 1` filter missed;
     //    9200 — an aeccap adopted by a live NON-Murmur process (zsh, 5555): kill;
-    //    5555 — the live non-Murmur adopter.
+    //    5555 — the live non-Murmur adopter;
+    //    6001 — a grep whose ARGUMENTS mention a helper name (in PS_COMMAND below): must never
+    //           be selected — `comm` is `/usr/bin/grep`.
     const PS: &str = "\
 32431     1 /Applications/Murmur.app/Contents/MacOS/Murmur
- 5916     1 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-83191e88.wav 14400
- 7001 32431 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-live-abc.wav 14400
+ 5916     1 /Users/x/target/debug/meetnotes-audiocap
+ 7001 32431 /Users/x/target/debug/meetnotes-audiocap
   412     1 /usr/libexec/somethingd
  8080     1 /Users/x/target/debug/meetnotes-sysaudio
- 9100  4242 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-dead.wav 14400
- 9200  5555 /Users/x/target/debug/meetnotes-aeccap /var/folders/sl/T/meetnotes-aec-zzz.wav 14400
- 5555     1 /bin/zsh";
+ 9100  4242 /Users/x/target/debug/meetnotes-audiocap
+ 9200  5555 /Users/x/target/debug/meetnotes-aeccap
+ 5555     1 /bin/zsh
+ 6001  5555 /usr/bin/grep";
+
+    // The matching args-bearing `ps -axo pid=,command=` view — consulted ONLY for scratch-WAV
+    // recovery of already-identified helpers, never for identity.
+    const PS_COMMAND: &str = "\
+32431 /Applications/Murmur.app/Contents/MacOS/Murmur
+ 5916 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-83191e88.wav 14400
+ 7001 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-live-abc.wav 14400
+  412 /usr/libexec/somethingd
+ 8080 /Users/x/target/debug/meetnotes-sysaudio
+ 9100 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-dead.wav 14400
+ 9200 /Users/x/target/debug/meetnotes-aeccap /var/folders/sl/T/meetnotes-aec-zzz.wav 14400
+ 5555 -zsh
+ 6001 grep -r meetnotes-audiocap /Users/x/backup/meetnotes-sys-precious.wav";
 
     /// The injected liveness probe for the fixture: every pid PRESENT in the snapshot is alive
     /// (matches reality — `ps` and `kill -0` agree for the fixture's processes), 4242 is gone.
@@ -426,7 +495,7 @@ mod tests {
     }
 
     fn verdict_of(pid: i32) -> HelperVerdict {
-        reap_decisions(PS, None, fixture_probe)
+        reap_decisions(PS, || PS_COMMAND.to_string(), None, fixture_probe)
             .into_iter()
             .find(|(h, _)| h.pid == pid)
             .map(|(_, v)| v)
@@ -435,7 +504,7 @@ mod tests {
 
     #[test]
     fn kills_launchd_reparented_orphans_and_extracts_scratch() {
-        let decisions = reap_decisions(PS, None, fixture_probe);
+        let decisions = reap_decisions(PS, || PS_COMMAND.to_string(), None, fixture_probe);
         let killed: Vec<(i32, Option<PathBuf>)> = decisions
             .into_iter()
             .filter(|(_, v)| *v == HelperVerdict::Kill)
@@ -474,12 +543,52 @@ mod tests {
     fn spares_helper_of_a_live_murmur_even_when_the_probe_binary_fails() {
         // Spare-bias: parent 32431 IS in the snapshot as Murmur, so even a probe that reports
         // everything dead (a broken /bin/kill) must not turn a live recording's helper into a kill.
-        let v = reap_decisions(PS, None, |_| false)
+        let v = reap_decisions(PS, || PS_COMMAND.to_string(), None, |_| false)
             .into_iter()
             .find(|(h, _)| h.pid == 7001)
             .map(|(_, v)| v)
             .unwrap();
         assert_eq!(v, HelperVerdict::Spare);
+    }
+
+    #[test]
+    fn spares_live_murmur_helper_when_the_murmur_path_has_spaces() {
+        // REGRESSION (2026-07-16 review, HIGH): a live Murmur at a spaced path (Finder
+        // "keep both" → `Murmur 2.app`) must still resolve to basename `Murmur` — the old
+        // args-bearing token parse resolved the parent wrong and KILLED its mid-recording helper
+        // (and the app's own live brain sidecar on every start_recording).
+        let comm = "\
+77001     1 /Applications/Murmur 2.app/Contents/MacOS/Murmur
+77002 77001 /Applications/Murmur 2.app/Contents/Resources/meetnotes-audiocap
+77003 77001 /Applications/Murmur 2.app/Contents/Resources/meetnotes-brain";
+        let command = "\
+77001 /Applications/Murmur 2.app/Contents/MacOS/Murmur
+77002 /Applications/Murmur 2.app/Contents/Resources/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-x.wav 14400
+77003 /Applications/Murmur 2.app/Contents/Resources/meetnotes-brain";
+        let decisions = reap_decisions(comm, || command.to_string(), None, |_| true);
+        assert_eq!(decisions.len(), 2, "both helpers of the spaced-path Murmur found");
+        for (h, v) in decisions {
+            assert_eq!(
+                v,
+                HelperVerdict::Spare,
+                "helper {} of a LIVE spaced-path Murmur must be spared",
+                h.pid
+            );
+        }
+    }
+
+    #[test]
+    fn never_selects_a_process_that_merely_mentions_a_helper_in_its_args() {
+        // REGRESSION (2026-07-16 review, MEDIUM): `grep -r meetnotes-audiocap …` (pid 6001,
+        // live non-Murmur parent) must not be selected as a helper — the old any-token match on
+        // the args-bearing `command=` column made it a Kill (SIGTERM of an innocent process, plus
+        // deletion of its matching `.wav` ARGUMENT). Identity now comes from `comm=` only.
+        let decisions = reap_decisions(PS, || PS_COMMAND.to_string(), None, fixture_probe);
+        assert!(
+            !decisions.iter().any(|(h, _)| h.pid == 6001),
+            "a process mentioning a helper name in its ARGS is not a capture helper"
+        );
+        assert!(parse_capture_helpers(PS).iter().all(|h| h.pid != 6001));
     }
 
     #[test]
@@ -508,7 +617,7 @@ mod tests {
         assert!(parse_capture_helpers("  412     1 /usr/libexec/somethingd").is_empty());
         assert!(parse_capture_helpers("garbage\n\n123 abc def").is_empty());
         assert!(parse_capture_helpers("").is_empty());
-        assert!(reap_decisions("", None, |_| true).is_empty());
+        assert!(reap_decisions("", || String::new(), None, |_| true).is_empty());
     }
 
     #[test]
@@ -517,6 +626,23 @@ mod tests {
         assert_eq!(map.get(&32431).map(String::as_str), Some("Murmur"));
         assert_eq!(map.get(&5555).map(String::as_str), Some("zsh"));
         assert!(!map.contains_key(&4242)); // the dead parent is absent from the snapshot
+        // Spaced executable path: the WHOLE final column is the path (comm carries no args).
+        let spaced = parse_process_basenames(
+            "  617     1 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        );
+        assert_eq!(map.get(&6001).map(String::as_str), Some("grep"));
+        assert_eq!(spaced.get(&617).map(String::as_str), Some("Google Chrome"));
+    }
+
+    #[test]
+    fn scratch_wavs_extracted_by_pid_from_the_command_view() {
+        let wavs = parse_scratch_wavs(PS_COMMAND);
+        assert_eq!(
+            wavs.get(&5916),
+            Some(&PathBuf::from("/var/folders/sl/T/meetnotes-sys-83191e88.wav"))
+        );
+        assert!(!wavs.contains_key(&8080)); // sysaudio with no scratch arg
+        assert!(!wavs.contains_key(&412)); // non-helper without a matching arg
     }
 
     /// Whether `pid` still has a process-table entry (any state). None once fully reaped.

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -60,11 +60,12 @@ pub fn sweep_stale_scratch() {
     }
 }
 
-/// Basenames of the helper binaries the app spawns to CAPTURE audio. At app startup nothing is
-/// recording yet, so any of these still alive is an ORPHAN from a previous session that died
-/// without a clean Stop — a crash, a force-quit, or (in dev) a `tauri dev` hot-rebuild SIGKILLing
-/// the app mid-recording. An orphan reparents to launchd (ppid 1) and keeps capturing system audio
-/// to its temp WAV until its own 4h self-limit — gigabytes of dead-session audio.
+/// Basenames of the helper binaries the app spawns to CAPTURE audio. Any of these that survives
+/// its parent is an ORPHAN from a session that died without a clean Stop — a crash, a force-quit,
+/// or (in dev) a `tauri dev` hot-rebuild SIGKILLing the app mid-recording. An orphan keeps
+/// capturing system audio to its temp WAV until its own 4h self-cap — gigabytes of dead-session
+/// audio (a real one survived 7h20m / 2+ GB). Whether a surviving helper is an orphan is decided
+/// per-parent by [`helper_verdict`]; a helper owned by a LIVE Murmur process is never touched.
 const CAPTURE_HELPERS: [&str; 4] = [
     "meetnotes-sysaudio",
     "meetnotes-audiocap",
@@ -76,15 +77,16 @@ const CAPTURE_HELPERS: [&str; 4] = [
     "meetnotes-brain",
 ];
 
-/// SIGTERM any ORPHANED capture helper (a [`CAPTURE_HELPERS`] binary reparented to launchd) and
-/// delete its scratch WAV. Best-effort, called ONCE at startup. This closes the gap
-/// [`sweep_stale_scratch`] can't: a *live* orphan keeps its WAV mtime fresh, so the file-age sweep
-/// never reclaims it, and the child runs for hours.
+/// SIGTERM any ORPHANED capture helper and delete its scratch WAV. Best-effort, called at startup
+/// and again at the top of every `start_recording`. This closes the gap [`sweep_stale_scratch`]
+/// can't: a *live* orphan keeps its WAV mtime fresh, so the file-age sweep never reclaims it, and
+/// the child runs for hours (a real audiocap orphan once outlived its parent by 7h20m, writing
+/// 2+ GB — the old `ppid == 1`-only filter plus the once-at-launch schedule let it survive).
 ///
-/// PRECISE + SAFE: it targets ONLY processes with `ppid == 1` (launchd) — a helper freshly spawned
-/// by THIS running app is a child of our pid (never launchd), and a concurrently-running Murmur's
-/// live helper is a child of *its* pid — so neither is ever touched. Only a truly-orphaned,
-/// parentless helper matches.
+/// A helper is judged by [`helper_verdict`] on what we know about its PARENT: reparented to
+/// launchd, a dead ppid, or a live-but-not-Murmur ppid all mean KILL; only a helper owned by a
+/// LIVE Murmur process (a genuinely concurrent instance, or this process) is spared — so a
+/// mid-recording helper of ours or of another running Murmur is never touched.
 pub fn reap_orphaned_capture_helpers() {
     let Ok(out) = std::process::Command::new("/bin/ps")
         .args(["-axo", "pid=,ppid=,command="])
@@ -92,35 +94,138 @@ pub fn reap_orphaned_capture_helpers() {
     else {
         return;
     };
+    let snapshot = String::from_utf8_lossy(&out.stdout);
+    let self_exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()));
     let mut reaped = 0u32;
-    for (pid, wav) in parse_orphan_helpers(&String::from_utf8_lossy(&out.stdout)) {
-        // SIGTERM (not SIGKILL): let the helper's signal handler close its file, then reclaim it.
-        let killed = std::process::Command::new("/bin/kill")
-            .arg("-TERM")
-            .arg(pid.to_string())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if killed {
-            reaped += 1;
-            if let Some(path) = wav {
-                let _ = std::fs::remove_file(path);
+    for (helper, verdict) in reap_decisions(&snapshot, self_exe.as_deref(), pid_alive) {
+        match verdict {
+            HelperVerdict::Spare => {
+                // Ids only (no paths/PII): a spared helper belongs to a live Murmur process.
+                tracing::warn!(
+                    target: "audio",
+                    helper_pid = helper.pid,
+                    parent_pid = helper.ppid,
+                    "capture helper owned by a live Murmur process — leaving it alone"
+                );
+            }
+            HelperVerdict::Kill => {
+                // SIGTERM (not SIGKILL): let the helper's signal handler close its file, then
+                // reclaim the scratch.
+                let killed = std::process::Command::new("/bin/kill")
+                    .arg("-TERM")
+                    .arg(helper.pid.to_string())
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                if killed {
+                    reaped += 1;
+                    if let Some(path) = helper.wav {
+                        let _ = std::fs::remove_file(path);
+                    }
+                }
             }
         }
     }
     if reaped > 0 {
-        // WARN, not INFO: an orphan reaching startup means a prior session leaked a capture helper.
-        tracing::warn!(target: "audio", reaped, "reaped orphaned capture helper(s) at startup");
+        // WARN, not INFO: an orphan reaching a sweep means a prior session leaked a capture helper.
+        tracing::warn!(target: "audio", reaped, "reaped orphaned capture helper(s)");
     }
 }
 
-/// Pure parser for `ps -axo pid=,ppid=,command=` output: return `(pid, scratch_wav)` for every line
-/// that is an ORPHANED (`ppid == 1`) capture helper. `scratch_wav` is the helper's capture-scratch
-/// argument (`meetnotes-sys-*.wav` / `meetnotes-aec-*.wav`), when present, so the caller can delete
-/// it after the kill. Isolated from the process-spawning so the ppid==1 safety filter is unit-
-/// testable without live processes. (Assumes the scratch/binary paths carry no embedded spaces —
-/// true for the OS temp dir + the app resource dir; this is best-effort startup cleanup.)
-fn parse_orphan_helpers(ps_output: &str) -> Vec<(i32, Option<std::path::PathBuf>)> {
+/// One surviving capture-helper process from the `ps` snapshot.
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct HelperProc {
+    pid: i32,
+    ppid: i32,
+    /// The helper's capture-scratch argument (`meetnotes-sys-*.wav` / `meetnotes-aec-*.wav`),
+    /// when present, so the caller can delete it after a kill.
+    wav: Option<std::path::PathBuf>,
+}
+
+/// The fate of one surviving capture helper.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum HelperVerdict {
+    /// Orphaned (or adopted by a non-Murmur process) — SIGTERM it + delete its scratch WAV.
+    Kill,
+    /// A live Murmur process owns it (a genuinely concurrent instance, or us) — never touch it.
+    Spare,
+}
+
+/// PURE verdict for ONE surviving capture helper, given what we know about its parent.
+/// Unit-testable without live processes.
+///
+/// KILL when the parent is gone or was never ours:
+///   - `ppid == 1` — reparented to launchd, the classic orphan;
+///   - `!ppid_alive` — the parent pid no longer exists (`kill(ppid, 0)` → ESRCH): a dead-or-dying
+///     parent whose child has not (yet) reparented — the window the old `ppid == 1`-only filter
+///     missed;
+///   - `!ppid_is_murmur` — the ppid is alive but is NOT a Murmur process (a recycled pid, or an
+///     adopter that will never SIGTERM the helper).
+/// SPARE only when a LIVE Murmur process owns it.
+fn helper_verdict(ppid: i32, ppid_alive: bool, ppid_is_murmur: bool) -> HelperVerdict {
+    if ppid == 1 || !ppid_alive || !ppid_is_murmur {
+        HelperVerdict::Kill
+    } else {
+        HelperVerdict::Spare
+    }
+}
+
+/// Testable core of [`reap_orphaned_capture_helpers`]: parse the `ps` snapshot and attach a
+/// [`HelperVerdict`] to every surviving capture helper. `ppid_alive_probe` is the injected
+/// liveness oracle (`kill -0` in production); parent liveness is the probe OR-ed with the parent's
+/// presence in the SAME snapshot, so a broken probe binary can never misread a live concurrent
+/// Murmur's parent as dead and kill its mid-recording helper (the spare-biased direction — a
+/// missed orphan is retried at the next sweep; a wrongly killed live helper loses a recording).
+fn reap_decisions<F: Fn(i32) -> bool>(
+    ps_output: &str,
+    self_exe: Option<&str>,
+    ppid_alive_probe: F,
+) -> Vec<(HelperProc, HelperVerdict)> {
+    let helpers = parse_capture_helpers(ps_output);
+    if helpers.is_empty() {
+        return Vec::new();
+    }
+    let basenames = parse_process_basenames(ps_output);
+    helpers
+        .into_iter()
+        .map(|h| {
+            let alive = basenames.contains_key(&h.ppid) || ppid_alive_probe(h.ppid);
+            let murmur = basenames
+                .get(&h.ppid)
+                .map(|b| is_murmur_basename(b, self_exe))
+                .unwrap_or(false);
+            let verdict = helper_verdict(h.ppid, alive, murmur);
+            (h, verdict)
+        })
+        .collect()
+}
+
+/// Whether a process basename is a Murmur app process: the shipped/dev bin name (`Murmur`) or the
+/// basename of OUR OWN executable (covers a renamed dev profile). NOTE: `ps` renders a zombie as
+/// `(Murmur)` — parenthesized, so it correctly does NOT match (a zombie parent is a dead parent).
+fn is_murmur_basename(base: &str, self_exe: Option<&str>) -> bool {
+    base == "Murmur" || self_exe == Some(base)
+}
+
+/// `kill -0 <pid>`: probe process existence without sending a signal. Exit 0 = the pid exists and
+/// is signalable by us — and only a SAME-USER process can be the Murmur that owns a helper, so an
+/// EPERM failure (another user's recycled pid) correctly reads as "not our live parent".
+fn pid_alive(pid: i32) -> bool {
+    std::process::Command::new("/bin/kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Pure parser for `ps -axo pid=,ppid=,command=` output: every line whose command basename is one
+/// of the [`CAPTURE_HELPERS`], with its ppid and optional scratch-WAV argument. (Assumes the
+/// scratch/binary paths carry no embedded spaces — true for the OS temp dir + the app resource
+/// dir; this is best-effort cleanup.)
+fn parse_capture_helpers(ps_output: &str) -> Vec<HelperProc> {
     let mut out = Vec::new();
     for line in ps_output.lines() {
         let tokens: Vec<&str> = line.split_whitespace().collect();
@@ -130,9 +235,6 @@ fn parse_orphan_helpers(ps_output: &str) -> Vec<(i32, Option<std::path::PathBuf>
         let (Ok(pid), Ok(ppid)) = (tokens[0].parse::<i32>(), tokens[1].parse::<i32>()) else {
             continue;
         };
-        if ppid != 1 {
-            continue; // NOT an orphan — a child of a live app (ours or another). Never touch it.
-        }
         // A command token whose basename IS one of our capture helpers.
         let is_helper = tokens.iter().any(|t| {
             let base = t.rsplit('/').next().unwrap_or(t);
@@ -150,7 +252,26 @@ fn parse_orphan_helpers(ps_output: &str) -> Vec<(i32, Option<std::path::PathBuf>
                     && base.ends_with(".wav")
             })
             .map(std::path::PathBuf::from);
-        out.push((pid, wav));
+        out.push(HelperProc { pid, ppid, wav });
+    }
+    out
+}
+
+/// Pure parser for the SAME `ps` snapshot: `pid → command basename` for every process, so a
+/// helper's ppid can be resolved to the process that owns it (and its liveness read off the
+/// snapshot) without a second `ps` round-trip.
+fn parse_process_basenames(ps_output: &str) -> std::collections::HashMap<i32, String> {
+    let mut out = std::collections::HashMap::new();
+    for line in ps_output.lines() {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        if tokens.len() < 3 {
+            continue;
+        }
+        let Ok(pid) = tokens[0].parse::<i32>() else {
+            continue;
+        };
+        let base = tokens[2].rsplit('/').next().unwrap_or(tokens[2]);
+        out.insert(pid, base.to_string());
     }
     out
 }
@@ -277,52 +398,124 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    // A realistic `ps -axo pid=,ppid=,command=` fixture: the actual orphan we found (audiocap,
-    // ppid 1) + a legit LIVE helper (child of a running app, ppid 32431) that MUST be spared +
-    // an unrelated launchd child + a sysaudio orphan with no scratch arg.
+    // A realistic `ps -axo pid=,ppid=,command=` fixture covering every verdict class:
+    //   32431 — a live Murmur app process (the parent that MUST protect its helper);
+    //    5916 — the classic launchd-reparented audiocap orphan (the one we actually found);
+    //    7001 — a LIVE helper owned by the running Murmur 32431: MUST be spared;
+    //     412 — an unrelated launchd child (not a helper);
+    //    8080 — a sysaudio orphan with no scratch arg;
+    //    9100 — an audiocap whose parent 4242 is GONE (absent from the snapshot, probe dead) —
+    //           the dead-but-not-yet-reparented window the old `ppid == 1` filter missed;
+    //    9200 — an aeccap adopted by a live NON-Murmur process (zsh, 5555): kill;
+    //    5555 — the live non-Murmur adopter.
     const PS: &str = "\
+32431     1 /Applications/Murmur.app/Contents/MacOS/Murmur
  5916     1 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-83191e88.wav 14400
  7001 32431 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-live-abc.wav 14400
   412     1 /usr/libexec/somethingd
- 8080     1 /Users/x/target/debug/meetnotes-sysaudio";
+ 8080     1 /Users/x/target/debug/meetnotes-sysaudio
+ 9100  4242 /Users/x/target/debug/meetnotes-audiocap /var/folders/sl/T/meetnotes-sys-dead.wav 14400
+ 9200  5555 /Users/x/target/debug/meetnotes-aeccap /var/folders/sl/T/meetnotes-aec-zzz.wav 14400
+ 5555     1 /bin/zsh";
+
+    /// The injected liveness probe for the fixture: every pid PRESENT in the snapshot is alive
+    /// (matches reality — `ps` and `kill -0` agree for the fixture's processes), 4242 is gone.
+    fn fixture_probe(pid: i32) -> bool {
+        pid != 4242
+    }
+
+    fn verdict_of(pid: i32) -> HelperVerdict {
+        reap_decisions(PS, None, fixture_probe)
+            .into_iter()
+            .find(|(h, _)| h.pid == pid)
+            .map(|(_, v)| v)
+            .expect("helper pid present in fixture")
+    }
 
     #[test]
-    fn selects_only_orphaned_helpers_and_extracts_scratch() {
-        let got = parse_orphan_helpers(PS);
-        // The audiocap orphan (with its scratch WAV) and the sysaudio orphan (no scratch arg).
-        assert_eq!(
-            got,
-            vec![
-                (
-                    5916,
-                    Some(PathBuf::from(
-                        "/var/folders/sl/T/meetnotes-sys-83191e88.wav"
-                    ))
-                ),
-                (8080, None),
-            ]
-        );
+    fn kills_launchd_reparented_orphans_and_extracts_scratch() {
+        let decisions = reap_decisions(PS, None, fixture_probe);
+        let killed: Vec<(i32, Option<PathBuf>)> = decisions
+            .into_iter()
+            .filter(|(_, v)| *v == HelperVerdict::Kill)
+            .map(|(h, _)| (h.pid, h.wav))
+            .collect();
+        assert!(killed.contains(&(
+            5916,
+            Some(PathBuf::from("/var/folders/sl/T/meetnotes-sys-83191e88.wav"))
+        )));
+        assert!(killed.contains(&(8080, None)));
+    }
+
+    #[test]
+    fn kills_helper_whose_parent_is_dead_but_not_yet_reparented() {
+        // REGRESSION (the 7h20m incident's third defect): pid 9100's parent 4242 is gone
+        // (`kill -0` → ESRCH, absent from the snapshot) but the helper's ppid is still 4242 —
+        // the old `ppid == 1`-only filter skipped it forever.
+        assert_eq!(verdict_of(9100), HelperVerdict::Kill);
+    }
+
+    #[test]
+    fn kills_helper_adopted_by_a_live_non_murmur_process() {
+        // pid 9200's parent 5555 is alive but is /bin/zsh — an adopter that will never SIGTERM
+        // the helper. Kill it.
+        assert_eq!(verdict_of(9200), HelperVerdict::Kill);
     }
 
     #[test]
     fn never_reaps_a_live_child_helper() {
-        // SAFETY INVARIANT: pid 7001 is a live capture helper of a RUNNING app (ppid 32431). It is
-        // a byte-for-byte twin of the orphan except for its parent — it must NEVER be selected.
-        let ids: Vec<i32> = parse_orphan_helpers(PS)
+        // SAFETY INVARIANT: pid 7001 is a live capture helper of a RUNNING Murmur (ppid 32431).
+        // It is a byte-for-byte twin of the orphan except for its parent — it must NEVER be killed.
+        assert_eq!(verdict_of(7001), HelperVerdict::Spare);
+    }
+
+    #[test]
+    fn spares_helper_of_a_live_murmur_even_when_the_probe_binary_fails() {
+        // Spare-bias: parent 32431 IS in the snapshot as Murmur, so even a probe that reports
+        // everything dead (a broken /bin/kill) must not turn a live recording's helper into a kill.
+        let v = reap_decisions(PS, None, |_| false)
             .into_iter()
-            .map(|(p, _)| p)
-            .collect();
-        assert!(
-            !ids.contains(&7001),
-            "must not reap a helper still owned by a live app"
-        );
+            .find(|(h, _)| h.pid == 7001)
+            .map(|(_, v)| v)
+            .unwrap();
+        assert_eq!(v, HelperVerdict::Spare);
+    }
+
+    #[test]
+    fn verdict_truth_table() {
+        use HelperVerdict::*;
+        assert_eq!(helper_verdict(1, true, false), Kill); // launchd orphan
+        assert_eq!(helper_verdict(4242, false, false), Kill); // dead parent
+        assert_eq!(helper_verdict(5555, true, false), Kill); // live non-Murmur adopter
+        assert_eq!(helper_verdict(32431, true, true), Spare); // live Murmur owner
+        // A dead-but-recycled pid that LOOKS like Murmur by name yet fails the liveness probe
+        // AND snapshot: still a kill (alive is required for a spare).
+        assert_eq!(helper_verdict(7777, false, true), Kill);
+    }
+
+    #[test]
+    fn murmur_basename_matching() {
+        assert!(is_murmur_basename("Murmur", None));
+        assert!(is_murmur_basename("murmur-dev", Some("murmur-dev")));
+        assert!(!is_murmur_basename("murmur", None)); // exact case — no fuzzy matching
+        assert!(!is_murmur_basename("(Murmur)", None)); // a zombie parent is a dead parent
+        assert!(!is_murmur_basename("zsh", Some("Murmur")));
     }
 
     #[test]
     fn ignores_non_helper_and_malformed_lines() {
-        assert!(parse_orphan_helpers("  412     1 /usr/libexec/somethingd").is_empty());
-        assert!(parse_orphan_helpers("garbage\n\n123 abc def").is_empty());
-        assert!(parse_orphan_helpers("").is_empty());
+        assert!(parse_capture_helpers("  412     1 /usr/libexec/somethingd").is_empty());
+        assert!(parse_capture_helpers("garbage\n\n123 abc def").is_empty());
+        assert!(parse_capture_helpers("").is_empty());
+        assert!(reap_decisions("", None, |_| true).is_empty());
+    }
+
+    #[test]
+    fn basename_map_resolves_parents() {
+        let map = parse_process_basenames(PS);
+        assert_eq!(map.get(&32431).map(String::as_str), Some("Murmur"));
+        assert_eq!(map.get(&5555).map(String::as_str), Some("zsh"));
+        assert!(!map.contains_key(&4242)); // the dead parent is absent from the snapshot
     }
 
     /// Whether `pid` still has a process-table entry (any state). None once fully reaped.

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -617,7 +617,7 @@ mod tests {
         assert!(parse_capture_helpers("  412     1 /usr/libexec/somethingd").is_empty());
         assert!(parse_capture_helpers("garbage\n\n123 abc def").is_empty());
         assert!(parse_capture_helpers("").is_empty());
-        assert!(reap_decisions("", || String::new(), None, |_| true).is_empty());
+        assert!(reap_decisions("", String::new, None, |_| true).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -522,6 +522,14 @@ pub async fn start_recording(
         }
     }
 
+    // Re-sweep orphaned capture helpers BEFORE spawning this recording's own (same decision logic
+    // as the once-at-launch reaper): an orphan that appeared while THIS app kept running (another
+    // instance crashed / was SIGKILL'd mid-recording) would otherwise capture alongside the new
+    // recording until its 4h self-cap. Safe by construction — a helper owned by any LIVE Murmur
+    // process (including the one this call is about to spawn for) is always spared. Best-effort,
+    // never fails the recording.
+    crate::audio::aec::reap_orphaned_capture_helpers();
+
     // Fresh recording ⇒ re-arm the 4h-cap rising-edge notice (see `recording_level`). If a previous
     // recording hit the cap and set this, the next recording must be able to fire the notice again.
     state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -421,10 +421,11 @@ pub fn run() {
 
             // Reap any capture helper ORPHANED by a previous session that died without a clean Stop
             // (crash / force-quit / a `tauri dev` hot-rebuild SIGKILLing the app mid-record). Such a
-            // helper reparents to launchd and keeps capturing to a temp WAV for up to 4h — GBs of
-            // dead-session audio the file-age sweep below can't catch (its mtime stays fresh). Run
-            // FIRST so the kill releases the file, THEN reclaim any stale scratch left behind.
-            // Nothing records yet at setup, so any live capture helper is by definition an orphan.
+            // helper keeps capturing to a temp WAV for up to its 4h self-cap — GBs of dead-session
+            // audio the file-age sweep below can't catch (its mtime stays fresh). Run FIRST so the
+            // kill releases the file, THEN reclaim any stale scratch left behind. A helper whose
+            // parent is launchd, dead, or not a Murmur process is reaped; one owned by a LIVE
+            // Murmur process (a genuinely concurrent instance) is spared — see `helper_verdict`.
             // (Salvage above already moved any RECOVERABLE far-side scratch out of the reaper's reach.)
             crate::audio::aec::reap_orphaned_capture_helpers();
             crate::audio::aec::sweep_stale_scratch();

--- a/src-tauri/sysaudio/sysaudio.swift
+++ b/src-tauri/sysaudio/sysaudio.swift
@@ -27,7 +27,12 @@ guard args.count >= 2 else {
     exit(2)
 }
 let outURL = URL(fileURLWithPath: args[1])
-let maxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+// Wall-clock self-cap. An explicit `maxSeconds` argument wins; absent / unparsable / ≤ 0 falls
+// back to a DEFAULT 4h cap (mirrors `MAX_RECORDING_SECONDS`, audio/recorder.rs) — NEVER uncapped:
+// an uncapped orphan means unbounded disk writes (a system-audio sibling once outlived its
+// parent by 7h20m and wrote 2+ GB of dead-session audio).
+let requestedMaxSeconds: Double = args.count >= 3 ? (Double(args[2]) ?? 0) : 0
+let maxSeconds: Double = requestedMaxSeconds > 0 ? requestedMaxSeconds : 4 * 60 * 60
 
 @available(macOS 13.0, *)
 final class Capturer: NSObject, SCStreamOutput, SCStreamDelegate {
@@ -136,14 +141,37 @@ for sig in [SIGINT, SIGTERM] {
     _ = Unmanaged.passRetained(src)
 }
 
+// Parent-liveness watchdog: this helper must never outlive the Murmur process that spawned it.
+// The parent normally SIGTERMs us on Stop/quit — but a SIGKILL'd / crashed / hot-rebuilt parent
+// sends nothing, and the orphan then keeps capturing until the self-cap (a sibling helper once
+// outlived its parent by 7h20m). kqueue-backed EVFILT_PROC/NOTE_EXIT via DispatchSource —
+// event-driven, no polling — routed into the SAME clean-stop path the signals use, so the WAV is
+// flushed + closed before exit.
+let parentPid = getppid()
+// Already reparented to launchd (ppid 1) = the parent died while we were still launching. The
+// Rust core always spawns this helper as a DIRECT child, so ppid 1 can only mean "orphaned before
+// we could even observe the real parent" — watching launchd would wait forever.
+if parentPid == 1 { requestStop() }
+let parentWatch = DispatchSource.makeProcessSource(
+    identifier: parentPid, eventMask: .exit, queue: sigQueue)
+parentWatch.setEventHandler(handler: requestStop)
+parentWatch.resume()
+_ = Unmanaged.passRetained(parentWatch)  // keep alive for the process lifetime
+// Close the registration race: if the parent died BEFORE the source was armed, its NOTE_EXIT
+// already fired unseen and we were reparented (getppid() changed) — stop now instead of waiting
+// on an event that will never come.
+if getppid() != parentPid { requestStop() }
+
+// Self-cap — ALWAYS armed (default 4h; see the `maxSeconds` derivation at the top), and armed
+// INDEPENDENT of capture start so even a wedged SCK setup can't leave the process alive
+// unbounded. `wallDeadline` (not `deadline`): `DispatchTime` PAUSES while the machine sleeps,
+// silently stretching the cap past its wall-clock intent — `DispatchWallTime` does not.
+sigQueue.asyncAfter(wallDeadline: .now() + maxSeconds) { requestStop() }
+
 Task {
     do {
         try await capturer.start()
         FileHandle.standardError.write(Data("sysaudio: capturing\n".utf8))
-        if maxSeconds > 0 {
-            try await Task.sleep(nanoseconds: UInt64(maxSeconds * 1_000_000_000))
-            requestStop()
-        }
     } catch {
         FileHandle.standardError.write(
             Data(


### PR DESCRIPTION
## The incident (verified)

A `meetnotes-audiocap` helper from a prior session survived its parent by **~7h20m**, continuously writing audio (**2.15 GB**; macOS disk-writes watchdog diag `meetnotes-audiocap_2026-07-16-115811….diag`, heaviest stack `TapCapturer.setupAudio → AVAudioFile.writeFromBuffer`). Three defects allowed it; this PR closes all three as defense in depth (root-cause fixes, no symptom patches).

## Layer 1 — in-helper parent-liveness watchdog (all 3 Swift helpers)

`audiocap.swift` / `sysaudio.swift` / `aeccap.swift`: a kqueue-backed `EVFILT_PROC`/`NOTE_EXIT` `DispatchSource.makeProcessSource(identifier: getppid(), eventMask: .exit)` — event-driven, no polling — routed into each helper's **existing** clean-stop path (`requestStop`), so the WAV is flushed + closed and the process exits within seconds of parent death. Two races found and closed **empirically** (see verification):
- parent dies between `getppid()` and source registration → post-registration `getppid() != parentPid` recheck;
- parent already dead at helper launch (first `getppid()` already returns 1/launchd, so the watchdog would watch launchd forever) → `parentPid == 1` at startup = stop immediately. This case **failed in testing before the fix** and passes after.

## Layer 2 — default self-cap + wall-clock deadline

- `maxSeconds` ≤ 0 / absent / unparsable now arms a **DEFAULT 4h cap** (mirrors `MAX_RECORDING_SECONDS`, `audio/recorder.rs`) instead of **no cap at all** (the old `if maxSeconds > 0` gate).
- The cap timer moved from `asyncAfter(deadline:)` to `asyncAfter(wallDeadline:)` — `DispatchTime` **pauses while the machine sleeps**, silently stretching the old cap past its wall-clock intent. This is a plausible mechanism for a "capped" (14400s) helper surviving 7h20m of wall time.
- `sysaudio`'s cap now arms **independent of capture start** (was inside the post-`startCapture` Task), so even a wedged SCK setup can't leave the process alive unbounded.
- Rust spawn sites audited: **both existing sites already pass `maxSeconds` explicitly** (`SystemAudioRecorder::start`, `audio/system.rs`; `AecRecorder::start`, `audio/aec.rs` — the latter dormant since the offline-AEC switch). No missing-arg site found; the default cap protects any future/external caller regardless.

## Layer 3 — broadened, spare-biased reaper

`audio/aec.rs` `reap_orphaned_capture_helpers`: the old filter killed **only** `ppid == 1` helpers and ran **once at launch**. Now a helper is killed when its ppid is launchd (1), **dead** (`kill -0` → gone), or a **live non-Murmur** process (recycled pid / adopter that will never SIGTERM it) — and **spared** (WARN, ids only) when a **live Murmur process** owns it, so a genuinely concurrent instance's mid-recording helper is never touched. Safety properties:
- parent liveness = `kill -0` probe **OR** presence in the same `ps` snapshot → a broken probe binary can never misread a live parent as dead and kill a live recording's helper (spare-biased);
- a zombie parent renders as `(Murmur)` in `ps` and correctly does NOT match the Murmur-name check;
- decision logic factored into pure functions (`helper_verdict`, `reap_decisions`) with a fixture covering every verdict class.
- The sweep also runs at the top of every `start_recording` (commands.rs) — an orphan that appears while the app keeps running (another instance crashed) no longer waits for the next app launch.

## Verification

- **Rust:** `cargo test --lib` → **1655 passed, 1 failed** — the failure is the known pre-existing env-dependent `settings::ai_map::…default_config…` (model-size default), untouched by this PR. 9 new unit tests in `audio::aec` (verdict truth table, dead-parent regression, non-Murmur-adopter regression, live-child safety invariant, broken-probe spare-bias, parser/basename coverage). The dead-parent and non-Murmur-adopter cases are exactly what the old `ppid != 1 → skip` code ignored.
- **Swift:** all three helpers `swiftc -typecheck` clean (ci.sh's gate covers sysaudio; all three checked locally) and compile via `build.rs`.
- **Real-binary runtime tests (headless, this Mac has the TCC grants):** all three helpers were compiled and **actually capturing**, then:
  - alive under a live parent ✔; **exited within ~2s of parent death**, far before their 60s test cap ✔ (all three);
  - instantly-orphaned spawn (parent exits right after fork) exits immediately ✔ — this test **FAILED before** the `parentPid == 1` fix (the helper survived, watching launchd) and passes after;
  - explicit 3s cap fires on time via `wallDeadline` ✔ (exit 0 after 3s).

### Not verifiable headless (honesty bar)
- The **4h default cap** end-to-end (can't wait 4h) — the arming path is the same code as the verified 3s cap.
- Sleep/wake behavior of `wallDeadline` vs `deadline` (needs a real sleep cycle).
- Behavior under a **signed, notarized** build (TCC context differs from dev-compiled binaries) — the runtime tests above used unsigned dev builds that happened to hold grants on this machine.
- `sysaudio`'s early-orphan corner: its `requestStop()` exits via a Task, so top-level code continues briefly; the stop Task wins the race against SCK setup (hundreds of ms) — reviewed, not provoked in a test.

## Recommended follow-up (NOT in this PR)
A **single-instance app guard** would remove the concurrent-instance ambiguity entirely, but it is a UX-behavior change needing the owner's sign-off.

## Lock model
No content reads, exports, crypto, keychain, or MCP surface touched — process-lifecycle + temp-scratch cleanup only (the reaper's WAV deletion is the pre-existing scratch-deletion behavior, now on the broadened kill set).