### PR TITLE
feat(brain): typed link engine — wikilink edges by id + semantic auto-links

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1805,6 +1805,13 @@ pub(crate) fn update_note_inner_with(
     // sealed-folder gate inside; never fails the save (the plaintext is already durable).
     reindex_meeting_after_edit(state, meeting_id, embedder);
 
+    // Brain v3 PR-3 — LINK ENGINE: re-index this meeting note's `[[Title]]` wikilink edges (resolved
+    // target ids) + refresh its semantic suggestions from the re-derived vectors (model-gated). Both
+    // best-effort — a link failure never fails the note save. The wikilink pass runs regardless of
+    // the embedder (deterministic); the semantic pass self-gates on `embed_model_present`.
+    index_wikilinks_best_effort(state, crate::links::LinkKind::Meeting, meeting_id, markdown);
+    auto_link_semantic_best_effort(state, crate::links::LinkKind::Meeting, meeting_id);
+
     Ok(NoteDto {
         meeting_id: meeting_id.to_string(),
         provider_id: existing.provider_id,
@@ -2453,6 +2460,11 @@ pub(crate) fn get_or_create_companion_note_inner(
         None => {
             let id = create_note_inner(state, None, &meeting_name)?;
             state.db.set_document_meeting_id(&id, meeting_id)?;
+            // Brain v3 PR-3 — record the structured `companion` edge (note → meeting) alongside the
+            // `documents.meeting_id` column, so the link graph carries it beyond the migrate backfill.
+            if let Err(e) = state.db.set_companion_link(&id, meeting_id) {
+                tracing::warn!(target: "links", error = %e, "companion link edge failed (note linked)");
+            }
             // Stamp the front-matter `meeting: "[[…]]"` link on the fresh (empty) note so the
             // document-first editor mounts on a note that already carries the link (no body added).
             if let Some(row) = state.db.get_note_row(&id)? {
@@ -3232,6 +3244,10 @@ pub(crate) fn create_note_inner(
         state.db.insert_note(&id, &folder_id, &name, title, "", now)?;
     }
     // No chunks to index for an empty body — `update_note` re-indexes once the user writes.
+    // Brain v3 PR-3 — LINK ENGINE: index the (empty) body's wikilinks so a create with no body
+    // establishes a clean empty edge set; the first `update_note_doc` re-indexes real `[[Title]]`s.
+    // No semantic pass on birth (no vectors yet). Best-effort.
+    index_wikilinks_best_effort(state, crate::links::LinkKind::Note, &id, "");
     tracing::info!(target: "notes", note_id = %id, folder_id = %folder_id, "note created");
     Ok(id)
 }
@@ -3480,6 +3496,12 @@ pub(crate) fn update_note_doc_inner(
     if let Err(e) = index_note_body_chunks(state, id, title, markdown, embedder.as_deref()) {
         tracing::warn!(target: "rag", error = %e, "note re-index on update failed (text saved)");
     }
+
+    // Brain v3 PR-3 — LINK ENGINE: (a) re-index this note's `[[Title]]` wikilink edges by resolved
+    // TARGET id (rename-proof), and (b) refresh its semantic suggestions from the fresh vectors
+    // (model-gated). Both best-effort — a link failure never fails the note save.
+    index_wikilinks_best_effort(state, crate::links::LinkKind::Note, id, markdown);
+    auto_link_semantic_best_effort(state, crate::links::LinkKind::Note, id);
 
     // Re-export the vault `.md` (best-effort). A sealed folder has no export (gated above), so this
     // only runs for a visible note.
@@ -6264,6 +6286,13 @@ pub async fn build_and_persist_entities(
         }
     }
 
+    // Brain v3 PR-3 — LINK ENGINE (post-pipeline): index the finalized meeting note's `[[Title]]`
+    // wikilink edges (resolved target ids) and suggest content-similar neighbours from the meeting's
+    // chunks/vectors (indexed earlier in the pipeline; model-gated inside). Both best-effort — a link
+    // failure never fails the graph/note (both already succeeded).
+    index_wikilinks_best_effort(state, crate::links::LinkKind::Meeting, meeting_id, markdown);
+    auto_link_semantic_best_effort(state, crate::links::LinkKind::Meeting, meeting_id);
+
     Ok(payload)
 }
 
@@ -7687,6 +7716,278 @@ pub fn get_backlinks(
     };
     let unlocked = unlocked_snapshot(state.inner())?;
     state.db.backlinks_for_visible(kind, &target_id, &unlocked)
+}
+
+/// Parse an IPC link-endpoint kind string into [`crate::links::LinkKind`], or a clean `InvalidArg`.
+fn parse_link_kind(s: &str) -> Result<crate::links::LinkKind, AppError> {
+    crate::links::LinkKind::parse(s).ok_or_else(|| {
+        AppError::InvalidArg(format!(
+            "unknown link kind {s:?} (expected \"meeting\", \"note\", or \"document\")"
+        ))
+    })
+}
+
+/// Brain v3 PR-3 — every persisted link edge incident on `(kind, id)`, BOTH endpoints
+/// visibility-gated in [`crate::storage::db::Db::links_for_visible`] (the queried item must be
+/// visible or the list is empty — no existence leak — and each edge's neighbour is dropped unless it
+/// too is visible). Snapshots the LIVE session unlock set. `kind` is `"meeting" | "note" |
+/// "document"`. Dismissed edges are never returned; suggested (semantic) edges are, so the FE can
+/// render Accept/Dismiss.
+#[tauri::command]
+pub fn list_links(
+    state: State<'_, AppState>,
+    kind: String,
+    id: String,
+) -> Result<Vec<crate::storage::models::LinkEdge>, AppError> {
+    let link_kind = parse_link_kind(&kind)?;
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.links_for_visible(link_kind, &id, &unlocked)
+}
+
+/// Brain v3 PR-3 — ACCEPT a suggested (semantic) link: flip it `status='active'`,
+/// `created_by='accepted'`, AND materialize the neighbour's `[[Title]]` into the SOURCE's markdown
+/// via the managed `apply_link_markers` block (the ONLY path that writes a semantic link into a
+/// `.md` — the auto pass never does). GATED: the SOURCE endpoint must be session-visible (else refuse
+/// — never write plaintext behind a lock, and never reveal a locked neighbour). Idempotent.
+#[tauri::command]
+pub fn accept_link(state: State<'_, AppState>, id: i64) -> Result<(), AppError> {
+    accept_link_inner(state.inner(), id)
+}
+
+pub(crate) fn accept_link_inner(state: &AppState, id: i64) -> Result<(), AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    let Some((src_kind, src_id, dst_kind, dst_id, _et, _status)) = state.db.link_by_id(id)? else {
+        return Err(AppError::InvalidArg(format!("no link {id}")));
+    };
+    let unlocked = unlocked_snapshot(state)?;
+    // Flip the row first: the graph edge is active even if the .md materialize below is skipped
+    // (e.g. neither endpoint is a locally-owned editable note). The panel reflects the accept.
+    state.db.accept_link(id)?;
+    // A semantic edge is undirected — materialize the neighbour's [[Title]] into whichever endpoint
+    // is a LOCAL, session-VISIBLE note we own the markdown of. Try src's note first, then dst's.
+    // Best-effort: a materialize skip/failure never rolls back the accept.
+    let endpoints = [
+        (src_kind.as_str(), src_id.as_str(), dst_kind.as_str(), dst_id.as_str()),
+        (dst_kind.as_str(), dst_id.as_str(), src_kind.as_str(), src_id.as_str()),
+    ];
+    for (owner_k, owner_id, other_k, other_id) in endpoints {
+        let (Some(owner_kind), Some(other_kind)) = (
+            crate::links::LinkKind::parse(owner_k),
+            crate::links::LinkKind::parse(other_k),
+        ) else {
+            continue;
+        };
+        // Resolve the neighbour's current gated title; skip if the neighbour is sealed (no leak).
+        let Some(title) =
+            state.db.link_endpoint_title_visible(other_kind, other_id, &unlocked)?
+        else {
+            continue;
+        };
+        if materialize_accepted_link(state, owner_kind, owner_id, &title)? {
+            break; // wrote (or found already-present) in one owned, visible source — done.
+        }
+    }
+    tracing::info!(target: "links", link_id = id, "accept_link");
+    Ok(())
+}
+
+/// Materialize the accepted neighbour's `[[Title]]` into the OWNER `(kind, id)`'s markdown via the
+/// managed `apply_link_markers` block — but ONLY when the owner is a LOCAL, session-VISIBLE note we
+/// own the markdown of (a meeting AI note, or an authored note). Returns `true` when the owner IS
+/// such a note (whether it wrote or the link was already present), `false` when the owner is not a
+/// writable/visible target (the caller then tries the other endpoint). Merges with the related-notes
+/// hits already rendered in the block so the auto block is preserved.
+fn materialize_accepted_link(
+    state: &AppState,
+    kind: crate::links::LinkKind,
+    id: &str,
+    title: &str,
+) -> Result<bool, AppError> {
+    let hit = crate::enrich::ContextHit {
+        source: match kind {
+            crate::links::LinkKind::Meeting => "meeting",
+            _ => "note",
+        }
+        .to_string(),
+        detail: format!("[[{title}]]"),
+        url: None,
+    };
+    match kind {
+        crate::links::LinkKind::Meeting => {
+            // GATE: the meeting's note must be session-visible to write plaintext.
+            if !meeting_is_unlocked(state, id)? {
+                return Ok(false);
+            }
+            let Some(existing) = state.db.get_latest_note_for_meeting(id)? else {
+                return Ok(false);
+            };
+            // Skip a sealed (blob-present) note (the seal-safety gate `link_related_notes_inner` uses).
+            let sealed = state
+                .db
+                .sealable_notes_for_meeting(id)?
+                .iter()
+                .any(|n| n.content_blob.is_some());
+            if sealed {
+                return Ok(false);
+            }
+            let merged = merge_related_hit(&existing.markdown, hit);
+            if merged != existing.markdown {
+                update_note_inner(state, id, &merged)?;
+            }
+            Ok(true)
+        }
+        crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
+            let Some(row) = state.db.get_note_row(id)? else {
+                return Ok(false); // a raw document has no editable note markdown here.
+            };
+            if !folder_is_unlocked(state, &row.folder_id)? {
+                return Ok(false);
+            }
+            let title_disp = row
+                .title
+                .clone()
+                .filter(|t| !t.is_empty())
+                .unwrap_or_else(|| row.name.clone());
+            let merged = merge_related_hit(&row.text, hit);
+            if merged != row.text {
+                update_note_doc_inner(state, id, &title_disp, &merged)?;
+            }
+            Ok(true)
+        }
+    }
+}
+
+/// Append ONE `[[Title]]` [`ContextHit`] to a note's managed `murmur:links` block WITHOUT dropping
+/// any related-notes hits already rendered there. `apply_link_markers` is a full-block REPLACE, so we
+/// re-collect the existing rendered hits ([`crate::enrich::extract_link_hits`]), add the new one
+/// (deduped by rendered detail), and re-apply — the block stays idempotent and the auto related-notes
+/// entries survive an accept.
+fn merge_related_hit(markdown: &str, new_hit: crate::enrich::ContextHit) -> String {
+    let mut hits = crate::enrich::extract_link_hits(markdown);
+    if !hits.iter().any(|h| h.detail == new_hit.detail) {
+        hits.push(new_hit);
+    }
+    crate::enrich::apply_link_markers(markdown, &hits)
+}
+
+/// Brain v3 PR-3 — DISMISS a suggested link: TOMBSTONE it so no later auto pass re-suggests it. No
+/// markdown is touched (dismiss is graph-only). Idempotent.
+#[tauri::command]
+pub fn dismiss_link(state: State<'_, AppState>, id: i64) -> Result<(), AppError> {
+    state.db.dismiss_link(id)?;
+    tracing::info!(target: "links", link_id = id, "dismiss_link");
+    Ok(())
+}
+
+/// Brain v3 PR-3 — WRITE-TIME wikilink indexing hook, called from every note-save funnel AFTER the
+/// text is durable. Resolves `[[Title]]` → TARGET IDS and (delete-then-insert) stores this source's
+/// `wikilink` edges. BEST-EFFORT: a failure logs (ids/counts only, no PII) and never fails the save
+/// — the plaintext is already the canonical copy. `src_kind` is `Meeting` for an AI note funnel,
+/// `Note` for an authored-note funnel.
+fn index_wikilinks_best_effort(
+    state: &AppState,
+    src_kind: crate::links::LinkKind,
+    src_id: &str,
+    body: &str,
+) {
+    let unlocked = match unlocked_snapshot(state) {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(target: "links", error = %e, "wikilink index skipped (unlock snapshot)");
+            return;
+        }
+    };
+    if let Err(e) = state
+        .db
+        .index_wikilinks_for_source(src_kind, src_id, body, &unlocked)
+    {
+        tracing::warn!(target: "links", error = %e, "wikilink index failed (text saved)");
+    }
+}
+
+/// Brain v3 PR-3 — SEMANTIC AUTO-LINK hook, called AFTER a successful REAL-embedder index of an item
+/// (never on the stub — model-gated at the CALL SITE, mirroring the chunk-index gate). Suggests up to
+/// `SEMANTIC_LINK_CAP` content-similar neighbours (mutual-kNN / floor / cap; see `auto_link_semantic`).
+/// BEST-EFFORT: a failure logs (counts only) and never fails the caller. O(k·log n) — no corpus scan.
+fn auto_link_semantic_best_effort(state: &AppState, kind: crate::links::LinkKind, id: &str) {
+    // GUARD: only run with the real embedder present — a stub vector carries no meaning, so a
+    // stub-space "neighbour" would be noise. (The chunk index itself already refuses stub vectors.)
+    if !crate::embed::embed_model_present() {
+        return;
+    }
+    let unlocked = match unlocked_snapshot(state) {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(target: "links", error = %e, "semantic auto-link skipped (unlock snapshot)");
+            return;
+        }
+    };
+    if let Err(e) = state.db.auto_link_semantic(kind, id, &unlocked) {
+        tracing::warn!(target: "links", error = %e, "semantic auto-link failed (index intact)");
+    }
+}
+
+/// Brain v3 PR-3 — RE-DERIVE the link engine for every meeting + note in a JUST-UNSEALED folder
+/// (their `links` rows were purged on seal). Re-runs the WIKILINK pass (resolved target ids, from the
+/// restored body) + the SEMANTIC pass (model-gated inside) per item, against the supplied unlock set.
+/// Called from the unlock restore closure; each item's index is BEST-EFFORT so one bad row never
+/// aborts the whole unlock. Logs ids/counts only.
+fn rederive_links_for_folder(
+    state: &AppState,
+    folder_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+) {
+    // Meetings in the folder → re-index each latest note's wikilinks + semantic neighbours.
+    match state.db.meeting_ids_in_folder(folder_id) {
+        Ok(mids) => {
+            for mid in mids {
+                if let Ok(Some(note)) = state.db.get_latest_note_for_meeting(&mid) {
+                    if let Err(e) = state.db.index_wikilinks_for_source(
+                        crate::links::LinkKind::Meeting,
+                        &mid,
+                        &note.markdown,
+                        unlocked,
+                    ) {
+                        tracing::warn!(target: "links", error = %e, "unlock wikilink re-derive (meeting) failed");
+                    }
+                }
+                if crate::embed::embed_model_present() {
+                    if let Err(e) =
+                        state.db.auto_link_semantic(crate::links::LinkKind::Meeting, &mid, unlocked)
+                    {
+                        tracing::warn!(target: "links", error = %e, "unlock semantic re-derive (meeting) failed");
+                    }
+                }
+            }
+        }
+        Err(e) => tracing::warn!(target: "links", error = %e, "unlock link re-derive: meeting-id list failed"),
+    }
+    // Documents/notes in the folder → re-index authored notes' wikilinks + semantic neighbours (a raw
+    // document has no wikilinks but still gets a semantic pass over its chunks).
+    match state.db.document_ids_in_folder(folder_id) {
+        Ok(dids) => {
+            for did in dids {
+                if let Ok(Some(row)) = state.db.get_note_row(&did) {
+                    if let Err(e) = state.db.index_wikilinks_for_source(
+                        crate::links::LinkKind::Note,
+                        &did,
+                        &row.text,
+                        unlocked,
+                    ) {
+                        tracing::warn!(target: "links", error = %e, "unlock wikilink re-derive (note) failed");
+                    }
+                }
+                if crate::embed::embed_model_present() {
+                    if let Err(e) =
+                        state.db.auto_link_semantic(crate::links::LinkKind::Note, &did, unlocked)
+                    {
+                        tracing::warn!(target: "links", error = %e, "unlock semantic re-derive (doc) failed");
+                    }
+                }
+            }
+        }
+        Err(e) => tracing::warn!(target: "links", error = %e, "unlock link re-derive: document-id list failed"),
+    }
 }
 
 /// Resolve a clicked `[[Title]]` wikilink to a VISIBLE note/meeting/org-item to navigate to.
