### PR TITLE
feat(audit): weekly schedule + on-device judge tier + per-finding AI explain

### DIFF
--- a/e2e/brain/audit-inbox.spec.ts
+++ b/e2e/brain/audit-inbox.spec.ts
@@ -146,3 +146,180 @@ test("Vault audit: inbox mounts, groups, resolves, and refetches on event", asyn
 
   expect(consoleErrors).toEqual([]);
 });
+
+/**
+ * Phase 3 — weekly schedule chip + per-finding "Explain (AI)" (mocked IPC):
+ *  - the passive header chip renders from `get_audit_schedule`
+ *    ("Weekly: on · last run yesterday") without expanding the section;
+ *  - "Explain (AI)" fetches `explain_audit_finding` and renders the returned
+ *    markdown INLINE in the row, with the provider name subtly attached;
+ *  - once loaded the button toggles the collapsible block (no re-fetch);
+ *  - a rejection (consent-missing / Locked, verbatim) raises a danger toast
+ *    and leaves the row unchanged — no explanation block appears.
+ */
+test("Vault audit: schedule chip renders and Explain (AI) loads inline or toasts", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    get_audit_schedule: () => ({
+      enabled: true,
+      // Exactly one day back → the chip's relative label is "yesterday".
+      lastRunAt: Math.floor(Date.now() / 1000) - 86_400,
+      nextDueAt: Math.floor(Date.now() / 1000) + 6 * 86_400,
+    }),
+    list_audit_findings: () => [
+      {
+        id: "f-ok",
+        kind: "contradiction",
+        sourceKind: "note",
+        sourceId: "n-1",
+        sourceTitle: "Project Atlas decision",
+        targetTitle: "Atlas kickoff meeting",
+        evidenceMd: "One note says **ship in Q3**, the other **Q4**.",
+        acceptAction: "",
+        status: "pending",
+        createdAt: 1752600000,
+        resolvedAt: null,
+      },
+      {
+        id: "f-err",
+        kind: "orphan",
+        sourceKind: "note",
+        sourceId: "n-2",
+        sourceTitle: "Scratch note",
+        targetTitle: null,
+        evidenceMd: "No links in, no links out.",
+        acceptAction: "",
+        status: "pending",
+        createdAt: 1752600001,
+        resolvedAt: null,
+      },
+    ],
+    explain_audit_finding: (args: { id: string }) => {
+      if (args.id === "f-err") {
+        throw new Error(
+          "AI consent required — enable cloud assistance in Settings",
+        );
+      }
+      return {
+        findingId: args.id,
+        explanationMd:
+          "These two notes disagree because **Q3 slipped to Q4** after the June review.",
+        provider: "Claude",
+      };
+    },
+  });
+
+  await page.goto("/brain");
+  const section = page.locator("app-audit");
+  await expect(section).toBeVisible();
+
+  // The passive schedule chip renders in the (still collapsed) header.
+  await expect(section.locator(".au-weekly")).toHaveText(
+    /Weekly: on · last run yesterday/,
+  );
+
+  // Expand the inbox.
+  await section.locator(".au-toggle").click();
+  const okRow = section
+    .locator(".au-item")
+    .filter({ hasText: "Project Atlas decision" });
+  const errRow = section
+    .locator(".au-item")
+    .filter({ hasText: "Scratch note" });
+
+  // Explain success: the markdown renders inline + the provider is credited.
+  await okRow.getByRole("button", { name: "Explain (AI)" }).click();
+  await expect(okRow.locator(".au-explain strong")).toHaveText(
+    "Q3 slipped to Q4",
+  );
+  await expect(okRow.locator(".au-explain-provider")).toHaveText(/via Claude/);
+
+  // Once loaded the button toggles the collapsible block instead of re-fetching.
+  await okRow.getByRole("button", { name: "Hide explanation" }).click();
+  await expect(okRow.locator(".au-explain")).toHaveCount(0);
+  await okRow.getByRole("button", { name: "Show explanation" }).click();
+  await expect(okRow.locator(".au-explain")).toBeVisible();
+
+  // Explain rejection: danger toast with the backend message, row unchanged.
+  await errRow.getByRole("button", { name: "Explain (AI)" }).click();
+  await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
+    /AI consent required — enable cloud assistance in Settings/,
+  );
+  await expect(errRow.locator(".au-explain")).toHaveCount(0);
+  await expect(
+    errRow.getByRole("button", { name: "Explain (AI)" }),
+  ).toBeEnabled();
+  await expect(errRow.getByRole("button", { name: "Dismiss" })).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * Phase 3 — the Settings → AI & Models "Weekly vault audit" toggle
+ * (confirm-then-update, never optimistic):
+ *  - the switch loads DISABLED until `get_audit_schedule` resolves, then
+ *    mirrors the backend state;
+ *  - flipping it calls `set_audit_schedule { enabled }` and settles on the
+ *    RESPONSE;
+ *  - a rejected commit raises a danger toast and the switch reverts to the
+ *    last confirmed state.
+ */
+test("Settings: weekly-audit toggle commits via set_audit_schedule and reverts on failure", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_audit_schedule: () => ({
+      enabled: false,
+      lastRunAt: null,
+      nextDueAt: null,
+    }),
+    set_audit_schedule: (args: { enabled: boolean }) => {
+      const w = window as unknown as { __setAuditCalls: boolean[] };
+      w.__setAuditCalls = [...(w.__setAuditCalls ?? []), args.enabled];
+      if (args.enabled === false) {
+        // Second flip (on → off) rejects, proving the revert path.
+        throw new Error("Locked: unlock the vault to change the schedule");
+      }
+      return { enabled: args.enabled, lastRunAt: null, nextDueAt: null };
+    },
+  });
+
+  await page.goto("/settings");
+  await page.getByText("AI & Models").first().click();
+
+  const row = page
+    .locator("app-on-device-intelligence-block label.toggle-row")
+    .filter({ hasText: "Weekly vault audit" });
+  const input = row.locator("mur-toggle input");
+
+  // Loaded state mirrors the backend: off, and interactive.
+  await expect(input).toBeEnabled();
+  await expect(input).not.toBeChecked();
+
+  // Flip ON → set_audit_schedule({ enabled: true }) confirms → stays on.
+  await input.click();
+  await expect(input).toBeChecked();
+  await expect(input).toBeEnabled();
+
+  // Flip OFF → the backend rejects → toast + revert to the confirmed ON.
+  await input.click();
+  await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
+    /Locked: unlock the vault to change the schedule/,
+  );
+  await expect(input).toBeChecked();
+  await expect(input).toBeEnabled();
+
+  // The command saw exactly the two user flips, in order.
+  expect(
+    await page.evaluate(
+      () => (window as unknown as { __setAuditCalls: boolean[] }).__setAuditCalls,
+    ),
+  ).toEqual([true, false]);
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -801,6 +801,18 @@ scope to the GA-critical path only.
       case "meeting_org_shares": return [];
       case "org_live_shares_for_source": return [];
 
+      // ── Vault audit — weekly schedule + AI explain ──
+      // Object-shaped (a bare `get_` name would fall through to the `[]`
+      // fallback below — the FE expects an AuditSchedule, not an array).
+      case "get_audit_schedule": return { enabled: false, lastRunAt: null, nextDueAt: null };
+      case "set_audit_schedule": return { enabled: !!args.enabled, lastRunAt: null, nextDueAt: null };
+      case "explain_audit_finding":
+        return {
+          findingId: args.id,
+          explanationMd: "This finding flags content worth a second look — review the evidence above and accept or dismiss.",
+          provider: "On-device",
+        };
+
       // ── exports / misc ──
       case "export_audio": case "export_note": case "export_mic_master": case "export_sys_master": return null;
       case "export_canvas": return `${VAULT}/Canvas/Q2-Roadmap.canvas`;

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -62,12 +62,44 @@ pub struct AuditRunSummary {
     pub run_id: String,
     pub started_at: i64,
     pub finished_at: i64,
-    /// Findings newly staged THIS pass (post-dedupe).
+    /// Findings newly staged THIS pass (post-dedupe, PRE-judge — the deterministic pass's count;
+    /// `demoted` says how many of them the judge then deleted).
     pub findings_new: usize,
-    /// Total pending findings after the pass (includes survivors of earlier passes).
+    /// Total pending findings after the pass (includes survivors of earlier passes; refreshed
+    /// AFTER the judge tier when it ran).
     pub findings_total_pending: usize,
     /// New findings per kind, e.g. `{"broken_link": 2, "orphan": 1}`.
     pub counts: BTreeMap<String, usize>,
+    /// Judge tier (Phase 3): how many of this run's `contradiction`/`stale` findings the LOCAL
+    /// judge scored (0 when the light model is absent — the stub skip).
+    pub judged: usize,
+    /// …and how many it demoted (deleted outright as noise; they may re-stage next pass).
+    pub demoted: usize,
+}
+
+/// The weekly-schedule wire DTO (`get_audit_schedule` / `set_audit_schedule`). Both timestamps
+/// are EPOCH MILLISECONDS — the same unit as `AuditFinding.createdAt`/`resolvedAt` and the
+/// `audit_runs` columns (everything on the audit surface flows from
+/// `chrono::Utc::now().timestamp_millis()`). `next_due_at` is `last_run_at + 7 days` when
+/// enabled; `None` when disabled, OR when enabled but never run — the never-ran case is due at
+/// the NEXT hourly check (the FE reads `None` + `enabled` as "runs within the hour").
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditSchedule {
+    pub enabled: bool,
+    pub last_run_at: Option<i64>,
+    pub next_due_at: Option<i64>,
+}
+
+/// The `explain_audit_finding` wire DTO. RETURN-ONLY — the explanation is never persisted
+/// anywhere (no new derived-plaintext at rest); `provider` names the connection that produced it
+/// (the egress-ledger row is the durable record of the call, content-free as always).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditExplanation {
+    pub finding_id: String,
+    pub explanation_md: String,
+    pub provider: String,
 }
 
 /// One finding, FE-shaped. `evidence_md`/`accept_action` are blanked once resolved (only
@@ -258,6 +290,10 @@ pub fn run_audit_pass(
         findings_new,
         findings_total_pending,
         counts,
+        // The judge tier runs AFTER the deterministic pass (see `judge_run_findings`); the
+        // caller folds its stats in.
+        judged: 0,
+        demoted: 0,
     })
 }
 
@@ -284,6 +320,293 @@ pub(crate) fn reconcile_run_on_epoch_advance(
         "seal epoch advanced during the pass; the run's staged findings were withdrawn"
     );
     Ok((0, BTreeMap::new()))
