### PR TITLE
feat(audit): Vault Audit v1 — deterministic vault health findings + inbox

### DIFF
--- a/e2e/brain/audit-inbox.spec.ts
+++ b/e2e/brain/audit-inbox.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Vault Audit inbox smoke (mocked IPC — no Rust core behind it):
+ *  - the section mounts on /brain as a sibling of Scheduled briefs, with the
+ *    pending count badged on the collapsed header;
+ *  - "Audit now" auto-expands the section and surfaces the run summary line;
+ *  - groups render in the stable kind order (contradiction → stale →
+ *    broken_link → unlinked_mention → orphan), dropping empty kinds;
+ *  - Accept is offered ONLY when the backend staged an `acceptAction`
+ *    (dismiss-only findings get no Accept button);
+ *  - Dismiss is confirm-then-update: the row leaves the inbox only after
+ *    `resolve_audit_finding` resolves, and the badge follows;
+ *  - an `audit-updated` backend event triggers a silent refetch (no errors).
+ */
+test("Vault audit: inbox mounts, groups, resolves, and refetches on event", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    list_audit_findings: () => [
+      {
+        id: "f-1",
+        kind: "contradiction",
+        sourceKind: "note",
+        sourceId: "n-1",
+        sourceTitle: "Project Atlas decision",
+        targetTitle: "Atlas kickoff meeting",
+        evidenceMd: "One note says **ship in Q3**, the other **Q4**.",
+        acceptAction: "",
+        status: "pending",
+        createdAt: 1752600000,
+        resolvedAt: null,
+      },
+      {
+        id: "f-2",
+        kind: "broken_link",
+        sourceKind: "note",
+        sourceId: "n-2",
+        sourceTitle: "Roadmap 2026",
+        targetTitle: "Pricing experiments",
+        evidenceMd: "`[[Pricing experiments]]` has no matching note.",
+        acceptAction: "Create the missing note “Pricing experiments”",
+        status: "pending",
+        createdAt: 1752600001,
+        resolvedAt: null,
+      },
+      {
+        id: "f-3",
+        kind: "orphan",
+        sourceKind: "note",
+        sourceId: "n-3",
+        sourceTitle: "Scratch note",
+        targetTitle: null,
+        evidenceMd: "No links in, no links out.",
+        acceptAction: "",
+        status: "pending",
+        createdAt: 1752600002,
+        resolvedAt: null,
+      },
+    ],
+    run_vault_audit: () => ({
+      runId: "run-1",
+      startedAt: 1752600100,
+      finishedAt: 1752600101,
+      findingsNew: 2,
+      findingsTotalPending: 3,
+      counts: { contradiction: 1, broken_link: 1, orphan: 1 },
+    }),
+    resolve_audit_finding: (args: { id: string; action: string }) => ({
+      id: args.id,
+      kind: "contradiction",
+      sourceKind: "note",
+      sourceId: "n-1",
+      sourceTitle: "Project Atlas decision",
+      targetTitle: null,
+      evidenceMd: "",
+      acceptAction: "",
+      status: args.action === "accept" ? "accepted" : "dismissed",
+      createdAt: 1752600000,
+      resolvedAt: 1752600200,
+    }),
+  });
+
+  await page.goto("/brain");
+
+  const section = page.locator("app-audit");
+  await expect(section).toBeVisible();
+
+  // Collapsed header badges the pending count; the inbox body stays hidden.
+  await expect(section.locator(".au-count")).toHaveText("3");
+  await expect(section.locator(".au-group")).toHaveCount(0);
+
+  // A backend audit-updated ping refetches silently (badge unchanged, no errors).
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __demoEmit: (event: string, payload: unknown) => void;
+      }
+    ).__demoEmit("murmur://audit-updated", { findingsTotalPending: 3 });
+  });
+  await expect(section.locator(".au-count")).toHaveText("3");
+
+  // "Audit now" auto-expands and surfaces the summary line.
+  await section.locator(".au-run").click();
+  await expect(section.locator(".au-toggle")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(section.locator(".au-summary")).toHaveText(
+    /2 new findings · 3 pending/,
+  );
+
+  // Groups render in the stable kind order, empty kinds dropped.
+  await expect(section.locator(".au-group-title")).toHaveText([
+    "Contradictions",
+    "Broken links",
+    "Orphans",
+  ]);
+
+  // Accept only where an acceptAction was staged; dismiss-only rows get none.
+  const contradiction = section
+    .locator(".au-item")
+    .filter({ hasText: "Project Atlas decision" });
+  const brokenLink = section
+    .locator(".au-item")
+    .filter({ hasText: "Roadmap 2026" });
+  await expect(contradiction.locator(".btn-primary")).toHaveCount(0);
+  await expect(brokenLink.locator(".btn-primary")).toHaveAttribute(
+    "title",
+    "Create the missing note “Pricing experiments”",
+  );
+
+  // Dismiss = confirm-then-update: the row leaves only after the IPC resolves.
+  await contradiction.getByRole("button", { name: "Dismiss" }).click();
+  await expect(
+    section.locator(".au-item").filter({ hasText: "Project Atlas decision" }),
+  ).toHaveCount(0);
+  await expect(section.locator(".au-count")).toHaveText("2");
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -1,0 +1,1686 @@
+//! Vault Audit v1 — DETERMINISTIC vault-health passes over the user's visible notes. Zero
+//! egress, zero LLM: every finding is derived by pure string/graph/SQL analysis, staged as a
+//! propose→accept row (`audit_findings`), and only ever APPLIED to a vault `.md` as an
+//! append-only line under the managed `## Audit` section (see
+//! [`crate::export::obsidian::AUDIT_SECTION`]).
+//!
+//! ## Lock model (audited by the lock-security review)
+//! The corpus is built EXCLUSIVELY through the gated readers with the EMPTY unlock set —
+//! `list_meetings_visible` + `get_note_if_visible` + `list_notes_visible` +
+//! `note_markdown_if_visible` — the SAME discipline as the memory consolidation job
+//! ([`crate::memory`]) and the scheduled-brief runner ([`crate::brief_runner`]): a background
+//! job must never see session-unlocked plaintext, let alone sealed content. A pending finding's
+//! `evidence_md` is derived plaintext (a quoted line, counts, suggested `[[links]]`), so it is
+//! the SAME purge class as pending brief runs: every seal path purges pending findings whose
+//! source or target is being sealed (`Db::purge_pending_audit_findings_tx`), and resolve
+//! (accept OR dismiss) blanks `evidence_md`/`accept_action` — only PENDING rows ever hold
+//! derived plaintext.
+//!
+//! ## The seal-epoch TOCTOU guard
+//! Exactly like [`crate::memory::run_consolidation_pass`], the pass snapshots
+//! `AppState::seal_epoch` before any read and re-checks it before EVERY finding insert: a seal /
+//! relock / remove-lock interleaving with the pass aborts the write phase silently (the next
+//! manual run re-derives against the post-seal visible set). Without this, a seal landing
+//! between the gated corpus read and the findings write could persist just-sealed content into a
+//! pending finding the seal's own purge had already run for.
+//!
+//! No PII in logs: ids, kinds, counts only.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::storage::Db;
+
+/// Bound on the visible-meetings scan (mirrors the brief runner's corpus cap posture — a
+/// deterministic bound, not pagination).
+const AUDIT_MAX_MEETINGS: i64 = 10_000;
+
+/// Max unlinked-mention findings emitted per SOURCE note per pass (spec cap).
+const MAX_MENTIONS_PER_NOTE: usize = 3;
+
+/// Max reconnection suggestions computed for one orphan finding (spec cap).
+const MAX_ORPHAN_SUGGESTIONS: usize = 3;
+
+/// Minimum title length (chars) for the unlinked-mention matcher — shorter titles ("Sync",
+/// "Notes") false-positive on ordinary prose.
+const MIN_MENTION_TITLE_CHARS: usize = 6;
+
+/// Staleness thresholds: a meeting note is flagged when it carries at least this many facts…
+const STALE_MIN_FACTS: usize = 3;
+/// …and at least half of them are closed (superseded). Expressed as closed*2 >= total.
+
+// ── Wire DTOs (the pinned FE seam — the Angular builder codes against exactly these) ─────────
+
+/// Summary of one completed (or seal-aborted) audit pass.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditRunSummary {
+    pub run_id: String,
+    pub started_at: i64,
+    pub finished_at: i64,
+    /// Findings newly staged THIS pass (post-dedupe).
+    pub findings_new: usize,
+    /// Total pending findings after the pass (includes survivors of earlier passes).
+    pub findings_total_pending: usize,
+    /// New findings per kind, e.g. `{"broken_link": 2, "orphan": 1}`.
+    pub counts: BTreeMap<String, usize>,
+}
+
+/// One finding, FE-shaped. `evidence_md`/`accept_action` are blanked once resolved (only
+/// PENDING rows hold derived plaintext).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditFinding {
+    pub id: String,
+    /// broken_link | orphan | stale | contradiction | unlinked_mention.
+    pub kind: String,
+    /// meeting | note.
+    pub source_kind: String,
+    pub source_id: String,
+    pub source_title: String,
+    pub target_title: Option<String>,
+    pub evidence_md: String,
+    /// Human description of what accept will do; empty = dismiss-only.
+    pub accept_action: String,
+    /// pending | accepted | dismissed.
+    pub status: String,
+    pub created_at: i64,
+    pub resolved_at: Option<i64>,
+}
+
+// ── DB-shaped rows ────────────────────────────────────────────────────────────────────────────
+
+/// A full `audit_findings` row (superset of the wire DTO: adds `target_id`/`dedupe_key`/`run_id`).
+#[derive(Debug, Clone)]
+pub struct AuditFindingRow {
+    pub id: String,
+    pub kind: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub source_title: String,
+    pub target_title: Option<String>,
+    pub target_id: Option<String>,
+    /// "meeting" | "note" when `target_id` is set — lets the list layer re-gate the TARGET side
+    /// against the right table. Row-only (not on the pinned wire DTO).
+    pub target_kind: Option<String>,
+    pub evidence_md: String,
+    pub accept_action: String,
+    pub dedupe_key: String,
+    pub status: String,
+    pub run_id: String,
+    pub created_at: i64,
+    pub resolved_at: Option<i64>,
+}
+
+impl AuditFindingRow {
+    pub fn into_dto(self) -> AuditFinding {
+        AuditFinding {
+            id: self.id,
+            kind: self.kind,
+            source_kind: self.source_kind,
+            source_id: self.source_id,
+            source_title: self.source_title,
+            target_title: self.target_title,
+            evidence_md: self.evidence_md,
+            accept_action: self.accept_action,
+            status: self.status,
+            created_at: self.created_at,
+            resolved_at: self.resolved_at,
+        }
+    }
+}
+
+/// A finding BEFORE insert (no id/run/timestamps — the insert assigns them). `dedupe_key` is the
+/// stable identity across runs: an existing PENDING or DISMISSED row with the same key suppresses
+/// re-creation (dismissed = "don't nag again"); an ACCEPTED one does not (evidence may recur).
+#[derive(Debug, Clone)]
+pub struct NewAuditFinding {
+    pub kind: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub source_title: String,
+    pub target_title: Option<String>,
+    pub target_id: Option<String>,
+    /// "meeting" | "note" when `target_id` is set (the list layer's target re-gate key).
+    pub target_kind: Option<String>,
+    pub evidence_md: String,
+    pub accept_action: String,
+    pub dedupe_key: String,
+}
+
+/// One visible corpus document — a meeting note or a standalone authored note.
+#[derive(Debug, Clone)]
+pub(crate) struct CorpusDoc {
+    /// "meeting" | "note".
+    pub kind: &'static str,
+    pub id: String,
+    pub title: String,
+    pub body: String,
+}
+
+// ── The pass ─────────────────────────────────────────────────────────────────────────────────
+
+/// ONE deterministic audit pass: build the gated corpus (EMPTY unlock set), run the five passes,
+/// stage new findings via the dedupe rule, record an `audit_runs` row, return the summary.
+/// `now_ms` is injected (test determinism); `vault_dir` feeds the vault-wide title walker so a
+/// user-authored vault file or entity stub never counts as a broken-link target.
+pub fn run_audit_pass(
+    db: &Db,
+    vault_dir: Option<&Path>,
+    now_ms: i64,
+    seal_epoch: &AtomicU64,
+) -> Result<AuditRunSummary> {
+    // Snapshot BEFORE any read — every finding insert below re-checks against this (the
+    // consolidation-pass TOCTOU discipline, see the module doc).
+    let epoch_at_start = seal_epoch.load(Ordering::SeqCst);
+    let seal_interleaved = || seal_epoch.load(Ordering::SeqCst) != epoch_at_start;
+
+    let corpus = build_corpus(db)?;
+
+    // The broken-link resolver union: vault file stems (user-authored files + entity stubs) +
+    // the gated resolve_wikilink (notes/meetings/org items). Corpus titles resolve through
+    // resolve_wikilink anyway; the stem set is the extra "anything already in the vault" leg.
+    let vault_titles: HashSet<String> = match vault_dir {
+        Some(dir) => match crate::export::obsidian::list_vault_titles(dir) {
+            Ok(v) => v.into_iter().collect(),
+            Err(e) => {
+                tracing::warn!(target: "audit", error = %e, "vault title walk failed; resolving links against the DB only");
+                HashSet::new()
+            }
+        },
+        None => HashSet::new(),
+    };
+    let no_unlocks: HashSet<String> = HashSet::new();
+
+    let mut findings: Vec<NewAuditFinding> = Vec::new();
+    findings.extend(broken_link_pass(&corpus, &mut |title: &str| {
+        if vault_titles.contains(title) {
+            return Ok(true);
+        }
+        Ok(db.resolve_wikilink(title, &no_unlocks)?.is_some())
+    })?);
+    let entity_sets = entity_sets_for(db, &corpus)?;
+    findings.extend(orphan_pass(&corpus, &entity_sets));
+    findings.extend(unlinked_mention_pass(&corpus));
+    findings.extend(stale_pass(db, &corpus)?);
+    findings.extend(contradiction_pass(db, &corpus)?);
+
+    // ── Write phase, seal-epoch guarded ──
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut findings_new = 0usize;
+    for f in &findings {
+        // A seal/relock landed since the snapshot ⇒ the corpus read above may include
+        // now-sealed content. Stop staging findings (already-staged ones referencing the sealed
+        // ids were purged by the seal tx itself). Ids/counts logged only.
+        if seal_interleaved() {
+            tracing::info!(
+                target: "audit",
+                staged = findings_new,
+                dropped = findings.len() - findings_new,
+                "seal epoch advanced mid-pass; remaining findings discarded"
+            );
+            break;
+        }
+        if db.insert_audit_finding_if_new(f, &run_id, now_ms)? {
+            findings_new += 1;
+            *counts.entry(f.kind.clone()).or_default() += 1;
+        }
+    }
+    // End-of-pass reconciliation (the TOCTOU shrink): if the epoch is observed advanced NOW —
+    // catching a seal that landed after any insert's own pre-check — withdraw everything this
+    // run staged (a stale row inserted after the seal's purge tx ran would otherwise survive).
+    let (findings_new, counts) =
+        reconcile_run_on_epoch_advance(db, &run_id, seal_interleaved(), findings_new, counts)?;
+
+    // The run row is content-free (id + timestamps + per-kind counts) — safe to record even on
+    // an aborted pass.
+    let counts_json = serde_json::to_string(&counts)
+        .map_err(|e| crate::error::AppError::Storage(format!("counts serialize failed: {e}")))?;
+    db.insert_audit_run(&run_id, now_ms, now_ms, &counts_json)?;
+    let findings_total_pending = db.count_pending_audit_findings()?;
+    tracing::info!(
+        target: "audit",
+        run_id = %run_id,
+        corpus = corpus.len(),
+        new = findings_new,
+        pending = findings_total_pending,
+        "vault audit pass complete"
+    );
+    Ok(AuditRunSummary {
+        run_id,
+        started_at: now_ms,
+        finished_at: now_ms,
+        findings_new,
+        findings_total_pending,
+        counts,
+    })
+}
+
+/// End-of-pass seal-epoch reconciliation: when `advanced` (the epoch moved at ANY point during
+/// the pass), every PENDING row this run staged is withdrawn in one statement and the pass
+/// reports zero — closing the residual window where an insert lands AFTER the interleaving
+/// seal's own purge tx already ran (that purge can't see a row inserted later). The next manual
+/// run re-derives from the post-seal visible corpus. Content-free logging.
+pub(crate) fn reconcile_run_on_epoch_advance(
+    db: &Db,
+    run_id: &str,
+    advanced: bool,
+    findings_new: usize,
+    counts: BTreeMap<String, usize>,
+) -> Result<(usize, BTreeMap<String, usize>)> {
+    if !advanced {
+        return Ok((findings_new, counts));
+    }
+    let withdrawn = db.delete_pending_audit_findings_for_run(run_id)?;
+    tracing::info!(
+        target: "audit",
+        run_id = %run_id,
+        withdrawn,
+        "seal epoch advanced during the pass; the run's staged findings were withdrawn"
+    );
+    Ok((0, BTreeMap::new()))
+}
+
+/// The gated corpus: every VISIBLE meeting note + standalone note, read with the EMPTY unlock
+/// set (sealed-and-not-session-unlocked content never enters the audit — see the module doc).
+fn build_corpus(db: &Db) -> Result<Vec<CorpusDoc>> {
+    let no_unlocks: HashSet<String> = HashSet::new();
+    let mut corpus = Vec::new();
+    for m in db.list_meetings_visible(AUDIT_MAX_MEETINGS, &no_unlocks)? {
+        let Some(note) = db.get_note_if_visible(&m.id, &no_unlocks)? else {
+            continue;
+        };
+        if note.markdown.trim().is_empty() {
+            continue;
+        }
+        corpus.push(CorpusDoc {
+            kind: "meeting",
+            id: m.id.clone(),
+            title: m.title.clone().unwrap_or_default().trim().to_string(),
+            body: note.markdown,
+        });
+    }
+    for s in db.list_notes_visible(None, &no_unlocks)? {
+        let Some(body) = db.note_markdown_if_visible(&s.id, &no_unlocks)? else {
+            continue;
+        };
+        if body.trim().is_empty() {
+            continue;
+        }
+        corpus.push(CorpusDoc {
+            kind: "note",
+            id: s.id,
+            title: s.title.trim().to_string(),
+            body,
+        });
+    }
+    Ok(corpus)
+}
+
+/// Entity-mention sets per VISIBLE corpus MEETING (the orphan pass's Jaccard substrate). Keyed
+/// on ids already gated into the corpus; the read itself is scoped to exactly those ids.
+fn entity_sets_for(db: &Db, corpus: &[CorpusDoc]) -> Result<HashMap<String, HashSet<String>>> {
+    let mut out = HashMap::new();
+    for doc in corpus.iter().filter(|d| d.kind == "meeting") {
+        let ids = db.entity_ids_for_meeting(&doc.id)?;
+        if !ids.is_empty() {
+            out.insert(doc.id.clone(), ids.into_iter().collect());
+        }
+    }
+    Ok(out)
+}
+
+// ── Pass 1: broken links ─────────────────────────────────────────────────────────────────────
+
+/// Every `[[wikilink]]` in a visible body that resolves NOWHERE (not a vault file stem, not a
+/// visible note/meeting/org item). Evidence quotes ONLY the link line.
+fn broken_link_pass(
+    corpus: &[CorpusDoc],
+    resolves: &mut dyn FnMut(&str) -> Result<bool>,
+) -> Result<Vec<NewAuditFinding>> {
+    let mut out = Vec::new();
+    for doc in corpus {
+        for title in crate::storage::db::extract_wikilink_titles(&doc.body) {
+            if resolves(&title)? {
+                continue;
+            }
+            let line = doc
+                .body
+                .lines()
+                .find(|l| l.contains("[[") && l.contains(title.as_str()))
+                .unwrap_or("")
+                .trim();
+            out.push(NewAuditFinding {
+                kind: "broken_link".into(),
+                source_kind: doc.kind.into(),
+                source_id: doc.id.clone(),
+                source_title: doc.title.clone(),
+                target_title: Some(title.clone()),
+                target_id: None,
+                target_kind: None,
+                evidence_md: format!("> {line}"),
+                accept_action: "Append a [!broken-link] note under ## Audit".into(),
+                dedupe_key: format!("broken_link|{}|{}", doc.id, dedupe_disc(&title)),
+            });
+        }
+    }
+    Ok(out)
+}
+
+// ── Pass 2: orphans ──────────────────────────────────────────────────────────────────────────
+
+/// Notes with ZERO wikilinks out (none at all — even an unresolvable link is an outgoing edge;
+/// flagging it is the broken-link pass's job) and ZERO corpus notes linking in. Reconnection
+/// suggestions, deterministic: (i) other visible notes that MENTION this note's exact title
+/// unlinked, then (ii) meeting-to-meeting entity overlap (Jaccard, ties broken by title then id).
+fn orphan_pass(
+    corpus: &[CorpusDoc],
+    entity_sets: &HashMap<String, HashSet<String>>,
+) -> Vec<NewAuditFinding> {
+    // title → corpus indices (visible titles only; collisions keep all).
+    let mut by_title: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, doc) in corpus.iter().enumerate() {
+        if !doc.title.is_empty() {
+            by_title.entry(doc.title.as_str()).or_default().push(i);
+        }
+    }
+    let mut has_out = vec![false; corpus.len()];
+    let mut has_in = vec![false; corpus.len()];
+    for (i, doc) in corpus.iter().enumerate() {
+        for t in crate::storage::db::extract_wikilink_titles(&doc.body) {
+            has_out[i] = true; // any wikilink at all is an outgoing edge.
+            if let Some(targets) = by_title.get(t.as_str()) {
+                for &j in targets {
+                    if j != i {
+                        has_in[j] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (i, doc) in corpus.iter().enumerate() {
+        if has_out[i] || has_in[i] {
+            continue;
+        }
+        let mut suggestions: Vec<String> = Vec::new();
+        // (i) other notes that mention this title (unlinked) — linking FROM them reconnects.
+        if doc.title.chars().count() >= MIN_MENTION_TITLE_CHARS {
+            for (j, other) in corpus.iter().enumerate() {
+                if j == i || suggestions.len() >= MAX_ORPHAN_SUGGESTIONS {
+                    continue;
+                }
+                if other.title.is_empty() || suggestions.contains(&other.title) {
+                    continue;
+                }
+                if find_unlinked_mention_line(&other.body, &doc.title).is_some() {
+                    suggestions.push(other.title.clone());
+                }
+            }
+        }
+        // (ii) entity overlap (meetings only): Jaccard over entity_mentions sets, top-down.
+        if suggestions.len() < MAX_ORPHAN_SUGGESTIONS && doc.kind == "meeting" {
+            if let Some(mine) = entity_sets.get(&doc.id) {
+                let mut scored: Vec<(f64, &CorpusDoc)> = corpus
+                    .iter()
+                    .enumerate()
+                    .filter(|(j, o)| *j != i && o.kind == "meeting" && !o.title.is_empty())
+                    .filter_map(|(_, o)| {
+                        let theirs = entity_sets.get(&o.id)?;
+                        let inter = mine.intersection(theirs).count();
+                        if inter == 0 {
+                            return None;
+                        }
+                        let union = mine.union(theirs).count();
+                        Some((inter as f64 / union as f64, o))
+                    })
+                    .collect();
+                scored.sort_by(|a, b| {
+                    b.0.partial_cmp(&a.0)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.1.title.cmp(&b.1.title))
+                        .then_with(|| a.1.id.cmp(&b.1.id))
+                });
+                for (_, o) in scored {
+                    if suggestions.len() >= MAX_ORPHAN_SUGGESTIONS {
+                        break;
+                    }
+                    if o.title != doc.title && !suggestions.contains(&o.title) {
+                        suggestions.push(o.title.clone());
+                    }
+                }
+            }
+        }
+        // Evidence deliberately writes suggestion titles as [[links]] and NOTHING ELSE as a
+        // wikilink — the accept path re-extracts them via `extract_wikilink_titles`.
+        let (evidence_md, accept_action) = if suggestions.is_empty() {
+            (
+                "This note has no wikilinks in or out.".to_string(),
+                String::new(), // dismiss-only.
+            )
+        } else {
+            (
+                format!(
+                    "This note has no wikilinks in or out.\n\nSuggested connections: {}",
+                    suggestions
+                        .iter()
+                        .map(|s| format!("[[{s}]]"))
+                        .collect::<Vec<_>>()
+                        .join(" · ")
+                ),
+                "Append suggested [[links]] under ## Audit".to_string(),
+            )
+        };
+        out.push(NewAuditFinding {
+            kind: "orphan".into(),
+            source_kind: doc.kind.into(),
+            source_id: doc.id.clone(),
+            source_title: doc.title.clone(),
+            target_title: None,
+            target_id: None,
+            target_kind: None,
+            evidence_md,
+            accept_action,
+            dedupe_key: format!("orphan|{}|", doc.id),
+        });
+    }
+    out
+}
+
+// ── Pass 3: unlinked mentions ────────────────────────────────────────────────────────────────
+
+/// A visible body contains another visible note's EXACT title (≥6 chars, word-boundary, not
+/// already inside a `[[..]]`, not inside a code fence) — suggest the `[[link]]`. Capped at 3
+/// per source note.
+fn unlinked_mention_pass(corpus: &[CorpusDoc]) -> Vec<NewAuditFinding> {
+    let mut out = Vec::new();
+    for src in corpus {
+        let existing: HashSet<String> =
+            crate::storage::db::extract_wikilink_titles(&src.body).into_iter().collect();
+        let mut per_source = 0usize;
+        for target in corpus {
+            if per_source >= MAX_MENTIONS_PER_NOTE {
+                break;
+            }
+            if target.id == src.id && target.kind == src.kind {
+                continue;
+            }
+            let t = target.title.as_str();
+            if t.chars().count() < MIN_MENTION_TITLE_CHARS || t == src.title {
+                continue;
+            }
+            if existing.contains(t) {
+                continue; // already linked somewhere in this body.
+            }
+            let Some(line) = find_unlinked_mention_line(&src.body, t) else {
+                continue;
+            };
+            out.push(NewAuditFinding {
+                kind: "unlinked_mention".into(),
+                source_kind: src.kind.into(),
+                source_id: src.id.clone(),
+                source_title: src.title.clone(),
+                target_title: Some(t.to_string()),
+                target_id: Some(target.id.clone()),
+                target_kind: Some(target.kind.to_string()),
+                evidence_md: format!("> {}\n\nSuggested link: [[{t}]]", line.trim()),
+                accept_action: "Append the suggested [[link]] under ## Audit".into(),
+                dedupe_key: format!("unlinked_mention|{}|{}", src.id, dedupe_disc(t)),
+            });
+            per_source += 1;
+        }
+    }
+    out
+}
+
+/// Title-free dedupe discriminator: the first 16 hex chars of sha256(text). A `dedupe_key`
+/// OUTLIVES resolve (a dismissed row keeps its key forever, that's the suppression), so it must
+/// carry ZERO title/content material at rest — the variable part of every key is hashed.
+/// Deterministic across runs, so dismissed suppression still matches the regenerated key.
+fn dedupe_disc(text: &str) -> String {
+    crate::export::note_content_hash(text)[..16].to_string()
+}
+
+/// The deterministic mention matcher: the first body LINE carrying `title` as an exact,
+/// word-bounded, un-linked occurrence outside any ``` code fence. PURE.
+pub(crate) fn find_unlinked_mention_line<'a>(body: &'a str, title: &str) -> Option<&'a str> {
+    if title.chars().count() < MIN_MENTION_TITLE_CHARS {
+        return None;
+    }
+    let mut in_fence = false;
+    for line in body.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        for (idx, _) in line.match_indices(title) {
+            // Word boundary on both sides (a title embedded in a longer word is not a mention).
+            let before_ok = line[..idx]
+                .chars()
+                .next_back()
+                .map(|c| !c.is_alphanumeric())
+                .unwrap_or(true);
+            let after_ok = line[idx + title.len()..]
+                .chars()
+                .next()
+                .map(|c| !c.is_alphanumeric())
+                .unwrap_or(true);
+            if !before_ok || !after_ok {
+                continue;
+            }
+            // Not already inside a [[..]]: an unclosed "[[" before the occurrence means the
+            // occurrence is the link target (or its alias) itself.
+            let prefix = &line[..idx];
+            let last_open = prefix.rfind("[[");
+            let last_close = prefix.rfind("]]");
+            let inside_link = match (last_open, last_close) {
+                (Some(o), Some(c)) => o > c,
+                (Some(_), None) => true,
+                _ => false,
+            };
+            if inside_link {
+                continue;
+            }
+            // Not inside an INLINE `code span` either (adversarial LOW — fences alone missed
+            // these): an ODD number of backticks before the occurrence means an open span.
+            if prefix.matches('`').count() % 2 == 1 {
+                continue;
+            }
+            return Some(line);
+        }
+    }
+    None
+}
+
+// ── Pass 4: stale notes ──────────────────────────────────────────────────────────────────────
+
+/// A meeting note most of whose facts have been superseded by later meetings. Attribution is the
+/// `facts.meeting_id` anchor (verified: every fact row carries the source meeting; sealed
+/// meetings' facts are additionally purged on seal). Flagged when total ≥ 3 AND closed/total ≥
+/// 0.5. Superseding source titles are resolved through GATED reads — a not-visible superseding
+/// source appears as "a later meeting", never its title.
+fn stale_pass(db: &Db, corpus: &[CorpusDoc]) -> Result<Vec<NewAuditFinding>> {
+    let no_unlocks: HashSet<String> = HashSet::new();
+    // Open facts (visible sources only), indexed by the reconcile identity key.
+    let open = db.list_open_facts_visible(&no_unlocks)?;
+    let mut open_by_key: HashMap<(String, String, String), Vec<&crate::facts::Fact>> =
+        HashMap::new();
+    for f in &open {
+        open_by_key
+            .entry((
+                f.entity_id.clone(),
+                crate::facts::norm(&f.subject),
+                crate::facts::norm(&f.predicate),
+            ))
+            .or_default()
+            .push(f);
+    }
+
+    let mut out = Vec::new();
+    for doc in corpus.iter().filter(|d| d.kind == "meeting") {
+        let facts = db.fact_rows_for_meeting_visible(&doc.id, &no_unlocks)?;
+        let total = facts.len();
+        if total < STALE_MIN_FACTS {
+            continue;
+        }
+        let closed: Vec<_> = facts.iter().filter(|f| f.valid_to.is_some()).collect();
+        if closed.len() * 2 < total {
+            continue;
+        }
+        // Up to 2 superseding sources: the OPEN fact sharing each closed fact's identity key,
+        // sourced in a DIFFERENT meeting. Titles only through the gate.
+        let mut labels: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        'outer: for cf in &closed {
+            let key = (
+                cf.entity_id.clone(),
+                crate::facts::norm(&cf.subject),
+                crate::facts::norm(&cf.predicate),
+            );
+            if let Some(opens) = open_by_key.get(&key) {
+                for of in opens {
+                    let Some(mid) = &of.meeting_id else { continue };
+                    if mid == &doc.id || seen.contains(mid) {
+                        continue;
+                    }
+                    seen.insert(mid.clone());
+                    let label = if db.meeting_is_visible(mid, &no_unlocks)? {
+                        db.get_meeting(mid)?
+                            .and_then(|m| m.title)
+                            .map(|t| t.trim().to_string())
+                            .filter(|t| !t.is_empty())
+                            .map(|t| format!("[[{t}]]"))
+                            .unwrap_or_else(|| "a later meeting".to_string())
+                    } else {
+                        "a later meeting".to_string()
+                    };
+                    labels.push(label);
+                    if labels.len() >= 2 {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        let see = if labels.is_empty() {
+            String::new()
+        } else {
+            format!(" — see {}", labels.join(" and "))
+        };
+        out.push(NewAuditFinding {
+            kind: "stale".into(),
+            source_kind: "meeting".into(),
+            source_id: doc.id.clone(),
+            source_title: doc.title.clone(),
+            target_title: None,
+            target_id: None,
+            target_kind: None,
+            evidence_md: format!(
+                "> {} of {} facts recorded in this note have since been superseded{see}",
+                closed.len(),
+                total
+            ),
+            accept_action: "Append a [!stale] callout under ## Audit".into(),
+            dedupe_key: format!("stale|{}|", doc.id),
+        });
+    }
+    Ok(out)
+}
+
+// ── Pass 5: contradictions ───────────────────────────────────────────────────────────────────
+
+/// Two OPEN facts with the same reconcile identity key (entity + normalized subject+predicate),
+/// DIFFERENT objects, from DIFFERENT source meetings — the open-open collisions
+/// [`crate::facts::reconcile_facts`] never saw in one batch. Both sources must be IN THE CORPUS
+/// (visible + carrying a note — accept stamps both notes). A pair already staged in the Re-Truth
+/// supersession review queue (pending, same normalized predicate, same two meetings) is skipped —
+/// one review surface per conflict.
+fn contradiction_pass(db: &Db, corpus: &[CorpusDoc]) -> Result<Vec<NewAuditFinding>> {
+    let no_unlocks: HashSet<String> = HashSet::new();
+    let corpus_meetings: HashMap<&str, &CorpusDoc> = corpus
+        .iter()
+        .filter(|d| d.kind == "meeting")
+        .map(|d| (d.id.as_str(), d))
+        .collect();
+    let open = db.list_open_facts_visible(&no_unlocks)?;
+    let mut by_key: BTreeMap<(String, String, String), Vec<&crate::facts::Fact>> = BTreeMap::new();
+    for f in &open {
+        by_key
+            .entry((
+                f.entity_id.clone(),
+                crate::facts::norm(&f.subject),
+                crate::facts::norm(&f.predicate),
+            ))
+            .or_default()
+            .push(f);
+    }
+
+    let mut out = Vec::new();
+    for ((entity_id, _nsubj, npred), facts) in &by_key {
+        if facts.len() < 2 {
+            continue;
+        }
+        // Deterministic order: oldest valid_from first, then id.
+        let mut facts = facts.clone();
+        facts.sort_by(|a, b| a.valid_from.cmp(&b.valid_from).then_with(|| a.id.cmp(&b.id)));
+        for i in 0..facts.len() {
+            for j in (i + 1)..facts.len() {
+                let (a, b) = (facts[i], facts[j]);
+                if crate::facts::norm(&a.object) == crate::facts::norm(&b.object) {
+                    continue;
+                }
+                let (Some(mid_a), Some(mid_b)) = (&a.meeting_id, &b.meeting_id) else {
+                    continue;
+                };
+                if mid_a == mid_b {
+                    continue; // same source — reconcile's own within-batch problem, not ours.
+                }
+                let (Some(doc_a), Some(doc_b)) = (
+                    corpus_meetings.get(mid_a.as_str()),
+                    corpus_meetings.get(mid_b.as_str()),
+                ) else {
+                    continue; // a source outside the visible corpus contributes nothing.
+                };
+                if db.pending_supersession_for_pair(npred, mid_a, mid_b)? {
+                    continue; // already staged for Re-Truth review — don't double-surface.
+                }
+                let (min_id, max_id) = if mid_a <= mid_b {
+                    (mid_a.as_str(), mid_b.as_str())
+                } else {
+                    (mid_b.as_str(), mid_a.as_str())
+                };
+                out.push(NewAuditFinding {
+                    kind: "contradiction".into(),
+                    source_kind: "meeting".into(),
+                    source_id: doc_a.id.clone(),
+                    source_title: doc_a.title.clone(),
+                    target_title: Some(doc_b.title.clone()),
+                    target_id: Some(doc_b.id.clone()),
+                    target_kind: Some("meeting".into()),
+                    evidence_md: format!(
+                        "> **{} · {}** — \"{}\" (this note) vs \"{}\" ([[{}]])",
+                        a.subject, a.predicate, a.object, b.object, doc_b.title
+                    ),
+                    accept_action: "Append [!conflict] callouts cross-linking both sources".into(),
+                    // Meeting/entity ids are opaque; the predicate is FACT TEXT — hash the
+                    // (entity, predicate) discriminator so the key carries no content material.
+                    dedupe_key: format!(
+                        "contradiction|{min_id}|{max_id}|{}",
+                        dedupe_disc(&format!("{entity_id}|{npred}"))
+                    ),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::facts::{FactOp, NewFact};
+    use crate::storage::models::{EntityKind, Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn file_db(label: &str) -> Db {
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-audit-{label}"), "sqlite");
+        Db::open_with_key(&p, TEST_DEK).unwrap()
+    }
+
+    fn quiet_epoch() -> AtomicU64 {
+        AtomicU64::new(0)
+    }
+
+    fn doc(kind: &'static str, id: &str, title: &str, body: &str) -> CorpusDoc {
+        CorpusDoc {
+            kind,
+            id: id.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+        }
+    }
+
+    fn seed_meeting_note(db: &Db, id: &str, title: &str, note: &str, folder_id: Option<&str>) {
+        db.insert_meeting(&Meeting {
+            id: id.to_string(),
+            started_at: format!("2026-07-0{}T09:00:00Z", (id.len() % 8) + 1),
+            ended_at: None,
+            title: Some(title.to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: id.to_string(),
+            provider_id: "claude_code".to_string(),
+            markdown: note.to_string(),
+            created_at: "2026-07-01T09:05:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_meeting_folder(id, folder_id).unwrap();
+    }
+
+    fn make_folder(db: &Db, id: &str, name: &str) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
+    fn add_fact(
+        db: &Db,
+        entity_id: &str,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        at: &str,
+        meeting_id: &str,
+    ) {
+        db.apply_fact_ops(&[FactOp::Add(NewFact {
+            entity_id: entity_id.to_string(),
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: at.to_string(),
+            recorded_at: at.to_string(),
+            confidence: 1.0,
+            meeting_id: Some(meeting_id.to_string()),
+        })])
+        .unwrap();
+    }
+
+    /// Close (supersede) the open fact matching the key by reconciling a different object.
+    fn supersede_fact(
+        db: &Db,
+        entity_id: &str,
+        subject: &str,
+        predicate: &str,
+        new_object: &str,
+        at: &str,
+        meeting_id: &str,
+    ) {
+        let existing = db.list_facts_visible(entity_id, &HashSet::new()).unwrap();
+        let mut ops = crate::facts::reconcile_facts(
+            &existing,
+            &[crate::facts::FactCandidate {
+                entity_id: entity_id.to_string(),
+                subject: subject.to_string(),
+                predicate: predicate.to_string(),
+                object: new_object.to_string(),
+                confidence: 1.0,
+            }],
+            at,
+        );
+        crate::facts::set_meeting_id(&mut ops, meeting_id);
+        db.apply_fact_ops(&ops).unwrap();
+    }
+
+    /// The PINNED FE seam: the Angular inbox codes against exactly these camelCase keys — a
+    /// field rename silently breaks the wire contract.
+    #[test]
+    fn wire_dtos_serialize_camel_case_per_the_pinned_seam() {
+        let summary = AuditRunSummary {
+            run_id: "r1".into(),
+            started_at: 1,
+            finished_at: 2,
+            findings_new: 3,
+            findings_total_pending: 4,
+            counts: [("broken_link".to_string(), 3usize)].into_iter().collect(),
+        };
+        assert_eq!(
+            serde_json::to_string(&summary).unwrap(),
+            r#"{"runId":"r1","startedAt":1,"finishedAt":2,"findingsNew":3,"findingsTotalPending":4,"counts":{"broken_link":3}}"#
+        );
+        let finding = AuditFinding {
+            id: "f1".into(),
+            kind: "orphan".into(),
+            source_kind: "note".into(),
+            source_id: "n1".into(),
+            source_title: "T".into(),
+            target_title: None,
+            evidence_md: "e".into(),
+            accept_action: "a".into(),
+            status: "pending".into(),
+            created_at: 1,
+            resolved_at: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&finding).unwrap(),
+            r#"{"id":"f1","kind":"orphan","sourceKind":"note","sourceId":"n1","sourceTitle":"T","targetTitle":null,"evidenceMd":"e","acceptAction":"a","status":"pending","createdAt":1,"resolvedAt":null}"#
+        );
+    }
+
+    // ── mention matcher (pure) ──
+
+    #[test]
+    fn mention_matcher_negatives_and_positive() {
+        // Positive: word-bounded, plain prose.
+        assert!(find_unlinked_mention_line("We synced on Project Atlas today", "Project Atlas")
+            .is_some());
+        // Too short a title (< 6 chars).
+        assert!(find_unlinked_mention_line("Quick Sync today", "Sync").is_none());
+        // Already linked — inside [[..]].
+        assert!(
+            find_unlinked_mention_line("See [[Project Atlas]] for details", "Project Atlas")
+                .is_none()
+        );
+        // Aliased link — still inside [[..]].
+        assert!(find_unlinked_mention_line(
+            "See [[Project Atlas|the project]] for details",
+            "Project Atlas"
+        )
+        .is_none());
+        // Inside a code fence.
+        assert!(find_unlinked_mention_line(
+            "```\nProject Atlas config\n```\nnothing else",
+            "Project Atlas"
+        )
+        .is_none());
+        // Inside an INLINE code span (adversarial LOW): `Project Atlas` is code, not a mention.
+        assert!(
+            find_unlinked_mention_line("run `Project Atlas` locally", "Project Atlas").is_none()
+        );
+        // …but prose AFTER a closed span on the same line still matches.
+        assert!(find_unlinked_mention_line(
+            "run `the tool` then open Project Atlas",
+            "Project Atlas"
+        )
+        .is_some());
+        // Word boundary: embedded in a longer token.
+        assert!(find_unlinked_mention_line("xProject Atlasy is not it", "Project Atlas").is_none());
+        // A fence CLOSES again — mention after it is found.
+        assert!(find_unlinked_mention_line(
+            "```\ncode\n```\nProject Atlas resumed",
+            "Project Atlas"
+        )
+        .is_some());
+    }
+
+    // ── broken links (pure, injected resolver) ──
+
+    #[test]
+    fn broken_link_flags_unresolvable_only_and_quotes_the_link_line() {
+        let corpus = vec![doc(
+            "meeting",
+            "m1",
+            "Kickoff",
+            "# Kickoff\nintro line\n- see [[Known Note]] for context\n- and [[Ghost Note]] too\n",
+        )];
+        let known: HashSet<&str> = ["Known Note"].into_iter().collect();
+        let found = broken_link_pass(&corpus, &mut |t| Ok(known.contains(t))).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].target_title.as_deref(), Some("Ghost Note"));
+        assert_eq!(
+            found[0].dedupe_key,
+            format!("broken_link|m1|{}", dedupe_disc("Ghost Note")),
+            "key = source id + hashed (title-free) target discriminator"
+        );
+        // Evidence quotes ONLY the link line — not the whole body.
+        assert!(found[0].evidence_md.contains("[[Ghost Note]]"));
+        assert!(!found[0].evidence_md.contains("intro line"));
+    }
+
+    // ── orphan degree + suggestions (pure) ──
+
+    #[test]
+    fn orphan_flags_zero_degree_only_and_suggests_mentioners() {
+        let corpus = vec![
+            // a → links to b: NOT an orphan (out-degree).
+            doc("note", "a", "Alpha Note", "body [[Beta Note]]\n"),
+            // b: linked FROM a: NOT an orphan (in-degree).
+            doc("note", "b", "Beta Note", "no links here\n"),
+            // c: no links either way → ORPHAN; "Gamma Note" is mentioned (unlinked) by d.
+            doc("note", "c", "Gamma Note", "isolated content\n"),
+            // d mentions c's title without linking it.
+            doc("note", "d", "Delta Note", "talked about Gamma Note today [[Alpha Note]]\n"),
+        ];
+        let found = orphan_pass(&corpus, &HashMap::new());
+        assert_eq!(found.len(), 1, "only the zero-degree note is an orphan");
+        assert_eq!(found[0].source_id, "c");
+        assert!(
+            found[0].evidence_md.contains("[[Delta Note]]"),
+            "the mentioning note is suggested: {}",
+            found[0].evidence_md
+        );
+        assert!(!found[0].accept_action.is_empty(), "suggestions ⇒ acceptable");
+    }
+
+    #[test]
+    fn orphan_without_suggestions_is_dismiss_only() {
+        let corpus = vec![doc("note", "solo", "Lonely Note", "nothing links anywhere\n")];
+        let found = orphan_pass(&corpus, &HashMap::new());
+        assert_eq!(found.len(), 1);
+        assert!(found[0].accept_action.is_empty(), "no suggestions ⇒ dismiss-only");
+    }
+
+    // ── unlinked mentions (pure) ──
+
+    #[test]
+    fn unlinked_mention_caps_at_three_and_skips_linked_and_fenced() {
+        let body = "We covered Target One and Target Two and Target Three and Target Four.\n\
+                    Also [[Target Five]] is already linked.\n\
+                    ```\nTarget Sixxx appears only in code\n```\n";
+        let mut corpus = vec![doc("note", "src", "Source Note", body)];
+        for (i, t) in [
+            "Target One",
+            "Target Two",
+            "Target Three",
+            "Target Four",
+            "Target Five",
+            "Target Sixxx",
+        ]
+        .iter()
+        .enumerate()
+        {
+            corpus.push(doc("note", &format!("t{i}"), t, "content\n"));
+        }
+        let found = unlinked_mention_pass(&corpus);
+        let for_src: Vec<_> = found.iter().filter(|f| f.source_id == "src").collect();
+        assert_eq!(for_src.len(), 3, "capped at 3 per source note");
+        let targets: Vec<_> = for_src
+            .iter()
+            .map(|f| f.target_title.as_deref().unwrap())
+            .collect();
+        assert!(!targets.contains(&"Target Five"), "already-linked title skipped");
+        assert!(!targets.contains(&"Target Sixxx"), "code-fenced mention skipped");
+    }
+
+    // ── stale (file DB) ──
+
+    #[test]
+    fn stale_flags_majority_superseded_and_cites_gated_titles() {
+        let db = file_db("stale");
+        seed_meeting_note(&db, "m-old", "Planning", "# Plan\n", None);
+        seed_meeting_note(&db, "m-new", "Review", "# Review\n", None);
+        let e = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+
+        // 4 facts from m-old; 2 then superseded from m-new → ratio 0.5, total ≥ 3 → flagged.
+        add_fact(&db, &e, "Atlas", "status", "in-progress", "2026-07-01T09:00:00Z", "m-old");
+        add_fact(&db, &e, "Atlas", "owner", "Anna", "2026-07-01T09:00:00Z", "m-old");
+        add_fact(&db, &e, "Atlas", "deadline", "Q3", "2026-07-01T09:00:00Z", "m-old");
+        add_fact(&db, &e, "Atlas", "budget", "small", "2026-07-01T09:00:00Z", "m-old");
+        supersede_fact(&db, &e, "Atlas", "status", "shipped", "2026-07-05T09:00:00Z", "m-new");
+        supersede_fact(&db, &e, "Atlas", "owner", "Bob", "2026-07-05T09:00:00Z", "m-new");
+
+        let corpus = build_corpus(&db).unwrap();
+        let found = stale_pass(&db, &corpus).unwrap();
+        assert_eq!(found.len(), 1, "only the majority-superseded note is stale");
+        assert_eq!(found[0].source_id, "m-old");
+        assert!(
+            found[0].evidence_md.contains("2 of 4"),
+            "counts cited: {}",
+            found[0].evidence_md
+        );
+        assert!(
+            found[0].evidence_md.contains("[[Review]]"),
+            "visible superseding title cited: {}",
+            found[0].evidence_md
+        );
+    }
+
+    #[test]
+    fn stale_threshold_needs_three_facts_and_half_closed() {
+        let db = file_db("stale-thresh");
+        seed_meeting_note(&db, "m1", "Tiny", "# T\n", None);
+        seed_meeting_note(&db, "m2", "Later", "# L\n", None);
+        let e = db.upsert_entity("Beta", EntityKind::Project).unwrap();
+        // Only 2 facts (below the ≥3 floor) even though both get superseded.
+        add_fact(&db, &e, "Beta", "status", "alpha", "2026-07-01T09:00:00Z", "m1");
+        add_fact(&db, &e, "Beta", "owner", "Kim", "2026-07-01T09:00:00Z", "m1");
+        supersede_fact(&db, &e, "Beta", "status", "beta", "2026-07-05T09:00:00Z", "m2");
+        supersede_fact(&db, &e, "Beta", "owner", "Lee", "2026-07-05T09:00:00Z", "m2");
+        let corpus = build_corpus(&db).unwrap();
+        assert!(stale_pass(&db, &corpus).unwrap().is_empty(), "below the fact floor");
+
+        // 4 facts, only 1 closed → ratio below 0.5 → not stale.
+        let db2 = file_db("stale-ratio");
+        seed_meeting_note(&db2, "m1", "Big", "# B\n", None);
+        seed_meeting_note(&db2, "m2", "Later", "# L\n", None);
+        let e2 = db2.upsert_entity("Gamma", EntityKind::Project).unwrap();
+        for (p, o) in [("status", "x"), ("owner", "y"), ("deadline", "z"), ("budget", "w")] {
+            add_fact(&db2, &e2, "Gamma", p, o, "2026-07-01T09:00:00Z", "m1");
+        }
+        supersede_fact(&db2, &e2, "Gamma", "status", "x2", "2026-07-05T09:00:00Z", "m2");
+        let corpus2 = build_corpus(&db2).unwrap();
+        assert!(stale_pass(&db2, &corpus2).unwrap().is_empty(), "ratio below half");
+    }
+
+    // ── contradiction (file DB) ──
+
+    #[test]
+    fn contradiction_open_open_cross_source_only_and_queue_exclusion() {
+        let db = file_db("contra");
+        seed_meeting_note(&db, "m-a", "Meeting A", "# A\n", None);
+        seed_meeting_note(&db, "m-b", "Meeting B", "# B\n", None);
+        let e = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+
+        // Two OPEN facts, same key, different object, different source → candidate.
+        add_fact(&db, &e, "Atlas", "status", "shipped", "2026-07-01T09:00:00Z", "m-a");
+        add_fact(&db, &e, "Atlas", "Status", "cancelled", "2026-07-02T09:00:00Z", "m-b");
+        // A CLOSED pair on another predicate — excluded (only open-open collide).
+        add_fact(&db, &e, "Atlas", "owner", "Anna", "2026-07-01T09:00:00Z", "m-a");
+        supersede_fact(&db, &e, "Atlas", "owner", "Bob", "2026-07-02T09:00:00Z", "m-b");
+        // A same-source open duplicate on a third predicate — excluded (same meeting).
+        add_fact(&db, &e, "Atlas", "budget", "small", "2026-07-01T09:00:00Z", "m-a");
+        add_fact(&db, &e, "Atlas", "budget", "large", "2026-07-01T10:00:00Z", "m-a");
+
+        let corpus = build_corpus(&db).unwrap();
+        let found = contradiction_pass(&db, &corpus).unwrap();
+        assert_eq!(found.len(), 1, "exactly the open-open cross-source pair: {found:#?}");
+        assert_eq!(found[0].source_id, "m-a", "source = the OLDER fact's meeting");
+        assert_eq!(found[0].target_id.as_deref(), Some("m-b"));
+        assert!(found[0].evidence_md.contains("shipped"));
+        assert!(found[0].evidence_md.contains("cancelled"));
+        // Lock review: the key must carry no fact-text material (predicate is hashed).
+        assert!(
+            !found[0].dedupe_key.contains("status"),
+            "contradiction key carries predicate text: {}",
+            found[0].dedupe_key
+        );
+
+        // The identical pair already PENDING in the Re-Truth queue → excluded.
+        db.record_supersessions(&[crate::storage::models::SupersessionRow {
+            id: "s1".to_string(),
+            superseding_meeting_id: "m-b".to_string(),
+            source_meeting_id: "m-a".to_string(),
+            entity: "Atlas".to_string(),
+            predicate: "status".to_string(),
+            old_value: "shipped".to_string(),
+            new_value: "cancelled".to_string(),
+            created_at: "2026-07-02T09:00:00Z".to_string(),
+            applied_at: None,
+            source_pre_image: None,
+            superseding_pre_image: None,
+        }])
+        .unwrap();
+        let found = contradiction_pass(&db, &corpus).unwrap();
+        assert!(found.is_empty(), "a pair pending Re-Truth review is not re-surfaced");
+    }
+
+    // ── the lock gate: sealed content contributes NOTHING ──
+
+    #[test]
+    fn sealed_folder_contributes_zero_findings() {
+        let db = file_db("sealed");
+        make_folder(&db, "f-lock", "Secret");
+        // Sealed meeting whose note is FULL of audit bait: a broken link, an orphan shape, a
+        // mention of the open note's title, facts.
+        seed_meeting_note(
+            &db,
+            "m-sealed",
+            "SECRET-ACQUISITION",
+            "plan [[Nonexistent Ghost]] and Open Standup Notes mention\n",
+            Some("f-lock"),
+        );
+        let e = db.upsert_entity("SecretCo", EntityKind::Project).unwrap();
+        add_fact(&db, &e, "SecretCo", "price", "5M", "2026-07-01T09:00:00Z", "m-sealed");
+        // An open meeting (its own broken link keeps the pass productive). The sealed TITLE
+        // deliberately exists ONLY on the sealed side — a visible body is always quotable, so
+        // the leak assertion below is about the sealed side surfacing, not visible prose.
+        seed_meeting_note(
+            &db,
+            "m-open",
+            "Open Standup Notes",
+            "regular sync today, [[Nowhere Note]]\n",
+            None,
+        );
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let summary =
+            run_audit_pass(&db, None, 1_700_000_000_000, &quiet_epoch()).unwrap();
+        assert!(summary.findings_new > 0, "the open note still yields findings");
+        let rows = db.list_audit_finding_rows("pending").unwrap();
+        for r in &rows {
+            assert_ne!(r.source_id, "m-sealed", "no finding sources sealed content");
+            assert_ne!(r.target_id.as_deref(), Some("m-sealed"));
+            let all_text = format!(
+                "{} {} {} {}",
+                r.source_title,
+                r.target_title.clone().unwrap_or_default(),
+                r.evidence_md,
+                r.accept_action
+            );
+            assert!(
+                !all_text.contains("SECRET-ACQUISITION"),
+                "sealed TITLE must not leak into any finding text: {all_text}"
+            );
+            assert!(
+                !all_text.contains("Nonexistent Ghost"),
+                "sealed BODY content must not leak into any finding text: {all_text}"
+            );
+        }
+        // The sealed body's mention of the open title produced nothing sourced at the sealed note.
+        assert!(
+            rows.iter().all(|r| r.kind != "unlinked_mention" || r.source_id == "m-open"),
+            "mentions only ever source from visible bodies"
+        );
+    }
+
+    // ── dedupe / idempotence ──
+
+    #[test]
+    fn audit_pass_is_idempotent_on_pending_and_dismissed_but_accepted_recurs() {
+        let db = file_db("dedupe");
+        seed_meeting_note(&db, "m1", "Kickoff", "see [[Ghost Note]]\n", None);
+
+        let first = run_audit_pass(&db, None, 1_700_000_000_000, &quiet_epoch()).unwrap();
+        assert_eq!(first.findings_new, 1, "the broken link staged once: {first:?}");
+        let second = run_audit_pass(&db, None, 1_700_000_000_001, &quiet_epoch()).unwrap();
+        assert_eq!(second.findings_new, 0, "a PENDING twin suppresses re-creation");
+        assert_eq!(second.findings_total_pending, 1);
+
+        // DISMISS → still suppressed (don't nag again).
+        let row = &db.list_audit_finding_rows("pending").unwrap()[0];
+        db.resolve_audit_finding_row(&row.id, "dismissed", 1_700_000_000_002).unwrap();
+        let third = run_audit_pass(&db, None, 1_700_000_000_003, &quiet_epoch()).unwrap();
+        assert_eq!(third.findings_new, 0, "a DISMISSED twin suppresses re-creation");
+
+        // ACCEPT (simulated status flip) → the evidence persisting means it MAY recur.
+        let row_id = db.list_audit_finding_rows("dismissed").unwrap()[0].id.clone();
+        db.resolve_audit_finding_row(&row_id, "accepted", 1_700_000_000_004).unwrap();
+        let fourth = run_audit_pass(&db, None, 1_700_000_000_005, &quiet_epoch()).unwrap();
+        assert_eq!(fourth.findings_new, 1, "an ACCEPTED twin does NOT suppress recurrence");
+    }
+
+    // ── purge-on-seal / purge-on-delete (RED→GREEN both directions) ──
+
+    fn stage_finding(db: &Db, source_id: &str, target_id: Option<&str>, key: &str) {
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "broken_link".into(),
+                source_kind: "meeting".into(),
+                source_id: source_id.to_string(),
+                source_title: "T".into(),
+                target_title: None,
+                target_id: target_id.map(str::to_string),
+                target_kind: target_id.map(|_| "meeting".to_string()),
+                evidence_md: "> evidence".into(),
+                accept_action: "".into(),
+                dedupe_key: key.to_string(),
+            },
+            "run-x",
+            1,
+        )
+        .unwrap();
+    }
+
+    /// A SEAL purges ALL pending findings — the memory-rollups posture (adversarial HIGH): a
+    /// finding's evidence may cite THIRD-PARTY titles the id-matched purge can never cover, and a
+    /// seal anywhere invalidates the pass's visibility snapshot. Resolved rows (blanked) survive.
+    #[test]
+    fn sealing_purges_all_pending_findings() {
+        let db = file_db("purge-seal");
+        make_folder(&db, "f1", "Secret");
+        seed_meeting_note(&db, "m1", "Sealed soon", "# S\n", Some("f1"));
+        stage_finding(&db, "m1", None, "k-source");
+        stage_finding(&db, "m-other", Some("m1"), "k-target");
+        // NOT id-related to m1 — the rollup posture still purges it on the seal.
+        stage_finding(&db, "m-other", None, "k-unrelated");
+        // An accepted row referencing m1 SURVIVES (evidence already blanked on accept).
+        stage_finding(&db, "m1", None, "k-accepted");
+        let accepted_id = db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .iter()
+            .find(|r| r.dedupe_key == "k-accepted")
+            .unwrap()
+            .id
+            .clone();
+        db.resolve_audit_finding_row(&accepted_id, "accepted", 2).unwrap();
+
+        // The SEAL tx (lock_folder's purge leg) drops EVERY pending row.
+        db.set_folder_locked("f1", true, None).unwrap();
+        let _ = db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert!(
+            pending.is_empty(),
+            "a seal purges ALL pending findings (rollup posture): {pending:#?}"
+        );
+        assert!(
+            db.get_audit_finding(&accepted_id).unwrap().is_some(),
+            "an accepted (already-blanked) row survives the seal"
+        );
+    }
+
+    /// The adversarial HIGH repro, RED-first: an OPEN meeting's stale finding cites
+    /// `see [[Review]]` in its evidence with `target_id = None` — sealing Review's folder must
+    /// still remove it (nothing in the pending table may reference the sealed title).
+    #[test]
+    fn sealing_third_party_folder_purges_findings_citing_it() {
+        let db = file_db("purge-thirdparty");
+        make_folder(&db, "f-r", "ReviewVault");
+        seed_meeting_note(&db, "m-old", "Planning", "# Plan\n", None);
+        seed_meeting_note(&db, "m-new", "Review", "# Review\n", Some("f-r"));
+        let e = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+        add_fact(&db, &e, "Atlas", "status", "in-progress", "2026-07-01T09:00:00Z", "m-old");
+        add_fact(&db, &e, "Atlas", "owner", "Anna", "2026-07-01T09:00:00Z", "m-old");
+        add_fact(&db, &e, "Atlas", "deadline", "Q3", "2026-07-01T09:00:00Z", "m-old");
+        supersede_fact(&db, &e, "Atlas", "status", "shipped", "2026-07-05T09:00:00Z", "m-new");
+        supersede_fact(&db, &e, "Atlas", "owner", "Bob", "2026-07-05T09:00:00Z", "m-new");
+
+        // Stage the REAL stale finding: source = the open m-old, evidence cites [[Review]],
+        // target_id None — exactly the shape an id-matched purge can never reach.
+        let corpus = build_corpus(&db).unwrap();
+        let stale = stale_pass(&db, &corpus).unwrap();
+        assert_eq!(stale.len(), 1);
+        assert!(
+            stale[0].evidence_md.contains("[[Review]]"),
+            "precondition: the evidence cites the third-party title: {}",
+            stale[0].evidence_md
+        );
+        assert!(stale[0].target_id.is_none(), "precondition: no id for the citation");
+        assert!(db.insert_audit_finding_if_new(&stale[0], "run-3p", 1).unwrap());
+
+        // Seal REVIEW's folder (the lock_folder purge leg for ITS meeting only).
+        db.set_folder_locked("f-r", true, None).unwrap();
+        let _ = db.purge_chunks_for_meetings(&["m-new".to_string()]).unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert!(
+            pending.iter().all(|r| !format!(
+                "{} {} {}",
+                r.evidence_md,
+                r.source_title,
+                r.target_title.clone().unwrap_or_default()
+            )
+            .contains("Review")),
+            "no pending finding may still cite the sealed title: {pending:#?}"
+        );
+        assert!(
+            pending.is_empty(),
+            "the citing finding is GONE after the third-party seal: {pending:#?}"
+        );
+    }
+
+    #[test]
+    fn relock_tx_purges_all_pending_findings() {
+        let db = file_db("purge-relock");
+        make_folder(&db, "f1", "Secret");
+        seed_meeting_note(&db, "m1", "Sealed", "# S\n", Some("f1"));
+        db.insert_document("d1", "f1", "note-a", "body", "note", 1).unwrap();
+        stage_finding(&db, "m1", None, "k-meeting");
+        stage_finding(&db, "d1", None, "k-doc");
+        stage_finding(&db, "m-else", Some("d1"), "k-doc-target");
+        stage_finding(&db, "m-else", None, "k-unrelated");
+
+        let folders: HashSet<String> = ["f1".to_string()].into_iter().collect();
+        let _ = db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert!(
+            pending.is_empty(),
+            "a relock purges ALL pending findings (rollup posture): {pending:#?}"
+        );
+    }
+
+    #[test]
+    fn startup_reconcile_purges_all_pending_findings_when_any_folder_locked() {
+        let db = file_db("purge-startup");
+        make_folder(&db, "f1", "Secret");
+        seed_meeting_note(&db, "m1", "Sealed", "# S\n", Some("f1"));
+        db.insert_document("d1", "f1", "note-a", "body", "note", 1).unwrap();
+        db.set_folder_locked("f1", true, None).unwrap();
+        stage_finding(&db, "m1", None, "k-meeting");
+        stage_finding(&db, "d1", None, "k-doc");
+        stage_finding(&db, "m-else", None, "k-unrelated");
+
+        let _ = db.reblank_locked_folders_at_rest().unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert!(
+            pending.is_empty(),
+            "the startup reconcile purges ALL pending findings (rollup posture): {pending:#?}"
+        );
+    }
+
+    #[test]
+    fn meeting_and_note_delete_purge_pending_findings() {
+        let db = file_db("purge-delete");
+        seed_meeting_note(&db, "m1", "Doomed", "# D\n", None);
+        make_folder(&db, "fn1", "Notes");
+        db.insert_document("d1", "fn1", "note-a", "body", "note", 1).unwrap();
+        stage_finding(&db, "m1", None, "k-m");
+        stage_finding(&db, "m-x", Some("m1"), "k-m-target");
+        stage_finding(&db, "d1", None, "k-d");
+        stage_finding(&db, "m-x", None, "k-keep");
+
+        let _ = db.delete_meeting("m1").unwrap();
+        db.delete_document("d1").unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert_eq!(pending.len(), 1, "delete purges by source AND target: {pending:#?}");
+        assert_eq!(pending[0].dedupe_key, "k-keep");
+    }
+
+    // ── migration idempotence (extended) ──
+
+    #[test]
+    fn audit_migration_is_idempotent_and_tables_exist() {
+        let db = file_db("migrate");
+        // migrate() already ran inside open_with_key; run it again — must be a no-op.
+        db.migrate().unwrap();
+        db.migrate().unwrap();
+        // Both tables exist and accept rows.
+        stage_finding(&db, "m1", None, "k1");
+        db.insert_audit_run("r1", 1, 2, "{}").unwrap();
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 1);
+    }
+
+    // ── resolve blanks evidence + ALL title material ──
+
+    #[test]
+    fn resolve_blanks_evidence_and_accept_action_on_both_paths() {
+        let db = file_db("blank");
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "orphan".into(),
+                source_kind: "note".into(),
+                source_id: "n1".into(),
+                source_title: "T".into(),
+                target_title: None,
+                target_id: None,
+                target_kind: None,
+                evidence_md: "> secret-ish derived text".into(),
+                accept_action: "Append suggested [[links]] under ## Audit".into(),
+                dedupe_key: "orphan|n1|".into(),
+            },
+            "r1",
+            1,
+        )
+        .unwrap();
+        let id = db.list_audit_finding_rows("pending").unwrap()[0].id.clone();
+        db.resolve_audit_finding_row(&id, "dismissed", 5).unwrap();
+        let row = db.get_audit_finding(&id).unwrap().unwrap();
+        assert_eq!(row.status, "dismissed");
+        assert_eq!(row.resolved_at, Some(5));
+        assert!(row.evidence_md.is_empty(), "dismiss blanks the derived plaintext");
+        assert!(row.accept_action.is_empty(), "dismiss blanks the accept action");
+
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "stale".into(),
+                source_kind: "meeting".into(),
+                source_id: "m1".into(),
+                source_title: "T".into(),
+                target_title: None,
+                target_id: None,
+                target_kind: None,
+                evidence_md: "> counts".into(),
+                accept_action: "Append a [!stale] callout under ## Audit".into(),
+                dedupe_key: "stale|m1|".into(),
+            },
+            "r1",
+            1,
+        )
+        .unwrap();
+        let id2 = db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .iter()
+            .find(|r| r.source_id == "m1")
+            .unwrap()
+            .id
+            .clone();
+        db.resolve_audit_finding_row(&id2, "accepted", 6).unwrap();
+        let row2 = db.get_audit_finding(&id2).unwrap().unwrap();
+        assert_eq!(row2.status, "accepted");
+        assert!(row2.evidence_md.is_empty(), "accept blanks the derived plaintext too");
+        assert!(row2.accept_action.is_empty());
+    }
+
+    /// Lock review (BLOCKING leak): titles are content material too. Resolved rows survive every
+    /// purge (pending-only) and the list's SOURCE re-gate — so a dismissed/accepted row keeping a
+    /// later-sealed TARGET's title would serve it forever. Resolve must blank BOTH titles in the
+    /// same UPDATE: only PENDING rows carry ANY title/evidence material at rest.
+    #[test]
+    fn resolved_rows_carry_no_title_material() {
+        let db = file_db("blank-titles");
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "unlinked_mention".into(),
+                source_kind: "meeting".into(),
+                source_id: "m-open".into(),
+                source_title: "Open Standup".into(),
+                target_title: Some("SECRET-TARGET-TITLE".into()),
+                target_id: Some("m-t".into()),
+                target_kind: Some("meeting".into()),
+                evidence_md: "> mentioned SECRET-TARGET-TITLE".into(),
+                accept_action: "Append the suggested [[link]] under ## Audit".into(),
+                dedupe_key: "k-titles-dismiss".into(),
+            },
+            "r1",
+            1,
+        )
+        .unwrap();
+        let id = db.list_audit_finding_rows("pending").unwrap()[0].id.clone();
+        db.resolve_audit_finding_row(&id, "dismissed", 5).unwrap();
+        let row = db.get_audit_finding(&id).unwrap().unwrap();
+        assert!(
+            row.source_title.is_empty(),
+            "dismiss blanks the source title: {row:?}"
+        );
+        assert!(
+            row.target_title.is_none(),
+            "dismiss blanks the target title: {row:?}"
+        );
+        assert!(row.evidence_md.is_empty() && row.accept_action.is_empty());
+
+        // The accepted path blanks identically (the seal of the target later must find NOTHING).
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "contradiction".into(),
+                source_kind: "meeting".into(),
+                source_id: "m-a".into(),
+                source_title: "Meeting A".into(),
+                target_title: Some("SECRET-OTHER-TITLE".into()),
+                target_id: Some("m-b".into()),
+                target_kind: Some("meeting".into()),
+                evidence_md: "> objects".into(),
+                accept_action: "Append [!conflict] callouts cross-linking both sources".into(),
+                dedupe_key: "k-titles-accept".into(),
+            },
+            "r1",
+            1,
+        )
+        .unwrap();
+        let id2 = db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .iter()
+            .find(|r| r.dedupe_key == "k-titles-accept")
+            .unwrap()
+            .id
+            .clone();
+        db.resolve_audit_finding_row(&id2, "accepted", 6).unwrap();
+        let row2 = db.get_audit_finding(&id2).unwrap().unwrap();
+        assert!(row2.source_title.is_empty(), "accept blanks the source title");
+        assert!(row2.target_title.is_none(), "accept blanks the target title");
+    }
+
+    /// Lock review: `dedupe_key` outlives resolve (dismissed suppression), so it must carry ZERO
+    /// title/content material — the variable part is hashed. Deterministic across runs (the
+    /// suppression still matches) and distinct across targets.
+    #[test]
+    fn dedupe_keys_carry_no_title_material() {
+        let corpus = vec![doc(
+            "meeting",
+            "m1",
+            "Kickoff",
+            "see [[SECRET Ghost Title]] and [[Other Missing One]]\nplus Mentioned Secret Note here\n",
+        ),
+        doc("note", "n-t", "Mentioned Secret Note", "content\n")];
+        let broken = broken_link_pass(&corpus, &mut |_| Ok(false)).unwrap();
+        assert_eq!(broken.len(), 2);
+        for f in &broken {
+            assert!(
+                !f.dedupe_key.contains("SECRET") && !f.dedupe_key.contains("Ghost")
+                    && !f.dedupe_key.contains("Missing"),
+                "broken_link key carries title material: {}",
+                f.dedupe_key
+            );
+        }
+        assert_ne!(broken[0].dedupe_key, broken[1].dedupe_key, "distinct per target");
+        // Deterministic: a second pass over the same corpus regenerates identical keys (this is
+        // what keeps dismissed suppression working).
+        let again = broken_link_pass(&corpus, &mut |_| Ok(false)).unwrap();
+        assert_eq!(broken[0].dedupe_key, again[0].dedupe_key);
+
+        let mentions = unlinked_mention_pass(&corpus);
+        let mention = mentions
+            .iter()
+            .find(|f| f.source_id == "m1")
+            .expect("the unlinked mention staged");
+        assert!(
+            !mention.dedupe_key.contains("Secret") && !mention.dedupe_key.contains("Mentioned"),
+            "unlinked_mention key carries title material: {}",
+            mention.dedupe_key
+        );
+    }
+
+    /// Lock review + adversarial A: `discard_folder_seal` purges ALL pending findings too (a
+    /// TOCTOU-orphaned row — including one merely CITING this folder's titles — must not survive
+    /// the discard; same rollup posture as every other lock-surface mutation).
+    #[test]
+    fn discard_folder_seal_purges_all_pending_findings() {
+        let db = file_db("purge-discard");
+        make_folder(&db, "f1", "Secret");
+        seed_meeting_note(&db, "m1", "Sealed", "# S\n", Some("f1"));
+        db.insert_document("d1", "f1", "note-a", "body", "note", 1).unwrap();
+        db.set_folder_locked("f1", true, None).unwrap();
+        stage_finding(&db, "m1", None, "k-m");
+        stage_finding(&db, "d1", None, "k-d");
+        stage_finding(&db, "m-else", Some("m1"), "k-t");
+        stage_finding(&db, "m-else", None, "k-unrelated");
+
+        let _ = db.discard_folder_seal("f1").unwrap();
+
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert!(
+            pending.is_empty(),
+            "a discard purges ALL pending findings: {pending:#?}"
+        );
+    }
+
+    /// Lock review (TOCTOU shrink): a run whose seal epoch advanced is withdrawn wholesale — the
+    /// staged rows are deleted by run_id and the pass reports zero; a quiet run keeps its rows.
+    #[test]
+    fn epoch_advance_withdraws_staged_run_rows() {
+        let db = file_db("epoch-withdraw");
+        stage_finding(&db, "m1", None, "k-race-1"); // run-x (the helper's run id)
+        stage_finding(&db, "m2", None, "k-race-2");
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: "orphan".into(),
+                source_kind: "meeting".into(),
+                source_id: "m3".into(),
+                source_title: "T".into(),
+                target_title: None,
+                target_id: None,
+                target_kind: None,
+                evidence_md: "> e".into(),
+                accept_action: "".into(),
+                dedupe_key: "k-other-run".into(),
+            },
+            "run-other",
+            1,
+        )
+        .unwrap();
+
+        // Quiet epoch (advanced = false): everything stays.
+        let counts: BTreeMap<String, usize> =
+            [("broken_link".to_string(), 2usize)].into_iter().collect();
+        let (n, c) =
+            reconcile_run_on_epoch_advance(&db, "run-x", false, 2, counts.clone()).unwrap();
+        assert_eq!((n, c.len()), (2, 1));
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 3);
+
+        // Advanced epoch: the run's rows are withdrawn, the OTHER run's row survives, zeros out.
+        let (n, c) = reconcile_run_on_epoch_advance(&db, "run-x", true, 2, counts).unwrap();
+        assert_eq!(n, 0, "an interleaved run reports zero staged");
+        assert!(c.is_empty());
+        let pending = db.list_audit_finding_rows("pending").unwrap();
+        assert_eq!(pending.len(), 1, "only the other run's row survives: {pending:#?}");
+        assert_eq!(pending[0].dedupe_key, "k-other-run");
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1631,6 +1631,36 @@ pub(crate) fn refresh_meeting_note_exported_hash(
     Ok(())
 }
 