@@ -13619,6 +13920,11 @@ pub async fn unlock_folder(
                 .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
                 .clone()
         };
+        // Brain v3 PR-3 — RE-DERIVE the LINK ENGINE for the just-unsealed items: their `links` rows
+        // were purged on seal, so re-run the wikilink pass (deterministic) + the semantic pass
+        // (model-gated inside) for every meeting + note in this folder, using the now-updated unlock
+        // set. Best-effort — a re-derive failure never fails the unlock (the content is restored).
+        rederive_links_for_folder(&state, &folder_id, &unlocked);
         let counts = state.db.count_notes_per_folder(&unlocked)?;
         let kind = state
             .db
@@ -13984,6 +14290,25 @@ pub(crate) fn remove_lock_inner(state: &AppState, folder_id: String) -> Result<(
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
         g.remove(&folder_id);
     }
+
+    // NIT-8 (link lifecycle): the folder's `links` rows were purged on the ORIGINAL seal
+    // (`purge_links_tx`). The SESSION unlock (`unlock_folder`) re-derives them; the PERMANENT unseal
+    // must too, or a permanently-unlocked folder stays link-empty until the next note edit. Mirror
+    // `unlock_folder`: re-run the wikilink pass (deterministic) + the semantic pass (model-gated
+    // inside) for every meeting + note now that the folder is fully OPEN. The folder is `locked=0`
+    // above, so it is visible under ANY unlock set; add its id to the live snapshot to match the
+    // session path exactly. Best-effort — a re-derive failure never fails the permanent unlock (the
+    // content is already restored).
+    let live_set = {
+        let mut s = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+            .clone();
+        s.insert(folder_id.clone());
+        s
+    };
+    rederive_links_for_folder(state, &folder_id, &live_set);
     Ok(())
 }
 
@@ -21615,6 +21940,61 @@ mod lifecycle_tests {
         assert!(
             rn.blob.is_none(),
             "manual_notes_blob cleared on remove-lock"
+        );
+    }
+
+    /// NIT-8 (RED-before-GREEN — link lifecycle): PERMANENTLY removing a folder's lock must
+    /// re-derive the folder's `links` (purged on the original seal), mirroring the session unlock —
+    /// otherwise a permanently-unlocked folder has no links until the next note edit. RED on the
+    /// pre-fix `remove_lock_inner` (restored plaintext + re-indexed chunks/vectors but never called
+    /// `rederive_links_for_folder`), so the wikilink edge stayed empty after remove-lock.
+    #[test]
+    fn remove_lock_rederives_wikilinks() {
+        let state = build_state("remove-lock-rederive-links");
+        // Open target the wikilink points at (a standalone note in an OPEN folder).
+        make_open_folder(&state.db, "f-open", "Open");
+        state
+            .db
+            .insert_note("other", "f-open", "Other Note", "Other Note", "body", 1_700_000_000_000)
+            .unwrap();
+        // Locked folder holds a meeting whose note links to the open target.
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_meeting(&state.db, "m1", "see [[Other Note]] for context", Some("f-lock"));
+
+        // Index the wikilink while open (as a real save would), then verify it exists.
+        let nothing = std::collections::HashSet::new();
+        state
+            .db
+            .index_wikilinks_for_source(
+                crate::links::LinkKind::Meeting,
+                "m1",
+                "see [[Other Note]] for context",
+                &nothing,
+            )
+            .unwrap();
+        // Count m1's OUTBOUND wikilink edges through the PUBLIC gated reader (open folder → visible).
+        let wikilink_edges = |db: &crate::storage::Db, unlocked: &HashSet<String>| -> usize {
+            db.links_for_visible(crate::links::LinkKind::Meeting, "m1", unlocked)
+                .unwrap()
+                .into_iter()
+                .filter(|e| e.edge_type == "wikilink")
+                .count()
+        };
+        assert_eq!(wikilink_edges(&state.db, &nothing), 1, "wikilink edge exists before seal");
+
+        // LOCK → the seal's purge_links_tx drops the edge at rest (and the sealed source is masked).
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        assert_eq!(wikilink_edges(&state.db, &nothing), 0, "wikilink edge purged by the seal");
+
+        // Cache the KEK, then PERMANENTLY remove the lock.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
+        remove_lock_inner(&state, "f-lock".to_string()).unwrap();
+
+        assert_eq!(
+            wikilink_edges(&state.db, &nothing),
+            1,
+            "wikilink edge is RE-DERIVED after remove-lock (the folder is fully open again)"
         );
     }
 

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -550,6 +550,17 @@ pub(crate) fn vec_to_blob(v: &[f32]) -> Vec<u8> {
     out
 }
 
