### PR TITLE
chore(hardening): panic-log sanitize, download timeouts, embedder cache release, reaper drift, async reap, sysaudio stop lock

### DIFF
--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -245,8 +245,10 @@ fn split_numeric_prefix(line: &str, numeric_cols: usize) -> Option<(Vec<i32>, &s
 }
 
 /// Whether a process basename is a Murmur app process: the shipped/dev bin name (`Murmur`) or the
-/// basename of OUR OWN executable (covers a renamed dev profile). NOTE: `ps` renders a zombie as
-/// `(Murmur)` — parenthesized, so it correctly does NOT match (a zombie parent is a dead parent).
+/// basename of OUR OWN executable (covers a renamed dev profile). NOTE: `ps` renders a zombie's
+/// `comm` specially — the BSD man page documents a parenthesized name (`(Murmur)`), but Darwin 25
+/// actually renders `<defunct>` — and NEITHER equals the live basename, so a zombie parent
+/// correctly reads as dead under both renderings.
 fn is_murmur_basename(base: &str, self_exe: Option<&str>) -> bool {
     base == "Murmur" || self_exe == Some(base)
 }
@@ -608,7 +610,9 @@ mod tests {
         assert!(is_murmur_basename("Murmur", None));
         assert!(is_murmur_basename("murmur-dev", Some("murmur-dev")));
         assert!(!is_murmur_basename("murmur", None)); // exact case — no fuzzy matching
-        assert!(!is_murmur_basename("(Murmur)", None)); // a zombie parent is a dead parent
+        // A zombie parent is a dead parent — BOTH zombie renderings must fail the match:
+        assert!(!is_murmur_basename("(Murmur)", None)); // the BSD-man-page-documented form
+        assert!(!is_murmur_basename("<defunct>", None)); // what Darwin 25 actually renders
         assert!(!is_murmur_basename("zsh", Some("Murmur")));
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -527,8 +527,16 @@ pub async fn start_recording(
     // instance crashed / was SIGKILL'd mid-recording) would otherwise capture alongside the new
     // recording until its 4h self-cap. Safe by construction — a helper owned by any LIVE Murmur
     // process (including the one this call is about to spawn for) is always spared. Best-effort,
-    // never fails the recording.
-    crate::audio::aec::reap_orphaned_capture_helpers();
+    // never fails the recording. Hardening 2026-07-16: the sweep shells out to /bin/ps (×2) plus
+    // a per-candidate `kill -0`, so it runs on a BLOCKING worker instead of stalling this async
+    // runtime thread — but it is still AWAITED: the sweep MUST complete before this recording's
+    // own helpers spawn (ordering guarantee unchanged).
+    if let Err(e) =
+        tauri::async_runtime::spawn_blocking(crate::audio::aec::reap_orphaned_capture_helpers)
+            .await
+    {
+        tracing::warn!(target: "audio", error = %e, "orphan-helper sweep join failed; recording continues");
+    }
 
     // Fresh recording ⇒ re-arm the 4h-cap rising-edge notice (see `recording_level`). If a previous
     // recording hit the cap and set this, the next recording must be able to fire the notice again.

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -460,8 +460,19 @@ pub fn active_embedder() -> Box<dyn Embedder> {
     if std::env::var_os("MURMUR_TEST_REAL_EMBED").is_none() {
         return Box::new(StubEmbedder);
     }
-    let model = selected_embed_model();
-    if embed_model_present() {
+    active_embedder_impl(embed_model_present(), selected_embed_model())
+}
+
+/// Testable core of [`active_embedder`]'s presence-keyed selection (split out so the
+/// model-absent → cache-release rule can be driven deterministically in tests, past both the
+/// `cfg(test)` stub guard and this machine's real on-disk model state).
+///
+/// Hardening 2026-07-16: when the selected model is NOT present (the user deleted the model dir
+/// mid-session, or switched to a not-yet-downloaded model), the process-wide cache entry is
+/// RELEASED before serving the stub — previously the evicted-only-on-dir-change cache kept the
+/// once-loaded instance (~470 MB of e5 weights) pinned until restart.
+fn active_embedder_impl(model_present: bool, model: &'static EmbedModel) -> Box<dyn Embedder> {
+    if model_present {
         let built = embed_model_dir().and_then(|dir| cached_real_embedder(dir, model));
         match built {
             Ok(e) => return Box::new(SharedEmbedder(e)),
@@ -470,9 +481,26 @@ pub fn active_embedder() -> Box<dyn Embedder> {
             }
         }
     } else {
+        release_real_embedder_cache();
         tracing::info!(target: "embed", model_id = %model.id, "no local embed model present; using stub embedder");
     }
     Box::new(StubEmbedder)
+}
+
+/// Drop the process-wide cached real-embedder entry so a deleted/deselected model actually
+/// returns its RAM (the `Arc` + lazily-loaded weights) instead of pinning it until restart.
+/// Poison-safe (the cache holds no invariant worth failing over — recover the guard and clear)
+/// and panic-free; a no-op when nothing is cached. An in-flight forward pass holding its own
+/// `Arc` clone finishes safely — the weights free when the LAST clone drops.
+fn release_real_embedder_cache() {
+    let evicted = REAL_EMBEDDER_CACHE
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+        .is_some();
+    if evicted {
+        tracing::info!(target: "embed", "released cached embed model (model no longer present)");
+    }
 }
 
 /// FNV-1a 64-bit hash of a string (stable across runs/platforms — no `DefaultHasher` randomization).
@@ -2170,6 +2198,46 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(&dir1);
         let _ = std::fs::remove_dir_all(&dir2);
+    }
+
+    /// Hardening item 3 (RED-before-GREEN): deleting the model dir MID-SESSION must RELEASE the
+    /// process-wide cached instance. Pre-fix, `active_embedder`'s model-absent branch served the
+    /// stub while `REAL_EMBEDDER_CACHE` kept the previous instance (~470 MB once loaded) pinned
+    /// until restart — the cache only ever evicted on a dir CHANGE, never on absence. Drives the
+    /// REAL selection core (`active_embedder_impl`, exactly what `active_embedder` calls past its
+    /// `cfg(test)` stub guard) with `model_present == false` and asserts the entry is gone.
+    #[test]
+    fn model_absent_releases_the_cached_embedder() {
+        let _g = EMBED_SELECTION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Populate: the cache holds the instance for a (fake) on-disk model dir.
+        let dir = fake_model_dir("release");
+        let cached = cached_real_embedder(dir.clone(), default_embed_model()).unwrap();
+        {
+            let g = REAL_EMBEDDER_CACHE
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            let (key, arc) = g.as_ref().expect("precondition: the cache holds an entry");
+            assert_eq!(key, &dir);
+            assert!(Arc::ptr_eq(arc, &cached));
+        }
+        drop(cached); // the cache now holds the LAST Arc — exactly the mid-session steady state
+
+        // The model dir disappears mid-session (user deleted it to reclaim disk).
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // The next embedder resolution sees model_present == false → stub AND a cleared cache.
+        let e = active_embedder_impl(false, default_embed_model());
+        assert_eq!(e.dim(), EMBED_DIM, "the stub is served when the model is absent");
+        assert!(
+            REAL_EMBEDDER_CACHE
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_none(),
+            "the cached instance must be RELEASED when the model is no longer present \
+             (otherwise ~470 MB stays pinned until restart)"
+        );
     }
 
     /// A missing model file makes the cache resolution fail LOUD (Err, never a panic) and never

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,9 +112,14 @@ pub fn run() {
     // production pipeline panic left ZERO evidence in murmur.log (the "wedged on Transcribing…"
     // forensics found an idle process and an empty trail). Route every panic through `tracing`
     // (which tees to murmur.log) FIRST, then chain to the previous hook so dev stderr/backtrace
-    // behavior is preserved. PII: message + source location only — panic payloads from our code
-    // carry no note/transcript content, and no content fields are added here.
+    // behavior is preserved. PII: the PAYLOAD is sanitized before persisting (home-dir prefix
+    // redacted + length-capped — an `expect` on an `io::Error` embeds the failing path, and under
+    // the vault that filename is note-title-derived); the source LOCATION is compiled-in and
+    // carries no user content, so it stays verbatim.
     let previous_panic_hook = std::panic::take_hook();
+    // Resolved ONCE here, not inside the hook — the hook must do no avoidable work while the
+    // process is already panicking.
+    let panic_home = dirs::home_dir().map(|h| h.to_string_lossy().into_owned());
     std::panic::set_hook(Box::new(move |info| {
         let location = info
             .location()
@@ -127,6 +132,7 @@ pub fn run() {
         } else {
             "non-string panic payload".to_string()
         };
+        let message = sanitize_panic_message(&message, panic_home.as_deref());
         tracing::error!(target: "panic", %location, %message, "panic");
         previous_panic_hook(info);
     }));
@@ -439,6 +445,7 @@ pub fn run() {
             //   4) SPAWN the async salvage worker: reconstruct each claimed recording + run it through
             //      the EXISTING post-Stop pipeline → a real transcript+note. After the reap so the
             //      paired helper is already down. Best-effort; never deletes un-salvaged audio.
+            //   (3+4 run inside ONE detached task below — sequenced, off the setup thread.)
             let salvage_jobs = {
                 let state = app.state::<AppState>();
                 let (jobs, claimed) = crate::audio::spill::claim_inflight(&state.db);
@@ -451,13 +458,39 @@ pub fn run() {
             // Reap any capture helper ORPHANED by a previous session that died without a clean Stop
             // (crash / force-quit / a `tauri dev` hot-rebuild SIGKILLing the app mid-record). Such a
             // helper keeps capturing to a temp WAV for up to its 4h self-cap — GBs of dead-session
-            // audio the file-age sweep below can't catch (its mtime stays fresh). Run FIRST so the
-            // kill releases the file, THEN reclaim any stale scratch left behind. A helper whose
-            // parent is launchd, dead, or not a Murmur process is reaped; one owned by a LIVE
-            // Murmur process (a genuinely concurrent instance) is spared — see `helper_verdict`.
-            // (Salvage above already moved any RECOVERABLE far-side scratch out of the reaper's reach.)
-            crate::audio::aec::reap_orphaned_capture_helpers();
-            crate::audio::aec::sweep_stale_scratch();
+            // audio the file-age sweep can't catch (its mtime stays fresh). The reap runs FIRST so
+            // the kill releases the file, THEN stale scratch is reclaimed. A helper whose parent is
+            // launchd, dead, or not a Murmur process is reaped; one owned by a LIVE Murmur process
+            // (a genuinely concurrent instance) is spared — see `helper_verdict`. (Salvage above
+            // already moved any RECOVERABLE far-side scratch out of the reaper's reach.)
+            //
+            // Hardening 2026-07-16: steps 3+4 moved OFF the setup thread — the reap shells out to
+            // /bin/ps (×2) plus a per-candidate `kill -0`, which blocked launch. The LOAD-BEARING
+            // order (see the block comment above: reap[3] completes BEFORE the salvage worker[4]
+            // spawns, so a crashed session's paired helper is already down) is preserved INSIDE
+            // one detached task: the blocking reap+sweep is AWAITED to completion, then the
+            // salvage worker spawns. Steps 1+2 (claim + reconcile) already ran synchronously
+            // above, so the claim still beats the reaper to any recoverable far-side scratch.
+            // Racing an early user-initiated `start_recording` is safe by construction — the reap
+            // spares every helper owned by a live Murmur process, and `start_recording` runs its
+            // own awaited sweep anyway.
+            {
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let joined = tauri::async_runtime::spawn_blocking(|| {
+                        crate::audio::aec::reap_orphaned_capture_helpers();
+                        crate::audio::aec::sweep_stale_scratch();
+                    })
+                    .await;
+                    if let Err(e) = joined {
+                        tracing::warn!(target: "startup", error = %e, "orphan-helper reap join failed; salvage continues");
+                    }
+                    // STAGE 2 salvage worker (async, detached): now that the reaper has downed any
+                    // orphan helper, reconstruct + pipeline each claimed crashed recording. No-op
+                    // when nothing crashed.
+                    crate::audio::spill::spawn_salvage(app_handle, salvage_jobs);
+                });
+            }
             // R1: reclaim any STALE `*.part` model-download residue (a crash / force-quit / aborted
             // model switch mid-download orphans up to ~3.1 GB). Only removes a `.part` older than 1 h
             // so a live in-progress download is never raced. Best-effort; never fatal to launch.
@@ -475,10 +508,6 @@ pub fn run() {
                     crate::export::obsidian::sweep_stale_export_tmp(std::path::Path::new(&vault));
                 }
             }
-
-            // STAGE 2 salvage worker (async, detached): now that the reaper has downed any orphan
-            // helper, reconstruct + pipeline each claimed crashed recording. No-op when nothing crashed.
-            crate::audio::spill::spawn_salvage(app.handle().clone(), salvage_jobs);
 
             create_bar_window(app.handle())?;
             if let Err(e) = app.global_shortcut().register(SUMMON_SHORTCUT) {
@@ -662,6 +691,34 @@ pub fn run() {
                 crate::reason::sidecar::kill_on_quit();
             }
         });
+}
+
+/// Max chars of a panic PAYLOAD persisted to murmur.log by the global hook. Generous for every
+/// panic message our code produces, while a pathological payload (a formatted struct dump, a
+/// whole file body threaded into an `expect`) can no longer flood the log.
+const PANIC_MESSAGE_MAX_CHARS: usize = 400;
+
+/// Sanitize a panic payload before the global hook persists it to murmur.log (hardening
+/// 2026-07-16): redact the user's home-directory prefix (→ `~`) and length-cap the result
+/// ([`PANIC_MESSAGE_MAX_CHARS`]). An `expect` on an `io::Error` embeds the failing PATH in the
+/// payload, and under the vault that filename is note-title-derived — i.e. PII the log must not
+/// carry (rule: logs carry IDs/stages/counts only). The panic LOCATION is handled separately by
+/// the caller and stays verbatim — compiled-in source paths carry no user content.
+///
+/// PURE + PANIC-FREE (this runs inside the panic hook): char-boundary-safe truncation, no
+/// allocation tricks, no unwraps. A `home` of `None` or a degenerate one-char home (redacting
+/// `/` would blank every path separator) skips redaction.
+fn sanitize_panic_message(message: &str, home: Option<&str>) -> String {
+    let redacted = match home {
+        Some(h) if h.len() > 1 => message.replace(h, "~"),
+        _ => message.to_string(),
+    };
+    // `char_indices` finds the byte offset of the cap-th char (if any) — boundary-safe for
+    // multi-byte payloads, and O(cap) instead of counting the whole string.
+    match redacted.char_indices().nth(PANIC_MESSAGE_MAX_CHARS) {
+        Some((byte_idx, _)) => format!("{}…[truncated]", &redacted[..byte_idx]),
+        None => redacted,
+    }
 }
 
 /// Lifecycle-hook context tags. `app-exit` is the TRUE quit (stop capture + relock); `window-close`
@@ -875,5 +932,68 @@ fn position_bar_top_center(win: &tauri::WebviewWindow) {
         let x = ((screen.width as f64 - size.width as f64) / 2.0).max(0.0);
         let y = (48.0 * scale).min(screen.height as f64 * 0.3);
         let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Hardening item 1 (RED-before-GREEN): the panic hook used to persist the RAW payload to
+    /// murmur.log, so an `expect` on an `io::Error` leaked the failing vault path — whose
+    /// filename is note-title-derived, i.e. PII. Every home-dir occurrence must now be redacted
+    /// to `~` before the payload reaches `tracing`.
+    #[test]
+    fn panic_message_redacts_the_home_dir_prefix() {
+        let msg = "failed to export note: No such file or directory (os error 2) \
+                   at /Users/jane/Vault/Meetings/Salary review with Bob.md \
+                   (backup: /Users/jane/Vault/.trash/Salary review with Bob.md)";
+        let out = sanitize_panic_message(msg, Some("/Users/jane"));
+        assert!(
+            !out.contains("/Users/jane"),
+            "the home prefix must not survive: {out}"
+        );
+        assert!(
+            out.contains("~/Vault/Meetings/Salary review with Bob.md"),
+            "the path is kept readable, just home-relative: {out}"
+        );
+        assert!(
+            out.contains("~/Vault/.trash/"),
+            "EVERY occurrence is redacted, not just the first: {out}"
+        );
+    }
+
+    /// The payload is length-capped so a pathological panic (a struct dump / file body threaded
+    /// into an `expect`) cannot flood murmur.log. The cap is marked, and multi-byte chars at the
+    /// boundary must never split (this fn runs INSIDE the panic hook — it must not panic).
+    #[test]
+    fn panic_message_is_length_capped_char_boundary_safe() {
+        // 600 two-byte chars ('ł') — a byte-indexed truncation at 400 would split a char.
+        let long = "ł".repeat(600);
+        let out = sanitize_panic_message(&long, None);
+        assert!(out.ends_with("…[truncated]"), "a capped payload is marked: {out}");
+        let kept = out.trim_end_matches("…[truncated]");
+        assert_eq!(
+            kept.chars().count(),
+            PANIC_MESSAGE_MAX_CHARS,
+            "exactly the cap survives"
+        );
+        assert!(kept.chars().all(|c| c == 'ł'), "no mangled chars at the cut");
+    }
+
+    /// A short, home-free payload passes through byte-identical (the common case — our own panic
+    /// messages), and degenerate homes (`None` / `"/"`) never trigger redaction ("/"-replacement
+    /// would blank every path separator).
+    #[test]
+    fn panic_message_passthrough_and_degenerate_home() {
+        let msg = "recorder mutex poisoned";
+        assert_eq!(sanitize_panic_message(msg, None), msg);
+        assert_eq!(sanitize_panic_message(msg, Some("/")), msg);
+        let pathy = "open /etc/hosts failed";
+        assert_eq!(
+            sanitize_panic_message(pathy, Some("/")),
+            pathy,
+            "a one-char home must not be substituted into every separator"
+        );
     }
 }

--- a/src-tauri/src/summarize/ollama.rs
+++ b/src-tauri/src/summarize/ollama.rs
@@ -17,12 +17,21 @@ const AVAILABILITY_TIMEOUT: Duration = Duration::from_millis(500);
 /// the readiness probe (a cold Ollama can be slow to answer) but still bounded so the UI never
 /// hangs on a dead server.
 const LIST_MODELS_TIMEOUT: Duration = Duration::from_secs(5);
+/// Overall timeout for the `/api/generate` calls (`summarize` / `complete`). The other providers
+/// are already bounded (anthropic 120 s via `build_client`, claude_code 180 s via
+/// `CLAUDE_TIMEOUT`); Ollama was NOT, so a dead/wedged local server hung a summarize forever.
+/// Local models on modest hardware can be genuinely slow on a long transcript, so this is
+/// deliberately the most generous of the three — but still bounded.
+const GENERATE_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Talks to a local Ollama server's HTTP API (default `http://localhost:11434`).
 pub struct OllamaProvider {
     client: reqwest::Client,
     base_url: String,
     model: String,
+    /// Per-request cap on `/api/generate` ([`GENERATE_TIMEOUT`]; overridable in tests so the
+    /// stalled-server regression doesn't wait 10 minutes).
+    generate_timeout: Duration,
 }
 
 impl OllamaProvider {
@@ -43,7 +52,15 @@ impl OllamaProvider {
             client: reqwest::Client::new(),
             base_url,
             model,
+            generate_timeout: GENERATE_TIMEOUT,
         }
+    }
+
+    /// Test-only: shrink the `/api/generate` timeout so a stalled-server regression fails fast.
+    #[cfg(test)]
+    fn with_generate_timeout(mut self, timeout: Duration) -> Self {
+        self.generate_timeout = timeout;
+        self
     }
 
     /// `GET {base}/api/tags` → list of locally installed model names for the Settings dropdown.
@@ -156,6 +173,7 @@ impl SummarizerProvider for OllamaProvider {
             .client
             .post(&url)
             .json(&body)
+            .timeout(self.generate_timeout)
             .send()
             .await
             .map_err(|e| AppError::Summarize(format!("Ollama request failed: {e}")))?;
@@ -196,6 +214,7 @@ impl SummarizerProvider for OllamaProvider {
             .client
             .post(&url)
             .json(&body)
+            .timeout(self.generate_timeout)
             .send()
             .await
             .map_err(|e| AppError::Summarize(format!("Ollama request failed: {e}")))?;
@@ -259,5 +278,54 @@ mod tests {
             names.is_empty(),
             "an OpenAI-shaped body must degrade to an empty list, not misparse"
         );
+    }
+
+    /// Hardening item 2 (RED-before-GREEN, Ollama leg): a local server that ACCEPTS the
+    /// `/api/generate` POST and then never answers must fail `summarize` within the request
+    /// timeout. Pre-fix, the generate call carried NO timeout (unlike anthropic's 120 s /
+    /// claude_code's 180 s), so a dead/wedged local server hung a summarize forever. The outer
+    /// 10 s `tokio::time::timeout` is the RED detector: unpatched, it fires (test FAILs); with
+    /// `.timeout(self.generate_timeout)` the request errors in ~0.4 s (PASS).
+    #[tokio::test]
+    async fn summarize_times_out_on_a_stalled_server_instead_of_hanging() {
+        use crate::summarize::provider::{MeetingMeta, SummarizeRequest, SummarizerProvider};
+        use std::io::Read;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Accept ONE connection, read the request, then go silent (socket held open) for LONGER
+        // than the outer 10 s RED detector — a shorter stall would end in a connection close,
+        // which even the unpatched (timeout-less) code surfaces as an error, masking the hang.
+        // The handle is dropped (not joined) — the thread dies with the test process.
+        let _server = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 8192];
+                let _ = sock.read(&mut buf);
+                std::thread::sleep(std::time::Duration::from_secs(30)); // never respond
+            }
+        });
+
+        let provider = OllamaProvider::new(format!("http://{addr}"), "llama3.1".to_string())
+            .with_generate_timeout(std::time::Duration::from_millis(400));
+        let req = SummarizeRequest {
+            transcript: "We shipped v2 and agreed Anna owns the rollout.".to_string(),
+            meta: MeetingMeta {
+                date_iso: "2026-07-16".to_string(),
+                title_hint: None,
+                duration_s: 60,
+                language: Some("en".to_string()),
+            },
+            template: "TEMPLATE".to_string(),
+            vault_titles: vec![],
+            related_context: None,
+            user_notes: None,
+            live_bullets: None,
+        };
+        let res = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            provider.summarize(&req),
+        )
+        .await
+        .expect("a stalled Ollama server must RESOLVE (as Err) within the timeout — not hang");
+        assert!(res.is_err(), "a stalled generate must surface an error");
     }
 }

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -405,6 +405,10 @@ where
     F: FnMut(u64, Option<u64>),
 {
     let dir = parakeet_dir()?;
+    // Connect-bounded, total-uncapped (same posture as the whisper fetch): a parakeet weights file
+    // is multi-hundred-MB — a legitimate slow download can outlast any fixed total cap, and this
+    // path is user-driven with live progress. ONE client is reused across the four files.
+    let client = download_client(None);
     // Aggregate progress across the four files: carry the bytes of already-finished files forward
     // so each file's per-file `downloaded` is offset onto the running total.
     let mut base: u64 = 0;
@@ -416,7 +420,7 @@ where
             base = base.saturating_add(std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0));
             continue;
         }
