### PR TITLE
feat(pipeline): salvage-from-disk re-run for died-in-transcription recordings + wedge hardening

### DIFF
--- a/src-tauri/src/audio/spill.rs
+++ b/src-tauri/src/audio/spill.rs
@@ -376,6 +376,120 @@ fn claim_system_scratch(src: &Path, dir: &Path, meeting_id: &str) -> Option<Path
     }
 }
 
+// ── Disk salvage (STAGE 3, 2026-07-16): re-run the pipeline off a surviving ARCHIVE WAV ─────────
+
+/// A stuck-`RECORDING` meeting claimed for a FROM-DISK pipeline re-run: its original pipeline died
+/// AFTER `finalize_meeting` wrote the archive WAV (so `audio_path` points at real audio) but before
+/// a terminal status. Pre-fix these rows were reconciled straight to `ERROR` with intact audio on
+/// disk that was never re-transcribed.
+pub struct DiskSalvageJob {
+    pub meeting_id: String,
+    pub wav_path: PathBuf,
+}
+
+/// The startup disk-salvage decision for ONE stuck-`RECORDING` row, as a PURE fn (unit-tested).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskSalvagePlan {
+    /// A plaintext archive WAV exists AND the meeting's folder is open (or absent) → re-run the
+    /// pipeline from disk. Salvage owns the row's final status; reconcile must skip it.
+    Salvage,
+    /// The audio exists only sealed (`.enc`), or the folder is locked (at launch the session
+    /// unlock set is ALWAYS empty, so a locked folder can never be salvaged here). NEVER decrypt
+    /// for salvage — leave the row to reconcile (terminal `ERROR`, audio untouched), recoverable
+    /// via `retry_transcription` after a Touch ID unlock.
+    DeferSealed,
+    /// No archive audio on disk at all → nothing to re-transcribe; reconcile flips it to `ERROR`
+    /// exactly as before.
+    NoAudio,
+}
+
+/// PURE disk-salvage decision. `folder_open` = the meeting has no folder OR its folder is not
+/// locked. FAIL-CLOSED: a locked folder defers even when a plaintext WAV exists (a crash-window
+/// leftover) — re-pipelining would write fresh plaintext (segments/note) behind the lock.
+pub fn disk_salvage_plan(wav_exists: bool, enc_exists: bool, folder_open: bool) -> DiskSalvagePlan {
+    if !folder_open {
+        return DiskSalvagePlan::DeferSealed;
+    }
+    if wav_exists {
+        DiskSalvagePlan::Salvage
+    } else if enc_exists {
+        DiskSalvagePlan::DeferSealed
+    } else {
+        DiskSalvagePlan::NoAudio
+    }
+}
+
+/// SYNCHRONOUS startup disk-salvage claim — runs in `lib.rs` setup AFTER [`claim_inflight`]
+/// (SPILL SALVAGE WINS: a spill job has both streams — mic + far side — so a meeting already in
+/// `already_claimed` is skipped here) and BEFORE `reconcile_stuck_recordings_except`, so a claimed
+/// row is not flipped to `ERROR` under the salvage worker. Per remaining stuck-`RECORDING` row it
+/// decides via [`disk_salvage_plan`]; `DeferSealed`/`NoAudio` rows are NOT claimed (reconcile makes
+/// them honest terminal `ERROR` rows — audio and `.enc` files are never touched here).
+///
+/// Returns `(jobs, claimed_meeting_ids)`. Best-effort + panic-free; logs carry UUIDs + counts only.
+pub fn claim_disk_salvage(db: &Db, already_claimed: &[String]) -> (Vec<DiskSalvageJob>, Vec<String>) {
+    let mut jobs = Vec::new();
+    let mut claimed = Vec::new();
+    let ids = match db.stuck_recording_ids() {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(target: "startup", error = %e, "disk salvage: could not list stuck recordings; skipping claim");
+            return (jobs, claimed);
+        }
+    };
+    for id in ids {
+        if already_claimed.contains(&id) {
+            continue; // the spill salvage owns this row (it has the richer dual-stream audio).
+        }
+        let meeting = match db.get_meeting(&id) {
+            Ok(Some(m)) => m,
+            _ => continue,
+        };
+        let Some(path) = meeting.audio_path.filter(|p| !p.trim().is_empty()) else {
+            continue; // NoAudio — reconcile flips it to ERROR exactly as before.
+        };
+        // Normalize: `audio_path` may name the plaintext WAV or (post-seal) the `.enc` itself.
+        let plaintext = path.trim_end_matches(".enc").to_string();
+        let wav_exists = Path::new(&plaintext).exists();
+        let enc_exists = Path::new(&format!("{plaintext}.enc")).exists();
+        // At launch the session unlock set is EMPTY, so "open" is purely the folder's lock bit.
+        let folder_open = match db.folder_for_meeting(&id) {
+            Ok(Some(fid)) => match db.folder_by_id(&fid) {
+                Ok(Some(f)) => !f.locked,
+                Ok(None) => true,
+                Err(_) => false, // unreadable folder row ⇒ fail closed (defer).
+            },
+            Ok(None) => true,
+            Err(_) => false, // fail closed.
+        };
+        match disk_salvage_plan(wav_exists, enc_exists, folder_open) {
+            DiskSalvagePlan::Salvage => {
+                jobs.push(DiskSalvageJob {
+                    meeting_id: id.clone(),
+                    wav_path: PathBuf::from(plaintext),
+                });
+                claimed.push(id);
+            }
+            DiskSalvagePlan::DeferSealed => {
+                tracing::info!(
+                    target: "startup",
+                    meeting_id = %id,
+                    "disk salvage deferred: the recording's audio is sealed / its folder is locked — the row becomes ERROR; unlock the folder and use Retry transcription"
+                );
+            }
+            DiskSalvagePlan::NoAudio => {}
+        }
+    }
+    if !claimed.is_empty() {
+        tracing::info!(
+            target: "startup",
+            salvaging = claimed.len(),
+            "claimed crashed recording(s) with surviving archive audio for from-disk re-transcription"
+        );
+    }
+    (jobs, claimed)
+}
+
 /// GC pass over the inflight dir: delete any orphaned `<id>.sys.wav` whose paired spill (`<id>.f32le`)
 /// AND sidecar (`<id>.json`) are BOTH gone — i.e. its salvage lifecycle is over (the job succeeded, was
 /// discarded, or preserved the far-side track on a mic-read error) and the file is now garbage that
