### PR TITLE
feat(brain): Receipts — every note claim clickable to the second of audio

### DIFF
--- a/e2e/detail/receipts.spec.ts
+++ b/e2e/detail/receipts.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Brain v3 PR-5 (Receipts) — END-TO-END FE wiring. The backend
+ * (`get_note_receipts`, `meeting_is_unlocked`-gated + deterministic
+ * `align_claims_to_segments`) is proven by `cargo test --lib`; this drives the
+ * REAL Angular bundle (only the Tauri IPC boundary is mocked) to prove the
+ * user-facing claim the adversarial verifier flagged as absent dead code:
+ *
+ *   - a receipt chip renders in the Note tab for each aligned claim,
+ *   - clicking it switches to the Audio tab, seeks the player to the claim's
+ *     second, and FLASHES the proving transcript segment (`.frag.is-flash`).
+ *
+ * RED contract (fails on commit 43b7926, the unwired state): `getNoteReceipts`
+ * had zero callers, `note-panel` had no `[receipts]` input and rendered no chip,
+ * and `audio-panel` had no `[seekTarget]` input driving the flash — so the
+ * `.receipt-chip` below never existed and the click had nothing to drive.
+ */
+test.describe("Detail — Receipts (claim → second of audio)", () => {
+  test("a note claim's receipt chip seeks the Audio tab and flashes its segment", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // A meeting whose note has ONE claim line that the transcript proves.
+      // The mocked `get_note_receipts` mirrors the backend's shape: an alignment
+      // for that claim (claimIndex into `markdown.split('\n')`) → segment idx 1.
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-receipts",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T09:10:00Z",
+          title: "Receipts meeting",
+          durationS: 600,
+          audioPath: null,
+          status: "EXPORTED",
+          folderId: null,
+        },
+        note: {
+          meetingId: "m-receipts",
+          providerId: "claude_code",
+          // Line 0 heading, line 1 blank, line 2 the claim (matches segment 1).
+          markdown:
+            "## Decisions\n\nWe will ship the redaction firewall next sprint.",
+          exportedPath: null,
+        },
+        segments: [
+          {
+            idx: 0,
+            startS: 0,
+            endS: 30,
+            text: "Intro chatter before the decision.",
+            speaker: "others",
+          },
+          {
+            idx: 1,
+            startS: 120,
+            endS: 150,
+            text: "We will ship the redaction firewall next sprint.",
+            speaker: "me",
+          },
+        ],
+        assistantInteractions: [],
+        locked: false,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
+      // The gated receipt read. Line index 2 = the claim; segment idx 1 at 120s.
+      get_note_receipts: () => [
+        {
+          claimIndex: 2,
+          segmentId: 1,
+          startS: 120,
+          endS: 150,
+          speaker: "me",
+          confidence: 0.92,
+          overlap: 0.85,
+        },
+      ],
+    });
+
+    await page.goto("/meeting/m-receipts");
+
+    // The Note tab is the default: the receipt chip renders, labelled with the
+    // claim snippet + speaker + m:ss timestamp.
+    const chip = page.locator("button.receipt-chip");
+    await expect(chip).toHaveCount(1, { timeout: 10_000 });
+    await expect(chip).toContainText("redaction firewall");
+    await expect(chip).toContainText("Me");
+    await expect(chip).toContainText("2:00");
+
+    // Clicking it switches to the Audio tab (its panel is now mounted).
+    await chip.click();
+    await expect(page.getByRole("tab", { name: "Audio" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    // The proving segment (idx 1) flashes — the wired-up `flashSegId` pulse.
+    const flashed = page.locator(".frag.is-flash");
+    await expect(flashed).toHaveCount(1, { timeout: 10_000 });
+    await expect(flashed).toContainText("redaction firewall");
+  });
+
+  test("a locked meeting surfaces NO receipt chips (backend returns none)", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      // A masked/locked meeting: the backend nulls the note + audio and the gated
+      // `get_note_receipts` returns []. The Note tab must render no receipt chip.
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-locked",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T09:10:00Z",
+          title: "🔒 Locked",
+          durationS: 600,
+          audioPath: null,
+          status: "EXPORTED",
+          folderId: "f-locked",
+        },
+        note: null,
+        segments: [],
+        assistantInteractions: [],
+        locked: true,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
+      get_note_receipts: () => [],
+    });
+
+    await page.goto("/meeting/m-locked");
+    // The lock gate renders; no receipt chip exists behind the lock.
+    await expect(page.locator("button.receipt-chip")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  });
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2688,6 +2688,59 @@ pub(crate) fn get_manual_notes_inner(
     state.db.get_manual_notes(meeting_id)
 }
 
