### PR TITLE
fix(lock): relock purges unsealed plaintext segments + Drop-armed salvage lock finalizer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14433,6 +14433,16 @@ fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppErr
         if let Some(enc) = reblank_audio(sys)? {
             state.db.set_meeting_sys_master_path(&mid, Some(&enc))?;
         }
+        // FAIL-CLOSED sweep (2026-07-16 review): segments carrying PLAINTEXT with NO sealed blob —
+        // the crash window of a salvage/live pipeline killed before its seal step — are invisible
+        // to the blob-guarded re-blanks above and would sit plaintext-at-rest behind the lock
+        // forever. They are DERIVED data and their source audio survives sealed (re-blanked just
+        // above), so the relock deletes them; unlock + retry re-derives the transcript. This makes
+        // the invariant universal: after a relock, NO plaintext segment row exists in the folder.
+        let purged = state.db.delete_unsealed_segments(&mid)?;
+        if purged > 0 {
+            tracing::warn!(target: "lock", meeting_id = %mid, purged, "relock purged unsealed plaintext segments left by an interrupted pipeline (audio stays sealed; unlock + retry to re-transcribe)");
+        }
     }
     // Document ingestion: re-blank the plaintext text of every sealed document ONLY WHERE its
     // `text_blob` exists (never destroy the only copy), and PURGE the doc chunks the session unlock
