### PR TITLE
feat(record): companion note per recording with robust meeting link

### DIFF
--- a/docs/superpowers/specs/2026-07-16-recording-companion-note-design.md
+++ b/docs/superpowers/specs/2026-07-16-recording-companion-note-design.md
@@ -1,0 +1,156 @@
+# Recording-time companion note — design spec
+
+Date: 2026-07-16
+Status: approved (design), pre-implementation
+Branch: `feat/recording-companion-note`
+
+## Problem
+
+During an active recording the "Notes" panel (`MeetingConversationComponent`) lets the user
+either jot a plain note or type `@brain <question>` to open an agentic thread. Two defects:
+
+1. **A plain jot is a dead end.** It is written to the meeting's `manual_notes` buffer
+   (`save_manual_notes` → a `\n`-joined plaintext blob on the meeting row). It never becomes a
+   real note: it is not in the Notes surface, not a `.md` in the Obsidian vault, not linkable,
+   not a first-class citizen of the user's second brain. This is the "note that adds nothing".
+2. **You cannot reliably link a recording from a note via `[[name]]`.** `resolve_wikilink` has a
+   meeting leg, but (a) during recording the meeting often has no stable human title yet
+   (auto-title lands on close), (b) the resolver tries the note leg first, and (c) there is no
+   structured `meeting_id` on a standalone note — the link is a fragile title string.
+
+## Goal
+
+Make in-recording note-taking produce **real, linked notes**, keep the thread-based `@brain`
+interaction, and make the recording↔note link robust — with a satisfying "saved to Notes"
+confirmation carrying the reference.
+
+## Decisions (locked with the user)
+
+- **One living companion note per meeting** (not one-note-per-jot, not document-first).
+- **Structured `meeting_id` link + a visible `[[Meeting]]` wikilink** (root-cause, not a
+  title-string patch).
+
+## Model — companion note + thread
+
+- **One meeting ⇒ one companion note.** A row in `documents` (`kind='note'`), created **lazily on
+  the first sent note or first accepted `@brain` draft** — no content, no note (this kills the
+  empty "Untitled" note complaint at its root).
+- **No title field shown** (satisfies "bez tytułu"). Under the hood the note carries a managed
+  title equal to the meeting's display title, kept in sync; the user never edits a title on this
+  surface. String-collision with the meeting is handled deterministically in the resolver (see
+  §Linking, self-link avoidance) — the companion note is never the target of its own `[[Meeting]]`.
+- **Folder:** the always-open Notes ROOT (unfiled) — no lock complications while recording.
+- **Thread stays primary.** The panel remains a thread that interleaves, in time order: the user's
+  sent notes (rendered as "saved note" cards) and `@brain` exchanges. Every send appends a block to
+  the companion note.
+
+## Composer — reuse, not duplicate
+
+New design-system component `mur-markdown-composer` (`src/app/design-system/markdown-composer/`):
+an auto-growing textarea with `/` slash-block menu, `[[` link picker, ⌘B/⌘I/⌘1-3 formatting, list
+continuation, Enter = send / Shift+Enter = newline. It **reuses** the already-presentational
+`LinkPickerComponent`, `MarkdownComponent` (for preview/cards), and IPC
+`listLinkCandidates`/`resolveWikilink`. The shipped `NoteEditorComponent` (2284 lines) is **left
+untouched** in this change; migrating its inline editor onto the shared composer is an explicit
+**fast-follow** (stated openly — this change does not yet dedupe the two editors).
+
+## Linking (root-cause)
+
+Two link artifacts, both derived from one authoritative structured relation:
+
+1. **App-level (authoritative):** new additive column `documents.meeting_id TEXT` (nullable,
+   indexed), set on the companion note at creation. Drives navigation (by id, never by string),
+   and the meeting's "Linked mentions"/backlinks. Survives meeting rename/auto-title.
+2. **Vault-level (Obsidian-native, user-visible):** on export, the note's YAML front-matter carries
+   the meeting wikilink (e.g. `meeting: "[[<meeting display name>]]"`). Kept in sync with the
+   meeting's final title on close/rename.
+
+**Self-link avoidance (firm rule):** the companion note's title equals its meeting's title, so a
+user-typed `[[Meeting]]` could otherwise hit the companion note via the note-leg-first order. Fix:
+in `resolve_wikilink`, a note carrying a non-null `meeting_id` is **excluded from the note-leg when
+the queried title equals that note's own meeting's title** — so `[[Meeting]]` always resolves to the
+meeting, never to its companion note. Companion→meeting navigation (the card chip) goes by
+`meeting_id` directly and never relies on string resolution.
+
+**General wikilink fix (the user's explicit concern):** make `[[Meeting Title]]` reliably resolve
+to a meeting: (a) ensure meetings are surfaced in `list_link_candidates` so the `[[` picker offers
+them, (b) give the in-progress meeting a **stable provisional name at record start** if it has none,
+so the link is meaningful immediately, (c) confirm the meeting leg of `resolve_wikilink` is reached
+for meeting-kind targets even when a same-named note exists (structured link wins for the companion
+case; for user-typed links, disambiguate by candidate kind chosen in the picker).
+
+## Confirmation card ("fajne przedstawienie")
+
+Each sent note renders in the thread as a card: the rendered markdown of the entry + a subtle
+footer bar: `✓ Zapisano w Notatkach` (primary click → opens the companion note in a new tab via
+`TabsService`) and a `🔗 [[Meeting]] →` chip (navigates to the meeting by `meeting_id`). Same card
+shape for an accepted `@brain` draft.
+
+## `@brain` + backward compat
+
+- `@brain` thread flow unchanged. Its "Add to notes" (`acceptIntoNotes`) routes the accepted draft
+  through the same append-to-companion-note path and shows the same card.
+- **`manual_notes` is preserved additively.** Each send still updates `manual_notes` (the summary /
+  "enhance my notes → outline" pipeline reads it) AND appends to the companion note. No change to
+  the enhance feature; the companion note is the new durable, linked, vault-exported artifact.
+
+## Technical seams
+
+### Backend (`src-tauri/src/`)
+- **Schema:** `add_column_if_missing(documents, meeting_id TEXT)` in `Db::migrate()` (additive,
+  idempotent) + an index on `meeting_id`.
+- **Command:** `append_to_companion_note(meeting_id, markdown) -> { note_id, meeting_wikilink }` —
+  lazily gets-or-creates the companion note (in Notes ROOT, meeting_id set, managed title), appends
+  the markdown block atomically (single-writer, no FE read-modify-write race), writes/refreshes the
+  front-matter `[[Meeting]]` link, re-exports the vault `.md`, returns the id + the display wikilink
+  for the card. Registered in `lib.rs generate_handler!`.
+- **Wikilink:** extend `list_link_candidates` to include meetings; ensure the meeting leg of
+  `resolve_wikilink` is reliable; ensure a stable provisional meeting name at record start.
+- **Backlinks:** a note with `meeting_id` surfaces under that meeting's `get_backlinks`/"Linked
+  mentions" (lock-gated as today).
+- **Title sync:** when a meeting is (auto-)titled/renamed, refresh the companion note's managed
+  title + front-matter wikilink target.
+
+### Frontend (`src/app/`)
+- `design-system/markdown-composer/` — the `mur-markdown-composer` (reuses `LinkPickerComponent`).
+- `MeetingConversationComponent` — swap the plain composer textarea for `mur-markdown-composer`.
+- `MeetingConversationStore.addNote()` and `acceptIntoNotes()` — call `appendToCompanionNote`, and
+  render the returned reference in the saved-note card. `NoteItem` gains fields for the saved
+  companion note id + meeting wikilink.
+- `IpcService.appendToCompanionNote(meetingId, markdown)` — one typed method; result model
+  `CompanionAppendResult { noteId: string; meetingWikilink: string }` in `core/models.ts`.
+- `note-item.component` — render the saved-note card footer (open-note + meeting chip).
+
+## Security / lock model
+
+The companion note is user-authored content in the always-open Notes ROOT — it does not contain the
+sealed transcript, only what the user typed + accepted drafts. Still routed through
+**lock-security-reviewer**: every content read/export gated (`meeting_is_unlocked` /
+`visibility_clause`), backlinks lock-gated, no PII in logs, the `meeting_id` column adds no leak
+path. Schema change is additive (no `DROP`/`DELETE`); nothing is destroyed so verify-before-destroy
+does not apply, but the append command must not blank prior content on failure.
+
+## Verification (Definition of Done)
+
+- Static: `cargo test --lib` + `npx ng lint` + `npx ng build` green; final `scripts/ci.sh`.
+- RED→GREEN regression for the wikilink meeting-leg fix and for the append/lazy-create path.
+- Runtime: Playwright against `:1420` with mocked Tauri `invoke` — send a note → card appears with
+  the reference; `@brain` accept → same card; no stale-result/leak/abort.
+- Adversarial-verifier owns PASS/FAIL; lock-security-reviewer is a required gate (touches
+  reads/exports/backlinks/schema).
+
+## Build phases (Workflow)
+
+1. **Backend** — column + `append_to_companion_note` + wikilink/candidates fix + stable meeting
+   name + backlinks + title sync; `cargo test --lib`.
+2. **FE composer** — `mur-markdown-composer` reusing the link picker.
+3. **FE rewire** — store/surface/card + IPC + models.
+4. **Verify** — lock-security-reviewer + adversarial-verifier + `scripts/ci.sh`; QueaT commit; PR to
+   `murmur`.
+
+## Explicit non-goals / fast-follows
+
+- Migrating `NoteEditorComponent`'s inline editor onto `mur-markdown-composer` (fast-follow).
+- Backfilling companion notes for pre-existing meetings' `manual_notes` (new behavior applies going
+  forward).
+- Streaming `@brain` answers (separate Phase-9 work).

