### PR TITLE
feat(notes): minimalist find-related / link-picker

### DIFF
--- a/e2e/notes/brain-popover.spec.ts
+++ b/e2e/notes/brain-popover.spec.ts
@@ -157,9 +157,9 @@ test("Find related: an org-kind citation routes to the read-only /org-item viewe
   await expect(popover).toBeVisible();
   await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
 
-  await expect(popover.getByText("2 related sources in your brain.")).toBeVisible();
-  // Fix 3 (2026-07-15): `find_related` rows are now ACTIONABLE — "Insert link" (primary)
-  // + "Open" (secondary), replacing the old single passive `.pop-cite` chip.
+  // Minimalist reshape (2026-07-16): the count lead-line is gone — the rows ARE the
+  // result. Each row's primary action inserts a link (accessible name "Insert link
+  // to <title>"); "Open" stays as the quiet secondary action.
   const orgRow = popover.locator(".pop-cite-row", { hasText: "Anna's launchcode notes" });
   await expect(orgRow).toBeVisible();
   await expect(orgRow.locator(".pop-cite-kind")).toHaveText("org");
@@ -230,12 +230,13 @@ test("Find related: Insert link drops a [[Title]] wikilink into the body instead
   const popover = page.locator("app-note-brain-popover");
   await expect(popover).toBeVisible();
   await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
-  await expect(popover.getByText("1 related source in your brain.")).toBeVisible();
 
+  // Minimalist reshape (2026-07-16): no count lead-line — wait on the row itself.
   const row = popover.locator(".pop-cite-row", { hasText: "Weekly plan" });
   await expect(row).toBeVisible();
-  // Both actions are present — Insert link (primary) AND Open (secondary), never
-  // removing the existing capability.
+  // Both actions are present — Insert link (the row's primary action, accessible
+  // name "Insert link to Weekly plan") AND Open (secondary), never removing the
+  // existing capability.
   await expect(row.getByRole("button", { name: "Insert link" })).toBeVisible();
   await expect(row.getByRole("button", { name: "Open" })).toBeVisible();
 

--- a/src/app/features/notes/link-picker/link-picker.component.html
+++ b/src/app/features/notes/link-picker/link-picker.component.html
@@ -13,6 +13,8 @@
   aria-label="Link to note"
 >
   @if (candidates().length > 0) {
+    <!-- Minimalist rows (2026-07-16): title leads, the kind is a quiet trailing
+         hint — no leading uppercase badge competing with the title. -->
     @for (c of candidates(); track c.kind + c.id; let i = $index) {
       <button
         type="button"
@@ -22,8 +24,8 @@
         [attr.aria-selected]="i === activeIndex()"
         (click)="pick(c)"
       >
-        <span class="link-pop-kind">{{ c.kind }}</span>
         <span class="link-pop-title">{{ c.title }}</span>
+        <span class="link-pop-kind">{{ c.kind }}</span>
       </button>
     }
   } @else if (loading()) {

--- a/src/app/features/notes/link-picker/link-picker.component.scss
+++ b/src/app/features/notes/link-picker/link-picker.component.scss
@@ -29,32 +29,34 @@
   backdrop-filter: none;
 }
 
+/* Minimalist rows (2026-07-16): flat single-line rows, tight --space-1/2 padding,
+   no per-row border/card. Hover is NEUTRAL; the keyboard selection uses the native
+   flat accent fill (the house quick-search pattern). */
 .link-pop-row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   width: 100%;
-  padding: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border: 0;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-primary);
   font: inherit;
   font-size: 0.8125rem;
   text-align: left;
   cursor: pointer;
+  transition: background var(--transition-fast);
 }
