### PR TITLE
fix(brain): close staleness + seal-vs-index gaps in the retrieval index

### DIFF
--- a/docs/research/2026-07-17-brain-v3-maximization.md
+++ b/docs/research/2026-07-17-brain-v3-maximization.md
@@ -1,0 +1,140 @@
+<!-- Generated 2026-07-17 via /research (5 code audits + 5 murmur-researcher fan-out, wf_7167f584-80f). Pricing/version claims = point-in-time. -->
+# Research: Brain v3 — beat Obsidian's graph + ClickUp Brain (huge-doc ingest, link engine, full-brain graph, killer features)
+
+## TL;DR / Verdict
+
+The brain's substrate is already excellent — hybrid FTS5+vec0+entity-graph fusion, bitemporal facts,
+consolidation, lock-safe doc chunk/vector/FTS tables — but it is **format-crippled** (`.md`/`.txt` only),
+**edge-less** (the ONLY persisted relation is `entity_mentions`; wikilinks/co-occurrence/related are
+recomputed per read), **staleness-prone** (meeting-note edits never re-index vectors), and its graph UI
+renders **one node type and one edge type**. No competitor holds "local-first + meetings + docs + typed
+knowledge graph + E2EE sharing" together; NotebookLM caps sources at 500k words and has no meetings/local
+mode, ClickUp Brain is cloud-only per-seat ($9–28/u/mo), Obsidian's graph is a link-topology toy without
+semantics. The gap to "credibly the best AI brain" is narrow and concrete — five build tracks below.
+
+**Positioning one-liner:** *"The only second brain that hears your meetings, reads your documents, and
+draws the connections — entirely on your Mac, in files you own."*
+
+## Co już mamy (verified in code)
+
+- **Doc pipeline, generic but gated to md/txt:** `commands.rs: import_document_inner` (ext allowlist
+  `DOC_ALLOWED_EXTS=["md","txt"]`), single gated seam `ingest_into_folder`, `doc_chunks` +
+  `doc_vec_chunks` (vec0 384) + `fts_doc_chunks` with purge-on-seal / re-embed-on-unlock — **the storage
+  layer already generalizes; only `extract(path)→text` is missing.** Sync command, whole-file
+  `read_to_string`, one-batch `embed_passage` (memory ∝ doc size), no progress events.
+- **Retrieval:** `search_hybrid_visible` (FTS+KNN+graph, `score_fuse` 0.4/0.4/0.2), doc leg via
+  `fuse_doc_hits` (RRF). Agentic Ask: 6 steps, `RESULT_BUDGET=4000` chars/tool result, **no paging** on
+  `get_document`/`get_meeting` → a big doc is unreachable past ~1 page; floor path shows ONE 800-char
+  chunk per doc. No doc summaries / hierarchy / map-reduce anywhere.
+- **Links:** `extract_wikilink_titles` + `backlinks_for_visible` (O(vault) live scan per open, exact
+  title match), `resolve_wikilink`, `list_link_candidates`, `documents.meeting_id` companion leg,
+  `link_related_notes_inner` (writes `[[Title]]` into markdown, max 4). **No edges table.** Imported
+  docs get no entity extraction, no meeting links, no semantic links.
+- **Graph UI:** entity cards + co-occurrence edges only (`build_graph`, `graph_edges_visible` LIMIT 600,
+  computed per read); brain-map canvas (top-60, one-shot 3-D Fruchterman-Reingold); no graph lib.
+- **Org Shared Brain:** notes-only, 1 MiB/item, opaque blobs (client-side envelope evolution = zero server
+  change), receivers re-chunk+re-embed locally, `clean_note_body` **flattens wikilinks at egress** (edges
+  destroyed), org items outside the entity graph. Push-side poison-retry risk on oversized blobs.
+- **Facts/memory:** bitemporal `reconcile_facts` (invalidate-not-delete), hourly consolidation, rollups
+  purge-on-seal, empty-unlock-set reads. **Nobody in the market has this** — and we don't surface it.
+
+## Audit — real gaps found (fix-worthy, evidence in audit_gaps)
+
+| # | Sev | Gap | Fix | Effort |
+|---|-----|-----|-----|--------|
+| 1 | Staleness | Meeting-note EDIT never re-derives chunks/vectors (`update_note_inner` lacks `index_meeting_chunks`); deleted text keeps surfacing in semantic search + snippets | mirror `update_note_doc_inner`'s re-index idiom | S |
+| 2 | Staleness | No repair tick: model download / flag-flip / model-absent unlock leave vectors missing until manual Reindex | generalize `backfill_topic_chunks_idempotent` startup tick + FE post-download prompt | M |
+| 3 | Quality | Manual Reindex re-embeds authored notes WITH YAML front-matter (`reindex_embeddings_inner` ignores `kind`) | route by kind → `index_note_chunks` | S |
+| 4 | Staleness | Rename/edit never refreshes aug-headers, entities, facts (old title embedded in every chunk) | fold into #1's re-index + rename hook | M |
+| 5 | Quality | Entity dedup = exact `(lower(name),kind)`; no aliases/merge → split nodes | `entity_aliases` + merge command (defer) | M/L |
+| 7 | Low | `tools.rs` SearchSemantic arm misses `embed_model_present()` guard | one line | S |
+
+Clean (verified): deletes purge everything incl. vec0 orphans; FTS triggers fresh; no stub vectors at
+rest; no ungated reads found; consolidation hygiene correct. Measured (do not re-litigate):
+hybrid 0.90 vs semantic 0.95 on the semantic-skewed set is CORRECT hybrid behavior; reranker adds
+nothing (pointwise-LLM exhausts 3 s); the real lever is a cross-encoder, deferred.
+
+## Findings (per angle, cited in the full agent briefs)
+
+1. **Large-doc RAG (SOTA 2025-26):** Anthropic contextual retrieval (−49…67% failure w/ BM25+rerank);
+   RAPTOR's collapsed-tree (embed doc-summaries alongside leaves); LlamaIndex parent-document expansion;
+   LazyGraphRAG's core lesson = **defer LLM work to query time** (never LLM-process a 500-page PDF at
+   ingest); Chroma "context rot" (tight ≤6k-token contexts beat stuffing); Karpathy: "context engineering
+   = filling the window with just the right information." Late chunking needs an 8k-token embedder — not
+   available at 384-dim/512-token e5-small; skip. → **3-level hierarchy on existing `doc_chunks`**
+   (L0 800-char leaves embedded+FTS; L1 section parents ~6k chars FTS-only, fetched by expansion;
+   L2 deterministic outline/summary embedded+FTS), deterministic headers `doc | section_path | p.N`.
+   Math: 500-page PDF ≈ 1600 leaves ≈ 2.5 MB vectors; 20 books ≈ 50 MB — vec0 brute-force still fine.
+2. **Extraction stack (macOS, AGPL-ok, minimal deps):** **PDFKit via `objc2-pdf-kit`** (same objc2 family
+   we ship; per-page text + outline free; wrap in `objc2::exception::catch`, crash-safe-FFI rule) +
+   **pure-Rust OOXML** (DOCX/PPTX = walking `zip`+`quick-xml`, both ALREADY compiled in transitively) +
+   `calamine` (XLSX) + `html2text` (HTML). Rejected: extractous (stale GraalVM blob), mupdf (huge C tree),
+   pdfium (dylib signing burden). Scanned-PDF OCR = Vision `VNRecognizeTextRequest` phase 2.
+   **Dep requests: `objc2-pdf-kit`, `calamine`, `html2text` + promote `zip`/`quick-xml` to direct.**
+3. **Auto-linking:** e5 cosine is compressed (~0.7–1.0, InfoNCE τ=0.01) — naive thresholds link
+   everything; use **mutual-kNN (k=10) + cosine floor 0.80** (cos = 1 − d²/2 on L2-normalized vectors),
+   ≥0.88 bypasses mutuality, cap 5 semantic edges/node, O(k·log n) per insert via vec0 kNN. Persist a
+   **typed `links` table** (wikilink|semantic|entity|temporal|companion; status active|suggested|dismissed).
+   Deterministic types auto-active; **semantic = suggest-then-accept, never silently injected into `.md`**
+   (the Reflect/Mem lesson). Accepted → materialize `[[Title]]` via existing `apply_link_markers`.
+4. **Competitors:** matrix in the brief. Attack lines: ingest a 1000-page PDF locally (NotebookLM can't —
+   500k-word cap, cloud), auto-link it to the meeting where it was discussed (Obsidian can't — no
+   semantics/meetings), share E2EE with zero per-seat AI fee (ClickUp can't). Rewind/Limitless died
+   Dec 2025 → orphaned local-first audience.
+5. **Killer features (ranked by moat):**
+   - **Receipts** — every claim in a note/answer/dossier clickable to the SECOND of audio (extend
+     `grounding.rs` alignment → `(claim → segment_id, start_s, speaker, confidence)`; seek the shipped
+     timeline). Granola *deletes* audio post-transcription; ClickUp keeps it in their cloud. Structural moat.
+   - **Knowledge Diff** — surface the bitemporal facts: as-of queries, per-entity decision ledger
+     (supersession = old fact → new fact → source meeting → receipt), "changed since you last met X" in
+     briefs. Pure interval algebra (`AS OF t` = `valid_from ≤ t AND (valid_to IS NULL OR valid_to > t)`),
+     deterministic; reasoner only narrates. No competitor keeps bitemporal state at all.
+   - Semantic Edge Layer ranks third only because it's already covered by the user's link-engine ask.
+
+## Fit z ograniczeniami Murmur
+
+Everything on-device (extraction, chunking, embedding, linking, diffing); zero new egress. Additive
+migrations only (`links` table, `doc_chunks` level/parent/section/page columns, `entity_aliases`).
+Lock model: edges + hierarchy rows are DERIVED content → purge-on-seal / re-derive-on-unlock exactly like
+`doc_chunks` today; every read gates BOTH endpoints (the `backlinks_for_visible` two-gate template);
+Receipts ride `meeting_is_unlocked` + the masked-DTO audio rule. Org: doc sharing needs zero wire change
+below 1 MiB (v2 envelope already round-trips Document source-kind); edges/large docs → v3 append-only
+envelope later; add a client-side pre-upload size check to kill the poison-retry loop. New crates named
+above require approval — they are the minimal set entailed by the explicitly requested PDF/DOCX feature.
+
+## Plan — 6 PR tracks (dependency-ordered)
+
+1. **PR-1 Brain integrity** (S/M): audit fixes #1 #3 #7 (+#4 rename hook, +#2 repair tick).
+2. **PR-2 Universal ingest** (M/L): `extract/` module (`ExtractedBlock {text, page, heading_path}`),
+   DOCX/PPTX pure-Rust, PDF via PDFKit, XLSX/HTML; async + `perf::run_heavy` + RAM floor + progress
+   events + sub-batched embeds; hierarchical chunks + L2 summaries; `get_document`/`get_meeting` tool
+   paging (offset/section args) so the agent can actually read big docs.
+3. **PR-3 Link engine** (M): `links` table + write-time wikilink indexing (hook: note-save funnels +
+   `build_and_persist_entities`) + mutual-kNN semantic suggester + entity/temporal persist +
+   Connections panel + backlinks reader switched to indexed lookup.
+4. **PR-4 Full-brain graph** (M): typed nodes (meetings/notes/docs/entities) + typed edges from `links`,
+   lenses/filters, on the existing canvas idiom.
+5. **PR-5 Receipts** (S/M): grounding alignments → clickable per-claim citations seeking audio.
+6. **PR-6 Knowledge Diff** (M): `facts_as_of_visible` + pure `diff_snapshots` + entity timeline panel +
+   MCP `knowledge_diff` tool.
+
+Every PR: RED-before-GREEN, adversarial-verifier + lock-security-reviewer (all touch gated reads or
+derived-content storage), `scripts/ci.sh`, QueaT commit, PR to `murmur`.
+
+## Otwarte pytania / nieweryfikowalne headless
+
+- PDFKit RAM/fidelity on a real 500-page PDF + `attributedString` heading heuristics — real-Mac measure.
+- e5-small cosine separation on the real PL/EN vault — the 0.80/0.88 thresholds need the 20-note spike
+  (hand-label precision@5; raise floor if garbage >20%).
+- Claim→segment alignment quality on paraphrased LLM note lines — spike in PR-5.
+- Vision OCR Polish quality; `murmur://` deep-link registration — phase 2 / real Mac.
+
+## Sources
+
+Agent briefs (full citations inside): audit_{ingest,retrieval,linking,org,gaps}, research_{rag,parsing,
+competitors,autolink,killer} — workflow wf_7167f584-80f, 2026-07-17. Key external: anthropic.com/news/
+contextual-retrieval · arxiv 2401.18059 (RAPTOR) · microsoft.com LazyGraphRAG · trychroma.com/research/
+context-rot · x.com/karpathy/status/1937902205765607626 · jina.ai late-chunking · github.com/brianpetro/
+obsidian-smart-connections · support.google.com/gemininotebook (NotebookLM caps) · clickup.com/brain/pricing ·
+granola.ai/security · simonwillison.net lethal-trifecta · docs.rs objc2-pdf-kit/objc2-vision · crates.io
+API (calamine, html2text, pdf-extract, extractous, mupdf, pdfium-render licenses/versions).

--- a/docs/superpowers/specs/2026-07-17-brain-v3-design.md
+++ b/docs/superpowers/specs/2026-07-17-brain-v3-design.md
@@ -1,0 +1,191 @@
+# Brain v3 — design spec (universal ingest · link engine · full-brain graph · Receipts · Knowledge Diff)
+
+Date: 2026-07-17 · Status: approved-by-goal (autonomous program), pre-implementation
+Basis: `docs/research/2026-07-17-brain-v3-maximization.md` (5 code audits + 5 research briefs, wf_7167f584-80f)
+
+Goal (user): the brain must ingest documents of ANY size (PDF/DOCX/…), auto-link notes/meetings/docs
+(manual `[[wikilinks]]` + content similarity), visualize ALL connections, fix storage gaps, and ship 2
+killer features — mathematically grounded, shareable via org, merged to `murmur`.
+
+Six PR tracks, dependency-ordered. Every track: RED-before-GREEN, adversarial-verifier +
+lock-security-reviewer, `cargo test --lib` + `ng lint` + `ng build` per PR, final `scripts/ci.sh`,
+QueaT commits, PR to `murmur` (never direct push).
+
+---
+
+## PR-1 — Brain integrity (backend, S/M) — fixes the audit's real gaps
+
+1. **Meeting-note edit re-index** (`commands.rs: update_note_inner`): after upsert/reseal, best-effort
+   `embed_model_present().then(active_embedder)` → `db.index_meeting_chunks(mid, &segments, emb)`,
+   warn-and-continue posture — the exact idiom of `update_note_doc_inner → index_note_body_chunks`.
+   RED: edit a note, assert semantic snippet no longer serves deleted text / vectors refreshed.
+2. **Reindex kind-routing** (`commands.rs: reindex_embeddings_inner` + the unseal doc re-index sites):
+   `documents.kind='note'` rows go through `index_note_chunks` (front-matter stripped), never raw
+   `index_document_chunks`. RED: reindex leaves an authored note's chunks front-matter-free.
+3. **Stub-query guard** (`tools.rs` SearchSemantic arm): add `embed_model_present()` before
+   `active_embedder().embed_query(...)` (mirror the citations site).
+4. **Rename staleness** (`commands.rs: rename_meeting` / title-set path): trigger the same model-gated
+   `index_meeting_chunks` so aug-headers/FTS/vectors carry the new title.
+5. **Idempotent repair tick** (`lib.rs` setup, generalizing `backfill_topic_chunks_idempotent`):
+   probe visible meetings with note-but-no-chunks / chunks-but-no-vectors and docs via
+   `document_has_chunks`; model+flag+RAM gated; runs `index_*` per item. FE: after successful embed-model
+   download (`settings.store.ts: downloadEmbedModel`), surface a "Reindex now" prompt (or auto-run).
+6. **Org push pre-check** (`commands.rs: publish_org_body`): client-side ciphertext-size check vs
+   `MAX_ORG_ITEM_BLOB_BYTES` → terminal `set_org_share_failed("too_large")`, not an infinite retry.
+
+Lock notes: all re-index paths operate on already-gated plaintext of VISIBLE items only; the repair tick
+reads with gated readers. lock-security-reviewer confirms no sealed text enters an index.
+
+## PR-2 — Universal document ingestion (backend M/L + FE S)
+
+**New module `src-tauri/src/extract/`** — `ExtractedBlock { text: String, page: Option<u32>,
+heading_path: Option<String> }`, `extract_blocks(path, ext) -> Result<Vec<ExtractedBlock>>`:
+- `md`/`txt`: current `read_to_string` (one block).
+- `docx`/`pptx`: pure-Rust walk of the OOXML zip (`zip` + `quick-xml`, both already compiled in
+  transitively — promote to direct deps): `w:p`/`w:t` runs, `w:pStyle` Heading1..9 → `heading_path`,
+  `w:tbl` → pipe-rows; slides: `a:t`, slide N = page, title placeholder = heading. Unit-testable with
+  fixture files in `cargo test --lib`.
+- `pdf`: **PDFKit via `objc2-pdf-kit`** (same objc2 family as shipped deps; zero new binaries):
+  `PDFDocument::initWithURL` → per-page `pageAtIndex(i).string` loop (bounded memory),
+  `outlineRoot` → heading_path, wrapped in `objc2::exception::catch` (enable objc2 `exception`
+  feature) → fail-closed `AppError::InvalidArg`. Crash-safe-FFI rule honored; real-Mac verify for
+  fidelity/RAM. Scanned-PDF OCR (Vision) = explicit phase 2, NOT in this PR.
+- `xlsx`: `calamine` (sheet name = heading, rows → pipe text). `html`: `html2text`.
+- **Dep requests (minimal set entailed by the explicitly requested feature; all MIT-family):**
+  `objc2-pdf-kit`, `calamine`, `html2text`, promote `zip` + `quick-xml`. NO extractous/mupdf/pdfium.
+
+**Async + progress:** `import_document` becomes async; extract+chunk+embed inside `perf::run_heavy`;
+RAM floor `topic_backfill_ram_permits_now()`; typed progress events in `events.rs`
+(stages: extracting/chunking/embedding + counts) consumed by the Brain tab. Embedding sub-batched
+(mirror `index_meeting_chunks`'s batching), chunk inserts committed in batches.
+
+**Hierarchical index (additive cols on `doc_chunks`):** `level INTEGER NOT NULL DEFAULT 0`,
+`parent_id INTEGER`, `section_path TEXT`, `page_no INTEGER` via `add_column_if_missing`.
+- L0 leaf: 800-char paragraph-greedy chunks that NEVER cross heading boundaries; embed-text =
+  `"<doc> | <section_path> | p.<N>"\n<raw>` (extends the shipped deterministic contextual-header
+  mechanism); **embedded + FTS**.
+- L1 section-parent: heading-bounded ≤ ~6000 chars, **FTS + fetch-by-id only, NOT embedded** (vector
+  count stays flat).
+- L2 doc outline: deterministic heading tree + first sentence per section (1–3 chunks),
+  **embedded + FTS** (RAPTOR collapsed-tree effect). No LLM at ingest (LazyGraphRAG lesson).
+- Retrieval: new gated helper `expand_doc_parents_visible` — when ≥2 L0 leaves of one parent hit, or for
+  the top-3 fused doc hits, replace leaves with the L1 parent text; wire into `pack_doc_chunks` +
+  the tools doc leg. Context budget to the reasoner stays tight (context-rot).
+- `index_document_chunks` gains the hierarchy; purge/seal/unseal untouched semantics (rows live in
+  `doc_chunks` → existing purge-on-seal + re-embed-on-unlock cover them; L>0 rows excluded from
+  `doc_vec_chunks` except L2).
+
+**Agent paging:** `get_document` tool gains `offset`/`max_chars` args (default today's behavior);
+`get_meeting` transcript likewise — so the agentic loop can iterate a big doc past `RESULT_BUDGET`.
+MCP mirrors (`tools_spec`/`dispatch_tool`).
+
+**FE:** Brain-tab dialog filter → `["md","txt","pdf","docx","pptx","xlsx","html"]`; progress UI off the
+new events; `friendlyImportError` mapping for unsupported/encrypted/scanned-PDF-no-text.
+
+**Storage decision:** we store EXTRACTED TEXT only (documents.text), never the source binary (no new
+seal path). Original filename kept in `documents.name`.
+
+## PR-3 — Link engine (backend M + FE S/M)
+
+**Additive `links` table** (in `Db::migrate`, `CREATE TABLE IF NOT EXISTS`):
+`links(id INTEGER PK, src_kind TEXT, src_id TEXT, dst_kind TEXT, dst_id TEXT,
+edge_type TEXT /* wikilink|companion|semantic */, score REAL DEFAULT 1.0,
+created_by TEXT /* user|auto|accepted */, status TEXT DEFAULT 'active' /* active|suggested|dismissed */,
+created_at INTEGER, UNIQUE(src_kind,src_id,dst_kind,dst_id,edge_type))` + both-direction indexes.
+Kinds: `meeting|note|document` (entity edges stay live-computed — see PR-4). Undirected semantic edges
+canonicalize `src<dst`; wikilink/companion keep direction. `dismissed` = tombstone (a rejected
+suggestion never reappears).
+
+**Write-time wikilink indexing:** at the note-save funnels (`update_note_doc_inner`,
+`create_note_inner`, meeting-note `update_note_inner`, `build_and_persist_entities` post-pipeline) run
+`extract_wikilink_titles` → `resolve_wikilink` → upsert `edge_type='wikilink'` rows storing TARGET IDS
+(rename-proof; the audit's title-string fragility fixed at the root). Remove stale wikilink rows for the
+source on each pass (delete-then-insert in one tx). Companion notes backfill `documents.meeting_id` →
+`edge_type='companion'` rows (one-time additive backfill in migrate, idempotent).
+
+**Semantic auto-linker (the math):** after a successful `index_document_chunks` /
+`index_meeting_chunks` / `index_note_body_chunks` with the real embedder:
+1. item centroid = L2-normalized mean of its chunk vectors (idiom: `related_meetings_visible`);
+2. vec0 kNN `MATCH centroid AND k=10` over `vec_chunks` ∪ `doc_vec_chunks`, roll chunk→item keeping
+   BEST distance; drop self;
+3. cos = 1 − d²/2 (unit vectors, L2 metric);
+4. keep candidate iff (mutual: this item ∈ candidate's top-10) OR cos ≥ 0.88; floor cos ≥ 0.80;
+5. cap 5 semantic edges/node; upsert `status='suggested'`, `score=cos`, `created_by='auto'`.
+Named consts `SEMANTIC_LINK_FLOOR=0.80`, `SEMANTIC_LINK_STRONG=0.88`, `SEMANTIC_LINK_K=10`,
+`SEMANTIC_LINK_CAP=5`. O(k·log n) per insert — no corpus scans. e5 cosine is compressed (~0.7–1.0), so
+mutual-kNN is load-bearing against hubness; thresholds are start values, calibrated by a dev-vault spike
+(hand-label precision@5; if garbage >20% raise floor).
+
+**Policy:** wikilink/companion → `active` immediately (deterministic). Semantic → **suggest-then-accept**;
+Accept flips `created_by='accepted'`, `status='active'` AND materializes `[[Title]]` in the source
+markdown via the existing `apply_link_markers`; Dismiss tombstones. **Never silently inject semantic
+links into `.md`.**
+
+**Lock discipline (binding):** links rows are DERIVED relations; purge rows touching a sealed folder's
+items inside every seal tx (new `purge_links_tx` next to `purge_doc_chunks_tx` /
+`purge_memory_rollups_tx`); re-derive on unlock (re-run wikilink pass + semantic pass for unsealed
+items). Every read gates BOTH endpoints via `visibility_clause` (the `backlinks_for_visible` two-gate
+template). RED tests: sealed endpoint hides the edge both directions; unlock restores; round-trip.
+
+**Commands:** `list_links(kind,id)` (gated both endpoints), `accept_link(id)`, `dismiss_link(id)`;
+register in `lib.rs`. `backlinks_for_visible` gains an indexed fast path over `links`
+(keeps the live-scan as fallback for legacy bodies until first save re-indexes).
+
+**FE:** `app-connections` panel (detail Note tab + note-editor, next to backlinks): grouped by edge
+type, semantic rows show 3-tier confidence chip (≥0.88 / ≥0.84 / ≥0.80) + Accept/Dismiss. Opaque
+overlays, tokens only, signals-first.
+
+## PR-4 — Full-brain graph (backend S + FE M)
+
+**Backend:** `get_full_graph` → `Db::build_full_graph(&unlocked, opts)`:
+- nodes: entities (as today) + VISIBLE meetings, notes, documents (id, kind, title, date, degree);
+- edges: entity↔entity co-occurrence (live, as today) + entity→meeting mentions +
+  `links` rows (active; suggested behind a flag);
+- caps with honest disclosure (mirror today's 500-cap + `hasHidden`); every leg visibility-gated.
+**FE:** extend the brain-map canvas + graph feature: per-kind node colors (tokens), lenses = node-type
+and edge-type toggles, click-through (meeting → detail, note/doc → editor/preview, entity → entity
+detail), suggested edges rendered dashed when the toggle is on. Reuse the deterministic
+Fruchterman-Reingold idiom; no graph lib (no new npm deps).
+
+## PR-5 — Killer feature 1: Receipts (claim → second of audio) (backend S/M + FE S/M)
+
+Extend `summarize/grounding.rs`'s deterministic token-overlap alignment to EMIT
+`ClaimAlignment { claim_idx, segment_id, start_s, end_s, speaker, confidence, overlap_score }` per
+note line/bullet (best-matching segment; threshold on overlap; no LLM). New gated command
+`get_note_receipts(meeting_id)` → alignments for the CURRENT note, `meeting_is_unlocked`-gated,
+recomputed on demand (no new storage → no new seal path). FE: in the meeting Note panel, an unobtrusive
+per-claim chip (»receipt«) that seeks the shipped timeline/audio player to `start_s` and flashes the
+matching transcript segment; speaker (Me/Others) + ASR confidence in the tooltip. Locked meeting →
+no receipts (the masked DTO already nulls audio). Obsidian export unchanged in v1 (deep-link scheme =
+fast-follow). Moat: Granola deletes audio post-transcription; ClickUp keeps it cloud-side — nobody can
+answer "prove it" locally.
+
+## PR-6 — Killer feature 2: Knowledge Diff (backend M + FE S/M)
+
+Pure functions in `facts.rs`: `snapshot_as_of(facts, t)` (open at t: `valid_from ≤ t AND (valid_to IS
+NULL OR valid_to > t)`) and `diff_snapshots(a, b) -> {added, removed, changed}` keyed
+`(norm(subject), norm(predicate))` — deterministic set algebra, unit-tested headless. Gated command
+`get_entity_knowledge_diff(entity_id, from, to)` reading via the visible-facts reader (facts anchored
+to `meeting_id` keep the gate); returns the ledger: each change carries old/new object, valid_from,
+source meeting id. FE: entity-detail "Zmiany / Decision ledger" section — chronological supersessions
+(old → new, source-meeting chip; receipt chip when PR-5 present). MCP tool `knowledge_diff` mirrored in
+`tools_spec`/`dispatch_tool`. "Changed since you last met" brief injection = fast-follow after the
+ledger proves itself. Moat: nobody else keeps bitemporal state; ClickUp/Notion answer only current
+state.
+
+---
+
+## Explicit non-goals (v1)
+Vision OCR for scanned PDFs; org sharing of large docs (v3 envelope) beyond the pre-upload size check;
+cross-encoder reranker; entity alias/merge (audit #5); temporal edge type; `murmur://` deep-link scheme;
+storing source binaries.
+
+## Verification matrix
+| PR | adversarial-verifier | lock-security-reviewer | real-Mac note |
+|----|----|----|----|
+| 1 | yes | yes (index paths touch gated plaintext) | — |
+| 2 | yes (async/RAM/progress) | yes (new content at rest via extraction) | PDF fidelity/RAM on 500-page PDF |
+| 3 | yes (RED both-endpoint gates) | yes (derived-relation purge/gate) | threshold spike on dev vault |
+| 4 | yes | yes (new aggregate read) | — |
+| 5 | yes | yes (audio-adjacent read) | seek UX on dev app |
+| 6 | yes | yes (facts read) | — |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1574,7 +1574,22 @@ pub async fn update_note(
     meeting_id: String,
     markdown: String,
 ) -> Result<NoteDto, AppError> {
-    let dto = update_note_inner(state.inner(), &meeting_id, &markdown)?;
+    // PERF (PR-1 finding 2): `update_note_inner` does the durable seal-on-write upsert + vault
+    // re-write AND (Brain v3 gap #1) re-derives the meeting's chunks/vectors via Candle/Metal — a
+    // multi-second stall on a long meeting / cold e5 if run INLINE on this async command's Tokio
+    // worker. Route the whole synchronous body through the shared heavy-inference gate on the
+    // blocking pool (the `unlock_folder` / `reindex_embeddings` precedent). Re-fetch `AppState`
+    // inside the closure via `app.state()` — a bare `&AppState` cannot be captured by a `'static`
+    // closure. Behavior is identical; it just no longer blocks the runtime thread.
+    let heavy_inference = state.heavy_inference.clone();
+    let app_for_edit = app.clone();
+    let meeting_for_edit = meeting_id.clone();
+    let markdown_for_edit = markdown.clone();
+    let dto = crate::perf::run_heavy(&heavy_inference, move || -> Result<NoteDto, AppError> {
+        let state = app_for_edit.state::<AppState>();
+        update_note_inner(&state, &meeting_for_edit, &markdown_for_edit)
+    })
+    .await?;
     // If the edit re-published ≥1 org copy, ping open org views (Notes list + Settings) so the fresh
     // title/body shows without a manual "Sync now". Best-effort — a republish failure never fails the save.
     if republish_org_shares_for_source(state.inner(), Some(&meeting_id), None)
@@ -1672,13 +1687,80 @@ pub(crate) fn refresh_meeting_note_exported_hash(
 // fresh from the exact content it wrote (and `write_note` never clobbers different bytes, so an
 // externally-edited exported file is preserved untouched rather than baseline-juggled).
 
+/// Brain v3 (audit gap #1/#4) — BEST-EFFORT re-index of ONE meeting's note/transcript/topic chunks
+/// after a content-affecting edit (note edit via [`update_note_inner`], rename via
+/// [`rename_meeting`]). Without this, deleted note text / the old title kept surfacing in semantic
+/// search + snippets (chunks are only re-derived by the pipeline, the manual Reindex, and unlock).
+///
+/// MODEL POLICY — the `embedder` is resolved by the CALLER (`embed_model_present().then(active_embedder)`)
+/// and injected, exactly like [`reindex_meetings_after_unseal`]: `None` (model absent) writes NOTHING
+/// (`index_meeting_chunks` has no chunk-only mode → any write would be a forbidden stub vector), and
+/// injection keeps the model-present branch deterministically testable with the stub.
+///
+/// SEAL GATE (load-bearing): the re-index runs under the EMPTY unlock set, so
+/// `index_meeting_if_enabled`'s visibility check admits ONLY a meeting whose folder is OPEN — a
+/// SEALED folder's plaintext (even while session-unlocked) is never re-chunked by an edit. The
+/// unlock/relock lifecycle owns those rows (`reindex_meetings_after_unseal` rebuilds on unlock;
+/// `purge_chunks_tx` re-purges on relock), so the sealed-at-rest state never gains an index row here.
+///
+/// FLAG CONSISTENCY (Brain v3 audit gap, PR-1): the re-index respects `semantic_search_enabled`,
+/// exactly like the pipeline's `should_auto_index` and the startup repair tick. When semantic is OFF
+/// the `note_chunks`/`vec_chunks` are not retrieval-active (the semantic search paths short-circuit
+/// on the flag), and raw FTS over the note/transcript stays fresh via its own triggers on the
+/// plaintext write — so skipping the chunk re-index here is correct AND consistent (an edit/rename
+/// must not be the ONE meeting-index path that ignores the flag).
+///
+/// BEST-EFFORT: a failure WARNs (ids only, no PII) and NEVER fails the save/rename — the plaintext
+/// write already succeeded.
+pub(crate) fn reindex_meeting_after_edit(
+    state: &AppState,
+    meeting_id: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
+) {
+    let Some(embedder) = embedder else {
+        return; // model absent → never a stub vector (mirrors the pipeline/reindex/unseal policy).
+    };
+    // Respect the master flag — an OFF flag means the vector chunks are not retrieval-active, so a
+    // re-embed would be wasted work AND inconsistent with every other auto-index path.
+    let enabled = state
+        .config
+        .lock()
+        .map(|c| c.semantic_search_enabled)
+        .unwrap_or(false);
+    let empty = std::collections::HashSet::new();
+    if let Err(e) =
+        crate::pipeline::index_meeting_if_enabled(&state.db, meeting_id, enabled, &empty, embedder)
+    {
+        tracing::warn!(
+            target: "rag",
+            error = %e,
+            "meeting re-index after edit failed (content saved unaffected)"
+        );
+    }
+}
+
 /// Inner of [`update_note`] taking `&AppState` — the FULL command body (gate + lifecycle guard +
 /// seal-on-write upsert + vault re-write), so the seal-on-write regression binds the COMMAND
-/// surface, not just the `upsert_note_reseal_if_locked` helper (residual W6).
+/// surface, not just the `upsert_note_reseal_if_locked` helper (residual W6). Resolves the
+/// model-gated embedder and delegates to [`update_note_inner_with`] (embedder injected for
+/// deterministic tests — the `reindex_meetings_after_unseal` precedent).
 pub(crate) fn update_note_inner(
     state: &AppState,
     meeting_id: &str,
     markdown: &str,
+) -> Result<NoteDto, AppError> {
+    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    update_note_inner_with(state, meeting_id, markdown, embedder.as_deref())
+}
+
+/// Core of [`update_note_inner`] with the re-index embedder INJECTED (`None` = model absent →
+/// no re-index; `Some` = re-derive the meeting's chunks/vectors after the save so deleted text
+/// stops surfacing in semantic search — Brain v3 audit gap #1).
+pub(crate) fn update_note_inner_with(
+    state: &AppState,
+    meeting_id: &str,
+    markdown: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
 ) -> Result<NoteDto, AppError> {
     // BLK-1 / TOCTOU (2026-07-10 audit F4): hold the lifecycle guard across gate+write so a
     // concurrent relock/seal cannot land between the unlock check and the upsert.
@@ -1717,6 +1799,11 @@ pub(crate) fn update_note_inner(
     if let Some(path) = existing.exported_path.as_deref() {
         overwrite_exported_note_guarded(state, meeting_id, &existing.provider_id, path, markdown)?;
     }
+
+    // Brain v3 (audit gap #1): re-derive the meeting's chunks/vectors from the FRESH markdown so
+    // deleted text stops surfacing in semantic search/snippets. Best-effort + empty-unlock-set
+    // sealed-folder gate inside; never fails the save (the plaintext is already durable).
+    reindex_meeting_after_edit(state, meeting_id, embedder);
 
     Ok(NoteDto {
         meeting_id: meeting_id.to_string(),
@@ -2717,8 +2804,14 @@ fn ingest_into_folder(
     // REAL e5 model is present (never write stub vectors). Best-effort: a failure logs (no PII) and
     // does NOT fail the ingest (the row + plaintext are durable; a later unlock re-chunk / reindex
     // recovers the index).
+    //
+    // KIND-ROUTED (PR-1 finding 4): a pasted note (`kind='note'`) can carry YAML front-matter in its
+    // raw `text`, which must NEVER be embedded/indexed (DESIGN §1a — tags/properties pollute the
+    // vectors + snippets). Route through the ONE front-matter-stripping seam so the ingest matches
+    // every other note-index path; an uploaded document (`kind='document'`) has no front-matter and
+    // takes the raw path unchanged inside the router.
     let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
-    if let Err(e) = state.db.index_document_chunks(&id, embedder.as_deref()) {
+    if let Err(e) = index_document_row_kind_routed(&state.db, &id, embedder.as_deref()) {
         tracing::warn!(target: "rag", error = %e, "ingest: chunk/embed failed (content stored)");
     }
 
@@ -5113,20 +5206,51 @@ fn remove_meeting_audio_files(audio_path: Option<&str>) {
 }
 
 /// Rename a meeting's title (in-app + Library list). Does not rename the vault file.
+///
+/// PERF (PR-1 finding 2): after Brain v3 gap #4 the rename re-derives every chunk header/vector
+/// (the title is baked into `chunk_note`/`augment_chunk_text`) — Candle/Metal work that stalls a
+/// SYNC command's IPC thread for seconds on a long meeting / cold e5. Now `async` + routed through
+/// the shared heavy-inference gate on the blocking pool (the `update_note` / `unlock_folder`
+/// precedent). `AppHandle` is injected by Tauri (the FE `invoke('rename_meeting', {...})` is
+/// unchanged); it gives the `run_heavy` closure a `'static` `AppState` via `app.state()`.
 #[tauri::command]
-pub fn rename_meeting(
+pub async fn rename_meeting(
+    app: AppHandle,
     state: State<'_, AppState>,
     meeting_id: String,
     title: String,
+) -> Result<(), AppError> {
+    let heavy_inference = state.heavy_inference.clone();
+    crate::perf::run_heavy(&heavy_inference, move || -> Result<(), AppError> {
+        let state = app.state::<AppState>();
+        let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+        rename_meeting_inner(&state, &meeting_id, &title, embedder.as_deref())
+    })
+    .await
+}
+
+/// Inner of [`rename_meeting`] with the re-index embedder INJECTED (deterministic tests — the
+/// `reindex_meetings_after_unseal` precedent). Brain v3 (audit gap #4): the meeting TITLE is baked
+/// into every chunk's header + augmented text (`chunk_note`/`augment_chunk_text`), so a rename left
+/// the OLD title in every vector/snippet until a manual full reindex — re-derive best-effort after
+/// the title is persisted.
+pub(crate) fn rename_meeting_inner(
+    state: &AppState,
+    meeting_id: &str,
+    title: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
 ) -> Result<(), AppError> {
     let title = title.trim();
     if title.is_empty() {
         return Err(AppError::InvalidArg("title cannot be empty".into()));
     }
-    state.db.set_meeting_title(&meeting_id, title)?;
+    state.db.set_meeting_title(meeting_id, title)?;
     // Keep the companion note's managed title + front-matter `[[Meeting]]` link in sync with the new
     // title. Best-effort — a sync failure NEVER fails the rename (the title is already persisted).
-    sync_companion_note_title_best_effort(state.inner(), &meeting_id);
+    sync_companion_note_title_best_effort(state, meeting_id);
+    // Brain v3 (audit gap #4): refresh chunk headers/vectors so they carry the NEW title.
+    // Best-effort + sealed-folder gate inside (empty unlock set); never fails the rename.
+    reindex_meeting_after_edit(state, meeting_id, embedder);
     Ok(())
 }
 
@@ -11972,25 +12096,12 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
     // DOCUMENT backfill first — doc_chunks + the FTS index are model-INDEPENDENT (keyword retrieval
     // must work on a default install), so this runs even when the e5 model is absent. Visible
     // documents only (`visible_document_ids` applies `visibility_clause`; a sealed folder's docs
-    // stay purged). Model present ⇒ full purge-then-reinsert re-embed. Model ABSENT ⇒ chunk-only
-    // backfill of documents with NO chunks yet (the write-only legacy rows) — never a
-    // purge-then-reinsert of an already-chunked document, which would DESTROY its existing real
-    // vectors without replacing them.
-    let doc_embedder = model_present.then_some(embedder);
-    let mut docs_indexed = 0usize;
-    for did in db.visible_document_ids(unlocked)? {
-        let should_index = model_present || !db.document_has_chunks(&did)?;
-        if !should_index {
-            continue;
-        }
-        match db.index_document_chunks(&did, doc_embedder) {
-            Ok(()) => docs_indexed += 1,
-            Err(e) => {
-                // Never abort the whole backfill on one bad document — log (no PII) and continue.
-                tracing::warn!(target: "rag", error = %e, "reindex: indexing one document failed (skipped)");
-            }
-        }
-    }
+    // stay purged). Model present ⇒ full purge-then-reinsert re-embed (`force_reembed`). Model
+    // ABSENT ⇒ chunk-only backfill of documents with NO chunks yet (the write-only legacy rows) —
+    // never a purge-then-reinsert of an already-chunked document, which would DESTROY its existing
+    // real vectors without replacing them. The shared leg is kind-ROUTED (Brain v3 audit gap #3):
+    // authored notes re-chunk through the front-matter-stripping path, never raw `documents.text`.
+    let docs_indexed = backfill_document_chunks(db, unlocked, model_present, embedder, true)?;
     if docs_indexed > 0 {
         tracing::info!(target: "rag", docs_indexed, "reindex: document chunks backfilled");
     }
@@ -12052,6 +12163,158 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
         indexed,
         total,
     })
+}
+
+/// Brain v3 (audit gap #3) — KIND-ROUTED (re)index of one `documents`-table row. An authored note
+/// (`kind='note'`) carries YAML front-matter in its raw `text` column, which the note-save path
+/// deliberately STRIPS before chunking (`index_note_body_chunks` → `split_front_matter` — DESIGN
+/// §1a: tags/properties must never pollute the vectors). The reindex/unseal paths previously called
+/// raw [`Db::index_document_chunks`] for EVERY row regardless of kind, re-embedding notes WITH their
+/// front-matter — this helper is the ONE routing seam they all share now.
+///
+/// GATING: NOT a new read path — callers only pass ids already admitted by a gated reader
+/// (`visible_document_ids` / the unseal path's own CK-decrypted rows), the exact contract
+/// `index_document_chunks` already documents ("caller MUST only invoke this for visible content").
+pub(crate) fn index_document_row_kind_routed(
+    db: &crate::storage::Db,
+    document_id: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
+) -> Result<(), AppError> {
+    match db.get_note_row(document_id)? {
+        Some(row) => {
+            // `kind='note'` — mirror `update_note_doc_inner`'s title fallback + body strip exactly.
+            let title = row.title.as_deref().unwrap_or(&row.name);
+            let title = title.trim();
+            let title = if title.is_empty() { "Untitled" } else { title };
+            let (_yaml, body) = crate::storage::db::split_front_matter(&row.text);
+            db.index_note_chunks(document_id, title, &body, embedder)
+        }
+        // Uploaded document (`kind='document'`) — the raw-text path is correct (no front-matter).
+        None => db.index_document_chunks(document_id, embedder),
+    }
+}
+
+/// The DOCUMENT backfill leg shared by [`reindex_embeddings_inner`] (`force_reembed = true`: the
+/// user-triggered full pass — model present ⇒ purge-then-reinsert re-embed of EVERY visible doc)
+/// and the startup repair tick [`backfill_missing_brain_indexes`] (`force_reembed = false`:
+/// NEEDS-ONLY — touch a row only when it has no chunks at all, or has chunks but ZERO vectors while
+/// the real model is present, so an idempotent re-run does no work). Chunk-only backfill (no
+/// vectors) runs even with the model absent, exactly like the original reindex doc leg. Every row
+/// routes through [`index_document_row_kind_routed`] (front-matter never re-enters a note's chunks).
+///
+/// GATING (lock-model): the corpus is exactly `visible_document_ids(unlocked)` — a
+/// sealed-and-not-in-`unlocked` folder's documents are never returned, so their (blank) plaintext
+/// is never chunked and their index rows STAY purged.
+fn backfill_document_chunks(
+    db: &crate::storage::Db,
+    unlocked: &std::collections::HashSet<String>,
+    model_present: bool,
+    embedder: &dyn crate::embed::Embedder,
+    force_reembed: bool,
+) -> Result<usize, AppError> {
+    let doc_embedder = model_present.then_some(embedder);
+    let mut docs_indexed = 0usize;
+    for did in db.visible_document_ids(unlocked)? {
+        let should_index = if force_reembed {
+            model_present || !db.document_has_chunks(&did)?
+        } else {
+            // Repair-tick probe (counts only, no content): missing chunks entirely (chunk-only
+            // backfill works model-less), or chunked-but-vectorless while the REAL model is present
+            // (the model arrived after import) — never a wholesale re-embed.
+            let (chunks, vectors) = db.doc_chunk_vector_counts(&did)?;
+            chunks == 0 || (model_present && vectors == 0)
+        };
+        if !should_index {
+            continue;
+        }
+        match index_document_row_kind_routed(db, &did, doc_embedder) {
+            Ok(()) => docs_indexed += 1,
+            Err(e) => {
+                // Never abort the whole backfill on one bad document — log (no PII) and continue.
+                tracing::warn!(target: "rag", error = %e, "doc backfill: indexing one document failed (skipped)");
+            }
+        }
+    }
+    Ok(docs_indexed)
+}
+
+/// Brain v3 (audit gap #2) — the IDEMPOTENT startup REPAIR TICK. Vector/chunk coverage previously
+/// only recovered via the manual Settings → Reindex: an embed-model download, a flag flip, or a
+/// model-absent unlock left meetings/documents chunk- or vector-less until the user noticed.
+/// Generalizes the `backfill_topic_chunks_idempotent` startup pattern; wired into the SAME
+/// `lib.rs` setup `spawn_blocking` (behind the same `topic_backfill_ram_permits_now()` RAM floor).
+///
+/// THE CONSOLIDATION INVARIANT (load-bearing): every read runs under the EMPTY unlock set — a
+/// sealed folder's meetings/documents are invisible here EVEN MID-SESSION-UNLOCK, so sealed
+/// plaintext is never touched by a background task (this fn deliberately takes no unlock set).
+///
+/// Gating matrix (mirrors the existing code exactly):
+/// - DOC half: needs-only [`backfill_document_chunks`] — chunk/FTS backfill runs even with the
+///   model absent (the reindex doc-leg policy); vectors only when `model_present`.
+/// - MEETING half: `index_meeting_chunks` has no chunk-only mode, so it requires the REAL model
+///   (never a stub vector) AND — being an AUTOMATIC index — the `semantic_search_enabled` flag
+///   (the pipeline's `should_auto_index` posture, same as the topic backfill's flag gate).
+///
+/// Idempotent: a re-run finds full coverage and touches nothing (returns `(0, 0)`). Logs counts
+/// only — no PII.
+pub(crate) fn backfill_missing_brain_indexes(
+    db: &crate::storage::Db,
+    semantic_enabled: bool,
+    model_present: bool,
+    embedder: &dyn crate::embed::Embedder,
+) -> Result<(usize, usize), AppError> {
+    let empty = std::collections::HashSet::new();
+
+    // DOC half — needs-only (never the reindex command's wholesale re-embed).
+    let docs = backfill_document_chunks(db, &empty, model_present, embedder, false)?;
+
+    // MEETING half — flag + model gated (see the gating matrix above).
+    let mut meetings = 0usize;
+    if semantic_enabled && model_present {
+        for m in db.list_meetings_visible(100_000, &empty)? {
+            // Defense-in-depth (the reindex idiom): only a meeting whose latest note is visible
+            // under the SAME empty set is considered — and "has a note" is the tick's precondition.
+            match db.get_note_if_visible(&m.id, &empty) {
+                Ok(Some(_note)) => {}
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::warn!(target: "rag", error = %e, "repair tick: visibility check failed (skipped)");
+                    continue;
+                }
+            }
+            // Needs probe (counts only): note-but-zero-chunks, or chunks-but-zero-vectors.
+            let (chunks, vectors) = match db.meeting_chunk_vector_counts(&m.id) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(target: "rag", error = %e, "repair tick: chunk probe failed (skipped)");
+                    continue;
+                }
+            };
+            if chunks > 0 && vectors > 0 {
+                continue; // covered — the idempotent no-op leg.
+            }
+            match db.get_segments(&m.id) {
+                Ok(segments) => {
+                    if let Err(e) = db.index_meeting_chunks(&m.id, &segments, embedder) {
+                        tracing::warn!(target: "rag", error = %e, "repair tick: indexing one meeting failed (skipped)");
+                    } else {
+                        meetings += 1;
+                        // Topic chunks follow the note/transcript index (the reindex idiom) —
+                        // under the SAME empty unlock set (sealed context never persists).
+                        if let Err(e) =
+                            db.index_meeting_topic_chunks(&m.id, &segments, embedder, &empty)
+                        {
+                            tracing::warn!(target: "rag", error = %e, "repair tick: topic indexing failed (skipped)");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(target: "rag", error = %e, "repair tick: reading segments failed (skipped)");
+                }
+            }
+        }
+    }
+    Ok((meetings, docs))
 }
 
 /// True iff the on-device PERSON-name NER model (Phase D) is present on disk. Pure existence probe;
@@ -14741,12 +15004,13 @@ fn unseal_folder_extras(
     }
     // Re-index the restored documents: chunks + the FTS index come back UNCONDITIONALLY (keyword
     // retrieval must survive a lock/unlock cycle on a model-less install); vectors ONLY when the
-    // REAL e5 model is present (never stub vectors; mirrors `import_document`). Best-effort: a
-    // failure logs (no PII) and does NOT fail the unlock — the plaintext text is already restored.
+    // REAL e5 model is present (never stub vectors; mirrors `import_document`). KIND-ROUTED (Brain
+    // v3 audit gap #3): an authored note re-chunks through the front-matter-stripping path.
+    // Best-effort: a failure logs (no PII) and does NOT fail the unlock — the text is restored.
     if !restored_doc_ids.is_empty() {
         let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
         for did in &restored_doc_ids {
-            if let Err(e) = state.db.index_document_chunks(did, embedder.as_deref()) {
+            if let Err(e) = index_document_row_kind_routed(&state.db, did, embedder.as_deref()) {
                 tracing::warn!(target: "rag", error = %e, "document re-index on unlock failed (text restored)");
             }
         }
@@ -15030,10 +15294,11 @@ fn unseal_folder_extras_permanent(
     }
     if !restored_doc_ids.is_empty() {
         // Chunks + FTS come back unconditionally (keyword retrieval works model-less); vectors only
-        // when the REAL e5 model is present (never stub vectors).
+        // when the REAL e5 model is present (never stub vectors). KIND-ROUTED (Brain v3 audit gap
+        // #3): an authored note re-chunks through the front-matter-stripping path.
         let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
         for did in &restored_doc_ids {
-            if let Err(e) = state.db.index_document_chunks(did, embedder.as_deref()) {
+            if let Err(e) = index_document_row_kind_routed(&state.db, did, embedder.as_deref()) {
                 tracing::warn!(target: "rag", error = %e, "document re-index on remove-lock failed (text restored)");
             }
         }
@@ -24117,6 +24382,421 @@ mod lifecycle_tests {
         );
     }
 
+    /// Brain v3 audit gap #1 (RED-before-GREEN): an in-app note EDIT (`update_note_inner`) upserted
+    /// the markdown + re-exported the vault `.md` but NEVER re-derived the meeting's chunks/vectors —
+    /// deleted text kept surfacing in semantic search (snippets read from `note_chunks` at hit time).
+    /// Deterministic via the injected-embedder seam (`update_note_inner_with`), the exact
+    /// `unseal_folder_extras` precedent: pre-fix the production body had NO re-index at all, so the
+    /// stale text stayed even with `Some(&StubEmbedder)` — RED. Also pins the model-ABSENT branch
+    /// (`None` ⇒ the index is untouched — never a stub vector).
+    #[test]
+    fn update_note_edit_reindexes_meeting_chunks_replacing_stale_text() {
+        let state = build_state("edit-reindex-meeting");
+        make_open_folder(&state.db, "f-edit", "Team");
+        seed_meeting(
+            &state.db,
+            "m1",
+            "# Plan\n\nzebrafish budget line for next quarter",
+            Some("f-edit"),
+        );
+        // Index the ORIGINAL note (the pipeline's job at summarize time).
+        let segments = state.db.get_segments("m1").unwrap();
+        state
+            .db
+            .index_meeting_chunks("m1", &segments, &crate::embed::StubEmbedder)
+            .unwrap();
+        let before = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            before.contains("zebrafish"),
+            "precondition: the original text is indexed"
+        );
+
+        // MODEL ABSENT (None): the save persists but the index is untouched (no chunk-only mode for
+        // meetings → any write would be a forbidden stub vector; mirrors the unseal/reindex policy).
+        update_note_inner_with(&state, "m1", "# Plan\n\ninterim model-less edit", None).unwrap();
+        let mid_pass = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            mid_pass.contains("zebrafish"),
+            "model-absent edit leaves the index untouched (never a stub vector)"
+        );
+
+        // MODEL PRESENT (Some): the edit re-derives the chunks — deleted text GONE, fresh text in.
+        update_note_inner_with(
+            &state,
+            "m1",
+            "# Plan\n\naardvark forecast line replaces it",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        let after = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            !after.contains("zebrafish"),
+            "deleted note text must STOP surfacing (RED pre-fix: update_note_inner never re-indexed)"
+        );
+        assert!(
+            after.contains("aardvark"),
+            "the fresh markdown is indexed after the edit"
+        );
+        assert!(
+            state.db.note_vec_count("m1").unwrap() > 0,
+            "vectors refreshed alongside the chunks"
+        );
+    }
+
+    /// Brain v3 audit gap #1, the SEAL GATE leg: an edit made while a LOCKED folder is
+    /// session-unlocked re-seals the markdown (seal-on-write) but must NOT re-chunk the sealed
+    /// folder's plaintext — the edit re-index runs under the EMPTY unlock set, so a sealed folder
+    /// (even session-unlocked, plaintext restored — the worst case) is invisible to it. The
+    /// unlock/relock lifecycle owns those rows.
+    #[test]
+    fn update_note_edit_never_reindexes_sealed_folder_chunks() {
+        let state = build_state("edit-reindex-sealed-gate");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "T0 secret note", Some("f-lock"));
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "purged on lock"
+        );
+
+        // Session-unlock + restore the note markdown exactly like `unlock_folder` does.
+        let ck = session_unlock(&state, "f-lock");
+        for n in state.db.notes_in_folder("f-lock").unwrap() {
+            if let Some(blob) = &n.content_blob {
+                let aad = aad_content("f-lock", &n.meeting_id, &n.provider_id, "note");
+                let pt = crate::crypto::decrypt(&ck, blob, &aad).unwrap();
+                state
+                    .db
+                    .restore_note_markdown(&n.meeting_id, &n.provider_id, &String::from_utf8(pt).unwrap())
+                    .unwrap();
+            }
+        }
+
+        // Edit while session-unlocked WITH the model "present" (stub injected): the write gate
+        // passes and the fresh markdown is re-sealed — but NO chunk/vector row may appear.
+        update_note_inner_with(
+            &state,
+            "m1",
+            "T1 secret edit under session unlock",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "a sealed folder's edit never lands in note_chunks (empty-unlock-set gate)"
+        );
+        assert_eq!(
+            state.db.note_vec_count("m1").unwrap(),
+            0,
+            "…and never in vec_chunks"
+        );
+    }
+
+    /// Brain v3 audit gap #4 (RED-before-GREEN): a RENAME left the OLD title baked into every
+    /// chunk's header/augmented text/vector until a manual full reindex (`chunk_note` embeds
+    /// `<title> · <date>` into each chunk). Pre-fix `rename_meeting` only set the title + synced the
+    /// companion note — no re-index — so the old title stayed even with `Some(&StubEmbedder)`: RED.
+    #[test]
+    fn rename_meeting_refreshes_stale_chunk_titles() {
+        let state = build_state("rename-reindex");
+        make_open_folder(&state.db, "f-open", "Team");
+        // `seed_meeting` titles the meeting "Quarterly strategy".
+        seed_meeting(&state.db, "m1", "# Plan\n\nbudget details", Some("f-open"));
+        let segments = state.db.get_segments("m1").unwrap();
+        state
+            .db
+            .index_meeting_chunks("m1", &segments, &crate::embed::StubEmbedder)
+            .unwrap();
+        let before = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            before.contains("Quarterly strategy"),
+            "precondition: chunk headers carry the seeded title"
+        );
+
+        rename_meeting_inner(
+            &state,
+            "m1",
+            "Atlas kickoff renamed",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+
+        let after = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            after.contains("Atlas kickoff renamed"),
+            "chunk headers carry the NEW title (RED pre-fix: rename never re-indexed)"
+        );
+        assert!(
+            !after.contains("Quarterly strategy"),
+            "the OLD title is gone from every chunk"
+        );
+    }
+
+    /// Brain v3 flag-consistency (PR-1 finding 3): `reindex_meeting_after_edit` hardcoded `enabled=true`,
+    /// so an edit/rename with `semantic_search_enabled = false` + the model present STILL re-chunked the
+    /// meeting — the ONE meeting-index path ignoring the flag. Now it respects the flag exactly like the
+    /// repair tick + `should_auto_index`. RED-before-GREEN: restore the hardcoded `true` and the OFF-flag
+    /// edit re-derives the chunks (the assertion below that the ORIGINAL text survives untouched fails).
+    #[test]
+    fn edit_and_rename_reindex_respect_semantic_flag_off() {
+        let state = build_state("edit-rename-flag-off");
+        // Flag OFF: vectors are not retrieval-active, so an edit/rename must not re-chunk.
+        state.config.lock().unwrap().semantic_search_enabled = false;
+        make_open_folder(&state.db, "f-open", "Team");
+        seed_meeting(
+            &state.db,
+            "m1",
+            "# Plan\n\nzebrafish budget line for next quarter",
+            Some("f-open"),
+        );
+        let segments = state.db.get_segments("m1").unwrap();
+        state
+            .db
+            .index_meeting_chunks("m1", &segments, &crate::embed::StubEmbedder)
+            .unwrap();
+        let before = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(before.contains("zebrafish"), "precondition: original indexed");
+
+        // EDIT with the model "present" (stub) but the flag OFF → index left untouched.
+        update_note_inner_with(
+            &state,
+            "m1",
+            "# Plan\n\naardvark forecast replaces it",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        let after_edit = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            after_edit.contains("zebrafish") && !after_edit.contains("aardvark"),
+            "flag OFF: an edit must NOT re-chunk the meeting (RED pre-fix: hardcoded enabled=true)"
+        );
+
+        // RENAME likewise leaves the stale-title chunks untouched while the flag is OFF.
+        rename_meeting_inner(
+            &state,
+            "m1",
+            "Atlas kickoff renamed",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        let after_rename = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            after_rename.contains("Quarterly strategy") && !after_rename.contains("Atlas kickoff renamed"),
+            "flag OFF: a rename must NOT re-chunk the meeting"
+        );
+
+        // Flip the flag ON → an edit re-derives again (proves the guard is the flag, not a no-op).
+        state.config.lock().unwrap().semantic_search_enabled = true;
+        update_note_inner_with(
+            &state,
+            "m1",
+            "# Plan\n\naardvark forecast replaces it",
+            Some(&crate::embed::StubEmbedder),
+        )
+        .unwrap();
+        let after_on = state.db.note_chunk_texts("m1").unwrap().join("\n");
+        assert!(
+            after_on.contains("aardvark") && !after_on.contains("zebrafish"),
+            "flag ON: the edit re-indexes as before"
+        );
+    }
+
+    /// Brain v3 audit gap #3 (RED-before-GREEN): the manual Reindex iterated `visible_document_ids`
+    /// with NO kind filter and chunked raw `documents.text` — for an authored note (`kind='note'`)
+    /// that raw text includes the YAML front-matter the note-save path deliberately strips
+    /// (`index_note_body_chunks` → `split_front_matter`). The fixed path routes `kind='note'` rows
+    /// through the stripping `index_note_chunks`; pre-fix the front-matter token landed in
+    /// `doc_chunks` — RED.
+    #[test]
+    fn reindex_strips_front_matter_from_authored_note_chunks() {
+        let state = build_state("reindex-kind-routing");
+        make_open_folder(&state.db, "f-notes", "Notes");
+        state
+            .db
+            .insert_note(
+                "n-fm",
+                "f-notes",
+                "plan",
+                "Plan",
+                "---\ntags: [zzfrontmattertag]\n---\n\nQuarterly zzbodytoken results paragraph.",
+                1,
+            )
+            .unwrap();
+        let empty: HashSet<String> = HashSet::new();
+        reindex_embeddings_inner(
+            &state.db,
+            &empty,
+            true,
+            &crate::embed::StubEmbedder,
+            |_, _| {},
+        )
+        .unwrap();
+        let chunks = state.db.doc_chunk_texts("n-fm").unwrap().join("\n");
+        assert!(
+            chunks.contains("zzbodytoken"),
+            "the note BODY is chunked by the reindex"
+        );
+        assert!(
+            !chunks.contains("zzfrontmattertag"),
+            "front-matter must NEVER reach an authored note's chunks (RED pre-fix: raw text was chunked)"
+        );
+    }
+
+    /// Brain v3 finding 4 (RED-before-GREEN): INGEST of a `kind='note'` via `import_text` raw-chunked
+    /// `documents.text`, so a pasted note with YAML front-matter got its tags/properties into
+    /// `doc_chunks` at ingest time — contradicting the "ONE routing seam" contract. The fix routes
+    /// ingest through `index_document_row_kind_routed` (front-matter stripped). RED pre-fix: the ingest
+    /// called raw `index_document_chunks` and the front-matter token landed in the chunks.
+    #[test]
+    fn ingest_note_strips_front_matter_from_chunks() {
+        let state = build_state("ingest-note-frontmatter");
+        make_open_folder(&state.db, "f-notes", "Notes");
+        let id = import_text_inner(
+            &state,
+            "pasted plan",
+            "---\ntags: [zzingestfmtag]\n---\n\nQuarterly zzingestbody results paragraph.",
+            "f-notes",
+        )
+        .unwrap();
+        let chunks = state.db.doc_chunk_texts(&id).unwrap().join("\n");
+        assert!(
+            chunks.contains("zzingestbody"),
+            "the pasted note BODY is chunked at ingest"
+        );
+        assert!(
+            !chunks.contains("zzingestfmtag"),
+            "front-matter must NEVER reach an ingested note's chunks (RED pre-fix: raw ingest chunking)"
+        );
+    }
+
+    /// Brain v3 audit gap #2 — the startup REPAIR TICK is complete and IDEMPOTENT:
+    /// - model-ABSENT pass: documents with no chunks get a chunk-only backfill (keyword retrieval
+    ///   works on a default install); meetings untouched (no chunk-only mode → stub vectors).
+    /// - model-PRESENT pass: chunked-but-vectorless docs re-embed, note-carrying meetings with no
+    ///   chunks index (note + transcript + vectors), kind-routing keeps front-matter out.
+    /// - re-run: full coverage ⇒ `(0, 0)` — a no-op.
+    #[test]
+    fn repair_tick_backfills_missing_indexes_idempotently() {
+        let state = build_state("repair-tick-idempotent");
+        make_open_folder(&state.db, "f-open", "Team");
+        seed_meeting(
+            &state.db,
+            "m1",
+            "# Plan\n\nquarterly zzmeetingtoken details",
+            Some("f-open"),
+        );
+        state
+            .db
+            .insert_document("d1", "f-open", "spec.md", "spec zzdoctoken body", "document", 1)
+            .unwrap();
+        state
+            .db
+            .insert_note(
+                "n1",
+                "f-open",
+                "note",
+                "Note",
+                "---\ntags: [zztickfmtag]\n---\n\nnote zznotetoken body",
+                1,
+            )
+            .unwrap();
+
+        // PASS 1 — MODEL ABSENT.
+        let (meetings, docs) =
+            backfill_missing_brain_indexes(&state.db, true, false, &crate::embed::StubEmbedder)
+                .unwrap();
+        assert_eq!(meetings, 0, "model absent: no meeting indexing (no stub vectors)");
+        assert_eq!(docs, 2, "model absent: both documents chunk-only backfilled");
+        let (d_chunks, d_vecs) = state.db.doc_chunk_vector_counts("d1").unwrap();
+        assert!(d_chunks > 0, "doc chunks present after the chunk-only pass");
+        assert_eq!(d_vecs, 0, "no vectors without the model");
+        assert_eq!(state.db.note_chunk_count("m1").unwrap(), 0);
+
+        // PASS 2 — MODEL PRESENT (the model-arrived-later recovery the audit gap describes).
+        let (meetings, docs) =
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
+        assert_eq!(meetings, 1, "the note-carrying meeting is indexed");
+        assert_eq!(docs, 2, "chunked-but-vectorless docs re-embed once the model arrives");
+        assert!(state.db.doc_chunk_vector_counts("d1").unwrap().1 > 0);
+        assert!(state.db.note_chunk_count("m1").unwrap() > 0);
+        assert!(state.db.note_vec_count("m1").unwrap() > 0);
+        // Kind routing respected (audit gap #3): the authored note's chunks carry no front-matter.
+        let note_chunks = state.db.doc_chunk_texts("n1").unwrap().join("\n");
+        assert!(note_chunks.contains("zznotetoken"));
+        assert!(!note_chunks.contains("zztickfmtag"));
+
+        // PASS 3 — IDEMPOTENT: full coverage ⇒ a re-run touches nothing.
+        let (meetings, docs) =
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
+        assert_eq!((meetings, docs), (0, 0), "re-run is a no-op");
+    }
+
+    /// Brain v3 audit gap #2, the FLAG leg: the tick is an AUTOMATIC index, so its meeting half
+    /// respects `semantic_search_enabled` exactly like the pipeline's `should_auto_index` and the
+    /// topic backfill — flag OFF ⇒ no meeting indexing even with the model present.
+    #[test]
+    fn repair_tick_meeting_half_respects_semantic_flag() {
+        let state = build_state("repair-tick-flag-off");
+        make_open_folder(&state.db, "f-open", "Team");
+        seed_meeting(&state.db, "m1", "# Plan\n\nnotes", Some("f-open"));
+        let (meetings, _docs) =
+            backfill_missing_brain_indexes(&state.db, false, true, &crate::embed::StubEmbedder)
+                .unwrap();
+        assert_eq!(
+            meetings, 0,
+            "flag OFF: an automatic tick never indexes meetings (should_auto_index posture)"
+        );
+        assert_eq!(state.db.note_chunk_count("m1").unwrap(), 0);
+    }
+
+    /// Brain v3 audit gap #2, the LOCK-DISCIPLINE leg (the consolidation invariant): the repair tick
+    /// reads with the EMPTY unlock set, so a SEALED folder's meeting is never touched — even in the
+    /// worst case where the folder is session-unlocked and its note plaintext is restored (a
+    /// live-unlock-set bug would index that plaintext; the empty set must not).
+    #[test]
+    fn repair_tick_never_touches_sealed_folder_even_mid_session_unlock() {
+        let state = build_state("repair-tick-sealed");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "# Secret\n\nzzsealedtoken plan", Some("f-lock"));
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "purged on lock"
+        );
+
+        // Session-unlock (folder in the LIVE unlock set) + restore the note plaintext.
+        let ck = session_unlock(&state, "f-lock");
+        for n in state.db.notes_in_folder("f-lock").unwrap() {
+            if let Some(blob) = &n.content_blob {
+                let aad = aad_content("f-lock", &n.meeting_id, &n.provider_id, "note");
+                let pt = crate::crypto::decrypt(&ck, blob, &aad).unwrap();
+                state
+                    .db
+                    .restore_note_markdown(&n.meeting_id, &n.provider_id, &String::from_utf8(pt).unwrap())
+                    .unwrap();
+            }
+        }
+
+        let (meetings, docs) =
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
+        assert_eq!(
+            (meetings, docs),
+            (0, 0),
+            "a sealed folder's content is never touched — even while session-unlocked"
+        );
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "no chunks materialize for the sealed meeting"
+        );
+    }
+
     /// RELOCK re-purges the freshly-rebuilt meeting chunks: a lock → unlock (re-index) → relock cycle
     /// must leave ZERO meeting chunks/vectors at rest — `relock_folder` → `blank_sealed_notes_in_folders`
     /// → `purge_chunks_tx` covers the rows the unlock re-index rebuilt, so a re-sealed folder never
@@ -30949,6 +31629,74 @@ mod lifecycle_tests {
         );
     }
 
+    /// Brain v3 ORG PUSH SIZE PRE-CHECK (RED-before-GREEN): the server hard-caps an org item blob
+    /// at `MAX_ORG_ITEM_BLOB_BYTES` (1 MiB) — pre-fix an oversized share egressed the blob, got a
+    /// 413, landed `failed("upload_failed")`, and the launch sweep re-attempted it on EVERY start
+    /// (the poison loop; against this size-blind mock the sweep retry would even "succeed", which
+    /// is the RED shape). Post-fix: the share fails CLIENT-SIDE before any egress with the TERMINAL
+    /// `too_large` reason, and the sweep never requeues it.
+    #[test]
+    fn oversized_org_share_fails_terminal_too_large_and_sweep_never_requeues() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-share-too-large");
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        make_open_folder(&state.db, "f-big", "Team");
+        // Plaintext > the cap ⇒ the sealed ciphertext (≥ plaintext) certainly exceeds it.
+        let big_body = format!(
+            "# Big\n\n{}",
+            "x".repeat(murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES + 64 * 1024)
+        );
+        state
+            .db
+            .insert_note("n-big", "f-big", "big", "Big", &big_body, 1)
+            .unwrap();
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = mock.base.clone();
+        seed_live_session(&state);
+        seed_ock(&state, "org-1", 1);
+
+        // The share is refused client-side: no blob upload, no publish, terminal reason on the row.
+        let res = block_on(share_to_org_inner(
+            &state,
+            "org-1",
+            None,
+            Some("n-big".to_string()),
+            true,
+        ));
+        assert!(res.is_err(), "an oversized share is refused before any egress");
+        let rows = state.db.list_org_shares_for_org("org-1").unwrap();
+        assert_eq!(rows.len(), 1, "exactly one local row records the refusal");
+        assert_eq!(rows[0].state, "failed");
+        assert_eq!(
+            rows[0].last_error.as_deref(),
+            Some(ORG_SHARE_ERR_TOO_LARGE),
+            "the row carries the TERMINAL too_large reason"
+        );
+        assert!(rows[0].item_id.is_none(), "nothing was published");
+        assert!(
+            mock.log.lock().unwrap().published.is_empty(),
+            "the server never saw a publish"
+        );
+        let updated_at_before_sweep = rows[0].updated_at.clone();
+
+        // The launch sweep must NOT requeue it (RED pre-fix: every failed row was re-attempted).
+        let advanced = block_on(org_sweep_pending_inner(&state)).unwrap();
+        assert_eq!(advanced, 0, "too_large is TERMINAL for the sweep");
+        let row = &state.db.list_org_shares_for_org("org-1").unwrap()[0];
+        assert_eq!(row.state, "failed", "the row is left exactly where it was");
+        assert_eq!(row.last_error.as_deref(), Some(ORG_SHARE_ERR_TOO_LARGE));
+        // Binds the sweep EXCLUSION itself (not just the client-side refusal): a re-ATTEMPT would
+        // re-arm + re-fail the row, rewriting `updated_at` — a skipped row is byte-identical.
+        assert_eq!(
+            row.updated_at, updated_at_before_sweep,
+            "the sweep never even re-attempted the too_large row"
+        );
+        assert!(
+            mock.log.lock().unwrap().published.is_empty(),
+            "the sweep produced no egress for the oversized row"
+        );
+    }
+
     /// ITEM 2 — `org_resolve_source` maps an uploaded org item back to its LOCAL editable source, and
     /// returns `None` for an unknown item id (a colleague's item this device never published).
     #[test]
@@ -32805,6 +33553,15 @@ async fn collapse_org_share_dups_for_source(
     Ok(Some(keeper))
 }
 
+/// TERMINAL `org_shares.last_error` reason (Brain v3 org push size pre-check): the sealed
+/// ciphertext exceeds the server's per-item blob cap
+/// (`murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES`, 1 MiB). The launch sweep NEVER retries a row
+/// failed with this reason — retrying cannot shrink the content, so requeueing it every start was a
+/// poison loop (the server 413s forever). Recovery is content-driven: a manual re-share
+/// (`share_to_org_inner` reuses + re-arms the row) or an edit-save republish re-reads the trimmed
+/// source and clears the reason on success.
+pub(crate) const ORG_SHARE_ERR_TOO_LARGE: &str = "too_large";
+
 /// The org publish CORE, shared by the FIRST share (`share_to_org_inner`, `rev = 1`) and the
 /// re-publish-on-edit supersede (`republish_org_shares_for_source`, `rev = old_rev + 1`). It owns the
 /// FULL gate chain so a republish INHERITS it rather than re-implementing (the leak-safety single
@@ -32941,6 +33698,22 @@ pub(crate) async fn publish_org_body(
                 return Err(e);
             }
         };
+
+    // SIZE PRE-CHECK (Brain v3): the server hard-caps an org item blob at
+    // `MAX_ORG_ITEM_BLOB_BYTES` — an oversized ciphertext would 413 on EVERY attempt, and the
+    // launch sweep would requeue it forever (the poison loop). Fail CLIENT-SIDE, before any
+    // egress, with the TERMINAL `too_large` reason the sweep excludes from retry. Sizes only —
+    // never content.
+    if ciphertext.len() > murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES {
+        state
+            .db
+            .set_org_share_failed(&row_id, ORG_SHARE_ERR_TOO_LARGE, &now)?;
+        return Err(AppError::InvalidArg(format!(
+            "this item is too large to share ({} bytes sealed; the org limit is {} bytes) — shorten it and share again",
+            ciphertext.len(),
+            murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES
+        )));
+    }
 
     // (6) upload the ciphertext blob → publish the item. On failure, mark the row `failed` (the
     // launch sweep retries a `queued`/`failed` row later).
@@ -33210,6 +33983,23 @@ pub(crate) async fn republish_org_shares_for_source(
                     continue;
                 }
             };
+
+        // SIZE PRE-CHECK (Brain v3): oversized ciphertext would 413 forever — mark the row with
+        // the TERMINAL `too_large` reason (excluded from the launch sweep) instead of egressing.
+        // The OLD item stays live on the server (never tombstone-into-nothing); a later edit-save
+        // that shrinks the source re-enters via `org_shares_for_source` and heals the row.
+        if ciphertext.len() > murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES {
+            state
+                .db
+                .set_org_share_failed(&row.id, ORG_SHARE_ERR_TOO_LARGE, &now)?;
+            tracing::warn!(
+                target: "org",
+                sealed_bytes = ciphertext.len(),
+                cap_bytes = murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES,
+                "republish skipped: sealed item exceeds the org blob cap (terminal too_large)"
+            );
+            continue;
+        }
 
         // (6) upload → publish the NEW rev. On failure, mark the row `failed` (the launch sweep retries)
         // but do NOT tombstone (the OLD copy stays live — never leave the org with no copy).
@@ -33842,6 +34632,13 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
     //    queueing NEVER egresses (the read-gate refuses → the row stays `failed`).
     for state_label in ["queued", "failed"] {
         for row in state.db.list_org_shares_in_state(state_label)? {
+            // Brain v3 size pre-check: `too_large` is TERMINAL for the sweep — retrying cannot
+            // shrink the content, so requeueing it every launch is exactly the poison loop the
+            // client-side cap check exists to kill. Recovery is content-driven (a manual re-share /
+            // an edit-save republish re-reads the possibly-trimmed source and re-arms the row).
+            if row.last_error.as_deref() == Some(ORG_SHARE_ERR_TOO_LARGE) {
+                continue;
+            }
             if row.item_id.is_some() {
                 // Was live before: this row's LAST attempt was a REPUBLISH (not the initial publish)
                 // and it failed — `set_org_share_failed` deliberately retains the OLD, still-server-live

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -568,9 +568,6 @@ pub fn run() {
                     .map(|c| c.semantic_search_enabled)
                     .unwrap_or(false);
                 tauri::async_runtime::spawn_blocking(move || {
-                    if !semantic_enabled || !crate::embed::embed_model_present() {
-                        return;
-                    }
                     // 2026-07-13 launch-freeze incident: on a RAM-starved machine, defer the whole
                     // backfill (incl. the lazy Candle/Metal embedder load) rather than starting it
                     // at launch — it is content-hash idempotent, so a later, healthier launch just
@@ -579,8 +576,37 @@ pub fn run() {
                         tracing::info!(target: "rag", "topic-chunk backfill skipped: low system RAM");
                         return;
                     }
-                    let started = std::time::Instant::now();
+                    // Brain v3 (audit gap #2) — the IDEMPOTENT repair tick: backfill meetings with a
+                    // note but no chunks / chunks but no vectors, and documents via the needs-only
+                    // probe (chunk-only backfill runs even MODEL-ABSENT, like the reindex doc leg —
+                    // so it runs BEFORE the model/flag early-return below). All reads inside run
+                    // under the EMPTY unlock set (sealed content is never touched, even
+                    // mid-session-unlock). Counts only — no PII.
+                    let model_present = crate::embed::embed_model_present();
                     let embedder = crate::embed::active_embedder();
+                    match crate::commands::backfill_missing_brain_indexes(
+                        &db,
+                        semantic_enabled,
+                        model_present,
+                        embedder.as_ref(),
+                    ) {
+                        Ok((meetings, docs)) if meetings + docs > 0 => {
+                            tracing::info!(
+                                target: "rag",
+                                meetings,
+                                docs,
+                                "brain index repair tick backfilled missing chunks/vectors"
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(target: "rag", error = %e, "brain index repair tick failed");
+                        }
+                    }
+                    if !semantic_enabled || !model_present {
+                        return;
+                    }
+                    let started = std::time::Instant::now();
                     match db.backfill_topic_chunks_idempotent(embedder.as_ref()) {
                         Ok(indexed) if indexed > 0 => {
                             tracing::info!(

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -134,6 +134,29 @@ fn chunk_hash(text: &str) -> u64 {
     h
 }
 
+/// TOCTOU seal re-check for a `documents`-table row (a note OR an uploaded document), run INSIDE the
+/// caller's write transaction. The seal (`seal_document`, `blank_sealed_notes_in_folders`'s document
+/// leg) blanks the plaintext `text` into `text_blob` (`text=''`, `text_blob` kept) — a
+/// session-independent, DB-side sealed-at-rest invariant. When a `lock_folder` commits mid-embed the
+/// indexer's slow embedding already ran against the now-stale plaintext; keying the refusal on this
+/// invariant (not a caller's `unlocked` snapshot) stops the derived plaintext chunks/vectors from
+/// landing at rest behind the lock. Returns `true` ⇒ the caller must refuse the write (rollback via
+/// drop). UNSEAL/session-unlock un-blanks `text` before re-indexing, so this reads `false` there and
+/// the write proceeds — the same contract the meeting/note-`notes` re-check carries.
+fn doc_sealed_at_rest_tx(tx: &rusqlite::Transaction<'_>, document_id: &str) -> Result<bool> {
+    tx.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM documents
+            WHERE id = ?1
+              AND text_blob IS NOT NULL
+              AND (text IS NULL OR text = '')
+         )",
+        rusqlite::params![document_id],
+        |r| Ok(r.get::<_, i64>(0)? != 0),
+    )
+    .map_err(map_err)
+}
+
 /// Embed a batch of augmented chunk texts in small sub-batches instead of ONE call sized to the
 /// whole meeting/document/topic list. A long meeting or document can produce dozens of chunks
 /// (topic chunks merge to a 60s floor — a 1h+ recording can have 40-60; transcript chunks target
@@ -3537,6 +3560,30 @@ impl Db {
         let this_meeting = [meeting_id.to_string()];
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        // TOCTOU re-check INSIDE the write tx (mirrors `index_meeting_topic_chunks_reporting`): the
+        // gated/visible read above ran BEFORE the slow embed, and any caller `unlocked` snapshot can be
+        // stale by now. A `lock_folder` committing mid-embed blanks the note plaintext (`markdown=''`,
+        // `content_blob` kept) — that DB-side sealed-at-rest invariant is session-independent, so key the
+        // re-check on it: if the meeting is sealed at rest RIGHT NOW, inserting its derived plaintext
+        // chunks/vectors would leave sealed content at rest until the next relock/startup reconcile.
+        // Refuse (rollback via drop) — a benign no-op for every best-effort caller. UNSEAL/session-unlock
+        // paths un-blank `markdown` before re-indexing, so `sealed_at_rest` is false there and the write
+        // proceeds (defense-in-depth beyond the purge-on-seal, not a new refusal for legitimate work).
+        let sealed_at_rest: bool = tx
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM notes
+                    WHERE meeting_id = ?1
+                      AND content_blob IS NOT NULL
+                      AND (markdown IS NULL OR markdown = '')
+                 )",
+                rusqlite::params![meeting_id],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if sealed_at_rest {
+            return Ok(()); // sealed-at-rest mid-flight: never persist its plaintext chunks.
+        }
         Self::purge_chunks_tx(&tx, &this_meeting)?;
         {
             let mut ins_chunk = tx
@@ -4779,6 +4826,78 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// `(chunk_count, vector_count)` for ONE document's `doc_chunks` / `doc_vec_chunks` — COUNTS
+    /// ONLY, never content (no text leaves this probe). Production caller: the startup repair tick
+    /// (`backfill_missing_brain_indexes`), which passes ONLY ids already returned by the gated
+    /// [`Db::visible_document_ids`] — the same posture as [`Db::document_has_chunks`].
+    pub fn doc_chunk_vector_counts(&self, document_id: &str) -> Result<(i64, i64)> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT
+               (SELECT COUNT(*) FROM doc_chunks WHERE document_id = ?1),
+               (SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN
+                  (SELECT id FROM doc_chunks WHERE document_id = ?1))",
+            rusqlite::params![document_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .map_err(map_err)
+    }
+
+    /// `(chunk_count, vector_count)` for ONE meeting's `note_chunks` / `vec_chunks` — COUNTS ONLY,
+    /// never content. The MEETING analogue of [`Db::doc_chunk_vector_counts`], powering the startup
+    /// repair tick's needs-a-reindex probe; callers pass ONLY ids already returned by the gated
+    /// `list_meetings_visible`.
+    pub fn meeting_chunk_vector_counts(&self, meeting_id: &str) -> Result<(i64, i64)> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT
+               (SELECT COUNT(*) FROM note_chunks WHERE meeting_id = ?1),
+               (SELECT COUNT(*) FROM vec_chunks v
+                  JOIN note_chunks nc ON nc.id = v.chunk_id
+                 WHERE nc.meeting_id = ?1)",
+            rusqlite::params![meeting_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .map_err(map_err)
+    }
+
+    /// The `text` column of every `note_chunks` row for a MEETING (insertion order). Test-only
+    /// reader: lets the edit/rename re-index regressions assert stale text is GONE from the index
+    /// without reaching the private connection.
+    #[cfg(test)]
+    pub(crate) fn note_chunk_texts(&self, meeting_id: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT text FROM note_chunks WHERE meeting_id = ?1 ORDER BY id ASC")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// The `text` column of every `doc_chunks` row for a document (insertion order). Test-only
+    /// reader for the reindex kind-routing regression (front-matter must never reach the chunks).
+    #[cfg(test)]
+    pub(crate) fn doc_chunk_texts(&self, document_id: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT text FROM doc_chunks WHERE document_id = ?1 ORDER BY id ASC")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![document_id], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     /// Number of `note_chunks` rows currently indexed for a MEETING (0 when never indexed or purged
     /// on lock). The meeting analogue of [`Db::doc_chunk_count`] — used by the lock tests to assert
     /// purge-on-lock / re-index-on-unlock without reaching the private connection. Test-only.
@@ -4998,6 +5117,9 @@ impl Db {
         let this_doc = [document_id.to_string()];
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        if doc_sealed_at_rest_tx(&tx, document_id)? {
+            return Ok(()); // sealed-at-rest mid-flight: never persist its plaintext chunks.
+        }
         Self::purge_doc_chunks_tx(&tx, &this_doc)?;
         {
             let mut ins_chunk = tx
@@ -5047,6 +5169,9 @@ impl Db {
         let this_doc = [note_id.to_string()];
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        if doc_sealed_at_rest_tx(&tx, note_id)? {
+            return Ok(()); // sealed-at-rest mid-flight: never persist its plaintext chunks.
+        }
         Self::purge_doc_chunks_tx(&tx, &this_doc)?;
         {
             let mut ins_chunk = tx
@@ -17334,6 +17459,104 @@ mod tests {
             .is_empty());
     }
 
+    /// TOCTOU (lock-security finding, PR-1): `index_document_chunks` must REFUSE the entire write —
+    /// including its clean-replace PURGE — when the row is sealed at rest RIGHT NOW (a `lock_folder`
+    /// committing mid-embed blanks `text` into `text_blob`). The re-check runs BEFORE the purge, so a
+    /// refused racing index leaves the DB untouched rather than re-deriving from the (now-blank) read.
+    /// RED-before-GREEN distinguisher: index once (chunks present) → seal at rest WITHOUT purging
+    /// (`seal_document` blanks `text`/sets `text_blob`, mirroring the read-gate-independent-of-purge
+    /// pattern) → index again. WITH the guard the indexer early-returns before the purge, so the prior
+    /// chunks SURVIVE the refused write; WITHOUT it the purge runs and the blank re-read leaves ZERO —
+    /// the two outcomes differ, so removing `doc_sealed_at_rest_tx` fails this test.
+    #[test]
+    fn document_index_refuses_write_when_sealed_at_rest_mid_flight() {
+        let db = mem_db();
+        seed_folder(&db, "f-lock", "Secret");
+        db.insert_document(
+            "d1",
+            "f-lock",
+            "spec.md",
+            "the pistachio launch is in March",
+            "document",
+            100,
+        )
+        .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+        assert!(
+            db.doc_chunk_count("d1").unwrap() >= 1,
+            "precondition: the open document is chunked"
+        );
+
+        // Seal at rest exactly like `seal_document` (blank text, blob kept) WITHOUT purging chunks —
+        // isolates the guard from the seal-time purge (the `list_facts_visible_excludes_sealed_meeting`
+        // read-gate pattern). A racing `index_document_chunks` must now refuse the whole write.
+        db.seal_document("d1", &[0u8]).unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+        assert!(
+            db.doc_chunk_count("d1").unwrap() >= 1,
+            "the in-tx sealed-at-rest re-check must REFUSE the write (guard runs before the purge) — \
+             without it the purge+blank-read would zero the chunks, so this survival IS the guard"
+        );
+
+        // Restore the plaintext (session unlock un-blanks `text`) → indexing proceeds again (re-derives).
+        db.set_document_text("d1", "the pistachio launch is in March; new pistachio milestone")
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+        let texts: String = {
+            let conn = db.lock();
+            let mut stmt = conn
+                .prepare("SELECT text FROM doc_chunks WHERE document_id = 'd1' ORDER BY chunk_index")
+                .unwrap();
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect::<Vec<_>>();
+            rows.join("\n")
+        };
+        assert!(
+            texts.contains("milestone"),
+            "an unsealed (un-blanked) document re-indexes the fresh plaintext"
+        );
+    }
+
+    /// TOCTOU (lock-security finding, PR-1): the authored-NOTE twin — `index_note_chunks` (the
+    /// front-matter-stripped note path) must ALSO refuse when the note's `documents` row is sealed at
+    /// rest mid-flight. RED-before-GREEN: remove the `doc_sealed_at_rest_tx` guard in
+    /// `index_note_chunks` → the note's body chunks persist behind the seal.
+    #[test]
+    fn note_index_refuses_write_when_sealed_at_rest_mid_flight() {
+        let db = mem_db();
+        seed_folder(&db, "f-lock", "Secret");
+        db.insert_document(
+            "n1",
+            "f-lock",
+            "meeting-notes.md",
+            "budget owner is Dana; pistachio ship date confirmed",
+            "note",
+            100,
+        )
+        .unwrap();
+        db.seal_document("n1", &[0u8]).unwrap();
+
+        db.index_note_chunks("n1", "Meeting notes", "budget owner is Dana", None)
+            .unwrap();
+        assert_eq!(
+            db.doc_chunk_count("n1").unwrap(),
+            0,
+            "the in-tx sealed-at-rest re-check must refuse writing note body chunks"
+        );
+
+        db.set_document_text("n1", "budget owner is Dana; pistachio ship date confirmed")
+            .unwrap();
+        db.index_note_chunks("n1", "Meeting notes", "budget owner is Dana", None)
+            .unwrap();
+        assert!(
+            db.doc_chunk_count("n1").unwrap() >= 1,
+            "an unsealed (un-blanked) note indexes again"
+        );
+    }
+
     /// GATE twin of `doc_chunk_search_is_gated_by_visibility` for the KEYWORD leg: a doc chunk row
     /// that deliberately SURVIVES in a sealed-not-unlocked folder is EXCLUDED by
     /// `search_doc_chunks_fts_visible` (defense-in-depth `visibility_clause`) and reappears only
@@ -20038,6 +20261,30 @@ mod lock_tests {
         }]
     }
 
+    /// `(note_chunks, vec_chunks)` currently indexed for a meeting — the `index_meeting_chunks`
+    /// analogue of `topic_counts`, so the seal-TOCTOU test can assert ZERO rows survive a refused
+    /// write.
+    fn meeting_chunk_counts(db: &Db, meeting_id: &str) -> (i64, i64) {
+        let conn = db.lock();
+        let chunks: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM note_chunks WHERE meeting_id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let vecs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM vec_chunks v
+                   JOIN note_chunks nc ON nc.id = v.chunk_id
+                  WHERE nc.meeting_id = ?1",
+                rusqlite::params![meeting_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        (chunks, vecs)
+    }
+
     /// PURGE-ON-SEAL (L1.1, lock-critical): sealing a folder via `blank_sealed_notes_in_folders`
     /// (the same tx that blanks the plaintext) must drop the meeting's topic_chunks AND their
     /// topic_vec_chunks rows AND the aug_text tokens from fts_topic_chunks. RED-before-GREEN:
@@ -20203,6 +20450,57 @@ mod lock_tests {
             topic_counts(&db, "m1").0,
             0,
             "the in-tx sealed-at-rest re-check must refuse writing topic plaintext"
+        );
+    }
+
+    /// TOCTOU (lock-security finding, PR-1): the SAME race for `index_meeting_chunks` (note-summary +
+    /// transcript chunks/vectors). A `lock_folder` committing between the caller's pre-check and this
+    /// indexer's write tx is simulated by sealing the note at rest (markdown blanked, `content_blob`
+    /// kept). The indexer must refuse to write the meeting's derived plaintext chunks/vectors.
+    /// RED-before-GREEN: remove the in-tx `sealed_at_rest` re-check in `index_meeting_chunks` and this
+    /// asserts non-zero rows (a sealed folder's plaintext chunks/vectors persisted at rest — the leak).
+    #[test]
+    fn meeting_index_refuses_write_when_sealed_at_rest_mid_flight() {
+        let db = file_db("meeting-toctou");
+        seed_folder(&db, "f-lock", "Secret");
+        seed_note(&db, "m1", "atlas planning notes", Some("f-lock"));
+        let segs = one_topic_segment("omawiamy harmonogram projektu atlas i budżet");
+        db.insert_segments("m1", &segs).unwrap();
+
+        // "lock_folder committed mid-embed": note sealed at rest (markdown='', content_blob kept) —
+        // exactly what `blank_sealed_notes_in_folders` leaves.
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        {
+            let conn = db.lock();
+            conn.execute(
+                "UPDATE notes SET markdown = '', content_blob = X'00' WHERE meeting_id = 'm1'",
+                [],
+            )
+            .unwrap();
+        }
+        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder)
+            .unwrap();
+        assert_eq!(
+            meeting_chunk_counts(&db, "m1"),
+            (0, 0),
+            "the in-tx sealed-at-rest re-check must refuse writing meeting chunks/vectors"
+        );
+
+        // Session-unlock un-blanks the plaintext BEFORE re-indexing → the write proceeds.
+        {
+            let conn = db.lock();
+            conn.execute(
+                "UPDATE notes SET markdown = 'atlas planning notes' WHERE meeting_id = 'm1'",
+                [],
+            )
+            .unwrap();
+        }
+        db.index_meeting_chunks("m1", &segs, &crate::embed::StubEmbedder)
+            .unwrap();
+        let (chunks, vecs) = meeting_chunk_counts(&db, "m1");
+        assert!(
+            chunks > 0 && vecs == chunks,
+            "an unsealed (un-blanked) meeting indexes again"
         );
     }
 

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -444,6 +444,29 @@ pub fn execute_tool(
                     format_hits_and_docs(&hits, &docs)
                 ));
             }
+            // MODEL GUARD (Brain v3 audit gap #7, mirrors the citations site in `commands.rs`
+            // `gather_note_enhance_citations`, which checks BOTH flags): the flag can be ON with the
+            // REAL e5 model ABSENT — `active_embedder()` is then the deterministic hash STUB, and
+            // embedding the query with it would inject a garbage vector into the KNN/fusion legs.
+            // Degrade to the SAME gated keyword search as flag-off, honestly labelled — a stub
+            // query vector never enters fusion.
+            if !crate::embed::embed_model_present() {
+                let hits = db
+                    .search_visible_in_range(q, 20, unlocked, date_filter)
+                    .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
+                let docs = db
+                    .search_doc_chunks_fts_visible(q, 20, unlocked)
+                    .unwrap_or_default();
+                if hits.is_empty() && docs.is_empty() {
+                    return Ok(format!(
+                        "No meetings or documents match \"{q}\" (keyword match — the semantic model is not installed)."
+                    ));
+                }
+                return Ok(format!(
+                    "Keyword (exact-word) matches — the semantic model is not installed:\n{}",
+                    format_hits_and_docs(&hits, &docs)
+                ));
+            }
             // Embed the query with the SAME active embedder used to index, then HYBRID-search through
             // the SAME visibility gate as `search_meetings` (both FTS + vector legs are gated).
             let embedder = crate::embed::active_embedder();
@@ -1890,6 +1913,38 @@ mod tests {
             .build()
             .unwrap()
             .block_on(f)
+    }
+
+    /// Brain v3 audit gap #7: with `semantic_search_enabled` ON but the REAL e5 model ABSENT, the
+    /// SearchSemantic arm must DEGRADE to gated keyword matching — never `embed_query` with the
+    /// deterministic hash stub (a garbage query vector entering KNN/fusion; the sibling citations
+    /// site in `commands.rs` checks BOTH flags). Deterministic only in a model-less environment
+    /// (CI / default install): when a real model is installed on the dev box the guard leg is
+    /// unreachable, so the test exits early (the model-present hybrid path has its own coverage).
+    #[test]
+    fn search_semantic_degrades_to_keyword_when_model_absent() {
+        if crate::embed::embed_model_present() {
+            return; // real model installed in this env → the guard leg cannot fire.
+        }
+        let db = tmp_db();
+        let config = AppConfig {
+            semantic_search_enabled: true,
+            ..AppConfig::default()
+        };
+        let unlocked = HashSet::new();
+        let out = execute_tool(
+            &ToolCall::SearchSemantic {
+                query: "anything".into(),
+            },
+            &db,
+            &unlocked,
+            &config,
+        )
+        .unwrap();
+        assert!(
+            out.contains("semantic model is not installed"),
+            "model-absent semantic search must degrade honestly to keyword matching, never a stub-vector KNN: {out}"
+        );
     }
 
     // ── Feature C — query_database filter grammar (Rust-parsed, deterministic) ───────────────────


### PR DESCRIPTION
PR-1 of the Brain v3 program (research: docs/research/2026-07-17-brain-v3-maximization.md, spec: docs/superpowers/specs/2026-07-17-brain-v3-design.md). Backend-only integrity fixes that keep the brain's derived index consistent with edits and lock state.

## Fixes
- **Edit/rename staleness** — meeting-note edits and renames now re-derive chunks/vectors (previously stale: deleted text kept surfacing in semantic search and in hit snippets, which are read from `note_chunks`). Off-thread via `perf::run_heavy`.
- **Front-matter kind-routing** — reindex, unseal, and ingest route authored notes (`documents(kind='note')`) through front-matter-stripping indexing so YAML never pollutes chunks/vectors.
- **Stub-query guard** — the SearchSemantic tool checks `embed_model_present()` before embedding a query, so a stub (hash-bag) vector never enters fusion.
- **Idempotent repair tick** — a startup best-effort backfill re-derives missing chunks/vectors under the **empty unlock set** (never touches sealed content), gated on the flag + model presence + RAM floor; generalizes the topic-chunk backfill.
- **Org publish size pre-check** — publish pre-checks ciphertext size vs `MAX_ORG_ITEM_BLOB_BYTES` and marks the share terminal `too_large` so the retry sweep can't poison-loop on a server 413.

## Lock safety
All three content indexers (meeting / note / document) gain an **in-tx sealed-at-rest refuse-the-write re-check**, mirroring the existing topic-chunk indexer — closing a seal-vs-index TOCTOU where a `lock_folder` committing mid-embed could leave a sealed folder's plaintext-derived chunks at rest. Unlock/restore paths un-blank plaintext before re-indexing, so legitimate restores still proceed.

## Verification
- `cargo test --lib` → **1780 passed / 0 failed** on the branch rebased onto trunk.
- RED-before-GREEN per behavior change (each guard/fix independently reverted to prove the test goes red).
- adversarial-verifier: PASS. lock-security-reviewer: PASS (TOCTOU closed across all four indexers; no bypass path; restore paths preserved; no stub vectors at rest; no PII in logs).

Additive migrations only; no new dependencies; no new seal path. Signed-build-only behaviors (Touch ID, real lock-at-rest) unaffected and unverifiable headless as usual.