--- a/e2e/record/companion-note-card.spec.ts
+++ b/e2e/record/companion-note-card.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * A recording-time jot is now a REAL, LINKED note.
+ *
+ * `MeetingConversationStore.addNote()` optimistically appends the flow line, then
+ * routes the markdown through `ipc.appendToCompanionNote(meetingId, markdown)` —
+ * the backend lazily gets-or-creates the meeting's ONE living companion note and
+ * returns `{ noteId, meetingWikilink }`. On resolve the store stamps that
+ * reference onto the line (`saveState: "saved"`), and `NoteItemComponent` renders
+ * a "✓ Saved to Notes" card footer: the primary affordance opens the companion
+ * note by id, and a `🔗 [[Meeting]] →` chip navigates to the meeting.
+ *
+ * RED contract: before this change `addNote` only buffered into `manual_notes`
+ * (no companion note, no card) — the "✓ Saved to Notes" affordance never existed,
+ * so `getByRole("button", { name: /Saved to Notes/ })` finds nothing.
+ */
+test.describe("Record — a sent note becomes a linked companion note", () => {
+  test("sending a jot renders the '✓ Saved to Notes' card with the meeting chip", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-rec",
+        startedAt: "2026-07-01T09:00:00Z",
+      }),
+      get_manual_notes: () => "",
+      save_manual_notes: () => null,
+      // The append lazily creates + appends to the companion note and returns the
+      // card reference (id to open by + the visible [[Meeting]] wikilink).
+      append_to_companion_note: () => ({
+        noteId: "n1",
+        meetingWikilink: "[[Test Meeting]]",
+      }),
+    });
+
+    await page.goto("/record");
+
+    await page.locator("button.start-btn").click();
+    await expect(page.locator("button.stop-btn")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The shared markdown composer replaced the plain textarea.
+    const composer = page.locator("mur-markdown-composer textarea.body-area");
+    await expect(composer).toBeEnabled({ timeout: 10_000 });
+    await composer.fill("ship the three flows people actually use");
+    await composer.press("Enter");
+
+    // The note line renders…
+    await expect(
+      page.getByText("ship the three flows people actually use"),
+    ).toBeVisible();
+
+    // …and the companion-note card footer appears with the primary affordance
+    // ("✓ Saved to Notes" visible text; aria-label "Open this note in Notes").
+    await expect(
+      page.getByRole("button", { name: /Open this note in Notes/ }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(".saved-open")).toContainText("Saved to Notes");
+
+    // …plus the 🔗 [[Meeting]] chip labeled with the returned wikilink (brackets
+    // stripped for display).
+    await expect(page.locator(".meeting-chip .chip-name")).toHaveText(
+      "Test Meeting",
+    );
+  });
+
+  test("a failed append keeps the note line and shows a retry", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-rec",
+        startedAt: "2026-07-01T09:00:00Z",
+      }),
+      get_manual_notes: () => "",
+      save_manual_notes: () => null,
+      // The append fails — the line must be KEPT (content never dropped) and the
+      // card must surface a retry, not a silent loss.
+      append_to_companion_note: () =>
+        Promise.reject("Storage: could not write the companion note"),
+    });
+
+    await page.goto("/record");
+
+    await page.locator("button.start-btn").click();
+    await expect(page.locator("button.stop-btn")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const composer = page.locator("mur-markdown-composer textarea.body-area");
+    await expect(composer).toBeEnabled({ timeout: 10_000 });
+    await composer.fill("a note whose append will fail");
+    await composer.press("Enter");
+
+    // The note line is never dropped even when the append fails.
+    await expect(
+      page.getByText("a note whose append will fail"),
+    ).toBeVisible();
+
+    // The failure is surfaced with a retry (never a silent swallow / lie).
+    await expect(
+      page.getByRole("button", { name: /Retry saving this note/ }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/record/note-save-failure-toast.spec.ts
+++ b/e2e/record/note-save-failure-toast.spec.ts
@@ -36,6 +36,12 @@ test.describe("Record — a rejected note save surfaces an error, not a silent l
         Promise.reject(
           "Locked: this meeting's folder is locked — unlock it to edit your notes",
         ),
+      // The companion-note append is a SEPARATE, additive persist path; keep it
+      // succeeding so this test isolates the `manual_notes` save-failure toast.
+      append_to_companion_note: () => ({
+        noteId: "n-companion",
+        meetingWikilink: "[[Meeting]]",
+      }),
     });
 
     await page.goto("/record");
@@ -45,7 +51,7 @@ test.describe("Record — a rejected note save surfaces an error, not a silent l
       timeout: 10_000,
     });
 
-    const composer = page.locator("textarea.composer-input");
+    const composer = page.locator("mur-markdown-composer textarea.body-area");
     await expect(composer).toBeEnabled({ timeout: 10_000 });
     await composer.fill("ship the 3 flows people actually use");
     await composer.press("Enter");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -559,6 +559,15 @@ pub async fn start_recording(
     let meeting_id = meeting_uuid.to_string();
     let started_at = chrono::Utc::now().to_rfc3339();
 
+    // STABLE PROVISIONAL TITLE (2026-07-16 companion note, Task 4): at record start `meetings.title`
+    // was previously NULL — so `[[Meeting]]` had no meaningful target during the recording (the FE
+    // showed a placeholder). Give the in-progress meeting a stable, human, date/time-based title up
+    // front so a jotted companion note's `[[<name>]]` link is meaningful IMMEDIATELY. This is a
+    // PROVISIONAL name: the existing auto-title-on-close (`pipeline::set_meeting_title` from the
+    // generated note's front-matter) UPGRADES it, and the companion-note title-sync then refreshes
+    // the note's managed title + link. Local time (matches how the user experiences "when").
+    let provisional_title = provisional_meeting_title(&chrono::Local::now());
+
     // Persist the meeting in RECORDING state up-front so a crash mid-capture leaves a row behind
     // rather than losing the meeting silently. If this process dies before `stop_recording`, that
     // row is reconciled to the terminal ERROR state at the next launch
@@ -569,7 +578,7 @@ pub async fn start_recording(
         id: meeting_id.clone(),
         started_at,
         ended_at: None,
-        title: None,
+        title: Some(provisional_title),
         duration_s: 0,
         audio_path: None,
         status: MeetingStatus::Recording,
@@ -2198,6 +2207,253 @@ pub(crate) fn save_manual_notes_inner(
     set_manual_notes_reseal_if_locked(state, meeting_id, text)?;
     // PII rule: log only the meeting id + buffer length, never the typed text.
     tracing::debug!(target: "notes", meeting_id = %meeting_id, len = text.len(), "manual notes saved");
+    Ok(())
+}
+
+// ── Recording-time COMPANION NOTE (2026-07-16) ───────────────────────────────────────────────────
+//
+// During a recording, a jotted note must become a REAL, linked, standalone note — one living
+// companion note per meeting (a `documents` row, kind='note', in the always-open Notes ROOT). The
+// companion note is authored content only (what the user typed / accepted @brain drafts) — NEVER
+// the sealed transcript — so it lives in the open root and is not itself a seal target. The link is
+// TWO artifacts derived from ONE structured relation: the authoritative `documents.meeting_id`
+// column, and a user-visible YAML front-matter `meeting: "[[<name>]]"` wikilink kept in sync.
+
+/// The stable display NAME for a meeting used in the companion note's `[[<name>]]` wikilink + managed
+/// title. `meetings.title` when non-empty (Task 4 gives every in-progress meeting a provisional
+/// title at record start, upgraded by auto-title-on-close), else a safe fallback ("Untitled meeting")
+/// so the link is never `[[]]`. PURE — the caller supplies the current title.
+fn meeting_display_name(title: Option<&str>) -> String {
+    match title.map(str::trim) {
+        Some(t) if !t.is_empty() => t.to_string(),
+        _ => "Untitled meeting".to_string(),
+    }
+}
+
+/// A stable, human PROVISIONAL title for a meeting at record start ("Meeting 2026-07-16 14:05") from
+/// the local start time. PURE (the caller supplies `now`) so it is unit-testable without racing the
+/// clock. Meaningful immediately (so `[[<name>]]` links work during the recording) and stable (never
+/// changes mid-recording); auto-title-on-close upgrades it to a content-derived headline.
+fn provisional_meeting_title<Tz: chrono::TimeZone>(now: &chrono::DateTime<Tz>) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    format!("Meeting {}", now.format("%Y-%m-%d %H:%M"))
+}
+
+/// Result of [`append_to_companion_note`] — the companion note's id (for opening it) and the
+/// user-visible `[[<meeting display name>]]` wikilink the FE renders on the saved-note card.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompanionAppendResult {
+    pub note_id: String,
+    pub meeting_wikilink: String,
+}
+
+/// IDEMPOTENTLY ensure the note markdown's YAML front-matter carries `meeting: "[[<name>]]"`, then
+/// APPEND `block` to the body with a blank-line separator. PURE (no DB / no state) so the composition
+/// is unit-testable in isolation. Never blanks existing content: the prior body + prior front-matter
+/// keys are preserved; only the single managed `meeting:` key is (re)written to the current name, and
+/// the new block is added after the existing body.
+///
+/// - No front-matter yet → a fresh `---\nmeeting: "[[name]]"\n---` block is prepended.
+/// - Front-matter present, no `meeting:` key → the key is inserted (other keys untouched).
+/// - Front-matter present WITH a `meeting:` key → that line is rewritten to the current name
+///   (keeps the link correct across a rename); no duplicate key is ever added.
+fn compose_companion_markdown(current: &str, meeting_name: &str, block: &str) -> String {
+    let link_value = format!("\"[[{meeting_name}]]\"");
+    let (yaml, body) = crate::storage::db::split_front_matter(current);
+
+    // Rebuild the front-matter lines: rewrite an existing top-level `meeting:` key, else append it.
+    let mut fm_lines: Vec<String> = Vec::new();
+    let mut wrote_meeting = false;
+    if !yaml.is_empty() {
+        for raw in yaml.lines() {
+            // A top-level (unindented) `meeting:` key is the managed link line — rewrite it.
+            let is_meeting_key = !raw.starts_with(char::is_whitespace)
+                && raw
+                    .split_once(':')
+                    .map(|(k, _)| k.trim().eq_ignore_ascii_case("meeting"))
+                    .unwrap_or(false);
+            if is_meeting_key {
+                fm_lines.push(format!("meeting: {link_value}"));
+                wrote_meeting = true;
+            } else {
+                fm_lines.push(raw.to_string());
+            }
+        }
+    }
+    if !wrote_meeting {
+        fm_lines.push(format!("meeting: {link_value}"));
+    }
+    let front_matter = format!("---\n{}\n---", fm_lines.join("\n"));
+
+    // Append the block to the body with a blank-line separator (never overwrite prior body).
+    let body_trimmed = body.trim_end();
+    let block_trimmed = block.trim();
+    let new_body = if body_trimmed.is_empty() {
+        block_trimmed.to_string()
+    } else if block_trimmed.is_empty() {
+        body_trimmed.to_string()
+    } else {
+        format!("{body_trimmed}\n\n{block_trimmed}")
+    };
+
+    if new_body.is_empty() {
+        format!("{front_matter}\n")
+    } else {
+        format!("{front_matter}\n\n{new_body}\n")
+    }
+}
+
+/// `append_to_companion_note(meeting_id, markdown)` — turn an in-recording jot (or an accepted
+/// `@brain` draft) into a REAL, linked, standalone companion note. GATED: refuses a
+/// sealed-and-not-session-unlocked meeting (`AppError::Locked`) — mirrors the `save_note` tool's
+/// gate. Lazily gets-or-creates the ONE companion note (Notes ROOT, `meeting_id` set, managed title =
+/// the meeting's display name), APPENDS the block atomically under the lifecycle guard, refreshes the
+/// front-matter `[[Meeting]]` link, re-indexes + re-exports through the guarded standalone-note path,
+/// AND additively appends the same block to `manual_notes` (so the enhance/summary pipeline keeps
+/// seeing in-meeting notes — mirrors `tools::save_note`). Returns the note id + the display wikilink
+/// for the confirmation card. Never blanks prior content on any failure.
+#[tauri::command]
+pub fn append_to_companion_note(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    markdown: String,
+) -> Result<CompanionAppendResult, AppError> {
+    append_to_companion_note_inner(state.inner(), &meeting_id, &markdown)
+}
+
+/// Inner of [`append_to_companion_note`] taking `&AppState` (unit-testable gate + lazy-create).
+pub(crate) fn append_to_companion_note_inner(
+    state: &AppState,
+    meeting_id: &str,
+    markdown: &str,
+) -> Result<CompanionAppendResult, AppError> {
+    let block = markdown.trim();
+    if block.is_empty() {
+        return Err(AppError::InvalidArg("nothing to note".into()));
+    }
+    if meeting_id.trim().is_empty() {
+        return Err(AppError::Locked(
+            "no meeting is being recorded — there is nothing to attach the note to".into(),
+        ));
+    }
+    // BLK-1 / TOCTOU: hold the lifecycle guard across gate + get-or-create + append so a concurrent
+    // lock/relock cannot land between the unlock check and the writes. `create_note_inner` /
+    // `update_note_doc_inner` also take this (reentrant `MutexGuard` is NOT allowed) — so we do NOT
+    // hold it here; instead we re-run the gate first, then delegate to those guarded helpers. The
+    // gate is re-checked inside each helper's own guard as well (defense-in-depth).
+    // GATE: refuse a sealed-and-not-session-unlocked meeting — never resurrect content behind a lock.
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Err(AppError::Locked(
+            "this meeting is locked — unlock it to save a note".into(),
+        ));
+    }
+
+    // The meeting's current display title drives the managed note title + the `[[<name>]]` link.
+    let Some(meeting) = state.db.get_meeting(meeting_id)? else {
+        return Err(AppError::InvalidArg(format!("no meeting {meeting_id}")));
+    };
+    let meeting_name = meeting_display_name(meeting.title.as_deref());
+    let meeting_wikilink = format!("[[{meeting_name}]]");
+
+    // GET-OR-CREATE the companion note in the always-open Notes ROOT (folder_id = None). A new
+    // companion note is birthed with the managed title = the meeting name, then structurally linked
+    // by `meeting_id`. `create_note_inner` holds its own lifecycle guard.
+    let note_id = match state.db.companion_note_for_meeting(meeting_id)? {
+        Some(id) => id,
+        None => {
+            let id = create_note_inner(state, None, &meeting_name)?;
+            state.db.set_document_meeting_id(&id, meeting_id)?;
+            tracing::info!(target: "notes", note_id = %id, meeting_id = %meeting_id, "companion note created");
+            id
+        }
+    };
+
+    // APPEND the block: read the current body, compose (front-matter link refreshed idempotently +
+    // block appended), and save through the standalone-note update path (re-index + guarded
+    // re-export). Read the CURRENT text via the row (the note is in the open root, so no mask). The
+    // managed title stays the meeting name — never blank it, never a user-facing title edit.
+    let Some(row) = state.db.get_note_row(&note_id)? else {
+        return Err(AppError::InvalidArg(format!("no note {note_id}")));
+    };
+    let new_markdown = compose_companion_markdown(&row.text, &meeting_name, block);
+    // `update_note_doc_inner` re-checks the folder gate under its own lifecycle guard, re-indexes,
+    // and re-exports through the guarded standalone-note path (external-edit preservation intact).
+    update_note_doc_inner(state, &note_id, &meeting_name, &new_markdown)?;
+
+    // ADDITIVELY append the SAME block to `manual_notes` so the enhance/summary pipeline keeps
+    // seeing in-meeting notes — mirrors `tools::save_note` (append, never overwrite; reseal-aware).
+    let existing = state.db.get_manual_notes(meeting_id).unwrap_or_default();
+    let merged = if existing.trim().is_empty() {
+        block.to_string()
+    } else {
+        format!("{existing}\n{block}")
+    };
+    set_manual_notes_reseal_if_locked(state, meeting_id, &merged)?;
+
+    // PII rule: ids + block length only — never the note text or the meeting title.
+    tracing::info!(target: "notes", note_id = %note_id, meeting_id = %meeting_id, len = block.len(), "appended to companion note");
+    Ok(CompanionAppendResult {
+        note_id,
+        meeting_wikilink,
+    })
+}
+
+/// Best-effort: refresh the COMPANION note's managed title + its front-matter `meeting: "[[…]]"`
+/// wikilink so the link/label stays correct when a meeting is (auto-)titled or renamed. A sync
+/// failure NEVER fails the rename (the meeting title is already persisted). No-op when the meeting
+/// has no companion note. Skips when the companion note's folder is sealed-not-unlocked (never write
+/// plaintext behind a lock — the sync re-applies on the next unlock+append).
+pub(crate) fn sync_companion_note_title_best_effort(state: &AppState, meeting_id: &str) {
+    if let Err(e) = sync_companion_note_title(state, meeting_id) {
+        // ids only — never the title text.
+        tracing::warn!(target: "notes", meeting_id = %meeting_id, error = %e, "companion note title sync failed (meeting title unaffected)");
+    }
+}
+
+fn sync_companion_note_title(state: &AppState, meeting_id: &str) -> Result<(), AppError> {
+    let Some(note_id) = state.db.companion_note_for_meeting(meeting_id)? else {
+        return Ok(()); // no companion note — nothing to sync.
+    };
+    let Some(meeting) = state.db.get_meeting(meeting_id)? else {
+        return Ok(());
+    };
+    let meeting_name = meeting_display_name(meeting.title.as_deref());
+    let Some(row) = state.db.get_note_row(&note_id)? else {
+        return Ok(());
+    };
+    // Skip a sealed-not-unlocked companion note (its plaintext is blanked; unlocking + a later
+    // append re-applies the correct title/link). `update_note_doc_inner` would refuse anyway.
+    if !folder_is_unlocked(state, &row.folder_id)? {
+        return Ok(());
+    }
+    // Nothing to do if the title AND the front-matter link already match (idempotent).
+    let (yaml, _body) = crate::storage::db::split_front_matter(&row.text);
+    let link_ok = yaml.lines().any(|l| {
+        !l.starts_with(char::is_whitespace)
+            && l.split_once(':')
+                .map(|(k, v)| {
+                    k.trim().eq_ignore_ascii_case("meeting")
+                        && v.contains(&format!("[[{meeting_name}]]"))
+                })
+                .unwrap_or(false)
+    });
+    let title_ok = row
+        .title
+        .as_deref()
+        .map(str::trim)
+        .map(|t| t == meeting_name)
+        .unwrap_or(false);
+    if link_ok && title_ok {
+        return Ok(());
+    }
+    // Re-write the managed title + refresh the `meeting:` front-matter line; body is UNCHANGED
+    // (empty block append). Routes through the guarded update path (re-index + re-export).
+    let new_markdown = compose_companion_markdown(&row.text, &meeting_name, "");
+    update_note_doc_inner(state, &note_id, &meeting_name, &new_markdown)?;
+    tracing::info!(target: "notes", note_id = %note_id, meeting_id = %meeting_id, "companion note title/link synced");
     Ok(())
 }
 
@@ -4759,7 +5015,11 @@ pub fn rename_meeting(
     if title.is_empty() {
         return Err(AppError::InvalidArg("title cannot be empty".into()));
     }
-    state.db.set_meeting_title(&meeting_id, title)
+    state.db.set_meeting_title(&meeting_id, title)?;
+    // Keep the companion note's managed title + front-matter `[[Meeting]]` link in sync with the new
+    // title. Best-effort — a sync failure NEVER fails the rename (the title is already persisted).
+    sync_companion_note_title_best_effort(state.inner(), &meeting_id);
+    Ok(())
 }
 
 /// Grounded Q&A over a meeting's transcript ("chat with the meeting"). The configured
