### PR TITLE
feat(export): never clobber external edits to exported vault notes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1499,6 +1499,84 @@ pub async fn update_note(
     Ok(dto)
 }
 
+/// Export-collision guard — the ONE way a MEETING note's exported vault `.md` is FULLY
+/// overwritten with DB-derived markdown. Before the overwrite, compares the CURRENT file bytes
+/// against the stored `exported_hash` baseline (what Murmur last wrote): a mismatch means the user
+/// (or their own vault-side agent, e.g. Claude Code over the vault) edited the file externally,
+/// and the external version is preserved as a `<stem> (external edit …)` sibling instead of
+/// silently destroyed. After the overwrite the baseline is re-stamped from the exact content
+/// written. A NULL baseline (legacy row exported before the guard) is grandfathered — no sibling.
+/// No PII in logs: meeting id + a boolean only, never the path (it embeds the note title).
+pub(crate) fn overwrite_exported_note_guarded(
+    state: &AppState,
+    meeting_id: &str,
+    provider_id: &str,
+    path: &str,
+    markdown: &str,
+) -> Result<(), AppError> {
+    let expected = state.db.get_note_exported_hash(meeting_id, provider_id)?;
+    let path = std::path::Path::new(path);
+    let sibling = crate::export::preserve_external_edit_if_any(path, expected.as_deref())?;
+    crate::export::overwrite_note(path, markdown)?;
+    state.db.set_note_exported_hash(
+        meeting_id,
+        provider_id,
+        Some(&crate::export::note_content_hash(markdown)),
+    )?;
+    if sibling.is_some() {
+        tracing::info!(
+            target: "export",
+            meeting_id = %meeting_id,
+            sibling_created = true,
+            "external vault edit preserved as a sibling before overwrite"
+        );
+    }
+    Ok(())
+}
+
+/// Export-collision guard, APPEND side: after a read-modify-write of the CURRENT file (Re-Truth
+/// stamps — which respect external edits by construction, so NO sibling is ever needed), re-stamp
+/// the stored `exported_hash` baseline from the FINAL written content — but ONLY when the
+/// PRE-APPEND bytes still matched the old baseline (or the row is legacy/NULL — grandfathered,
+/// there is no signal to preserve). Re-stamping over a MISMATCH would LAUNDER an external edit
+/// into the baseline: the next DB-derived full overwrite would see hash == baseline and destroy
+/// the edit with no sibling (the adversarial MEDIUM). Keeping the stale baseline instead makes
+/// that next overwrite preserve the whole file — external edit + appended callout — as a sibling.
+/// Skipping the refresh in the CLEAN case would be the opposite bug (a false sibling out of
+/// Murmur's own append), so the match check is what separates the two. Keyed on the LATEST
+/// provider row — the same row `note_file_for` resolved the exported `.md` from.
+pub(crate) fn refresh_meeting_note_exported_hash(
+    state: &AppState,
+    meeting_id: &str,
+    pre_append: &str,
+    written: &str,
+) -> Result<(), AppError> {
+    if let Some(latest) = state.db.get_latest_note_for_meeting(meeting_id)? {
+        let baseline = state
+            .db
+            .get_note_exported_hash(meeting_id, &latest.provider_id)?;
+        if let Some(b) = &baseline {
+            if *b != crate::export::note_content_hash(pre_append) {
+                // External edit present BEFORE the append — keep the stale baseline so the next
+                // full overwrite preserves (edit + callout) as a sibling. Ids + boolean only.
+                tracing::info!(
+                    target: "export",
+                    meeting_id = %meeting_id,
+                    baseline_kept_stale = true,
+                    "append over an externally-edited note — baseline deliberately not re-stamped"
+                );
+                return Ok(());
+            }
+        }
+        state.db.set_note_exported_hash(
+            meeting_id,
+            &latest.provider_id,
+            Some(&crate::export::note_content_hash(written)),
+        )?;
+    }
+    Ok(())
+}
+
 /// Inner of [`update_note`] taking `&AppState` — the FULL command body (gate + lifecycle guard +
 /// seal-on-write upsert + vault re-write), so the seal-on-write regression binds the COMMAND
 /// surface, not just the `upsert_note_reseal_if_locked` helper (residual W6).
@@ -1542,7 +1620,7 @@ pub(crate) fn update_note_inner(
     )?;
 
     if let Some(path) = existing.exported_path.as_deref() {
-        crate::export::overwrite_note(std::path::Path::new(path), markdown)?;
+        overwrite_exported_note_guarded(state, meeting_id, &existing.provider_id, path, markdown)?;
     }
 
     Ok(NoteDto {
@@ -1694,7 +1772,7 @@ pub(crate) fn apply_note_verify_markers_inner(
         },
     )?;
     if let Some(path) = existing.exported_path.as_deref() {
-        crate::export::overwrite_note(std::path::Path::new(path), &marked)?;
+        overwrite_exported_note_guarded(state, &meeting_id, &existing.provider_id, path, &marked)?;
     }
     Ok(NoteDto {
         meeting_id,
@@ -1874,7 +1952,7 @@ pub(crate) fn apply_note_enrichment_inner(
         },
     )?;
     if let Some(path) = existing.exported_path.as_deref() {
-        crate::export::overwrite_note(std::path::Path::new(path), &enriched)?;
+        overwrite_exported_note_guarded(state, &meeting_id, &existing.provider_id, path, &enriched)?;
     }
     Ok(NoteDto {
         meeting_id,
@@ -1990,7 +2068,7 @@ pub(crate) fn link_related_notes_inner(state: &AppState, meeting_id: &str) -> Re
         },
     )?;
     if let Some(path) = existing.exported_path.as_deref() {
-        crate::export::overwrite_note(std::path::Path::new(path), &linked)?;
+        overwrite_exported_note_guarded(state, meeting_id, &existing.provider_id, path, &linked)?;
     }
     Ok(())
 }
@@ -2987,6 +3065,13 @@ fn write_note_to_vault(
     )?;
     let path_str = path.to_string_lossy().to_string();
     state.db.set_note_doc_exported_path(&row.id, Some(&path_str))?;
+    // Export-collision guard: stamp the baseline from the text this export wrote. `write_note`
+    // never overwrites different content (it collision-suffixes), so the file at `path` is
+    // byte-equal to `row.text` in every branch — including the unlock/remove-lock re-export,
+    // where any pre-lock baseline is stale and must be re-stamped fresh.
+    state
+        .db
+        .set_note_doc_exported_hash(&row.id, Some(&crate::export::note_content_hash(&row.text)))?;
     Ok(Some(path_str))
 }
 
