### PR TITLE
fix(ci): clear the clippy backlog from the audit PRs + machine-independent whisper-default test

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -51,7 +51,7 @@ const MIN_MENTION_TITLE_CHARS: usize = 6;
 
 /// Staleness thresholds: a meeting note is flagged when it carries at least this many facts…
 const STALE_MIN_FACTS: usize = 3;
-/// …and at least half of them are closed (superseded). Expressed as closed*2 >= total.
+// …and at least half of them are closed (superseded). Expressed as closed*2 >= total.
 
 // ── Wire DTOs (the pinned FE seam — the Angular builder codes against exactly these) ─────────
 
@@ -352,6 +352,7 @@ pub fn weekly_due(now_ms: i64, last_scheduled_finished_at: Option<i64>, enabled:
 /// - runs the SAME gated deterministic pass as the manual command (EMPTY unlock set inside
 ///   `run_audit_pass`), then the judge tier, then emits the count-only
 ///   [`crate::events::EVENT_AUDIT_UPDATED`] exactly like the manual command.
+///
 /// NEVER panics; every failure is a warn (ids/counts only — no PII).
 pub async fn audit_weekly_tick(handle: &tauri::AppHandle) {
     use tauri::Manager;
@@ -2261,7 +2262,7 @@ mod tests {
         let r3 = stage_judged_finding(&db, "k-resolved", "stale");
         db.resolve_audit_finding_row(&r3.id, "accepted", 5).unwrap();
         let demote = VerdictReasoner::keeping(vec![Some(false)]);
-        let stats = judge_findings_sync(&db, &demote, &[r3.clone()], JUDGE_STAGE_BUDGET_MS);
+        let stats = judge_findings_sync(&db, &demote, std::slice::from_ref(&r3), JUDGE_STAGE_BUDGET_MS);
         assert_eq!(stats.demoted, 0, "a resolved row is never deleted");
         assert_eq!(
             db.get_audit_finding(&r3.id).unwrap().unwrap().status,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11796,13 +11796,13 @@ fn move_note_inner_impl(
 
     // Best-effort FS move only when a plaintext .md exists (target is open here).
     if let Some(src_path) = exported {
-        if let Some(vault) = vault_path(&state) {
+        if let Some(vault) = vault_path(state) {
             let target_rel = match folder_id.as_deref() {
                 Some(fid) => state.db.folder_by_id(fid)?.map(|f| f.path),
                 None => None,
             };
             move_note_file(
-                &state,
+                state,
                 &meeting_id,
                 &src_path,
                 &vault,
@@ -24622,6 +24622,7 @@ mod lifecycle_tests {
     // ── Vault Audit — accept/dismiss/list (command layer) ─────────────────────
 
     /// Stage one pending audit finding directly (the pass is tested in `crate::audit`).
+    #[allow(clippy::too_many_arguments)]
     fn stage_audit_finding(
         state: &AppState,
         kind: &str,

--- a/src-tauri/src/settings/ai_map.rs
+++ b/src-tauri/src/settings/ai_map.rs
@@ -170,7 +170,10 @@ mod tests {
         assert!(!reactions.routable);
         let tr = row(&rows, "transcription");
         assert_eq!(tr.engine, "Whisper");
-        assert_eq!(tr.model, "small");
+        // The default whisper size is machine-conditional (downloaded models + RAM decide, see
+        // transcribe::model::default_model_size_now) — assert the row mirrors that ONE decision
+        // instead of hardcoding "small", which only holds on a model-less machine.
+        assert_eq!(tr.model, crate::transcribe::model::default_model_size_now());
         assert!(tr.on_device);
     }
 


### PR DESCRIPTION
## What

Two gate fixes found by running the FULL `scripts/ci.sh` on the merged trunk after #348/#349/#353 (the merge-skew discipline):

1. **6 clippy `-D warnings` lints** the `cargo test --lib` inner loop cannot see (doc-comment shape ×2, `needless_borrow` ×2, `cloned_ref_to_slice_refs` in a test, `too_many_arguments` allow on a test-only helper).
2. **`settings::ai_map::default_config_…` was machine-dependent**: it asserted the whisper default is the literal `"small"`, but `AppConfig::default()` resolves `default_model_size_now()` (downloaded models + RAM decide) — so the test failed on any Mac with a model downloaded (it pre-dates this program; both Phase-2/3 verifiers independently confirmed it fails in isolation with settings untouched). It now asserts the row mirrors that ONE machine-conditional decision — the actual invariant.

## How verified

`bash scripts/ci.sh` fully green end-to-end on this tree: **"✅ CI: all gates green"** — swiftc, clippy `-D warnings`, `cargo test --lib` (1725 passed), cargo audit/deny, build, `ng lint`, `ng build`, headless core E2E + mixed-audio E2E.