-.link-pop-row:hover,
-.link-pop-row.is-active {
+.link-pop-row:hover {
   background: var(--surface-hover);
 }
-.link-pop-kind {
-  flex: none;
-  font-size: 0.63rem;
-  font-weight: 660;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+.link-pop-row.is-active {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.link-pop-row.is-active .link-pop-kind {
+  color: var(--text-on-accent);
 }
 .link-pop-title {
   flex: 1;
@@ -63,10 +65,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* The kind ("note"/"meeting"/"org") is a quiet trailing hint, not a badge. */
+.link-pop-kind {
+  flex: none;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
 .link-pop-empty {
   margin: 0;
-  padding: var(--space-3) var(--space-2);
+  padding: var(--space-1) var(--space-2);
   color: var(--text-muted);
-  font-size: 0.8125rem;
-  text-align: center;
+  font-size: 0.78rem;
 }

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
@@ -315,54 +315,42 @@
               </div>
             }
 
-            <!-- info — read-only. `find_related` is an ACTIONABLE discovery aid: each row's
-                 PRIMARY action is "Insert link" (drops a [[Title]] wikilink into the note at
-                 the caret — the same wikilink text the link-picker/toolbar op builds), with
-                 "Open" kept as a secondary action (2026-07-15: this used to be a single passive
-                 "tap to open" row — direct user feedback called that confusing/low-value).
-                 `fact_check`/`ask` produce a real answer you can copy or insert into the note. -->
+            <!-- info — read-only. `find_related` is ONE quiet compact list (minimalist,
+                 2026-07-16 — direct owner feedback: the two-buttons-per-card shape was too
+                 busy): the ROW ITSELF is the primary action (click inserts a [[Title]]
+                 wikilink — the same wikilink text the link-picker/toolbar op builds; the
+                 accessible name stays "Insert link to <title>"), with a small quiet "Open"
+                 as the secondary action. No count lead-line, no per-row card, no Done button
+                 (the header ✕ and Esc already close). `fact_check`/`ask` produce a real
+                 answer you can copy or insert into the note. -->
             @case ("info") {
               @if (res.action === "find_related") {
                 @if (res.citations.length > 0) {
-                  <p class="pop-info-lead">{{ res.suggestion }}</p>
                   <ul class="pop-cite-rows" aria-label="Related sources">
                     @for (cite of res.citations; track cite.id) {
                       <li class="pop-cite-row" [attr.title]="cite.snippet">
-                        <span class="pop-cite-kind">{{ cite.kind }}</span>
-                        <span class="pop-cite-title">{{ cite.title }}</span>
-                        <span class="pop-cite-actions">
-                          <button
-                            type="button"
-                            class="btn btn-primary pop-cite-btn"
-                            (click)="insertLinkFor(cite)"
-                          >
-                            Insert link
-                          </button>
-                          <button
-                            type="button"
-                            class="btn btn-ghost pop-cite-btn"
-                            (click)="openCitation(cite)"
-                          >
-                            Open
-                          </button>
-                        </span>
+                        <button
+                          type="button"
+                          class="pop-cite-main"
+                          [attr.aria-label]="'Insert link to ' + cite.title"
+                          (click)="insertLinkFor(cite)"
+                        >
+                          <span class="pop-cite-title">{{ cite.title }}</span>
+                          <span class="pop-cite-kind">{{ cite.kind }}</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="pop-cite-open"
+                          (click)="openCitation(cite)"
+                        >
+                          Open
+                        </button>
                       </li>
                     }
                   </ul>
                 } @else {
-                  <div class="pop-info-answer">
-                    Nothing related found in your brain yet.
-                  </div>
+                  <p class="pop-empty">Nothing related found in your brain yet.</p>
                 }
-                <div class="pop-buttons">
-                  <button
-                    type="button"
-                    class="btn btn-ghost pop-btn"
-                    (click)="discard()"
-                  >
-                    Done
-                  </button>
-                </div>
               } @else {
                 <div class="pop-info-answer">{{ res.suggestion }}</div>
                 @if (res.citations.length > 0) {

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
@@ -463,20 +463,6 @@
   font-weight: 600;
   color: var(--text-primary);
 }
-/* find_related lead line (the count) — plain text above the source chips, not a boxed answer. */
-.pop-info-lead {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 0.85rem;
-  line-height: 1.5;
-}
-/* Quiet caption under the source chips ("Tap a source to open it."). */
-.pop-hint {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 0.72rem;
-}
-
 /* --- Citation chips -------------------------------------------------------- */
 .pop-cites {
   display: flex;
@@ -517,12 +503,13 @@
   max-width: 180px;
 }
 
-/* --- find_related ACTIONABLE rows (Fix 3: Insert link primary + Open secondary,
-   replacing the old passive "tap the chip to open" pill) --- */
+/* --- find_related — ONE quiet compact list (minimalist, 2026-07-16): flat
+   single-line rows, no per-row card/border/shadow. The row itself is the
+   primary "insert link" action (neutral hover, like .pop-row); "Open" rides
+   along as a small quiet secondary. --- */
 .pop-cite-rows {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -530,27 +517,63 @@
 .pop-cite-row {
   display: flex;
   align-items: center;
+  gap: var(--space-1);
+}
+.pop-cite-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+.pop-cite-main:hover {
   background: var(--surface-hover);
 }
-.pop-cite-row .pop-cite-title {
+.pop-cite-main:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1.5px var(--accent-ring);
+}
+.pop-cite-main .pop-cite-title {
   flex: 1;
   min-width: 0;
   max-width: none;
-  color: var(--text-primary);
-  font-size: 0.78rem;
 }
-.pop-cite-actions {
-  display: flex;
+/* The kind ("note"/"meeting"/"org") is a quiet trailing hint, not an accent badge. */
+.pop-cite-main .pop-cite-kind {
   flex: none;
-  gap: var(--space-1);
-}
-.pop-cite-btn {
-  padding: 3px var(--space-2);
+  color: var(--text-muted);
   font-size: 0.72rem;
+  text-transform: none;
+}
+.pop-cite-open {
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.pop-cite-open:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.pop-cite-open:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1.5px var(--accent-ring);
 }
 
 .pop-redacted {

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -521,10 +521,12 @@ export class NoteBrainPopoverComponent {
 
   /**
    * Insert a `[[Title]]` wikilink to this citation's source, then dismiss the
-   * popover (Fix 3 — the "Insert link" PRIMARY action alongside "Open" on every
-   * `find_related` citation row: reuses the SAME gated citation data, only the
-   * interaction changes). The editor applies it exactly like an `insert` outcome
-   * (appended after the selection), so this needs no new textarea-splice logic.
+   * popover — the PRIMARY action of a `find_related` row (the row itself; its
+   * accessible name is "Insert link to <title>"), with "Open" as the quiet
+   * secondary (minimalist reshape 2026-07-16; reuses the SAME gated citation
+   * data, only the interaction changed). The editor applies it exactly like an
+   * `insert` outcome (appended after the selection), so this needs no new
+   * textarea-splice logic.
    */
   insertLinkFor(cite: NoteCitation): void {
     this.accepted.emit({ kind: "insertLink", title: cite.title });


### PR DESCRIPTION
## What

Owner feedback on the Notes link/related UI: *"ten UI powinien być bardziej minimalistyczny"*. This strips the visual weight from both surfaces while keeping **every** behavior.

### Find related (`note-brain-popover`, the surface folded by #335)
- **One quiet flat list** — no per-row cards (border/background/radius gone), single-line rows, tight `--space-1/2` spacing.
- **The row itself is the primary action**: clicking a row inserts the `[[Title]]` wikilink (same `insertLinkFor` path as before). Its accessible name is `Insert link to <title>`, so the existing capability assertions keep passing verbatim. **"Open"** remains per row as a small quiet secondary button (org → `/org-item`, note/meeting → tracked tabs — unchanged routing).
- **Killed redundant chrome**: the count lead-line ("N related sources in your brain." — a count that carries no decision), the boxed empty-state card (now a quiet one-liner), and the **Done** button (the header ✕ and Esc already dismiss).
- Deleted now-dead styles: `.pop-info-lead`, `.pop-hint` (was already unreferenced), `.pop-cite-actions`, `.pop-cite-btn`.

### `[[` / slash-command link picker (`link-picker`)
- Title leads the row; the kind (`note`/`meeting`/`org`) is a **quiet trailing muted hint** instead of a leading bold-uppercase badge.
- Tighter row padding (`--space-1/2`), and the keyboard selection is now the **native flat accent fill** (`--accent` + `--text-on-accent`, the house `quick-search` pattern) instead of being indistinguishable from hover.
- Keyboard flow untouched: ↑/↓ + Enter inserts, Esc closes (all owned by `note-editor`, not modified).

Both popovers remain **opaque overlays** (T3): `--surface-overlay`, `border-strong`, `shadow-lg`, `backdrop-filter: none`. All values are existing design tokens — no new tokens needed, no new deps, no behavior/IPC changes (FE-only; Rust untouched).

## How verified

- `npx ng lint` — *All files pass linting.*
- `npx ng build` — clean (component style budgets fine).
- `npx playwright test e2e/notes/ --reporter=line` — **27 passed** against a **proven-fresh** `:4210` server (verified via `DEBUG=pw:webserver`: fresh "Application bundle generation complete" of this branch's code before the run — an earlier run had silently reused a stale server, which is why the fresh-boot proof matters).
- e2e adapted ONLY where the DOM legitimately changed: the two waits anchored on the removed count lead-line now wait on the citation rows themselves. Every capability assertion is unchanged — `Insert link` + `Open` buttons per row, wikilink lands in the body with no navigation, org citation routes to `/org-item`, zero-console-error gates intact.
- Before/after screenshots (Playwright harness, element shots):
  - `…/scratchpad/shots/before-link-picker.png` / `after-link-picker.png`
  - `…/scratchpad/shots/before-find-related.png` / `after-find-related.png`
  - full prefix: `/private/tmp/claude-501/-Users-jakubgawronski-Projects-meetnotes/7d96e941-8284-4324-836f-637e2e535e01/scratchpad/shots/`

## Honest gaps

- Screenshots + e2e are Chromium against the mocked-IPC harness — final look should be eyeballed in the real dev/packaged app (WKWebView), and light theme wasn't screenshotted (all colors are existing tokens with light overrides, so risk is low).
- The backend still *generates* the `find_related` count suggestion string; the FE simply no longer renders it for this action (other info-shape actions still render `suggestion`). No backend change made.