### PR TITLE
fix(pipeline): guarantee a terminal status for every recording Stop (wedged "Transcribing…" forever)

### DIFF
--- a/e2e/record/reload-reconcile-stage.spec.ts
+++ b/e2e/record/reload-reconcile-stage.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Webview-(re)load stage reconciliation — `RecorderStore.init()` now queries the
+ * backend's `recording_status` once and reconciles the FE stage with the Rust
+ * process's truth (the fix's FE half for the "pipeline future died / webview
+ * swapped" wedge).
+ *
+ * Two shapes:
+ *
+ * 1. RED-able resync: the backend is GENUINELY recording (webview reloaded
+ *    mid-recording — tauri-dev hot reload, Cmd-R, webview crash). Pre-fix the
+ *    fresh store booted at "idle" (nothing ever called `recording_status`), so
+ *    the surface showed the Start button while the backend recorder was live —
+ *    and the next Start hit the "already recording" guard. Post-fix the surface
+ *    boots straight into the recording strip.
+ *
+ * 2. The wedge's reload contract: the backend is NOT recording and the last
+ *    meeting errored out (the pipeline task died before this webview session
+ *    even loaded — its terminal events fired into the void). The (re)loaded
+ *    record surface must NOT show any optimistic "Transcribing…" processing
+ *    state — it settles on the idle surface, ready to record again.
+ */
+test.describe("Record — webview (re)load reconciles the stage with the backend", () => {
+  test("a webview loaded while the backend is genuinely recording resyncs to the recording strip", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      recording_status: () => ({
+        recording: true,
+        meetingId: "m-live",
+        startedAt: new Date(Date.now() - 90_000).toISOString(),
+      }),
+    });
+
+    await page.goto("/record");
+
+    // WITHOUT clicking Start: the store's init() resync must adopt the
+    // backend's in-flight recording.
+    await expect(page.locator(".rec-strip.is-recording")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator("button.stop-btn")).toBeVisible();
+    await expect(page.locator("button.start-btn")).toHaveCount(0);
+  });
+
+  test("a webview loaded after the pipeline died (backend idle, last meeting ERROR) never shows the optimistic transcribing state", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      // The backend's truth after the wedge: nothing is recording or
+      // processing — the pipeline task is gone and the ghost meeting row was
+      // marked ERROR by the terminal-status guard.
+      recording_status: () => ({
+        recording: false,
+        meetingId: null,
+        startedAt: null,
+      }),
+      list_meetings: () => [
+        {
+          id: "m-dead",
+          startedAt: "2026-07-16T09:00:00Z",
+          endedAt: null,
+          title: "Wedged meeting",
+          durationS: 1200,
+          audioPath: null,
+          status: "ERROR",
+          folderId: null,
+        },
+      ],
+    });
+
+    await page.goto("/record");
+
+    // The idle surface — never the processing view.
+    await expect(page.locator("button.start-btn")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(/Transcribing on-device/i)).toHaveCount(0);
+    await expect(page.locator("button.stop-btn")).toHaveCount(0);
+    await expect(page.locator(".rec-strip.is-recording")).toHaveCount(0);
+  });
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -608,6 +608,9 @@ scope to the GA-critical path only.
       case "start_recording": return { meetingId: DEMO_MEETING_ID };
       case "stop_recording": return { meetingId: DEMO_MEETING_ID, markdown: NOTE_MD, exportedPath: `${VAULT}/Meetings/Q2-Roadmap-Planning.md` };
       case "recording_level": return 0.28 + Math.random() * 0.55;
+      // Backend truth for "is a recording in flight" — the fresh-webview stage resync
+      // (RecorderStore.reconcileStage). Idle by default; tests override per scenario.
+      case "recording_status": return { recording: false, meetingId: null, startedAt: null };
       case "set_mic_muted": return null;
       case "is_mic_muted": return false;
       case "list_input_devices": return [{ name: "MacBook Pro Microphone", isDefault: true }, { name: "AirPods Pro", isDefault: false }, { name: "Shure MV7", isDefault: false }];

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -789,14 +789,17 @@ pub async fn stop_recording(
     };
 
     // STAGE 2 crash-salvage: take the spill writer into a guard whose `Drop` stops the writer thread
-    // and DELETES the plaintext spill + sidecar on EVERY exit path of this Stop (success, `?`-error,
-    // panic) — mirroring `pipeline::ScratchWav`. It is held across `run_after_stop` below (dropped at
-    // end of scope), so it survives until the archive WAV is written; after a normal Stop the spill is
-    // gone. ONLY a crash (this function never runs) leaves it behind for next-launch salvage.
+    // and DELETES the plaintext spill + sidecar on EVERY exit path of the pipeline (success,
+    // `?`-error, panic-unwind) — mirroring `pipeline::ScratchWav`. It is MOVED INTO the detached
+    // pipeline task below (2026-07-16) and dropped there right after `run_after_stop` returns, so
+    // its drop timing relative to the pipeline is unchanged (it survives until the archive WAV is
+    // written) — but it is now immune to THIS command future being dropped mid-await (webview
+    // teardown): the spill lives exactly as long as the pipeline that is consuming the audio.
+    // ONLY a process crash (the task never finishes) leaves it behind for next-launch salvage.
     // A POISONED `spill_writer` mutex (`.lock().ok()` ⇒ None) merely DEFERS this clean-stop cleanup:
     // the spill lingers to next launch, where `claim_inflight` sees the row is no longer RECORDING and
     // DiscardOrphans it — benign (no leak, no content loss), so tolerating the poison here is correct.