+/// Inverse of [`vec_to_blob`]: decode a little-endian f32 byte blob (as stored in / read back from a
+/// `vec0 float[N]` column) into an `f32` vector. A trailing partial group (length not a multiple of
+/// 4) is ignored defensively — the caller checks the length against [`EMBED_DIM`] anyway. Used by the
+/// link engine's centroid math (Brain v3 PR-3), which reads the STORED per-chunk vectors directly
+/// rather than re-embedding.
+pub(crate) fn blob_to_vec(blob: &[u8]) -> Vec<f32> {
+    blob.chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
 /// Scalar-quantize an L2-normalized f32 embedding (components in ≈[-1, 1]) into an int8 byte blob
 /// for binding to a `vec0 int8[N]` column via `vec_int8(?)` (the M6 org partition — int8 is 3.7×
 /// smaller than f32 and holds in-query-budget at 300k chunks, the scale-spike finding).

--- a/src-tauri/src/enrich.rs
+++ b/src-tauri/src/enrich.rs
@@ -83,6 +83,51 @@ pub fn apply_link_markers(note_md: &str, hits: &[ContextHit]) -> String {
     apply_fenced_block(note_md, LINKS_FENCE_START, LINKS_FENCE_END, callout, &body)
 }
 
+/// Brain v3 PR-3 — INVERSE of the links block: parse the `> - {detail} (via {source})[ — {url}]`
+/// body lines of the managed `murmur:links` block back into [`ContextHit`]s, so an accepted semantic
+/// link can be MERGED into the block without clobbering the auto related-notes rows already there
+/// (the block is a full REPLACE — see [`apply_link_markers`]). Only the links fence is read (the
+/// connector `murmur:context` block is left untouched). A note with no links block yields `[]`.
+///
+/// Best-effort parse (the block is our OWN deterministic render, so the shape is stable): a body line
+/// that does not match the render shape is skipped rather than mis-parsed. The `callout` header line
+/// (`> [!related]-…`) is not a `> - ` bullet, so it is naturally excluded.
+pub fn extract_link_hits(note_md: &str) -> Vec<ContextHit> {
+    let Some(start) = note_md.rfind(LINKS_FENCE_START) else {
+        return Vec::new();
+    };
+    let Some(end_rel) = note_md[start..].find(LINKS_FENCE_END) else {
+        return Vec::new();
+    };
+    let block = &note_md[start..start + end_rel];
+    let mut out: Vec<ContextHit> = Vec::new();
+    for line in block.lines() {
+        let Some(rest) = line.strip_prefix("> - ") else {
+            continue;
+        };
+        // Split an optional trailing " — {url}" (em-dash separator the renderer used). rsplit once so
+        // an em-dash inside the detail itself is not mistaken for the url separator.
+        let (head, url) = match rest.rsplit_once(" — ") {
+            Some((h, u)) => (h, Some(u.trim().to_string())),
+            None => (rest, None),
+        };
+        // The " (via {source})" suffix carries the source label.
+        let (detail, source) = match head.rsplit_once(" (via ") {
+            Some((d, s)) => (d.trim().to_string(), s.trim_end_matches(')').trim().to_string()),
+            None => (head.trim().to_string(), String::new()),
+        };
+        if detail.is_empty() {
+            continue;
+        }
+        out.push(ContextHit {
+            source,
+            detail,
+            url,
+        });
+    }
+    out
+}
+
 /// Render ONE hit as a collapsed, sanitized, loudly-attributed callout body line (no trailing
 /// newline — the block writer adds the break). Shared by BOTH lanes (context + links) so the line
 /// shape + injection-hardening are identical everywhere.
@@ -207,6 +252,50 @@ mod tests {
             hit("Murmur", "We agreed the Q3 roadmap and the budget runway.", Some("[[Q2 Planning]]")),
             hit("Murmur", "The bed comfort trial went well.", Some("[[Bed Comfort]]")),
         ]
+    }
+
+    /// Brain v3 PR-3 — `extract_link_hits` is the INVERSE of the links block: applying hits then
+    /// extracting them round-trips the rendered detail/source/url, so an accept can MERGE a new
+    /// `[[Title]]` without clobbering the existing related-notes rows.
+    #[test]
+    fn extract_link_hits_round_trips_the_links_block() {
+        let md = "# Notes\n- a line\n";
+        let rendered = apply_link_markers(md, &related_hits());
+        let extracted = extract_link_hits(&rendered);
+        assert_eq!(extracted.len(), 2, "both related rows recovered");
+        // The url-bearing hit round-trips detail + source + url.
+        let q2 = extracted
+            .iter()
+            .find(|h| h.detail.contains("Q3 roadmap"))
+            .expect("Q2 row present");
+        assert_eq!(q2.source, "Murmur");
+        assert_eq!(q2.url.as_deref(), Some("[[Q2 Planning]]"));
+        // A note WITHOUT a links block yields no hits.
+        assert!(extract_link_hits(md).is_empty());
+    }
+
+    /// Brain v3 PR-3 — accept materialization MERGES a new `[[Title]]` into the block, PRESERVES the
+    /// existing related-notes rows, and is idempotent (a second merge of the same title is a no-op).
+    #[test]
+    fn merge_new_wikilink_preserves_existing_related_rows() {
+        let md = "# Notes\n- a line\n";
+        let with_related = apply_link_markers(md, &related_hits());
+        // Merge an accepted [[Design Spec]] into the block (mirrors commands::merge_related_hit).
+        let mut hits = extract_link_hits(&with_related);
+        let new = hit("note", "[[Design Spec]]", None);
+        if !hits.iter().any(|h| h.detail == new.detail) {
+            hits.push(new.clone());
+        }
+        let merged = apply_link_markers(&with_related, &hits);
+        assert!(merged.contains("[[Q2 Planning]]"), "existing related row preserved");
+        assert!(merged.contains("[[Design Spec]]"), "accepted wikilink materialized");
+        // Idempotent: re-merging the same accepted title adds nothing.
+        let mut hits2 = extract_link_hits(&merged);
+        if !hits2.iter().any(|h| h.detail == new.detail) {
+            hits2.push(new);
+        }
+        let merged2 = apply_link_markers(&merged, &hits2);
+        assert_eq!(merged, merged2, "re-accepting the same link is a byte-exact no-op");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod export;
 pub mod extract;
 pub mod facts;
+pub mod links;
 pub mod mcp;
 pub mod memory;
 pub mod orchestrate;
@@ -325,6 +326,9 @@ pub fn run() {
             commands::get_graph,
             commands::get_entity_detail,
             commands::get_backlinks,
+            commands::list_links,
+            commands::accept_link,
+            commands::dismiss_link,
             commands::resolve_wikilink,
             commands::list_link_candidates,
             commands::get_person_dossier,

--- a/src-tauri/src/links.rs
+++ b/src-tauri/src/links.rs
@@ -1,0 +1,262 @@
+//! Brain v3 PR-3 — the LINK ENGINE's pure, deterministic, headless-testable core.
+//!
+//! The persisted `links` table + its gated readers live in [`crate::storage::db`] (SQL is
+//! co-located with the schema, as every other table). THIS module owns the parts that are pure
+//! functions of their inputs — no DB, no clock, no network — so they are unit-testable in isolation:
+//!
+//! - the [`LinkKind`] endpoint enum (`meeting|note|document`) + its string round-trip;
+//! - the [`EdgeType`] enum (`wikilink|companion|semantic`) + directedness;
+//! - endpoint CANONICALIZATION for undirected (semantic) edges (`src<dst` so a pair is stored once);
+//! - the SEMANTIC AUTO-LINKER math: the mutual-kNN / floor / cap candidate selection over already-
+//!   computed cosine similarities (the DB layer runs the vec0 kNN + supplies the numbers).
+//!
+//! Lock model note: this module holds NO content and touches NO gate — a link ROW is a
+//! content-revealing derived relation, so its purge-on-seal + both-endpoint read gating are enforced
+//! at the DB/command layer (see `purge_links_tx` / `links_for_visible`). Nothing here can leak.
+
+use serde::{Deserialize, Serialize};
+
+/// The three thresholds + fan-out constants of the semantic auto-linker (DESIGN §PR-3). These are
+/// e5-cosine START VALUES needing a real-vault calibration spike (hand-label precision@5; e5's
+/// cosine range is compressed, so a per-corpus floor sweep is the honest calibration) — NOT proven
+/// by `cargo test`, which only pins the SELECTION LOGIC (mutual-kNN / floor / cap) against synthetic
+/// cosines.
+///
+/// - [`SEMANTIC_LINK_FLOOR`] — a candidate below this cosine is never a link, regardless of mutuality.
+/// - [`SEMANTIC_LINK_STRONG`] — at/above this cosine a candidate is kept even if NOT mutual (a
+///   confidently-close neighbour survives one-directional; below it, mutuality is REQUIRED, which is
+///   the load-bearing defence against e5 hubness — a hub is near everything but reciprocated by few).
+/// - [`SEMANTIC_LINK_K`] — the kNN fan-out per node (also the mutuality window: "is src in cand's own
+///   top-K").
+/// - [`SEMANTIC_LINK_CAP`] — at most this many semantic edges are suggested per node per pass.
+pub const SEMANTIC_LINK_FLOOR: f32 = 0.80;
+pub const SEMANTIC_LINK_STRONG: f32 = 0.88;
+pub const SEMANTIC_LINK_K: i64 = 10;
+pub const SEMANTIC_LINK_CAP: usize = 5;
+
+/// Which kind of owned-content row a link ENDPOINT is. `document` and `note` are BOTH `documents`
+/// rows (a note is `kind='note'`); they are distinct link kinds so the FE can route/label without a
+/// second DB read, but they share the `documents` id space (so a `document_ids` purge covers both).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkKind {
+    Meeting,
+    Note,
+    Document,
+}
+
+impl LinkKind {
+    /// Stable lowercase string persisted in `links.src_kind`/`links.dst_kind`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LinkKind::Meeting => "meeting",
+            LinkKind::Note => "note",
+            LinkKind::Document => "document",
+        }
+    }
+
+    /// Parse a persisted/IPC kind string; `None` for anything unknown (the caller rejects it as
+    /// `InvalidArg` — never silently coerces).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "meeting" => Some(LinkKind::Meeting),
+            "note" => Some(LinkKind::Note),
+            "document" => Some(LinkKind::Document),
+            _ => None,
+        }
+    }
+}
+
+/// The relation an edge encodes. `wikilink`/`companion` are DIRECTED (source → target, kept as
+/// written); `semantic` is UNDIRECTED (a symmetric similarity — stored ONCE with canonicalized
+/// endpoints so A~B and B~A are the same row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeType {
+    Wikilink,
+    Companion,
+    Semantic,
+}
+
+impl EdgeType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EdgeType::Wikilink => "wikilink",
+            EdgeType::Companion => "companion",
+            EdgeType::Semantic => "semantic",
+        }
+    }
+
+    /// `true` for the undirected (semantic) edge — the ONLY edge type whose endpoints are
+    /// canonicalized so the pair is stored once. Directed edges keep (src, dst) as written.
+    pub fn is_undirected(self) -> bool {
+        matches!(self, EdgeType::Semantic)
+    }
+}
+
+/// One endpoint = `(kind, id)`. Comparable so an undirected edge can canonicalize to a stable order.
+pub type Endpoint = (LinkKind, String);
+
+/// Canonicalize the two endpoints of an UNDIRECTED (semantic) edge so the smaller endpoint is `src`
+/// — the storage rule that makes A~B and B~A the SAME row (backed by the table's UNIQUE constraint).
+/// Directed edges never call this (they keep their written direction). Order key is
+/// `(kind_str, id)` — a total, deterministic ordering independent of insertion order.
+pub fn canonicalize_endpoints(a: Endpoint, b: Endpoint) -> (Endpoint, Endpoint) {
+    let key_a = (a.0.as_str(), a.1.as_str());
+    let key_b = (b.0.as_str(), b.1.as_str());
+    if key_a <= key_b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// Convert a vec0 L2 DISTANCE (over UNIT vectors, the e5 convention) to COSINE similarity:
+/// `cos = 1 − d²/2`. Clamped to `[-1, 1]` so a tiny floating-point overshoot never produces a
+/// nonsense score. (DESIGN §PR-3 step 3.)
+pub fn cosine_from_l2_distance(d: f32) -> f32 {
+    (1.0 - d * d / 2.0).clamp(-1.0, 1.0)
+}
+
+/// One kNN candidate the DB layer surfaced for the SOURCE item: the neighbour item's `(kind, id)`,
+/// the best (max) cosine over its chunks, and whether the SOURCE appears in the NEIGHBOUR's OWN
+/// top-K (the mutuality flag — computed by the DB layer via a second kNN keyed on the neighbour's
+/// centroid, or an in-set check).
+#[derive(Debug, Clone)]
+pub struct SemanticCandidate {
+    pub kind: LinkKind,
+    pub id: String,
+    pub cos: f32,
+    pub mutual: bool,
+}
+
+/// The SEMANTIC AUTO-LINKER selection math (DESIGN §PR-3 steps 4–5), a PURE function of the
+/// already-scored candidates:
+///
+/// 1. FLOOR: drop any candidate with `cos < SEMANTIC_LINK_FLOOR` (never a link, whatever else).
+/// 2. KEEP iff `mutual` OR `cos >= SEMANTIC_LINK_STRONG` — mutuality is the hubness defence below the
+///    strong threshold; a confidently-close neighbour survives one-directionally.
+/// 3. RANK by cosine DESC, ties broken by `(kind, id)` ASC — fully DETERMINISTIC (no dependence on the
+///    kNN's row order).
+/// 4. CAP at `SEMANTIC_LINK_CAP`.
+///
+/// Self is assumed ALREADY dropped by the DB layer (a source is trivially its own nearest hit); this
+/// function does not know the source id, so it never re-adds it.
+pub fn select_semantic_candidates(candidates: &[SemanticCandidate]) -> Vec<SemanticCandidate> {
+    let mut kept: Vec<SemanticCandidate> = candidates
+        .iter()
+        .filter(|c| c.cos >= SEMANTIC_LINK_FLOOR && (c.mutual || c.cos >= SEMANTIC_LINK_STRONG))
+        .cloned()
+        .collect();
+    // Deterministic order: strongest first, then a stable (kind, id) tiebreak.
+    kept.sort_by(|a, b| {
+        b.cos
+            .partial_cmp(&a.cos)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.kind.as_str().cmp(b.kind.as_str()))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    kept.truncate(SEMANTIC_LINK_CAP);
+    kept
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(kind: LinkKind, id: &str, cos: f32, mutual: bool) -> SemanticCandidate {
+        SemanticCandidate {
+            kind,
+            id: id.to_string(),
+            cos,
+            mutual,
+        }
+    }
+
+    #[test]
+    fn link_kind_and_edge_type_round_trip_strings() {
+        for k in [LinkKind::Meeting, LinkKind::Note, LinkKind::Document] {
+            assert_eq!(LinkKind::parse(k.as_str()), Some(k));
+        }
+        assert_eq!(LinkKind::parse("bogus"), None);
+        assert_eq!(EdgeType::Semantic.as_str(), "semantic");
+        assert!(EdgeType::Semantic.is_undirected());
+        assert!(!EdgeType::Wikilink.is_undirected());
+        assert!(!EdgeType::Companion.is_undirected());
+    }
+
+    #[test]
+    fn canonicalize_is_order_independent_and_stable() {
+        let a = (LinkKind::Meeting, "m1".to_string());
+        let b = (LinkKind::Note, "n1".to_string());
+        // Both argument orders canonicalize to the SAME (src, dst) pair.
+        assert_eq!(
+            canonicalize_endpoints(a.clone(), b.clone()),
+            canonicalize_endpoints(b, a)
+        );
+        // "meeting" < "note" lexically, so meeting is src.
+        let (src, dst) = canonicalize_endpoints(
+            (LinkKind::Note, "n1".to_string()),
+            (LinkKind::Meeting, "m1".to_string()),
+        );
+        assert_eq!(src.0, LinkKind::Meeting);
+        assert_eq!(dst.0, LinkKind::Note);
+    }
+
+    #[test]
+    fn cosine_from_distance_matches_the_unit_vector_identity() {
+        // d = 0 (identical) → cos 1; d = sqrt(2) (orthogonal) → cos 0; d = 2 (antipodal) → cos -1.
+        assert!((cosine_from_l2_distance(0.0) - 1.0).abs() < 1e-6);
+        assert!(cosine_from_l2_distance(std::f32::consts::SQRT_2).abs() < 1e-6);
+        assert!((cosine_from_l2_distance(2.0) + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn floor_drops_low_cosine_even_when_mutual() {
+        // Mutual but below the 0.80 floor → dropped.
+        let out = select_semantic_candidates(&[cand(LinkKind::Note, "n1", 0.79, true)]);
+        assert!(out.is_empty(), "sub-floor candidate must never be kept");
+    }
+
+    #[test]
+    fn strong_cosine_kept_without_mutuality_but_weak_needs_mutual() {
+        // 0.90 (>= STRONG) survives one-directional; 0.82 (< STRONG, not mutual) does NOT.
+        let out = select_semantic_candidates(&[
+            cand(LinkKind::Note, "strong", 0.90, false),
+            cand(LinkKind::Note, "weak-solo", 0.82, false),
+            cand(LinkKind::Note, "weak-mutual", 0.82, true),
+        ]);
+        let ids: Vec<&str> = out.iter().map(|c| c.id.as_str()).collect();
+        assert!(ids.contains(&"strong"), "strong non-mutual must be kept");
+        assert!(
+            !ids.contains(&"weak-solo"),
+            "below-strong non-mutual must be dropped (hubness defence)"
+        );
+        assert!(
+            ids.contains(&"weak-mutual"),
+            "above-floor mutual must be kept"
+        );
+    }
+
+    #[test]
+    fn cap_and_deterministic_tiebreak() {
+        // Seven strong candidates, some cosine-tied; only SEMANTIC_LINK_CAP survive, strongest-first,
+        // ties broken by (kind, id) ASC — fully deterministic regardless of input order.
+        let out = select_semantic_candidates(&[
+            cand(LinkKind::Note, "b", 0.90, true),
+            cand(LinkKind::Note, "a", 0.90, true), // tie with "b" → "a" sorts first
+            cand(LinkKind::Meeting, "m", 0.95, true),
+            cand(LinkKind::Note, "c", 0.91, true),
+            cand(LinkKind::Note, "d", 0.89, true),
+            cand(LinkKind::Note, "e", 0.885, true),
+            cand(LinkKind::Note, "f", 0.881, true),
+        ]);
+        assert_eq!(out.len(), SEMANTIC_LINK_CAP, "must cap at SEMANTIC_LINK_CAP");
+        assert_eq!(out[0].id, "m", "0.95 strongest first");
+        assert_eq!(out[1].id, "c", "0.91 next");
+        // The two 0.90 ties: "a" before "b" (kind equal → id ASC).
+        assert_eq!(out[2].id, "a");
+        assert_eq!(out[3].id, "b");
+        assert_eq!(out[4].id, "d", "0.89 fills the last cap slot");
+    }
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -957,6 +957,84 @@ impl Db {
             )
             .map_err(map_err)?;
         }
+
+        // Brain v3 PR-3 — the LINK ENGINE table (wikilink/companion/semantic edges between
+        // meetings/notes/documents) + its one-time companion backfill. Additive + guarded so
+        // migrate() stays idempotent. Runs LAST so the companion backfill can read the (now-migrated)
+        // `documents.meeting_id` column. See `migrate_links`.
+        Self::migrate_links(&conn)?;
+        Ok(())
+    }
+
+    /// Brain v3 PR-3 — idempotent LINK-ENGINE schema: the `links` table records DERIVED, content-
+    /// revealing relations between `meeting|note|document` rows. Three edge kinds:
+    ///   • `wikilink`  — a `[[Title]]` in a source body, RESOLVED to the target's id at write time
+    ///                   (rename-proof — the root-cause fix over title-string scanning). DIRECTED,
+    ///                   `status='active'`, `created_by='user'`.
+    ///   • `companion` — the structured `documents.meeting_id` link (recording-time companion note →
+    ///                   its meeting). DIRECTED, `active`, `user`.
+    ///   • `semantic`  — a vec0-kNN content-similarity SUGGESTION. UNDIRECTED (endpoints
+    ///                   canonicalized `src<dst`), `status='suggested'`, `created_by='auto'`,
+    ///                   `score`=cosine. Accept flips it `active`/`accepted`; dismiss tombstones it.
+    /// `UNIQUE(src_kind,src_id,dst_kind,dst_id,edge_type)` makes upsert idempotent; both-direction
+    /// indexes serve the gated `links_for_visible` reader from either endpoint.
+    ///
+    /// Lock model (load-bearing): a link ROW names a neighbour (its existence + title reveal a
+    /// possibly-sealed item), so it is PURGED on seal (`purge_links_tx`, run inside every seal/delete
+    /// tx) and RE-DERIVED on unlock; every read gates BOTH endpoints. The table itself is additive +
+    /// guarded — no DROP, no destructive rewrite of user rows.
+    fn migrate_links(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS links (
+               id INTEGER PRIMARY KEY,
+               src_kind TEXT NOT NULL,
+               src_id TEXT NOT NULL,
+               dst_kind TEXT NOT NULL,
+               dst_id TEXT NOT NULL,
+               edge_type TEXT NOT NULL,
+               score REAL NOT NULL DEFAULT 1.0,
+               created_by TEXT NOT NULL DEFAULT 'user',
+               status TEXT NOT NULL DEFAULT 'active',
+               created_at INTEGER NOT NULL,
+               UNIQUE (src_kind, src_id, dst_kind, dst_id, edge_type)
+             );
+             CREATE INDEX IF NOT EXISTS idx_links_src ON links(src_kind, src_id);
+             CREATE INDEX IF NOT EXISTS idx_links_dst ON links(dst_kind, dst_id);",
+        )
+        .map_err(map_err)?;
+
+        // ONE-TIME idempotent COMPANION backfill: every existing companion note
+        // (`documents.kind='note'` with a non-null `meeting_id`) gets its directed
+        // note → meeting `companion` edge. Sentinel-guarded so it runs EXACTLY once (later maintenance
+        // is at the write site, `set_companion_link`); a fresh DB has no companion rows so the
+        // INSERT is a harmless no-op either way. `INSERT OR IGNORE` respects the UNIQUE constraint so
+        // even a re-run (were the sentinel ever lost) never duplicates. Uses the held `conn` directly
+        // (self.set_setting would re-lock and deadlock). created_at = the note's own created_at (a
+        // non-content epoch already on the row) so the backfilled edge carries a real timestamp.
+        let backfilled: Option<String> = conn
+            .query_row(
+                "SELECT value FROM settings WHERE key = 'links_companion_backfill_v1'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        if backfilled.is_none() {
+            conn.execute(
+                "INSERT OR IGNORE INTO links
+                   (src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status, created_at)
+                 SELECT 'note', d.id, 'meeting', d.meeting_id, 'companion', 1.0, 'user', 'active', d.created_at
+                   FROM documents d
+                  WHERE d.kind = 'note' AND d.meeting_id IS NOT NULL",
+                [],
+            )
+            .map_err(map_err)?;
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('links_companion_backfill_v1', '1')",
+                [],
+            )
+            .map_err(map_err)?;
+        }
         Ok(())
     }
 
@@ -3353,6 +3431,9 @@ impl Db {
         // same tx — its `evidence_md` quotes the deleted meeting's note/title (resolved rows were
         // blanked on resolve and carry no content).
         Self::purge_pending_audit_findings_tx(&tx, &[id.to_string()])?;
+        // Brain v3 PR-3: purge every `links` row whose SRC OR DST is this deleted meeting in the same
+        // tx — a link to a gone meeting is a dangling edge (and would name a now-absent neighbour).
+        Self::purge_links_tx(&tx, &[id.to_string()], &[])?;
         // Brain v2 L2.1: purge ALL memory rollups in this same tx — a rollup may paraphrase the
         // deleted meeting's (now-gone) facts; the survivors regenerate on the next hourly pass
         // from the remaining visible facts only. The caller deletes the exported `.md`s.
@@ -4047,6 +4128,12 @@ impl Db {
         // id to match, e.g. a stale finding's `see [[superseding note]]`; a seal anywhere
         // invalidates the pass's visibility snapshot). Resolved rows were blanked on resolve.
         Self::purge_all_pending_audit_findings_tx(&tx)?;
+        // Brain v3 PR-3 LINK-ENGINE LOCK-SAFETY: purge every `links` row whose SRC OR DST is a
+        // just-sealed meeting in this SAME seal tx — a link names a neighbour (its title/existence
+        // reveals a possibly-sealed item), so it must not survive at rest for a sealed endpoint.
+        // Re-derived on unlock (wikilink + semantic pass). Document endpoints of these folders are
+        // covered by the `purge_doc_chunks_for_documents` leg the lock caller runs alongside.
+        Self::purge_links_tx(&tx, meeting_ids, &[])?;
         // Brain v2 L2.1 LOCK-SAFETY: memory ROLLUPS are cross-meeting synthesis that may paraphrase
         // the just-sealed facts — purge ALL of them in this SAME seal tx (cheap, re-derivable: the
         // next hourly pass regenerates from the still-VISIBLE facts only). The caller deletes the
@@ -5105,6 +5192,9 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         Self::purge_doc_chunks_tx(&tx, &[id.to_string()])?;
+        // Brain v3 PR-3: purge every `links` row whose SRC OR DST is this deleted document/note in the
+        // same tx — a note id IS a document id, so both kinds are covered by `purge_links_tx`.
+        Self::purge_links_tx(&tx, &[], &[id.to_string()])?;
         // Vault Audit: a pending finding sourcing or targeting this document/note quotes its
         // content/title — drop it in the same delete tx (mirrors `delete_meeting`'s purge).
         Self::purge_pending_audit_findings_tx(&tx, &[id.to_string()])?;
@@ -5333,6 +5423,10 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         Self::purge_doc_chunks_tx(&tx, document_ids)?;
+        // Brain v3 PR-3 LINK-ENGINE LOCK-SAFETY: purge every `links` row whose SRC OR DST is a
+        // just-sealed document/note (a note id IS a document id) in this SAME seal tx — a link names
+        // a neighbour, so it must not survive at rest for a sealed endpoint. Re-derived on unlock.
+        Self::purge_links_tx(&tx, &[], document_ids)?;
         // Vault Audit LOCK-SAFETY: the callers are seal-side (`lock_folder`'s document leg, the
         // relock reblank) — purge ALL pending findings in this SAME tx (rollup posture; evidence
         // may cite third-party titles no document id can match). Findings are cheap re-derivable
@@ -8032,6 +8126,13 @@ impl Db {
             out
         };
         Self::purge_doc_chunks_tx(&tx, &document_ids)?;
+        // NIT-3 (link lifecycle): the derived documents about to be deleted may be an endpoint of a
+        // `links` row (e.g. a semantic edge to another doc, or a wikilink pointing AT one of them).
+        // Purge every edge incident on a to-be-deleted document id in the SAME tx so no link row is
+        // left dangling to a row that no longer exists. Only the deleted derived-document ids need
+        // purging: authored notes + meetings are REPARENTED out of the folder (above / by the command
+        // layer), never deleted here, so their edges stay valid. Same choke-point as the seal purge.
+        Self::purge_links_tx(&tx, &[], &document_ids)?;
         // Explicit (rather than FK-cascade) so the delete is deterministic and trigger-visible. Scoped
         // to non-authored documents — authored notes were reparented out above (and refused if not).
         tx.execute(
@@ -8318,6 +8419,11 @@ impl Db {
             // snapshot). Resolved rows were blanked on resolve and survive.
             Self::purge_all_pending_audit_findings_tx(&tx)?;
 
+            // Brain v3 PR-3 LINK-ENGINE LOCK-SAFETY: purge every `links` row whose SRC OR DST is a
+            // meeting OR document/note in these (re-blanked / sealed) folders in this SAME relock tx —
+            // a link names a neighbour (its title/existence reveals a possibly-sealed item). Same
+            // purge-on-seal contract as the chunks above; re-derived on unlock.
+            Self::purge_links_tx(&tx, &meeting_ids, &document_ids)?;
             // Brain v2 L2.1 LOCK-SAFETY: purge ALL memory rollups in this SAME relock tx — a rollup
             // may paraphrase the just-re-sealed facts. Cheap re-derivable synthesis; regenerates
             // from VISIBLE facts on the next hourly pass. The caller deletes the exported `.md`s.
@@ -8548,6 +8654,27 @@ impl Db {
             "DELETE FROM doc_chunks WHERE document_id IN \
                (SELECT id FROM documents WHERE folder_id IN \
                   (SELECT id FROM folders WHERE locked = 1))",
+            [],
+        )
+        .map_err(map_err)?;
+        // Brain v3 PR-3 LINK-ENGINE LOCK-SAFETY: purge every `links` row whose meeting endpoint is in
+        // a locked folder, OR whose document/note endpoint is in a locked folder, in this same
+        // reconciliation transaction — so a crash-while-unlocked (which may have re-derived
+        // wikilink/semantic edges against since-sealed items) cannot leave a link naming a sealed
+        // neighbour at rest after a restart. Re-derived on the next unlock. A note id IS a document
+        // id, so the document leg's `IN ('note','document')` covers both kinds.
+        tx.execute(
+            &format!(
+                "DELETE FROM links WHERE \
+                   ((src_kind = 'meeting' AND src_id IN ({LOCKED_MEETINGS})) \
+                    OR (dst_kind = 'meeting' AND dst_id IN ({LOCKED_MEETINGS}))) \
+                   OR (src_kind IN ('note','document') AND src_id IN \
+                        (SELECT id FROM documents WHERE folder_id IN \
+                           (SELECT id FROM folders WHERE locked = 1))) \
+                   OR (dst_kind IN ('note','document') AND dst_id IN \
+                        (SELECT id FROM documents WHERE folder_id IN \
+                           (SELECT id FROM folders WHERE locked = 1)))"
+            ),
             [],
         )
         .map_err(map_err)?;
@@ -9637,6 +9764,599 @@ impl Db {
                 })
                 .optional()
                 .map_err(map_err)
+            }
+        }
+    }
+
+    // ── Brain v3 PR-3 — LINK ENGINE ───────────────────────────────────────────────────────────
+    //
+    // Persisted `links` rows (wikilink/companion/semantic) between meetings/notes/documents. A row
+    // is a DERIVED, content-revealing relation, so: PURGED on seal (`purge_links_tx`), RE-DERIVED on
+    // unlock, and read with BOTH endpoints visibility-gated (`links_for_visible`). SQL only — the
+    // pure edge math (canonicalization, kNN selection) lives in `crate::links`.
+
+    /// Upsert ONE edge (idempotent on the UNIQUE key). For an UNDIRECTED (semantic) edge the caller
+    /// MUST have canonicalized endpoints (`src<dst`) so A~B and B~A collapse to one row. On a
+    /// conflict we REFRESH the mutable fields (`score`, `created_by`, `status`, `created_at`) — a
+    /// re-run of the semantic pass updates a suggestion's score; a wikilink re-index refreshes its
+    /// timestamp. EXCEPTION: a `dismissed` semantic row is a TOMBSTONE — never resurrected by a later
+    /// auto pass (the `WHERE ... status != 'dismissed'` guard on the DO UPDATE). Runs inside a tx.
+    #[allow(clippy::too_many_arguments)]
+    fn upsert_link_tx(
+        tx: &rusqlite::Transaction<'_>,
+        src_kind: &str,
+        src_id: &str,
+        dst_kind: &str,
+        dst_id: &str,
+        edge_type: &str,
+        score: f64,
+        created_by: &str,
+        status: &str,
+        created_at: i64,
+    ) -> Result<()> {
+        tx.execute(
+            // On conflict we REFRESH the score/created_at, but we must NOT clobber a user's decision:
+            //  - `WHERE links.status != 'dismissed'` — a dismissed TOMBSTONE is never resurrected (a
+            //    later auto pass can't re-suggest it).
+            //  - The `CASE` guards status/created_by against a DOWNGRADE: when the incoming write is a
+            //    `suggested` auto re-suggest but the existing edge is already `active` (user-accepted or
+            //    a materialized wikilink/companion), KEEP the existing `status`/`created_by`. Only the
+            //    score is refreshed. An INCOMING `active` (accept, or a fresh wikilink/companion) still
+            //    promotes normally. This preserves an accepted edge across every later semantic pass.
+            "INSERT INTO links
+               (src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT (src_kind, src_id, dst_kind, dst_id, edge_type) DO UPDATE SET
+               score = excluded.score,
+               created_by = CASE
+                 WHEN excluded.status = 'suggested' AND links.status = 'active'
+                   THEN links.created_by
+                 ELSE excluded.created_by
+               END,
+               status = CASE
+                 WHEN excluded.status = 'suggested' AND links.status = 'active'
+                   THEN links.status
+                 ELSE excluded.status
+               END,
+               created_at = excluded.created_at
+             WHERE links.status != 'dismissed'",
+            rusqlite::params![
+                src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status, created_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// WRITE-TIME WIKILINK INDEXING (DESIGN §PR-3): resolve every `[[Title]]` in `body` to its TARGET
+    /// ID (rename-proof) through the gated [`Self::resolve_wikilink`], then DELETE-THEN-INSERT this
+    /// source's `edge_type='wikilink'` rows in one tx. Storing resolved IDs — not the title strings —
+    /// is the root-cause fix: a later target rename never strands the edge. Unresolved titles (no
+    /// visible target, or an org-only target — orgs are outside the folder-lock link domain) are
+    /// simply skipped; the next re-index picks them up once a matching local target exists.
+    ///
+    /// `src_kind`/`src_id` identify the SOURCE (`meeting` for an AI note, `note` for an authored
+    /// note). Called from the note-save funnels + `build_and_persist_entities`. Best-effort at the
+    /// call site (a failure logs, never fails the save). Logs ids/counts only.
+    pub fn index_wikilinks_for_source(
+        &self,
+        src_kind: crate::links::LinkKind,
+        src_id: &str,
+        body: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<()> {
+        // Resolve OUTSIDE the write tx (resolve_wikilink takes its own connection lock).
+        let titles = extract_wikilink_titles(body);
+        let mut targets: Vec<(crate::links::LinkKind, String)> = Vec::new();
+        for t in &titles {
+            if let Some(target) = self.resolve_wikilink(t, unlocked)? {
+                let kind = match target.kind.as_str() {
+                    "meeting" => crate::links::LinkKind::Meeting,
+                    "note" => crate::links::LinkKind::Note,
+                    // "org" targets live outside the folder-lock link domain (PR-4) — skip.
+                    _ => continue,
+                };
+                // Never self-link (a note whose title resolves to itself).
+                if kind == src_kind && target.id == src_id {
+                    continue;
+                }
+                if !targets.iter().any(|(k, i)| *k == kind && i == &target.id) {
+                    targets.push((kind, target.id));
+                }
+            }
+        }
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        // Clean replace: drop this source's OLD wikilink rows first, then insert the fresh set. A
+        // removed `[[Title]]` therefore vanishes from the graph on the next save (self-healing).
+        tx.execute(
+            "DELETE FROM links WHERE src_kind = ?1 AND src_id = ?2 AND edge_type = 'wikilink'",
+            rusqlite::params![src_kind.as_str(), src_id],
+        )
+        .map_err(map_err)?;
+        for (dst_kind, dst_id) in &targets {
+            Self::upsert_link_tx(
+                &tx,
+                src_kind.as_str(),
+                src_id,
+                dst_kind.as_str(),
+                dst_id,
+                "wikilink",
+                1.0,
+                "user",
+                "active",
+                now,
+            )?;
+        }
+        tx.commit().map_err(map_err)?;
+        tracing::debug!(
+            target: "links",
+            src_kind = src_kind.as_str(),
+            resolved = targets.len(),
+            total = titles.len(),
+            "index_wikilinks_for_source"
+        );
+        Ok(())
+    }
+
+    /// COMPANION edge maintenance: (re)assert the directed `note → meeting` `companion` edge when a
+    /// companion note's `documents.meeting_id` is set. Idempotent (UNIQUE upsert). Called wherever
+    /// `set_document_meeting_id` runs, so the edge is maintained beyond the one-time migrate backfill.
+    pub fn set_companion_link(&self, note_id: &str, meeting_id: &str) -> Result<()> {
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        Self::upsert_link_tx(
+            &tx, "note", note_id, "meeting", meeting_id, "companion", 1.0, "user", "active", now,
+        )?;
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// PURGE every link row whose SRC OR DST is a sealed/deleted meeting or document (a note id IS a
+    /// `documents` id, so `document_ids` covers the `note` kind too). Runs INSIDE an existing seal /
+    /// delete tx so a link — which reveals a neighbour's existence + title — never outlives the
+    /// plaintext it was derived from. BOTH endpoint kinds for a meeting id are matched (`src`/`dst`);
+    /// likewise for a document/note id across `document`/`note` kinds. Re-derived on unlock.
+    /// Mirrors the `purge_chunks_tx` / `purge_doc_chunks_tx` choke-point idiom.
+    fn purge_links_tx(
+        tx: &rusqlite::Transaction<'_>,
+        meeting_ids: &[String],
+        document_ids: &[String],
+    ) -> Result<()> {
+        for mid in meeting_ids {
+            tx.execute(
+                "DELETE FROM links
+                   WHERE (src_kind = 'meeting' AND src_id = ?1)
+                      OR (dst_kind = 'meeting' AND dst_id = ?1)",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+        }
+        for did in document_ids {
+            // A note and a document share the `documents` id space — purge BOTH kinds for the id.
+            tx.execute(
+                "DELETE FROM links
+                   WHERE (src_kind IN ('note','document') AND src_id = ?1)
+                      OR (dst_kind IN ('note','document') AND dst_id = ?1)",
+                rusqlite::params![did],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
+    /// SUGGEST-scope purge: a link's SOURCE re-runs its own auto pass, so drop this source's PRIOR
+    /// `semantic` SUGGESTIONS (never its accepted/active or dismissed rows) before re-suggesting —
+    /// keeps the suggestion set fresh without churning a user's decisions. Undirected semantic edges
+    /// are stored canonicalized, so a source may be either endpoint: match both. Runs inside a tx.
+    fn clear_semantic_suggestions_tx(
+        tx: &rusqlite::Transaction<'_>,
+        kind: &str,
+        id: &str,
+    ) -> Result<()> {
+        tx.execute(
+            "DELETE FROM links
+               WHERE edge_type = 'semantic' AND status = 'suggested'
+                 AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
+            rusqlite::params![kind, id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The centroid (L2-normalized mean of a `vec0` table's per-chunk vectors) for ONE item. Reuses
+    /// [`Self::related_meetings_visible`]'s centroid math but reads the STORED vectors directly (no
+    /// re-embed) from `vec_chunks` (meeting/note note_chunks) or `doc_vec_chunks` (documents/notes).
+    /// `None` (skip — never an error) when the item has no vectors or a degenerate all-zero centroid.
+    fn item_centroid(&self, kind: crate::links::LinkKind, id: &str) -> Result<Option<Vec<f32>>> {
+        let conn = self.lock();
+        // Which vector source table + join predicate this kind reads.
+        let sql = match kind {
+            crate::links::LinkKind::Meeting => {
+                "SELECT v.embedding FROM vec_chunks v
+                   JOIN note_chunks nc ON nc.id = v.chunk_id
+                  WHERE nc.meeting_id = ?1"
+            }
+            crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
+                "SELECT v.embedding FROM doc_vec_chunks v
+                   JOIN doc_chunks dc ON dc.id = v.chunk_id
+                  WHERE dc.document_id = ?1"
+            }
+        };
+        let mut stmt = conn.prepare(sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![id], |r| r.get::<_, Vec<u8>>(0))
+            .map_err(map_err)?;
+        let dim = crate::embed::EMBED_DIM;
+        let mut centroid = vec![0f32; dim];
+        let mut counted = 0usize;
+        for r in rows {
+            let blob = r.map_err(map_err)?;
+            let v = crate::embed::blob_to_vec(&blob);
+            if v.len() != dim {
+                continue; // defensive: skip a malformed stored vector.
+            }
+            for (acc, x) in centroid.iter_mut().zip(v.iter()) {
+                *acc += *x;
+            }
+            counted += 1;
+        }
+        if counted == 0 {
+            return Ok(None);
+        }
+        for x in centroid.iter_mut() {
+            *x /= counted as f32;
+        }
+        let norm = centroid.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm == 0.0 {
+            return Ok(None);
+        }
+        for x in centroid.iter_mut() {
+            *x /= norm;
+        }
+        Ok(Some(centroid))
+    }
+
+    /// vec0 kNN of `centroid` over BOTH vector tables (`vec_chunks` ∪ `doc_vec_chunks`), rolled
+    /// chunk→ITEM keeping the BEST (min) distance, converted to cosine, self dropped. `(kind, id) →
+    /// cos`, best-first. GATED by `visibility_clause` on each leg's folder (a sealed neighbour is
+    /// invisible — defense-in-depth on top of the seal-time chunk purge). `k` is the vec0 fan-out.
+    /// This is the O(k·log n) neighbour probe the semantic auto-linker rolls up — no corpus scan.
+    fn knn_items_visible(
+        &self,
+        centroid: &[f32],
+        k: i64,
+        self_kind: crate::links::LinkKind,
+        self_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<(crate::links::LinkKind, String, f32)>> {
+        if centroid.is_empty() || k <= 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let vis_note = visibility_clause("f", unlocked);
+        let vis_doc = visibility_clause("f", unlocked);
+        // Each vec0 table gets its own single-MATCH CTE (vec0 allows one MATCH+k per query); the
+        // meeting leg maps chunk→meeting and gates on the meeting's note folder; the doc leg maps
+        // chunk→document and gates on the document's folder, tagging note vs document by kind.
+        let sql = format!(
+            "WITH knn_note(chunk_id, distance) AS (
+                 SELECT chunk_id, distance FROM vec_chunks WHERE embedding MATCH ?1 AND k = ?2
+             ),
+             knn_doc(chunk_id, distance) AS (
+                 SELECT chunk_id, distance FROM doc_vec_chunks WHERE embedding MATCH ?1 AND k = ?2
+             ),
+             hits(kind, id, distance) AS (
+                 SELECT 'meeting', nc.meeting_id, kn.distance
+                   FROM knn_note kn JOIN note_chunks nc ON nc.id = kn.chunk_id
+                   JOIN meetings m ON m.id = nc.meeting_id
+                   WHERE EXISTS (
+                       SELECT 1 FROM notes n
+                        LEFT JOIN folders f ON f.id = n.folder_id
+                        WHERE n.meeting_id = m.id AND {vis_note}
+                   )
+                 UNION ALL
+                 SELECT CASE WHEN d.kind = 'note' THEN 'note' ELSE 'document' END, d.id, kd.distance
+                   FROM knn_doc kd JOIN doc_chunks dc ON dc.id = kd.chunk_id
+                   JOIN documents d ON d.id = dc.document_id
+                   JOIN folders f ON f.id = d.folder_id
+                   WHERE {vis_doc}
+             ),
+             best(kind, id, distance) AS (
+                 SELECT kind, id, MIN(distance) FROM hits GROUP BY kind, id
+             )
+             SELECT kind, id, distance FROM best ORDER BY distance ASC, kind ASC, id ASC"
+        );
+        let blob = crate::embed::vec_to_blob(centroid);
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![blob, k], |r| {
+                let kind: String = r.get(0)?;
+                let id: String = r.get(1)?;
+                let d: f64 = r.get(2)?;
+                Ok((kind, id, d as f32))
+            })
+            .map_err(map_err)?;
+        let mut out: Vec<(crate::links::LinkKind, String, f32)> = Vec::new();
+        for r in rows {
+            let (kind_s, id, d) = r.map_err(map_err)?;
+            let Some(kind) = crate::links::LinkKind::parse(&kind_s) else {
+                continue;
+            };
+            if kind == self_kind && id == self_id {
+                continue; // drop self.
+            }
+            out.push((kind, id, crate::links::cosine_from_l2_distance(d)));
+        }
+        Ok(out)
+    }
+
+    /// SEMANTIC AUTO-LINKER (DESIGN §PR-3) — after a real-embedder index of ONE item, suggest up to
+    /// `SEMANTIC_LINK_CAP` content-similar neighbours. Deterministic; O(k·log n) per call (two vec0
+    /// probes: the source's kNN + one back-probe per candidate for mutuality — bounded by `k`, no
+    /// corpus scan). Steps: source centroid → kNN(k) → for each candidate compute MUTUALITY (source ∈
+    /// candidate's OWN kNN) → `crate::links::select_semantic_candidates` (floor/strong-or-mutual/cap)
+    /// → upsert each survivor as a canonicalized UNDIRECTED `semantic` `suggested` edge (score=cos).
+    ///
+    /// GATED end to end: `knn_items_visible` applies `visibility_clause` on every leg, so a sealed
+    /// neighbour is never a candidate and never surfaces the source to a sealed item. Model-gated at
+    /// the CALL SITE (only invoked when `embed_model_present()` — never on stub vectors). Idempotent:
+    /// this source's prior SUGGESTIONS are cleared first (never its accepted/dismissed rows).
+    pub fn auto_link_semantic(
+        &self,
+        kind: crate::links::LinkKind,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<usize> {
+        use crate::links::{select_semantic_candidates, SemanticCandidate, SEMANTIC_LINK_K};
+        // 1. Source centroid from its STORED vectors (skip silently if none / degenerate).
+        let Some(centroid) = self.item_centroid(kind, id)? else {
+            return Ok(0);
+        };
+        // 2. Source kNN. Ask for k+1 (self is the nearest) then self is dropped inside.
+        let neighbours = self.knn_items_visible(&centroid, SEMANTIC_LINK_K + 1, kind, id, unlocked)?;
+        // 3. Mutuality: for each candidate, back-probe ITS kNN and check the source appears.
+        let mut scored: Vec<SemanticCandidate> = Vec::new();
+        for (nk, nid, cos) in neighbours.into_iter().take(SEMANTIC_LINK_K as usize) {
+            let mutual = match self.item_centroid(nk, &nid)? {
+                Some(nc) => {
+                    let back =
+                        self.knn_items_visible(&nc, SEMANTIC_LINK_K + 1, nk, &nid, unlocked)?;
+                    back.into_iter()
+                        .take(SEMANTIC_LINK_K as usize)
+                        .any(|(bk, bid, _)| bk == kind && bid == id)
+                }
+                None => false,
+            };
+            scored.push(SemanticCandidate {
+                kind: nk,
+                id: nid,
+                cos,
+                mutual,
+            });
+        }
+        // 4. Pure selection (floor / strong-or-mutual / rank / cap).
+        let kept = select_semantic_candidates(&scored);
+        // 5. Upsert each survivor as a canonicalized UNDIRECTED semantic suggestion.
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        // Refresh: drop this source's stale suggestions (keeps accepted/dismissed) before re-adding.
+        Self::clear_semantic_suggestions_tx(&tx, kind.as_str(), id)?;
+        let mut written = 0usize;
+        for c in &kept {
+            let (src, dst) = crate::links::canonicalize_endpoints(
+                (kind, id.to_string()),
+                (c.kind, c.id.clone()),
+            );
+            Self::upsert_link_tx(
+                &tx,
+                src.0.as_str(),
+                &src.1,
+                dst.0.as_str(),
+                &dst.1,
+                "semantic",
+                c.cos as f64,
+                "auto",
+                "suggested",
+                now,
+            )?;
+            written += 1;
+        }
+        tx.commit().map_err(map_err)?;
+        tracing::debug!(
+            target: "links",
+            kind = kind.as_str(),
+            suggested = written,
+            "auto_link_semantic"
+        );
+        Ok(written)
+    }
+
+    /// Read ONE link row by id (for accept/dismiss). Returns `(src_kind, src_id, dst_kind, dst_id,
+    /// edge_type, status)`. `None` for an unknown id.
+    #[allow(clippy::type_complexity)]
+    pub fn link_by_id(
+        &self,
+        link_id: i64,
+    ) -> Result<Option<(String, String, String, String, String, String)>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT src_kind, src_id, dst_kind, dst_id, edge_type, status FROM links WHERE id = ?1",
+            rusqlite::params![link_id],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, String>(5)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// ACCEPT a suggested semantic link: flip `status='active'`, `created_by='accepted'`. Idempotent
+    /// (re-accepting is a no-op). The command layer materializes the `[[Title]]` into the source `.md`
+    /// AFTER this — never here (a DB write must not touch the vault).
+    pub fn accept_link(&self, link_id: i64) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE links SET status = 'active', created_by = 'accepted' WHERE id = ?1",
+            rusqlite::params![link_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// DISMISS a suggested link: TOMBSTONE it (`status='dismissed'`) so a later auto pass never
+    /// re-suggests it (the `upsert_link_tx` DO-UPDATE guard skips dismissed rows). Idempotent.
+    pub fn dismiss_link(&self, link_id: i64) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE links SET status = 'dismissed' WHERE id = ?1",
+            rusqlite::params![link_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// BOTH-ENDPOINT-GATED reader (DESIGN §PR-3, the `backlinks_for_visible` two-gate template):
+    /// every non-dismissed link edge incident on `(kind, id)`, with the OTHER endpoint's current
+    /// title resolved through the SAME visibility gate. Two hard gates, fail-closed:
+    ///
+    /// 1. **QUERIED-ITEM GATE (first).** If `(kind, id)` is itself sealed-and-not-session-unlocked
+    ///    (its title does not resolve through the gate), return `Ok(vec![])` BEFORE any edge is read —
+    ///    so a locked item never reveals that it HAS links (no existence leak).
+    /// 2. **NEIGHBOUR GATE.** For each incident edge, resolve the OTHER endpoint's title through the
+    ///    gate; an edge whose neighbour is sealed-not-unlocked is DROPPED (its title/existence never
+    ///    leaks). Only edges with BOTH endpoints visible are returned.
+    ///
+    /// Ordering: active-then-suggested (deterministic wikilink/companion first), then score DESC,
+    /// then id — stable for the FE. Logs ids/counts only, never titles.
+    pub fn links_for_visible(
+        &self,
+        kind: crate::links::LinkKind,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<crate::storage::models::LinkEdge>> {
+        // ── GATE 1: the queried item must itself be visible. ──
+        if self.link_endpoint_title_visible(kind, id, unlocked)?.is_none() {
+            return Ok(Vec::new());
+        }
+        // Read every incident, non-dismissed edge (either endpoint). Direction tells the FE which
+        // side the queried item sits on. No content columns — ids/kinds/metadata only.
+        let rows: Vec<LinkRowRaw> = {
+            let conn = self.lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, src_kind, src_id, dst_kind, dst_id, edge_type, created_by, status,
+                            score, created_at
+                       FROM links
+                      WHERE status != 'dismissed'
+                        AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))
+                      ORDER BY (status = 'active') DESC, score DESC, id ASC",
+                )
+                .map_err(map_err)?;
+            let mapped = stmt
+                .query_map(rusqlite::params![kind.as_str(), id], |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, String>(2)?,
+                        r.get::<_, String>(3)?,
+                        r.get::<_, String>(4)?,
+                        r.get::<_, String>(5)?,
+                        r.get::<_, String>(6)?,
+                        r.get::<_, String>(7)?,
+                        r.get::<_, f64>(8)?,
+                        r.get::<_, i64>(9)?,
+                    ))
+                })
+                .map_err(map_err)?;
+            let mut out = Vec::new();
+            for r in mapped {
+                out.push(r.map_err(map_err)?);
+            }
+            out
+        };
+        let mut edges: Vec<crate::storage::models::LinkEdge> = Vec::new();
+        for (lid, sk, si, dk, di, et, cb, st, score, created_at) in rows {
+            // Identify the OTHER endpoint (the one that is NOT the queried item) + the direction.
+            let (direction, other_kind_s, other_id) = if sk == kind.as_str() && si == id {
+                ("out", dk, di)
+            } else {
+                ("in", sk, si)
+            };
+            let Some(other_kind) = crate::links::LinkKind::parse(&other_kind_s) else {
+                continue; // corrupt kind → skip defensively.
+            };
+            // ── GATE 2: the neighbour must be visible; else drop the edge (no title/existence leak). ──
+            let Some(other_title) =
+                self.link_endpoint_title_visible(other_kind, &other_id, unlocked)?
+            else {
+                continue;
+            };
+            edges.push(crate::storage::models::LinkEdge {
+                id: lid,
+                direction: direction.to_string(),
+                other_kind: other_kind_s,
+                other_id,
+                other_title,
+                edge_type: et,
+                created_by: cb,
+                status: st,
+                score,
+                created_at,
+            });
+        }
+        tracing::debug!(target: "links", count = edges.len(), "links_for_visible resolved");
+        Ok(edges)
+    }
+
+    /// Resolve a link endpoint's CURRENT display title through the visibility gate; `None` iff the
+    /// endpoint is unknown OR sealed-and-not-session-unlocked (indistinguishable — no existence leak).
+    /// Meeting → the gated `meetings.title`/`meeting_is_visible`; note/document → the gated
+    /// `documents.title`/`name` under `visibility_clause`. The single title source for BOTH gates in
+    /// [`Self::links_for_visible`], and for the accept command's neighbour-title resolve.
+    pub fn link_endpoint_title_visible(
+        &self,
+        kind: crate::links::LinkKind,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        match kind {
+            crate::links::LinkKind::Meeting => {
+                if !self.meeting_is_visible(id, unlocked)? {
+                    return Ok(None);
+                }
+                let conn = self.lock();
+                conn.query_row(
+                    "SELECT COALESCE(NULLIF(TRIM(title), ''), 'Meeting') FROM meetings WHERE id = ?1",
+                    rusqlite::params![id],
+                    |r| r.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(map_err)
+            }
+            crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
+                let conn = self.lock();
+                let visible = visibility_clause("f", unlocked);
+                let sql = format!(
+                    "SELECT COALESCE(NULLIF(TRIM(d.title), ''), d.name)
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE d.id = ?1 AND {visible}
+                      LIMIT 1"
+                );
+                conn.query_row(&sql, rusqlite::params![id], |r| r.get::<_, String>(0))
+                    .optional()
+                    .map_err(map_err)
             }
         }
     }
@@ -12335,6 +13055,12 @@ fn backlink_sort_key(b: &BacklinkSource) -> i64 {
         .map(|dt| dt.timestamp_millis())
         .unwrap_or(i64::MIN)
 }
+
+/// Brain v3 PR-3 — the raw `links` row shape read by [`Db::links_for_visible`] before it is resolved
+/// into a [`crate::storage::models::LinkEdge`]: `(id, src_kind, src_id, dst_kind, dst_id, edge_type,
+/// created_by, status, score, created_at)`. Aliased so the reader's row `Vec` stays under clippy's
+/// type-complexity bar.
+type LinkRowRaw = (i64, String, String, String, String, String, String, String, f64, i64);
 
 fn visibility_clause(_alias: &str, unlocked: &HashSet<String>) -> String {
     let mut clause = String::from("(f.locked IS NULL OR f.locked = 0");
@@ -15964,6 +16690,46 @@ mod tests {
         );
     }
 
+    /// NIT-3 (RED-before-GREEN — link lifecycle): deleting a folder purges every `links` edge
+    /// incident on a to-be-deleted DERIVED document, so no link row is left dangling to a row that
+    /// no longer exists. RED on the pre-fix `delete_folder` (docs + chunks purged, but `links` were
+    /// not) — the `d1`-incident edges survived the delete.
+    #[test]
+    fn delete_folder_purges_links_referencing_deleted_documents() {
+        let db = mem_db();
+        seed_folder(&db, "f-docs", "Research");
+        seed_folder(&db, "f-keep", "Keep");
+        db.insert_document("d1", "f-docs", "spec.md", "the spec body", "document", 1)
+            .unwrap();
+        // A surviving note in ANOTHER folder that links AT the doc, plus a semantic edge between two
+        // docs in the deleted folder — both are incident on `d1` and must be purged with it.
+        db.insert_document("d2", "f-docs", "notes.md", "adjacent doc", "document", 1)
+            .unwrap();
+        seed_note_doc(&db, "keeper", "f-keep", "Keeper", "");
+        let now = 1_700_000_000_000i64;
+        {
+            let mut conn = db.lock();
+            let tx = conn.transaction().unwrap();
+            // keeper (survives) --wikilink--> d1 (deleted): src stays, dst vanishes.
+            Db::upsert_link_tx(&tx, "note", "keeper", "document", "d1", "wikilink", 1.0, "user", "active", now).unwrap();
+            // d1 <--semantic--> d2 (both deleted).
+            Db::upsert_link_tx(&tx, "document", "d1", "document", "d2", "semantic", 0.8, "auto", "suggested", now).unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(link_count(&db, "document", "d1", "wikilink"), 1, "edge to d1 exists before delete");
+        assert_eq!(link_count(&db, "document", "d1", "semantic"), 1, "semantic edge on d1 exists before delete");
+
+        db.delete_folder("f-docs").unwrap();
+
+        assert_eq!(
+            count_raw(&db, "SELECT COUNT(*) FROM links WHERE src_id IN ('d1','d2') OR dst_id IN ('d1','d2')"),
+            0,
+            "no links row references a deleted document id after delete_folder"
+        );
+        // The surviving note in the OTHER folder keeps its own row-space clean (its dangling edge gone).
+        assert_eq!(link_count(&db, "note", "keeper", "wikilink"), 0, "the surviving note's edge to the deleted doc is purged");
+    }
+
     /// F5 (RED-before-GREEN): the RELOCK tx (`blank_sealed_notes_in_folders`, both the
     /// `relock_folder` and `relock_all_inner` legs) must purge the four derived-content families the
     /// LOCK tx (`purge_chunks_for_meetings`) and the STARTUP reconcile
@@ -18167,6 +18933,326 @@ mod tests {
             .related_meetings_visible("bare", &stub, 5, &nothing)
             .unwrap();
         assert!(hits.is_empty(), "no chunks ⇒ empty related result");
+    }
+
+    // ── Brain v3 PR-3 — LINK ENGINE (persisted `links` rows) ──────────────────────────────────
+
+    /// Count `links` rows incident on `(kind, id)` with the given `edge_type` (any status).
+    fn link_count(db: &Db, kind: &str, id: &str, edge_type: &str) -> i64 {
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM links
+                   WHERE edge_type = ?3
+                     AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
+                rusqlite::params![kind, id, edge_type],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// A note-doc (`kind='note'`) with a title, in a folder, indexed via the stub so it has vectors.
+    fn seed_note_doc(db: &Db, id: &str, folder_id: &str, title: &str, body: &str) {
+        db.insert_note(id, folder_id, title, title, body, 1_700_000_000_000)
+            .unwrap();
+        db.index_note_chunks(id, title, body, Some(&crate::embed::StubEmbedder))
+            .unwrap();
+    }
+
+    /// The `links` table is created by migrate and survives a re-migrate (idempotency).
+    #[test]
+    fn migrate_creates_links_table_idempotently() {
+        let db = mem_db();
+        let has_links = |db: &Db| -> bool {
+            db.lock()
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'links'",
+                    [],
+                    |_| Ok(()),
+                )
+                .optional()
+                .unwrap()
+                .is_some()
+        };
+        assert!(has_links(&db), "links table missing after migrate");
+        db.migrate().unwrap();
+        db.migrate().unwrap();
+        assert!(has_links(&db), "links table missing after re-migrate (idempotency broken)");
+        // The companion-backfill sentinel is set exactly once and re-migrate does not error.
+        let sentinel: Option<String> = db
+            .lock()
+            .query_row(
+                "SELECT value FROM settings WHERE key = 'links_companion_backfill_v1'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(sentinel.as_deref(), Some("1"), "companion backfill sentinel missing");
+    }
+
+    /// WIKILINK edges are stored by RESOLVED TARGET ID and SURVIVE a target rename — the root-cause
+    /// fix. Index `[[Target]]` in a source note, rename the target, and the edge still resolves via
+    /// the stored id (a title-string edge would have gone stale).
+    #[test]
+    fn wikilink_edges_stored_by_id_survive_rename() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+        // Target note titled "Target" + a source note whose body links [[Target]].
+        seed_note_doc(&db, "target", "f1", "Target", "the target body");
+        db.insert_note("source", "f1", "Source", "Source", "see [[Target]] for context", 1)
+            .unwrap();
+
+        let unlocked = HashSet::new();
+        db.index_wikilinks_for_source(crate::links::LinkKind::Note, "source", "see [[Target]] for context", &unlocked)
+            .unwrap();
+
+        // One wikilink edge source → target, storing the TARGET's id (not the title).
+        let (dk, di): (String, String) = db
+            .lock()
+            .query_row(
+                "SELECT dst_kind, dst_id FROM links
+                   WHERE src_kind='note' AND src_id='source' AND edge_type='wikilink'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(dk, "note");
+        assert_eq!(di, "target", "edge must store the resolved target ID, not the title string");
+
+        // RENAME the target: the edge id is unchanged, so the link still resolves through the reader.
+        db.lock()
+            .execute("UPDATE documents SET title = 'Renamed' WHERE id='target'", [])
+            .unwrap();
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "source", &unlocked).unwrap();
+        let hit = edges.iter().find(|e| e.other_id == "target").expect("edge survives rename");
+        assert_eq!(hit.other_title, "Renamed", "reader resolves the CURRENT title from the stored id");
+        assert_eq!(hit.edge_type, "wikilink");
+
+        // Re-index a body that no longer links [[Target]] → the stale edge is dropped (self-healing).
+        db.index_wikilinks_for_source(crate::links::LinkKind::Note, "source", "no links now", &unlocked)
+            .unwrap();
+        assert_eq!(link_count(&db, "note", "source", "wikilink"), 0, "removed wikilink is dropped");
+    }
+
+    /// SEMANTIC auto-linker: two meetings with IDENTICAL stub-embedded text are mutual nearest
+    /// neighbours (cos 1.0 ≥ STRONG), so each suggests the other as a `semantic` `suggested` edge;
+    /// self is never suggested; the CAP bounds the fan-out.
+    #[test]
+    fn semantic_auto_linker_mutual_knn_suggests_and_caps() {
+        let db = mem_db();
+        let body = "quarterly revenue growth and the hiring plan for the platform team";
+        // 8 identical-text meetings — every pair is a mutual nearest neighbour in stub space.
+        for i in 0..8 {
+            let id = format!("m{i}");
+            db.insert_meeting(&sample_meeting(&id, "2026-06-24T10:00:00Z")).unwrap();
+            note_for(&db, &id, "claude_code", body);
+            db.index_meeting_chunks(&id, &[], &crate::embed::StubEmbedder).unwrap();
+        }
+        let unlocked = HashSet::new();
+        let written = db.auto_link_semantic(crate::links::LinkKind::Meeting, "m0", &unlocked).unwrap();
+        assert_eq!(written, crate::links::SEMANTIC_LINK_CAP, "cap bounds the fan-out to SEMANTIC_LINK_CAP");
+
+        // Every suggested edge is semantic/suggested/auto, undirected (canonicalized), score≈1.0, and
+        // never points at self. Assert per-row inside the query_map (no complex-tuple intermediate).
+        let conn = db.lock();
+        let mut stmt = conn
+            .prepare("SELECT src_kind, src_id, dst_kind, dst_id, edge_type, status, created_by, score FROM links")
+            .unwrap();
+        let mut seen = 0usize;
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(r) = rows.next().unwrap() {
+            let sk: String = r.get(0).unwrap();
+            let si: String = r.get(1).unwrap();
+            let dk: String = r.get(2).unwrap();
+            let di: String = r.get(3).unwrap();
+            let et: String = r.get(4).unwrap();
+            let st: String = r.get(5).unwrap();
+            let cb: String = r.get(6).unwrap();
+            let score: f64 = r.get(7).unwrap();
+            assert_eq!(et, "semantic");
+            assert_eq!(st, "suggested");
+            assert_eq!(cb, "auto");
+            assert!(score >= 0.80, "score is the cosine, above floor");
+            assert!(!(sk == "meeting" && si == "m0" && dk == "meeting" && di == "m0"), "never self-links");
+            // Canonicalized: src <= dst by (kind, id).
+            assert!((sk.as_str(), si.as_str()) <= (dk.as_str(), di.as_str()), "undirected edge canonicalized");
+            // m0 is one of the two endpoints.
+            assert!(si == "m0" || di == "m0", "edge incident on the source");
+            seen += 1;
+        }
+        assert_eq!(seen, crate::links::SEMANTIC_LINK_CAP);
+    }
+
+    /// PURGE-ON-SEAL, BOTH DIRECTIONS (existence-leak RED→GREEN): a wikilink edge between two notes in
+    /// DIFFERENT folders is purged when EITHER folder is sealed — from the sealed side AND from the
+    /// still-open side (the open note's reader must not surface the sealed neighbour).
+    #[test]
+    fn purge_links_tx_drops_edges_on_seal_both_directions() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-secret", "Secret");
+        seed_note_doc(&db, "open", "f-open", "Open Note", "links [[Secret Note]]");
+        seed_note_doc(&db, "secret", "f-secret", "Secret Note", "the secret body");
+
+        let nothing = HashSet::new();
+        db.index_wikilinks_for_source(crate::links::LinkKind::Note, "open", "links [[Secret Note]]", &nothing)
+            .unwrap();
+        assert_eq!(link_count(&db, "note", "open", "wikilink"), 1, "edge exists before seal");
+
+        // Seal the SECRET folder (its document is a to-be-sealed endpoint). Set locked + run the
+        // relock reblank, which carries the `purge_links_tx` leg.
+        db.seal_note("secret", "claude_code", b"x").ok(); // best-effort (documents have no notes row)
+        db.set_folder_locked("f-secret", true, None).unwrap();
+        let mut folders = HashSet::new();
+        folders.insert("f-secret".to_string());
+        db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+        // Edge is gone at rest (no `links` row survives for the sealed endpoint) — BOTH directions.
+        assert_eq!(link_count(&db, "note", "secret", "wikilink"), 0, "sealed endpoint's edge purged (dst side)");
+        assert_eq!(link_count(&db, "note", "open", "wikilink"), 0, "open source's edge to the sealed note purged (src side)");
+
+        // And the gated reader on the OPEN note surfaces nothing about the sealed neighbour.
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "open", &nothing).unwrap();
+        assert!(edges.is_empty(), "open note's link list must not name the sealed neighbour");
+    }
+
+    /// BOTH-ENDPOINT READ GATE: even if a stray `links` row survived (defense-in-depth), the reader
+    /// hides an edge whose OTHER endpoint is sealed-not-unlocked, AND returns empty when the QUERIED
+    /// item is itself sealed (existence-leak guard) — the two-gate model.
+    #[test]
+    fn links_for_visible_gates_both_endpoints() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-secret", "Secret");
+        seed_note_doc(&db, "open", "f-open", "Open Note", "");
+        seed_note_doc(&db, "secret", "f-secret", "Secret Note", "");
+        // Insert a raw edge open → secret WITHOUT purging (simulate a stray survivor).
+        let now = 1_700_000_000_000i64;
+        {
+            let mut conn = db.lock();
+            let tx = conn.transaction().unwrap();
+            Db::upsert_link_tx(&tx, "note", "open", "note", "secret", "wikilink", 1.0, "user", "active", now).unwrap();
+            tx.commit().unwrap();
+        }
+        db.set_folder_locked("f-secret", true, None).unwrap();
+
+        // GATE 2 (neighbour sealed): querying the OPEN note with an empty unlock set drops the edge.
+        let nothing = HashSet::new();
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "open", &nothing).unwrap();
+        assert!(edges.is_empty(), "edge to a sealed neighbour must not surface (neighbour gate)");
+
+        // GATE 1 (queried item sealed): querying the SECRET note itself returns empty (existence leak
+        // guard) — even though the stray edge is incident on it.
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "secret", &nothing).unwrap();
+        assert!(edges.is_empty(), "a sealed queried item must not reveal it HAS links (queried-item gate)");
+
+        // Session-unlock the secret folder → both endpoints visible → the edge appears from either side.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-secret".to_string());
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "open", &unlocked).unwrap();
+        assert_eq!(edges.len(), 1, "both-visible edge surfaces once");
+        assert_eq!(edges[0].other_id, "secret");
+        assert_eq!(edges[0].other_title, "Secret Note");
+    }
+
+    /// DISMISS TOMBSTONES: a dismissed semantic suggestion is never re-suggested by a later auto pass.
+    #[test]
+    fn dismiss_tombstones_a_semantic_suggestion() {
+        let db = mem_db();
+        let body = "identical clustering text for the semantic neighbour test";
+        for id in ["a", "b"] {
+            db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z")).unwrap();
+            note_for(&db, id, "claude_code", body);
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
+        }
+        let unlocked = HashSet::new();
+        db.auto_link_semantic(crate::links::LinkKind::Meeting, "a", &unlocked).unwrap();
+        let (link_id, _): (i64, String) = db
+            .lock()
+            .query_row(
+                "SELECT id, status FROM links WHERE edge_type='semantic' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get::<_, String>(1)?)),
+            )
+            .unwrap();
+        db.dismiss_link(link_id).unwrap();
+        // Re-run the auto pass on 'a' → the dismissed edge stays dismissed (never resurrected).
+        db.auto_link_semantic(crate::links::LinkKind::Meeting, "a", &unlocked).unwrap();
+        let status: String = db
+            .lock()
+            .query_row("SELECT status FROM links WHERE id = ?1", rusqlite::params![link_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(status, "dismissed", "a dismissed suggestion is a permanent tombstone");
+        // The reader never returns a dismissed edge.
+        let edges = db.links_for_visible(crate::links::LinkKind::Meeting, "a", &unlocked).unwrap();
+        assert!(edges.iter().all(|e| e.id != link_id), "dismissed edge is never surfaced");
+    }
+
+    /// NIT (RED-before-GREEN — no downgrade of a user's decision): once a user ACCEPTS a semantic
+    /// edge (`status='active'`, `created_by='accepted'`), a LATER auto semantic pass that re-suggests
+    /// the SAME edge must NOT downgrade it back to `suggested`. The `upsert_link_tx` DO-UPDATE guard
+    /// preserves an existing `active` row's status/created_by against an incoming `suggested` write
+    /// (refreshing only the score). RED on the pre-fix upsert (`status = excluded.status` clobbered
+    /// the accepted edge back to `suggested` on every re-run).
+    #[test]
+    fn accepted_semantic_edge_survives_auto_resuggest() {
+        let db = mem_db();
+        let body = "identical clustering text for the semantic neighbour test";
+        for id in ["a", "b"] {
+            db.insert_meeting(&sample_meeting(id, "2026-06-24T10:00:00Z")).unwrap();
+            note_for(&db, id, "claude_code", body);
+            db.index_meeting_chunks(id, &[], &crate::embed::StubEmbedder).unwrap();
+        }
+        let unlocked = HashSet::new();
+        db.auto_link_semantic(crate::links::LinkKind::Meeting, "a", &unlocked).unwrap();
+        let link_id: i64 = db
+            .lock()
+            .query_row("SELECT id FROM links WHERE edge_type='semantic' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        // User ACCEPTS it: active + accepted.
+        db.accept_link(link_id).unwrap();
+
+        // Re-run the auto pass on 'a' → the accepted edge is re-suggested by the linker but MUST NOT
+        // be downgraded.
+        db.auto_link_semantic(crate::links::LinkKind::Meeting, "a", &unlocked).unwrap();
+        let (status, cb): (String, String) = db
+            .lock()
+            .query_row(
+                "SELECT status, created_by FROM links WHERE id = ?1",
+                rusqlite::params![link_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "active", "an accepted semantic edge stays active across a re-suggest");
+        assert_eq!(cb, "accepted", "created_by is preserved as 'accepted', never reset to 'auto'");
+    }
+
+    /// ACCEPT flips status + created_by (the .md materialize is command-layer; this pins the DB flip).
+    #[test]
+    fn accept_flips_status_and_created_by() {
+        let db = mem_db();
+        let now = 1_700_000_000_000i64;
+        {
+            let mut conn = db.lock();
+            let tx = conn.transaction().unwrap();
+            Db::upsert_link_tx(&tx, "meeting", "m1", "meeting", "m2", "semantic", 0.9, "auto", "suggested", now).unwrap();
+            tx.commit().unwrap();
+        }
+        let link_id: i64 = db
+            .lock()
+            .query_row("SELECT id FROM links WHERE edge_type='semantic' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        db.accept_link(link_id).unwrap();
+        let (status, cb): (String, String) = db
+            .lock()
+            .query_row(
+                "SELECT status, created_by FROM links WHERE id = ?1",
+                rusqlite::params![link_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "active");
+        assert_eq!(cb, "accepted");
     }
 
     /// PURGE-ON-LOCK: index a meeting's chunks while visible, then re-blank its folder (the relock

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1077,6 +1077,32 @@ pub struct BacklinkSource {
     pub timestamp: String,
 }
 
+/// Brain v3 PR-3 — one persisted `links` row surfaced to the FE, with the OTHER endpoint's display
+/// title resolved through the SAME visibility gate as the queried endpoint (both-endpoint gating).
+/// `direction` says whether the queried item is this edge's `src` ("out") or `dst` ("in") so the FE
+/// can render an arrow; `other_kind`/`other_id` are the neighbour to navigate to. `edge_type` ∈
+/// `wikilink|companion|semantic`, `created_by` ∈ `user|auto|accepted`, `status` ∈
+/// `active|suggested|dismissed` (dismissed rows are never returned). `score` is the semantic cosine
+/// (1.0 for the deterministic wikilink/companion edges). Only ever built when BOTH endpoints are
+/// VISIBLE — a sealed neighbour can never appear, and a sealed queried item yields an empty list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkEdge {
+    pub id: i64,
+    /// "out" (queried item is `src`) | "in" (queried item is `dst`).
+    pub direction: String,
+    /// The neighbour endpoint kind: `meeting|note|document`.
+    pub other_kind: String,
+    pub other_id: String,
+    /// The neighbour's current display title, resolved through the visibility gate.
+    pub other_title: String,
+    pub edge_type: String,
+    pub created_by: String,
+    pub status: String,
+    pub score: f64,
+    pub created_at: i64,
+}
+
 /// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, or (2026-07-15)
 /// org (Shared Brain) item whose exact title the link names, so the FE can route `/notes/:id`,
 /// `/meeting/:id`, or `/org-item/:id`. Resolution is visibility-gated: a sealed-and-not-

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -8,6 +8,8 @@ import type {
   Analytics,
   AppConfigDto,
   BacklinkSource,
+  LinkEdge,
+  LinkKind,
   WikiTarget,
   CompanionAppendResult,
   SourceKind,
@@ -1127,6 +1129,38 @@ export class IpcService {
     targetId: string,
   ): Promise<BacklinkSource[]> {
     return invoke<BacklinkSource[]>("get_backlinks", { targetKind, targetId });
+  }
+
+  /**
+   * Brain v3 PR-3 — every persisted link edge incident on `(kind, id)` for the
+   * "Connections" panel: deterministic `wikilink`/`companion` edges + `semantic`
+   * suggestions (with a cosine `score`). BOTH endpoints are visibility-gated
+   * server-side — a sealed queried item yields `[]` (no existence leak) and a
+   * sealed neighbour is dropped — so the caller MUST STILL skip the fetch while
+   * the item itself is locked/masked (never surface connections behind a lock).
+   * `dismissed` edges are never returned.
+   */
+  listLinks(kind: LinkKind, id: string): Promise<LinkEdge[]> {
+    return invoke<LinkEdge[]>("list_links", { kind, id });
+  }
+
+  /**
+   * Brain v3 PR-3 — ACCEPT a suggested (semantic) link: flip it active and (when
+   * either endpoint is a locally-owned, session-visible note) materialize the
+   * neighbour's `[[Title]]` into that note's managed link block. GATED + idempotent
+   * server-side. The caller re-runs {@link listLinks} afterward to reflect the flip.
+   */
+  acceptLink(id: number): Promise<void> {
+    return invoke<void>("accept_link", { id });
+  }
+
+  /**
+   * Brain v3 PR-3 — DISMISS a suggested link: tombstone it so no later auto pass
+   * re-suggests it (graph-only, no markdown touched). Idempotent. The caller
+   * re-runs {@link listLinks} afterward to drop the row.
+   */
+  dismissLink(id: number): Promise<void> {
+    return invoke<void>("dismiss_link", { id });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1312,6 +1312,40 @@ export interface BacklinkSource {
 }
 
 /**
+ * Brain v3 PR-3 — one persisted `links` edge incident on `(kind, id)`, surfaced to the
+ * "Connections" panel (`list_links(kind, id)`). Both endpoints are visibility-gated
+ * server-side: a sealed queried item yields `[]` (no existence leak) and a sealed
+ * neighbour is never included, so the caller MUST STILL skip/hide the panel while the
+ * item itself is locked/masked (never surface connections behind a lock).
+ *
+ * - `direction` — `"out"` (the queried item is this edge's `src`) | `"in"` (it is `dst`).
+ * - `otherKind` — the neighbour endpoint kind: `"meeting" | "note" | "document"`
+ *   (route `meeting` → `/meeting/:id`, `note`/`document` → `/notes/:id`).
+ * - `edgeType` — `"wikilink" | "companion" | "semantic"`. `wikilink`/`companion` are
+ *   DETERMINISTIC edges (rendered as plain link chips); `semantic` is a SUGGESTED edge
+ *   the user can Accept/Dismiss, with `score` the cosine confidence.
+ * - `createdBy` — `"user" | "auto" | "accepted"`; `status` — `"active" | "suggested"`
+ *   (`"dismissed"` rows are never returned). `score` is `1.0` for deterministic edges.
+ *
+ * Mirrors the Rust `LinkEdge` (serde camelCase).
+ */
+export interface LinkEdge {
+  id: number;
+  direction: "out" | "in";
+  otherKind: "meeting" | "note" | "document";
+  otherId: string;
+  otherTitle: string;
+  edgeType: "wikilink" | "companion" | "semantic";
+  createdBy: "user" | "auto" | "accepted";
+  status: "active" | "suggested";
+  score: number;
+  createdAt: number;
+}
+
+/** The link-endpoint kind an `app-connections` panel is anchored to (`list_links` `kind`). */
+export type LinkKind = "meeting" | "note" | "document";
+
+/**
  * A resolved `[[Title]]` wikilink navigation target — the VISIBLE note/meeting/org
  * (Shared Brain) item to open (`resolveWikilink(title)`). `null` when nothing matches
  * OR the only local match is sealed-and-not-session-unlocked (gated server-side, so a

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -328,6 +328,13 @@
     <app-backlinks [sources]="backlinks()" />
   }
 
+  <!-- CONNECTIONS (Brain v3 PR-3) — deterministic wikilink/companion link chips +
+       semantic suggestions (confidence chip + Accept/Dismiss), self-loaded & gated.
+       Beside "Linked mentions". note-panel only renders for an unlocked meeting
+       (detail's `@else (!locked())`), so `locked` stays the default false; the panel
+       still re-asks on a session lock-tree change. -->
+  <app-connections kind="meeting" [id]="meetingId()" />
+
   <!-- LIVE CONTEXT — enrich this note with fresh detail from connected tools (Jira / Slack / web).
        Sits right after the note summary; egress is on-demand + kept loud. Only rendered for an
        unlocked meeting (note-panel itself is under the detail view's `@else (!locked())`). Bubbles

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -12,6 +12,7 @@ import type { BacklinkSource, GraphPayload } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { AssistantSourcesComponent } from "../../../shared/assistant-sources/assistant-sources.component";
 import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
+import { ConnectionsComponent } from "../../../shared/connections/connections.component";
 import { MoveToMenuComponent } from "../../folders/move-to-menu/move-to-menu.component";
 import { MeetingActionsComponent } from "../meeting-actions/meeting-actions.component";
 import { MeetingChatComponent } from "../meeting-chat/meeting-chat.component";
@@ -80,6 +81,7 @@ export interface AssistantQa {
     MarkdownComponent,
     AssistantSourcesComponent,
     BacklinksComponent,
+    ConnectionsComponent,
     MoveToMenuComponent,
     MeetingActionsComponent,
     MeetingChatComponent,

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -503,6 +503,16 @@
             <app-backlinks [sources]="backlinks()" />
           }
 
+          <!-- CONNECTIONS (Brain v3 PR-3) — deterministic wikilink/companion link
+               chips + semantic suggestions (confidence chip + Accept/Dismiss),
+               self-loaded & gated. Beside "Linked mentions". Hidden when embedded
+               (the recording panel's Ask Brain tab owns relationships). The panel
+               owns its gated fetch, skips it while `locked`, and re-asks on a
+               session lock-tree change. -->
+          @if (!embedded() && note(); as doc) {
+            <app-connections kind="note" [id]="doc.id" [locked]="doc.locked" />
+          }
+
           <!-- Body: preview (cached computed) OR the source-of-truth textarea.
                Formatting lives in the floating bubble on selection (below) +
                ⌘B/⌘I shortcuts + the `/` slash menu — no persistent toolbar.

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -37,6 +37,7 @@ import { FoldersService } from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
 import { ToastService } from "../../../services/toast.service";
 import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
+import { ConnectionsComponent } from "../../../shared/connections/connections.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { LinkPickerComponent } from "../link-picker/link-picker.component";
 import { NOTE_ASSIST_CATALOG } from "../note-brain-popover/note-assist-catalog";
@@ -155,6 +156,7 @@ const FULL_WIDTH_KEY = "murmur-note-full-width";
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     BacklinksComponent,
+    ConnectionsComponent,
     LinkPickerComponent,
     MarkdownComponent,
     NoteBrainPopoverComponent,

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -1,0 +1,80 @@
+@if (deterministic().length || suggestions().length) {
+  <div class="cx">
+    <!-- DETERMINISTIC edges (wikilink / companion) — plain link chips, mirroring
+         the "Linked mentions" chip row. -->
+    @if (deterministic().length) {
+      <div class="cx-group">
+        <span class="cx-label">Connections</span>
+        @for (e of deterministic(); track e.id) {
+          <a class="cx-chip" [routerLink]="routeFor(e)">
+            @switch (e.otherKind) {
+              @case ("meeting") {
+                <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+              }
+              @case ("document") {
+                <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+              }
+              @default {
+                <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+              }
+            }
+            <span class="cx-title">{{ e.otherTitle }}</span>
+            @if (e.edgeType === "companion") {
+              <span class="cx-edge" aria-hidden="true">companion</span>
+            } @else {
+              <span class="cx-edge" aria-hidden="true">link</span>
+            }
+          </a>
+        }
+      </div>
+    }
+
+    <!-- SEMANTIC suggestions — a confidence chip + Accept / Dismiss per row. -->
+    @if (suggestions().length) {
+      <div class="cx-group">
+        <span class="cx-label">Suggested connections</span>
+        @for (e of suggestions(); track e.id) {
+          <div class="cx-row" [class.is-pending]="isPending(e.id)">
+            <a class="cx-chip cx-chip--suggested" [routerLink]="routeFor(e)">
+              @switch (e.otherKind) {
+                @case ("meeting") {
+                  <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+                }
+                @case ("document") {
+                  <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+                }
+                @default {
+                  <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+                }
+              }
+              <span class="cx-title">{{ e.otherTitle }}</span>
+              <span
+                class="cx-score"
+                [class]="'cx-score--' + tier(e.score)"
+                [attr.title]="'Confidence ' + scoreLabel(e.score)"
+              >{{ scoreLabel(e.score) }}</span>
+            </a>
+            <div class="cx-actions">
+              <button
+                type="button"
+                class="cx-btn cx-btn--accept"
+                [disabled]="isPending(e.id)"
+                (click)="accept(e)"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                class="cx-btn cx-btn--dismiss"
+                [disabled]="isPending(e.id)"
+                (click)="dismiss(e)"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+}

--- a/src/app/shared/connections/connections.component.scss
+++ b/src/app/shared/connections/connections.component.scss
@@ -1,0 +1,168 @@
+:host {
+  display: block;
+}
+
+.cx {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* One labelled cluster (deterministic chips, or suggestion rows). */
+.cx-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.cx-label {
+  flex: 0 0 100%;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Chip — mirrors `app-backlinks`'s `.bl-chip` language. */
+.cx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 22rem;
+  padding: 6px var(--space-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 13px;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+.cx-chip:hover {
+  border-color: var(--accent-ring);
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+
+/* Neighbour-kind badge. */
+.cx-kind {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.cx-kind--meeting {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.cx-kind--note {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+.cx-kind--doc {
+  background: var(--surface-overlay);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.cx-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Edge-type hint on the deterministic chip. */
+.cx-edge {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+/* --- Semantic suggestion rows ------------------------------------------ */
+.cx-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  transition: opacity var(--transition-fast);
+}
+.cx-row.is-pending {
+  opacity: 0.55;
+}
+
+.cx-chip--suggested {
+  border-style: dashed;
+}
+
+/* 3-tier confidence chip. */
+.cx-score {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.cx-score--high {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.cx-score--med {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+.cx-score--low {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.cx-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.cx-btn {
+  padding: 4px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+.cx-btn:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.cx-btn--accept {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-ring);
+  color: var(--accent-hover);
+}
+.cx-btn--accept:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.cx-btn--dismiss {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+}
+.cx-btn--dismiss:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -1,0 +1,184 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+import { RouterLink } from "@angular/router";
+
+import { IpcService } from "../../core/ipc.service";
+import type { LinkEdge, LinkKind } from "../../core/models";
+import { FoldersService } from "../../services/folders.service";
+
+/** One rendered semantic-suggestion confidence tier (chip color + label). */
+type ConfidenceTier = "high" | "med" | "low";
+
+/**
+ * Brain v3 PR-3 "Connections" — a self-contained panel of the persisted link
+ * edges incident on one item (`list_links(kind, id)`), shown BESIDE the existing
+ * "Linked mentions" backlinks chip row in the meeting Note tab and the note
+ * editor. It renders two groups:
+ *
+ *  - DETERMINISTIC edges (`wikilink` / `companion`) as plain link chips that route
+ *    to the neighbour (`meeting` → `/meeting/:id`, `note`/`document` → `/notes/:id`),
+ *    mirroring the `app-backlinks` chip visual language.
+ *  - SEMANTIC suggestions (`status === "suggested"`) as rows carrying a 3-tier
+ *    confidence chip (score ≥ 0.88 high / ≥ 0.84 med / ≥ 0.80 low) plus Accept /
+ *    Dismiss buttons. Accept flips the edge active (and materializes the
+ *    `[[Title]]` server-side); Dismiss tombstones it. Both re-fetch on success.
+ *
+ * SELF-LOADING (unlike the presentational `app-backlinks`, whose host owns the
+ * fetch): it takes `kind` + `id` + `locked` inputs and owns the gated fetch, so a
+ * host only drops the tag in. The fetch is skipped/cleared while `locked` is true
+ * (never surface connections behind a lock) and re-runs on a session lock-tree
+ * change (a folder unlock/relock, or screen-share relock-all) so sealed neighbours
+ * drop out — or reappear — live, exactly like `graph.component`'s `_refetchOnLock`.
+ */
+@Component({
+  selector: "app-connections",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
+  templateUrl: "./connections.component.html",
+  styleUrl: "./connections.component.scss",
+})
+export class ConnectionsComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+
+  /** The link-endpoint kind this panel is anchored to. */
+  readonly kind = input.required<LinkKind>();
+  /** The anchored item's id; changing it re-loads the panel. */
+  readonly id = input.required<string>();
+  /**
+   * Whether the anchored item is currently locked/masked. While true the fetch
+   * is skipped and the edges are cleared — connections are never surfaced behind
+   * a lock (belt-and-braces with the backend's own both-endpoint visibility gate).
+   */
+  readonly locked = input(false);
+
+  /** The visible edges for the current `(kind, id)`; `[]` while locked/loading. */
+  readonly edges = signal<LinkEdge[]>([]);
+  /** In-flight Accept/Dismiss link ids — disables that row's buttons meanwhile. */
+  private readonly pending = signal<ReadonlySet<number>>(new Set());
+
+  /**
+   * Monotonic request token — a late `list_links` reply for a superseded
+   * `(kind, id)` or lock transition is dropped (stale-result guard, FE failure
+   * mode #4), the same idiom as `entity-detail`'s `_load` / `detail`'s backlinks.
+   */
+  private seq = 0;
+
+  /** Deterministic edges (`wikilink` / `companion`) → plain link chips. */
+  readonly deterministic = computed(() =>
+    this.edges().filter((e) => e.edgeType !== "semantic"),
+  );
+
+  /** Semantic suggestions (`status === "suggested"`) → Accept/Dismiss rows. */
+  readonly suggestions = computed(() =>
+    this.edges().filter(
+      (e) => e.edgeType === "semantic" && e.status === "suggested",
+    ),
+  );
+
+  /**
+   * Load the edges whenever `(kind, id)`, `locked`, OR the session lock-tree
+   * changes. Reading `folders.tree()` registers this effect as its dependent so a
+   * later unlock/relock re-asks the backend (sealed neighbours drop out / reappear
+   * live). A legitimate signal-writing effect (T1): async IPC keyed on inputs with
+   * a stale-result guard; the `seq` check drops a reply for a superseded item.
+   */
+  private readonly _load = effect(() => {
+    const kind = this.kind();
+    const id = this.id();
+    const locked = this.locked();
+    // Establish the lock-tree dependency (value unused — the backend is the
+    // authority on visibility; we just re-ask when it may have changed).
+    this.folders.tree();
+    const seq = ++this.seq;
+    if (locked || !id) {
+      this.edges.set([]);
+      return;
+    }
+    void this.fetch(kind, id, seq);
+  });
+
+  private async fetch(kind: LinkKind, id: string, seq: number): Promise<void> {
+    try {
+      const rows = await this.ipc.listLinks(kind, id);
+      if (seq !== this.seq) {
+        return; // superseded by a newer item / lock transition
+      }
+      this.edges.set(Array.isArray(rows) ? rows : []);
+    } catch {
+      if (seq === this.seq) {
+        this.edges.set([]);
+      }
+    }
+  }
+
+  /** The confidence tier for a semantic suggestion's cosine score. */
+  tier(score: number): ConfidenceTier {
+    if (score >= 0.88) {
+      return "high";
+    }
+    if (score >= 0.84) {
+      return "med";
+    }
+    return "low";
+  }
+
+  /** Whole-number percentage label for a suggestion's confidence chip. */
+  scoreLabel(score: number): string {
+    return `${Math.round(score * 100)}%`;
+  }
+
+  /** True while an Accept/Dismiss for this edge is in flight (buttons disabled). */
+  isPending(id: number): boolean {
+    return this.pending().has(id);
+  }
+
+  /** The click-through route array for an edge's neighbour, split by kind. */
+  routeFor(e: LinkEdge): unknown[] {
+    return e.otherKind === "meeting"
+      ? ["/meeting", e.otherId]
+      : ["/notes", e.otherId];
+  }
+
+  /** Accept a suggestion → materialize server-side, then re-fetch to reflect it. */
+  accept(e: LinkEdge): void {
+    void this.mutate(e.id, () => this.ipc.acceptLink(e.id));
+  }
+
+  /** Dismiss a suggestion → tombstone server-side, then re-fetch to drop it. */
+  dismiss(e: LinkEdge): void {
+    void this.mutate(e.id, () => this.ipc.dismissLink(e.id));
+  }
+
+  /**
+   * Run an Accept/Dismiss mutation guarded by the pending set, then re-fetch the
+   * edges for the CURRENT `(kind, id)` (never a stale closure) so the panel reflects
+   * the server truth. The seq token drops a reply for a since-changed item.
+   */
+  private async mutate(id: number, run: () => Promise<void>): Promise<void> {
+    if (this.isPending(id)) {
+      return;
+    }
+    this.pending.update((s) => new Set(s).add(id));
+    try {
+      await run();
+      const seq = ++this.seq;
+      await this.fetch(this.kind(), this.id(), seq);
+    } catch {
+      // Leave the current edges untouched; drop the pending flag below.
+    } finally {
+      this.pending.update((s) => {
+        const next = new Set(s);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+}


### PR DESCRIPTION
PR-3 of the Brain v3 program (spec: docs/superpowers/specs/2026-07-17-brain-v3-design.md). Replaces per-read link recomputation with a persisted typed relation graph, and adds automatic semantic linking on top of manual wikilinks.

## New `links` table (additive)
`wikilink | companion | semantic`, status `active | suggested | dismissed`, both-direction indexes, `UNIQUE(src,dst,type)`.

## Manual wikilinks — stored by resolved id
`[[wikilinks]]` are indexed at every note save, resolved through the existing gated `resolve_wikilink` and stored as **target ids** — so a rename no longer breaks the link (the old title-string fragility is gone). Companion (`documents.meeting_id`) edges are backfilled once and maintained.

## Automatic semantic linking (mutual-kNN)
For each freshly-embedded item: centroid → vec0 kNN (`k=10`), `cos = 1 − d²/2`, keep iff `cos ≥ 0.80 AND (mutual OR cos ≥ 0.88)`, cap 5 — proposed as **`suggested`**, never injected into `.md`. Model-gated (never on the stub embedder), `O(k·log n)`, no corpus scan.

## Suggest-then-accept
Accept flips to `active` + materializes `[[Title]]` via the existing link-marker path; dismiss tombstones (never re-suggested); an accepted edge is not downgraded by a later auto re-suggest. New **`app-connections`** panel (detail Note tab + note-editor): grouped edges, 3-tier confidence chips, accept/dismiss, stale-guarded + cleared while locked.

## Lock model
`links` are derived, content-revealing relations. `purge_links_tx` runs inside **every** seal / relock / startup-reconcile / delete tx (meeting, document, folder); every read (`links_for_visible`) gates **both** endpoints (existence-leak guard on the queried item + neighbour visibility); re-derived on **session and permanent** unlock.

## Verification
- `cargo test --lib` → **1830 / 0**; `clippy --lib --tests -D warnings` clean; `ng lint` + `ng build` clean.
- RED-before-GREEN on all invariants (both-endpoint gate, purge-on-seal both directions, rename-proof ids, dismiss tombstone, accept preservation).
- **adversarial-verifier: PASS. lock-security-reviewer: PASS** (twice — after the initial build and after three lifecycle-completeness fixes).

Additive migration only. No new deps. Calibration note: `0.80`/`0.88` are start thresholds; a real-vault precision@5 spike should confirm semantic-link quality before relying on it (unverifiable headless).