### PR TITLE
fix(clippy): repair trunk clippy break from vault-audit merges

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -51,7 +51,7 @@ const MIN_MENTION_TITLE_CHARS: usize = 6;
 
 /// Staleness thresholds: a meeting note is flagged when it carries at least this many facts…
 const STALE_MIN_FACTS: usize = 3;
-/// …and at least half of them are closed (superseded). Expressed as closed*2 >= total.
+// …and at least half of them are closed (superseded). Expressed as closed*2 >= total.
 
 // ── Wire DTOs (the pinned FE seam — the Angular builder codes against exactly these) ─────────
 

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -352,6 +352,7 @@ pub fn weekly_due(now_ms: i64, last_scheduled_finished_at: Option<i64>, enabled:
 /// - runs the SAME gated deterministic pass as the manual command (EMPTY unlock set inside
 ///   `run_audit_pass`), then the judge tier, then emits the count-only
 ///   [`crate::events::EVENT_AUDIT_UPDATED`] exactly like the manual command.
+///
 /// NEVER panics; every failure is a warn (ids/counts only — no PII).
 pub async fn audit_weekly_tick(handle: &tauri::AppHandle) {
     use tauri::Manager;
@@ -2261,7 +2262,7 @@ mod tests {
         let r3 = stage_judged_finding(&db, "k-resolved", "stale");
         db.resolve_audit_finding_row(&r3.id, "accepted", 5).unwrap();
         let demote = VerdictReasoner::keeping(vec![Some(false)]);
-        let stats = judge_findings_sync(&db, &demote, &[r3.clone()], JUDGE_STAGE_BUDGET_MS);
+        let stats = judge_findings_sync(&db, &demote, std::slice::from_ref(&r3), JUDGE_STAGE_BUDGET_MS);
         assert_eq!(stats.demoted, 0, "a resolved row is never deleted");
         assert_eq!(
             db.get_audit_finding(&r3.id).unwrap().unwrap().status,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11796,13 +11796,13 @@ fn move_note_inner_impl(
 
     // Best-effort FS move only when a plaintext .md exists (target is open here).
     if let Some(src_path) = exported {
-        if let Some(vault) = vault_path(&state) {
+        if let Some(vault) = vault_path(state) {
             let target_rel = match folder_id.as_deref() {
                 Some(fid) => state.db.folder_by_id(fid)?.map(|f| f.path),
                 None => None,
             };
             move_note_file(
-                &state,
+                state,
                 &meeting_id,
                 &src_path,
                 &vault,
@@ -24622,6 +24622,7 @@ mod lifecycle_tests {
     // ── Vault Audit — accept/dismiss/list (command layer) ─────────────────────
 
     /// Stage one pending audit finding directly (the pass is tested in `crate::audit`).
+    #[allow(clippy::too_many_arguments)]
     fn stage_audit_finding(
         state: &AppState,
         kind: &str,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6767,6 +6767,7 @@ pub(crate) fn set_audit_schedule_inner(
 /// 3. the provider builds through the [`crate::summarize::provider_for`] chain BEFORE any prompt
 ///    content is assembled — the fail-closed consent gate, the redaction firewall, and the
 ///    egress ledger all live inside that seam (the brief runner's posture).
+///
 /// The prompt carries the finding's own evidence + a bounded, GATED excerpt of the source note
 /// (current session set). RETURN-ONLY: the explanation is never persisted (no new derived
 /// plaintext at rest). A seal interleaving with the in-flight provider call affects only the
@@ -32288,6 +32289,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState) -> bool {
 ///     item after the new one lands) rather than restarting at `rev = 1` and minting a duplicate item
 ///     alongside the still-live stuck one;
 ///   - `revoke_pending` → tombstone the item server-side → `revoked`.
+///
 /// Returns the number of rows ADVANCED. Reads ONLY the retained local rows' key/hash context — for a
 /// re-seal it re-reads the SOURCE note, so the per-row re-share still passes the READ-GATE (a source
 /// sealed since queueing refuses and the row is left `failed`, never egressing sealed content).


### PR DESCRIPTION
Trunk is RED on `clippy -D warnings` since #349/#353 merged (their gates ran against an older base — the merge-skew class). Every open PR's `ci.sh` gate now fails on 4 errors in files outside its own diff:

- `audit.rs`: `empty_lines_after_doc_comment` — the dangling doc line after `STALE_MIN_FACTS` becomes a plain `//` comment (it documents threshold prose, not an item).
- `commands.rs` `move_note_inner_impl`: 2× `needless_borrow` — `state` is already `&State`, dropped the extra `&` at the `vault_path`/`move_note_file` call sites.
- `commands.rs` `stage_audit_finding` (test helper, 8 args): `#[allow(clippy::too_many_arguments)]`, matching the file's four existing allows.

No behavior change. Verified: the exact 4 errors reported by the failing gates of #350/#351/#352 (e.g. run 29514872609) map to these sites; this PR's own gate proves clippy green.