@@ -5492,6 +5752,11 @@ pub async fn build_and_persist_entities(
     title: &str,
     markdown: &str,
 ) -> Result<crate::summarize::graph::GraphPayload, AppError> {
+    // COMPANION NOTE title sync (2026-07-16): every pipeline finish path calls this AFTER the
+    // meeting's final title is persisted (auto-title-on-close via `set_meeting_title`), so this is
+    // the one funnel to refresh a companion note's managed title + `[[Meeting]]` front-matter link
+    // to the final title. Best-effort — never fails the graph/note (which already succeeded).
+    sync_companion_note_title_best_effort(state, meeting_id);
     let config = {
         state
             .config
@@ -18964,6 +19229,169 @@ mod lifecycle_tests {
         })
         .unwrap();
         db.set_meeting_folder(mid, Some(folder_id)).unwrap();
+    }
+
+    // ── Recording-time COMPANION NOTE (2026-07-16) ───────────────────────────────────────────────
+
+    /// PURE: `provisional_meeting_title` yields a stable, human, date/time-based headline.
+    #[test]
+    fn provisional_meeting_title_is_stable_and_human() {
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-07-16T14:05:33-04:00").unwrap();
+        assert_eq!(provisional_meeting_title(&dt), "Meeting 2026-07-16 14:05");
+    }
+
+    /// PURE: `meeting_display_name` uses the title when present, else a safe non-empty fallback
+    /// (so `[[<name>]]` is never `[[]]`).
+    #[test]
+    fn meeting_display_name_falls_back_when_blank() {
+        assert_eq!(meeting_display_name(Some("Q3 Planning")), "Q3 Planning");
+        assert_eq!(meeting_display_name(Some("  Trimmed  ")), "Trimmed");
+        assert_eq!(meeting_display_name(Some("   ")), "Untitled meeting");
+        assert_eq!(meeting_display_name(None), "Untitled meeting");
+    }
+
+    /// PURE: `compose_companion_markdown` inserts/refreshes the managed `meeting:` front-matter key
+    /// IDEMPOTENTLY and APPENDS blocks with a blank-line separator, never blanking prior content.
+    #[test]
+    fn compose_companion_markdown_idempotent_link_and_append() {
+        // First append onto empty content: fresh front-matter + the block as the body.
+        let m1 = compose_companion_markdown("", "Q3 Planning", "First jot.");
+        assert!(m1.contains("meeting: \"[[Q3 Planning]]\""));
+        assert!(m1.contains("First jot."));
+        assert_eq!(m1.matches("meeting:").count(), 1, "exactly one meeting key");
+
+        // Second append: prior body preserved, block appended, still ONE meeting key (no duplicate).
+        let m2 = compose_companion_markdown(&m1, "Q3 Planning", "Second jot.");
+        assert!(m2.contains("First jot."), "prior content is never blanked");
+        assert!(m2.contains("Second jot."));
+        assert_eq!(m2.matches("meeting:").count(), 1, "no duplicate meeting key on re-append");
+
+        // A rename REWRITES the link line to the new name (no duplicate, body intact).
+        let m3 = compose_companion_markdown(&m2, "Q3 Planning (final)", "");
+        assert!(m3.contains("meeting: \"[[Q3 Planning (final)]]\""));
+        assert!(!m3.contains("[[Q3 Planning]]\""), "the stale link is replaced");
+        assert!(m3.contains("First jot.") && m3.contains("Second jot."));
+        assert_eq!(m3.matches("meeting:").count(), 1);
+
+        // A note that ALREADY has OTHER front-matter keys keeps them + gains the meeting key.
+        let with_tags = "---\ntags: [a, b]\n---\n\nBody here.";
+        let m4 = compose_companion_markdown(with_tags, "Sync", "New line.");
+        assert!(m4.contains("tags: [a, b]"), "existing keys preserved");
+        assert!(m4.contains("meeting: \"[[Sync]]\""));
+        assert!(m4.contains("Body here.") && m4.contains("New line."));
+    }
+
+    /// LAZY-CREATE + APPEND (RED→GREEN for the append/lazy-create path): the FIRST append creates ONE
+    /// companion note in the open Notes ROOT, links it by `meeting_id`, stamps the `[[Meeting]]`
+    /// front-matter, and mirrors the block into `manual_notes`. A SECOND append reuses the SAME note
+    /// (one-note-per-meeting) and preserves the first block. RED against no-lazy-create / overwrite.
+    #[test]
+    fn append_to_companion_note_lazy_creates_then_reuses() {
+        let state = build_state("companion-append");
+        // An OPEN, in-progress meeting with a provisional title (as start_recording now sets).
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-rec".to_string(),
+                started_at: "2026-07-16T10:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Meeting 2026-07-16 10:00".to_string()),
+                duration_s: 0,
+                audio_path: None,
+                status: MeetingStatus::Recording,
+                folder_id: None,
+            })
+            .unwrap();
+
+        let r1 = append_to_companion_note_inner(&state, "m-rec", "First jotted note.").unwrap();
+        assert_eq!(r1.meeting_wikilink, "[[Meeting 2026-07-16 10:00]]");
+        // Structurally linked + exactly one companion note.
+        assert_eq!(
+            state
+                .db
+                .companion_note_for_meeting("m-rec")
+                .unwrap()
+                .as_deref(),
+            Some(r1.note_id.as_str())
+        );
+        // manual_notes mirrors the block (enhance/summary pipeline still sees it).
+        assert!(state
+            .db
+            .get_manual_notes("m-rec")
+            .unwrap()
+            .contains("First jotted note."));
+
+        // Second append reuses the SAME note and preserves the first block.
+        let r2 = append_to_companion_note_inner(&state, "m-rec", "Second jotted note.").unwrap();
+        assert_eq!(r2.note_id, r1.note_id, "one living companion note per meeting");
+        let row = state.db.get_note_row(&r1.note_id).unwrap().unwrap();
+        assert!(row.text.contains("First jotted note."), "first block preserved");
+        assert!(row.text.contains("Second jotted note."));
+        assert_eq!(row.text.matches("meeting:").count(), 1, "no duplicate front-matter link");
+        // manual_notes appended (never overwritten): both blocks present.
+        let mn = state.db.get_manual_notes("m-rec").unwrap();
+        assert!(mn.contains("First jotted note.") && mn.contains("Second jotted note."));
+    }
+
+    /// GATE (RED→GREEN for the leak class): `append_to_companion_note` on a SEALED-and-not-session-
+    /// unlocked meeting REFUSES with `AppError::Locked` and writes NOTHING; a session-unlock reverses
+    /// it. Mirrors the `save_note` tool's gate. RED against dropping the `meeting_is_unlocked` check.
+    #[test]
+    fn append_to_companion_note_refused_for_sealed_meeting() {
+        let state = build_state("companion-lockgate");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_titled_meeting(&state.db, "m-locked", "Board strategy", "/data/m.wav", "f-lock");
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        // NOT session-unlocked.
+
+        let err =
+            append_to_companion_note_inner(&state, "m-locked", "secret note").unwrap_err();
+        assert!(
+            matches!(err, AppError::Locked(_)),
+            "a sealed meeting must refuse with Locked, got: {err:?}"
+        );
+        // Nothing written: no companion note exists.
+        assert!(state
+            .db
+            .companion_note_for_meeting("m-locked")
+            .unwrap()
+            .is_none());
+    }
+
+    /// TITLE SYNC (Task 6): renaming a meeting refreshes its companion note's managed title +
+    /// front-matter `[[Meeting]]` link. Best-effort — never fails the rename.
+    #[test]
+    fn companion_note_title_syncs_on_rename() {
+        let state = build_state("companion-titlesync");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m-sync".to_string(),
+                started_at: "2026-07-16T11:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Meeting 2026-07-16 11:00".to_string()),
+                duration_s: 0,
+                audio_path: None,
+                status: MeetingStatus::Recording,
+                folder_id: None,
+            })
+            .unwrap();
+        let r = append_to_companion_note_inner(&state, "m-sync", "a jot").unwrap();
+
+        // Rename the meeting → sync updates the note's title + link.
+        state.db.set_meeting_title("m-sync", "Renamed Topic").unwrap();
+        sync_companion_note_title_best_effort(&state, "m-sync");
+
+        let row = state.db.get_note_row(&r.note_id).unwrap().unwrap();
+        assert_eq!(row.title.as_deref(), Some("Renamed Topic"), "managed title synced");
+        assert!(
+            row.text.contains("meeting: \"[[Renamed Topic]]\""),
+            "front-matter link synced to the new title"
+        );
+        assert!(row.text.contains("a jot"), "body content preserved through the sync");
     }
 
     /// #2 (0.7 security fast-follow): `list_meetings` MUST mask a sealed-and-NOT-session-unlocked

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,7 @@ pub fn run() {
             commands::link_related_notes,
             commands::save_manual_notes,
             commands::get_manual_notes,
+            commands::append_to_companion_note,
             commands::import_document,
             commands::import_text,
             commands::brain_overview,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -984,6 +984,17 @@ impl Db {
             "kind",
             "TEXT NOT NULL DEFAULT 'document'",
         )?;
+        // Recording-time COMPANION NOTE (2026-07-16): the authoritative, STRUCTURED link from a
+        // standalone note (kind='note') back to the meeting it was jotted during. Nullable — only
+        // companion notes carry it; every other note/document stays NULL. Drives navigation
+        // (by id, never by a fragile title string), the meeting's backlinks, and survives
+        // meeting rename/auto-title. Additive + guarded so migrate() stays idempotent; legacy rows
+        // default to NULL. NON-content (an id) — rides the SQLCipher-at-rest layer, never sealed.
+        Self::add_column_if_missing(conn, "documents", "meeting_id", "TEXT")?;
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_documents_meeting_id ON documents(meeting_id);",
+        )
+        .map_err(map_err)?;
         // The vec0 column width is the embedder's EMBED_DIM (== the note vec_chunks width). Format the
         // DDL (no user input). Parallel to `vec_chunks` but keyed to `doc_chunks.id`.
         conn.execute_batch(&format!(
@@ -5853,6 +5864,39 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// Recording-time COMPANION NOTE — set the STRUCTURED `documents.meeting_id` link on a
+    /// standalone note (`kind='note'`). Idempotent on an unknown id / non-note row (0 rows). The
+    /// column is a non-content id (rides the SQLCipher-at-rest layer, never sealed/blanked). Callers
+    /// set this immediately after `create_note_inner` births the companion note.
+    pub fn set_document_meeting_id(&self, id: &str, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE documents SET meeting_id = ?2 WHERE id = ?1 AND kind = 'note'",
+            rusqlite::params![id, meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Recording-time COMPANION NOTE — the note id of the ONE companion note (`kind='note'`) linked
+    /// to `meeting_id`, or `None` when none exists yet (the append command then lazily creates it).
+    /// Structured lookup by the indexed `meeting_id` column — never a fragile title-string match.
+    /// One-note-per-meeting is a model invariant (the append command is the only writer); should a
+    /// duplicate ever exist, the newest-updated row wins (deterministic).
+    pub fn companion_note_for_meeting(&self, meeting_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id FROM documents
+               WHERE kind = 'note' AND meeting_id = ?1
+               ORDER BY COALESCE(updated_at, created_at) DESC, id ASC
+               LIMIT 1",
+            rusqlite::params![meeting_id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
     /// Update an authored note's `title` + `text` + `updated_at` (write path, OPEN folders only).
     /// Leaves `text_blob` alone. A write into a session-unlocked LOCKED folder must NOT come here —
     /// the relock reblank discards the plaintext and restores the stale blob (content loss) — it goes
@@ -8834,6 +8878,13 @@ impl Db {
         {
             let conn = self.lock();
             let visible = visibility_clause("f", unlocked);
+            // SELF-LINK AVOIDANCE (2026-07-16 companion note): a companion note's managed title
+            // equals its meeting's title, so a user-typed `[[Meeting]]` could otherwise hit the
+            // companion note via this note-leg-first order. EXCLUDE a note carrying a non-null
+            // `meeting_id` WHEN the queried title equals THAT note's own meeting's title — so
+            // `[[Meeting]]` always falls through to the meeting leg below, never resolving to its
+            // own companion note. (A companion note IS still a valid target for OTHER titles that
+            // happen to name it — only the self-title collision is excluded.)
             let sql = format!(
                 "SELECT d.id
                    FROM documents d
@@ -8841,6 +8892,11 @@ impl Db {
                   WHERE d.kind = 'note'
                     AND COALESCE(NULLIF(TRIM(d.title), ''), d.name) = ?1
                     AND {visible}
+                    AND NOT (
+                          d.meeting_id IS NOT NULL
+                          AND EXISTS (SELECT 1 FROM meetings m
+                                       WHERE m.id = d.meeting_id AND m.title = ?1)
+                        )
                   ORDER BY d.updated_at DESC, d.id ASC
                   LIMIT 1"
             );
@@ -9169,6 +9225,50 @@ impl Db {
             }
         }
         drop(doc_stmt);
+
+        // ── GATE 2, STRUCTURED companion-note leg (2026-07-16): for a MEETING target, a companion
+        // note is linked by the authoritative `documents.meeting_id` id — NOT by a fragile
+        // front-matter `[[Title]]` string that the two title-scan legs above depend on. Surface it
+        // structurally so the meeting's "Linked mentions" always includes its companion note even
+        // if the title drifted mid-rename or never round-tripped as a wikilink. Lock-gated exactly
+        // like the string leg (`visibility_clause` on the note's folder), and DEDUPED against
+        // `note_hits` so a companion note that ALSO matched the string scan is listed once. ──
+        if target_kind == SourceKind::Meeting {
+            let already: HashSet<String> = note_hits.iter().map(|b| b.id.clone()).collect();
+            let visible_docs = visibility_clause("f", unlocked);
+            let comp_sql = format!(
+                "SELECT d.id, d.title, d.name, COALESCE(d.updated_at, d.created_at)
+                   FROM documents d
+                   JOIN folders f ON f.id = d.folder_id
+                  WHERE d.kind = 'note' AND d.meeting_id = ?1 AND {visible_docs}
+                  ORDER BY COALESCE(d.updated_at, d.created_at) DESC, d.id ASC"
+            );
+            let mut comp_stmt = conn.prepare(&comp_sql).map_err(map_err)?;
+            let comp_rows = comp_stmt
+                .query_map(rusqlite::params![target_id], |r| {
+                    let id: String = r.get(0)?;
+                    let title: Option<String> = r.get(1)?;
+                    let name: String = r.get(2)?;
+                    let ts: i64 = r.get(3)?;
+                    Ok((id, title, name, ts))
+                })
+                .map_err(map_err)?;
+            for row in comp_rows {
+                let (id, title, name, ts) = row.map_err(map_err)?;
+                if already.contains(&id) {
+                    continue; // already counted by the string-scan leg — never duplicate.
+                }
+                note_hits.push(BacklinkSource {
+                    id,
+                    kind: SourceKind::Note,
+                    title: title.filter(|t| !t.is_empty()).unwrap_or(name),
+                    timestamp: chrono::DateTime::from_timestamp_millis(ts)
+                        .map(|dt| dt.to_rfc3339())
+                        .unwrap_or_default(),
+                });
+            }
+            drop(comp_stmt);
+        }
         drop(conn);
 
         // Merge the two legs newest-first. Both legs now emit an RFC3339 `timestamp`, so
@@ -14521,6 +14621,148 @@ mod tests {
 
         assert!(db.resolve_wikilink("Nope", &nothing).unwrap().is_none());
         assert!(db.resolve_wikilink("   ", &nothing).unwrap().is_none());
+    }
+
+    /// SELF-LINK AVOIDANCE (2026-07-16 companion note): a companion note (`documents` row with a
+    /// non-null `meeting_id`) whose managed title EQUALS its meeting's title must be EXCLUDED from the
+    /// note-leg, so `[[Meeting Title]]` resolves to the MEETING (kind='meeting'), never to its own
+    /// companion note. RED against the pre-fix note-leg-first resolver (which returned the companion
+    /// note, kind='note', because the note leg matched first). A companion note is STILL a valid
+    /// target for an UNRELATED title that names it (the exclusion is only the self-title collision).
+    #[test]
+    fn resolve_wikilink_companion_note_self_title_resolves_to_meeting() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // A meeting titled "Q3 Planning" (its AI note lives in `notes` so it is visible).
+        let mut m = sample_meeting("m-q3", "2026-07-16T10:00:00Z");
+        m.title = Some("Q3 Planning".to_string());
+        db.insert_meeting(&m).unwrap();
+        note_for(&db, "m-q3", "claude_code", "ai note body");
+        db.set_note_folder("m-q3", Some("f-open")).unwrap();
+
+        // A COMPANION note whose managed title == the meeting title, structurally linked by meeting_id.
+        db.insert_note("n-comp", "f-open", "q3-planning", "Q3 Planning", "jotted body", 2_000)
+            .unwrap();
+        db.set_document_meeting_id("n-comp", "m-q3").unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let t = db
+            .resolve_wikilink("Q3 Planning", &nothing)
+            .unwrap()
+            .expect("[[Q3 Planning]] resolves");
+        assert_eq!(
+            t.kind, "meeting",
+            "[[Meeting Title]] must resolve to the MEETING, never its own companion note"
+        );
+        assert_eq!(t.id, "m-q3");
+
+        // A companion note is STILL a valid target for a DIFFERENT title that names it.
+        db.insert_note("n-other", "f-open", "sidebar", "Sidebar", "x", 3_000)
+            .unwrap();
+        db.set_document_meeting_id("n-other", "m-q3").unwrap(); // linked, but title != meeting title.
+        let o = db
+            .resolve_wikilink("Sidebar", &nothing)
+            .unwrap()
+            .expect("[[Sidebar]] resolves");
+        assert_eq!(o.kind, "note");
+        assert_eq!(o.id, "n-other");
+    }
+
+    /// STRUCTURED backlink leg (2026-07-16 companion note): a companion note linked by
+    /// `documents.meeting_id` surfaces under its meeting's "Linked mentions" EVEN WHEN its body/
+    /// front-matter carries no matching `[[Title]]` string (the string-scan legs would miss it). RED
+    /// against the pre-fix backlinks (title-scan only). Lock-gated: sealed companion note → absent.
+    #[test]
+    fn backlinks_include_meeting_id_linked_companion_note() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        let mut m = sample_meeting("m-bl", "2026-07-16T09:00:00Z");
+        m.title = Some("Weekly Sync".to_string());
+        db.insert_meeting(&m).unwrap();
+        note_for(&db, "m-bl", "claude_code", "ai note"); // makes the meeting visible.
+        db.set_note_folder("m-bl", Some("f-open")).unwrap();
+
+        // A companion note with NO `[[Weekly Sync]]` string anywhere — only the structured meeting_id.
+        db.insert_note("n-bl", "f-open", "weekly-sync", "Weekly Sync", "just a jot, no wikilink", 5_000)
+            .unwrap();
+        db.set_document_meeting_id("n-bl", "m-bl").unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let got = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-bl", &nothing)
+            .unwrap();
+        let ids: Vec<&str> = got.iter().map(|b| b.id.as_str()).collect();
+        assert!(
+            ids.contains(&"n-bl"),
+            "the meeting_id-linked companion note must surface in backlinks even without a [[]] string; got {ids:?}"
+        );
+        // No duplicate: exactly one entry for the companion note.
+        assert_eq!(
+            ids.iter().filter(|id| **id == "n-bl").count(),
+            1,
+            "companion note must appear exactly once (structured leg deduped against the string leg)"
+        );
+    }
+
+    /// The structured companion-backlink leg is LOCK-GATED: a companion note in a sealed-not-unlocked
+    /// folder never surfaces under its meeting's backlinks; a session-unlock reverses it.
+    #[test]
+    fn backlinks_companion_note_leg_is_lock_gated() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        let mut m = sample_meeting("m-g", "2026-07-16T08:00:00Z");
+        m.title = Some("Board Prep".to_string());
+        db.insert_meeting(&m).unwrap();
+        note_for(&db, "m-g", "claude_code", "ai note");
+        db.set_note_folder("m-g", Some("f-open")).unwrap();
+
+        // Companion note filed into the LOCKED folder, linked by meeting_id.
+        db.insert_note("n-g", "f-locked", "board-prep", "Board Prep", "sensitive jot", 6_000)
+            .unwrap();
+        db.set_document_meeting_id("n-g", "m-g").unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let sealed = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-g", &nothing)
+            .unwrap();
+        assert!(
+            !sealed.iter().any(|b| b.id == "n-g"),
+            "a sealed-not-unlocked companion note must NOT surface in backlinks"
+        );
+
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let visible = db
+            .backlinks_for_visible(SourceKind::Meeting, "m-g", &unlocked)
+            .unwrap();
+        assert!(
+            visible.iter().any(|b| b.id == "n-g"),
+            "a session-unlock surfaces the companion note in backlinks"
+        );
+    }
+
+    /// The additive `documents.meeting_id` migration + helpers: set/read round-trips, `None` when
+    /// unset, and one-note-per-meeting lookup by the structured column.
+    #[test]
+    fn companion_note_meeting_id_set_and_lookup() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        db.insert_note("n1", "f-open", "n1", "N1", "body", 1_000)
+            .unwrap();
+        assert!(db.companion_note_for_meeting("m1").unwrap().is_none());
+        db.set_document_meeting_id("n1", "m1").unwrap();
+        assert_eq!(
+            db.companion_note_for_meeting("m1").unwrap().as_deref(),
+            Some("n1")
+        );
+        // An unrelated meeting id still resolves to None.
+        assert!(db.companion_note_for_meeting("m2").unwrap().is_none());
     }
 
     /// GATED: a `[[Title]]` pointing at a SEALED-and-not-session-unlocked note resolves to `None`

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -9,6 +9,7 @@ import type {
   AppConfigDto,
   BacklinkSource,
   WikiTarget,
+  CompanionAppendResult,
   SourceKind,
   ContextHit,
   MyShareEntry,
@@ -1949,6 +1950,27 @@ export class IpcService {
    */
   getManualNotes(meetingId: string): Promise<string> {
     return invoke<string>("get_manual_notes", { meetingId });
+  }
+
+  /**
+   * Append a recording-time jot (or an accepted `@brain` draft) to the meeting's
+   * ONE living companion note. The backend lazily gets-or-creates the companion
+   * note (in the always-open Notes ROOT, `meeting_id` set, managed title synced to
+   * the meeting), appends the markdown block atomically (single-writer — no FE
+   * read-modify-write race), refreshes the front-matter `[[Meeting]]` link, and
+   * re-exports the vault `.md`. Returns the note's id + the display wikilink for
+   * the "✓ Saved to Notes" card. The text is the user's OWN words / an accepted
+   * draft — no new cloud egress. GATED like every content write; a failure must
+   * not blank prior content (verify-before-destroy N/A — additive only).
+   */
+  appendToCompanionNote(
+    meetingId: string,
+    markdown: string,
+  ): Promise<CompanionAppendResult> {
+    return invoke<CompanionAppendResult>("append_to_companion_note", {
+      meetingId,
+      markdown,
+    });
   }
 
   // ── folders + per-folder lock lifecycle (PHASE0-PLAN Stage C) ──

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -151,6 +151,27 @@ export interface NoteItem {
   threadPending: boolean;
   persisted: boolean;
   threadId: string | null;
+  /**
+   * COMPANION NOTE reference. A sent plain jot / accepted `@brain` draft is
+   * appended to the meeting's ONE living companion note via
+   * `append_to_companion_note`; on success the returned reference is stamped here
+   * so the line renders a "✓ Saved to Notes" card:
+   *   - `savedNoteId`     — the companion note's document id (open it by id via
+   *                         `TabsService.openNote`); `undefined` while the append
+   *                         is in flight or if it hasn't been routed through the
+   *                         companion path (a hydrated / thread-anchor line);
+   *   - `meetingWikilink` — the visible `[[Meeting]]` display link for the card's
+   *                         meeting chip (navigation goes by `meetingId`, not this
+   *                         string);
+   *   - `saveState`       — the append lifecycle: `"saving"` (optimistic, in
+   *                         flight), `"saved"` (reference stamped), or `"error"`
+   *                         (the append failed — the line is kept, never dropped,
+   *                         and the card shows a retry). Absent for lines that
+   *                         never went through the companion path.
+   */
+  savedNoteId?: string;
+  meetingWikilink?: string;
+  saveState?: "saving" | "saved" | "error";
 }
 
 /**
@@ -713,25 +734,99 @@ export class MeetingConversationStore {
   }
 
   /**
-   * Add a plain NOTE line to the main flow (the non-@brain path) + persist. The
-   * line is the user's own note (never sent to the agent). A no-op for blank text.
+   * Add a plain NOTE line to the main flow (the non-@brain path). The line is the
+   * user's own note (never sent to the agent). A no-op for blank text.
+   *
+   * The line is now a REAL, LINKED note: OPTIMISTICALLY appended to the flow
+   * (`saveState: "saving"`), then persisted to the meeting's ONE living companion
+   * note via {@link appendCompanion} — on success the returned
+   * `{ noteId, meetingWikilink }` is stamped onto THIS line so it renders the
+   * "✓ Saved to Notes" card; on failure the line stays (never dropped) with
+   * `saveState: "error"` + a retry. `manual_notes` is ALSO refreshed additively
+   * (the summary / enhance pipeline still reads it — see {@link persistNotes}).
    */
   addNote(text: string): void {
     const t = text.trim();
     if (!t) return;
+    const noteId = this.nextNoteId++;
     this._notes.update((ns) => [
       ...ns,
       {
-        id: this.nextNoteId++,
+        id: noteId,
         text: t,
         thread: null,
         threadOpen: false,
         threadPending: false,
         persisted: true,
         threadId: null,
+        saveState: "saving",
       },
     ]);
+    // Additive: keep the manual_notes buffer in sync (enhance/summary reads it).
     this.persistNotes();
+    // Durable, linked artifact: append to the companion note + stamp the card ref.
+    void this.appendCompanion(noteId, t);
+  }
+
+  /**
+   * Append a flow line's markdown to the meeting's companion note and stamp the
+   * returned reference onto THAT line so its "✓ Saved to Notes" card can render.
+   *
+   * STALE-RESULT GUARDED two ways: (1) the meeting id is captured at call time —
+   * a response that lands after the store points at a DIFFERENT meeting is
+   * dropped (the line belongs to the old meeting, whose flow was cleared); (2) the
+   * target line is re-found by its stable, never-reused `id` at resolve time — if
+   * it's gone (a new recording / meeting change cleared the flow) the response is
+   * a no-op, never mis-stamped onto a different line. On success:
+   * `saveState: "saved"` + `savedNoteId` + `meetingWikilink`; on failure:
+   * `saveState: "error"` (the line is KEPT — never destroy content the user typed;
+   * the card offers a retry). A no-op when there's no meeting yet (nothing to link
+   * to — the line still shows locally; a later {@link retrySave} once a meeting
+   * exists can persist it).
+   */
+  private async appendCompanion(noteId: number, markdown: string): Promise<void> {
+    const meetingId = this._meetingId();
+    if (!meetingId) {
+      // No meeting to link to yet — leave the optimistic "saving" state off (the
+      // line simply isn't a companion note yet). Clear the transient flag so it
+      // doesn't spin forever with nothing in flight.
+      this.patchNote(noteId, { saveState: undefined });
+      return;
+    }
+    try {
+      const res = await this.ipc.appendToCompanionNote(meetingId, markdown);
+      // Drop a response that landed after we left this meeting (its line is gone).
+      if (this._meetingId() !== meetingId) return;
+      this.patchNote(noteId, {
+        saveState: "saved",
+        savedNoteId: res.noteId,
+        meetingWikilink: res.meetingWikilink,
+      });
+    } catch {
+      if (this._meetingId() !== meetingId) return;
+      // Keep the line; surface the failure on the card (retryable), never drop it.
+      this.patchNote(noteId, { saveState: "error" });
+    }
+  }
+
+  /** Immutably patch ONE flow line by its stable id (a no-op if it's gone). */
+  private patchNote(noteId: number, patch: Partial<NoteItem>): void {
+    this._notes.update((ns) =>
+      ns.map((n) => (n.id === noteId ? { ...n, ...patch } : n)),
+    );
+  }
+
+  /**
+   * Retry a FAILED companion-note append (the "✓ Saved to Notes" card's error
+   * state offers this). Re-optimistic (`saveState: "saving"`) then re-run the
+   * append for the line's current text. A no-op for a line that isn't in the
+   * error state.
+   */
+  retrySave(noteId: number): void {
+    const note = this._notes().find((n) => n.id === noteId);
+    if (!note || note.saveState !== "error") return;
+    this.patchNote(noteId, { saveState: "saving" });
+    void this.appendCompanion(noteId, note.text);
   }
 
   /**
@@ -1032,6 +1127,7 @@ export class MeetingConversationStore {
     // Append the PROPOSED note draft, never the whole conversational reply.
     const text = (turn.proposedNote ?? "").trim();
     if (!text) return;
+    const acceptedNoteId = this.nextNoteId++;
     this._notes.update((ns) => {
       const marked = ns.map((n) => {
         if (n.id !== noteId || !n.thread) return n;
@@ -1045,17 +1141,22 @@ export class MeetingConversationStore {
       return [
         ...marked,
         {
-          id: this.nextNoteId++,
+          id: acceptedNoteId,
           text,
           thread: null,
           threadOpen: false,
           threadPending: false,
           persisted: true,
           threadId: null,
+          // An accepted draft is a real, linked companion note too (same card).
+          saveState: "saving",
         },
       ];
     });
+    // Additive: keep manual_notes in sync (enhance/summary reads it).
     this.persistNotes();
+    // Route the accepted draft through the SAME companion-note path as a jot.
+    void this.appendCompanion(acceptedNoteId, text);
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1311,6 +1311,23 @@ export interface WikiTarget {
   id: string;
 }
 
+/**
+ * The result of appending a recording-time jot (or an accepted `@brain` draft) to
+ * a meeting's ONE living companion note (`append_to_companion_note`). The backend
+ * lazily gets-or-creates the companion note in the Notes ROOT on the first send,
+ * appends the markdown block, and returns:
+ *   - `noteId` — the companion note's document id, so the "✓ Saved to Notes" card
+ *     can open it by id (via `TabsService.openNote`), never by a fragile title;
+ *   - `meetingWikilink` — the visible `[[Meeting]]` display link, rendered on the
+ *     card's meeting chip (navigation to the meeting itself goes by the store's
+ *     `meetingId`, not by resolving this string). Mirrors the Rust
+ *     `CompanionAppendResult` (serde camelCase).
+ */
+export interface CompanionAppendResult {
+  noteId: string;
+  meetingWikilink: string;
+}
+
 /** The two entity kinds the self-assembling graph resolves (Rust `EntityKind`, camelCase). */
 export type EntityKind = "person" | "project";
 

--- a/src/app/design-system/markdown-composer/markdown-composer.component.html
+++ b/src/app/design-system/markdown-composer/markdown-composer.component.html
@@ -1,0 +1,76 @@
+<!-- Auto-growing textarea (CSS grid-mirror, no per-keystroke JS reflow) + a `/`
+     slash menu + a `[[` link picker + a Send affordance. Presentational: the host
+     owns persistence and just listens to (send)/(escape). -->
+<div class="composer" [class.is-disabled]="disabled()">
+  <div class="body-wrap">
+    <!-- The `::after` mirror (fed by [data-value]) sizes the single grid cell; the
+         textarea overlays + fills it → auto-grows with content, zero JS reflow. -->
+    <div class="body-grow" [attr.data-value]="text()">
+      <textarea
+        #bodyArea
+        class="body-area"
+        [placeholder]="placeholder()"
+        [disabled]="disabled()"
+        aria-label="Write a note"
+        autocapitalize="sentences"
+        autocomplete="off"
+        spellcheck="true"
+        rows="1"
+        [value]="text()"
+        (input)="onInput($event)"
+        (keydown)="onKeydown($event)"
+      ></textarea>
+    </div>
+
+    <!-- Slash menu (opaque overlay, T3). -->
+    @if (slashOpen()) {
+      <div class="menu slash-menu" role="listbox" aria-label="Insert block">
+        @for (item of slashItems; track item.id; let i = $index) {
+          <button
+            type="button"
+            class="menu-item"
+            role="option"
+            [class.is-active]="i === slashIndex()"
+            [attr.aria-selected]="i === slashIndex()"
+            (mousedown)="$event.preventDefault()"
+            (click)="pickSlash(item)"
+          >
+            {{ item.label }}
+          </button>
+        }
+      </div>
+    }
+  </div>
+
+  <!-- Send: Enter also sends (handled in onKeydown). Disabled until there's text. -->
+  <button
+    type="button"
+    class="btn btn-primary send-btn"
+    aria-label="Send note"
+    [disabled]="!canSend()"
+    (click)="submit()"
+  >
+    <svg viewBox="0 0 16 16" width="15" height="15" fill="none" aria-hidden="true">
+      <path
+        d="M2.5 8h9M8 3.5 12.5 8 8 12.5"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
+</div>
+
+<!-- Link picker — Obsidian-style `[[` / "Link to note" autocomplete. Opened by the
+     raw `[[` keystroke OR the slash-menu "Link to note" entry (ONE shared trigger).
+     Caret stays in the textarea; this reuses the presentational LinkPickerComponent. -->
+@if (linkPickerTrigger(); as trigger) {
+  <app-link-picker
+    [anchorRect]="trigger.rect"
+    [query]="linkPickerQuery()"
+    [activeIndex]="linkPickerActiveIndex()"
+    (picked)="pickLinkCandidate($event)"
+    (candidatesChange)="onLinkPickerCandidates($event)"
+  />
+}

--- a/src/app/design-system/markdown-composer/markdown-composer.component.scss
+++ b/src/app/design-system/markdown-composer/markdown-composer.component.scss
@@ -1,0 +1,121 @@
+/* Design System — mur-markdown-composer.
+   A lean rich-markdown input: an auto-growing textarea (CSS grid-mirror), a `/`
+   slash menu + a `[[` link picker (opaque overlays, T3), and a Send button.
+   Tokens only — every color/space/radius/shadow comes from src/design-tokens. */
+
+:host {
+  display: block;
+}
+
+/* The input row: a frosted in-flow surface (.card language) holding the textarea
+   and the send button. Content chrome, not a floating overlay → the translucent
+   raised surface is correct here (T3 only bans it for FLOATING popovers). */
+.composer {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-fast);
+}
+.composer:focus-within {
+  border-color: var(--accent-ring);
+}
+.composer.is-disabled {
+  opacity: 0.6;
+}
+
+/* Body wrapper — the anchor for the absolutely-positioned slash menu. */
+.body-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+/* The grid mirror: the `::after` pseudo (fed by [data-value]="text()") renders the
+   SAME text HIDDEN and sizes the single grid cell; the textarea overlays + fills it,
+   so it auto-grows with content with ZERO per-keystroke JS reflow. */
+.body-grow {
+  display: grid;
+}
+.body-grow::after {
+  content: attr(data-value) " ";
+  visibility: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+.body-grow > .body-area,
+.body-grow::after {
+  grid-area: 1 / 1 / 2 / 2;
+  width: 100%;
+  min-height: 1.6rem;
+  max-height: 40vh;
+  box-sizing: border-box;
+  font: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  padding: 0;
+  border: 0;
+  margin: 0;
+}
+.body-area {
+  display: block;
+  background: transparent;
+  color: var(--text-primary);
+  resize: none;
+  overflow-y: auto;
+}
+.body-area::placeholder {
+  color: var(--text-muted);
+}
+.body-area:focus {
+  outline: none;
+  box-shadow: none;
+}
+.body-area:disabled {
+  cursor: not-allowed;
+}
+.body-area::selection {
+  background: color-mix(in srgb, var(--accent) 42%, transparent);
+  color: var(--text-primary);
+}
+.body-area::-moz-selection {
+  background: color-mix(in srgb, var(--accent) 42%, transparent);
+  color: var(--text-primary);
+}
+
+/* Slash menu — anchored above the caret line; opaque overlay via the global .menu
+   primitive (--surface-overlay + backdrop-filter:none). Here we only position it +
+   size it; the visual chrome + rows come from primitives.css .menu/.menu-item. */
+.slash-menu {
+  position: absolute;
+  bottom: calc(100% + var(--space-2));
+  left: 0;
+  z-index: 18;
+  min-width: 200px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.slash-menu .menu-item.is-active {
+  background: var(--surface-hover);
+}
+
+/* Send button — a compact icon square (the global .btn-primary supplies the fill). */
+.send-btn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer {
+    transition: none;
+  }
+}

--- a/src/app/design-system/markdown-composer/markdown-composer.component.ts
+++ b/src/app/design-system/markdown-composer/markdown-composer.component.ts
@@ -1,0 +1,631 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import type { NoteCitation } from "../../core/models";
+import { LinkPickerComponent } from "../../features/notes/link-picker/link-picker.component";
+
+/** The formatting ops the ⌘-shortcuts / slash snippets wrap or toggle. */
+type FormatOp = "bold" | "italic" | "h1" | "h2" | "h3" | "wikilink";
+
+/**
+ * One slash-menu block insertion — mirrors the note-editor's `SlashItem` shape.
+ * The `snippet` is inserted at the caret with `$` marking the final caret; the
+ * special `linkToNote` entry has NO `snippet` and opens the link picker instead.
+ */
+interface SlashItem {
+  id: string;
+  label: string;
+  snippet?: string;
+}
+
+/**
+ * The composer's slash-block catalog — a lean, purpose-built subset of the
+ * note-editor's SLASH_ITEMS (no table/callout — those belong to a full document
+ * editor, not a recording-time companion jot). `linkToNote` (no `snippet`) opens
+ * the SAME link picker the raw `[[` keystroke opens (one shared codepath).
+ */
+const SLASH_ITEMS: readonly SlashItem[] = [
+  { id: "h1", label: "Heading 1", snippet: "# $" },
+  { id: "h2", label: "Heading 2", snippet: "## $" },
+  { id: "h3", label: "Heading 3", snippet: "### $" },
+  { id: "ul", label: "Bullet list", snippet: "- $" },
+  { id: "ol", label: "Numbered list", snippet: "1. $" },
+  { id: "check", label: "Checklist", snippet: "- [ ] $" },
+  { id: "quote", label: "Quote", snippet: "> $" },
+  { id: "code", label: "Code block", snippet: "```\n$\n```" },
+  { id: "divider", label: "Divider", snippet: "---\n$" },
+  // No `snippet` — opens the inline `[[` link picker (Obsidian-style autocomplete).
+  { id: "linkToNote", label: "Link to note" },
+];
+
+/**
+ * Design System — `<mur-markdown-composer>`: a lean, reusable rich-markdown input
+ * for the recording surface (and, as a fast-follow, the Notes editor). It mirrors
+ * the shipped {@link import('../../features/notes/note-editor/note-editor.component').NoteEditorComponent}'s
+ * editing affordances — auto-growing textarea, `/` slash-block menu, `[[` link
+ * picker, ⌘B/⌘I/⌘1-3 formatting, list auto-continue, Tab/Shift-Tab indent — but is
+ * purpose-built for "type a jot and send it", not a persisted document editor.
+ *
+ * PRESENTATIONAL + STATELESS-of-persistence: it owns only the in-progress markdown
+ * (a private signal) and emits the finished string via `send`; the host owns any
+ * persistence. Reuses {@link LinkPickerComponent} (already presentational) for the
+ * `[[` autocomplete — the caret STAYS in the textarea (Obsidian parity), this
+ * component owns the picker's `query`/`activeIndex` and the textarea splice on pick.
+ *
+ * Signals-first (private `value` signal, `computed` derivations); DOM work runs
+ * synchronously off the live textarea ref (no per-keystroke reflow — CSS grid-mirror
+ * auto-grow; no `setTimeout`/`rAF`). The link picker's fetch + positioning + stale
+ * guard live inside {@link LinkPickerComponent}.
+ */
+@Component({
+  selector: "mur-markdown-composer",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LinkPickerComponent],
+  templateUrl: "./markdown-composer.component.html",
+  styleUrl: "./markdown-composer.component.scss",
+})
+export class MarkdownComposerComponent {
+  /** The empty-state placeholder shown in the textarea. */
+  readonly placeholder = input("");
+  /** Disable the composer (in flight / no target) — blocks send + input. */
+  readonly disabled = input(false);
+
+  /** Emitted on Enter (no Shift, no open menu) — the current markdown, then cleared. */
+  readonly send = output<string>();
+  /** Emitted on Esc when NO menu is open (host may close the surface / blur). */
+  readonly escape = output<void>();
+
+  /** The in-progress markdown (source state) — nothing writable is exposed. */
+  private readonly value = signal("");
+  /** Read-only view of the current text for the template (auto-grow mirror). */
+  readonly text = this.value.asReadonly();
+
+  private readonly bodyArea =
+    viewChild<ElementRef<HTMLTextAreaElement>>("bodyArea");
+
+  /** The slash-menu block catalog (template `@for`). */
+  protected readonly slashItems = SLASH_ITEMS;
+
+  // --- Slash menu ----------------------------------------------------------
+  readonly slashOpen = signal(false);
+  readonly slashIndex = signal(0);
+
+  // --- Link picker (Obsidian-style `[[` autocomplete) ----------------------
+  /**
+   * The open picker's trigger span start (text position right after `[[`, to be
+   * replaced with `[[Title]]` on pick) + the caret's viewport anchor rect for
+   * positioning. Set by BOTH trigger paths (raw `[[` and the slash "Link to note"
+   * entry). `null` when closed.
+   */
+  readonly linkPickerTrigger = signal<{
+    start: number;
+    rect: { top: number; left: number; right: number; bottom: number };
+  } | null>(null);
+  /** Keyboard-highlighted row in the open picker (↑/↓). */
+  readonly linkPickerActiveIndex = signal(0);
+  /** The picker's live candidates (via its `candidatesChange`) so ↑/↓/Enter act on them. */
+  readonly linkPickerCandidates = signal<NoteCitation[]>([]);
+
+  /**
+   * The live filter text: the chars typed since the trigger. Tracks `value()`
+   * (a signal, re-runs per keystroke) plus the live caret so the picker re-queries.
+   */
+  readonly linkPickerQuery = computed(() => {
+    const trigger = this.linkPickerTrigger();
+    const body = this.value();
+    const el = this.bodyArea()?.nativeElement;
+    if (!trigger || !el) {
+      return "";
+    }
+    const caret = Math.max(trigger.start, el.selectionStart);
+    return body.slice(trigger.start, caret);
+  });
+
+  /** True when the send button should be enabled (non-empty, not disabled). */
+  readonly canSend = computed(
+    () => !this.disabled() && this.value().trim().length > 0,
+  );
+
+  // ── Input ────────────────────────────────────────────────────────────────
+
+  onInput(event: Event): void {
+    const el = event.target as HTMLTextAreaElement;
+    this.value.set(el.value);
+    this.maybeOpenSlash(el);
+    this.maybeOpenLinkPicker(el);
+  }
+
+  // ── Submit / keyboard ─────────────────────────────────────────────────────
+
+  onKeydown(event: KeyboardEvent): void {
+    const el = this.bodyArea()?.nativeElement;
+    if (!el) {
+      return;
+    }
+
+    // The link picker takes priority over everything when open — its ↑/↓/Enter/Esc
+    // navigate/pick/close rather than sending or moving the caret.
+    if (this.linkPickerTrigger()) {
+      if (this.handleLinkPickerKey(event)) {
+        return;
+      }
+    }
+
+    // Slash-menu navigation takes priority when open.
+    if (this.slashOpen()) {
+      if (this.handleSlashKey(event)) {
+        return;
+      }
+    }
+
+    const meta = event.metaKey || event.ctrlKey;
+    if (meta) {
+      switch (event.key.toLowerCase()) {
+        case "b":
+          event.preventDefault();
+          return this.format("bold");
+        case "i":
+          event.preventDefault();
+          return this.format("italic");
+        case "1":
+          event.preventDefault();
+          return this.format("h1");
+        case "2":
+          event.preventDefault();
+          return this.format("h2");
+        case "3":
+          event.preventDefault();
+          return this.format("h3");
+      }
+    }
+
+    // Enter = send (no menu open, no Shift). Shift+Enter falls through to the list
+    // continuation / native newline. The menu-open cases already returned above.
+    if (event.key === "Enter" && !event.shiftKey) {
+      if (this.handleListEnter(el, event)) {
+        return;
+      }
+      event.preventDefault();
+      this.submit();
+      return;
+    }
+
+    if (event.key === "Tab") {
+      if (this.handleListTab(el, event)) {
+        return;
+      }
+    }
+
+    if (event.key === "Escape") {
+      if (this.slashOpen()) {
+        event.preventDefault();
+        this.slashOpen.set(false);
+        return;
+      }
+      if (this.linkPickerTrigger()) {
+        event.preventDefault();
+        this.closeLinkPicker();
+        return;
+      }
+      // No menu open — bubble the intent to the host (e.g. close the surface).
+      event.preventDefault();
+      this.escape.emit();
+    }
+  }
+
+  /** Emit the current markdown (trimmed of trailing whitespace) + clear. Click or Enter. */
+  submit(): void {
+    if (!this.canSend()) {
+      return;
+    }
+    const markdown = this.value().replace(/\s+$/, "");
+    if (markdown.length === 0) {
+      return;
+    }
+    this.send.emit(markdown);
+    this.reset();
+  }
+
+  /** Blank the composer + close any open menu, syncing the live textarea. */
+  private reset(): void {
+    this.value.set("");
+    this.closeLinkPicker();
+    this.slashOpen.set(false);
+    const el = this.bodyArea()?.nativeElement;
+    if (el) {
+      el.value = "";
+    }
+  }
+
+  // ── Formatting (⌘B/⌘I/⌘1-3, wikilink) ────────────────────────────────────
+
+  private format(op: FormatOp): void {
+    const el = this.bodyArea()?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const value = el.value;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const selected = value.slice(start, end);
+
+    switch (op) {
+      case "bold": {
+        const inner = selected || "bold";
+        this.replaceRange(el, start, end, `**${inner}**`, start + 2, start + 2 + inner.length);
+        return;
+      }
+      case "italic": {
+        const inner = selected || "italic";
+        this.replaceRange(el, start, end, `*${inner}*`, start + 1, start + 1 + inner.length);
+        return;
+      }
+      case "wikilink": {
+        const inner = selected || "Note";
+        const link = this.wikilinkText(inner);
+        this.replaceRange(el, start, end, link, start + 2, start + 2 + inner.length);
+        return;
+      }
+      case "h1":
+        return this.applyLinePrefix(el, "# ");
+      case "h2":
+        return this.applyLinePrefix(el, "## ");
+      case "h3":
+        return this.applyLinePrefix(el, "### ");
+    }
+  }
+
+  /** The `[[Title]]` wikilink markdown — the ONE place the string is built. */
+  private wikilinkText(title: string): string {
+    return `[[${title}]]`;
+  }
+
+  /**
+   * Toggle a heading prefix on every line the selection touches — replacing any
+   * existing heading prefix (mirrors the note-editor's `applyLinePrefix` heading
+   * branch; the composer only wires headings to line-prefix formatting).
+   */
+  private applyLinePrefix(el: HTMLTextAreaElement, prefix: string): void {
+    const value = el.value;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const lineStart = value.lastIndexOf("\n", start - 1) + 1;
+    const lineEnd = value.indexOf("\n", end);
+    const blockEnd = lineEnd === -1 ? value.length : lineEnd;
+    const block = value.slice(lineStart, blockEnd);
+
+    const lines = block.split("\n");
+    const allHave = lines.every((l) => l.startsWith(prefix));
+    const newLines = lines.map((line) => {
+      const stripped = line.replace(/^#{1,6}\s+/, "");
+      return allHave ? stripped : prefix + stripped;
+    });
+    const replacement = newLines.join("\n");
+    this.replaceRange(
+      el,
+      lineStart,
+      blockEnd,
+      replacement,
+      lineStart,
+      lineStart + replacement.length,
+    );
+  }
+
+  /** Splice `replacement` into the textarea, sync the signal, restore the caret. */
+  private replaceRange(
+    el: HTMLTextAreaElement,
+    from: number,
+    to: number,
+    replacement: string,
+    caretStart: number,
+    caretEnd: number,
+  ): void {
+    const value = el.value;
+    const next = value.slice(0, from) + replacement + value.slice(to);
+    this.value.set(next);
+    el.value = next;
+    el.setSelectionRange(caretStart, caretEnd);
+    el.focus();
+  }
+
+  // ── List behaviors (Enter continuation, Tab/Shift-Tab indent) ─────────────
+
+  /**
+   * Enter inside a list/checkbox item: auto-continue the marker on the next line
+   * (renumbering ordered items), OR exit the list when the current item is empty.
+   * Returns true when consumed (so the caller does NOT send).
+   */
+  private handleListEnter(el: HTMLTextAreaElement, event: KeyboardEvent): boolean {
+    const value = el.value;
+    const pos = el.selectionStart;
+    if (pos !== el.selectionEnd) {
+      return false;
+    }
+    const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+    const line = value.slice(lineStart, pos);
+    const m = /^(\s*)(- \[[ xX]\] |[-*] |(\d+)\. )(.*)$/.exec(line);
+    if (!m) {
+      return false;
+    }
+    const [, indent, marker, num, rest] = m;
+    // Empty item → exit the list (delete the marker, drop to a blank line).
+    if (rest.trim() === "") {
+      event.preventDefault();
+      this.replaceRange(el, lineStart, pos, indent, lineStart + indent.length, lineStart + indent.length);
+      return true;
+    }
+    // Continue: renumber ordered lists, reset a checkbox to unchecked.
+    let nextMarker = marker;
+    if (num) {
+      nextMarker = `${Number(num) + 1}. `;
+    } else if (marker.startsWith("- [")) {
+      nextMarker = "- [ ] ";
+    }
+    event.preventDefault();
+    const insert = `\n${indent}${nextMarker}`;
+    this.replaceRange(el, pos, pos, insert, pos + insert.length, pos + insert.length);
+    return true;
+  }
+
+  /** Tab / Shift-Tab indent or outdent the current list line. Returns true when consumed. */
+  private handleListTab(el: HTMLTextAreaElement, event: KeyboardEvent): boolean {
+    const value = el.value;
+    const pos = el.selectionStart;
+    const nextNl = value.indexOf("\n", pos);
+    const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+    const line = value.slice(lineStart, nextNl === -1 ? value.length : nextNl);
+    if (!/^\s*(?:- \[[ xX]\] |[-*] |\d+\. )/.test(line)) {
+      return false; // not a list line — let Tab do its default (blur/focus).
+    }
+    event.preventDefault();
+    if (event.shiftKey) {
+      if (line.startsWith("  ")) {
+        this.replaceRange(el, lineStart, lineStart + 2, "", Math.max(lineStart, pos - 2), Math.max(lineStart, pos - 2));
+      }
+    } else {
+      this.replaceRange(el, lineStart, lineStart, "  ", pos + 2, pos + 2);
+    }
+    return true;
+  }
+
+  // ── Slash menu ─────────────────────────────────────────────────────────────
+
+  /** Open the slash menu when `/` was just typed alone at the start of a line. */
+  private maybeOpenSlash(el: HTMLTextAreaElement): void {
+    const pos = el.selectionStart;
+    const value = el.value;
+    const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+    const line = value.slice(lineStart, pos);
+    if (line === "/") {
+      this.slashIndex.set(0);
+      this.slashOpen.set(true);
+    } else if (!line.startsWith("/") || line.includes(" ")) {
+      this.slashOpen.set(false);
+    }
+  }
+
+  /** Handle ↑/↓/Enter/Esc in the open slash menu. Returns true when consumed. */
+  private handleSlashKey(event: KeyboardEvent): boolean {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        this.slashIndex.update((i) => (i + 1) % SLASH_ITEMS.length);
+        return true;
+      case "ArrowUp":
+        event.preventDefault();
+        this.slashIndex.update((i) => (i - 1 + SLASH_ITEMS.length) % SLASH_ITEMS.length);
+        return true;
+      case "Enter":
+        event.preventDefault();
+        this.pickSlash(SLASH_ITEMS[this.slashIndex()]);
+        return true;
+      case "Escape":
+        event.preventDefault();
+        this.slashOpen.set(false);
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * Insert a slash-menu block (replacing the `/` trigger, caret at the `$`), OR for
+   * the `linkToNote` entry (no `snippet`) open the SAME link picker the raw `[[`
+   * keystroke opens, anchored where the `/` was.
+   */
+  pickSlash(item: SlashItem): void {
+    const el = this.bodyArea()?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const value = el.value;
+    const pos = el.selectionStart;
+    const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+    this.slashOpen.set(false);
+    if (item.snippet === undefined) {
+      const openBrackets = "[[";
+      this.replaceRange(
+        el,
+        lineStart,
+        pos,
+        openBrackets,
+        lineStart + openBrackets.length,
+        lineStart + openBrackets.length,
+      );
+      this.openLinkPickerAt(el, lineStart + openBrackets.length);
+      return;
+    }
+    const caretMarker = item.snippet.indexOf("$");
+    const snippet = item.snippet.replace("$", "");
+    const caret = lineStart + (caretMarker === -1 ? snippet.length : caretMarker);
+    this.replaceRange(el, lineStart, pos, snippet, caret, caret);
+  }
+
+  // ── Link picker (`[[` autocomplete) ───────────────────────────────────────
+
+  /**
+   * Open the picker when the two chars before the caret are `[[` (raw keystroke
+   * path), or close it when the trigger context is broken (caret backed up before
+   * the trigger, a newline / `]]` was typed).
+   */
+  private maybeOpenLinkPicker(el: HTMLTextAreaElement): void {
+    const trigger = this.linkPickerTrigger();
+    const pos = el.selectionStart;
+    const value = el.value;
+    if (!trigger) {
+      if (pos >= 2 && value.slice(pos - 2, pos) === "[[") {
+        this.openLinkPickerAt(el, pos);
+      }
+      return;
+    }
+    const from = trigger.start;
+    if (
+      pos < from ||
+      value.slice(from - 2, from) !== "[[" ||
+      value.slice(from, pos).includes("\n") ||
+      value.slice(from, pos).includes("]]")
+    ) {
+      this.closeLinkPicker();
+    }
+  }
+
+  /** Open the picker anchored at `start` (the text position right after `[[`). */
+  private openLinkPickerAt(el: HTMLTextAreaElement, start: number): void {
+    const rect = this.caretRect(el, start);
+    if (!rect) {
+      return;
+    }
+    this.linkPickerActiveIndex.set(0);
+    this.linkPickerCandidates.set([]);
+    this.linkPickerTrigger.set({ start, rect });
+  }
+
+  /** ↑/↓/Enter/Tab/Esc while the picker is open. Returns true when consumed. */
+  private handleLinkPickerKey(event: KeyboardEvent): boolean {
+    const rows = this.linkPickerCandidates();
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.linkPickerActiveIndex.update((i) => (i + 1) % rows.length);
+        }
+        return true;
+      case "ArrowUp":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.linkPickerActiveIndex.update((i) => (i - 1 + rows.length) % rows.length);
+        }
+        return true;
+      case "Enter":
+      case "Tab":
+        if (rows.length > 0) {
+          event.preventDefault();
+          this.pickLinkCandidate(rows[this.linkPickerActiveIndex()]);
+        }
+        return true;
+      case "Escape":
+        event.preventDefault();
+        this.closeLinkPicker();
+        return true;
+    }
+    return false;
+  }
+
+  /** The picker's resolved candidates for the current query (drives keyboard nav). */
+  onLinkPickerCandidates(rows: NoteCitation[]): void {
+    this.linkPickerCandidates.set(rows);
+  }
+
+  /**
+   * A candidate was picked (click or Enter): replace the trigger span (`[[` +
+   * whatever was typed since) with `[[Title]]`, then collapse the caret after it.
+   */
+  pickLinkCandidate(candidate: NoteCitation): void {
+    const el = this.bodyArea()?.nativeElement;
+    const trigger = this.linkPickerTrigger();
+    if (!el || !trigger) {
+      return;
+    }
+    const link = this.wikilinkText(candidate.title);
+    const from = trigger.start - 2; // include the `[[` itself.
+    const to = el.selectionStart;
+    this.closeLinkPicker();
+    this.replaceRange(el, from, to, link, from + link.length, from + link.length);
+  }
+
+  /** Close the picker without inserting anything (Esc / caret moved away / picked). */
+  closeLinkPicker(): void {
+    this.linkPickerTrigger.set(null);
+    this.linkPickerCandidates.set([]);
+  }
+
+  /**
+   * The viewport rect of the caret at text position `pos` — a lightweight measure
+   * via a mirror element mimicking the textarea's box, so the picker anchors at the
+   * caret. Returns null if unmeasurable. No `setTimeout`/`rAF` — a synchronous read
+   * against the live DOM node, mirroring the note-editor's `selectionRect`.
+   */
+  private caretRect(
+    el: HTMLTextAreaElement,
+    pos: number,
+  ): { top: number; left: number; right: number; bottom: number } | null {
+    const doc = el.ownerDocument;
+    const mirror = doc.createElement("div");
+    const style = getComputedStyle(el);
+    for (const prop of [
+      "boxSizing",
+      "width",
+      "paddingTop",
+      "paddingRight",
+      "paddingBottom",
+      "paddingLeft",
+      "borderTopWidth",
+      "borderRightWidth",
+      "borderBottomWidth",
+      "borderLeftWidth",
+      "fontFamily",
+      "fontSize",
+      "fontWeight",
+      "lineHeight",
+      "letterSpacing",
+      "textTransform",
+      "whiteSpace",
+      "wordBreak",
+      "overflowWrap",
+    ] as const) {
+      mirror.style[prop] = style[prop];
+    }
+    mirror.style.position = "absolute";
+    mirror.style.visibility = "hidden";
+    mirror.style.whiteSpace = "pre-wrap";
+    mirror.style.overflowWrap = "break-word";
+    mirror.style.pointerEvents = "none";
+
+    const rect = el.getBoundingClientRect();
+    mirror.style.left = `${rect.left}px`;
+    mirror.style.top = `${rect.top}px`;
+
+    const before = el.value.slice(0, pos);
+    mirror.textContent = before;
+    const marker = doc.createElement("span");
+    marker.textContent = "​";
+    mirror.appendChild(marker);
+    doc.body.appendChild(mirror);
+
+    const markerRect = marker.getBoundingClientRect();
+    const anchor = {
+      top: markerRect.top - el.scrollTop,
+      left: markerRect.left - el.scrollLeft,
+      right: markerRect.right - el.scrollLeft,
+      bottom: markerRect.bottom - el.scrollTop,
+    };
+    doc.body.removeChild(mirror);
+    return anchor;
+  }
+}

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.html
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.html
@@ -16,7 +16,7 @@
       } @else if (enhanceAware() && store.hasPersistedNotes()) {
         ✨ These bullets will shape your summary
       } @else {
-        Type <span class="kbd">&#64;brain</span> to ask in a thread
+        Saved as linked notes · <span class="kbd">&#64;brain</span> to ask
       }
     </span>
   </div>
@@ -79,9 +79,9 @@
   <div class="flow" #flow [class.is-enhancing]="enhancing()">
     @if (!store.hasNotes()) {
       <p class="flow-empty text-muted">
-        Jot your notes here — they're saved with the meeting. Type
-        <span class="kbd">&#64;brain</span> + a question to open a thread; the
-        assistant answers there and you choose what to add to your notes.
+        Jot your notes here — each one is saved as a real, linked note in your
+        vault. Type <span class="kbd">&#64;brain</span> + a question to open a
+        thread; the assistant answers there and you choose what to keep.
       </p>
     }
     @for (n of store.notes(); track n.id; let i = $index) {
@@ -93,7 +93,7 @@
     }
   </div>
 
-  <form class="composer" (submit)="submit($event)">
+  <div class="composer">
     <button
       type="button"
       class="mic-btn"
@@ -118,75 +118,13 @@
         />
       </svg>
     </button>
-    <div class="composer-editor">
-      <textarea
-        #ta
-        class="composer-input"
-        rows="1"
-        autocomplete="off"
-        spellcheck="true"
-        [disabled]="!store.loaded()"
-        [placeholder]="
-          store.loaded()
-            ? 'write a note… (@brain to open a thread)'
-            : 'Loading notes…'
-        "
-        [value]="draft()"
-        (input)="onInput($event)"
-        (keydown)="onKeydown($event)"
-        (blur)="onBlur()"
-        aria-label="Note or @brain question"
-      ></textarea>
-
-      @if (menuOpen()) {
-        <div
-          class="mention-menu"
-          role="listbox"
-          aria-label="Mention"
-          [style.top.px]="menuTop()"
-          [style.left.px]="menuLeft()"
-        >
-          <button
-            type="button"
-            class="mention-item"
-            role="option"
-            [attr.aria-selected]="true"
-            (mousedown)="$event.preventDefault()"
-            (click)="chooseBrain()"
-          >
-            <span class="mention-ico" aria-hidden="true">🧠</span>
-            <span class="mention-text">
-              <span class="mention-label">brain</span>
-              <span class="mention-hint">open a thread + ask</span>
-            </span>
-          </button>
-        </div>
-      }
-    </div>
-    <button
-      type="submit"
-      class="btn btn-primary composer-send"
-      [class.is-brain]="draftIsBrain()"
-      [disabled]="!canSend()"
-      [attr.aria-label]="draftIsBrain() ? 'Open a @brain thread' : 'Save note'"
-      [title]="draftIsBrain() ? 'Ask (Enter)' : 'Save note (Enter)'"
-    >
-      <svg
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        aria-hidden="true"
-      >
-        <path
-          d="M5 12h14M13 6l6 6-6 6"
-          stroke="currentColor"
-          stroke-width="2.2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-    </button>
-  </form>
+    <mur-markdown-composer
+      class="composer-editor"
+      [placeholder]="composerPlaceholder()"
+      [disabled]="!store.loaded()"
+      (send)="onSend($event)"
+      (escape)="onEscape()"
+    />
+  </div>
 </div>
   

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
@@ -95,72 +95,19 @@
   color: var(--text-secondary);
 }
 
-/* ── input row: voice mic + text composer, pinned at the foot ───────── */
+/* ── input row: voice mic + the shared markdown composer, pinned at the
+   foot. The composer (`mur-markdown-composer`) owns its own auto-grow
+   textarea + the OPAQUE `/`/`[[` menus (trap T3 handled inside it); here we
+   only lay it out beside the voice mic. ──────────────────────────────── */
 .composer {
   display: flex;
   align-items: flex-end;
   gap: var(--space-2);
   flex: none;
 }
-/* Positioned wrapper so the caret-anchored @brain popover can be placed
-   relative to the textarea. */
 .composer-editor {
-  position: relative;
   flex: 1;
   min-width: 0;
-}
-
-/* ── @brain mention popover — FLOATS over the composer → OPAQUE (trap T3).
-   NOT the frosted .card: a translucent surface would bleed the notes flow
-   behind it through (a broken-looking menu). ──────────────────────────── */
-.mention-menu {
-  position: absolute;
-  z-index: 20;
-  min-width: 200px;
-  max-width: 260px;
-  padding: var(--space-1);
-  background: var(--surface-overlay);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-}
-.mention-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-2) var(--space-3);
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--transition);
-}
-.mention-item:hover,
-.mention-item:focus-visible {
-  outline: none;
-  background: var(--accent-soft);
-}
-.mention-ico {
-  font-size: 1.05rem;
-  line-height: 1;
-}
-.mention-text {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-.mention-label {
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-.mention-hint {
-  font-size: 0.76rem;
-  color: var(--text-muted);
 }
 .mic-btn {
   flex: 0 0 auto;
@@ -211,33 +158,6 @@
     box-shadow: 0 0 0 8px rgba(110, 118, 255, 0);
   }
 }
-.composer-input {
-  display: block;
-  width: 100%;
-  min-height: 40px;
-  max-height: 140px;
-  padding: var(--space-2) var(--space-3);
-  resize: none;
-  line-height: 1.45;
-  font-size: 0.9rem;
-}
-.composer-send {
-  flex: 0 0 auto;
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  justify-content: center;
-}
-/* When the line is an @brain ask, the send button reads as the accent
-   "ask" affordance (vs the calmer save-note default). */
-.composer-send.is-brain {
-  box-shadow: 0 0 0 2px var(--accent-ring);
-}
-.composer-send:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .mic-btn.is-listening {
     animation: none;

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
@@ -9,10 +9,10 @@ import {
   effect,
   inject,
   input,
-  signal,
   viewChild,
 } from "@angular/core";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
+import { MarkdownComposerComponent } from "../../../design-system/markdown-composer/markdown-composer.component";
 import { AiOrbComponent } from "../ai-orb/ai-orb.component";
 import { NoteItemComponent } from "../note-item/note-item.component";
 import { ProactiveHintCardComponent } from "../proactive-hint-card/proactive-hint-card.component";
@@ -23,20 +23,19 @@ const BRAIN_MARKER = "@brain";
 
 /**
  * Match `@brain` ONLY as a STANDALONE token — preceded by start-or-whitespace AND
- * followed by whitespace-or-end — mirroring the popover's `/\s/.test(prev)` word-
- * boundary check. This is load-bearing for PRIVACY + correctness: a plain note
- * that merely CONTAINS the substring ("bob@brainpower.com", "jane@brainstorm.io",
- * "@brainstorming session") must stay a NOTE (saved verbatim, NEVER shipped to
- * `ask_assistant_chat` → no cloud egress, no mid-string corruption). Only a real
- * standalone `@brain` opens a thread. The capture groups frame the marker so the
- * QUESTION is exactly the text AFTER the standalone token (never a mid-substring
- * splice). `g` so we can scan for the FIRST standalone occurrence.
+ * followed by whitespace-or-end. This is load-bearing for PRIVACY + correctness: a
+ * plain note that merely CONTAINS the substring ("bob@brainpower.com",
+ * "jane@brainstorm.io", "@brainstorming session") must stay a NOTE (saved as a
+ * real companion note, NEVER shipped to `ask_assistant_chat` → no cloud egress, no
+ * mid-string corruption). Only a real standalone `@brain` opens a thread. The
+ * capture group frames the marker so the QUESTION is exactly the text AFTER the
+ * standalone token (never a mid-substring splice).
  */
 const BRAIN_TOKEN_RE = /(^|\s)@brain(?=\s|$)/;
 
 /**
- * Resolve a composer line to a `@brain` thread vs a plain note. Returns the
- * QUESTION (everything after the FIRST standalone `@brain`, marker removed,
+ * Resolve a submitted composer line to a `@brain` thread vs a plain note. Returns
+ * the QUESTION (everything after the FIRST standalone `@brain`, marker removed,
  * trimmed) when the line carries a standalone `@brain` token, else `null` (→ a
  * plain note, kept verbatim). Anything matching only as a substring
  * ("a@brainx", "x@brain.io") returns `null` and is therefore treated as a note.
@@ -54,29 +53,36 @@ export function parseBrainLine(text: string): string | null {
  * The in-meeting NOTES + `@brain` THREADS surface — the full-height main view of
  * the record screen (Slack-style; the agent PROPOSES, the user ACCEPTS).
  *
- * The MAIN flow is the user's NOTES — a vertical list of note lines persisted to
- * `manual_notes`. The ONE composer at the foot splits a submitted line by the
- * only signal — `@brain`:
+ * The MAIN flow is the user's NOTES — a vertical list of note lines that are now
+ * REAL, LINKED companion notes (each send appends a block to the meeting's ONE
+ * living companion note in the Notes ROOT + renders a "✓ Saved to Notes" card).
+ * The ONE composer at the foot is the shared design-system
+ * {@link MarkdownComposerComponent} (`/` slash blocks, `[[` link picker, ⌘B/⌘I/⌘1-3,
+ * list continuation, Enter = send / Shift+Enter = newline). On send the host splits
+ * the emitted markdown by the only signal — a standalone `@brain`:
  *   - a line WITHOUT `@brain` is a plain NOTE → {@link MeetingConversationStore.addNote}
- *     (appended to the flow + saved);
- *   - a line WITH `@brain` OPENS an anchored, multi-turn THREAD under a new note
- *     line → {@link MeetingConversationStore.openThread} (the marker stripped),
- *     which ships the thread's history to the agent. Each agent reply offers
- *     "✓ Add to notes" — the only path content enters the notes.
+ *     (appended to the flow + persisted to the companion note);
+ *   - a line WITH `@brain` OPENS an anchored, multi-turn THREAD (the marker
+ *     stripped) → {@link MeetingConversationStore.openThread}, which ships the
+ *     thread's history to the agent. Each agent reply offers "✓ Add to notes" — the
+ *     only path an accepted draft enters the notes (also as a companion note).
  *
- * The `@brain` autocomplete (typing `@` at a word boundary → an OPAQUE caret-
- * anchored popover offering "brain", trap T3) + the keyed-debounce service are
- * preserved. Each note line + its thread renders via {@link NoteItemComponent}
- * (split out so the per-component style budgets stay well under 16 kB).
+ * The `@brain` hint lives in the composer placeholder + the panel hint copy (the
+ * composer owns its own textarea/caret, so the former caret-anchored `@brain`
+ * autocomplete popover is replaced by that lightweight equivalent — typing
+ * `@brain <q>` and sending still opens a thread). Each note line + its thread
+ * renders via {@link NoteItemComponent}.
  *
  * This surface is IN-FLOW (not a floating overlay) — the frosted `.card` is
- * correct here; only the `@brain` popover floats → it uses `var(--surface-overlay)`.
+ * correct here (trap T3 N/A for the panel; the composer's own `/`/`[[` menus float
+ * OPAQUE inside it).
  */
 @Component({
   selector: "app-meeting-conversation",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AiOrbComponent,
+    MarkdownComposerComponent,
     NoteItemComponent,
     ProactiveHintCardComponent,
     WhisperCardComponent,
@@ -88,11 +94,11 @@ export class MeetingConversationComponent implements OnInit {
   protected readonly store = inject(MeetingConversationStore);
   private readonly injector = inject(Injector);
   private readonly flow = viewChild<ElementRef<HTMLElement>>("flow");
-  private readonly textarea = viewChild<ElementRef<HTMLTextAreaElement>>("ta");
 
   /**
    * The active recording's meeting id (null when there's no meeting yet). Pushed
-   * into the store so a note line appends to THIS meeting's `manual_notes`.
+   * into the store so a note line appends to THIS meeting's companion note +
+   * `manual_notes`.
    */
   readonly meetingId = input<string | null>(null);
 
@@ -119,46 +125,26 @@ export class MeetingConversationComponent implements OnInit {
     return Math.min(i, 10) * 180;
   }
 
-  /** The composer draft (signal-backed — zoneless). */
-  protected readonly draft = signal("");
-
   /**
-   * True when the current line carries a STANDALONE `@brain` token (drives the
-   * send-button accent). Uses the word-boundary matcher — a substring like
-   * "bob@brainpower.com" is NOT an ask, so the button reads as "save note".
+   * The composer placeholder: the notes are still hydrating from `manual_notes`
+   * until `loaded()` (the composer is disabled meanwhile — see the store's
+   * hydrate-vs-type race note), then a hint that a jot becomes a linked note and
+   * `@brain` opens a thread.
    */
-  protected readonly draftIsBrain = computed(
-    () => BRAIN_TOKEN_RE.test(this.draft()),
+  protected readonly composerPlaceholder = computed(() =>
+    this.store.loaded()
+      ? "Jot a note… / for blocks, [[ to link, @brain to ask"
+      : "Loading notes…",
   );
-
-  /**
-   * Submit is allowed when there's non-blank text AND the meeting's notes have
-   * finished hydrating from `manual_notes`. Gating on `loaded()` closes the
-   * hydrate-vs-type race: a note submitted before `getManualNotes` resolves would
-   * otherwise overwrite the server buffer with just the fresh line, then skip
-   * hydration (length > 0) → the pre-existing server notes would be lost.
-   */
-  protected readonly canSend = computed(
-    () => this.store.loaded() && this.draft().trim().length > 0,
-  );
-
-  /** Whether the @brain mention popover is open + its caret-anchored position. */
-  protected readonly menuOpen = signal(false);
-  protected readonly menuTop = signal(0);
-  protected readonly menuLeft = signal(0);
-  /** Index of the `@` that opened the current mention (replaced on select). */
-  private atIndex = -1;
 
   constructor() {
     // Keep the store pointed at the active meeting so a note line appends to the
-    // right `manual_notes` buffer. The effect reads the `meetingId` input and the
-    // store method writes the store's `_meetingId` signal (signal writes in
-    // effects are allowed since Angular 19).
-    effect(
-      () => {
-        this.store.setMeetingId(this.meetingId());
-      },
-    );
+    // right meeting's companion note + `manual_notes`. The effect reads the
+    // `meetingId` input and the store method writes the store's `_meetingId`
+    // signal (signal writes in effects are allowed since Angular 19).
+    effect(() => {
+      this.store.setMeetingId(this.meetingId());
+    });
 
     // Auto-scroll the flow to the newest line whenever the notes change. Tracks
     // the notes signal in the effect, schedules the DOM work via afterNextRender
@@ -183,27 +169,26 @@ export class MeetingConversationComponent implements OnInit {
   }
 
   /**
-   * Submit the composer line. The ONLY signal is a STANDALONE `@brain` token:
-   *   - line WITH a standalone `@brain` → the QUESTION is the text AFTER it; OPEN
-   *     a thread (the agent answers in the nested thread; the user accepts what to
+   * A composer line was SENT (Enter with no Shift/menu, or the Send button). The
+   * composer self-clears; the host routes the emitted markdown by the ONLY signal —
+   * a STANDALONE `@brain` token:
+   *   - line WITH a standalone `@brain` → the QUESTION is the text AFTER it; OPEN a
+   *     thread (the agent answers in the nested thread; the user accepts what to
    *     keep);
-   *   - line WITHOUT a standalone `@brain` → it's a NOTE, kept VERBATIM (persist to
-   *     `manual_notes` + a flow line). A substring like "bob@brainpower.com" stays
-   *     a note — never spliced, never shipped to the agent (no cloud egress).
-   * Blank text / not-yet-hydrated is a no-op. A note never waits on a thread
-   * (notes save while a thread is still processing — threads are independent).
+   *   - line WITHOUT a standalone `@brain` → it's a NOTE, kept VERBATIM (append to
+   *     the companion note + a flow line). A substring like "bob@brainpower.com"
+   *     stays a note — never spliced, never shipped to the agent (no cloud egress).
+   * Blank text / not-yet-hydrated is a no-op (the composer also guards non-empty).
+   * A note never waits on a thread (notes save while a thread still processes).
    */
-  protected submit(event: Event): void {
-    event.preventDefault();
-    this.menuOpen.set(false);
+  protected onSend(markdown: string): void {
     if (!this.store.loaded()) return; // guard the hydrate-vs-type race (see store)
-    const text = this.draft().trim();
+    const text = markdown.trim();
     if (!text) return;
 
     const question = parseBrainLine(text);
     if (question !== null) {
-      if (!question) return; // bare standalone "@brain" with no question → keep draft
-      this.draft.set("");
+      if (!question) return; // bare standalone "@brain" with no question → drop
       void this.store.openThread(question).catch(() => {
         /* the store resolves the agent turn with an error in the thread */
       });
@@ -211,172 +196,16 @@ export class MeetingConversationComponent implements OnInit {
     }
 
     // Plain line → a note, kept VERBATIM (saved + shown), independent of any thread.
-    this.draft.set("");
     this.store.addNote(text);
   }
 
   /**
-   * Keyboard on the composer: drive the @brain mention popover first (Esc closes,
-   * Enter/Tab selects), else Enter (no Shift) submits the line.
+   * Esc in the composer with no `/`/`[[` menu open. Nothing to close on this
+   * always-visible in-flow surface — kept as a no-op hook so the composer's
+   * `escape` output has a defined target (rewire contract).
    */
-  protected onKeydown(event: KeyboardEvent): void {
-    if (this.menuOpen()) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        this.menuOpen.set(false);
-        return;
-      }
-      if (event.key === "Enter" || event.key === "Tab") {
-        event.preventDefault();
-        this.chooseBrain();
-        return;
-      }
-      return;
-    }
-    if (event.key === "Enter" && !event.shiftKey) {
-      this.submit(event);
-    }
-  }
-
-  /** Composer input: update the draft + recompute the @brain mention popover. */
-  protected onInput(event: Event): void {
-    const ta = event.target as HTMLTextAreaElement;
-    this.draft.set(ta.value);
-    this.updateMentionMenu(ta);
-  }
-
-  /** Close the mention menu when focus leaves the textarea (click-away). */
-  protected onBlur(): void {
-    this.menuOpen.set(false);
-  }
-
-  /**
-   * Re-evaluate the @brain popover from the live caret. Open it when the caret
-   * sits inside an `@`-token at a word boundary whose text is a prefix of
-   * "brain"; otherwise close it. Anchors the popover just below the caret.
-   */
-  private updateMentionMenu(ta: HTMLTextAreaElement): void {
-    const value = ta.value;
-    const caret = ta.selectionStart ?? value.length;
-    let at = -1;
-    for (let i = caret - 1; i >= 0; i--) {
-      const ch = value[i];
-      if (ch === "@") {
-        const prev = i === 0 ? " " : value[i - 1];
-        if (/\s/.test(prev)) at = i;
-        break;
-      }
-      if (/\s/.test(ch)) break; // whitespace before any '@' → not in a token
-    }
-    if (at === -1) {
-      this.menuOpen.set(false);
-      return;
-    }
-    const query = value.slice(at + 1, caret);
-    if (!/^[a-z]*$/i.test(query) || !"brain".startsWith(query.toLowerCase())) {
-      this.menuOpen.set(false);
-      return;
-    }
-    this.atIndex = at;
-    const anchor = this.caretAnchor(ta, caret);
-    const left = Math.max(0, Math.min(anchor.left, ta.clientWidth - 200));
-    this.menuTop.set(ta.offsetTop + anchor.top + anchor.height);
-    this.menuLeft.set(ta.offsetLeft + left);
-    this.menuOpen.set(true);
-  }
-
-  /** Select "brain": replace the typed `@…` token with `@brain ` + re-focus. */
-  protected chooseBrain(): void {
-    const ta = this.textarea()?.nativeElement;
-    if (!ta || this.atIndex < 0) {
-      this.menuOpen.set(false);
-      return;
-    }
-    const value = this.draft();
-    const caret = ta.selectionStart ?? value.length;
-    const before = value.slice(0, this.atIndex);
-    const after = value.slice(caret);
-    const insert = `${BRAIN_MARKER} `;
-    const next = before + insert + after;
-    const pos = before.length + insert.length;
-    this.menuOpen.set(false);
-    this.draft.set(next);
-    this.focusAt(pos);
-  }
-
-  /** Focus the textarea + place the caret at `pos` after the DOM updates. */
-  private focusAt(pos: number): void {
-    afterNextRender(
-      () => {
-        const ta = this.textarea()?.nativeElement;
-        if (!ta) return;
-        ta.focus();
-        ta.setSelectionRange(pos, pos);
-      },
-      { injector: this.injector },
-    );
-  }
-
-  /**
-   * Caret pixel position inside a textarea via the mirror-div technique: clone
-   * the textarea's box + text up to the caret into a hidden div, measure a marker
-   * span. Returns coords relative to the textarea's border box + the line height.
-   */
-  private caretAnchor(
-    ta: HTMLTextAreaElement,
-    caret: number,
-  ): { top: number; left: number; height: number } {
-    const style = getComputedStyle(ta);
-    const div = document.createElement("div");
-    const ds = div.style;
-    ds.position = "absolute";
-    ds.visibility = "hidden";
-    ds.whiteSpace = "pre-wrap";
-    ds.overflowWrap = "break-word";
-    ds.overflow = "hidden";
-    const copy = [
-      "box-sizing",
-      "padding-top",
-      "padding-right",
-      "padding-bottom",
-      "padding-left",
-      "border-top-width",
-      "border-right-width",
-      "border-bottom-width",
-      "border-left-width",
-      "font-family",
-      "font-size",
-      "font-weight",
-      "font-style",
-      "font-variant",
-      "letter-spacing",
-      "line-height",
-      "text-transform",
-      "word-spacing",
-      "text-indent",
-      "tab-size",
-    ];
-    for (const p of copy) ds.setProperty(p, style.getPropertyValue(p));
-    ds.width = `${ta.clientWidth}px`;
-    ds.height = "auto";
-    const value = ta.value;
-    div.textContent = value.slice(0, caret);
-    const marker = document.createElement("span");
-    marker.textContent = value.slice(caret) || ".";
-    div.appendChild(marker);
-    document.body.appendChild(div);
-    const lhRaw = parseFloat(style.lineHeight);
-    const height = Number.isNaN(lhRaw)
-      ? parseFloat(style.fontSize) * 1.4
-      : lhRaw;
-    const top =
-      marker.offsetTop + parseFloat(style.borderTopWidth || "0") - ta.scrollTop;
-    const left =
-      marker.offsetLeft +
-      parseFloat(style.borderLeftWidth || "0") -
-      ta.scrollLeft;
-    document.body.removeChild(div);
-    return { top, left, height };
+  protected onEscape(): void {
+    /* no floating surface to dismiss here — the panel stays in flow */
   }
 
   /**

--- a/src/app/features/record/note-item/note-item.component.html
+++ b/src/app/features/record/note-item/note-item.component.html
@@ -40,6 +40,60 @@
         </button>
       }
     </div>
+
+    <!-- ── SAVED-NOTE card footer — a sent jot / accepted @brain draft is a
+         REAL, LINKED companion note now. IN-FLOW (not floating → trap T3 N/A),
+         token-styled. "✓ Saved to Notes" opens the companion note by id in a new
+         tab; the "🔗 [[Meeting]] →" chip navigates to the meeting by id. ────── -->
+    @switch (n.saveState) {
+      @case ("saving") {
+        <div class="saved-bar is-saving" role="status">
+          <span class="saved-spin" aria-hidden="true"></span>
+          <span class="saved-label">Saving to Notes…</span>
+        </div>
+      }
+      @case ("saved") {
+        <div class="saved-bar" role="group" aria-label="Saved note links">
+          <button
+            type="button"
+            class="saved-open"
+            (click)="openSavedNote()"
+            title="Open this note in a new tab"
+            aria-label="Open this note in Notes"
+          >
+            <span class="saved-check" aria-hidden="true">✓</span>
+            Saved to Notes
+          </button>
+          @if (meetingChipLabel(); as label) {
+            <button
+              type="button"
+              class="meeting-chip"
+              (click)="openMeeting()"
+              [title]="'Go to ' + label"
+              [attr.aria-label]="'Go to the meeting ' + label"
+            >
+              <span class="chip-link" aria-hidden="true">🔗</span>
+              <span class="chip-name">{{ label }}</span>
+              <span class="chip-arrow" aria-hidden="true">→</span>
+            </button>
+          }
+        </div>
+      }
+      @case ("error") {
+        <div class="saved-bar is-error" role="alert">
+          <span class="saved-warn" aria-hidden="true">⚠</span>
+          <span class="saved-label">Couldn't save to Notes.</span>
+          <button
+            type="button"
+            class="saved-retry"
+            (click)="retrySave()"
+            aria-label="Retry saving this note"
+          >
+            Retry
+          </button>
+        </div>
+      }
+    }
   }
 
   @if (n.thread) {

--- a/src/app/features/record/note-item/note-item.component.scss
+++ b/src/app/features/record/note-item/note-item.component.scss
@@ -87,6 +87,136 @@
   }
 }
 
+/* ── SAVED-NOTE card footer — a sent jot / accepted @brain draft became a
+   REAL, LINKED companion note. A subtle in-flow bar (NOT a floating overlay,
+   so trap T3 N/A) with the "✓ Saved to Notes" primary affordance + a
+   "🔗 [[Meeting]] →" chip. var(--token) only. ─────────────────────────────── */
+.saved-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-left: calc(var(--space-2) + 13px + var(--space-2));
+  padding: 2px 0;
+  font-size: 0.74rem;
+}
+/* The primary "✓ Saved to Notes" affordance — opens the companion note. */
+.saved-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    color var(--transition);
+}
+.saved-open:hover {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.saved-open:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.saved-check {
+  font-size: 0.78rem;
+  line-height: 1;
+}
+/* The "🔗 [[Meeting]] →" chip — navigates to the meeting by id. */
+.meeting-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  cursor: pointer;
+  transition:
+    color var(--transition),
+    border-color var(--transition),
+    background var(--transition);
+}
+.meeting-chip:hover {
+  color: var(--accent-hover);
+  border-color: var(--accent-ring);
+  background: var(--surface-hover);
+}
+.meeting-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.chip-name {
+  min-width: 0;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.chip-arrow {
+  color: var(--text-muted);
+}
+/* Transient "Saving to Notes…" state. */
+.saved-bar.is-saving {
+  color: var(--text-muted);
+}
+.saved-label {
+  color: var(--text-muted);
+}
+.saved-spin {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-ring);
+  border-top-color: var(--accent);
+  animation: spin 0.7s linear infinite;
+}
+/* Error state — the append failed; the line is kept, offer a retry. */
+.saved-bar.is-error {
+  color: var(--danger);
+}
+.saved-warn {
+  color: var(--danger);
+  font-size: 0.8rem;
+  line-height: 1;
+}
+.saved-bar.is-error .saved-label {
+  color: var(--text-secondary);
+}
+.saved-retry {
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent-hover);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    color var(--transition);
+}
+.saved-retry:hover {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.saved-retry:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
 /* ── @brain THREAD toggle (Slack-style header): caret + "Thread (N)" + a
    short snippet of the user's question when collapsed. The question itself
    renders as the user's first RIGHT-aligned bubble once expanded. ───────── */

--- a/src/app/features/record/note-item/note-item.component.ts
+++ b/src/app/features/record/note-item/note-item.component.ts
@@ -13,6 +13,7 @@ import {
 } from "@angular/core";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
 import type { NoteItem, ThreadTurn } from "../../../core/meeting-conversation.store";
+import { TabsService } from "../../../core/tabs.service";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { AssistantSourcesComponent } from "../../../shared/assistant-sources/assistant-sources.component";
 
@@ -53,6 +54,7 @@ import { AssistantSourcesComponent } from "../../../shared/assistant-sources/ass
 })
 export class NoteItemComponent {
   protected readonly store = inject(MeetingConversationStore);
+  private readonly tabs = inject(TabsService);
   private readonly injector = inject(Injector);
 
   /** The note line (with its thread, if any) — the single source of truth. */
@@ -201,5 +203,42 @@ export class NoteItemComponent {
       default:
         return "";
     }
+  }
+
+  /**
+   * The `[[Meeting]]` chip label: the meeting's display name with the wikilink
+   * brackets stripped (e.g. `[[Weekly sync]]` → `Weekly sync`). Empty when the
+   * line carries no companion reference yet.
+   */
+  protected meetingChipLabel(): string {
+    const raw = this.note().meetingWikilink ?? "";
+    return raw.replace(/^\[\[/, "").replace(/\]\]$/, "").trim();
+  }
+
+  /**
+   * "✓ Saved to Notes" — open the companion note in a new tab BY ID (never by a
+   * fragile title string). Navigating away from the recording is acceptable per
+   * the spec. A no-op if the reference hasn't been stamped yet.
+   */
+  protected openSavedNote(): void {
+    const id = this.note().savedNoteId;
+    if (!id) return;
+    void this.tabs.openNote(id);
+  }
+
+  /**
+   * The `🔗 [[Meeting]] →` chip — navigate to THIS recording's meeting by id
+   * (the store's anchored `meetingId`, the authoritative structured relation),
+   * never by resolving the wikilink string. A no-op when there's no meeting.
+   */
+  protected openMeeting(): void {
+    const id = this.store.meetingId();
+    if (!id) return;
+    void this.tabs.openMeeting(id, this.meetingChipLabel() || "Meeting");
+  }
+
+  /** Retry a failed companion-note append (the card's error state). */
+  protected retrySave(): void {
+    this.store.retrySave(this.note().id);
   }
 }


### PR DESCRIPTION
## What

During a recording, jotted notes were a dead end — plain text concatenated into the meeting's \`manual_notes\` blob: not a real note, not in the Notes surface, not in the vault, not linkable. And a recording could not be reliably linked from a note via \`[[name]]\` (meetings were inserted with \`title = NULL\` at record start, so the wikilink had no target).

This makes in-recording note-taking produce **real, first-class, linked notes**, keeps the \`@brain\` thread, and makes the recording↔note link robust.

### Model
- **One living companion note per meeting** (a standalone \`documents\` note), created **lazily on the first jot / first accepted @brain draft** — no content, no note (kills the empty "Untitled" note).
- Lives in the always-open **Notes ROOT**; no title field shown (managed, tracks the meeting title).
- The recording panel stays a **thread** interleaving your saved-note cards and \`@brain\` exchanges.

### Robust linking (root-cause)
- Additive \`documents.meeting_id\` column + index → authoritative structured backlink (survives rename; shows in the meeting's Linked mentions).
- Visible \`[[Meeting]]\` wikilink in the note front-matter for Obsidian-native linking.
- \`resolve_wikilink\` self-link exclusion so \`[[Meeting]]\` resolves to the **meeting**, never its companion note.
- **Stable provisional meeting title at record start** ("Meeting YYYY-MM-DD HH:MM", was NULL) so links resolve immediately and the meeting appears in the \`[[\` picker; \`set_meeting_title\` is unconditional so auto-title-on-close still upgrades it; companion title/link sync on rename.

### UX
- New reusable \`mur-markdown-composer\` (design-system): \`/\` blocks, \`[[\` links (reuses \`LinkPickerComponent\`), ⌘B/⌘I formatting, Enter = send / Shift+Enter = newline.
- Each sent jot / accepted \`@brain\` draft shows a **"✓ Saved to Notes · [[Meeting]] →"** card.
- \`manual_notes\` preserved additively (the summary/enhance pipeline still reads it).

## How verified
- \`cargo test --lib\` — 1756 passed / 0 failed (10 new tests, several RED→GREEN: gate, lazy-create/reuse, self-link resolve, backlinks structured leg + lock-gating, compose idempotence, title sync).
- \`npx ng lint\`, \`npx ng build\`, Playwright \`e2e/record/\` (8) — green.
- \`scripts/ci.sh\` — ✅ all gates green (clippy -D warnings + tests + lint + build + headless E2E).
- **adversarial-verifier: PASS** (0 findings; auto-title regression disproven RED→GREEN) · **lock-security-reviewer: PASS** (write meeting-gated, backlinks/resolver keep \`visibility_clause\`, no sealed-content leak, verify-before-destroy on \`manual_notes\`, no PII in logs, migration additive).

## Notes / fast-follows
- The caret-anchored \`@brain\` mention popup was removed (the composer owns its own textarea); the ability to open a thread is unchanged (\`@brain <q>\` + send → \`openThread\`). Restoring the popup needs an @-mention mode on the composer — flagged as a fast-follow.
- Migrating \`NoteEditorComponent\`'s inline editor onto \`mur-markdown-composer\` is a separate fast-follow (this change leaves the shipped Notes editor untouched).
- Touch ID / lock-at-rest / screen-share are signed-build-only and untouched by this diff.

Spec: \`docs/superpowers/specs/2026-07-16-recording-companion-note-design.md\`