### PR TITLE
feat(brain): ingest any document (PDF/DOCX/PPTX/XLSX/HTML) with a hierarchical index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +775,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml",
+ "serde",
+ "zip 8.6.0",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,7 +827,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke 0.8.3",
- "zip",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -1108,6 +1135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -1637,6 +1673,12 @@ dependencies = [
  "libdbus-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "defmac"
@@ -2205,6 +2247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2323,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3274,6 +3323,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "html2text"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c97eea9d3e6524d8d2a4643ce0e3135500c4c7ca1d02393a485f871bef69d8"
+dependencies = [
+ "html5ever 0.39.0",
+ "tendril 0.5.1",
+ "thiserror 2.0.18",
+ "unicode-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3352,16 @@ checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -4121,6 +4192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.1",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,7 +4427,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "hf-hub",
  "hound",
- "html2text",
+ "html2text 0.16.7",
  "http",
  "image",
  "indexmap 2.14.0",
@@ -4563,6 +4645,7 @@ dependencies = [
  "async-trait",
  "bip39",
  "block2",
+ "calamine",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -4575,6 +4658,7 @@ dependencies = [
  "hkdf",
  "hound",
  "hpke",
+ "html2text 0.17.1",
  "keyring",
  "murmur-protocol",
  "objc2",
@@ -4583,7 +4667,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-pdf-kit",
  "opaque-ke",
+ "quick-xml",
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
@@ -4611,6 +4697,7 @@ dependencies = [
  "uuid 1.23.4",
  "whisper-rs",
  "zeroize",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -5123,6 +5210,17 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-pdf-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c14ed801ae810c6ba487cedd7616bb48f9a8e37940042f57e862538e2c7db117"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -5756,6 +5854,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -10187,16 +10286,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
  "typed-path",
+ "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -135,6 +135,16 @@ opaque-ke = { version = "4", features = ["argon2"] }
 # CSPRNG source for HPKE seal / keypair generation (rand_core 0.6 ecosystem, matches hpke 0.12).
 rand = "0.8"
 
+# ── Universal document extraction (Brain v3 PR-2 — `src/extract/`) ──
+# DOCX/PPTX are pure-Rust OOXML walks over the zip container + XML stream — NO parsing crate: `zip`
+# and `quick-xml` are ALREADY compiled transitively (zip via candle-core, quick-xml via plist/tauri),
+# here PROMOTED to direct deps pinned to the versions cargo already resolved (no new build cost).
+zip = { version = "7", default-features = false, features = ["deflate"] }
+quick-xml = "0.41"
+# XLSX (sheet → pipe rows) and HTML (→ plain text). Both MIT-family, pure-Rust.
+calamine = "0.36"
+html2text = "0.17"
+
 # ── Misc ──
 chrono = { version = "0.4", features = ["clock", "serde"] }
 dirs = "5"
@@ -153,11 +163,19 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # NSException risk): objc2-core-graphics CGWindow + objc2-core-foundation CFArray/CFDictionary/
 # CFString for reading window owner + title. macOS-only — gated under cfg(target_os = "macos").
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
+# `exception` feature: `objc2::exception::catch` — Brain v3 PR-2 wraps EVERY PDFKit call so a stray
+# ObjC NSException (e.g. a malformed/encrypted PDF) is CAUGHT and mapped to `AppError::InvalidArg`
+# instead of unwinding across FFI and aborting the process (rules §7 crash-safe-FFI; the screenshare
+# war story). A feature flip on an existing dep, no new crate.
+objc2 = { version = "0.6", features = ["exception"] }
 block2 = "0.6"
+# PDF text + outline extraction via Apple's PDFKit (same objc2 0.6/0.3 family we already ship; zero
+# new binaries, no dylib to sign). Only the PDFDocument/PDFPage/PDFOutline/PDFDestination surface is
+# needed — `src/extract/pdf.rs`. All calls wrapped in `objc2::exception::catch`. macOS-only.
+objc2-pdf-kit = { version = "0.3", default-features = false, features = ["PDFDocument", "PDFPage", "PDFOutline", "PDFDestination"] }
 # `NSProcessInfo` feature: the typed `thermalState` binding for the live-loop thermal governor
 # (`src/thermal.rs`) — a feature flip on an existing dep, no new crate.
-objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSProcessInfo"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSProcessInfo", "NSURL"] }
 objc2-app-kit = { version = "0.3", features = ["NSScreen"] }
 objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGWindow"] }
 objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFDictionary", "CFString"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2675,55 +2675,143 @@ pub(crate) fn get_manual_notes_inner(
     state.db.get_manual_notes(meeting_id)
 }
 
-/// The md/txt extensions document ingestion accepts. md/txt only — NO new parsing crate; the file is
-/// read as UTF-8 text via `std::fs::read_to_string`. Anything else is rejected with `InvalidArg`.
-const DOC_ALLOWED_EXTS: &[&str] = &["md", "txt"];
+/// The extensions document ingestion accepts (Brain v3 PR-2). Text (md/txt) plus the extracted
+/// formats: PDF (macOS PDFKit), DOCX/PPTX (pure-Rust OOXML), XLSX (calamine), HTML. Dispatch +
+/// extraction live in `crate::extract`; anything else is rejected with `InvalidArg`.
+const DOC_ALLOWED_EXTS: &[&str] = &["md", "txt", "pdf", "docx", "pptx", "xlsx", "html", "htm"];
 
-/// Document ingestion — upload a local md/txt file INTO a folder so its text is chunked + embedded
+/// Document ingestion — upload a local file INTO a folder so its EXTRACTED text is chunked + embedded
 /// into the on-device vector layer and the brain/Ask can retrieve it. Returns the new document id.
+/// ASYNC (Brain v3 PR-2): a large PDF's extract+chunk+embed runs off the UI thread behind the shared
+/// heavy-inference permit + the RAM floor, emitting counts-only progress via [`EVENT_DOC_IMPORT`].
 ///
 /// LOCK-MODEL:
 /// - WRITE-GATE: refuse a sealed-and-NOT-session-unlocked folder (`AppError::Locked`) — an ungated
 ///   write would land plaintext at rest behind the lock (mirrors `save_manual_notes`'s gate).
-/// - Extension allowlist (`md`/`txt`) — reject anything else with `AppError::InvalidArg`; NO new
-///   crate (read as UTF-8 text).
+/// - Extension allowlist — reject anything else with `AppError::InvalidArg`.
+/// - We store the EXTRACTED TEXT only (`documents.text`), never the source binary — no new seal path.
 /// - EMBED only when the REAL e5 model is present (`embed_model_present()`): otherwise the chunks are
 ///   stored WITHOUT vectors (no stub vectors polluting the index — mirrors `should_auto_index`).
 /// - The text is SEALED-AND-RESTORED with the folder on lock/unlock; its chunks are PURGED on lock,
 ///   re-embeddable on unlock.
 #[tauri::command]
-pub fn import_document(
+pub async fn import_document(
+    app: AppHandle,
     state: State<'_, AppState>,
     path: String,
     folder_id: String,
 ) -> Result<String, AppError> {
-    import_document_inner(state.inner(), &path, &folder_id)
+    // 0) WRITE-GATE up front, on the async task (touches the borrowed `&AppState`): a
+    //    sealed-and-NOT-session-unlocked folder is refused BEFORE any file work so the caller fails
+    //    fast (`AppError::Locked`), and an unknown folder is `InvalidArg`. The gate is RE-CHECKED
+    //    inside the blocking closure right before the plaintext INSERT (below) using the cloned
+    //    `unlocked_folders` handle, so a relock racing between here and the insert can't land
+    //    plaintext at rest behind the lock.
+    import_document_write_gate(state.inner(), &folder_id)?;
+
+    // Clone ONLY the `Arc` handles that cross into the blocking closure — `AppState` itself is not
+    // `Clone`. `db` for insert+index, `unlocked_folders` for the pre-insert gate re-check,
+    // `heavy_inference` for the ONE heavy permit. Everything past this point is `'static`.
+    let db = std::sync::Arc::clone(&state.inner().db);
+    let unlocked = std::sync::Arc::clone(&state.inner().unlocked_folders);
+    let sem = std::sync::Arc::clone(&state.inner().heavy_inference);
+
+    // RAM floor: under memory pressure, do the (still off-thread) extract+insert but SKIP the embed —
+    // the chunks + FTS are durable (keyword retrieval works) and the idempotent repair tick / a later
+    // Reindex fills the vectors. Never fail the import over a busy machine. Decided here (on the async
+    // task) and passed INTO the closure so the whole heavy pipeline stays inside ONE `run_heavy` scope.
+    let ram_permits = crate::transcribe::model::topic_backfill_ram_permits_now();
+
+    // The WHOLE pipeline — extract (whole-file read + zip/XML parse for OOXML/XLSX, or the per-page
+    // PDFKit loop; multi-second on a large doc), insert the row + chunk (FTS durable), then embed —
+    // runs OFF the Tokio worker behind the ONE heavy-inference permit (rust-tauri rule: long-running
+    // work never blocks the runtime thread). Progress events fire from inside across the stages
+    // (extracting → chunking → embedding → done); the `AppHandle` is `Clone` + `Send` so the emitter
+    // reaches the FE from the blocking thread. Best-effort per stage: the row/chunks stay durable even
+    // if the embed fails.
+    let app2 = app.clone();
+    let path2 = path.clone();
+    let folder2 = folder_id.clone();
+    crate::perf::run_heavy(&sem, move || {
+        crate::events::emit_doc_import(&app2, "", "extracting", 0, 0);
+        // EXTRACT (pure `path → text`, no DB/state).
+        let (name, stored) = extract_document_text(&path2)?;
+
+        crate::events::emit_doc_import(&app2, "", "chunking", 0, 0);
+        // GATE (re-checked from the cloned handle) + INSERT + CHUNK-ONLY index (FTS durable now).
+        let id = insert_extracted_document(&db, &unlocked, &folder2, &name, &stored)?;
+
+        // EMBED only if the RAM floor permitted (else defer to the repair tick). Best-effort: a
+        // failure logs (no PII) and leaves the durable chunks/FTS + row in place.
+        if ram_permits {
+            let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+            crate::events::emit_doc_import(&app2, &id, "embedding", 0, 0);
+            if let Err(e) = index_document_row_kind_routed(&db, &id, embedder.as_deref()) {
+                tracing::warn!(target: "rag", error = %e, document_id = %id, "import: embed failed (content stored)");
+            }
+        } else {
+            tracing::info!(target: "documents", document_id = %id, "import: RAM floor — deferring embed to repair tick");
+        }
+        crate::events::emit_doc_import(&app2, &id, "done", 0, 0);
+        Ok(id)
+    })
+    .await
 }
 
-/// Inner of [`import_document`] taking `&AppState` (so the gate + allowlist are unit-testable without
-/// a `tauri::State`).
+/// Inner of [`import_document`] taking `&AppState` (so the gate + allowlist + EXTRACTION are
+/// unit-testable without a `tauri::State`). EXTRACTS the file to blocks, stores the serialized text,
+/// inserts the row (write-gated), and DOES NOT embed (the async wrapper embeds behind the RAM floor /
+/// permit; a unit test with the model absent still gets chunk-only indexing via `ingest_into_folder`).
+///
+/// This runs SYNCHRONOUSLY (the async command wrapper does the same extract→insert→embed pipeline
+/// entirely inside `perf::run_heavy` / `spawn_blocking` — see [`import_document`]); this seam exists
+/// only so the extract + gate + insert are testable without a `tauri::State` or a runtime. It has no
+/// production caller (the async wrapper composes `extract_document_text` + `insert_extracted_document`
+/// directly), so it is compiled only under `cfg(test)`.
+#[cfg(test)]
 pub(crate) fn import_document_inner(
     state: &AppState,
     path: &str,
     folder_id: &str,
 ) -> Result<String, AppError> {
-    // Extension allowlist (md/txt only). Lowercased; an extension-less path is rejected.
+    // EXTRACT (allowlist + `path → text`, pure, no DB/state).
+    let (name, stored) = extract_document_text(path)?;
+    // GATE + INSERT + chunk-only index (the shared seam the async wrapper also uses).
+    insert_extracted_document(&state.db, &state.unlocked_folders, folder_id, &name, &stored)
+}
+
+/// EXTRACT a supported document to its storable text form — PURE `path → (display_name, text)`, with
+/// NO `AppState`/DB/keychain touch, so the whole (potentially multi-second: whole-file read + zip
+/// decompress + XML parse for OOXML/XLSX, or the per-page PDFKit loop) extraction can run OFF the
+/// Tokio runtime inside `run_heavy`. Fails CLOSED with `AppError::InvalidArg` for an unsupported /
+/// extension-less / unreadable / no-extractable-text file. Returns the file-name component as the
+/// display name (never an on-disk path — no PII in the stored name/logs).
+fn extract_document_text(path: &str) -> Result<(String, String), AppError> {
+    // Extension allowlist. Lowercased; an extension-less path is rejected.
     let p = std::path::Path::new(path);
-    let ext_ok = p
+    let ext = p
         .extension()
         .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase())
-        .map(|e| DOC_ALLOWED_EXTS.contains(&e.as_str()))
-        .unwrap_or(false);
-    if !ext_ok {
+        .map(|e| e.to_ascii_lowercase());
+    let ext = match ext {
+        Some(e) if DOC_ALLOWED_EXTS.contains(&e.as_str()) => e,
+        _ => {
+            return Err(AppError::InvalidArg(
+                "unsupported document type — import md, txt, pdf, docx, pptx, xlsx, or html".into(),
+            ))
+        }
+    };
+
+    // EXTRACT to blocks (page/heading preserved), then serialize to the storable text form. A
+    // non-UTF-8 / unreadable / malformed / scanned-PDF / zip-bomb file fails closed inside
+    // `extract_blocks` (the OOXML/XLSX decompression-ratio guard lives there — see extract/ooxml.rs).
+    let blocks = crate::extract::extract_blocks(p, &ext)?;
+    if blocks.is_empty() || blocks.iter().all(|b| b.text.trim().is_empty()) {
         return Err(AppError::InvalidArg(
-            "only .md and .txt documents can be imported".into(),
+            "this document has no extractable text".into(),
         ));
     }
-
-    // Read the file as UTF-8 text (no parsing crate). A non-UTF-8 / unreadable file fails closed.
-    let text = std::fs::read_to_string(p)
-        .map_err(|e| AppError::InvalidArg(format!("could not read document: {e}")))?;
+    let stored = crate::extract::blocks_to_stored_text(&blocks);
 
     // The display name = the file name (component only — never an on-disk path with personal content
     // in logs). Fallback to "document" if the path has no file-name component.
@@ -2732,8 +2820,77 @@ pub(crate) fn import_document_inner(
         .and_then(|n| n.to_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| "document".to_string());
+    Ok((name, stored))
+}
 
-    ingest_into_folder(state, folder_id, &name, &text, "document")
+/// The WRITE-GATE for an uploaded document, evaluated from `Arc` handles (not a `&AppState`), so it
+/// can be RE-CHECKED inside the blocking closure right before the plaintext INSERT — a relock racing
+/// between the up-front async gate and the insert can't land plaintext at rest behind a lock. Mirrors
+/// [`ingest_into_folder_opts`]'s gate exactly: unknown folder ⇒ `InvalidArg`; sealed-and-NOT-session-
+/// unlocked ⇒ `AppError::Locked`; open OR session-unlocked ⇒ Ok.
+fn insert_extracted_document(
+    db: &std::sync::Arc<crate::storage::Db>,
+    unlocked_folders: &std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    folder_id: &str,
+    name: &str,
+    stored: &str,
+) -> Result<String, AppError> {
+    // The folder must exist (so the FK holds + the gating has an anchor).
+    let folder = db
+        .folder_by_id(folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+
+    // WRITE-GATE: a sealed-and-not-session-unlocked folder is refused (never resurrect plaintext at
+    // rest behind a lock). Same predicate as `folder_is_unlocked`, evaluated from the cloned handle.
+    if folder.locked {
+        let session_unlocked = unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .contains(folder_id);
+        if !session_unlocked {
+            return Err(AppError::Locked(
+                "this folder is locked — unlock it to add to the brain".into(),
+            ));
+        }
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let created_at = chrono::Utc::now().timestamp_millis();
+    db.insert_document(&id, folder_id, name, stored, "document", created_at)?;
+
+    // CHUNK-ONLY inline (FTS durable now); the caller embeds under the RAM floor + heavy permit. A
+    // failure logs (no PII) and does NOT fail the ingest (the row + plaintext are durable; a later
+    // unlock re-chunk / reindex recovers the index).
+    if let Err(e) = index_document_row_kind_routed(db, &id, None) {
+        tracing::warn!(target: "rag", error = %e, "ingest: chunk failed (content stored)");
+    }
+
+    // PII rule: log only ids, the kind, and byte counts — never the text/name.
+    tracing::info!(
+        target: "documents",
+        document_id = %id,
+        folder_id = %folder_id,
+        kind = "document",
+        bytes = stored.len(),
+        "ingested document into brain"
+    );
+    Ok(id)
+}
+
+/// The WRITE-GATE for an uploaded document evaluated from a borrowed `&AppState` (the up-front,
+/// fail-fast check on the async task before any file work). Same predicate as
+/// [`insert_extracted_document`]'s re-check; delegates to the existing `folder_is_unlocked`.
+fn import_document_write_gate(state: &AppState, folder_id: &str) -> Result<(), AppError> {
+    let folder = state
+        .db
+        .folder_by_id(folder_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    if folder.locked && !folder_is_unlocked(state, folder_id)? {
+        return Err(AppError::Locked(
+            "this folder is locked — unlock it to add to the brain".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Ingest TYPED text as a brain `note` (the Brain page "+ Add note"). Same gated ingest path + seal
@@ -2766,12 +2923,15 @@ pub(crate) fn import_text_inner(
     ingest_into_folder(state, folder_id, name, text, "note")
 }
 
-/// The SINGLE gated ingest path for both an uploaded document (`kind="document"`) and a typed note
-/// (`kind="note"`): look up the folder, WRITE-GATE it (a sealed-not-unlocked folder is refused so
-/// content can never appear at rest behind a lock), insert the `documents` row, and index its chunks
-/// into the vector layer ONLY when the REAL e5 model is present (never stub vectors — mirrors
-/// `should_auto_index`). The row is sealed-and-restored + purged-on-lock identically regardless of
-/// kind. Returns the new id.
+/// The SINGLE gated ingest path for a typed note (`kind="note"`): look up the folder, WRITE-GATE it
+/// (a sealed-not-unlocked folder is refused so content can never appear at rest behind a lock),
+/// insert the `documents` row, and index its chunks into the vector layer ONLY when the REAL e5 model
+/// is present (never stub vectors — mirrors `should_auto_index`). The row is sealed-and-restored +
+/// purged-on-lock identically to an uploaded document. Returns the new id.
+///
+/// An uploaded DOCUMENT (`kind="document"`) takes the sibling [`insert_extracted_document`] seam
+/// instead — same gate + insert + chunk-only index, but reachable from `Arc` handles so the whole
+/// extract→insert→embed pipeline runs off the Tokio runtime inside `run_heavy` (Brain v3 PR-2).
 fn ingest_into_folder(
     state: &AppState,
     folder_id: &str,
@@ -2800,7 +2960,7 @@ fn ingest_into_folder(
         .insert_document(&id, folder_id, name, text, kind, created_at)?;
 
     // ALWAYS chunk (doc_chunks + the fts_doc_chunks triggers) so keyword retrieval works on a
-    // DEFAULT install — an ingested document must never be write-only memory. Vectors ONLY when the
+    // DEFAULT install — an ingested note must never be write-only memory. Vectors ONLY when the
     // REAL e5 model is present (never write stub vectors). Best-effort: a failure logs (no PII) and
     // does NOT fail the ingest (the row + plaintext are durable; a later unlock re-chunk / reindex
     // recovers the index).
@@ -2808,8 +2968,7 @@ fn ingest_into_folder(
     // KIND-ROUTED (PR-1 finding 4): a pasted note (`kind='note'`) can carry YAML front-matter in its
     // raw `text`, which must NEVER be embedded/indexed (DESIGN §1a — tags/properties pollute the
     // vectors + snippets). Route through the ONE front-matter-stripping seam so the ingest matches
-    // every other note-index path; an uploaded document (`kind='document'`) has no front-matter and
-    // takes the raw path unchanged inside the router.
+    // every other note-index path.
     let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
     if let Err(e) = index_document_row_kind_routed(&state.db, &id, embedder.as_deref()) {
         tracing::warn!(target: "rag", error = %e, "ingest: chunk/embed failed (content stored)");
@@ -2864,7 +3023,9 @@ pub(crate) fn get_document_inner(state: &AppState, id: &str) -> Result<String, A
     if !folder_is_unlocked(state, &folder_id)? {
         return Ok(String::new()); // sealed-not-unlocked ⇒ masked, never the stored text.
     }
-    Ok(text)
+    // Brain v3 PR-2: strip the block-structure markers a PR-2 upload stores in `text` — the FE gets
+    // clean readable text (a note / md / txt / legacy row has no markers → unchanged).
+    Ok(crate::extract::render_display_text(&text))
 }
 
 /// Headline counts + semantic flags for the Brain page ("what's in my brain"). All counts are over
@@ -21499,28 +21660,20 @@ mod lifecycle_tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, id);
         assert!(listed[0].name.ends_with(".md"));
-        // CHUNKING is unconditional (keyword/FTS retrieval must work on a default install);
-        // only the VECTORS stay model-presence-gated (never write stub vectors — mirrors
-        // `should_auto_index`'s no-stub contract). So:
-        //   - always          → ≥1 doc_chunks row;
-        //   - model present   → matching real e5 vectors;
-        //   - model ABSENT    → exactly 0 doc_vec_chunks rows (no stub poisoning).
+        // CHUNKING is unconditional (keyword/FTS retrieval must work on a default install). Brain v3
+        // PR-2: `import_document_inner` is CHUNK-ONLY by design — it NEVER embeds inline (the async
+        // `import_document` wrapper does the authoritative embed behind the RAM floor + heavy-inference
+        // permit). So the inner leaves ZERO doc_vec_chunks rows regardless of model presence; keyword
+        // FTS is durable immediately. (The no-stub contract still holds trivially — no vectors here.)
         assert!(
             state.db.doc_chunk_count(&id).unwrap() >= 1,
             "the document must be chunked regardless of model presence (always-chunk)"
         );
-        if crate::embed::embed_model_present() {
-            assert!(
-                state.db.doc_vec_count(&id).unwrap() >= 1,
-                "with the e5 model present, the chunks must carry real vectors"
-            );
-        } else {
-            assert_eq!(
-                state.db.doc_vec_count(&id).unwrap(),
-                0,
-                "with no e5 model, NO stub vectors are written (no-stub contract)"
-            );
-        }
+        assert_eq!(
+            state.db.doc_vec_count(&id).unwrap(),
+            0,
+            "the inner is chunk-only (embed deferred to the async wrapper): no vectors here"
+        );
 
         // A .txt import is also accepted.
         let txt = write_temp_doc("txt", "txt", "plain text notes about hiring");
@@ -21529,18 +21682,19 @@ mod lifecycle_tests {
         assert!(!id2.is_empty());
     }
 
-    /// ALLOWLIST: a non-md/txt extension (and an extension-less path) is rejected with InvalidArg,
-    /// and NO row is inserted (the folder stays empty).
+    /// ALLOWLIST (Brain v3 PR-2): an UNSUPPORTED extension (`.rtf`) and an extension-less path are
+    /// rejected with InvalidArg, and NO row is inserted (the folder stays empty). md/txt/pdf/docx/
+    /// pptx/xlsx/html are the supported set; anything else fails closed at the allowlist.
     #[test]
-    fn import_document_rejects_non_md_txt() {
+    fn import_document_rejects_unsupported_extension() {
         let state = build_state("doc-allowlist");
         make_open_folder(&state.db, "f-open", "Project");
 
-        let pdf = write_temp_doc("pdf", "pdf", "%PDF-1.4 ...");
-        let err = import_document_inner(&state, pdf.to_str().unwrap(), "f-open").unwrap_err();
+        let rtf = write_temp_doc("rtf", "rtf", "{\\rtf1 unsupported}");
+        let err = import_document_inner(&state, rtf.to_str().unwrap(), "f-open").unwrap_err();
         assert!(
             matches!(err, AppError::InvalidArg(_)),
-            "pdf must be rejected, got {err:?}"
+            "an unsupported extension must be rejected, got {err:?}"
         );
 
         // Extension-less path.
@@ -21620,6 +21774,54 @@ mod lifecycle_tests {
         );
         let md3 = write_temp_doc("seal3", "md", "after unlock");
         import_document_inner(&state, md3.to_str().unwrap(), "f-lock").unwrap();
+    }
+
+    /// WRITE-GATE (race-safe re-check): the `Arc`-handle seam the async `import_document` runs OFF
+    /// the runtime — `insert_extracted_document` — enforces the SAME gate as the on-`&AppState` path.
+    /// A sealed-and-not-session-unlocked folder is refused with `Locked` (so a relock racing between
+    /// the up-front gate and the off-thread insert can't land plaintext at rest); an unknown folder
+    /// is `InvalidArg`; a session-unlocked folder inserts. This pins the exact predicate the blocking
+    /// closure re-evaluates, independent of the sync `import_document_inner` seam.
+    #[test]
+    fn insert_extracted_document_gate_matches_on_arc_handles() {
+        let state = build_state("doc-arc-gate");
+        make_open_folder(&state.db, "f-arc", "Vault");
+        state
+            .db
+            .set_folder_locked("f-arc", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        let db = std::sync::Arc::clone(&state.db);
+        let unlocked = std::sync::Arc::clone(&state.unlocked_folders);
+
+        // Unknown folder → InvalidArg.
+        let e0 = insert_extracted_document(&db, &unlocked, "nope", "x.md", "hi").unwrap_err();
+        assert!(matches!(e0, AppError::InvalidArg(_)), "got {e0:?}");
+
+        // Sealed + NOT in the session set → Locked (never insert plaintext behind the lock).
+        let e1 = insert_extracted_document(&db, &unlocked, "f-arc", "x.md", "secret").unwrap_err();
+        assert!(matches!(e1, AppError::Locked(_)), "sealed insert must be Locked, got {e1:?}");
+        assert!(
+            list_documents_inner(&state, "f-arc").unwrap().is_empty(),
+            "no row inserted while sealed"
+        );
+
+        // Session-unlock → the same seam inserts.
+        unlocked.lock().unwrap().insert("f-arc".to_string());
+        let id = insert_extracted_document(&db, &unlocked, "f-arc", "x.md", "now allowed").unwrap();
+        assert!(!id.is_empty());
+        assert_eq!(
+            get_document_inner(&state, &id).unwrap(),
+            "now allowed",
+            "unlocked insert is readable"
+        );
+
+        // And the up-front async-task gate agrees on every case.
+        assert!(import_document_write_gate(&state, "f-arc").is_ok(), "unlocked passes the up-front gate");
+        assert!(
+            matches!(import_document_write_gate(&state, "nope"), Err(AppError::InvalidArg(_))),
+            "unknown folder fails the up-front gate"
+        );
     }
 
     /// IMPORT_TEXT round-trip: typed text is ingested as a kind='note' document — stored + readable,

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -601,6 +601,259 @@ pub fn chunk_note(title: &str, date: &str, markdown: &str) -> Vec<String> {
     chunks
 }
 
+// ── Brain v3 PR-2 — HIERARCHICAL document chunking ───────────────────────────────────────────────
+//
+// A document extracted into [`crate::extract::ExtractedBlock`]s becomes a 3-level tree persisted in
+// the SAME `doc_chunks` table (see `Db::index_document_chunks`):
+//   - L0 leaves: 800-char paragraph-greedy chunks that NEVER cross a heading boundary — embedded
+//     (with a deterministic contextual header) AND FTS-indexed.
+//   - L1 section-parents: one per heading section, heading-bounded, capped ~6000 chars — FTS +
+//     fetch-by-id ONLY, NOT embedded (the vector count stays flat; parents are pulled by expansion).
+//   - L2 doc-summary: a deterministic outline (heading tree + first sentence per section, 1..=3
+//     chunks) — embedded + FTS (the RAPTOR collapsed-tree effect at ZERO LLM cost).
+// The contextual header extends the shipped `chunk_note` header mechanism (Anthropic contextual
+// retrieval): every embed-text is prefixed `"<name> | <section_path> | p.<N>"\n<raw>` so a chunk
+// carries its provenance into both the vector and the FTS legs, while the RAW text is kept separate
+// for snippet display.
+
+/// L1 section-parent cap (chars). Heading-bounded parents beyond this are truncated for the FTS/fetch
+/// row (the leaves under them still carry the full text).
+const SECTION_PARENT_CHAR_CAP: usize = 6000;
+
+/// Level tag for a [`HierChunk`]: 0 = leaf, 1 = section-parent, 2 = doc-summary.
+pub const HIER_LEVEL_LEAF: i64 = 0;
+pub const HIER_LEVEL_SECTION: i64 = 1;
+pub const HIER_LEVEL_SUMMARY: i64 = 2;
+
+/// One node of a document's chunk hierarchy, ready to persist into `doc_chunks` (+ its `doc_vec_chunks`
+/// row when `embed`-worthy). Pure data — the DB layer assigns row ids and resolves `parent` indices to
+/// row ids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HierChunk {
+    /// [`HIER_LEVEL_LEAF`] / [`HIER_LEVEL_SECTION`] / [`HIER_LEVEL_SUMMARY`].
+    pub level: i64,
+    /// Index (into the produced `Vec<HierChunk>`) of this chunk's parent, or `None`. A leaf points at
+    /// its L1 section; L1/L2 have no parent. The DB layer maps these indices to inserted row ids.
+    pub parent: Option<usize>,
+    /// The RAW chunk text (for snippet display + the FTS/`text` column).
+    pub raw: String,
+    /// The EMBED text: the contextual header + raw (what actually gets vectorized, for L0/L2).
+    pub embed_text: String,
+    /// Heading trail this chunk sits under ("A › B"), or `None`.
+    pub section_path: Option<String>,
+    /// 1-based page/slide, or `None` (flow formats).
+    pub page_no: Option<u32>,
+    /// Whether this level is EMBEDDED (L0 + L2 true; L1 false). The DB layer skips a `doc_vec_chunks`
+    /// row when false — this is what keeps L1 parents FTS-only.
+    pub embed: bool,
+}
+
+/// The deterministic contextual header prefixed onto a leaf/summary's embed-text:
+/// `"<name> | <section_path> | p.<N>"` (empty components omitted). Extends `chunk_note`'s
+/// `<title> · <date>` provenance mechanism to documents.
+fn hier_header(name: &str, section_path: Option<&str>, page_no: Option<u32>) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(3);
+    let name = name.trim();
+    if !name.is_empty() {
+        parts.push(name.to_string());
+    }
+    if let Some(sp) = section_path {
+        let sp = sp.trim();
+        if !sp.is_empty() {
+            parts.push(sp.to_string());
+        }
+    }
+    if let Some(p) = page_no {
+        parts.push(format!("p.{p}"));
+    }
+    parts.join(" | ")
+}
+
+/// Prefix `raw` with the contextual header for embedding (the header rides the embedding AND the FTS
+/// text). A leaf with no header context embeds the raw text unchanged.
+fn hier_embed_text(name: &str, section_path: Option<&str>, page_no: Option<u32>, raw: &str) -> String {
+    let header = hier_header(name, section_path, page_no);
+    if header.is_empty() {
+        raw.to_string()
+    } else {
+        format!("{header}\n{raw}")
+    }
+}
+
+/// Greedily pack blank-line-separated paragraphs of `text` into ≤[`CHUNK_CHAR_TARGET`] leaf strings
+/// (the SAME sizing as `chunk_note`, minus the header — the header is added per-leaf later). A single
+/// oversized paragraph becomes its own leaf.
+fn pack_leaves(text: &str) -> Vec<String> {
+    let paragraphs: Vec<&str> = text
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect();
+    let mut out: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    for p in paragraphs {
+        if !cur.is_empty() && cur.len() + 1 + p.len() > CHUNK_CHAR_TARGET {
+            out.push(std::mem::take(&mut cur));
+        }
+        if !cur.is_empty() {
+            cur.push('\n');
+        }
+        cur.push_str(p);
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// The first sentence of `text` (up to the first `. ! ?` followed by whitespace/end, capped so a
+/// run-on line can't dominate the outline). Deterministic; used to build the L2 outline summary.
+fn first_sentence(text: &str) -> String {
+    const CAP: usize = 240;
+    let text = text.trim();
+    let bytes = text.as_bytes();
+    let mut end = text.len();
+    for (i, &b) in bytes.iter().enumerate() {
+        if (b == b'.' || b == b'!' || b == b'?')
+            && bytes.get(i + 1).map(|c| c.is_ascii_whitespace()).unwrap_or(true)
+        {
+            end = i + 1;
+            break;
+        }
+    }
+    // `end` is a byte index at an ASCII sentence terminator (or the full byte len) — always a char
+    // boundary, so `&text[..end]` is safe. Then char-cap so a run-on line can't dominate the outline.
+    text[..end].chars().take(CAP).collect::<String>().trim().to_string()
+}
+
+/// A running heading section being assembled by [`chunk_document_hierarchical`].
+struct Section {
+    path: Option<String>,
+    page_no: Option<u32>,
+    /// Accumulated raw block texts (joined by blank lines for leaf packing).
+    body: String,
+}
+
+/// Turn a document's extracted `blocks` into the full 3-level [`HierChunk`] tree. Deterministic; no
+/// LLM. Sections are delimited by a CHANGE in `heading_path` (a run of blocks sharing the same
+/// heading trail is one section). `name` is the document/display name for the contextual header.
+///
+/// Produced order: for each section — its L1 parent, then its L0 leaves (parent = that L1's index) —
+/// followed by the L2 summary chunk(s) at the end. The DB layer inserts in this order so a leaf's
+/// `parent` index precedes it.
+pub fn chunk_document_hierarchical(name: &str, blocks: &[crate::extract::ExtractedBlock]) -> Vec<HierChunk> {
+    // 1) Coalesce consecutive blocks that share a heading trail into sections (the page_no of the
+    //    section is the FIRST block's page).
+    let mut sections: Vec<Section> = Vec::new();
+    for b in blocks {
+        let text = b.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        // Append to the current section iff it shares this block's heading trail; else start a new
+        // one. `last_mut()` gives both the same-trail check and the mutable append in one borrow (no
+        // `unwrap`/`expect` — a `None` last simply starts the first section).
+        match sections.last_mut() {
+            Some(sec) if sec.path.as_deref() == b.heading_path.as_deref() => {
+                sec.body.push_str("\n\n");
+                sec.body.push_str(text);
+            }
+            _ => sections.push(Section {
+                path: b.heading_path.clone(),
+                page_no: b.page,
+                body: text.to_string(),
+            }),
+        }
+    }
+    if sections.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out: Vec<HierChunk> = Vec::new();
+
+    // 2) Per section: emit the L1 parent, then its L0 leaves.
+    for sec in &sections {
+        let leaves = pack_leaves(&sec.body);
+        if leaves.is_empty() {
+            continue;
+        }
+        // L1 section-parent (heading-bounded, capped, FTS-only — NOT embedded).
+        let parent_raw: String = {
+            let mut s = sec.body.clone();
+            if s.len() > SECTION_PARENT_CHAR_CAP {
+                // char-safe truncation
+                s = s.chars().take(SECTION_PARENT_CHAR_CAP).collect();
+            }
+            s
+        };
+        let parent_idx = out.len();
+        out.push(HierChunk {
+            level: HIER_LEVEL_SECTION,
+            parent: None,
+            embed_text: String::new(), // never embedded
+            raw: parent_raw,
+            section_path: sec.path.clone(),
+            page_no: sec.page_no,
+            embed: false,
+        });
+        // L0 leaves under this parent.
+        for leaf in leaves {
+            let embed_text = hier_embed_text(name, sec.path.as_deref(), sec.page_no, &leaf);
+            out.push(HierChunk {
+                level: HIER_LEVEL_LEAF,
+                parent: Some(parent_idx),
+                embed_text,
+                raw: leaf,
+                section_path: sec.path.clone(),
+                page_no: sec.page_no,
+                embed: true,
+            });
+        }
+    }
+
+    // 3) L2 doc-summary: deterministic outline = heading tree + first sentence per section. Packed
+    //    into 1..=3 chunks of ≤CHUNK_CHAR_TARGET (embedded + FTS). If there is no heading structure
+    //    at all (a flat md/txt), still emit ONE summary from the first sentences (bounded).
+    let mut outline_lines: Vec<String> = Vec::new();
+    for sec in &sections {
+        let sentence = first_sentence(&sec.body);
+        match &sec.path {
+            Some(p) if !p.trim().is_empty() => {
+                if sentence.is_empty() {
+                    outline_lines.push(format!("# {p}"));
+                } else {
+                    outline_lines.push(format!("# {p}: {sentence}"));
+                }
+            }
+            _ => {
+                if !sentence.is_empty() {
+                    outline_lines.push(sentence);
+                }
+            }
+        }
+    }
+    let outline = outline_lines.join("\n");
+    if !outline.trim().is_empty() {
+        // Pack the outline into ≤3 leaf-sized summary chunks (an unusually deep doc yields a few).
+        let mut summary_chunks = pack_leaves(&outline);
+        summary_chunks.truncate(3);
+        for sc in summary_chunks {
+            let embed_text = hier_embed_text(name, None, None, &sc);
+            out.push(HierChunk {
+                level: HIER_LEVEL_SUMMARY,
+                parent: None,
+                embed_text,
+                raw: sc,
+                section_path: None,
+                page_no: None,
+                embed: true,
+            });
+        }
+    }
+
+    out
+}
+
 /// Render `seconds` as `mm:ss` (minutes uncapped past 60 — a 75-minute meeting reads `75:xx`, not
 /// `01:15:xx`; provenance, not a clock). Negative/NaN clamp to `0`.
 fn mmss(seconds: f64) -> String {
@@ -1262,6 +1515,105 @@ mod tests {
         }
         // Blank markdown → no chunks.
         assert!(chunk_note("T", "D", "   \n\n  ").is_empty());
+    }
+
+    use crate::extract::ExtractedBlock;
+
+    fn blk(text: &str, page: Option<u32>, heading: Option<&str>) -> ExtractedBlock {
+        ExtractedBlock {
+            text: text.to_string(),
+            page,
+            heading_path: heading.map(|s| s.to_string()),
+        }
+    }
+
+    /// The hierarchical chunker emits: per section an L1 parent (NOT embedded) then its L0 leaves
+    /// (embedded, parent → the L1 index, contextual header on the embed text), plus an L2 summary
+    /// (embedded). Deterministic.
+    #[test]
+    fn hierarchical_chunker_builds_the_three_levels_with_headers_and_parents() {
+        let blocks = vec![
+            blk("The budget is 100k for the quarter.", Some(1), Some("Design")),
+            blk("Anna owns delivery of the API.", Some(1), Some("Design › Storage")),
+            blk("Closing thoughts on the roadmap.", Some(2), Some("Design › Storage")),
+        ];
+        let out = chunk_document_hierarchical("Spec.pdf", &blocks);
+        assert_eq!(out, chunk_document_hierarchical("Spec.pdf", &blocks), "deterministic");
+
+        // Two sections (Design, Design › Storage) → 2 L1 parents; the last two blocks coalesce.
+        let l1: Vec<&HierChunk> = out.iter().filter(|c| c.level == HIER_LEVEL_SECTION).collect();
+        assert_eq!(l1.len(), 2, "one L1 per heading section");
+        assert!(l1.iter().all(|c| !c.embed), "L1 parents are NEVER embedded (FTS-only)");
+        assert_eq!(l1[0].section_path.as_deref(), Some("Design"));
+        assert_eq!(l1[1].section_path.as_deref(), Some("Design › Storage"));
+
+        // L0 leaves: embedded, each points at an L1 parent, embed_text carries the contextual header.
+        let l0: Vec<(usize, &HierChunk)> = out
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.level == HIER_LEVEL_LEAF)
+            .collect();
+        assert!(!l0.is_empty(), "must have leaves");
+        for (_, leaf) in &l0 {
+            assert!(leaf.embed, "L0 leaves are embedded");
+            let parent = leaf.parent.expect("leaf must have a parent");
+            assert_eq!(
+                out[parent].level, HIER_LEVEL_SECTION,
+                "a leaf's parent must be its L1 section"
+            );
+            // Contextual header: "<name> | <section_path> | p.<N>\n<raw>".
+            assert!(
+                leaf.embed_text.starts_with("Spec.pdf | "),
+                "embed text must carry the doc name header: {:?}",
+                leaf.embed_text
+            );
+            assert!(
+                leaf.embed_text.contains(&format!("p.{}", leaf.page_no.unwrap())),
+                "embed text must carry the page: {:?}",
+                leaf.embed_text
+            );
+            assert!(
+                leaf.embed_text.ends_with(&leaf.raw),
+                "raw text must be preserved verbatim after the header"
+            );
+        }
+
+        // Exactly one L2 summary here (small doc), embedded, no parent.
+        let l2: Vec<&HierChunk> = out.iter().filter(|c| c.level == HIER_LEVEL_SUMMARY).collect();
+        assert!(!l2.is_empty() && l2.len() <= 3, "1..=3 summary chunks");
+        assert!(l2.iter().all(|c| c.embed && c.parent.is_none()));
+        // The outline references the headings.
+        assert!(
+            l2.iter().any(|c| c.raw.contains("Design")),
+            "L2 outline must reference the heading tree"
+        );
+    }
+
+    /// A flat (heading-less) document still produces leaves + an L2 summary, all with page None.
+    #[test]
+    fn hierarchical_chunker_handles_flat_documents() {
+        let blocks = vec![blk(
+            "First idea about the plan.\n\nSecond idea about hiring engineers.",
+            None,
+            None,
+        )];
+        let out = chunk_document_hierarchical("notes.txt", &blocks);
+        assert!(
+            out.iter().any(|c| c.level == HIER_LEVEL_LEAF && c.embed),
+            "a flat doc still yields embedded leaves"
+        );
+        assert!(
+            out.iter().any(|c| c.level == HIER_LEVEL_SUMMARY),
+            "a flat doc still yields an L2 summary"
+        );
+        assert!(out.iter().all(|c| c.page_no.is_none()), "flow format → page None");
+    }
+
+    /// Empty input → no chunks.
+    #[test]
+    fn hierarchical_chunker_empty_input_yields_nothing() {
+        assert!(chunk_document_hierarchical("x", &[]).is_empty());
+        assert!(chunk_document_hierarchical("x", &[blk("   ", None, None)]).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -226,6 +226,40 @@ pub struct NerDownloadPayload {
     pub done: bool,
 }
 
+/// Brain v3 PR-2 — progress for an in-flight document import (`import_document`): the extract →
+/// chunk → embed pipeline for ONE document. Carries the document id + a stage + counts ONLY — NO PII
+/// (no filename, no text, no heading; the id is a random UUID). Lets the Brain tab show a progress
+/// bar for a large PDF instead of a frozen dialog.
+pub const EVENT_DOC_IMPORT: &str = "murmur://doc-import";
+
+/// Payload for [`EVENT_DOC_IMPORT`]. `stage` is `"extracting"` | `"chunking"` | `"embedding"` |
+/// `"done"`. `done`/`total` are chunk counts within the embedding stage (0/0 for the earlier
+/// stages). The `document_id` is a random UUID (no content). NO PII.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocImportPayload {
+    pub document_id: String,
+    /// "extracting" | "chunking" | "embedding" | "done"
+    pub stage: String,
+    pub done: usize,
+    pub total: usize,
+}
+
+/// Emit [`EVENT_DOC_IMPORT`] to the FE (best-effort). Swallows the emit failure with a non-PII warn.
+pub fn emit_doc_import(app: &AppHandle, document_id: &str, stage: &str, done: usize, total: usize) {
+    if let Err(e) = app.emit(
+        EVENT_DOC_IMPORT,
+        DocImportPayload {
+            document_id: document_id.to_string(),
+            stage: stage.to_string(),
+            done,
+            total,
+        },
+    ) {
+        tracing::warn!(target: "documents", error = %e, stage, "emit doc-import failed");
+    }
+}
+
 /// Progress for the semantic-search backfill (`reindex_embeddings`) over all visible meetings.
 /// Carries COUNTS ONLY — no meeting ids, titles, or content (NO PII).
 pub const EVENT_REINDEX: &str = "murmur://reindex-embeddings";

--- a/src-tauri/src/extract/html.rs
+++ b/src-tauri/src/extract/html.rs
@@ -1,0 +1,74 @@
+//! HTML extraction via `html2text` (pure-Rust). The whole document renders to plain text as one
+//! [`ExtractedBlock`] (page `None`, heading `None`) — HTML has no reliable page axis and we keep the
+//! flow-format contract identical to md/txt. Deterministic + headless-testable.
+//!
+//! Lock model: pure `path → blocks`, no DB/keychain; failures map to `AppError::InvalidArg`. No PII.
+
+use std::path::Path;
+
+use super::ExtractedBlock;
+use crate::error::{AppError, Result};
+
+/// Wrap width for `html2text` rendering. Wide enough that paragraphs are not aggressively hard-wrapped
+/// (we want readable flow text for embedding/snippets, not a terminal column layout).
+const RENDER_WIDTH: usize = 100;
+
+/// Extract an HTML file into one plain-text block.
+pub fn extract_html(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read HTML: {e}")))?;
+    let text = html2text::from_read(bytes.as_slice(), RENDER_WIDTH)
+        .map_err(|e| AppError::InvalidArg(format!("could not render HTML: {e}")))?;
+    let text = text.trim().to_string();
+    if text.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(vec![ExtractedBlock::plain(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_html(body: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-html-{}-{}.html",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    /// HTML: tags are stripped, visible text survives, one block, no page / heading.
+    #[test]
+    fn html_renders_to_one_plain_text_block() {
+        let p = write_html(
+            "<html><body><h1>Spec</h1><p>The budget is <b>100k</b>.</p>\
+             <ul><li>Anna owns delivery</li></ul></body></html>",
+        );
+        let blocks = extract_html(&p).unwrap();
+        assert_eq!(blocks.len(), 1, "one block for the whole HTML doc");
+        let text = &blocks[0].text;
+        // `html2text`'s plain decorator renders markdown-flavored plain text (a `#` heading, `**bold**`,
+        // `*` list bullets) — the exact decoration is not load-bearing; what matters is that the
+        // VISIBLE text survives and the raw HTML TAGS are gone.
+        assert!(text.contains("Spec"), "heading text survives: {text:?}");
+        assert!(text.contains("100k"), "inline text survives: {text:?}");
+        assert!(text.contains("budget is"), "paragraph text survives: {text:?}");
+        assert!(text.contains("Anna owns delivery"), "list item survives: {text:?}");
+        assert!(!text.contains("<b>"), "raw tags must be stripped: {text:?}");
+        assert!(!text.contains("<li>"), "raw tags must be stripped: {text:?}");
+        assert_eq!(blocks[0].page, None);
+        assert_eq!(blocks[0].heading_path, None);
+    }
+
+    /// An empty / whitespace-only HTML file yields NO block (nothing to ingest).
+    #[test]
+    fn empty_html_yields_no_blocks() {
+        let p = write_html("<html><body>   </body></html>");
+        let blocks = extract_html(&p).unwrap();
+        assert!(blocks.is_empty(), "no visible text → no block");
+    }
+}

--- a/src-tauri/src/extract/mod.rs
+++ b/src-tauri/src/extract/mod.rs
@@ -1,0 +1,332 @@
+//! Universal document extraction (Brain v3 PR-2). Turns a local file of a supported format into a
+//! sequence of [`ExtractedBlock`]s — plain text, optionally tagged with a page number and a
+//! heading path — that the ingest pipeline chunks + embeds. We store the EXTRACTED TEXT only
+//! (`documents.text`), never the source binary, so there is no new seal path here; the extracted
+//! text rides the SAME `documents` seal/unseal the md/txt path already uses.
+//!
+//! Format matrix (dispatched by lowercased extension in [`extract_blocks`]):
+//! - `md` / `txt` — the whole file as ONE block (page `None`, heading `None`). Byte-for-byte the
+//!   pre-PR-2 behavior (a plain `read_to_string`), so an existing import is unchanged.
+//! - `docx` / `pptx` — PURE-RUST OOXML: [`ooxml`] walks the zip + streams the XML (no docx crate).
+//! - `pdf` — Apple PDFKit ([`pdf`], macOS-only), every call wrapped in `objc2::exception::catch`
+//!   so a malformed/encrypted PDF fails CLOSED with `AppError::InvalidArg`, never an FFI abort.
+//! - `xlsx` — [`calamine`](self::xlsx) (sheet name = heading, rows → pipe text).
+//! - `html` / `htm` — [`html`] via `html2text` (one plain-text block).
+//! - anything else — [`AppError::InvalidArg`].
+//!
+//! Lock model: extraction is a pure `path → Vec<ExtractedBlock>` transform with no DB / keychain
+//! access. Every gate lives at the ingest seam (`ingest_into_folder`) that consumes the result; the
+//! WRITE-GATE there refuses a sealed folder before any block is persisted. NO PII is logged here.
+
+use std::path::Path;
+
+use crate::error::{AppError, Result};
+
+pub mod html;
+pub mod ooxml;
+#[cfg(target_os = "macos")]
+pub mod pdf;
+pub mod xlsx;
+
+/// One extracted unit of a document: a run of plain text, optionally located by 1-based `page`
+/// (PDF page / PPTX slide; `None` for flow formats) and by `heading_path` — the accumulated
+/// heading trail to this block joined with " › " (e.g. `"Design › Storage"`), `None` when the
+/// block sits under no heading.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedBlock {
+    pub text: String,
+    pub page: Option<u32>,
+    pub heading_path: Option<String>,
+}
+
+impl ExtractedBlock {
+    /// A flow block with no page / heading context (md/txt/html and un-headed paragraphs).
+    pub fn plain(text: impl Into<String>) -> Self {
+        ExtractedBlock {
+            text: text.into(),
+            page: None,
+            heading_path: None,
+        }
+    }
+}
+
+/// The heading-trail separator used everywhere a `heading_path` is built or rendered (deterministic).
+pub const HEADING_SEP: &str = " › ";
+
+/// DECOMPRESSION-BOMB CEILING for a SINGLE OOXML/XLSX (zip-container) extraction — the maximum TOTAL
+/// number of DECOMPRESSED bytes we will accumulate across all inflated entries of one document before
+/// failing closed with [`AppError::InvalidArg`]. This is NOT a cap on the original (compressed) file
+/// size — a legitimately huge document stays importable ("arbitrary size" promise); it caps only the
+/// EXPANSION, so a tiny "zip bomb" that inflates to gigabytes (a classic OOM-availability attack via
+/// the ingest surface) is stopped. 512 MiB is far above any real docx/pptx/xlsx's decompressed XML
+/// yet small enough to never let a bomb exhaust memory. Enforced in [`ooxml`] and [`xlsx`].
+pub const MAX_EXTRACT_DECOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Extract a supported document into its blocks, dispatching on the LOWERCASED `ext` (the extension
+/// WITHOUT the dot). An unsupported extension is [`AppError::InvalidArg`]. `path` must point at a
+/// readable local file; a read/parse failure is mapped to `InvalidArg` (fail-closed), never a
+/// panic. Deterministic: the same file always yields the same block sequence.
+pub fn extract_blocks(path: &Path, ext: &str) -> Result<Vec<ExtractedBlock>> {
+    match ext.to_ascii_lowercase().as_str() {
+        "md" | "txt" => extract_text(path),
+        "docx" => ooxml::extract_docx(path),
+        "pptx" => ooxml::extract_pptx(path),
+        "xlsx" => xlsx::extract_xlsx(path),
+        "html" | "htm" => html::extract_html(path),
+        #[cfg(target_os = "macos")]
+        "pdf" => pdf::extract_pdf(path),
+        #[cfg(not(target_os = "macos"))]
+        "pdf" => Err(AppError::InvalidArg(
+            "PDF extraction is only available on macOS".into(),
+        )),
+        other => Err(AppError::InvalidArg(format!(
+            "unsupported document type: .{other}"
+        ))),
+    }
+}
+
+/// md/txt: the whole file as ONE block, byte-for-byte the pre-PR-2 `read_to_string` behavior. A
+/// non-UTF-8 / unreadable file fails closed with `InvalidArg`.
+fn extract_text(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read document: {e}")))?;
+    Ok(vec![ExtractedBlock::plain(text)])
+}
+
+/// Join two heading-path components with [`HEADING_SEP`], skipping empties. Public for the chunker
+/// (which builds the same trail from a block's `heading_path`).
+pub fn join_heading(prefix: Option<&str>, leaf: &str) -> String {
+    match prefix {
+        Some(p) if !p.is_empty() => format!("{p}{HEADING_SEP}{leaf}"),
+        _ => leaf.to_string(),
+    }
+}
+
+/// A control-char sentinel prefix for the per-block metadata line in the stored text. `\u{001E}`
+/// (RECORD SEPARATOR) never appears in extracted document text, so a stored document round-trips its
+/// block structure losslessly WITHOUT a new column — the hierarchy (page/heading) survives a
+/// seal/unseal/re-index cycle that only has `documents.text` to work from. NON-md/txt documents use
+/// this; md/txt store their single block verbatim (no sentinel), so the plaintext a user sees for a
+/// `.md` upload is byte-identical to before.
+const BLOCK_SENTINEL: char = '\u{001E}';
+
+/// Serialize extracted `blocks` into the `documents.text` string. A single un-located block (md/txt,
+/// html) is stored VERBATIM (no sentinel — the readable plaintext is unchanged). Otherwise each block
+/// is preceded by a `<RS>page<US>heading` metadata line, then its text, so [`blocks_from_stored_text`]
+/// can reconstruct the hierarchy on re-index. Deterministic + lossless.
+pub fn blocks_to_stored_text(blocks: &[ExtractedBlock]) -> String {
+    // The common flow-format case: exactly one block, no page/heading → store its text verbatim.
+    if blocks.len() == 1 && blocks[0].page.is_none() && blocks[0].heading_path.is_none() {
+        return blocks[0].text.clone();
+    }
+    let mut out = String::new();
+    for b in blocks {
+        // Metadata line: <RS> <page-or-empty> <US> <heading-or-empty>
+        out.push(BLOCK_SENTINEL);
+        if let Some(p) = b.page {
+            out.push_str(&p.to_string());
+        }
+        out.push('\u{001F}'); // UNIT SEPARATOR between page and heading
+        if let Some(h) = &b.heading_path {
+            out.push_str(h);
+        }
+        out.push('\n');
+        out.push_str(&b.text);
+        out.push('\n');
+    }
+    out
+}
+
+/// Reconstruct blocks from a `documents.text` produced by [`blocks_to_stored_text`]. Text WITHOUT the
+/// sentinel (a legacy md/txt upload, a typed note, or any pre-PR-2 row) is returned as ONE plain
+/// block — so every existing document re-indexes correctly (backward compatible). Deterministic.
+pub fn blocks_from_stored_text(text: &str) -> Vec<ExtractedBlock> {
+    if !text.contains(BLOCK_SENTINEL) {
+        // Legacy / flow format: one whole-text block (identical to the pre-PR-2 chunking input).
+        return vec![ExtractedBlock::plain(text.to_string())];
+    }
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    // Split on the sentinel; the first fragment before the first sentinel (if any) is preamble-less.
+    for segment in text.split(BLOCK_SENTINEL) {
+        if segment.is_empty() {
+            continue;
+        }
+        // segment = "<meta-line>\n<body...>". Split off the first line as metadata.
+        let (meta, body) = match segment.split_once('\n') {
+            Some((m, b)) => (m, b),
+            None => (segment, ""),
+        };
+        // meta = "<page><US><heading>"
+        let (page_s, heading_s) = match meta.split_once('\u{001F}') {
+            Some((p, h)) => (p, h),
+            None => ("", meta),
+        };
+        let page = page_s.trim().parse::<u32>().ok();
+        let heading = {
+            let h = heading_s.trim();
+            (!h.is_empty()).then(|| h.to_string())
+        };
+        // Trim exactly one trailing '\n' we appended after the body (keep interior text intact).
+        let body = body.strip_suffix('\n').unwrap_or(body);
+        blocks.push(ExtractedBlock {
+            text: body.to_string(),
+            page,
+            heading_path: heading,
+        });
+    }
+    blocks
+}
+
+/// Render a stored `documents.text` into CLEAN human-readable text for display / agent reading: the
+/// per-block metadata markers (page/heading sentinel lines) are stripped and blocks are joined by
+/// blank lines. Text with NO sentinel (md/txt/note/legacy) is returned UNCHANGED — so a `.md`
+/// upload, a typed note, and every pre-PR-2 row read byte-identically to before. Deterministic.
+pub fn render_display_text(stored: &str) -> String {
+    if !stored.contains(BLOCK_SENTINEL) {
+        return stored.to_string();
+    }
+    let blocks = blocks_from_stored_text(stored);
+    let mut parts: Vec<String> = Vec::with_capacity(blocks.len());
+    for b in blocks {
+        let t = b.text.trim();
+        if t.is_empty() {
+            continue;
+        }
+        parts.push(t.to_string());
+    }
+    parts.join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_tmp(ext: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-extract-{}-{}.{ext}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    /// md/txt: the whole file becomes ONE block with no page / heading — byte-for-byte the
+    /// pre-PR-2 `read_to_string` behavior (regression guard against the ingest text changing).
+    #[test]
+    fn md_and_txt_extract_the_whole_file_as_one_plain_block() {
+        let body = "# Spec\n\nThe budget is 100k.\n\nAnna owns delivery.";
+        for ext in ["md", "txt"] {
+            let p = write_tmp(ext, body.as_bytes());
+            let blocks = extract_blocks(&p, ext).unwrap();
+            assert_eq!(blocks.len(), 1, ".{ext} must be one block");
+            assert_eq!(blocks[0].text, body, ".{ext} text must be byte-identical");
+            assert_eq!(blocks[0].page, None);
+            assert_eq!(blocks[0].heading_path, None);
+        }
+    }
+
+    /// An unknown extension fails closed with `InvalidArg` (never a panic / never a leak).
+    #[test]
+    fn unknown_extension_is_invalid_arg() {
+        let p = write_tmp("xyz", b"whatever");
+        let err = extract_blocks(&p, "xyz").unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    /// `extract_blocks` lowercases the extension before dispatch (a `.MD` / `.TXT` still routes to
+    /// the text path).
+    #[test]
+    fn extension_dispatch_is_case_insensitive() {
+        let p = write_tmp("MD", b"hello");
+        let blocks = extract_blocks(&p, "MD").unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, "hello");
+    }
+
+    #[test]
+    fn join_heading_builds_the_trail_and_skips_empty_prefix() {
+        assert_eq!(join_heading(None, "Design"), "Design");
+        assert_eq!(join_heading(Some(""), "Design"), "Design");
+        assert_eq!(join_heading(Some("Design"), "Storage"), "Design › Storage");
+    }
+
+    /// A single flow block is stored VERBATIM (no sentinel) so a `.md` upload's plaintext is
+    /// byte-identical to the pre-PR-2 behavior, and it round-trips back to one plain block.
+    #[test]
+    fn single_flow_block_stores_verbatim_and_round_trips() {
+        let block = ExtractedBlock::plain("# Spec\n\nThe budget is 100k.");
+        let stored = blocks_to_stored_text(std::slice::from_ref(&block));
+        assert_eq!(stored, "# Spec\n\nThe budget is 100k.", "stored verbatim, no markers");
+        let back = blocks_from_stored_text(&stored);
+        assert_eq!(back, vec![block], "round-trips to one plain block");
+    }
+
+    /// Located blocks (page + heading) round-trip losslessly through the stored-text form.
+    #[test]
+    fn located_blocks_round_trip_losslessly() {
+        let blocks = vec![
+            ExtractedBlock {
+                text: "The budget is 100k.".into(),
+                page: Some(1),
+                heading_path: Some("Design".into()),
+            },
+            ExtractedBlock {
+                text: "Anna owns delivery.\nSecond line.".into(),
+                page: Some(2),
+                heading_path: Some("Design › Storage".into()),
+            },
+            ExtractedBlock {
+                text: "No heading here.".into(),
+                page: None,
+                heading_path: None,
+            },
+        ];
+        let stored = blocks_to_stored_text(&blocks);
+        let back = blocks_from_stored_text(&stored);
+        assert_eq!(back, blocks, "page + heading + text all survive the round trip");
+    }
+
+    /// Legacy text WITHOUT any sentinel (a pre-PR-2 row) reconstructs as ONE plain block (backward
+    /// compatible — every existing document re-indexes correctly).
+    #[test]
+    fn legacy_text_without_sentinel_is_one_block() {
+        let back = blocks_from_stored_text("plain legacy note body\n\nwith paragraphs");
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].text, "plain legacy note body\n\nwith paragraphs");
+        assert_eq!(back[0].page, None);
+        assert_eq!(back[0].heading_path, None);
+    }
+
+    /// `render_display_text` strips the block markers to clean readable text; sentinel-free text
+    /// (md/txt/note/legacy) passes through byte-identically.
+    #[test]
+    fn render_display_text_strips_markers_and_passes_plain_through() {
+        // Plain passes through unchanged.
+        assert_eq!(
+            render_display_text("# Spec\n\nThe budget is 100k."),
+            "# Spec\n\nThe budget is 100k."
+        );
+        // Located blocks → clean joined text, no control chars.
+        let blocks = vec![
+            ExtractedBlock {
+                text: "The budget is 100k.".into(),
+                page: Some(1),
+                heading_path: Some("Design".into()),
+            },
+            ExtractedBlock {
+                text: "Anna owns delivery.".into(),
+                page: Some(2),
+                heading_path: Some("Design › Storage".into()),
+            },
+        ];
+        let stored = blocks_to_stored_text(&blocks);
+        let display = render_display_text(&stored);
+        assert_eq!(display, "The budget is 100k.\n\nAnna owns delivery.");
+        assert!(
+            !display.contains('\u{001E}') && !display.contains('\u{001F}'),
+            "display text must carry no control-char markers"
+        );
+    }
+}

--- a/src-tauri/src/extract/ooxml.rs
+++ b/src-tauri/src/extract/ooxml.rs
@@ -1,0 +1,703 @@
+//! Pure-Rust OOXML (DOCX / PPTX) extraction — NO docx/pptx crate. We open the file as a zip
+//! container (`zip`) and stream its XML parts (`quick-xml`), both ALREADY compiled in the tree and
+//! only promoted to direct deps for PR-2. Everything here is deterministic and fully unit-testable
+//! headless (the tests build tiny in-memory .docx/.pptx zips), so unlike the PDFKit path this
+//! verifies on any machine.
+//!
+//! DOCX (`word/document.xml`): stream paragraphs (`w:p`). Inside each paragraph, `w:pStyle` with a
+//! `w:val` of `Heading1`..`Heading9` promotes the paragraph to a heading at that level (updating the
+//! running heading trail); `w:t` runs concatenate into the paragraph text; a table (`w:tbl`) renders
+//! its rows as pipe-delimited (`a | b | c`) text. Each non-heading paragraph → one [`ExtractedBlock`]
+//! carrying the CURRENT heading trail (`page = None`).
+//!
+//! PPTX (`ppt/slides/slideN.xml`, ordered by N): each slide is one page (`page = Some(N)`). `a:t`
+//! runs are the text; the TITLE placeholder (`p:ph` with `type="title"` or `type="ctrTitle"`) becomes
+//! the slide's heading. One block per slide (all its body text joined), heading = the title.
+//!
+//! Lock model: pure `path → blocks`, no DB/keychain. Failures map to `AppError::InvalidArg`
+//! (fail-closed), never a panic. No PII logged.
+
+use std::io::Read;
+use std::path::Path;
+
+use quick_xml::events::Event;
+use quick_xml::{Reader, XmlVersion};
+
+use super::{join_heading, ExtractedBlock};
+use crate::error::{AppError, Result};
+
+/// The XML version we normalize entities under — OOXML parts are XML 1.0. Used by the
+/// feature-agnostic `decoded_and_normalized_value` / `xml_content` calls (the deprecated
+/// `unescape`/`unescape_value` helpers are cfg'd OUT whenever quick-xml's `encoding` feature is
+/// enabled anywhere in the tree — which it is here transitively — so we use the stable ones).
+const XML_1_0: XmlVersion = XmlVersion::Implicit1_0;
+
+/// Open `path` as a zip archive, reading the whole file into memory first (documents are bounded —
+/// the ingest caller sizes them). Fail-closed to `InvalidArg`.
+fn open_zip(path: &Path) -> Result<zip::ZipArchive<std::io::Cursor<Vec<u8>>>> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read document: {e}")))?;
+    zip::ZipArchive::new(std::io::Cursor::new(bytes))
+        .map_err(|e| AppError::InvalidArg(format!("not a valid OOXML (zip) document: {e}")))
+}
+
+/// A running DECOMPRESSED-bytes budget for ONE document's extraction — the decompression-bomb guard
+/// (finding: OOM availability). Starts at [`MAX_EXTRACT_DECOMPRESSED_BYTES`] and is drained as each
+/// zip entry is inflated; the first entry that would push the TOTAL past the ceiling fails closed
+/// with [`AppError::InvalidArg`]. Bounds the ACTUAL bytes read (not the zip header's claimed size,
+/// which a bomb lies about), so a tiny archive that inflates to gigabytes is stopped mid-read before
+/// it can exhaust memory. NOT a cap on the original file size — a legitimately large document
+/// (bounded, real XML) fits comfortably under the generous ceiling.
+struct DecompressBudget {
+    remaining: u64,
+}
+
+impl DecompressBudget {
+    fn new() -> Self {
+        Self::with_ceiling(crate::extract::MAX_EXTRACT_DECOMPRESSED_BYTES)
+    }
+    /// A budget with an explicit ceiling — the production path uses [`Self::new`]
+    /// ([`crate::extract::MAX_EXTRACT_DECOMPRESSED_BYTES`]); tests inject a tiny ceiling so a small
+    /// synthetic archive can trip the bomb guard without materializing 512 MiB.
+    fn with_ceiling(ceiling: u64) -> Self {
+        DecompressBudget { remaining: ceiling }
+    }
+}
+
+/// DECOMPRESSION-BOMB pre-flight for a zip-container document whose entries we DON'T read directly
+/// (the XLSX path hands the file to `calamine`, which inflates internally). Opens `path` as a zip and
+/// bounded-inflates EVERY entry against one [`DecompressBudget`]; the first entry that pushes the
+/// running total past [`crate::extract::MAX_EXTRACT_DECOMPRESSED_BYTES`] fails closed with
+/// `InvalidArg("document too large / possible zip bomb")`. A non-zip / corrupt file also fails closed
+/// here (mirrors calamine's own open failure into the same InvalidArg domain). Reads each entry via
+/// `Read::take` so a lying header can't force a giant allocation — the guard itself is bounded by the
+/// ceiling. This inflates once up front, then calamine inflates the (now-proven-bounded) file again;
+/// the cost is bounded by the ceiling and only paid on the (rare) large XLSX.
+pub(crate) fn guard_zip_not_a_bomb(path: &Path) -> Result<()> {
+    guard_zip_with_ceiling(path, crate::extract::MAX_EXTRACT_DECOMPRESSED_BYTES)
+}
+
+/// [`guard_zip_not_a_bomb`] with an explicit ceiling — production passes the shared const; tests pass
+/// a tiny ceiling so a small synthetic over-limit archive trips the guard without a 512 MiB payload.
+fn guard_zip_with_ceiling(path: &Path, ceiling: u64) -> Result<()> {
+    let mut zip = open_zip(path)?;
+    let mut budget = DecompressBudget::with_ceiling(ceiling);
+    for i in 0..zip.len() {
+        let file = zip
+            .by_index(i)
+            .map_err(|e| AppError::InvalidArg(format!("corrupt zip entry: {e}")))?;
+        // Discard the inflated bytes — we only need to prove the TOTAL stays under the ceiling.
+        let mut sink = SinkCounter::default();
+        let limit = budget.remaining.saturating_add(1);
+        let read = std::io::copy(&mut file.take(limit), &mut sink)
+            .map_err(|e| AppError::InvalidArg(format!("could not decode zip entry: {e}")))?;
+        if read > budget.remaining {
+            return Err(AppError::InvalidArg(
+                "document too large / possible zip bomb".into(),
+            ));
+        }
+        budget.remaining -= read;
+    }
+    Ok(())
+}
+
+/// A `Write` sink that only counts bytes (never allocates) — for the [`guard_zip_not_a_bomb`]
+/// pre-flight, which needs the inflated SIZE, not the inflated content.
+#[derive(Default)]
+struct SinkCounter {
+    _n: u64,
+}
+
+impl std::io::Write for SinkCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self._n = self._n.saturating_add(buf.len() as u64);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Read ONE named entry from the archive as a UTF-8 string, charging its DECOMPRESSED size against
+/// `budget`. `None` if the entry is absent; `Err` on a corrupt entry OR on a decompression-bomb
+/// (the inflated bytes would exceed the remaining budget). We read at most `remaining + 1` bytes via
+/// `Read::take` so a lying zip header can't trick us into allocating gigabytes: if the reader yields
+/// MORE than `remaining`, it's over the ceiling and we fail closed without holding the whole bomb.
+fn read_entry(
+    zip: &mut zip::ZipArchive<std::io::Cursor<Vec<u8>>>,
+    name: &str,
+    budget: &mut DecompressBudget,
+) -> Result<Option<String>> {
+    let file = match zip.by_name(name) {
+        Ok(f) => f,
+        Err(zip::result::ZipError::FileNotFound) => return Ok(None),
+        Err(e) => return Err(AppError::InvalidArg(format!("corrupt OOXML entry: {e}"))),
+    };
+    read_capped(file, budget).map(Some)
+}
+
+/// Inflate a single zip entry into a `String`, bounded by `budget`. Reads at most `remaining + 1`
+/// bytes; if the source produced more than `remaining` (or the running total would exceed the
+/// ceiling), fail closed as a possible zip bomb. On success, charges the actual byte count against
+/// the budget. Shared by DOCX/PPTX (and the sibling XLSX guard mirrors the same ceiling).
+fn read_capped<R: Read>(reader: R, budget: &mut DecompressBudget) -> Result<String> {
+    // Allow reading up to `remaining + 1` so an entry that EXACTLY fills the remaining budget still
+    // succeeds, while the +1 overflow byte trips the bomb check. `usize` guard: on a 32-bit target
+    // clamp so `take`'s limit is representable (the budget is far below usize::MAX on 64-bit).
+    let limit = budget.remaining.saturating_add(1);
+    let mut buf = Vec::new();
+    let read = reader
+        .take(limit)
+        .read_to_end(&mut buf)
+        .map_err(|e| AppError::InvalidArg(format!("could not decode OOXML entry: {e}")))?
+        as u64;
+    if read > budget.remaining {
+        return Err(AppError::InvalidArg(
+            "document too large / possible zip bomb".into(),
+        ));
+    }
+    budget.remaining -= read;
+    String::from_utf8(buf).map_err(|e| AppError::InvalidArg(format!("could not decode OOXML entry: {e}")))
+}
+
+/// The local name of an element (strip the `w:` / `a:` / `p:` namespace prefix).
+fn local_name(raw: &[u8]) -> &[u8] {
+    match raw.iter().position(|&b| b == b':') {
+        Some(i) => &raw[i + 1..],
+        None => raw,
+    }
+}
+
+/// The value of an attribute whose LOCAL name matches `want` (namespace-prefix-insensitive), decoded
+/// + normalized to an owned `String`. `None` when absent. `decoder` comes from the active reader.
+fn attr_local<'a>(
+    e: &'a quick_xml::events::BytesStart<'a>,
+    want: &[u8],
+    decoder: quick_xml::encoding::Decoder,
+) -> Option<String> {
+    for a in e.attributes().flatten() {
+        if local_name(a.key.as_ref()) == want {
+            return a
+                .decoded_and_normalized_value(XML_1_0, decoder)
+                .ok()
+                .map(|v| v.into_owned());
+        }
+    }
+    None
+}
+
+/// Parse a `w:pStyle` / heading style value into a 1..=9 heading level, or `None` if it is not a
+/// `HeadingN` style. Case-insensitive on the "heading" prefix; accepts the common `Heading1` and the
+/// display-name `heading 1` shapes.
+fn heading_level(style_val: &str) -> Option<u8> {
+    let v = style_val.trim().to_ascii_lowercase();
+    let rest = v.strip_prefix("heading")?.trim_start();
+    let n: u8 = rest.parse().ok()?;
+    (1..=9).contains(&n).then_some(n)
+}
+
+/// The running heading trail: a stack of (level, label). Pushing a heading of level L pops every
+/// entry at level ≥ L first (so an H2 replaces the previous H2/H3/… but keeps the H1), then pushes
+/// the new one. [`Self::path`] renders the trail joined by ` › `.
+#[derive(Default)]
+struct HeadingStack {
+    stack: Vec<(u8, String)>,
+}
+
+impl HeadingStack {
+    fn push(&mut self, level: u8, label: String) {
+        self.stack.retain(|(l, _)| *l < level);
+        self.stack.push((level, label));
+    }
+    /// The current trail as an `Option<String>` (`None` when empty), built with the shared joiner.
+    fn path(&self) -> Option<String> {
+        if self.stack.is_empty() {
+            return None;
+        }
+        let mut acc: Option<String> = None;
+        for (_, label) in &self.stack {
+            acc = Some(join_heading(acc.as_deref(), label));
+        }
+        acc
+    }
+}
+
+/// Extract a DOCX into blocks (one per non-heading paragraph, carrying the current heading trail).
+pub fn extract_docx(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    let mut zip = open_zip(path)?;
+    let mut budget = DecompressBudget::new();
+    let Some(xml) = read_entry(&mut zip, "word/document.xml", &mut budget)? else {
+        return Err(AppError::InvalidArg(
+            "DOCX is missing word/document.xml".into(),
+        ));
+    };
+    parse_docx_xml(&xml)
+}
+
+/// The DOCX body walk, split out for direct unit testing on a raw `document.xml` string.
+fn parse_docx_xml(xml: &str) -> Result<Vec<ExtractedBlock>> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let decoder = reader.decoder();
+
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    let mut headings = HeadingStack::default();
+
+    // Per-paragraph accumulator.
+    let mut in_paragraph = false;
+    let mut para_text = String::new();
+    let mut para_heading: Option<u8> = None;
+    // Table-cell pipe accumulation: a `w:tr` collects its cells' text into `row_cells`.
+    let mut row_cells: Vec<String> = Vec::new();
+    let mut cell_open = false;
+    // Whether the next `w:t` char-run belongs to a table cell (routes to the cell) vs a paragraph.
+    let mut capture_text = false;
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => match local_name(e.name().as_ref()) {
+                b"tr" => row_cells.clear(),
+                b"tc" => {
+                    cell_open = true;
+                    para_text.clear(); // a cell's paragraphs accumulate into the cell text
+                }
+                b"p" => {
+                    if !cell_open {
+                        in_paragraph = true;
+                        para_text.clear();
+                        para_heading = None;
+                    }
+                    capture_text = true;
+                }
+                b"t" => capture_text = true,
+                _ => {}
+            },
+            Ok(Event::Empty(e)) => {
+                // `w:pStyle w:val="HeadingN"` is an empty element — read its heading level.
+                if local_name(e.name().as_ref()) == b"pStyle" {
+                    if let Some(v) = attr_local(&e, b"val", decoder) {
+                        if let Some(lvl) = heading_level(&v) {
+                            para_heading = Some(lvl);
+                        }
+                    }
+                }
+            }
+            Ok(Event::Text(t)) => {
+                if capture_text {
+                    let txt = t
+                        .xml_content(XML_1_0)
+                        .map_err(|e| AppError::InvalidArg(format!("bad DOCX text: {e}")))?;
+                    para_text.push_str(&txt);
+                }
+            }
+            Ok(Event::End(e)) => match local_name(e.name().as_ref()) {
+                b"t" => capture_text = false,
+                b"tc" => {
+                    cell_open = false;
+                    row_cells.push(para_text.trim().to_string());
+                    para_text.clear();
+                }
+                b"tr" => {
+                    if !row_cells.is_empty() {
+                        let row = row_cells.join(" | ");
+                        if !row.trim().is_empty() {
+                            blocks.push(ExtractedBlock {
+                                text: row,
+                                page: None,
+                                heading_path: headings.path(),
+                            });
+                        }
+                        row_cells.clear();
+                    }
+                }
+                b"p" => {
+                    if in_paragraph && !cell_open {
+                        let text = para_text.trim().to_string();
+                        if let Some(lvl) = para_heading {
+                            if !text.is_empty() {
+                                headings.push(lvl, text);
+                            }
+                        } else if !text.is_empty() {
+                            blocks.push(ExtractedBlock {
+                                text,
+                                page: None,
+                                heading_path: headings.path(),
+                            });
+                        }
+                    }
+                    in_paragraph = false;
+                }
+                _ => {}
+            },
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(AppError::InvalidArg(format!("malformed DOCX XML: {e}")));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+    Ok(blocks)
+}
+
+/// Extract a PPTX into blocks — one per slide, in slide-number order (`ppt/slides/slideN.xml`).
+pub fn extract_pptx(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    let mut zip = open_zip(path)?;
+    // ONE decompression budget across ALL slides — a bomb split into many entries can't evade the
+    // ceiling by staying under it per-entry (the total across slides is what's charged).
+    let mut budget = DecompressBudget::new();
+
+    // Collect the slide entry names, then sort by the numeric N in `slideN.xml` (a lexicographic
+    // sort would order slide10 before slide2 — wrong page order).
+    let mut slide_names: Vec<String> = (0..zip.len())
+        .filter_map(|i| zip.by_index(i).ok().map(|f| f.name().to_string()))
+        .filter(|n| n.starts_with("ppt/slides/slide") && n.ends_with(".xml"))
+        .collect();
+    slide_names.sort_by_key(|n| slide_number(n));
+
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    for name in slide_names {
+        let num = slide_number(&name);
+        if let Some(xml) = read_entry(&mut zip, &name, &mut budget)? {
+            if let Some(block) = parse_pptx_slide(&xml, num)? {
+                blocks.push(block);
+            }
+        }
+    }
+    Ok(blocks)
+}
+
+/// The trailing integer N of a `.../slideN.xml` name (0 when it can't be parsed — deterministic).
+fn slide_number(name: &str) -> u32 {
+    let stem = name
+        .rsplit('/')
+        .next()
+        .unwrap_or(name)
+        .trim_end_matches(".xml")
+        .trim_start_matches("slide");
+    stem.parse().unwrap_or(0)
+}
+
+/// Parse ONE slide's XML into a block: title placeholder → heading; all `a:t` runs → body text.
+/// `None` when the slide has no extractable text at all.
+fn parse_pptx_slide(xml: &str, slide_num: u32) -> Result<Option<ExtractedBlock>> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let decoder = reader.decoder();
+
+    let mut title: Option<String> = None;
+    let mut body_paras: Vec<String> = Vec::new();
+
+    // A `p:sp` (shape) is one text container. Track whether the current shape is the TITLE placeholder
+    // (its `p:ph type="title"|"ctrTitle"`), and accumulate its text. `a:p` = a paragraph inside the
+    // shape's text body; `a:t` = a text run.
+    let mut in_shape = false;
+    let mut shape_is_title = false;
+    let mut shape_text = String::new();
+    let mut capture_text = false;
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => match local_name(e.name().as_ref()) {
+                b"sp" => {
+                    in_shape = true;
+                    shape_is_title = false;
+                    shape_text.clear();
+                }
+                b"ph" => {
+                    if in_shape {
+                        if let Some(ty) = attr_local(&e, b"type", decoder) {
+                            let ty = ty.to_ascii_lowercase();
+                            if ty == "title" || ty == "ctrtitle" {
+                                shape_is_title = true;
+                            }
+                        }
+                    }
+                }
+                b"t" => capture_text = true,
+                // paragraph boundary inside a shape → newline between paragraphs.
+                b"p" if in_shape && !shape_text.is_empty() && !shape_text.ends_with('\n') => {
+                    shape_text.push('\n');
+                }
+                _ => {}
+            },
+            Ok(Event::Empty(e)) => {
+                if local_name(e.name().as_ref()) == b"ph" && in_shape {
+                    if let Some(ty) = attr_local(&e, b"type", decoder) {
+                        let ty = ty.to_ascii_lowercase();
+                        if ty == "title" || ty == "ctrtitle" {
+                            shape_is_title = true;
+                        }
+                    }
+                }
+            }
+            Ok(Event::Text(t)) => {
+                if capture_text && in_shape {
+                    let txt = t
+                        .xml_content(XML_1_0)
+                        .map_err(|e| AppError::InvalidArg(format!("bad PPTX text: {e}")))?;
+                    shape_text.push_str(&txt);
+                }
+            }
+            Ok(Event::End(e)) => match local_name(e.name().as_ref()) {
+                b"t" => capture_text = false,
+                b"sp" => {
+                    let text = shape_text.trim().to_string();
+                    if !text.is_empty() {
+                        if shape_is_title && title.is_none() {
+                            title = Some(text);
+                        } else {
+                            body_paras.push(text);
+                        }
+                    }
+                    in_shape = false;
+                }
+                _ => {}
+            },
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(AppError::InvalidArg(format!("malformed PPTX XML: {e}"))),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let body = body_paras.join("\n");
+    if title.is_none() && body.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(ExtractedBlock {
+        text: body,
+        page: Some(slide_num),
+        heading_path: title,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a minimal OOXML .docx/.pptx zip in memory from (entry-name, content) pairs and write it
+    /// to a temp file, returning the path.
+    fn build_ooxml(ext: &str, entries: &[(&str, &str)]) -> std::path::PathBuf {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut cursor);
+            let opts: zip::write::FileOptions<'_, ()> =
+                zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            for (name, content) in entries {
+                zw.start_file(*name, opts).unwrap();
+                zw.write_all(content.as_bytes()).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-ooxml-{}-{}.{ext}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, cursor.into_inner()).unwrap();
+        p
+    }
+
+    const DOCX_XML: &str = r#"<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Design</w:t></w:r></w:p>
+    <w:p><w:r><w:t>The budget is </w:t></w:r><w:r><w:t>100k.</w:t></w:r></w:p>
+    <w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Storage</w:t></w:r></w:p>
+    <w:p><w:r><w:t>Anna owns delivery.</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r><w:t>Owner</w:t></w:r></w:p></w:tc>
+      </w:tr>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t>API</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r><w:t>Bob</w:t></w:r></w:p></w:tc>
+      </w:tr>
+    </w:tbl>
+  </w:body>
+</w:document>"#;
+
+    /// DOCX: paragraph text is extracted, `w:t` runs concatenate, headings build the trail, and a
+    /// table renders pipe-delimited rows under the current heading.
+    #[test]
+    fn docx_extracts_paragraphs_headings_and_table_rows() {
+        let p = build_ooxml("docx", &[("word/document.xml", DOCX_XML)]);
+        let blocks = extract_docx(&p).unwrap();
+
+        // Body paragraphs: budget (under Design), Anna (under Design › Storage), + 2 table rows.
+        let budget = blocks.iter().find(|b| b.text.contains("budget")).unwrap();
+        assert_eq!(budget.text, "The budget is 100k.", "w:t runs must concatenate");
+        assert_eq!(budget.heading_path.as_deref(), Some("Design"));
+
+        let anna = blocks.iter().find(|b| b.text.contains("Anna")).unwrap();
+        assert_eq!(anna.heading_path.as_deref(), Some("Design › Storage"));
+
+        let header_row = blocks.iter().find(|b| b.text.contains("Owner")).unwrap();
+        assert_eq!(header_row.text, "Name | Owner", "table row → pipe-delimited");
+        assert_eq!(header_row.heading_path.as_deref(), Some("Design › Storage"));
+        assert!(
+            blocks.iter().any(|b| b.text == "API | Bob"),
+            "second table row must render too"
+        );
+        // Headings themselves are NOT emitted as content blocks.
+        assert!(
+            !blocks.iter().any(|b| b.text == "Design" || b.text == "Storage"),
+            "heading text must not become a content block"
+        );
+        // Every block has page None (DOCX is a flow format).
+        assert!(blocks.iter().all(|b| b.page.is_none()));
+    }
+
+    const PPTX_SLIDE1: &str = r#"<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+      <p:txBody><a:p><a:r><a:t>Quarterly Plan</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+    <p:sp>
+      <p:txBody>
+        <a:p><a:r><a:t>Ship the ingest feature</a:t></a:r></a:p>
+        <a:p><a:r><a:t>Hire two engineers</a:t></a:r></a:p>
+      </p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>"#;
+
+    const PPTX_SLIDE2: &str = r#"<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree>
+    <p:sp><p:txBody><a:p><a:r><a:t>Closing thoughts</a:t></a:r></a:p></p:txBody></p:sp>
+  </p:spTree></p:cSld>
+</p:sld>"#;
+
+    /// PPTX: title placeholder → heading, body runs → text, slide N → page, in slide-number order
+    /// (slide2 does NOT sort before slide10-style names).
+    #[test]
+    fn pptx_extracts_title_body_and_slide_page_in_order() {
+        // Insert slide2 BEFORE slide1 in the zip to prove we sort by slide number, not zip order.
+        let p = build_ooxml(
+            "pptx",
+            &[
+                ("ppt/slides/slide2.xml", PPTX_SLIDE2),
+                ("ppt/slides/slide1.xml", PPTX_SLIDE1),
+            ],
+        );
+        let blocks = extract_pptx(&p).unwrap();
+        assert_eq!(blocks.len(), 2, "one block per slide");
+
+        assert_eq!(blocks[0].page, Some(1), "slide1 must come first");
+        assert_eq!(blocks[0].heading_path.as_deref(), Some("Quarterly Plan"));
+        assert!(blocks[0].text.contains("Ship the ingest feature"));
+        assert!(blocks[0].text.contains("Hire two engineers"));
+
+        assert_eq!(blocks[1].page, Some(2), "slide2 second");
+        assert!(blocks[1].text.contains("Closing thoughts"));
+    }
+
+    /// A non-zip / corrupt file fails closed with InvalidArg.
+    #[test]
+    fn corrupt_docx_is_invalid_arg() {
+        let mut p = std::env::temp_dir();
+        p.push(format!("murmur-badzip-{}.docx", std::process::id()));
+        std::fs::write(&p, b"not a zip at all").unwrap();
+        let err = extract_docx(&p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn heading_level_parses_word_styles() {
+        assert_eq!(heading_level("Heading1"), Some(1));
+        assert_eq!(heading_level("heading 3"), Some(3));
+        assert_eq!(heading_level("Heading9"), Some(9));
+        assert_eq!(heading_level("Heading10"), None);
+        assert_eq!(heading_level("BodyText"), None);
+        assert_eq!(heading_level("Title"), None);
+    }
+
+    // ── DECOMPRESSION-BOMB GUARD (finding 2: OOM availability) ────────────────────────────────────
+    //
+    // A highly-compressible payload (a long run of one char) deflates to a few bytes but inflates to
+    // its full length — the classic zip-bomb shape. We inject a TINY ceiling so a modest synthetic
+    // entry trips the guard without materializing 512 MiB. The production ceiling
+    // (`MAX_EXTRACT_DECOMPRESSED_BYTES`) is proven separately to be far above real documents.
+
+    /// The `read_capped` entry-read path (used by DOCX/PPTX extraction) fails CLOSED when an entry's
+    /// DECOMPRESSED size exceeds the remaining budget — the bytes are never fully buffered.
+    #[test]
+    fn read_capped_rejects_oversized_entry() {
+        // 4 KiB of a single char (deflates tiny) against a 1 KiB budget → over the ceiling.
+        let payload = "A".repeat(4096);
+        let p = build_ooxml("docx", &[("word/document.xml", &payload)]);
+        let mut zip = open_zip(&p).unwrap();
+        let mut budget = DecompressBudget::with_ceiling(1024);
+        let err = read_entry(&mut zip, "word/document.xml", &mut budget).unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArg(m) if m.contains("zip bomb")),
+            "oversized entry must be rejected as a zip bomb, got {err:?}"
+        );
+    }
+
+    /// A normal-sized entry passes `read_capped` and DRAINS exactly its byte count from the budget.
+    #[test]
+    fn read_capped_accepts_normal_entry_and_charges_budget() {
+        let payload = "hello world"; // 11 bytes
+        let p = build_ooxml("docx", &[("word/document.xml", payload)]);
+        let mut zip = open_zip(&p).unwrap();
+        let mut budget = DecompressBudget::with_ceiling(1_000_000);
+        let got = read_entry(&mut zip, "word/document.xml", &mut budget)
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, payload);
+        assert_eq!(
+            budget.remaining,
+            1_000_000 - payload.len() as u64,
+            "the budget must be charged the actual decompressed byte count"
+        );
+    }
+
+    /// The `guard_zip_not_a_bomb` PRE-FLIGHT (used by the XLSX path, which lets calamine inflate)
+    /// fails CLOSED when the TOTAL decompressed size across entries exceeds the ceiling.
+    #[test]
+    fn guard_zip_rejects_bomb_across_entries() {
+        // Two entries of 3 KiB each = 6 KiB total, against a 4 KiB ceiling → tripped.
+        let big = "Z".repeat(3072);
+        let p = build_ooxml(
+            "xlsx",
+            &[("xl/a.xml", &big), ("xl/b.xml", &big)],
+        );
+        let err = guard_zip_with_ceiling(&p, 4096).unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArg(m) if m.contains("zip bomb")),
+            "total decompressed size over the ceiling must be rejected, got {err:?}"
+        );
+    }
+
+    /// The pre-flight guard PASSES a within-ceiling archive (a legitimate document is untouched).
+    #[test]
+    fn guard_zip_accepts_within_ceiling() {
+        let small = "ok".repeat(50); // 100 bytes
+        let p = build_ooxml("xlsx", &[("xl/a.xml", &small)]);
+        assert!(
+            guard_zip_with_ceiling(&p, 1_000_000).is_ok(),
+            "a within-ceiling archive must pass the bomb guard"
+        );
+    }
+
+    /// The production ceiling is generous (512 MiB) — a normal DOCX extracts fine under it (the guard
+    /// is invisible to real documents; only a bomb hits it).
+    #[test]
+    fn production_ceiling_leaves_normal_docx_unaffected() {
+        let p = build_ooxml("docx", &[("word/document.xml", DOCX_XML)]);
+        let blocks = extract_docx(&p).unwrap();
+        assert!(!blocks.is_empty(), "a normal DOCX must extract under the production ceiling");
+    }
+}

--- a/src-tauri/src/extract/pdf.rs
+++ b/src-tauri/src/extract/pdf.rs
@@ -1,0 +1,225 @@
+//! PDF extraction via Apple **PDFKit** (`objc2-pdf-kit`) — macOS-only. Per-page text + the outline
+//! tree come for free from the framework; there is NO new binary and no dylib to sign (same objc2
+//! 0.6/0.3 family we already ship).
+//!
+//! CRASH-SAFE FFI (rules §7, the `screenshare.rs` war story): a malformed / encrypted / unusual PDF
+//! can make PDFKit raise an Objective-C `NSException`, which — if it unwinds across the FFI boundary
+//! — ABORTS the process ("Rust cannot catch foreign exceptions"). So EVERY PDFKit call here runs
+//! inside `objc2::exception::catch`, and ANY caught exception (or a nil document) is mapped to a
+//! fail-closed `AppError::InvalidArg` — never a panic, never an abort. `objc2`'s `exception` feature
+//! is enabled in Cargo.toml for exactly this.
+//!
+//! Output: one [`ExtractedBlock`] per page (`page = Some(i+1)`), text = the page's `string`. When the
+//! document has an outline (`outlineRoot`), each page's `heading_path` is the outline entry whose
+//! destination page is nearest-at-or-before that page (best-effort; `None` when no outline). A PDF
+//! with NO extractable text on ANY page (a scanned/image-only PDF) returns a specific `InvalidArg`
+//! the FE maps to "scanned PDF — OCR not yet supported". Vision OCR is explicitly NOT in scope.
+//!
+//! REAL-MAC CAVEAT: this compiles everywhere but only TRULY verifies on a signed build on a real Mac
+//! (PDFKit text/outline fidelity, RAM on a 500-page PDF). `cargo test` cannot exercise the FFI path —
+//! the headless test here only asserts the fail-closed behavior for a non-PDF input.
+
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+
+use objc2::exception::catch;
+use objc2::AllocAnyThread;
+use objc2_foundation::{NSString, NSURL};
+use objc2_pdf_kit::{PDFDocument, PDFPage};
+
+use super::ExtractedBlock;
+use crate::error::{AppError, Result};
+
+/// Map a caught-exception / nil / empty result into a single fail-closed error.
+fn read_failed() -> AppError {
+    AppError::InvalidArg("could not read PDF".into())
+}
+
+/// Run an ObjC closure that borrows non-`UnwindSafe` PDFKit handles inside `objc2::exception::catch`.
+/// PDFKit reads have no interior-mutability hazard across a caught exception (we only read text /
+/// outline; nothing is left half-mutated), so wrapping the borrows in `AssertUnwindSafe` is sound —
+/// and it is REQUIRED because `Retained<_>`/`&PDFDocument` are not `UnwindSafe`. Returns `None` on a
+/// caught ObjC exception, `Some(r)` otherwise (the closure's own `Option`/value is inside `r`).
+fn catch_objc<R>(f: impl FnOnce() -> R) -> Option<R> {
+    catch(AssertUnwindSafe(f)).ok()
+}
+
+/// Extract a PDF into per-page blocks. Fail-closed on any FFI exception / unreadable document; a
+/// text-layer-less (scanned) PDF returns a distinct OCR-hint error.
+pub fn extract_pdf(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    let path_str = path.to_string_lossy().to_string();
+
+    // Open the document. `initWithURL` + everything downstream is UNSAFE ObjC that MAY throw — wrap
+    // the whole open in catch. On a caught exception OR a nil document, fail closed.
+    let doc: objc2::rc::Retained<PDFDocument> = catch_objc(|| {
+        // SAFETY: standard PDFKit open. `fileURLWithPath` never throws for a well-formed path; the
+        // whole closure is inside `catch` regardless so any ObjC exception is contained.
+        let ns_path = NSString::from_str(&path_str);
+        let url = NSURL::fileURLWithPath(&ns_path);
+        let alloc = PDFDocument::alloc();
+        unsafe { PDFDocument::initWithURL(alloc, &url) }
+    })
+    .flatten() // Some(None) = nil document (unreadable) / None = ObjC exception → both fail closed
+    .ok_or_else(read_failed)?;
+
+    // Refuse an encrypted-and-locked PDF explicitly (a nicer error than empty text). `isLocked` means
+    // the content is password-protected and unreadable without the password.
+    let locked = catch_objc(|| unsafe { doc.isLocked() }).unwrap_or(false);
+    if locked {
+        return Err(AppError::InvalidArg(
+            "this PDF is password-protected — unlock it and re-import".into(),
+        ));
+    }
+
+    let page_count: usize = catch_objc(|| unsafe { doc.pageCount() }).ok_or_else(read_failed)?;
+    if page_count == 0 {
+        return Err(read_failed());
+    }
+
+    // Best-effort outline → (page-index → heading label). Never let it fail the extraction.
+    let headings = outline_headings(&doc, page_count).unwrap_or_default();
+
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    let mut any_text = false;
+    for i in 0..page_count {
+        // Each page fetch + `string` read is a separate catch — one bad page never aborts the rest.
+        let page_text: Option<String> = catch_objc(|| {
+            let page = unsafe { doc.pageAtIndex(i) }?;
+            let s = unsafe { page.string() }?;
+            Some(s.to_string())
+        })
+        .flatten();
+
+        let text = page_text.unwrap_or_default();
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            any_text = true;
+        }
+        // Emit a block per page even when a single page is blank, so page numbering stays 1:1 with
+        // the source; a page with no text simply carries empty text (still located by page number).
+        blocks.push(ExtractedBlock {
+            text: trimmed.to_string(),
+            page: Some((i + 1) as u32),
+            heading_path: heading_for_page(&headings, i),
+        });
+    }
+
+    if !any_text {
+        // A PDF with text on NO page is a scanned/image PDF — OCR (Vision) is out of scope for v1.
+        return Err(AppError::InvalidArg(
+            "scanned PDF — OCR not yet supported".into(),
+        ));
+    }
+
+    Ok(blocks)
+}
+
+/// Walk the PDF outline (`outlineRoot` tree) and collect `(page_index, label)` pairs, sorted by page
+/// index. Every PDFKit call is inside `catch`; a missing/broken outline yields an empty map (headings
+/// are best-effort). Returns `None` only if the outline root fetch itself throws.
+fn outline_headings(doc: &PDFDocument, page_count: usize) -> Option<Vec<(usize, String)>> {
+    let root = catch_objc(|| unsafe { doc.outlineRoot() }).flatten()?;
+
+    let mut out: Vec<(usize, String)> = Vec::new();
+    // Iterative DFS over the outline tree, bounded so a pathological/cyclic outline cannot spin.
+    let mut stack: Vec<objc2::rc::Retained<objc2_pdf_kit::PDFOutline>> = vec![root];
+    let mut visited = 0usize;
+    const MAX_OUTLINE_NODES: usize = 4096;
+    while let Some(node) = stack.pop() {
+        visited += 1;
+        if visited > MAX_OUTLINE_NODES {
+            break;
+        }
+        let n: usize = catch_objc(|| unsafe { node.numberOfChildren() }).unwrap_or(0);
+        for idx in 0..n {
+            let child = match catch_objc(|| unsafe { node.childAtIndex(idx) }).flatten() {
+                Some(c) => c,
+                None => continue,
+            };
+            // Label + destination page for this child (both inside catch).
+            let label = catch_objc(|| unsafe { child.label() })
+                .flatten()
+                .map(|s| s.to_string())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            let page_idx = outline_child_page_index(doc, &child, page_count);
+            if let (Some(label), Some(pi)) = (label, page_idx) {
+                out.push((pi, label));
+            }
+            stack.push(child);
+        }
+    }
+    out.sort_by_key(|(pi, _)| *pi);
+    Some(out)
+}
+
+/// The 0-based page index an outline entry points at, via `destination().page()` →
+/// `doc.indexForPage(&page)`. All PDFKit calls inside `catch`; `None` on any failure / out-of-range.
+fn outline_child_page_index(
+    doc: &PDFDocument,
+    child: &objc2_pdf_kit::PDFOutline,
+    page_count: usize,
+) -> Option<usize> {
+    let page: objc2::rc::Retained<PDFPage> = catch_objc(|| {
+        let dest = unsafe { child.destination() }?;
+        unsafe { dest.page() }
+    })
+    .flatten()?;
+    let idx: usize = catch_objc(|| unsafe { doc.indexForPage(&page) })?;
+    // PDFKit returns NSNotFound (a very large value) when the page isn't in the doc — reject it.
+    (idx < page_count).then_some(idx)
+}
+
+/// The heading label for a 0-based page: the outline entry whose destination page is the greatest
+/// index ≤ the target page (i.e. the nearest heading at or above this page). `None` when no entry
+/// qualifies (a page before the first outline entry, or no outline).
+fn heading_for_page(headings: &[(usize, String)], page_index: usize) -> Option<String> {
+    // `headings` is sorted by page index (asc), so the LAST entry whose page ≤ target is the nearest
+    // preceding heading. Iterate from the back and take the first match (cheaper than `.last()`).
+    headings
+        .iter()
+        .rev()
+        .find(|(pi, _)| *pi <= page_index)
+        .map(|(_, label)| label.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// heading_for_page picks the nearest-at-or-before outline entry (pure logic, no FFI).
+    #[test]
+    fn heading_for_page_picks_nearest_preceding_entry() {
+        let headings = vec![
+            (0usize, "Intro".to_string()),
+            (3usize, "Design".to_string()),
+            (7usize, "Appendix".to_string()),
+        ];
+        assert_eq!(heading_for_page(&headings, 0).as_deref(), Some("Intro"));
+        assert_eq!(heading_for_page(&headings, 2).as_deref(), Some("Intro"));
+        assert_eq!(heading_for_page(&headings, 3).as_deref(), Some("Design"));
+        assert_eq!(heading_for_page(&headings, 6).as_deref(), Some("Design"));
+        assert_eq!(heading_for_page(&headings, 99).as_deref(), Some("Appendix"));
+        assert_eq!(heading_for_page(&[], 0), None);
+    }
+
+    /// A non-PDF file fails CLOSED with InvalidArg — proves the nil-document path (the FFI open
+    /// returns nil for non-PDF bytes) does NOT abort and maps to our error. (True PDF fidelity needs
+    /// a real Mac + a signed build; this only guards the fail-closed contract.)
+    #[test]
+    fn non_pdf_file_fails_closed_without_abort() {
+        let mut p = std::env::temp_dir();
+        p.push(format!("murmur-notpdf-{}.pdf", std::process::id()));
+        std::fs::write(&p, b"this is definitely not a pdf").unwrap();
+        let err = extract_pdf(&p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    /// A missing path fails closed too (no panic).
+    #[test]
+    fn missing_pdf_fails_closed() {
+        let p = std::path::Path::new("/nonexistent/murmur/does-not-exist.pdf");
+        let err = extract_pdf(p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+}

--- a/src-tauri/src/extract/xlsx.rs
+++ b/src-tauri/src/extract/xlsx.rs
@@ -1,0 +1,161 @@
+//! XLSX extraction via `calamine` (pure-Rust). Each worksheet becomes one heading (the sheet name);
+//! every non-empty row becomes one pipe-delimited [`ExtractedBlock`] under that heading. `page` is
+//! `None` (a spreadsheet has no page axis). Deterministic + headless-testable.
+//!
+//! Lock model: pure `path → blocks`, no DB/keychain; failures map to `AppError::InvalidArg`. No PII.
+
+use std::path::Path;
+
+use calamine::{open_workbook, Data, Reader, Xlsx};
+
+use super::ExtractedBlock;
+use crate::error::{AppError, Result};
+
+/// Extract every sheet of an XLSX into blocks (one per non-empty row, heading = sheet name).
+pub fn extract_xlsx(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    // DECOMPRESSION-BOMB guard (OOM-availability): calamine inflates the workbook internally, so we
+    // pre-flight the zip once and reject if the TOTAL decompressed size exceeds the shared ceiling
+    // (`MAX_EXTRACT_DECOMPRESSED_BYTES`). NOT a cap on the original file size — a legitimately large
+    // spreadsheet passes; only a tiny archive that inflates to gigabytes is stopped.
+    super::ooxml::guard_zip_not_a_bomb(path)?;
+
+    let mut workbook: Xlsx<_> = open_workbook(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not open XLSX: {e}")))?;
+
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    for sheet in workbook.sheet_names() {
+        let range = match workbook.worksheet_range(&sheet) {
+            Ok(r) => r,
+            Err(_) => continue, // skip an unreadable sheet, never abort the whole doc
+        };
+        for row in range.rows() {
+            // Render each cell via its `Display`; an empty cell is an empty string. Join with " | ".
+            let cells: Vec<String> = row.iter().map(cell_text).collect();
+            let line = cells.join(" | ");
+            // A wholly-empty row (every cell blank → " |  | " with no content) is skipped.
+            if line.chars().all(|c| c == '|' || c.is_whitespace()) {
+                continue;
+            }
+            blocks.push(ExtractedBlock {
+                text: line,
+                page: None,
+                heading_path: Some(sheet.clone()),
+            });
+        }
+    }
+    Ok(blocks)
+}
+
+/// Render one cell to text. `calamine::Data` already implements `Display` (empty → ""); this wraps
+/// it and trims surrounding whitespace so a padded numeric cell stays clean.
+fn cell_text(cell: &Data) -> String {
+    cell.to_string().trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a minimal valid XLSX (one sheet, inline strings) in memory and write it to a temp file.
+    /// calamine reads inline strings (`t="inlineStr"`), so no sharedStrings part is needed.
+    fn build_xlsx(sheet_name: &str, rows: &[&[&str]]) -> std::path::PathBuf {
+        let mut sheet_data = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>"#,
+        );
+        for (r, row) in rows.iter().enumerate() {
+            sheet_data.push_str(&format!("<row r=\"{}\">", r + 1));
+            for (c, val) in row.iter().enumerate() {
+                let col = (b'A' + c as u8) as char;
+                sheet_data.push_str(&format!(
+                    "<c r=\"{col}{}\" t=\"inlineStr\"><is><t>{}</t></is></c>",
+                    r + 1,
+                    val
+                ));
+            }
+            sheet_data.push_str("</row>");
+        }
+        sheet_data.push_str("</sheetData></worksheet>");
+
+        let workbook_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="{sheet_name}" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#
+        );
+        let workbook_rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#;
+        let content_types = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#;
+        let root_rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#;
+
+        let entries = [
+            ("[Content_Types].xml", content_types.to_string()),
+            ("_rels/.rels", root_rels.to_string()),
+            ("xl/workbook.xml", workbook_xml),
+            ("xl/_rels/workbook.xml.rels", workbook_rels.to_string()),
+            ("xl/worksheets/sheet1.xml", sheet_data),
+        ];
+
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zw = zip::ZipWriter::new(&mut cursor);
+            let opts: zip::write::FileOptions<'_, ()> =
+                zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            for (name, content) in &entries {
+                zw.start_file(*name, opts).unwrap();
+                zw.write_all(content.as_bytes()).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-xlsx-{}-{}.xlsx",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, cursor.into_inner()).unwrap();
+        p
+    }
+
+    /// XLSX: sheet name → heading, each row → pipe-delimited text, page None.
+    #[test]
+    fn xlsx_extracts_rows_as_pipe_text_under_the_sheet_heading() {
+        let p = build_xlsx(
+            "Budget",
+            &[
+                &["Item", "Cost", "Owner"],
+                &["API", "10000", "Bob"],
+                &["Design", "5000", "Anna"],
+            ],
+        );
+        let blocks = extract_xlsx(&p).unwrap();
+        assert_eq!(blocks.len(), 3, "one block per non-empty row");
+        assert_eq!(blocks[0].text, "Item | Cost | Owner");
+        assert_eq!(blocks[0].heading_path.as_deref(), Some("Budget"));
+        assert_eq!(blocks[0].page, None);
+        assert_eq!(blocks[1].text, "API | 10000 | Bob");
+        assert_eq!(blocks[2].text, "Design | 5000 | Anna");
+    }
+
+    #[test]
+    fn corrupt_xlsx_is_invalid_arg() {
+        let mut p = std::env::temp_dir();
+        p.push(format!("murmur-badxlsx-{}.xlsx", std::process::id()));
+        std::fs::write(&p, b"definitely not a workbook").unwrap();
+        let err = extract_xlsx(&p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod eval;
 pub mod events;
 pub mod export;
+pub mod extract;
 pub mod facts;
 pub mod mcp;
 pub mod memory;

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -241,13 +241,13 @@ fn tools_spec() -> Value {
         },
         {
             "name": "get_meeting",
-            "description": "Get a meeting's AI note (summary) and full transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text.",
-            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain"], "description": "Transcript rendering (default 'structured')." } }, "required": ["meetingId"] }
+            "description": "Get a meeting's AI note (summary) and full transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text. For a very long transcript, page through it with offset + maxChars.",
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain"], "description": "Transcript rendering (default 'structured')." }, "offset": { "type": "number", "description": "Chars to skip into the transcript (default 0)." }, "maxChars": { "type": "number", "description": "Max transcript chars to return from offset (default all)." } }, "required": ["meetingId"] }
         },
         {
             "name": "get_document",
-            "description": "Get the full body of one standalone note or imported/uploaded document by id (from a search hit labelled 'document:...'). Use this — not get_meeting — for ids from the DOCUMENTS section of a search result.",
-            "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" } }, "required": ["documentId"] }
+            "description": "Get the full body of one standalone note or imported/uploaded document by id (from a search hit labelled 'document:...'). Use this — not get_meeting — for ids from the DOCUMENTS section of a search result. For a big document, page through it with offset + maxChars.",
+            "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" }, "offset": { "type": "number", "description": "Chars to skip into the body (default 0)." }, "maxChars": { "type": "number", "description": "Max body chars to return from offset (default all)." } }, "required": ["documentId"] }
         },
         {
             "name": "list_recent_meetings",
@@ -321,6 +321,15 @@ fn handle_tool_call(
 /// so a sealed-and-not-unlocked meeting is invisible to all of them. JSON-RPC error codes for the
 /// transport concerns (unknown tool, missing required arg) are produced HERE; runtime tool failures
 /// map to `-32000` exactly as before. Returns the tool's text payload or a `(code, message)` error.
+/// Brain v3 PR-2 — read an optional non-negative integer MCP arg (agent paging). Absent / non-numeric
+/// → 0 (the DEFAULT, mapped to today's byte-identical behavior by the tool).
+fn mcp_usize_arg(args: &Value, key: &str) -> usize {
+    args.get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(usize::MAX as u64) as usize
+}
+
 fn dispatch_tool(
     db: &Db,
     name: &str,
@@ -357,6 +366,9 @@ fn dispatch_tool(
                 .filter(|f| *f == "plain")
                 .unwrap_or("structured")
                 .to_string(),
+            // Brain v3 PR-2 — agent paging (absent → 0 → today's behavior).
+            offset: mcp_usize_arg(args, "offset"),
+            max_chars: mcp_usize_arg(args, "maxChars"),
         },
         "get_document" => ToolCall::GetDocument {
             document_id: args
@@ -364,6 +376,8 @@ fn dispatch_tool(
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_string(),
+            offset: mcp_usize_arg(args, "offset"),
+            max_chars: mcp_usize_arg(args, "maxChars"),
         },
         "list_recent_meetings" => ToolCall::ListRecentMeetings {
             limit: args

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -998,6 +998,21 @@ impl Db {
              CREATE INDEX IF NOT EXISTS idx_doc_chunks_document ON doc_chunks(document_id);",
         )
         .map_err(map_err)?;
+        // Brain v3 PR-2 — HIERARCHICAL doc chunks (additive, guarded, idempotent). A document's
+        // chunks form a 3-level tree in the SAME `doc_chunks` table (rows still ride the exact
+        // seal/unseal/purge/gating already proven for the flat layout):
+        //   - `level`        0 = leaf (embedded + FTS), 1 = section-parent (FTS + fetch-by-id ONLY,
+        //                    NOT embedded — no `doc_vec_chunks` row), 2 = doc-summary/outline
+        //                    (embedded + FTS). Legacy/flat rows default to 0.
+        //   - `parent_id`    a leaf's L1 section-parent row id (NULL for L1/L2 and legacy leaves).
+        //   - `section_path` the heading trail ("A › B") this chunk sits under (NULL when none).
+        //   - `page_no`      1-based page/slide (PDF/PPTX); NULL for flow formats.
+        // All four are pure PROVENANCE/structure over already-derived plaintext — nothing new is
+        // sealed. The vec0 table is UNCHANGED (only L0+L2 rows get a `doc_vec_chunks` entry).
+        Self::add_column_if_missing(conn, "doc_chunks", "level", "INTEGER NOT NULL DEFAULT 0")?;
+        Self::add_column_if_missing(conn, "doc_chunks", "parent_id", "INTEGER")?;
+        Self::add_column_if_missing(conn, "doc_chunks", "section_path", "TEXT")?;
+        Self::add_column_if_missing(conn, "doc_chunks", "page_no", "INTEGER")?;
         // `kind` distinguishes an UPLOADED file ('document') from a TYPED brain note ('note'). Additive
         // + guarded so migrate() stays idempotent; legacy rows default to 'document'. Both kinds ride
         // the SAME seal/unseal/purge/gating — `kind` is a presentation split for the Brain page only.
@@ -4930,6 +4945,12 @@ impl Db {
 
     /// A document's `(folder_id, name, plaintext text)`, or `None` if unknown. The COMMAND layer gates
     /// the folder before surfacing the text to the FE.
+    ///
+    /// Brain v3 PR-2: `documents.text` may store a PR-2 upload's block STRUCTURE (page/heading markers,
+    /// control-char sentinels invisible to any human text). This getter returns the RAW stored text
+    /// (structure intact) so re-index can reconstruct the hierarchy; the RENDERED display text is
+    /// produced by the command layer via [`crate::extract::render_display_text`] before it reaches the
+    /// FE. (md/txt/note/legacy rows have no markers → raw == display.)
     pub fn get_document(&self, id: &str) -> Result<Option<(String, String, String)>> {
         let conn = self.lock();
         conn.query_row(
@@ -4967,13 +4988,16 @@ impl Db {
               WHERE d.id = ?1 AND {visible}"
         );
         conn.query_row(&sql, rusqlite::params![id], |r| {
+            let raw: String = r.get(5)?;
             Ok(DocumentSummary {
                 id: r.get(0)?,
                 folder_id: r.get(1)?,
                 kind: r.get(2)?,
                 name: r.get(3)?,
                 title: r.get(4)?,
-                markdown: r.get(5)?,
+                // Brain v3 PR-2: render clean display text (strip the block-structure markers a PR-2
+                // upload stores). A note / legacy row has no markers → unchanged.
+                markdown: crate::extract::render_display_text(&raw),
                 updated_at: r.get(6)?,
             })
         })
@@ -5106,13 +5130,37 @@ impl Db {
         let Some((_folder_id, name, text)) = self.get_document(document_id)? else {
             return Ok(()); // unknown document — nothing to index.
         };
-        // Header carries the document name as provenance (the date axis is N/A for an upload, so the
-        // header is just the name — `chunk_note` tolerates an empty date).
-        let chunks = crate::embed::chunk_note(&name, "", &text);
-        let vectors = match embedder {
-            Some(e) if !chunks.is_empty() => e.embed_passage(&chunks)?,
+        // Brain v3 PR-2 — HIERARCHICAL chunking. Reconstruct the extracted BLOCKS (page/heading) from
+        // the stored text (lossless for a PR-2 upload; a legacy/flat row reconstructs as one block →
+        // identical leaves + a summary), then build the L0/L1/L2 tree. `name` provenance carries into
+        // the deterministic contextual header on the embed text.
+        let blocks = crate::extract::blocks_from_stored_text(&text);
+        let hier = crate::embed::chunk_document_hierarchical(&name, &blocks);
+        // Embed ONLY the embed-worthy chunks (L0 leaves + L2 summary; L1 parents are FTS-only). We
+        // sub-batch to bound the per-call Metal tensor for a large PDF (mirror index_meeting_chunks).
+        // Build the parallel embed-text list, remembering which HierChunk index each maps to.
+        let embed_indices: Vec<usize> = hier
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.embed)
+            .map(|(i, _)| i)
+            .collect();
+        let embed_texts: Vec<String> = embed_indices
+            .iter()
+            .map(|&i| hier[i].embed_text.clone())
+            .collect();
+        let embed_vecs: Vec<Vec<f32>> = match embedder {
+            Some(e) if !embed_texts.is_empty() => embed_in_sub_batches(e, &embed_texts)?,
             _ => Vec::new(), // model absent → chunk-only (FTS still covers it); vectors come later.
         };
+        // Map HierChunk-index → its vector (only for embed-worthy chunks that actually got embedded).
+        let mut vec_by_hier: std::collections::HashMap<usize, &Vec<f32>> =
+            std::collections::HashMap::new();
+        for (slot, &hi) in embed_indices.iter().enumerate() {
+            if let Some(v) = embed_vecs.get(slot) {
+                vec_by_hier.insert(hi, v);
+            }
+        }
 
         let this_doc = [document_id.to_string()];
         let mut conn = self.lock();
@@ -5124,19 +5172,35 @@ impl Db {
         {
             let mut ins_chunk = tx
                 .prepare(
-                    "INSERT INTO doc_chunks (document_id, chunk_index, text)
-                     VALUES (?1, ?2, ?3)",
+                    "INSERT INTO doc_chunks
+                       (document_id, chunk_index, text, level, parent_id, section_path, page_no)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 )
                 .map_err(map_err)?;
             let mut ins_vec = tx
                 .prepare("INSERT INTO doc_vec_chunks(chunk_id, embedding) VALUES (?1, ?2)")
                 .map_err(map_err)?;
-            for (idx, text) in chunks.iter().enumerate() {
+            // HierChunk-index → the inserted row id, so a leaf can point `parent_id` at its L1 row.
+            // The chunker emits every parent BEFORE its children, so the parent id is always known.
+            let mut row_id_by_hier: Vec<i64> = vec![0; hier.len()];
+            for (idx, c) in hier.iter().enumerate() {
+                let parent_row: Option<i64> = c.parent.map(|pi| row_id_by_hier[pi]);
                 ins_chunk
-                    .execute(rusqlite::params![document_id, idx as i64, text])
+                    .execute(rusqlite::params![
+                        document_id,
+                        idx as i64,
+                        c.raw,
+                        c.level,
+                        parent_row,
+                        c.section_path,
+                        c.page_no,
+                    ])
                     .map_err(map_err)?;
-                if let Some(vector) = vectors.get(idx) {
-                    let chunk_id = tx.last_insert_rowid();
+                let chunk_id = tx.last_insert_rowid();
+                row_id_by_hier[idx] = chunk_id;
+                // Vector ONLY for embed-worthy chunks that were actually embedded (L0+L2, model
+                // present). L1 parents NEVER get a vec0 row — the vector count stays flat.
+                if let Some(vector) = vec_by_hier.get(&idx) {
                     let blob = crate::embed::vec_to_blob(vector);
                     ins_vec
                         .execute(rusqlite::params![chunk_id, blob])
@@ -5409,6 +5473,89 @@ impl Db {
             }
         }
         Ok(hits)
+    }
+
+    /// Brain v3 PR-2 — GATED parent-document expansion (LlamaIndex parent-document / RAPTOR effect).
+    /// For each of the given `document_ids` (the TOP fused doc hits), return the document's DOMINANT
+    /// L1 section-parent text — the section covering the MOST leaf chunks — so the reasoner reads a
+    /// coherent SECTION instead of an isolated 800-char leaf. Documents with no L1 parents (a flat /
+    /// legacy doc, or one section only) are simply omitted (the caller keeps the original leaf hit).
+    ///
+    /// GATING (lock-model, load-bearing): the query applies EXACTLY the same `visibility_clause`
+    /// predicate over `doc_chunks → documents → folders` as the doc-search readers — a document in a
+    /// sealed-and-not-session-unlocked folder yields NOTHING here (its `level=1` rows are purged while
+    /// sealed anyway, and the gate is defense-in-depth on top). No raw-SQL bypass; parents are DERIVED
+    /// content, so this is a pure gated READ that never widens what the session can see.
+    ///
+    /// Returns `document_id → (name, folder_id, parent_text)`. `parent_text` is the L1 `text` (already
+    /// capped at ingest to ~6000 chars — the reasoner budget stays tight).
+    pub fn expand_doc_parents_visible(
+        &self,
+        document_ids: &[String],
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<DocChunkHit>> {
+        if document_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        // For each doc's L1 parents, count how many L0 leaves point at each parent, then pick the
+        // parent with the most leaves (ties broken by lowest parent id, deterministic). One row per
+        // document. `child.parent_id = parent.id` is the hierarchy edge. Gate on the parent's folder.
+        let placeholders = document_ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "WITH parent_counts AS (
+                 SELECT p.id AS parent_id,
+                        p.document_id AS document_id,
+                        p.text AS parent_text,
+                        COUNT(c.id) AS leaf_count
+                   FROM doc_chunks p
+                   JOIN documents d ON d.id = p.document_id
+                   JOIN folders f ON f.id = d.folder_id
+                   LEFT JOIN doc_chunks c
+                          ON c.parent_id = p.id AND c.level = 0
+                  WHERE p.level = 1
+                    AND p.document_id IN ({placeholders})
+                    AND {visible}
+                  GROUP BY p.id
+             ),
+             ranked AS (
+                 SELECT parent_counts.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY document_id
+                            ORDER BY leaf_count DESC, parent_id ASC
+                        ) AS rn
+                   FROM parent_counts
+             )
+             SELECT d.id, d.name, d.folder_id, r.parent_text, d.kind
+               FROM ranked r
+               JOIN documents d ON d.id = r.document_id
+              WHERE r.rn = 1"
+        );
+        let params: Vec<&dyn rusqlite::ToSql> =
+            document_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(params.as_slice(), |row| {
+                Ok(DocChunkHit {
+                    document_id: row.get(0)?,
+                    name: row.get(1)?,
+                    folder_id: row.get(2)?,
+                    snippet: row.get(3)?,
+                    kind: row.get(4)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
     }
 
     // ── M6 Shared Brain — org feed INGEST + local RETRIEVAL ─────────────────────────────────────
@@ -17322,15 +17469,30 @@ mod tests {
         assert_eq!(name, "spec.md");
         assert_eq!(text, "budget planning for the quarter");
 
-        // Chunks + 1:1 vectors exist.
+        // Chunks + vectors exist. Brain v3 PR-2 HIERARCHY: L1 section-parents are FTS-only (NOT
+        // embedded), so vectors are 1:1 with the EMBED-WORTHY rows (L0 leaves + L2 summary), NOT with
+        // ALL doc_chunks. Assert exactly that: every L0/L2 row has a vec0 row, no L1 row does.
         let count = |sql: &str| -> i64 { db.lock().query_row(sql, [], |r| r.get(0)).unwrap() };
         let chunks = count("SELECT COUNT(*) FROM doc_chunks WHERE document_id = 'd1'");
         let vecs = count(
             "SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN \
                (SELECT id FROM doc_chunks WHERE document_id = 'd1')",
         );
+        let embed_worthy = count(
+            "SELECT COUNT(*) FROM doc_chunks WHERE document_id = 'd1' AND level IN (0, 2)",
+        );
+        let l1 = count("SELECT COUNT(*) FROM doc_chunks WHERE document_id = 'd1' AND level = 1");
         assert!(chunks >= 1, "document must be chunked");
-        assert_eq!(chunks, vecs, "doc_vec_chunks is 1:1 with doc_chunks");
+        assert!(l1 >= 1, "a section-parent (L1) must exist");
+        assert_eq!(vecs, embed_worthy, "vectors are 1:1 with the EMBED-worthy L0+L2 rows");
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN \
+                   (SELECT id FROM doc_chunks WHERE document_id = 'd1' AND level = 1)"
+            ),
+            0,
+            "L1 section-parents are NEVER embedded (no vec0 row)"
+        );
 
         // Purge drops BOTH chunks and vectors.
         db.purge_doc_chunks_for_documents(&["d1".to_string()])
@@ -17348,6 +17510,144 @@ mod tests {
         assert_eq!(
             db.get_document("d1").unwrap().unwrap().2,
             "budget planning for the quarter"
+        );
+    }
+
+    /// Brain v3 PR-2 — HIERARCHY persists: an imported document (stored via `blocks_to_stored_text`
+    /// so its page/heading structure survives) indexes into L0 leaves (embedded), L1 section-parents
+    /// (FTS-only, page_no + section_path set), and an L2 summary (embedded). Purge drops ALL levels +
+    /// their vec0 rows.
+    #[test]
+    fn hierarchical_index_persists_levels_and_purges_all() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Project");
+        let blocks = vec![
+            crate::extract::ExtractedBlock {
+                text: "The budget is 100k for the quarter.".into(),
+                page: Some(1),
+                heading_path: Some("Design".into()),
+            },
+            crate::extract::ExtractedBlock {
+                text: "Anna owns delivery of the API layer.".into(),
+                page: Some(2),
+                heading_path: Some("Design › Storage".into()),
+            },
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document("d1", "f-open", "spec.pdf", &stored, "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder))
+            .unwrap();
+
+        // (level, parent_id, section_path, page_no) per doc_chunks row.
+        type DocChunkMetaRow = (i64, Option<i64>, Option<String>, Option<i64>);
+        let rows: Vec<DocChunkMetaRow> = {
+            let conn = db.lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT level, parent_id, section_path, page_no FROM doc_chunks \
+                       WHERE document_id = 'd1' ORDER BY chunk_index",
+                )
+                .unwrap();
+            let mapped = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            mapped
+        };
+        let l0 = rows.iter().filter(|r| r.0 == 0).count();
+        let l1 = rows.iter().filter(|r| r.0 == 1).count();
+        let l2 = rows.iter().filter(|r| r.0 == 2).count();
+        assert_eq!(l1, 2, "two heading sections → two L1 parents");
+        assert!(l0 >= 2, "leaves for each section");
+        assert!(l2 >= 1, "an L2 summary");
+        // Every L0 leaf points at an L1 parent; L1/L2 have no parent.
+        assert!(
+            rows.iter().filter(|r| r.0 == 0).all(|r| r.1.is_some()),
+            "every leaf has a parent_id"
+        );
+        assert!(
+            rows.iter().filter(|r| r.0 != 0).all(|r| r.1.is_none()),
+            "L1/L2 rows have no parent"
+        );
+        // Section path + page carried on the leaves.
+        assert!(rows.iter().any(|r| r.2.as_deref() == Some("Design › Storage")));
+        assert!(rows.iter().any(|r| r.3 == Some(2)));
+
+        // Vectors: exactly the L0+L2 rows (never L1).
+        let vec_count = |sql: &str| -> i64 { db.lock().query_row(sql, [], |r| r.get(0)).unwrap() };
+        assert_eq!(
+            vec_count(
+                "SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN \
+                   (SELECT id FROM doc_chunks WHERE document_id='d1' AND level IN (0,2))"
+            ),
+            (l0 + l2) as i64
+        );
+        assert_eq!(
+            vec_count(
+                "SELECT COUNT(*) FROM doc_vec_chunks WHERE chunk_id IN \
+                   (SELECT id FROM doc_chunks WHERE document_id='d1' AND level=1)"
+            ),
+            0,
+            "L1 parents are never embedded"
+        );
+
+        // Purge removes ALL levels + all vec rows.
+        db.purge_doc_chunks_for_documents(&["d1".to_string()]).unwrap();
+        assert_eq!(db.doc_chunk_count("d1").unwrap(), 0);
+        assert_eq!(vec_count("SELECT COUNT(*) FROM doc_vec_chunks"), 0);
+    }
+
+    /// Brain v3 PR-2 — `expand_doc_parents_visible` returns the dominant L1 SECTION-parent text for a
+    /// top doc hit, and is GATED: a sealed-not-unlocked folder's document yields NOTHING (RED if the
+    /// `visibility_clause` were removed), and unlocking restores it.
+    #[test]
+    fn expand_doc_parents_is_gated_and_returns_section_text() {
+        let db = mem_db();
+        seed_folder(&db, "f-lock", "Secret");
+        let blocks = vec![
+            crate::extract::ExtractedBlock {
+                text: "First paragraph about the classified launch plan for the product.".into(),
+                page: Some(1),
+                heading_path: Some("Launch".into()),
+            },
+            crate::extract::ExtractedBlock {
+                text: "Second paragraph under the same launch heading with more detail here.".into(),
+                page: Some(1),
+                heading_path: Some("Launch".into()),
+            },
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document("d1", "f-lock", "plan.pdf", &stored, "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder))
+            .unwrap();
+
+        let ids = vec!["d1".to_string()];
+        // Open folder → the dominant L1 "Launch" section text comes back.
+        let nothing = std::collections::HashSet::new();
+        let open = db.expand_doc_parents_visible(&ids, &nothing).unwrap();
+        assert_eq!(open.len(), 1, "one document → one dominant parent");
+        assert!(
+            open[0].snippet.contains("classified launch plan"),
+            "parent text is the SECTION body, got: {:?}",
+            open[0].snippet
+        );
+
+        // Seal → gated OUT with empty unlock set.
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        assert!(
+            db.expand_doc_parents_visible(&ids, &nothing).unwrap().is_empty(),
+            "sealed-not-unlocked parent leaked through expand gate"
+        );
+        // Unlock → restored.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        assert_eq!(
+            db.expand_doc_parents_visible(&ids, &unlocked).unwrap().len(),
+            1,
+            "unlock restores the parent"
         );
     }
 

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -226,9 +226,30 @@ fn pack_doc_chunks(
         db.search_doc_chunks_visible(query_vec, 20, unlocked)?
     };
     let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked)?;
-    let hits = crate::embed::fuse_doc_hits(knn, fts);
+    let mut hits = crate::embed::fuse_doc_hits(knn, fts);
     if hits.is_empty() {
         return Ok(());
+    }
+    // Brain v3 PR-2 — GATED PARENT EXPANSION: for the top-3 fused doc hits, replace the isolated
+    // leaf snippet with the document's dominant L1 SECTION-parent text (coherent section beats a
+    // fragment; context-rot lesson keeps it to the top few). `expand_doc_parents_visible` re-applies
+    // the visibility gate, so a sealed-not-unlocked doc contributes nothing. A doc with no L1 parent
+    // (flat/legacy) keeps its original leaf snippet unchanged.
+    const EXPAND_TOP_N: usize = 3;
+    let top_ids: Vec<String> = hits
+        .iter()
+        .take(EXPAND_TOP_N)
+        .map(|h| h.document_id.clone())
+        .collect();
+    if !top_ids.is_empty() {
+        let parents = db.expand_doc_parents_visible(&top_ids, unlocked)?;
+        for p in parents {
+            if let Some(h) = hits.iter_mut().find(|h| h.document_id == p.document_id) {
+                if !p.snippet.trim().is_empty() {
+                    h.snippet = p.snippet;
+                }
+            }
+        }
     }
     for h in hits {
         if corpus.len() >= budget {

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -131,11 +131,24 @@ pub enum ToolCall {
     GetMeeting {
         meeting_id: String,
         transcript_format: String,
+        /// Brain v3 PR-2 — agent PAGING: skip this many chars into the TRANSCRIPT before returning
+        /// (default 0 = today's behavior). Lets the agentic loop iterate a long transcript past the
+        /// per-result budget. The NOTE is always returned in full (it's short).
+        offset: usize,
+        /// Max chars of transcript to return from `offset` (0 = unlimited = today's behavior).
+        max_chars: usize,
     },
     /// The full body of one standalone note OR imported/uploaded document by id (Feature D). Gated
     /// by [`Db::get_document_if_visible`] — a sealed-and-not-session-unlocked document is invisible
     /// (the masked "No data" sentinel), never distinguished from a never-existed id.
-    GetDocument { document_id: String },
+    GetDocument {
+        document_id: String,
+        /// Brain v3 PR-2 — agent PAGING: skip this many chars into the BODY (default 0). Lets the
+        /// agent read a big document past the per-result budget by calling again with a larger offset.
+        offset: usize,
+        /// Max chars of body to return from `offset` (0 = unlimited = today's behavior).
+        max_chars: usize,
+    },
     /// The most recent meetings (already clamped to 1..=100 by the caller/parser).
     ListRecentMeetings { limit: i64 },
     /// Hybrid semantic + FTS search. Gated behind the `semantic_search_enabled` config flag.
@@ -242,16 +255,35 @@ pub fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "get_meeting".into(),
-            description: "Fetch one meeting's AI note and full transcript by its id (from a prior search hit).".into(),
-            parameters: str_arg("meetingId", "The meeting id from a prior search result."),
+            description: "Fetch one meeting's AI note and full transcript by its id (from a prior \
+                          search hit). For a very long transcript, page through it with offset + \
+                          maxChars.".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "meetingId": { "type": "string", "description": "The meeting id from a prior search result." },
+                    "offset": { "type": "integer", "description": "Chars to skip into the transcript (default 0)." },
+                    "maxChars": { "type": "integer", "description": "Max transcript chars to return from offset (default all)." }
+                },
+                "required": ["meetingId"]
+            }),
             write: false,
         },
         ToolSpec {
             name: "get_document".into(),
             description: "Get the full body of one standalone note or imported/uploaded document by \
                           id (from a search hit labelled 'document:...'). Use this — not get_meeting \
-                          — for ids from the DOCUMENTS section of a search result.".into(),
-            parameters: str_arg("documentId", "The document id from a prior search result (a 'document:...' hit)."),
+                          — for ids from the DOCUMENTS section of a search result. For a big document, \
+                          page through it with offset + maxChars.".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "documentId": { "type": "string", "description": "The document id from a prior search result (a 'document:...' hit)." },
+                    "offset": { "type": "integer", "description": "Chars to skip into the body (default 0)." },
+                    "maxChars": { "type": "integer", "description": "Max body chars to return from offset (default all)." }
+                },
+                "required": ["documentId"]
+            }),
             write: false,
         },
         ToolSpec {
@@ -485,7 +517,24 @@ pub fn execute_tool(
             let fts_docs = db
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
                 .unwrap_or_default();
-            let docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
+            let mut docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
+            // Brain v3 PR-2 — GATED PARENT EXPANSION: for the top-3 fused doc hits, swap the isolated
+            // leaf snippet for the document's dominant L1 SECTION-parent text so the agent reads a
+            // coherent section. `expand_doc_parents_visible` re-applies the visibility gate (a
+            // sealed-not-unlocked doc yields nothing); a flat/legacy doc keeps its leaf snippet.
+            let top_ids: Vec<String> =
+                docs.iter().take(3).map(|h| h.document_id.clone()).collect();
+            if !top_ids.is_empty() {
+                if let Ok(parents) = db.expand_doc_parents_visible(&top_ids, unlocked) {
+                    for p in parents {
+                        if let Some(h) = docs.iter_mut().find(|h| h.document_id == p.document_id) {
+                            if !p.snippet.trim().is_empty() {
+                                h.snippet = p.snippet;
+                            }
+                        }
+                    }
+                }
+            }
             match db.search_hybrid_visible(q, &query_vec, 20, unlocked, date_filter) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))
@@ -497,6 +546,8 @@ pub fn execute_tool(
         ToolCall::GetMeeting {
             meeting_id,
             transcript_format,
+            offset,
+            max_chars,
         } => {
             let mid = meeting_id.as_str();
             // A sealed-and-not-unlocked meeting is invisible — including its transcript AND its
@@ -524,7 +575,7 @@ pub fn execute_tool(
                     // timestamps). `transcript_format == "plain"` keeps the LEGACY byte-identical flat
                     // space-join for backward compatibility; every other value (incl. absent/default,
                     // which the MCP/dispatch layer maps to "structured") uses the structured renderer.
-                    let transcript = if transcript_format == "plain" {
+                    let full_transcript = if transcript_format == "plain" {
                         segs.iter()
                             .map(|s| s.text.trim())
                             .filter(|t| !t.is_empty())
@@ -533,6 +584,9 @@ pub fn execute_tool(
                     } else {
                         format_structured_transcript(&segs)
                     };
+                    // Brain v3 PR-2 — agent PAGING: default (offset 0, max_chars 0) is byte-identical
+                    // to today. A non-default window returns a char-safe slice of the transcript.
+                    let transcript = page_text(&full_transcript, *offset, *max_chars);
                     match note {
                         Some(n) => Ok(format!(
                             "{title_line}NOTE:\n{}\n\nTRANSCRIPT:\n{transcript}",
@@ -546,7 +600,11 @@ pub fn execute_tool(
                 }
             }
         }
-        ToolCall::GetDocument { document_id } => {
+        ToolCall::GetDocument {
+            document_id,
+            offset,
+            max_chars,
+        } => {
             let id = document_id.as_str();
             // GATE: `get_document_if_visible` applies the SAME `visibility_clause` JOIN as the doc
             // search readers, so a document in a sealed-and-not-session-unlocked folder resolves to a
@@ -564,10 +622,10 @@ pub fn execute_tool(
                         .map(str::trim)
                         .filter(|t| !t.is_empty())
                         .unwrap_or(doc.name.trim());
-                    Ok(format!(
-                        "TITLE: [[{title}]]\nKIND: {}\n\nBODY:\n{}",
-                        doc.kind, doc.markdown
-                    ))
+                    // Brain v3 PR-2 — agent PAGING: default (0, 0) returns the full body (today's
+                    // behavior); a window returns a char-safe slice so the agent can iterate a big doc.
+                    let body = page_text(&doc.markdown, *offset, *max_chars);
+                    Ok(format!("TITLE: [[{title}]]\nKIND: {}\n\nBODY:\n{}", doc.kind, body))
                 }
             }
         }
@@ -1398,6 +1456,27 @@ fn format_typed_rows(
     out
 }
 
+/// Brain v3 PR-2 — agent PAGING helper. Return a CHAR-safe slice of `text` starting at char `offset`,
+/// at most `max_chars` chars (0 = unlimited). The DEFAULT `(offset=0, max_chars=0)` returns the whole
+/// string unchanged (byte-identical to the pre-paging behavior). An `offset` past the end returns an
+/// explicit end-of-content marker so the agent stops paging instead of looping on an empty result.
+/// Char-based (never byte) so a multi-byte Polish transcript never slices mid-codepoint.
+fn page_text(text: &str, offset: usize, max_chars: usize) -> String {
+    if offset == 0 && max_chars == 0 {
+        return text.to_string();
+    }
+    let total = text.chars().count();
+    if offset >= total {
+        return "[end of content]".to_string();
+    }
+    let mut it = text.chars().skip(offset);
+    if max_chars == 0 {
+        it.collect()
+    } else {
+        it.by_ref().take(max_chars).collect()
+    }
+}
+
 /// Feature D — render a meeting's transcript segments as a STRUCTURED, one-line-per-segment block:
 /// `[<start_s>–<end_s>] <Speaker>: <text>`. RAW SECONDS (never MM:SS) so a 2h+ meeting can never
 /// wrap/clip a minutes field. Speaker maps the cheap 2-way stream attribution
@@ -1618,6 +1697,14 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                 .unwrap_or("")
                 .to_string()
         };
+        // Brain v3 PR-2 — optional non-negative integer arg (agent paging). Absent / non-numeric → 0
+        // (the DEFAULT, which the tool maps to today's behavior).
+        let u = |k: &str| {
+            args.get(k)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                .min(usize::MAX as u64) as usize
+        };
         // Brain v2 L5 — DYNAMIC MCP dispatch. The allowlist above already proved this exact tool
         // was advertised THIS turn (scope Connectors/Full + row enabled + consented); the row is
         // re-read + re-checked here anyway (fail-closed against a mid-turn revoke), then the query
@@ -1660,6 +1747,8 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                     &ToolCall::GetMeeting {
                         meeting_id: s("meetingId"),
                         transcript_format: fmt,
+                        offset: u("offset"),
+                        max_chars: u("maxChars"),
                     },
                     self.db,
                     &unlocked,
@@ -1669,6 +1758,8 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             "get_document" => execute_tool(
                 &ToolCall::GetDocument {
                     document_id: s("documentId"),
+                    offset: u("offset"),
+                    max_chars: u("maxChars"),
                 },
                 self.db,
                 &unlocked,
@@ -3512,14 +3603,14 @@ mod tests {
         // LOCKED, not unlocked → both are the masked sentinel (never their bodies/titles).
         let nothing = HashSet::new();
         let note_locked = execute_tool(
-            &ToolCall::GetDocument { document_id: "doc-note".into() },
+            &ToolCall::GetDocument { document_id: "doc-note".into(), offset: 0, max_chars: 0 },
             &db,
             &nothing,
             &cfg,
         )
         .unwrap();
         let upload_locked = execute_tool(
-            &ToolCall::GetDocument { document_id: "doc-upload".into() },
+            &ToolCall::GetDocument { document_id: "doc-upload".into(), offset: 0, max_chars: 0 },
             &db,
             &nothing,
             &cfg,
@@ -3540,14 +3631,14 @@ mod tests {
         let mut unlocked = HashSet::new();
         unlocked.insert("f-lock".to_string());
         let note_open = execute_tool(
-            &ToolCall::GetDocument { document_id: "doc-note".into() },
+            &ToolCall::GetDocument { document_id: "doc-note".into(), offset: 0, max_chars: 0 },
             &db,
             &unlocked,
             &cfg,
         )
         .unwrap();
         let upload_open = execute_tool(
-            &ToolCall::GetDocument { document_id: "doc-upload".into() },
+            &ToolCall::GetDocument { document_id: "doc-upload".into(), offset: 0, max_chars: 0 },
             &db,
             &unlocked,
             &cfg,
@@ -3592,7 +3683,7 @@ mod tests {
         let unlocked = HashSet::new(); // f-open is not locked → visible.
 
         let note = execute_tool(
-            &ToolCall::GetDocument { document_id: "n1".into() },
+            &ToolCall::GetDocument { document_id: "n1".into(), offset: 0, max_chars: 0 },
             &db,
             &unlocked,
             &cfg,
@@ -3603,7 +3694,7 @@ mod tests {
         );
 
         let upload = execute_tool(
-            &ToolCall::GetDocument { document_id: "u1".into() },
+            &ToolCall::GetDocument { document_id: "u1".into(), offset: 0, max_chars: 0 },
             &db,
             &unlocked,
             &cfg,
@@ -3659,6 +3750,8 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m1".into(),
                 transcript_format: "structured".into(),
+                offset: 0,
+                max_chars: 0,
             },
             &db,
             &HashSet::new(),
@@ -3734,6 +3827,8 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m2".into(),
                 transcript_format: "plain".into(),
+                offset: 0,
+                max_chars: 0,
             },
             &db,
             &HashSet::new(),
@@ -3843,5 +3938,57 @@ mod tests {
             out2.contains("[document:document:d-secret]"),
             "unlocked document must reappear in search: {out2}"
         );
+    }
+
+    /// Brain v3 PR-2 — agent PAGING helper: default (0,0) is byte-identical (full text); a window
+    /// returns a char-safe slice; offset past the end signals end-of-content; multi-byte safe.
+    #[test]
+    fn page_text_paging_is_char_safe_and_default_is_full() {
+        let text = "abcdefghij"; // 10 chars
+        assert_eq!(page_text(text, 0, 0), "abcdefghij", "default returns the whole text");
+        assert_eq!(page_text(text, 3, 0), "defghij", "offset with no cap → to the end");
+        assert_eq!(page_text(text, 3, 4), "defg", "offset + max_chars window");
+        assert_eq!(page_text(text, 20, 5), "[end of content]", "offset past end → marker");
+        // Multi-byte (Polish) — never slices mid-codepoint.
+        let pl = "zażółć gęślą"; // has multi-byte chars
+        let windowed = page_text(pl, 0, 6);
+        assert_eq!(windowed.chars().count(), 6, "counts CHARS, not bytes");
+        assert!(windowed.starts_with("zażół"), "no mid-codepoint slice: {windowed}");
+    }
+
+    /// Brain v3 PR-2 — `get_document` honors offset/max_chars: default returns the full body; a
+    /// window returns a slice; the DEFAULT path is unchanged from before paging.
+    #[test]
+    fn get_document_paging_windows_the_body() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_folder(&db, "f-open", "Docs");
+        db.insert_document(
+            "d-big",
+            "f-open",
+            "big.md",
+            "0123456789ABCDEFGHIJ",
+            "document",
+            1_700_000_000,
+        )
+        .unwrap();
+        let nothing = HashSet::new();
+        let full = execute_tool(
+            &ToolCall::GetDocument { document_id: "d-big".into(), offset: 0, max_chars: 0 },
+            &db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(full.contains("0123456789ABCDEFGHIJ"), "default returns the whole body: {full}");
+        let windowed = execute_tool(
+            &ToolCall::GetDocument { document_id: "d-big".into(), offset: 10, max_chars: 5 },
+            &db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(windowed.contains("BODY:\nABCDE"), "windowed body: {windowed}");
+        assert!(!windowed.contains("01234"), "the offset skipped the first 10 chars: {windowed}");
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -28,6 +28,7 @@ import type {
   GatewayModel,
   ReindexProgress,
   ReindexResult,
+  DocImportProgress,
   InputDeviceInfo,
   AskVaultResult,
   AssistantThreadRow,
@@ -141,6 +142,8 @@ export const EVENT_WHISPER_CARD = "murmur://whisper-card";
 // brain2 RAG — semantic-search model download + reindex backfill event streams.
 export const EVENT_EMBED_DOWNLOAD = "murmur://embed-download";
 export const EVENT_REINDEX = "murmur://reindex-embeddings";
+// Brain v3 PR-2 — extract→chunk→embed progress for an in-flight document import (counts + stage, NO PII).
+export const EVENT_DOC_IMPORT = "murmur://doc-import";
 // Phase D — on-device PERSON-name NER (redaction) model download progress stream.
 export const EVENT_NER_DOWNLOAD = "murmur://ner-download";
 // Recording-storage: an AUTO-prune freed ≥1 old recording's audio to stay under the cap.
@@ -2476,6 +2479,18 @@ export class IpcService {
   /** Fires with COUNT-only progress for the in-flight semantic reindex backfill. */
   onReindex(cb: (p: ReindexProgress) => void): Promise<UnlistenFn> {
     return listen<ReindexProgress>(EVENT_REINDEX, (e) => cb(e.payload));
+  }
+
+  /**
+   * Fires with STAGE + COUNT-only progress for the in-flight document import
+   * (`importDocument`): extracting → chunking → embedding → done. Counts-only,
+   * NO PII (the `documentId` is a random UUID; no filename/text). Subscribe once
+   * per open Brain view and release the returned {@link UnlistenFn} on teardown.
+   */
+  onDocImportProgress(
+    cb: (p: DocImportProgress) => void,
+  ): Promise<UnlistenFn> {
+    return listen<DocImportProgress>(EVENT_DOC_IMPORT, (e) => cb(e.payload));
   }
 
   /** Fires with per-file progress for the in-flight PERSON-name NER model download. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -542,6 +542,21 @@ export interface ReindexProgress {
 }
 
 /**
+ * Brain v3 PR-2 — progress for an in-flight document import (`importDocument`):
+ * the extract → chunk → embed pipeline for ONE document. Mirrors the backend
+ * `DocImportPayload` (camelCase). Counts + a stage ONLY — NO PII (`documentId`
+ * is a random UUID; no filename / text). `done`/`total` are chunk counts within
+ * the embedding stage (`0`/`0` for the earlier stages). `stage`:
+ * `"extracting"` | `"chunking"` | `"embedding"` | `"done"`.
+ */
+export interface DocImportProgress {
+  documentId: string;
+  stage: "extracting" | "chunking" | "embedding" | "done";
+  done: number;
+  total: number;
+}
+
+/**
  * brain2 RAG — result of `reindexEmbeddings()`. Mirrors the backend `ReindexResult`
  * (camelCase). `status` is `"model_missing"` when the real e5 model is absent (no
  * indexing was attempted — the FE nudges the user to download it first), else

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.html
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.html
@@ -82,6 +82,13 @@
       }
     </div>
 
+    @if (busy() && progress(); as prog) {
+      <p class="sc-progress" role="status" aria-live="polite">
+        <span class="sc-progress-dot" aria-hidden="true"></span>
+        <span class="sc-progress-text">{{ prog }}</span>
+      </p>
+    }
+
     @if (blocked()) {
       <div class="banner is-accent sc-locked" role="status">
         <span class="sc-locked-glyph" aria-hidden="true"></span>

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.scss
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.scss
@@ -115,6 +115,37 @@
   box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
+/* Import progress line under the Add button (extract → chunk → embed). */
+.sc-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+.sc-progress-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-hover);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  animation: sc-progress-pulse 1.2s ease-in-out infinite;
+}
+.sc-progress-text {
+  font-variant-numeric: tabular-nums;
+}
+@keyframes sc-progress-pulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 .sc-state {
   margin: 0;
   padding: var(--space-2) 0;
@@ -183,6 +214,9 @@
   }
   .sc:hover {
     transform: none;
+  }
+  .sc-progress-dot {
+    animation: none;
   }
 }
     

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.ts
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.ts
@@ -50,6 +50,11 @@ export class BrainSourceCardComponent {
   readonly addLabel = input("Add");
   readonly busyLabel = input("Adding…");
   readonly emptyLabel = input("Nothing here yet.");
+  /**
+   * Optional fine-grained progress line shown under the Add button while
+   * {@link busy} (e.g. a document's extract → chunk → embed stage). Null hides it.
+   */
+  readonly progress = input<string | null>(null);
 
   readonly add = output<void>();
   readonly deleteItem = output<DocumentInfo>();

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -136,6 +136,7 @@
         [expanded]="docsExpanded()"
         [loading]="listLoading()"
         [busy]="importing()"
+        [progress]="importProgressLabel()"
         [deletingId]="deletingId()"
         [blocked]="selectedBlocked()"
         addLabel="Add document"

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -1,16 +1,19 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   computed,
   effect,
   inject,
   signal,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../../core/ipc.service";
 import type {
   BrainOverview,
+  DocImportProgress,
   DocumentInfo,
   FolderNode,
   GraphData,
@@ -91,6 +94,7 @@ export class BrainComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // ── "Enable the brain" nudge — shown only when an on-device model is missing ─
   /**
@@ -250,6 +254,42 @@ export class BrainComponent {
   readonly savingNote = signal(false);
   readonly deletingId = signal<string | null>(null);
 
+  /**
+   * Latest progress for the in-flight document import (from `EVENT_DOC_IMPORT`),
+   * or null when no import is running. Fed by the `onDocImportProgress` listener
+   * subscribed once in the constructor; cleared when the import settles. Counts +
+   * stage only — NO PII (see {@link DocImportProgress}).
+   */
+  private readonly importProgress = signal<DocImportProgress | null>(null);
+
+  /**
+   * A short, human progress line for the importing Documents card, e.g.
+   * "Extracting…" or "Embedding 12/40". Null unless an import is running.
+   */
+  readonly importProgressLabel = computed<string | null>(() => {
+    if (!this.importing()) {
+      return null;
+    }
+    const p = this.importProgress();
+    if (!p) {
+      return "Preparing…";
+    }
+    switch (p.stage) {
+      case "extracting":
+        return "Extracting text…";
+      case "chunking":
+        return "Chunking…";
+      case "embedding":
+        return p.total > 0
+          ? `Embedding ${p.done}/${p.total}`
+          : "Embedding…";
+      case "done":
+        return "Finishing…";
+      default:
+        return "Working…";
+    }
+  });
+
   readonly documents = computed(() =>
     this.items().filter((d) => d.kind !== "note"),
   );
@@ -357,6 +397,22 @@ export class BrainComponent {
         void this.fetchGraph();
       },
     );
+
+    // Subscribe ONCE to the document-import progress stream (extract → chunk →
+    // embed). Payloads are counts + stage only (NO PII); we push the latest into
+    // `importProgress` so the Documents card shows live progress instead of a
+    // frozen "Adding…". The listener is released on teardown (RecorderStore.init
+    // idiom). `import_document` is a one-shot, so no stale-result guard is needed
+    // — the `importing` flag already gates a second import.
+    let unlisten: UnlistenFn | null = null;
+    void this.ipc
+      .onDocImportProgress((p) => this.importProgress.set(p))
+      .then((fn) => {
+        unlisten = fn;
+      });
+    this.destroyRef.onDestroy(() => {
+      unlisten?.();
+    });
   }
 
   /** Probe both on-device models; null on any failure (nudge stays hidden). */
@@ -452,7 +508,12 @@ export class BrainComponent {
     this.selectedFolderId.set((event.target as HTMLSelectElement).value);
   }
 
-  /** Open the native file dialog (md/txt) → import the chosen path as a document. */
+  /**
+   * Open the native file dialog (Markdown / text / PDF / Word / PowerPoint /
+   * Excel / HTML) → import the chosen path as a document. The backend extracts
+   * the text, then chunks + embeds it behind the RAM floor, streaming progress
+   * over `EVENT_DOC_IMPORT` (surfaced on the card via {@link importProgressLabel}).
+   */
   async pickAndImportDocument(): Promise<void> {
     const folderId = this.addTargetId();
     if (!folderId || this.selectedBlocked() || this.importing()) {
@@ -460,12 +521,27 @@ export class BrainComponent {
     }
     const chosen = await open({
       multiple: false,
-      filters: [{ name: "Documents", extensions: ["md", "txt"] }],
+      filters: [
+        {
+          name: "Documents",
+          extensions: [
+            "md",
+            "txt",
+            "pdf",
+            "docx",
+            "pptx",
+            "xlsx",
+            "html",
+            "htm",
+          ],
+        },
+      ],
     });
     if (typeof chosen !== "string") {
       return;
     }
 
+    this.importProgress.set(null);
     this.importing.set(true);
     try {
       await this.ipc.importDocument(chosen, folderId);
@@ -476,6 +552,7 @@ export class BrainComponent {
       this.toast.danger(this.friendlyImportError(e));
     } finally {
       this.importing.set(false);
+      this.importProgress.set(null);
     }
   }
 
@@ -553,13 +630,38 @@ export class BrainComponent {
     await this.fetchOverview();
   }
 
+  /**
+   * Map a raw backend error string into a friendly, actionable message. The
+   * backend serializes `AppError` as `to_string()` — so the strings we match
+   * are the `import_document` / `extract` messages, prefixed by the variant tag
+   * (`"locked: …"`, `"invalid argument: …"`). Order matters: the SPECIFIC
+   * extraction failures are checked before the generic "unsupported type" one.
+   */
   private friendlyImportError(e: unknown): string {
     const msg = String(e);
-    if (/lock/i.test(msg)) {
+    // Write-gate: a sealed-not-unlocked folder ("locked: …").
+    if (/^locked:|\block/i.test(msg)) {
       return "That folder is locked — unlock it first to add to the brain.";
     }
-    if (/\.md and \.txt|only .*md|invalid/i.test(msg)) {
-      return "Only Markdown (.md) and text (.txt) files can be imported.";
+    // Scanned / image-only PDF — no text layer, OCR not supported yet.
+    if (/scanned pdf|no extractable text|has no extractable/i.test(msg)) {
+      return "That file has no extractable text (a scanned or image-only document). OCR isn’t supported yet.";
+    }
+    // Encrypted / password-protected PDF.
+    if (/password-protected|password|encrypted/i.test(msg)) {
+      return "That PDF is password-protected — unlock it and try again.";
+    }
+    // Corrupt / unreadable / malformed file (bad zip, malformed XML, unreadable PDF).
+    if (
+      /could not read|could not open|could not render|not a valid|corrupt|malformed|bad (docx|pptx)/i.test(
+        msg,
+      )
+    ) {
+      return "That file couldn’t be read — it may be corrupt or in an unexpected format.";
+    }
+    // Unsupported extension (allowlist reject) — the catch-all invalid-argument case.
+    if (/unsupported document type|only .*md|invalid argument/i.test(msg)) {
+      return "That file type can’t be imported. Try Markdown, text, PDF, Word, PowerPoint, Excel, or HTML.";
     }
     return "Couldn’t add that to the brain. Please try again.";
   }


### PR DESCRIPTION
PR-2 of the Brain v3 program (spec: docs/superpowers/specs/2026-07-17-brain-v3-design.md). Turns the Brain "Add document" button from md/txt-only into universal, arbitrary-size ingestion, and gives big documents a real hierarchical index so retrieval can reason over them.

## Extraction — new `src-tauri/src/extract/` module
- **PDF** via macOS **PDFKit** (`objc2-pdf-kit`): per-page text + outline headings. Every FFI call wrapped in `objc2::exception::catch` → a malformed/encrypted/scanned PDF fails closed to `InvalidArg`, never aborts the process (the crash-safe-FFI rule).
- **DOCX / PPTX** via pure-Rust `zip` + `quick-xml` (headings, tables, slide order).
- **XLSX** via `calamine`, **HTML** via `html2text`.
- `ExtractedBlock { text, page, heading_path }`. Only extracted **text** is stored (no source binary), riding the existing document seal.

## Hierarchical index (RAPTOR-style, deterministic, zero LLM at ingest)
- **L0** 800-char leaves (heading-bounded, contextual header `doc | section | p.N`) — embedded + FTS.
- **L1** section parents — FTS-only (vector count stays flat).
- **L2** deterministic doc outline — embedded + FTS.
- Gated **parent expansion** (`expand_doc_parents_visible`) hands Ask/tools/MCP the richer section context when several leaves of a section hit.

## Async + safety
- The whole extract → insert → embed pipeline runs **off the runtime thread** via `perf::run_heavy` behind the RAM floor; counts-only progress events drive a Brain-tab indicator.
- **Race-safe write-gate** re-checked inside the blocking closure before insert; the sealed-at-rest guard fires on the derived-chunk write; **decompression-bomb ceiling** (512 MiB decompressed — no cap on original file size, so "arbitrary size" holds).
- `get_document` / `get_meeting` gain `offset`/`max_chars` **paging** so the agent can read past a large document; mirrored on MCP.

## Verification
- `cargo test --lib` → **1812 / 0**; `ng lint` + `ng build` clean.
- RED-before-GREEN on the seal guard, the parent-expansion gate, and the zip-bomb guard.
- **adversarial-verifier: PASS.** **lock-security-reviewer: PASS** (final state, moved write-gate) — every read gated, all chunk levels + vec0 rows purge on seal & delete, verify-before-destroy intact, no PII in logs, FFI fail-closed.

Additive migration only (`doc_chunks` gains `level`/`parent_id`/`section_path`/`page_no`). New deps (`objc2-pdf-kit`, `calamine`, `html2text`; `zip`/`quick-xml` promoted from transitive) are pre-approved for this feature.

Follow-up (noted by lock-security, not a blocker): a residual microsecond gate→insert TOCTOU shared with the existing note-import path — worth closing across the whole ingest family in one transaction later. PDFKit text/RAM fidelity on a real 500-page PDF needs a signed-build Mac check.