### PR TITLE
fix(notes,shell): [[ link-picker infinite scroll + drill-down tab strip clears the traffic lights

### DIFF
--- a/.claude/learnings/adversarial-verifier.md
+++ b/.claude/learnings/adversarial-verifier.md
@@ -33,6 +33,19 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-07-17 link-picker pagination] Playwright `reuseExistingServer` on the fixed :4210 silently tested ANOTHER checkout's build
+- **Pattern:** mid-verification e2e runs flipped green→red for no code reason — `playwright.config.ts`
+  has `reuseExistingServer: true` on the fixed port 4210, and a CONCURRENT session's `ng serve`
+  (cwd = the main checkout, pre-fix bundle) was holding the port, so the specs silently exercised the
+  WRONG tree. Evidence gathered while any other checkout can own :4210 is unreliable in both
+  directions (false RED here; a false PASS is equally possible).
+- **Caught by:** adversarial-verifier (probe results contradicted the code under review; `lsof -p` of
+  the :4210 owner showed a foreign cwd).
+- **Lesson:** before trusting any e2e evidence, prove WHICH tree the server on the port is serving
+  (`lsof -ti :4210` → `lsof -p <pid> | grep cwd`). When more than one checkout/session is alive, run
+  the suite on a private port with `reuseExistingServer: false` (temp config), never the shared 4210.
+- **Status:** journal
+
 ### [2026-07-05 detail redesign — #194] a PASS on a tree that didn't build
 - **Pattern:** A build workflow's verify phase ran WHILE the build phases had left the tree
   NON-BUILDING (a Split agent died mid-response + a syntax error cascaded), yet a structure-level

--- a/e2e/notes/link-picker.spec.ts
+++ b/e2e/notes/link-picker.spec.ts
@@ -113,6 +113,77 @@ test("slash menu 'Link to note' opens the autocomplete popover and inserts [[Tit
 });
 
 /**
+ * Infinite scroll (2026-07-17) — the picker walks the WHOLE candidate list page
+ * by page instead of the old fixed top-8: page 0 renders one full backend page,
+ * and scrolling near the popover's bottom appends the next page (offset = rows
+ * already loaded) until the backend runs dry. The mock serves 100 candidates in
+ * 40-row pages straight from the `offset`/`limit` args, so this pins the REAL
+ * request arithmetic, not a canned reply.
+ */
+test("scrolling the picker to the bottom loads further candidate pages", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    // Page-side + self-contained (mockTauri serializes it): 100 notes, sliced
+    // by the offset/limit the component actually sends.
+    list_link_candidates: (args: { prefix: string; offset: number; limit: number }) => {
+      const total = 100;
+      const rows = [];
+      const end = Math.min(total, (args.offset ?? 0) + (args.limit ?? 40));
+      for (let i = args.offset ?? 0; i < end; i++) {
+        rows.push({
+          kind: "note",
+          id: `bulk-${i}`,
+          title: `Bulk note ${String(i).padStart(3, "0")}`,
+          snippet: "",
+        });
+      }
+      return rows;
+    },
+  });
+  await page.goto("/notes/n1");
+
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("[");
+  await body.press("[");
+
+  const picker = page.locator("app-link-picker");
+  await expect(picker).toBeVisible();
+  const rows = picker.locator(".link-pop-row");
+  // Page 0: exactly one backend page, not the old top-8.
+  await expect(rows).toHaveCount(40);
+
+  // Scroll the popover itself to the bottom → the next page appends.
+  const pop = picker.locator(".link-pop");
+  await pop.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(rows).toHaveCount(80);
+
+  // And again → the final short page lands; a further scroll stays at 100.
+  await pop.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(rows).toHaveCount(100);
+  await expect(rows.last()).toHaveText(/Bulk note 099/);
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
  * Fix 2 (parity) — typing the raw `[[` keystroke ALSO opens the picker (not just
  * the slash-menu entry), confirming the ONE shared trigger/component contract.
  */