+}
+
+// ── Phase 3: the weekly schedule ──────────────────────────────────────────────────────────────
+
+/// One week in milliseconds — the scheduled-audit cadence.
+pub const WEEKLY_AUDIT_INTERVAL_MS: i64 = 7 * 24 * 60 * 60 * 1_000;
+
+/// Is a scheduled audit pass due? PURE (now + the last SCHEDULED run's `finished_at` are
+/// injected). Due when enabled AND (never scheduled-ran, OR a full week has elapsed since the
+/// last scheduled run — `>=`, the brief runner's catch-up semantics: a late tick still fires).
+/// A claim row inserted before a pass counts as "ran", so a crashed/failed pass holds the week
+/// (claim-before-run — no hourly retry storm).
+pub fn weekly_due(now_ms: i64, last_scheduled_finished_at: Option<i64>, enabled: bool) -> bool {
+    if !enabled {
+        return false;
+    }
+    match last_scheduled_finished_at {
+        None => true,
+        Some(last) => now_ms.saturating_sub(last) >= WEEKLY_AUDIT_INTERVAL_MS,
+    }
+}
+
+/// ONE hourly due-check (called from the `lib.rs` consolidation-cadence loop — the first check is
+/// a full interval after launch, so run-on-launch-if-due comes free at +1h). Discipline:
+/// - re-reads the LIVE flag + last-scheduled-run from `AppState` each tick;
+/// - skips WITHOUT claiming on thermal ≥ Serious or a refusing RAM gate (retries next hour —
+///   the deterministic pass is always allowed once the gates pass);
+/// - CLAIMS the week (inserts the `scheduled = 1` run row) BEFORE the pass, so a crash/failure
+///   cannot re-fire until next week;
+/// - runs the SAME gated deterministic pass as the manual command (EMPTY unlock set inside
+///   `run_audit_pass`), then the judge tier, then emits the count-only
+///   [`crate::events::EVENT_AUDIT_UPDATED`] exactly like the manual command.
+/// NEVER panics; every failure is a warn (ids/counts only — no PII).
+pub async fn audit_weekly_tick(handle: &tauri::AppHandle) {
+    use tauri::Manager;
+    let Some(state) = handle.try_state::<crate::state::AppState>() else {
+        return; // init failed — nothing to audit.
+    };
+    let enabled = state
+        .config
+        .lock()
+        .map(|c| c.vault_audit_weekly_enabled)
+        .unwrap_or(false); // poisoned config ⇒ skip this tick (fail quiet, retry next hour).
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let last = match state.db.last_scheduled_audit_run_finished_at() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(target: "audit", error = %e, "weekly tick: schedule read failed");
+            return;
+        }
+    };
+    if !weekly_due(now_ms, last, enabled) {
+        return;
+    }
+    // Gates — checked BEFORE the claim so a hot/starved machine retries next hour instead of
+    // burning its weekly slot on a skip.
+    if crate::thermal::read_thermal_level() >= crate::thermal::ThermalLevel::Serious {
+        tracing::info!(target: "audit", "weekly audit skipped: thermal pressure (retrying next hour)");
+        return;
+    }
+    if !crate::transcribe::model::topic_backfill_ram_permits_now() {
+        tracing::info!(target: "audit", "weekly audit skipped: low system RAM (retrying next hour)");
+        return;
+    }
+    // CLAIM the week before running — a pass that crashes below cannot storm.
+    let claim_id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) = state.db.insert_scheduled_audit_run_claim(&claim_id, now_ms) {
+        tracing::warn!(target: "audit", error = %e, "weekly tick: claim insert failed; skipping");
+        return;
+    }
+    // The deterministic pass on a blocking worker (the manual command's exact shape).
+    let tick_handle = handle.clone();
+    let joined = tokio::task::spawn_blocking(move || {
+        let state = tick_handle.state::<crate::state::AppState>();
+        let vault = state
+            .config
+            .lock()
+            .ok()
+            .and_then(|c| c.vault_path.clone())
+            .filter(|p| !p.is_empty());
+        run_audit_pass(
+            &state.db,
+            vault.as_deref().map(Path::new),
+            chrono::Utc::now().timestamp_millis(),
+            &state.seal_epoch,
+        )
+    })
+    .await;
+    let summary = match joined {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            tracing::warn!(target: "audit", error = %e, "weekly audit pass failed; next attempt next week");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(target: "audit", error = %e, "weekly audit task join failed; next attempt next week");
+            return;
+        }
+    };
+    let stats = judge_run_findings(state.inner(), &summary.run_id).await;
+    let pending = state.db.count_pending_audit_findings().unwrap_or(0);
+    crate::events::emit_audit_updated(handle, pending as u32);
+    tracing::info!(
+        target: "audit",
+        run_id = %summary.run_id,
+        new = summary.findings_new,
+        judged = stats.judged,
+        demoted = stats.demoted,
+        pending,
+        "weekly vault audit complete"
+    );
+}
+
+// ── Phase 3: the LOCAL judge tier (noise demoter — NEVER cloud) ───────────────────────────────
+
+/// Hard wall-clock budget for ONE whole judge stage (all findings together) — the rerank.rs
+/// budget pattern, sized up because a judged finding is a full evidence block rather than a
+/// snippet, and the stage runs at most weekly (plus on manual runs).
+pub const JUDGE_STAGE_BUDGET_MS: u64 = 10_000;
+
+/// Hard decode cap per pointwise judge call — the answer is a one-key JSON bool.
+const JUDGE_MAX_TOKENS: usize = 32;
+
+/// The finding kinds the judge may score. Deliberately ONLY the two heuristic-noise-prone kinds:
+/// broken links / orphans / unlinked mentions are exact string/graph facts a model cannot
+/// out-judge.
+const JUDGED_KINDS: [&str; 2] = ["contradiction", "stale"];
+
+/// Judge-stage outcome (counts only — the observability AND the summary fields).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JudgeStats {
+    /// Findings whose judge call returned a parseable verdict.
+    pub judged: usize,
+    /// Findings deleted as noise (`keep = false`).
+    pub demoted: usize,
+}
+
+/// The pointwise judge core (SYNC — runs on the blocking pool under the heavy-inference permit).
+/// For each row: one strict tiny-JSON `{"keep": bool}` call on the LOCAL reasoner, deadline-
+/// checked BETWEEN rows, each call bounded by [`JUDGE_MAX_TOKENS`] + the remaining wall-clock
+/// budget (the rerank.rs pattern). The prompt carries ONLY the finding's own `kind` +
+/// `evidence_md` — already visible-by-construction (staged by the gated pass, purged on seal) —
+/// and reaches ONLY the on-device model (zero egress by construction; the orchestrator resolves
+/// `ReasonerCell::light`, local-or-stub, never cloud).
+///
+/// LOSS-SAFE degrade contract (the rerank posture): any error, malformed reply, or deadline
+/// expiry KEEPS the finding. `keep = false` DELETES the pending row outright — NOT dismiss, whose
+/// `dedupe_key` suppression would permanently silence a real issue; a deleted finding re-stages
+/// on the next pass if the evidence recurs. A row resolved/purged since the read is left alone
+/// (`delete_pending_audit_finding` is pending-only). Logs counts only.
+pub(crate) fn judge_findings_sync(
+    db: &Db,
+    reasoner: &dyn crate::reason::LocalReasoner,
+    rows: &[AuditFindingRow],
+    budget_ms: u64,
+) -> JudgeStats {
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + Duration::from_millis(budget_ms);
+    // Tiny schema (< 512 B serialized) — the strict-JSON pointwise shape.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": { "keep": { "type": "boolean" } },
+        "required": ["keep"]
+    });
+    let system = "You review automated vault-audit findings for noise. Reply ONLY with JSON: \
+                  {\"keep\": true} if the finding flags a real, useful issue worth showing the \
+                  user, {\"keep\": false} if it is noise (trivial, self-evident, or not \
+                  actionable).";
+
+    let mut stats = JudgeStats::default();
+    for row in rows {
+        let now = Instant::now();
+        if now >= deadline {
+            break; // out of budget — the rest are kept (degrade toward keeping everything).
+        }
+        let user = format!("Finding kind: {}\n\nEvidence:\n{}", row.kind, row.evidence_md);
+        let opts = crate::reason::GenOptions {
+            max_tokens: Some(JUDGE_MAX_TOKENS),
+            temperature: Some(0.0),
+            enable_thinking: false,
+            timeout: Some(deadline - now),
+            ..crate::reason::GenOptions::default()
+        };
+        match reasoner.structured_with(system, &user, &schema, opts) {
+            Ok(v) => {
+                let Some(keep) = v.get("keep").and_then(|b| b.as_bool()) else {
+                    continue; // malformed shape ⇒ keep (uncounted).
+                };
+                stats.judged += 1;
+                if !keep {
+                    match db.delete_pending_audit_finding(&row.id) {
+                        Ok(true) => stats.demoted += 1,
+                        Ok(false) => {} // resolved/purged since the read — left alone.
+                        Err(e) => {
+                            tracing::warn!(target: "audit", error = %e, "judge demote delete failed; keeping");
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                // Any reasoner failure ⇒ keep. No PII in logs — the counts below are the
+                // observability (the rerank.rs posture).
+            }
+        }
+    }
+    tracing::info!(
+        target: "audit",
+        candidates = rows.len(),
+        judged = stats.judged,
+        demoted = stats.demoted,
+        "audit judge stage complete"
+    );
+    stats
+}
+
+/// Judge THIS run's newly staged `contradiction`/`stale` findings (each finding is judged exactly
+/// once, at staging time — survivors are not re-judged by later passes). Resolves the LIGHT local
+/// engine (local-or-stub, NEVER cloud — the consolidation-job discipline) and SKIPS on the stub;
+/// takes the ONE global heavy-inference permit for the whole stage. Degrades to keep-everything
+/// on any failure — this function never errors.
+pub async fn judge_run_findings(state: &crate::state::AppState, run_id: &str) -> JudgeStats {
+    let reasoner = state.reasoner.light();
+    if reasoner.id() == "stub" {
+        tracing::debug!(target: "audit", "no local light model; skipping the audit judge stage");
+        return JudgeStats::default();
+    }
+    let rows: Vec<AuditFindingRow> = match state.db.list_audit_finding_rows("pending") {
+        Ok(rows) => rows
+            .into_iter()
+            .filter(|r| r.run_id == run_id && JUDGED_KINDS.contains(&r.kind.as_str()))
+            .collect(),
+        Err(e) => {
+            tracing::warn!(target: "audit", error = %e, "judge stage: pending read failed; keeping everything");
+            return JudgeStats::default();
+        }
+    };
+    if rows.is_empty() {
+        return JudgeStats::default();
+    }
+    let db = state.db.clone();
+    match crate::perf::run_heavy(&state.heavy_inference, move || {
+        Ok(judge_findings_sync(&db, reasoner.as_ref(), &rows, JUDGE_STAGE_BUDGET_MS))
+    })
+    .await
+    {
+        Ok(stats) => stats,
+        Err(e) => {
+            tracing::warn!(target: "audit", error = %e, "judge stage failed; keeping everything");
+            JudgeStats::default()
+        }
+    }
+}
+
+// ── Phase 3: the explain prompt (user-initiated; the PROVIDER seam owns consent/redaction) ─────
+
+/// Char cap on the gated source-note excerpt the explanation prompt carries (a bounded snippet,
+/// not the whole note — the brief runner's budget posture, sized for one note).
+pub(crate) const EXPLAIN_SNIPPET_CHARS: usize = 4_000;
+
+/// Compose the (system, user) prompt for one finding explanation. PURE. `source_snippet` is the
+/// caller's ALREADY-GATED, already-capped excerpt of the source note (current session unlock
+/// set); everything else comes off the pending row itself (pending rows hold the derived
+/// plaintext by design).
+pub(crate) fn build_explain_prompt(row: &AuditFindingRow, source_snippet: &str) -> (String, String) {
+    let system = "You are Murmur's vault-health assistant. Explain ONE automated audit finding \
+                  to the user: what was detected, why it matters for their notes, and what \
+                  accepting the suggested action would do. Reply in concise markdown (a short \
+                  paragraph, optionally a few bullets). Ground every statement in the provided \
+                  evidence — do not invent content."
+        .to_string();
+    let mut user = format!(
+        "Finding kind: {}\nSource note: {}\n",
+        row.kind, row.source_title
+    );
+    if let Some(t) = row.target_title.as_deref().filter(|t| !t.is_empty()) {
+        user.push_str(&format!("Related note: {t}\n"));
+    }
+    user.push_str(&format!("\nEvidence:\n{}\n", row.evidence_md));
+    if !row.accept_action.is_empty() {
+        user.push_str(&format!("\nSuggested action on accept: {}\n", row.accept_action));
+    }
+    if !source_snippet.trim().is_empty() {
+        user.push_str(&format!(
+            "\nSource note excerpt (may be truncated):\n{source_snippet}\n"
+        ));
+    }
+    (system, user)
 }
 
 /// The gated corpus: every VISIBLE meeting note + standalone note, read with the EMPTY unlock
@@ -906,10 +1229,30 @@ mod tests {
             findings_new: 3,
             findings_total_pending: 4,
             counts: [("broken_link".to_string(), 3usize)].into_iter().collect(),
+            judged: 2,
+            demoted: 1,
         };
         assert_eq!(
             serde_json::to_string(&summary).unwrap(),
-            r#"{"runId":"r1","startedAt":1,"finishedAt":2,"findingsNew":3,"findingsTotalPending":4,"counts":{"broken_link":3}}"#
+            r#"{"runId":"r1","startedAt":1,"finishedAt":2,"findingsNew":3,"findingsTotalPending":4,"counts":{"broken_link":3},"judged":2,"demoted":1}"#
+        );
+        let schedule = AuditSchedule {
+            enabled: true,
+            last_run_at: Some(10),
+            next_due_at: Some(10 + WEEKLY_AUDIT_INTERVAL_MS),
+        };
+        assert_eq!(
+            serde_json::to_string(&schedule).unwrap(),
+            r#"{"enabled":true,"lastRunAt":10,"nextDueAt":604800010}"#
+        );
+        let explanation = AuditExplanation {
+            finding_id: "f1".into(),
+            explanation_md: "because".into(),
+            provider: "claude_code".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&explanation).unwrap(),
+            r#"{"findingId":"f1","explanationMd":"because","provider":"claude_code"}"#
         );
         let finding = AuditFinding {
             id: "f1".into(),
@@ -1682,5 +2025,287 @@ mod tests {
         let pending = db.list_audit_finding_rows("pending").unwrap();
         assert_eq!(pending.len(), 1, "only the other run's row survives: {pending:#?}");
         assert_eq!(pending[0].dedupe_key, "k-other-run");
+    }
+
+    // ── Phase 3: the weekly schedule ──
+
+    /// The pure due predicate: enabled + (never-ran OR a full week elapsed, `>=` catch-up).
+    #[test]
+    fn weekly_due_matrix() {
+        let now = 1_700_000_000_000i64;
+        // Never scheduled-ran + enabled → due.
+        assert!(weekly_due(now, None, true));
+        // Disabled → never due, even never-ran.
+        assert!(!weekly_due(now, None, false));
+        assert!(!weekly_due(now, Some(now - WEEKLY_AUDIT_INTERVAL_MS - 1), false));
+        // Ran 6 days ago → holds.
+        assert!(!weekly_due(now, Some(now - WEEKLY_AUDIT_INTERVAL_MS + 1), true));
+        // EXACTLY a week ago → fires (>= — a late hourly tick still catches up).
+        assert!(weekly_due(now, Some(now - WEEKLY_AUDIT_INTERVAL_MS), true));
+        // Over a week ago → fires.
+        assert!(weekly_due(now, Some(now - WEEKLY_AUDIT_INTERVAL_MS - 3_600_000), true));
+        // Clock skew (a claim stamped in the future) → holds, never a storm.
+        assert!(!weekly_due(now, Some(now + 60_000), true));
+    }
+
+    /// CLAIM-BEFORE-RUN: the scheduled claim row alone (no completed pass — the crash case) holds
+    /// the week; manual (unscheduled) run rows never count toward due-ness. Also proves the
+    /// additive `scheduled` migration is idempotent and the claim/read round-trips.
+    #[test]
+    fn scheduled_claim_holds_the_week_and_manual_runs_do_not() {
+        let db = file_db("sched-claim");
+        db.migrate().unwrap(); // second run — the scheduled column migration is idempotent.
+        assert_eq!(db.last_scheduled_audit_run_finished_at().unwrap(), None);
+
+        // A MANUAL pass's bookkeeping row (scheduled = 0) leaves the weekly runner due.
+        let t0 = 1_700_000_000_000i64;
+        db.insert_audit_run("r-manual", t0, t0, "{}").unwrap();
+        assert_eq!(
+            db.last_scheduled_audit_run_finished_at().unwrap(),
+            None,
+            "manual runs never push the weekly cadence"
+        );
+        assert!(weekly_due(t0 + 1, None, true));
+
+        // The CLAIM row (inserted BEFORE the pass) holds the week even though no pass completed.
+        db.insert_scheduled_audit_run_claim("r-claim", t0).unwrap();
+        assert_eq!(db.last_scheduled_audit_run_finished_at().unwrap(), Some(t0));
+        assert!(
+            !weekly_due(t0 + 3_600_000, Some(t0), true),
+            "a failed/crashed pass cannot re-fire within the claimed week"
+        );
+        assert!(weekly_due(t0 + WEEKLY_AUDIT_INTERVAL_MS, Some(t0), true));
+
+        // The NEWEST claim wins.
+        let t1 = t0 + WEEKLY_AUDIT_INTERVAL_MS;
+        db.insert_scheduled_audit_run_claim("r-claim-2", t1).unwrap();
+        assert_eq!(db.last_scheduled_audit_run_finished_at().unwrap(), Some(t1));
+    }
+
+    // ── Phase 3: the local judge tier ──
+
+    /// A test reasoner with a canned verdict stream (or a hard failure).
+    struct VerdictReasoner {
+        /// `Some(bool)` = `{"keep": bool}`; `None` = malformed reply (no `keep` key).
+        verdicts: Vec<Option<bool>>,
+        calls: std::sync::atomic::AtomicUsize,
+        fail: bool,
+        delay_ms: u64,
+    }
+    impl VerdictReasoner {
+        fn keeping(verdicts: Vec<Option<bool>>) -> Self {
+            Self { verdicts, calls: std::sync::atomic::AtomicUsize::new(0), fail: false, delay_ms: 0 }
+        }
+    }
+    impl crate::reason::LocalReasoner for VerdictReasoner {
+        fn id(&self) -> &str {
+            "judge-test"
+        }
+        fn reason(&self, _s: &str, _u: &str) -> Result<String> {
+            Ok(String::new())
+        }
+        fn structured(
+            &self,
+            _s: &str,
+            _u: &str,
+            _schema: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            if self.delay_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(self.delay_ms));
+            }
+            if self.fail {
+                return Err(crate::error::AppError::Unavailable("model wedged".into()));
+            }
+            let i = self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.verdicts.get(i).copied().flatten() {
+                Some(keep) => Ok(serde_json::json!({ "keep": keep })),
+                None => Ok(serde_json::json!({ "not_the_schema": 1 })),
+            }
+        }
+    }
+
+    /// Stage one judged-kind finding and return its row.
+    fn stage_judged_finding(db: &Db, key: &str, kind: &str) -> AuditFindingRow {
+        db.insert_audit_finding_if_new(
+            &NewAuditFinding {
+                kind: kind.into(),
+                source_kind: "meeting".into(),
+                source_id: "m-j".into(),
+                source_title: "T".into(),
+                target_title: None,
+                target_id: None,
+                target_kind: None,
+                evidence_md: "> a vs b".into(),
+                accept_action: "".into(),
+                dedupe_key: key.to_string(),
+            },
+            "run-judge",
+            1,
+        )
+        .unwrap();
+        db.list_audit_finding_rows("pending")
+            .unwrap()
+            .into_iter()
+            .find(|r| r.dedupe_key == key)
+            .unwrap()
+    }
+
+    /// `keep = false` DELETES the row outright (not dismiss) — so the SAME dedupe key can be
+    /// re-staged by a later pass (a real issue recurs); `keep = true` keeps it pending.
+    #[test]
+    fn judge_demote_deletes_and_the_finding_can_restage() {
+        let db = file_db("judge-demote");
+        let kept = stage_judged_finding(&db, "k-keep", "contradiction");
+        let demoted = stage_judged_finding(&db, "k-demote", "stale");
+
+        let reasoner = VerdictReasoner::keeping(vec![Some(true), Some(false)]);
+        let stats = judge_findings_sync(
+            &db,
+            &reasoner,
+            &[kept.clone(), demoted.clone()],
+            JUDGE_STAGE_BUDGET_MS,
+        );
+        assert_eq!((stats.judged, stats.demoted), (2, 1));
+        assert!(db.get_audit_finding(&kept.id).unwrap().is_some(), "keep=true survives");
+        assert!(
+            db.get_audit_finding(&demoted.id).unwrap().is_none(),
+            "keep=false is DELETED (not dismissed)"
+        );
+        // Deletion (unlike dismissal) leaves NO dedupe twin — the issue can re-stage next pass.
+        assert!(
+            db.insert_audit_finding_if_new(
+                &NewAuditFinding {
+                    kind: "stale".into(),
+                    source_kind: "meeting".into(),
+                    source_id: "m-j".into(),
+                    source_title: "T".into(),
+                    target_title: None,
+                    target_id: None,
+                    target_kind: None,
+                    evidence_md: "> a vs b".into(),
+                    accept_action: "".into(),
+                    dedupe_key: "k-demote".into(),
+                },
+                "run-next",
+                2,
+            )
+            .unwrap(),
+            "a demoted finding re-stages on the next pass"
+        );
+    }
+
+    /// The degrade matrix: an exhausted budget, a malformed reply, and a hard reasoner failure
+    /// ALL keep every finding (loss-safe — the judge can only ever delete on an explicit false).
+    #[test]
+    fn judge_degrades_keep_everything_on_budget_malformed_and_error() {
+        let db = file_db("judge-degrade");
+        let r1 = stage_judged_finding(&db, "k-1", "contradiction");
+        let r2 = stage_judged_finding(&db, "k-2", "stale");
+        let rows = vec![r1, r2];
+
+        // Budget already exhausted (0 ms) → nothing judged, nothing deleted.
+        let demote_all = VerdictReasoner::keeping(vec![Some(false), Some(false)]);
+        let stats = judge_findings_sync(&db, &demote_all, &rows, 0);
+        assert_eq!((stats.judged, stats.demoted), (0, 0));
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 2);
+
+        // Malformed replies (no `keep` key) → kept, uncounted.
+        let malformed = VerdictReasoner::keeping(vec![None, None]);
+        let stats = judge_findings_sync(&db, &malformed, &rows, JUDGE_STAGE_BUDGET_MS);
+        assert_eq!((stats.judged, stats.demoted), (0, 0));
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 2);
+
+        // Hard failures → kept.
+        let failing = VerdictReasoner {
+            verdicts: vec![],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            fail: true,
+            delay_ms: 0,
+        };
+        let stats = judge_findings_sync(&db, &failing, &rows, JUDGE_STAGE_BUDGET_MS);
+        assert_eq!((stats.judged, stats.demoted), (0, 0));
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 2);
+
+        // The STUB reasoner's reply carries no `keep` key either → the same keep-everything path
+        // (the orchestrator additionally skips the stage entirely on id() == "stub").
+        let stats = judge_findings_sync(&db, &crate::reason::StubReasoner, &rows, JUDGE_STAGE_BUDGET_MS);
+        assert_eq!((stats.judged, stats.demoted), (0, 0));
+        assert_eq!(db.list_audit_finding_rows("pending").unwrap().len(), 2);
+    }
+
+    /// A slow first call blows the stage deadline: later findings are NEVER judged (kept), and
+    /// a row resolved between the read and the verdict is left alone (pending-only delete).
+    #[test]
+    fn judge_deadline_and_resolved_row_are_loss_safe() {
+        let db = file_db("judge-deadline");
+        let r1 = stage_judged_finding(&db, "k-slow-1", "contradiction");
+        let r2 = stage_judged_finding(&db, "k-slow-2", "stale");
+
+        // 30 ms budget vs a 60 ms call: the FIRST verdict (false) lands past its own in-call
+        // timeout budget but the call itself is judged at t≈0; the SECOND row falls past the
+        // deadline and is kept.
+        let slow = VerdictReasoner {
+            verdicts: vec![Some(false), Some(false)],
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            fail: false,
+            delay_ms: 60,
+        };
+        let stats = judge_findings_sync(&db, &slow, &[r1.clone(), r2.clone()], 30);
+        assert!(stats.judged <= 1, "at most the first row is judged: {stats:?}");
+        assert!(
+            db.get_audit_finding(&r2.id).unwrap().is_some(),
+            "a past-deadline row is kept"
+        );
+
+        // Pending-only delete: a row the user resolved between read and verdict survives.
+        let r3 = stage_judged_finding(&db, "k-resolved", "stale");
+        db.resolve_audit_finding_row(&r3.id, "accepted", 5).unwrap();
+        let demote = VerdictReasoner::keeping(vec![Some(false)]);
+        let stats = judge_findings_sync(&db, &demote, &[r3.clone()], JUDGE_STAGE_BUDGET_MS);
+        assert_eq!(stats.demoted, 0, "a resolved row is never deleted");
+        assert_eq!(
+            db.get_audit_finding(&r3.id).unwrap().unwrap().status,
+            "accepted",
+            "the resolved row is untouched"
+        );
+    }
+
+    // ── Phase 3: the explain prompt (pure) ──
+
+    #[test]
+    fn explain_prompt_carries_evidence_action_and_snippet_only() {
+        let row = AuditFindingRow {
+            id: "f1".into(),
+            kind: "contradiction".into(),
+            source_kind: "meeting".into(),
+            source_id: "m-a".into(),
+            source_title: "Meeting A".into(),
+            target_title: Some("Meeting B".into()),
+            target_id: Some("m-b".into()),
+            target_kind: Some("meeting".into()),
+            evidence_md: "> \"shipped\" vs \"cancelled\"".into(),
+            accept_action: "Append [!conflict] callouts cross-linking both sources".into(),
+            dedupe_key: "k".into(),
+            status: "pending".into(),
+            run_id: "r".into(),
+            created_at: 1,
+            resolved_at: None,
+        };
+        let (system, user) = build_explain_prompt(&row, "the gated excerpt");
+        assert!(system.contains("do not invent"), "grounding instruction present");
+        assert!(user.contains("contradiction"));
+        assert!(user.contains("Meeting A") && user.contains("Meeting B"));
+        assert!(user.contains("shipped") && user.contains("cancelled"));
+        assert!(user.contains("Append [!conflict]"));
+        assert!(user.contains("the gated excerpt"));
+
+        // No snippet / no action / no target → those sections are simply absent.
+        let mut bare = row.clone();
+        bare.target_title = None;
+        bare.accept_action = String::new();
+        let (_, user) = build_explain_prompt(&bare, "");
+        assert!(!user.contains("Related note:"));
+        assert!(!user.contains("Suggested action"));
+        assert!(!user.contains("excerpt"));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6291,7 +6291,7 @@ pub async fn run_vault_audit(
     app: AppHandle,
 ) -> Result<crate::audit::AuditRunSummary, AppError> {
     let handle = app.clone();
-    let summary = tokio::task::spawn_blocking(move || {
+    let mut summary = tokio::task::spawn_blocking(move || {
         let state = handle.state::<AppState>();
         let vault = vault_path(&state);
         crate::audit::run_audit_pass(
@@ -6303,6 +6303,18 @@ pub async fn run_vault_audit(
     })
     .await
     .map_err(|e| AppError::Other(anyhow::anyhow!("audit task join failed: {e}")))??;
+    // Phase 3 judge tier: score THIS run's contradiction/stale findings on the LOCAL light
+    // engine (skip on stub, budget-bounded, degrade-to-keep — see `judge_run_findings`), then
+    // report/emit the POST-judge pending count.
+    {
+        let state = app.state::<AppState>();
+        let stats = crate::audit::judge_run_findings(state.inner(), &summary.run_id).await;
+        summary.judged = stats.judged;
+        summary.demoted = stats.demoted;
+        if stats.demoted > 0 {
+            summary.findings_total_pending = state.db.count_pending_audit_findings()?;
+        }
+    }
     crate::events::emit_audit_updated(&app, summary.findings_total_pending as u32);
     Ok(summary)
 }
@@ -6333,25 +6345,13 @@ pub(crate) fn list_audit_findings_inner(
     let rows = state.db.list_audit_finding_rows(status)?;
     let mut out = Vec::new();
     for r in rows {
-        let visible = match r.source_kind.as_str() {
-            "meeting" => state.db.meeting_is_visible(&r.source_id, &unlocked)?,
-            _ => state.db.note_is_visible(&r.source_id, &unlocked)?,
-        };
-        if !visible {
+        // SOURCE + TARGET re-gate (lock review, defense in depth): a pending row's titles/
+        // evidence reference both sides, so either side sealing between pass and list hides the
+        // row. `audit_row_visible` fails CLOSED on an untyped target (`target_id` without
+        // `target_kind` — such a row cannot be re-gated against the right table), and the
+        // explain command shares the same helper so the two gates can never diverge.
+        if !audit_row_visible(state, &r, &unlocked)? {
             continue; // sealed since the pass — hide, never mask.
-        }
-        // TARGET side too (lock review, defense in depth): a pending row's title/evidence
-        // reference its target, so a target whose folder sealed between pass and list must hide
-        // the row — `target_kind` picks the right table (`meeting_is_visible` treats an unknown
-        // id as visible, so an untyped check would fail open for note targets).
-        if let (Some(tid), Some(tkind)) = (&r.target_id, &r.target_kind) {
-            let target_visible = match tkind.as_str() {
-                "meeting" => state.db.meeting_is_visible(tid, &unlocked)?,
-                _ => state.db.note_is_visible(tid, &unlocked)?,
-            };
-            if !target_visible {
-                continue;
-            }
         }
         out.push(r.into_dto());
     }
@@ -6665,6 +6665,185 @@ fn audit_link_target_ok(state: &AppState, title: &str) -> Result<bool, AppError>
 fn emit_audit_updated_after_purge(app: &AppHandle, state: &AppState) {
     let pending = state.db.count_pending_audit_findings().unwrap_or(0);
     crate::events::emit_audit_updated(app, pending as u32);
+}
+
+/// Re-gate ONE finding row against a session unlock set: the SOURCE must be visible, and when a
+/// target id rides on the row its TARGET must be visible too, checked against the table its
+/// `target_kind` names. FAIL-CLOSED on an UNTYPED target (`target_id` set, `target_kind` NULL):
+/// such a row cannot be target-re-gated, so it is treated as not visible (lock-review NIT,
+/// 2026-07-16 — the previous inline check silently SKIPPED the target re-gate for untyped rows,
+/// which fails open exactly when the target seals between pass and read). Shared by the list
+/// re-gate and `explain_audit_finding` so the two can never diverge.
+fn audit_row_visible(
+    state: &AppState,
+    row: &crate::audit::AuditFindingRow,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<bool, AppError> {
+    let source_visible = match row.source_kind.as_str() {
+        "meeting" => state.db.meeting_is_visible(&row.source_id, unlocked)?,
+        _ => state.db.note_is_visible(&row.source_id, unlocked)?,
+    };
+    if !source_visible {
+        return Ok(false);
+    }
+    if let Some(tid) = &row.target_id {
+        let Some(tkind) = row.target_kind.as_deref() else {
+            return Ok(false); // untyped target — cannot be re-gated ⇒ fail closed.
+        };
+        let target_visible = match tkind {
+            "meeting" => state.db.meeting_is_visible(tid, unlocked)?,
+            _ => state.db.note_is_visible(tid, unlocked)?,
+        };
+        if !target_visible {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+// ── Vault Audit Phase 3 — weekly schedule + cloud explain ───────────────────────────────────────
+
+/// The weekly-audit schedule for the FE settings surface: the enabled flag + the last SCHEDULED
+/// run + the derived next due time (see [`crate::audit::AuditSchedule`] for the `nextDueAt`
+/// semantics). Read-only; content-free.
+#[tauri::command]
+pub fn get_audit_schedule(
+    state: State<'_, AppState>,
+) -> Result<crate::audit::AuditSchedule, AppError> {
+    get_audit_schedule_inner(state.inner())
+}
+
+pub(crate) fn get_audit_schedule_inner(
+    state: &AppState,
+) -> Result<crate::audit::AuditSchedule, AppError> {
+    let enabled = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .vault_audit_weekly_enabled;
+    let last_run_at = state.db.last_scheduled_audit_run_finished_at()?;
+    let next_due_at = if enabled {
+        last_run_at.map(|l| l + crate::audit::WEEKLY_AUDIT_INTERVAL_MS)
+    } else {
+        None
+    };
+    Ok(crate::audit::AuditSchedule {
+        enabled,
+        last_run_at,
+        next_due_at,
+    })
+}
+
+/// Enable/disable the weekly scheduled audit. The ONLY mutator of the flag (preserve-only on the
+/// settings DTO), persisted through the dedicated `AppConfig::set_vault_audit_weekly` (persist
+/// first, flip in-memory on durable success). Returns the updated schedule.
+#[tauri::command]
+pub fn set_audit_schedule(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<crate::audit::AuditSchedule, AppError> {
+    set_audit_schedule_inner(state.inner(), enabled)
+}
+
+pub(crate) fn set_audit_schedule_inner(
+    state: &AppState,
+    enabled: bool,
+) -> Result<crate::audit::AuditSchedule, AppError> {
+    {
+        let mut cache = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        cache.set_vault_audit_weekly(&state.db, enabled)?;
+    }
+    tracing::info!(target: "audit", enabled, "weekly audit schedule updated");
+    get_audit_schedule_inner(state)
+}
+
+/// USER-INITIATED cloud explanation of one PENDING finding. Gates, in order:
+/// 1. the finding exists and is still pending (`InvalidArg` otherwise);
+/// 2. its source AND typed target are visible under the CURRENT session unlock set —
+///    [`audit_row_visible`], untyped targets fail closed — else `AppError::Locked`;
+/// 3. the provider builds through the [`crate::summarize::provider_for`] chain BEFORE any prompt
+///    content is assembled — the fail-closed consent gate, the redaction firewall, and the
+///    egress ledger all live inside that seam (the brief runner's posture).
+/// The prompt carries the finding's own evidence + a bounded, GATED excerpt of the source note
+/// (current session set). RETURN-ONLY: the explanation is never persisted (no new derived
+/// plaintext at rest). A seal interleaving with the in-flight provider call affects only the
+/// already-read excerpt — the same accepted posture as an in-flight brief/digest synthesis.
+#[tauri::command]
+pub async fn explain_audit_finding(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<crate::audit::AuditExplanation, AppError> {
+    explain_audit_finding_inner(state.inner(), &id).await
+}
+
+pub(crate) async fn explain_audit_finding_inner(
+    state: &AppState,
+    id: &str,
+) -> Result<crate::audit::AuditExplanation, AppError> {
+    let row = state
+        .db
+        .get_audit_finding(id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no audit finding {id}")))?;
+    if row.status != "pending" {
+        return Err(AppError::InvalidArg(
+            "only a pending finding can be explained".into(),
+        ));
+    }
+    // User-initiated read ⇒ the CURRENT session unlock set (unlike the background pass's
+    // deliberately EMPTY set).
+    let unlocked = unlocked_snapshot(state)?;
+    if !audit_row_visible(state, &row, &unlocked)? {
+        return Err(AppError::Locked(
+            "this finding's source is locked — unlock it to explain".into(),
+        ));
+    }
+    // Provider FIRST: an unconsented cloud target refuses HERE (`Unavailable`) and no content is
+    // even assembled; a consented one is redaction-wrapped + ledgered inside the factory.
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let provider = crate::summarize::provider_for(
+        crate::summarize::roles::Role::Notes,
+        &config,
+        &state.heavy_inference,
+    )?;
+    // Bounded, GATED source excerpt. The visibility check above passed, so a `None` here means
+    // the source sealed (or its note vanished) in between — fail CLOSED rather than explain
+    // from evidence alone.
+    let body = match row.source_kind.as_str() {
+        "meeting" => state
+            .db
+            .get_note_if_visible(&row.source_id, &unlocked)?
+            .map(|n| n.markdown),
+        _ => state.db.note_markdown_if_visible(&row.source_id, &unlocked)?,
+    }
+    .ok_or_else(|| {
+        AppError::Locked("this finding's source is locked — unlock it to explain".into())
+    })?;
+    let snippet: String = body
+        .chars()
+        .take(crate::audit::EXPLAIN_SNIPPET_CHARS)
+        .collect();
+    let (system, user) = crate::audit::build_explain_prompt(&row, &snippet);
+    let explanation_md = provider.complete(&system, &user).await?;
+    tracing::info!(
+        target: "audit",
+        finding_id = %id,
+        provider = %provider.id(),
+        chars = explanation_md.len(),
+        "audit finding explained"
+    );
+    // RETURN-ONLY — nothing stored.
+    Ok(crate::audit::AuditExplanation {
+        finding_id: row.id,
+        explanation_md,
+        provider: provider.id().to_string(),
+    })
 }
 
 /// Does a wikilink title resolve AT ALL right now — the gated `resolve_wikilink` (live session
@@ -9378,6 +9557,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // (`#[serde(default)]`), so a partial/older save can never silently enable it. Unlike
         // `cloud_egress_consented` (preserved-only), this one is settable.
         semantic_search_enabled: d.semantic_search_enabled,
+        // Vault Audit Phase 3: the weekly-audit schedule is NOT carried on the settings DTO —
+        // preserve the live value; only the dedicated `set_audit_schedule` command may flip it
+        // (an omitting/older FE save can never silently disable the weekly pass).
+        vault_audit_weekly_enabled: current.vault_audit_weekly_enabled,
         // brain2 RAG Phase 2: the SELECTED embedder id is NOT carried on the settings DTO — it is
         // owned exclusively by the dedicated `select_embed_model` command (which validates the id and
         // reports whether a re-index is needed). Preserve the live value, so a generic settings save
@@ -24899,6 +25082,173 @@ mod lifecycle_tests {
             let rows = state.db.list_audit_finding_rows("pending").unwrap();
             rows.iter().find(|r| r.dedupe_key == "k-keep").unwrap().id.clone()
         });
+    }
+
+    /// Stage a pending finding whose target is UNTYPED (`target_id` set, `target_kind` NULL) —
+    /// the shape a pre-`target_kind` DB row (or a bug upstream) would take. Returns the row id.
+    fn stage_untyped_target_finding(state: &AppState, source_id: &str, target_id: &str) -> String {
+        state
+            .db
+            .insert_audit_finding_if_new(
+                &crate::audit::NewAuditFinding {
+                    kind: "unlinked_mention".into(),
+                    source_kind: "meeting".into(),
+                    source_id: source_id.into(),
+                    source_title: "T".into(),
+                    target_title: Some("Sealed Target Title".into()),
+                    target_id: Some(target_id.into()),
+                    target_kind: None,
+                    evidence_md: "> mentions Sealed Target Title".into(),
+                    accept_action: "".into(),
+                    dedupe_key: "k-untyped".into(),
+                },
+                "r-test",
+                1,
+            )
+            .unwrap();
+        state
+            .db
+            .list_audit_finding_rows("pending")
+            .unwrap()
+            .into_iter()
+            .find(|r| r.dedupe_key == "k-untyped")
+            .unwrap()
+            .id
+    }
+
+    /// RED-first (lock-review NIT, 2026-07-16): a pending row carrying `target_id` but NO
+    /// `target_kind` cannot be target-re-gated — the list must FAIL CLOSED (hide it), not skip
+    /// the target check. The old inline `if let (Some, Some)` fell OPEN exactly when the target
+    /// sealed: this row's title/evidence reference the sealed note and would still be served.
+    #[test]
+    fn audit_list_hides_untyped_target_rows_fail_closed() {
+        let state = build_state("audit-untyped-target");
+        make_open_folder(&state.db, "f1", "Secret");
+        seed_meeting(&state.db, "m-t", "# target body\n", Some("f1"));
+        seed_meeting(&state.db, "m-src", "# open body\n", None);
+        // Seal FIRST, then stage (the TOCTOU-orphan shape the re-gate exists for — the seal's
+        // own purge ran before this row existed).
+        state.db.set_folder_locked("f1", true, None).unwrap();
+        stage_untyped_target_finding(&state, "m-src", "m-t");
+
+        let listed = list_audit_findings_inner(&state, None).unwrap();
+        assert!(
+            listed.is_empty(),
+            "an untyped-target row must be hidden (fail closed): {listed:#?}"
+        );
+    }
+
+    // ── Vault Audit Phase 3 — schedule + explain (command layer) ─────────────
+
+    /// `get_audit_schedule` / `set_audit_schedule`: default ON; `lastRunAt`/`nextDueAt` derive
+    /// from the SCHEDULED claim rows only; disable persists durably and clears `nextDueAt`.
+    #[test]
+    fn audit_schedule_get_set_round_trips() {
+        let state = build_state("audit-sched");
+        let s = get_audit_schedule_inner(&state).unwrap();
+        assert!(s.enabled, "weekly audit defaults ON");
+        assert_eq!(s.last_run_at, None);
+        assert_eq!(s.next_due_at, None, "never-ran ⇒ due at the next hourly check");
+
+        // A scheduled claim stamps lastRunAt and derives nextDueAt = last + 7 days.
+        state
+            .db
+            .insert_scheduled_audit_run_claim("c1", 1_700_000_000_000)
+            .unwrap();
+        let s = get_audit_schedule_inner(&state).unwrap();
+        assert_eq!(s.last_run_at, Some(1_700_000_000_000));
+        assert_eq!(
+            s.next_due_at,
+            Some(1_700_000_000_000 + crate::audit::WEEKLY_AUDIT_INTERVAL_MS)
+        );
+
+        // Disable → persists (a fresh load sees it) + nextDueAt clears; re-enable restores.
+        let s = set_audit_schedule_inner(&state, false).unwrap();
+        assert!(!s.enabled);
+        assert_eq!(s.next_due_at, None, "disabled ⇒ no next due time");
+        assert!(
+            !AppConfig::load(&state.db).unwrap().vault_audit_weekly_enabled,
+            "the opt-out persists durably"
+        );
+        let s = set_audit_schedule_inner(&state, true).unwrap();
+        assert!(s.enabled);
+        assert_eq!(
+            s.next_due_at,
+            Some(1_700_000_000_000 + crate::audit::WEEKLY_AUDIT_INTERVAL_MS),
+            "re-enable derives from the surviving claim row"
+        );
+    }
+
+    /// `explain_audit_finding` gate matrix: missing id → InvalidArg; already-resolved →
+    /// InvalidArg; sealed-since source → Locked; untyped target (target_id without target_kind)
+    /// → Locked (fail closed — the same rule the list re-gate enforces).
+    #[test]
+    fn explain_gate_refuses_missing_resolved_locked_and_untyped() {
+        let state = build_state("explain-gate");
+
+        // Missing.
+        assert!(matches!(
+            block_on(explain_audit_finding_inner(&state, "nope")),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // Already resolved.
+        seed_meeting(&state.db, "m-open", "# open body\n", None);
+        let id = stage_audit_finding(
+            &state, "stale", "meeting", "m-open", None, "> ev", "", "k-exp-resolved",
+        );
+        state
+            .db
+            .resolve_audit_finding_row(&id, "dismissed", 5)
+            .unwrap();
+        assert!(matches!(
+            block_on(explain_audit_finding_inner(&state, &id)),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        // Sealed-since source (staged after the seal — the orphan shape) → Locked.
+        make_open_folder(&state.db, "f-exp", "Secret");
+        seed_meeting(&state.db, "m-sealed", "# sealed body\n", Some("f-exp"));
+        state.db.set_folder_locked("f-exp", true, None).unwrap();
+        let id_locked = stage_audit_finding(
+            &state, "stale", "meeting", "m-sealed", None, "> ev", "", "k-exp-locked",
+        );
+        assert!(matches!(
+            block_on(explain_audit_finding_inner(&state, &id_locked)),
+            Err(AppError::Locked(_))
+        ));
+
+        // Untyped target on a visible source → Locked (fail closed), never explained.
+        let id_untyped = stage_untyped_target_finding(&state, "m-open", "m-sealed");
+        assert!(matches!(
+            block_on(explain_audit_finding_inner(&state, &id_untyped)),
+            Err(AppError::Locked(_))
+        ));
+    }
+
+    /// Egress fail-closed: with the default (unconsented) config the cloud Notes provider refuses
+    /// to BUILD — the explain returns `Unavailable` before any content is assembled — and the
+    /// pending row is untouched (still pending, evidence intact; nothing stored anywhere).
+    #[test]
+    fn explain_fails_closed_without_cloud_consent_and_stores_nothing() {
+        let state = build_state("explain-consent");
+        assert!(!state.config.lock().unwrap().cloud_egress_consented);
+        seed_meeting(&state.db, "m-open", "# open body\n", None);
+        let id = stage_audit_finding(
+            &state, "contradiction", "meeting", "m-open", None, "> a vs b", "", "k-exp-consent",
+        );
+
+        let res = block_on(explain_audit_finding_inner(&state, &id));
+        assert!(
+            matches!(res, Err(AppError::Unavailable(_))),
+            "unconsented cloud provider must fail closed"
+        );
+
+        // Nothing stored / mutated — the row is byte-identical to its staged state.
+        let row = state.db.get_audit_finding(&id).unwrap().unwrap();
+        assert_eq!(row.status, "pending");
+        assert_eq!(row.evidence_md, "> a vs b", "evidence untouched by a refused explain");
+        assert!(row.resolved_at.is_none());
     }
 
     /// Phase-0 follow-up (a): every seal path that NULLs `exported_path` blanks the path-coupled

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,6 +185,10 @@ pub fn run() {
             commands::run_vault_audit,
             commands::list_audit_findings,
             commands::resolve_audit_finding,
+            // Vault Audit Phase 3 — weekly schedule + user-initiated cloud explain.
+            commands::get_audit_schedule,
+            commands::set_audit_schedule,
+            commands::explain_audit_finding,
             commands::get_config,
             commands::get_mcp_config,
             commands::save_config,
@@ -574,6 +578,12 @@ pub fn run() {
                         if let Err(e) = joined {
                             tracing::warn!(target: "memory", error = %e, "consolidation tick join failed");
                         }
+                        // Vault Audit Phase 3 — the WEEKLY scheduled-audit due-check rides this
+                        // same hourly cadence (no new cadence class; first check a full interval
+                        // after launch, so run-on-launch-if-due comes free at +1h). The tick
+                        // claims-before-run, gates on thermal/RAM, runs the pass on a blocking
+                        // worker, and never errors (warn-and-continue inside).
+                        crate::audit::audit_weekly_tick(&handle).await;
                     }
                 });
             }

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -319,6 +319,16 @@ pub struct AppConfig {
     /// persists (a stored `false` is honored across reload; see `semantic_flag_off_round_trips`).
     #[serde(default = "default_true")]
     pub semantic_search_enabled: bool,
+    /// Vault Audit Phase 3 — the WEEKLY scheduled audit pass (an hourly due-check inside the
+    /// consolidation-loop cadence; see `crate::audit::audit_weekly_tick`). Default ON — the
+    /// feature's promise is ambient vault health (the pass is deterministic, zero-egress and
+    /// thermal/RAM-gated, so default-on costs a model-less install nothing beyond one weekly
+    /// deterministic scan). `#[serde(default = "default_true")]` ⇒ a config persisted before this
+    /// field existed loads as `true`. Preserve-only on the settings DTO: the dedicated
+    /// `set_audit_schedule` command is the ONLY mutator (a partial/older settings save can never
+    /// silently flip the schedule).
+    #[serde(default = "default_true")]
+    pub vault_audit_weekly_enabled: bool,
     /// brain2 RAG Phase 2 — the SELECTED on-device embedding model id (from
     /// [`crate::embed::EMBED_MODELS`], e.g. `"multilingual-e5-small"` (default) / `"mmlw-retrieval-e5-small"`).
     /// `None`/empty (the default) resolves to `multilingual-e5-small` ⇒ BYTE-IDENTICAL to the
@@ -657,6 +667,7 @@ impl Default for AppConfig {
             org_egress_consented: false,
             sharing_choice_made: false,
             semantic_search_enabled: true,
+            vault_audit_weekly_enabled: true,
             embed_model_id: None,
             brain_model_path: None,
             brain_model_id: None,
@@ -749,6 +760,7 @@ const K_SHARE_EGRESS_CONSENTED: &str = "share_egress_consented";
 const K_ORG_EGRESS_CONSENTED: &str = "org_egress_consented";
 const K_SHARING_CHOICE_MADE: &str = "sharing_choice_made";
 const K_SEMANTIC_SEARCH_ENABLED: &str = "semantic_search_enabled";
+const K_VAULT_AUDIT_WEEKLY_ENABLED: &str = "vault_audit_weekly_enabled";
 const K_EMBED_MODEL_ID: &str = "embed_model_id";
 const K_BRAIN_MODEL_PATH: &str = "brain_model_path";
 const K_BRAIN_MODEL_ID: &str = "brain_model_id";
@@ -954,6 +966,9 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_SEMANTIC_SEARCH_ENABLED)? {
             cfg.semantic_search_enabled = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_VAULT_AUDIT_WEEKLY_ENABLED)? {
+            cfg.vault_audit_weekly_enabled = v == "true";
         }
         cfg.embed_model_id = opt(db.get_setting(K_EMBED_MODEL_ID)?);
         // Publish the selection to the process-global seam the zero-arg embedder resolvers read
@@ -1263,6 +1278,14 @@ impl AppConfig {
             },
         )?;
         db.set_setting(
+            K_VAULT_AUDIT_WEEKLY_ENABLED,
+            if self.vault_audit_weekly_enabled {
+                "true"
+            } else {
+                "false"
+            },
+        )?;
+        db.set_setting(
             K_EMBED_MODEL_ID,
             self.embed_model_id.as_deref().unwrap_or(""),
         )?;
@@ -1502,6 +1525,19 @@ impl AppConfig {
     pub fn set_sharing_choice_made(&mut self, db: &Db) -> Result<()> {
         db.set_setting(K_SHARING_CHOICE_MADE, "true")?;
         self.sharing_choice_made = true;
+        Ok(())
+    }
+
+    /// Vault Audit Phase 3 — flip the weekly scheduled-audit flag. The ONLY mutator (the field is
+    /// preserve-only on the settings DTO, so a generic settings save can never flip it). Mirrors
+    /// [`set_sharing_choice_made`]'s fail-safe ordering: persist FIRST, flip the in-memory flag
+    /// ONLY on a durable write success. Idempotent.
+    pub fn set_vault_audit_weekly(&mut self, db: &Db, enabled: bool) -> Result<()> {
+        db.set_setting(
+            K_VAULT_AUDIT_WEEKLY_ENABLED,
+            if enabled { "true" } else { "false" },
+        )?;
+        self.vault_audit_weekly_enabled = enabled;
         Ok(())
     }
 
@@ -2037,6 +2073,43 @@ mod tests {
         };
         cfg.save(&db).unwrap();
         assert!(!AppConfig::load(&db).unwrap().semantic_search_enabled);
+    }
+
+    /// Vault Audit Phase 3: the weekly-audit flag defaults ON (a fresh DB and a config persisted
+    /// before the field existed both load `true`), an explicit opt-out round-trips, and the
+    /// dedicated mutator (the only supported one) persists durably.
+    #[test]
+    fn vault_audit_weekly_defaults_on_and_mutator_round_trips() {
+        let db = temp_db();
+        assert!(AppConfig::default().vault_audit_weekly_enabled);
+        assert!(
+            AppConfig::load(&db).unwrap().vault_audit_weekly_enabled,
+            "an empty DB (no stored key) must default the weekly audit ON"
+        );
+        // A config JSON that OMITS the field (persisted before it existed) loads as true —
+        // the same pre-field payload shape `missing_semantic_flag_defaults_on` exercises.
+        let json = r#"{
+            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
+            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
+            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
+            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
+            "diarizeOthers":false,"aecEnabled":false,"postAecEnabled":true,"modelSize":"large-v3","voiceTrigger":false,
+            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
+            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
+            "cloudEgressConsented":false
+        }"#;
+        let omitted: AppConfig = serde_json::from_str(json).unwrap();
+        assert!(omitted.vault_audit_weekly_enabled, "serde default must be true");
+
+        let mut cfg = AppConfig::load(&db).unwrap();
+        cfg.set_vault_audit_weekly(&db, false).unwrap();
+        assert!(!cfg.vault_audit_weekly_enabled, "mutator flips the in-memory flag");
+        assert!(
+            !AppConfig::load(&db).unwrap().vault_audit_weekly_enabled,
+            "the opt-out persists across reload"
+        );
+        cfg.set_vault_audit_weekly(&db, true).unwrap();
+        assert!(AppConfig::load(&db).unwrap().vault_audit_weekly_enabled);
     }
 
     /// Tier 3b (B): `ground_summary` defaults OFF / opt-in (empty DB ⇒ false, thresholds uncalibrated),

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1470,6 +1470,11 @@ impl Db {
         // the TARGET side against the right table (lock review, same branch). Guarded for dev DBs
         // that created the table before the column existed.
         Self::add_column_if_missing(conn, "audit_findings", "target_kind", "TEXT")?;
+        // Weekly schedule (Phase 3): `scheduled = 1` marks a run row staged by the WEEKLY runner —
+        // both the claim row inserted BEFORE the pass (crash-safe claim-before-run, the
+        // brief-runner discipline) and nothing else. Due-ness reads MAX(finished_at) over
+        // scheduled rows only, so manual runs never push the weekly cadence. Additive + guarded.
+        Self::add_column_if_missing(conn, "audit_runs", "scheduled", "INTEGER NOT NULL DEFAULT 0")?;
         Ok(())
     }
 
@@ -11468,6 +11473,50 @@ impl Db {
         )
         .map_err(map_err)?;
         Ok(())
+    }
+
+    /// Weekly runner CLAIM row — inserted BEFORE the scheduled pass runs (the brief runner's
+    /// claim-before-run discipline): once this row exists, `weekly_due` holds for the next 7 days
+    /// even if the pass itself crashes/fails, so a persistently-failing pass can never become an
+    /// hourly storm. Content-free (`scheduled = 1`, empty counts); the pass still records its own
+    /// normal (unscheduled) bookkeeping row on completion.
+    pub fn insert_scheduled_audit_run_claim(&self, id: &str, claimed_at: i64) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO audit_runs (id, started_at, finished_at, counts_json, scheduled)
+             VALUES (?1, ?2, ?2, '{}', 1)",
+            rusqlite::params![id, claimed_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// `finished_at` of the newest SCHEDULED audit run (the weekly claim rows) — the due-ness
+    /// anchor. Manual runs (`scheduled = 0`) never count, so running the audit by hand does not
+    /// push the weekly cadence.
+    pub fn last_scheduled_audit_run_finished_at(&self) -> Result<Option<i64>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT MAX(finished_at) FROM audit_runs WHERE scheduled = 1",
+            [],
+            |r| r.get::<_, Option<i64>>(0),
+        )
+        .map_err(map_err)
+    }
+
+    /// Judge-tier DEMOTE: delete ONE pending finding outright (NOT dismiss — a dismissed row's
+    /// `dedupe_key` suppresses re-creation forever; deletion lets a real issue re-stage on the
+    /// next pass). Pending-only by construction: a row the user resolved (or a seal purged)
+    /// between the judge's read and this delete is left alone. Returns whether a row was deleted.
+    pub fn delete_pending_audit_finding(&self, id: &str) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "DELETE FROM audit_findings WHERE id = ?1 AND status = 'pending'",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
     }
 
     /// Vault Audit DELETE-SAFETY: delete every PENDING `audit_findings` row whose SOURCE or

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -71,8 +71,10 @@ import type {
   BriefSchedule,
   BriefRun,
   BriefProposedPayload,
+  AuditExplanation,
   AuditFinding,
   AuditRunSummary,
+  AuditSchedule,
   VerifyFindingDto,
   ProviderStatus,
   SavedRecipe,
@@ -1338,6 +1340,29 @@ export class IpcService {
    */
   onAuditUpdated(cb: () => void): Promise<UnlistenFn> {
     return listen(EVENT_AUDIT_UPDATED, () => cb());
+  }
+
+  /** The weekly-audit schedule state (enabled + last-run / next-due epochs). */
+  getAuditSchedule(): Promise<AuditSchedule> {
+    return invoke<AuditSchedule>("get_audit_schedule");
+  }
+
+  /**
+   * Turn the weekly scheduled audit on or off. Resolves with the CONFIRMED
+   * schedule — the FE reflects the response, never an optimistic flip.
+   * Scheduled runs emit the same audit-updated event manual runs do.
+   */
+  setAuditSchedule(enabled: boolean): Promise<AuditSchedule> {
+    return invoke<AuditSchedule>("set_audit_schedule", { enabled });
+  }
+
+  /**
+   * Ask the configured AI provider to explain ONE staged finding (any kind).
+   * May reject with a consent-missing or `AppError::Locked` message — surface
+   * it verbatim. Cloud providers only ever see redacted content.
+   */
+  explainAuditFinding(id: string): Promise<AuditExplanation> {
+    return invoke<AuditExplanation>("explain_audit_finding", { id });
   }
 
   // ── brain2 documents — expand the brain with imported .md/.txt files ────

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1170,6 +1170,29 @@ export interface AuditFinding {
 }
 
 /**
+ * Vault Audit — the weekly-schedule state (`get_audit_schedule` /
+ * `set_audit_schedule`). Timestamps are epoch numbers; `lastRunAt` is
+ * null/absent before the first scheduled run, `nextDueAt` while disabled.
+ */
+export interface AuditSchedule {
+  enabled: boolean;
+  lastRunAt?: number | null;
+  nextDueAt?: number | null;
+}
+
+/**
+ * Vault Audit — one AI explanation of a staged finding
+ * (`explain_audit_finding`). `explanationMd` renders through the shared
+ * markdown component; `provider` names the AI provider that produced it
+ * (cloud providers only ever see redacted content).
+ */
+export interface AuditExplanation {
+  findingId: string;
+  explanationMd: string;
+  provider: string;
+}
+
+/**
  * Phase D — progress for the on-device PERSON-name NER model (mDeBERTa-v3)
  * download (`EVENT_NER_DOWNLOAD`). Mirrors the backend `NerDownloadPayload`: the
  * model is 3 files, so progress is reported per-file (`fileIndex` / `fileCount`).

--- a/src/app/design-system/toggle/toggle.component.html
+++ b/src/app/design-system/toggle/toggle.component.html
@@ -1,4 +1,5 @@
 <input
+  #box
   class="switch"
   type="checkbox"
   [checked]="checked()"

--- a/src/app/design-system/toggle/toggle.component.ts
+++ b/src/app/design-system/toggle/toggle.component.ts
@@ -1,9 +1,11 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  type ElementRef,
   forwardRef,
   input,
   signal,
+  viewChild,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from "@angular/forms";
 
@@ -32,11 +34,24 @@ export class MurToggleComponent implements ControlValueAccessor {
   readonly checked = signal(false);
   readonly disabled = signal(false);
 
+  private readonly box =
+    viewChild<ElementRef<HTMLInputElement>>("box");
+
   private onChange: (v: boolean) => void = () => undefined;
   private onTouched: () => void = () => undefined;
 
   writeValue(v: unknown): void {
-    this.checked.set(!!v);
+    const val = !!v;
+    this.checked.set(val);
+    // A confirm-then-REVERT (user flips → backend rejects → setValue back)
+    // coalesces the signal's false→true→false into a net no-change inside one
+    // CD cycle, so the [checked] binding never rewrites the NATIVE property
+    // the click already flipped. Sync it directly — exactly what Angular's
+    // CheckboxControlValueAccessor does.
+    const el = this.box()?.nativeElement;
+    if (el && el.checked !== val) {
+      el.checked = val;
+    }
   }
   registerOnChange(fn: (v: boolean) => void): void {
     this.onChange = fn;

--- a/src/app/features/audit/audit.store.ts
+++ b/src/app/features/audit/audit.store.ts
@@ -11,6 +11,7 @@ import type {
   AuditFinding,
   AuditFindingKind,
   AuditRunSummary,
+  AuditSchedule,
 } from "../../core/models";
 
 /** Stable render order for the grouped inbox — most consequential kinds first. */
@@ -63,6 +64,13 @@ export class AuditStore {
   private readonly _error = signal<string | null>(null);
   readonly error = this._error.asReadonly();
 
+  /**
+   * The weekly-schedule state — read by the inbox chip AND the Settings
+   * toggle row. Null until the first {@link loadSchedule} resolves.
+   */
+  private readonly _schedule = signal<AuditSchedule | null>(null);
+  readonly schedule = this._schedule.asReadonly();
+
   readonly pendingCount = computed(
     () => this._findings().filter((f) => f.status === "pending").length,
   );
@@ -83,17 +91,23 @@ export class AuditStore {
   init(): void {
     if (this.initialized) {
       void this.load();
+      void this.loadSchedule();
       return;
     }
     this.initialized = true;
     void this.ipc
-      .onAuditUpdated(() => void this.load())
+      .onAuditUpdated(() => {
+        void this.load();
+        // Scheduled runs emit the same event — keep "last run" fresh too.
+        void this.loadSchedule();
+      })
       .then((un) => (this.unlisten = un));
     this.destroyRef.onDestroy(() => {
       this.unlisten?.();
       this.unlisten = null;
     });
     void this.load();
+    void this.loadSchedule();
   }
 
   /** Reload the pending findings. Cached rows stay visible while in flight. */
@@ -123,6 +137,31 @@ export class AuditStore {
     } finally {
       this._running.set(false);
     }
+  }
+
+  /**
+   * Reload the weekly-schedule state. A failure leaves the signal as-is — the
+   * chip / toggle simply don't render fresher state, the inbox stays usable.
+   */
+  async loadSchedule(): Promise<void> {
+    try {
+      const s = await this.ipc.getAuditSchedule();
+      this._schedule.set(s);
+    } catch {
+      // Decorative state — never let it error the inbox.
+    }
+  }
+
+  /**
+   * Turn the weekly audit on/off — confirm-then-update, never optimistic:
+   * the signal only takes the CONFIRMED schedule from the response; on
+   * rejection it keeps the previous state and the error propagates so the
+   * caller can toast + revert its visual.
+   */
+  async setSchedule(enabled: boolean): Promise<AuditSchedule> {
+    const s = await this.ipc.setAuditSchedule(enabled);
+    this._schedule.set(s);
+    return s;
   }
 
   /**

--- a/src/app/features/audit/audit/audit.component.html
+++ b/src/app/features/audit/audit/audit.component.html
@@ -31,6 +31,14 @@
         Broken links, stale notes and contradictions — found for your review.
       </span>
     </button>
+    @if (weeklyChip(); as chip) {
+      <span
+        class="pill au-weekly"
+        title="Turn the weekly audit on or off in Settings → AI &amp; Models"
+      >
+        {{ chip }}
+      </span>
+    }
     <button
       type="button"
       class="btn btn-ghost au-run"
@@ -105,12 +113,43 @@
                   [markdown]="f.evidenceMd"
                   compact
                 />
+                @let ex = explanations().get(f.id);
+                @if (ex && !explainCollapsed().has(f.id)) {
+                  <div class="au-explain">
+                    <app-markdown [markdown]="ex.explanationMd" compact />
+                    <span class="au-explain-provider text-muted">
+                      via {{ ex.provider }}
+                    </span>
+                  </div>
+                }
                 <div class="au-item-actions">
                   @if (f.acceptAction) {
                     <span class="au-accept-hint text-secondary">
                       {{ f.acceptAction }}
                     </span>
                   }
+                  <button
+                    type="button"
+                    class="btn btn-ghost au-explain-btn"
+                    title="May use your configured AI provider; cloud providers see only redacted content"
+                    (click)="explain(f)"
+                    [disabled]="explaining().has(f.id)"
+                  >
+                    @if (explaining().has(f.id)) {
+                      <mur-spinner [size]="12" />
+                      <span>Explaining…</span>
+                    } @else if (ex) {
+                      <span>
+                        {{
+                          explainCollapsed().has(f.id)
+                            ? "Show explanation"
+                            : "Hide explanation"
+                        }}
+                      </span>
+                    } @else {
+                      <span>Explain (AI)</span>
+                    }
+                  </button>
                   <button
                     type="button"
                     class="btn btn-ghost"

--- a/src/app/features/audit/audit/audit.component.scss
+++ b/src/app/features/audit/audit/audit.component.scss
@@ -68,6 +68,19 @@
   gap: var(--space-1);
 }
 
+/* Passive weekly-schedule chip (the toggle lives in Settings). */
+.au-weekly {
+  flex: none;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+@media (max-width: 560px) {
+  .au-weekly {
+    display: none;
+  }
+}
+
 /* The "N new findings · M pending" line after a manual run. */
 .au-summary {
   margin: 0;
@@ -137,6 +150,26 @@
 }
 .au-evidence {
   font-size: 0.9rem;
+}
+
+/* Inline AI explanation — collapsible block under the evidence. */
+.au-explain {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  font-size: 0.9rem;
+}
+.au-explain-provider {
+  font-size: 0.75rem;
+}
+.au-explain-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
 }
 .au-item-actions {
   display: flex;

--- a/src/app/features/audit/audit/audit.component.ts
+++ b/src/app/features/audit/audit/audit.component.ts
@@ -5,7 +5,12 @@ import {
   inject,
   signal,
 } from "@angular/core";
-import type { AuditFinding, AuditFindingKind } from "../../../core/models";
+import type {
+  AuditExplanation,
+  AuditFinding,
+  AuditFindingKind,
+} from "../../../core/models";
+import { IpcService } from "../../../core/ipc.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { ToastService } from "../../../services/toast.service";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
@@ -44,6 +49,37 @@ const KIND_META: Record<
 };
 
 /**
+ * Epoch → "today" / "yesterday" / "N days ago" / a short date (the
+ * people-page idiom). The backend timestamps are epoch numbers; values below
+ * 10^12 are seconds, above are millis — normalize so either shape renders.
+ */
+function relativeDayLabel(epoch: number): string {
+  const ms = epoch < 1_000_000_000_000 ? epoch * 1000 : epoch;
+  const d = new Date(ms);
+  if (isNaN(d.getTime())) {
+    return "";
+  }
+  const now = new Date();
+  const startOfDay = (x: Date): number =>
+    new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const days = Math.round((startOfDay(now) - startOfDay(d)) / 86_400_000);
+  if (days <= 0) {
+    return "today";
+  }
+  if (days === 1) {
+    return "yesterday";
+  }
+  if (days < 7) {
+    return `${days} days ago`;
+  }
+  const opts: Intl.DateTimeFormatOptions =
+    d.getFullYear() === now.getFullYear()
+      ? { month: "short", day: "numeric" }
+      : { month: "short", day: "numeric", year: "numeric" };
+  return d.toLocaleDateString(undefined, opts);
+}
+
+/**
  * VAULT AUDIT — a collapsible Brain-page section (mirrors the scheduled-briefs
  * section): an "Audit now" trigger plus the propose-accept FINDINGS INBOX,
  * grouped by kind. Every finding is review-then-apply: Accept (only offered
@@ -66,6 +102,7 @@ const KIND_META: Record<
 })
 export class AuditComponent {
   protected readonly store = inject(AuditStore);
+  private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
 
   /** The user's manual collapse/expand toggle (auto-opens on "Audit now"). */
@@ -74,7 +111,33 @@ export class AuditComponent {
   /** The finding id with a resolve in flight (disables just that row's buttons). */
   readonly busyId = signal<string | null>(null);
 
+  /** Finding ids with an explain in flight — at most ONE per row. */
+  readonly explaining = signal<ReadonlySet<string>>(new Set());
+
+  /** Resolved AI explanations by finding id (rendered inline, collapsible). */
+  readonly explanations = signal<ReadonlyMap<string, AuditExplanation>>(
+    new Map(),
+  );
+
+  /** Finding ids whose loaded explanation the user collapsed. */
+  readonly explainCollapsed = signal<ReadonlySet<string>>(new Set());
+
   readonly listEmpty = computed(() => this.store.pendingCount() === 0);
+
+  /**
+   * The passive weekly-schedule chip: "Weekly: on · last run yesterday".
+   * Read-only ON PURPOSE — the toggle lives in Settings (no navigation
+   * coupling from the inbox). Null until the schedule loads.
+   */
+  readonly weeklyChip = computed<string | null>(() => {
+    const s = this.store.schedule();
+    if (!s) {
+      return null;
+    }
+    const state = s.enabled ? "on" : "off";
+    const last = s.lastRunAt ? relativeDayLabel(s.lastRunAt) : "";
+    return last ? `Weekly: ${state} · last run ${last}` : `Weekly: ${state}`;
+  });
 
   /** "N new findings · M pending" — shown once a manual run completed. */
   readonly summaryLine = computed(() => {
@@ -126,6 +189,49 @@ export class AuditComponent {
       this.toast.danger(String(e));
     } finally {
       this.busyId.set(null);
+    }
+  }
+
+  /**
+   * "Explain (AI)" — fetch (once) an AI explanation for one finding and render
+   * it inline; once loaded the button toggles the collapsible block instead of
+   * re-fetching. One in flight per row; a rejection toasts the backend message
+   * VERBATIM (consent-missing / Locked included) and leaves the row unchanged.
+   * Stale guard: a response landing after the row resolved or vanished
+   * (accept/dismiss/seal-purge mid-flight) is dropped.
+   */
+  async explain(f: AuditFinding): Promise<void> {
+    const id = f.id;
+    if (this.explaining().has(id)) {
+      return;
+    }
+    if (this.explanations().has(id)) {
+      this.explainCollapsed.update((s) => {
+        const next = new Set(s);
+        if (!next.delete(id)) {
+          next.add(id);
+        }
+        return next;
+      });
+      return;
+    }
+    this.explaining.update((s) => new Set(s).add(id));
+    try {
+      const ex = await this.ipc.explainAuditFinding(id);
+      const stillPending = this.store
+        .findings()
+        .some((x) => x.id === id && x.status === "pending");
+      if (stillPending) {
+        this.explanations.update((m) => new Map(m).set(id, ex));
+      }
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.explaining.update((s) => {
+        const next = new Set(s);
+        next.delete(id);
+        return next;
+      });
     }
   }
 }

--- a/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.html
+++ b/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.html
@@ -114,5 +114,25 @@
       }
     </div>
   </div>
+
+  <!-- ── Vault hygiene ─────────────────────────────────────────────── -->
+  <div class="use-group">
+    <span class="use-group-label text-muted">Vault hygiene</span>
+    <div class="audit-weekly">
+      <label class="toggle-row">
+        <span class="toggle-copy">
+          <span class="toggle-title">Weekly vault audit</span>
+          <span class="text-secondary toggle-sub">
+            Runs the deterministic vault audit once a week, on-device, zero
+            egress.
+          </span>
+        </span>
+        <mur-toggle
+          [formControl]="auditControl"
+          ariaLabel="Weekly vault audit"
+        />
+      </label>
+    </div>
+  </div>
 </div>
   

--- a/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.scss
+++ b/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.scss
@@ -88,6 +88,17 @@
   font-size: 0.85rem;
 }
 
+/* --- Weekly vault audit — scheduled hygiene subsection --- */
+.audit-weekly {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
+}
+
 /* Toggle row (for semantic-search checkbox). */
 .toggle-row {
   display: flex;

--- a/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.ts
+++ b/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.ts
@@ -1,5 +1,14 @@
-import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
-import { ReactiveFormsModule } from "@angular/forms";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { AuditStore } from "../../../../audit/audit.store";
+import { ToastService } from "../../../../../services/toast.service";
 import { SettingsStore } from "../../../settings.store";
 import { MurToggleComponent } from "../../../../../design-system/toggle/toggle.component";
 
@@ -10,6 +19,13 @@ import { MurToggleComponent } from "../../../../../design-system/toggle/toggle.c
  * re-index controls. The always-on-device honesty rows (Embeddings / Name
  * redaction / Transcription) now live in the "What runs where" map card, so
  * the badges that used to sit here were removed.
+ *
+ * Also hosts the "Vault hygiene" group: the weekly-vault-audit toggle. Unlike
+ * the config-form toggles above it, the schedule is its own backend state
+ * (`get_audit_schedule` / `set_audit_schedule`, shared with the Brain-page
+ * inbox via {@link AuditStore}), so it binds a standalone control with
+ * confirm-then-update: the control only settles on the schedule the backend
+ * CONFIRMED — a rejection toasts and the visual reverts.
  *
  * All work is on-device — no cloud calls, no consent requirement.
  */
@@ -23,6 +39,8 @@ import { MurToggleComponent } from "../../../../../design-system/toggle/toggle.c
 })
 export class OnDeviceIntelligenceBlockComponent {
   private readonly store = inject(SettingsStore);
+  private readonly audit = inject(AuditStore);
+  private readonly toast = inject(ToastService);
 
   readonly form = this.store.form;
   readonly embedModelPresent = this.store.embedModelPresent;
@@ -36,11 +54,71 @@ export class OnDeviceIntelligenceBlockComponent {
   readonly reindexResult = this.store.reindexResult;
   readonly reindexError = this.store.reindexError;
 
+  /**
+   * Weekly-vault-audit switch — DISABLED until the schedule loads (an unknown
+   * state must not present as "off"), then mirrors the store's confirmed
+   * schedule via the `_syncAuditSchedule` effect below.
+   */
+  readonly auditControl = new FormControl(
+    { value: false, disabled: true },
+    { nonNullable: true },
+  );
+
+  /** A `set_audit_schedule` in flight — blocks re-entry + the effect's resync. */
+  private readonly auditBusy = signal(false);
+
+  /**
+   * Mirror the CONFIRMED schedule into the control whenever it changes and no
+   * commit is in flight. Because `auditBusy` is tracked, the flip back to
+   * false after a FAILED commit re-runs this and reverts the visual to the
+   * last confirmed state (the store keeps it on rejection).
+   */
+  private readonly _syncAuditSchedule = effect(() => {
+    const s = this.audit.schedule();
+    const busy = this.auditBusy();
+    if (!s || busy) {
+      return;
+    }
+    this.auditControl.setValue(s.enabled, { emitEvent: false });
+    if (this.auditControl.disabled) {
+      this.auditControl.enable({ emitEvent: false });
+    }
+  });
+
+  constructor() {
+    void this.audit.loadSchedule();
+    // The same commit-on-change idiom the settings form's auto-save uses —
+    // programmatic writes above pass `emitEvent: false`, so ONLY a user flip
+    // lands here.
+    this.auditControl.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((v) => void this.commitWeeklyAudit(v));
+  }
+
   downloadEmbedModel(): void {
     void this.store.downloadEmbedModel();
   }
 
   reindexEmbeddings(): void {
     void this.store.reindexEmbeddings();
+  }
+
+  /**
+   * Confirm-then-update: disable the switch while `set_audit_schedule` is in
+   * flight; on success the store signal carries the response, on failure it
+   * keeps the previous schedule — either way the effect resyncs the visual
+   * from the CONFIRMED state once `auditBusy` drops.
+   */
+  private async commitWeeklyAudit(enabled: boolean): Promise<void> {
+    this.auditBusy.set(true);
+    this.auditControl.disable({ emitEvent: false });
+    try {
+      await this.audit.setSchedule(enabled);
+    } catch (e) {
+      this.toast.danger(String(e));
+    } finally {
+      this.auditControl.enable({ emitEvent: false });
+      this.auditBusy.set(false);
+    }
   }
 }


### PR DESCRIPTION
## What

Completes the vault-agent program's audit loop (Phase 3 of `docs/research/2026-07-16-obsidian-claude-code-vault-agent.md`; builds on #348/#345/#349):

- **Weekly scheduled audit** — `vault_audit_weekly_enabled` (default ON), additive `audit_runs.scheduled`, pure `weekly_due` with catch-up-on-launch, **claim-before-run** (crash-proof, no storms; manual runs never push the cadence), rides the existing hourly loop, thermal/RAM skips **without** claiming, count-only `audit-updated` after scheduled passes.
- **Local judge tier (never cloud)** — the light sidecar reasoner demotes noisy contradiction/stale findings ({"keep":bool} strict tiny schema, 10s wall-clock stage budget, global heavy-inference permit, stub-skip). keep=false **deletes** the pending row so a real issue re-stages next pass (never a dedupe-poisoning dismiss); every degrade path keeps everything.
- **`explain_audit_finding`** — user-initiated; pending + visible under the **current** session set via the shared `audit_row_visible` (which also fixes the Phase-2 NIT: `target_id`-Some/`target_kind`-NULL now **fails closed** — RED→GREEN, the old gate served a sealed target's title); consent-fail-closed provider seam (redaction + egress ledger); 4k-char gated snippet; **return-only** (nothing stored).
- **FE** — Settings "Weekly vault audit" `mur-toggle` (confirm-then-update + revert-on-failure), passive schedule chip, per-row "Explain (AI)" with inline markdown, stale guard, verbatim error toasts. Plus a root-cause `mur-toggle` CVA fix: `writeValue` now syncs the native input property (user-flip + programmatic revert previously stranded the wrong visual — reproduced live pre-fix).

## How verified (implementer did not self-certify)

- **adversarial-verifier: PASS** — RED observed empirically on both fixes (git-archive HEAD + test injection for the fail-closed gate, where the leaked DTO carried the sealed title; live-app monkey-patch of pre-fix `writeValue` for the toggle). Seam byte-checks (commands/args/DTOs/epoch-ms), judge loss-safety matrix, claim semantics, explain storage hunt (return-only confirmed), live browser render with PNGs, zero console errors. Gates observed: `cargo test --lib` 1724 passed / 12 ignored / 1 pre-existing machine-conditional failure (`settings::ai_map`); `ng lint`+`ng build` clean; Playwright **85/85**.
- **lock-security-reviewer: PASS** — explain gate ordering verified (visibility → consent-fail-closed provider → gated snippet), judge is local-or-stub only (zero `provider_for` in audit.rs), scheduled tick = the same EMPTY-unlock-set pass, migration additive. **Default-ON adjudicated acceptable**: the scheduled path is zero-egress by construction; pinned caveat — any future provider call in the tick/judge invalidates this and requires consent or default-OFF.

## Known limits (honest)

Real weekly cadence / thermal / RAM behavior over time, a real GGUF judge verdict, and a consented cloud explain (redaction on the wire + ledger row) need a live/signed Mac. Low-risk residuals recorded by the verifier (accept-vs-judge ≤10s race is loss-safe; manual run waits on the heavy permit during transcription).