### PR TITLE
feat(brain): full-brain graph — every node and edge, not just people

### DIFF
--- a/e2e/brain/full-brain-graph.spec.ts
+++ b/e2e/brain/full-brain-graph.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Brain v3 PR-4 smoke: the FULL-BRAIN graph mounts over a mocked `get_full_graph`,
+ * renders its lens chips + canvas with NO console errors (guards NG0600 /
+ * forwardRef / paint regressions), a node-type lens toggle filters the view WITHOUT
+ * re-fetching (the lens is a client-side computed), and the "Suggested" toggle
+ * DOES re-fetch (it changes `includeSuggested` server-side).
+ *
+ * Call bookkeeping lives on `window` (the mock overrides run page-side, serialized
+ * to strings — no closures over test scope), so the test reads it back afterwards.
+ */
+test("full-brain graph: mounts, lens filters client-side, Suggested re-fetches, clean console", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    // A tiny typed graph: one node of each kind + edges of a few kinds. The
+    // `includeSuggested` flag toggles whether a suggested semantic edge appears
+    // — proving the re-fetch semantics.
+    get_full_graph: (args: {
+      opts?: { includeSuggested?: boolean } | null;
+    }) => {
+      const w = window as unknown as { __fullGraphCalls?: number };
+      w.__fullGraphCalls = (w.__fullGraphCalls ?? 0) + 1;
+      const suggested = !!args?.opts?.includeSuggested;
+      return {
+        nodes: [
+          { id: "e1", kind: "entity", label: "Alice", date: null, degree: 2 },
+          { id: "m1", kind: "meeting", label: "Standup", date: "2026-07-01", degree: 2 },
+          { id: "n1", kind: "note", label: "Roadmap", date: "2026-07-02", degree: 1 },
+          { id: "d1", kind: "document", label: "Spec.pdf", date: "2026-07-03", degree: 1 },
+        ],
+        edges: [
+          { src: "e1", dst: "m1", kind: "mention", score: 1, status: "active" },
+          { src: "m1", dst: "n1", kind: "companion", score: 1, status: "active" },
+          ...(suggested
+            ? [{ src: "n1", dst: "d1", kind: "semantic", score: 0.8, status: "suggested" }]
+            : []),
+        ],
+        hasHidden: false,
+        totalVisibleNodes: 4,
+      };
+    },
+  });
+
+  await page.goto("/brain");
+
+  // Open the collapsible "Full brain graph" section.
+  await page.getByRole("button", { name: /Full brain graph/i }).click();
+
+  const graph = page.locator("app-full-brain-graph");
+  await expect(graph).toBeVisible();
+  await expect(graph.locator("canvas.fbg-canvas")).toBeVisible();
+
+  // Lens chips render (one per node kind + one per edge kind + Suggested).
+  await expect(graph.getByRole("button", { name: "Meetings" })).toBeVisible();
+  await expect(graph.getByRole("button", { name: "Wikilinks" })).toBeVisible();
+  await expect(graph.getByRole("button", { name: "Suggested" })).toBeVisible();
+
+  // The caption reflects the drawn counts (4 items, 2 active links).
+  await expect(graph.getByText(/4 items · 2 links/)).toBeVisible();
+
+  const callsAfterLoad = await page.evaluate(
+    () => (window as unknown as { __fullGraphCalls?: number }).__fullGraphCalls ?? 0,
+  );
+
+  // Toggle OFF the Meetings node lens → the view recomputes CLIENT-SIDE (no
+  // re-fetch): the meeting node + its edges drop, so the count changes but the
+  // fetch count does NOT.
+  await graph.getByRole("button", { name: "Meetings" }).click();
+  await expect(graph.getByText(/3 items · 0 links/)).toBeVisible();
+  const callsAfterLens = await page.evaluate(
+    () => (window as unknown as { __fullGraphCalls?: number }).__fullGraphCalls ?? 0,
+  );
+  expect(callsAfterLens).toBe(callsAfterLoad); // NO re-fetch on a lens toggle
+
+  // Toggle ON Suggested → this DOES re-fetch (includeSuggested changes the payload).
+  await graph.getByRole("button", { name: "Suggested" }).click();
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => (window as unknown as { __fullGraphCalls?: number }).__fullGraphCalls ?? 0,
+      ),
+    )
+    .toBeGreaterThan(callsAfterLens);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,8 @@ use crate::state::AppState;
 use crate::storage::models::{
     ActionItem, Analytics, AskVaultResult, BrainOverview, BuiltinRecipe, CalendarContext,
     CalendarEvent, CalendarEventFull, ChatTurn, Commitment, DigestResult, DocumentInfo,
-    EntityDetail, EntityDossierResult, Folder, FolderNode, GraphData, Meeting,
+    EntityDetail, EntityDossierResult, Folder, FolderNode, FullGraphData, FullGraphOpts, GraphData,
+    Meeting,
     MeetingActionSummary, MeetingStatus, MeetingTimeline, NoteAssistRequest, NoteAssistResult,
     NoteCitation, NoteDoc, NoteFolder, NoteRecord, NoteSummary, OrganizeMove, OrganizePlan,
     PeopleList, PinResult, PropertyKind, PropertySchemaField, RecipeRecord, SavedView, SearchHit,
@@ -7665,6 +7666,22 @@ const ENTITY_NEIGHBOR_LIMIT: i64 = 12;
 pub fn get_graph(state: State<'_, AppState>) -> Result<GraphData, AppError> {
     let unlocked = unlocked_snapshot(state.inner())?;
     state.db.build_graph(&unlocked)
+}
+
+/// The FULL-BRAIN graph (Brain v3 PR-4): a SEPARATE, additive read that unifies entities + VISIBLE
+/// meetings + notes + documents as TYPED nodes and every relation (entity co-occurrence + entity→
+/// meeting mentions + `links` rows) as TYPED edges. Snapshots the live session `unlocked` set exactly
+/// like `get_graph`, so a sealed-and-not-session-unlocked meeting/note/document contributes NOTHING —
+/// no node, and no edge touching it (BOTH endpoints are gated against the visible-node set). `opts`
+/// defaults to all-off; `includeSuggested` admits un-accepted (`status='suggested'`) semantic links.
+/// Pure read: no writes, no new storage. `get_graph` is untouched + byte-compatible for its FE.
+#[tauri::command]
+pub fn get_full_graph(
+    state: State<'_, AppState>,
+    opts: Option<FullGraphOpts>,
+) -> Result<FullGraphData, AppError> {
+    let unlocked = unlocked_snapshot(state.inner())?;
+    state.db.build_full_graph(&unlocked, opts.unwrap_or_default())
 }
 
 /// `/people` personal CRM: one card per VISIBLE Person entity, rolled up over the SAME gated

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -324,6 +324,7 @@ pub fn run() {
             commands::pin_moment,
             commands::link_meeting_entities,
             commands::get_graph,
+            commands::get_full_graph,
             commands::get_entity_detail,
             commands::get_backlinks,
             commands::list_links,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -13,6 +13,7 @@ use crate::storage::models::{
     Analytics, AssistantInteraction, AssistantThreadRow, BacklinkSource, Commitment,
     CorrectionRecord, DayCount,
     DocChunkHit, DocumentInfo, DocumentSummary, EntityDetail, EntityKind, EntityNeighbor, Folder,
+    FullGraphData, FullGraphEdge, FullGraphEdgeKind, FullGraphNode, FullGraphNodeKind, FullGraphOpts,
     GraphData,
     GraphEdge, GraphEntity, GraphNode, Meeting, MeetingActionSummary, MeetingStatus, NoteCitation,
     NoteFolder,
@@ -11217,6 +11218,368 @@ impl Db {
         })
     }
 
+    /// Build the FULL-BRAIN graph payload (`get_full_graph`, DESIGN §PR-4). A PURE READ — no writes,
+    /// no new storage — that unifies FOUR node kinds and FIVE edge kinds under one visibility model:
+    ///
+    /// NODES (each via its EXISTING gated reader; a sealed-and-not-session-unlocked item yields none):
+    ///   • entities  — `list_entities_visible` (already 500-capped, HAVING visible mention);
+    ///   • meetings  — `list_meetings_visible` (visible if no notes OR any visible note);
+    ///   • notes + documents — `full_graph_content_nodes` over `documents JOIN folders` under
+    ///     `visibility_clause` (a sealed folder's rows are absent), split by `kind`.
+    ///
+    /// EDGES (BOTH endpoints must be in the visible-node set built above — an edge to a sealed node
+    /// is DROPPED, so no edge can leak a hidden node's existence):
+    ///   • co_occurrence — entity↔entity (`graph_edges_visible`, already gated);
+    ///   • mention       — entity→meeting (`entity_mentions`, gated by the SAME meeting predicate);
+    ///   • wikilink/companion/semantic — `links` rows with `status='active'` (+ `status='suggested'`
+    ///     semantic ONLY when `opts.include_suggested`), each endpoint re-checked against the set.
+    ///
+    /// Deterministic: nodes ordered by (kind, id ASC), edges by (kind, src, dst, status). Honest caps:
+    /// `total_visible_nodes` is the pre-cap true count so the FE can disclose a silent trim; `has_hidden`
+    /// reflects LOCKED folders (mirrors the entity graph). No PII logged — ids/counts only.
+    pub fn build_full_graph(
+        &self,
+        unlocked: &HashSet<String>,
+        opts: FullGraphOpts,
+    ) -> Result<FullGraphData> {
+        // ── NODES: enumerate via the existing gated readers, keyed by (kind_str, id) so a cross-kind
+        //    id collision can never conflate two nodes when an edge is gated. ──
+        let mut nodes: Vec<FullGraphNode> = Vec::new();
+        let mut visible: HashSet<(&'static str, String)> = HashSet::new();
+
+        // Entities (already render-capped at 500 inside the reader).
+        for e in self.list_entities_visible(unlocked)? {
+            visible.insert((FullGraphNodeKind::Entity.as_str(), e.id.clone()));
+            nodes.push(FullGraphNode {
+                id: e.id,
+                kind: FullGraphNodeKind::Entity,
+                label: e.name,
+                date: None,
+                degree: 0,
+            });
+        }
+        // Meetings (visible-meeting predicate; capped to keep the payload bounded).
+        for m in self.list_meetings_visible(MAX_FULL_GRAPH_PER_KIND as i64, unlocked)? {
+            visible.insert((FullGraphNodeKind::Meeting.as_str(), m.id.clone()));
+            let label = m
+                .title
+                .as_deref()
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .unwrap_or("Meeting")
+                .to_string();
+            nodes.push(FullGraphNode {
+                id: m.id,
+                kind: FullGraphNodeKind::Meeting,
+                label,
+                date: Some(m.started_at),
+                degree: 0,
+            });
+        }
+        // Notes + documents (one gated pass over `documents`, split by kind).
+        for (kind, id, label, date) in self.full_graph_content_nodes(unlocked)? {
+            visible.insert((kind.as_str(), id.clone()));
+            nodes.push(FullGraphNode {
+                id,
+                kind,
+                label,
+                date,
+                degree: 0,
+            });
+        }
+        // TRUE (uncapped) visible-node count for honest disclosure — computed with NO per-kind LIMIT,
+        // so `total_visible_nodes > nodes.len()` whenever a per-kind cap silently trimmed a leg (the
+        // twin of the entity graph's `total_visible_entities`). Mirrors, never derives from, the capped
+        // `nodes.len()`.
+        let total_visible_nodes = self.count_full_graph_nodes_visible(unlocked)?;
+
+        // ── EDGES: every leg is dropped unless BOTH endpoints are in `visible`. Degree is tallied
+        //    INLINE with the true endpoint node-kinds (a links edge can connect meeting↔note, so the
+        //    endpoint kinds are NOT derivable from the edge kind alone — they must be carried here). ──
+        let mut edges: Vec<FullGraphEdge> = Vec::new();
+        let mut degree: std::collections::HashMap<(&'static str, String), i64> =
+            std::collections::HashMap::new();
+        let bump = |degree: &mut std::collections::HashMap<(&'static str, String), i64>,
+                    k: &'static str,
+                    id: &str| {
+            *degree.entry((k, id.to_string())).or_insert(0) += 1;
+        };
+        let ent = FullGraphNodeKind::Entity.as_str();
+        let mtg = FullGraphNodeKind::Meeting.as_str();
+
+        // co_occurrence — entity↔entity (already visibility-gated; re-check both endpoints against the
+        // capped node set so an edge to a >500-cap-dropped entity is also dropped).
+        for ge in self.graph_edges_visible(unlocked)? {
+            if visible.contains(&(ent, ge.source.clone())) && visible.contains(&(ent, ge.target.clone()))
+            {
+                bump(&mut degree, ent, &ge.source);
+                bump(&mut degree, ent, &ge.target);
+                edges.push(FullGraphEdge {
+                    src: ge.source,
+                    dst: ge.target,
+                    kind: FullGraphEdgeKind::CoOccurrence,
+                    score: ge.weight as f64,
+                    status: "active".to_string(),
+                });
+            }
+        }
+        // mention — entity→meeting (gated by the SAME meeting-visible predicate; both endpoints then
+        // re-checked against the node set, so a mention into a sealed OR cap-dropped meeting is gone).
+        for (entity_id, meeting_id, weight) in self.entity_meeting_mentions_visible(unlocked)? {
+            if visible.contains(&(ent, entity_id.clone())) && visible.contains(&(mtg, meeting_id.clone()))
+            {
+                bump(&mut degree, ent, &entity_id);
+                bump(&mut degree, mtg, &meeting_id);
+                edges.push(FullGraphEdge {
+                    src: entity_id,
+                    dst: meeting_id,
+                    kind: FullGraphEdgeKind::Mention,
+                    score: weight as f64,
+                    status: "active".to_string(),
+                });
+            }
+        }
+        // links rows — wikilink/companion/semantic. active always; suggested semantic behind the flag.
+        // BOTH endpoints re-checked against the visible-node set (the links kind strings map 1:1 onto
+        // the node-kind strings: meeting|note|document), so a link to a sealed/absent node is dropped.
+        for (src_kind, src_id, dst_kind, dst_id, edge_type, score, status) in
+            self.full_graph_links(opts.include_suggested)?
+        {
+            let (Some(src_k), Some(dst_k)) = (
+                full_graph_link_kind_str(&src_kind),
+                full_graph_link_kind_str(&dst_kind),
+            ) else {
+                continue; // corrupt/unknown kind → skip defensively.
+            };
+            if !visible.contains(&(src_k, src_id.clone()))
+                || !visible.contains(&(dst_k, dst_id.clone()))
+            {
+                continue;
+            }
+            let Some(kind) = full_graph_edge_kind_from_type(&edge_type) else {
+                continue; // unknown edge_type → skip.
+            };
+            bump(&mut degree, src_k, &src_id);
+            bump(&mut degree, dst_k, &dst_id);
+            edges.push(FullGraphEdge {
+                src: src_id,
+                dst: dst_id,
+                kind,
+                score,
+                status,
+            });
+        }
+
+        // ── Degrees: assign each node its in-graph incident-edge count (a layout hint, never the true
+        //    corpus degree). Keyed by (kind, id) to avoid cross-kind id collisions. ──
+        for n in &mut nodes {
+            n.degree = degree
+                .get(&(n.kind.as_str(), n.id.clone()))
+                .copied()
+                .unwrap_or(0);
+        }
+
+        // Deterministic ordering: nodes by (kind, id ASC); edges by (kind, src, dst, status).
+        nodes.sort_by(|a, b| {
+            a.kind
+                .as_str()
+                .cmp(b.kind.as_str())
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        edges.sort_by(|a, b| {
+            a.kind
+                .as_str()
+                .cmp(b.kind.as_str())
+                .then_with(|| a.src.cmp(&b.src))
+                .then_with(|| a.dst.cmp(&b.dst))
+                .then_with(|| a.status.cmp(&b.status))
+        });
+
+        let has_hidden = self.has_hidden_folders(unlocked)?;
+        tracing::debug!(
+            target: "graph",
+            nodes = nodes.len(),
+            edges = edges.len(),
+            has_hidden,
+            "build_full_graph resolved"
+        );
+        Ok(FullGraphData {
+            nodes,
+            edges,
+            has_hidden,
+            total_visible_nodes,
+        })
+    }
+
+    /// The VISIBLE note + document nodes for the full-brain graph: `(kind, id, label, date)` per row,
+    /// gated by `visibility_clause` over `documents JOIN folders` (a sealed-and-not-session-unlocked
+    /// folder's rows are ABSENT — never masked). `kind='note'` → [`FullGraphNodeKind::Note`], anything
+    /// else → [`FullGraphNodeKind::Document`]. `label` = title, else the filesystem `name`. `date` =
+    /// the `updated_at`/`created_at` epoch-ms as a string (a sortable hint for the FE). Per-kind capped
+    /// (`MAX_FULL_GRAPH_PER_KIND`) ordered newest-first so the most-relevant rows survive on a big
+    /// vault; visibility is enforced in WHERE, so the cap trims magnitude only.
+    fn full_graph_content_nodes(
+        &self,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<FullGraphContentNode>> {
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        // Two capped passes (one per kind) so notes and documents each get their own budget rather
+        // than one starving the other on a lopsided vault.
+        let mut out: Vec<FullGraphContentNode> = Vec::new();
+        for (kind_str, node_kind) in [
+            ("note", FullGraphNodeKind::Note),
+            ("document", FullGraphNodeKind::Document),
+        ] {
+            let sql = format!(
+                "SELECT d.id, COALESCE(NULLIF(TRIM(d.title), ''), d.name),
+                        COALESCE(d.updated_at, d.created_at)
+                   FROM documents d
+                   JOIN folders f ON f.id = d.folder_id
+                  WHERE d.kind = ?1 AND {visible}
+                  ORDER BY COALESCE(d.updated_at, d.created_at) DESC, d.id ASC
+                  LIMIT {MAX_FULL_GRAPH_PER_KIND}"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![kind_str], |r| {
+                    let id: String = r.get(0)?;
+                    let label: String = r.get(1)?;
+                    let ts: Option<i64> = r.get(2)?;
+                    Ok((id, label, ts))
+                })
+                .map_err(map_err)?;
+            for r in rows {
+                let (id, label, ts) = r.map_err(map_err)?;
+                out.push((node_kind, id, label, ts.map(|t| t.to_string())));
+            }
+        }
+        Ok(out)
+    }
+
+    /// The TRUE (UNCAPPED) count of VISIBLE full-brain nodes: entities + meetings + notes +
+    /// documents, each under the SAME visibility predicate as its node reader but with NO per-kind
+    /// LIMIT. Drives `FullGraphData::total_visible_nodes` so the FE can disclose when a per-kind
+    /// render cap silently trimmed the graph (mirrors `count_entities_visible` for the entity graph).
+    /// A sealed-and-not-session-unlocked item is NOT counted (leak-free — a bare total).
+    fn count_full_graph_nodes_visible(&self, unlocked: &HashSet<String>) -> Result<i64> {
+        // Entities reuse the dedicated uncapped counter (same HAVING-visible-mention predicate).
+        let entities = self.count_entities_visible(unlocked, None)?;
+        let conn = self.lock();
+        // Meetings — the `list_meetings_visible` predicate, uncapped.
+        let m_visible = visibility_clause("f", unlocked);
+        let meetings: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM meetings m
+                       WHERE NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                          OR EXISTS (SELECT 1 FROM notes n
+                                       LEFT JOIN folders f ON f.id = n.folder_id
+                                      WHERE n.meeting_id = m.id AND {m_visible})"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        // Notes + documents — folder-gated, uncapped, both kinds.
+        let d_visible = visibility_clause("f", unlocked);
+        let docs: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE d.kind IN ('note', 'document') AND {d_visible}"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(entities + meetings + docs)
+    }
+
+    /// Entity→meeting MENTION edges for the full-brain graph: `(entity_id, meeting_id, weight)` for
+    /// every mention landing in a VISIBLE meeting (the SAME `EXISTS(visible note) OR NOT EXISTS(any
+    /// note)` predicate as `list_meetings_visible`/`graph_edges_visible`). `weight` is always 1 (one
+    /// mention row per (entity, meeting) — the PK guarantees it); kept as a field for edge-uniformity.
+    /// A mention into a sealed-and-not-session-unlocked meeting yields NO row, so it can never surface
+    /// a hidden meeting. Capped ordered by entity/meeting id for a bounded, deterministic payload.
+    fn entity_meeting_mentions_visible(
+        &self,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<(String, String, i64)>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        const MAX_MENTION_EDGES: usize = 2000;
+        let sql = format!(
+            "SELECT em.entity_id, em.meeting_id
+               FROM entity_mentions em
+               JOIN meetings m ON m.id = em.meeting_id
+              WHERE (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              ORDER BY em.entity_id ASC, em.meeting_id ASC
+              LIMIT {MAX_MENTION_EDGES}"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, 1i64))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Raw `links` rows for the full-brain graph, PRE-gating (the caller gates both endpoints against
+    /// the visible-node set). `status='active'` always; `status='suggested'` semantic rows ONLY when
+    /// `include_suggested`. `dismissed` rows are NEVER returned. Returns
+    /// `(src_kind, src_id, dst_kind, dst_id, edge_type, score, status)` ordered deterministically.
+    /// This reads no content columns — ids/kinds/metadata only — and is gated by the caller, so it is
+    /// leak-free at every call site.
+    fn full_graph_links(&self, include_suggested: bool) -> Result<Vec<FullGraphLinkRow>> {
+        let conn = self.lock();
+        // active: any edge_type. suggested: ONLY semantic (wikilink/companion are always active by
+        // construction; there is no "suggested wikilink"). dismissed tombstones stay excluded.
+        let status_pred = if include_suggested {
+            "(status = 'active' OR (status = 'suggested' AND edge_type = 'semantic'))"
+        } else {
+            "status = 'active'"
+        };
+        let sql = format!(
+            "SELECT src_kind, src_id, dst_kind, dst_id, edge_type, score, status
+               FROM links
+              WHERE {status_pred}
+              ORDER BY edge_type ASC, src_id ASC, dst_id ASC, id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, f64>(5)?,
+                    r.get::<_, String>(6)?,
+                ))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     /// Build the detail payload for one entity (`get_entity_detail`): the entity, its visible
     /// backlinked meetings, and its top co-occurring neighbors. `None` if the entity is unknown
     /// OR has ZERO visible mentions (mentioned only in sealed-not-unlocked meetings). The
@@ -13061,6 +13424,47 @@ fn backlink_sort_key(b: &BacklinkSource) -> i64 {
 /// created_by, status, score, created_at)`. Aliased so the reader's row `Vec` stays under clippy's
 /// type-complexity bar.
 type LinkRowRaw = (i64, String, String, String, String, String, String, String, f64, i64);
+
+/// One VISIBLE note/document node row for the full-brain graph, pre-typed: `(kind, id, label, date)`
+/// (`date` = the `updated_at`/`created_at` epoch-ms as a string). Aliased to keep
+/// [`Db::full_graph_content_nodes`]'s return under clippy's type-complexity bar.
+type FullGraphContentNode = (FullGraphNodeKind, String, String, Option<String>);
+
+/// One raw `links` row for the full-brain graph, PRE-gating: `(src_kind, src_id, dst_kind, dst_id,
+/// edge_type, score, status)` (ids/kinds/metadata only — no content). Aliased to keep
+/// [`Db::full_graph_links`]'s return under clippy's type-complexity bar.
+type FullGraphLinkRow = (String, String, String, String, String, f64, String);
+
+/// Per-kind render cap for the full-brain graph (`build_full_graph`, DESIGN §PR-4). Meetings, notes,
+/// and documents are each capped independently (entities keep their own 500 cap inside
+/// `list_entities_visible`) so the payload stays bounded on a large vault; visibility is enforced in
+/// WHERE, so the cap trims magnitude only — it can never widen what is visible. Mirrors the
+/// `MAX_GRAPH_EDGES`/`MAX_VISIBLE_ENTITIES` posture, disclosed via `total_visible_nodes`.
+const MAX_FULL_GRAPH_PER_KIND: usize = 500;
+
+/// Map a persisted `links.src_kind`/`dst_kind` string onto the STABLE full-graph node-kind key
+/// (`meeting`/`note`/`document`). `None` for anything unknown (a corrupt row → its edge is dropped).
+/// Deliberately NOT reusing `LinkKind::parse` → `.as_str()` so the returned `&'static str` is the
+/// canonical node-kind key used in the visible-node set (they happen to coincide, kept explicit).
+fn full_graph_link_kind_str(kind: &str) -> Option<&'static str> {
+    match kind {
+        "meeting" => Some(FullGraphNodeKind::Meeting.as_str()),
+        "note" => Some(FullGraphNodeKind::Note.as_str()),
+        "document" => Some(FullGraphNodeKind::Document.as_str()),
+        _ => None,
+    }
+}
+
+/// Map a persisted `links.edge_type` onto the full-graph edge kind. `None` for an unknown type (the
+/// edge is dropped). co_occurrence/mention are computed edges, never stored, so they are not here.
+fn full_graph_edge_kind_from_type(edge_type: &str) -> Option<FullGraphEdgeKind> {
+    match edge_type {
+        "wikilink" => Some(FullGraphEdgeKind::Wikilink),
+        "companion" => Some(FullGraphEdgeKind::Companion),
+        "semantic" => Some(FullGraphEdgeKind::Semantic),
+        _ => None,
+    }
+}
 
 fn visibility_clause(_alias: &str, unlocked: &HashSet<String>) -> String {
     let mut clause = String::from("(f.locked IS NULL OR f.locked = 0");
@@ -23051,6 +23455,244 @@ mod graph_tests {
                 .len(),
             1
         );
+    }
+
+    // ── Brain v3 PR-4 — full-brain graph gating + honesty tests ────────────────────────────────
+
+    /// Seed one `links` row directly (test helper; mirrors the raw-insert pattern the PR-3 link
+    /// tests use). Bypasses the write-time indexers so a test can pin `build_full_graph`'s edge
+    /// gating in isolation.
+    fn seed_link(
+        db: &Db,
+        src: (&str, &str),
+        dst: (&str, &str),
+        edge_type: &str,
+        status: &str,
+        score: f64,
+    ) {
+        db.lock()
+            .execute(
+                "INSERT INTO links
+                   (src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'auto', ?7, 1)",
+                rusqlite::params![src.0, src.1, dst.0, dst.1, edge_type, score, status],
+            )
+            .unwrap();
+    }
+
+    /// GATE (the load-bearing PR-4 test): sealing a folder removes its meeting/note/document NODES
+    /// from the full-brain graph AND every edge that touches them (both endpoints gated) — while the
+    /// open folder's nodes/edges survive. Session-unlocking the folder id restores everything.
+    /// RED-before-GREEN: drop the visible-node-set both-endpoint check (or read `documents`/meetings
+    /// ungated) and the sealed meeting/note/document — or an edge into them — leaks.
+    #[test]
+    fn build_full_graph_excludes_sealed_nodes_and_their_edges() {
+        let db = file_db("fullgraph-gate");
+        let kek = crate::crypto::random_key().unwrap();
+        seed_folder(&db, "open", "Open");
+        seed_folder(&db, "secret", "Secret");
+
+        // OPEN folder: a meeting (via seed_note), an authored note, and a document.
+        seed_note(&db, "m-open", "# open meeting", Some("open"));
+        db.insert_note("n-open", "open", "open-note", "Open Note", "body", 1_000)
+            .unwrap();
+        db.insert_document("d-open", "open", "open.pdf", "doc body", "document", 1_000)
+            .unwrap();
+        // SECRET folder: a meeting, a note, a document — all sealed below.
+        seed_note(&db, "m-secret", "# secret meeting", Some("secret"));
+        db.insert_note("n-secret", "secret", "secret-note", "Secret Note", "body", 1_000)
+            .unwrap();
+        db.insert_document("d-secret", "secret", "secret.pdf", "hush", "document", 1_000)
+            .unwrap();
+
+        // An entity mentioned in BOTH meetings (co-occurrence needs ≥2 in a meeting, but a single
+        // mention still makes a `mention` edge). Add a second entity so both meetings co-occur them.
+        let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+        let nova = db.upsert_entity("Nova", EntityKind::Person).unwrap();
+        db.add_mention(&atlas, "m-open").unwrap();
+        db.add_mention(&nova, "m-open").unwrap();
+        db.add_mention(&atlas, "m-secret").unwrap();
+        db.add_mention(&nova, "m-secret").unwrap();
+
+        // Links spanning the boundary:
+        //  - a wikilink open-note → secret-note (must vanish when secret seals: sealed endpoint);
+        //  - a companion secret-note → secret-meeting (both sealed → vanishes);
+        //  - a wikilink open-note → open-meeting (both open → survives).
+        seed_link(&db, ("note", "n-open"), ("note", "n-secret"), "wikilink", "active", 1.0);
+        seed_link(&db, ("note", "n-secret"), ("meeting", "m-secret"), "companion", "active", 1.0);
+        seed_link(&db, ("note", "n-open"), ("meeting", "m-open"), "wikilink", "active", 1.0);
+
+        let empty: HashSet<String> = HashSet::new();
+        let opts = FullGraphOpts::default();
+
+        // BEFORE sealing: every node + edge present.
+        let g0 = db.build_full_graph(&empty, opts).unwrap();
+        for id in ["m-open", "m-secret", "n-open", "n-secret", "d-open", "d-secret"] {
+            assert!(g0.nodes.iter().any(|n| n.id == id), "node {id} present pre-seal");
+        }
+        assert!(
+            g0.edges
+                .iter()
+                .any(|e| e.src == "n-open" && e.dst == "n-secret"),
+            "cross-folder wikilink present pre-seal"
+        );
+        assert!(!g0.has_hidden, "no locked folder pre-seal");
+
+        // SEAL the secret folder.
+        seal_folder(&db, "secret", &kek);
+        db.set_folder_locked("secret", true, None).unwrap();
+
+        let g1 = db.build_full_graph(&empty, opts).unwrap();
+        // The secret folder's nodes are GONE; the open ones survive.
+        for id in ["m-secret", "n-secret", "d-secret"] {
+            assert!(
+                !g1.nodes.iter().any(|n| n.id == id),
+                "sealed node {id} must not appear (leak)"
+            );
+        }
+        for id in ["m-open", "n-open", "d-open"] {
+            assert!(g1.nodes.iter().any(|n| n.id == id), "open node {id} survives");
+        }
+        // EVERY edge touching a sealed node is dropped — both directions.
+        assert!(
+            !g1.edges
+                .iter()
+                .any(|e| e.src.contains("secret") || e.dst.contains("secret")),
+            "no edge may touch a sealed node (both-endpoint gate)"
+        );
+        // The all-open wikilink survives.
+        assert!(
+            g1.edges
+                .iter()
+                .any(|e| e.src == "n-open" && e.dst == "m-open"),
+            "all-open wikilink survives the seal"
+        );
+        // The mention edges into the sealed meeting are gone; the open one survives.
+        assert!(
+            g1.edges
+                .iter()
+                .any(|e| e.kind == FullGraphEdgeKind::Mention && e.dst == "m-open"),
+            "mention into the open meeting survives"
+        );
+        assert!(
+            !g1.edges
+                .iter()
+                .any(|e| e.kind == FullGraphEdgeKind::Mention && e.dst == "m-secret"),
+            "mention into the sealed meeting is dropped"
+        );
+        assert!(g1.has_hidden, "a sealed-not-unlocked folder sets has_hidden");
+
+        // SESSION-UNLOCK the folder id → everything reappears.
+        let unlocked = unlocked_set(&["secret"]);
+        let g2 = db.build_full_graph(&unlocked, opts).unwrap();
+        for id in ["m-secret", "n-secret", "d-secret"] {
+            assert!(
+                g2.nodes.iter().any(|n| n.id == id),
+                "sealed node {id} reappears once the folder id is unlocked"
+            );
+        }
+        assert!(
+            g2.edges
+                .iter()
+                .any(|e| e.src == "n-open" && e.dst == "n-secret"),
+            "cross-folder wikilink returns when unlocked"
+        );
+        assert!(!g2.has_hidden, "no hidden folder once the only lock is unlocked");
+    }
+
+    /// A `status='suggested'` semantic link is HIDDEN unless `include_suggested` is on; an `active`
+    /// link is always present. RED-before-GREEN: read all non-dismissed rows regardless of the flag
+    /// and the suggested edge leaks into the default graph.
+    #[test]
+    fn build_full_graph_suggested_semantic_behind_opts_flag() {
+        let db = file_db("fullgraph-suggested");
+        seed_folder(&db, "f", "Notes");
+        db.insert_note("n1", "f", "n1", "Note One", "body", 1_000)
+            .unwrap();
+        db.insert_note("n2", "f", "n2", "Note Two", "body", 1_000)
+            .unwrap();
+        // An ACTIVE wikilink (always shown) + a SUGGESTED semantic (flag-gated), both n1↔n2.
+        seed_link(&db, ("note", "n1"), ("note", "n2"), "wikilink", "active", 1.0);
+        seed_link(&db, ("note", "n1"), ("note", "n2"), "semantic", "suggested", 0.9);
+
+        let empty: HashSet<String> = HashSet::new();
+        // DEFAULT (flag off): only the active wikilink edge.
+        let off = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        assert!(
+            off.edges
+                .iter()
+                .any(|e| e.kind == FullGraphEdgeKind::Wikilink),
+            "the active wikilink is always present"
+        );
+        assert!(
+            !off.edges
+                .iter()
+                .any(|e| e.kind == FullGraphEdgeKind::Semantic),
+            "a suggested semantic edge is hidden with the flag off"
+        );
+        // Flag ON: the suggested semantic edge appears with status='suggested'.
+        let on = db
+            .build_full_graph(
+                &empty,
+                FullGraphOpts {
+                    include_suggested: true,
+                },
+            )
+            .unwrap();
+        let sem = on
+            .edges
+            .iter()
+            .find(|e| e.kind == FullGraphEdgeKind::Semantic)
+            .expect("suggested semantic edge present with the flag on");
+        assert_eq!(sem.status, "suggested");
+        assert!((sem.score - 0.9).abs() < 1e-9, "semantic score = cosine");
+    }
+
+    /// HONEST CAPS: the per-kind node cap trims `nodes` while `total_visible_nodes` reports the TRUE
+    /// pre-cap count, and `has_hidden` reflects LOCKED folders independently. RED-before-GREEN: set
+    /// `total_visible_nodes = nodes.len()` and the silent cap-drop is invisible to the FE.
+    #[test]
+    fn build_full_graph_cap_and_has_hidden_are_honest() {
+        let db = file_db("fullgraph-cap");
+        seed_folder(&db, "f", "Notes");
+        // Seed one more note than the per-kind cap so the note leg is trimmed.
+        let over = MAX_FULL_GRAPH_PER_KIND + 3;
+        for i in 0..over {
+            db.insert_note(&format!("n{i:04}"), "f", &format!("n{i}"), &format!("Note {i}"), "body", 1_000)
+                .unwrap();
+        }
+        let empty: HashSet<String> = HashSet::new();
+        let g = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        let note_nodes = g
+            .nodes
+            .iter()
+            .filter(|n| n.kind == FullGraphNodeKind::Note)
+            .count();
+        assert_eq!(
+            note_nodes, MAX_FULL_GRAPH_PER_KIND,
+            "the note leg is capped at MAX_FULL_GRAPH_PER_KIND"
+        );
+        assert_eq!(
+            g.nodes.len(),
+            MAX_FULL_GRAPH_PER_KIND,
+            "the emitted node list is trimmed by the cap (only notes here)"
+        );
+        assert_eq!(
+            g.total_visible_nodes, over as i64,
+            "total_visible_nodes reports the TRUE (UNCAPPED) count — > nodes.len() when the cap trimmed"
+        );
+        assert!(
+            g.total_visible_nodes > g.nodes.len() as i64,
+            "the honest disclosure exposes the silent cap-drop"
+        );
+        // has_hidden is false with no locked folder — even though the cap trimmed rows (the two
+        // signals are distinct: cap-drop is disclosed via total_visible_nodes, not has_hidden).
+        assert!(!g.has_hidden, "cap-drop must NOT masquerade as a locked-folder hide");
+
+        // Lock a folder → has_hidden flips true, independent of the cap.
+        db.set_folder_locked("f", true, None).unwrap();
+        let g2 = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        assert!(g2.has_hidden, "a locked folder sets has_hidden");
     }
 
     /// `/people` CRM GATE: a Person mentioned ONLY in a sealed-and-not-session-unlocked meeting is

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -70,6 +70,116 @@ pub struct GraphData {
     pub total_visible_entities: i64,
 }
 
+// ── Brain v3 PR-4 — the FULL-BRAIN graph (typed, multi-kind) ─────────────────────────────────
+//
+// `get_graph` (above) is the ENTITY-ONLY graph and stays byte-compatible for its FE consumers.
+// The full-brain graph is a SEPARATE, additive payload that unifies entities + meetings + notes +
+// documents as TYPED nodes and every relation (co-occurrence + entity→meeting mentions + `links`
+// rows) as TYPED edges. It is a PURE READ — no writes, no new storage. Every node is emitted only
+// via its existing *_visible gate, and every edge requires BOTH endpoints to be in the visible-node
+// set (an edge to a sealed node is dropped). A sealed-and-not-session-unlocked meeting/note/document
+// contributes NOTHING — no node, and no edge that touches it.
+
+/// The kind of a full-brain graph NODE. `entity` = a person/project from the self-assembling graph;
+/// `meeting`/`note`/`document` = an owned-content item. Serialized lowercase for the FE lens toggles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FullGraphNodeKind {
+    Entity,
+    Meeting,
+    Note,
+    Document,
+}
+
+impl FullGraphNodeKind {
+    /// Stable lowercase discriminant (used in the visible-node-set key + deterministic ordering).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FullGraphNodeKind::Entity => "entity",
+            FullGraphNodeKind::Meeting => "meeting",
+            FullGraphNodeKind::Note => "note",
+            FullGraphNodeKind::Document => "document",
+        }
+    }
+}
+
+/// One TYPED node in the full-brain graph. `label` is the display title (already resolved through
+/// the visibility gate — a sealed item never produces a node, so a label is never a leak). `date` is
+/// an ISO-8601 / epoch-derived timestamp string when the source row carries one (`None` for
+/// entities). `degree` is the node's edge count WITHIN the returned (gated + capped) graph — a
+/// layout hint, never the true corpus degree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullGraphNode {
+    pub id: String,
+    pub kind: FullGraphNodeKind,
+    pub label: String,
+    pub date: Option<String>,
+    pub degree: i64,
+}
+
+/// The relation a full-brain edge encodes. `co_occurrence` = entity↔entity (shared visible meeting);
+/// `mention` = entity→meeting (`entity_mentions`); `wikilink`/`companion`/`semantic` = a `links` row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FullGraphEdgeKind {
+    CoOccurrence,
+    Mention,
+    Wikilink,
+    Companion,
+    Semantic,
+}
+
+impl FullGraphEdgeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FullGraphEdgeKind::CoOccurrence => "co_occurrence",
+            FullGraphEdgeKind::Mention => "mention",
+            FullGraphEdgeKind::Wikilink => "wikilink",
+            FullGraphEdgeKind::Companion => "companion",
+            FullGraphEdgeKind::Semantic => "semantic",
+        }
+    }
+}
+
+/// One TYPED edge in the full-brain graph. `src`/`dst` are node ids that MUST both be present in
+/// the returned `nodes` (BOTH-endpoint-gated — an edge to a sealed node is never emitted). `status`
+/// is `active` for deterministic edges (co-occurrence/mention/wikilink/companion + accepted
+/// semantic) and `suggested` for un-accepted semantic edges (only present when the opts flag is on).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullGraphEdge {
+    pub src: String,
+    pub dst: String,
+    pub kind: FullGraphEdgeKind,
+    pub score: f64,
+    pub status: String,
+}
+
+/// Options for `get_full_graph` / `build_full_graph`. Additive + all-default so the FE can call it
+/// with no args. `include_suggested` (default `false`) admits un-accepted (`status='suggested'`)
+/// semantic `links` rows — OFF by default so the graph shows only confirmed relations.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullGraphOpts {
+    #[serde(default)]
+    pub include_suggested: bool,
+}
+
+/// The full-brain graph payload (`get_full_graph`): TYPED nodes + TYPED edges + the same honest
+/// disclosure the entity graph makes. `has_hidden` is true when ≥1 folder is sealed-and-not-unlocked
+/// (some nodes/edges may be hidden). `total_visible_nodes` is the TRUE count of visible nodes BEFORE
+/// the per-kind render caps trimmed `nodes` — `total_visible_nodes > nodes.len()` means a cap
+/// dropped rows (distinct from `has_hidden`, which only reflects LOCKED folders).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullGraphData {
+    pub nodes: Vec<FullGraphNode>,
+    pub edges: Vec<FullGraphEdge>,
+    pub has_hidden: bool,
+    pub total_visible_nodes: i64,
+}
+
 /// A co-occurring neighbor of a selected entity (the neighborhood satellites), with the
 /// number of VISIBLE meetings the two share.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -46,6 +46,8 @@ import type {
   EntityDetail,
   Folder,
   FolderNode,