-    let _spill_guard = state.spill_writer.lock().ok().and_then(|mut s| s.take());
+    let spill_guard = state.spill_writer.lock().ok().and_then(|mut s| s.take());
 
     // The recording is definitively over — clear the accumulated live-caption buffer NOW so a
     // stale tail can never be injected into assistant prompts after Stop (nor keep egressing once
@@ -858,22 +861,57 @@ pub async fn stop_recording(
     // Duration from the persisted started_at, falling back to a sample-count estimate.
     let duration_s = compute_duration_s(&state, &meeting_id, samples.len(), src_rate);
 
-    let result = pipeline::run_after_stop(
-        &app,
-        &state,
-        &meeting_id,
-        samples,
-        src_rate,
-        duration_s,
-        system_wav,
-        aec_mic_wav,
-        mic_started_at,
-        system_started_at,
-    )
-    .await?;
-
-    // Resume voice listening if it's still enabled (the mic is free again).
-    restart_voice_listener(app);
+    // DETACHED, panic-mapped pipeline execution (2026-07-16). The verified production wedge:
+    // `run_after_stop` was awaited INLINE in this command future, and Tauri never settles the JS
+    // invoke Promise for a command future that PANICS (tokio swallows the panic at the task
+    // boundary) or is DROPPED mid-await — the FE stayed on "Transcribing…" forever with the
+    // meeting row stuck at RECORDING and no terminal event. Running the pipeline in a REAL
+    // spawned task fixes both halves:
+    //   • a pipeline PANIC surfaces here as a `JoinError` → mapped to an `AppError` so the
+    //     invoke Promise REJECTS (FE catch → "error"), and the in-task `TerminalStatusGuard`
+    //     has already persisted `Error` + emitted the terminal `error` event during the unwind;
+    //   • if THIS command future is dropped (webview teardown/reload), the detached task keeps
+    //     running to completion and still performs its own status writes + event emits — the
+    //     (re)loaded FE recovers via the event path even without the Promise.
+    let task_app = app.clone();
+    let task_meeting_id = meeting_id.clone();
+    let pipeline_task = tauri::async_runtime::spawn(async move {
+        // Owns the crash-salvage spill for exactly the pipeline's lifetime — see the comment at
+        // the `take()` above. Dropped (spill deleted) when this scope exits: success, error, or
+        // panic-unwind — never before the pipeline has finished with the audio.
+        let _spill_guard = spill_guard;
+        let state = task_app.state::<AppState>();
+        // Armed NOW; disarmed on BOTH normal arms below. Fires ONLY on a panic-unwind (or an
+        // unexpected early exit) — `run_after_stop`'s Err arm already persists `Error` + emits
+        // the `error` stage itself, so there is no double-emit.
+        let terminal_guard = pipeline::TerminalStatusGuard::arm(
+            Some(task_app.clone()),
+            state.db.clone(),
+            &task_meeting_id,
+        );
+        let result = pipeline::run_after_stop(
+            &task_app,
+            &state,
+            &task_meeting_id,
+            samples,
+            src_rate,
+            duration_s,
+            system_wav,
+            aec_mic_wav,
+            mic_started_at,
+            system_started_at,
+        )
+        .await;
+        terminal_guard.disarm();
+        // Resume voice listening if it's still enabled (the mic is free again). Inside the task
+        // (Ok arm only, preserving the pre-change `?` semantics) so it still runs when the outer
+        // command future was dropped mid-pipeline.
+        if result.is_ok() {
+            restart_voice_listener(task_app.clone());
+        }
+        result
+    });
+    let result = await_pipeline_task(pipeline_task).await?;
 
     Ok(StopResult {
         meeting_id: result.meeting_id,
@@ -882,6 +920,22 @@ pub async fn stop_recording(
             .exported_path
             .map(|p| p.to_string_lossy().to_string()),
     })
+}
+
+/// Await the detached pipeline task, mapping a join failure (= the pipeline task PANICKED; it is
+/// never aborted) into a real [`AppError`] so the invoke Promise REJECTS instead of never
+/// settling (the FE's `stop()` catch then shows the error state). The panic's message +
+/// location are logged by the global panic hook (`lib.rs`); the `JoinError` here carries no
+/// note/transcript content, so the surfaced message is PII-safe.
+async fn await_pipeline_task<T>(
+    task: tauri::async_runtime::JoinHandle<Result<T, AppError>>,
+) -> Result<T, AppError> {
+    task.await.map_err(|e| {
+        AppError::Other(anyhow::anyhow!(
+            "note pipeline crashed unexpectedly ({e}) — the meeting was marked failed; \
+             try re-summarizing from the meeting page"
+        ))
+    })?
 }
 
 /// Best-effort recording duration in whole seconds: prefer `now - started_at` from the
@@ -31546,5 +31600,48 @@ mod storage_cmd_tests {
         .unwrap();
         assert_eq!(s.freed_bytes, 0);
         let _ = std::fs::remove_file(&p);
+    }
+}
+
+#[cfg(test)]
+mod pipeline_task_tests {
+    use super::*;
+
+    /// The panic-mapping contract of the detached pipeline execution (2026-07-16 wedge fix): a
+    /// PANIC inside the spawned pipeline task must surface from `await_pipeline_task` as a real
+    /// `Err(AppError)` — which is what makes the JS invoke Promise REJECT (FE catch → "error")
+    /// instead of never settling. Pre-fix there was no spawn at all: the panic unwound through
+    /// the command future, tokio swallowed it at the task boundary, and the Promise hung forever.
+    #[tokio::test]
+    async fn pipeline_task_panic_maps_to_a_rejecting_err() {
+        let task: tauri::async_runtime::JoinHandle<Result<u32, AppError>> =
+            tauri::async_runtime::spawn(async { panic!("simulated pipeline panic") });
+        let res = await_pipeline_task(task).await;
+        match res {
+            Err(AppError::Other(e)) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("pipeline crashed"),
+                    "the mapped error must say the pipeline crashed (got: {msg})"
+                );
+            }
+            other => panic!("a panicked pipeline task must map to Err(AppError::Other), got {other:?}"),
+        }
+    }
+
+    /// Ok and Err results of the spawned task pass through `await_pipeline_task` unchanged —
+    /// the join mapping only covers the panic case.
+    #[tokio::test]
+    async fn pipeline_task_results_pass_through_unchanged() {
+        let ok = tauri::async_runtime::spawn(async { Ok::<u32, AppError>(42) });
+        assert_eq!(await_pipeline_task(ok).await.unwrap(), 42);
+
+        let err = tauri::async_runtime::spawn(async {
+            Err::<u32, AppError>(AppError::Transcribe("real stage failure".into()))
+        });
+        match await_pipeline_task(err).await {
+            Err(AppError::Transcribe(msg)) => assert_eq!(msg, "real stage failure"),
+            other => panic!("an inner Err must pass through unchanged, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,30 @@ pub fn run() {
         None => tracing_subscriber::fmt().with_env_filter(log_filter).init(),
     }
 
+    // PANIC VISIBILITY (2026-07-16): tokio swallows a panic at the task boundary and the default
+    // hook prints only to stderr — which LaunchServices discards for a double-clicked app, so a
+    // production pipeline panic left ZERO evidence in murmur.log (the "wedged on Transcribing…"
+    // forensics found an idle process and an empty trail). Route every panic through `tracing`
+    // (which tees to murmur.log) FIRST, then chain to the previous hook so dev stderr/backtrace
+    // behavior is preserved. PII: message + source location only — panic payloads from our code
+    // carry no note/transcript content, and no content fields are added here.
+    let previous_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()))
+            .unwrap_or_else(|| "unknown".to_string());
+        let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "non-string panic payload".to_string()
+        };
+        tracing::error!(target: "panic", %location, %message, "panic");
+        previous_panic_hook(info);
+    }));
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(

--- a/src-tauri/src/perf.rs
+++ b/src-tauri/src/perf.rs
@@ -23,14 +23,25 @@ where
     F: FnOnce() -> Result<T> + Send + 'static,
     T: Send + 'static,
 {
-    let _permit = semaphore
+    let permit = semaphore
         .clone()
         .acquire_owned()
         .await
         .map_err(|_| AppError::Other(anyhow::anyhow!("heavy-inference semaphore closed")))?;
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|e| AppError::Other(anyhow::anyhow!("heavy inference task panicked: {e}")))?
+    tokio::task::spawn_blocking(move || {
+        // The permit is moved INTO the blocking closure (2026-07-16) — not held by this async
+        // future. If the CALLER's future is dropped mid-await (e.g. the pipeline's ASR watchdog
+        // `tokio::time::timeout` firing), the orphaned blocking closure keeps running to
+        // completion (blocking closures are not cancellable) and MUST keep the one
+        // heavy-inference permit until it actually finishes — otherwise a newly-started heavy
+        // call would co-run with the orphan (the whisper/diarizer co-residency class this
+        // semaphore exists to prevent). Held-in-future vs held-in-closure is identical on the
+        // normal Ok/Err paths (the JoinHandle resolves only after the closure ends).
+        let _permit = permit;
+        f()
+    })
+    .await
+    .map_err(|e| AppError::Other(anyhow::anyhow!("heavy inference task panicked: {e}")))?
 }
 
 /// macOS kernel memory-pressure level via `sysctl -n kern.memorystatus_vm_pressure_level` — the
