### PR TITLE
perf(embed): one process-wide cached embedder; org-ingest embeds through run_heavy

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -30585,8 +30585,9 @@ async fn org_sync_one(
 ) -> Result<(), AppError> {
     // ── ASYNC PULL PHASE — drain the feed, opening each cell; buffer decrypted items ──────────────
     // The embedder (`dyn Embedder`, !Send) is deliberately NOT constructed here: the whole async
-    // section is Send-safe, and the synchronous INGEST phase below owns the embedder entirely (never
-    // held across an `.await`). A tombstone applies immediately (no key/blob needed).
+    // section is Send-safe, and the INGEST phase below owns the embedder entirely INSIDE its
+    // `perf::run_heavy` blocking closure (never held across an `.await`). A tombstone applies
+    // immediately (no key/blob needed).
     //
     // FIX D — per-item failures are classified TRANSIENT vs TERMINAL so one poison item never stalls
     // the WHOLE feed forever (pre-fix: EVERY failure did `break 'pages`, so a single un-openable cell
@@ -30730,79 +30731,100 @@ async fn org_sync_one(
         cursor = cursor.max(feed.next_seq);
     }
 
-    // ── SYNC INGEST PHASE — embedder built ONCE, never crosses an await ───────────────────────────
-    // Scoped in its own block: `embedder`/`embedder_ref` (`dyn Embedder`, !Send) MUST be fully dropped
-    // before the backfill's `.await` below, or the whole `org_sync_now` future stops being `Send` (Tauri
-    // commands must be `Send`) — a bare `drop(x)` call does NOT shrink NLL liveness the way going out of
-    // scope does, so this needs the block, not just an explicit drop.
-    {
-        let embedder: Option<Box<dyn crate::embed::Embedder>> = if report.fts_only {
-            None
-        } else {
-            Some(crate::embed::active_embedder())
-        };
-        let embedder_ref: Option<&dyn crate::embed::Embedder> = embedder.as_deref();
-        let mut applied = cursor;
-        for action in actions {
-            match action {
-                FeedAction::Tombstone { item_id, seq } => {
-                    state.db.tombstone_org_item(&item_id)?;
-                    report.tombstoned += 1;
-                    applied = applied.max(seq);
+    // ── INGEST PHASE — on the blocking pool, through the ONE global heavy-inference gate ──────────
+    // Ingesting an item embeds it via Candle/Metal (`upsert_org_item` → `embed_passage`), which used
+    // to run INLINE on this async command's Tokio worker AND outside `perf::run_heavy` — a large feed
+    // pull could run an ungated Metal forward pass concurrently with transcription/diarization. Route
+    // the whole apply loop through the shared gate like every other heavy native call site (the
+    // `unlock_folder` restore is the exemplar). SKIPPED entirely when the pull produced no actions —
+    // the every-60s background tick's common case — so an idle tick no longer constructs an embedder
+    // (or takes the heavy permit) per org. The embedder lives entirely INSIDE the blocking closure,
+    // so the old "must drop before the backfill's `.await` or the future stops being `Send`" block
+    // dance is now moot by construction; `active_embedder()` itself is a cheap handle to the ONE
+    // process-wide cached engine (see `embed::REAL_EMBEDDER_CACHE`), not a fresh per-org instance.
+    if !actions.is_empty() {
+        let db = state.db.clone();
+        let org_id = org.org_id.clone();
+        let fts_only = report.fts_only;
+        let (tombstoned, ingested) = crate::perf::run_heavy(
+            &state.heavy_inference,
+            move || -> Result<(u32, u32), AppError> {
+                let embedder: Option<Box<dyn crate::embed::Embedder>> = if fts_only {
+                    None
+                } else {
+                    Some(crate::embed::active_embedder())
+                };
+                let embedder_ref: Option<&dyn crate::embed::Embedder> = embedder.as_deref();
+                let mut tombstoned: u32 = 0;
+                let mut ingested: u32 = 0;
+                let mut applied = cursor;
+                for action in actions {
+                    match action {
+                        FeedAction::Tombstone { item_id, seq } => {
+                            db.tombstone_org_item(&item_id)?;
+                            tombstoned += 1;
+                            applied = applied.max(seq);
+                        }
+                        // FIX D: a permanently un-ingestable item advances the cursor past its seq (no DB
+                        // write), so it never stalls the feed — the good item behind it ingests on the SAME sync.
+                        FeedAction::SkipTerminal { seq } => {
+                            applied = applied.max(seq);
+                            db.set_org_last_seq(&org_id, applied as i64)?;
+                        }
+                        FeedAction::Ingest {
+                            item_id,
+                            seq,
+                            rev,
+                            generation,
+                            env,
+                            sha,
+                            author_user_id,
+                        } => {
+                            // AUTHOR (root-cause fix, 2026-07-15): pass the feed's server-authoritative author
+                            // id DIRECTLY into the upsert (in both the INSERT and the `ON CONFLICT`'s
+                            // `COALESCE`, so it can never be clobbered back to NULL by a later light re-upsert)
+                            // instead of a separate follow-up `set_org_item_author` call — this row is correct
+                            // the moment it's written, not one extra statement later. Server never sends an
+                            // empty author id, but guard anyway — an empty string is passed through as `None`
+                            // rather than stamping a blank value.
+                            let author_ref = if author_user_id.is_empty() {
+                                None
+                            } else {
+                                Some(author_user_id.as_str())
+                            };
+                            db.upsert_org_item(
+                                &item_id,
+                                &org_id,
+                                seq,
+                                &env.author_hint,
+                                &env.title,
+                                &env.markdown,
+                                &env.created_at,
+                                rev,
+                                generation,
+                                &sha,
+                                // Straight off the opened envelope: `Some("document"|"meeting")` for an item
+                                // published from a v2 wire envelope (this device's own publishes, or a peer
+                                // already on v2); `None` for one opened off an old v1 envelope (no wire signal) —
+                                // honest "unclassified", never guessed.
+                                env.source_kind
+                                    .map(crate::share::org_envelope::OrgSourceKind::as_str),
+                                author_ref,
+                                embedder_ref,
+                            )?;
+                            ingested += 1;
+                            applied = applied.max(seq);
+                        }
+                    }
+                    // Advance the cursor per successfully-applied item (monotonic; Core's setter no-ops backward).
+                    db.set_org_last_seq(&org_id, applied as i64)?;
                 }
-                // FIX D: a permanently un-ingestable item advances the cursor past its seq (no DB
-                // write), so it never stalls the feed — the good item behind it ingests on the SAME sync.
-                FeedAction::SkipTerminal { seq } => {
-                    applied = applied.max(seq);
-                    state.db.set_org_last_seq(&org.org_id, applied as i64)?;
-                }
-                FeedAction::Ingest {
-                    item_id,
-                    seq,
-                    rev,
-                    generation,
-                    env,
-                    sha,
-                    author_user_id,
-                } => {
-                    // AUTHOR (root-cause fix, 2026-07-15): pass the feed's server-authoritative author
-                    // id DIRECTLY into the upsert (in both the INSERT and the `ON CONFLICT`'s
-                    // `COALESCE`, so it can never be clobbered back to NULL by a later light re-upsert)
-                    // instead of a separate follow-up `set_org_item_author` call — this row is correct
-                    // the moment it's written, not one extra statement later. Server never sends an
-                    // empty author id, but guard anyway — an empty string is passed through as `None`
-                    // rather than stamping a blank value.
-                    let author_ref = if author_user_id.is_empty() {
-                        None
-                    } else {
-                        Some(author_user_id.as_str())
-                    };
-                    state.db.upsert_org_item(
-                        &item_id,
-                        &org.org_id,
-                        seq,
-                        &env.author_hint,
-                        &env.title,
-                        &env.markdown,
-                        &env.created_at,
-                        rev,
-                        generation,
-                        &sha,
-                        // Straight off the opened envelope: `Some("document"|"meeting")` for an item
-                        // published from a v2 wire envelope (this device's own publishes, or a peer
-                        // already on v2); `None` for one opened off an old v1 envelope (no wire signal) —
-                        // honest "unclassified", never guessed.
-                        env.source_kind.map(crate::share::org_envelope::OrgSourceKind::as_str),
-                        author_ref,
-                        embedder_ref,
-                    )?;
-                    report.ingested += 1;
-                    applied = applied.max(seq);
-                }
-            }
-            // Advance the cursor per successfully-applied item (monotonic; Core's setter no-ops backward).
-            state.db.set_org_last_seq(&org.org_id, applied as i64)?;
-        }
+                Ok((tombstoned, ingested))
+            },
+        )
+        .await?;
+        report.tombstoned += tombstoned;
+        report.ingested += ingested;
     }
 
     // STALE-INGEST BACKFILL (2026-07-15): the cursor-based pull above only ever asks for `seq > cursor`,

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -18,7 +18,7 @@
 use crate::error::Result;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 /// The REAL on-device embedder (multilingual-e5-small via candle). ALWAYS compiled; the real impl is
 /// selected at runtime by [`active_embedder`] when the e5 model dir is present, else the stub.
@@ -327,6 +327,102 @@ impl Embedder for StubEmbedder {
     }
 }
 
+/// Process-wide cache of the constructed REAL embedder, keyed by the resolved model DIR — the one
+/// input that can change at runtime (the Settings picker writes a new `embed_model_id` via
+/// [`set_selected_embed_model_id`], which resolves a DIFFERENT subdir; the cache rebuilds on the
+/// key change so a stale wrong-model embedder is never served).
+///
+/// WHY a cache: [`candle_bert::CandleBertEmbedder`]'s heavy safetensors/tokenizer load is lazy PER
+/// INSTANCE (its `inner: Mutex<Option<Arc<Loaded>>>`), so the historical "construct one per
+/// operation" idiom meant each instance's loaded Metal weights died with it and the NEXT operation
+/// re-loaded them from scratch. The 60s org-sync tick made the churn visible: one construction per
+/// joined org per tick (~7,200/day at 5 orgs), each re-stat'ing the model files and logging
+/// "ready (lazy load)". One shared instance loads the weights at most once per process (per model
+/// switch); its inner mutex already serializes the lazy load, and concurrent `embed` calls on the
+/// shared instance are safe (`&self` over immutable tensors — the `Loaded` engine is read-only
+/// after construction). Actual forward passes stay gated by the heavy-inference semaphore
+/// (`crate::perf::run_heavy`) at the call sites that run them.
+///
+/// LOCKING (no-deadlock contract): this lock is held ONLY for the key compare + `Arc` clone /
+/// insert — NEVER across a model load or a forward pass (construction happens before the write
+/// lock; the heavy lazy load happens later, inside the instance, on first `embed`). A poisoned
+/// lock degrades to serving an uncached instance — never a panic.
+///
+/// MEMORY residency (honest note): once the shared instance has embedded anything, the e5 weights
+/// stay resident for the life of the process instead of dropping with the last per-operation
+/// instance. Under real usage (indexing / retrieval / org sync) the weights were being re-loaded
+/// almost immediately anyway — the steady-state RAM is similar, minus the reload churn (and the
+/// known candle Metal-object leak per load/forward cycle, huggingface/candle#2271).
+static REAL_EMBEDDER_CACHE: RwLock<Option<(PathBuf, Arc<candle_bert::CandleBertEmbedder>)>> =
+    RwLock::new(None);
+
+/// Resolve the process-wide SHARED instance of the real embedder for `dir` (the SELECTED model's
+/// resolved on-disk dir): a hit is an `Arc` clone; a miss (first use, or the selection now resolves
+/// a different dir) constructs a fresh instance (cheap — three `is_file` stats; the weights load
+/// lazily on first `embed`) and installs it, evicting the previous model's entry. `dir` is a
+/// parameter (not re-resolved here) so tests can drive the cache against temp dirs
+/// deterministically. NEVER panics; NEVER holds the cache lock across construction.
+fn cached_real_embedder(
+    dir: PathBuf,
+    model: &'static EmbedModel,
+) -> Result<Arc<candle_bert::CandleBertEmbedder>> {
+    if let Ok(g) = REAL_EMBEDDER_CACHE.read() {
+        if let Some((key, arc)) = g.as_ref() {
+            if *key == dir {
+                return Ok(arc.clone());
+            }
+        }
+    }
+    // Miss (or poisoned read lock): construct OUTSIDE any lock, then install.
+    let built = Arc::new(candle_bert::CandleBertEmbedder::new(
+        dir.clone(),
+        model.query_prefix,
+        model.passage_prefix,
+    )?);
+    match REAL_EMBEDDER_CACHE.write() {
+        Ok(mut g) => {
+            // Double-check under the write lock: a racing caller may have installed the same dir
+            // first — keep the incumbent (its weights may already be loaded), drop ours (unloaded).
+            if let Some((key, arc)) = g.as_ref() {
+                if *key == dir {
+                    return Ok(arc.clone());
+                }
+            }
+            *g = Some((dir, built.clone()));
+            // The one-per-process (per model switch) readiness line — previously logged on EVERY
+            // construction, i.e. 5×/min from the 5-org background sync tick alone.
+            tracing::info!(target: "embed", model_id = %model.id, "local embed model ready (lazy load)");
+        }
+        Err(_) => {
+            tracing::warn!(target: "embed", model_id = %model.id, "embed cache lock poisoned; serving an uncached embedder");
+        }
+    }
+    Ok(built)
+}
+
+/// A thin [`Embedder`] handle over the process-wide cached [`candle_bert::CandleBertEmbedder`]
+/// (see [`REAL_EMBEDDER_CACHE`]), so [`active_embedder`]'s `Box<dyn Embedder>` contract is
+/// unchanged for its ~30 call sites while every returned box shares ONE lazily-loaded engine.
+/// ALL FOUR trait methods delegate — `embed_passage`/`embed_query` must reach the inner instance's
+/// per-model prefix overrides; falling back to this trait's default impls would silently re-apply
+/// the DEFAULT module-const prefixes to a non-default model.
+struct SharedEmbedder(Arc<candle_bert::CandleBertEmbedder>);
+
+impl Embedder for SharedEmbedder {
+    fn dim(&self) -> usize {
+        self.0.dim()
+    }
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.0.embed(texts)
+    }
+    fn embed_passage(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.0.embed_passage(texts)
+    }
+    fn embed_query(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.0.embed_query(texts)
+    }
+}
+
 /// The single active embedding backend used by BOTH the index path (chunking a note on creation)
 /// and the query path (Ask-My-Vault / MCP `search_semantic`). Returning a boxed trait object keeps
 /// the model a swappable seam.
@@ -343,9 +439,13 @@ impl Embedder for StubEmbedder {
 /// width EQUALS [`EMBED_DIM`] — ZERO `vec_chunks` schema migration. (A future model whose dimension
 /// differs would be a `vec_chunks float[N]` SCHEMA change — an additive migration to a new-width vec0
 /// table plus a full re-index, NOT a code one-liner; a mismatched-width insert fails loud, never
-/// silently.) Cheap to construct (the stub is zero-sized; the candle backend defers the heavy load),
-/// so callers build one per operation. NEVER invoked when `semantic_search_enabled` is off (the gate
-/// short-circuits before this is called) — building the real embedder does NOT flip that flag.
+/// silently.) Still cheap to call per operation (the stub is zero-sized; the real backend is an
+/// `Arc` clone of the ONE process-wide cached instance — see [`REAL_EMBEDDER_CACHE`] — so repeated
+/// calls share the same lazily-loaded engine instead of re-loading weights per instance). Model
+/// presence + selection are RE-CHECKED on every call, so a model download or a Settings model
+/// switch takes effect on the next embed with no restart. NEVER invoked when
+/// `semantic_search_enabled` is off (the gate short-circuits before this is called) — building the
+/// real embedder does NOT flip that flag.
 ///
 /// TEST-BUILD SAFETY NET: `cargo test --lib` must never attempt a real Metal forward pass (see the
 /// header doc on `embed::candle_bert` — "NEVER runs a forward pass here"). That was previously true
@@ -362,14 +462,9 @@ pub fn active_embedder() -> Box<dyn Embedder> {
     }
     let model = selected_embed_model();
     if embed_model_present() {
-        let built = embed_model_dir().and_then(|dir| {
-            candle_bert::CandleBertEmbedder::new(dir, model.query_prefix, model.passage_prefix)
-        });
+        let built = embed_model_dir().and_then(|dir| cached_real_embedder(dir, model));
         match built {
-            Ok(e) => {
-                tracing::info!(target: "embed", model_id = %model.id, "local embed model ready (lazy load)");
-                return Box::new(e);
-            }
+            Ok(e) => return Box::new(SharedEmbedder(e)),
             Err(e) => {
                 tracing::warn!(target: "embed", model_id = %model.id, error = %e, "local embed init failed; using stub embedder");
             }
@@ -2010,5 +2105,95 @@ mod tests {
             let norm: f32 = a[0].iter().map(|x| x * x).sum::<f32>().sqrt();
             assert!((norm - 1.0).abs() < 1e-5);
         }
+    }
+
+    /// A unique temp "model dir" holding the three (dummy) files `CandleBertEmbedder::new` stats.
+    /// Construction only checks existence — the heavy load is lazy and these tests NEVER call
+    /// `embed`, so garbage file contents are fine (and no Metal is ever touched).
+    fn fake_model_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-embed-cache-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        for f in EMBED_MODEL_FILES {
+            std::fs::write(dir.join(f), b"dummy").unwrap();
+        }
+        dir
+    }
+
+    /// THE org-tick fix's mechanism: two consecutive resolutions for the SAME model dir return the
+    /// SAME shared instance (`Arc::ptr_eq`) — so per-org-per-tick `active_embedder()` calls now
+    /// share one lazily-loaded engine, and the "ready (lazy load)" log line (which lives on the
+    /// cache-INSTALL path this test proves runs once) fires once per process/model-switch instead
+    /// of once per call (5×/min at 5 orgs). Serialized on the shared test lock because the cache
+    /// is a process global.
+    #[test]
+    fn cached_real_embedder_reuses_one_instance_for_the_same_dir() {
+        let _g = EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = fake_model_dir("same");
+        let a = cached_real_embedder(dir.clone(), default_embed_model()).unwrap();
+        let b = cached_real_embedder(dir.clone(), default_embed_model()).unwrap();
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "the same model dir must resolve to the SAME cached instance"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The runtime model-CHANGE path (a Settings switch writes a new `embed_model_id`, which
+    /// resolves a DIFFERENT model subdir): the cache is keyed on the resolved dir, so a changed dir
+    /// yields a FRESH instance (never a stale wrong-model embedder), which is then itself cached.
+    #[test]
+    fn cached_real_embedder_rebuilds_on_a_model_dir_change() {
+        let _g = EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir1 = fake_model_dir("change-1");
+        let dir2 = fake_model_dir("change-2");
+        let first = cached_real_embedder(dir1.clone(), default_embed_model()).unwrap();
+        let switched = cached_real_embedder(dir2.clone(), default_embed_model()).unwrap();
+        assert!(
+            !Arc::ptr_eq(&first, &switched),
+            "a changed model dir must yield a FRESH instance, never the previous model's"
+        );
+        let again = cached_real_embedder(dir2.clone(), default_embed_model()).unwrap();
+        assert!(
+            Arc::ptr_eq(&switched, &again),
+            "the new dir's instance is itself cached"
+        );
+        let _ = std::fs::remove_dir_all(&dir1);
+        let _ = std::fs::remove_dir_all(&dir2);
+    }
+
+    /// A missing model file makes the cache resolution fail LOUD (Err, never a panic) and never
+    /// installs a broken entry — the next call with a valid dir still caches normally.
+    #[test]
+    fn cached_real_embedder_errors_on_a_missing_file_without_poisoning_the_cache() {
+        let _g = EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let bad = std::env::temp_dir().join(format!(
+            "murmur-embed-cache-bad-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&bad).unwrap(); // dir exists but has NO model files
+        assert!(cached_real_embedder(bad.clone(), default_embed_model()).is_err());
+        let good = fake_model_dir("recover");
+        let a = cached_real_embedder(good.clone(), default_embed_model()).unwrap();
+        let b = cached_real_embedder(good.clone(), default_embed_model()).unwrap();
+        assert!(Arc::ptr_eq(&a, &b), "cache recovers after a failed resolve");
+        let _ = std::fs::remove_dir_all(&bad);
+        let _ = std::fs::remove_dir_all(&good);
     }
 }


### PR DESCRIPTION
## Verified defect

Every 60s background org-sync tick logged FIVE consecutive `embed: local embed model ready (lazy load)` lines — one per joined org — because `org_sync_one`'s ingest phase called `crate::embed::active_embedder()` once per org per tick (~7,200 constructions/day at 5 orgs), never caching across orgs or ticks. Additionally, when ingest actually embedded pulled items, the Candle/Metal forward pass ran on the async Tokio worker WITHOUT going through `perf::run_heavy` — the global one-heavy-inference-at-a-time gate every other heavy native call site honors.

## What construction actually costs (honest framing)

`CandleBertEmbedder::new` itself is cheap: three `is_file` stats + storing the dir/prefixes — the heavy safetensors/tokenizer load is lazy on first `.embed()`. So an idle tick's per-org construction was mostly log noise + redundant disk probes, NOT a per-tick model load. The real resource bug is one step further: the lazy-loaded engine is cached **per instance** (`inner: Mutex<Option<Arc<Loaded>>>`), so the construct-per-operation idiom meant any operation that actually embedded (org ingest, note indexing, retrieval) loaded the full weights onto Metal and then dropped them with the instance — the next operation re-loaded from scratch, churning ~0.5 GB per cycle on top of the known candle Metal leak (huggingface/candle#2271). The 5×/min log line was the visible symptom of that churn pattern.

## The fix (at the source — fixes every call site, not just the org loop)

- **`embed.rs`** — `active_embedder()` now resolves the real backend through a process-wide `REAL_EMBEDDER_CACHE` (`RwLock<Option<(PathBuf, Arc<CandleBertEmbedder>)>>`) keyed on the **resolved model dir**, the one input that changes at runtime (the Settings model switch resolves a different subdir → cache miss → fresh instance; a stale wrong-model embedder is never served). Presence + selection are still re-checked per call, so a model download/switch takes effect on the next embed with no restart. The public `Box<dyn Embedder>` contract is unchanged for all ~30 call sites via a thin `SharedEmbedder` handle delegating **all four** trait methods (the prefix pair must reach the inner per-model overrides). Deadlock safety: the cache lock is held only for the key-compare + Arc clone/insert — never across construction, the lazy load, or a forward pass; a poisoned lock degrades to an uncached instance. `CandleBertEmbedder` is `Send + Sync` (compiler-enforced by the static; concurrent `embed`s are `&self` over immutable tensors, and the inner mutex serializes only the one-time lazy load).
- **`commands.rs` `org_sync_one`** — the ingest phase now runs inside `perf::run_heavy` on the blocking pool (same pattern as the `unlock_folder` restore), and is **skipped entirely when the pull produced no actions** — the every-60s common case. An idle tick no longer constructs an embedder, takes the heavy permit, or logs. The old "embedder must drop before the backfill's await or the future stops being Send" block dance is moot: the embedder lives entirely inside the blocking closure.
- The `ready (lazy load)` log line moved to the cache-install path → fires once per process (or per model switch) instead of once per construction.

## Tests

- `embed::tests::cached_real_embedder_reuses_one_instance_for_the_same_dir` — two consecutive resolutions are `Arc::ptr_eq` (the install path, where the log line lives, runs once).
- `embed::tests::cached_real_embedder_rebuilds_on_a_model_dir_change` — the runtime model-switch path yields a fresh instance, itself cached.
- `embed::tests::cached_real_embedder_errors_on_a_missing_file_without_poisoning_the_cache` — loud `Err`, cache recovers.
- Existing `org_sync_now_over_two_orgs_iterates_both` / `org_sync_skips_a_terminal_item_and_ingests_the_next` / `org_sync_backfills_null_author_for_an_already_ingested_item` pass unchanged and now exercise the `run_heavy` ingest path on a real Tokio runtime.
- `cargo test --lib`: **1652 passed / 10 ignored / 1 failed** — the failure is the known pre-existing env-dependent `settings::ai_map::…default_config…` whisper-default assertion (machine-RAM dependent), unrelated to this change. `cargo clippy --lib -- -D warnings`: clean.

## Behavior notes

- Memory residency (deliberate trade-off): after the first real embed, the e5 weights stay resident for the process lifetime instead of dropping with the last per-op instance. Under real usage they were re-loaded almost immediately anyway; steady-state RAM is similar minus the reload churn. The heavy-inference semaphore still gates all forward passes.
- Not verified headless: the actual on-Mac log cadence (once-per-process `ready (lazy load)`) and Metal load behavior need a dev/signed run — the unit tests prove the mechanism (single install per dir), not the live log stream.
- No FE changes; no lock-model surface touched (org items are outside the folder-lock domain; the ingest path's gating semantics are unchanged — only WHERE it runs moved).