+  FullGraphData,
+  FullGraphOpts,
   GraphData,
   GraphPayload,
   Meeting,
@@ -1109,6 +1111,20 @@ export class IpcService {
    */
   getGraph(): Promise<GraphData> {
     return invoke<GraphData>("get_graph");
+  }
+
+  /**
+   * The FULL-BRAIN graph (Brain v3 PR-4): TYPED nodes (entities + VISIBLE
+   * meetings + notes + documents) and TYPED edges (co-occurrence + entity→meeting
+   * mentions + `links` rows). Snapshots the live session `unlocked` set exactly
+   * like {@link getGraph}, so re-fetch on a FoldersService lock-state change to
+   * drop / re-admit sealed nodes live. `opts.includeSuggested` (default `false`)
+   * admits un-accepted (`status: "suggested"`) semantic links — the ONLY option
+   * the FE must re-fetch on (every other lens filters the returned graph
+   * client-side). All-default, so a bare call returns the confirmed graph.
+   */
+  getFullGraph(opts?: FullGraphOpts): Promise<FullGraphData> {
+    return invoke<FullGraphData>("get_full_graph", { opts: opts ?? null });
   }
 
   /** Detail for one entity: the entity + its visible backlinked meetings + top neighbors. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1421,6 +1421,89 @@ export interface GraphData {
   totalVisibleEntities: number;
 }
 
+// ── Brain v3 PR-4 — the FULL-BRAIN graph (typed, multi-kind) ─────────────────
+//
+// A SEPARATE, additive payload (`getFullGraph`) from the entity-only `getGraph`.
+// It unifies entities + VISIBLE meetings + notes + documents as TYPED nodes and
+// every relation (entity co-occurrence + entity→meeting mentions + `links` rows)
+// as TYPED edges. Fully lock-gated server-side: a sealed-and-not-session-unlocked
+// item contributes NOTHING — no node, no edge touching it.
+
+/**
+ * The kind of a full-brain graph NODE (Rust `FullGraphNodeKind`, snake_case →
+ * these lowercase literals). Drives the per-kind node color + the node lens.
+ */
+export type FullGraphNodeKind = "entity" | "meeting" | "note" | "document";
+
+/**
+ * One TYPED node in the full-brain graph. `label` is the display title (already
+ * resolved through the visibility gate — a sealed item never produces a node).
+ * `date` is an ISO-8601 / epoch-derived string when the source carries one
+ * (`null` for entities). `degree` is the node's edge count WITHIN the returned
+ * (gated + capped) graph — a layout hint, never the true corpus degree.
+ */
+export interface FullGraphNode {
+  id: string;
+  kind: FullGraphNodeKind;
+  label: string;
+  date: string | null;
+  degree: number;
+}
+
+/**
+ * The relation a full-brain edge encodes (Rust `FullGraphEdgeKind`, snake_case).
+ * `co_occurrence` = entity↔entity; `mention` = entity→meeting; `wikilink` /
+ * `companion` / `semantic` = a `links` row. Drives the per-kind edge style + the
+ * edge lens.
+ */
+export type FullGraphEdgeKind =
+  | "co_occurrence"
+  | "mention"
+  | "wikilink"
+  | "companion"
+  | "semantic";
+
+/**
+ * One TYPED edge in the full-brain graph. `src`/`dst` are node ids that BOTH
+ * appear in `nodes` (both-endpoint-gated). `status` is `"active"` for
+ * deterministic edges (co-occurrence/mention/wikilink/companion + accepted
+ * semantic) and `"suggested"` for un-accepted semantic edges (only present when
+ * `includeSuggested` was on) — a suggested edge is drawn dashed.
+ */
+export interface FullGraphEdge {
+  src: string;
+  dst: string;
+  kind: FullGraphEdgeKind;
+  score: number;
+  status: "active" | "suggested";
+}
+
+/**
+ * Options for `getFullGraph`. All-default so the FE can call it with none.
+ * `includeSuggested` (default `false`) admits un-accepted (`status: "suggested"`)
+ * semantic `links` rows — the "Suggested links" lens toggle. Toggling it is the
+ * ONE case that re-fetches (the backend must include/exclude the rows); every
+ * other lens filters the already-fetched graph client-side (no re-fetch).
+ */
+export interface FullGraphOpts {
+  includeSuggested: boolean;
+}
+
+/**
+ * The full-brain graph payload from `getFullGraph()`: TYPED nodes + TYPED edges +
+ * the same honest disclosure the entity graph makes. `hasHidden` is true when
+ * ≥1 folder is sealed-and-not-unlocked (some nodes/edges may be hidden).
+ * `totalVisibleNodes` is the TRUE count of visible nodes BEFORE the per-kind
+ * render caps trimmed `nodes` (`totalVisibleNodes > nodes.length` = a cap
+ * dropped rows — distinct from `hasHidden`, which only reflects LOCKED folders).
+ */
+export interface FullGraphData {
+  nodes: FullGraphNode[];
+  edges: FullGraphEdge[];
+  hasHidden: boolean;
+  totalVisibleNodes: number;
+}
+
 /** A co-occurring neighbor of a selected entity (a neighborhood satellite). */
 export interface EntityNeighbor {
   id: string;

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -244,6 +244,44 @@
     }
   </section>
 
+  <!-- 3b — FULL BRAIN: entities + meetings + notes + documents as ONE typed,
+       lens-filterable graph (Brain v3 PR-4). Collapsed by default; the child
+       self-loads via IPC + the folder tree only once opened. -->
+  <section class="b-conn">
+    <button
+      type="button"
+      class="b-conn-toggle"
+      [attr.aria-expanded]="fullBrainOpen()"
+      (click)="fullBrainOpen.set(!fullBrainOpen())"
+    >
+      <svg
+        class="b-conn-chevron"
+        [class.is-open]="fullBrainOpen()"
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M5.5 4l5 4-5 4"
+          stroke="currentColor"
+          stroke-width="1.7"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="b-conn-title">Full brain graph</span>
+      <span class="b-conn-sub">
+        Everything — meetings, notes, documents and people — as one map.
+      </span>
+    </button>
+
+    @if (fullBrainOpen()) {
+      <app-full-brain-graph />
+    }
+  </section>
+
   <!-- 4 — MEMORY: "what the brain knows about you" (collapsible) --------- -->
   <app-brain-memory />
 

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -22,6 +22,7 @@ import { FoldersService } from "../../../services/folders.service";
 import { ToastService } from "../../../services/toast.service";
 import { BrainEnableCardComponent } from "../brain-enable-card/brain-enable-card.component";
 import { BrainMapComponent } from "../brain-map/brain-map.component";
+import { FullBrainGraphComponent } from "../full-brain-graph/full-brain-graph.component";
 import { BrainMemoryComponent } from "../brain-memory/brain-memory.component";
 import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor.component";
 import { BrainSourceCardComponent } from "../brain-source-card/brain-source-card.component";
@@ -83,6 +84,7 @@ interface FolderOption {
     BrainSourceCardComponent,
     BrainNoteEditorComponent,
     BrainMapComponent,
+    FullBrainGraphComponent,
     BrainMemoryComponent,
     BriefsComponent,
     AuditComponent,
@@ -306,6 +308,13 @@ export class BrainComponent {
   readonly graphLoading = signal(true);
   readonly graphError = signal<string | null>(null);
   readonly connOpen = signal(false);
+
+  /**
+   * The FULL-BRAIN graph section (entities + meetings + notes + documents as one
+   * typed graph, Brain v3 PR-4) — collapsed by default; its component self-loads
+   * via IPC + the folder tree, so it costs nothing until opened.
+   */
+  readonly fullBrainOpen = signal(false);
 
   protected readonly nodeCount = computed(
     () => this.graphData()?.nodes.length ?? 0,

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
@@ -1,0 +1,143 @@
+<section class="fbg">
+  @if (loading()) {
+    <div class="card state-card">
+      <p class="empty">Loading your brain…</p>
+    </div>
+  } @else if (error()) {
+    <div class="card empty-state">
+      <span class="empty-mark" aria-hidden="true"></span>
+      <p class="empty-title">Couldn’t load the graph</p>
+      <p class="empty">{{ error() }}</p>
+    </div>
+  } @else if (totalNodes() === 0) {
+    <div class="card empty-state">
+      <span class="empty-mark" aria-hidden="true"></span>
+      <p class="empty-title">Your brain graph builds itself</p>
+      <p class="empty">
+        As you record meetings and add notes and documents, they’ll appear here
+        — connected by the people, wikilinks and companions they share.
+      </p>
+    </div>
+  } @else {
+    <!-- Honest disclosures (mirror the entity graph). -->
+    @if (hasHidden()) {
+      <div class="banner is-accent fbg-banner" role="status">
+        <span class="fbg-banner-glyph" aria-hidden="true"></span>
+        <span>Some items are hidden — unlock a folder to include them.</span>
+      </div>
+    }
+    @if (capDisclosure(); as msg) {
+      <div class="banner is-accent fbg-banner" role="status">
+        <span class="fbg-banner-glyph" aria-hidden="true"></span>
+        <span>{{ msg }}</span>
+      </div>
+    }
+
+    <!-- LENSES — node-type + edge-type toggle chips (filter what's drawn). -->
+    <div class="fbg-lenses">
+      <div class="fbg-lens-group" role="group" aria-label="Show node types">
+        <span class="fbg-lens-label">Nodes</span>
+        @for (l of nodeLenses; track l.kind) {
+          <button
+            type="button"
+            class="fbg-chip"
+            [class.is-off]="!nodeLens()[l.kind]"
+            [attr.aria-pressed]="nodeLens()[l.kind]"
+            (click)="toggleNode(l.kind)"
+          >
+            <span
+              class="fbg-chip-dot"
+              [style.background]="'var(' + l.token + ')'"
+              aria-hidden="true"
+            ></span>
+            {{ l.label }}
+          </button>
+        }
+      </div>
+
+      <div class="fbg-lens-group" role="group" aria-label="Show edge types">
+        <span class="fbg-lens-label">Links</span>
+        @for (l of edgeLenses; track l.kind) {
+          <button
+            type="button"
+            class="fbg-chip"
+            [class.is-off]="!edgeLens()[l.kind]"
+            [attr.aria-pressed]="edgeLens()[l.kind]"
+            (click)="toggleEdge(l.kind)"
+          >
+            <span
+              class="fbg-chip-dot"
+              [style.background]="'var(' + l.token + ')'"
+              aria-hidden="true"
+            ></span>
+            {{ l.label }}
+          </button>
+        }
+        <button
+          type="button"
+          class="fbg-chip is-suggested"
+          [class.is-off]="!showSuggested()"
+          [attr.aria-pressed]="showSuggested()"
+          (click)="toggleSuggested()"
+        >
+          <span class="fbg-chip-dash" aria-hidden="true"></span>
+          Suggested
+        </button>
+      </div>
+    </div>
+
+    <div class="fbg-frame">
+      <canvas
+        appFullBrainScene
+        class="fbg-canvas"
+        role="img"
+        [attr.aria-label]="ariaLabel()"
+        [sceneNodes]="sceneNodes()"
+        [sceneEdges]="sceneEdges()"
+        [selectedId]="selectedId()"
+        (nodePick)="onPick($event)"
+        (nodeHover)="hoverId.set($event)"
+      ></canvas>
+
+      <div class="fbg-toolbar" role="toolbar" aria-label="Graph controls">
+        <div class="fbg-pill fbg-count" aria-hidden="true">
+          {{ drawnNodeCount() }} items · {{ drawnEdgeCount() }} links
+        </div>
+        <div class="fbg-pill fbg-zoom">
+          <button
+            type="button"
+            class="fbg-zbtn"
+            aria-label="Zoom in"
+            (click)="zoomIn()"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            class="fbg-zbtn"
+            aria-label="Zoom out"
+            (click)="zoomOut()"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            class="fbg-zbtn fbg-zreset"
+            aria-label="Reset view"
+            (click)="resetView()"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <p class="fbg-hint" aria-live="polite">
+      @if (hoverLabel(); as label) {
+        {{ label }}
+      } @else {
+        Drag to pan · scroll to zoom · click a node to open it.
+      }
+    </p>
+  }
+</section>

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.scss
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.scss
@@ -1,0 +1,188 @@
+:host {
+  display: block;
+}
+.fbg {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Honest-disclosure banner (mirrors the entity graph's g-banner). */
+.fbg-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.fbg-banner-glyph {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  flex: none;
+}
+
+/* ── LENSES — node/edge toggle chips (in-flow, above the frame) ── */
+.fbg-lenses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+.fbg-lens-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.fbg-lens-label {
+  font: 600 0.75rem var(--font-sans);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-right: var(--space-1);
+}
+.fbg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  appearance: none;
+  height: 28px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  font: 600 0.8125rem var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+.fbg-chip:hover {
+  background: var(--surface-raised);
+}
+.fbg-chip:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+}
+/* An OFF lens reads muted + hollow — its content is filtered out. */
+.fbg-chip.is-off {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+  opacity: 0.7;
+}
+.fbg-chip.is-off .fbg-chip-dot,
+.fbg-chip.is-off .fbg-chip-dash {
+  opacity: 0.4;
+}
+.fbg-chip-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: var(--radius-pill);
+  flex: none;
+}
+.fbg-chip-dash {
+  width: 14px;
+  height: 0;
+  flex: none;
+  border-top: 2px dashed var(--graph-document);
+}
+
+/* ── the canvas frame + floating chrome ── */
+.fbg-frame {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+}
+.fbg-canvas {
+  display: block;
+  width: 100%;
+  height: clamp(440px, 66vh, 720px);
+  /* The scene's FIXED deep-indigo floor (mirrors the directive's BG). NOT a
+     surface token: glow/tint only reads on dark, so the graph stays a dark
+     field even under the light theme (same rationale as the neural map). */
+  background: #080914;
+  touch-action: none;
+  user-select: none;
+  outline: none;
+}
+
+/* Floating chrome INSIDE the frame — OPAQUE pills (--surface-overlay, never
+   the frosted .card) so the graph never bleeds through them (rule T3). */
+.fbg-toolbar {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  right: var(--space-3);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  pointer-events: none;
+}
+.fbg-toolbar > * {
+  pointer-events: auto;
+}
+.fbg-pill {
+  display: inline-flex;
+  align-items: center;
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: none;
+}
+.fbg-count {
+  padding: 0 var(--space-4);
+  height: 32px;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+.fbg-zoom {
+  padding: 2px;
+  gap: 2px;
+}
+.fbg-zbtn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 0.9375rem/1 var(--font-sans);
+  min-width: 28px;
+  height: 26px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+.fbg-zbtn:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.fbg-zbtn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+}
+.fbg-zreset {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.fbg-hint {
+  margin: 0;
+  min-height: 1.1em;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fbg-chip,
+  .fbg-zbtn {
+    transition: none;
+  }
+}

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -1,0 +1,491 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { Router } from "@angular/router";
+import { IpcService } from "../../../core/ipc.service";
+import type {
+  FullGraphData,
+  FullGraphEdge,
+  FullGraphEdgeKind,
+  FullGraphNode,
+  FullGraphNodeKind,
+} from "../../../core/models";
+import { FoldersService } from "../../../services/folders.service";
+import { TabsService } from "../../../core/tabs.service";
+import {
+  FullBrainSceneDirective,
+  type FullSceneEdge,
+  type FullSceneNode,
+} from "./full-brain-scene.directive";
+
+/** Per-kind node lens chip metadata (label + the token that colors its dot). */
+interface NodeLens {
+  kind: FullGraphNodeKind;
+  label: string;
+  token: string;
+}
+/** Per-kind edge lens chip metadata. */
+interface EdgeLens {
+  kind: FullGraphEdgeKind;
+  label: string;
+  token: string;
+}
+
+/** Rendered-node hard cap — the strongest-degree top-K keep the draw bounded. */
+const MAX_NODES = 140;
+/** Fixed force-directed iteration count — run ONCE, synchronously, no loop. */
+const ITERATIONS = 260;
+/** Logical world scale (world units); the scene camera fits to the cloud. */
+const WORLD = 1000;
+
+/**
+ * The FULL-BRAIN GRAPH — `getFullGraph()` rendered as one unified, typed graph:
+ * entities + meetings + notes + documents as per-kind-colored somas, and every
+ * relation (co-occurrence / mention / wikilink / companion / semantic) as a
+ * per-kind styled edge (suggested semantic links drawn DASHED, admitted only
+ * when their lens is on).
+ *
+ * SPLIT OF RESPONSIBILITY (zoneless):
+ * - THIS COMPONENT owns the pure data: the IPC effect-load (stale-guarded,
+ *   re-fetching on a {@link FoldersService} lock-state change, and — only for
+ *   the "Suggested links" toggle — passing `includeSuggested` so the backend
+ *   admits/omits those rows), the LENS signals (node-kind + edge-kind toggle
+ *   chips), the filtered view `computed()` (a lens toggle NEVER re-fetches — it
+ *   recomputes over the already-fetched graph), and the deterministic one-shot
+ *   Fruchterman-Reingold layout `computed()`.
+ * - {@link FullBrainSceneDirective} owns every DOM-loop concern (ResizeObserver,
+ *   invalidate-on-demand paint, pointer input) per angular-zoneless §5.
+ *
+ * CLICK-THROUGH: a node click routes by kind — meeting → `/meeting/:id`,
+ * note/document → the note editor (`/notes/:id`, both are `documents` rows),
+ * entity → the `/graph` page with `?entity=<id>` preselected (reuse existing
+ * nav). Sizing is handled by the directive's ResizeObserver (no `setTimeout`).
+ */
+@Component({
+  selector: "app-full-brain-graph",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FullBrainSceneDirective],
+  templateUrl: "./full-brain-graph.component.html",
+  styleUrl: "./full-brain-graph.component.scss",
+})
+export class FullBrainGraphComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly folders = inject(FoldersService);
+  private readonly router = inject(Router);
+  private readonly tabs = inject(TabsService);
+
+  private readonly scene = viewChild(FullBrainSceneDirective);
+
+  // ── fetched state ────────────────────────────────────────────────────────
+  readonly graphData = signal<FullGraphData | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  // ── lenses (node-type + edge-type toggle chips) ──────────────────────────
+  /** Which NODE kinds are drawn. All on by default. */
+  private readonly _nodeLens = signal<Record<FullGraphNodeKind, boolean>>({
+    entity: true,
+    meeting: true,
+    note: true,
+    document: true,
+  });
+  /** Which EDGE kinds are drawn. All on by default. */
+  private readonly _edgeLens = signal<Record<FullGraphEdgeKind, boolean>>({
+    co_occurrence: true,
+    mention: true,
+    wikilink: true,
+    companion: true,
+    semantic: true,
+  });
+  readonly nodeLens = this._nodeLens.asReadonly();
+  readonly edgeLens = this._edgeLens.asReadonly();
+
+  /**
+   * Include un-accepted (`status: "suggested"`) semantic links. This is the ONE
+   * lens that RE-FETCHES (the backend must add/remove those rows); its `effect`
+   * re-runs `getFullGraph({ includeSuggested })`. Every other lens filters the
+   * already-fetched graph client-side.
+   */
+  readonly showSuggested = signal(false);
+
+  protected readonly nodeLenses: readonly NodeLens[] = [
+    { kind: "entity", label: "People & projects", token: "--graph-entity" },
+    { kind: "meeting", label: "Meetings", token: "--graph-meeting" },
+    { kind: "note", label: "Notes", token: "--graph-note" },
+    { kind: "document", label: "Documents", token: "--graph-document" },
+  ];
+  protected readonly edgeLenses: readonly EdgeLens[] = [
+    { kind: "co_occurrence", label: "Co-occurrence", token: "--text-muted" },
+    { kind: "mention", label: "Mentions", token: "--text-secondary" },
+    { kind: "wikilink", label: "Wikilinks", token: "--accent" },
+    { kind: "companion", label: "Companion", token: "--graph-note" },
+    { kind: "semantic", label: "Semantic", token: "--graph-document" },
+  ];
+
+  // ── hover hint (a11y / affordance) ───────────────────────────────────────
+  readonly hoverId = signal<string | null>(null);
+  readonly selectedId = signal<string | null>(null);
+
+  // ── honest disclosures (mirror the entity graph) ─────────────────────────
+  protected readonly hasHidden = computed(
+    () => this.graphData()?.hasHidden ?? false,
+  );
+  protected readonly isCapped = computed(() => {
+    const d = this.graphData();
+    return !!d && d.totalVisibleNodes > d.nodes.length;
+  });
+  protected readonly capDisclosure = computed<string | null>(() => {
+    const d = this.graphData();
+    if (!d || !this.isCapped()) {
+      return null;
+    }
+    return `Showing ${d.nodes.length} of ${d.totalVisibleNodes} items.`;
+  });
+
+  /** Total nodes the backend returned (before any lens filtering). */
+  protected readonly totalNodes = computed(
+    () => this.graphData()?.nodes.length ?? 0,
+  );
+
+  // ── the LENS-FILTERED view-model (pure computed — NO re-fetch on toggle) ──
+  /**
+   * The nodes actually drawn: the fetched nodes, keeping only lens-enabled kinds.
+   * A lens toggle recomputes THIS — it never re-issues an IPC call (the graph is
+   * already in hand). `showSuggested` is the sole exception and is handled by the
+   * fetch effect, not here.
+   */
+  private readonly filteredNodes = computed<FullGraphNode[]>(() => {
+    const d = this.graphData();
+    if (!d) {
+      return [];
+    }
+    const lens = this._nodeLens();
+    return d.nodes.filter((n) => lens[n.kind]);
+  });
+
+  /** The edges drawn: both endpoints kind-visible AND the edge kind lens-enabled. */
+  private readonly filteredEdges = computed<FullGraphEdge[]>(() => {
+    const d = this.graphData();
+    if (!d) {
+      return [];
+    }
+    const eLens = this._edgeLens();
+    const visible = new Set(this.filteredNodes().map((n) => n.id));
+    return d.edges.filter(
+      (e) => eLens[e.kind] && visible.has(e.src) && visible.has(e.dst),
+    );
+  });
+
+  /** Counts for the header caption ("N items · M links"), post-lens. */
+  protected readonly drawnNodeCount = computed(
+    () => this.filteredNodes().length,
+  );
+  protected readonly drawnEdgeCount = computed(
+    () => this.filteredEdges().length,
+  );
+
+  /**
+   * The laid-out scene nodes — a PURE derivation of the lens-filtered graph.
+   * Top-{@link MAX_NODES} by in-graph degree (id tiebreak), circular seed keyed
+   * by sort index, a fixed {@link ITERATIONS}-iteration 2-D Fruchterman-Reingold
+   * pass (pairwise repulsion + edge springs + gentle centre pull), then an
+   * overlap-relaxation pass. Deterministic: no `Math.random`, coincident points
+   * get index-hash nudges — same data → identical layout every render.
+   */
+  protected readonly sceneNodes = computed<FullSceneNode[]>(() => {
+    const all = this.filteredNodes();
+    if (all.length === 0) {
+      return [];
+    }
+    // Deterministic order: highest-degree first, id as a stable tiebreak.
+    const ordered = [...all].sort(
+      (a, b) => b.degree - a.degree || a.id.localeCompare(b.id),
+    );
+    const nodes = ordered.slice(0, MAX_NODES);
+    const n = nodes.length;
+    const idIndex = new Map(nodes.map((x, i) => [x.id, i]));
+
+    // Degree → soma radius (7…20 world units), sqrt-scaled.
+    const maxDeg = Math.max(1, ...nodes.map((x) => x.degree));
+    const radii = nodes.map(
+      (x) => 7 + (Math.sqrt(x.degree) / Math.sqrt(maxDeg)) * 13,
+    );
+
+    // SEED: a golden-angle spiral keyed by sort index → identical every render.
+    const golden = Math.PI * (3 - Math.sqrt(5));
+    const seedR = WORLD * 0.42;
+    const xs = new Float64Array(n);
+    const ys = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      const rr = seedR * Math.sqrt((i + 0.5) / n);
+      const ang = i * golden;
+      xs[i] = rr * Math.cos(ang);
+      ys[i] = rr * Math.sin(ang);
+    }
+
+    // Only edges whose endpoints both survived the cap participate in springs.
+    const edges = this.filteredEdges().filter(
+      (e) => idIndex.has(e.src) && idIndex.has(e.dst),
+    );
+    const degree = new Map<string, number>();
+    for (const e of edges) {
+      degree.set(e.src, (degree.get(e.src) ?? 0) + 1);
+      degree.set(e.dst, (degree.get(e.dst) ?? 0) + 1);
+    }
+
+    // 2-D Fruchterman-Reingold.
+    const k = Math.sqrt((WORLD * WORLD) / Math.max(1, n)) * 1.1;
+    const k2 = k * k;
+    let temp = WORLD * 0.14;
+    const cool = temp / (ITERATIONS + 1);
+    const dxs = new Float64Array(n);
+    const dys = new Float64Array(n);
+
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      dxs.fill(0);
+      dys.fill(0);
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          let dx = xs[i] - xs[j];
+          let dy = ys[i] - ys[j];
+          let d2 = dx * dx + dy * dy;
+          if (d2 < 0.01) {
+            dx = ((i * 31 + j) % 7) - 3 + 0.5;
+            dy = ((i * 17 + j) % 5) - 2 + 0.5;
+            d2 = dx * dx + dy * dy;
+          }
+          const dist = Math.sqrt(d2);
+          const force = k2 / dist;
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          dxs[i] += fx;
+          dys[i] += fy;
+          dxs[j] -= fx;
+          dys[j] -= fy;
+        }
+      }
+      for (const e of edges) {
+        const i = idIndex.get(e.src) as number;
+        const j = idIndex.get(e.dst) as number;
+        const dx = xs[i] - xs[j];
+        const dy = ys[i] - ys[j];
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        // Attenuate hub springs (÷√min-degree) so high-degree nodes don't crush
+        // their whole neighbourhood into one clump.
+        const hub = Math.sqrt(
+          Math.min(degree.get(e.src) ?? 1, degree.get(e.dst) ?? 1),
+        );
+        const force = ((dist * dist) / k / hub) * 0.9;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        dxs[i] -= fx;
+        dys[i] -= fy;
+        dxs[j] += fx;
+        dys[j] += fy;
+      }
+      for (let i = 0; i < n; i++) {
+        const dl = Math.sqrt(dxs[i] * dxs[i] + dys[i] * dys[i]) || 1;
+        const step = Math.min(dl, temp);
+        xs[i] += (dxs[i] / dl) * step;
+        ys[i] += (dys[i] / dl) * step;
+        xs[i] -= xs[i] * 0.006;
+        ys[i] -= ys[i] * 0.006;
+      }
+      temp = Math.max(0, temp - cool);
+    }
+
+    // Recentre on the centroid.
+    let mx = 0;
+    let my = 0;
+    for (let i = 0; i < n; i++) {
+      mx += xs[i];
+      my += ys[i];
+    }
+    mx /= n;
+    my /= n;
+    for (let i = 0; i < n; i++) {
+      xs[i] -= mx;
+      ys[i] -= my;
+    }
+
+    // OVERLAP RELAXATION: push any two somas apart until clear.
+    for (let pass = 0; pass < 30; pass++) {
+      let moved = false;
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          let dx = xs[i] - xs[j];
+          let dy = ys[i] - ys[j];
+          let dist = Math.sqrt(dx * dx + dy * dy);
+          const need = radii[i] + radii[j] + 16;
+          if (dist >= need) {
+            continue;
+          }
+          if (dist < 0.01) {
+            dx = ((i * 31 + j) % 7) - 3 + 0.5;
+            dy = ((i * 17 + j) % 5) - 2 + 0.5;
+            dist = Math.sqrt(dx * dx + dy * dy);
+          }
+          const push = (need - dist) / 2 / dist;
+          xs[i] += dx * push;
+          ys[i] += dy * push;
+          xs[j] -= dx * push;
+          ys[j] -= dy * push;
+          moved = true;
+        }
+      }
+      if (!moved) {
+        break;
+      }
+    }
+
+    return nodes.map((node, i) => ({
+      id: node.id,
+      kind: node.kind,
+      label: node.label,
+      r: radii[i],
+      x: xs[i],
+      y: ys[i],
+    }));
+  });
+
+  /** The scene edges (between surviving nodes), with a stable key + dashed flag. */
+  protected readonly sceneEdges = computed<FullSceneEdge[]>(() => {
+    const ids = new Set(this.sceneNodes().map((p) => p.id));
+    const out: FullSceneEdge[] = [];
+    for (const e of this.filteredEdges()) {
+      if (ids.has(e.src) && ids.has(e.dst)) {
+        out.push({
+          key: `${e.src}::${e.dst}::${e.kind}`,
+          src: e.src,
+          dst: e.dst,
+          kind: e.kind,
+          suggested: e.status === "suggested",
+        });
+      }
+    }
+    return out;
+  });
+
+  protected readonly ariaLabel = computed(() => {
+    const nodes = this.drawnNodeCount();
+    const edges = this.drawnEdgeCount();
+    if (nodes === 0) {
+      return "Full-brain graph — empty.";
+    }
+    return (
+      `Full-brain graph of ${nodes} ${nodes === 1 ? "item" : "items"} and ` +
+      `${edges} ${edges === 1 ? "connection" : "connections"}.`
+    );
+  });
+
+  /** The label of the currently hovered node, for the live affordance line. */
+  protected readonly hoverLabel = computed<string | null>(() => {
+    const id = this.hoverId();
+    if (!id) {
+      return null;
+    }
+    return this.filteredNodes().find((n) => n.id === id)?.label ?? null;
+  });
+
+  constructor() {
+    // Make sure the folder tree is loaded (drives the lock-aware re-fetch below).
+    void this.folders.load();
+
+    /**
+     * Load the full graph, re-loading whenever the folder lock-state changes OR
+     * the "Suggested links" toggle flips (the ONLY option that changes what the
+     * backend returns). Reading `folders.tree()` + `showSuggested()` registers
+     * both as dependencies; a stale-result guard drops a late response so a fast
+     * toggle/unlock never leaves a mismatched graph. Every OTHER lens filters
+     * the fetched graph via `computed()` — it must NOT re-fetch.
+     */
+    let seq = 0;
+    effect(() => {
+      this.folders.tree();
+      const includeSuggested = this.showSuggested();
+      const mine = ++seq;
+      this.error.set(null);
+      void (async () => {
+        try {
+          const data = await this.ipc.getFullGraph({ includeSuggested });
+          if (mine !== seq) {
+            return; // superseded by a newer fetch
+          }
+          this.graphData.set(data);
+          // Drop a selection whose node vanished (re-sealed / lens-hidden).
+          const sel = this.selectedId();
+          if (sel && !data.nodes.some((n) => n.id === sel)) {
+            this.selectedId.set(null);
+          }
+        } catch (e) {
+          if (mine !== seq) {
+            return;
+          }
+          this.graphData.set(null);
+          this.error.set(String(e));
+        } finally {
+          if (mine === seq) {
+            this.loading.set(false);
+          }
+        }
+      })();
+    });
+  }
+
+  // ── lens toggles (recompute the view; never re-fetch) ────────────────────
+  protected toggleNode(kind: FullGraphNodeKind): void {
+    this._nodeLens.update((l) => ({ ...l, [kind]: !l[kind] }));
+  }
+  protected toggleEdge(kind: FullGraphEdgeKind): void {
+    this._edgeLens.update((l) => ({ ...l, [kind]: !l[kind] }));
+  }
+  protected toggleSuggested(): void {
+    this.showSuggested.update((v) => !v);
+  }
+
+  // ── camera toolbar (delegates to the scene directive) ────────────────────
+  protected zoomIn(): void {
+    this.scene()?.zoomBy(1.25);
+  }
+  protected zoomOut(): void {
+    this.scene()?.zoomBy(0.8);
+  }
+  protected resetView(): void {
+    this.scene()?.resetView();
+  }
+
+  // ── click-through (route by node kind — reuse existing nav) ──────────────
+  protected onPick(id: string | null): void {
+    if (id === null) {
+      this.selectedId.set(null);
+      return;
+    }
+    const node = this.graphData()?.nodes.find((n) => n.id === id);
+    if (!node) {
+      return;
+    }
+    this.selectedId.set(id);
+    switch (node.kind) {
+      case "meeting":
+        void this.router.navigate(["/meeting", id]);
+        break;
+      case "note":
+      case "document":
+        // Both are `documents` rows — the note editor renders either.
+        void this.tabs.openNote(id, node.label || "Note");
+        break;
+      case "entity":
+        // Reuse the /graph page's entity detail via a preselect deep-link.
+        void this.router.navigate(["/graph"], {
+          queryParams: { entity: id },
+        });
+        break;
+    }
+  }
+}