+/// The AUTHORED-NOTE twin of [`refresh_meeting_note_exported_hash`] — the same conditional
+/// (anti-laundering) append-side baseline rule, against `documents.exported_hash`: re-stamp from
+/// the final written content ONLY when the pre-append bytes still matched the stored baseline
+/// (or the row is legacy/NULL — grandfathered). A mismatch keeps the stale baseline so the next
+/// full overwrite preserves (external edit + appended stamp) as a sibling.
+pub(crate) fn refresh_note_doc_exported_hash(
+    state: &AppState,
+    note_id: &str,
+    pre_append: &str,
+    written: &str,
+) -> Result<(), AppError> {
+    let baseline = state.db.get_note_doc_exported_hash(note_id)?;
+    if let Some(b) = &baseline {
+        if *b != crate::export::note_content_hash(pre_append) {
+            // External edit present BEFORE the append — keep the stale baseline. Ids only.
+            tracing::info!(
+                target: "export",
+                note_id = %note_id,
+                baseline_kept_stale = true,
+                "append over an externally-edited note — baseline deliberately not re-stamped"
+            );
+            return Ok(());
+        }
+    }
+    state
+        .db
+        .set_note_doc_exported_hash(note_id, Some(&crate::export::note_content_hash(written)))?;
+    Ok(())
+}
+
 /// Inner of [`update_note`] taking `&AppState` — the FULL command body (gate + lifecycle guard +
 /// seal-on-write upsert + vault re-write), so the seal-on-write regression binds the COMMAND
 /// surface, not just the `upsert_note_reseal_if_locked` helper (residual W6).