@@ -139,6 +150,56 @@ mod tests {
             max_concurrent.load(Ordering::SeqCst),
             1,
             "two run_heavy calls on the same semaphore must never overlap"
+        );
+    }
+
+    /// 2026-07-16 (pipeline hang watchdog, RED-before-GREEN): when the CALLER's future is dropped
+    /// mid-flight — exactly what `tokio::time::timeout` around the pipeline's ASR stage does — the
+    /// orphaned `spawn_blocking` closure keeps running (blocking closures are not cancellable) and
+    /// MUST keep the one heavy-inference permit until it actually finishes. Before the fix the
+    /// permit lived in `run_heavy`'s async future, so the timeout-drop released it while the
+    /// blocking thread still ran — letting a second heavy inference co-run with the orphan (the
+    /// whisper/diarizer co-residency class this semaphore exists to prevent).
+    #[tokio::test]
+    async fn run_heavy_keeps_the_permit_while_an_orphaned_closure_still_runs() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let finished_in = finished.clone();
+        let fut = run_heavy(&sem, move || -> Result<()> {
+            std::thread::sleep(Duration::from_millis(400));
+            finished_in.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+        // Time the caller out long before the closure finishes — the future is DROPPED here,
+        // but the blocking closure is already running (or queued) and will run to completion.
+        let timed_out = tokio::time::timeout(Duration::from_millis(50), fut).await;
+        assert!(timed_out.is_err(), "the caller must observe the timeout");
+
+        // The orphaned closure is still running → the permit MUST still be held.
+        assert!(
+            !finished.load(Ordering::SeqCst),
+            "closure must still be running at this point (timing precondition)"
+        );
+        assert_eq!(
+            sem.available_permits(),
+            0,
+            "the permit must stay with the still-running orphaned closure, not the dropped future"
+        );
+
+        // Once the closure finishes, the permit is released (poll with a deadline — no flaky sleep).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while sem.available_permits() == 0 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            finished.load(Ordering::SeqCst),
+            "the orphaned closure must have run to completion"
+        );
+        assert_eq!(
+            sem.available_permits(),
+            1,
+            "the permit must be released once the orphaned closure completes"
         );
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -86,6 +86,147 @@ fn emit_status(app: &AppHandle, stage: &str, message: &str, meeting_id: &str) {
     }
 }
 