@@ -23955,6 +23965,79 @@ mod lifecycle_tests {
         assert!(!wav.exists(), "the plaintext WAV is removed (a sealed copy exists)");
         assert!(enc.exists(), "the sealed .enc twin is never touched");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// LOCK MODEL (2026-07-16 review, MEDIUM): a RELOCK must purge blob-less plaintext segments —
+    /// the crash window where a salvage/live pipeline died between its segment insert and its
+    /// seal/finalize step. The blob-guarded re-blank can never cover those rows; before this fix
+    /// they sat plaintext-at-rest behind the lock through every later relock.
+    #[test]
+    fn relock_reblank_purges_unsealed_plaintext_segments() {
+        let state = build_state("relock-unsealed-purge");
+        seed_meeting(&state.db, "m-crashed", "# crashed salvage", None);
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-crash".into(),
+                name: "Crash".into(),
+                path: "Crash".into(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-crashed", Some("f-crash"))
+            .unwrap();
+        assert!(
+            !state.db.raw_segments("m-crashed").unwrap().is_empty(),
+            "precondition: fresh blob-less plaintext segments exist behind the lock"
+        );
+
+        reblank_folder_extras(&state, "f-crash").unwrap();
+
+        assert!(
+            state.db.raw_segments("m-crashed").unwrap().is_empty(),
+            "the relock re-blank purges blob-less plaintext rows — nothing plaintext survives a relock"
+        );
+    }
+
+    /// DEFENSE-IN-DEPTH (2026-07-16 review, MEDIUM): the salvage lock finalizer is Drop-armed —
+    /// a panic unwinding out of the pipeline scope still runs it, so the mid-run-relock purge
+    /// cannot be skipped by a crash between the segment insert and the sequential finalizer call.
+    #[test]
+    fn salvage_lock_finalizer_guard_runs_on_a_panic_unwind() {
+        let state = build_state("salvage-guard-panic");
+        seed_meeting(&state.db, "m-panic", "# raced", None);
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-panic".into(),
+                name: "Panic".into(),
+                path: "Panic".into(),
+                parent_id: None,
+                locked: true, // locked, NOT session-unlocked → the purge branch
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-panic", Some("f-panic"))
+            .unwrap();
+
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = crate::pipeline::SalvageLockFinalizer {
+                state: &state,
+                meeting_id: "m-panic",
+            };
+            panic!("simulated pipeline death between segment insert and finalizer");
+        }));
+        assert!(unwound.is_err(), "the panic really unwound through the guard scope");
+        assert!(
+            state.db.raw_segments("m-panic").unwrap().is_empty(),
+            "the Drop-armed finalizer purged the unsealed plaintext despite the panic"
+        );
     }
 
     /// `finalize_salvage_lock_state` never removes a plaintext WAV WITHOUT a surviving sealed

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14405,6 +14405,20 @@ fn reexport_notes_in_folder(state: &AppState, folder_id: &str) {
 /// remove the decrypted session WAV, re-pointing audio_path back at the `.enc`. The `*_blob`
 /// columns + the `.enc` stay (the folder is still `locked=1`). Idempotent.
 fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppError> {
+    // SEAL-NET KEY (2026-07-16 lock review of #356): resolve the folder CK from the SESSION-CACHED
+    // KEK only — never a keychain/biometric prompt (this runs on relock / app-close / screen-share).
+    // `relock_all_inner` zeroizes the KEK BEFORE its sweep by design (screen-share posture), so the
+    // net is live on the `relock_folder` path and absent on relock-all — there, non-rederivable
+    // rows are left in place and warned about instead (a bounded residue beats destroying content).
+    let seal_ck: Option<Zeroizing<[u8; 32]>> = (|| {
+        let kek = state.master_kek.lock().ok()?.clone()?;
+        let wrapped = state.db.folder_wrapped_key(folder_id).ok().flatten()?;
+        let bytes = Zeroizing::new(
+            crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(folder_id)).ok()?,
+        );
+        let arr: [u8; 32] = bytes.as_slice().try_into().ok()?;
+        Some(Zeroizing::new(arr))
+    })();
     for mid in state.db.meeting_ids_in_folder(folder_id)? {
         for s in state.db.raw_segments(&mid)? {
             if s.text_blob.is_some() && !s.text.is_empty() {
@@ -14433,15 +14447,54 @@ fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppErr
         if let Some(enc) = reblank_audio(sys)? {
             state.db.set_meeting_sys_master_path(&mid, Some(&enc))?;
         }
-        // FAIL-CLOSED sweep (2026-07-16 review): segments carrying PLAINTEXT with NO sealed blob —
-        // the crash window of a salvage/live pipeline killed before its seal step — are invisible
-        // to the blob-guarded re-blanks above and would sit plaintext-at-rest behind the lock
-        // forever. They are DERIVED data and their source audio survives sealed (re-blanked just
-        // above), so the relock deletes them; unlock + retry re-derives the transcript. This makes
-        // the invariant universal: after a relock, NO plaintext segment row exists in the folder.
-        let purged = state.db.delete_unsealed_segments(&mid)?;
-        if purged > 0 {
-            tracing::warn!(target: "lock", meeting_id = %mid, purged, "relock purged unsealed plaintext segments left by an interrupted pipeline (audio stays sealed; unlock + retry to re-transcribe)");
+        // FAIL-CLOSED sweep (2026-07-16 reviews: #352 adversarial MEDIUM, then the #356 lock-review
+        // FAIL that scoped it): segment rows carrying PLAINTEXT with NO sealed blob — a
+        // pipeline/move killed before its seal step — are invisible to the blob-guarded re-blanks
+        // above. Decided per meeting, on PROOF, never on the comment's say-so:
+        //   1. provably RE-DERIVABLE (status Error/Recording — exactly the states the retry gate
+        //      accepts — AND this meeting's audio survives on disk, plaintext or `.enc`): DELETE.
+        //      Unlock + retry re-transcribes; nothing unrecoverable is destroyed.
+        //   2. otherwise, with the folder CK resolvable from the session KEK: SEAL them in place
+        //      (verify-before-blank via `seal_meeting_extras`, which also covers the same crash's
+        //      unsealed timeline/manual-notes/audio) — e.g. a kill mid-`move_note` leaves a
+        //      COMPLETED meeting's transcript unsealed; deleting it would destroy the only copy.
+        //   3. neither: LEAVE + WARN. A bounded plaintext residue behind the SQLCipher layer is
+        //      strictly better than loss — content is NEVER deleted without a provable copy.
+        let has_unsealed = state
+            .db
+            .raw_segments(&mid)?
+            .iter()
+            .any(|s| s.text_blob.is_none());
+        if has_unsealed {
+            let rederivable = state.db.get_meeting(&mid)?.is_some_and(|m| {
+                matches!(
+                    m.status,
+                    MeetingStatus::Recording | MeetingStatus::Error
+                ) && m.audio_path.as_deref().is_some_and(|p| {
+                    let plain = p.strip_suffix(ENC_SUFFIX).unwrap_or(p);
+                    std::path::Path::new(plain).exists()
+                        || std::path::Path::new(&format!("{plain}{ENC_SUFFIX}")).exists()
+                })
+            });
+            if rederivable {
+                let purged = state.db.delete_unsealed_segments(&mid)?;
+                if purged > 0 {
+                    tracing::warn!(target: "lock", meeting_id = %mid, purged, "relock purged unsealed plaintext segments left by an interrupted pipeline (audio survives on disk; unlock + retry to re-transcribe)");
+                }
+            } else if let Some(ck) = seal_ck.as_ref() {
+                // Best-effort by design: a seal failure must not abort the relock (that would
+                // leave MORE plaintext) — the rows stay, warned about, recoverable via unlock.
+                match seal_meeting_extras(state, folder_id, &mid, ck) {
+                    Ok(()) => {
+                        tracing::warn!(target: "lock", meeting_id = %mid, "relock sealed crash-window plaintext (interrupted move/seal) in place under the folder CK");
+                    }
+                    Err(e) => {
+                        tracing::warn!(target: "lock", meeting_id = %mid, error = %e, "relock could not seal crash-window plaintext segments — left in place (never deleted without a provable copy)");
+                    }
+                }
+            } else {
+                tracing::warn!(target: "lock", meeting_id = %mid, "relock found unsealed plaintext segments that are not provably re-derivable and no session KEK is cached — left in place (unlock the folder to seal or retry)");
+            }
         }
     }
     // Document ingestion: re-blank the plaintext text of every sealed document ONLY WHERE its
@@ -23967,14 +24020,34 @@ mod lifecycle_tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// LOCK MODEL (2026-07-16 review, MEDIUM): a RELOCK must purge blob-less plaintext segments —
-    /// the crash window where a salvage/live pipeline died between its segment insert and its
-    /// seal/finalize step. The blob-guarded re-blank can never cover those rows; before this fix
-    /// they sat plaintext-at-rest behind the lock through every later relock.
+    /// LOCK MODEL (2026-07-16 reviews): a RELOCK purges blob-less plaintext segments ONLY when
+    /// re-derivation is PROVEN — status Error/Recording (the retry gate's accepted states) AND the
+    /// meeting's audio surviving on disk. This is the #352 crash window (pipeline died between
+    /// segment insert and seal); before the fix those rows sat plaintext-at-rest behind the lock.
     #[test]
     fn relock_reblank_purges_unsealed_plaintext_segments() {
         let state = build_state("relock-unsealed-purge");
+        let dir =
+            std::env::temp_dir().join(format!("murmur-relock-purge-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wav = dir.join("m-crashed.wav");
+        std::fs::write(&wav, b"RIFF-archived-audio").unwrap();
+
         seed_meeting(&state.db, "m-crashed", "# crashed salvage", None);
+        state
+            .db
+            .finalize_meeting(
+                "m-crashed",
+                "2026-07-16T10:00:00Z",
+                60,
+                &wav.to_string_lossy(),
+            )
+            .unwrap();
+        state
+            .db
+            .update_meeting_status("m-crashed", MeetingStatus::Error)
+            .unwrap();
         state
             .db
             .insert_folder(&Folder {
@@ -23999,7 +24072,80 @@ mod lifecycle_tests {
 
         assert!(
             state.db.raw_segments("m-crashed").unwrap().is_empty(),
-            "the relock re-blank purges blob-less plaintext rows — nothing plaintext survives a relock"
+            "provably re-derivable blob-less rows (Error status + on-disk audio) are purged"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// LOCK MODEL (2026-07-16 lock-review FAIL on the first #356 cut): the relock purge must
+    /// NEVER destroy the only copy. A COMPLETED (Summarized) meeting whose blob-less plaintext
+    /// landed in a locked folder (kill mid-`move_note`: folder set before the seal) with NO audio
+    /// on disk and NO session KEK is neither retryable nor sealable — the rows must SURVIVE.
+    #[test]
+    fn relock_reblank_never_deletes_the_only_copy_without_proof() {
+        let state = build_state("relock-noloss");
+        seed_meeting(&state.db, "m-only", "# completed meeting", None);
+        state
+            .db
+            .update_meeting_status("m-only", MeetingStatus::Summarized)
+            .unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-only".into(),
+                name: "Only".into(),
+                path: "Only".into(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-only", Some("f-only"))
+            .unwrap();
+
+        reblank_folder_extras(&state, "f-only").unwrap();
+
+        let segs = state.db.raw_segments("m-only").unwrap();
+        assert!(
+            !segs.is_empty() && segs.iter().any(|s| !s.text.is_empty()),
+            "non-rederivable blob-less plaintext is LEFT IN PLACE (a bounded residue beats loss)"
+        );
+    }
+
+    /// LOCK MODEL (2026-07-16 lock-review fix direction): with the session KEK cached (the
+    /// `relock_folder` path), non-rederivable crash-window plaintext is SEALED in place under the
+    /// folder CK (verify-before-blank) instead of deleted or left plaintext.
+    #[test]
+    fn relock_reblank_seals_non_rederivable_plaintext_when_kek_is_cached() {
+        let state = build_state("relock-sealnet");
+        make_open_folder(&state.db, "f-net", "Net");
+        seed_meeting(&state.db, "m-prior", "# already sealed", Some("f-net"));
+        lock_folder_inner(&state, "f-net".to_string()).unwrap(); // real lock: CK minted + wrapped
+
+        // The mid-move crash shape: a COMPLETED meeting's blob-less plaintext segments appear in
+        // the locked folder (move_note set the folder, died before seal_moved_note).
+        seed_meeting(&state.db, "m-moved", "# moved note", None);
+        state
+            .db
+            .update_meeting_status("m-moved", MeetingStatus::Summarized)
+            .unwrap();
+        state
+            .db
+            .set_meeting_folder("m-moved", Some("f-net"))
+            .unwrap();
+        // Session KEK cached (as after any interactive lock/unlock this session).
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
+
+        reblank_folder_extras(&state, "f-net").unwrap();
+
+        let segs = state.db.raw_segments("m-moved").unwrap();
+        assert!(!segs.is_empty(), "rows survive — sealed, never deleted");
+        assert!(
+            segs.iter().all(|s| s.text_blob.is_some() && s.text.is_empty()),
+            "crash-window rows are sealed in place under the folder CK (blob set, plaintext blanked)"
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24114,6 +24114,93 @@ mod lifecycle_tests {
         );
     }
 
+    /// Pins the STATUS leg of the delete condition ALONE (adversarial re-review R2): a COMPLETED
+    /// (Summarized) meeting with audio ON DISK still must not be purged — retry refuses non-Error
+    /// status, so deletion would be loss even though the audio survives.
+    #[test]
+    fn relock_reblank_leaves_completed_meeting_even_with_audio_on_disk() {
+        let state = build_state("relock-noloss-status-leg");
+        let dir =
+            std::env::temp_dir().join(format!("murmur-relock-statusleg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let wav = dir.join("m-sum.wav");
+        std::fs::write(&wav, b"RIFF-archived-audio").unwrap();
+
+        seed_meeting(&state.db, "m-sum", "# completed", None);
+        state
+            .db
+            .finalize_meeting("m-sum", "2026-07-16T10:00:00Z", 60, &wav.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .update_meeting_status("m-sum", MeetingStatus::Summarized)
+            .unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-sum".into(),
+                name: "Sum".into(),
+                path: "Sum".into(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state.db.set_meeting_folder("m-sum", Some("f-sum")).unwrap();
+
+        reblank_folder_extras(&state, "f-sum").unwrap();
+
+        let segs = state.db.raw_segments("m-sum").unwrap();
+        assert!(
+            !segs.is_empty() && segs.iter().any(|s| !s.text.is_empty()),
+            "a Summarized meeting's blob-less rows survive even with audio on disk (retry refuses non-Error)"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Pins the AUDIO leg of the delete condition ALONE (adversarial re-review R3): an Error
+    /// meeting whose archived audio is GONE from disk (pruned/dangling path) must not be purged —
+    /// there is nothing to re-transcribe from, so deletion would be loss.
+    #[test]
+    fn relock_reblank_leaves_error_meeting_whose_audio_is_gone() {
+        let state = build_state("relock-noloss-audio-leg");
+        seed_meeting(&state.db, "m-err", "# failed run", None);
+        state
+            .db
+            .finalize_meeting(
+                "m-err",
+                "2026-07-16T10:00:00Z",
+                60,
+                "/nonexistent/murmur-pruned/m-err.wav",
+            )
+            .unwrap();
+        state
+            .db
+            .update_meeting_status("m-err", MeetingStatus::Error)
+            .unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f-err".into(),
+                name: "Err".into(),
+                path: "Err".into(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-07-16T00:00:00Z".into(),
+            })
+            .unwrap();
+        state.db.set_meeting_folder("m-err", Some("f-err")).unwrap();
+
+        reblank_folder_extras(&state, "f-err").unwrap();
+
+        let segs = state.db.raw_segments("m-err").unwrap();
+        assert!(
+            !segs.is_empty() && segs.iter().any(|s| !s.text.is_empty()),
+            "an Error meeting's blob-less rows survive when its audio is gone (nothing to re-derive from)"
+        );
+    }
+
     /// LOCK MODEL (2026-07-16 lock-review fix direction): with the session KEK cached (the
     /// `relock_folder` path), non-rederivable crash-window plaintext is SEALED in place under the
     /// folder CK (verify-before-blank) instead of deleted or left plaintext.

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -367,20 +367,41 @@ pub async fn run_salvage_from_disk(
         }
     };
     let duration_s = (samples.len() as f64 / rate as f64).round() as i64;
+    // Reconcile the fresh output with the folder's CURRENT lock state on EVERY exit — Ok, Err, a
+    // panic unwinding through the detached task, or this future being dropped mid-await. A plain
+    // sequential call after the await left a crash window (2026-07-16 review): a kill between the
+    // segment insert and the finalizer skipped the re-seal/purge, stranding fresh plaintext behind
+    // a lock (the relock-side sweep in `reblank_folder_extras` is the second, universal net).
+    // Best-effort by contract: a finalizer failure is logged inside and never masks the result.
+    let _finalizer = SalvageLockFinalizer { state, meeting_id };
     // Single stream, anchored to a fresh Instant (the original capture clocks are gone) — the
     // merge sees one stream, so the anchor only offsets absolute timestamps uniformly.
     let now = std::time::Instant::now();
-    let result = run_after_stop(
+    run_after_stop(
         app, state, meeting_id, samples, rate, duration_s, None, // no system stream
         None, // no AEC helper track
         now, None,
     )
-    .await;
-    // Reconcile the fresh output with the folder's CURRENT lock state on BOTH arms (an Err run may
-    // already have inserted plaintext segments before failing). Best-effort: a finalizer failure is
-    // logged inside and must never mask the pipeline result.
-    crate::commands::finalize_salvage_lock_state(state, meeting_id);
-    result
+    .await
+}
+
+/// Drop-armed wrapper for [`crate::commands::finalize_salvage_lock_state`] — the salvage lock
+/// finalizer MUST run on every exit from [`run_salvage_from_disk`]'s pipeline scope, including a
+/// panic unwind and a mid-await future drop, or the crash window leaves unsealed plaintext behind
+/// a lock. Drop is unwind-safe: the body is `catch_unwind`-wrapped (a panic escaping `Drop`
+/// during an unwind would abort the process) and the finalizer itself is best-effort.
+pub(crate) struct SalvageLockFinalizer<'a> {
+    pub(crate) state: &'a AppState,
+    pub(crate) meeting_id: &'a str,
+}
+
+impl Drop for SalvageLockFinalizer<'_> {
+    fn drop(&mut self) {
+        let (state, meeting_id) = (self.state, self.meeting_id);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::commands::finalize_salvage_lock_state(state, meeting_id);
+        }));
+    }
 }
 
 /// Transcribe one 16 kHz stream at the Accurate profile, VAD-segmented. With a `VadSegmenter`,


### PR DESCRIPTION
Closes the MEDIUM from PR #352's adversarial review (merged before this hardening landed): a salvage/live pipeline killed between its segment insert and its seal/finalize step leaves fresh PLAINTEXT segment rows (no sealed blob) that the relock's blob-guarded re-blank can never cover — plaintext-at-rest behind the lock, surviving every later relock.

## Root cause fix
`reblank_folder_extras` (the one helper both `relock_folder` and `relock_all_inner` use) now deletes every segment row carrying plaintext with NO sealed blob. Those rows are derived data and their source audio survives sealed in the same pass (re-blanked to `.enc`), so nothing unrecoverable is destroyed — unlock + Retry transcription re-derives the transcript. The invariant becomes universal: **after a relock, no plaintext segment row exists in the folder**, regardless of which future writer produces the crash window.

## Defense-in-depth
`run_salvage_from_disk`'s lock-state finalizer is now a Drop guard (`SalvageLockFinalizer`, catch_unwind-wrapped): it runs on Ok, Err, a panic unwinding through the detached task, AND a mid-await future drop — the sequential call it replaces was skipped by exactly the crash window the review proved.

## Verification
- RED-before-GREEN: `relock_reblank_purges_unsealed_plaintext_segments` FAILS with the purge disabled (observed); `salvage_lock_finalizer_guard_runs_on_a_panic_unwind` pins the Drop-during-unwind path.
- `cargo test --lib` on this branch (= current trunk + this commit): **1745 passed / 0 failed / 12 ignored** — fully green (incl. #355's machine-independent whisper-default fix).
- Lock-security + adversarial delta reviews requested before merge (this touches the relock path).

Honest gaps: the live screen-share auto-relock racing a real salvage needs a signed build; headless tests pin the state machine.