+/// Brain v3 PR-5 (Receipts): the audio receipt for every claim in a meeting's CURRENT note — the
+/// transcript segment each note line most likely derives from, so the FE can seek the shipped audio
+/// player/timeline to that second and prove the claim (speaker + ASR confidence in the tooltip).
+///
+/// Deterministic + on-device (extends `summarize::grounding`'s token-overlap pass — no LLM, no
+/// egress). Recomputed on demand from the current note + segments, so there is NO new storage and
+/// therefore NO new seal path (nothing at rest to encrypt/verify-before-destroy).
+///
+/// LOCK-MODEL (audio-adjacent read): the `meeting_is_unlocked` gate is FIRST. A sealed-and-NOT-
+/// session-unlocked meeting returns an EMPTY list — never a segment time, speaker, or overlap that
+/// would leak WHEN something was said or by WHOM, matching the masked DTO that already nulls
+/// `audio_path`. Past the gate we read the note + segments through the SAME gated readers the detail
+/// DTO uses (`get_latest_note_for_meeting` / `get_segments`), align, and return alignments only —
+/// the DTO carries no note/transcript text (just a line index + the segment's audio coordinates +
+/// non-content metadata). No PII in logs (id + count only).
+#[tauri::command]
+pub fn get_note_receipts(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<crate::summarize::grounding::ClaimAlignment>, AppError> {
+    get_note_receipts_inner(state.inner(), &meeting_id)
+}
+
+/// Inner of [`get_note_receipts`] taking `&AppState` (unit-testable gate). Empty list for a
+/// sealed-not-unlocked meeting; empty list when there is no note yet (nothing to receipt).
+pub(crate) fn get_note_receipts_inner(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<Vec<crate::summarize::grounding::ClaimAlignment>, AppError> {
+    // GATE FIRST — a locked meeting leaks NOTHING (no segment times, no speakers, no overlaps).
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Ok(Vec::new());
+    }
+    let Some(note) = state.db.get_latest_note_for_meeting(meeting_id)? else {
+        return Ok(Vec::new()); // no note yet ⇒ nothing to receipt.
+    };
+    let segments = state.db.get_segments(meeting_id)?;
+    // `claim_index` refers to the RAW markdown lines (`markdown.split('\n')`) the FE renders, so a
+    // chip maps straight back to its note line. `align_claims_to_segments` itself skips
+    // front-matter/headings/blockquotes/etc., so passing every line is safe.
+    let lines: Vec<&str> = note.markdown.split('\n').collect();
+    let receipts = crate::summarize::grounding::align_claims_to_segments(&lines, &segments);
+    tracing::debug!(
+        target: "receipts",
+        meeting = %meeting_id,
+        note_lines = lines.len(),
+        segments = segments.len(),
+        receipts = receipts.len(),
+        "computed note receipts"
+    );
+    Ok(receipts)
+}
+
 /// The extensions document ingestion accepts (Brain v3 PR-2). Text (md/txt) plus the extracted
 /// formats: PDF (macOS PDFKit), DOCX/PPTX (pure-Rust OOXML), XLSX (calamine), HTML. Dispatch +
 /// extraction live in `crate::extract`; anything else is rejected with `InvalidArg`.
@@ -21752,6 +21805,162 @@ mod lifecycle_tests {
             get_manual_notes_inner(&state, "m1").unwrap(),
             "secret typed plaintext",
             "the refused write must not have mutated the buffer"
+        );
+    }
+
+    /// RECEIPTS happy path (Brain v3 PR-5): on an OPEN meeting, `get_note_receipts` aligns each
+    /// supported note line to the transcript segment it derives from, carrying that segment's raw-
+    /// second coordinates + speaker + confidence. A paraphrased/unsupported line earns no receipt.
+    #[test]
+    fn get_note_receipts_returns_alignments_when_unlocked() {
+        let state = build_state("receipts-open");
+        // No folder ⇒ always open. Seed a note + two distinctive segments directly.
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m1".to_string(),
+                started_at: "2026-06-27T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Receipts".to_string()),
+                duration_s: 60,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m1".to_string(),
+                provider_id: "claude_code".to_string(),
+                // Line 0 heading, 1 blank, 2 supported claim, 3 blank, 4 unsupported paraphrase.
+                markdown: "## Summary\n\nWe shipped the login page and the payment flow.\n\nThe entirely separate teleporter prototype launched successfully.".to_string(),
+                created_at: "2026-06-27T09:05:00Z".to_string(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state
+            .db
+            .insert_segments(
+                "m1",
+                &[
+                    Segment {
+                        idx: 5,
+                        start_s: 11.0,
+                        end_s: 17.5,
+                        text: "we finally shipped the login page and the payment flow this week"
+                            .to_string(),
+                        speaker: Some("me".to_string()),
+                        confidence: Some(0.88),
+                    },
+                    Segment {
+                        idx: 6,
+                        start_s: 40.0,
+                        end_s: 44.0,
+                        text: "and then we grabbed some coffee downstairs".to_string(),
+                        speaker: Some("others".to_string()),
+                        confidence: None,
+                    },
+                ],
+            )
+            .unwrap();
+
+        let receipts = get_note_receipts_inner(&state, "m1").unwrap();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "only the supported claim earns a receipt; got:\n{receipts:?}"
+        );
+        let r = &receipts[0];
+        assert_eq!(r.claim_index, 2, "receipt maps to the supported note line");
+        assert_eq!(r.segment_id, 5, "aligned to the login/payment segment");
+        assert_eq!(r.start_s, 11.0, "raw-second seek target");
+        assert_eq!(r.end_s, 17.5);
+        assert_eq!(r.speaker.as_deref(), Some("me"));
+        assert_eq!(r.confidence, Some(0.88));
+    }
+
+    /// RECEIPTS lock-gate (RED-before-GREEN): a sealed-and-NOT-session-unlocked meeting returns an
+    /// EMPTY receipt list — never a segment time, speaker, or overlap that would leak WHEN/BY WHOM —
+    /// EVEN THOUGH the note + segments still exist. Session-unlocking the folder restores receipts.
+    /// Remove the `meeting_is_unlocked` gate in `get_note_receipts_inner` and this fails (RED).
+    #[test]
+    fn get_note_receipts_masked_when_sealed_then_restored_on_unlock() {
+        let state = build_state("receipts-sealed");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m1".to_string(),
+                started_at: "2026-06-27T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Secret".to_string()),
+                duration_s: 60,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m1".to_string(),
+                provider_id: "claude_code".to_string(),
+                markdown: "We shipped the login page and the payment flow.".to_string(),
+                created_at: "2026-06-27T09:05:00Z".to_string(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state
+            .db
+            .insert_segments(
+                "m1",
+                &[Segment {
+                    idx: 1,
+                    start_s: 3.0,
+                    end_s: 9.0,
+                    text: "we shipped the login page and the payment flow today".to_string(),
+                    speaker: Some("me".to_string()),
+                    confidence: Some(0.9),
+                }],
+            )
+            .unwrap();
+        state.db.set_meeting_folder("m1", Some("f-lock")).unwrap();
+
+        // Precondition: while OPEN, the receipt is present (proves the mask below is the gate, not
+        // an empty computation).
+        assert_eq!(
+            get_note_receipts_inner(&state, "m1").unwrap().len(),
+            1,
+            "precondition: open folder yields a receipt"
+        );
+
+        // Seal the folder (locked, NOT in the session unlock set).
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        assert!(
+            get_note_receipts_inner(&state, "m1").unwrap().is_empty(),
+            "sealed-not-unlocked meeting must leak NO receipts (no times/speakers)"
+        );
+
+        // Session-unlock the folder ⇒ receipts return.
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-lock".to_string());
+        assert_eq!(
+            get_note_receipts_inner(&state, "m1").unwrap().len(),
+            1,
+            "session-unlock restores receipts"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,7 @@ pub fn run() {
             commands::link_related_notes,
             commands::save_manual_notes,
             commands::get_manual_notes,
+            commands::get_note_receipts,
             commands::append_to_companion_note,
             commands::get_or_create_companion_note,
             commands::delete_companion_note_if_empty,

--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -31,6 +31,8 @@
 
 use std::collections::HashSet;
 
+use serde::{Deserialize, Serialize};
+
 use crate::summarize::related_context::{is_stopword, tokenize};
 use crate::transcribe::types::Segment;
 
@@ -162,6 +164,156 @@ pub fn annotate_unverified(note_markdown: &str, segments: &[Segment]) -> String 
         Some(fm) => format!("{fm}{annotated_body}"),
         None => annotated_body,
     }
+}
+
+// ── RECEIPTS (Brain v3 PR-5) ─────────────────────────────────────────────────────────────────────
+//
+// The GROUNDING pass above answers "is this claim supported?" with a `> unverified` marker. Receipts
+// answer the dual question — "WHERE (which second of audio) did this claim come from?" — using the
+// SAME deterministic token-overlap math, no LLM, no egress. For every candidate note line (a bullet,
+// a checklist item, a prose sentence) we find the transcript segment it overlaps most, and emit that
+// segment's audio coordinates (`start_s`/`end_s`), speaker, and ASR confidence so the UI can seek the
+// already-shipped audio player/timeline to that second and prove the claim.
+//
+// PURE + on-device: `align_claims_to_segments` reads NOTHING but the passed note lines + segments —
+// no DB, no clock, no LLM. The command wrapper (`commands::get_note_receipts`) is what gates the read.
+// Timestamps are RAW SECONDS straight off `Segment` (never a formatted MM:SS string — the 2h-wrap bug
+// the perf work fought), so the FE seeks with a plain `float` and formats for display itself.
+
+/// The minimum token-overlap ratio (overlapping distinct content tokens / the claim's distinct
+/// content tokens) for a claim to earn a receipt. Below this the claim is left UN-aligned (no
+/// `ClaimAlignment` emitted) rather than pointing the user at a weakly-related second of audio — a
+/// wrong receipt is worse than none. Chosen to match `GROUND_MIN_COVERAGE` (the same "half its words
+/// were actually spoken" bar the grounding pass already uses); calibration of the operating point on
+/// paraphrased LLM lines is a dev-app follow-up, not provable by `cargo test --lib`.
+const RECEIPT_MIN_OVERLAP: f32 = 0.5;
+
+/// One claim → the transcript segment it most likely derives from. Emitted only for note lines that
+/// clear [`RECEIPT_MIN_OVERLAP`]; a paraphrased/unsupported line gets no entry (the FE renders no
+/// receipt chip for it). Serialized camelCase to match `Segment`'s FE convention. Carries NO note or
+/// transcript TEXT — only the claim's line index, the segment's audio coordinates, and non-content
+/// metadata (speaker label + ASR probability) — so the DTO is safe to hand a caller that has already
+/// passed the read gate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimAlignment {
+    /// Index of the claim in the `note_lines` slice passed to [`align_claims_to_segments`] (the FE
+    /// maps this back to the rendered note line to place the receipt chip).
+    pub claim_index: usize,
+    /// `Segment.idx` of the best-matching transcript segment (stable id the FE can flash/highlight).
+    pub segment_id: i64,
+    /// Segment start in RAW SECONDS — the audio player/timeline seek target.
+    pub start_s: f64,
+    /// Segment end in RAW SECONDS.
+    pub end_s: f64,
+    /// `"me"` / `"others"` / `None` — straight from the segment (no new field, no diarization).
+    pub speaker: Option<String>,
+    /// Per-segment ASR confidence in `[0,1]`, or `None` when whisper did not compute it. Straight
+    /// from the segment; the FE shows it in the receipt tooltip.
+    pub confidence: Option<f32>,
+    /// The token-overlap ratio that won this alignment (`[RECEIPT_MIN_OVERLAP, 1.0]`) — lets the FE
+    /// tier receipt strength if it wants to.
+    pub overlap: f32,
+}
+
+/// Deterministically align each candidate note line to the transcript segment it most likely derives
+/// from, by normalized content-token overlap (the SAME `content_tokens` math the grounding pass uses).
+///
+/// - `note_lines`: the note body lines (front-matter already split off by the caller is fine — this
+///   fn also skips headings / code fences / blockquotes / wikilink-only / protected sections / too-
+///   short lines itself, so a claim index always refers to a REAL claim line and never a heading).
+/// - For each candidate line: score overlap against every non-empty, non-assistant-directed segment;
+///   pick the segment with the MOST overlapping distinct content tokens (ties → the EARLIEST segment,
+///   for determinism); emit a [`ClaimAlignment`] iff `overlapping / claim_tokens >= RECEIPT_MIN_OVERLAP`.
+/// - Below threshold ⇒ NO entry for that line (a paraphrased LLM line the transcript doesn't clearly
+///   support gets no — possibly wrong — receipt).
+///
+/// Pure: no DB, no clock, no LLM, no I/O. Deterministic: same inputs ⇒ byte-identical output.
+pub fn align_claims_to_segments(note_lines: &[&str], segments: &[Segment]) -> Vec<ClaimAlignment> {
+    // Per-segment content-token set, keeping the segment's audio coordinates + metadata. Filtered
+    // with the IDENTICAL predicate as the grounding pass (drop empty + assistant-directed spans — an
+    // assistant command is not transcript evidence to point a receipt at).
+    let seg_index: Vec<(HashSet<String>, &Segment)> = segments
+        .iter()
+        .filter(|s| {
+            let t = s.text.trim();
+            !t.is_empty() && !crate::audio::wake::is_assistant_directed(t)
+        })
+        .map(|s| (content_tokens(&s.text), s))
+        .collect();
+
+    if seg_index.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out: Vec<ClaimAlignment> = Vec::new();
+    let mut in_code_fence = false;
+    let mut in_skipped_section = false;
+
+    for (i, &line) in note_lines.iter().enumerate() {
+        let trimmed = line.trim();
+
+        // Code fences: toggle state; never a claim.
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+        // Headings re-evaluate the protected-section state; a heading is never a claim.
+        if trimmed.starts_with('#') {
+            in_skipped_section = is_skipped_heading(trimmed);
+            continue;
+        }
+        if in_skipped_section {
+            continue;
+        }
+        // Blanks, blockquotes (incl. our own `> unverified` markers) — never a claim.
+        if trimmed.is_empty() || trimmed.starts_with('>') {
+            continue;
+        }
+
+        // Strip the list/checkbox marker; skip wikilink-only citation lines.
+        let unit = unit_content(trimmed);
+        if is_wikilink_only(unit) {
+            continue;
+        }
+        let toks = content_tokens(unit);
+        if toks.len() < GROUND_MIN_CONTENT_TOKENS {
+            continue;
+        }
+
+        // Best-matching segment = most overlapping distinct content tokens; ties → EARLIEST (first
+        // wins because we only replace on a STRICTLY greater overlap). Deterministic.
+        let mut best_overlap = 0usize;
+        let mut best: Option<&Segment> = None;
+        for (seg_toks, seg) in &seg_index {
+            let overlap = toks.iter().filter(|t| seg_toks.contains(*t)).count();
+            if overlap > best_overlap {
+                best_overlap = overlap;
+                best = Some(seg);
+            }
+        }
+
+        let Some(seg) = best else { continue };
+        let ratio = best_overlap as f32 / toks.len() as f32;
+        if ratio < RECEIPT_MIN_OVERLAP {
+            continue; // paraphrase / unsupported ⇒ no (possibly wrong) receipt.
+        }
+
+        out.push(ClaimAlignment {
+            claim_index: i,
+            segment_id: seg.idx,
+            start_s: seg.start_s,
+            end_s: seg.end_s,
+            speaker: seg.speaker.clone(),
+            confidence: seg.confidence,
+            overlap: ratio,
+        });
+    }
+
+    out
 }
 
 /// Distinct, lowercased, stopword-stripped content tokens (reusing the retrieval tokenizer +