--- a/e2e/notes/tab-strip-drilldown-clearance.spec.ts
+++ b/e2e/notes/tab-strip-drilldown-clearance.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Drill-down routes (/settings, /org-item) render NO sidebar/pill chrome, so
+ * `mur-tab-strip` starts flush at the window's LEFT edge — exactly where the
+ * overlay macOS traffic lights float (trafficLightPosition 32,30 → buttons
+ * span ≈ x 32..84, vertically inside the 48px strip). The strip must reserve
+ * left clearance there (`app-shell.drilldown` host class + the `:host-context`
+ * rule in tab-strip.component.scss) while keeping its normal padding in
+ * sidebar mode, where it sits right of the sidebar panel. Headless Playwright
+ * has no real macOS window chrome, so this pins the CSS contract (the computed
+ * clearance), not the OS pixels.
+ */
+test("the tab strip clears the traffic-light zone on drill-down routes", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page);
+
+  // Put a tab on the strip through the real in-app open action (a goto
+  // deep-link deliberately opens no tab — see link-picker.spec.ts).
+  await page.goto("/notes");
+  await page.getByRole("button", { name: "My First Note" }).click();
+  await expect(page.locator(".tab-strip .tab-item")).toHaveCount(1);
+
+  // Sidebar mode: the strip sits right of the sidebar panel — normal padding
+  // (--space-5 = 24px), no traffic lights anywhere near it.
+  const strip = page.locator(".tab-strip");
+  await expect(strip).toHaveCSS("padding-left", "24px");
+
+  // Enter the Settings drill-down through the real sidebar affordance: the
+  // chrome unmounts, the strip now starts at the window edge → clearance on.
+  await page.getByRole("link", { name: "Settings", exact: true }).click();
+  await expect(page).toHaveURL(/\/settings/);
+  await expect(strip).toHaveCSS("padding-left", "96px");
+
+  // Leaving the drill-down restores the normal padding.
+  await page.getByRole("button", { name: "Back to Murmur" }).click();
+  await expect(strip).toHaveCSS("padding-left", "24px");
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7315,25 +7315,36 @@ pub fn resolve_wikilink(
 /// (note-editor Fix 2). Distinct from [`resolve_wikilink`] (exact-title resolve on Enter/click) and
 /// from `note_assistant_action`'s `find_related` (SELECTION+semantic retrieval — the wrong shape
 /// for filtering on a short, growing keystroke prefix): this is a lightweight, gated title-prefix
-/// scan, capped at `MAX_LINK_CANDIDATES` total rows across notes + meetings + (when joined) the
-/// Shared Brain. GATED exactly like every other content read: notes/meetings go through
+/// scan. GATED exactly like every other content read: notes/meetings go through
 /// `Db::list_link_candidates_visible` (`visibility_clause` on both legs, same as `resolve_wikilink`);
 /// org items go through `search_org_brain_hits`, the SAME retrieval-only, membership+enabled-gated,
 /// zero-egress reader `find_related` already uses (never a provider/egress call). Reuses
 /// [`crate::storage::models::NoteCitation`] — the popover renders it exactly like a `find_related`
 /// citation row, and `kind == "org"` carries an org item id (never a local id), matching that
 /// contract verbatim.
+///
+/// PAGINATED (2026-07-17 — the picker is an infinite scroll over the whole vault now, not a fixed
+/// top-8): one call returns the `limit`-sized page at `offset` of the stable combined ordering
+/// [visible notes] ++ [visible meetings] ++ [org hits] (org only for a non-empty prefix, folded in
+/// after the local total the Db reader reports). The FE owns its page size; the clamp keeps one
+/// IPC reply from ever dumping an unbounded slice of the vault.
 #[tauri::command]
 pub fn list_link_candidates(
     state: State<'_, AppState>,
     prefix: String,
+    offset: Option<u32>,
+    limit: Option<u32>,
 ) -> Result<Vec<crate::storage::models::NoteCitation>, AppError> {
-    const MAX_LINK_CANDIDATES: i64 = 8;
+    const DEFAULT_PAGE: i64 = 40;
+    const MAX_PAGE: i64 = 100;
+    let limit = limit.map_or(DEFAULT_PAGE, i64::from).clamp(1, MAX_PAGE);
+    let offset = i64::from(offset.unwrap_or(0));
     let unlocked = unlocked_snapshot(state.inner())?;
-    let mut out = state
-        .db
-        .list_link_candidates_visible(&prefix, MAX_LINK_CANDIDATES, &unlocked)?;
-    if (out.len() as i64) < MAX_LINK_CANDIDATES {
+    let (mut out, local_total) =
+        state
+            .db
+            .list_link_candidates_visible(&prefix, limit, offset, &unlocked)?;
+    if (out.len() as i64) < limit {
         let config = {
             state
                 .config
@@ -7343,9 +7354,14 @@ pub fn list_link_candidates(
         };
         let q = prefix.trim();
         if !q.is_empty() && crate::tools::org_brain_available(&state.db, &config) {
-            let remaining = (MAX_LINK_CANDIDATES - out.len() as i64).max(0) as usize;
+            // Earlier pages consumed `local_total` local rows, then `offset - local_total`
+            // org rows once the offset ran past the local legs — skip exactly those. The
+            // org reader is bounded (≤20 per leg pre-fusion), so skip/take over its Vec
+            // is real pagination, not a hidden re-scan.
+            let org_skip = (offset - local_total).max(0) as usize;
+            let remaining = (limit - out.len() as i64).max(0) as usize;
             let org_hits = crate::tools::search_org_brain_hits(&state.db, &config, q)?;
-            for hit in org_hits.into_iter().take(remaining) {
+            for hit in org_hits.into_iter().skip(org_skip).take(remaining) {
                 out.push(crate::storage::models::NoteCitation {
                     kind: "org".into(),
                     id: hit.item_id,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -8955,49 +8955,77 @@ impl Db {
     /// slash-menu link-insertion autocomplete (distinct from [`resolve_wikilink`]'s exact-title
     /// resolve and from `gather_note_enhance_citations`'s SELECTION+semantic retrieval — this is a
     /// lightweight `LIKE prefix%` title scan, the right shape for filtering-as-you-type). GATED
-    /// identically to every other title/content read: `visibility_clause` on both legs, so a
-    /// sealed-and-not-session-unlocked note/meeting never appears as a candidate. An empty/blank
-    /// `prefix` returns the most-recently-updated visible notes+meetings (so the popover has
-    /// something to show the instant it opens, before the user has typed anything). Capped at
-    /// `limit` total rows across BOTH kinds, notes first (mirrors `resolve_wikilink`'s note-first
-    /// preference), newest-updated first within each kind.
+    /// identically to every other title/content read: `visibility_clause` on both legs — on the
+    /// page queries AND their COUNT twins — so a sealed-and-not-session-unlocked note/meeting
+    /// neither appears as a candidate nor inflates the pagination totals. An empty/blank `prefix`
+    /// returns the most-recently-updated visible notes+meetings (so the popover has something to
+    /// show the instant it opens, before the user has typed anything).
+    ///
+    /// PAGINATED (2026-07-17 — the picker scrolls the whole vault now, not a fixed top-8):
+    /// returns the `limit`-sized page starting at `offset` of ONE stable combined ordering,
+    /// [all matching notes, newest-updated first] ++ [all matching meetings, newest-started
+    /// first] (notes first mirrors `resolve_wikilink`'s note-first preference), plus the TOTAL
+    /// number of matching local rows across both legs — `commands::list_link_candidates` needs
+    /// that total to know how far into the org (Shared Brain) leg it folds in after the local
+    /// rows that earlier pages have already consumed. Both legs run under ONE connection lock so
+    /// the counts and the page rows are a single consistent snapshot.
     pub fn list_link_candidates_visible(
         &self,
         prefix: &str,
         limit: i64,
+        offset: i64,
         unlocked: &HashSet<String>,
-    ) -> Result<Vec<NoteCitation>> {
+    ) -> Result<(Vec<NoteCitation>, i64)> {
         let prefix = prefix.trim();
+        let limit = limit.max(0);
+        let offset = offset.max(0);
+        // `None` ⇒ the `:pat IS NULL` arm short-circuits the LIKE, so ONE SQL string serves
+        // both the empty-prefix (recency browse) and the typed-prefix (filter) shapes.
+        let pat: Option<String> = if prefix.is_empty() {
+            None
+        } else {
+            Some(format!("{}%", escape_like(prefix)))
+        };
         let mut out: Vec<NoteCitation> = Vec::new();
+        let conn = self.lock();
 
-        // Notes leg.
-        {
-            let conn = self.lock();
-            let visible = visibility_clause("f", unlocked);
-            let like_pred = if prefix.is_empty() {
-                String::new()
-            } else {
-                " AND COALESCE(NULLIF(TRIM(d.title), ''), d.name) LIKE ?2 ESCAPE '\\'".to_string()
-            };
+        // Notes leg — the COUNT twin shares the page query's exact WHERE body, so the
+        // offset arithmetic below can never drift from what the page query returns.
+        let visible_notes = visibility_clause("f", unlocked);
+        let notes_where = format!(
+            "d.kind = 'note' AND {visible_notes}
+             AND (:pat IS NULL OR COALESCE(NULLIF(TRIM(d.title), ''), d.name) LIKE :pat ESCAPE '\\')"
+        );
+        let note_count: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE {notes_where}"
+                ),
+                rusqlite::named_params! { ":pat": pat },
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        if offset < note_count && (out.len() as i64) < limit {
             let sql = format!(
                 "SELECT d.id, COALESCE(NULLIF(TRIM(d.title), ''), d.name)
                    FROM documents d
                    JOIN folders f ON f.id = d.folder_id
-                  WHERE d.kind = 'note' AND {visible}{like_pred}
+                  WHERE {notes_where}
                   ORDER BY d.updated_at DESC, d.id ASC
-                  LIMIT ?1"
+                  LIMIT :limit OFFSET :offset"
             );
             let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-            let map_row = |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
-                Ok((r.get(0)?, r.get(1)?))
-            };
-            let rows = if prefix.is_empty() {
-                stmt.query_map(rusqlite::params![limit], map_row)
-            } else {
-                let pat = format!("{}%", escape_like(prefix));
-                stmt.query_map(rusqlite::params![limit, pat], map_row)
-            }
-            .map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::named_params! { ":pat": pat, ":limit": limit, ":offset": offset },
+                    |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
+                        Ok((r.get(0)?, r.get(1)?))
+                    },
+                )
+                .map_err(map_err)?;
             for r in rows {
                 let (id, title) = r.map_err(map_err)?;
                 out.push(NoteCitation {
@@ -9009,42 +9037,52 @@ impl Db {
             }
         }
 
-        // Meetings leg (only if the notes leg hasn't already filled the cap).
-        if (out.len() as i64) < limit {
-            let remaining = limit - out.len() as i64;
-            let conn = self.lock();
-            let visible = visibility_clause("n", unlocked);
-            let like_pred = if prefix.is_empty() {
-                String::new()
-            } else {
-                " AND m.title LIKE ?2 ESCAPE '\\'".to_string()
-            };
+        // Meetings leg — starts where the notes leg ends in the combined ordering: pages
+        // that fell entirely inside the notes leg read meetings from offset 0; pages past
+        // it skip exactly the meeting rows earlier pages consumed.
+        let visible_meetings = visibility_clause("n", unlocked);
+        let meetings_where = format!(
+            "m.title IS NOT NULL AND TRIM(m.title) != ''
+             AND (:pat IS NULL OR m.title LIKE :pat ESCAPE '\\')
+             AND (
+               NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+               OR EXISTS (
+                 SELECT 1 FROM notes n
+                  LEFT JOIN folders f ON f.id = n.folder_id
+                  WHERE n.meeting_id = m.id AND {visible_meetings}
+               )
+             )"
+        );
+        let meeting_count: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM meetings m WHERE {meetings_where}"),
+                rusqlite::named_params! { ":pat": pat },
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        let remaining = limit - out.len() as i64;
+        let meeting_offset = (offset - note_count).max(0);
+        if remaining > 0 && meeting_offset < meeting_count {
             let sql = format!(
                 "SELECT m.id, m.title
                    FROM meetings m
-                  WHERE m.title IS NOT NULL AND TRIM(m.title) != ''{like_pred}
-                    AND (
-                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
-                      OR EXISTS (
-                        SELECT 1 FROM notes n
-                         LEFT JOIN folders f ON f.id = n.folder_id
-                         WHERE n.meeting_id = m.id AND {visible}
-                      )
-                    )
+                  WHERE {meetings_where}
                   ORDER BY m.started_at DESC, m.id DESC
-                  LIMIT ?1"
+                  LIMIT :limit OFFSET :offset"
             );
             let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-            let map_row = |r: &Row<'_>| -> rusqlite::Result<(String, Option<String>)> {
-                Ok((r.get(0)?, r.get(1)?))
-            };
-            let rows = if prefix.is_empty() {
-                stmt.query_map(rusqlite::params![remaining], map_row)
-            } else {
-                let pat = format!("{}%", escape_like(prefix));
-                stmt.query_map(rusqlite::params![remaining, pat], map_row)
-            }
-            .map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::named_params! {
+                        ":pat": pat,
+                        ":limit": remaining,
+                        ":offset": meeting_offset,
+                    },
+                    |r: &Row<'_>| -> rusqlite::Result<(String, Option<String>)> {
+                        Ok((r.get(0)?, r.get(1)?))
+                    },
+                )
+                .map_err(map_err)?;
             for r in rows {
                 let (id, title) = r.map_err(map_err)?;
                 out.push(NoteCitation {
@@ -9055,7 +9093,7 @@ impl Db {
                 });
             }
         }
-        Ok(out)
+        Ok((out, note_count + meeting_count))
     }
 
     /// The latest visible note for a meeting (MCP `get_meeting`); `None` if the meeting's note
@@ -14919,8 +14957,8 @@ mod tests {
         let nothing = std::collections::HashSet::new();
 
         // "Alp" matches "Alpha Project" (note) and "Alpine Standup" (meeting), not "Alternate Plan".
-        let hits = db
-            .list_link_candidates_visible("Alp", 10, &nothing)
+        let (hits, total) = db
+            .list_link_candidates_visible("Alp", 10, 0, &nothing)
             .unwrap();
         let titles: Vec<&str> = hits.iter().map(|c| c.title.as_str()).collect();
         assert!(titles.contains(&"Alpha Project"));
@@ -14928,25 +14966,90 @@ mod tests {
         assert!(!titles.contains(&"Alternate Plan"));
         // Notes leg is queried first (mirrors `resolve_wikilink`'s note-first preference).
         assert_eq!(hits[0].kind, "note");
+        assert_eq!(total, 2, "local total counts exactly the matching rows");
 
         // Case-insensitive (SQLite LIKE is ASCII-case-insensitive by default, same as the
         // existing `search_snippet`/path LIKE readers in this file).
-        let ci = db
-            .list_link_candidates_visible("alp", 10, &nothing)
+        let (ci, _) = db
+            .list_link_candidates_visible("alp", 10, 0, &nothing)
             .unwrap();
         assert_eq!(ci.len(), hits.len());
 
         // Empty prefix returns everything (capped), not nothing.
-        let all = db
-            .list_link_candidates_visible("", 10, &nothing)
+        let (all, _) = db
+            .list_link_candidates_visible("", 10, 0, &nothing)
             .unwrap();
         assert!(all.len() >= 3, "empty prefix should list existing candidates");
 
-        // A cap of 1 returns exactly 1 row (notes leg fills it before the meetings leg runs).
-        let capped = db
-            .list_link_candidates_visible("Alp", 1, &nothing)
+        // A cap of 1 returns exactly 1 row (notes leg fills it before the meetings leg runs) —
+        // while the reported total still spans BOTH legs (it feeds the org-leg offset math).
+        let (capped, capped_total) = db
+            .list_link_candidates_visible("Alp", 1, 0, &nothing)
             .unwrap();
         assert_eq!(capped.len(), 1);
+        assert_eq!(capped_total, 2);
+    }
+
+    /// PAGINATION: `offset` walks the ONE combined [notes ++ meetings] ordering without
+    /// duplicating or skipping rows across page boundaries — including the page that straddles
+    /// the notes→meetings seam — and runs dry with an empty page past the end.
+    #[test]
+    fn list_link_candidates_paginates_across_the_notes_meetings_seam() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // 3 notes (newest-updated first: n3, n2, n1) + 2 meetings (newest-started first: m2, m1).
+        for (id, name, title, at) in [
+            ("n1", "one", "Note One", 1_000i64),
+            ("n2", "two", "Note Two", 2_000),
+            ("n3", "three", "Note Three", 3_000),
+        ] {
+            db.insert_note(id, "f-open", name, title, "body", at).unwrap();
+        }
+        for (id, started, title) in [
+            ("m1", "2026-06-20T10:00:00Z", "Meeting One"),
+            ("m2", "2026-06-24T10:00:00Z", "Meeting Two"),
+        ] {
+            let mut m = sample_meeting(id, started);
+            m.title = Some(title.to_string());
+            db.insert_meeting(&m).unwrap();
+            note_for(&db, id, "claude_code", "note");
+            db.set_note_folder(id, Some("f-open")).unwrap();
+        }
+
+        let nothing = std::collections::HashSet::new();
+        let page = |offset: i64| {
+            db.list_link_candidates_visible("", 2, offset, &nothing)
+                .unwrap()
+        };
+
+        // Page 0: the two newest notes. Total spans both legs on every page.
+        let (p0, total) = page(0);
+        assert_eq!(
+            p0.iter().map(|c| c.title.as_str()).collect::<Vec<_>>(),
+            vec!["Note Three", "Note Two"]
+        );
+        assert_eq!(total, 5);
+
+        // Page 1 straddles the seam: the last note, then the newest meeting.
+        let (p1, _) = page(2);
+        assert_eq!(
+            p1.iter()
+                .map(|c| (c.kind.as_str(), c.title.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("note", "Note One"), ("meeting", "Meeting Two")]
+        );
+
+        // Page 2: entirely inside the meetings leg.
+        let (p2, _) = page(4);
+        assert_eq!(
+            p2.iter().map(|c| c.title.as_str()).collect::<Vec<_>>(),
+            vec!["Meeting One"]
+        );
+
+        // Past the end: an empty page, never an error (the FE's "has more" probe).
+        let (p3, _) = page(5);
+        assert!(p3.is_empty());
     }
 
     /// GATED: a sealed-and-not-session-unlocked note/meeting never appears as a link candidate,
@@ -14977,20 +15080,25 @@ mod tests {
         db.set_note_folder("m-secret", Some("f-locked")).unwrap();
 
         let nothing = std::collections::HashSet::new();
-        let hidden = db
-            .list_link_candidates_visible("Secret", 10, &nothing)
+        let (hidden, hidden_total) = db
+            .list_link_candidates_visible("Secret", 10, 0, &nothing)
             .unwrap();
         assert!(
             hidden.is_empty(),
             "sealed-and-not-unlocked note/meeting must not be a link candidate"
         );
+        assert_eq!(
+            hidden_total, 0,
+            "the pagination total must not leak that sealed rows exist"
+        );
 
         let mut unlocked = std::collections::HashSet::new();
         unlocked.insert("f-locked".to_string());
-        let visible = db
-            .list_link_candidates_visible("Secret", 10, &unlocked)
+        let (visible, visible_total) = db
+            .list_link_candidates_visible("Secret", 10, 0, &unlocked)
             .unwrap();
         assert_eq!(visible.len(), 2, "unlocking reveals both the note and the meeting");
+        assert_eq!(visible_total, 2);
     }
 
     /// FAIL-CLOSED: a correction row with a NULL `meeting_id` (legacy/unattributed) is never returned

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -178,6 +178,12 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     // not this margin) for their own fixed-host offset — adding the margin
     // there too would desync the two.
     "[class.sidebar-visible]": "!inDrilldown() && !barMode()",
+    // True on drill-down routes (/settings, /org-item), where NO sidebar/pill
+    // chrome renders and `.main-col` spans from the window's LEFT edge —
+    // `mur-tab-strip` reads this via `:host-context` to reserve clearance for
+    // the overlay macOS traffic lights, which otherwise sit on the first tab
+    // (2026-07-17 fix; see tab-strip.component.scss).
+    "[class.drilldown]": "inDrilldown()",
     // (The former `notes-wide-route` binding is GONE, 2026-07-12: `.app-main`
     // is `max-width: none; width: 100%` for EVERY main route now — see the
     // `.app-main` comment in styles.css. Views that want a narrower reading

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1138,15 +1138,27 @@ export class IpcService {
   /**
    * Live keystroke-prefix candidates for the inline `[[` / slash-menu link-insertion
    * autocomplete — a lightweight, GATED title-prefix scan over VISIBLE notes + meetings +
-   * (when joined) the Shared Brain, capped server-side. Distinct from {@link resolveWikilink}
+   * (when joined) the Shared Brain. Distinct from {@link resolveWikilink}
    * (exact-title resolve on Enter/click) and from `noteAssistantAction`'s `find_related`
    * (SELECTION+semantic retrieval — the wrong shape for filtering on a short, growing
    * prefix). Reuses the {@link NoteCitation} shape so the popover renders it exactly like a
    * `find_related` row. An empty/blank `prefix` returns the most-recently-updated visible
    * candidates (so the popover has something to show the instant it opens).
+   *
+   * PAGINATED: returns the `limit`-sized page starting at `offset` of one stable combined
+   * ordering (notes, then meetings, then org hits) — `LinkPickerComponent`'s infinite
+   * scroll walks it page by page. The backend clamps `limit` to a sane ceiling (100).
    */
-  listLinkCandidates(prefix: string): Promise<NoteCitation[]> {
-    return invoke<NoteCitation[]>("list_link_candidates", { prefix });
+  listLinkCandidates(
+    prefix: string,
+    offset: number,
+    limit: number,
+  ): Promise<NoteCitation[]> {
+    return invoke<NoteCitation[]>("list_link_candidates", {
+      prefix,
+      offset,
+      limit,
+    });
   }
 
   /**

--- a/src/app/design-system/tab-strip/tab-strip.component.scss
+++ b/src/app/design-system/tab-strip/tab-strip.component.scss
@@ -33,6 +33,21 @@
   overflow-x: auto;
 }
 
+/* Drill-down routes (/settings, /org-item — `app-shell.drilldown`, a host
+   binding mirroring `inDrilldown()`) render NO sidebar/pill chrome, so
+   `.main-col` — and with it this strip — starts flush at the window's LEFT
+   edge, exactly where the overlay macOS traffic lights float
+   (trafficLightPosition 32,30 in tauri.conf.json → the three buttons span
+   ≈ x 32..84, vertically inside this 48px row). Reserve left clearance so
+   the first tab never sits beneath them (same structural-constant family as
+   `.pill-bar`'s `100vw - 170px` and `.sidebar-drag`'s 48px in styles.css).
+   Every other chrome mode already clears the lights: the full sidebar and
+   the icon rail sit left of this strip, and pill mode pushes `.main-col`
+   84px down. */
+:host-context(app-shell.drilldown) .tab-strip {
+  padding-left: 96px;
+}
+
 .tab-item {
   display: flex;
   align-items: center;

--- a/src/app/features/notes/link-picker/link-picker.component.html
+++ b/src/app/features/notes/link-picker/link-picker.component.html
@@ -2,12 +2,15 @@
      Positioned in JS (afterNextRender) at the caret's anchor rect. Re-positions
      on any scroll/resize via the shared directive (DestroyRef-cleaned listeners).
      PRESENTATIONAL: the caret stays in the editor textarea (Obsidian parity) —
-     this renders the live candidate list only; the host owns query + keyboard nav. -->
+     this renders the live candidate list only; the host owns query + keyboard nav.
+     Its own (scroll) is the infinite-scroll probe: nearing the bottom appends
+     the next backend page (see loadMore). -->
 <div
   #popover
   class="link-pop"
   appRepositionOnScroll
   (reposition)="reposition()"
+  (scroll)="onScroll()"
   (mousedown)="$event.preventDefault()"
   role="listbox"
   aria-label="Link to note"

--- a/src/app/features/notes/link-picker/link-picker.component.scss
+++ b/src/app/features/notes/link-picker/link-picker.component.scss
@@ -14,7 +14,9 @@
   left: 0;
   width: 280px;
   max-width: calc(100vw - 2 * var(--space-3));
-  max-height: 240px;
+  /* Tall enough for ~9 rows — the list is an infinite scroll over the whole
+     visible vault now, so give browsing more viewport than the old top-8. */
+  max-height: 320px;
   overflow-y: auto;
   pointer-events: auto;
   display: flex;

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -22,6 +22,16 @@ import { RepositionOnScrollDirective } from "../note-brain-popover/reposition-on
 const QUERY_DEBOUNCE_MS = 150;
 /** The debounce-service key — only one picker is ever open at a time. */
 const DEBOUNCE_KEY = "link-picker-query";
+/**
+ * One backend page of the infinite scroll. A page that comes back exactly this
+ * size means more may exist; a shorter page means the list ran dry. The backend
+ * clamps whatever it is asked for to its own ceiling (100).
+ */
+const PAGE_SIZE = 40;
+/** Load the next page once the scroll position is within this many px of the bottom. */
+const SCROLL_LOAD_THRESHOLD_PX = 56;
+/** Keyboard ↑/↓: pull the next page once the active row is within this many rows of the end. */
+const KEYBOARD_LOAD_AHEAD_ROWS = 3;
 
 /**
  * The inline `[[` / slash-menu "Link to note" autocomplete (note-editor Fix 2) —
@@ -43,6 +53,13 @@ const DEBOUNCE_KEY = "link-picker-query";
  * `query()`, dropping a late reply for a superseded query). The resolved
  * `candidates()` is re-exposed via `candidatesChange` so the host's keyboard
  * handler can navigate/pick without duplicating the fetch.
+ *
+ * INFINITE SCROLL (2026-07-17): the backend paginates (`offset`/`limit`), so the
+ * popover walks the WHOLE visible vault instead of a fixed top-8 — the query
+ * fetch loads page 0 and each scroll-near-bottom (or ↑/↓ reaching the tail of
+ * what's loaded) appends the next page, deduped by `kind+id` (the `@for` track
+ * key must stay unique even if a row shifts pages mid-scroll). A query change
+ * resets the accumulation via the same `requestSeq` stale-guard.
  *
  * OPAQUE overlay (T3): `--surface-overlay`, `--border-strong`, `--shadow-lg`,
  * `backdrop-filter:none` — never the frosted `.card`, since this floats over the
@@ -90,6 +107,14 @@ export class LinkPickerComponent {
 
   /** Monotonic request token — a late reply for a superseded query is dropped (T1 stale-guard). */
   private requestSeq = 0;
+  /**
+   * True when the last page came back full, so another page may exist. Plain
+   * private fields (same precedent as {@link requestSeq}) — neither is read by
+   * the template; they only guard the fetch orchestration.
+   */
+  private hasMore = false;
+  /** Re-entrancy guard: one append fetch at a time. */
+  private loadingMore = false;
 
   constructor() {
     // Fetch on every query change (debounced) — a legitimate signal-writing effect
@@ -107,6 +132,26 @@ export class LinkPickerComponent {
       this.anchorRect(); // track
       this.reposition();
     });
+    // Keyboard nav over a paginated list: keep the active row scrolled into
+    // view (the host moves `activeIndex` without focus ever entering the
+    // popover), and pull the next page once ↑/↓ nears the tail of what's
+    // loaded. `afterNextRender` so the `.is-active` class from THIS change-
+    // detection pass is painted before we scroll to it.
+    effect(() => {
+      const idx = this.activeIndex();
+      const total = this.candidates().length;
+      if (total > 0 && idx >= total - KEYBOARD_LOAD_AHEAD_ROWS) {
+        void this.loadMore();
+      }
+      afterNextRender(
+        () => {
+          this.popoverEl()
+            ?.nativeElement.querySelector(".link-pop-row.is-active")
+            ?.scrollIntoView({ block: "nearest" });
+        },
+        { injector: this.injector },
+      );
+    });
     this.destroyRef.onDestroy(() => this.debounce.cancel(DEBOUNCE_KEY));
   }
 
@@ -114,14 +159,19 @@ export class LinkPickerComponent {
     const seq = ++this.requestSeq;
     this._loading.set(true);
     try {
-      const rows = await this.ipc.listLinkCandidates(q);
+      const rows = await this.ipc.listLinkCandidates(q, 0, PAGE_SIZE);
       if (seq !== this.requestSeq) {
         return; // superseded by a newer query.
       }
+      this.hasMore = rows.length === PAGE_SIZE;
       this.candidates.set(rows);
       this.candidatesChange.emit(rows);
+      // The list height changed (fresh page) — re-fit around the caret so a
+      // flipped-above popover never grows down over the line being typed.
+      this.reposition();
     } catch {
       if (seq === this.requestSeq) {
+        this.hasMore = false;
         this.candidates.set([]);
         this.candidatesChange.emit([]);
       }
@@ -129,6 +179,62 @@ export class LinkPickerComponent {
       if (seq === this.requestSeq) {
         this._loading.set(false);
       }
+    }
+  }
+
+  /**
+   * Append the next backend page (scroll neared the bottom, or ↑/↓ neared the
+   * tail of the loaded rows). Guarded by the SAME `requestSeq` as {@link fetch}:
+   * a query change mid-flight bumps it and the stale append is dropped whole.
+   */
+  private async loadMore(): Promise<void> {
+    if (!this.hasMore || this.loadingMore || this._loading()) {
+      return;
+    }
+    const seq = this.requestSeq;
+    this.loadingMore = true;
+    try {
+      const page = await this.ipc.listLinkCandidates(
+        this.query(),
+        this.candidates().length,
+        PAGE_SIZE,
+      );
+      if (seq !== this.requestSeq) {
+        return; // a newer query reset the list while this page was in flight.
+      }
+      this.hasMore = page.length === PAGE_SIZE;
+      // Dedupe on append: a row that shifted pages mid-scroll (e.g. a title
+      // edit reordered recency) must not repeat — the template's
+      // `track c.kind + c.id` requires unique keys.
+      const seen = new Set(this.candidates().map((c) => c.kind + c.id));
+      const fresh = page.filter((c) => !seen.has(c.kind + c.id));
+      if (fresh.length > 0) {
+        const next = [...this.candidates(), ...fresh];
+        this.candidates.set(next);
+        this.candidatesChange.emit(next);
+        this.reposition();
+      }
+    } catch {
+      if (seq === this.requestSeq) {
+        // Keep what's loaded; stop probing so a failing backend isn't hammered
+        // on every scroll tick. The next query change resets the flow.
+        this.hasMore = false;
+      }
+    } finally {
+      this.loadingMore = false;
+    }
+  }
+
+  /** Infinite scroll: fetch the next page when nearing the bottom of the popover. */
+  onScroll(): void {
+    const el = this.popoverEl()?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const nearBottom =
+      el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_LOAD_THRESHOLD_PX;
+    if (nearBottom) {
+      void this.loadMore();
     }
   }
 


### PR DESCRIPTION
Two user-reported UI bugs, root-caused and fixed:

## 1. `[[` link picker showed only a few candidates → real pagination + infinite scroll

**Root cause:** `list_link_candidates` had a hard `MAX_LINK_CANDIDATES = 8` cap and no pagination — the picker could never show more than 8 rows no matter how many linkable notes/meetings exist.

**Fix (mechanism replaced, not patched):**
- `Db::list_link_candidates_visible(prefix, limit, offset, unlocked)` now paginates ONE stable combined ordering — [visible notes, newest-updated first] ++ [visible meetings, newest-started first] — and returns `(page, local_total)`. The COUNT twins share the page queries' exact WHERE bodies (including `visibility_clause` on both legs), so sealed-not-unlocked rows neither appear nor inflate the totals (`hidden_total == 0` pinned in the sealed-sources test).
- `commands::list_link_candidates` takes `offset`/`limit` (clamped 1..=100, default 40) and folds the org (Shared Brain) leg in after the local rows, offset by `local_total` — same membership + `context_enabled` gates as before, org still skipped on an empty prefix.
- `LinkPickerComponent` accumulates pages: scroll-near-bottom or keyboard ↑/↓ nearing the tail appends the next page, deduped by `kind+id` (the `@for` track key), under the SAME `requestSeq` stale-guard as the query fetch (a mid-flight query change drops the stale append whole). The active row now scrolls into view during keyboard nav; the popover grew 240→320px and re-fits around the caret when the list height changes.

## 2. Tab strip sat under the macOS traffic lights on drill-down routes

**Root cause:** on `/settings` (and `/org-item`) the app-shell chrome unmounts, `.main-col` spans from the window's LEFT edge, and the first tab of `mur-tab-strip` landed exactly under the overlay traffic lights (`trafficLightPosition` 32,30 → buttons span ≈ x 32..84 inside the 48px strip row).

**Fix:** `AppShellComponent` exposes a `drilldown` host class (= `inDrilldown()`); `tab-strip.component.scss` reserves `padding-left: 96px` via `:host-context(app-shell.drilldown)`. Every other chrome mode already clears the lights (sidebar/rail sit left of the strip; pill mode pushes `.main-col` 84px down) and keeps its exact old layout — pinned in the new e2e spec.

## Verification

- `cargo test --lib`: **1763 passed / 0 failed** — including a new pagination test walking the notes→meetings seam page-by-page (dup-free, runs dry with an empty page) and the extended sealed-sources test asserting the pagination total leaks nothing.
- New Playwright spec `link-picker` **infinite scroll**: mock serves 100 candidates in 40-row pages from the REAL `offset`/`limit` args; scrolling the popover bottom loads 40 → 80 → 100 with zero console errors. All existing picker specs still green.
- New Playwright spec `tab-strip-drilldown-clearance`: padding-left 24px in sidebar mode → 96px on `/settings` → back to 24px on leaving the drill-down.
- `npx ng lint` + `npx ng build` green; full `scripts/ci.sh` green (see PR checks section below).
- Independent adversarial-verifier PASS + lock-security-reviewer PASS (visibility-gated read path audit).