@@ -5093,7 +5178,13 @@ pub fn patch_note_tasks(
         },
     )?;
     if let Some(path) = existing.exported_path.as_deref() {
-        crate::export::overwrite_note(std::path::Path::new(path), &patched)?;
+        overwrite_exported_note_guarded(
+            state.inner(),
+            &meeting_id,
+            &existing.provider_id,
+            path,
+            &patched,
+        )?;
     }
     Ok(NoteDto {
         meeting_id,
@@ -5256,7 +5347,13 @@ pub fn pin_moment(
     )?;
     let url = match existing.exported_path.as_deref() {
         Some(path) => {
-            crate::export::overwrite_note(std::path::Path::new(path), &new_md)?;
+            overwrite_exported_note_guarded(
+                state.inner(),
+                &meeting_id,
+                &existing.provider_id,
+                path,
+                &new_md,
+            )?;
             let vault = {
                 state
                     .config
@@ -5864,6 +5961,16 @@ pub(crate) fn apply_supersessions_inner(
             superseding_file.as_ref().map(|(_, s)| s.as_str()),
         );
         crate::export::obsidian::overwrite_note(std::path::Path::new(&source_path), &new_source)?;
+        // Export-collision guard: this is a read-modify-write APPEND of the CURRENT file (external
+        // edits are preserved in place by construction — no sibling). The baseline is re-stamped
+        // from the final written content ONLY when the pre-append bytes still matched it — see
+        // the helper's laundering rationale.
+        refresh_meeting_note_exported_hash(
+            state,
+            &row.source_meeting_id,
+            &current_source,
+            &new_source,
+        )?;
 
         // Stamp the SUPERSEDING backlink (its pristine pre-image is now durably stored). Append to its
         // CURRENT content (idempotent).
@@ -5879,6 +5986,13 @@ pub(crate) fn apply_supersessions_inner(
                 &source_stem,
             );
             crate::export::obsidian::overwrite_note(std::path::Path::new(sup_path), &new_sup)?;
+            // Same conditional append-side baseline refresh as the source stamp above.
+            refresh_meeting_note_exported_hash(
+                state,
+                &row.superseding_meeting_id,
+                &current_sup,
+                &new_sup,
+            )?;
         }
 
         // APPLIED is the LAST write — flipped only after the note(s) are safely stamped.
@@ -6012,7 +6126,14 @@ pub(crate) fn undo_supersessions_inner(state: &AppState, ids: &[String]) -> Resu
                 }
             }
         }
-        crate::export::obsidian::overwrite_note(std::path::Path::new(path), &text)?;
+        // Export-collision guard: the undo rebuild is a FULL overwrite from the stored pre-image
+        // (+ survivor replays), so an external edit made since apply is preserved as a sibling
+        // first, and the baseline re-stamped from the rebuilt content.
+        if let Some(latest) = state.db.get_latest_note_for_meeting(meeting_id)? {
+            overwrite_exported_note_guarded(state, meeting_id, &latest.provider_id, path, &text)?;
+        } else {
+            crate::export::obsidian::overwrite_note(std::path::Path::new(path), &text)?;
+        }
     }
 
     // Clear the applied state on the undone rows ONLY (pre-images dropped); survivors stay applied.
@@ -11141,6 +11262,9 @@ fn seal_moved_note(
     seal_meeting_extras(state, folder_id, meeting_id, ck)?;
     // AFTER the column writes, remove the vault `.md` files (a leftover .md is reconcilable; lost
     // content is not — so this is last).
+    // Export-collision guard: NO external-edit sibling on a seal delete — privacy wins over
+    // preservation (a plaintext sibling of a to-be-sealed note would be a leak; see the same
+    // decision in `lock_folder_inner`).
     for p in exported_paths {
         let _ = std::fs::remove_file(&p);
     }
@@ -11202,6 +11326,11 @@ fn move_note_file(
     std::fs::create_dir_all(&dest_dir)
         .map_err(|e| AppError::Export(format!("create move dir failed: {e}")))?;
     // Write the destination atomically, THEN remove the source (never lose bytes).
+    // Export-collision guard: a move copies the CURRENT file bytes verbatim (external edits ride
+    // along), so it is NOT a Murmur-authored write — the stored `exported_hash` baseline is
+    // deliberately LEFT ALONE. It still describes what Murmur last authored, so an external edit
+    // made before the move is still detected (and preserved) by the next DB-derived overwrite at
+    // the new path. Re-stamping from the moved bytes would erase that signal.
     crate::export::overwrite_note(&dest, &bytes)?;
     let _ = std::fs::remove_file(src);
     // Re-point the exported path for every provider row of this meeting.
@@ -11369,6 +11498,10 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
 
     // AFTER the column writes, delete the vault `.md` files (a leftover .md is reconcilable;
     // lost content is not — so this is last).
+    // Export-collision guard: the seal delete deliberately does NOT preserve an external-edit
+    // sibling — privacy wins over preservation. A plaintext sibling of a to-be-sealed note would
+    // be exactly the leak the lock exists to prevent. External edits to a locked note's `.md`
+    // are accepted-loss by design; the DB blob remains the canonical recoverable copy.
     for p in exported_paths {
         let _ = std::fs::remove_file(&p);
     }
@@ -11974,6 +12107,15 @@ pub(crate) fn remove_lock_inner(state: &AppState, folder_id: String) -> Result<(
                 &latest.provider_id,
                 &path.to_string_lossy(),
             )?;
+            // Export-collision guard: the pre-lock baseline is stale (the `.md` was deleted on
+            // seal) — re-stamp it FRESH from the markdown this re-export just wrote. A file that
+            // already existed at the target with different content was collision-suffixed by
+            // `write_note`, never overwritten, so the file at `path` equals `latest.markdown`.
+            state.db.set_note_exported_hash(
+                &n.meeting_id,
+                &latest.provider_id,
+                Some(&crate::export::note_content_hash(&latest.markdown)),
+            )?;
         }
     }
 
@@ -12441,6 +12583,9 @@ fn move_note_file_to_root(
             .map_err(|e| AppError::Export(format!("create move dir failed: {e}")))?;
     }
     // Write the destination atomically, THEN remove the source (never lose bytes).
