### PR TITLE
feat(record): document-first recording note + Ask Brain tab

### DIFF
--- a/docs/superpowers/specs/2026-07-16-recording-companion-note-design.md
+++ b/docs/superpowers/specs/2026-07-16-recording-companion-note-design.md
@@ -154,3 +154,54 @@ does not apply, but the append command must not blank prior content on failure.
 - Backfilling companion notes for pre-existing meetings' `manual_notes` (new behavior applies going
   forward).
 - Streaming `@brain` answers (separate Phase-9 work).
+
+---
+
+# v2 redesign — document-first + separate Ask Brain tab (2026-07-17)
+
+**Why:** live test of v1 failed the *product* bar (v1 was code-green + dual-verified, but wrong UX). The
+thread-of-badges read as chat with stickers, not note-writing; a "second note" was confusing because the
+one-growing-document was invisible; and users want an in-note brain (like create-note) plus a separate
+place to ask about the meeting. User decisions: **document-first**, **tabs** (Note | Ask Brain), **reuse the
+real create-note editor**.
+
+## New model
+The recording panel (`MeetingConversationComponent`) becomes a **two-tab surface**:
+
+- **Tab "Note" (default, primary):** the companion note rendered as ONE editable document — the real
+  create-note editing experience: `/` blocks, `[[` links, formatting toolbar on selection, and the
+  **in-note Ask Brain** (selection → Ask Brain → `NoteBrainPopover` rewrites/answers INTO the note),
+  autosave, auto `[[Meeting]]` link. Title/properties/share/backlinks chrome hidden. It is ONE growing
+  document — no per-jot "Saved" badges.
+- **Tab "Ask Brain":** the conversational thread — ask about the meeting & related things, answers with
+  sources + follow-ups (the existing `@brain` thread logic). An answer's "Add to note" appends into the
+  companion note.
+
+## Reuse (root-cause, "tak jak w create note")
+- **Embed `NoteEditorComponent` in an additive `embedded` mode.** New inputs `embedded = input(false)` and
+  `noteIdInput = input<string|null>(null)`; when embedded, load the note from `noteIdInput` instead of the
+  route, and wrap the header/title/properties/share/backlinks chrome in `@if (!embedded())`. Body +
+  selection-toolbar + brain-popover + link-picker + autosave stay. The routed `/notes/:id` usage must be
+  byte-for-byte unchanged (regression-gated).
+- **Retire `mur-markdown-composer`** (the v1 send-and-clear input was the wrong primitive for a document) —
+  remove the component + its wiring. The Ask Brain question input is a plain single-line input.
+
+## Backend
+- New command `get_or_create_companion_note(meeting_id) -> { noteId, meetingWikilink }` (eager create so the
+  Note tab has a document to mount on). Reuse v1's lazy get-or-create + gate + `[[Meeting]]` front-matter.
+- Keep `append_to_companion_note` (used by the Ask Brain "Add to note").
+- **Single source of truth for the user's in-meeting notes:** `summarize`/pipeline reads the companion note
+  body (front-matter stripped) as `user_notes` (the `pipeline.rs` `get_manual_notes` read site), falling back
+  to `manual_notes` when no companion note exists (legacy). This keeps "enhance"/`## My notes` fold working
+  without a mirror. (Optional: reroute the agent `save_note` tool to append to the companion note so an
+  autonomous save isn't lost — do it if low-risk, else note it.)
+
+## Persistence
+The Note tab autosaves the companion note through the normal note editor path (`save_note_text` /
+`update_note_doc`). No `manual_notes` mirror. "Add to note" (Ask Brain) → `append_to_companion_note`; the Note
+tab reloads its body on tab-activation so appended content shows.
+
+## Verify (unchanged discipline)
+Adversarial-verifier + lock-security-reviewer (pipeline + optional agent-tool touch the summary/lock path);
+**regression-gate the routed `/notes/:id` Notes editor** (embedded mode must not change it); `scripts/ci.sh`.
+Spec-review MUST confirm the built surface matches: tabs, document-first, in-note brain, separate Ask Brain.


### PR DESCRIPTION
## Why (live-test feedback on v1 / #358)

The v1 companion-note surface was code-green + dual-verified but failed the **product** bar when tested live: sent notes rendered as separate **"Saved to Notes" badge lines** — reading as a chat of stickers, not note-writing — and the "one growing note" was invisible (a second note "did nothing"). Users want a **bigger single-note document** with an **in-note brain** (like create-note), plus a **separate place to ask about the meeting**.

## What

The recording panel is rebuilt as a **document-first two-tab surface**:

- **Tab "Note" (default):** the companion note edited via the **real create-note editor**, embedded. New *additive* `NoteEditorComponent` inputs `embedded` + `noteIdInput` hide the title/properties/share/backlinks chrome and keep the body editor (`/` blocks, `[[` links), the **in-note Ask Brain** (select text → Ask Brain), and autosave. One growing document — **no per-jot badges**.
- **Tab "Ask Brain":** the `@brain` conversation about the meeting (sources, follow-ups); an answer's **"Add to note"** appends into the companion note.
- **Backend:** `get_or_create_companion_note` (eager, no body) + a stop-time `delete_companion_note_if_empty` cleanup; the summary pipeline now reads the **companion note body** (front-matter stripped) as the user's notes, falling back to `manual_notes` for legacy — a **single source of truth** for "enhance"/`## My notes`.
- **Retire** the v1 `mur-markdown-composer` (the send-and-clear input was the wrong primitive for a document).

## The content-loss bug both verifiers caught (and the fix)

The first cut **FAILed** adversarial + lock-security review: `stop_recording` ran `delete_companion_note_if_empty` before the Note editor's **600ms-debounced** autosave landed, so typing then clicking **Stop within ~600ms** deleted the just-typed prose (lost from note, vault, AND summary). **Fix:** `RecorderStore.stop()` now `await`s a `RecordingFlushService` flush of the (now always-mounted) companion editor **before** `ipc.stopRecording()` — the DB reflects the user's text before delete-if-empty evaluates emptiness. **Regression-tested RED→GREEN** (`e2e/record/companion-note-flush-before-stop.spec.ts`).

## How verified

- `cargo test --lib` 1765/0 (3 new v2 tests incl. RED→GREEN) · `npx ng lint` · `npx ng build` · Playwright `e2e/record/` + `e2e/notes/` **38/38** (incl. the routed `/notes/:id` regression — the embedded change is additive) · `scripts/ci.sh` ✅ all gates green (clippy `-D warnings`).
- **adversarial-verifier: PASS** — the Stop race is closed RED→GREEN; document-first/no-badges/tabs/in-note-brain confirmed; content-loss #1 (tab re-mount) defended.
- **lock-security-reviewer:** the delete-if-empty predicate is conservative (front-matter-only ⇒ empty; any prose ⇒ kept); both new commands `meeting_is_unlocked`-gated; pipeline read scoped + producer-side; its one FAIL (the Stop race) is closed by the FE flush, backend unchanged.

## Residual / follow-ups

- **Floating-bar cross-window Stop** (separate WKWebView window, own `RecorderStore`, no hosted editor) does not flush the main-window editor — a **low-severity** documented follow-up (mitigated by the editor's own debounce + blur-save). Closing it needs a cross-window signal.
- Real recording→note→vault→summary + Touch ID / lock-at-rest are signed-build-only.

Supersedes the v1 UX shipped in #358. Spec: `docs/superpowers/specs/2026-07-16-recording-companion-note-design.md` (§ "v2 redesign").