--- a/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
@@ -1,0 +1,606 @@
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  untracked,
+} from "@angular/core";
+import type {
+  FullGraphEdgeKind,
+  FullGraphNodeKind,
+} from "../../../core/models";
+
+/**
+ * A node the {@link FullBrainGraphComponent} has already laid out (world units,
+ * origin-centred) — the directive only projects + paints it, never lays out.
+ */
+export interface FullSceneNode {
+  id: string;
+  kind: FullGraphNodeKind;
+  label: string;
+  /** Radius in world units (degree-scaled by the component). */
+  r: number;
+  x: number;
+  y: number;
+}
+
+/** A laid-out edge whose endpoints both survived the lens filter. */
+export interface FullSceneEdge {
+  /** `${src}::${dst}::${kind}` — stable identity. */
+  key: string;
+  src: string;
+  dst: string;
+  kind: FullGraphEdgeKind;
+  /** `true` = un-accepted semantic suggestion → drawn DASHED. */
+  suggested: boolean;
+}
+
+type Rgb = [number, number, number];
+
+/* ── THE SCENE PALETTE — a FIXED dark field, independent of the page theme ──
+ * Same rationale as neural-scene.directive.ts: glow/tint only reads on a dark
+ * surface, so the canvas is its own artwork field even under the light theme
+ * (design review R3). The four node hues MIRROR the DOM tokens
+ * `--graph-entity/-meeting/-note/-document` (whose values the chips + legend
+ * dots consume) — kept in sync by intent, exactly like the neural-scene
+ * PERSON/PROJECT constants mirror the legend dots. */
+const BG: Rgb = [8, 9, 20];
+const BG_LIFT: Rgb = [17, 19, 40];
+const NODE_COLORS: Record<FullGraphNodeKind, Rgb> = {
+  entity: [91, 189, 255], // #5bbdff azure
+  meeting: [255, 157, 92], // #ff9d5c amber
+  note: [76, 224, 160], // #4ce0a0 mint
+  document: [200, 111, 242], // #c86ff2 orchid
+};
+const LABEL: Rgb = [216, 222, 242];
+const WHITE: Rgb = [255, 255, 255];
+
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 4;
+
+function rgba(c: Rgb, a: number): string {
+  return `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+}
+
+function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/**
+ * The FULL-BRAIN scene renderer — a canvas-drawn, pan/zoom multi-kind graph over
+ * the typed nodes/edges the {@link FullBrainGraphComponent} lays out: per-kind
+ * colored somas with labels, per-kind styled edges (co-occurrence/mention thin,
+ * wikilink/companion solid accent, semantic — suggested drawn DASHED), hover +
+ * click-through, on a fixed deep-indigo field.
+ *
+ * ZONELESS RULE (.claude/rules/angular-zoneless.md §5): a bare rAF/timer or a
+ * DOM observer in a COMPONENT is banned — every DOM-loop concern (the
+ * ResizeObserver, the reduced-motion + visibilitychange + color-scheme
+ * listeners, the invalidate-on-demand paint) lives HERE in a directive and is
+ * released in `DestroyRef.onDestroy()`. There is NO continuous animation loop:
+ * the scene is a still that repaints on input / camera / hover change via
+ * `invalidate()` (a single one-shot `requestAnimationFrame`), so it costs
+ * nothing at rest and needs no reduced-motion branch beyond skipping repaints
+ * while hidden.
+ *
+ * The component owns the deterministic Fruchterman-Reingold LAYOUT (a pure
+ * `computed()`); this directive owns only projection, paint, and pointer input.
+ */
+@Directive({
+  selector: "canvas[appFullBrainScene]",
+  host: {
+    "[style.cursor]": "cursor()",
+    "(pointerdown)": "onPointerDown($event)",
+    "(pointermove)": "onPointerMove($event)",
+    "(pointerup)": "onPointerUp($event)",
+    "(pointercancel)": "onPointerUp($event)",
+    "(pointerleave)": "onPointerLeave()",
+    "(wheel)": "onWheel($event)",
+  },
+})
+export class FullBrainSceneDirective {
+  private readonly hostRef = inject<ElementRef<HTMLCanvasElement>>(ElementRef);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Laid-out nodes (world coordinates, origin-centred). */
+  readonly sceneNodes = input<FullSceneNode[]>([]);
+  /** Laid-out edges between surviving nodes. */
+  readonly sceneEdges = input<FullSceneEdge[]>([]);
+  /** The focused node id (null = no focus) — drives neighbourhood dimming. */
+  readonly selectedId = input<string | null>(null);
+
+  /** Click: a node id, or null for empty space (the component owns navigation). */
+  readonly nodePick = output<string | null>();
+  /** Hover enter/leave over a node (the component drives an aria-live hint). */
+  readonly nodeHover = output<string | null>();
+
+  private readonly _hoverId = signal<string | null>(null);
+  private readonly _dragging = signal(false);
+  protected readonly cursor = computed(() =>
+    this._dragging()
+      ? "grabbing"
+      : this._hoverId() !== null
+        ? "pointer"
+        : "grab",
+  );
+
+  /** Selected node + its one-hop neighbours (null = no focus). */
+  private readonly neighborSet = computed<Set<string> | null>(() => {
+    const sel = this.selectedId();
+    if (!sel) {
+      return null;
+    }
+    const set = new Set<string>([sel]);
+    for (const e of this.sceneEdges()) {
+      if (e.src === sel) {
+        set.add(e.dst);
+      } else if (e.dst === sel) {
+        set.add(e.src);
+      }
+    }
+    return set;
+  });
+
+  // camera (world → screen: screen = center + pan + world * scale)
+  private scale = 1;
+  private panX = 0;
+  private panY = 0;
+  private fitted = false;
+
+  // pointer
+  private pointerDown = false;
+  private dragMoved = false;
+  private downX = 0;
+  private downY = 0;
+  private lastPX = 0;
+  private lastPY = 0;
+
+  // projected screen positions (index-aligned with sceneNodes())
+  private proj: { sx: number; sy: number; sr: number }[] = [];
+
+  private cssW = 0;
+  private cssH = 0;
+  private oneShotId: number | null = null;
+  private ctx: CanvasRenderingContext2D | null;
+
+  private readonly ro = new ResizeObserver((entries) => {
+    const rect = entries[entries.length - 1]?.contentRect;
+    if (!rect || rect.width < 2 || rect.height < 2) {
+      return;
+    }
+    const wasZero = this.cssW < 2 || this.cssH < 2;
+    this.cssW = rect.width;
+    this.cssH = rect.height;
+    if (wasZero) {
+      this.fitted = false; // (re)fit once we have a real size
+    }
+    this.invalidate();
+  });
+  private readonly onVisibility = (): void => {
+    if (!document.hidden) {
+      this.invalidate();
+    }
+  };
+  private readonly scheme = window.matchMedia("(prefers-color-scheme: light)");
+  private readonly onScheme = (): void => this.invalidate();
+
+  constructor() {
+    this.ctx = this.hostRef.nativeElement.getContext("2d");
+    this.ro.observe(this.hostRef.nativeElement);
+    document.addEventListener("visibilitychange", this.onVisibility);
+    this.scheme.addEventListener("change", this.onScheme);
+
+    // Refit + repaint when the laid-out graph changes; a signal write inside a
+    // tracked effect is allowed since Angular 19. The hover read is untracked so
+    // hovering doesn't refit.
+    effect(() => {
+      const nodes = this.sceneNodes();
+      this.sceneEdges();
+      this.fitted = false;
+      const hover = untracked(() => this._hoverId());
+      if (hover !== null && !nodes.some((n) => n.id === hover)) {
+        this._hoverId.set(null);
+        this.nodeHover.emit(null);
+      }
+      this.invalidate();
+    });
+
+    // Repaint on selection/hover change (neighbourhood dimming).
+    effect(() => {
+      this.selectedId();
+      this._hoverId();
+      this.invalidate();
+    });
+
+    this.destroyRef.onDestroy(() => {
+      if (this.oneShotId !== null) {
+        cancelAnimationFrame(this.oneShotId);
+        this.oneShotId = null;
+      }
+      this.ro.disconnect();
+      document.removeEventListener("visibilitychange", this.onVisibility);
+      this.scheme.removeEventListener("change", this.onScheme);
+    });
+  }
+
+  // ── public camera API (the component's toolbar drives these) ──────────
+
+  zoomBy(factor: number): void {
+    const old = this.scale;
+    this.scale = clamp(old * factor, MIN_SCALE, MAX_SCALE);
+    const k = this.scale / old;
+    this.panX *= k;
+    this.panY *= k;
+    this.invalidate();
+  }
+
+  resetView(): void {
+    this.fitted = false;
+    this.panX = 0;
+    this.panY = 0;
+    this.invalidate();
+  }
+
+  // ── pointer / wheel (host listeners) ──────────────────────────────────
+
+  protected onPointerDown(event: PointerEvent): void {
+    if (event.button !== 0) {
+      return;
+    }
+    this.pointerDown = true;
+    this.dragMoved = false;
+    this.downX = event.clientX;
+    this.downY = event.clientY;
+    this.lastPX = event.clientX;
+    this.lastPY = event.clientY;
+    (event.target as Element).setPointerCapture?.(event.pointerId);
+  }
+
+  protected onPointerMove(event: PointerEvent): void {
+    if (this.pointerDown) {
+      const dx = event.clientX - this.lastPX;
+      const dy = event.clientY - this.lastPY;
+      this.lastPX = event.clientX;
+      this.lastPY = event.clientY;
+      if (
+        !this.dragMoved &&
+        Math.hypot(event.clientX - this.downX, event.clientY - this.downY) > 4
+      ) {
+        this.dragMoved = true;
+        this._dragging.set(true);
+      }
+      if (this.dragMoved) {
+        this.panX += dx;
+        this.panY += dy;
+        this.invalidate();
+      }
+      return;
+    }
+    const hit = this.hitTest(event);
+    if (hit !== this._hoverId()) {
+      this._hoverId.set(hit);
+      this.nodeHover.emit(hit);
+      this.invalidate();
+    }
+  }
+
+  protected onPointerUp(event: PointerEvent): void {
+    const wasClick = this.pointerDown && !this.dragMoved;
+    this.pointerDown = false;
+    this.dragMoved = false;
+    this._dragging.set(false);
+    (event.target as Element).releasePointerCapture?.(event.pointerId);
+    if (wasClick) {
+      this.nodePick.emit(this.hitTest(event));
+    }
+    this.invalidate();
+  }
+
+  protected onPointerLeave(): void {
+    if (this._hoverId() !== null) {
+      this._hoverId.set(null);
+      this.nodeHover.emit(null);
+      this.invalidate();
+    }
+  }
+
+  /** Wheel = zoom toward the cursor (the point under it stays put). */
+  protected onWheel(event: WheelEvent): void {
+    event.preventDefault();
+    const rect = this.hostRef.nativeElement.getBoundingClientRect();
+    const ox = event.clientX - rect.left - rect.width / 2;
+    const oy = event.clientY - rect.top - rect.height / 2;
+    const factor = Math.exp(clamp(event.deltaY, -80, 80) * -0.0016);
+    const old = this.scale;
+    this.scale = clamp(old * factor, MIN_SCALE, MAX_SCALE);
+    const k = this.scale / old;
+    this.panX = ox - (ox - this.panX) * k;
+    this.panY = oy - (oy - this.panY) * k;
+    this.invalidate();
+  }
+
+  // ── paint (invalidate-on-demand, no continuous loop) ──────────────────
+
+  /** One-shot repaint; coalesces multiple invalidations into one frame. */
+  private invalidate(): void {
+    if (this.oneShotId !== null || document.hidden) {
+      return;
+    }
+    this.oneShotId = requestAnimationFrame(() => {
+      this.oneShotId = null;
+      this.render();
+    });
+  }
+
+  /** Fit the laid-out cloud into the padded viewport (once per graph/resize). */
+  private fit(): void {
+    const nodes = this.sceneNodes();
+    if (nodes.length === 0 || this.cssW < 4 || this.cssH < 4) {
+      this.scale = 1;
+      this.panX = 0;
+      this.panY = 0;
+      return;
+    }
+    let maxX = 1;
+    let maxY = 1;
+    for (const n of nodes) {
+      maxX = Math.max(maxX, Math.abs(n.x) + n.r);
+      maxY = Math.max(maxY, Math.abs(n.y) + n.r);
+    }
+    const padW = this.cssW / 2 - 40;
+    const padH = this.cssH / 2 - 40;
+    this.scale = clamp(
+      Math.min(padW / maxX, padH / maxY),
+      MIN_SCALE,
+      MAX_SCALE,
+    );
+    this.panX = 0;
+    this.panY = 0;
+  }
+
+  private render(): void {
+    const ctx = this.ctx;
+    const canvas = this.hostRef.nativeElement;
+    const w = this.cssW;
+    const h = this.cssH;
+    if (!ctx || w < 4 || h < 4 || document.hidden) {
+      return;
+    }
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const bw = Math.max(1, Math.round(w * dpr));
+    const bh = Math.max(1, Math.round(h * dpr));
+    if (canvas.width !== bw || canvas.height !== bh) {
+      canvas.width = bw;
+      canvas.height = bh;
+    }
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    if (!this.fitted) {
+      this.fit();
+      this.fitted = true;
+    }
+
+    // ── backdrop (deep-indigo field + gentle vignette) ──
+    const bg = ctx.createLinearGradient(0, 0, 0, h);
+    bg.addColorStop(0, rgba(BG_LIFT, 1));
+    bg.addColorStop(0.6, rgba(BG, 1));
+    bg.addColorStop(1, rgba(mix(BG, BG_LIFT, 0.35), 1));
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, w, h);
+    const vg = ctx.createRadialGradient(
+      w / 2,
+      h / 2,
+      Math.min(w, h) * 0.4,
+      w / 2,
+      h / 2,
+      Math.max(w, h) * 0.78,
+    );
+    vg.addColorStop(0, "rgba(0,0,0,0)");
+    vg.addColorStop(1, "rgba(0,0,0,0.45)");
+    ctx.fillStyle = vg;
+    ctx.fillRect(0, 0, w, h);
+
+    const nodes = this.sceneNodes();
+    const n = nodes.length;
+    if (n === 0) {
+      return;
+    }
+
+    const cx = w / 2 + this.panX;
+    const cy = h / 2 + this.panY;
+    const s = this.scale;
+    const idIndex = new Map(nodes.map((nd, i) => [nd.id, i]));
+    this.proj = nodes.map((nd) => ({
+      sx: cx + nd.x * s,
+      sy: cy + nd.y * s,
+      sr: Math.max(2.5, nd.r * s),
+    }));
+
+    const hover = this._hoverId();
+    const selId = this.selectedId();
+    const focus = this.neighborSet();
+
+    // ── edges (per-kind style; suggested = dashed) ──
+    ctx.lineCap = "round";
+    for (const e of this.sceneEdges()) {
+      const a = idIndex.get(e.src);
+      const b = idIndex.get(e.dst);
+      if (a === undefined || b === undefined) {
+        continue;
+      }
+      const A = this.proj[a];
+      const B = this.proj[b];
+      const inFocus =
+        !focus || (focus.has(e.src) && focus.has(e.dst));
+      const touchesSel =
+        selId !== null && (e.src === selId || e.dst === selId);
+      const hoverHit =
+        hover !== null && (e.src === hover || e.dst === hover);
+
+      const style = this.edgeStyle(e.kind);
+      let alpha = style.alpha;
+      let width = style.width;
+      if (!focus) {
+        // no selection — everything at rest strength
+      } else if (inFocus) {
+        alpha = Math.min(0.95, alpha * 1.8);
+        width += 0.4;
+      } else {
+        alpha *= 0.22; // out-of-neighbourhood ghost
+      }
+      if (touchesSel) {
+        alpha = Math.min(1, alpha * 1.4);
+        width += 0.6;
+      }
+      if (hoverHit) {
+        alpha = Math.min(1, alpha * 1.5);
+      }
+
+      ctx.globalAlpha = alpha;
+      ctx.strokeStyle = rgba(style.color, 1);
+      ctx.lineWidth = width;
+      ctx.setLineDash(e.suggested ? [5, 5] : []);
+      ctx.beginPath();
+      ctx.moveTo(A.sx, A.sy);
+      ctx.lineTo(B.sx, B.sy);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+
+    // ── nodes (per-kind color; label when big/hovered/focused) ──
+    const t = getComputedStyle(canvas);
+    const font =
+      t.getPropertyValue("--font-sans").trim() || "system-ui, sans-serif";
+    ctx.font = `600 12px ${font}`;
+    ctx.textAlign = "center";
+    ctx.lineJoin = "round";
+    for (let i = 0; i < n; i++) {
+      const nd = nodes[i];
+      const p = this.proj[i];
+      const inSet = !focus || focus.has(nd.id);
+      const a = inSet ? 1 : 0.28;
+      const isSel = selId === nd.id;
+      const isHover = hover === nd.id;
+      const col = NODE_COLORS[nd.kind];
+
+      // soft halo
+      ctx.globalAlpha = a * 0.5;
+      const halo = ctx.createRadialGradient(
+        p.sx,
+        p.sy,
+        0,
+        p.sx,
+        p.sy,
+        p.sr * 2.4,
+      );
+      halo.addColorStop(0, rgba(col, 0.4));
+      halo.addColorStop(1, rgba(col, 0));
+      ctx.fillStyle = halo;
+      ctx.beginPath();
+      ctx.arc(p.sx, p.sy, p.sr * 2.4, 0, Math.PI * 2);
+      ctx.fill();
+
+      // core
+      ctx.globalAlpha = a;
+      const core = ctx.createRadialGradient(
+        p.sx - p.sr * 0.25,
+        p.sy - p.sr * 0.25,
+        0,
+        p.sx,
+        p.sy,
+        p.sr,
+      );
+      core.addColorStop(0, rgba(mix(col, WHITE, 0.6), 1));
+      core.addColorStop(0.7, rgba(col, 1));
+      core.addColorStop(1, rgba(mix(col, BG, 0.4), 1));
+      ctx.fillStyle = core;
+      ctx.beginPath();
+      ctx.arc(p.sx, p.sy, p.sr, 0, Math.PI * 2);
+      ctx.fill();
+
+      if (isSel || isHover) {
+        ctx.globalAlpha = 0.95;
+        ctx.strokeStyle = rgba(isSel ? col : WHITE, 0.95);
+        ctx.lineWidth = isSel ? 2.4 : 1.4;
+        ctx.beginPath();
+        ctx.arc(p.sx, p.sy, p.sr + (isSel ? 4 : 2.5), 0, Math.PI * 2);
+        ctx.stroke();
+      }
+
+      // label — always for the focused set / hovered / selected, else only
+      // reasonably large somas (keeps dense graphs legible).
+      const showLabel =
+        isSel || isHover || (focus ? inSet : p.sr >= 7);
+      if (showLabel && p.sr >= 3) {
+        const label =
+          nd.label.length > 26 ? nd.label.slice(0, 25) + "…" : nd.label;
+        const ly = p.sy + p.sr + 13;
+        ctx.globalAlpha = isSel || isHover ? 1 : a * 0.85;
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = rgba(BG, 0.9);
+        ctx.strokeText(label, p.sx, ly);
+        ctx.fillStyle = rgba(isSel || isHover ? WHITE : LABEL, 1);
+        ctx.fillText(label, p.sx, ly);
+      }
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  /** Per-edge-kind stroke color + base alpha/width (design encoding). */
+  private edgeStyle(kind: FullGraphEdgeKind): {
+    color: Rgb;
+    alpha: number;
+    width: number;
+  } {
+    switch (kind) {
+      case "co_occurrence":
+        return { color: [120, 130, 170], alpha: 0.28, width: 1 };
+      case "mention":
+        return { color: [150, 160, 210], alpha: 0.34, width: 1.1 };
+      case "wikilink":
+        return { color: [110, 118, 255], alpha: 0.55, width: 1.6 };
+      case "companion":
+        return { color: [76, 224, 160], alpha: 0.55, width: 1.6 };
+      case "semantic":
+        return { color: [200, 111, 242], alpha: 0.5, width: 1.4 };
+    }
+  }
+
+  /** Nearest node under the pointer (uses the last frame's projection). */
+  private hitTest(event: PointerEvent): string | null {
+    const rect = this.hostRef.nativeElement.getBoundingClientRect();
+    const px = event.clientX - rect.left;
+    const py = event.clientY - rect.top;
+    const nodes = this.sceneNodes();
+    let best: string | null = null;
+    let bestR = Infinity;
+    for (let i = 0; i < nodes.length; i++) {
+      const p = this.proj[i];
+      if (!p) {
+        continue;
+      }
+      const rr = Math.max(p.sr, 9) + 3;
+      const dx = px - p.sx;
+      const dy = py - p.sy;
+      const d2 = dx * dx + dy * dy;
+      if (d2 <= rr * rr && d2 < bestR) {
+        bestR = d2;
+        best = nodes[i].id;
+      }
+    }
+    return best;
+  }
+}

--- a/src/app/features/graph/graph/graph.component.ts
+++ b/src/app/features/graph/graph/graph.component.ts
@@ -6,6 +6,9 @@ import {
   inject,
   signal,
 } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { map } from "rxjs";
 import { IpcService } from "../../../core/ipc.service";
 import type { GraphData, GraphNode } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
@@ -46,6 +49,18 @@ interface DirectorySection {
 export class GraphComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
+  private readonly route = inject(ActivatedRoute);
+
+  /**
+   * An optional `?entity=<id>` query param — the entry point the full-brain
+   * graph uses for its entity click-through ("reuse existing nav"). Read as a
+   * signal; an effect preselects it once the graph resolves (a `computed`
+   * `selectedId` can't be user-toggled, so it seeds a writable signal instead).
+   */
+  private readonly entityParam = toSignal(
+    this.route.queryParamMap.pipe(map((p) => p.get("entity"))),
+    { initialValue: null },
+  );
 
   readonly graphData = signal<GraphData | null>(null);
   readonly loading = signal(true);
@@ -158,6 +173,23 @@ export class GraphComponent {
     // fetchGraph() writes the loading/error/data signals (synchronously before
     // its first await), so this tracked effect must be allowed to write.
   );
+
+  /**
+   * Preselect the `?entity=<id>` deep-link once its node is visible in the
+   * loaded graph (the full-brain graph navigates here for entity click-through).
+   * Only applies while nothing is selected yet, so it seeds the initial view
+   * without stomping a later user selection; a missing/sealed entity is ignored.
+   */
+  private readonly _applyEntityParam = effect(() => {
+    const wanted = this.entityParam();
+    const data = this.graphData();
+    if (!wanted || !data) {
+      return;
+    }
+    if (this.selectedId() === null && data.nodes.some((n) => n.id === wanted)) {
+      this.selectedId.set(wanted);
+    }
+  });
 
   private async fetchGraph(): Promise<void> {
     this.error.set(null);

--- a/src/design-tokens/colors.css
+++ b/src/design-tokens/colors.css
@@ -56,4 +56,15 @@
   --shape-insert: #43c59e;
   --shape-info: #e0a944;
   --shape-artifact: #c86ff2;
+
+  /* --- Full-brain graph NODE-KIND hues (Brain v3 PR-4) --------------------
+     One hue per node kind in the full-brain graph — used for the DOM lens
+     chips + the legend dots. The canvas scene mirrors these as fixed scene
+     constants on its own dark field (see full-brain-scene.directive.ts, same
+     rationale as the neural-scene PERSON/PROJECT palette). ≥60° hue apart so
+     the four kinds read as distinct dots. */
+  --graph-entity: #5bbdff;   /* azure — people/projects (matches the map)   */
+  --graph-meeting: #ff9d5c;  /* warm amber — recorded meetings              */
+  --graph-note: #4ce0a0;     /* mint — authored notes                       */
+  --graph-document: #c86ff2; /* orchid — imported documents                 */
 }

--- a/src/design-tokens/theme-light.css
+++ b/src/design-tokens/theme-light.css
@@ -38,6 +38,12 @@
   --shape-insert: #128a67;
   --shape-info: #b07d1a;
   --shape-artifact: #9d3fca;
+  /* Full-brain graph node-kind hues — darkened for legibility on the light
+     surface (the DOM chips/legend dots; the canvas keeps its own dark field). */
+  --graph-entity: #1c86d6;
+  --graph-meeting: #d16a1e;
+  --graph-note: #128a5e;
+  --graph-document: #9d3fca;
   --shadow-sm: 0 1px 2px rgba(18, 18, 40, 0.10);
   --shadow-md: 0 12px 30px rgba(18, 18, 40, 0.10);
   --shadow-lg: 0 22px 55px rgba(18, 18, 40, 0.13);
@@ -93,6 +99,10 @@
     --shape-insert: #128a67;
     --shape-info: #b07d1a;
     --shape-artifact: #9d3fca;
+    --graph-entity: #1c86d6;
+    --graph-meeting: #d16a1e;
+    --graph-note: #128a5e;
+    --graph-document: #9d3fca;
     --shadow-sm: 0 1px 2px rgba(18, 18, 40, 0.10);
     --shadow-md: 0 12px 30px rgba(18, 18, 40, 0.10);
     --shadow-lg: 0 22px 55px rgba(18, 18, 40, 0.13);


### PR DESCRIPTION
PR-4 of the Brain v3 program (spec: docs/superpowers/specs/2026-07-17-brain-v3-design.md). The graph view goes from entities-only to the whole brain.

## What's new
- **`get_full_graph` / `build_full_graph`** — typed nodes (`entity | meeting | note | document`) + typed edges (`co_occurrence | mention | wikilink | companion | semantic`), sourced from the PR-3 links engine plus the entity graph.
- **Lenses** — node-type and edge-type toggle chips filter the view **client-side** (a `computed()` recompute, never a refetch); suggested semantic edges show only behind an opt-in flag (the one option that refetches).
- **New `full-brain-scene` directive** — multi-kind canvas, one-shot 2-D Fruchterman–Reingold, `ResizeObserver` + invalidate-on-demand paint, `DestroyRef` cleanup (no rAF loop, no `setTimeout`). Click-through: meeting → detail, note/document → note tab, entity → entity detail.
- The existing entity-only `get_graph` / `build_graph` / `app-brain-map` are **byte-compatible** (no regression).

## Lock model
A pure, additive, fully-gated aggregate read: every node comes from a `*_visible` reader, every edge requires **both** endpoints in the gated visible-node set — a sealed folder's meeting/note/document and any edge touching it are **absent** (not masked). Honest disclosure: `has_hidden` (locked folders) is distinct from the per-kind 500 cap (`total_visible_nodes` reports the true count).

## Verification
- New gating tests RED-before-GREEN (sealed nodes + their edges excluded; suggested-behind-flag; cap/has_hidden honesty). `clippy --lib --tests -D warnings` clean; `ng lint` + `ng build` clean (new component SCSS 4.1 kB < 16 kB budget).
- **adversarial-verifier: PASS. lock-security-reviewer: PASS.**
- No new dependencies (reuses the existing canvas idiom — no graph lib).

Note: a full-suite run may intermittently flake on 3 pre-existing `reason::` sidecar-timeout tests under CPU contention (unrelated to this PR — it touches no `reason/` code; they pass in isolation).