@@ -2438,6 +2468,8 @@ pub async fn delete_document(
     if was_note {
         crate::events::emit_content_deleted(&app, "note", &id);
     }
+    // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
 }
 
@@ -2900,11 +2932,16 @@ pub(crate) fn save_note_text_inner(
 /// folder path (the old vault file is removed by the export path's move). Idempotent.
 #[tauri::command]
 pub fn move_note_doc(
+    app: AppHandle,
     state: State<'_, AppState>,
     id: String,
     folder_id: String,
 ) -> Result<(), AppError> {
-    move_note_doc_inner(state.inner(), &id, &folder_id)
+    move_note_doc_inner(state.inner(), &id, &folder_id)?;
+    // A move INTO a locked folder seals + purges ALL pending audit findings; an open-target move
+    // purges nothing — the count-only ping is correct (and cheap) either way.
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(())
 }
 
 /// Inner of [`move_note_doc`] taking `&AppState` (unit-testable gate).
@@ -2972,6 +3009,10 @@ pub(crate) fn move_note_doc_inner(
         state
             .db
             .move_note_row_sealed(id, folder_id, &title, &row.text, &blob, updated_at)?;
+        // Vault Audit LOCK-SAFETY: a move-into-locked is a SEAL — purge ALL pending findings
+        // (the rollup posture; this note's title may be cited in third-party evidence no id can
+        // match). The other seal paths purge inside their chunk-purge txs; this path has none.
+        state.db.purge_all_pending_audit_findings()?;
     } else {
         remove_note_export_before_move(row.exported_path.as_deref())?;
         state.db.set_note_doc_folder(id, folder_id)?;
@@ -3021,6 +3062,8 @@ pub async fn delete_note(
 ) -> Result<(), AppError> {
     delete_note_inner(state.inner(), &id).await?;
     crate::events::emit_content_deleted(&app, "note", &id);
+    // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
 }
 
@@ -4646,6 +4689,8 @@ pub async fn delete_meeting(
 ) -> Result<(), AppError> {
     delete_meeting_inner(state.inner(), &meeting_id).await?;
     crate::events::emit_content_deleted(&app, "meeting", &meeting_id);
+    // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
 }
 
@@ -5923,6 +5968,11 @@ pub(crate) fn apply_supersessions_inner(
     state: &AppState,
     ids: &[String],
 ) -> Result<ApplyResult, AppError> {
+    // Seal-vs-write TOCTOU (Phase-0 lock-review follow-up): hold the lifecycle guard across the
+    // per-row re-gate + `.md` writes, so a concurrent lock/relock cannot land between
+    // `source_is_stampable` and the append (the same guard `update_note_inner` and every other
+    // vault-writing command already holds).
+    let _lifecycle = lifecycle_guard(state);
     let mut applied = 0usize;
     let mut skipped_sealed = 0usize;
     let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
@@ -6092,6 +6142,10 @@ pub fn undo_supersessions(state: State<'_, AppState>, ids: Vec<String>) -> Resul
 }
 
 pub(crate) fn undo_supersessions_inner(state: &AppState, ids: &[String]) -> Result<(), AppError> {
+    // Seal-vs-write TOCTOU (Phase-0 lock-review follow-up): same guard as
+    // `apply_supersessions_inner` — the folder-open checks below and the restore writes must not
+    // interleave with a concurrent lock/relock.
+    let _lifecycle = lifecycle_guard(state);
     let undo_set: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
 
     // Collect the DISTINCT affected note files touched by the UNDO SET (`path -> (meeting_id,
@@ -6182,12 +6236,18 @@ pub(crate) fn undo_supersessions_inner(state: &AppState, ids: &[String]) -> Resu
         }
         // Export-collision guard: the undo rebuild is a FULL overwrite from the stored pre-image
         // (+ survivor replays), so an external edit made since apply is preserved as a sibling
-        // first, and the baseline re-stamped from the rebuilt content.
-        if let Some(latest) = state.db.get_latest_note_for_meeting(meeting_id)? {
-            overwrite_exported_note_guarded(state, meeting_id, &latest.provider_id, path, &text)?;
-        } else {
-            crate::export::obsidian::overwrite_note(std::path::Path::new(path), &text)?;
-        }
+        // first, and the baseline re-stamped from the rebuilt content. The no-note-row branch is
+        // dead-defensive (`affected` is only ever keyed via `note_file_for`, which requires a
+        // note row) — it still routes through the ONE guarded overwrite (Phase-0 follow-up): a
+        // missing row reads a NULL baseline (grandfathered, no sibling) and its hash re-stamp
+        // updates zero rows, so behavior is identical while the invariant "every full overwrite
+        // of an exported note goes through the guard" holds structurally.
+        let provider_id = state
+            .db
+            .get_latest_note_for_meeting(meeting_id)?
+            .map(|n| n.provider_id)
+            .unwrap_or_default();
+        overwrite_exported_note_guarded(state, meeting_id, &provider_id, path, &text)?;
     }
 
     // Clear the applied state on the undone rows ONLY (pre-images dropped); survivors stay applied.
@@ -6211,6 +6271,421 @@ fn superseding_link_stem(
         return Ok(None);
     }
     Ok(note_file_for(state, &s.superseding_meeting_id)?.map(|(_, stem)| stem))
+}
+
+// ── Vault Audit v1 — deterministic vault-health inbox (see `crate::audit`) ──────────────────────
+
+/// Run ONE deterministic audit pass over the visible corpus (EMPTY unlock set — the background-job
+/// discipline; see the `crate::audit` module doc) on a blocking worker, then ping the FE inbox.
+/// Zero egress, zero LLM.
+#[tauri::command]
+pub async fn run_vault_audit(
+    app: AppHandle,
+) -> Result<crate::audit::AuditRunSummary, AppError> {
+    let handle = app.clone();
+    let summary = tokio::task::spawn_blocking(move || {
+        let state = handle.state::<AppState>();
+        let vault = vault_path(&state);
+        crate::audit::run_audit_pass(
+            &state.db,
+            vault.as_deref().map(std::path::Path::new),
+            chrono::Utc::now().timestamp_millis(),
+            &state.seal_epoch,
+        )
+    })
+    .await
+    .map_err(|e| AppError::Other(anyhow::anyhow!("audit task join failed: {e}")))??;
+    crate::events::emit_audit_updated(&app, summary.findings_total_pending as u32);
+    Ok(summary)
+}
+
+/// List findings by status (default `pending`). DEFENSIVELY re-filters each row's SOURCE
+/// visibility against the LIVE session unlock set before returning — belt-and-braces on top of
+/// purge-on-seal (which already drops pending rows, by source AND target id, inside every seal
+/// tx), so a finding whose folder sealed between pass and list can never surface.
+#[tauri::command]
+pub fn list_audit_findings(
+    state: State<'_, AppState>,
+    status: Option<String>,
+) -> Result<Vec<crate::audit::AuditFinding>, AppError> {
+    list_audit_findings_inner(state.inner(), status.as_deref())
+}
+
+pub(crate) fn list_audit_findings_inner(
+    state: &AppState,
+    status: Option<&str>,
+) -> Result<Vec<crate::audit::AuditFinding>, AppError> {
+    let status = status.unwrap_or("pending");
+    if !matches!(status, "pending" | "accepted" | "dismissed") {
+        return Err(AppError::InvalidArg(
+            "status must be pending, accepted or dismissed".into(),
+        ));
+    }
+    let unlocked = unlocked_snapshot(state)?;
+    let rows = state.db.list_audit_finding_rows(status)?;
+    let mut out = Vec::new();
+    for r in rows {
+        let visible = match r.source_kind.as_str() {
+            "meeting" => state.db.meeting_is_visible(&r.source_id, &unlocked)?,
+            _ => state.db.note_is_visible(&r.source_id, &unlocked)?,
+        };
+        if !visible {
+            continue; // sealed since the pass — hide, never mask.
+        }
+        // TARGET side too (lock review, defense in depth): a pending row's title/evidence
+        // reference its target, so a target whose folder sealed between pass and list must hide
+        // the row — `target_kind` picks the right table (`meeting_is_visible` treats an unknown
+        // id as visible, so an untyped check would fail open for note targets).
+        if let (Some(tid), Some(tkind)) = (&r.target_id, &r.target_kind) {
+            let target_visible = match tkind.as_str() {
+                "meeting" => state.db.meeting_is_visible(tid, &unlocked)?,
+                _ => state.db.note_is_visible(tid, &unlocked)?,
+            };
+            if !target_visible {
+                continue;
+            }
+        }
+        out.push(r.into_dto());
+    }
+    Ok(out)
+}
+
+/// Resolve one PENDING finding: `"accept"` applies its append-only vault action (re-gated at
+/// apply time), `"dismiss"` just flips the status. BOTH paths blank `evidence_md` +
+/// `accept_action` — only pending rows ever hold derived plaintext. Returns the updated finding.
+#[tauri::command]
+pub fn resolve_audit_finding(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+    action: String,
+) -> Result<crate::audit::AuditFinding, AppError> {
+    let out = resolve_audit_finding_inner(state.inner(), &id, &action)?;
+    let pending = state.db.count_pending_audit_findings().unwrap_or(0);
+    crate::events::emit_audit_updated(&app, pending as u32);
+    Ok(out)
+}
+
+pub(crate) fn resolve_audit_finding_inner(
+    state: &AppState,
+    id: &str,
+    action: &str,
+) -> Result<crate::audit::AuditFinding, AppError> {
+    // Seal-vs-write TOCTOU: hold the lifecycle guard across the re-gate + the vault append, so a
+    // concurrent lock/relock cannot land between the check and the write (the same discipline as
+    // `update_note_inner` / `apply_supersessions_inner`).
+    let _lifecycle = lifecycle_guard(state);
+    let row = state
+        .db
+        .get_audit_finding(id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no audit finding {id}")))?;
+    if row.status != "pending" {
+        return Err(AppError::InvalidArg("this finding was already handled".into()));
+    }
+    let status = match action {
+        "dismiss" => "dismissed",
+        "accept" => {
+            if row.accept_action.is_empty() {
+                return Err(AppError::InvalidArg(
+                    "this finding is dismiss-only — it has no accept action".into(),
+                ));
+            }
+            apply_audit_accept(state, &row)?;
+            "accepted"
+        }
+        _ => {
+            return Err(AppError::InvalidArg(
+                "action must be \"accept\" or \"dismiss\"".into(),
+            ))
+        }
+    };
+    state
+        .db
+        .resolve_audit_finding_row(id, status, chrono::Utc::now().timestamp_millis())?;
+    let updated = state
+        .db
+        .get_audit_finding(id)?
+        .ok_or_else(|| AppError::Storage("finding vanished during resolve".into()))?;
+    tracing::info!(target: "audit", finding_id = %id, kind = %updated.kind, status = %status, "audit finding resolved");
+    Ok(updated.into_dto())
+}
+
+/// APPLY one finding's accept action: an APPEND-ONLY stamp under `## Audit` in the source's
+/// exported `.md` (both sources for a contradiction). Every path RE-GATES at apply time
+/// (the prune↔seal TOCTOU discipline — a source sealed since the pass refuses with
+/// `AppError::Locked`, never stamps), and every appended `[[link]]` is re-resolved against the
+/// LIVE vault/session first (the `list_vault_titles` anti-hallucination rule).
+fn apply_audit_accept(
+    state: &AppState,
+    row: &crate::audit::AuditFindingRow,
+) -> Result<(), AppError> {
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    match row.kind.as_str() {
+        "broken_link" => {
+            let target = row.target_title.as_deref().unwrap_or("").trim().to_string();
+            if target.is_empty() {
+                return Err(AppError::InvalidArg("this finding has no link target".into()));
+            }
+            // LIVE re-resolve (lock review): the target may have been created since the pass —
+            // the stamp would then assert a falsehood. REFUSE, loss-safe: nothing is written and
+            // the row stays pending with its evidence, so the user dismisses or re-runs the
+            // audit (chosen over auto-dismiss so no status flips without an explicit choice).
+            if broken_link_target_resolves(state, &target)? {
+                return Err(AppError::InvalidArg(
+                    "the link target now resolves — dismiss this finding or re-run the audit"
+                        .into(),
+                ));
+            }
+            // The [[..]] rides in a CODE SPAN so the stamp itself never becomes another
+            // (broken) wikilink — the one deliberate exception to "appended links resolve".
+            // Worded as an observation at audit time, not a standing claim.
+            let body = format!("> `[[{target}]]` — link target was not found at audit time");
+            stamp_audit_source(state, row, |md| {
+                crate::export::obsidian::append_audit_callout(md, &date, "broken-link", &body)
+            })
+        }
+        "stale" => {
+            // Counts recomputed LIVE through the gated reader (they may have moved since the
+            // pass); the callout carries counts only — never superseding titles (leak-safe even
+            // if a superseding source sealed since the pass).
+            let unlocked = unlocked_snapshot(state)?;
+            let facts = state
+                .db
+                .fact_rows_for_meeting_visible(&row.source_id, &unlocked)?;
+            let total = facts.len();
+            let closed = facts.iter().filter(|f| f.valid_to.is_some()).count();
+            let body = format!(
+                "> {closed} of {total} facts recorded in this note have since been superseded by later meetings"
+            );
+            stamp_audit_source(state, row, |md| {
+                crate::export::obsidian::append_audit_callout(md, &date, "stale", &body)
+            })
+        }
+        "contradiction" => {
+            let other_id = row
+                .target_id
+                .as_deref()
+                .ok_or_else(|| AppError::InvalidArg("this finding has no counterpart".into()))?;
+            // Re-gate BOTH sides BEFORE stamping either (never stamp into, or reference, a
+            // sealed note — and never leave a half-stamped pair).
+            let source_path = audit_source_file(state, &row.source_kind, &row.source_id)?;
+            let other_path = audit_source_file(state, "meeting", other_id)?;
+            let source_stem = file_stem_of(&source_path);
+            let other_stem = file_stem_of(&other_path);
+            append_to_audit_source(state, &row.source_kind, &row.source_id, &source_path, |md| {
+                crate::export::obsidian::append_audit_callout(
+                    md,
+                    &date,
+                    "conflict",
+                    &format!("> conflicting facts recorded here and in [[{other_stem}]] — review which is current"),
+                )
+            })?;
+            append_to_audit_source(state, "meeting", other_id, &other_path, |md| {
+                crate::export::obsidian::append_audit_callout(
+                    md,
+                    &date,
+                    "conflict",
+                    &format!("> conflicting facts recorded here and in [[{source_stem}]] — review which is current"),
+                )
+            })
+        }
+        "unlinked_mention" => {
+            let target = row.target_title.as_deref().unwrap_or("").trim().to_string();
+            if target.is_empty() {
+                return Err(AppError::InvalidArg("this finding has no link target".into()));
+            }
+            if !audit_link_target_ok(state, &target)? {
+                return Err(AppError::InvalidArg(
+                    "the suggested link target no longer exists — dismiss this finding instead".into(),
+                ));
+            }
+            let line = format!("- Suggested link: [[{target}]]");
+            stamp_audit_source(state, row, |md| {
+                crate::export::obsidian::append_audit_line(md, &line)
+            })
+        }
+        "orphan" => {
+            // The suggestions live as [[links]] inside the (still-pending) evidence — re-extract
+            // and RE-RESOLVE each against the live vault/session; only survivors are appended.
+            let mut suggestions = Vec::new();
+            for t in crate::storage::db::extract_wikilink_titles(&row.evidence_md) {
+                if audit_link_target_ok(state, &t)? {
+                    suggestions.push(format!("[[{t}]]"));
+                }
+            }
+            if suggestions.is_empty() {
+                return Err(AppError::InvalidArg(
+                    "no suggested link still resolves — dismiss this finding instead".into(),
+                ));
+            }
+            let line = format!("- Suggested links: {}", suggestions.join(" · "));
+            stamp_audit_source(state, row, |md| {
+                crate::export::obsidian::append_audit_line(md, &line)
+            })
+        }
+        _ => Err(AppError::InvalidArg(format!(
+            "unknown finding kind {}",
+            row.kind
+        ))),
+    }
+}
+
+/// Resolve + stamp a finding's (single) source in one step.
+fn stamp_audit_source(
+    state: &AppState,
+    row: &crate::audit::AuditFindingRow,
+    stamp: impl Fn(&str) -> String,
+) -> Result<(), AppError> {
+    let path = audit_source_file(state, &row.source_kind, &row.source_id)?;
+    append_to_audit_source(state, &row.source_kind, &row.source_id, &path, stamp)
+}
+
+/// Read-modify-write APPEND of one audit stamp: read the CURRENT file, apply the (idempotent)
+/// append, write only on change, then refresh the export-collision baseline with the Phase-0
+/// CONDITIONAL rule — meetings via [`refresh_meeting_note_exported_hash`], authored notes via
+/// [`refresh_note_doc_exported_hash`] (an externally-edited file keeps its stale baseline, so the
+/// next full overwrite preserves edit + stamp as a sibling instead of laundering the edit away).
+fn append_to_audit_source(
+    state: &AppState,
+    source_kind: &str,
+    source_id: &str,
+    path: &str,
+    stamp: impl Fn(&str) -> String,
+) -> Result<(), AppError> {
+    let current = std::fs::read_to_string(path)
+        .map_err(|e| AppError::Export(format!("read note before audit stamp failed: {e}")))?;
+    let written = stamp(&current);
+    if written == current {
+        return Ok(()); // already stamped — idempotent no-op.
+    }
+    crate::export::obsidian::overwrite_note(std::path::Path::new(path), &written)?;
+    match source_kind {
+        "meeting" => refresh_meeting_note_exported_hash(state, source_id, &current, &written),
+        _ => refresh_note_doc_exported_hash(state, source_id, &current, &written),
+    }
+}
+
+/// Re-gate + resolve a finding source's exported `.md` at APPLY time (the TOCTOU re-check —
+/// the Re-Truth `source_is_stampable` posture, extended to authored notes): a meeting source
+/// must be session-unlocked AND open-on-disk with an exported file; a note source's folder must
+/// be session-unlocked AND open-on-disk (a sealed note's `.md` was deleted on seal, and a write
+/// into a locked-on-disk folder would be dropped at relock). Refusals are `AppError::Locked`.
+fn audit_source_file(
+    state: &AppState,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<String, AppError> {
+    match source_kind {
+        "meeting" => {
+            if !source_is_stampable(state, source_id)? {
+                return Err(AppError::Locked(
+                    "this note's folder is locked — unlock it to apply the audit action".into(),
+                ));
+            }
+            match note_file_for(state, source_id)? {
+                Some((path, _)) => Ok(path),
+                None => Err(AppError::InvalidArg(
+                    "this note has no exported vault file to stamp".into(),
+                )),
+            }
+        }
+        "note" => {
+            let row = state
+                .db
+                .get_note_row(source_id)?
+                .ok_or_else(|| AppError::InvalidArg(format!("no note {source_id}")))?;
+            let locked_on_disk = state
+                .db
+                .folder_by_id(&row.folder_id)?
+                .map(|f| f.locked)
+                .unwrap_or(true);
+            if locked_on_disk || !folder_is_unlocked(state, &row.folder_id)? {
+                return Err(AppError::Locked(
+                    "this note's folder is locked — unlock it to apply the audit action".into(),
+                ));
+            }
+            match row.exported_path {
+                Some(p) if !p.trim().is_empty() => Ok(p),
+                _ => Err(AppError::InvalidArg(
+                    "this note has no exported vault file to stamp".into(),
+                )),
+            }
+        }
+        other => Err(AppError::InvalidArg(format!(
+            "unknown finding source kind {other}"
+        ))),
+    }
+}
+
+/// The anti-hallucination re-check for an appended `[[link]]`: the title must resolve NOW —
+/// through the GATED `resolve_wikilink` (notes/meetings/org, live session set) to a target whose
+/// folder is also open ON DISK (a link into a merely session-unlocked folder would break at
+/// relock — the `superseding_link_stem` bar), or be an existing vault file stem.
+fn audit_link_target_ok(state: &AppState, title: &str) -> Result<bool, AppError> {
+    let unlocked = unlocked_snapshot(state)?;
+    match state.db.resolve_wikilink(title, &unlocked)? {
+        Some(t) if t.kind == "meeting" => Ok(!folder_locked_on_disk(state, &t.id)?),
+        Some(t) if t.kind == "note" => {
+            let Some(row) = state.db.get_note_row(&t.id)? else {
+                return Ok(false);
+            };
+            Ok(state
+                .db
+                .folder_by_id(&row.folder_id)?
+                .map(|f| !f.locked)
+                .unwrap_or(false))
+        }
+        Some(_) => Ok(true), // org item — deliberately-disclosed, outside the folder-lock domain.
+        None => {
+            // Not a note/meeting/org — an existing user-authored vault file still resolves.
+            let Some(vault) = vault_path(state) else {
+                return Ok(false);
+            };
+            Ok(
+                crate::export::obsidian::list_vault_titles(std::path::Path::new(&vault))?
+                    .iter()
+                    .any(|t| t == title),
+            )
+        }
+    }
+}
+
+/// Ping the FE audit inbox after a purge-bearing lock/relock/delete/discard/move-into-locked
+/// mutation (count-only payload, adversarial B): pending findings vanish reactively instead of
+/// on the next manual refetch. Mirrors the screen-share relock's emit posture — best-effort by
+/// construction (`emit_audit_updated` swallows failures).
+fn emit_audit_updated_after_purge(app: &AppHandle, state: &AppState) {
+    let pending = state.db.count_pending_audit_findings().unwrap_or(0);
+    crate::events::emit_audit_updated(app, pending as u32);
+}
+
+/// Does a wikilink title resolve AT ALL right now — the gated `resolve_wikilink` (live session
+/// set) OR an existing vault file stem: the SAME union the pass's broken-link resolver uses, so
+/// accept and pass agree on "broken". Distinct from [`audit_link_target_ok`] (which adds the
+/// open-on-disk bar for APPENDING a link — here we only ask whether the "broken" claim is still
+/// true; a sealed-not-unlocked target stays "not found", consistent with the gate posture).
+fn broken_link_target_resolves(state: &AppState, title: &str) -> Result<bool, AppError> {
+    let unlocked = unlocked_snapshot(state)?;
+    if state.db.resolve_wikilink(title, &unlocked)?.is_some() {
+        return Ok(true);
+    }
+    let Some(vault) = vault_path(state) else {
+        return Ok(false);
+    };
+    Ok(
+        crate::export::obsidian::list_vault_titles(std::path::Path::new(&vault))?
+            .iter()
+            .any(|t| t == title),
+    )
+}
+
+/// A path's file stem (the wikilink target Obsidian resolves) — empty on a pathological path.
+fn file_stem_of(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Read the meeting's OWN @brain THREAD TURNS for user-fact extraction (design spec D5), GATED by the
@@ -11058,7 +11533,31 @@ fn ensure_meeting_folder_target(
 ///   with, so we refuse rather than leave plaintext in a locked folder. The FE must unlock first.
 #[tauri::command]
 pub fn move_note(
+    app: AppHandle,
     state: State<'_, AppState>,
+    meeting_id: String,
+    folder_id: Option<String>,
+) -> Result<(), AppError> {
+    move_note_command_body(&app, state, meeting_id, folder_id)
+}
+
+/// Body of [`move_note`], split so the audit-inbox ping fires once after EVERY successful move
+/// (a move INTO a locked folder seals + purges ALL pending findings via
+/// `purge_chunks_for_meetings`; an open-target move purges nothing — the count-only ping is
+/// correct either way).
+fn move_note_command_body(
+    app: &AppHandle,
+    state: State<'_, AppState>,
+    meeting_id: String,
+    folder_id: Option<String>,
+) -> Result<(), AppError> {
+    move_note_inner_impl(&state, meeting_id, folder_id)?;
+    emit_audit_updated_after_purge(app, state.inner());
+    Ok(())
+}
+
+fn move_note_inner_impl(
+    state: &State<'_, AppState>,
     meeting_id: String,
     folder_id: Option<String>,
 ) -> Result<(), AppError> {
@@ -11404,8 +11903,15 @@ fn move_note_file(
 /// DB write but before the `.md` delete leaves a stale plaintext `.md` (reconcilable) — never
 /// lost content.
 #[tauri::command]
-pub fn lock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
-    lock_folder_inner(state.inner(), folder_id)
+pub fn lock_folder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    folder_id: String,
+) -> Result<(), AppError> {
+    lock_folder_inner(state.inner(), folder_id)?;
+    // The seal purged ALL pending audit findings — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(())
 }
 
 /// BLK-1: acquire the coarse [`AppState::lifecycle`] guard so a folder-lock state-machine op never
@@ -11556,6 +12062,16 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
     // sibling — privacy wins over preservation. A plaintext sibling of a to-be-sealed note would
     // be exactly the leak the lock exists to prevent. External edits to a locked note's `.md`
     // are accepted-loss by design; the DB blob remains the canonical recoverable copy.
+    // Phase-0 follow-up: siblings ALREADY preserved by an earlier overwrite are user-authored
+    // files we never delete — but they are plaintext that survives this seal on disk, so WARN
+    // (counts only) so the exposure is at least visible in the log.
+    let doc_export_rows = state.db.note_exported_path_rows_in_folder(&folder_id)?;
+    warn_external_edit_siblings(
+        "lock",
+        exported_paths
+            .iter()
+            .chain(doc_export_rows.iter().map(|(_, p)| p)),
+    );
     for p in exported_paths {
         let _ = std::fs::remove_file(&p);
     }
@@ -11569,7 +12085,7 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
     // the next relock/startup pass retries the file (the pre-fix bulk clear forgot the leaked
     // `.md` forever). The lock itself still completes (the DB blob is the recoverable copy).
     // Count-only log — never paths (they embed note titles).
-    for (doc_id, p) in state.db.note_exported_path_rows_in_folder(&folder_id)? {
+    for (doc_id, p) in doc_export_rows {
         let removed = match std::fs::remove_file(&p) {
             Ok(()) => true,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
@@ -11591,6 +12107,41 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
     // the moment a folder seals (post clear-on-Stop it is normally already empty; idempotent).
     clear_stale_live_transcript(state);
     Ok(())
+}
+
+/// Phase-0 lock-review follow-up: count `<stem> (external edit …).md` siblings sitting next to
+/// the given exported `.md` paths and WARN (counts only — paths embed note titles). The seal /
+/// relock paths delete ONLY the canonical exports; an external-edit sibling is USER-AUTHORED
+/// content the collision guard preserved, so it is deliberately NEVER deleted — but it is
+/// plaintext that survives the seal on disk, and that exposure must at least be visible.
+fn warn_external_edit_siblings<'a>(stage: &str, paths: impl Iterator<Item = &'a String>) {
+    let mut siblings = 0usize;
+    for p in paths {
+        let path = std::path::Path::new(p);
+        let (Some(parent), Some(stem)) = (path.parent(), path.file_stem().and_then(|s| s.to_str()))
+        else {
+            continue;
+        };
+        let prefix = format!("{stem} (external edit ");
+        let Ok(entries) = std::fs::read_dir(parent) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            if let Some(name) = e.file_name().to_str() {
+                if name.starts_with(&prefix) && name.ends_with(".md") {
+                    siblings += 1;
+                }
+            }
+        }
+    }
+    if siblings > 0 {
+        tracing::warn!(
+            target: "lock",
+            stage,
+            siblings,
+            "external-edit sibling .md files remain next to sealed notes' exports — left in place (user-authored, never deleted by the seal), but they are plaintext outside the seal"
+        );
+    }
 }
 
 /// Lock-surface RAM hygiene: clear the live-transcript buffer ONLY when no recording is active —
@@ -11859,7 +12410,11 @@ pub async fn unlock_folder(
 /// markdown of its sealed notes and drop the folder from the unlock set. The `content_blob`
 /// stays — the folder is still `locked=1` on disk.
 #[tauri::command]
-pub fn relock_folder(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
+pub fn relock_folder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    folder_id: String,
+) -> Result<(), AppError> {
     // BLK-1: serialize with the rest of the lock state machine (it re-blanks the same columns
     // `remove_lock` is mid-restoring).
     let _lifecycle = lifecycle_guard(state.inner());
@@ -11888,14 +12443,21 @@ pub fn relock_folder(state: State<'_, AppState>, folder_id: String) -> Result<()
     // Phase 0.5 — re-blank the transcript + timeline plaintext and drop the decrypted session WAV
     // (the .enc + the *_blob columns stay; the folder is still locked=1 on disk).
     reblank_folder_extras(state.inner(), &folder_id)?;
+    // The relock purged ALL pending audit findings — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
 }
 
 /// Relock ALL session-unlocked folders + zeroize the cached KEK (called on screen-share start in
 /// Stage E, and exposed as a command). Re-blanks the plaintext markdown of every sealed note.
 #[tauri::command]
-pub fn relock_all(state: State<'_, AppState>) -> Result<(), AppError> {
-    relock_all_inner(&state)
+pub fn relock_all(app: AppHandle, state: State<'_, AppState>) -> Result<(), AppError> {
+    relock_all_inner(&state)?;
+    // The relock-all purged ALL pending audit findings — ping the FE inbox (count-only). The
+    // off-thread `relock_all_inner` callers emit from their own handles (screen-share) or are
+    // app teardown (window-close/exit — nothing left to notify).
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(())
 }
 
 /// Inner relock-all usable without a command boundary (Stage E screen-share watcher, window-close,
@@ -12208,10 +12770,14 @@ pub(crate) fn remove_lock_inner(state: &AppState, folder_id: String) -> Result<(
 /// (readable plaintext with a NULL blob) is PRESERVED (`Db::discard_folder_seal`).
 #[tauri::command]
 pub async fn discard_unrecoverable_folder_lock(
+    app: AppHandle,
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<FolderNode, AppError> {
-    discard_unrecoverable_folder_lock_inner(state.inner(), folder_id).await
+    let node = discard_unrecoverable_folder_lock_inner(state.inner(), folder_id).await?;
+    // The discard purged ALL pending audit findings — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(node)
 }
 
 pub(crate) async fn discard_unrecoverable_folder_lock_inner(
@@ -12802,6 +13368,7 @@ pub async fn unlock_meeting(
 /// folder is already open.
 #[tauri::command]
 pub async fn discard_unrecoverable_meeting_lock(
+    app: AppHandle,
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<Option<FolderNode>, AppError> {
@@ -12815,9 +13382,10 @@ pub async fn discard_unrecoverable_meeting_lock(
     if !folder.locked {
         return Ok(None);
     }
-    discard_unrecoverable_folder_lock_inner(state.inner(), folder_id)
-        .await
-        .map(Some)
+    let node = discard_unrecoverable_folder_lock_inner(state.inner(), folder_id).await?;
+    // The discard purged ALL pending audit findings — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(Some(node))
 }
 
 // ── Phase 0.5 full per-folder lock: transcript + timeline + audio seal helpers ──
@@ -13472,7 +14040,11 @@ fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppErr
     // the path is cleared ONLY after its `.md` was actually deleted (or is already absent) — a
     // FAILED delete keeps the path recorded so the next relock/startup pass retries (the pre-fix
     // bulk clear forgot the leaked `.md` forever). Count-only log — never paths (note titles).
-    for (doc_id, p) in state.db.note_exported_path_rows_in_folder(folder_id)? {
+    // Phase-0 follow-up: warn (counts only) when external-edit siblings sit next to these
+    // exports — the relock deletes only the canonical `.md`s, never a preserved sibling.
+    let relock_doc_rows = state.db.note_exported_path_rows_in_folder(folder_id)?;
+    warn_external_edit_siblings("relock", relock_doc_rows.iter().map(|(_, p)| p));
+    for (doc_id, p) in relock_doc_rows {
         let removed = match std::fs::remove_file(&p) {
             Ok(()) => true,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
@@ -23854,6 +24426,523 @@ mod lifecycle_tests {
             "canonical file carries the DB content"
         );
         let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    // ── Vault Audit — accept/dismiss/list (command layer) ─────────────────────
+
+    /// Stage one pending audit finding directly (the pass is tested in `crate::audit`).
+    fn stage_audit_finding(
+        state: &AppState,
+        kind: &str,
+        source_kind: &str,
+        source_id: &str,
+        target_title: Option<&str>,
+        evidence: &str,
+        accept_action: &str,
+        key: &str,
+    ) -> String {
+        state
+            .db
+            .insert_audit_finding_if_new(
+                &crate::audit::NewAuditFinding {
+                    kind: kind.into(),
+                    source_kind: source_kind.into(),
+                    source_id: source_id.into(),
+                    source_title: "T".into(),
+                    target_title: target_title.map(str::to_string),
+                    target_id: None,
+                    target_kind: None,
+                    evidence_md: evidence.into(),
+                    accept_action: accept_action.into(),
+                    dedupe_key: key.into(),
+                },
+                "r-test",
+                1,
+            )
+            .unwrap();
+        state
+            .db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .into_iter()
+            .find(|r| r.dedupe_key == key)
+            .unwrap()
+            .id
+    }
+
+    /// Stage a pending finding CARRYING a target id+kind (the list layer's target re-gate seam).
+    fn stage_audit_finding_with_target(
+        state: &AppState,
+        source_id: &str,
+        target_id: &str,
+        target_kind: &str,
+        key: &str,
+    ) -> String {
+        state
+            .db
+            .insert_audit_finding_if_new(
+                &crate::audit::NewAuditFinding {
+                    kind: "unlinked_mention".into(),
+                    source_kind: "meeting".into(),
+                    source_id: source_id.into(),
+                    source_title: "T".into(),
+                    target_title: Some("Sealed Target Title".into()),
+                    target_id: Some(target_id.into()),
+                    target_kind: Some(target_kind.into()),
+                    evidence_md: "> mentions Sealed Target Title".into(),
+                    accept_action: "Append the suggested [[link]] under ## Audit".into(),
+                    dedupe_key: key.into(),
+                },
+                "r-test",
+                1,
+            )
+            .unwrap();
+        state
+            .db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .into_iter()
+            .find(|r| r.dedupe_key == key)
+            .unwrap()
+            .id
+    }
+
+    /// Accept appends the callout under `## Audit`, re-stamps the baseline (clean case), blanks
+    /// the evidence, and a SECOND identical accept is refused while a re-staged twin's accept is
+    /// an idempotent no-op on the file.
+    #[test]
+    fn audit_accept_appends_stamp_blanks_evidence_and_is_idempotent() {
+        let vault = tmp_vault("audit-accept");
+        let state = build_state_with_vault("audit-accept", &vault);
+        seed_meeting(&state.db, "m-a", "# Kickoff\n", None);
+        let md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-a", &md, "# Kickoff\n");
+
+        let id = stage_audit_finding(
+            &state,
+            "broken_link",
+            "meeting",
+            "m-a",
+            Some("Ghost Note"),
+            "> see [[Ghost Note]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|m-a|Ghost Note",
+        );
+        let resolved = resolve_audit_finding_inner(&state, &id, "accept").unwrap();
+        assert_eq!(resolved.status, "accepted");
+        assert!(resolved.evidence_md.is_empty(), "accept blanks the evidence");
+        assert!(resolved.accept_action.is_empty());
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert!(after.contains("## Audit"), "managed section created: {after}");
+        assert!(after.contains("[!broken-link]"), "callout appended: {after}");
+        assert!(after.contains("`[[Ghost Note]]`"), "target in a code span: {after}");
+        assert_eq!(
+            state.db.get_note_exported_hash("m-a", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash(&after)),
+            "clean-case baseline re-stamped from the appended content"
+        );
+        assert!(external_edit_siblings(&vault).is_empty(), "append creates no sibling");
+
+        // Already handled → refused.
+        assert!(matches!(
+            resolve_audit_finding_inner(&state, &id, "accept"),
+            Err(AppError::InvalidArg(_))
+        ));
+        // An ACCEPTED twin may recur (dedupe allows it); accepting the recurrence is an
+        // idempotent no-op on the file (the callout body is the marker).
+        let id2 = stage_audit_finding(
+            &state,
+            "broken_link",
+            "meeting",
+            "m-a",
+            Some("Ghost Note"),
+            "> see [[Ghost Note]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|m-a|Ghost Note",
+        );
+        resolve_audit_finding_inner(&state, &id2, "accept").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&md).unwrap(),
+            after,
+            "re-accepting the same finding never double-stamps"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// The external-edit interplay (mirrors
+    /// `append_over_external_edit_keeps_stale_baseline_so_overwrite_preserves_sibling`): an
+    /// audit accept over an externally-edited file appends in place but must NOT launder the
+    /// baseline — the next DB-derived full overwrite preserves (edit + stamp) as a sibling.
+    #[test]
+    fn audit_accept_over_external_edit_keeps_stale_baseline() {
+        let vault = tmp_vault("audit-launder");
+        let state = build_state_with_vault("audit-launder", &vault);
+        seed_meeting(&state.db, "m-a", "# Kickoff\n", None);
+        let md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-a", &md, "# Kickoff\n");
+        // The user edits the exported file BEFORE the accept lands.
+        std::fs::write(&md, "# Kickoff\nMY EXTERNAL NOTE\n").unwrap();
+
+        let id = stage_audit_finding(
+            &state,
+            "broken_link",
+            "meeting",
+            "m-a",
+            Some("Ghost Note"),
+            "> see [[Ghost Note]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|m-a|Ghost Note",
+        );
+        resolve_audit_finding_inner(&state, &id, "accept").unwrap();
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert!(after.contains("MY EXTERNAL NOTE"), "edit preserved in place");
+        assert!(after.contains("[!broken-link]"), "stamp appended");
+        assert!(external_edit_siblings(&vault).is_empty(), "the append creates no sibling");
+        assert_eq!(
+            state.db.get_note_exported_hash("m-a", "claude_code").unwrap(),
+            Some(crate::export::note_content_hash("# Kickoff\n")),
+            "baseline NOT laundered over the externally-edited file"
+        );
+        // The next full overwrite preserves (edit + stamp) as a sibling.
+        update_note_inner(&state, "m-a", "# Kickoff rewritten\n").unwrap();
+        let siblings = external_edit_siblings(&vault);
+        assert_eq!(siblings.len(), 1, "external edit + stamp survive as a sibling");
+        let preserved = std::fs::read_to_string(&siblings[0]).unwrap();
+        assert!(preserved.contains("MY EXTERNAL NOTE") && preserved.contains("[!broken-link]"));
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Dismiss blanks the evidence with NO vault write; accepting a finding whose source folder
+    /// sealed between pass and resolve is REFUSED with `Locked` (the row stays pending); the
+    /// list defensively hides a finding whose folder sealed between pass and list.
+    #[test]
+    fn audit_dismiss_locked_accept_and_list_regating() {
+        let vault = tmp_vault("audit-gate");
+        let state = build_state_with_vault("audit-gate", &vault);
+        make_open_folder(&state.db, "f1", "Secret");
+        seed_meeting(&state.db, "m-a", "# Kickoff\n", Some("f1"));
+        let md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-a", &md, "# Kickoff\n");
+
+        // Dismiss path: no vault write, evidence blanked.
+        let id_dismiss = stage_audit_finding(
+            &state,
+            "orphan",
+            "meeting",
+            "m-a",
+            None,
+            "This note has no wikilinks in or out.",
+            "",
+            "orphan|m-a|",
+        );
+        let before = std::fs::read_to_string(&md).unwrap();
+        let resolved = resolve_audit_finding_inner(&state, &id_dismiss, "dismiss").unwrap();
+        assert_eq!(resolved.status, "dismissed");
+        assert!(resolved.evidence_md.is_empty());
+        assert_eq!(std::fs::read_to_string(&md).unwrap(), before, "dismiss never writes");
+
+        // Accepting a dismiss-only finding is refused.
+        let id_dismiss_only = stage_audit_finding(
+            &state, "orphan", "meeting", "m-a", None, "no links", "", "orphan|m-a|2",
+        );
+        assert!(matches!(
+            resolve_audit_finding_inner(&state, &id_dismiss_only, "accept"),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // Seal the folder DIRECTLY at the DB layer — simulating the pass→resolve race window
+        // where the disk-truth flipped but this row was staged in between (the command-level
+        // seal would have purged it; the TOCTOU re-gate must hold regardless).
+        let id_locked = stage_audit_finding(
+            &state,
+            "broken_link",
+            "meeting",
+            "m-a",
+            Some("Ghost Note"),
+            "> see [[Ghost Note]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|m-a|Ghost Note",
+        );
+        state.db.set_folder_locked("f1", true, None).unwrap();
+        assert!(matches!(
+            resolve_audit_finding_inner(&state, &id_locked, "accept"),
+            Err(AppError::Locked(_))
+        ));
+        let row = state.db.get_audit_finding(&id_locked).unwrap().unwrap();
+        assert_eq!(row.status, "pending", "a refused accept leaves the row pending");
+        assert!(!row.evidence_md.is_empty(), "…with its evidence intact");
+
+        // The LIST defensively hides it (source no longer visible), while an open-source
+        // finding still lists.
+        seed_meeting(&state.db, "m-open", "# Open\n", None);
+        stage_audit_finding(
+            &state, "orphan", "meeting", "m-open", None, "no links", "", "orphan|m-open|",
+        );
+        let listed = list_audit_findings_inner(&state, None).unwrap();
+        assert_eq!(listed.len(), 1, "sealed-source finding hidden: {listed:#?}");
+        assert_eq!(listed[0].source_id, "m-open");
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// The anti-hallucination re-check: accepting an unlinked-mention whose target no longer
+    /// resolves is refused (never append a dead `[[link]]`); a resolvable target appends the
+    /// suggested-link line under `## Audit`.
+    #[test]
+    fn audit_unlinked_mention_accept_reresolves_target() {
+        let vault = tmp_vault("audit-mention");
+        let state = build_state_with_vault("audit-mention", &vault);
+        seed_meeting(&state.db, "m-src", "# Kickoff\n", None);
+        let md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-src", &md, "# Kickoff\n");
+
+        // Target that resolves: another visible meeting with that exact title.
+        db_insert_titled_meeting(&state.db, "m-t", "Project Atlas Review");
+        let id_ok = stage_audit_finding(
+            &state,
+            "unlinked_mention",
+            "meeting",
+            "m-src",
+            Some("Project Atlas Review"),
+            "> mentioned Project Atlas Review\n\nSuggested link: [[Project Atlas Review]]",
+            "Append the suggested [[link]] under ## Audit",
+            "unlinked_mention|m-src|Project Atlas Review",
+        );
+        resolve_audit_finding_inner(&state, &id_ok, "accept").unwrap();
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert!(
+            after.contains("- Suggested link: [[Project Atlas Review]]"),
+            "link line appended: {after}"
+        );
+
+        // Target that does NOT resolve anywhere → refused, row stays pending.
+        let id_gone = stage_audit_finding(
+            &state,
+            "unlinked_mention",
+            "meeting",
+            "m-src",
+            Some("Vanished Note Title"),
+            "> mentioned Vanished Note Title\n\nSuggested link: [[Vanished Note Title]]",
+            "Append the suggested [[link]] under ## Audit",
+            "unlinked_mention|m-src|Vanished Note Title",
+        );
+        assert!(matches!(
+            resolve_audit_finding_inner(&state, &id_gone, "accept"),
+            Err(AppError::InvalidArg(_))
+        ));
+        assert_eq!(
+            state.db.get_audit_finding(&id_gone).unwrap().unwrap().status,
+            "pending"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// The AUTHORED-NOTE (documents) side of accept: the stamp lands in the note's exported
+    /// `.md` and the baseline refresh rides `documents.exported_hash` with the SAME conditional
+    /// anti-laundering rule as the meeting side.
+    #[test]
+    fn audit_accept_on_note_source_uses_doc_baseline_conditionally() {
+        let vault = tmp_vault("audit-doc");
+        let state = build_state_with_vault("audit-doc", &vault);
+        make_open_folder(&state.db, "fn1", "Notes");
+        state
+            .db
+            .insert_document("n1", "fn1", "My Note", "# My Note\n", "note", 1)
+            .unwrap();
+        let md = vault.join("My Note.md");
+        std::fs::write(&md, "# My Note\n").unwrap();
+        state
+            .db
+            .set_note_doc_exported_path("n1", Some(&md.to_string_lossy()))
+            .unwrap();
+        state
+            .db
+            .set_note_doc_exported_hash(
+                "n1",
+                Some(&crate::export::note_content_hash("# My Note\n")),
+            )
+            .unwrap();
+
+        // Clean accept → append + baseline re-stamped from the appended content.
+        let id = stage_audit_finding(
+            &state,
+            "broken_link",
+            "note",
+            "n1",
+            Some("Ghost"),
+            "> [[Ghost]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|n1|Ghost",
+        );
+        resolve_audit_finding_inner(&state, &id, "accept").unwrap();
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert!(after.contains("[!broken-link]"), "stamp appended: {after}");
+        assert_eq!(
+            state.db.get_note_doc_exported_hash("n1").unwrap(),
+            Some(crate::export::note_content_hash(&after)),
+            "clean-case doc baseline re-stamped"
+        );
+
+        // External edit BEFORE the next accept → the append lands in place but the baseline
+        // stays at Murmur's last write (not laundered).
+        std::fs::write(&md, format!("{after}EXTERNAL EDIT LINE\n")).unwrap();
+        let id2 = stage_audit_finding(
+            &state,
+            "broken_link",
+            "note",
+            "n1",
+            Some("Ghost Two"),
+            "> [[Ghost Two]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|n1|Ghost Two",
+        );
+        resolve_audit_finding_inner(&state, &id2, "accept").unwrap();
+        let after2 = std::fs::read_to_string(&md).unwrap();
+        assert!(after2.contains("EXTERNAL EDIT LINE"), "edit preserved in place");
+        assert!(after2.contains("Ghost Two"), "second stamp appended");
+        assert_eq!(
+            state.db.get_note_doc_exported_hash("n1").unwrap(),
+            Some(crate::export::note_content_hash(&after)),
+            "doc baseline NOT laundered over the externally-edited file"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Minimal titled-meeting seed for wikilink-resolution targets (no note needed beyond one
+    /// row so `list_meetings_visible` keeps it).
+    fn db_insert_titled_meeting(db: &Db, id: &str, title: &str) {
+        db.insert_meeting(&crate::storage::models::Meeting {
+            id: id.to_string(),
+            started_at: "2026-07-02T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some(title.to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: crate::storage::models::MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+    }
+
+    /// Lock review: accepting a broken_link whose target NOW resolves must refuse (the stamp
+    /// would assert a falsehood) — loss-safe: nothing written, the row stays pending.
+    #[test]
+    fn audit_broken_link_accept_refuses_when_target_now_resolves() {
+        let vault = tmp_vault("audit-resolves-now");
+        let state = build_state_with_vault("audit-resolves-now", &vault);
+        seed_meeting(&state.db, "m-src", "# Kickoff\n", None);
+        let md = vault.join("2026-07-01 0900 - Kickoff.md");
+        seed_exported_note(&state, "m-src", &md, "# Kickoff\n");
+        // The once-missing target EXISTS by accept time (created after the pass staged it).
+        db_insert_titled_meeting(&state.db, "m-t", "Now Existing Note");
+
+        let id = stage_audit_finding(
+            &state,
+            "broken_link",
+            "meeting",
+            "m-src",
+            Some("Now Existing Note"),
+            "> see [[Now Existing Note]]",
+            "Append a [!broken-link] note under ## Audit",
+            "broken_link|m-src|now-existing",
+        );
+        let before = std::fs::read_to_string(&md).unwrap();
+        assert!(matches!(
+            resolve_audit_finding_inner(&state, &id, "accept"),
+            Err(AppError::InvalidArg(_))
+        ));
+        assert_eq!(
+            std::fs::read_to_string(&md).unwrap(),
+            before,
+            "a refused accept writes nothing"
+        );
+        assert_eq!(
+            state.db.get_audit_finding(&id).unwrap().unwrap().status,
+            "pending",
+            "the row stays pending (the user dismisses or re-runs the audit)"
+        );
+        let _ = std::fs::remove_dir_all(&vault);
+    }
+
+    /// Lock review (defense in depth): the list also re-gates the TARGET side — a pending finding
+    /// whose target's folder sealed between pass and list is hidden (its title/evidence reference
+    /// the now-sealed content), while purge-on-seal remains the primary cleaner.
+    #[test]
+    fn audit_list_hides_pending_finding_whose_target_sealed() {
+        let state = build_state("audit-target-gate");
+        make_open_folder(&state.db, "f1", "Secret");
+        seed_meeting(&state.db, "m-t", "# target body\n", Some("f1"));
+        seed_meeting(&state.db, "m-src", "# open body\n", None);
+        stage_audit_finding_with_target(&state, "m-src", "m-t", "meeting", "k-target-gate");
+        stage_audit_finding(
+            &state, "orphan", "meeting", "m-src", None, "no links", "", "k-keep",
+        );
+
+        // Both list while the target folder is open.
+        assert_eq!(list_audit_findings_inner(&state, None).unwrap().len(), 2);
+
+        // Seal the TARGET's folder db-level only (simulating the pass→list race window the
+        // in-tx purge did not see because the row was staged in between).
+        state.db.set_folder_locked("f1", true, None).unwrap();
+        let listed = list_audit_findings_inner(&state, None).unwrap();
+        assert_eq!(listed.len(), 1, "sealed-target finding hidden: {listed:#?}");
+        assert_eq!(listed[0].id, {
+            let rows = state.db.list_audit_finding_rows("pending").unwrap();
+            rows.iter().find(|r| r.dedupe_key == "k-keep").unwrap().id.clone()
+        });
+    }
+
+    /// Phase-0 follow-up (a): every seal path that NULLs `exported_path` blanks the path-coupled
+    /// `exported_hash` in the SAME statement — a stale baseline surviving the seal would
+    /// mis-classify the fresh unlock re-export.
+    #[test]
+    fn seal_paths_blank_exported_hash_with_exported_path() {
+        let state = build_state("seal-hash-blank");
+        make_open_folder(&state.db, "f1", "Secret");
+        seed_meeting(&state.db, "m-a", "# body\n", Some("f1"));
+        state
+            .db
+            .set_note_exported_path("m-a", "claude_code", "/tmp/x.md")
+            .unwrap();
+        state
+            .db
+            .set_note_exported_hash("m-a", "claude_code", Some("abc"))
+            .unwrap();
+        state.db.seal_note("m-a", "claude_code", b"blob").unwrap();
+        assert_eq!(
+            state.db.get_note_exported_hash("m-a", "claude_code").unwrap(),
+            None,
+            "seal_note blanks the baseline with the path"
+        );
+
+        // Documents: clearing the path (the per-row seal cleanup) clears the baseline too.
+        state
+            .db
+            .insert_document("n1", "f1", "note-a", "body", "note", 1)
+            .unwrap();
+        state
+            .db
+            .set_note_doc_exported_path("n1", Some("/tmp/n1.md"))
+            .unwrap();
+        state.db.set_note_doc_exported_hash("n1", Some("def")).unwrap();
+        state.db.set_note_doc_exported_path("n1", None).unwrap();
+        assert_eq!(
+            state.db.get_note_doc_exported_hash("n1").unwrap(),
+            None,
+            "clearing the doc path clears the baseline"
+        );
+        // …and setting a path again does NOT resurrect a hash.
+        state
+            .db
+            .set_note_doc_exported_path("n1", Some("/tmp/n1b.md"))
+            .unwrap();
+        assert_eq!(state.db.get_note_doc_exported_hash("n1").unwrap(), None);
+
+        // The folder-wide seal clear blanks both.
+        state.db.set_note_doc_exported_hash("n1", Some("ghi")).unwrap();
+        state.db.clear_note_exported_paths_in_folder("f1").unwrap();
+        assert_eq!(state.db.get_note_doc_exported_hash("n1").unwrap(), None);
     }
 
     /// Deleting an OPEN folder moves its notes to the vault ROOT (folder_id = NULL), survives the

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -380,6 +380,31 @@ pub fn emit_content_deleted(app: &AppHandle, kind: &'static str, id: &str) {
     }
 }
 
+/// Emitted after a Vault-Audit pass completes and after each finding resolve (accept/dismiss) —
+/// a "something changed, re-fetch" ping for the FE audit inbox, exactly the
+/// [`EVENT_ORG_FEED_UPDATED`] shape. Carries the pending COUNT only — never a finding's content.
+pub const EVENT_AUDIT_UPDATED: &str = "murmur://audit-updated";
+
+/// Payload for [`EVENT_AUDIT_UPDATED`]. A single count only — NO PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditUpdatedPayload {
+    /// Pending findings after the pass/resolve.
+    pub pending: u32,
+}
+
+/// Emit [`EVENT_AUDIT_UPDATED`] to the FE (best-effort). Swallows the emit failure with a
+/// `tracing::warn!` so a failed emit can NEVER fail the audit pass or a resolve. NO PII (a count).
+pub fn emit_audit_updated(app: &AppHandle, pending: u32) {
+    if let Err(e) = app.emit(EVENT_AUDIT_UPDATED, AuditUpdatedPayload { pending }) {
+        tracing::warn!(
+            target: "audit",
+            error = %e,
+            "failed to emit audit-updated notice"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,6 +413,14 @@ mod tests {
     #[test]
     fn org_feed_updated_event_name_is_stable() {
         assert_eq!(EVENT_ORG_FEED_UPDATED, "murmur://org-feed-updated");
+    }
+
+    /// The FE listens on this exact event name; a rename silently drops the audit-inbox refresh.
+    #[test]
+    fn audit_updated_event_name_and_payload_are_stable() {
+        assert_eq!(EVENT_AUDIT_UPDATED, "murmur://audit-updated");
+        let json = serde_json::to_string(&AuditUpdatedPayload { pending: 4 }).unwrap();
+        assert_eq!(json, r#"{"pending":4}"#);
     }
 
     /// The FE listens on this exact event name; a rename silently drops the tab-strip fan-out.

--- a/src-tauri/src/export/obsidian.rs
+++ b/src-tauri/src/export/obsidian.rs
@@ -673,6 +673,12 @@ pub fn append_supersedes_callout(
 /// body without its date); `block` is the full multi-line callout to append. Append-only: the input
 /// markdown is never rewritten, only extended. Creates [`RETRUTH_SECTION`] once if absent.
 fn append_under_section(markdown: &str, marker: &str, block: &str) -> String {
+    append_under_named_section(markdown, RETRUTH_SECTION, marker, block)
+}
+
+/// The generalized core behind [`append_under_section`] (Re-Truth) and the Vault-Audit appends:
+/// idempotent on `marker`, append-only, creates `section` once if absent.
+fn append_under_named_section(markdown: &str, section: &str, marker: &str, block: &str) -> String {
     // Idempotent: the exact body line already present → nothing to do (applying twice is a no-op).
     if markdown.contains(marker) {
         return markdown.to_string();
@@ -681,12 +687,36 @@ fn append_under_section(markdown: &str, marker: &str, block: &str) -> String {
     if !out.ends_with('\n') {
         out.push('\n');
     }
-    if !out.contains(RETRUTH_SECTION) {
-        out.push_str(&format!("\n{RETRUTH_SECTION}\n"));
+    if !out.contains(section) {
+        out.push_str(&format!("\n{section}\n"));
     }
     out.push('\n');
     out.push_str(block);
     out
+}
+
+// ── Vault Audit: append-only findings stamps ────────────────────────────────
+
+/// The managed heading Vault-Audit stamps live under. Created once per note (idempotent) so
+/// repeated stamps stay contiguous and never duplicate the heading — the [`RETRUTH_SECTION`]
+/// convention, one section per feature.
+pub const AUDIT_SECTION: &str = "## Audit";
+
+/// APPEND an audit callout (`[!stale]` / `[!conflict]` / `[!broken-link]`) under the managed
+/// [`AUDIT_SECTION`]. Pure + APPEND-ONLY + idempotent on the callout BODY (everything but the
+/// date), exactly like [`append_supersession_callout`]. `body` must already be a quoted (`> `)
+/// callout body line.
+pub fn append_audit_callout(markdown: &str, date: &str, callout: &str, body: &str) -> String {
+    let block = format!("> [!{callout}] {date}\n{body}\n");
+    append_under_named_section(markdown, AUDIT_SECTION, body, &block)
+}
+
+/// APPEND a plain suggested-links line (the unlinked-mention / orphan accepts) under the managed
+/// [`AUDIT_SECTION`]. Pure, append-only, idempotent on the exact line. The CALLER is responsible
+/// for the anti-hallucination rule: every `[[link]]` in `line` must have been re-resolved against
+/// the live vault/session before this is written.
+pub fn append_audit_line(markdown: &str, line: &str) -> String {
+    append_under_named_section(markdown, AUDIT_SECTION, line, &format!("{line}\n"))
 }
 
 // ── Vault detection (from ~/Library/Application Support/obsidian/obsidian.json) ──

--- a/src-tauri/src/facts.rs
+++ b/src-tauri/src/facts.rs
@@ -90,8 +90,9 @@ pub enum FactOp {
 
 /// Normalize a subject/predicate/object for IDENTITY comparison: trim + full-Unicode lowercase
 /// (so "Status"/"status" and "Shipped"/"shipped" compare equal). The ORIGINAL casing is preserved
-/// in the stored row; this is only the dedup/supersession key.
-fn norm(s: &str) -> String {
+/// in the stored row; this is only the dedup/supersession key. `pub(crate)` so the Vault Audit's
+/// stale/contradiction passes key facts IDENTICALLY to this reconcile (`crate::audit`).
+pub(crate) fn norm(s: &str) -> String {
     s.trim().to_lowercase()
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod audio;
+pub mod audit;
 pub mod brain_reactions;
 pub mod brief_runner;
 pub mod calendar;
@@ -180,6 +181,10 @@ pub fn run() {
             commands::preview_supersessions,
             commands::apply_supersessions,
             commands::undo_supersessions,
+            // Vault Audit v1 — deterministic vault-health inbox (run + list + resolve).
+            commands::run_vault_audit,
+            commands::list_audit_findings,
+            commands::resolve_audit_finding,
             commands::get_config,
             commands::get_mcp_config,
             commands::save_config,

--- a/src-tauri/src/screenshare.rs
+++ b/src-tauri/src/screenshare.rs
@@ -193,6 +193,10 @@ fn on_capture_started(app: &AppHandle) {
             "failed to emit screen-share-started event"
         );
     }
+    // The auto-relock purged ALL pending audit findings — ping the FE inbox too (count-only,
+    // same posture as the share-started emit above; best-effort).
+    let pending = state.db.count_pending_audit_findings().unwrap_or(0);
+    crate::events::emit_audit_updated(app, pending as u32);
 }
 
 /// Pure heuristic decision: does an on-screen window (owner + title) look like a LIVE screen-share

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -679,6 +679,9 @@ impl Db {
         // table (see `crate::connectors::mcp`). Additive + guarded so migrate() stays idempotent.
         Self::migrate_briefs(&conn)?;
         Self::migrate_mcp_servers(&conn)?;
+        // Vault Audit v1 — deterministic vault-health findings + run bookkeeping (see
+        // `crate::audit`). Additive + guarded so migrate() stays idempotent.
+        Self::migrate_audit(&conn)?;
         // M6 Shared Brain — the local org state + the outbound org-share state machine (mirrors
         // `outbound_shares`). NOT the org_items/chunks ingest tables (a later slice owns those).
         // Additive + guarded so migrate() stays idempotent.
@@ -1421,6 +1424,53 @@ impl Db {
              CREATE INDEX IF NOT EXISTS idx_brief_runs_schedule ON brief_runs(schedule_id);",
         )
         .map_err(map_err)
+    }
+
+    /// Vault Audit v1 — idempotent audit schema (see `crate::audit`). `audit_findings` stages one
+    /// propose→accept finding per row; `evidence_md`/`accept_action`/BOTH TITLES are DERIVED
+    /// PLAINTEXT that only PENDING rows may hold (resolve blanks all four; every seal path purges
+    /// pending rows whose source or target seals — `purge_pending_audit_findings_tx`, the
+    /// brief-runs purge class). `dedupe_key` is the stable cross-run identity and OUTLIVES
+    /// resolve, so its variable part is HASHED (title-free — `crate::audit::dedupe_disc`): an
+    /// existing PENDING or DISMISSED twin suppresses re-creation (dismissed = don't nag again);
+    /// an ACCEPTED one may recur. Enforced in code (`insert_audit_finding_if_new`), not by a
+    /// UNIQUE constraint — accepted twins must be able to coexist with a recurring pending row.
+    /// `audit_runs` is content-free bookkeeping (id + timestamps + per-kind counts).
+    fn migrate_audit(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS audit_findings (
+               id TEXT PRIMARY KEY,
+               kind TEXT NOT NULL,
+               source_kind TEXT NOT NULL,
+               source_id TEXT NOT NULL,
+               source_title TEXT NOT NULL,
+               target_title TEXT,
+               target_id TEXT,
+               evidence_md TEXT NOT NULL,
+               accept_action TEXT NOT NULL DEFAULT '',
+               dedupe_key TEXT NOT NULL,
+               status TEXT NOT NULL DEFAULT 'pending',
+               run_id TEXT NOT NULL,
+               created_at INTEGER NOT NULL,
+               resolved_at INTEGER
+             );
+             CREATE INDEX IF NOT EXISTS idx_audit_findings_status ON audit_findings(status);
+             CREATE INDEX IF NOT EXISTS idx_audit_findings_dedupe ON audit_findings(dedupe_key);
+             CREATE INDEX IF NOT EXISTS idx_audit_findings_source ON audit_findings(source_id);
+             CREATE INDEX IF NOT EXISTS idx_audit_findings_target ON audit_findings(target_id);
+             CREATE TABLE IF NOT EXISTS audit_runs (
+               id TEXT PRIMARY KEY,
+               started_at INTEGER NOT NULL,
+               finished_at INTEGER,
+               counts_json TEXT NOT NULL DEFAULT '{}'
+             );",
+        )
+        .map_err(map_err)?;
+        // `target_kind` ("meeting" | "note") rides with `target_id` so the list layer can re-gate
+        // the TARGET side against the right table (lock review, same branch). Guarded for dev DBs
+        // that created the table before the column existed.
+        Self::add_column_if_missing(conn, "audit_findings", "target_kind", "TEXT")?;
+        Ok(())
     }
 
     /// Brain v2 L5 — idempotent MCP-SERVER config schema. One row per user-configured external MCP
@@ -3217,6 +3267,10 @@ impl Db {
         // tx — its `note_md` paraphrases the deleted meeting's note (accepted rows were consumed
         // on accept and keep only ids + timestamps).
         Self::purge_pending_brief_runs_tx(&tx, &[id.to_string()])?;
+        // Vault Audit: purge any PENDING finding whose source OR target is this meeting in the
+        // same tx — its `evidence_md` quotes the deleted meeting's note/title (resolved rows were
+        // blanked on resolve and carry no content).
+        Self::purge_pending_audit_findings_tx(&tx, &[id.to_string()])?;
         // Brain v2 L2.1: purge ALL memory rollups in this same tx — a rollup may paraphrase the
         // deleted meeting's (now-gone) facts; the survivors regenerate on the next hourly pass
         // from the remaining visible facts only. The caller deletes the exported `.md`s.
@@ -3882,6 +3936,11 @@ impl Db {
         // referencing a just-sealed meeting in this SAME seal tx (accepted rows were consumed on
         // accept and carry no content). Same purge-on-seal contract as the rollups below.
         Self::purge_pending_brief_runs_tx(&tx, meeting_ids)?;
+        // Vault Audit LOCK-SAFETY: purge ALL pending findings in this SAME seal tx — the
+        // memory-rollups posture (adversarial HIGH: evidence may cite THIRD-PARTY titles with no
+        // id to match, e.g. a stale finding's `see [[superseding note]]`; a seal anywhere
+        // invalidates the pass's visibility snapshot). Resolved rows were blanked on resolve.
+        Self::purge_all_pending_audit_findings_tx(&tx)?;
         // Brain v2 L2.1 LOCK-SAFETY: memory ROLLUPS are cross-meeting synthesis that may paraphrase
         // the just-sealed facts — purge ALL of them in this SAME seal tx (cheap, re-derivable: the
         // next hourly pass regenerates from the still-VISIBLE facts only). The caller deletes the
@@ -4859,6 +4918,9 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         Self::purge_doc_chunks_tx(&tx, &[id.to_string()])?;
+        // Vault Audit: a pending finding sourcing or targeting this document/note quotes its
+        // content/title — drop it in the same delete tx (mirrors `delete_meeting`'s purge).
+        Self::purge_pending_audit_findings_tx(&tx, &[id.to_string()])?;
         tx.execute("DELETE FROM documents WHERE id = ?1", rusqlite::params![id])
             .map_err(map_err)?;
         tx.commit().map_err(map_err)?;
@@ -5038,6 +5100,11 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         Self::purge_doc_chunks_tx(&tx, document_ids)?;
+        // Vault Audit LOCK-SAFETY: the callers are seal-side (`lock_folder`'s document leg, the
+        // relock reblank) — purge ALL pending findings in this SAME tx (rollup posture; evidence
+        // may cite third-party titles no document id can match). Findings are cheap re-derivable
+        // rows — the next pass re-stages anything still true (never content loss).
+        Self::purge_all_pending_audit_findings_tx(&tx)?;
         tx.commit().map_err(map_err)?;
         Ok(())
     }
@@ -5812,9 +5879,11 @@ impl Db {
         updated_at: i64,
     ) -> Result<()> {
         let conn = self.lock();
+        // `exported_hash` is NULLed with `exported_path` (path-coupled collision-guard baseline —
+        // a note sealed into the locked target has no on-disk export to compare against).
         conn.execute(
             "UPDATE documents SET folder_id = ?2, title = ?3, text = ?4, text_blob = ?5,
-                    updated_at = ?6, exported_path = NULL
+                    updated_at = ?6, exported_path = NULL, exported_hash = NULL
                WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id, folder_id, title, text, text_blob, updated_at],
         )
@@ -5824,11 +5893,18 @@ impl Db {
 
     /// Persist (or clear with `None`) an authored NOTE's exported vault `.md` path. Set on
     /// export/unlock re-export; cleared (NULL) when the folder seals and the vault file is deleted.
-    /// Named `_doc` to disambiguate from the MEETING-note [`Db::set_note_exported_path`].
+    /// Clearing the path ALSO clears the path-coupled `exported_hash` baseline in the same
+    /// statement (the export-collision guard has no file to compare once the `.md` is gone; the
+    /// next export re-stamps both fresh). Setting a path leaves the hash to the caller's explicit
+    /// stamp (`write_note_to_vault`). Named `_doc` to disambiguate from the MEETING-note
+    /// [`Db::set_note_exported_path`].
     pub fn set_note_doc_exported_path(&self, id: &str, path: Option<&str>) -> Result<()> {
         let conn = self.lock();
         conn.execute(
-            "UPDATE documents SET exported_path = ?2 WHERE id = ?1 AND kind = 'note'",
+            "UPDATE documents
+                SET exported_path = ?2,
+                    exported_hash = CASE WHEN ?2 IS NULL THEN NULL ELSE exported_hash END
+              WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id, path],
         )
         .map_err(map_err)?;
@@ -5912,12 +5988,13 @@ impl Db {
         Ok(out)
     }
 
-    /// NULL the `exported_path` of every authored NOTE in a folder (called on seal, after the vault
-    /// `.md` files are deleted — a sealed note has no on-disk export). Re-set on unlock re-export.
+    /// NULL the `exported_path` (+ its path-coupled `exported_hash` baseline) of every authored
+    /// NOTE in a folder (called on seal, after the vault `.md` files are deleted — a sealed note
+    /// has no on-disk export). Both re-set on unlock re-export.
     pub fn clear_note_exported_paths_in_folder(&self, folder_id: &str) -> Result<()> {
         let conn = self.lock();
         conn.execute(
-            "UPDATE documents SET exported_path = NULL
+            "UPDATE documents SET exported_path = NULL, exported_hash = NULL
                WHERE folder_id = ?1 AND kind = 'note'",
             rusqlite::params![folder_id],
         )
@@ -7321,10 +7398,11 @@ impl Db {
             }
         }
 
-        // Notes: blank plaintext + export path ONLY of rows that WERE sealed (blob present); a
-        // never-sealed row (blob NULL) keeps its readable plaintext. Then drop the unrecoverable blob.
+        // Notes: blank plaintext + export path (+ its collision-guard hash baseline, which is
+        // path-coupled) ONLY of rows that WERE sealed (blob present); a never-sealed row (blob
+        // NULL) keeps its readable plaintext. Then drop the unrecoverable blob.
         tx.execute(
-            "UPDATE notes SET markdown = '', exported_path = NULL WHERE folder_id = ?1 AND content_blob IS NOT NULL",
+            "UPDATE notes SET markdown = '', exported_path = NULL, exported_hash = NULL WHERE folder_id = ?1 AND content_blob IS NOT NULL",
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
@@ -7418,6 +7496,13 @@ impl Db {
         // (Deliberate, mirrors `memory_rollups`: PENDING `brief_runs` are NOT purged on discard —
         // discard returns every source meeting to OPEN plaintext, so a pending brief over now-open
         // content is not a leak. Every SEAL path purges them: `purge_pending_brief_runs_tx`.)
+
+        // Vault Audit (lock review + adversarial HIGH): pending findings ARE purged on discard,
+        // unlike brief runs — ALL of them (the rollup posture): a TOCTOU-orphaned row (staged in
+        // the pass↔seal race the epoch withdrawal narrows but cannot fully close) may CITE this
+        // folder's titles in its evidence with no matching id, so a scoped purge cannot cover it.
+        // Cheap re-derivable rows; the next pass re-stages anything still true.
+        Self::purge_all_pending_audit_findings_tx(&tx)?;
 
         // Documents anchored on this folder: drop sealed ciphertext + plaintext + their chunks/vectors.
         tx.execute(
@@ -7679,8 +7764,13 @@ impl Db {
         content_blob: &[u8],
     ) -> Result<()> {
         let conn = self.lock();
+        // Export-collision guard: the baseline `exported_hash` is blanked in the SAME seal
+        // UPDATE that clears `exported_path` — a sealed note has no on-disk export, and a stale
+        // baseline surviving the seal would mis-classify the fresh unlock re-export
+        // (`write_note_to_vault` / `remove_lock` re-stamp both columns fresh).
         conn.execute(
-            "UPDATE notes SET content_blob = ?3, markdown = '', exported_path = NULL
+            "UPDATE notes SET content_blob = ?3, markdown = '', exported_path = NULL,
+                    exported_hash = NULL
              WHERE meeting_id = ?1 AND provider_id = ?2",
             rusqlite::params![meeting_id, provider_id, content_blob],
         )
@@ -7816,6 +7906,11 @@ impl Db {
             // paraphrases the sealed notes (accepted rows were consumed on accept). Same
             // purge-on-seal contract as the rollups below.
             Self::purge_pending_brief_runs_tx(&tx, &meeting_ids)?;
+            // Vault Audit LOCK-SAFETY: purge ALL pending findings in this SAME relock tx — the
+            // memory-rollups posture (adversarial HIGH: evidence may cite third-party titles no
+            // meeting/document id can match; a relock invalidates the pass's visibility
+            // snapshot). Resolved rows were blanked on resolve and survive.
+            Self::purge_all_pending_audit_findings_tx(&tx)?;
 
             // Brain v2 L2.1 LOCK-SAFETY: purge ALL memory rollups in this SAME relock tx — a rollup
             // may paraphrase the just-re-sealed facts. Cheap re-derivable synthesis; regenerates
@@ -7991,6 +8086,25 @@ impl Db {
             [],
         )
         .map_err(map_err)?;
+        // Vault Audit LOCK-SAFETY: purge ALL pending audit findings in this same reconciliation
+        // transaction — the memory-rollups posture (adversarial HIGH: a finding staged while a
+        // since-sealed folder was visible may CITE its titles in evidence with no matching id,
+        // e.g. a stale finding's `see [[superseding note]]`; scoping the purge to the locked
+        // folders' ids cannot cover that). A crash-while-unlocked therefore leaves no finding
+        // plaintext at rest after a restart. GUARDED on any locked folder existing: this
+        // reconcile runs at EVERY launch, and with zero locked folders there is no seal whose
+        // snapshot a finding could violate — a lock-free vault keeps its inbox across restarts.
+        // Resolved rows were blanked on resolve and survive either way.
+        let any_locked: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM folders WHERE locked = 1)",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        if any_locked {
+            Self::purge_all_pending_audit_findings_tx(&tx)?;
+        }
         // brain2 realtime notes LOCK-SAFETY: re-blank the typed-notes plaintext of every meeting in a
         // locked folder ONLY WHERE its `manual_notes_blob` exists (the sealed copy is present) — so a
         // crash-while-unlocked (which restored the plaintext) cannot leave typed plaintext at rest
@@ -11193,6 +11307,349 @@ impl Db {
             .map_err(map_err)?;
         Ok(n)
     }
+
+    // ── Vault Audit v1 (see `crate::audit`) ─────────────────────────────────────────────────────
+
+    /// Stage one audit finding UNLESS a PENDING or DISMISSED twin (same `dedupe_key`) already
+    /// exists — pending = already surfaced, dismissed = the user said "don't nag again". An
+    /// ACCEPTED twin does NOT suppress (the evidence may legitimately recur later). Returns
+    /// whether a row was inserted.
+    pub fn insert_audit_finding_if_new(
+        &self,
+        f: &crate::audit::NewAuditFinding,
+        run_id: &str,
+        created_at: i64,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let suppressed: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM audit_findings
+                   WHERE dedupe_key = ?1 AND status IN ('pending', 'dismissed'))",
+                rusqlite::params![f.dedupe_key],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        if suppressed {
+            return Ok(false);
+        }
+        conn.execute(
+            "INSERT INTO audit_findings
+               (id, kind, source_kind, source_id, source_title, target_title, target_id,
+                target_kind, evidence_md, accept_action, dedupe_key, status, run_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12, ?13)",
+            rusqlite::params![
+                uuid::Uuid::new_v4().to_string(),
+                f.kind,
+                f.source_kind,
+                f.source_id,
+                f.source_title,
+                f.target_title,
+                f.target_id,
+                f.target_kind,
+                f.evidence_md,
+                f.accept_action,
+                f.dedupe_key,
+                run_id,
+                created_at,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(true)
+    }
+
+    /// All findings with `status`, newest first. RAW row read — the COMMAND layer defensively
+    /// re-filters each row's SOURCE visibility against the live session unlock set before
+    /// returning (belt-and-braces on top of purge-on-seal).
+    pub fn list_audit_finding_rows(
+        &self,
+        status: &str,
+    ) -> Result<Vec<crate::audit::AuditFindingRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, source_kind, source_id, source_title, target_title, target_id,
+                        target_kind, evidence_md, accept_action, dedupe_key, status, run_id,
+                        created_at, resolved_at
+                   FROM audit_findings WHERE status = ?1
+                  ORDER BY created_at DESC, id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![status], row_to_audit_finding)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// One finding by id (any status).
+    pub fn get_audit_finding(&self, id: &str) -> Result<Option<crate::audit::AuditFindingRow>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id, kind, source_kind, source_id, source_title, target_title, target_id,
+                    target_kind, evidence_md, accept_action, dedupe_key, status, run_id,
+                    created_at, resolved_at
+               FROM audit_findings WHERE id = ?1",
+            rusqlite::params![id],
+            row_to_audit_finding,
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Flip a finding to `accepted`/`dismissed` and BLANK the derived plaintext — `evidence_md`,
+    /// `accept_action` AND BOTH TITLES — in the SAME statement (the brief-runs consume-on-accept
+    /// posture). Titles are content material too (lock review, 2026-07-16): resolved rows survive
+    /// every purge (pending-only) and the list's source re-gate, so a resolved row keeping a
+    /// later-sealed target's title would serve it forever. Only PENDING rows carry ANY
+    /// title/evidence material at rest; ids/kind/timestamps are all a resolved row keeps.
+    pub fn resolve_audit_finding_row(
+        &self,
+        id: &str,
+        status: &str,
+        resolved_at: i64,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE audit_findings
+                SET status = ?2, resolved_at = ?3, evidence_md = '', accept_action = '',
+                    source_title = '', target_title = NULL
+              WHERE id = ?1",
+            rusqlite::params![id, status, resolved_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Delete every PENDING row a given audit run staged — the end-of-pass seal-epoch
+    /// reconciliation (see `crate::audit::run_audit_pass`): when the epoch is observed advanced
+    /// at pass end, the whole run's staged rows are withdrawn in ONE statement, turning the
+    /// residual insert-vs-seal-purge race into a no-op. Pending-only by construction (a
+    /// just-staged run's rows cannot be resolved yet; the filter is belt-and-braces).
+    pub fn delete_pending_audit_findings_for_run(&self, run_id: &str) -> Result<usize> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "DELETE FROM audit_findings WHERE run_id = ?1 AND status = 'pending'",
+                rusqlite::params![run_id],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
+
+    /// Count of pending findings (the summary/event payload — a count, never content).
+    pub fn count_pending_audit_findings(&self) -> Result<usize> {
+        let conn = self.lock();
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_findings WHERE status = 'pending'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(n as usize)
+    }
+
+    /// Record one audit run (content-free bookkeeping: id + timestamps + per-kind counts JSON).
+    pub fn insert_audit_run(
+        &self,
+        id: &str,
+        started_at: i64,
+        finished_at: i64,
+        counts_json: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO audit_runs (id, started_at, finished_at, counts_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![id, started_at, finished_at, counts_json],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Vault Audit DELETE-SAFETY: delete every PENDING `audit_findings` row whose SOURCE or
+    /// TARGET is any of `ids`, within an EXISTING transaction. This precise id-matched purge is
+    /// for the DELETE paths ONLY (`delete_meeting` / `delete_document`) — a delete invalidates
+    /// nothing else, so unrelated findings survive. SEAL paths use
+    /// [`Db::purge_all_pending_audit_findings_tx`] instead (a pending finding may cite
+    /// THIRD-PARTY titles no id can match). RESOLVED rows are left alone (blanked on resolve —
+    /// ids + kind only).
+    pub(crate) fn purge_pending_audit_findings_tx(
+        tx: &rusqlite::Transaction<'_>,
+        ids: &[String],
+    ) -> Result<()> {
+        for id in ids {
+            tx.execute(
+                "DELETE FROM audit_findings
+                  WHERE status = 'pending' AND (source_id = ?1 OR target_id = ?1)",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
+    /// Vault Audit LOCK-SAFETY (adversarial HIGH, 2026-07-16): on ANY lock-surface mutation
+    /// (seal, relock, startup reconcile, discard, move-into-locked), purge ALL pending findings —
+    /// the memory-rollups posture, not the per-id brief-runs one. A pending finding's
+    /// `evidence_md` may cite THIRD-PARTY titles (a stale finding's `see [[superseding note]]`,
+    /// an orphan's suggested `[[titles]]`) carried with `target_id = NULL`, which an id-matched
+    /// purge can never cover — and a seal anywhere invalidates the pass's whole visibility
+    /// snapshot. Findings are cheap re-derivable rows: the next manual run re-stages everything
+    /// still true over the post-seal corpus. RESOLVED rows survive (blanked on resolve).
+    pub(crate) fn purge_all_pending_audit_findings_tx(
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<()> {
+        tx.execute("DELETE FROM audit_findings WHERE status = 'pending'", [])
+            .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Standalone-transaction wrapper of [`Db::purge_all_pending_audit_findings_tx`] for the
+    /// lock-surface call sites with no open transaction of their own (the note move-into-locked
+    /// seal in `move_note_doc_inner`).
+    pub fn purge_all_pending_audit_findings(&self) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        Self::purge_all_pending_audit_findings_tx(&tx)?;
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// GATED: every OPEN fact whose source meeting is VISIBLE — the SAME meeting-visibility
+    /// predicate as [`Db::list_facts_visible`] (a NULL `meeting_id` is fail-closed via the INNER
+    /// JOIN). The audit's stale/contradiction substrate.
+    pub fn list_open_facts_visible(
+        &self,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<crate::facts::Fact>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT ft.id, ft.entity_id, ft.subject, ft.predicate, ft.object, ft.valid_from, \
+                    ft.valid_to, ft.recorded_at, ft.meeting_id, ft.confidence \
+               FROM facts ft \
+               JOIN meetings m ON m.id = ft.meeting_id \
+              WHERE ft.valid_to IS NULL \
+                AND ( \
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id) \
+                   OR EXISTS ( \
+                        SELECT 1 FROM notes n \
+                         LEFT JOIN folders f ON f.id = n.folder_id \
+                         WHERE n.meeting_id = m.id AND {visible} \
+                      ) \
+                    ) \
+              ORDER BY ft.valid_from ASC, ft.id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt.query_map([], row_to_fact).map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// GATED: ONE meeting's FULL fact rows (open + closed), visible-predicate-gated exactly like
+    /// [`Db::list_facts_visible`] — a sealed-and-not-session-unlocked meeting returns EMPTY
+    /// (its facts are also purged on seal; this gate is defense-in-depth). Distinct from the
+    /// rendered-strings reader [`Db::facts_for_meeting_visible`]: the audit's staleness math
+    /// needs the `valid_to` axis, not a display string.
+    pub fn fact_rows_for_meeting_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<crate::facts::Fact>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT ft.id, ft.entity_id, ft.subject, ft.predicate, ft.object, ft.valid_from, \
+                    ft.valid_to, ft.recorded_at, ft.meeting_id, ft.confidence \
+               FROM facts ft \
+               JOIN meetings m ON m.id = ft.meeting_id \
+              WHERE ft.meeting_id = ?1 \
+                AND ( \
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id) \
+                   OR EXISTS ( \
+                        SELECT 1 FROM notes n \
+                         LEFT JOIN folders f ON f.id = n.folder_id \
+                         WHERE n.meeting_id = m.id AND {visible} \
+                      ) \
+                    ) \
+              ORDER BY ft.valid_from ASC, ft.id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], row_to_fact)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// The DISTINCT entity ids mentioned by ONE meeting (the orphan pass's Jaccard substrate).
+    /// Non-content metadata (opaque ids); the caller only ever passes ids already gated into its
+    /// visible corpus. Crate-internal on purpose — not a general read surface.
+    pub(crate) fn entity_ids_for_meeting(&self, meeting_id: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT entity_id FROM entity_mentions
+                   WHERE meeting_id = ?1 ORDER BY entity_id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Is the SAME conflict pair already staged for Re-Truth review? True when a PENDING
+    /// (`applied_at IS NULL`) supersession row carries the same normalized predicate and the same
+    /// two meetings (either orientation) — the audit's contradiction pass then skips the pair
+    /// (one review surface per conflict).
+    pub fn pending_supersession_for_pair(
+        &self,
+        norm_predicate: &str,
+        meeting_a: &str,
+        meeting_b: &str,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM supersessions
+               WHERE applied_at IS NULL
+                 AND lower(trim(predicate)) = ?1
+                 AND ((source_meeting_id = ?2 AND superseding_meeting_id = ?3)
+                   OR (source_meeting_id = ?3 AND superseding_meeting_id = ?2)))",
+            rusqlite::params![norm_predicate, meeting_a, meeting_b],
+            |r| r.get(0),
+        )
+        .map_err(map_err)
+    }
+
+    /// Whether ONE authored note is VISIBLE (open or session-unlocked folder) — the lightweight
+    /// existence twin of [`Db::note_markdown_if_visible`], used by the audit list's defensive
+    /// re-filter. Fail-closed on an unknown id.
+    pub fn note_is_visible(&self, note_id: &str, unlocked: &HashSet<String>) -> Result<bool> {
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT EXISTS(SELECT 1 FROM documents d
+               JOIN folders f ON f.id = d.folder_id
+              WHERE d.id = ?1 AND d.kind = 'note' AND {visible})"
+        );
+        conn.query_row(&sql, rusqlite::params![note_id], |r| r.get(0))
+            .map_err(map_err)
+    }
 }
 
 /// Collision-proof unique temp path for file-backed tests.
@@ -11636,6 +12093,28 @@ fn row_to_meeting(row: &Row<'_>) -> rusqlite::Result<Result<Meeting>> {
 }
 
 /// Map a `facts` row (column order matches every facts SELECT) to a [`crate::facts::Fact`].
+/// Map one `audit_findings` row (the full column order of `list_audit_finding_rows` /
+/// `get_audit_finding`) to its DB-shaped struct.
+fn row_to_audit_finding(row: &Row<'_>) -> rusqlite::Result<crate::audit::AuditFindingRow> {
+    Ok(crate::audit::AuditFindingRow {
+        id: row.get(0)?,
+        kind: row.get(1)?,
+        source_kind: row.get(2)?,
+        source_id: row.get(3)?,
+        source_title: row.get(4)?,
+        target_title: row.get(5)?,
+        target_id: row.get(6)?,
+        target_kind: row.get(7)?,
+        evidence_md: row.get(8)?,
+        accept_action: row.get(9)?,
+        dedupe_key: row.get(10)?,
+        status: row.get(11)?,
+        run_id: row.get(12)?,
+        created_at: row.get(13)?,
+        resolved_at: row.get(14)?,
+    })
+}
+
 fn row_to_fact(row: &Row<'_>) -> rusqlite::Result<crate::facts::Fact> {
     Ok(crate::facts::Fact {
         id: row.get(0)?,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -71,6 +71,8 @@ import type {
   BriefSchedule,
   BriefRun,
   BriefProposedPayload,
+  AuditFinding,
+  AuditRunSummary,
   VerifyFindingDto,
   ProviderStatus,
   SavedRecipe,
@@ -144,6 +146,9 @@ export const EVENT_STORAGE_PRUNED = "murmur://storage-pruned";
 export const EVENT_RECORDING_CAPPED = "murmur://recording-capped";
 // Brain v2 L5 — a scheduled brief was STAGED (propose-accept; run id + label + size only).
 export const EVENT_BRIEF_PROPOSED = "murmur://brief-proposed";
+// Vault Audit — the audit state changed (a run finished / findings purged by a seal or delete).
+// Payload shape is deliberately untrusted — listeners refetch via list_audit_findings.
+export const EVENT_AUDIT_UPDATED = "murmur://audit-updated";
 // Shared Brain — the background org-sync loop INGESTED/TOMBSTONED ≥1 org item this tick
 // (content-free "something changed, re-fetch" ping; drives the Notes org picker live refresh).
 export const EVENT_ORG_FEED_UPDATED = "murmur://org-feed-updated";
@@ -1296,6 +1301,43 @@ export class IpcService {
     return listen<BriefProposedPayload>(EVENT_BRIEF_PROPOSED, (e) =>
       cb(e.payload),
     );
+  }
+
+  // ── Vault Audit — deterministic hygiene passes (propose-accept inbox) ────
+
+  /**
+   * Run a full audit pass NOW (broken links / orphans / stale / contradictions
+   * / unlinked mentions) and resolve with the run's summary. Findings are only
+   * STAGED for review — nothing in the vault changes until one is accepted.
+   */
+  runVaultAudit(): Promise<AuditRunSummary> {
+    return invoke<AuditRunSummary>("run_vault_audit");
+  }
+
+  /** Audit findings by status — defaults to the PENDING inbox rows. */
+  listAuditFindings(status = "pending"): Promise<AuditFinding[]> {
+    return invoke<AuditFinding[]>("list_audit_findings", { status });
+  }
+
+  /**
+   * Accept (apply its `acceptAction`) or dismiss ONE finding. Resolves with the
+   * updated row — the FE swaps the row in only AFTER this confirms; a rejection
+   * leaves it pending (no optimistic success UI).
+   */
+  resolveAuditFinding(
+    id: string,
+    action: "accept" | "dismiss",
+  ): Promise<AuditFinding> {
+    return invoke<AuditFinding>("resolve_audit_finding", { id, action });
+  }
+
+  /**
+   * The audit state changed (a run finished / findings were purged by a seal
+   * or a delete). The payload shape is deliberately NOT trusted — refetch via
+   * {@link listAuditFindings} instead of reading it.
+   */
+  onAuditUpdated(cb: () => void): Promise<UnlistenFn> {
+    return listen(EVENT_AUDIT_UPDATED, () => cb());
   }
 
   // ── brain2 documents — expand the brain with imported .md/.txt files ────

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1126,6 +1126,49 @@ export interface BriefProposedPayload {
   charCount: number;
 }
 
+/** Vault Audit — the deterministic hygiene-pass kinds. */
+export type AuditFindingKind =
+  | "broken_link"
+  | "orphan"
+  | "stale"
+  | "contradiction"
+  | "unlinked_mention";
+
+/**
+ * Vault Audit — one run's summary (`run_vault_audit` / the audit-updated
+ * event). `counts` maps a finding kind → how many PENDING findings of that
+ * kind exist after the run. Timestamps are epoch numbers.
+ */
+export interface AuditRunSummary {
+  runId: string;
+  startedAt: number;
+  finishedAt: number;
+  findingsNew: number;
+  findingsTotalPending: number;
+  counts: Record<string, number>;
+}
+
+/**
+ * Vault Audit — one STAGED finding (`audit_findings`, propose-accept).
+ * `evidenceMd` is a short markdown snippet built backend-side from
+ * VISIBLE-only content; `acceptAction` is the human description of what
+ * Accept will do — "" means the finding is dismiss-only. Timestamps are
+ * epoch numbers.
+ */
+export interface AuditFinding {
+  id: string;
+  kind: AuditFindingKind;
+  sourceKind: "meeting" | "note";
+  sourceId: string;
+  sourceTitle: string;
+  targetTitle?: string | null;
+  evidenceMd: string;
+  acceptAction: string;
+  status: "pending" | "accepted" | "dismissed";
+  createdAt: number;
+  resolvedAt?: number | null;
+}
+
 /**
  * Phase D — progress for the on-device PERSON-name NER model (mDeBERTa-v3)
  * download (`EVENT_NER_DOWNLOAD`). Mirrors the backend `NerDownloadPayload`: the

--- a/src/app/features/audit/audit.store.ts
+++ b/src/app/features/audit/audit.store.ts
@@ -1,0 +1,144 @@
+import {
+  DestroyRef,
+  Injectable,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../core/ipc.service";
+import type {
+  AuditFinding,
+  AuditFindingKind,
+  AuditRunSummary,
+} from "../../core/models";
+
+/** Stable render order for the grouped inbox — most consequential kinds first. */
+export const AUDIT_KIND_ORDER: readonly AuditFindingKind[] = [
+  "contradiction",
+  "stale",
+  "broken_link",
+  "unlinked_mention",
+  "orphan",
+];
+
+/** One rendered inbox section: a kind plus its pending findings. */
+export interface AuditKindGroup {
+  kind: AuditFindingKind;
+  findings: AuditFinding[];
+}
+
+/**
+ * Vault Audit — the FINDINGS-INBOX store (propose-accept), signals-first.
+ * Root-provided so the pending rows survive the inbox component's
+ * destroy+recreate (stale-while-revalidate, angular-zoneless §8).
+ *
+ * `init()` is idempotent: the first caller subscribes ONCE to the backend's
+ * `EVENT_AUDIT_UPDATED` stream (a run finished, or findings were purged by a
+ * seal/delete) and refreshes on every event — the payload shape is deliberately
+ * NOT trusted, the store always re-fetches via `listAuditFindings()`. The
+ * `UnlistenFn` is released on destroy (the root injector's teardown).
+ *
+ * Resolving a finding is NEVER optimistic: the row only changes after the
+ * backend confirms; a rejection propagates to the caller (which toasts) and
+ * the row stays pending.
+ */
+@Injectable({ providedIn: "root" })
+export class AuditStore {
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _findings = signal<AuditFinding[]>([]);
+  readonly findings = this._findings.asReadonly();
+
+  private readonly _loading = signal(true);
+  readonly loading = this._loading.asReadonly();
+
+  private readonly _running = signal(false);
+  readonly running = this._running.asReadonly();
+
+  private readonly _lastRun = signal<AuditRunSummary | null>(null);
+  readonly lastRun = this._lastRun.asReadonly();
+
+  private readonly _error = signal<string | null>(null);
+  readonly error = this._error.asReadonly();
+
+  readonly pendingCount = computed(
+    () => this._findings().filter((f) => f.status === "pending").length,
+  );
+
+  /** Pending findings grouped by kind in {@link AUDIT_KIND_ORDER}; empty kinds dropped. */
+  readonly byKind = computed<AuditKindGroup[]>(() => {
+    const pending = this._findings().filter((f) => f.status === "pending");
+    return AUDIT_KIND_ORDER.map((kind) => ({
+      kind,
+      findings: pending.filter((f) => f.kind === kind),
+    })).filter((g) => g.findings.length > 0);
+  });
+
+  private initialized = false;
+  private unlisten: UnlistenFn | null = null;
+
+  /** Subscribe to the audit-updated stream ONCE + load the inbox. Idempotent. */
+  init(): void {
+    if (this.initialized) {
+      void this.load();
+      return;
+    }
+    this.initialized = true;
+    void this.ipc
+      .onAuditUpdated(() => void this.load())
+      .then((un) => (this.unlisten = un));
+    this.destroyRef.onDestroy(() => {
+      this.unlisten?.();
+      this.unlisten = null;
+    });
+    void this.load();
+  }
+
+  /** Reload the pending findings. Cached rows stay visible while in flight. */
+  async load(): Promise<void> {
+    try {
+      const findings = await this.ipc.listAuditFindings();
+      this._findings.set(findings);
+      this._error.set(null);
+    } catch (e) {
+      this._error.set(String(e));
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Run a full audit pass now, then refresh the inbox. Resolves with the run
+   * summary; a rejection propagates to the caller (toast there).
+   */
+  async runNow(): Promise<AuditRunSummary> {
+    this._running.set(true);
+    try {
+      const summary = await this.ipc.runVaultAudit();
+      this._lastRun.set(summary);
+      await this.load();
+      return summary;
+    } finally {
+      this._running.set(false);
+    }
+  }
+
+  /**
+   * Accept or dismiss one finding — confirm-then-update, never optimistic:
+   * the resolved row from the RESPONSE replaces the pending one (dropping it
+   * from the pending groups); on rejection nothing changes and the error
+   * propagates so the caller can toast.
+   */
+  async resolve(
+    id: string,
+    action: "accept" | "dismiss",
+  ): Promise<AuditFinding> {
+    const resolved = await this.ipc.resolveAuditFinding(id, action);
+    this._findings.update((rows) =>
+      rows.map((f) => (f.id === id ? resolved : f)),
+    );
+    return resolved;
+  }
+}

--- a/src/app/features/audit/audit/audit.component.html
+++ b/src/app/features/audit/audit/audit.component.html
@@ -1,0 +1,141 @@
+<section class="au">
+  <div class="au-head">
+    <button
+      type="button"
+      class="au-toggle"
+      [attr.aria-expanded]="open()"
+      (click)="open.set(!open())"
+    >
+      <svg
+        class="au-chevron"
+        [class.is-open]="open()"
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M5.5 4l5 4-5 4"
+          stroke="currentColor"
+          stroke-width="1.7"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="au-title">Vault audit</span>
+      @if (store.pendingCount() > 0) {
+        <span class="count au-count">{{ store.pendingCount() }}</span>
+      }
+      <span class="au-sub">
+        Broken links, stale notes and contradictions — found for your review.
+      </span>
+    </button>
+    <button
+      type="button"
+      class="btn btn-ghost au-run"
+      (click)="runNow()"
+      [disabled]="store.running()"
+    >
+      @if (store.running()) {
+        <mur-spinner [size]="14" />
+        <span>Auditing…</span>
+      } @else {
+        <span>Audit now</span>
+      }
+    </button>
+  </div>
+
+  @if (open()) {
+    @if (summaryLine(); as line) {
+      <p class="au-summary text-secondary">{{ line }}</p>
+    }
+
+    @if (listEmpty() && store.loading()) {
+      <div class="card state-card">
+        <p class="empty">Loading audit findings…</p>
+      </div>
+    } @else if (store.error()) {
+      <div class="card empty-state">
+        <span class="empty-mark" aria-hidden="true"></span>
+        <p class="empty-title">Couldn’t load the audit inbox</p>
+        <p class="empty">{{ store.error() }}</p>
+      </div>
+    } @else if (listEmpty()) {
+      <div class="card empty-state">
+        <span class="empty-mark" aria-hidden="true"></span>
+        <p class="empty-title">Nothing pending — run your first audit</p>
+        <p class="empty">
+          Murmur scans your vault for broken [[wikilinks]], orphaned notes,
+          stale content, contradictions and unlinked mentions. Every finding
+          waits here for your review — nothing changes until you accept it.
+        </p>
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="runNow()"
+          [disabled]="store.running()"
+        >
+          {{ store.running() ? "Auditing…" : "Run your first audit" }}
+        </button>
+      </div>
+    } @else {
+      @for (group of store.byKind(); track group.kind) {
+        <div class="card au-group">
+          <header class="au-group-head">
+            <h3 class="au-group-title">{{ kindMeta[group.kind].label }}</h3>
+            <span class="count">{{ group.findings.length }}</span>
+            <span class="au-group-explain text-secondary">
+              {{ kindMeta[group.kind].explain }}
+            </span>
+          </header>
+          <ul class="au-list">
+            @for (f of group.findings; track f.id) {
+              <li class="au-item">
+                <div class="au-item-head">
+                  <span class="pill au-chip">{{ kindMeta[f.kind].chip }}</span>
+                  <span class="au-item-source">{{ f.sourceTitle }}</span>
+                  @if (f.targetTitle) {
+                    <span class="au-item-arrow" aria-hidden="true">→</span>
+                    <span class="au-item-target">{{ f.targetTitle }}</span>
+                  }
+                </div>
+                <app-markdown
+                  class="au-evidence"
+                  [markdown]="f.evidenceMd"
+                  compact
+                />
+                <div class="au-item-actions">
+                  @if (f.acceptAction) {
+                    <span class="au-accept-hint text-secondary">
+                      {{ f.acceptAction }}
+                    </span>
+                  }
+                  <button
+                    type="button"
+                    class="btn btn-ghost"
+                    (click)="dismiss(f)"
+                    [disabled]="busyId() === f.id"
+                  >
+                    Dismiss
+                  </button>
+                  @if (f.acceptAction) {
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      [title]="f.acceptAction"
+                      (click)="accept(f)"
+                      [disabled]="busyId() === f.id"
+                    >
+                      {{ busyId() === f.id ? "Applying…" : "Accept" }}
+                    </button>
+                  }
+                </div>
+              </li>
+            }
+          </ul>
+        </div>
+      }
+    }
+  }
+</section>

--- a/src/app/features/audit/audit/audit.component.scss
+++ b/src/app/features/audit/audit/audit.component.scss
@@ -1,0 +1,154 @@
+:host {
+  display: block;
+}
+.au {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Header row: the collapsible toggle + the "Audit now" trigger beside it
+   (a sibling, not nested — a button can't live inside a button). */
+.au-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Collapsible header — mirrors the briefs / memory / Connections sections. */
+.au-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-2) 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.au-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+  border-radius: var(--radius-sm);
+}
+.au-chevron {
+  flex: none;
+  color: var(--text-muted);
+  transition: transform var(--transition);
+}
+.au-chevron.is-open {
+  transform: rotate(90deg);
+}
+.au-title {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.au-count {
+  flex: none;
+}
+.au-sub {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-left: var(--space-2);
+}
+@media (max-width: 560px) {
+  .au-sub {
+    display: none;
+  }
+}
+.au-run {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* The "N new findings · M pending" line after a manual run. */
+.au-summary {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+/* One kind group. */
+.au-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.au-group-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.au-group-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+.au-group-explain {
+  font-size: 0.82rem;
+  margin-left: var(--space-1);
+}
+
+/* Finding rows. */
+.au-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.au-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
+}
+.au-item-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.au-chip {
+  flex: none;
+}
+.au-item-source,
+.au-item-target {
+  font-size: 0.925rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.au-item-arrow {
+  flex: none;
+  color: var(--text-muted);
+}
+.au-evidence {
+  font-size: 0.9rem;
+}
+.au-item-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+.au-accept-hint {
+  font-size: 0.82rem;
+  margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/app/features/audit/audit/audit.component.ts
+++ b/src/app/features/audit/audit/audit.component.ts
@@ -1,0 +1,131 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import type { AuditFinding, AuditFindingKind } from "../../../core/models";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import { ToastService } from "../../../services/toast.service";
+import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { AuditStore } from "../audit.store";
+
+/** Per-kind copy: the section heading, its one-line explanation, and the row chip. */
+const KIND_META: Record<
+  AuditFindingKind,
+  { label: string; chip: string; explain: string }
+> = {
+  contradiction: {
+    label: "Contradictions",
+    chip: "Contradiction",
+    explain: "Two places in your vault say conflicting things.",
+  },
+  stale: {
+    label: "Stale notes",
+    chip: "Stale",
+    explain: "Content that newer meetings or notes have likely overtaken.",
+  },
+  broken_link: {
+    label: "Broken links",
+    chip: "Broken link",
+    explain: "[[Wikilinks]] that point at a note that doesn't exist.",
+  },
+  unlinked_mention: {
+    label: "Unlinked mentions",
+    chip: "Unlinked mention",
+    explain: "A known title mentioned in text without a [[link]].",
+  },
+  orphan: {
+    label: "Orphans",
+    chip: "Orphan",
+    explain: "Notes nothing links to — disconnected from the rest of the vault.",
+  },
+};
+
+/**
+ * VAULT AUDIT — a collapsible Brain-page section (mirrors the scheduled-briefs
+ * section): an "Audit now" trigger plus the propose-accept FINDINGS INBOX,
+ * grouped by kind. Every finding is review-then-apply: Accept (only offered
+ * when the backend staged an `acceptAction`) applies that action; Dismiss
+ * discards. Neither is optimistic — the row leaves the inbox only after the
+ * backend confirms ({@link AuditStore.resolve}); failures toast and the row
+ * stays pending.
+ *
+ * Signals-first + OnPush; all state lives in {@link AuditStore} (root-provided,
+ * so cached rows survive remounts — loading never hides them, §8). Evidence
+ * snippets render through the shared `app-markdown` (sanitized, wikilink chips
+ * clickable) — the same renderer chat/recipes/notes use.
+ */
+@Component({
+  selector: "app-audit",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MarkdownComponent, MurSpinnerComponent],
+  templateUrl: "./audit.component.html",
+  styleUrl: "./audit.component.scss",
+})
+export class AuditComponent {
+  protected readonly store = inject(AuditStore);
+  private readonly toast = inject(ToastService);
+
+  /** The user's manual collapse/expand toggle (auto-opens on "Audit now"). */
+  readonly open = signal(false);
+
+  /** The finding id with a resolve in flight (disables just that row's buttons). */
+  readonly busyId = signal<string | null>(null);
+
+  readonly listEmpty = computed(() => this.store.pendingCount() === 0);
+
+  /** "N new findings · M pending" — shown once a manual run completed. */
+  readonly summaryLine = computed(() => {
+    const s = this.store.lastRun();
+    if (!s) {
+      return null;
+    }
+    const noun = s.findingsNew === 1 ? "new finding" : "new findings";
+    return `${s.findingsNew} ${noun} · ${s.findingsTotalPending} pending`;
+  });
+
+  protected readonly kindMeta = KIND_META;
+
+  constructor() {
+    this.store.init();
+  }
+
+  async runNow(): Promise<void> {
+    if (this.store.running()) {
+      return;
+    }
+    this.open.set(true);
+    try {
+      await this.store.runNow();
+    } catch (e) {
+      this.toast.danger(String(e));
+    }
+  }
+
+  async accept(f: AuditFinding): Promise<void> {
+    if (!f.acceptAction) {
+      return;
+    }
+    this.busyId.set(f.id);
+    try {
+      await this.store.resolve(f.id, "accept");
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+
+  async dismiss(f: AuditFinding): Promise<void> {
+    this.busyId.set(f.id);
+    try {
+      await this.store.resolve(f.id, "dismiss");
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+}

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -249,6 +249,9 @@
   <!-- 5 — SCHEDULED BRIEFS: propose-accept recurring digests (Brain v2 L5) -->
   <app-briefs />
 
+  <!-- 6 — VAULT AUDIT: on-demand hygiene findings inbox (review-then-apply) -->
+  <app-audit />
+
   @if (noteEditorOpen()) {
     <app-brain-note-editor
       [saving]="savingNote()"

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -23,6 +23,7 @@ import { BrainMemoryComponent } from "../brain-memory/brain-memory.component";
 import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor.component";
 import { BrainSourceCardComponent } from "../brain-source-card/brain-source-card.component";
 import { BriefsComponent } from "../../briefs/briefs/briefs.component";
+import { AuditComponent } from "../../audit/audit/audit.component";
 
 /** The hard cap the map applies — kept in sync with BrainMapComponent's MAX_NODES. */
 const MAP_NODE_CAP = 60;
@@ -81,6 +82,7 @@ interface FolderOption {
     BrainMapComponent,
     BrainMemoryComponent,
     BriefsComponent,
+    AuditComponent,
   ],
   templateUrl: "./brain.component.html",
   styleUrl: "./brain.component.scss",


### PR DESCRIPTION
## What

The audit leg of the vault-agent program (research: `docs/research/2026-07-16-obsidian-claude-code-vault-agent.md`): **"your vault reads itself" — zero tokens, zero egress, never deletes.**

- **5 deterministic passes** over ONLY-visible content (EMPTY unlock set, the `brief_runner`/`memory.rs` posture): broken `[[links]]` (vault-stem + gated resolver union), orphan notes (+ up to 3 deterministic reconnection suggestions), unlinked mentions (word-boundary, fence- and code-span-aware), stale notes (`superseded-facts ratio` over the bitemporal store — explainable staleness with a citation), open-fact contradictions (same entity+predicate, different object, different sources; Re-Truth queue excluded).
- **Propose→accept inbox** on the Brain page (briefs idiom): accept = append-only `## Audit` callouts/suggested links (idempotent, Re-Truth machinery, collision-guard-aware hash refresh); dismiss never writes; **nothing is ever auto-deleted**.
- **Lock model**: only PENDING rows hold title/evidence material; resolve blanks titles+evidence in one UPDATE; dedupe keys are hashed (title-free); list re-gates source AND target (typed `target_kind`); **purge-ALL pending findings inside every seal/relock/startup/discard/move-into-locked tx** (deletes keep the precise purge); seal-epoch pincer (entry-bump purge-all + end-of-pass run-id withdrawal); `murmur://audit-updated` (count-only) emitted from every lock surface incl. screen-share auto-relock so the inbox is lock-reactive.
- Folds in the Phase-0 (#348) lock-review follow-ups: `exported_hash` blanked wherever seal NULLs `exported_path`; `lifecycle_guard` in `apply/undo_supersessions_inner`; lock-time external-edit-sibling warn (counts only); doc-side conditional hash refresh.

## How verified (the implementer did not self-certify)

- **adversarial-verifier**: round 1 **FAIL** — 1 HIGH (third-party sealed-title retention in stale/orphan evidence beyond id-matched purge + source-only re-gate), 1 MEDIUM (inbox not lock-reactive), 1 LOW (inline code spans) → fixes → re-verify **PASS** with the demanded RED observed (`sealing_third_party_folder_purges_findings_citing_it` fails by construction on the old purge SQL). Gates observed: `cargo test --lib` 1704 passed / 10 ignored / 1 pre-existing machine-conditional failure (`settings::ai_map`, fails in isolation, settings untouched); `ng lint` + `ng build` clean; Playwright **83/83** + a live failure-path probe (Locked rejection → toast, row stays pending, no console errors).
- **lock-security-reviewer**: round 1 **FAIL** — 1 blocking LEAK (title material on resolved rows served past seal) → fixes → **PASS**: leak closed at 3 layers, purge-ALL verified on every lock surface, startup EXISTS-guard adjudicated *safe by construction*, epoch TOCTOU closed by pincer, events counts-only.
- 30 audit tests, every leak fix RED-first.

## Known trades (deliberate)

- Any seal/relock (incl. screen-share auto-relock) empties the whole pending inbox — privacy over convenience; findings are cheaply re-derivable by re-running the audit.
- Signed-Mac-only residuals: Touch ID unlock→accept interplay, live screen-share auto-relock → inbox refresh observed end-to-end.