-        download_model_streaming(&parakeet_model_url(file), &dest, |d, _t| {
+        download_model_streaming(&client, &parakeet_model_url(file), &dest, |d, _t| {
             // The aggregate total is unknown across four files (mixed Content-Length availability),
             // so report the running byte sum with `None` total — the FE shows an indeterminate/byte
             // progress, consistent with the whisper multi-GB bar.
@@ -485,7 +489,9 @@ where
     let dir = models_dir()?;
     let file = model_filename(&size, language);
     let dest = dir.join(&file);
-    download_model_streaming(&model_url(&file), &dest, on_progress).await?;
+    // Connect-bounded, total-uncapped: a multi-GB whisper model on a slow link can legitimately
+    // outlast any fixed total cap (see the constants above).
+    download_model_streaming(&download_client(None), &model_url(&file), &dest, on_progress).await?;
     Ok(dest)
 }
 
@@ -525,13 +531,45 @@ pub async fn ensure_diarization_models() -> Result<(PathBuf, PathBuf)> {
     Ok((seg, emb))
 }
 
+/// Connect timeout for EVERY model download (mirrors the hardened cloud client in
+/// `summarize::anthropic::build_client`): a dead / blackholed host fails in seconds instead of
+/// hanging the first-use fetch on the pipeline path.
+const DOWNLOAD_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Overall wall-clock cap for the SMALL model downloads (Silero VAD ~2 MB, diarization
+/// segmentation ~6 MB / embedding ~28 MB): generous even on a slow link, but BOUNDED — these are
+/// awaited by `pipeline::run_inner` OUTSIDE the ASR stage watchdog, so before this cap a mid-body
+/// stall on first use hung a transcription silently ("wedged on Transcribing…" with zero trail).
+/// The multi-GB whisper fetch deliberately keeps NO total cap (a legitimate slow download of a
+/// 3+ GB model can exceed any fixed number; it is user-driven with live progress UI) — it gets
+/// the connect timeout only.
+const SMALL_MODEL_DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Build the reqwest client for a model download: always a bounded connect, plus an optional
+/// overall request cap (see [`SMALL_MODEL_DOWNLOAD_TIMEOUT`] for who passes what). Falls back to
+/// `Client::new()` only if the builder somehow fails (same never-un-constructible posture as
+/// `summarize::anthropic::build_client`).
+fn download_client(total_timeout: Option<std::time::Duration>) -> reqwest::Client {
+    let mut builder = reqwest::Client::builder().connect_timeout(DOWNLOAD_CONNECT_TIMEOUT);
+    if let Some(t) = total_timeout {
+        builder = builder.timeout(t);
+    }
+    builder.build().unwrap_or_else(|_| reqwest::Client::new())
+}
+
 /// Download `url` to `dest` atomically (`dest.part` → rename), invoking `on_progress(downloaded,
 /// total)` as bytes arrive (`total` is `None` when the server omits `Content-Length`). INBOUND
 /// ONLY: fetches a model file and sends NO request body / NO meeting content (no egress). Streams
 /// via `Response::chunk` (no extra stream-combinator dep) so a multi-GB whisper model reports live
 /// progress instead of buffering the whole body in memory. Overwrites any stale partial. Verifies a
-/// non-empty body before the rename. NO PII is logged (model id / byte counts only).
-async fn download_model_streaming<F>(url: &str, dest: &Path, mut on_progress: F) -> Result<()>
+/// non-empty body before the rename. NO PII is logged (model id / byte counts only). The `client`
+/// carries the caller's timeout posture (see [`download_client`]).
+async fn download_model_streaming<F>(
+    client: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    mut on_progress: F,
+) -> Result<()>
 where
     F: FnMut(u64, Option<u64>),
 {
@@ -539,7 +577,9 @@ where
 
     tracing::info!(target: "transcribe", file = %dest.display(), "downloading whisper model");
 
-    let mut resp = reqwest::get(url)
+    let mut resp = client
+        .get(url)
+        .send()
         .await
         .map_err(|e| AppError::Transcribe(format!("model download request failed: {e}")))?;
     if !resp.status().is_success() {
@@ -667,8 +707,14 @@ pub fn sweep_stale_model_parts(models_dir: &Path) {
 
 /// Non-progress download for the VAD + diarization models (small, no UI progress bar). Delegates to
 /// [`download_model_streaming`] with a no-op callback so all model fetches share one atomic path.
+/// FULLY time-bounded ([`SMALL_MODEL_DOWNLOAD_TIMEOUT`]): these first-use fetches run inside
+/// `pipeline::run_inner` OUTSIDE the ASR watchdog, where a stalled body used to hang the
+/// transcription silently — a timeout here degrades gracefully at both call sites
+/// ([`ensure_vad_model`] → whole-buffer transcribe; [`ensure_diarization_models`] → single
+/// "others" label).
 async fn download_model(url: &str, dest: &Path) -> Result<()> {
-    download_model_streaming(url, dest, |_, _| {}).await
+    let client = download_client(Some(SMALL_MODEL_DOWNLOAD_TIMEOUT));
+    download_model_streaming(&client, url, dest, |_, _| {}).await
 }
 
 #[cfg(test)]
@@ -720,7 +766,7 @@ mod tests {
         let dest = dir.join("ggml-tiny.bin");
         let url = format!("http://{addr}/model.bin");
 
-        let res = download_model_streaming(&url, &dest, |_, _| {}).await;
+        let res = download_model_streaming(&download_client(None), &url, &dest, |_, _| {}).await;
         assert!(res.is_err(), "a truncated body must surface an error");
 
         // `with_extension("part")` maps `ggml-tiny.bin` → `ggml-tiny.part`.
@@ -732,6 +778,60 @@ mod tests {
         assert!(!dest.exists(), "no model file is produced from a failed download");
 
         let _ = server.join();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Hardening item 2 (RED-before-GREEN, stalled-body path): a server that ACCEPTS the
+    /// connection, sends headers + a few bytes, then goes SILENT (socket held open, no more data,
+    /// no close) must ERROR within the client's overall timeout. Pre-fix, the bare `reqwest::get`
+    /// had NO timeout, so this future never resolved — and the VAD/diarization first-use fetch it
+    /// backs is awaited by `pipeline::run_inner` OUTSIDE the ASR watchdog → a silent transcription
+    /// hang. The outer 10 s `tokio::time::timeout` is the RED detector: on the unpatched code it
+    /// fires (test FAILs); with the timeout-bearing client the download errors in ~0.4 s (PASS)
+    /// and the `PartFileGuard` reclaims the partial.
+    #[tokio::test]
+    async fn download_times_out_on_a_stalled_body_instead_of_hanging() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Serve ONE connection: promise 1 MB, deliver 8 bytes, then hold the socket open silently.
+        // The handle is dropped (not joined) — the thread is killed with the test process.
+        let _server = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf); // consume the request line/headers
+                let _ = sock.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\n",
+                );
+                let _ = sock.write_all(b"PARTIAL0");
+                let _ = sock.flush();
+                // STALL: keep the socket open without delivering the remaining bytes — for LONGER
+                // than the outer 10 s RED detector, or a socket close would end the "hang" early
+                // and the unpatched code would pass on a mere connection-closed error (observed:
+                // an 8 s stall made this test useless as a regression).
+                std::thread::sleep(std::time::Duration::from_secs(30));
+            }
+        });
+
+        let dir = parts_tmp_dir("stall");
+        let dest = dir.join("silero-vad.onnx");
+        let url = format!("http://{addr}/model.onnx");
+
+        // Same client shape as the production small-model path, with a test-sized total cap.
+        let client = download_client(Some(std::time::Duration::from_millis(400)));
+        let res = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            download_model_streaming(&client, &url, &dest, |_, _| {}),
+        )
+        .await
+        .expect("a stalled download must RESOLVE (as Err) within the client timeout — not hang");
+        assert!(res.is_err(), "a stalled body must surface an error");
+        assert!(
+            !dest.with_extension("part").exists(),
+            "the stalled `.part` must be reclaimed by the guard"
+        );
+        assert!(!dest.exists(), "no model file is produced from a stalled download");
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/sysaudio/sysaudio.swift
+++ b/src-tauri/sysaudio/sysaudio.swift
@@ -124,11 +124,21 @@ final class Capturer: NSObject, SCStreamOutput, SCStreamDelegate {
 
 let capturer = Capturer(outURL: outURL)
 
-// Clean shutdown on SIGINT/SIGTERM from the parent (Rust) process.
+// Clean shutdown on SIGINT/SIGTERM from the parent (Rust) process. `stopping` is written from
+// BOTH the signal/kqueue dispatch queue (`sigQueue`) and the main thread (the ppid re-checks
+// below), so the double-stop guard is NSLock-protected — an unsynchronized check-then-set could
+// let two racing stop requests both pass the guard and tear down twice. Mirrors the exact
+// pattern in audiocap.swift / aeccap.swift.
 var stopping = false
+let stopLock = NSLock()
 func requestStop() {
-    if stopping { return }
+    stopLock.lock()
+    if stopping {
+        stopLock.unlock()
+        return
+    }
     stopping = true
+    stopLock.unlock()
     Task { await capturer.stop(); exit(0) }
 }
 let sigQueue = DispatchQueue(label: "meetnotes.sig")


### PR DESCRIPTION
## What

Six independent mechanical hardening fixes (task #58), one branch:

1. **Panic-log payload sanitizer** (`src-tauri/src/lib.rs`) — the global panic hook (PR #346) persisted the RAW payload to murmur.log. It now runs through a pure `sanitize_panic_message` fn: every home-directory occurrence is redacted to `~` (an `expect` on an `io::Error` embeds the failing path — under the vault that filename is note-title-derived PII) and the payload is capped at 400 chars, char-boundary-safe (`…[truncated]` marker). The source `location` stays verbatim (compiled-in paths, no user content). Home is resolved once at hook install, not while panicking.
2. **Download / generate timeouts** —
   - `transcribe/model.rs`: all model downloads now go through a `download_client()` with a **15 s connect timeout**; the small VAD + diarization fetches (awaited by `pipeline::run_inner` OUTSIDE the ASR watchdog — a stalled first-use download hung a transcription silently) additionally get a **600 s total cap**. The multi-GB whisper/parakeet fetches deliberately keep NO total cap (user-driven, live progress; a slow legitimate download must not be killed mid-flight).
   - `summarize/ollama.rs`: `/api/generate` (`summarize` + `complete`) gets a **600 s request timeout** — anthropic (120 s) and claude_code (180 s) were already bounded; Ollama was not, so a dead/wedged local server hung a summarize forever. 600 s because local models on modest hardware are legitimately slow.
3. **Embedder cache release** (`src-tauri/src/embed.rs`) — deleting the e5 model dir mid-session kept the `REAL_EMBEDDER_CACHE` entry (and its once-loaded ~470 MB of weights) pinned until restart. `active_embedder`'s selection core now clears the entry (poison-safe `take()`) before serving the stub whenever the model is absent. An in-flight forward pass holding its own `Arc` clone finishes safely.
4. **Reaper zombie-rendering drift** (`src-tauri/src/audio/aec.rs`) — comment on `is_murmur_basename` corrected: on Darwin 25 a zombie's `comm` renders `<defunct>`, not the BSD-documented `(Murmur)`. `murmur_basename_matching` now asserts BOTH renderings fail the live-Murmur match (both already did — the exact-match code was correct; this pins it).
5. **Async reap off the hot paths** — `reap_orphaned_capture_helpers` shells out to `/bin/ps` twice + per-candidate `kill -0`. `start_recording` (`commands.rs`) now runs it via `tauri::async_runtime::spawn_blocking` **and awaits it** (the sweep MUST complete before this recording's own helpers spawn — ordering guarantee unchanged). The `lib.rs` startup call sites (reap → stale-scratch sweep → salvage-worker spawn) moved into ONE detached task that awaits the blocking reap+sweep to completion BEFORE `spawn_salvage` — the ordering comment there is load-bearing (the reaper must down a crashed session's paired helper before salvage runs), so fire-and-forget for the reap alone was not an option. Steps 1+2 (claim + reconcile) stay synchronous in setup, so the claim still beats the reaper to recoverable far-side scratch.
6. **sysaudio stop lock** (`src-tauri/sysaudio/sysaudio.swift`) — the `stopping` double-stop flag is written from both the signal/kqueue dispatch queue and the main thread with no synchronization; it is now NSLock-guarded, mirroring the exact pattern already in `audiocap.swift` / `aeccap.swift`.

## How verified

- **RED-before-GREEN** (fixes temporarily reverted, tests run, then restored): all five behavioral regressions FAILED against the pre-fix code — `panic_message_redacts_the_home_dir_prefix`, `panic_message_is_length_capped_char_boundary_safe`, `download_times_out_on_a_stalled_body_instead_of_hanging`, `summarize_times_out_on_a_stalled_server_instead_of_hanging`, `model_absent_releases_the_cached_embedder` (0 passed / 5 failed on the reverted code). Notably, the first RED run caught that an 8 s server stall was too short to reproduce the hang (the socket close masked it) — the fixtures now stall 30 s, longer than the 10 s outer detector.
- `cargo test --lib`: **1719 passed / 1 failed / 12 ignored** — the single failure is the KNOWN pre-existing machine-dependent `settings::ai_map::tests::default_config_is_cloud_claude_with_inactive_reactions` (expects "small", this machine resolves the turbo default), identical to the pre-change baseline. Zero compiler warnings.
- `swiftc -typecheck src-tauri/sysaudio/sysaudio.swift`: clean (audiocap re-typechecked as a sanity baseline).

## Honest gaps

- The sysaudio double-stop race fix is typecheck-verified only — an actual racing SIGTERM + parent-exit needs a live capture session on a real Mac.
- The lib.rs startup reap→salvage reordering has no unit-level ordering assertion (it would need a tauri app harness); the order is enforced by construction (sequential awaits inside one task) and documented inline. A dev-app boot smoke test was not run here.
- Item 5's "launch no longer blocks on /bin/ps" is not empirically measured — it follows from moving the calls off the setup thread.
- Bare `reqwest::get` also exists in `embed.rs` (`download_embed_model`) and `summarize/redact.rs` (`download_ner_model`) — user-driven Settings downloads, OUT of this task's scope; noted as follow-up candidates.
- Explicitly out of scope per the task: the single-instance app guard (needs owner sign-off).

None of the changes touch the lock model, gates, or seal paths.