@@ -414,16 +528,16 @@ fn reap_orphaned_system_wavs(dir: &Path) {
 /// pipeline sequentially. Best-effort + panic-free: a job failure marks that meeting `Error` (via
 /// `run_after_stop`) with its salvaged audio still attached — it NEVER deletes audio and NEVER
 /// crashes launch. A no-op when there are no jobs.
-pub fn spawn_salvage(app: AppHandle, jobs: Vec<SalvageJob>) {
-    if jobs.is_empty() {
+pub fn spawn_salvage(app: AppHandle, jobs: Vec<SalvageJob>, disk_jobs: Vec<DiskSalvageJob>) {
+    if jobs.is_empty() && disk_jobs.is_empty() {
         return;
     }
     let _ = std::thread::Builder::new()
         .name("murmur-crash-salvage".into())
-        .spawn(move || run_salvage_jobs(app, jobs));
+        .spawn(move || run_salvage_jobs(app, jobs, disk_jobs));
 }
 
-fn run_salvage_jobs(app: AppHandle, jobs: Vec<SalvageJob>) {
+fn run_salvage_jobs(app: AppHandle, jobs: Vec<SalvageJob>, disk_jobs: Vec<DiskSalvageJob>) {
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -436,8 +550,13 @@ fn run_salvage_jobs(app: AppHandle, jobs: Vec<SalvageJob>) {
             return;
         }
     };
+    // Spill jobs FIRST (richer dual-stream audio), then the from-disk re-runs. Sequential on one
+    // thread — heavy ASR additionally serializes through the shared `perf::run_heavy` gate.
     for job in jobs {
         rt.block_on(salvage_one(&app, job));
+    }
+    for job in disk_jobs {
+        rt.block_on(salvage_disk_one(&app, job));
     }
 }
 
@@ -500,6 +619,70 @@ async fn salvage_one(app: &AppHandle, job: SalvageJob) {
         Err(e) => tracing::warn!(target: "startup", meeting_id = %job.meeting_id, error = %e, "salvage pipeline failed; audio attached, meeting marked Error"),
     }
     cleanup_job_files(&job);
+}
+
+/// FROM-DISK re-run of one claimed stuck-`RECORDING` meeting (STAGE 3 — see [`claim_disk_salvage`]).
+/// Re-runs the EXISTING post-Stop pipeline off the surviving archive WAV
+/// ([`crate::pipeline::run_salvage_from_disk`] — same heavy-inference gate, ASR watchdog, and
+/// seal-aware persist as a live Stop). Fail-closed re-checks at run time (the detached worker can
+/// start seconds after the claim): the lock gate (a folder locked since the claim defers — flip to
+/// `ERROR`, audio untouched, recoverable via unlock + retry) and the recorder (a user already
+/// recording defers the same way — a salvage must not contend with a live capture; the row stays
+/// retryable). A pipeline error is already persisted terminal by `run_after_stop`'s Err arm; a
+/// PANIC is caught by the armed `TerminalStatusGuard`. NEVER deletes audio.
+async fn salvage_disk_one(app: &AppHandle, job: DiskSalvageJob) {
+    let state = app.state::<AppState>();
+
+    let defer_to_error = |reason: &str| {
+        let _ = state
+            .db
+            .update_meeting_status(&job.meeting_id, MeetingStatus::Error);
+        tracing::warn!(
+            target: "startup",
+            meeting_id = %job.meeting_id,
+            reason,
+            "disk salvage deferred; the recording stays terminal-Error with its audio intact (Retry transcription re-runs it)"
+        );
+    };
+
+    // Lock gate, re-checked fail-closed at run time (claim-time state can be stale).
+    match crate::commands::meeting_is_unlocked(&state, &job.meeting_id) {
+        Ok(true) => {}
+        Ok(false) => {
+            defer_to_error("folder locked");
+            return;
+        }
+        Err(_) => {
+            defer_to_error("lock state unreadable");
+            return;
+        }
+    }
+    // A recording the user started in the seconds since launch wins over the salvage.
+    let recording_active = state.recorder.lock().map(|r| r.is_some()).unwrap_or(true);
+    if recording_active {
+        defer_to_error("recording in progress");
+        return;
+    }
+
+    // Guard the non-terminal RECORDING row across the run: a panic inside the pipeline must still
+    // leave a terminal status (the guard is status-aware, so a healthy Summarized/Exported finish
+    // is never clobbered).
+    let terminal_guard = crate::pipeline::TerminalStatusGuard::arm(
+        Some(app.clone()),
+        state.db.clone(),
+        &job.meeting_id,
+    );
+    let result =
+        crate::pipeline::run_salvage_from_disk(app, &state, &job.meeting_id, &job.wav_path).await;
+    terminal_guard.disarm();
+    match result {
+        Ok(_) => {
+            tracing::info!(target: "startup", meeting_id = %job.meeting_id, "re-transcribed a crashed recording from its on-disk archive")
+        }
+        Err(e) => {
+            tracing::warn!(target: "startup", meeting_id = %job.meeting_id, error = %e, "from-disk salvage pipeline failed; audio intact, meeting marked Error")
+        }
+    }
 }
 
 /// Remove a job's inflight artifacts after processing. Best-effort + idempotent: the moved system WAV
@@ -839,5 +1022,185 @@ mod tests {
         assert!(half.exists(), "a half-live job (spill still present) is never reaped");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── STAGE 3: disk-salvage claims (2026-07-16 salvage-from-disk) ────────────────────────────
+
+    fn insert_meeting_with_audio(db: &Db, id: &str, status: MeetingStatus, audio: &Path) {
+        db.insert_meeting(&crate::storage::Meeting {
+            id: id.into(),
+            started_at: "2026-07-16T09:00:00Z".into(),
+            ended_at: None,
+            title: None,
+            duration_s: 60,
+            audio_path: Some(audio.to_string_lossy().to_string()),
+            status,
+            folder_id: None,
+        })
+        .unwrap();
+    }
+
+    /// Put `id` into a LOCKED folder — folder membership rides the meeting's NOTE row
+    /// (`folder_for_meeting` reads `notes.folder_id`), so a note row is required.
+    fn file_into_locked_folder(db: &Db, id: &str, folder_id: &str) {
+        db.insert_folder(&crate::storage::Folder {
+            id: folder_id.into(),
+            name: folder_id.into(),
+            path: folder_id.into(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-07-16T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.upsert_note(&crate::storage::NoteRecord {
+            meeting_id: id.into(),
+            provider_id: "claude_code".into(),
+            markdown: String::new(),
+            created_at: "2026-07-16T00:00:00Z".into(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_meeting_folder(id, Some(folder_id)).unwrap();
+    }
+
+    #[test]
+    fn disk_salvage_plan_truth_table() {
+        use DiskSalvagePlan::*;
+        assert_eq!(disk_salvage_plan(true, false, true), Salvage, "plaintext WAV + open folder ⇒ re-run");
+        assert_eq!(disk_salvage_plan(true, true, true), Salvage, "plaintext WAV present ⇒ re-run (the .enc twin is irrelevant)");
+        assert_eq!(disk_salvage_plan(false, true, true), DeferSealed, "only the sealed .enc ⇒ never decrypt for salvage");
+        assert_eq!(disk_salvage_plan(true, false, false), DeferSealed, "locked folder defers even with a plaintext WAV (fail closed)");
+        assert_eq!(disk_salvage_plan(false, true, false), DeferSealed);
+        assert_eq!(disk_salvage_plan(false, false, true), NoAudio, "nothing on disk ⇒ reconcile to ERROR as before");
+        assert_eq!(disk_salvage_plan(false, false, false), DeferSealed, "locked wins over missing audio (still fail closed)");
+    }
+
+    /// RED-before-GREEN (the ITEM-1 headline): pre-fix, a stuck-RECORDING row whose archive WAV
+    /// survived on disk (the pipeline died AFTER `finalize_meeting`) was reconciled straight to
+    /// ERROR — intact audio never re-transcribed. Post-fix the claim runs BEFORE reconcile and the
+    /// row is scheduled for a from-disk re-run instead of the ERROR flip.
+    #[test]
+    fn stuck_recording_with_surviving_archive_is_claimed_not_errored() {
+        let dir = tmp_dir("disk-claim");
+        let (db, db_path) = tmp_db();
+        let id = "disk-crash-1";
+        let wav = dir.join(format!("{id}.wav"));
+        std::fs::write(&wav, b"RIFF-fake-archive").unwrap();
+        insert_meeting_with_audio(&db, id, MeetingStatus::Recording, &wav);
+
+        // The exact lib.rs setup ordering: spill claim → disk claim → reconcile-except.
+        let (spill_jobs, mut claimed) = claim_inflight_in(&dir, &db);
+        assert!(spill_jobs.is_empty(), "no spill survives in this scenario");
+        let (disk_jobs, disk_claimed) = claim_disk_salvage(&db, &claimed);
+        claimed.extend(disk_claimed);
+        db.reconcile_stuck_recordings_except(&claimed).unwrap();
+
+        assert_eq!(disk_jobs.len(), 1, "the surviving archive is claimed for a from-disk re-run");
+        assert_eq!(disk_jobs[0].meeting_id, id);
+        assert_eq!(disk_jobs[0].wav_path, wav);
+        assert_eq!(
+            db.get_meeting(id).unwrap().unwrap().status,
+            MeetingStatus::Recording,
+            "a disk-claimed row must NOT be flipped to ERROR — the salvage worker owns its final status"
+        );
+        assert!(wav.exists(), "the claim never touches the audio file");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    /// A stuck-RECORDING row with NO usable audio (no `audio_path`, or the file is gone) is NOT
+    /// claimed — reconcile flips it to the honest terminal ERROR exactly as before.
+    #[test]
+    fn stuck_recording_without_audio_still_reconciles_to_error() {
+        let dir = tmp_dir("disk-noaudio");
+        let (db, db_path) = tmp_db();
+        insert_meeting(&db, "no-path", MeetingStatus::Recording); // audio_path: None
+        let gone = dir.join("gone.wav"); // named but never written
+        insert_meeting_with_audio(&db, "file-gone", MeetingStatus::Recording, &gone);
+
+        let (disk_jobs, claimed) = claim_disk_salvage(&db, &[]);
+        db.reconcile_stuck_recordings_except(&claimed).unwrap();
+
+        assert!(disk_jobs.is_empty() && claimed.is_empty(), "nothing to re-transcribe ⇒ nothing claimed");
+        for id in ["no-path", "file-gone"] {
+            assert_eq!(
+                db.get_meeting(id).unwrap().unwrap().status,
+                MeetingStatus::Error,
+                "an audio-less ghost still becomes a terminal ERROR row"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    /// LOCK MODEL: a stuck-RECORDING meeting in a LOCKED folder is NEVER claimed — with sealed
+    /// `.enc`-only audio there is nothing to decrypt with at launch (the session unlock set is
+    /// empty), and even a plaintext crash-window WAV must not be re-pipelined into fresh plaintext
+    /// behind the lock. The claim leaves every audio file byte-untouched; reconcile makes the row a
+    /// terminal ERROR that stays recoverable via unlock + `retry_transcription`.
+    #[test]
+    fn sealed_folder_salvage_defers_without_decrypting_or_leaking() {
+        let dir = tmp_dir("disk-sealed");
+        let (db, db_path) = tmp_db();
+
+        // Meeting A: audio exists ONLY as the sealed `.enc`.
+        let wav_a = dir.join("sealed-a.wav");
+        let enc_a = dir.join("sealed-a.wav.enc");
+        std::fs::write(&enc_a, b"AES-GCM-ciphertext").unwrap();
+        insert_meeting_with_audio(&db, "m-sealed-a", MeetingStatus::Recording, &wav_a);
+        file_into_locked_folder(&db, "m-sealed-a", "f-locked-a");
+
+        // Meeting B: a PLAINTEXT WAV survived the crash window inside a locked folder.
+        let wav_b = dir.join("sealed-b.wav");
+        std::fs::write(&wav_b, b"RIFF-fake-archive").unwrap();
+        insert_meeting_with_audio(&db, "m-sealed-b", MeetingStatus::Recording, &wav_b);
+        file_into_locked_folder(&db, "m-sealed-b", "f-locked-b");
+
+        let (disk_jobs, claimed) = claim_disk_salvage(&db, &[]);
+        assert!(
+            disk_jobs.is_empty() && claimed.is_empty(),
+            "a locked folder's meetings are never claimed for salvage (fail closed)"
+        );
+        assert!(enc_a.exists(), "the sealed .enc is byte-untouched");
+        assert!(!wav_a.exists(), "no plaintext was materialized for the sealed meeting");
+        assert!(wav_b.exists(), "the claim never deletes audio either");
+
+        db.reconcile_stuck_recordings_except(&claimed).unwrap();
+        for id in ["m-sealed-a", "m-sealed-b"] {
+            assert_eq!(
+                db.get_meeting(id).unwrap().unwrap().status,
+                MeetingStatus::Error,
+                "the deferred row becomes a terminal ERROR — recoverable via unlock + retry"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    /// Spill priority: a meeting the SPILL salvage already claimed (dual-stream audio — strictly
+    /// richer than the mixed archive) is skipped by the disk claim.
+    #[test]
+    fn spill_claim_wins_over_disk_claim() {
+        let dir = tmp_dir("disk-priority");
+        let (db, db_path) = tmp_db();
+        let id = "both-sources";
+        let wav = dir.join(format!("{id}.wav"));
+        std::fs::write(&wav, b"RIFF-fake-archive").unwrap();
+        insert_meeting_with_audio(&db, id, MeetingStatus::Recording, &wav);
+
+        let (disk_jobs, claimed) = claim_disk_salvage(&db, &[id.to_string()]);
+        assert!(
+            disk_jobs.is_empty() && claimed.is_empty(),
+            "a spill-claimed meeting is never double-claimed by the disk salvage"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_file(&db_path);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -941,7 +941,7 @@ async fn await_pipeline_task<T>(
     task.await.map_err(|e| {
         AppError::Other(anyhow::anyhow!(
             "note pipeline crashed unexpectedly ({e}) — the meeting was marked failed; \
-             try re-summarizing from the meeting page"
+             use Retry transcription on the recording to run it again"
         ))
     })?
 }
@@ -10027,7 +10027,21 @@ pub async fn resummarize(
             "this meeting's folder is locked — unlock it to re-summarize".into(),
         ));
     }
-    let result = pipeline::resummarize_existing(&app, &state, &meeting_id).await?;
+    // DETACHED, panic-mapped execution (the same #346 pattern as `stop_recording`): awaited
+    // INLINE, a panic inside `resummarize_existing` would leave the invoke Promise unsettled
+    // forever (Tauri never settles a panicked command future) — the sibling wedge. In a real
+    // spawned task the panic surfaces as a `JoinError` → `await_pipeline_task` maps it to an
+    // `AppError` so the Promise REJECTS. NO status-guard analog on purpose: every status
+    // resummarize can leave behind is already TERMINAL — it only writes `Summarized`/`Exported`
+    // on success and persists `Error` in its own Err arm, so a panic leaves the row at its prior
+    // terminal state and a Drop-guard would have nothing non-terminal to repair.
+    let task_app = app.clone();
+    let task_meeting_id = meeting_id.clone();
+    let resummarize_task = tauri::async_runtime::spawn(async move {
+        let state = task_app.state::<AppState>();
+        pipeline::resummarize_existing(&task_app, &state, &task_meeting_id).await
+    });
+    let result = await_pipeline_task(resummarize_task).await?;
     // COMMIT BOUNDARY: a re-summarize rewrites the meeting's note → BEST-EFFORT re-publish any org
     // shares of it so members see the fresh summary. Best-effort — never fails the re-summarize. If
     // ≥1 org copy was re-published, ping open org views so the fresh summary shows without a manual sync.
@@ -10045,6 +10059,126 @@ pub async fn resummarize(
             .exported_path
             .map(|p| p.to_string_lossy().to_string()),
     })
+}
+
+/// FROM-DISK re-transcription of a meeting in the terminal `Error` state whose ARCHIVE audio
+/// survived on disk (salvage-from-disk, 2026-07-16). The manual twin of the startup disk salvage:
+/// re-runs the SAME post-Stop pipeline (`pipeline::run_salvage_from_disk` → `run_after_stop`)
+/// off the archived WAV — heavy ASR rides the shared `perf::run_heavy` gate + the ASR watchdog
+/// exactly like a live Stop. Detached + panic-mapped like `stop_recording` (#346): a panic
+/// rejects the invoke Promise via `await_pipeline_task`, and the in-task `TerminalStatusGuard`
+/// (status-aware) restores a terminal state.
+///
+/// GATES (fail-closed, in order): refuse while a recording is ACTIVE (same check as
+/// `start_recording` — a salvage must not race a live capture); refuse a sealed-and-not-
+/// session-unlocked meeting (`meeting_is_unlocked` — this command NEVER decrypts a `.enc`; for a
+/// session-unlocked locked folder the playable WAV was already materialized by `unlock_folder`);
+/// refuse a non-`Error` row; refuse when no archive audio exists on disk. The single-flight
+/// CLAIM is the atomic `Error → Recording` status transition, so two concurrent retries can
+/// never both run — and a crash mid-retry leaves a stuck `RECORDING` row with an on-disk WAV,
+/// which the NEXT launch's disk salvage re-claims automatically.
+#[tauri::command]
+pub async fn retry_transcription(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<StopResult, AppError> {
+    let wav_path = retry_transcription_prep(state.inner(), &meeting_id)?;
+
+    let task_app = app.clone();
+    let task_meeting_id = meeting_id.clone();
+    let pipeline_task = tauri::async_runtime::spawn(async move {
+        let state = task_app.state::<AppState>();
+        // Armed NOW; disarmed after the run. The claim above flipped the row to the non-terminal
+        // `Recording`, so a panic-unwind must restore a terminal state (the guard's Drop persists
+        // `Error` — status-aware, so it never clobbers a row that already reached Summarized+).
+        let terminal_guard = pipeline::TerminalStatusGuard::arm(
+            Some(task_app.clone()),
+            state.db.clone(),
+            &task_meeting_id,
+        );
+        let result =
+            pipeline::run_salvage_from_disk(&task_app, &state, &task_meeting_id, &wav_path).await;
+        terminal_guard.disarm();
+        result
+    });
+    let result = await_pipeline_task(pipeline_task).await?;
+
+    Ok(StopResult {
+        meeting_id: result.meeting_id,
+        markdown: result.note_markdown,
+        exported_path: result
+            .exported_path
+            .map(|p| p.to_string_lossy().to_string()),
+    })
+}
+
+/// Synchronous prep/gate half of [`retry_transcription`], split out for headless tests: runs every
+/// fail-closed check, resolves the on-disk archive WAV, and — as the LAST step — atomically claims
+/// the row (`Error → Recording`). Nothing is mutated unless every gate passed.
+pub(crate) fn retry_transcription_prep(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    // No retry while a recording is in progress (mirror of `start_recording`'s own check).
+    {
+        let recorder = state
+            .recorder
+            .lock()
+            .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+        if recorder.is_some() {
+            return Err(AppError::Audio(
+                "a recording is in progress — stop it before retrying transcription".into(),
+            ));
+        }
+    }
+    // Lock gate: never re-pipeline (or decrypt) a sealed-and-not-session-unlocked meeting.
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting's folder is locked — unlock it to retry transcription".into(),
+        ));
+    }
+    let meeting = state
+        .db
+        .get_meeting(meeting_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no meeting with id {meeting_id}")))?;
+    if meeting.status != MeetingStatus::Error {
+        return Err(AppError::InvalidArg(
+            "retry transcription is only available for a failed recording".into(),
+        ));
+    }
+    let path = meeting.audio_path.filter(|p| !p.trim().is_empty()).ok_or_else(|| {
+        AppError::Storage(
+            "this recording has no archived audio on disk — nothing to re-transcribe".into(),
+        )
+    })?;
+    // Resolve a PLAINTEXT playable WAV. A `.enc`-only state past the gate (e.g. an unfiled row
+    // pointing at a sealed file) still refuses — this path never decrypts.
+    let plaintext = path.trim_end_matches(ENC_SUFFIX).to_string();
+    if !std::path::Path::new(&plaintext).exists() {
+        let enc = format!("{plaintext}{ENC_SUFFIX}");
+        if std::path::Path::new(&enc).exists() {
+            return Err(AppError::Locked(
+                "this recording's audio is sealed — unlock its folder, then retry".into(),
+            ));
+        }
+        return Err(AppError::Storage(
+            "this recording's audio file is no longer on disk — nothing to re-transcribe".into(),
+        ));
+    }
+    // Single-flight claim, LAST: only one retry may flip Error → Recording. (A crash after this
+    // leaves a stuck RECORDING row + an on-disk WAV — exactly what startup disk salvage re-claims.)
+    if !state.db.transition_meeting_status(
+        meeting_id,
+        MeetingStatus::Error,
+        MeetingStatus::Recording,
+    )? {
+        return Err(AppError::InvalidArg(
+            "a retry for this recording is already running".into(),
+        ));
+    }
+    tracing::info!(target: "pipeline", meeting_id = %meeting_id, "retry transcription claimed — re-running the pipeline from the archived audio");
+    Ok(std::path::PathBuf::from(plaintext))
 }
 
 /// Recent meetings for the Library list (newest first, capped). Sealed-and-not-session-unlocked
@@ -11784,6 +11918,88 @@ pub fn seal_auto_filed_note(
     folder_id: &str,
 ) -> Result<(), AppError> {
     move_into_locked_folder(state, meeting_id, folder_id)
+}
+
+/// LOCK-STATE FINALIZER for a from-disk pipeline re-run (`pipeline::run_salvage_from_disk` —
+/// `retry_transcription` + startup disk salvage). The re-run inserts fresh plaintext
+/// segments/audio exactly like a live Stop; for a meeting whose folder is LOCKED that fresh
+/// output must end up governed by the folder CK, matching what the normal pipeline's
+/// `SealInto` auto-file path produces. Called AFTER the pipeline on BOTH arms (an Err run may
+/// already have persisted segments before failing). Three branches, keyed on the folder's
+/// CURRENT lock state:
+///
+/// - **No folder / open folder** (every startup-salvage row — a stuck `RECORDING` meeting has no
+///   note rows, so no folder): nothing to do.
+/// - **Locked + session-unlocked** (a `retry_transcription` of a meeting in an unlocked locked
+///   folder): durably re-seal the fresh note/segments/timeline/audio under the folder CK via
+///   [`seal_auto_filed_note`] — the SAME verify-before-blank path a manual move / auto-file
+///   takes, which also restores the session plaintext afterward. Content is never lost.
+/// - **Locked + NOT unlocked** (a relock/screen-share auto-relock landed MID-RUN — the entry gate
+///   had passed): fail CLOSED. The relock's re-blank only covers rows with sealed blobs, so the
+///   fresh unsealed rows would otherwise sit plaintext-at-rest behind the lock forever. Purge the
+///   blob-less segments ([`Db::delete_unsealed_segments`] — derived data; the audio survives) and
+///   remove the plaintext WAV ONLY when its sealed `.enc` twin exists (never destroy the only
+///   copy). The row is already terminal `Error` (the note persist fail-closed with
+///   `AppError::Locked` inside the pipeline) and recoverable: unlock → retry.
+///
+/// Best-effort by contract: every failure is logged (ids/counts only) and swallowed — the
+/// finalizer must never mask the pipeline's own result.
+pub(crate) fn finalize_salvage_lock_state(state: &AppState, meeting_id: &str) {
+    let locked_folder = match state
+        .db
+        .folder_for_meeting(meeting_id)
+        .and_then(|fid| match fid {
+            Some(fid) => state.db.folder_by_id(&fid),
+            None => Ok(None),
+        }) {
+        Ok(f) => f.filter(|f| f.locked),
+        Err(e) => {
+            tracing::warn!(target: "lock", meeting_id = %meeting_id, error = %e, "salvage lock finalizer: folder lookup failed");
+            return;
+        }
+    };
+    let Some(folder) = locked_folder else {
+        return; // unfiled or open folder — the normal plaintext outcome is correct.
+    };
+    let session_unlocked = state
+        .unlocked_folders
+        .lock()
+        .map(|u| u.contains(&folder.id))
+        .unwrap_or(false); // poisoned set ⇒ treat as NOT unlocked (fail closed).
+    if session_unlocked {
+        // Same SealInto path as auto-file: seal fresh note+extras+audio (verify-before-blank),
+        // then restore the session plaintext. Idempotent for already-sealed rows.
+        if let Err(e) = seal_auto_filed_note(state, meeting_id, &folder.id) {
+            tracing::warn!(target: "lock", meeting_id = %meeting_id, error = %e, "salvage lock finalizer: re-seal into the unlocked locked folder failed");
+        } else {
+            tracing::info!(target: "lock", meeting_id = %meeting_id, "salvage output re-sealed into its session-unlocked locked folder");
+        }
+        return;
+    }
+    // Mid-run relock: purge the unsealed plaintext leftovers, fail closed.
+    match state.db.delete_unsealed_segments(meeting_id) {
+        Ok(n) if n > 0 => {
+            tracing::warn!(target: "lock", meeting_id = %meeting_id, purged = n, "salvage raced a relock — purged unsealed plaintext segments (audio stays sealed at rest; unlock + retry to re-transcribe)");
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(target: "lock", meeting_id = %meeting_id, error = %e, "salvage lock finalizer: unsealed-segment purge failed");
+        }
+    }
+    // Remove the freshly-written plaintext WAV ONLY when the sealed `.enc` twin exists — the
+    // audio content must never be destroyed without a surviving sealed copy.
+    if let Ok(Some(m)) = state.db.get_meeting(meeting_id) {
+        if let Some(path) = m.audio_path.as_deref().filter(|p| !p.ends_with(ENC_SUFFIX)) {
+            let enc = format!("{path}{ENC_SUFFIX}");
+            let sealed_copy_exists = std::path::Path::new(&enc).exists();
+            if sealed_copy_exists
+                && std::path::Path::new(path).exists()
+                && std::fs::remove_file(path).is_ok()
+            {
+                tracing::warn!(target: "lock", meeting_id = %meeting_id, "salvage raced a relock — removed the plaintext session WAV (sealed .enc retained)");
+            }
+        }
+    }
 }
 
 /// Seal ONE just-moved meeting's note (every provider row) + its transcript/timeline/audio under the
@@ -14202,7 +14418,9 @@ fn unlocked_snapshot(state: &AppState) -> Result<std::collections::HashSet<Strin
         .clone())
 }
 
-fn meeting_is_unlocked(state: &AppState, meeting_id: &str) -> Result<bool, AppError> {
+// `pub(crate)`: the disk-salvage worker (`audio::spill::salvage_disk_one`) re-checks this SAME
+// gate fail-closed right before re-running a claimed meeting through the pipeline.
+pub(crate) fn meeting_is_unlocked(state: &AppState, meeting_id: &str) -> Result<bool, AppError> {
     let folder_id = match state.db.folder_for_meeting(meeting_id)? {
         Some(f) => f,
         None => return Ok(true), // no folder / vault root → always open.
@@ -23408,6 +23626,188 @@ mod lifecycle_tests {
                 .markdown,
             MD
         );
+    }
+
+    // ── retry_transcription prep gates (salvage-from-disk, 2026-07-16) ──────────────────────────
+
+    /// Every fail-closed gate of `retry_transcription_prep`, in order: locked folder → `Locked`;
+    /// non-Error status → refused; missing audio → refused; happy path claims `Error → Recording`
+    /// exactly once (single-flight).
+    #[test]
+    fn retry_prep_gates_fail_closed_then_claims_single_flight() {
+        let state = build_state("retry-prep");
+
+        // Unknown meeting.
+        assert!(matches!(
+            retry_transcription_prep(&state, "m-none"),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // LOCKED folder → AppError::Locked (never re-pipeline sealed content).
+        seed_meeting(&state.db, "m-locked", "# sealed", None);
+        make_open_folder(&state.db, "f-retry-locked", "RetryLocked");
+        state
+            .db
+            .set_meeting_folder("m-locked", Some("f-retry-locked"))
+            .unwrap();
+        lock_folder_inner(&state, "f-retry-locked".to_string()).unwrap();
+        assert!(
+            matches!(
+                retry_transcription_prep(&state, "m-locked"),
+                Err(AppError::Locked(_))
+            ),
+            "a sealed-and-not-session-unlocked meeting must refuse with Locked"
+        );
+
+        // Non-Error status refused (seed_meeting leaves the row Summarized).
+        seed_meeting(&state.db, "m-summarized", "# fine", None);
+        assert!(matches!(
+            retry_transcription_prep(&state, "m-summarized"),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // Error status but NO audio on disk → refused, row untouched.
+        seed_meeting(&state.db, "m-no-audio", "# err", None);
+        state
+            .db
+            .update_meeting_status("m-no-audio", MeetingStatus::Error)
+            .unwrap();
+        assert!(matches!(
+            retry_transcription_prep(&state, "m-no-audio"),
+            Err(AppError::Storage(_))
+        ));
+        assert_eq!(
+            state.db.get_meeting("m-no-audio").unwrap().unwrap().status,
+            MeetingStatus::Error,
+            "a refused prep must not have claimed the row"
+        );
+
+        // Happy path: Error + a real on-disk WAV → claimed (Error → Recording), path resolved.
+        let wav = std::env::temp_dir().join(format!("murmur-retry-prep-{}.wav", std::process::id()));
+        std::fs::write(&wav, b"RIFF-fake").unwrap();
+        seed_meeting(&state.db, "m-retry", "# err", None);
+        state
+            .db
+            .finalize_meeting("m-retry", "2026-07-16T10:00:00Z", 60, &wav.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .update_meeting_status("m-retry", MeetingStatus::Error)
+            .unwrap();
+        let got = retry_transcription_prep(&state, "m-retry").unwrap();
+        assert_eq!(got, wav);
+        assert_eq!(
+            state.db.get_meeting("m-retry").unwrap().unwrap().status,
+            MeetingStatus::Recording,
+            "the claim flips Error → Recording (crash-safe: next launch's disk salvage re-claims it)"
+        );
+        // Single-flight: the row is no longer Error, so a second prep refuses.
+        assert!(retry_transcription_prep(&state, "m-retry").is_err());
+        let _ = std::fs::remove_file(&wav);
+    }
+
+    /// LOCK MODEL — the mid-run-relock fail-closed purge branch of `finalize_salvage_lock_state`:
+    /// a salvage/retry whose folder got LOCKED (and not session-unlocked) while the pipeline ran
+    /// must not leave fresh plaintext at rest behind the lock. Blob-less segments are purged and
+    /// the plaintext WAV is removed ONLY because its sealed `.enc` twin survives; an OPEN folder
+    /// (or no folder) is a strict no-op.
+    #[test]
+    fn finalize_salvage_lock_state_purges_unsealed_output_behind_a_relock() {
+        let state = build_state("salvage-finalize");
+
+        // No-op case first: an OPEN folder's meeting keeps its plaintext output.
+        seed_meeting(&state.db, "m-open", "# open", None);
+        finalize_salvage_lock_state(&state, "m-open");
+        assert_eq!(
+            state.db.get_segments("m-open").unwrap().len(),
+            2,
+            "an open/rootless meeting's fresh segments are untouched"
+        );
+
+        // Relock-raced case: meeting in a folder that is LOCKED and NOT session-unlocked, with
+        // fresh blob-less segments + a plaintext WAV whose sealed .enc twin exists.
+        let dir = std::env::temp_dir().join(format!("murmur-salvage-finalize-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wav = dir.join("m-raced.wav");
+        let enc = dir.join("m-raced.wav.enc");
+        std::fs::write(&wav, b"RIFF-fresh-plaintext").unwrap();
+        std::fs::write(&enc, b"AES-GCM-ciphertext").unwrap();
+
+        seed_meeting(&state.db, "m-raced", "# raced", None);
+        state
+            .db
+            .finalize_meeting("m-raced", "2026-07-16T10:00:00Z", 60, &wav.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-raced".into(),
+                name: "Raced".into(),
+                path: "Raced".into(),
+                parent_id: None,
+                locked: true, // locked, and deliberately NOT in the session unlock set
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-raced", Some("f-raced"))
+            .unwrap();
+
+        finalize_salvage_lock_state(&state, "m-raced");
+
+        assert!(
+            state.db.raw_segments("m-raced").unwrap().is_empty(),
+            "fresh blob-less plaintext segments are purged fail-closed"
+        );
+        assert!(!wav.exists(), "the plaintext WAV is removed (a sealed copy exists)");
+        assert!(enc.exists(), "the sealed .enc twin is never touched");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `finalize_salvage_lock_state` never removes a plaintext WAV WITHOUT a surviving sealed
+    /// `.enc` twin — content preservation beats the purge when no sealed copy exists.
+    #[test]
+    fn finalize_salvage_lock_state_keeps_the_only_audio_copy() {
+        let state = build_state("salvage-finalize-keep");
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-salvage-finalize-keep-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wav = dir.join("m-only.wav");
+        std::fs::write(&wav, b"RIFF-the-only-copy").unwrap();
+
+        seed_meeting(&state.db, "m-only", "# only", None);
+        state
+            .db
+            .finalize_meeting("m-only", "2026-07-16T10:00:00Z", 60, &wav.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-only".into(),
+                name: "Only".into(),
+                path: "Only".into(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-only", Some("f-only"))
+            .unwrap();
+
+        finalize_salvage_lock_state(&state, "m-only");
+
+        assert!(
+            wav.exists(),
+            "with no sealed .enc twin the plaintext WAV is the ONLY copy — never deleted"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// BLK-3: an `AppConfigDto` payload that OMITS `mcpRequireToken` deserializes to `true`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             commands::has_slack_token,
             commands::provider_statuses,
             commands::resummarize,
+            commands::retry_transcription,
             commands::list_meetings,
             commands::search_meetings,
             commands::delete_meeting,
@@ -425,27 +426,37 @@ pub fn run() {
                 ));
             }
 
-            // Crash-recovery (STAGE 2 salvage + STAGE 1 reconcile) + orphan reap. A session that died
-            // mid-record (crash / SIGKILL / `tauri dev` hot-rebuild) never ran `stop_recording`, so the
-            // meeting row `start_recording` inserted up-front sits as a `RECORDING` "ghost" AND its mic
-            // audio (RAM-only) + far-side scratch would be lost. ORDER IS LOAD-BEARING:
-            //   1) CLAIM salvage: find inflight mic spills of crashed recordings + MOVE the paired
-            //      far-side scratch out of $TMPDIR (before the reaper below deletes it). Runs FIRST so
-            //      the reaper can't eat a recoverable far-side track.
-            //   2) RECONCILE the remaining ghosts to terminal `ERROR` — SKIPPING the claimed rows
+            // Crash-recovery (STAGE 2 spill salvage + STAGE 3 disk salvage + STAGE 1 reconcile) +
+            // orphan reap. A session that died mid-record (crash / SIGKILL / `tauri dev` hot-rebuild)
+            // never ran `stop_recording`, so the meeting row `start_recording` inserted up-front sits
+            // as a `RECORDING` "ghost" AND its mic audio (RAM-only) + far-side scratch would be lost.
+            // ORDER IS LOAD-BEARING:
+            //   1) CLAIM spill salvage: find inflight mic spills of crashed recordings + MOVE the
+            //      paired far-side scratch out of $TMPDIR (before the reaper below deletes it). Runs
+            //      FIRST so the reaper can't eat a recoverable far-side track.
+            //   1b) CLAIM disk salvage (2026-07-16): among the ghosts the spill did NOT claim (spill
+            //      wins — it has both streams), any whose ARCHIVE WAV survived on disk (the pipeline
+            //      died AFTER finalize_meeting) is re-run from disk instead of being flipped to
+            //      ERROR with intact, never-re-transcribed audio. Sealed audio / a locked folder is
+            //      NEVER decrypted here — those rows fall through to reconcile (terminal ERROR, audio
+            //      untouched) and stay recoverable via `retry_transcription` after an unlock.
+            //   2) RECONCILE the remaining ghosts to terminal `ERROR` — SKIPPING every claimed row
             //      (salvage sets their final status itself), so a claimed row isn't clobbered.
             //   3) REAP orphaned capture helpers + sweep stale scratch (post-claim, so only truly-
             //      abandoned files remain).
             //   4) SPAWN the async salvage worker: reconstruct each claimed recording + run it through
             //      the EXISTING post-Stop pipeline → a real transcript+note. After the reap so the
             //      paired helper is already down. Best-effort; never deletes un-salvaged audio.
-            let salvage_jobs = {
+            let (salvage_jobs, disk_salvage_jobs) = {
                 let state = app.state::<AppState>();
-                let (jobs, claimed) = crate::audio::spill::claim_inflight(&state.db);
+                let (jobs, mut claimed) = crate::audio::spill::claim_inflight(&state.db);
+                let (disk_jobs, disk_claimed) =
+                    crate::audio::spill::claim_disk_salvage(&state.db, &claimed);
+                claimed.extend(disk_claimed);
                 if let Err(e) = state.db.reconcile_stuck_recordings_except(&claimed) {
                     tracing::warn!(target: "startup", error = %e, "could not reconcile stuck recordings");
                 }
-                jobs
+                (jobs, disk_jobs)
             };
 
             // Reap any capture helper ORPHANED by a previous session that died without a clean Stop
@@ -476,9 +487,10 @@ pub fn run() {
                 }
             }
 
-            // STAGE 2 salvage worker (async, detached): now that the reaper has downed any orphan
-            // helper, reconstruct + pipeline each claimed crashed recording. No-op when nothing crashed.
-            crate::audio::spill::spawn_salvage(app.handle().clone(), salvage_jobs);
+            // STAGE 2 + 3 salvage worker (async, detached): now that the reaper has downed any orphan
+            // helper, reconstruct + pipeline each claimed crashed recording — spill jobs first, then
+            // the from-disk re-runs. No-op when nothing crashed.
+            crate::audio::spill::spawn_salvage(app.handle().clone(), salvage_jobs, disk_salvage_jobs);
 
             create_bar_window(app.handle())?;
             if let Err(e) = app.global_shortcut().register(SUMMON_SHORTCUT) {

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -140,6 +140,35 @@ impl Drop for TerminalStatusGuard {
         }
         // Reached ONLY on a panic-unwind (or an unexpected early exit) out of the pipeline task.
         let body = std::panic::AssertUnwindSafe(|| {
+            // STATUS-AWARE (2026-07-16): if the row ALREADY reached a terminal status
+            // (Summarized/Exported/Error), skip the write AND the emit — a tail panic after
+            // "saved" (e.g. in a post-persist best-effort step) must not un-save the meeting by
+            // clobbering a healthy terminal state to Error, and must not flash a spurious error
+            // toast over a note that actually exists. Poison-safe read (`Db::lock` recovers via
+            // `into_inner`); a read failure or a missing row falls through to the conservative
+            // Error write exactly as before.
+            let already_terminal = self
+                .db
+                .get_meeting(&self.meeting_id)
+                .ok()
+                .flatten()
+                .map(|m| {
+                    matches!(
+                        m.status,
+                        MeetingStatus::Summarized
+                            | MeetingStatus::Exported
+                            | MeetingStatus::Error
+                    )
+                })
+                .unwrap_or(false);
+            if already_terminal {
+                tracing::warn!(
+                    target: "pipeline",
+                    meeting_id = %self.meeting_id,
+                    "pipeline task exited without disarming its guard, but the row is already terminal — skipping the Error overwrite"
+                );
+                return;
+            }
             if let Err(e) = self
                 .db
                 .update_meeting_status(&self.meeting_id, MeetingStatus::Error)
@@ -154,8 +183,8 @@ impl Drop for TerminalStatusGuard {
                 emit_status(
                     app,
                     "error",
-                    "Note processing failed unexpectedly. The recording was kept — try \
-                     re-summarizing from the meeting page.",
+                    "Note processing failed unexpectedly. The recording was kept — use \
+                     Retry transcription on the recording to run it again.",
                     &self.meeting_id,
                 );
             }
@@ -218,9 +247,13 @@ async fn with_stage_watchdog<T>(
                 bound_s = bound.as_secs(),
                 "stage watchdog fired — the stage is stuck; surfacing a terminal error"
             );
+            // Recovery pointer: re-summarizing can NOT re-run ASR (no segments were persisted by a
+            // stage that never finished) — the honest recovery is the from-disk re-transcription
+            // (`retry_transcription`), which re-runs the whole pipeline off the archived audio.
             Err(AppError::Transcribe(format!(
                 "transcription timed out after {} minutes (stage: {stage}) — the recording was \
-                 kept; try re-summarizing, or pick a smaller model in Settings",
+                 kept; use Retry transcription on the recording, or pick a smaller model in \
+                 Settings",
                 bound.as_secs() / 60
             )))
         }
@@ -281,6 +314,73 @@ pub async fn run_after_stop(
             Err(e)
         }
     }
+}
+
+/// FROM-DISK re-run of the post-Stop pipeline (2026-07-16, salvage-from-disk): re-transcribe a
+/// meeting whose ARCHIVE WAV survived on disk after its original pipeline died (crash / panic /
+/// force-quit between `finalize_meeting` and a terminal status), or whose user asked for a retry
+/// (`retry_transcription`). Reads the archived mix back into memory, then runs the EXACT SAME
+/// [`run_after_stop`] a live Stop takes — so the re-run inherits the heavy-inference gate
+/// (`perf::run_heavy`), the ASR watchdog, seal-aware note persist (`upsert_note_reseal_if_locked`)
+/// and the locked-folder export-skip branches with zero forking.
+///
+/// KNOWN, DOCUMENTED DEGRADATION: the archive is the COMBINED mic+system mix, so the re-run is
+/// single-stream — every segment is attributed to `me` (no `others` split, no diarization). A
+/// mono-attributed real transcript beats a dead `Error` row; the spill salvage (which still has
+/// both streams) always wins when present.
+///
+/// LOCK MODEL: callers MUST have passed the `meeting_is_unlocked` gate BEFORE handing a WAV path
+/// here (fail-closed — this fn never decrypts a sealed `.enc`). After the run — Ok or Err — the
+/// lock-state finalizer ([`crate::commands::finalize_salvage_lock_state`]) reconciles the fresh
+/// output with the folder's CURRENT lock state: a session-unlocked locked folder gets the fresh
+/// segments/timeline/audio durably re-sealed via the same `SealInto` path auto-file uses; a
+/// mid-run relock gets the unsealed plaintext leftovers purged fail-closed (audio survives as the
+/// sealed `.enc`).
+///
+/// A PRE-pipeline failure (unreadable/empty WAV) persists `Error` + emits the terminal `error`
+/// stage itself, mirroring `run_after_stop`'s Err arm, so the row never wedges non-terminal.
+pub async fn run_salvage_from_disk(
+    app: &AppHandle,
+    state: &AppState,
+    meeting_id: &str,
+    wav_path: &Path,
+) -> Result<PipelineResult> {
+    let prep: Result<(Vec<f32>, u32)> =
+        audio::read_wav_mono(wav_path).and_then(|(samples, rate)| {
+            if samples.is_empty() || rate == 0 {
+                Err(AppError::Audio(
+                    "archived recording audio is empty or unreadable — nothing to re-transcribe"
+                        .into(),
+                ))
+            } else {
+                Ok((samples, rate))
+            }
+        });
+    let (samples, rate) = match prep {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = state
+                .db
+                .update_meeting_status(meeting_id, MeetingStatus::Error);
+            emit_status(app, "error", &e.to_string(), meeting_id);
+            return Err(e);
+        }
+    };
+    let duration_s = (samples.len() as f64 / rate as f64).round() as i64;
+    // Single stream, anchored to a fresh Instant (the original capture clocks are gone) — the
+    // merge sees one stream, so the anchor only offsets absolute timestamps uniformly.
+    let now = std::time::Instant::now();
+    let result = run_after_stop(
+        app, state, meeting_id, samples, rate, duration_s, None, // no system stream
+        None, // no AEC helper track
+        now, None,
+    )
+    .await;
+    // Reconcile the fresh output with the folder's CURRENT lock state on BOTH arms (an Err run may
+    // already have inserted plaintext segments before failing). Best-effort: a finalizer failure is
+    // logged inside and must never mask the pipeline result.
+    crate::commands::finalize_salvage_lock_state(state, meeting_id);
+    result
 }
 
 /// Transcribe one 16 kHz stream at the Accurate profile, VAD-segmented. With a `VadSegmenter`,
@@ -844,7 +944,11 @@ async fn run_inner(
         tracing::info!(target: "transcribe", segments = merged_segments.len(), "merged mic + system streams (me/others)");
     }
 
-    state.db.insert_segments(meeting_id, &merged_segments)?;
+    // ATOMIC replace (delete + insert in one tx), not a keyed `INSERT OR REPLACE`: a fresh meeting
+    // is byte-identical (nothing to delete), but a RE-RUN of the pipeline over the same meeting
+    // (`retry_transcription` / disk salvage after a partial prior run) must not leave a stale
+    // higher-idx tail from the previous transcript interleaved into the new one.
+    state.db.replace_segments(meeting_id, &merged_segments)?;
     if echo_suppressed > 0 {
         tracing::info!(target: "transcribe", suppressed = echo_suppressed, "cross-stream echo segments removed");
         let _ = app.emit(
@@ -2460,6 +2564,33 @@ mod tests {
             status,
             MeetingStatus::Recording,
             "a disarmed guard must not touch the meeting status"
+        );
+    }
+
+    /// RED-before-GREEN (2026-07-16 status-aware guard): a guard left ARMED by a tail panic AFTER
+    /// the row already reached a TERMINAL status must not fire its Error write — "a tail panic
+    /// after 'saved' must not un-save". Pre-fix the Drop flipped the row to Error unconditionally,
+    /// so this failed with `Summarized != Error`.
+    #[test]
+    fn terminal_guard_drop_after_terminal_status_keeps_the_saved_status() {
+        let db = std::sync::Arc::new(
+            crate::storage::Db::open_with_key(&temp_db_path("guard-terminal"), TEST_DEK).unwrap(),
+        );
+        db.insert_meeting(&guard_test_meeting("m-saved")).unwrap();
+        db.update_meeting_status("m-saved", MeetingStatus::Summarized)
+            .unwrap();
+
+        let db_in = db.clone();
+        let unwound = std::panic::catch_unwind(move || {
+            let _guard = TerminalStatusGuard::arm(None, db_in, "m-saved");
+            panic!("simulated tail panic after the note was persisted");
+        });
+        assert!(unwound.is_err(), "the closure must have panicked");
+
+        assert_eq!(
+            db.get_meeting("m-saved").unwrap().unwrap().status,
+            MeetingStatus::Summarized,
+            "an armed guard dropped after the row reached a terminal status must NOT overwrite it with Error"
         );
     }
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -3021,6 +3021,43 @@ impl Db {
         Ok(())
     }
 
+    /// Compare-and-swap a meeting's status: set it to `to` ONLY if it is currently `from`.
+    /// Returns `true` when the transition landed (exactly one row changed), `false` when the row
+    /// was in a different status (or absent) — the loser of a concurrent claim. Used by
+    /// `retry_transcription` as its single-flight claim (`Error → Recording`): two simultaneous
+    /// retries of the same meeting can never both run the pipeline.
+    pub fn transition_meeting_status(
+        &self,
+        id: &str,
+        from: MeetingStatus,
+        to: MeetingStatus,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE meetings SET status = ?3 WHERE id = ?1 AND status = ?2",
+                rusqlite::params![id, from.as_str(), to.as_str()],
+            )
+            .map_err(map_err)?;
+        Ok(n == 1)
+    }
+
+    /// Ids of every meeting still stuck in the non-terminal `RECORDING` status — the crash "ghosts"
+    /// startup recovery must resolve (spill salvage / disk salvage / reconcile-to-`ERROR`).
+    /// UUIDs only, no content.
+    pub fn stuck_recording_ids(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT id FROM meetings WHERE status = ?1")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![MeetingStatus::Recording.as_str()], |r| {
+                r.get::<_, String>(0)
+            })
+            .map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+    }
+
     /// Crash-recovery reconcile: flip every meeting still stuck in `RECORDING` to the terminal
     /// `ERROR` state. Returns the number of rows reconciled.
     ///
@@ -3048,20 +3085,11 @@ impl Db {
     /// (no spill / not recoverable) is still flipped to the terminal `ERROR` state exactly as before.
     /// Idempotent + additive (the per-row `AND status = RECORDING` guard). Logs ids + counts, no PII.
     pub fn reconcile_stuck_recordings_except(&self, claimed: &[String]) -> Result<usize> {
-        let conn = self.lock();
         // Collect the ghost ids first (UUIDs — not PII) so the reconcile is auditable in the log.
-        let ids: Vec<String> = {
-            let mut stmt = conn
-                .prepare("SELECT id FROM meetings WHERE status = ?1")
-                .map_err(map_err)?;
-            let rows = stmt
-                .query_map(rusqlite::params![MeetingStatus::Recording.as_str()], |r| {
-                    r.get::<_, String>(0)
-                })
-                .map_err(map_err)?;
-            rows.collect::<rusqlite::Result<Vec<_>>>()
-                .map_err(map_err)?
-        };
+        // Done BEFORE taking the connection lock (`stuck_recording_ids` locks internally; the Mutex
+        // is not re-entrant).
+        let ids: Vec<String> = self.stuck_recording_ids()?;
+        let conn = self.lock();
         // Exclude the rows salvage claimed this launch — it owns their final status.
         let to_reconcile: Vec<&String> = ids.iter().filter(|id| !claimed.contains(id)).collect();
         if to_reconcile.is_empty() {
@@ -6497,6 +6525,63 @@ impl Db {
         }
         tx.commit().map_err(map_err)?;
         Ok(())
+    }
+
+    /// ATOMICALLY replace a meeting's transcript with `segments` — delete + insert in ONE
+    /// transaction, so either the full fresh set lands or the previous rows survive untouched
+    /// (never a half-replaced transcript, never a loss window). Needed by the from-disk
+    /// re-transcription path (`retry_transcription` / disk salvage): a keyed
+    /// `INSERT OR REPLACE` alone would leave a STALE TAIL when the fresh run yields fewer
+    /// segments than a prior partial run (old idx 12..40 interleaved into the new transcript).
+    /// The `_ad`/`_ai` FTS triggers fire inside the same transaction, so the search index stays
+    /// consistent with the swap.
+    pub fn replace_segments(&self, meeting_id: &str, segments: &[Segment]) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM segments WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO segments
+                       (meeting_id, idx, start_s, end_s, text, speaker, confidence)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                )
+                .map_err(map_err)?;
+            for seg in segments {
+                stmt.execute(rusqlite::params![
+                    meeting_id,
+                    seg.idx,
+                    seg.start_s,
+                    seg.end_s,
+                    seg.text,
+                    seg.speaker,
+                    seg.confidence,
+                ])
+                .map_err(map_err)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// FAIL-CLOSED cleanup for a salvage/retry pipeline that raced a mid-run relock: delete this
+    /// meeting's segments that carry PLAINTEXT with NO sealed blob (`text_blob IS NULL`) — the
+    /// unsealed fresh rows the relock's re-blank (guarded on `text_blob IS NOT NULL`) can never
+    /// cover. Rows WITH a blob (the durable sealed copies) are untouched. The deleted rows are
+    /// DERIVED data whose source audio survives sealed at rest (`.enc`), so nothing unrecoverable
+    /// is destroyed — privacy wins over keeping a re-derivable plaintext transcript behind a lock.
+    /// Returns the number of rows removed (ids/counts only in logs, never text).
+    pub fn delete_unsealed_segments(&self, meeting_id: &str) -> Result<usize> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM segments WHERE meeting_id = ?1 AND text_blob IS NULL",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)
     }
 
     /// All segments for a meeting, ordered by `idx`.
@@ -15757,6 +15842,99 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM segments", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// Salvage-from-disk: a pipeline RE-RUN over the same meeting must not interleave a stale tail
+    /// from a prior (longer) transcript — `replace_segments` swaps the whole set atomically in one
+    /// transaction (delete + insert), unlike the keyed `INSERT OR REPLACE` which would have left
+    /// old idx 2 alive.
+    #[test]
+    fn replace_segments_swaps_out_a_stale_tail_atomically() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-replace", "2026-07-16T10:00:00Z"))
+            .unwrap();
+        let seg = |idx: i64, text: &str| Segment {
+            idx,
+            start_s: idx as f64,
+            end_s: idx as f64 + 1.0,
+            text: text.into(),
+            speaker: None,
+            confidence: None,
+        };
+        db.insert_segments(
+            "m-replace",
+            &[seg(0, "old a"), seg(1, "old b"), seg(2, "stale tail")],
+        )
+        .unwrap();
+
+        // The fresh re-run yields FEWER segments — the stale idx-2 tail must be gone.
+        db.replace_segments("m-replace", &[seg(0, "new a"), seg(1, "new b")])
+            .unwrap();
+
+        let read = db.get_segments("m-replace").unwrap();
+        assert_eq!(read.len(), 2, "the stale higher-idx tail is swapped out");
+        assert_eq!(read[0].text, "new a");
+        assert_eq!(read[1].text, "new b");
+    }
+
+    /// `transition_meeting_status` is a compare-and-swap: only the caller that observes the
+    /// expected `from` status wins — the single-flight claim `retry_transcription` relies on.
+    #[test]
+    fn transition_meeting_status_is_a_single_flight_claim() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-cas", "2026-07-16T10:00:00Z"))
+            .unwrap();
+        db.update_meeting_status("m-cas", MeetingStatus::Error)
+            .unwrap();
+
+        assert!(
+            db.transition_meeting_status("m-cas", MeetingStatus::Error, MeetingStatus::Recording)
+                .unwrap(),
+            "the first claim (Error → Recording) wins"
+        );
+        assert!(
+            !db.transition_meeting_status("m-cas", MeetingStatus::Error, MeetingStatus::Recording)
+                .unwrap(),
+            "a second claim loses — the row is no longer in Error"
+        );
+        assert_eq!(
+            db.get_meeting("m-cas").unwrap().unwrap().status,
+            MeetingStatus::Recording
+        );
+        assert!(
+            !db.transition_meeting_status("m-none", MeetingStatus::Error, MeetingStatus::Recording)
+                .unwrap(),
+            "a missing row never transitions"
+        );
+    }
+
+    /// Mid-run-relock fail-closed purge: `delete_unsealed_segments` removes ONLY the blob-less
+    /// plaintext rows a relock's re-blank (guarded on `text_blob IS NOT NULL`) can never cover —
+    /// a sealed row (blob present) survives byte-untouched.
+    #[test]
+    fn delete_unsealed_segments_removes_only_blobless_rows() {
+        let db = mem_db();
+        db.insert_meeting(&sample_meeting("m-purge", "2026-07-16T10:00:00Z"))
+            .unwrap();
+        let seg = |idx: i64, text: &str| Segment {
+            idx,
+            start_s: idx as f64,
+            end_s: idx as f64 + 1.0,
+            text: text.into(),
+            speaker: None,
+            confidence: None,
+        };
+        db.insert_segments("m-purge", &[seg(0, "sealed row"), seg(1, "fresh plaintext")])
+            .unwrap();
+        // Seal row 0 (blob set, text blanked) — the durable copy a relock governs.
+        db.seal_segment("m-purge", 0, b"fake-ciphertext").unwrap();
+
+        assert_eq!(db.delete_unsealed_segments("m-purge").unwrap(), 1);
+
+        let raw = db.raw_segments("m-purge").unwrap();
+        assert_eq!(raw.len(), 1, "only the unsealed plaintext row was purged");
+        assert_eq!(raw[0].idx, 0, "the sealed row survives");
+        assert!(raw[0].text_blob.is_some(), "its sealed blob is untouched");
     }
 
     /// Tier 3b/A: `segments.confidence` persists through `insert_segments` → `get_segments`. A stored

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -959,6 +959,16 @@ export class IpcService {
     return invoke<StopResult>("resummarize", { meetingId });
   }
 
+  /**
+   * Re-run the FULL pipeline (ASR + summarize + export) from a failed recording's on-disk archive
+   * audio — the recovery for a pipeline that died mid-transcription (re-summarize alone cannot
+   * re-run ASR). Backend gates: meeting must be in the Error state, its folder unlocked, its
+   * archive audio present on disk, and no recording in progress.
+   */
+  retryTranscription(meetingId: string): Promise<StopResult> {
+    return invoke<StopResult>("retry_transcription", { meetingId });
+  }
+
   listMeetings(): Promise<Meeting[]> {
     return invoke<Meeting[]>("list_meetings");
   }


### PR DESCRIPTION
Closes the recovery + sibling gaps left after #346/#343/#344 (the silent post-Stop pipeline death fixes).

## What

### 1. Salvage-from-disk (the main feature)
A recording whose pipeline died **after** the archive WAV was written (`finalize_meeting` ran; status still `RECORDING`) was reconciled straight to `ERROR` at next launch — intact on-disk audio never re-transcribed.

- **Launch (STAGE 3):** `audio::spill::claim_disk_salvage` runs in `lib.rs` setup after `claim_inflight` (**spill wins** — it has both streams; a spill-claimed id is skipped) and **before** `reconcile_stuck_recordings_except`. A stuck-`RECORDING` row whose plaintext archive WAV survives is claimed and re-run through the **existing** post-Stop pipeline (`pipeline::run_salvage_from_disk` → `run_after_stop`: same `perf::run_heavy` gate, same ASR watchdog, same seal-aware persist / locked-folder export-skip branches — zero forking). The established setup ordering (claim → reconcile → reap → spawn_salvage) is preserved; the worker runs spill jobs first, then disk jobs, sequentially.
- **`retry_transcription` command** (registered in `generate_handler!`): re-runs the same from-disk pipeline for a meeting in `ERROR` whose archive audio exists. Gates, in order: refuses while a recording is active (same check as `start_recording`); `meeting_is_unlocked` fail-closed (`AppError::Locked`); status must be `Error`; audio must exist on disk. Single-flight claim = atomic `Error → Recording` CAS (`Db::transition_meeting_status`) — two concurrent retries can never both run, and a **crash mid-retry leaves a stuck `RECORDING` row + on-disk WAV, which the next launch's disk salvage re-claims automatically**. Detached + panic-mapped like `stop_recording` (#346), with a `TerminalStatusGuard` armed around the run.
- **FE seam (minimal by design):** one typed `IpcService.retryTranscription(meetingId): Promise<StopResult>`. No UI in this stream.
- `run_inner` now persists segments via `Db::replace_segments` (delete + insert in ONE transaction — byte-identical for a fresh meeting) so a re-run never interleaves a stale higher-idx tail from a prior partial transcript, and a failed insert rolls back to the previous rows (no loss window).

### Lock model (flagging for `lock-security-reviewer`)
- **Never decrypts for salvage.** At launch the session unlock set is empty, so any locked-folder meeting (or `.enc`-only audio) is **deferred**: not claimed, logged non-leakily (UUID + stage only), reconciled to terminal `ERROR` with every audio byte untouched — recoverable via Touch-ID unlock + `retry_transcription`. Fail-closed even when a plaintext crash-window WAV exists inside a locked folder.
- **Re-pipelined output flows through the normal gated paths.** The note persist rides `upsert_note_reseal_if_locked` (fail-closed on a missing session KEK) and the `meeting_locked` export-skip branches, exactly like a live Stop.
- **`finalize_salvage_lock_state`** (runs after the pipeline, both arms): a **session-unlocked locked** folder gets the fresh segments/timeline/audio durably re-sealed via `seal_auto_filed_note` — the *same* `SealInto` path auto-file/manual-move uses (verify-before-blank, session plaintext restored). A **mid-run relock** (the narrow race after the entry gate passed) is handled fail-closed: blob-less plaintext segments are purged (`Db::delete_unsealed_segments` — derived data; the audio survives as the sealed `.enc`), and the plaintext WAV is removed **only when its `.enc` twin exists** (never destroys the only copy; tested).
- No new read/export path: everything the FE sees still goes through the existing `meeting_is_unlocked`-gated commands and masked DTOs; `audio_path` handling is unchanged.
- **Known degradation (documented):** the archive is the combined mic+system mix, so a from-disk re-run is single-stream — segments are attributed `me` (no diarized `others`). Spill salvage (both streams) always wins when present.

### 2. `TerminalStatusGuard::drop` status-aware
On Drop it flipped the row to `Error` unconditionally; now a row already terminal (`Summarized`/`Exported`/`Error`) skips the write + emit — a tail panic after "saved" no longer un-saves. Poison-safe read, still wrapped in `catch_unwind`.

### 3. `resummarize` sibling wedge
`resummarize` awaited `resummarize_existing` inline — a panic left the invoke Promise unsettled (the #346 class). Now detached + `await_pipeline_task` (JoinError → AppError). No status-guard analog on purpose: every status resummarize can leave behind is already terminal (it writes `Summarized`/`Exported` on success and persists `Error` in its own Err arm).

### 4. Watchdog-timeout message
Pointed at "re-summarizing", which cannot re-run ASR (no segments persist). Now points at Retry transcription (also updated the guard-drop + join-error sibling strings).

## How verified

- `(cd src-tauri && cargo test --lib)` — **1725 passed; 1 failed; 12 ignored**. The single failure is the documented pre-existing machine-specific `settings::ai_map::tests::default_config_is_cloud_claude_with_inactive_reactions` (expects `small`, this machine has the turbo model) — unrelated to this diff and present on trunk.
- **RED-before-GREEN, proven by temporary revert:** with the pre-fix behavior simulated (`disk_salvage_plan` forced to `NoAudio`; guard terminal-check disabled), `stuck_recording_with_surviving_archive_is_claimed_not_errored` failed (`0 != 1` jobs, row → ERROR) and `terminal_guard_drop_after_terminal_status_keeps_the_saved_status` failed (`Error != Summarized`); both green on the real code.
- New tests (18 targeted, all green): `disk_salvage_plan_truth_table`, `stuck_recording_with_surviving_archive_is_claimed_not_errored`, `stuck_recording_without_audio_still_reconciles_to_error`, `sealed_folder_salvage_defers_without_decrypting_or_leaking`, `spill_claim_wins_over_disk_claim`, `terminal_guard_drop_after_terminal_status_keeps_the_saved_status`, `replace_segments_swaps_out_a_stale_tail_atomically`, `transition_meeting_status_is_a_single_flight_claim`, `delete_unsealed_segments_removes_only_blobless_rows`, `retry_prep_gates_fail_closed_then_claims_single_flight`, `finalize_salvage_lock_state_purges_unsealed_output_behind_a_relock`, `finalize_salvage_lock_state_keeps_the_only_audio_copy`.
- `npx ng lint` clean; `npx ng build` clean.

## Honest gaps
- The end-to-end salvage run (real whisper decode of a real archive at launch / via the command) needs a dev-app or signed-build session — headless tests prove the claim/gate/ordering/seal logic, not a live decode.
- Touch-ID-gated unlock → retry of a sealed meeting only truly verifies on a signed build (dev builds degrade biometrics to `Ok(true)`).
- During a retry the row status is transiently `RECORDING` (that is what makes a crashed retry auto-recoverable); the library may briefly render it as such until the pipeline's status events land. Cosmetic; no UI shipped in this stream.
- A stale cached timeline from a pre-retry partial run is not force-invalidated (it heals via `repair_coverage` / explicit regeneration); left out deliberately to keep the diff scoped.
- `scripts/ci.sh` (clippy `-D warnings` + E2E) not run here; new code avoids the known lint traps (`redundant_closure_call`, `collapsible_if` fixed during review).