@@ -325,6 +477,26 @@ mod tests {
         }
     }
 
+    /// A fully-specified segment for the receipts (`align_claims_to_segments`) tests: distinct
+    /// idx/timestamps/speaker/confidence so a receipt's audio coordinates can be asserted exactly.
+    fn seg_full(
+        idx: i64,
+        start_s: f64,
+        end_s: f64,
+        speaker: &str,
+        confidence: Option<f32>,
+        text: &str,
+    ) -> Segment {
+        Segment {
+            idx,
+            start_s,
+            end_s,
+            text: text.into(),
+            speaker: Some(speaker.into()),
+            confidence,
+        }
+    }
+
     /// RED-before-GREEN: an action item the transcript never supports gets a following `> unverified`
     /// line, while a SUPPORTED summary sentence stays clean. Reverting `annotate_unverified` to a
     /// no-op drops the marker (RED). The marker here is the PLAIN variant (no overlapping segment).
@@ -468,6 +640,143 @@ mod tests {
         assert_eq!(
             out, note,
             "a 2-token unsupported bullet is below the min and stays clean"
+        );
+    }
+
+    // ── RECEIPTS (align_claims_to_segments) ──────────────────────────────────────────────────────
+
+    /// RED-before-GREEN: a claim whose words are largely IN a segment aligns to THAT segment, carrying
+    /// its exact audio coordinates + speaker + confidence. Reverting `align_claims_to_segments` to
+    /// return `Vec::new()` drops the receipt (RED). Also proves the best-match picks the RIGHT segment
+    /// (the login one, not the migration one) and the claim_index points at the real claim line (not a
+    /// heading/blank).
+    #[test]
+    fn exact_overlap_claim_aligns_to_its_segment() {
+        let segments = vec![
+            seg_full(
+                7,
+                12.5,
+                18.0,
+                "me",
+                Some(0.91),
+                "we finally shipped the login page and the payment flow this week",
+            ),
+            seg_full(
+                8,
+                40.0,
+                47.0,
+                "others",
+                Some(0.80),
+                "the database migration is completely done now",
+            ),
+        ];
+        // Line indices: 0 heading, 1 blank, 2 the claim.
+        let lines: Vec<&str> = "## Summary\n\nWe shipped the login page and the payment flow."
+            .split('\n')
+            .collect();
+        let out = align_claims_to_segments(&lines, &segments);
+
+        assert_eq!(out.len(), 1, "exactly one claim line aligns; got:\n{out:?}");
+        let a = &out[0];
+        assert_eq!(a.claim_index, 2, "claim_index points at the real claim line");
+        assert_eq!(a.segment_id, 7, "aligned to the LOGIN segment, not migration");
+        assert_eq!(a.start_s, 12.5, "raw-seconds start seek target");
+        assert_eq!(a.end_s, 18.0);
+        assert_eq!(a.speaker.as_deref(), Some("me"));
+        assert_eq!(a.confidence, Some(0.91));
+        assert!(
+            a.overlap >= RECEIPT_MIN_OVERLAP,
+            "overlap ratio clears the receipt threshold"
+        );
+    }
+
+    /// A paraphrased claim whose distinct content tokens fall BELOW the overlap threshold earns NO
+    /// receipt (better none than a wrong second of audio). RED if the threshold is dropped/removed.
+    #[test]
+    fn paraphrase_below_threshold_gets_no_alignment() {
+        let segments = vec![seg_full(
+            1,
+            5.0,
+            9.0,
+            "others",
+            None,
+            "we should probably revisit the pricing tiers next quarter",
+        )];
+        // Shares only "quarter" (1 of 4 distinct content tokens after stopword-strip) → ratio < 0.5.
+        let lines: Vec<&str> =
+            "The acquisition negotiations concluded successfully this quarter."
+                .split('\n')
+                .collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert!(
+            out.is_empty(),
+            "a below-threshold paraphrase must earn no receipt; got:\n{out:?}"
+        );
+    }
+
+    /// Determinism: same inputs ⇒ byte-identical output. And on an overlap TIE, the EARLIEST segment
+    /// wins (first-seen kept because we only replace on strictly-greater overlap).
+    #[test]
+    fn alignment_is_deterministic_and_ties_pick_earliest() {
+        // Both segments overlap the claim on the SAME two tokens (roadmap, budget) — a tie.
+        let segments = vec![
+            seg_full(3, 1.0, 4.0, "me", None, "we reviewed the roadmap and the budget"),
+            seg_full(4, 30.0, 34.0, "others", None, "roadmap and budget again later on"),
+        ];
+        let lines: Vec<&str> = "We reviewed the roadmap and the budget in detail."
+            .split('\n')
+            .collect();
+        let first = align_claims_to_segments(&lines, &segments);
+        let second = align_claims_to_segments(&lines, &segments);
+        assert_eq!(first, second, "same inputs must give identical output");
+        assert_eq!(first.len(), 1);
+        assert_eq!(
+            first[0].segment_id, 3,
+            "an overlap tie resolves to the EARLIEST segment"
+        );
+    }
+
+    /// Headings, blanks, code fences, blockquotes, wikilink-only lines and too-short bullets are never
+    /// claims — a receipt's claim_index always refers to a REAL claim line.
+    #[test]
+    fn non_claim_lines_never_get_receipts() {
+        let segments = vec![seg_full(
+            1,
+            0.0,
+            5.0,
+            "me",
+            None,
+            "we shipped the invoice export feature and the reporting dashboard",
+        )];
+        let note = "# Heading with shipped invoice export reporting words\n\n> a blockquote mentioning shipped invoice export dashboard\n\n[[Shipped Invoice Export Reporting Note]]\n\n- ok\n\n```\nshipped invoice export reporting dashboard code\n```\n\nWe shipped the invoice export and the reporting dashboard.";
+        let lines: Vec<&str> = note.split('\n').collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert_eq!(out.len(), 1, "only the real prose claim aligns; got:\n{out:?}");
+        assert_eq!(
+            lines[out[0].claim_index].trim(),
+            "We shipped the invoice export and the reporting dashboard."
+        );
+    }
+
+    /// With no usable transcript (empty, or only assistant-directed spans) there are no receipts —
+    /// never point a chip at nothing.
+    #[test]
+    fn empty_or_assistant_only_segments_yield_no_receipts() {
+        let lines: Vec<&str> = "We shipped the login page and the payment flow today."
+            .split('\n')
+            .collect();
+        assert!(align_claims_to_segments(&lines, &[]).is_empty());
+        let cmd = vec![seg_full(
+            1,
+            0.0,
+            3.0,
+            "me",
+            None,
+            "Klaudku, shipped the login page and payment flow",
+        )];
+        assert!(
+            align_claims_to_segments(&lines, &cmd).is_empty(),
+            "assistant-directed spans are not transcript evidence for a receipt"
         );
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -8,6 +8,7 @@ import type {
   Analytics,
   AppConfigDto,
   BacklinkSource,
+  ClaimAlignment,
   LinkEdge,
   LinkKind,
   WikiTarget,
@@ -1614,6 +1615,19 @@ export class IpcService {
 
   getMeetingDetail(meetingId: string): Promise<MeetingDetail | null> {
     return invoke<MeetingDetail | null>("get_meeting_detail", { meetingId });
+  }
+
+  /**
+   * Per-claim "Receipts" (Brain v3 PR-5): each note line that clears the
+   * token-overlap bar aligned to the transcript segment it derives from, so the
+   * UI can seek the audio player to `startS` and prove the claim. GATED — a
+   * sealed-and-not-session-unlocked meeting returns `[]` (no segment times,
+   * speakers, or overlaps leak behind the lock), as does a meeting with no note
+   * yet. Carries no note/transcript TEXT (line index + audio coordinates + ASR
+   * metadata only).
+   */
+  getNoteReceipts(meetingId: string): Promise<ClaimAlignment[]> {
+    return invoke<ClaimAlignment[]>("get_note_receipts", { meetingId });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -866,6 +866,32 @@ export interface Segment {
 }
 
 /**
+ * One note claim → the transcript segment it most likely derives from (Brain v3
+ * PR-5 "Receipts"). Mirrors the Rust `ClaimAlignment` (serde camelCase). Carries
+ * NO note or transcript TEXT — only the claim's raw-markdown-line index, the
+ * segment's audio coordinates (RAW SECONDS, for the player seek), and non-content
+ * metadata (speaker label + ASR confidence) — so it is safe to hand a caller that
+ * has already passed the read gate. EMPTY list for a sealed-and-not-session-
+ * unlocked meeting (the backend returns nothing behind a lock).
+ */
+export interface ClaimAlignment {
+  /** Index of the claim in the note's raw `markdown.split("\n")` lines. */
+  claimIndex: number;
+  /** `Segment.idx` of the best-matching transcript segment (flash target). */
+  segmentId: number;
+  /** Segment start in RAW SECONDS — the audio player seek target. */
+  startS: number;
+  /** Segment end in RAW SECONDS. */
+  endS: number;
+  /** `"me"` / `"others"` / `null` — straight from the segment. */
+  speaker?: "me" | "others" | string | null;
+  /** Per-segment ASR confidence in `[0,1]`, or `null` when whisper didn't compute it. */
+  confidence?: number | null;
+  /** The token-overlap ratio that won this alignment (`[0.5, 1.0]`). */
+  overlap: number;
+}
+
+/**
  * One persisted in-meeting voice-assistant interaction (Q&A): the user's spoken
  * command, the assistant's answer, the grounding citations, and the dispatch
  * status. Surfaced in the meeting detail's "Asystent — Q&A" section. EMPTY when

--- a/src/app/features/detail/audio-panel/audio-panel.component.html
+++ b/src/app/features/detail/audio-panel/audio-panel.component.html
@@ -194,6 +194,8 @@
                     type="button"
                     class="frag"
                     [class.is-active]="activeSegKeys().has(s.idx)"
+                    [class.is-flash]="s.idx === flashSegId()"
+                    [attr.data-flash]="s.idx === flashSegId() ? flashKey() : null"
                     [disabled]="!audioSrc()"
                     (click)="seekTo(s.startS)"
                   >{{ s.text }} </button>

--- a/src/app/features/detail/audio-panel/audio-panel.component.scss
+++ b/src/app/features/detail/audio-panel/audio-panel.component.scss
@@ -355,6 +355,27 @@
   background: var(--accent-soft);
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
+// Receipt pulse (Brain v3 PR-5): a one-shot glow drawing the eye to the exact
+// transcript line that proves a note claim, after a receipt chip seeks here.
+.frag.is-flash {
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  animation: receipt-flash 1400ms var(--transition) both;
+}
+@keyframes receipt-flash {
+  0% {
+    background: var(--accent);
+    box-shadow: 0 0 0 4px var(--accent-soft);
+  }
+  60% {
+    background: var(--accent-soft);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+  }
+  100% {
+    background: transparent;
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
 .turn-empty,
 .empty-card {
   padding: var(--space-5);
@@ -374,8 +395,15 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .audio-panel,
-  .saved-toast {
+  .saved-toast,
+  .frag.is-flash {
     animation: none;
+  }
+  // Keep the pulse legible without motion: a static highlight that a subsequent
+  // user seek (which clears .is-flash) removes.
+  .frag.is-flash {
+    background: var(--accent-soft);
+    box-shadow: 0 0 0 3px var(--accent-soft);
   }
 }
 

--- a/src/app/features/detail/audio-panel/audio-panel.component.ts
+++ b/src/app/features/detail/audio-panel/audio-panel.component.ts
@@ -91,6 +91,20 @@ export class AudioPanelComponent {
   readonly pinMsg = input("");
   /** Inline pin error. */
   readonly pinError = input("");
+  /**
+   * A note-receipt seek request (Brain v3 PR-5 "Receipts"): the second of audio
+   * a note claim derives from, plus the transcript `Segment.idx` to flash. The
+   * shell sets this (and switches to the Audio tab) when the user clicks a receipt
+   * chip; the panel is (re)created for the Audio `@switch` case, so this arrives as
+   * an INPUT the panel applies on mount/change — a viewChild method call from the
+   * Note tab would hit a not-yet-existing panel. `seq` is bumped by the shell so
+   * clicking the SAME receipt twice re-fires the effect (a net-zero value wouldn't).
+   * Null when there is no pending receipt seek. Carries only audio-coordinate ints —
+   * no note/transcript text, no on-disk path.
+   */
+  readonly seekTarget = input<{ startS: number; segId: number; seq: number } | null>(
+    null,
+  );
 
   // --- Outputs back to the shell (which owns the IPC) ---------------------
   /** Retry the timeline fetch (from the timeline's (retry)). */
@@ -107,6 +121,21 @@ export class AudioPanelComponent {
   readonly currentTime = signal(0);
   readonly duration = signal(0);
   readonly playing = signal(false);
+  /**
+   * The `Segment.idx` to briefly PULSE (Brain v3 PR-5 "Receipts"): when a note
+   * receipt chip drives a seek, `seekTo(startS)` already lands the playhead inside
+   * that segment so `activeSegKeys` gives the persistent karaoke highlight — this
+   * adds a one-shot flash animation over it so the eye is drawn to the exact line
+   * that proves the claim. A bump `flashSeq` re-arms the pure-CSS animation when the
+   * SAME segment is receipted twice in a row (a net-zero id write wouldn't restart
+   * it). Cleared to null on any user-driven seek so a stray flash never lingers.
+   */
+  readonly flashSegId = signal<number | null>(null);
+  private readonly flashSeq = signal(0);
+  /** Composite the flash targets so the template re-arms on a repeat receipt. */
+  readonly flashKey = computed(
+    () => `${this.flashSegId() ?? ""}#${this.flashSeq()}`,
+  );
   /** Playback rate, cycled 1× → 1.25× → 1.5× → 2× → 1×. */
   readonly rate = signal(1);
   /** The rate as a trimmed label ("1", "1.25", "1.5", "2"). */
@@ -264,6 +293,50 @@ export class AudioPanelComponent {
             behavior: "smooth",
           });
         }
+      },
+      { injector: this.injector },
+    );
+  });
+
+  /**
+   * Apply a pending note-receipt seek (Brain v3 PR-5): when the shell sets
+   * `seekTarget` (and switches to this tab), seek the player to the claim's
+   * second of audio and PULSE the matching transcript segment so the eye lands
+   * on the exact line that proves the claim. Tracks `seq` (bumped by the shell)
+   * so re-clicking the SAME receipt re-arms; `flashSeq` re-arms the pure-CSS
+   * animation when the SAME segment is receipted twice (a net-zero `flashSegId`
+   * write wouldn't restart it). Legitimate signal-writing effect (T1): it
+   * reacts to an input and drives the player — no async fetch, no stale race.
+   */
+  private readonly _applyReceiptSeek = effect(() => {
+    const target = this.seekTarget();
+    if (!target) {
+      return;
+    }
+    // `seq` in the dependency set makes a repeat of the same receipt re-fire.
+    void target.seq;
+    this.seekTo(target.startS); // (also clears any prior flash)
+    this.flashSegId.set(target.segId);
+    this.flashSeq.update((n) => n + 1);
+    // Restart the pure-CSS pulse deterministically (a repeat of the SAME segment
+    // keeps the `.is-flash` class, so the animation wouldn't retrigger on its own)
+    // and bring the flashed fragment into view. One-shot, zoneless-safe: no timer.
+    const key = this.flashKey();
+    afterNextRender(
+      () => {
+        const box = this.scroller()?.nativeElement;
+        const frag = box?.querySelector<HTMLElement>(
+          `.frag[data-flash="${CSS.escape(key)}"]`,
+        );
+        if (!frag) {
+          return;
+        }
+        // Force the browser to drop the running animation, then re-apply it on
+        // the next frame — the canonical restart with no `@angular/animations`.
+        frag.style.animation = "none";
+        void frag.offsetWidth; // reflow — commits the "none" before re-enabling
+        frag.style.animation = "";
+        frag.scrollIntoView({ block: "center", behavior: "smooth" });
       },
       { injector: this.injector },
     );
@@ -439,6 +512,10 @@ export class AudioPanelComponent {
    * `currentTime` signal so the timeline highlight + playhead respond.
    */
   seekTo(startS: number): void {
+    // Clear any lingering receipt pulse so a user-driven seek never leaves a
+    // stray flash on an unrelated segment. The receipt path (`_applyReceiptSeek`)
+    // re-arms the flash AFTER this call, so its own pulse survives.
+    this.flashSegId.set(null);
     const el = this.el;
     if (!el) {
       const total = this.timelineTotal();

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -253,6 +253,8 @@
             [note]="note()"
             [interactions]="interactions()"
             [backlinks]="backlinks()"
+            [receipts]="receipts()"
+            [noteRaw]="d.note?.markdown ?? null"
             [exportedPath]="d.note?.exportedPath ?? null"
             [provenanceLabel]="provenanceLabel()"
             [busy]="busy()"
@@ -302,6 +304,7 @@
             (draftInput)="draft.set($event)"
             (copyPath)="copy(d.note?.exportedPath ?? '')"
             (openRelated)="openRelated($event)"
+            (seekReceipt)="onSeekReceipt($event)"
             (noteChanged)="reloadDetail()"
           />
           @if (config()?.jiraEnabled && config()?.jiraConsented && !locked()) {
@@ -316,6 +319,7 @@
             #audioPanel
             [audioSrc]="audioSrc()"
             [segments]="d.segments"
+            [seekTarget]="seekTarget()"
             [timeline]="timeline()"
             [timelineTotal]="timelineTotal()"
             [timelineLoading]="timelineLoading()"

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -24,6 +24,7 @@ import type {
   AppConfigDto,
   AssistantInteraction,
   BacklinkSource,
+  ClaimAlignment,
   FolderNode,
   GraphPayload,
   MeetingDetail,
@@ -345,6 +346,78 @@ export class DetailComponent implements OnInit {
     }
   }
 
+  // --- Receipts (Brain v3 PR-5): claim → second-of-audio ------------------
+  /**
+   * Per-claim audio receipts for the CURRENT note (backend `get_note_receipts`,
+   * `meeting_is_unlocked`-gated → EMPTY for a locked meeting). Fed to the note
+   * panel, which renders a chip per aligned claim. Empty until the first fetch
+   * resolves and whenever the meeting is locked/masked (the fetch is skipped).
+   */
+  readonly receipts = signal<ClaimAlignment[]>([]);
+  /** Stale-result guard token — a late reply for a superseded meeting is dropped. */
+  private receiptsSeq = 0;
+
+  /**
+   * A pending receipt seek handed to the Audio tab's player (Brain v3 PR-5). The
+   * panel is (re)created for the Audio `@switch` case, so a viewChild method call
+   * from the Note tab would hit a not-yet-existing instance — instead we pass the
+   * target as an INPUT the panel applies on mount. `seq` (bumped per click) makes
+   * a repeat click on the same receipt re-fire the panel effect. Null when idle.
+   */
+  readonly seekTarget = signal<{
+    startS: number;
+    segId: number;
+    seq: number;
+  } | null>(null);
+
+  /**
+   * Fetch this meeting's note receipts whenever the loaded meeting (or note
+   * body) changes, and SKIP the (gated) fetch while it is locked/masked — a
+   * locked meeting must surface no receipts (WHEN/BY-WHOM leak), and the backend
+   * returns an empty list there anyway. Re-fetches when the note markdown changes
+   * (an edit/re-summarize) so the chips track the current note. Legitimate
+   * signal-writing effect (T1): async IPC keyed on inputs with a stale-result guard.
+   */
+  private readonly _loadReceipts = effect(() => {
+    const id = this.detail()?.meeting.id ?? null;
+    const locked = this.locked();
+    // Track the note body so an edit/re-summarize re-derives the receipts.
+    const noteMd = this.detail()?.note?.markdown ?? null;
+    const seq = ++this.receiptsSeq;
+    if (!id || locked || !noteMd) {
+      this.receipts.set([]);
+      return;
+    }
+    void this.fetchReceipts(id, seq);
+  });
+
+  private async fetchReceipts(id: string, seq: number): Promise<void> {
+    try {
+      const rows = await this.ipc.getNoteReceipts(id);
+      if (seq !== this.receiptsSeq) {
+        return; // superseded by a newer meeting / lock / note-edit
+      }
+      this.receipts.set(Array.isArray(rows) ? rows : []);
+    } catch {
+      if (seq === this.receiptsSeq) {
+        this.receipts.set([]);
+      }
+    }
+  }
+
+  /**
+   * A receipt chip was clicked in the note panel: switch to the Audio tab and
+   * hand the player the seek/flash target. Carries only audio coordinates — no
+   * note/transcript text, no on-disk path. The Audio tab's panel is created by
+   * the `@switch`, so the target is an input it applies on mount (see the panel's
+   * `_applyReceiptSeek`); `seq` (already bumped by the note panel) survives so a
+   * repeat click on the same chip re-fires.
+   */
+  onSeekReceipt(target: { startS: number; segId: number; seq: number }): void {
+    this.seekTarget.set(target);
+    this.activeTab.set("audio");
+  }
+
   // --- Phase 5 model-provenance badge -------------------------------------
   /**
    * Human-readable label for the model-provenance badge in the Analysis header.
@@ -515,6 +588,10 @@ export class DetailComponent implements OnInit {
     this.graph.set(null);
     this.editing.set(false);
     this.draft.set("");
+    // Receipts leak WHEN/BY-WHOM: blank them (and any pending seek) synchronously
+    // on the mask, matching the note/segments/audio the masked DTO already nulls.
+    this.receipts.set([]);
+    this.seekTarget.set(null);
     this.tabsService.setTitle(tabKeyFor("meeting", d.meeting.id), "🔒 Locked");
   }
 
@@ -706,6 +783,11 @@ export class DetailComponent implements OnInit {
     this.renaming.set(false);
     this.moveOpen.set(false);
     this.confirmingDelete.set(false);
+    // Receipts (PR-5): drop the previous meeting's chips + any pending seek so a
+    // same-route reload never carries a stale claim→audio mapping (the `_loadReceipts`
+    // effect refetches for the new meeting once `detail()` resolves below).
+    this.receipts.set([]);
+    this.seekTarget.set(null);
     // Land on the Note tab for every meeting (identity-first default).
     this.activeTab.set("note");
     // (Audio-playback state now lives in <app-audio-panel>, which owns the

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -292,6 +292,39 @@
           </article>
         }
 
+        <!-- RECEIPTS (Brain v3 PR-5): every claim the transcript proves →
+             a chip that seeks the Audio tab to that second + flashes the
+             segment. Empty (nothing rendered) for a locked meeting (the
+             backend returns no receipts) or a note with no aligned claim. -->
+        @if (receiptChips().length) {
+          <article class="card receipts" aria-label="Audio receipts">
+            <div class="receipts-head">
+              <span class="section-label">Receipts</span>
+              <span class="count">{{ receiptChips().length }}</span>
+              <span class="receipts-hint">Click to hear the moment this was said</span>
+            </div>
+            <ul class="receipt-list">
+              @for (r of receiptChips(); track r.claimIndex) {
+                <li>
+                  <button
+                    type="button"
+                    class="receipt-chip"
+                    [attr.title]="'Play ' + r.time + (r.speaker ? ' · ' + r.speaker : '')"
+                    (click)="onReceipt(r)"
+                  >
+                    <span class="receipt-play" aria-hidden="true">▸</span>
+                    <span class="receipt-claim">{{ r.claim }}</span>
+                    @if (r.speaker) {
+                      <span class="receipt-speaker">{{ r.speaker }}</span>
+                    }
+                    <span class="receipt-time">{{ r.time }}</span>
+                  </button>
+                </li>
+              }
+            </ul>
+          </article>
+        }
+
         @if (justSaved()) {
           <div class="saved-toast" role="status">
             <span class="saved-toast-check" aria-hidden="true"></span>

--- a/src/app/features/detail/note-panel/note-panel.component.scss
+++ b/src/app/features/detail/note-panel/note-panel.component.scss
@@ -483,3 +483,79 @@
   }
 }
     
+
+/* RECEIPTS (Brain v3 PR-5): claim → second-of-audio chips under the note body. */
+.receipts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.receipts-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.receipts-hint {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-left: var(--space-2);
+}
+.receipt-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.receipt-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    border-color var(--transition),
+    background var(--transition),
+    color var(--transition);
+}
+.receipt-chip:hover {
+  border-color: var(--accent-ring);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+.receipt-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.receipt-play {
+  color: var(--accent);
+  font-size: 0.75rem;
+  flex: 0 0 auto;
+}
+.receipt-claim {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.receipt-speaker {
+  flex: 0 0 auto;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 0.72rem;
+}
+.receipt-time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+}

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -8,7 +8,11 @@ import {
   signal,
   viewChild,
 } from "@angular/core";
-import type { BacklinkSource, GraphPayload } from "../../../core/models";
+import type {
+  BacklinkSource,
+  ClaimAlignment,
+  GraphPayload,
+} from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { AssistantSourcesComponent } from "../../../shared/assistant-sources/assistant-sources.component";
 import { BacklinksComponent } from "../../../shared/backlinks/backlinks.component";
@@ -42,6 +46,30 @@ export interface ParsedNote {
   sections: NoteSection[];
   raw: string | null;
   enhanced: boolean;
+}
+
+/**
+ * One rendered "Receipt" (Brain v3 PR-5): a note claim that aligned to a
+ * transcript segment, decorated for display. Carries the claim's own text
+ * SNIPPET (from the raw markdown line at `claimIndex`) + the audio coordinate
+ * and speaker/timestamp labels — clicking it seeks the shipped audio player.
+ * `segId`/`startS`/`seq` drive the audio panel's flash + seek.
+ */
+export interface ReceiptChip {
+  /** Short label of the claim line this receipt proves. */
+  claim: string;
+  /** "Me" / "Others" / "" — from the segment speaker. */
+  speaker: string;
+  /** m:ss timestamp of the segment start. */
+  time: string;
+  /** The segment start in raw seconds (the player seek target). */
+  startS: number;
+  /** `Segment.idx` to flash in the transcript. */
+  segId: number;
+  /** The claim's line index — the stable UNIQUE key for `@for` track (two claims can share one segId). */
+  claimIndex: number;
+  /** Monotonic id so the parent can re-fire a repeat click on the same chip. */
+  seq: number;
 }
 
 /** One grounding citation, split into vault vs web shapes for rendering. */
@@ -106,6 +134,18 @@ export class NotePanelComponent {
    * locked (the shell skips the gated fetch there). Rendered below the note body.
    */
   readonly backlinks = input<BacklinkSource[]>([]);
+  /**
+   * Per-claim audio receipts (Brain v3 PR-5): each note line that aligned to a
+   * transcript segment (backend `get_note_receipts`, `meeting_is_unlocked`-gated,
+   * EMPTY for a locked meeting). `claimIndex` is an index into the note's raw
+   * `markdown.split("\n")` lines — mapped to a display snippet via {@link noteRaw}.
+   */
+  readonly receipts = input<ClaimAlignment[]>([]);
+  /**
+   * The note's RAW markdown (unparsed), used only to snippet the claim line a
+   * receipt's `claimIndex` points at. Null when there is no note / it is masked.
+   */
+  readonly noteRaw = input<string | null>(null);
   /** The vault export path from the note DTO (Saved-to-vault line). */
   readonly exportedPath = input<string | null>(null);
   /** Model provenance for the ghost badge (null → hidden). */
@@ -165,6 +205,12 @@ export class NotePanelComponent {
   readonly draftInput = output<string>();
   readonly copyPath = output<void>();
   readonly openRelated = output<string>();
+  /**
+   * A receipt chip was clicked (Brain v3 PR-5): asks the shell to switch to the
+   * Audio tab and seek/flash the proving segment. Carries only audio coordinates
+   * (`startS`/`segId`) + a `seq` so a repeat click on the same chip re-fires.
+   */
+  readonly seekReceipt = output<{ startS: number; segId: number; seq: number }>();
 
   // --- ⋯ More overlay menu (local presentational open/close) --------------
   private readonly moreAnchor =
@@ -184,6 +230,85 @@ export class NotePanelComponent {
   readonly hasTrailingBadge = computed(
     () => this.provenanceLabel() !== null,
   );
+
+  /** Monotonic click id so a repeat click on the SAME receipt re-fires downstream. */
+  private receiptSeq = 0;
+
+  /**
+   * The receipts decorated for display: each aligned claim → a chip labelled with
+   * a snippet of the claim line (from the raw markdown at `claimIndex`) + the
+   * speaker + m:ss timestamp of the proving segment. A receipt whose `claimIndex`
+   * is out of range (a stale note vs a just-recomputed alignment) is dropped so a
+   * chip never shows a wrong/blank claim. Pure `computed` (no template method).
+   */
+  readonly receiptChips = computed<ReceiptChip[]>(() => {
+    const raw = this.noteRaw();
+    if (!raw) {
+      return [];
+    }
+    const lines = raw.split("\n");
+    const out: ReceiptChip[] = [];
+    for (const r of this.receipts()) {
+      const line = lines[r.claimIndex];
+      const claim = line ? this.claimSnippet(line) : "";
+      if (!claim) {
+        continue; // out-of-range / non-content line ⇒ no chip
+      }
+      out.push({
+        claim,
+        speaker: this.speakerLabel(r.speaker),
+        time: this.fmtTime(r.startS),
+        startS: r.startS,
+        segId: r.segmentId,
+        claimIndex: r.claimIndex,
+        seq: 0, // filled at click time (a fresh id per click, see onReceipt)
+      });
+    }
+    return out;
+  });
+
+  /** Emit the seek/flash request for a clicked receipt (fresh `seq` each click). */
+  onReceipt(chip: ReceiptChip): void {
+    this.seekReceipt.emit({
+      startS: chip.startS,
+      segId: chip.segId,
+      seq: ++this.receiptSeq,
+    });
+  }
+
+  /** A short, marker-stripped snippet of a claim line for the chip label. */
+  private claimSnippet(line: string): string {
+    // Drop list/checkbox/quote markers and collapse whitespace; cap the length so
+    // the chip stays compact (the full claim stays in the note body above).
+    const cleaned = line
+      .replace(/^\s*(?:[-*+]\s+)?(?:\[[ xX]\]\s+)?/, "")
+      .replace(/^\s*>\s?/, "")
+      .replace(/[#*_`]/g, "")
+      .trim();
+    if (cleaned.length <= 64) {
+      return cleaned;
+    }
+    return cleaned.slice(0, 63).trimEnd() + "…";
+  }
+
+  /** "me"/"others"/legacy → "Me"/"Others"/"" for the chip. */
+  private speakerLabel(speaker: string | null | undefined): string {
+    if (speaker === "me") {
+      return "Me";
+    }
+    if (speaker === "others" || /^others-\d+$/.test(speaker ?? "")) {
+      return "Others";
+    }
+    return "";
+  }
+
+  /** Seconds → m:ss for the receipt timestamp. */
+  private fmtTime(s: number): string {
+    const total = Math.max(0, Math.floor(s || 0));
+    const m = Math.floor(total / 60);
+    const sec = total % 60;
+    return `${m}:${sec.toString().padStart(2, "0")}`;
+  }
 
   /** Map an interaction status to a global `.pill` variant. */
   qaStatusPillClass(status: string): string {


### PR DESCRIPTION
PR-5 of the Brain v3 program (spec: docs/superpowers/specs/2026-07-17-brain-v3-design.md). The first of the two killer features: provenance-grade notes.

## What it does
Every claim (line/bullet) in a meeting note is aligned to the transcript segment it derives from, so the UI shows a **receipt chip** that jumps the audio player to that exact second and flashes the matching segment — with speaker (Me/Others) and ASR confidence.

## Backend
- `summarize/grounding.rs` **`align_claims_to_segments`** — a PURE, deterministic token-overlap alignment (no LLM, no egress) → `ClaimAlignment { claim_index, segment_id, start_s, end_s, speaker, confidence, overlap }`. A claim below the overlap threshold gets no receipt.
- New gated command **`get_note_receipts(meeting_id)`**: `meeting_is_unlocked` **first** — a sealed-not-unlocked meeting returns **empty** (no segment times/speakers leaked, matching the masked-DTO audio-None rule). No new storage → no new seal path (recomputed on demand). Timestamps in **raw seconds** (no MM:SS wrap).

## Frontend
`getNoteReceipts` + a per-claim receipt chip in the note panel that seeks the existing audio player to `start_s` and flashes the segment (`afterNextRender`, no `setTimeout`; re-arms on a repeat click; `@for` tracked by the unique `claimIndex`).

## Why it's a moat
Retained on-device audio + per-segment speaker/confidence make this possible **locally** — competitors that delete audio after transcription structurally can't offer claim-level audio provenance.

## Verification
- `cargo test --lib` → **1840 / 0** (rebased on trunk); `clippy --lib --tests -D warnings` clean; `ng lint` + `ng build` clean.
- RED-before-GREEN: removing the `meeting_is_unlocked` gate fails the sealed-meeting test; neutralizing the aligner fails the positive tests.
- **adversarial-verifier: PASS. lock-security-reviewer: PASS** (the only new read is the gated command; no on-disk path reaches the FE; no PII in logs).

No new dependencies; no schema change. Seek UX + alignment quality on paraphrased LLM lines want a real-Mac dev check (not a leak surface).