+/// Drop-armed TERMINAL-STATUS guard for the detached post-Stop pipeline task (2026-07-16).
+///
+/// The production defect this closes: a PANIC (or unexpected early exit) anywhere inside the
+/// pipeline unwound out of the task with NO terminal `error` status emitted and the meeting row
+/// still at `RECORDING` — tokio swallows the panic at the task boundary, Tauri never settles the
+/// invoke Promise for a panicked command future, and the FE wedged on "Transcribing…" forever.
+///
+/// Armed at the pipeline task's entry; DISARMED on both the Ok and the Err path of
+/// `run_after_stop` (the Err arm already persists `Error` + emits the `error` stage itself —
+/// see `run_after_stop` — so the guard firing there would double-emit). If the scope exits any
+/// OTHER way (panic-unwind), `Drop` best-effort writes `MeetingStatus::Error` and emits a short
+/// non-PII `error` status so both the DB row and the FE always reach a terminal state.
+///
+/// `Drop` MUST NEVER PANIC (a panic inside Drop during an unwind aborts the process): it holds
+/// fully OWNED handles (`Arc<Db>` — whose internal connection lock is poison-safe via
+/// `into_inner`, an owned `AppHandle`), both effects are `Result`s that are logged rather than
+/// propagated, and the whole body is additionally wrapped in `catch_unwind` as the last line of
+/// defense. `app` is `Option` only so headless unit tests can exercise the DB half without a
+/// Tauri `AppHandle`.
+pub(crate) struct TerminalStatusGuard {
+    app: Option<AppHandle>,
+    db: std::sync::Arc<crate::storage::Db>,
+    meeting_id: String,
+    armed: bool,
+}
+
+impl TerminalStatusGuard {
+    pub(crate) fn arm(
+        app: Option<AppHandle>,
+        db: std::sync::Arc<crate::storage::Db>,
+        meeting_id: &str,
+    ) -> Self {
+        Self {
+            app,
+            db,
+            meeting_id: meeting_id.to_string(),
+            armed: true,
+        }
+    }
+
+    /// Consume the guard WITHOUT firing it — the pipeline reached a normal terminal path
+    /// (Ok emitted `done`; Err already persisted `Error` + emitted `error`).
+    pub(crate) fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalStatusGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Reached ONLY on a panic-unwind (or an unexpected early exit) out of the pipeline task.
+        let body = std::panic::AssertUnwindSafe(|| {
+            if let Err(e) = self
+                .db
+                .update_meeting_status(&self.meeting_id, MeetingStatus::Error)
+            {
+                tracing::warn!(
+                    target: "pipeline",
+                    error = %e,
+                    "terminal-status guard: persisting Error status failed"
+                );
+            }
+            if let Some(app) = &self.app {
+                emit_status(
+                    app,
+                    "error",
+                    "Note processing failed unexpectedly. The recording was kept — try \
+                     re-summarizing from the meeting page.",
+                    &self.meeting_id,
+                );
+            }
+            // IDs + stage only — never content (no-PII rule §8).
+            tracing::error!(
+                target: "pipeline",
+                meeting_id = %self.meeting_id,
+                "pipeline task exited without a terminal status — guard persisted Error + emitted the error stage"
+            );
+        });
+        if std::panic::catch_unwind(body).is_err() {
+            tracing::error!(
+                target: "pipeline",
+                "terminal-status guard: drop body panicked (suppressed to avoid a double-panic abort)"
+            );
+        }
+    }
+}
+
+/// Floor of the ASR/diarize stage watchdog: even a tiny recording gets this much wall-clock
+/// before the stage is declared stuck (model download-free load + decode on a busy machine).
+const ASR_WATCHDOG_FLOOR_S: u64 = 15 * 60;
+
+/// Per-second-of-audio multiplier for the ASR/diarize watchdog: a legitimate Accurate-profile
+/// decode of BOTH streams + diarization stays well under 4× realtime even on a throttled machine.
+const ASR_WATCHDOG_PER_AUDIO_S: u64 = 4;
+
+/// DURATION-SCALED watchdog bound for the heavy ASR/diarize stage:
+/// `max(15 min, 4 × audio duration)`. Generous enough that a legitimately slow large-model
+/// decode of a long meeting is never killed; bounded so a truly-stuck stage (the production
+/// hang this closes) surfaces as a terminal error instead of wedging the pipeline forever.
+/// Pure + deterministic for unit tests; a negative duration (clock skew) clamps to the floor.
+pub(crate) fn asr_watchdog_bound(duration_s: i64) -> std::time::Duration {
+    let scaled = (duration_s.max(0) as u64).saturating_mul(ASR_WATCHDOG_PER_AUDIO_S);
+    std::time::Duration::from_secs(scaled.max(ASR_WATCHDOG_FLOOR_S))
+}
+
+/// Bound a pipeline stage's future with a hang watchdog. On timeout the stage surfaces as
+/// [`AppError::Transcribe`] and propagates through `run_after_stop`'s existing Err arm
+/// (persist `Error` + emit the terminal `error` stage) — the FE is never left waiting forever.
+///
+/// IMPORTANT — what a timeout does and does NOT do: dropping the timed-out future CANCELS the
+/// async wrapper only. The heavy work runs in `perf::run_heavy`'s `spawn_blocking` closure,
+/// which is NOT cancelled by dropping the await — the orphaned whisper/diarizer thread keeps
+/// running to completion in the background. That is accepted: the heavy-inference semaphore
+/// permit is held INSIDE that closure (see `perf::run_heavy`), so no new heavy inference can
+/// co-run with the orphan; it simply finishes (or dies with the process) and releases the
+/// permit. This watchdog restores UI/pipeline liveness — it does NOT kill the computation.
+async fn with_stage_watchdog<T>(
+    bound: std::time::Duration,
+    stage: &'static str,
+    fut: impl std::future::Future<Output = Result<T>>,
+) -> Result<T> {
+    match tokio::time::timeout(bound, fut).await {
+        Ok(res) => res,
+        Err(_elapsed) => {
+            tracing::error!(
+                target: "pipeline",
+                stage,
+                bound_s = bound.as_secs(),
+                "stage watchdog fired — the stage is stuck; surfacing a terminal error"
+            );
+            Err(AppError::Transcribe(format!(
+                "transcription timed out after {} minutes (stage: {stage}) — the recording was \
+                 kept; try re-summarizing, or pick a smaller model in Settings",
+                bound.as_secs() / 60
+            )))
+        }
+    }
+}
+
 /// `<app-data>/<app_dir_name()>/audio`, created if absent (`MeetNotes` release, `MeetNotes-dev` dev).
 pub(crate) fn audio_dir() -> Result<PathBuf> {
     let base = dirs::data_dir()
@@ -553,8 +694,17 @@ async fn run_inner(
     // extraction, embedding — all now strictly sequential through this same closure + the
     // downstream summarize_and_export call). Logging elapsed_ms per stage (never audio/transcript
     // content) so the NEXT report comes with a real breakdown instead of another guess.
+    // ASR-stage WATCHDOG (2026-07-16): bound the whole heavy await — semaphore queue-wait +
+    // whisper load/decode of both streams + diarization — with a duration-scaled ceiling
+    // (`max(15 min, 4 × audio)`). A production hang left this await pending forever (all tokio
+    // workers parked, zero whisper frames) with the meeting wedged at RECORDING and no terminal
+    // event; the watchdog turns that into `AppError::Transcribe` → `run_after_stop`'s Err arm →
+    // a real terminal `error` status. Queue-wait is deliberately INSIDE the bound: a wedged
+    // permit-holder is exactly the class of stuck stage this must surface. See
+    // `with_stage_watchdog` for why the timeout does NOT kill the underlying blocking compute.
+    let asr_watchdog = asr_watchdog_bound(duration_s);
     let asr_diarize_started = std::time::Instant::now();
-    let (merged_segments, echo_suppressed, cluster_voiceprints) = crate::perf::run_heavy(&state.heavy_inference, move || -> Result<(Vec<crate::transcribe::types::Segment>, usize, Vec<crate::transcribe::diarize::ClusterVoiceprint>)> {
+    let (merged_segments, echo_suppressed, cluster_voiceprints) = with_stage_watchdog(asr_watchdog, "asr_diarize", crate::perf::run_heavy(&state.heavy_inference, move || -> Result<(Vec<crate::transcribe::types::Segment>, usize, Vec<crate::transcribe::diarize::ClusterVoiceprint>)> {
         use crate::audio::merge::{merge_streams, StreamInput, SPEAKER_ME, SPEAKER_OTHERS};
 
         let transcriber = Transcriber::load(&model_path_owned)?;
@@ -651,7 +801,7 @@ async fn run_inner(
         let (merged, echo_suppressed) =
             crate::audio::merge::suppress_cross_stream_echo(merge_streams(streams), leak.as_ref());
         Ok((merged, echo_suppressed, cluster_voiceprints))
-    })
+    }))
     .await?;
     tracing::info!(
         target: "perf",
@@ -2239,6 +2389,139 @@ mod tests {
 
     fn temp_db_path(label: &str) -> std::path::PathBuf {
         crate::storage::db::unique_temp_path(&format!("murmur-pipeline-test-{label}"), "sqlite")
+    }
+
+    // ── guaranteed terminal status + ASR watchdog (2026-07-16 pipeline-wedge fix) ─────────────
+
+    fn guard_test_meeting(id: &str) -> crate::storage::models::Meeting {
+        crate::storage::models::Meeting {
+            id: id.to_string(),
+            started_at: "2026-07-16T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("t".to_string()),
+            duration_s: 1200,
+            audio_path: None,
+            status: MeetingStatus::Recording,
+            folder_id: None,
+        }
+    }
+
+    /// RED-before-GREEN for the production wedge: a PANIC unwinding out of the pipeline scope
+    /// (tokio swallows it at the task boundary — no Err arm ever runs) used to leave the meeting
+    /// row at RECORDING forever with no terminal signal. The ARMED `TerminalStatusGuard`'s Drop
+    /// runs during that unwind and must persist `MeetingStatus::Error`. (The event half needs a
+    /// live `AppHandle`; the DB half is the headless-provable contract — `app: None`.)
+    #[test]
+    fn terminal_guard_armed_drop_during_panic_marks_meeting_error() {
+        let db = std::sync::Arc::new(
+            crate::storage::Db::open_with_key(&temp_db_path("guard-armed"), TEST_DEK).unwrap(),
+        );
+        db.insert_meeting(&guard_test_meeting("m-guard")).unwrap();
+
+        let db_in = db.clone();
+        let unwound = std::panic::catch_unwind(move || {
+            let _guard = TerminalStatusGuard::arm(None, db_in, "m-guard");
+            panic!("simulated pipeline panic");
+        });
+        assert!(unwound.is_err(), "the closure must have panicked");
+
+        let status = db.get_meeting("m-guard").unwrap().unwrap().status;
+        assert_eq!(
+            status,
+            MeetingStatus::Error,
+            "an armed guard dropped by a panic-unwind must persist the terminal Error status"
+        );
+    }
+
+    /// The normal paths DISARM the guard (Ok emitted `done`; Err already persisted Error +
+    /// emitted `error` itself) — a disarmed guard must leave the row untouched (no double-write,
+    /// and crucially no clobbering of a healthy terminal status).
+    #[test]
+    fn terminal_guard_disarmed_leaves_status_untouched() {
+        let db = std::sync::Arc::new(
+            crate::storage::Db::open_with_key(&temp_db_path("guard-disarmed"), TEST_DEK).unwrap(),
+        );
+        db.insert_meeting(&guard_test_meeting("m-ok")).unwrap();
+
+        let guard = TerminalStatusGuard::arm(None, db.clone(), "m-ok");
+        guard.disarm();
+
+        let status = db.get_meeting("m-ok").unwrap().unwrap().status;
+        assert_eq!(
+            status,
+            MeetingStatus::Recording,
+            "a disarmed guard must not touch the meeting status"
+        );
+    }
+
+    /// The guard's Drop is best-effort and must NEVER panic — even when the meeting row does not
+    /// exist (a delete raced the pipeline) the drop completes quietly. A panic inside Drop during
+    /// an unwind would abort the whole process.
+    #[test]
+    fn terminal_guard_drop_never_panics_on_a_missing_row() {
+        let db = std::sync::Arc::new(
+            crate::storage::Db::open_with_key(&temp_db_path("guard-missing"), TEST_DEK).unwrap(),
+        );
+        drop(TerminalStatusGuard::arm(None, db, "m-nonexistent"));
+    }
+
+    /// A stuck ASR stage (the verified production hang: the heavy await pending forever) must
+    /// surface as `AppError::Transcribe` through the watchdog instead of wedging the pipeline.
+    #[tokio::test]
+    async fn stage_watchdog_times_out_a_stuck_stage() {
+        let res: Result<()> = with_stage_watchdog(
+            std::time::Duration::from_millis(20),
+            "test_stage",
+            std::future::pending::<Result<()>>(),
+        )
+        .await;
+        match res {
+            Err(AppError::Transcribe(msg)) => {
+                assert!(
+                    msg.contains("timed out"),
+                    "the timeout error must say the stage timed out (got: {msg})"
+                );
+            }
+            other => panic!("a stuck stage must yield AppError::Transcribe, got {other:?}"),
+        }
+    }
+
+    /// A stage that completes within the bound passes its value — and its own `Err` — through
+    /// UNCHANGED (the watchdog must never re-label a real stage failure as a timeout).
+    #[tokio::test]
+    async fn stage_watchdog_passes_through_a_completing_stage() {
+        let ok = with_stage_watchdog(std::time::Duration::from_secs(5), "test_stage", async {
+            Ok(7)
+        })
+        .await;
+        assert_eq!(ok.unwrap(), 7);
+
+        let err: Result<u32> =
+            with_stage_watchdog(std::time::Duration::from_secs(5), "test_stage", async {
+                Err(AppError::Audio("real failure".into()))
+            })
+            .await;
+        match err {
+            Err(AppError::Audio(msg)) => assert_eq!(msg, "real failure"),
+            other => panic!("an inner Err must pass through unchanged, got {other:?}"),
+        }
+    }
+
+    /// The watchdog bound is duration-scaled with a generous floor: `max(15 min, 4 × audio)` —
+    /// a legitimately slow decode of a long meeting is never killed, a truly-stuck short one
+    /// still surfaces within the floor. Negative durations (clock skew) clamp to the floor and
+    /// the multiply saturates instead of overflowing.
+    #[test]
+    fn asr_watchdog_bound_scales_with_duration() {
+        assert_eq!(asr_watchdog_bound(0).as_secs(), 15 * 60);
+        assert_eq!(asr_watchdog_bound(-5).as_secs(), 15 * 60);
+        assert_eq!(asr_watchdog_bound(60).as_secs(), 15 * 60, "floor dominates short meetings");
+        assert_eq!(
+            asr_watchdog_bound(20 * 60).as_secs(),
+            80 * 60,
+            "the reported ~20-min meeting gets 4× its length"
+        );
+        assert_eq!(asr_watchdog_bound(i64::MAX).as_secs(), u64::MAX, "saturates, never overflows");
     }
 
     /// REGRESSION (adversarial find, seal content-leak class): `summarize_and_export` upserts the

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -81,6 +81,7 @@ import type {
   StatusPayload,
   EchoSuppressedPayload,
   RecordingCappedPayload,
+  RecordingStatus,
   StopResult,
   TopicThread,
   VoiceActionResultPayload,
@@ -184,6 +185,17 @@ export class IpcService {
 
   recordingLevel(): Promise<number> {
     return invoke<number>("recording_level");
+  }
+
+  /**
+   * The backend's truth for "is a recording in flight RIGHT NOW" (+ the
+   * in-progress meeting id / start time). `RecorderStore.init()` calls this once
+   * per webview load to reconcile a stale optimistic stage: a webview reload (or
+   * a pipeline task that died before this webview session even loaded) leaves
+   * the FE stage disagreeing with the long-lived Rust process.
+   */
+  recordingStatus(): Promise<RecordingStatus> {
+    return invoke<RecordingStatus>("recording_status");
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -22,6 +22,19 @@ export interface EchoSuppressedPayload {
 }
 
 /**
+ * Mirror of Rust `commands::RecordingStatus` (serde camelCase): whether the
+ * backend recorder is capturing RIGHT NOW, plus the in-progress meeting id and
+ * its RFC3339 start time. A freshly-(re)loaded webview queries this once in
+ * `RecorderStore.init()` to reconcile its stage with the backend's truth (a
+ * webview reload/crash swaps the FE without restarting the Rust process).
+ */
+export interface RecordingStatus {
+  recording: boolean;
+  meetingId: string | null;
+  startedAt: string | null;
+}
+
+/**
  * Payload of murmur://recording-capped — the 4h `MAX_RECORDING_SECONDS` hard
  * TIME cap was reached and the capture self-stopped. Length only, NO PII (no
  * content, meeting id, or path). Fires once per recording (rising edge).

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -101,6 +101,13 @@ export class RecorderStore {
     { initialValue: 0 },
   );
 
+  /**
+   * True once ANY `EVENT_STATUS` payload has been observed this webview session.
+   * The event stream is the live truth: `reconcileStage()` (the one-shot backend
+   * resync on init) must never override a stage the backend itself just pushed.
+   */
+  private statusSeen = false;
+
   private unlisten: UnlistenFn | null = null;
   private unlistenVoice: UnlistenFn | null = null;
   private unlistenToggle: UnlistenFn | null = null;
@@ -152,10 +159,52 @@ export class RecorderStore {
         void this.stop();
       }
     });
+    await this.reconcileStage();
     await this.refreshLastNote();
   }
 
+  /**
+   * One-shot reconcile of the FE stage against the BACKEND's truth on webview
+   * (re)load. Two desync shapes this closes:
+   *
+   * 1. The webview reloaded (tauri-dev hot reload, Cmd-R, webview crash) while
+   *    the long-lived Rust process is GENUINELY recording — the fresh store
+   *    boots at "idle" while `AppState.recorder` is `Some(..)`, so the next
+   *    Start hits `start_recording`'s "already recording" guard. Resync to
+   *    "recording" (anchoring the elapsed timer to the persisted `startedAt`).
+   * 2. A stale optimistic BUSY stage with the backend idle — e.g. the note
+   *    pipeline died before this webview session even loaded (its terminal
+   *    "error" event fired into a void). Clear it to "idle" so the surface can
+   *    never boot wedged on "Transcribing…".
+   *
+   * `statusSeen` guards both branches: once any live `EVENT_STATUS` payload has
+   * arrived (including a detached pipeline still emitting "summarizing"), the
+   * event stream is authoritative and this probe must not fight it. Best-effort:
+   * a failed probe never blocks init.
+   */
+  private async reconcileStage(): Promise<void> {
+    try {
+      const st = await this.ipc.recordingStatus();
+      if (this.statusSeen) return;
+      if (st?.recording) {
+        this._meetingId.set(st.meetingId);
+        const startedMs = st.startedAt ? Date.parse(st.startedAt) : NaN;
+        this._recStartMs = Number.isFinite(startedMs) ? startedMs : Date.now();
+        this._stage.set("recording");
+      } else if (
+        ["recording", "transcribing", "summarizing", "exporting"].includes(
+          this._stage(),
+        )
+      ) {
+        this._stage.set("idle");
+      }
+    } catch {
+      // Best-effort resync — never block init on the probe.
+    }
+  }
+
   private applyStatus(p: StatusPayload): void {
+    this.statusSeen = true;
     const wasRecording = this._stage() === "recording";
     this._stage.set(p.stage);
     this._message.set(p.message);


### PR DESCRIPTION
## The verified production defect

A ~20-min recording wedged the UI on "Transcribing on-device, then summarizing…" FOREVER. Forensics of the live hung release app: process alive but idle, all tokio workers parked, zero whisper frames (the pipeline task was GONE), meeting row still at RECORDING, no terminal event ever emitted.

Mechanics: `stop_recording` awaited `pipeline::run_after_stop` INLINE in the command future. Tauri 2.11 does not `catch_unwind` command futures and never settles the JS invoke Promise for a future that panics (tokio swallows the panic at the task boundary) or is dropped mid-await. `run_after_stop` emits a terminal status only in its Ok/Err arms — a panic between pipeline entry and the `Transcribed` write left a RECORDING ghost + a wedged FE + zero log evidence.

## The fix — one coherent mechanism replacement, four load-bearing parts

1. **Detached, panic-mapped pipeline execution** (`commands.rs` `stop_recording` + `await_pipeline_task`): `run_after_stop` now runs in a real `tauri::async_runtime::spawn` task; the command awaits the JoinHandle and maps a `JoinError` (= pipeline panic) to `AppError` so the invoke Promise **rejects** (FE catch → "error"). If the outer command future is dropped (webview teardown), the detached task keeps running and still performs its own status writes + event emits. The STAGE-2 crash-salvage **spill guard moves INTO the task** — identical drop timing relative to the pipeline (released only after `run_after_stop` returns; deleted on success/error/panic-unwind; survives a process crash for next-launch salvage), now also immune to outer-future cancellation.
2. **Drop-armed `TerminalStatusGuard`** (`pipeline.rs`): armed at task entry, disarmed on BOTH normal arms (the Err arm already persists `Error` + emits `error` — no double-emit). A panic-unwind now best-effort persists `MeetingStatus::Error` + emits a short non-PII terminal `error` status. Drop can never panic: fully owned handles, the Db connection lock is poison-safe (`unwrap_or_else(into_inner)`, db.rs `conn()`), plus a `catch_unwind` belt.
3. **ASR stage watchdog** (`pipeline.rs` `with_stage_watchdog` / `asr_watchdog_bound`): the heavy `run_heavy` await (whisper load/decode of both streams + diarization, INCLUDING semaphore queue-wait) is bounded by `max(15 min, 4 × audio duration)`; a stuck stage surfaces as `AppError::Transcribe` through the existing Err arm. **The timeout does NOT kill the compute** — documented in-code. Supporting change in `perf.rs::run_heavy`: the heavy-inference permit now lives INSIDE the `spawn_blocking` closure, so an orphaned decode keeps the permit until it actually finishes (pre-fix, dropping the future released the permit while the whisper thread still ran — a heavy-co-residency hazard; regression test proves RED→GREEN).
4. **Panic visibility + FE reconcile**: global panic hook in `lib.rs run()` (after tracing init) logs panic message + source location via `tracing target="panic"` into murmur.log (LaunchServices discards stderr), then chains to the previous hook — no content fields. `RecorderStore.init()` now calls the **existing** `recording_status` command once per webview load: resyncs to "recording" when the backend genuinely records (the documented-but-never-wired resync), clears a stale optimistic busy stage when it doesn't; a live `EVENT_STATUS` always wins over the probe (`statusSeen` guard).

## Files

- `src-tauri/src/commands.rs` — `stop_recording` (detached spawn, spill guard moved into the task), new `await_pipeline_task`, new `pipeline_task_tests`
- `src-tauri/src/pipeline.rs` — `TerminalStatusGuard`, `asr_watchdog_bound`, `with_stage_watchdog`, ASR stage wrapped; 6 new tests
- `src-tauri/src/perf.rs` — permit moved into the blocking closure; orphan-permit regression test
- `src-tauri/src/lib.rs` — global panic hook
- `src/app/core/{recorder.store,ipc.service,models}.ts` — `recordingStatus()` + init-time stage reconcile
- `scripts/screenshots/mock-tauri.js` — `recording_status` demo default
- `e2e/record/reload-reconcile-stage.spec.ts` — new Playwright spec (2 tests)

## Verification (implementer self-check — verdict NOT owned here)

- `cargo test --lib`: **1658 passed, 1 failed** — the failure is the pre-existing env-dependent `settings::ai_map::tests::default_config_is_cloud_claude_with_inactive_reactions` (machine-conditional `default_model_size_now()` vs a hard-coded "small"); **reproduced identically on clean trunk** in the same worktree.
- New Rust regressions (all green): `terminal_guard_armed_drop_during_panic_marks_meeting_error`, `terminal_guard_disarmed_leaves_status_untouched`, `terminal_guard_drop_never_panics_on_a_missing_row`, `stage_watchdog_times_out_a_stuck_stage`, `stage_watchdog_passes_through_a_completing_stage`, `asr_watchdog_bound_scales_with_duration`, `pipeline_task_panic_maps_to_a_rejecting_err`, `pipeline_task_results_pass_through_unchanged`, `run_heavy_keeps_the_permit_while_an_orphaned_closure_still_runs` (**RED-verified** against pre-fix `run_heavy`: permit was released on drop).
- Playwright: new `reload-reconcile-stage.spec.ts` — the resync test **RED-verified** against the pre-fix store (recording strip never appears), GREEN post-fix; full `e2e/record/` suite 6/6 green (incl. `stop-optimistic`).
- `npx ng lint` + `npx ng build` green.

## Not verified here (honest list)

- A REAL pipeline panic/hang on a signed release build (the original forensic shape) — needs a live recording on a real Mac; unit tests prove the guard/mapping/watchdog contracts, not the end-to-end release behavior.
- The panic hook writing to `murmur.log` in a LaunchServices-launched signed build.
- Watchdog bound adequacy on a thermally-throttled machine with `large-v3` — the 4×-realtime multiplier is generous per prior ASR measurements, but only field use proves it never kills a legitimate decode.

## Review requested

- **adversarial-verifier** — required before merge.
- **lock-security-reviewer** — `stop_recording`'s spill-guard ordering changed (moved into the detached task; the spill is plaintext-at-rest adjacent). Also audit: the detached task holds no new content read path (no gate changes), and the guard/watchdog error strings carry IDs/stages only.