+    // Export-collision guard: bytes move verbatim → the `exported_hash` baseline is deliberately
+    // left alone (see `move_note_file` — re-stamping from moved bytes would erase the
+    // external-edit signal).
     crate::export::overwrite_note(&dest, &bytes)?;
     let _ = std::fs::remove_file(src);
     if let Some(existing) = state.db.get_latest_note_for_meeting(meeting_id)? {
@@ -12560,6 +12705,9 @@ fn move_authored_note_md_to_folder(
             .map_err(|e| AppError::Export(format!("create move dir failed: {e}")))?;
     }
     // Write the destination atomically, THEN remove the source (never lose bytes).
+    // Export-collision guard: bytes move verbatim → the `exported_hash` baseline is deliberately
+    // left alone (see `move_note_file` — re-stamping from moved bytes would erase the
+    // external-edit signal).
     crate::export::overwrite_note(&dest, &content)?;
     let _ = std::fs::remove_file(&src_path);
     state
@@ -23377,6 +23525,281 @@ mod lifecycle_tests {
             "Projects/Q3",
             "the child's path moves under the renamed parent"
         );
+    }
+
+    // ── Export-collision guard ("never clobber external edits") ─────────────
+
+    /// The vault files whose name carries the external-edit preservation marker.
+    fn external_edit_siblings(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.contains("(external edit "))
+            })
+            .collect()
+    }
+
+    /// Simulate a completed export of `md` for the seeded meeting: the on-disk `.md`, the stored
+    /// `exported_path`, and the guard's baseline `exported_hash`.
+    fn seed_exported_note(state: &AppState, mid: &str, path: &std::path::Path, md: &str) {
+        std::fs::write(path, md).unwrap();
+        state
+            .db
+            .set_note_exported_path(mid, "claude_code", &path.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .set_note_exported_hash(
+                mid,
+                "claude_code",
+                Some(&crate::export::note_content_hash(md)),
+            )
+            .unwrap();
+    }
+
+    /// RED-before-GREEN core of the export-collision guard: an EXTERNAL edit to an exported `.md`
+    /// (the user, or their own vault-side agent) must be preserved as a sibling file when a
+    /// DB-derived full overwrite (`update_note`) lands — never silently destroyed. The canonical
+    /// file then carries the DB content and the stored baseline hash matches it.
+    #[test]
+    fn external_edit_is_preserved_as_sibling_on_overwrite() {
+        let vault = tmp_vault("collision-ext");
+        let state = build_state_with_vault("collision-ext", &vault);
+        seed_meeting(&state.db, "m-ext", "# v1\n", None);
+        let md = vault.join("2026-07-16 0900 - Sync.md");
+        seed_exported_note(&state, "m-ext", &md, "# v1\n");
+
+        // The user's agent rewrites the file in the vault behind Murmur's back.
+        std::fs::write(&md, "# my external edit\n").unwrap();
+
+        update_note_inner(&state, "m-ext", "# v2 from murmur\n").unwrap();
+
+        // Canonical file = the DB-derived content (Murmur stays canonical)…
+        assert_eq!(
+            std::fs::read_to_string(&md).unwrap(),
+            "# v2 from murmur\n",
+            "canonical file carries the DB content"
+        );
+        // …and the external version survives byte-exact as a sibling.
+        let siblings = external_edit_siblings(&vault);
+        assert_eq!(siblings.len(), 1, "exactly one preservation sibling");
+        assert_eq!(
+            std::fs::read_to_string(&siblings[0]).unwrap(),
+            "# my external edit\n",
+            "sibling carries EXACTLY the external bytes"
+        );
+        // The baseline is re-stamped to what Murmur just wrote.
+        assert_eq!(
+            state.db.get_note_exported_hash("m-ext", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash("# v2 from murmur\n")),
+            "stored hash re-baselined to the new canonical content"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// No external edit (file still matches the stored baseline) ⇒ a full overwrite creates NO
+    /// sibling, and the baseline moves to the new content.
+    #[test]
+    fn no_external_edit_no_sibling() {
+        let vault = tmp_vault("collision-clean");
+        let state = build_state_with_vault("collision-clean", &vault);
+        seed_meeting(&state.db, "m-clean", "# v1\n", None);
+        let md = vault.join("2026-07-16 0900 - Sync.md");
+        seed_exported_note(&state, "m-clean", &md, "# v1\n");
+
+        update_note_inner(&state, "m-clean", "# v2\n").unwrap();
+
+        assert!(
+            external_edit_siblings(&vault).is_empty(),
+            "no sibling when the file was untouched"
+        );
+        assert_eq!(std::fs::read_to_string(&md).unwrap(), "# v2\n");
+        assert_eq!(
+            state.db.get_note_exported_hash("m-clean", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash("# v2\n")),
+            "baseline refreshed after the overwrite"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// A LEGACY row (exported before the guard shipped → NULL `exported_hash`) is grandfathered:
+    /// the overwrite creates NO sibling even though the file drifted, and the first post-guard
+    /// write stamps the baseline.
+    #[test]
+    fn legacy_null_hash_grandfathered() {
+        let vault = tmp_vault("collision-legacy");
+        let state = build_state_with_vault("collision-legacy", &vault);
+        seed_meeting(&state.db, "m-legacy", "# v1\n", None);
+        let md = vault.join("2026-07-16 0900 - Sync.md");
+        // Legacy export: file + path recorded, but NO baseline hash.
+        std::fs::write(&md, "# drifted legacy content\n").unwrap();
+        state
+            .db
+            .set_note_exported_path("m-legacy", "claude_code", &md.to_string_lossy())
+            .unwrap();
+        assert_eq!(
+            state.db.get_note_exported_hash("m-legacy", "claude_code").unwrap(),
+            None,
+            "legacy row starts with no baseline"
+        );
+
+        update_note_inner(&state, "m-legacy", "# v2\n").unwrap();
+
+        assert!(
+            external_edit_siblings(&vault).is_empty(),
+            "legacy rows are grandfathered — no sibling"
+        );
+        assert_eq!(std::fs::read_to_string(&md).unwrap(), "# v2\n");
+        assert_eq!(
+            state.db.get_note_exported_hash("m-legacy", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash("# v2\n")),
+            "the first post-guard write stamps the baseline"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// APPEND paths (Re-Truth supersession stamps) read-modify-write the CURRENT file, so they
+    /// respect external edits by construction — they must NOT create a sibling, but they MUST
+    /// refresh the stored baseline to the final written content, or the NEXT full overwrite would
+    /// false-positive an "external edit" sibling out of Murmur's own append.
+    #[test]
+    fn append_paths_refresh_hash() {
+        let vault = tmp_vault("collision-append");
+        let state = build_state_with_vault("collision-append", &vault);
+
+        // SOURCE note (gets the [!superseded] callout) + SUPERSEDING note (gets the backlink),
+        // both at the vault root (open + unlocked).
+        seed_meeting(&state.db, "m-src", "# Kickoff\n", None);
+        let src_md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-src", &src_md, "# Kickoff\n");
+        seed_meeting(&state.db, "m-sup", "# Review\n", None);
+        let sup_md = vault.join("2026-07-15 0900 - Review.md");
+        seed_exported_note(&state, "m-sup", &sup_md, "# Review\n");
+
+        state
+            .db
+            .record_supersessions(&[crate::storage::models::SupersessionRow {
+                id: "s1".to_string(),
+                superseding_meeting_id: "m-sup".to_string(),
+                source_meeting_id: "m-src".to_string(),
+                entity: "Atlas".to_string(),
+                predicate: "status".to_string(),
+                old_value: "in-progress".to_string(),
+                new_value: "shipped".to_string(),
+                created_at: "2026-07-15T10:00:00Z".to_string(),
+                applied_at: None,
+                source_pre_image: None,
+                superseding_pre_image: None,
+            }])
+            .unwrap();
+
+        let result = apply_supersessions_inner(&state, &["s1".to_string()]).unwrap();
+        assert_eq!(result.applied, 1, "the stamp applied");
+
+        // The append landed on disk, and NO sibling was created (append respects the file).
+        let src_after = std::fs::read_to_string(&src_md).unwrap();
+        assert!(src_after.contains("[!superseded]"), "callout appended");
+        let sup_after = std::fs::read_to_string(&sup_md).unwrap();
+        assert!(sup_after.contains("[!supersedes]"), "backlink appended");
+        assert!(
+            external_edit_siblings(&vault).is_empty(),
+            "append paths never create siblings"
+        );
+        // Baselines re-stamped from the FINAL written content on BOTH sides…
+        assert_eq!(
+            state.db.get_note_exported_hash("m-src", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash(&src_after)),
+            "source baseline matches the on-disk content after the append"
+        );
+        assert_eq!(
+            state.db.get_note_exported_hash("m-sup", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash(&sup_after)),
+            "superseding baseline matches the on-disk content after the append"
+        );
+        // …so a subsequent DB-derived full overwrite sees no phantom external edit.
+        update_note_inner(&state, "m-src", "# Kickoff rewritten\n").unwrap();
+        assert!(
+            external_edit_siblings(&vault).is_empty(),
+            "no false 'external edit' sibling after Murmur's own append"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Adversarial regression (RED-before-GREEN) — pre-append external-edit LAUNDERING: when the
+    /// file was externally edited BEFORE a Re-Truth append, the append must NOT re-stamp the
+    /// baseline from the (edit + callout) content it wrote — that would make the next DB-derived
+    /// full overwrite see hash == baseline and silently destroy the external edit with no sibling.
+    /// The stale baseline is kept instead, so the next overwrite preserves the file (external
+    /// edit + appended callout) as a sibling.
+    #[test]
+    fn append_over_external_edit_keeps_stale_baseline_so_overwrite_preserves_sibling() {
+        let vault = tmp_vault("collision-launder");
+        let state = build_state_with_vault("collision-launder", &vault);
+
+        seed_meeting(&state.db, "m-src", "# Kickoff\n", None);
+        let src_md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-src", &src_md, "# Kickoff\n");
+        // Superseding meeting with NO exported `.md` → only the SOURCE-side append fires.
+        seed_meeting(&state.db, "m-sup2", "# Review\n", None);
+
+        // The user edits the exported file in the vault BEFORE any Re-Truth stamp lands.
+        std::fs::write(&src_md, "# Kickoff\nMY EXTERNAL NOTE\n").unwrap();
+
+        state
+            .db
+            .record_supersessions(&[crate::storage::models::SupersessionRow {
+                id: "s-launder".to_string(),
+                superseding_meeting_id: "m-sup2".to_string(),
+                source_meeting_id: "m-src".to_string(),
+                entity: "Atlas".to_string(),
+                predicate: "status".to_string(),
+                old_value: "in-progress".to_string(),
+                new_value: "shipped".to_string(),
+                created_at: "2026-07-15T10:00:00Z".to_string(),
+                applied_at: None,
+                source_pre_image: None,
+                superseding_pre_image: None,
+            }])
+            .unwrap();
+        let result = apply_supersessions_inner(&state, &["s-launder".to_string()]).unwrap();
+        assert_eq!(result.applied, 1, "the stamp applied");
+
+        // The append itself respects the file: external edit + callout are both on disk, and the
+        // append never creates a sibling.
+        let after_append = std::fs::read_to_string(&src_md).unwrap();
+        assert!(after_append.contains("MY EXTERNAL NOTE"), "edit preserved in place");
+        assert!(after_append.contains("[!superseded]"), "callout appended");
+        assert!(
+            external_edit_siblings(&vault).is_empty(),
+            "the append creates no sibling"
+        );
+        // The baseline must STAY at the pre-edit Murmur write — NOT be laundered to the
+        // (edit + callout) content the append wrote.
+        assert_eq!(
+            state.db.get_note_exported_hash("m-src", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash("# Kickoff\n")),
+            "the baseline is NOT re-stamped over an externally-edited file"
+        );
+
+        // The next DB-derived full overwrite therefore detects the divergence and preserves the
+        // (edit + callout) file as a sibling instead of destroying it.
+        update_note_inner(&state, "m-src", "# Kickoff rewritten\n").unwrap();
+        let siblings = external_edit_siblings(&vault);
+        assert_eq!(siblings.len(), 1, "the external edit survives as a sibling");
+        let preserved = std::fs::read_to_string(&siblings[0]).unwrap();
+        assert!(
+            preserved.contains("MY EXTERNAL NOTE") && preserved.contains("[!superseded]"),
+            "the sibling carries the external edit AND the appended callout: {preserved}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&src_md).unwrap(),
+            "# Kickoff rewritten\n",
+            "canonical file carries the DB content"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
     }
 
     /// Deleting an OPEN folder moves its notes to the vault ROOT (folder_id = NULL), survives the

--- a/src-tauri/src/export/obsidian.rs
+++ b/src-tauri/src/export/obsidian.rs
@@ -132,7 +132,7 @@ pub fn write_note(
     // (date, title, content): if a file with the exact base name already exists
     // and its content is byte-identical to `markdown`, return it without writing
     // a duplicate. Otherwise, suffix " (N)".
-    let final_path = resolve_unique_path(&target_dir, &stem, markdown)?;
+    let final_path = resolve_unique_path(&target_dir, &stem, markdown.as_bytes())?;
 
     // If resolve returned an existing identical file, we're done (idempotent).
     if final_path_is_existing_identical(&final_path, markdown)? {
@@ -160,8 +160,14 @@ pub fn write_note(
 
 /// Returns true if `path` already exists and its bytes equal `markdown`.
 fn final_path_is_existing_identical(path: &Path, markdown: &str) -> Result<bool> {
+    final_path_is_existing_identical_bytes(path, markdown.as_bytes())
+}
+
+/// Byte-slice core of [`final_path_is_existing_identical`] (the external-edit preservation path
+/// compares RAW bytes — an externally-edited file is not guaranteed to be UTF-8).
+fn final_path_is_existing_identical_bytes(path: &Path, content: &[u8]) -> Result<bool> {
     match std::fs::read(path) {
-        Ok(bytes) => Ok(bytes == markdown.as_bytes()),
+        Ok(bytes) => Ok(bytes == content),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(e) => Err(AppError::Export(format!("read existing note failed: {e}"))),
     }
@@ -172,12 +178,12 @@ fn final_path_is_existing_identical(path: &Path, markdown: &str) -> Result<bool>
 /// (idempotent re-export). If it exists with DIFFERENT content, we look for an
 /// identical sibling `<stem> (N).md`; if found, return it; else allocate the next
 /// free `(N)` slot.
-fn resolve_unique_path(dir: &Path, stem: &str, markdown: &str) -> Result<PathBuf> {
+fn resolve_unique_path(dir: &Path, stem: &str, content: &[u8]) -> Result<PathBuf> {
     let base = dir.join(format!("{stem}.md"));
     if !path_exists(&base)? {
         return Ok(base);
     }
-    if final_path_is_existing_identical(&base, markdown)? {
+    if final_path_is_existing_identical_bytes(&base, content)? {
         return Ok(base);
     }
 
@@ -187,7 +193,7 @@ fn resolve_unique_path(dir: &Path, stem: &str, markdown: &str) -> Result<PathBuf
         if !path_exists(&candidate)? {
             return Ok(candidate);
         }
-        if final_path_is_existing_identical(&candidate, markdown)? {
+        if final_path_is_existing_identical_bytes(&candidate, content)? {
             // Identical content already exported under this suffix → idempotent.
             return Ok(candidate);
         }
@@ -221,6 +227,12 @@ fn sanitize_for_tmp(stem: &str) -> String {
 /// Write `contents` to `path` and fsync both the file and its parent directory so
 /// the subsequent rename is durable.
 fn write_and_sync(path: &Path, contents: &str) -> Result<()> {
+    write_and_sync_bytes(path, contents.as_bytes())
+}
+
+/// Byte-slice core of [`write_and_sync`] — the external-edit preservation path copies the CURRENT
+/// file bytes verbatim (not guaranteed UTF-8), with the same durability discipline.
+fn write_and_sync_bytes(path: &Path, contents: &[u8]) -> Result<()> {
     use std::io::Write;
 
     let mut file = std::fs::OpenOptions::new()
@@ -230,7 +242,7 @@ fn write_and_sync(path: &Path, contents: &str) -> Result<()> {
         .open(path)
         .map_err(|e| AppError::Export(format!("open temp file failed: {e}")))?;
 
-    file.write_all(contents.as_bytes())
+    file.write_all(contents)
         .map_err(|e| AppError::Export(format!("write temp file failed: {e}")))?;
     file.sync_all()
         .map_err(|e| AppError::Export(format!("fsync temp file failed: {e}")))?;
@@ -243,6 +255,106 @@ fn write_and_sync(path: &Path, contents: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+// ── Export-collision guard: never clobber an external vault edit ─────────────
+
+/// SHA-256 (lowercase hex) of the EXACT bytes Murmur writes to an exported vault `.md`. Stored in
+/// `notes.exported_hash` / `documents.exported_hash` after every Murmur write, and compared against
+/// the CURRENT file bytes before the next full overwrite — a mismatch means the user (or their own
+/// vault-side agent) edited the file externally, and [`preserve_external_edit_if_any`] copies their
+/// version aside before Murmur's DB-derived markdown lands.
+pub fn note_content_hash(md: &str) -> String {
+    sha256_hex(md.as_bytes())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Export-collision guard: if the file at `path` was edited EXTERNALLY since Murmur last wrote it
+/// (its current bytes hash differently from `expected_hash`), copy the CURRENT bytes to a sibling
+/// `<stem> (external edit YYYY-MM-DD HHMM).md` in the same directory BEFORE the caller overwrites
+/// the canonical file. Returns `Some(sibling_path)` when an external edit was preserved (or already
+/// is, byte-identical), `None` otherwise.
+///
+/// No sibling is created when:
+/// - `expected_hash` is `None` — a LEGACY row exported before the guard shipped (grandfathered:
+///   there is no baseline to compare against, so treat the file as Murmur's own);
+/// - the file does not exist (nothing to preserve);
+/// - the current bytes hash to `expected_hash` (untouched since Murmur's last write).
+///
+/// Naming reuses [`resolve_unique_path`]'s `" (N)"` collision logic, so a second preservation in
+/// the same minute suffixes rather than clobbers, and a byte-identical existing sibling is reused
+/// (no duplicate). The sibling is written with the same tmp+fsync+rename discipline as
+/// [`write_note`], so it is durably on disk before the caller truncates the canonical file.
+pub fn preserve_external_edit_if_any(
+    path: &Path,
+    expected_hash: Option<&str>,
+) -> Result<Option<PathBuf>> {
+    let stamp = chrono::Local::now().format("%Y-%m-%d %H%M").to_string();
+    preserve_external_edit_with_stamp(path, expected_hash, &stamp)
+}
+
+/// Testable core of [`preserve_external_edit_if_any`] with the local-time minute stamp injected
+/// (mirrors the injectable-`now` pattern of [`sweep_export_tmp_dir`], so the `" (N)"` collision
+/// behavior is provable without racing a real minute boundary).
+fn preserve_external_edit_with_stamp(
+    path: &Path,
+    expected_hash: Option<&str>,
+    stamp: &str,
+) -> Result<Option<PathBuf>> {
+    let Some(expected) = expected_hash else {
+        return Ok(None); // legacy row (pre-guard export) — grandfathered.
+    };
+    let current = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(AppError::Export(format!(
+                "read note before overwrite failed: {e}"
+            )))
+        }
+    };
+    if sha256_hex(&current) == expected {
+        return Ok(None); // untouched since Murmur's last write.
+    }
+
+    // External edit detected — preserve the CURRENT bytes as a sibling BEFORE any overwrite.
+    let parent = path
+        .parent()
+        .ok_or_else(|| AppError::Export("note path has no parent".into()))?;
+    let stem = path
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .ok_or_else(|| AppError::Export("note path has no file stem".into()))?;
+    let sibling_stem = format!("{stem} (external edit {stamp})");
+    let sibling = resolve_unique_path(parent, &sibling_stem, &current)?;
+    if final_path_is_existing_identical_bytes(&sibling, &current)? {
+        // Already preserved byte-identical (e.g. two overwrites in one minute with no edit in
+        // between the preservations) — no duplicate sibling.
+        return Ok(Some(sibling));
+    }
+    let tmp_name = format!(
+        ".{}.{}.murmur.tmp",
+        sanitize_for_tmp(&sibling_stem),
+        std::process::id()
+    );
+    let tmp_path = parent.join(tmp_name);
+    write_and_sync_bytes(&tmp_path, &current).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp_path);
+    })?;
+    std::fs::rename(&tmp_path, &sibling).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        AppError::Export(format!("atomic rename failed: {e}"))
+    })?;
+    Ok(Some(sibling))
 }
 
 // ── Vault title listing ──────────────────────────────────────────────────────
@@ -1380,6 +1492,128 @@ mod tests {
             out, md,
             "cloud with no host/count → nothing to honestly stamp"
         );
+    }
+
+    // ── Export-collision guard: preserve_external_edit_if_any ───────────────
+
+    /// The hash helper is a stable lowercase-hex SHA-256 of the exact bytes.
+    #[test]
+    fn note_content_hash_is_lowercase_hex_sha256() {
+        // sha256("abc") — a well-known vector.
+        assert_eq!(
+            note_content_hash("abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_ne!(note_content_hash("a"), note_content_hash("b"));
+    }
+
+    /// A mismatching hash (external edit) preserves the CURRENT bytes as a timestamped sibling; the
+    /// canonical file itself is untouched by the preservation (the caller overwrites it after).
+    #[test]
+    fn preserve_creates_sibling_on_hash_mismatch() {
+        let dir = tmp_dir("preserve-mismatch");
+        let path = dir.join("2026-07-16 0900 - Sync.md");
+        std::fs::write(&path, "externally edited").unwrap();
+
+        let murmur_last_wrote = note_content_hash("murmur content");
+        let sibling = preserve_external_edit_if_any(&path, Some(&murmur_last_wrote))
+            .unwrap()
+            .expect("external edit must be preserved");
+
+        let name = sibling.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.starts_with("2026-07-16 0900 - Sync (external edit "),
+            "sibling name carries the marker: {name}"
+        );
+        assert!(name.ends_with(".md"), "sibling is a .md: {name}");
+        assert_eq!(
+            std::fs::read_to_string(&sibling).unwrap(),
+            "externally edited",
+            "sibling carries EXACTLY the external bytes"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "externally edited",
+            "the canonical file is not touched by the preservation itself"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A matching hash (no external edit) creates NO sibling.
+    #[test]
+    fn preserve_noop_when_hash_matches() {
+        let dir = tmp_dir("preserve-match");
+        let path = dir.join("Sync.md");
+        std::fs::write(&path, "murmur content").unwrap();
+        let h = note_content_hash("murmur content");
+        assert_eq!(preserve_external_edit_if_any(&path, Some(&h)).unwrap(), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A `None` expected hash (legacy row exported before the guard) is grandfathered: no sibling.
+    #[test]
+    fn preserve_noop_for_legacy_null_hash() {
+        let dir = tmp_dir("preserve-legacy");
+        let path = dir.join("Sync.md");
+        std::fs::write(&path, "anything at all").unwrap();
+        assert_eq!(preserve_external_edit_if_any(&path, None).unwrap(), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A missing file is a no-op (nothing to preserve), never an error.
+    #[test]
+    fn preserve_noop_when_file_missing() {
+        let dir = tmp_dir("preserve-missing");
+        let path = dir.join("Gone.md");
+        let h = note_content_hash("whatever");
+        assert_eq!(preserve_external_edit_if_any(&path, Some(&h)).unwrap(), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Two preservations in the same minute (fixed stamp via the injectable core): identical
+    /// external bytes REUSE the existing sibling (no duplicate); different external bytes get a
+    /// `" (N)"` suffix — the first sibling is never clobbered.
+    #[test]
+    fn preserve_sibling_name_collision_suffixes_or_dedups() {
+        let dir = tmp_dir("preserve-collide");
+        let path = dir.join("Sync.md");
+        let stale = note_content_hash("what murmur last wrote");
+        let stamp = "2026-07-16 0930"; // one fixed minute — the collision case by construction.
+
+        // First preservation.
+        std::fs::write(&path, "external v1").unwrap();
+        let s1 = preserve_external_edit_with_stamp(&path, Some(&stale), stamp)
+            .unwrap()
+            .expect("first preservation");
+        assert_eq!(
+            s1.file_name().unwrap().to_str().unwrap(),
+            "Sync (external edit 2026-07-16 0930).md"
+        );
+
+        // Same external bytes again (a retry / a second overwrite before any new edit): the
+        // byte-identical existing sibling is reused, not duplicated.
+        let s1_again = preserve_external_edit_with_stamp(&path, Some(&stale), stamp)
+            .unwrap()
+            .expect("still an external edit");
+        assert_eq!(s1, s1_again, "byte-identical sibling is reused");
+
+        // A DIFFERENT external edit in the same minute must NOT clobber the first sibling — it
+        // takes the next " (N)" slot.
+        std::fs::write(&path, "external v2").unwrap();
+        let s2 = preserve_external_edit_with_stamp(&path, Some(&stale), stamp)
+            .unwrap()
+            .expect("second preservation");
+        assert_eq!(
+            s2.file_name().unwrap().to_str().unwrap(),
+            "Sync (external edit 2026-07-16 0930) (1).md",
+            "second distinct edit is collision-suffixed"
+        );
+        assert_eq!(std::fs::read_to_string(&s1).unwrap(), "external v1");
+        assert_eq!(std::fs::read_to_string(&s2).unwrap(), "external v2");
+
+        // No temp residue from the preservation writes.
+        assert!(!dir_has_tmp(&dir), "preservation leaves no temp dotfiles");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ── Re-Truth: append-only supersession callouts ─────────────────────────

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1348,7 +1348,7 @@ async fn summarize_and_export(
                 when_iso,
                 &markdown,
             )?;
-            persist_note_exported_path(&state.db, config, meeting_id, &exported_path)?;
+            persist_note_exported_path(&state.db, config, meeting_id, &exported_path, &markdown)?;
             state.db.set_meeting_title(meeting_id, &title)?;
             state
                 .db
@@ -1449,9 +1449,18 @@ fn persist_note_exported_path(
     config: &AppConfig,
     meeting_id: &str,
     exported_path: &Path,
+    markdown: &str,
 ) -> Result<()> {
     let connection = crate::summarize::roles::provider_target(Role::Notes, config).connection;
-    db.set_note_exported_path(meeting_id, &connection, &exported_path.to_string_lossy())
+    db.set_note_exported_path(meeting_id, &connection, &exported_path.to_string_lossy())?;
+    // Export-collision guard: stamp the baseline from the EXACT markdown written — `write_note`
+    // either wrote it, found an identical file, or collision-suffixed a fresh one, so the file at
+    // `exported_path` is byte-equal to `markdown` in every branch.
+    db.set_note_exported_hash(
+        meeting_id,
+        &connection,
+        Some(&crate::export::note_content_hash(markdown)),
+    )
 }
 
 /// Finalize a summarized note when NO vault folder is configured. By this point the caller
@@ -2292,7 +2301,8 @@ mod tests {
             .unwrap();
 
         // The REAL production paired write.
-        persist_note_exported_path(&db, &config, mid, Path::new("/vault/Role export.md")).unwrap();
+        persist_note_exported_path(&db, &config, mid, Path::new("/vault/Role export.md"), "# body")
+            .unwrap();
 
         let note = db
             .get_latest_note_for_meeting(mid)
@@ -2313,6 +2323,13 @@ mod tests {
                 .any(|n| n.exported_path.as_deref() == Some("/vault/Role export.md")),
             "the seal deletion-target collection must see the exported .md"
         );
+        // Export-collision guard: the SAME paired write stamps the baseline hash on the SAME
+        // (role-resolved) row — a NULL here would grandfather every pipeline export forever.
+        assert_eq!(
+            db.get_note_exported_hash(mid, "anthropic").unwrap(),
+            Some(crate::export::note_content_hash("# body")),
+            "the pipeline export stamps the collision-guard baseline on the role-resolved row"
+        );
 
         // (b) LEGACY fallback (no role keys): the key is provider_id — unchanged behavior.
         let legacy_cfg = AppConfig::default(); // provider_id = claude_code, keys absent
@@ -2323,7 +2340,8 @@ mod tests {
             &crate::summarize::roles::provider_target(Role::Notes, &legacy_cfg).connection,
         ))
         .unwrap();
-        persist_note_exported_path(&db, &legacy_cfg, mid2, Path::new("/vault/Legacy.md")).unwrap();
+        persist_note_exported_path(&db, &legacy_cfg, mid2, Path::new("/vault/Legacy.md"), "# body")
+            .unwrap();
         let legacy_note = db
             .get_latest_note_for_meeting(mid2)
             .unwrap()

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -641,6 +641,16 @@ impl Db {
         Self::add_column_if_missing(&conn, "notes", "model_requested", "TEXT")?;
         Self::add_column_if_missing(&conn, "notes", "model_served", "TEXT")?;
         Self::add_column_if_missing(&conn, "notes", "gateway_host", "TEXT")?;
+        // Export-collision guard (2026-07-16): `exported_hash` = SHA-256 (lowercase hex) of the
+        // EXACT markdown Murmur last wrote to the exported vault `.md` at `exported_path`. Before
+        // every full DB-derived overwrite, the guard compares the CURRENT file bytes against this
+        // baseline — a mismatch means an EXTERNAL edit (the user or their own vault-side agent),
+        // which is preserved as a sibling file instead of silently clobbered
+        // (`export::preserve_external_edit_if_any`). NULL = legacy row exported before the guard
+        // shipped (grandfathered: no sibling until the next Murmur write stamps a baseline).
+        // NON-CONTENT metadata (a digest, never words): like `exported_path` it is not
+        // sealed/blanked — it rides the SQLCipher-at-rest layer. Additive + guarded (idempotent).
+        Self::add_column_if_missing(&conn, "notes", "exported_hash", "TEXT")?;
         // @brain THREADS: scope each persisted assistant exchange to a conversation thread.
         // `thread_id` is an OPAQUE id (FE-supplied for an @brain thread, backend-generated UUID for
         // the voice/wake path); `anchor_text` is the note text an @brain thread was anchored to
@@ -713,6 +723,11 @@ impl Db {
         Self::add_column_if_missing(&conn, "documents", "title", "TEXT")?;
         Self::add_column_if_missing(&conn, "documents", "updated_at", "INTEGER")?;
         Self::add_column_if_missing(&conn, "documents", "exported_path", "TEXT")?;
+        // Export-collision guard (2026-07-16): the authored-note twin of `notes.exported_hash` —
+        // the SHA-256 (lowercase hex) of the text Murmur last wrote to this note's exported vault
+        // `.md`. Refreshed on every vault (re)export; NULL for legacy rows (grandfathered). See the
+        // `notes.exported_hash` migration comment for the full contract. Additive + guarded.
+        Self::add_column_if_missing(&conn, "documents", "exported_hash", "TEXT")?;
         // NOTES feature — separate the Notes folder tree from the Meetings tree. `kind` defaults
         // 'meeting' so every existing folder + all meeting behavior stays byte-identical; note
         // folders are created with kind='note'. Lock/seal/CK machinery is folder-id-keyed and
@@ -5820,6 +5835,33 @@ impl Db {
         Ok(())
     }
 
+    /// The export-collision-guard baseline for an AUTHORED note (`documents(kind='note')`): the
+    /// SHA-256 (lowercase hex) of the text Murmur last wrote to its exported vault `.md`. `None`
+    /// for a legacy/never-exported row (grandfathered). Twin of [`Db::get_note_exported_hash`].
+    pub fn get_note_doc_exported_hash(&self, id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT exported_hash FROM documents WHERE id = ?1 AND kind = 'note'",
+            rusqlite::params![id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// Persist (or clear with `None`) an authored NOTE's export-collision-guard baseline —
+    /// refreshed on every vault (re)export. Twin of [`Db::set_note_exported_hash`].
+    pub fn set_note_doc_exported_hash(&self, id: &str, hash: Option<&str>) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE documents SET exported_hash = ?2 WHERE id = ?1 AND kind = 'note'",
+            rusqlite::params![id, hash],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     /// The vault `.md` paths of every authored NOTE in a folder that has one (`exported_path`
     /// non-NULL). Captured BEFORE seal so `lock_folder` can delete the on-disk `.md` (mirrors the
     /// meeting-notes `.md` deletion). No text — just paths (never PII-in-a-log; the caller doesn't
@@ -6556,6 +6598,46 @@ impl Db {
             "UPDATE notes SET exported_path = ?3
              WHERE meeting_id = ?1 AND provider_id = ?2",
             rusqlite::params![meeting_id, provider_id, path],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The export-collision-guard baseline for a MEETING note: the SHA-256 (lowercase hex) of the
+    /// markdown Murmur last wrote to this row's exported vault `.md`. `None` for a legacy row
+    /// exported before the guard shipped (grandfathered — no sibling is preserved until the next
+    /// Murmur write stamps a baseline) or when the row is unknown.
+    pub fn get_note_exported_hash(
+        &self,
+        meeting_id: &str,
+        provider_id: &str,
+    ) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT exported_hash FROM notes WHERE meeting_id = ?1 AND provider_id = ?2",
+            rusqlite::params![meeting_id, provider_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// Persist (or clear with `None`) a MEETING note's export-collision-guard baseline. Set after
+    /// EVERY write Murmur makes to the exported `.md` (full overwrites AND appends), computed from
+    /// the exact content written — a stale baseline causes false "external edit" siblings on the
+    /// next overwrite.
+    pub fn set_note_exported_hash(
+        &self,
+        meeting_id: &str,
+        provider_id: &str,
+        hash: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE notes SET exported_hash = ?3
+             WHERE meeting_id = ?1 AND provider_id = ?2",
+            rusqlite::params![meeting_id, provider_id, hash],
         )
         .map_err(map_err)?;
         Ok(())
@@ -12000,6 +12082,88 @@ mod tests {
             has_schemas(&db),
             "note_folder_schemas table missing after a second migrate (idempotency broken)"
         );
+
+        // Export-collision guard: the additive `exported_hash` column must exist on BOTH exporting
+        // tables after migrate and still be there (idempotently) after the re-migrates above —
+        // `add_column_if_missing` never duplicates or drops.
+        let has_column = |db: &Db, table: &str| -> bool {
+            db.lock()
+                .prepare(&format!("PRAGMA table_info({table})"))
+                .unwrap()
+                .query_map([], |r| r.get::<_, String>(1))
+                .unwrap()
+                .filter_map(|r| r.ok())
+                .any(|c| c == "exported_hash")
+        };
+        assert!(has_column(&db, "notes"), "notes.exported_hash missing");
+        assert!(
+            has_column(&db, "documents"),
+            "documents.exported_hash missing"
+        );
+    }
+
+    /// Export-collision guard: the `exported_hash` helpers round-trip on both exporting tables,
+    /// and a legacy row (exported before the guard) reads back `None` (grandfathered).
+    #[test]
+    fn exported_hash_round_trips_and_legacy_rows_read_none() {
+        let db = mem_db();
+
+        // MEETING note (`notes` table).
+        db.insert_meeting(&sample_meeting("m1", "2026-07-16T09:00:00Z"))
+            .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m1".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "# hello".to_string(),
+            created_at: "2026-07-16T09:05:00Z".to_string(),
+            exported_path: Some("/tmp/x.md".to_string()),
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        // Legacy shape: exported but never hashed → None.
+        assert_eq!(db.get_note_exported_hash("m1", "claude_code").unwrap(), None);
+        db.set_note_exported_hash("m1", "claude_code", Some("abc123")).unwrap();
+        assert_eq!(
+            db.get_note_exported_hash("m1", "claude_code").unwrap(),
+            Some("abc123".to_string())
+        );
+        // A row-preserving upsert (same PK) must NOT wipe the baseline (the hash column is owned
+        // by the export writes, not the note upsert).
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m1".to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: "# hello v2".to_string(),
+            created_at: "2026-07-16T09:06:00Z".to_string(),
+            exported_path: Some("/tmp/x.md".to_string()),
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        assert_eq!(
+            db.get_note_exported_hash("m1", "claude_code").unwrap(),
+            Some("abc123".to_string()),
+            "upsert_note leaves the guard baseline in place"
+        );
+        db.set_note_exported_hash("m1", "claude_code", None).unwrap();
+        assert_eq!(db.get_note_exported_hash("m1", "claude_code").unwrap(), None);
+        // Unknown row → None, never an error.
+        assert_eq!(db.get_note_exported_hash("nope", "x").unwrap(), None);
+
+        // AUTHORED note (`documents(kind='note')`).
+        let folder_id = db.ensure_default_note_folder().unwrap();
+        db.insert_note("n1", &folder_id, "n1", "T", "body", 1).unwrap();
+        assert_eq!(db.get_note_doc_exported_hash("n1").unwrap(), None);
+        db.set_note_doc_exported_hash("n1", Some("def456")).unwrap();
+        assert_eq!(
+            db.get_note_doc_exported_hash("n1").unwrap(),
+            Some("def456".to_string())
+        );
+        db.set_note_doc_exported_hash("n1", None).unwrap();
+        assert_eq!(db.get_note_doc_exported_hash("n1").unwrap(), None);
+        assert_eq!(db.get_note_doc_exported_hash("nope").unwrap(), None);
     }
 
     /// 2026-07-13 perf audit: `meetings.started_at` (every list/search sorts on it) and


### PR DESCRIPTION
## What

Closes the one-way-export data-loss gap found by the 2026-07-16 vault-agent research (`docs/research/2026-07-16-obsidian-claude-code-vault-agent.md`, lands in #345): any edit a user (or their vault-side agent) made to a Murmur-exported `.md` was silently destroyed by the next DB-derived rewrite.

- Additive `exported_hash` (SHA-256 of the last markdown Murmur wrote) on `notes` + `documents`, stamped at every export/write site (guarded, idempotent migration; NULL = grandfathered legacy).
- `preserve_external_edit_if_any`: before any of the 7 DB-derived full-overwrite paths (update_note, verify markers, enrichment, link pass, task patch, pin, undo-supersessions) truncates the file, an on-disk hash mismatch preserves the CURRENT bytes as `<stem> (external edit YYYY-MM-DD HHMM).md` — atomic tmp+fsync+rename, (N)-suffix collision handling, byte-identical dedup.
- Re-Truth append paths refresh the baseline ONLY when the pre-append bytes matched it, so an external edit under an append is still preserved by the next overwrite (adversarial round-1 MEDIUM, fixed + regression).
- Seal paths deliberately create NO sibling — privacy wins over preservation (commented at both delete sites).

## How verified

- **adversarial-verifier**: round 1 FAIL (MEDIUM: append-path baseline laundering) → surgical fix → re-verify **PASS**. RED→GREEN observed on `append_over_external_edit_keeps_stale_baseline_so_overwrite_preserves_sibling` (drives the REAL call sites) + 12 new/extended tests (guard lifecycle ×5, primitive ×6, db round-trip, migrate idempotence, role-resolved-row stamp).
- **lock-security-reviewer**: **PASS** — every guard call site behind existing gates under `lifecycle_guard`; sealed rows structurally unreachable (`exported_path` NULLed on seal); sibling bytes are always the user's own on-disk bytes, never DB plaintext; no PII in new logs; sibling-survives-later-seal tension adjudicated acceptable (deleting it would destroy the only copy of user content). Non-blocking follow-ups (hash-blank-on-seal, lock-time sibling warning, lifecycle_guard in apply/undo_supersessions) tracked for the Vault Audit PR.
- `cargo test --lib`: 1661 passed / 10 ignored / 1 pre-existing machine-dependent failure (`settings::ai_map` whisper-default test; this Mac has the turbo model downloaded — diff touches no settings/transcribe code).

No FE changes, no new commands, no new deps (`sha2` already in-tree).