### PR TITLE
feat: note↔meeting linking + source-scoped Brain

### DIFF
--- a/docs/superpowers/specs/2026-07-17-note-meeting-links-source-scoped-brain-design.md
+++ b/docs/superpowers/specs/2026-07-17-note-meeting-links-source-scoped-brain-design.md
@@ -1,0 +1,201 @@
+# Note↔Meeting linking + source-scoped Brain — design spec
+
+Date: 2026-07-17 · Status: pre-implementation (design approved by the 4 forks below)
+Base branch: `feat/note-meeting-links-source-brain`, forked from `feat/brain-v3-knowledge-diff`
+tip `830f48e` (brain v3 PR-1..4). Merges AFTER brain v3 lands on `murmur`.
+
+## Why this builds on brain v3 (not from scratch)
+
+Brain v3 PR-3 (`#364`) already ships the **link engine** this feature needs — do NOT duplicate it:
+
+- **`links` table** (`db.rs::migrate_links`): `id, src_kind, src_id, dst_kind, dst_id, edge_type,
+  score, created_by DEFAULT 'user', status DEFAULT 'active', created_at,
+  UNIQUE(src_kind,src_id,dst_kind,dst_id,edge_type)` + `idx_links_src`/`idx_links_dst`. Kinds
+  `meeting|note|document` (`links::LinkKind`); edge types `wikilink|companion|semantic`
+  (`links::EdgeType`).
+- **Gated readers/writers**: `links_for_visible(kind,id,unlocked)` (both-endpoint gate),
+  `upsert_link_tx`, `purge_links_tx` (drops edges touching a sealed folder's items, both
+  directions), `accept_link`/`dismiss_link`, `link_by_id`, `link_endpoint_title_visible`,
+  `index_wikilinks_for_source` (delete-then-insert `[[Title]]`→id edges on note save).
+- **`.md` materialization** (the reuse path for "wikilink when source is a note"):
+  `commands.rs::materialize_accepted_link` + `merge_related_hit` + `crate::enrich::apply_link_markers`
+  write a `[[Title]]` into an OWNED, session-VISIBLE note's managed `murmur:links` block, gated.
+- **FE**: `app-connections` (`src/app/shared/connections/`) self-loads `list_links(kind,id)` and is
+  ALREADY mounted in the note editor and the meeting Note tab; `list_link_candidates(prefix,offset,limit)`
+  + `LinkPickerComponent` (`features/notes/link-picker/`) is the paginated candidate search;
+  `LinkEdge`/`LinkKind` models in `core/models.ts`.
+
+Brain v3's link engine is the STORAGE + GRAPH + gating. This feature is the **user-control layer** on
+top: user-initiated links, a source picker that scopes Ask, link-aware retrieval, and a note-side Ask
+surface. The Ask retrieval (`ask_vault`/`ask_assistant_chat`/`chat_meeting` → `tools::execute_tool` /
+`summarize::vault_context`) does NOT traverse `links` today — closing that is the core value.
+
+## The 4 approved design forks
+
+1. **Base** = worktree off the brain-v3 branch; extend the `links` engine, no duplication.
+2. **Manual link semantics** = a `links` row ALWAYS (`edge_type='manual'`); ADDITIONALLY materialize
+   `[[Title]]` into the note body when the source is a note (reusing `apply_link_markers`). A meeting
+   source (no markdown body) creates the row only.
+3. **Source-picker default** = pre-fill the current item + its active links (removable chips); an empty
+   picker falls back to whole-vault retrieval (today's behavior).
+4. **"Ask about this note"** = a dedicated chat panel below the note body — the twin of the meeting's
+   `app-meeting-chat`.
+
+## Goal
+
+Let a user (a) link a meeting to N notes and a note to N meetings/notes from a first-class dropdown, (b)
+control exactly which meetings/notes feed any Brain answer via a source picker above every Ask input,
+(c) have the Brain automatically pull in a scoped item's LINKED items as context, and (d) ask the Brain
+about a single note. All gated by the lock model, all Obsidian-native, no new deps.
+
+---
+
+## PR-1 — Manual linking (backend M + FE M)
+
+**Backend.**
+- `links::EdgeType` gains `Manual` (DIRECTED, like `Wikilink`/`Companion`): extend `as_str`
+  (`"manual"`), `parse`, `is_undirected()` (→ false), and the two unit round-trip tests in `links.rs`.
+- New gated commands (register in `lib.rs` `generate_handler!`):
+  - `link_items(src_kind, src_id, dst_kind, dst_id) -> Result<()>`: parse kinds (reject unknown as
+    `InvalidArg`); require BOTH endpoints session-VISIBLE (`meeting_is_unlocked` for a meeting,
+    `folder_is_unlocked` for a note/document — mirror `materialize_accepted_link`'s gate order) —
+    refuse `AppError::Locked` otherwise (never link behind a lock, never reveal a locked neighbour).
+    Upsert one `manual` row (`created_by='user'`, `status='active'`, `score=1.0`) via `upsert_link_tx`.
+    Then, per fork #2, if `src_kind` is a note we own the markdown of, materialize `[[dst Title]]` into
+    it via the EXISTING `merge_related_hit` path (skip for a meeting/document source — no owned body).
+    Best-effort materialize: a skip never rolls back the row.
+  - `unlink_items(src_kind, src_id, dst_kind, dst_id) -> Result<()>`: delete the `manual` row; if the
+    source is an owned note, strip the matching `[[Title]]` from its managed block (best-effort, reuse
+    `apply_link_markers` with the hit removed). Never touches wikilink/companion/semantic rows.
+- **Display dedupe (avoid double chips)**: a note→meeting manual link that also materializes `[[Title]]`
+  will, on the next save, ALSO get a `wikilink` edge. `links_for_visible` (Connections) and
+  `backlinks_for_visible` MUST collapse edges to ONE chip per `(other_kind, other_id)` pair, preferring
+  the deterministic edge — the SAME dedupe idiom `backlinks_for_visible` already uses for the companion
+  structured leg vs the wikilink string-scan leg. Add a `manual` badge/label in the collapsed chip.
+
+**FE.**
+- `LinkEdge`/`LinkKind` already exist in `core/models.ts`; add `"manual"` to the `EdgeType` union and
+  IPC methods `linkItems`/`unlinkItems` (one per command, typed — angular-zoneless §3).
+- `app-connections` gains a `+ Link` control (a small button in its header) that opens a **source
+  picker** (the reusable `app-source-picker`, PR-3) filtered to `meeting|note|document`; on pick →
+  `linkItems(anchorKind, anchorId, pickedKind, pickedId)` then re-fetch. Manual (deterministic) chips
+  get a hover `×` → `unlinkItems(...)`. Wire the same into BOTH mount sites (note editor + meeting
+  `note-panel`) — `app-connections` is already in both, so this is one component change. Semantic
+  Accept/Dismiss rows are untouched.
+- The meeting Note tab's Connections panel is the "link notes to this meeting" surface; the note
+  editor's is the "link meetings/notes to this note" surface — SAME component, symmetric.
+
+**Lock discipline.** Manual edges are derived relations already covered by `purge_links_tx`
+(edge-type-agnostic) on seal and by `links_for_visible`'s both-endpoint gate on read. A materialized
+`[[Title]]` lives in an owned note's markdown → blanked by the normal note seal. RED tests
+(`db.rs`/`commands.rs` `#[test]`, headless):
+- `manual_link_row_created_and_gated_both_endpoints` (sealed src OR dst hides the edge both directions);
+- `link_from_meeting_creates_row_but_no_markdown` (meeting source → row only, no note body write);
+- `link_from_note_materializes_wikilink_and_dedupes` (note source → row + `[[Title]]` + ONE chip);
+- `unlink_removes_row_and_strips_marker`;
+- `link_items_refuses_sealed_endpoint` (`AppError::Locked`).
+
+---
+
+## PR-2 — Source-scoped + link-aware retrieval (backend M/L)
+
+**Parameter seam.** Add an OPTIONAL explicit-source list to the three Ask entry points (a `None`
+preserves today's whole-vault behavior byte-for-byte):
+- `ask_vault(question, history, ask_thread_id, explicit_sources: Option<Vec<SourceRef>>)`
+- `ask_assistant_chat(messages, thread_id, anchor_text, meeting_id, explicit_sources: Option<…>)`
+- `chat_meeting(meeting_id, question, history, explicit_sources: Option<…>)`
+- `SourceRef { kind: LinkKind, id: String }` (new `storage::models` DTO, `Serialize`/`Deserialize`,
+  FE camelCase `{kind,id}`).
+
+**Constraint point.** Thread `explicit_sources` into the context builders
+(`summarize::vault_context::build_vault_context_visible` / `build_vault_context_hybrid_visible`) and the
+tool executor (`tools::execute_tool`):
+- When `Some`, retrieval is PINNED to the explicit set: the FTS/vector search is SKIPPED entirely and
+  the corpus is exactly the explicit sources (meetings via `pack_meetings`, notes via a
+  `pack_notes`/`pack_doc_chunks` note leg) PLUS their capped link-expansion below — budget-bounded,
+  nothing else. That is the point of the picker: the user controls the context, so a scoped Ask never
+  silently pulls unlisted vault items. The `unlocked` visibility gate STILL applies AFTER the explicit
+  filter (a sealed explicit source contributes nothing — never a leak). When `None`, the existing
+  whole-vault search path is unchanged.
+- The tool executor's `search_meetings`/`get_meeting`/`get_document` legs, when `explicit_sources` is
+  `Some`, constrain their candidate set to that set (AFTER the visibility gate). No new
+  `AssistantScope` variant — this is an orthogonal candidate constraint, passed alongside the existing
+  scope.
+
+**Link-aware expansion (the "brain knows the connections" piece).** Before packing, expand each explicit
+source with its ACTIVE `links` neighbours via `links_for_visible(kind, id, unlocked)` — capped by a
+named const `LINK_CONTEXT_CAP` (start 8) per source, deduped, gated — so a scoped meeting automatically
+pulls its linked notes' bodies (and vice-versa). Neighbours are appended to the corpus with a lower
+priority than the explicit sources (explicit first, links fill remaining budget). This is what makes
+"1 note ↔ N recordings" actually feed the answer. `None` (whole-vault) does NOT auto-expand (search
+already spans the vault).
+
+**Lock discipline.** Every leg stays `unlocked`-gated; the expansion reuses `links_for_visible` (already
+both-endpoint gated). RED tests:
+- `scoped_ask_ignores_non_listed_meetings` (a meeting not in the set never appears in the corpus);
+- `sealed_explicit_source_contributes_nothing`;
+- `link_expansion_respects_visibility_gate` (a sealed linked neighbour is dropped);
+- `none_sources_preserves_whole_vault_corpus` (regression: identical corpus to pre-change).
+
+---
+
+## PR-3 — Reusable source picker + wiring (FE M)
+
+**New `app-source-picker`** (`src/app/design-system/source-picker/` — a reusable primitive, `mur-`
+family, per angular-zoneless §6b): a chip multiselect over the OPAQUE link-picker popover pattern.
+- Signal API: `selected = model<SourceRef[]>()`, `placeholder = input<string>()`, plus a trigger
+  button. Opens a popover (OPAQUE `--surface-overlay`, `backdrop-filter:none`, `--border-strong`,
+  `--shadow-lg` — trap T3) with a search field + paginated results from `list_link_candidates(prefix,
+  offset, 40)` FILTERED to `meeting|note|document`, keyboard nav + infinite scroll (reuse the
+  `LinkPickerComponent` / `RepositionOnScrollDirective` mechanics; extract the shared popover-search
+  scaffold if clean, else compose). Selected sources render as removable chips (kind badge + title +
+  `×`). Tokens only, signals-first, `afterNextRender` for focus/reposition.
+
+**Wire above every Ask input**, pre-filled per fork #3 (current item + `list_links` active neighbours,
+removable; empty → whole-vault):
+- meeting `app-meeting-chat` (detail Note tab);
+- the global Ask page (`features/ask/ask.component`);
+- the note chat (PR-4).
+Each surface passes `selected()` into its Ask IPC call as `explicit_sources` (PR-2). A default-prefill
+helper resolves `[currentRef, ...list_links(currentKind,currentId).filter(active)]` on load.
+
+---
+
+## PR-4 — "Ask about this note" panel (FE S/M)
+
+**New `app-note-chat`** (`src/app/features/notes/note-chat/`) — the twin of `app-meeting-chat`
+(`features/detail/meeting-chat/`): a self-contained chat (conversation/draft/pending/error signals)
+mounted BELOW the body in the ROUTED note editor (`embedded()===false` only). Its source picker
+(PR-3) defaults to `[thisNote + its active links]`. It calls the source-scoped Ask (PR-2) — reuse
+`ask_vault` with `explicit_sources` (simplest; thread persistence optional, mirror meeting chat if it
+comes cheap). Hidden when the note is locked/masked (same gate as backlinks/Connections). This IS the
+"zapytaj brain o tę notatkę" surface, and because its sources default to the note's links, it already
+answers with the linked meetings/notes in context.
+
+---
+
+## Dependency order & parallelism
+
+`PR-1` (manual links) ‖ `PR-2` (retrieval scope) — disjoint files (PR-1: links.rs/commands link cmds/
+connections FE; PR-2: vault_context/tools/ask commands). `PR-3` (picker) depends on PR-1 (something to
+link) + PR-2 (the param). `PR-4` (note chat) depends on PR-3 + PR-2. Backend PR-1/PR-2 run in parallel;
+FE PR-3/PR-4 serialize after them.
+
+## Explicit non-goals (v1)
+
+Linking persons/entities/orgs as sources (only `meeting|note|document`); org-shared source scoping;
+auto-suggesting manual links (semantic auto-link already covers suggestions); a `murmur://` deep-link
+scheme; changing brain v3's semantic thresholds or graph; connectors as pickable sources.
+
+## Verification matrix
+
+| PR | adversarial-verifier | lock-security-reviewer | real-Mac note |
+|----|----|----|----|
+| 1 | yes (RED both-endpoint gates, dedupe, unlink) | yes (new write/seal-adjacent path) | — |
+| 2 | yes (scope filter + None-regression) | yes (scoped/expanded reads must not leak sealed) | — |
+| 3 | yes (opaque overlay, stale-guarded fetch, signals) | n/a (read-only picker over gated candidates) | picker UX on dev app |
+| 4 | yes (twin-of-meeting-chat, lock-hidden) | yes (note-content read path) | Ask-about-note on dev app |
+
+Gates per PR: `cargo test --lib` + `npx ng lint` + `npx ng build`; final `bash scripts/ci.sh`. QueaT
+commits, PR to `murmur` (never direct push), no Claude trailers. The implementer never self-certifies —
+adversarial-verifier owns PASS/FAIL, lock-security-reviewer is the required second gate on PR-1/2/4.

--- a/e2e/ask/ask-source-scope.spec.ts
+++ b/e2e/ask/ask-source-scope.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Source-scoped Brain (Brain v3 PR-3) — the Ask page threads the
+ * `<mur-source-picker>` selection into `ask_vault` as `explicitSources`.
+ *
+ * The picker DEFAULTS to empty on the Ask page (whole-vault; the user opts in),
+ * so this test opens the picker, picks one candidate, then asks — and asserts
+ * `ask_vault` was called with the picked source as `[{kind, id}]`. A control
+ * turn asked with NO selection carries NO `explicitSources` key (undefined ⇒
+ * omitted ⇒ today's whole-vault behavior).
+ */
+test("Ask page threads the picked source into ask_vault's explicitSources (empty selection ⇒ omitted)", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    list_meetings: () => [
+      {
+        id: "m9",
+        startedAt: "2026-07-01T10:00:00Z",
+        endedAt: null,
+        title: "Planning sync",
+        durationS: 0,
+        audioPath: null,
+        status: "EXPORTED",
+      },
+    ],
+    list_notes: () => [],
+    // The picker's candidate feed — one meeting the user can scope to.
+    list_link_candidates: () => [
+      { kind: "meeting", id: "m9", title: "Planning sync" },
+    ],
+    ask_vault: (args: { explicitSources?: unknown }) => {
+      const w = window as unknown as {
+        __askCalls?: { explicitSources: unknown }[];
+      };
+      w.__askCalls = w.__askCalls ?? [];
+      w.__askCalls.push({ explicitSources: args.explicitSources ?? null });
+      return { answer: "Answer.", sources: [], citations: [] };
+    },
+  });
+
+  await page.goto("/ask");
+
+  const input = page.locator(".ask-input");
+  await expect(input).toBeVisible();
+
+  // Control turn: NO source picked → ask_vault gets no explicitSources.
+  await input.fill("Whole-vault question");
+  await input.press("Enter");
+  await expect(
+    page.locator(".ask-row.is-assistant .ask-bubble").last(),
+  ).toContainText("Answer.");
+
+  // The control turn already settled one user row.
+  await expect(page.locator(".ask-row.is-user")).toHaveCount(1);
+
+  // Open the picker, pick the one candidate → a chip appears.
+  await page.locator("mur-source-picker .sp-trigger").click();
+  await page.locator("mur-source-picker .sp-row").first().click();
+  await expect(page.locator("mur-source-picker .sp-chip-title")).toHaveText([
+    "Planning sync",
+  ]);
+  // Close the popover so the composer regains focus.
+  await page.locator("mur-source-picker .sp-scrim").click();
+  await expect(page.locator("mur-source-picker .sp-pop")).toHaveCount(0);
+
+  // Scoped turn: the picked meeting rides ask_vault as explicitSources. Click
+  // Send explicitly (deterministic) and wait for the SECOND user row to land.
+  await input.fill("Scoped question");
+  await page.locator(".ask-send").click();
+  await expect(page.locator(".ask-row.is-user")).toHaveCount(2);
+  await expect(page.locator(".ask-row.is-user").nth(1)).toContainText(
+    "Scoped question",
+  );
+
+  const calls = await page.evaluate(
+    () =>
+      (window as unknown as {
+        __askCalls?: { explicitSources: { kind: string; id: string }[] | null }[];
+      }).__askCalls ?? [],
+  );
+  expect(calls.length).toBe(2);
+  // First (control) call: no scope threaded.
+  expect(calls[0].explicitSources).toBeNull();
+  // Second (scoped) call: exactly the picked meeting as {kind, id}.
+  expect((calls[1].explicitSources ?? []).map((s) => `${s.kind}:${s.id}`)).toEqual([
+    "meeting:m9",
+  ]);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/detail/meeting-chat-source-scope.spec.ts
+++ b/e2e/detail/meeting-chat-source-scope.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Source-scoped Brain (Brain v3 PR-3) — the meeting "Ask about this meeting"
+ * chat pre-fills its `<mur-source-picker>` with THIS meeting + its ACTIVE linked
+ * neighbours and threads that selection into `chat_meeting` as `explicitSources`.
+ *
+ * `list_links` is mocked to return one active `meeting→note` edge, so the
+ * default scope is `[{meeting m-atlas-roadmap "Q2 Roadmap Planning"}, {note nX}]`;
+ * `chat_meeting` records the `explicitSources` it saw on `window`.
+ */
+test("meeting chat pre-fills this meeting + its links and sends chat_meeting with explicitSources", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    list_links: (args: { kind: string; id: string }) => {
+      if (args.kind === "meeting") {
+        return [
+          {
+            id: 1,
+            direction: "out",
+            otherKind: "note",
+            otherId: "nX",
+            otherTitle: "Companion note",
+            edgeType: "companion",
+            createdBy: "auto",
+            status: "active",
+            score: 0,
+            createdAt: 0,
+          },
+        ];
+      }
+      return [];
+    },
+    chat_meeting: (args: { explicitSources?: unknown }) => {
+      (window as unknown as { __chatSources?: unknown }).__chatSources =
+        args.explicitSources ?? null;
+      return "Grounded meeting answer.";
+    },
+  });
+
+  await page.goto("/meeting/m-atlas-roadmap");
+
+  // The meeting chat is on the default Note tab.
+  const chat = page.locator("app-meeting-chat");
+  await expect(chat).toBeVisible({ timeout: 10_000 });
+
+  // Pre-fill: this meeting (by its TITLE, not id) + its active linked note.
+  await expect(chat.locator(".sp-chip-title")).toHaveText([
+    "Q2 Roadmap Planning",
+    "Companion note",
+  ]);
+
+  // Ask a question — Enter sends.
+  const input = chat.locator(".chat-input");
+  await input.fill("What did we decide?");
+  await input.press("Enter");
+  await expect(
+    chat.locator(".chat-row.is-assistant .chat-bubble").last(),
+  ).toContainText("Grounded meeting answer.");
+
+  // chat_meeting carried the pinned scope: the meeting + its active link.
+  const sent = await page.evaluate(
+    () =>
+      (window as unknown as { __chatSources?: { kind: string; id: string }[] })
+        .__chatSources,
+  );
+  expect(sent).toBeTruthy();
+  expect((sent ?? []).map((s) => `${s.kind}:${s.id}`)).toEqual([
+    "meeting:m-atlas-roadmap",
+    "note:nX",
+  ]);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/notes/connections-linking.spec.ts
+++ b/e2e/notes/connections-linking.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * PR-1 — user-initiated linking UI in the shared `app-connections` panel (mounted
+ * in the note editor at /notes/n1). Verifies, against a mocked Tauri IPC:
+ *  - `list_links` renders a mix of chips; ONLY the `manual:true` chip shows a `×`.
+ *  - clicking that `×` invokes `unlink_items` with the anchor→neighbour args and
+ *    then re-fetches `list_links` (the chip drops out).
+ *  - the `+ Link` chooser opens the OPAQUE single-pick popover (`app-link-picker`),
+ *    and picking a candidate invokes `link_items(anchorKind, anchorId, kind, id)`
+ *    then re-fetches (the new chip appears).
+ *
+ * The mock records every link_items/unlink_items call on `window.__linkCalls` so the
+ * test can assert the exact args (the overrides are serialized page-side — no test
+ * closures — so they stash calls on `window` and drive `list_links` off a flag they
+ * also set on `window`). The core gate is ZERO console/page errors through the flow.
+ */
+test("connections panel: × only on manual chips (unlink), + Link chooser links a candidate — no console errors", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    // list_links: three chips before any mutation — a MANUAL (removable) wikilink,
+    // an AUTO companion (not removable), and a SEMANTIC suggestion. After an unlink
+    // or a link the mock flips window.__linksAfter so the re-fetch returns a fresh set.
+    list_links: () => {
+      const w = window as unknown as {
+        __linksAfterUnlink?: boolean;
+        __linksAfterLink?: boolean;
+      };
+      const rows = [
+        // The manual (removable) chip — dropped once __linksAfterUnlink flips.
+        {
+          id: 1,
+          direction: "out",
+          otherKind: "meeting",
+          otherId: "m-manual",
+          otherTitle: "Manual Meeting Link",
+          edgeType: "wikilink",
+          createdBy: "user",
+          status: "active",
+          score: 1.0,
+          createdAt: 1_720_000_100,
+          manual: true,
+        },
+        {
+          id: 2,
+          direction: "out",
+          otherKind: "note",
+          otherId: "n2",
+          otherTitle: "Weekly plan",
+          edgeType: "companion",
+          createdBy: "auto",
+          status: "active",
+          score: 1.0,
+          createdAt: 1_720_000_000,
+          manual: false,
+        },
+        {
+          id: 3,
+          direction: "in",
+          otherKind: "note",
+          otherId: "n-sugg",
+          otherTitle: "A suggested note",
+          edgeType: "semantic",
+          createdBy: "auto",
+          status: "suggested",
+          score: 0.86,
+          createdAt: 1_720_000_050,
+          manual: false,
+        },
+      ];
+      const out = w.__linksAfterUnlink
+        ? rows.filter((r) => r.id !== 1) // manual chip removed by unlink
+        : rows;
+      if (w.__linksAfterLink) {
+        out.push({
+          id: 9,
+          direction: "out",
+          otherKind: "note",
+          otherId: "n-picked",
+          otherTitle: "Picked Note",
+          edgeType: "manual",
+          createdBy: "user",
+          status: "active",
+          score: 1.0,
+          createdAt: 1_720_000_200,
+          manual: true,
+        });
+      }
+      return out;
+    },
+
+    // The single-pick chooser's candidate feed: a note + a meeting + an org row
+    // (org must be filtered out of the chooser as a non-linkable endpoint).
+    list_link_candidates: () => [
+      { kind: "note", id: "n-picked", title: "Picked Note", snippet: "" },
+      { kind: "meeting", id: "m-cand", title: "Some meeting", snippet: "" },
+      { kind: "org", id: "org-1", title: "Org item", snippet: "" },
+    ],
+
+    // Record link/unlink calls + flip the re-fetch flag so list_links changes.
+    link_items: (args: unknown) => {
+      const w = window as unknown as {
+        __linkCalls?: unknown[];
+        __linksAfterLink?: boolean;
+      };
+      (w.__linkCalls = w.__linkCalls || []).push({ cmd: "link_items", args });
+      w.__linksAfterLink = true;
+      return null;
+    },
+    unlink_items: (args: unknown) => {
+      const w = window as unknown as {
+        __linkCalls?: unknown[];
+        __linksAfterUnlink?: boolean;
+      };
+      (w.__linkCalls = w.__linkCalls || []).push({ cmd: "unlink_items", args });
+      w.__linksAfterUnlink = true;
+      return null;
+    },
+
+    // Keep backlinks empty so only the connections panel is under test.
+    get_backlinks: () => [],
+  });
+
+  await page.goto("/notes/n1");
+
+  const panel = page.locator("app-connections");
+  await expect(panel).toBeVisible();
+
+  // Three chips render; the manual one has a × remove button, the others do not.
+  await expect(panel.getByText("Manual Meeting Link")).toBeVisible();
+  await expect(panel.getByText("Weekly plan")).toBeVisible();
+  await expect(panel.getByText("A suggested note")).toBeVisible();
+
+  // Exactly ONE remove (×) button — on the manual chip only.
+  const removeButtons = panel.locator("button.cx-remove");
+  await expect(removeButtons).toHaveCount(1);
+  await expect(
+    panel.getByRole("button", { name: "Remove link to Manual Meeting Link" }),
+  ).toBeVisible();
+
+  // Click the × → unlink_items(anchorKind=note, anchorId=n1, otherKind=meeting,
+  // otherId=m-manual) is invoked, then the re-fetch drops the manual chip.
+  await removeButtons.first().click();
+  await expect(panel.getByText("Manual Meeting Link")).toHaveCount(0);
+
+  const afterUnlink = await page.evaluate(
+    () => (window as unknown as { __linkCalls?: unknown[] }).__linkCalls || [],
+  );
+  expect(afterUnlink).toEqual([
+    {
+      cmd: "unlink_items",
+      args: {
+        srcKind: "note",
+        srcId: "n1",
+        dstKind: "meeting",
+        dstId: "m-manual",
+      },
+    },
+  ]);
+
+  // Open the + Link chooser → the query input + the opaque picker popover appear.
+  await panel.getByRole("button", { name: "Link" }).click();
+  await expect(panel.getByPlaceholder(/Link a meeting, note/)).toBeVisible();
+  const picker = page.locator("app-link-picker");
+  await expect(picker).toBeVisible();
+
+  // The picker offers the candidates (org row is not a valid endpoint; picking a
+  // note candidate invokes link_items(anchor=note/n1 → note/n-picked)).
+  const pickedRow = picker.getByRole("option", { name: /Picked Note/ });
+  await expect(pickedRow).toBeVisible();
+  // mousedown is prevented on the popover (no focus steal), then click emits picked.
+  await pickedRow.dispatchEvent("click");
+
+  // The new manual chip appears from the re-fetch; link_items was called correctly.
+  await expect(panel.getByText("Picked Note")).toBeVisible();
+  const afterLink = await page.evaluate(
+    () => (window as unknown as { __linkCalls?: unknown[] }).__linkCalls || [],
+  );
+  expect(afterLink).toContainEqual({
+    cmd: "link_items",
+    args: { srcKind: "note", srcId: "n1", dstKind: "note", dstId: "n-picked" },
+  });
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/notes/note-chat-source-scope.spec.ts
+++ b/e2e/notes/note-chat-source-scope.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Source-scoped Brain (Brain v3 PR-4) — smoke over the "Ask about this note"
+ * panel mounted below the note body (ROUTED mode). It:
+ *   1. renders below the body for an OPEN note,
+ *   2. pre-fills its `<mur-source-picker>` with the note itself + its ACTIVE
+ *      linked neighbours (via `list_links`), and
+ *   3. sends `ask_vault` with a NON-empty `explicitSources` (the picked scope).
+ *
+ * The panel must be HIDDEN for a LOCKED note (the lock gate renders instead) —
+ * never surface a note-chat behind a lock.
+ *
+ * `list_links` is mocked to return one active `note→meeting` edge so the default
+ * scope is `[{note n1}, {meeting m9}]`; `ask_vault` records the `explicitSources`
+ * it was called with on `window` so the test can assert the exact wire shape.
+ */
+test("Ask-about-this-note renders below the body, pre-fills note + its links, and sends ask_vault with explicitSources", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page, {
+    // One ACTIVE deterministic link from this note → a meeting, so the picker
+    // pre-fills with the note + that neighbour. A `suggested` edge is included
+    // to prove it is EXCLUDED from the default scope.
+    list_links: (args: { kind: string; id: string }) => {
+      if (args.kind === "note" && args.id === "n1") {
+        return [
+          {
+            id: 1,
+            direction: "out",
+            otherKind: "meeting",
+            otherId: "m9",
+            otherTitle: "Planning sync",
+            edgeType: "wikilink",
+            createdBy: "auto",
+            status: "active",
+            score: 0,
+            createdAt: 0,
+          },
+          {
+            id: 2,
+            direction: "out",
+            otherKind: "note",
+            otherId: "n-sugg",
+            otherTitle: "A mere suggestion",
+            edgeType: "semantic",
+            createdBy: "auto",
+            status: "suggested",
+            score: 0.7,
+            createdAt: 0,
+          },
+        ];
+      }
+      return [];
+    },
+    ask_vault: (args: { explicitSources?: unknown }) => {
+      (window as unknown as { __askVaultSources?: unknown }).__askVaultSources =
+        args.explicitSources ?? null;
+      return { answer: "Grounded answer.", sources: [], citations: [] };
+    },
+  });
+
+  await page.goto("/notes/n1");
+
+  // The panel is mounted below the body.
+  const chat = page.locator("app-note-chat");
+  await expect(chat).toBeVisible();
+  await expect(chat.locator(".chat-title")).toHaveText("Ask about this note");
+
+  // Pre-fill: the note itself + its ACTIVE linked meeting render as chips; the
+  // `suggested` edge is excluded. Chip titles come from `SourceRef.title`.
+  const chips = chat.locator(".sp-chip-title");
+  await expect(chips).toHaveText(["My First Note", "Planning sync"]);
+
+  // Ask a question — Enter sends via the composer.
+  const input = chat.locator(".chat-input");
+  await input.fill("Summarize this note");
+  await input.press("Enter");
+  await expect(
+    chat.locator(".chat-row.is-assistant .chat-bubble").last(),
+  ).toContainText("Grounded answer.");
+
+  // ask_vault carried the pinned scope: exactly the note + its active link,
+  // each as `{kind, id}` (title is display-only; the backend ignores it).
+  const sent = await page.evaluate(
+    () =>
+      (window as unknown as { __askVaultSources?: { kind: string; id: string }[] })
+        .__askVaultSources,
+  );
+  expect(sent).toBeTruthy();
+  const pairs = (sent ?? []).map((s) => `${s.kind}:${s.id}`);
+  expect(pairs).toEqual(["note:n1", "meeting:m9"]);
+
+  expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * A LOCKED note renders the lock gate, and the Ask-about-this-note panel is
+ * NEVER mounted (it lives inside the not-locked branch, `!embedded()`).
+ */
+test("Ask-about-this-note is hidden for a locked note (lock gate shown, no chat)", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockNotes(page);
+  await page.goto("/notes/nlk");
+
+  // The lock gate is shown …
+  await expect(page.locator(".lock-gate")).toBeVisible();
+  // … and the note-chat panel is not mounted.
+  await expect(page.locator("app-note-chat")).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/notes/note-editor-embedded.spec.ts
+++ b/e2e/notes/note-editor-embedded.spec.ts
@@ -143,11 +143,14 @@ test("(b) embedded mount shows ONLY the body + working Ask Brain — no header/t
   await expect(body).toHaveValue(/Some body text to select\./);
 
   // CHROME IS GONE: no header, no title input, no properties bar, no backlinks,
-  // no Preview/Share toggle.
+  // no Preview/Share toggle, and no Ask-about-this-note panel (source-scoped
+  // Brain PR-4 — the recording companion's Ask Brain tab owns Q&A, so the
+  // embedded Note tab never mounts the note-chat).
   await expect(embed.locator(".editor-head")).toHaveCount(0);
   await expect(embed.locator(".note-title-input")).toHaveCount(0);
   await expect(embed.locator(".props")).toHaveCount(0);
   await expect(embed.locator("app-backlinks")).toHaveCount(0);
+  await expect(embed.locator("app-note-chat")).toHaveCount(0);
   await expect(embed.getByRole("button", { name: "Preview", exact: true })).toHaveCount(0);
 
   // The IN-NOTE Ask Brain works embedded: select body text → the formatting

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1398,9 +1398,17 @@ pub async fn ask_assistant_chat(
     thread_id: Option<String>,
     anchor_text: Option<String>,
     meeting_id: Option<String>,
+    explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
 ) -> Result<crate::voice_action::VoiceActionResult, AppError> {
     let (latest, conversation) = format_chat(&messages)?;
     let thread_id = crate::transcribe::live::ensure_thread_id(thread_id);
+    // note↔meeting-links PR-2 — SOURCE-SCOPED augmentation (PARTIAL, the SHOULD leg). The @brain
+    // assistant loop (`run_assistant_query`) is a deep current-first cascade whose tool executor +
+    // deterministic floor legs would need wide surgery to fully candidate-constrain; PR-2 threads
+    // the pinned sources one level in so the cloud AGENTIC cascade reasons with the gated pinned
+    // corpus injected into its conversation context. `None`/empty ⇒ byte-identical to before. The
+    // remaining full candidate-constraint of the floor/tool legs is a documented follow-up.
+    let explicit_sources = explicit_sources.filter(|s| !s.is_empty());
     tokio::task::spawn_blocking(move || {
         crate::transcribe::live::run_assistant_query(
             &app,
@@ -1410,6 +1418,7 @@ pub async fn ask_assistant_chat(
             &thread_id,
             anchor_text.as_deref(),
             meeting_id.as_deref(),
+            explicit_sources.as_deref(),
         )
     })
     .await
@@ -5504,6 +5513,7 @@ pub async fn chat_meeting(
     meeting_id: String,
     question: String,
     history: Vec<ChatTurn>,
+    explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
 ) -> Result<String, AppError> {
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
@@ -5521,7 +5531,7 @@ pub async fn chat_meeting(
             "this meeting has no transcript to chat about yet".into(),
         ));
     }
-    let transcript = segments
+    let mut transcript = segments
         .iter()
         .map(|s| format!("[{:.0}s] {}", s.start_s, s.text.trim()))
         .collect::<Vec<_>>()
@@ -5533,6 +5543,30 @@ pub async fn chat_meeting(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
             .clone()
     };
+    // Inject the gated cross-meeting USER MEMORY brief (parity with the @brain agentic loop): derived
+    // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
+    // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
+    let unlocked = unlocked_snapshot(state.inner())?;
+    // note↔meeting-links PR-2 — SOURCE-SCOPED augmentation: when the FE pins explicit sources (the
+    // linked notes/meetings the user chose above the chat input), APPEND their gated PINNED corpus
+    // (+ capped, gated link-expansion) to this meeting's transcript grounding — the meeting stays the
+    // primary context, the pinned items add cross-item context. Every leg is `unlocked`-gated (a
+    // sealed pinned source/neighbour contributes NOTHING — never a leak). `None`/empty ⇒ byte-
+    // identical to the pre-change transcript-only grounding.
+    if let Some(sources) = explicit_sources.filter(|s| !s.is_empty()) {
+        let ask_conn =
+            crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, &config)
+                .connection;
+        let (pinned, _) = crate::summarize::vault_context::build_vault_context_pinned_visible(
+            &state.db, &sources, &ask_conn, &unlocked,
+        )?;
+        if !pinned.trim().is_empty() {
+            transcript.push_str(
+                "\n\n=== LINKED NOTES & MEETINGS (the user pinned these as additional context) ===\n",
+            );
+            transcript.push_str(&pinned);
+        }
+    }
     // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
     // default provider as before (the legacy chat path always ignored `brain_backend`).
     let provider = crate::summarize::provider_for(
@@ -5540,10 +5574,6 @@ pub async fn chat_meeting(
         &config,
         &state.heavy_inference,
     )?;
-    // Inject the gated cross-meeting USER MEMORY brief (parity with the @brain agentic loop): derived
-    // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
-    // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
-    let unlocked = unlocked_snapshot(state.inner())?;
     let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked, &question);
     let (system, user) =
         crate::summarize::chat::build(&transcript, &history, &question, &memory_brief);
@@ -8419,6 +8449,7 @@ pub async fn ask_vault(
     question: String,
     history: Vec<ChatTurn>,
     ask_thread_id: Option<String>,
+    explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
 ) -> Result<AskVaultResult, AppError> {
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
@@ -8433,6 +8464,36 @@ pub async fn ask_vault(
     // The same 12-message discipline as the chat panel (CHAT_CONTEXT_TURNS): bounds prompt growth +
     // cloud egress on BOTH paths. The LATEST question still drives retrieval either way.
     let history: Vec<ChatTurn> = capped_ask_history(&history).to_vec();
+
+    // note↔meeting-links PR-2 — SOURCE-SCOPED (pinned) Ask. When the FE source picker sends a
+    // non-empty explicit source list, retrieval is PINNED to exactly those items (+ their capped,
+    // gated link-expansion) and answered DETERMINISTICALLY via the SAME floor answer path — the
+    // agentic vault-wide search is SKIPPED (the user controls the context, so a scoped Ask never
+    // pulls unlisted vault items). `None`/empty ⇒ this whole block is a no-op and the path below is
+    // BYTE-IDENTICAL to before.
+    let pinned_sources: Option<Vec<crate::storage::models::SourceRef>> =
+        explicit_sources.filter(|s| !s.is_empty());
+    if let Some(sources) = pinned_sources {
+        let unlocked = unlocked_snapshot(state.inner())?;
+        let memory_brief = gated_memory_brief_for_injection(state.inner(), &unlocked, &question);
+        let reranker = crate::rerank::active_reranker(
+            state
+                .reasoner
+                .current_for(crate::summarize::roles::Role::Ask),
+        );
+        return ask_vault_floor(
+            &state.db,
+            &config,
+            &unlocked,
+            &question,
+            &history,
+            &memory_brief,
+            Some(reranker),
+            &state.heavy_inference,
+            Some(sources),
+        )
+        .await;
+    }
 
     // Agentic path — CLOUD-connection roles only (the same rule as the in-meeting brain:
     // local-GGUF multi-step tool-call reliability is unproven). The eligibility gate keys on the
@@ -8482,6 +8543,7 @@ pub async fn ask_vault(
         &memory_brief,
         Some(reranker),
         &state.heavy_inference,
+        None, // whole-vault path: no explicit sources ⇒ the existing search corpus, unchanged.
     )
     .await
 }
@@ -8729,20 +8791,24 @@ fn build_ask_vault_floor_prompt(
     history: &[ChatTurn],
     memory_brief: &str,
     reranker: Option<&dyn crate::rerank::Reranker>,
+    explicit_sources: Option<&[crate::storage::models::SourceRef]>,
 ) -> Result<AskFloorPrompt, AppError> {
-    // Phase 2b (gated): when semantic search is ON, pick candidates by HYBRID retrieval (FTS ∪
-    // vector KNN, RRF-fused) — embedding the query with the active embedder — then pack with the
-    // SAME budget/citation logic and the SAME visibility gate. When OFF (the default) OR the index
-    // is empty, this falls back to the existing FTS-only path UNCHANGED (the hybrid query
-    // degenerates to FTS when no vectors exist; the flag-off branch is byte-for-byte the prior
-    // behavior).
     // Budget on the ASK-role provider's RESOLVED connection — the corpus egresses to it. With
     // role keys absent this is the legacy `provider_id` for EVERY brain_backend (the pre-role
     // floor always ignored `brain_backend`), so the packed corpus is byte-identical.
     let ask_conn =
         crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, config)
             .connection;
-    let (corpus, sources) = if config.semantic_search_enabled {
+    // note↔meeting-links PR-2 — PINNED corpus: when the caller supplied an explicit source list, the
+    // FTS/vector SEARCH is skipped entirely and the corpus is EXACTLY those sources (+ their capped,
+    // gated link-expansion) — the user controls the context. Same `unlocked` visibility gate as
+    // every search leg (a sealed source/neighbour contributes nothing). `None` ⇒ the exact existing
+    // whole-vault search below, byte-for-byte.
+    let (corpus, sources) = if let Some(sources) = explicit_sources.filter(|s| !s.is_empty()) {
+        crate::summarize::vault_context::build_vault_context_pinned_visible(
+            db, sources, &ask_conn, unlocked,
+        )?
+    } else if config.semantic_search_enabled {
         let embedder = crate::embed::active_embedder();
         // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
         let query_vec = embedder
@@ -8789,6 +8855,7 @@ async fn ask_vault_floor(
     memory_brief: &str,
     reranker: Option<Box<dyn crate::rerank::Reranker>>,
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
+    explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
 ) -> Result<AskVaultResult, AppError> {
     // `build_ask_vault_floor_prompt` does the LOCAL/on-device work — query embedding (Candle/
     // Metal) + hybrid FTS∪vector retrieval + reranker inference — synchronously. This is exactly
@@ -8814,6 +8881,7 @@ async fn ask_vault_floor(
             &history_owned,
             &memory_brief_owned,
             reranker.as_deref(),
+            explicit_sources.as_deref(),
         )
     })
     .await
@@ -9099,7 +9167,9 @@ mod ask_vault_tests {
         let (want_system, want_user) =
             crate::summarize::vault_chat::build(&corpus, &history, q, "");
 
-        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None).unwrap() {
+        match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None, None)
+            .unwrap()
+        {
             AskFloorPrompt::Ready {
                 system,
                 user,
@@ -9130,7 +9200,8 @@ mod ask_vault_tests {
 
         // The empty-vault early return keeps the EXACT pre-change canned answer.
         let empty = tmp_db();
-        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None).unwrap() {
+        match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None, None).unwrap()
+        {
             AskFloorPrompt::Empty(r) => {
                 assert_eq!(
                     r.answer,
@@ -9173,6 +9244,7 @@ mod ask_vault_tests {
             "",
             None,
             &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+            None,
         ));
         assert!(
             matches!(res, Err(AppError::Unavailable(_))),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8022,11 +8022,19 @@ fn link_endpoint_is_unlocked(
 ) -> Result<bool, AppError> {
     match kind {
         crate::links::LinkKind::Meeting => meeting_is_unlocked(state, id),
-        crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
-            match state.db.get_note_row(id)? {
-                Some(row) => folder_is_unlocked(state, &row.folder_id),
-                None => Ok(false), // unknown note/document → nothing to surface. Fail-closed.
-            }
+        crate::links::LinkKind::Note => match state.db.get_note_row(id)? {
+            Some(row) => folder_is_unlocked(state, &row.folder_id),
+            None => Ok(false), // unknown note → nothing to surface. Fail-closed.
+        },
+        crate::links::LinkKind::Document => {
+            // An imported `document` (kind != 'note') is NOT a `get_note_row` row, so routing it
+            // through `get_note_row` refused it fail-closed EVEN WHEN VISIBLE (a spurious `Locked`
+            // on the +Link chooser). Gate it via the canonical visibility reader
+            // (`get_document_if_visible` applies `visibility_clause` against the live unlock set):
+            // `Some` ⇒ visible/unlocked, `None` ⇒ sealed-or-unknown ⇒ refuse. Documents stay
+            // linkable (the chooser AND the Ask source-picker both offer them) and still fail-closed.
+            let unlocked = unlocked_snapshot(state)?;
+            Ok(state.db.get_document_if_visible(id, &unlocked)?.is_some())
         }
     }
 }
@@ -19802,6 +19810,54 @@ mod lifecycle_tests {
         assert!(
             matches!(err2, AppError::Locked(_)),
             "a sealed source endpoint must refuse with Locked; got {err2:?}"
+        );
+    }
+
+    /// A `document` endpoint (an imported PDF/DOCX, `kind='document'` — NOT a `get_note_row` row) must
+    /// be LINKABLE when visible and REFUSED when sealed. Before the dedicated `Document` gate arm,
+    /// `link_endpoint_is_unlocked` routed documents through `get_note_row` (which filters `kind='note'`)
+    /// → `None` → a spurious `Locked` even for an OPEN document. RED: the "open document links"
+    /// assertion fails on the pre-fix code path; the sealed-document refusal proves the gate still holds.
+    #[test]
+    fn link_items_gates_document_endpoint() {
+        let state = build_state("link-doc-endpoint");
+        make_open_folder(&state.db, "f-open", "Open");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "body\n");
+        // An OPEN imported document (linkable) + a SEALED imported document (must refuse).
+        state
+            .db
+            .insert_document("doc-open", "f-open", "Contract.pdf", "extracted text", "document", 0i64)
+            .unwrap();
+        state
+            .db
+            .insert_document("doc-seal", "f-lock", "Secret.pdf", "secret extracted", "document", 0i64)
+            .unwrap();
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        // Linking the OPEN document SUCCEEDS (RED before the Document gate arm — was a spurious Locked).
+        link_items_inner(&state, "note", "src", "document", "doc-open").unwrap();
+        let open = unlocked_snapshot(&state).unwrap();
+        assert_eq!(
+            state
+                .db
+                .links_for_visible(crate::links::LinkKind::Note, "src", &open)
+                .unwrap()
+                .iter()
+                .filter(|e| e.other_id == "doc-open")
+                .count(),
+            1,
+            "an open document must be linkable and visible from the note side"
+        );
+
+        // Linking the SEALED document REFUSES Locked (gate holds through the new arm; no row written).
+        let err = link_items_inner(&state, "note", "src", "document", "doc-seal").unwrap_err();
+        assert!(
+            matches!(err, AppError::Locked(_)),
+            "a sealed document endpoint must refuse with Locked; got {err:?}"
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7978,6 +7978,213 @@ pub fn dismiss_link(state: State<'_, AppState>, id: i64) -> Result<(), AppError>
     Ok(())
 }
 
+/// note↔meeting-links PR-1 — is a link ENDPOINT `(kind, id)` session-VISIBLE right now? Mirrors
+/// [`materialize_accepted_link`]'s gate order: a `Meeting` endpoint gates on [`meeting_is_unlocked`];
+/// a `Note`/`Document` endpoint resolves its owning folder via `get_note_row` and gates on
+/// [`folder_is_unlocked`]. An UNKNOWN endpoint (no such note/document) reports `false` — fail-closed,
+/// there is nothing legitimate to link. Used by `link_items`/`unlink_items` to refuse `AppError::Locked`
+/// before any write, so a manual edge is never created behind a lock and never reveals a locked
+/// neighbour.
+fn link_endpoint_is_unlocked(
+    state: &AppState,
+    kind: crate::links::LinkKind,
+    id: &str,
+) -> Result<bool, AppError> {
+    match kind {
+        crate::links::LinkKind::Meeting => meeting_is_unlocked(state, id),
+        crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
+            match state.db.get_note_row(id)? {
+                Some(row) => folder_is_unlocked(state, &row.folder_id),
+                None => Ok(false), // unknown note/document → nothing to surface. Fail-closed.
+            }
+        }
+    }
+}
+
+/// note↔meeting-links PR-1 — USER-INITIATED link: persist ONE directed `manual` edge
+/// `(src → dst)` AND, when the source is an OWNED note, materialize `[[dst Title]]` into its body.
+///
+/// GATE (BEFORE any write): BOTH endpoints must be session-VISIBLE — a `meeting` via
+/// [`meeting_is_unlocked`], a `note`/`document` via its folder ([`folder_is_unlocked`]). If either is
+/// sealed-and-not-session-unlocked → `AppError::Locked` (never link behind a lock, never reveal a
+/// locked neighbour). Unknown kinds are `AppError::InvalidArg`.
+///
+/// The `manual` row (`created_by='user'`, `status='active'`, `score=1.0`) is idempotent on the
+/// table's UNIQUE key. For a `note` SOURCE we own the markdown of, we ALSO materialize the neighbour's
+/// gated `[[Title]]` into the managed `murmur:links` block via the SAME [`materialize_accepted_link`]
+/// path the accept command uses — best-effort (a materialize skip never rolls back the row). A
+/// `meeting`/`document` source (no owned editable body) creates the row ONLY. The materialized
+/// wikilink is display-deduped against the manual edge in `links_for_visible`.
+#[tauri::command]
+pub fn link_items(
+    state: State<'_, AppState>,
+    src_kind: String,
+    src_id: String,
+    dst_kind: String,
+    dst_id: String,
+) -> Result<(), AppError> {
+    link_items_inner(state.inner(), &src_kind, &src_id, &dst_kind, &dst_id)
+}
+
+pub(crate) fn link_items_inner(
+    state: &AppState,
+    src_kind: &str,
+    src_id: &str,
+    dst_kind: &str,
+    dst_id: &str,
+) -> Result<(), AppError> {
+    let src = parse_link_kind(src_kind)?;
+    let dst = parse_link_kind(dst_kind)?;
+    // Refuse a self-link (a pair pointing at itself is meaningless and would pollute the graph).
+    if src == dst && src_id == dst_id {
+        return Err(AppError::InvalidArg("cannot link an item to itself".into()));
+    }
+    // BLK-1 / TOCTOU: SCOPE the lifecycle guard tightly around gate + row-write so a concurrent
+    // lock/relock cannot land between the visibility check and the edge upsert. It is RELEASED before
+    // the note-body materialize below — that callee (`update_note_doc_inner`) takes the guard ITSELF
+    // and re-checks the folder gate, so composing them under one held guard would re-enter a
+    // non-reentrant `Mutex<()>` (the lifecycle_guard doc: never hold it around a callee that takes
+    // it). Lock order `lifecycle ⊃ db`.
+    {
+        let _lifecycle = lifecycle_guard(state);
+        // ── GATE both endpoints BEFORE any write (fail-closed on a sealed/unknown endpoint). ──
+        if !link_endpoint_is_unlocked(state, src, src_id)?
+            || !link_endpoint_is_unlocked(state, dst, dst_id)?
+        {
+            return Err(AppError::Locked(
+                "one of these items is locked — unlock it to link".into(),
+            ));
+        }
+        // ── Persist the directed manual edge (idempotent on the UNIQUE key). ──
+        state
+            .db
+            .upsert_manual_link(src.as_str(), src_id, dst.as_str(), dst_id)?;
+    }
+    // ── Fork #2: a NOTE source ALSO gets the neighbour's [[Title]] in its body (best-effort). ──
+    // A meeting/document source has no owned editable markdown → row only. `materialize_accepted_link`
+    // re-gates the source folder itself before writing plaintext (never behind a lock).
+    if matches!(src, crate::links::LinkKind::Note) {
+        let unlocked = unlocked_snapshot(state)?;
+        // Resolve the dst's CURRENT gated title (skip if sealed — no leak; the gate above already
+        // proved it visible, so this normally resolves).
+        if let Some(title) = state.db.link_endpoint_title_visible(dst, dst_id, &unlocked)? {
+            // Reuse the EXACT accept-materialize path (managed `murmur:links` block, merge-preserving).
+            if let Err(e) = materialize_accepted_link(state, src, src_id, &title) {
+                // Best-effort: the graph row is authoritative; a markdown-write failure never fails the
+                // link (no PII — ids/error only).
+                tracing::warn!(
+                    target: "links",
+                    error = %e,
+                    "manual link materialize skipped (row persisted)"
+                );
+            }
+        }
+    }
+    tracing::info!(
+        target: "links",
+        src_kind = src.as_str(),
+        dst_kind = dst.as_str(),
+        "link_items"
+    );
+    Ok(())
+}
+
+/// note↔meeting-links PR-1 — REMOVE a user-initiated link: delete ONLY the directed `manual` edge
+/// `(src → dst)` and, when the source is an OWNED note, strip the matching `[[dst Title]]` from its
+/// managed `murmur:links` block. NEVER touches a `wikilink`/`companion`/`semantic` row for the pair.
+///
+/// GATE: BOTH endpoints must be session-VISIBLE (same gate as `link_items`) — never mutate a note's
+/// body behind a lock, never reveal a locked neighbour's title. The strip is BEST-EFFORT (a failure
+/// logs and never fails the unlink — the graph row is the authoritative removal). Unknown kinds are
+/// `AppError::InvalidArg`.
+#[tauri::command]
+pub fn unlink_items(
+    state: State<'_, AppState>,
+    src_kind: String,
+    src_id: String,
+    dst_kind: String,
+    dst_id: String,
+) -> Result<(), AppError> {
+    unlink_items_inner(state.inner(), &src_kind, &src_id, &dst_kind, &dst_id)
+}
+
+pub(crate) fn unlink_items_inner(
+    state: &AppState,
+    src_kind: &str,
+    src_id: &str,
+    dst_kind: &str,
+    dst_id: &str,
+) -> Result<(), AppError> {
+    let src = parse_link_kind(src_kind)?;
+    let dst = parse_link_kind(dst_kind)?;
+    // SCOPE the guard around gate + row-delete only; release before the note-body strip below (which
+    // re-enters the guard via `update_note_doc_inner`). Same non-reentrancy discipline as `link_items`.
+    {
+        let _lifecycle = lifecycle_guard(state);
+        // ── GATE both endpoints (never mutate a note body / reveal a neighbour behind a lock). ──
+        if !link_endpoint_is_unlocked(state, src, src_id)?
+            || !link_endpoint_is_unlocked(state, dst, dst_id)?
+        {
+            return Err(AppError::Locked(
+                "one of these items is locked — unlock it to unlink".into(),
+            ));
+        }
+        // ── Delete ONLY the manual edge (wikilink/companion/semantic rows for the pair untouched). ──
+        state
+            .db
+            .delete_manual_link(src.as_str(), src_id, dst.as_str(), dst_id)?;
+    }
+    // ── A NOTE source: strip the matching [[Title]] from its managed block (best-effort). ──
+    if matches!(src, crate::links::LinkKind::Note) {
+        let unlocked = unlocked_snapshot(state)?;
+        if let Some(title) = state.db.link_endpoint_title_visible(dst, dst_id, &unlocked)? {
+            if let Err(e) = strip_manual_link_marker(state, src_id, &title) {
+                tracing::warn!(
+                    target: "links",
+                    error = %e,
+                    "manual link marker strip skipped (row removed)"
+                );
+            }
+        }
+    }
+    tracing::info!(
+        target: "links",
+        src_kind = src.as_str(),
+        dst_kind = dst.as_str(),
+        "unlink_items"
+    );
+    Ok(())
+}
+
+/// note↔meeting-links PR-1 — remove ONE `[[title]]` [`ContextHit`] from an owned note's managed
+/// `murmur:links` block, re-applying the block with that hit filtered out (the INVERSE of
+/// [`merge_related_hit`]). Reuses [`crate::enrich::extract_link_hits`] +
+/// [`crate::enrich::apply_link_markers`] so the block stays idempotent and any auto related-notes /
+/// accepted-semantic hits that lived alongside it survive. WRITE-GATED via `update_note_doc_inner`
+/// (refuses a sealed folder). A no-op (the note is unchanged) when the block never carried the hit.
+fn strip_manual_link_marker(state: &AppState, note_id: &str, title: &str) -> Result<(), AppError> {
+    let Some(row) = state.db.get_note_row(note_id)? else {
+        return Ok(()); // no owned note markdown → nothing to strip.
+    };
+    let marker = format!("[[{title}]]");
+    let mut hits = crate::enrich::extract_link_hits(&row.text);
+    let before = hits.len();
+    hits.retain(|h| h.detail != marker);
+    if hits.len() == before {
+        return Ok(()); // the marker was not in the managed block → note unchanged.
+    }
+    let merged = crate::enrich::apply_link_markers(&row.text, &hits);
+    if merged != row.text {
+        let title_disp = row
+            .title
+            .clone()
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| row.name.clone());
+        update_note_doc_inner(state, note_id, &title_disp, &merged)?;
+    }
+    Ok(())
+}
+
 /// Brain v3 PR-3 — WRITE-TIME wikilink indexing hook, called from every note-save funnel AFTER the
 /// text is durable. Resolves `[[Title]]` → TARGET IDS and (delete-then-insert) stores this source's
 /// `wikilink` edges. BEST-EFFORT: a failure logs (ids/counts only, no PII) and never fails the save
@@ -19355,6 +19562,232 @@ mod lifecycle_tests {
                 .iter()
                 .any(|n| n.content_blob.is_some()),
             "the seal (content_blob) is left intact"
+        );
+    }
+
+    // ── note↔meeting-links PR-1 — MANUAL linking (command layer) ─────────────────────────────────
+
+    /// Seed a standalone note-doc (`kind='note'`) in a folder for the manual-link command tests. The
+    /// folder must already exist in the `folders` table (via `make_open_folder`) so the read gates
+    /// (`get_note_row` → `folder_is_unlocked`) resolve it.
+    fn seed_note_doc_cmd(db: &Db, id: &str, folder_id: &str, title: &str, body: &str) {
+        db.insert_note(id, folder_id, title, title, body, 1_700_000_000_000)
+            .unwrap();
+    }
+
+    /// Count the `manual` rows incident on `(kind, id)` (either endpoint).
+    fn manual_link_count(state: &AppState, kind: &str, id: &str) -> i64 {
+        state.db.link_edge_count(kind, id, "manual")
+    }
+
+    /// A MEETING source creates a `manual` row but writes NO markdown into the meeting's note (a
+    /// meeting has no owned editable body — row only, per fork #2).
+    #[test]
+    fn link_from_meeting_creates_row_but_no_markdown() {
+        let state = build_state("link-from-meeting");
+        make_open_folder(&state.db, "f-open", "Project");
+        seed_meeting(&state.db, "m1", "# Meeting note body\n", Some("f-open"));
+        state.db.set_meeting_title("m1", "Kickoff").unwrap();
+        seed_note_doc_cmd(&state.db, "n1", "f-open", "Design Doc", "the design body");
+
+        let before = state
+            .db
+            .get_latest_note_for_meeting("m1")
+            .unwrap()
+            .unwrap()
+            .markdown;
+
+        // Link meeting m1 → note n1.
+        link_items_inner(&state, "meeting", "m1", "note", "n1").unwrap();
+
+        // A manual row exists...
+        assert_eq!(manual_link_count(&state, "meeting", "m1"), 1, "manual row created");
+        // ...and the meeting's note markdown is UNTOUCHED (no injected [[...]] / links block).
+        let after = state
+            .db
+            .get_latest_note_for_meeting("m1")
+            .unwrap()
+            .unwrap()
+            .markdown;
+        assert_eq!(after, before, "a meeting source writes no markdown");
+        assert!(
+            !after.contains("murmur:links"),
+            "no managed links block injected into a meeting source"
+        );
+    }
+
+    /// A NOTE source creates a `manual` row AND materializes `[[Title]]` into the note body; after the
+    /// note's wikilinks are re-indexed, the pair shows as ONE deduped chip in `links_for_visible`.
+    #[test]
+    fn link_from_note_materializes_wikilink_and_dedupes() {
+        let state = build_state("link-from-note");
+        make_open_folder(&state.db, "f-open", "Project");
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "original body\n");
+        seed_note_doc_cmd(&state.db, "dst", "f-open", "Target Note", "target body");
+
+        // Link note src → note dst.
+        link_items_inner(&state, "note", "src", "note", "dst").unwrap();
+
+        // A manual row exists...
+        assert_eq!(manual_link_count(&state, "note", "src"), 1, "manual row created");
+        // ...and the source note body gained the [[Target Note]] marker (materialized).
+        let body = state.db.get_note_row("src").unwrap().unwrap().text;
+        assert!(
+            body.contains("[[Target Note]]"),
+            "the [[Title]] was materialized into the note body; got: {body}"
+        );
+        assert!(
+            body.starts_with("original body\n"),
+            "the original body is preserved; got: {body}"
+        );
+
+        // The materialize went through `update_note_doc_inner`, which re-indexes wikilinks — so a
+        // `wikilink` edge for the same pair now ALSO exists. The reader must collapse to ONE chip.
+        assert_eq!(link_count_in(&state, "note", "src", "wikilink"), 1, "wikilink edge also present");
+        let unlocked = unlocked_snapshot(&state).unwrap();
+        let edges = state
+            .db
+            .links_for_visible(crate::links::LinkKind::Note, "src", &unlocked)
+            .unwrap();
+        let to_dst: Vec<_> = edges.iter().filter(|e| e.other_id == "dst").collect();
+        assert_eq!(to_dst.len(), 1, "manual + wikilink collapse to ONE chip");
+        assert!(to_dst[0].manual, "the collapsed chip is flagged removable-manual");
+    }
+
+    /// Helper mirroring db.rs `link_count` for the command-test module.
+    fn link_count_in(state: &AppState, kind: &str, id: &str, edge_type: &str) -> i64 {
+        state.db.link_edge_count(kind, id, edge_type)
+    }
+
+    /// UNLINK removes the `manual` row and strips the materialized `[[Title]]` from the source note
+    /// body. The wikilink edge that the materialize produced is NOT deleted by unlink (only the manual
+    /// row is), but the strip removes the `[[Title]]`, so a follow-up re-index would drop the wikilink
+    /// too — here we assert the DIRECT contract: manual row gone + marker stripped.
+    #[test]
+    fn unlink_removes_row_and_strips_marker() {
+        let state = build_state("unlink-strips");
+        make_open_folder(&state.db, "f-open", "Project");
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "original body\n");
+        seed_note_doc_cmd(&state.db, "dst", "f-open", "Target Note", "target body");
+
+        link_items_inner(&state, "note", "src", "note", "dst").unwrap();
+        assert_eq!(manual_link_count(&state, "note", "src"), 1, "precondition: manual row exists");
+        assert!(
+            state.db.get_note_row("src").unwrap().unwrap().text.contains("[[Target Note]]"),
+            "precondition: marker materialized"
+        );
+
+        // Unlink note src → note dst.
+        unlink_items_inner(&state, "note", "src", "note", "dst").unwrap();
+
+        // The manual row is gone...
+        assert_eq!(manual_link_count(&state, "note", "src"), 0, "manual row deleted");
+        // ...and the [[Target Note]] marker is stripped from the body.
+        let body = state.db.get_note_row("src").unwrap().unwrap().text;
+        assert!(
+            !body.contains("[[Target Note]]"),
+            "the materialized marker is stripped on unlink; got: {body}"
+        );
+        assert!(
+            body.starts_with("original body\n"),
+            "the original body is preserved after strip; got: {body}"
+        );
+    }
+
+    /// A sealed-and-not-session-unlocked endpoint refuses the link with `AppError::Locked` BEFORE any
+    /// write — never link behind a lock, never reveal a locked neighbour.
+    #[test]
+    fn link_items_refuses_sealed_endpoint() {
+        let state = build_state("link-refuses-sealed");
+        // Open source note; sealed destination note (in a locked, NOT-session-unlocked folder).
+        make_open_folder(&state.db, "f-open", "Open");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "body");
+        seed_note_doc_cmd(&state.db, "dst", "f-lock", "Secret Note", "secret body");
+        // Seal the destination note + lock its folder (NOT session-unlocked).
+        state.db.seal_document("dst", &b"ciphertext"[..]).unwrap();
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+
+        // Link src → dst must refuse Locked.
+        let err = link_items_inner(&state, "note", "src", "note", "dst").unwrap_err();
+        assert!(
+            matches!(err, AppError::Locked(_)),
+            "a sealed destination endpoint must refuse with Locked; got {err:?}"
+        );
+        // No manual row was written (fail-closed BEFORE the write).
+        assert_eq!(manual_link_count(&state, "note", "src"), 0, "no row written behind the lock");
+        // And the source body was NOT materialized.
+        assert!(
+            !state.db.get_note_row("src").unwrap().unwrap().text.contains("[["),
+            "no marker written when the link is refused"
+        );
+
+        // Symmetric: a SEALED SOURCE also refuses (never mutate a locked note's body).
+        let err2 = link_items_inner(&state, "note", "dst", "note", "src").unwrap_err();
+        assert!(
+            matches!(err2, AppError::Locked(_)),
+            "a sealed source endpoint must refuse with Locked; got {err2:?}"
+        );
+    }
+
+    /// A MANUAL link is gated on read from BOTH sides after the fact: sealing EITHER endpoint hides
+    /// the edge in `links_for_visible` from BOTH directions; unsealing restores it. (Command-level
+    /// end-to-end mirror of the db-layer gate test — proves the command-created row rides the gate.)
+    #[test]
+    fn manual_link_created_and_gated_both_endpoints_cmd() {
+        let state = build_state("manual-gate-cmd");
+        make_open_folder(&state.db, "f-open", "Open");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        // A note source (open) and a MEETING destination in the lockable folder.
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "body\n");
+        seed_meeting(&state.db, "m-dst", "# Meeting body\n", Some("f-lock"));
+        state.db.set_meeting_title("m-dst", "Secret Meeting").unwrap();
+
+        link_items_inner(&state, "note", "src", "meeting", "m-dst").unwrap();
+
+        // Both open → edge visible from either side.
+        let open = unlocked_snapshot(&state).unwrap();
+        assert_eq!(
+            state.db.links_for_visible(crate::links::LinkKind::Note, "src", &open).unwrap()
+                .iter().filter(|e| e.other_id == "m-dst").count(),
+            1,
+            "edge visible from the note side while both open"
+        );
+        assert_eq!(
+            state.db.links_for_visible(crate::links::LinkKind::Meeting, "m-dst", &open).unwrap()
+                .iter().filter(|e| e.other_id == "src").count(),
+            1,
+            "edge visible from the meeting side while both open"
+        );
+
+        // Seal the MEETING's folder (not session-unlocked) → edge hidden BOTH directions.
+        state
+            .db
+            .set_folder_locked("f-lock", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        let sealed = unlocked_snapshot(&state).unwrap(); // still empty — f-lock not session-unlocked.
+        assert!(
+            state.db.links_for_visible(crate::links::LinkKind::Note, "src", &sealed).unwrap()
+                .iter().all(|e| e.other_id != "m-dst"),
+            "sealed meeting neighbour hidden from the note side"
+        );
+        assert!(
+            state.db.links_for_visible(crate::links::LinkKind::Meeting, "m-dst", &sealed).unwrap()
+                .is_empty(),
+            "a sealed queried meeting never reveals it HAS a manual link"
+        );
+
+        // Session-unlock the meeting's folder → edge restored on both sides.
+        state.unlocked_folders.lock().unwrap().insert("f-lock".to_string());
+        let unlocked = unlocked_snapshot(&state).unwrap();
+        assert_eq!(
+            state.db.links_for_visible(crate::links::LinkKind::Note, "src", &unlocked).unwrap()
+                .iter().filter(|e| e.other_id == "m-dst").count(),
+            1,
+            "edge restored from the note side once the meeting folder is unlocked"
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8791,6 +8791,7 @@ enum AskFloorPrompt {
 /// assembly (hybrid when semantic search is ON, FTS otherwise — Phase 2b semantics unchanged), the
 /// empty-corpus early return, and the corpus prompt build. The floor-equivalence test binds this
 /// to the original statement sequence.
+#[allow(clippy::too_many_arguments)] // cohesive gated-Ask surface: corpus/consent state + explicit sources.
 fn build_ask_vault_floor_prompt(
     db: &crate::storage::Db,
     config: &AppConfig,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,6 +332,8 @@ pub fn run() {
             commands::list_links,
             commands::accept_link,
             commands::dismiss_link,
+            commands::link_items,
+            commands::unlink_items,
             commands::resolve_wikilink,
             commands::list_link_candidates,
             commands::get_person_dossier,

--- a/src-tauri/src/links.rs
+++ b/src-tauri/src/links.rs
@@ -67,15 +67,23 @@ impl LinkKind {
     }
 }
 
-/// The relation an edge encodes. `wikilink`/`companion` are DIRECTED (source → target, kept as
-/// written); `semantic` is UNDIRECTED (a symmetric similarity — stored ONCE with canonicalized
+/// The relation an edge encodes. `wikilink`/`companion`/`manual` are DIRECTED (source → target, kept
+/// as written); `semantic` is UNDIRECTED (a symmetric similarity — stored ONCE with canonicalized
 /// endpoints so A~B and B~A are the same row).
+///
+/// `manual` (note↔meeting-links PR-1) is a USER-INITIATED directed edge: the user explicitly links
+/// two items from the Connections panel. Unlike `wikilink` (derived from a note's `[[Title]]` on
+/// save) or `semantic` (auto-suggested), a `manual` row is written directly by the `link_items`
+/// command with `created_by='user'`, `status='active'`, `score=1.0`. When the SOURCE is an owned
+/// note, the command ALSO materializes a `[[Title]]` into its body — so the same pair later gains a
+/// `wikilink` edge too; the display dedupe (`links_for_visible`) collapses the two to one chip.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EdgeType {
     Wikilink,
     Companion,
     Semantic,
+    Manual,
 }
 
 impl EdgeType {
@@ -84,11 +92,24 @@ impl EdgeType {
             EdgeType::Wikilink => "wikilink",
             EdgeType::Companion => "companion",
             EdgeType::Semantic => "semantic",
+            EdgeType::Manual => "manual",
+        }
+    }
+
+    /// Parse a persisted/IPC edge-type string; `None` for anything unknown (the caller rejects it).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "wikilink" => Some(EdgeType::Wikilink),
+            "companion" => Some(EdgeType::Companion),
+            "semantic" => Some(EdgeType::Semantic),
+            "manual" => Some(EdgeType::Manual),
+            _ => None,
         }
     }
 
     /// `true` for the undirected (semantic) edge — the ONLY edge type whose endpoints are
-    /// canonicalized so the pair is stored once. Directed edges keep (src, dst) as written.
+    /// canonicalized so the pair is stored once. Directed edges (wikilink/companion/manual) keep
+    /// (src, dst) as written.
     pub fn is_undirected(self) -> bool {
         matches!(self, EdgeType::Semantic)
     }
@@ -183,6 +204,27 @@ mod tests {
         assert!(EdgeType::Semantic.is_undirected());
         assert!(!EdgeType::Wikilink.is_undirected());
         assert!(!EdgeType::Companion.is_undirected());
+    }
+
+    /// Every edge type round-trips through `as_str`/`parse`, and `manual` (note↔meeting-links PR-1)
+    /// is DIRECTED (never canonicalized) exactly like `wikilink`/`companion`.
+    #[test]
+    fn edge_type_round_trips_all_variants_and_manual_is_directed() {
+        for et in [
+            EdgeType::Wikilink,
+            EdgeType::Companion,
+            EdgeType::Semantic,
+            EdgeType::Manual,
+        ] {
+            assert_eq!(EdgeType::parse(et.as_str()), Some(et));
+        }
+        assert_eq!(EdgeType::parse("manual"), Some(EdgeType::Manual));
+        assert_eq!(EdgeType::Manual.as_str(), "manual");
+        assert_eq!(EdgeType::parse("bogus"), None);
+        // Manual is a DIRECTED user edge — endpoints are NEVER canonicalized (src/dst as written).
+        assert!(!EdgeType::Manual.is_undirected());
+        // Only the semantic similarity edge is undirected.
+        assert!(EdgeType::Semantic.is_undirected());
     }
 
     #[test]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -10425,8 +10425,14 @@ impl Db {
             match edge_type {
                 "wikilink" => 0,
                 "companion" => 1,
-                "semantic" => 2,
-                "manual" => 3, // manual only wins when it is the sole edge for the pair.
+                // A `manual` edge is a user's ACTIVE, removable link — it MUST outrank a mere
+                // `semantic` SUGGESTION so a manually-linked pair that is ALSO auto-suggested collapses
+                // to the active manual chip (removable `×`), NOT an Accept/Dismiss suggestion row. It
+                // still loses to the deterministic wikilink/companion edges (which are also active).
+                "manual" => 2,
+                // A suggested semantic edge wins the representative slot ONLY when it is the SOLE edge
+                // for the pair (a genuine, unconfirmed suggestion).
+                "semantic" => 3,
                 _ => 4,
             }
         }
@@ -19749,6 +19755,55 @@ mod tests {
             to_target[0].manual,
             "the collapsed chip is flagged as a removable manual link"
         );
+    }
+
+    /// A pair carrying BOTH a user `manual` (active) edge AND an auto `semantic` (suggested) edge —
+    /// realistic, since a manually-linked pair is often also content-similar — must collapse to the
+    /// ACTIVE, removable MANUAL chip, NOT a semantic Accept/Dismiss suggestion. RED before the
+    /// `edge_rank` swap (a `manual` link must outrank a semantic SUGGESTION): the surviving chip was
+    /// `edge_type="semantic" status="suggested"`, so the FE rendered the user's active link as an
+    /// un-removable suggestion. (The manual+wikilink dedupe test above never exercised this collision,
+    /// because both of its edges are non-semantic/active.)
+    #[test]
+    fn links_for_visible_manual_beats_suggested_semantic() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+        seed_note_doc(&db, "target", "f1", "Target", "the target body");
+        seed_note_doc(&db, "source", "f1", "Source", "");
+        let unlocked = HashSet::new();
+        // A user MANUAL link source → target...
+        db.upsert_manual_link("note", "source", "note", "target").unwrap();
+        // ...AND an auto SEMANTIC SUGGESTION for the SAME pair.
+        {
+            let now = 1_700_000_000_000i64;
+            let mut conn = db.lock();
+            let tx = conn.transaction().unwrap();
+            Db::upsert_link_tx(
+                &tx, "note", "source", "note", "target", "semantic", 0.9, "auto", "suggested", now,
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(link_count(&db, "note", "source", "manual"), 1);
+        assert_eq!(link_count(&db, "note", "source", "semantic"), 1);
+
+        let edges = db
+            .links_for_visible(crate::links::LinkKind::Note, "source", &unlocked)
+            .unwrap();
+        let to_target: Vec<_> = edges.iter().filter(|e| e.other_id == "target").collect();
+        assert_eq!(to_target.len(), 1, "manual + semantic collapse to ONE chip");
+        let chip = to_target[0];
+        assert!(chip.manual, "the collapsed chip is a removable manual link");
+        // Load-bearing: the chip must NOT read as a suggested-semantic row — the FE partitions
+        // `edge_type=='semantic' && status=='suggested'` as an Accept/Dismiss suggestion, EXCLUDED
+        // from the removable deterministic chips (so a user's active link would lose its `×`).
+        assert!(
+            !(chip.edge_type == "semantic" && chip.status == "suggested"),
+            "a manually-linked pair must never render as an unconfirmed suggestion; got {} / {}",
+            chip.edge_type,
+            chip.status
+        );
+        assert_eq!(chip.status, "active", "a user manual link is active");
     }
 
     /// A pair with ONLY a `wikilink` edge (no manual) is NOT flagged `manual` — the FE renders it as

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -9915,6 +9915,83 @@ impl Db {
         Ok(())
     }
 
+    /// note↔meeting-links PR-1 — upsert ONE user-initiated DIRECTED `manual` edge (`created_by='user'`,
+    /// `status='active'`, `score=1.0`). Idempotent on the table's UNIQUE key (a repeat link is a no-op
+    /// refresh, never a duplicate row). Directed like wikilink/companion — endpoints are stored AS
+    /// PASSED (never canonicalized). The CALLER (`link_items_inner`) has already gated BOTH endpoints
+    /// session-visible before this write, so a `manual` row is never created behind a lock. Purged on
+    /// seal by the edge-type-agnostic `purge_links_tx`; read through the both-endpoint-gated
+    /// `links_for_visible`. This wrapper exposes the private `upsert_link_tx` to the command layer
+    /// exactly as `set_companion_link` does for the companion edge — no new SQL surface.
+    pub fn upsert_manual_link(
+        &self,
+        src_kind: &str,
+        src_id: &str,
+        dst_kind: &str,
+        dst_id: &str,
+    ) -> Result<()> {
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        Self::upsert_link_tx(
+            &tx, src_kind, src_id, dst_kind, dst_id, "manual", 1.0, "user", "active", now,
+        )?;
+        tx.commit().map_err(map_err)?;
+        tracing::info!(
+            target: "links",
+            src_kind = src_kind,
+            dst_kind = dst_kind,
+            "upsert_manual_link"
+        );
+        Ok(())
+    }
+
+    /// note↔meeting-links PR-1 — delete ONLY the DIRECTED `manual` edge for `(src → dst)`. NEVER
+    /// touches a `wikilink`/`companion`/`semantic` row for the same pair (the `edge_type='manual'`
+    /// predicate is exact): unlinking a manual link leaves any derived wikilink/companion/semantic
+    /// relation intact. Idempotent (0 rows for an already-absent edge). The CALLER strips the
+    /// materialized `[[Title]]` from the source note's body separately (best-effort).
+    pub fn delete_manual_link(
+        &self,
+        src_kind: &str,
+        src_id: &str,
+        dst_kind: &str,
+        dst_id: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM links
+               WHERE src_kind = ?1 AND src_id = ?2 AND dst_kind = ?3 AND dst_id = ?4
+                 AND edge_type = 'manual'",
+            rusqlite::params![src_kind, src_id, dst_kind, dst_id],
+        )
+        .map_err(map_err)?;
+        tracing::info!(
+            target: "links",
+            src_kind = src_kind,
+            dst_kind = dst_kind,
+            "delete_manual_link"
+        );
+        Ok(())
+    }
+
+    /// TEST-ONLY raw count of `links` rows of `edge_type` incident on `(kind, id)` (either endpoint).
+    /// Exposes the private connection to sibling-crate test modules (`commands.rs`) so they can assert
+    /// the PRE-collapse row counts (manual vs wikilink separately) that `links_for_visible` hides. Not
+    /// compiled into the shipping binary.
+    #[cfg(test)]
+    pub(crate) fn link_edge_count(&self, kind: &str, id: &str, edge_type: &str) -> i64 {
+        self.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM links
+                   WHERE edge_type = ?3
+                     AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
+                rusqlite::params![kind, id, edge_type],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
     /// PURGE every link row whose SRC OR DST is a sealed/deleted meeting or document (a note id IS a
     /// `documents` id, so `document_ids` covers the `note` kind too). Runs INSIDE an existing seal /
     /// delete tx so a link — which reveals a neighbour's existence + title — never outlives the
@@ -10314,10 +10391,79 @@ impl Db {
                 status: st,
                 score,
                 created_at,
+                // Set on the base build; the collapse pass below flips it true per (other_kind,
+                // other_id) pair that carries a `manual` edge.
+                manual: false,
             });
         }
+        let edges = Self::collapse_manual_duplicate_edges(edges);
         tracing::debug!(target: "links", count = edges.len(), "links_for_visible resolved");
         Ok(edges)
+    }
+
+    /// note↔meeting-links PR-1 — DISPLAY DEDUPE (avoid double chips): a note→meeting `manual` link
+    /// ALSO materializes `[[Title]]` into the note body, so the next save adds a `wikilink` edge for
+    /// the SAME `(other_kind, other_id)` pair. This collapses each such pair to ONE row so the FE
+    /// renders one chip, mirroring the `backlinks_for_visible` companion-vs-wikilink dedupe idiom.
+    ///
+    /// Rule per `(other_kind, other_id)` group:
+    /// - PREFER the DETERMINISTIC edge (`wikilink` > `companion` > `semantic`) for the surviving
+    ///   row's stable `id`/`edge_type` (its id is what accept/dismiss already key on), falling back to
+    ///   the `manual` row when it is the only edge for the pair.
+    /// - Set `manual = true` on the surviving row iff ANY edge in the group is a `manual` edge — so
+    ///   the FE knows the chip is user-created + REMOVABLE regardless of which `edge_type` won.
+    ///
+    /// Input order is already the reader's stable sort (active-then-suggested, score DESC, id ASC);
+    /// this preserves the FIRST-seen group's position so the output order stays deterministic. Pairs
+    /// with no `manual` edge are unchanged (`manual` stays false). Groups NEVER merge across different
+    /// `(other_kind, other_id)` — only true duplicates of the same neighbour collapse.
+    fn collapse_manual_duplicate_edges(
+        edges: Vec<crate::storage::models::LinkEdge>,
+    ) -> Vec<crate::storage::models::LinkEdge> {
+        // Preference rank: lower wins as the surviving deterministic representative.
+        fn edge_rank(edge_type: &str) -> u8 {
+            match edge_type {
+                "wikilink" => 0,
+                "companion" => 1,
+                "semantic" => 2,
+                "manual" => 3, // manual only wins when it is the sole edge for the pair.
+                _ => 4,
+            }
+        }
+        // Preserve first-seen group order for a deterministic output.
+        let mut order: Vec<(String, String)> = Vec::new();
+        let mut groups: std::collections::HashMap<
+            (String, String),
+            crate::storage::models::LinkEdge,
+        > = std::collections::HashMap::new();
+        for edge in edges {
+            let key = (edge.other_kind.clone(), edge.other_id.clone());
+            let has_manual = edge.edge_type == "manual";
+            match groups.get_mut(&key) {
+                None => {
+                    order.push(key.clone());
+                    let mut rep = edge;
+                    rep.manual = has_manual;
+                    groups.insert(key, rep);
+                }
+                Some(rep) => {
+                    // A manual edge anywhere in the group makes the surviving chip removable.
+                    if has_manual {
+                        rep.manual = true;
+                    }
+                    // Promote the representative to the more-deterministic edge (lower rank wins).
+                    if edge_rank(&edge.edge_type) < edge_rank(&rep.edge_type) {
+                        let manual_flag = rep.manual; // carry the group's removable flag forward.
+                        *rep = edge;
+                        rep.manual = manual_flag;
+                    }
+                }
+            }
+        }
+        order
+            .into_iter()
+            .filter_map(|k| groups.remove(&k))
+            .collect()
     }
 
     /// Resolve a link endpoint's CURRENT display title through the visibility gate; `None` iff the
@@ -19485,6 +19631,180 @@ mod tests {
             seen += 1;
         }
         assert_eq!(seen, crate::links::SEMANTIC_LINK_CAP);
+    }
+
+    // ── note↔meeting-links PR-1 — MANUAL edge (DB layer) ─────────────────────────────────────────
+
+    /// A user-initiated `manual` edge is created as a DIRECTED `active`/`user`/score=1.0 row, and its
+    /// gated reader hides it when EITHER endpoint is sealed-not-unlocked (both directions) — restored
+    /// when the sealed side is session-unlocked. Same both-endpoint gate the wikilink edge rides.
+    #[test]
+    fn manual_link_row_created_and_gated_both_endpoints() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-secret", "Secret");
+        seed_note_doc(&db, "open", "f-open", "Open Note", "");
+        seed_note_doc(&db, "secret", "f-secret", "Secret Note", "");
+
+        // Create the manual edge open → secret.
+        db.upsert_manual_link("note", "open", "note", "secret").unwrap();
+        assert_eq!(
+            link_count(&db, "note", "open", "manual"),
+            1,
+            "one directed manual row exists"
+        );
+        // It is `active`/`user`/1.0.
+        let (created_by, status, score): (String, String, f64) = db
+            .lock()
+            .query_row(
+                "SELECT created_by, status, score FROM links WHERE edge_type='manual'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(created_by, "user");
+        assert_eq!(status, "active");
+        assert!((score - 1.0).abs() < 1e-9);
+
+        // Both open → visible from either side.
+        let nothing = HashSet::new();
+        assert_eq!(
+            db.links_for_visible(crate::links::LinkKind::Note, "open", &nothing)
+                .unwrap()
+                .len(),
+            1,
+            "manual edge visible when both endpoints open (src side)"
+        );
+        assert_eq!(
+            db.links_for_visible(crate::links::LinkKind::Note, "secret", &nothing)
+                .unwrap()
+                .len(),
+            1,
+            "manual edge visible from the dst side too"
+        );
+
+        // Seal the SECRET folder → the manual edge vanishes from BOTH directions (neighbour gate on
+        // the open side; queried-item existence gate on the secret side).
+        db.set_folder_locked("f-secret", true, None).unwrap();
+        assert!(
+            db.links_for_visible(crate::links::LinkKind::Note, "open", &nothing)
+                .unwrap()
+                .is_empty(),
+            "manual edge hidden from the open side when its neighbour is sealed"
+        );
+        assert!(
+            db.links_for_visible(crate::links::LinkKind::Note, "secret", &nothing)
+                .unwrap()
+                .is_empty(),
+            "a sealed queried item never reveals it HAS a manual link"
+        );
+
+        // Session-unlock the secret folder → the manual edge is restored on both sides.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-secret".to_string());
+        let edges = db
+            .links_for_visible(crate::links::LinkKind::Note, "open", &unlocked)
+            .unwrap();
+        assert_eq!(edges.len(), 1, "manual edge restored once secret is unlocked");
+        assert_eq!(edges[0].edge_type, "manual");
+        assert!(edges[0].manual, "the surviving chip is flagged user-removable");
+    }
+
+    /// DISPLAY DEDUPE: a `manual` edge AND a `wikilink` edge for the SAME `(other_kind, other_id)`
+    /// pair collapse to ONE `links_for_visible` chip — preferring the deterministic `wikilink`
+    /// `edge_type` (its stable id) but flagging `manual=true` so the FE renders the removable `×`.
+    #[test]
+    fn links_for_visible_dedupes_manual_and_wikilink() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+        seed_note_doc(&db, "target", "f1", "Target", "the target body");
+        seed_note_doc(&db, "source", "f1", "Source", "");
+
+        let unlocked = HashSet::new();
+        // A manual edge source → target.
+        db.upsert_manual_link("note", "source", "note", "target").unwrap();
+        // AND a wikilink edge for the SAME pair (as if the [[Target]] materialized into the body).
+        db.index_wikilinks_for_source(
+            crate::links::LinkKind::Note,
+            "source",
+            "see [[Target]] for context",
+            &unlocked,
+        )
+        .unwrap();
+        // Two raw rows for the pair (manual + wikilink)...
+        assert_eq!(link_count(&db, "note", "source", "manual"), 1);
+        assert_eq!(link_count(&db, "note", "source", "wikilink"), 1);
+
+        // ...but ONE collapsed chip in the reader.
+        let edges = db
+            .links_for_visible(crate::links::LinkKind::Note, "source", &unlocked)
+            .unwrap();
+        let to_target: Vec<_> = edges.iter().filter(|e| e.other_id == "target").collect();
+        assert_eq!(to_target.len(), 1, "manual + wikilink collapse to ONE chip");
+        assert_eq!(
+            to_target[0].edge_type, "wikilink",
+            "the deterministic edge type wins the collapse"
+        );
+        assert!(
+            to_target[0].manual,
+            "the collapsed chip is flagged as a removable manual link"
+        );
+    }
+
+    /// A pair with ONLY a `wikilink` edge (no manual) is NOT flagged `manual` — the FE renders it as
+    /// an auto (non-removable) chip. Guards the collapse against over-flagging.
+    #[test]
+    fn links_for_visible_non_manual_pair_not_flagged() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+        seed_note_doc(&db, "target", "f1", "Target", "the target body");
+        seed_note_doc(&db, "source", "f1", "Source", "");
+        let unlocked = HashSet::new();
+        db.index_wikilinks_for_source(
+            crate::links::LinkKind::Note,
+            "source",
+            "see [[Target]] for context",
+            &unlocked,
+        )
+        .unwrap();
+        let edges = db
+            .links_for_visible(crate::links::LinkKind::Note, "source", &unlocked)
+            .unwrap();
+        let chip = edges.iter().find(|e| e.other_id == "target").unwrap();
+        assert_eq!(chip.edge_type, "wikilink");
+        assert!(!chip.manual, "a pure wikilink chip is not a removable manual link");
+    }
+
+    /// PURGE-ON-SEAL is edge-type-AGNOSTIC: a `manual` edge is dropped at rest exactly like a
+    /// wikilink when either endpoint's folder is sealed (the `purge_links_tx` leg on relock reblank).
+    #[test]
+    fn purge_links_tx_drops_manual_on_seal() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-secret", "Secret");
+        seed_note_doc(&db, "open", "f-open", "Open Note", "");
+        seed_note_doc(&db, "secret", "f-secret", "Secret Note", "");
+
+        db.upsert_manual_link("note", "open", "note", "secret").unwrap();
+        assert_eq!(link_count(&db, "note", "secret", "manual"), 1, "manual edge exists pre-seal");
+
+        // Seal the SECRET folder and run the relock reblank (carries the `purge_links_tx` leg).
+        db.set_folder_locked("f-secret", true, None).unwrap();
+        let mut folders = HashSet::new();
+        folders.insert("f-secret".to_string());
+        db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+        // The manual row is GONE at rest — both directions (the sealed dst side and the open src side).
+        assert_eq!(
+            link_count(&db, "note", "secret", "manual"),
+            0,
+            "sealed endpoint's manual edge purged (dst side)"
+        );
+        assert_eq!(
+            link_count(&db, "note", "open", "manual"),
+            0,
+            "open source's manual edge to the sealed note purged (src side)"
+        );
     }
 
     /// PURGE-ON-SEAL, BOTH DIRECTIONS (existence-leak RED→GREEN): a wikilink edge between two notes in

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1245,6 +1245,22 @@ pub struct WikiTarget {
     pub id: String,
 }
 
+/// note↔meeting-links PR-2 — one EXPLICIT source the user pinned in the Ask source picker: a
+/// `meeting|note|document` reference that SCOPES a Brain answer to exactly the listed items (plus
+/// their capped link-expansion) instead of a whole-vault search. Serialized camelCase `{kind, id}`
+/// so the FE can build it straight from a `LinkEdge`/`LinkKind`.
+///
+/// NO `deny_unknown_fields`: the FE picker sends an extra `title` field (for chip display) that the
+/// backend must harmlessly IGNORE. Every read of a pinned source stays visibility-gated in
+/// `build_vault_context_pinned_visible` — a sealed-and-not-session-unlocked source contributes
+/// nothing (E9), so pinning a locked item can never leak it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceRef {
+    pub kind: crate::links::LinkKind,
+    pub id: String,
+}
+
 /// Result of an Ask-My-Vault query: the grounded answer + the source meetings used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1191,10 +1191,18 @@ pub struct BacklinkSource {
 /// title resolved through the SAME visibility gate as the queried endpoint (both-endpoint gating).
 /// `direction` says whether the queried item is this edge's `src` ("out") or `dst` ("in") so the FE
 /// can render an arrow; `other_kind`/`other_id` are the neighbour to navigate to. `edge_type` ∈
-/// `wikilink|companion|semantic`, `created_by` ∈ `user|auto|accepted`, `status` ∈
+/// `wikilink|companion|semantic|manual`, `created_by` ∈ `user|auto|accepted`, `status` ∈
 /// `active|suggested|dismissed` (dismissed rows are never returned). `score` is the semantic cosine
-/// (1.0 for the deterministic wikilink/companion edges). Only ever built when BOTH endpoints are
-/// VISIBLE — a sealed neighbour can never appear, and a sealed queried item yields an empty list.
+/// (1.0 for the deterministic wikilink/companion/manual edges). Only ever built when BOTH endpoints
+/// are VISIBLE — a sealed neighbour can never appear, and a sealed queried item yields an empty list.
+///
+/// `manual` (note↔meeting-links PR-1) is the DISPLAY-DEDUPE flag: when a user-initiated `manual` edge
+/// AND a derived `wikilink` (or another deterministic edge) exist for the SAME `(other_kind,
+/// other_id)` pair, `links_for_visible` collapses them to ONE row (preferring the deterministic
+/// `edge_type` for its stable id) but sets `manual = true` so the FE knows the chip is user-created +
+/// REMOVABLE (renders the `×` → `unlink_items`). A pair with no `manual` edge has `manual = false`
+/// (an auto wikilink/semantic chip — not user-removable). Always present, defaults `false` for any
+/// non-manual edge, so an old FE reads it as absent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkEdge {
@@ -1211,6 +1219,12 @@ pub struct LinkEdge {
     pub status: String,
     pub score: f64,
     pub created_at: i64,
+    /// note↔meeting-links PR-1 — `true` iff a user-initiated `manual` edge exists for this
+    /// `(other_kind, other_id)` pair (whether this collapsed row's `edge_type` is `manual` itself or a
+    /// deterministic edge the manual link was deduped into). The FE renders the removable `×` only on
+    /// a `manual` chip. Defaults `false` (serde default) for every non-manual pair.
+    #[serde(default)]
+    pub manual: bool,
 }
 
 /// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, or (2026-07-15)

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -13,8 +13,16 @@
 use std::collections::HashSet;
 
 use crate::error::Result;
-use crate::storage::models::VaultSource;
+use crate::links::LinkKind;
+use crate::storage::models::{SourceRef, VaultSource};
 use crate::storage::Db;
+
+/// note↔meeting-links PR-2 — cap on the TOTAL number of link-expanded neighbours a PINNED Ask
+/// pulls in (deduped across all explicit sources AND against the explicit set). The explicit
+/// sources are packed FIRST at full budget; the neighbours fill only the remaining budget. Bounds
+/// the "brain knows the connections" auto-expansion so a densely-linked item can't drag the whole
+/// graph into one prompt.
+const LINK_CONTEXT_CAP: usize = 8;
 
 /// Char budget for the corpus, by provider. Local quantized models (Ollama) have tiny
 /// default context windows, so cap much tighter; API/Claude models get headroom.
@@ -316,6 +324,153 @@ fn pack_meetings(
     Ok((corpus, sources))
 }
 
+/// note↔meeting-links PR-2 — pack ONE standalone note/document (`documents` table row) into the
+/// budget-capped `corpus`, headed by a `### [[Title]] · id:` citation mirroring [`pack_meetings`].
+/// The read is GATED: `get_document_if_visible` returns `None` for a sealed-and-not-session-unlocked
+/// note/document, so its (possibly-stale-plaintext) body never enters the corpus (E9). Reads BOTH
+/// `kind='note'` and `kind='document'` rows (the gated reader is not kind-restricted). Returns
+/// `true` iff something was packed (so the caller can count what actually contributed).
+fn pack_notes(
+    db: &Db,
+    doc_id: &str,
+    budget: usize,
+    corpus: &mut String,
+    unlocked: &HashSet<String>,
+) -> Result<bool> {
+    if corpus.len() >= budget {
+        return Ok(false);
+    }
+    // GATE: sealed-and-not-unlocked note/document ⇒ `None` ⇒ contributes nothing.
+    let Some(doc) = db.get_document_if_visible(doc_id, unlocked)? else {
+        return Ok(false);
+    };
+    // Prefer the authored title; a `kind='document'` upload leaves title NULL → fall back to `name`.
+    let title = doc
+        .title
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or(doc.name);
+    let header = format!("\n\n### [[{title}]] · id:{}\n", doc.id);
+    let remaining = budget.saturating_sub(corpus.len() + header.len());
+    if remaining < 200 {
+        return Ok(false);
+    }
+    let chunk: String = doc.markdown.chars().take(remaining).collect();
+    if chunk.trim().is_empty() {
+        return Ok(false);
+    }
+    corpus.push_str(&header);
+    corpus.push_str(&chunk);
+    Ok(true)
+}
+
+/// note↔meeting-links PR-2 — build a PINNED corpus from an EXPLICIT source list plus its capped,
+/// gated link-expansion. This is the source-scoped Ask path: the corpus is EXACTLY the listed
+/// `sources` (packed FIRST, at full budget) plus up to [`LINK_CONTEXT_CAP`] of their ACTIVE linked
+/// neighbours (packed AFTER, filling remaining budget only) — NEVER a vault-wide search.
+///
+/// GATE (E9, load-bearing): every leg reads only through the `*_visible` readers against the live
+/// `unlocked` set. A meeting source packs through [`pack_meetings`] (its `get_note_if_visible`
+/// second gate drops a sealed meeting's note); a note/document source packs through [`pack_notes`]
+/// (`get_document_if_visible` gate). Link-expansion uses [`Db::links_for_visible`], which is ALREADY
+/// both-endpoint gated — so a sealed explicit source or a sealed neighbour contributes NOTHING and
+/// is never even enumerated. No content read bypasses these gates.
+///
+/// Returns `(corpus, sources)` — `sources` carries the VaultSource chips for the MEETING sources
+/// that actually packed (notes/documents are not meetings, so they add no chip, matching
+/// `pack_doc_chunks`).
+pub fn build_vault_context_pinned_visible(
+    db: &Db,
+    sources: &[SourceRef],
+    provider_id: &str,
+    unlocked: &HashSet<String>,
+) -> Result<(String, Vec<VaultSource>)> {
+    let budget = budget_for(provider_id);
+    let mut corpus = String::new();
+    let mut vault_sources: Vec<VaultSource> = Vec::new();
+
+    // The explicit set, for dedupe against the link-expansion below (a neighbour that IS an explicit
+    // source is already packed — never pack it twice).
+    let explicit: HashSet<(&str, &str)> = sources
+        .iter()
+        .map(|s| (s.kind.as_str(), s.id.as_str()))
+        .collect();
+
+    // ── 1) Pack the EXPLICIT sources first (full budget). ──
+    for src in sources {
+        if corpus.len() >= budget {
+            break;
+        }
+        match src.kind {
+            LinkKind::Meeting => {
+                // `pack_meetings` gates via `get_note_if_visible` — a sealed meeting packs nothing +
+                // adds no source. An unknown id yields `None` inside the packer → skipped.
+                if let Some(m) = db.get_meeting(&src.id)? {
+                    let (mut chunk_corpus, chunk_sources) =
+                        pack_meetings(db, vec![m], budget.saturating_sub(corpus.len()), unlocked)?;
+                    corpus.push_str(&chunk_corpus);
+                    chunk_corpus.clear();
+                    vault_sources.extend(chunk_sources);
+                }
+            }
+            LinkKind::Note | LinkKind::Document => {
+                pack_notes(db, &src.id, budget, &mut corpus, unlocked)?;
+            }
+        }
+    }
+
+    // ── 2) Link-aware expansion: gather ACTIVE neighbours of each explicit source, deduped across
+    // sources AND against the explicit set, capped at LINK_CONTEXT_CAP total, then pack AFTER the
+    // explicit sources (remaining budget only). `links_for_visible` is both-endpoint gated, so a
+    // sealed neighbour is never enumerated. ──
+    let mut seen_neighbours: HashSet<(String, String)> = HashSet::new();
+    let mut neighbours: Vec<(LinkKind, String)> = Vec::new();
+    'outer: for src in sources {
+        let edges = db.links_for_visible(src.kind, &src.id, unlocked)?;
+        for edge in edges {
+            // Only ACTIVE edges expand context (skip merely-suggested/dismissed relations).
+            if edge.status != "active" {
+                continue;
+            }
+            let Some(other_kind) = LinkKind::parse(&edge.other_kind) else {
+                continue;
+            };
+            // Never re-pack an explicit source, and dedupe the same neighbour across sources.
+            if explicit.contains(&(other_kind.as_str(), edge.other_id.as_str())) {
+                continue;
+            }
+            let key = (edge.other_kind.clone(), edge.other_id.clone());
+            if !seen_neighbours.insert(key) {
+                continue;
+            }
+            neighbours.push((other_kind, edge.other_id));
+            if neighbours.len() >= LINK_CONTEXT_CAP {
+                break 'outer;
+            }
+        }
+    }
+    for (kind, id) in neighbours {
+        if corpus.len() >= budget {
+            break;
+        }
+        match kind {
+            LinkKind::Meeting => {
+                if let Some(m) = db.get_meeting(&id)? {
+                    let (mut chunk_corpus, chunk_sources) =
+                        pack_meetings(db, vec![m], budget.saturating_sub(corpus.len()), unlocked)?;
+                    corpus.push_str(&chunk_corpus);
+                    chunk_corpus.clear();
+                    vault_sources.extend(chunk_sources);
+                }
+            }
+            LinkKind::Note | LinkKind::Document => {
+                pack_notes(db, &id, budget, &mut corpus, unlocked)?;
+            }
+        }
+    }
+
+    Ok((corpus, vault_sources))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,5 +687,203 @@ mod tests {
             corpus2.contains("LOCKED-SECRET"),
             "unlocked content must reappear in hybrid corpus"
         );
+    }
+
+    // ── note↔meeting-links PR-2 — source-scoped + link-aware PINNED retrieval ──
+
+    /// Seed a standalone note (`documents` `kind='note'`) into a folder. Returns nothing; the note is
+    /// addressable by `id` in the `documents` id space (the `LinkKind::Note` id space).
+    fn seed_doc_note(db: &Db, id: &str, folder_id: &str, name: &str, body: &str) {
+        db.insert_document(id, folder_id, name, body, "note", 1_700_000_000)
+            .unwrap();
+    }
+
+    fn m_src(id: &str) -> SourceRef {
+        SourceRef {
+            kind: LinkKind::Meeting,
+            id: id.to_string(),
+        }
+    }
+    fn n_src(id: &str) -> SourceRef {
+        SourceRef {
+            kind: LinkKind::Note,
+            id: id.to_string(),
+        }
+    }
+
+    /// The pinned corpus contains EXACTLY the listed sources — a meeting NOT in `sources` never
+    /// appears, even though it exists and would match a whole-vault search.
+    #[test]
+    fn pinned_corpus_only_includes_listed_sources() {
+        let db = temp_db();
+        seed_note(&db, "m-in", "In Meeting", "PINNED-BODY project apollo", None);
+        seed_note(&db, "m-out", "Out Meeting", "UNLISTED-BODY project zeus", None);
+
+        let nothing = HashSet::new();
+        let (corpus, sources) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-in")], "anthropic", &nothing)
+                .unwrap();
+        assert!(corpus.contains("PINNED-BODY"), "listed source is packed");
+        assert!(
+            !corpus.contains("UNLISTED-BODY"),
+            "an unlisted meeting must NEVER enter a pinned corpus: {corpus}"
+        );
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].meeting_id, "m-in");
+
+        // A note source packs the standalone note body; the unlisted meeting still absent.
+        seed_folder(&db, "f-open");
+        seed_doc_note(&db, "note-in", "f-open", "Pinned Note", "NOTE-BODY design decisions");
+        let (corpus2, _) =
+            build_vault_context_pinned_visible(&db, &[n_src("note-in")], "anthropic", &nothing)
+                .unwrap();
+        assert!(corpus2.contains("NOTE-BODY"), "note source packs its body");
+        assert!(!corpus2.contains("UNLISTED-BODY"));
+    }
+
+    /// A SEALED explicit source contributes NOTHING to the pinned corpus (E9) — pinning a locked
+    /// item can never leak it.
+    #[test]
+    fn pinned_corpus_sealed_source_contributes_nothing() {
+        let db = temp_db();
+        seed_folder(&db, "f-locked");
+        seed_note(
+            &db,
+            "m-sealed",
+            "Sealed Meeting",
+            "SEALED-BODY acquisition price",
+            Some("f-locked"),
+        );
+        seed_doc_note(&db, "note-sealed", "f-locked", "Sealed Note", "SEALED-NOTE-BODY roadmap");
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        // Nothing session-unlocked: both a sealed MEETING source and a sealed NOTE source pack nothing.
+        let nothing = HashSet::new();
+        let (corpus, sources) = build_vault_context_pinned_visible(
+            &db,
+            &[m_src("m-sealed"), n_src("note-sealed")],
+            "anthropic",
+            &nothing,
+        )
+        .unwrap();
+        assert!(
+            !corpus.contains("SEALED-BODY"),
+            "sealed meeting source leaked into pinned corpus (E9): {corpus}"
+        );
+        assert!(
+            !corpus.contains("SEALED-NOTE-BODY"),
+            "sealed note source leaked into pinned corpus (E9): {corpus}"
+        );
+        assert!(sources.is_empty(), "no source chip for a sealed source");
+
+        // Session-unlock the folder ⇒ the pinned sources legitimately reappear.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let (corpus2, _) = build_vault_context_pinned_visible(
+            &db,
+            &[m_src("m-sealed"), n_src("note-sealed")],
+            "anthropic",
+            &unlocked,
+        )
+        .unwrap();
+        assert!(corpus2.contains("SEALED-BODY"), "unlocked meeting source reappears");
+        assert!(corpus2.contains("SEALED-NOTE-BODY"), "unlocked note source reappears");
+    }
+
+    /// Link-aware expansion pulls in an explicit source's ACTIVE linked neighbour's content — and a
+    /// SEALED neighbour is DROPPED (the both-endpoint gate holds through the expansion).
+    #[test]
+    fn pinned_corpus_expands_active_links_gated() {
+        let db = temp_db();
+        // One explicit meeting, manually linked to (a) an OPEN neighbour meeting and (b) a SEALED one.
+        seed_note(&db, "m-anchor", "Anchor Meeting", "ANCHOR-BODY kickoff", None);
+        seed_note(&db, "m-open-neighbour", "Open Neighbour", "OPEN-NEIGHBOUR-BODY specs", None);
+        seed_folder(&db, "f-locked");
+        seed_note(
+            &db,
+            "m-sealed-neighbour",
+            "Sealed Neighbour",
+            "SEALED-NEIGHBOUR-BODY numbers",
+            Some("f-locked"),
+        );
+        // Manual links from the anchor to both neighbours (rows written BEFORE sealing).
+        db.upsert_manual_link("meeting", "m-anchor", "meeting", "m-open-neighbour")
+            .unwrap();
+        db.upsert_manual_link("meeting", "m-anchor", "meeting", "m-sealed-neighbour")
+            .unwrap();
+        db.set_folder_locked("f-locked", true, None).unwrap();
+
+        let nothing = HashSet::new();
+        let (corpus, _) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-anchor")], "anthropic", &nothing)
+                .unwrap();
+        assert!(corpus.contains("ANCHOR-BODY"), "explicit source packed");
+        assert!(
+            corpus.contains("OPEN-NEIGHBOUR-BODY"),
+            "an ACTIVE linked neighbour's body is auto-expanded into the corpus: {corpus}"
+        );
+        assert!(
+            !corpus.contains("SEALED-NEIGHBOUR-BODY"),
+            "a SEALED linked neighbour must be dropped by the gate (E9): {corpus}"
+        );
+    }
+
+    /// Link-expansion is capped at LINK_CONTEXT_CAP: more active neighbours than the cap are
+    /// truncated to exactly the cap (the explicit source is always packed on top).
+    #[test]
+    fn link_expansion_capped_at_link_context_cap() {
+        let db = temp_db();
+        seed_note(&db, "m-hub", "Hub Meeting", "HUB-BODY central", None);
+        // Seed CAP + 3 neighbours, each with a UNIQUELY greppable body, all actively linked to the hub.
+        let extra = 3usize;
+        for i in 0..(LINK_CONTEXT_CAP + extra) {
+            let id = format!("m-nb-{i}");
+            let body = format!("NEIGHBOUR-MARK-{i} content");
+            seed_note(&db, &id, &format!("Neighbour {i}"), &body, None);
+            db.upsert_manual_link("meeting", "m-hub", "meeting", &id)
+                .unwrap();
+        }
+
+        let nothing = HashSet::new();
+        let (corpus, _) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-hub")], "anthropic", &nothing)
+                .unwrap();
+        assert!(corpus.contains("HUB-BODY"), "hub packed");
+        let packed = (0..(LINK_CONTEXT_CAP + extra))
+            .filter(|i| corpus.contains(&format!("NEIGHBOUR-MARK-{i} ")))
+            .count();
+        assert_eq!(
+            packed, LINK_CONTEXT_CAP,
+            "exactly LINK_CONTEXT_CAP neighbours are expanded (got {packed}); the rest are truncated"
+        );
+    }
+
+    /// Regression guard: the whole-vault (`None`-sources) corpus is unchanged by PR-2 — the pinned
+    /// builder is a NEW, separate path. A whole-vault build over the same DB still contains every
+    /// visible meeting (the pre-change behavior), whereas a pinned build over a single source does
+    /// NOT. This binds "None preserves the whole vault" at the vault_context level.
+    #[test]
+    fn pinned_vs_whole_vault_none_preserves_whole_vault() {
+        let db = temp_db();
+        seed_note(&db, "m-a", "Meeting A", "WHOLE-A body one", None);
+        seed_note(&db, "m-b", "Meeting B", "WHOLE-B body two", None);
+
+        let nothing = HashSet::new();
+        // Whole-vault (the `None`/no-picker path): BOTH meetings present (empty query → recent list).
+        let (whole, whole_sources) =
+            build_vault_context_visible(&db, "", "anthropic", &nothing).unwrap();
+        assert!(whole.contains("WHOLE-A"), "whole-vault contains meeting A");
+        assert!(whole.contains("WHOLE-B"), "whole-vault contains meeting B");
+        assert_eq!(whole_sources.len(), 2);
+
+        // Pinned to A only: A present, B ABSENT — the scoped path is strictly narrower.
+        let (pinned, pinned_sources) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-a")], "anthropic", &nothing).unwrap();
+        assert!(pinned.contains("WHOLE-A"));
+        assert!(
+            !pinned.contains("WHOLE-B"),
+            "pinned corpus must not contain the unlisted meeting"
+        );
+        assert_eq!(pinned_sources.len(), 1);
     }
 }

--- a/src-tauri/src/transcribe/live.rs
+++ b/src-tauri/src/transcribe/live.rs
@@ -959,6 +959,7 @@ fn run_assistant_turn(
         &thread_id,
         None,
         meeting_id.as_deref(),
+        None, // the voice/wake/card twin has no FE source picker → whole-vault, unchanged.
     );
     let _ = app.emit(crate::events::EVENT_VOICE_ACTION_RESULT, result);
 }
@@ -992,6 +993,7 @@ fn run_assistant_turn(
 /// voice/wake fallback path; and only when there is neither does the live-recording pointer apply.
 /// The RESOLVED id is used for the executor scope, `gated_live_context`, AND the persisted
 /// thread binding — so a thread durably answers about its OWN meeting.
+#[allow(clippy::too_many_arguments)] // cohesive @brain entry: fe pointers + thread/anchor + pinned sources.
 pub fn run_assistant_query(
     app: &AppHandle,
     command: &str,
@@ -1000,6 +1002,7 @@ pub fn run_assistant_query(
     thread_id: &str,
     anchor_text: Option<&str>,
     fe_meeting_id: Option<&str>,
+    explicit_sources: Option<&[crate::storage::models::SourceRef]>,
 ) -> crate::voice_action::VoiceActionResult {
     let state = app.state::<AppState>();
     let config = match state.config.lock() {
@@ -1019,6 +1022,32 @@ pub fn run_assistant_query(
                 .with_thread_id(thread_id)
         }
     };
+    // note↔meeting-links PR-2 (PARTIAL) — SOURCE-SCOPED context: when the FE pins explicit sources,
+    // build their GATED pinned corpus (+ capped, gated link-expansion) and APPEND it to the loop's
+    // conversation as clearly-labelled additional context, so the cloud agentic cascade reasons over
+    // the pinned notes/meetings. Every leg is `unlocked`-gated (a sealed source/neighbour contributes
+    // NOTHING). `None`/empty ⇒ `loop_user` is byte-identical. A build error degrades to no injection
+    // (never fails the turn). The tool executor's candidate constraint + the deterministic floor legs
+    // are a documented follow-up (see the command doc).
+    let augmented_user: String = match explicit_sources.filter(|s| !s.is_empty()) {
+        Some(sources) => {
+            let ask_conn = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            match crate::summarize::vault_context::build_vault_context_pinned_visible(
+                &state.db, sources, &ask_conn, &unlocked,
+            ) {
+                Ok((pinned, _)) if !pinned.trim().is_empty() => format!(
+                    "{loop_user}\n\n=== PINNED NOTES & MEETINGS (the user scoped this question to these; ground your answer in them) ===\n{pinned}"
+                ),
+                _ => loop_user.to_string(),
+            }
+        }
+        None => loop_user.to_string(),
+    };
+    let loop_user: &str = &augmented_user;
     // Phase 6 precedence (generalizes Phase 4): FE-sent `fe_meeting_id` (a bound thread) WINS over
     // the FOCUS pointer (the meeting the user is viewing — the backend safety-net for any fallback
     // path, e.g. the voice/wake twin), which WINS over the recording pointer (`current_meeting`,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -11,6 +11,7 @@ import type {
   ClaimAlignment,
   LinkEdge,
   LinkKind,
+  SourceRef,
   WikiTarget,
   CompanionAppendResult,
   SourceKind,
@@ -1043,13 +1044,27 @@ export class IpcService {
     return invoke<void>("rename_meeting", { meetingId, title });
   }
 
-  /** Ask a grounded question about a meeting's transcript (chat with the meeting). */
+  /**
+   * Ask a grounded question about a meeting's transcript (chat with the meeting).
+   *
+   * `explicitSources` (source-scoped Brain) OPTIONALLY pins the answer to exactly
+   * the passed sources + their links (each `{kind, id}`; an extra `title` is
+   * ignored backend-side). Omitting it / `[]` / `null` keeps today's whole-vault
+   * behavior grounded on this meeting; a NON-empty array narrows the scope. Only
+   * sent when non-empty so existing callers are unaffected.
+   */
   chatMeeting(
     meetingId: string,
     question: string,
     history: ChatTurn[],
+    explicitSources?: SourceRef[],
   ): Promise<string> {
-    return invoke<string>("chat_meeting", { meetingId, question, history });
+    return invoke<string>("chat_meeting", {
+      meetingId,
+      question,
+      history,
+      ...(explicitSources?.length ? { explicitSources } : {}),
+    });
   }
 
   /** Built-in recipe templates (quick chips). */
@@ -1560,15 +1575,25 @@ export class IpcService {
    * 12 messages — send the full conversation and let it truncate; do NOT
    * trim FE-side.
    */
+  /**
+   * Ask a grounded question across the whole vault. `explicitSources`
+   * (source-scoped Brain) OPTIONALLY pins the answer to exactly the passed
+   * sources + their links (each `{kind, id}`; an extra `title` is ignored
+   * backend-side). Omitting it / `[]` / `null` keeps today's whole-vault
+   * behavior; a NON-empty array narrows the scope. Only sent when non-empty so
+   * existing callers are unaffected.
+   */
   askVault(
     question: string,
     history: ChatTurn[],
     askThreadId?: string,
+    explicitSources?: SourceRef[],
   ): Promise<AskVaultResult> {
     return invoke<AskVaultResult>("ask_vault", {
       question,
       history,
       askThreadId,
+      ...(explicitSources?.length ? { explicitSources } : {}),
     });
   }
 
@@ -2038,12 +2063,14 @@ export class IpcService {
     threadId?: string,
     anchorText?: string,
     meetingId?: string,
+    explicitSources?: SourceRef[],
   ): Promise<VoiceActionResultPayload> {
     return invoke<VoiceActionResultPayload>("ask_assistant_chat", {
       messages,
       threadId,
       anchorText,
       meetingId,
+      ...(explicitSources?.length ? { explicitSources } : {}),
     });
   }
 

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1203,6 +1203,37 @@ export class IpcService {
   }
 
   /**
+   * PR-1 — CREATE a user-initiated link from `(srcKind, srcId)` → `(dstKind, dstId)`
+   * (the anchored item is the src). Directed: linking FROM a note materializes the
+   * neighbour's `[[Title]]` into the note body server-side; FROM a meeting it creates
+   * a pure relation row. GATED — refuses (`Locked`) when either endpoint is sealed.
+   * The caller re-runs {@link listLinks} afterward so the new chip appears.
+   */
+  linkItems(
+    srcKind: LinkKind,
+    srcId: string,
+    dstKind: LinkKind,
+    dstId: string,
+  ): Promise<void> {
+    return invoke<void>("link_items", { srcKind, srcId, dstKind, dstId });
+  }
+
+  /**
+   * PR-1 — REMOVE a user-created link from `(srcKind, srcId)` → `(dstKind, dstId)`
+   * (the inverse of {@link linkItems}). Only manual links (`LinkEdge.manual === true`)
+   * are removable this way. GATED — refuses (`Locked`) when either endpoint is sealed.
+   * The caller re-runs {@link listLinks} afterward so the chip drops out.
+   */
+  unlinkItems(
+    srcKind: LinkKind,
+    srcId: string,
+    dstKind: LinkKind,
+    dstId: string,
+  ): Promise<void> {
+    return invoke<void>("unlink_items", { srcKind, srcId, dstKind, dstId });
+  }
+
+  /**
    * Resolve a clicked `[[Title]]` wikilink to the VISIBLE note/meeting to navigate to,
    * or `null` when nothing matches / the only match is sealed-and-not-session-unlocked
    * (gated server-side). The caller routes on `kind` or offers to create a note.

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -827,6 +827,9 @@ export class MeetingConversationStore {
         // meeting; omitting it would fall back to state.current_meeting → the
         // wrong-meeting bug). Null → undefined so the backend uses the recording.
         this._meetingId() ?? undefined,
+        // TODO(source-scope): record-time @brain picker once ask_assistant_chat
+        // full-pins — the backend scoping here is a documented partial, so the
+        // fifth `explicitSources` arg is intentionally omitted for now.
       );
       this.resolveTurn(noteId, agentTurnId, {
         status: reply.status,

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1347,11 +1347,17 @@ export interface BacklinkSource {
  * - `direction` — `"out"` (the queried item is this edge's `src`) | `"in"` (it is `dst`).
  * - `otherKind` — the neighbour endpoint kind: `"meeting" | "note" | "document"`
  *   (route `meeting` → `/meeting/:id`, `note`/`document` → `/notes/:id`).
- * - `edgeType` — `"wikilink" | "companion" | "semantic"`. `wikilink`/`companion` are
- *   DETERMINISTIC edges (rendered as plain link chips); `semantic` is a SUGGESTED edge
- *   the user can Accept/Dismiss, with `score` the cosine confidence.
+ * - `edgeType` — `"wikilink" | "companion" | "semantic" | "manual"`. `wikilink`/
+ *   `companion`/`manual` are DETERMINISTIC edges (rendered as plain link chips);
+ *   `semantic` is a SUGGESTED edge the user can Accept/Dismiss, with `score` the
+ *   cosine confidence.
  * - `createdBy` — `"user" | "auto" | "accepted"`; `status` — `"active" | "suggested"`
  *   (`"dismissed"` rows are never returned). `score` is `1.0` for deterministic edges.
+ * - `manual` (PR-1) — `true` when this chip represents a USER-created link (via the
+ *   `+ Link` chooser → `link_items`) that is removable with a `×` (→ `unlink_items`).
+ *   The backend dedupes a manual+wikilink pair into ONE chip and sets `manual:true`
+ *   on it. Defaults to `false`/absent for auto (wikilink/companion) and semantic
+ *   edges, which are NOT user-removable from the panel. (`#[serde(default)]`.)
  *
  * Mirrors the Rust `LinkEdge` (serde camelCase).
  */
@@ -1361,11 +1367,16 @@ export interface LinkEdge {
   otherKind: "meeting" | "note" | "document";
   otherId: string;
   otherTitle: string;
-  edgeType: "wikilink" | "companion" | "semantic";
+  edgeType: "wikilink" | "companion" | "semantic" | "manual";
   createdBy: "user" | "auto" | "accepted";
   status: "active" | "suggested";
   score: number;
   createdAt: number;
+  /**
+   * PR-1 — `true` when the chip is a user-created link that should show a
+   * removable `×`. Backend field `manual` (`#[serde(default)]` ⇒ may be absent).
+   */
+  manual?: boolean;
 }
 
 /** The link-endpoint kind an `app-connections` panel is anchored to (`list_links` `kind`). */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1372,6 +1372,19 @@ export interface LinkEdge {
 export type LinkKind = "meeting" | "note" | "document";
 
 /**
+ * One source the Brain has been scoped to (the `mur-source-picker` chip model) —
+ * a note/meeting/document the user picked to constrain an Ask over. Reuses the
+ * existing {@link LinkKind} tri-state (the picker drops person/entity/org
+ * `NoteCitation` rows). `title` is carried purely for chip display; identity is
+ * `kind + id` (a picked candidate is deduped, and re-picking never doubles it).
+ */
+export interface SourceRef {
+  kind: LinkKind;
+  id: string;
+  title?: string;
+}
+
+/**
  * A resolved `[[Title]]` wikilink navigation target — the VISIBLE note/meeting/org
  * (Shared Brain) item to open (`resolveWikilink(title)`). `null` when nothing matches
  * OR the only local match is sealed-and-not-session-unlocked (gated server-side, so a

--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -1,0 +1,172 @@
+<!-- Chip multiselect: "scope the Brain to these sources". The picked SourceRefs
+     render as removable chips above the trigger; the trigger opens the OPAQUE
+     candidate popover (T3). -->
+<div class="sp" [class.is-open]="open()">
+  @if (selected().length > 0) {
+    <ul class="sp-chips" aria-label="Selected sources">
+      @for (c of selected(); track c.kind + c.id) {
+        <li class="sp-chip pill">
+          <span class="sp-chip-badge" aria-hidden="true">
+            @switch (c.kind) {
+              @case ("meeting") {
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M8 3.5a2.2 2.2 0 1 0 0 4.4 2.2 2.2 0 0 0 0-4.4ZM3.2 13a4.8 4.8 0 0 1 9.6 0"
+                    stroke="currentColor"
+                    stroke-width="1.4"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              }
+              @default {
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M4 2.5h5.2L12 5.3V13a.7.7 0 0 1-.7.7H4a.7.7 0 0 1-.7-.7V3.2A.7.7 0 0 1 4 2.5Z"
+                    stroke="currentColor"
+                    stroke-width="1.4"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M9 2.6v2.8h2.8"
+                    stroke="currentColor"
+                    stroke-width="1.4"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              }
+            }
+          </span>
+          <span class="sp-chip-title">{{ c.title || c.id }}</span>
+          <button
+            type="button"
+            class="sp-chip-remove"
+            [attr.aria-label]="'Remove ' + (c.title || c.id)"
+            (click)="remove(c)"
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path
+                d="M4 4l8 8M12 4l-8 8"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </li>
+      }
+    </ul>
+  }
+
+  <button
+    #trigger
+    type="button"
+    class="btn btn-ghost sp-trigger"
+    [attr.aria-expanded]="open()"
+    aria-haspopup="listbox"
+    (click)="toggle()"
+  >
+    {{ triggerLabel() }}
+  </button>
+</div>
+
+@if (open()) {
+  <!-- Scrim: a click OUTSIDE the popover closes it. Transparent (only the panel
+       carries the opaque overlay — T3). role=button + Enter/Space/Esc satisfy the
+       a11y lints (mirrors the quick-search scrim). -->
+  <div
+    class="sp-scrim"
+    role="button"
+    tabindex="0"
+    aria-label="Close source picker"
+    (click)="close()"
+    (keydown.enter)="close()"
+    (keydown.space)="close(); $event.preventDefault()"
+    (keydown.escape)="close()"
+  ></div>
+
+  <!-- OPAQUE floating popover (T3): --surface-overlay + backdrop-filter:none via
+       the global .menu primitive. Positioned in JS (afterNextRender) under the
+       trigger; re-positioned on scroll/resize via the shared directive. -->
+  <div
+    #popover
+    class="sp-pop menu"
+    appRepositionOnScroll
+    (reposition)="reposition()"
+  >
+    <input
+      #search
+      type="text"
+      class="sp-search"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-controls="sp-listbox"
+      [attr.aria-expanded]="candidates().length > 0"
+      [placeholder]="placeholder()"
+      [value]="query()"
+      (input)="onQuery($any($event.target).value)"
+      (keydown)="onKeydown($event)"
+    />
+
+    <div
+      #list
+      id="sp-listbox"
+      class="sp-list"
+      role="listbox"
+      aria-label="Source candidates"
+      (scroll)="onScroll()"
+    >
+      @for (r of rows(); track r.candidate.kind + r.candidate.id; let i = $index) {
+        <button
+          type="button"
+          class="sp-row menu-item"
+          role="option"
+          [class.is-active]="i === activeIndex()"
+          [class.is-picked]="r.picked"
+          [attr.aria-selected]="i === activeIndex()"
+          (click)="pick(r.candidate)"
+        >
+          <span class="sp-title">{{ r.candidate.title }}</span>
+          @if (r.picked) {
+            <svg
+              class="sp-check"
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M3.5 8.5l3 3 6-6.5"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          } @else {
+            <span class="sp-kind">{{ r.candidate.kind }}</span>
+          }
+        </button>
+      } @empty {
+        @if (loading()) {
+          <p class="sp-empty">Searching…</p>
+        } @else {
+          <p class="sp-empty">No matching notes or meetings.</p>
+        }
+      }
+    </div>
+  </div>
+}

--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -1,0 +1,156 @@
+/* mur-source-picker — chip multiselect over the link-candidate feed.
+   Leans on the global primitives (.pill / .menu / .menu-item / .btn.btn-ghost);
+   only the layout, chip trimmings, popover positioning + list scroller live here.
+   The popover FLOATS over content → OPAQUE (T3) via the .menu primitive
+   (--surface-overlay, --border-strong, --shadow-lg, backdrop-filter:none). */
+
+.sp {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+/* While the popover is open the chips + trigger must stay clickable ABOVE the
+   full-viewport scrim (removing a just-added source, re-toggling) — raise the
+   in-flow chip strip over the scrim (z-index 40) without leaving normal flow. */
+.sp.is-open {
+  position: relative;
+  z-index: 42;
+}
+
+/* --- Selected chips ------------------------------------------------------- */
+.sp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+/* .pill carries the pill surface; tighten padding for the badge + × affordance. */
+.sp-chip {
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+  max-width: 220px;
+}
+.sp-chip-badge {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  flex: none;
+}
+.sp-chip-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+.sp-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex: none;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.sp-chip-remove:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.sp-chip-remove:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
+/* --- Trigger -------------------------------------------------------------- */
+.sp-trigger {
+  height: 28px;
+  padding: 0 var(--space-3);
+  font-size: 0.8125rem;
+  flex: none;
+}
+
+/* --- Popover (opaque overlay) --------------------------------------------- */
+/* A fixed full-viewport scrim so an outside click closes the popover; only the
+   panel is opaque — the scrim itself is transparent (T3: glass never on glass). */
+.sp-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: transparent;
+}
+.sp-pop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 41;
+  width: 300px;
+  max-width: calc(100vw - 2 * var(--space-3));
+  gap: var(--space-2);
+}
+
+.sp-search {
+  width: 100%;
+  height: 34px;
+}
+
+/* Scroller — the infinite-scroll list over the whole visible vault. */
+.sp-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* .menu-item carries the row surface; add the title/kind/check layout. */
+.sp-row {
+  justify-content: space-between;
+  font-size: 0.8125rem;
+}
+.sp-row.is-active {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.sp-row.is-active .sp-kind {
+  color: var(--text-on-accent);
+}
+.sp-row.is-picked {
+  color: var(--accent);
+}
+.sp-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* The kind ("note"/"meeting"/"document") is a quiet trailing hint, not a badge. */
+.sp-kind {
+  flex: none;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+.sp-check {
+  flex: none;
+  color: var(--accent);
+}
+.sp-row.is-active .sp-check {
+  color: var(--text-on-accent);
+}
+
+.sp-empty {
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -1,0 +1,395 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  model,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { IpcService } from "../../core/ipc.service";
+import type { LinkKind, NoteCitation, SourceRef } from "../../core/models";
+import { DebounceService } from "../../services/debounce.service";
+import { RepositionOnScrollDirective } from "../../features/notes/note-brain-popover/reposition-on-scroll.directive";
+
+/** How long to wait after the last keystroke before re-querying the backend. */
+const QUERY_DEBOUNCE_MS = 150;
+/** The debounce-service key — one source-picker popover open at a time per instance. */
+const DEBOUNCE_KEY = "source-picker-query";
+/**
+ * One backend page of the infinite scroll. A page that comes back exactly this
+ * size means more may exist; a shorter page means the list ran dry. The backend
+ * clamps whatever it is asked for to its own ceiling (100).
+ */
+const PAGE_SIZE = 40;
+/** Load the next page once the scroll position is within this many px of the bottom. */
+const SCROLL_LOAD_THRESHOLD_PX = 56;
+/** Keyboard ↑/↓: pull the next page once the active row is within this many rows of the end. */
+const KEYBOARD_LOAD_AHEAD_ROWS = 3;
+
+/** The `NoteCitation.kind`s the picker offers — the Brain scopes to these only. */
+const ALLOWED_KINDS: ReadonlySet<string> = new Set<LinkKind>([
+  "meeting",
+  "note",
+  "document",
+]);
+
+/**
+ * Design System — `<mur-source-picker>`: the "scope the Brain to these sources"
+ * chip multiselect. A small trigger opens an OPAQUE popover (T3) with a
+ * self-focused search over {@link IpcService.listLinkCandidates} — the SAME
+ * paginated candidate feed the `[[` link picker walks — filtered to
+ * note/meeting/document (person/entity/org rows are dropped, since a Brain scope
+ * is a document scope). Picking a row ADDS a {@link SourceRef} to `selected()`
+ * (deduped by `kind + id`) and keeps the popover open (multiselect); the picked
+ * sources render as removable chips.
+ *
+ * REUSES the link-picker mechanics wholesale — the debounced fetch (sanctioned
+ * {@link DebounceService}, never a bare `setTimeout`), the monotonic `requestSeq`
+ * stale-guard (a late reply for a superseded query is dropped), the `hasMore`/
+ * `loadingMore` infinite-scroll paging deduped by `kind + id`, the ↑/↓ tail
+ * look-ahead, and {@link RepositionOnScrollDirective} for scroll/resize
+ * re-anchoring. The one shape difference: this component OWNS its `query` (its
+ * own `<input>`, unlike the link picker whose caret stays in the editor), so the
+ * fetch effect keys on an internal `_query` signal instead of a host input.
+ *
+ * The popover is positioned in JS via `afterNextRender({injector})` under the
+ * trigger — never a `setTimeout`/`rAF` (rule §5).
+ */
+@Component({
+  selector: "mur-source-picker",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RepositionOnScrollDirective],
+  templateUrl: "./source-picker.component.html",
+  styleUrl: "./source-picker.component.scss",
+})
+export class SourcePickerComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly debounce = inject(DebounceService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Two-way: the picked sources rendered as removable chips. */
+  readonly selected = model<SourceRef[]>([]);
+  /** Placeholder for the popover search input. */
+  readonly placeholder = input("Add a note or meeting…");
+  /** Label on the trigger button. */
+  readonly triggerLabel = input("+ Source");
+
+  /** Whether the popover is open. */
+  readonly open = signal(false);
+  /** The live search text (owned here — this component has its own input). */
+  readonly query = signal("");
+  /** The live candidate rows for the current query (already kind-filtered). */
+  readonly candidates = signal<NoteCitation[]>([]);
+  /** Keyboard-highlighted row index. */
+  readonly activeIndex = signal(0);
+  /** True while the (debounced) fetch for the CURRENT query is in flight. */
+  readonly loading = computed(() => this._loading());
+  private readonly _loading = signal(false);
+
+  /** Fast membership set of already-picked sources, keyed `kind + id`. */
+  private readonly selectedKeys = computed(
+    () => new Set(this.selected().map((s) => s.kind + s.id)),
+  );
+
+  /** Rows annotated with whether they are already picked (no template method). */
+  readonly rows = computed(() =>
+    this.candidates().map((c) => ({
+      candidate: c,
+      picked: this.selectedKeys().has(c.kind + c.id),
+    })),
+  );
+
+  private readonly triggerEl = viewChild<ElementRef<HTMLButtonElement>>("trigger");
+  private readonly popoverEl = viewChild<ElementRef<HTMLDivElement>>("popover");
+  private readonly searchEl = viewChild<ElementRef<HTMLInputElement>>("search");
+  private readonly listEl = viewChild<ElementRef<HTMLDivElement>>("list");
+
+  /** Monotonic request token — a late reply for a superseded query is dropped. */
+  private requestSeq = 0;
+  /** True when the last page came back full, so another page may exist. */
+  private hasMore = false;
+  /** Re-entrancy guard: one append fetch at a time. */
+  private loadingMore = false;
+
+  constructor() {
+    // Fetch on every query change while open (debounced) — a legitimate
+    // signal-writing effect (T1): async IPC orchestration keyed on `query()`,
+    // with a `requestSeq` stale guard. Gated on `open()` so a closed picker
+    // isn't querying.
+    effect(() => {
+      if (!this.open()) {
+        return;
+      }
+      const q = this.query();
+      this.debounce.schedule(
+        DEBOUNCE_KEY,
+        () => void this.fetch(q),
+        QUERY_DEBOUNCE_MS,
+      );
+    });
+    // Keyboard nav over a paginated list: keep the active row scrolled into
+    // view and pull the next page once ↑/↓ nears the tail of what's loaded.
+    // `afterNextRender` so the `.is-active` class from THIS pass is painted
+    // before we scroll to it.
+    effect(() => {
+      const idx = this.activeIndex();
+      const total = this.candidates().length;
+      if (this.open() && total > 0 && idx >= total - KEYBOARD_LOAD_AHEAD_ROWS) {
+        void this.loadMore();
+      }
+      afterNextRender(
+        () => {
+          this.listEl()
+            ?.nativeElement.querySelector(".sp-row.is-active")
+            ?.scrollIntoView({ block: "nearest" });
+        },
+        { injector: this.injector },
+      );
+    });
+    this.destroyRef.onDestroy(() => this.debounce.cancel(DEBOUNCE_KEY));
+  }
+
+  // --- Popover open/close ---------------------------------------------------
+
+  toggle(): void {
+    if (this.open()) {
+      this.close();
+    } else {
+      this.openPopover();
+    }
+  }
+
+  private openPopover(): void {
+    this.open.set(true);
+    this.query.set("");
+    this.candidates.set([]);
+    this.activeIndex.set(0);
+    // Focus the search field + first fetch (empty prefix → recent candidates)
+    // once the popover renders. afterNextRender is the zoneless-safe one-shot;
+    // the injector is required outside field-init context.
+    afterNextRender(
+      () => {
+        this.searchEl()?.nativeElement.focus();
+      },
+      { injector: this.injector },
+    );
+    void this.fetch("");
+    this.reposition();
+  }
+
+  close(): void {
+    this.open.set(false);
+    this.debounce.cancel(DEBOUNCE_KEY);
+    // Return focus to the trigger for keyboard users.
+    afterNextRender(
+      () => {
+        this.triggerEl()?.nativeElement.focus();
+      },
+      { injector: this.injector },
+    );
+  }
+
+  // --- Search input + keyboard nav -----------------------------------------
+
+  onQuery(value: string): void {
+    this.query.set(value);
+    this.activeIndex.set(0);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        this.move(1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        this.move(-1);
+        break;
+      case "Enter": {
+        event.preventDefault();
+        const row = this.candidates()[this.activeIndex()];
+        if (row) {
+          this.pick(row);
+        }
+        break;
+      }
+      case "Escape":
+        event.preventDefault();
+        this.close();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private move(delta: number): void {
+    const n = this.candidates().length;
+    if (n === 0) {
+      return;
+    }
+    const next = Math.min(Math.max(this.activeIndex() + delta, 0), n - 1);
+    this.activeIndex.set(next);
+  }
+
+  // --- Fetch / paginate (reused from the link picker) ----------------------
+
+  private async fetch(q: string): Promise<void> {
+    const seq = ++this.requestSeq;
+    this._loading.set(true);
+    try {
+      const rows = await this.ipc.listLinkCandidates(q, 0, PAGE_SIZE);
+      if (seq !== this.requestSeq) {
+        return; // superseded by a newer query.
+      }
+      const kept = rows.filter((c) => ALLOWED_KINDS.has(c.kind));
+      // `hasMore` tracks the RAW backend page (unfiltered) — a full page means
+      // more rows exist upstream even if this page's kept rows are few.
+      this.hasMore = rows.length === PAGE_SIZE;
+      this.candidates.set(kept);
+      this.activeIndex.set(0);
+      this.reposition();
+    } catch {
+      if (seq === this.requestSeq) {
+        this.hasMore = false;
+        this.candidates.set([]);
+      }
+    } finally {
+      if (seq === this.requestSeq) {
+        this._loading.set(false);
+      }
+    }
+  }
+
+  /**
+   * Append the next backend page (scroll neared the bottom, or ↑/↓ neared the
+   * tail of the loaded rows). Guarded by the SAME `requestSeq` as {@link fetch}:
+   * a query change mid-flight bumps it and the stale append is dropped whole.
+   * Pages by RAW offset (unfiltered backend rows loaded so far), so dropped
+   * person/entity/org rows never desync the offset from the backend's ordering.
+   */
+  private async loadMore(): Promise<void> {
+    if (!this.hasMore || this.loadingMore || this._loading()) {
+      return;
+    }
+    const seq = this.requestSeq;
+    this.loadingMore = true;
+    try {
+      const page = await this.ipc.listLinkCandidates(
+        this.query(),
+        this.rawOffset,
+        PAGE_SIZE,
+      );
+      if (seq !== this.requestSeq) {
+        return; // a newer query reset the list while this page was in flight.
+      }
+      this.rawOffset += page.length;
+      this.hasMore = page.length === PAGE_SIZE;
+      const kept = page.filter((c) => ALLOWED_KINDS.has(c.kind));
+      // Dedupe on append: a row that shifted pages mid-scroll must not repeat —
+      // the template's `track c.kind + c.id` requires unique keys.
+      const seen = new Set(this.candidates().map((c) => c.kind + c.id));
+      const fresh = kept.filter((c) => !seen.has(c.kind + c.id));
+      if (fresh.length > 0) {
+        this.candidates.set([...this.candidates(), ...fresh]);
+        this.reposition();
+      }
+    } catch {
+      if (seq === this.requestSeq) {
+        // Keep what's loaded; stop probing so a failing backend isn't hammered.
+        this.hasMore = false;
+      }
+    } finally {
+      this.loadingMore = false;
+    }
+  }
+
+  /**
+   * RAW backend offset (rows requested so far, unfiltered). `fetch` resets it to
+   * page 0's length; `loadMore` advances by each raw page length. Kept separate
+   * from `candidates().length` because kept rows < raw rows once kinds are
+   * dropped. A private field mirrors `requestSeq`/`hasMore` (never templated).
+   */
+  private rawOffset = PAGE_SIZE;
+
+  /** Infinite scroll: fetch the next page when nearing the bottom of the list. */
+  onScroll(): void {
+    const el = this.listEl()?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const nearBottom =
+      el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_LOAD_THRESHOLD_PX;
+    if (nearBottom) {
+      void this.loadMore();
+    }
+  }
+
+  // --- Selection ------------------------------------------------------------
+
+  pick(candidate: NoteCitation): void {
+    const kind = candidate.kind as LinkKind;
+    if (!ALLOWED_KINDS.has(kind)) {
+      return;
+    }
+    const key = candidate.kind + candidate.id;
+    if (this.selectedKeys().has(key)) {
+      return; // already picked — multiselect dedupes by kind + id.
+    }
+    const ref: SourceRef = { kind, id: candidate.id, title: candidate.title };
+    this.selected.update((list) => [...list, ref]);
+    // Keep the popover open (multiselect) and refocus the search for the next add.
+    afterNextRender(
+      () => {
+        this.searchEl()?.nativeElement.focus();
+      },
+      { injector: this.injector },
+    );
+  }
+
+  remove(ref: SourceRef): void {
+    this.selected.update((list) =>
+      list.filter((s) => !(s.kind === ref.kind && s.id === ref.id)),
+    );
+  }
+
+  // --- Positioning (reused from the link picker) ---------------------------
+
+  reposition(): void {
+    afterNextRender(
+      () => {
+        const el = this.popoverEl()?.nativeElement;
+        const anchor = this.triggerEl()?.nativeElement;
+        if (!el || !anchor) {
+          return;
+        }
+        const rect = anchor.getBoundingClientRect();
+        const width = el.offsetWidth || 300;
+        const height = el.offsetHeight;
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+
+        let left = rect.left;
+        left = Math.max(8, Math.min(left, vw - width - 8));
+
+        // Prefer BELOW the trigger; flip above when there isn't room below.
+        let top = rect.bottom + 4;
+        if (top + height > vh - 8) {
+          top = Math.max(8, rect.top - height - 4);
+        }
+
+        el.style.left = `${Math.round(left)}px`;
+        el.style.top = `${Math.round(top)}px`;
+      },
+      { injector: this.injector },
+    );
+  }
+}

--- a/src/app/features/ask/ask/ask.component.html
+++ b/src/app/features/ask/ask/ask.component.html
@@ -159,6 +159,15 @@
         }
       </div>
 
+      <!-- Source-scoped Brain: OPTIONALLY narrow the answer to specific notes /
+           meetings (+ their links). Empty (the default) ⇒ the whole vault. -->
+      <mur-source-picker
+        class="ask-sources"
+        [(selected)]="sources"
+        triggerLabel="Sources"
+        placeholder="Scope to a note or meeting…"
+      />
+
       <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
       <form class="ask-composer" (submit)="onSubmit($event)">
         <textarea

--- a/src/app/features/ask/ask/ask.component.scss
+++ b/src/app/features/ask/ask/ask.component.scss
@@ -353,6 +353,13 @@
 }
 
 /* --- Composer --- */
+/* Source-scoped Brain picker — sits just above the composer (aligned with it,
+   both inset by the panel padding). */
+.ask-sources {
+  display: block;
+  margin-bottom: var(--space-2);
+}
+
 .ask-composer {
   display: flex;
   align-items: flex-end;

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -16,8 +16,10 @@ import { IpcService } from "../../../core/ipc.service";
 import type {
   AssistantToolPayload,
   ChatTurn,
+  SourceRef,
   VaultSource,
 } from "../../../core/models";
+import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { SourcesComponent } from "../../../shared/sources/sources.component";
 
@@ -79,7 +81,7 @@ const STARTERS: readonly string[] = [
 @Component({
   selector: "app-ask",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MarkdownComponent, SourcesComponent],
+  imports: [MarkdownComponent, SourcesComponent, SourcePickerComponent],
   templateUrl: "./ask.component.html",
   styleUrl: "./ask.component.scss",
 })
@@ -101,6 +103,14 @@ export class AskComponent implements OnInit {
   readonly error = signal<string | null>(null);
   /** Working copy of the composer text (textarea (input) → signal). */
   readonly draft = signal("");
+
+  /**
+   * Source-scoped Brain — the `<mur-source-picker>` selection. Default EMPTY:
+   * the Ask page answers across the WHOLE vault unless the user opts in by
+   * picking sources. A NON-empty selection pins the answer to those sources +
+   * their links; empty ⇒ pass `undefined` (whole-vault) to {@link askVault}.
+   */
+  readonly sources = signal<SourceRef[]>([]);
 
   /** Live tool-trace chips for the IN-FLIGHT question (cleared when it lands). */
   readonly trace = signal<AskTraceStep[]>([]);
@@ -330,11 +340,15 @@ export class AskComponent implements OnInit {
     this.pending.set(true);
     this.scrollToLatest();
 
+    // Source-scoped Brain: an empty selection ⇒ pass undefined (whole-vault);
+    // a non-empty selection pins the answer to those sources + their links.
+    const scope = this.sources();
     try {
       const result = await this.ipc.askVault(
         question,
         priorHistory,
         askThreadId,
+        scope.length ? scope : undefined,
       );
       this.conversation.update((turns) => [
         ...turns,

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -249,6 +249,7 @@
         @case ("note") {
           <app-note-panel
             [meetingId]="d.meeting.id"
+            [meetingTitle]="d.meeting.title"
             [folderId]="d.meeting.folderId ?? null"
             [note]="note()"
             [interactions]="interactions()"

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.html
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.html
@@ -101,6 +101,15 @@
     }
   </div>
 
+  <!-- Source-scoped Brain: pick which notes/meetings ground the answer (pre-filled
+       with this meeting + its active links). Empty ⇒ the whole-meeting default. -->
+  <mur-source-picker
+    class="chat-sources"
+    [(selected)]="sources"
+    triggerLabel="Sources"
+    placeholder="Scope to a note or meeting…"
+  />
+
   <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
   <form class="chat-composer" (submit)="onSubmit($event)">
     <textarea

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.scss
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.scss
@@ -226,6 +226,12 @@
 }
 
 /* --- Composer --- */
+/* Source-scoped Brain picker — sits just above the composer. */
+.chat-sources {
+  display: block;
+  margin-bottom: calc(-1 * var(--space-1));
+}
+
 .chat-composer {
   display: flex;
   align-items: flex-end;

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.ts
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.ts
@@ -5,13 +5,16 @@ import {
   Injector,
   afterNextRender,
   computed,
+  effect,
   inject,
   input,
   signal,
   viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
-import type { ChatTurn } from "../../../core/models";
+import type { ChatTurn, SourceRef } from "../../../core/models";
+import { SourceScopeService } from "../../../services/source-scope.service";
+import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 
 /** The starter prompts shown in the empty state — tap to ask immediately. */
@@ -38,16 +41,52 @@ const STARTERS: readonly string[] = [
 @Component({
   selector: "app-meeting-chat",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MarkdownComponent],
+  imports: [MarkdownComponent, SourcePickerComponent],
   templateUrl: "./meeting-chat.component.html",
   styleUrl: "./meeting-chat.component.scss",
 })
 export class MeetingChatComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly sourceScope = inject(SourceScopeService);
 
   /** The meeting whose transcript grounds every answer. */
   readonly meetingId = input.required<string>();
+  /**
+   * The meeting's display title — the label of the anchor chip pre-filled into
+   * the picker (falls back to the id when absent). Display-only; identity is
+   * `kind + id`.
+   */
+  readonly anchorTitle = input<string | null>(null);
+
+  /**
+   * Source-scoped Brain — the `<mur-source-picker>` selection (this meeting +
+   * its active links, pre-filled on load). A NON-empty selection PINS the answer
+   * to exactly those sources + their links; empty keeps the whole-meeting
+   * grounding. `send()` passes `undefined` when empty (see below).
+   */
+  readonly sources = signal<SourceRef[]>([]);
+
+  /**
+   * Pre-fill the picker with the default scope for THIS meeting (the meeting
+   * itself + its active linked neighbours) whenever the meeting id changes.
+   * A legitimate signal-writing IPC effect (T1): keyed on `meetingId()`, with a
+   * monotonic stale-result guard so a late reply for a superseded meeting is
+   * dropped (the id can change while the component is reused across meetings).
+   */
+  private prefillSeq = 0;
+  private readonly _prefill = effect(() => {
+    const id = this.meetingId();
+    const title = this.anchorTitle() ?? undefined;
+    const seq = ++this.prefillSeq;
+    void this.sourceScope
+      .defaultSources("meeting", id, title)
+      .then((defaults) => {
+        if (seq === this.prefillSeq) {
+          this.sources.set(defaults);
+        }
+      });
+  });
 
   /** The running conversation (optimistic user turns + grounded replies). */
   readonly conversation = signal<ChatTurn[]>([]);
@@ -145,11 +184,15 @@ export class MeetingChatComponent {
     this.pending.set(true);
     this.scrollToLatest();
 
+    // Source-scoped Brain: an empty selection ⇒ pass undefined so the backend
+    // keeps this-meeting grounding; a non-empty selection pins to those sources.
+    const scope = this.sources();
     try {
       const answer = await this.ipc.chatMeeting(
         this.meetingId(),
         question,
         priorHistory,
+        scope.length ? scope : undefined,
       );
       this.conversation.update((turns) => [
         ...turns,

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -422,7 +422,10 @@
 
   <!-- CHAT WITH THIS MEETING (grounded Q&A over the transcript). -->
   <section class="block">
-    <app-meeting-chat [meetingId]="meetingId()" />
+    <app-meeting-chat
+      [meetingId]="meetingId()"
+      [anchorTitle]="meetingTitle()"
+    />
   </section>
 
   <!-- RELATED BY MEANING (semantic neighbors; silent when empty). -->

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -123,6 +123,8 @@ export interface AssistantQa {
 export class NotePanelComponent {
   // --- Identity / meeting inputs ------------------------------------------
   readonly meetingId = input.required<string>();
+  /** The meeting's title — the anchor-chip label for the Ask-this-meeting picker. */
+  readonly meetingTitle = input<string | null>(null);
   readonly folderId = input<string | null>(null);
   /** The parsed note body (null when there is no note / masked). */
   readonly note = input<ParsedNote | null>(null);

--- a/src/app/features/notes/note-chat/note-chat.component.html
+++ b/src/app/features/notes/note-chat/note-chat.component.html
@@ -1,0 +1,143 @@
+<div class="chat card">
+  <div class="chat-head">
+    <div class="chat-head-text">
+      <h3 class="chat-title">Ask about this note</h3>
+      <span class="chat-sub"
+        >Answers are grounded in this note and its linked sources</span
+      >
+    </div>
+    @if (conversation().length) {
+      <button
+        type="button"
+        class="btn btn-ghost chat-clear"
+        (click)="clear()"
+        [disabled]="pending()"
+      >
+        Clear
+      </button>
+    }
+  </div>
+
+  <!-- Message list (also the scroll region) -->
+  <div
+    #scroller
+    class="chat-log"
+    role="log"
+    aria-live="polite"
+    aria-label="Conversation"
+  >
+    @if (conversation().length === 0 && !pending()) {
+      <!-- Empty state: a friendly prompt + tappable starter chips. -->
+      <div class="chat-empty">
+        <span class="chat-empty-mark" aria-hidden="true"></span>
+        <p class="chat-empty-title">Chat with this note</p>
+        <p class="chat-empty-copy">
+          Ask anything about this note — summarize it, spot gaps, or find
+          related meetings.
+        </p>
+        <div
+          class="chat-starters"
+          role="group"
+          aria-label="Suggested questions"
+        >
+          @for (s of starters; track s) {
+            <button
+              type="button"
+              class="chat-chip"
+              [style.--i]="$index"
+              (click)="ask(s)"
+            >
+              {{ s }}
+            </button>
+          }
+        </div>
+      </div>
+    } @else {
+      @for (turn of conversation(); track $index) {
+        <div
+          class="chat-row"
+          [class.is-user]="turn.role === 'user'"
+          [class.is-assistant]="turn.role === 'assistant'"
+        >
+          <div
+            class="chat-bubble"
+            [attr.aria-label]="
+              (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
+            "
+          >
+            @if (turn.role === "assistant") {
+              <app-markdown [markdown]="turn.content" compact />
+            } @else {
+              {{ turn.content }}
+            }
+          </div>
+        </div>
+      }
+
+      <!-- "Thinking…" typing indicator while a reply is in flight. -->
+      @if (pending()) {
+        <div class="chat-row is-assistant">
+          <div class="chat-bubble chat-typing" aria-label="Thinking">
+            <span class="chat-dot"></span>
+            <span class="chat-dot"></span>
+            <span class="chat-dot"></span>
+          </div>
+        </div>
+      }
+    }
+
+    <!-- Inline error with a retry affordance (keeps the question intact). -->
+    @if (error(); as err) {
+      <div class="chat-error" role="alert">
+        <span class="chat-error-text">{{ err }}</span>
+        <button
+          type="button"
+          class="btn btn-ghost chat-retry"
+          (click)="retry()"
+          [disabled]="pending()"
+        >
+          Retry
+        </button>
+      </div>
+    }
+  </div>
+
+  <!-- Source-scoped Brain: which notes/meetings ground the answer (pre-filled
+       with this note + its active links). Editable — add or remove sources. -->
+  <mur-source-picker
+    class="chat-sources"
+    [(selected)]="sources"
+    triggerLabel="Sources"
+    placeholder="Scope to a note or meeting…"
+  />
+
+  <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
+  <form class="chat-composer" (submit)="onSubmit($event)">
+    <textarea
+      #input
+      class="chat-input"
+      rows="1"
+      autocapitalize="sentences"
+      autocomplete="off"
+      spellcheck="true"
+      aria-label="Your question"
+      placeholder="Ask about this note…"
+      [value]="draft()"
+      [disabled]="pending()"
+      (input)="onDraftInput($event)"
+      (keydown)="onKeydown($event)"
+    ></textarea>
+    <button
+      type="submit"
+      class="btn btn-primary chat-send"
+      [disabled]="!canSend()"
+      [attr.aria-label]="pending() ? 'Sending' : 'Send'"
+    >
+      @if (pending()) {
+        <span class="chat-send-spin" aria-hidden="true"></span>
+      } @else {
+        <span class="chat-send-arrow" aria-hidden="true"></span>
+      }
+    </button>
+  </form>
+</div>

--- a/src/app/features/notes/note-chat/note-chat.component.scss
+++ b/src/app/features/notes/note-chat/note-chat.component.scss
@@ -1,0 +1,317 @@
+:host {
+  display: block;
+}
+
+.chat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  overflow: hidden;
+  animation: rise 420ms var(--transition) both;
+}
+/* A faint aurora wash to lift the glass above the page surface. */
+.chat::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    120% 90% at 88% -10%,
+    rgba(157, 123, 255, 0.1),
+    transparent 60%
+  );
+}
+.chat > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* --- Head --- */
+.chat-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.chat-head-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.chat-title {
+  margin: 0;
+}
+.chat-sub {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+.chat-clear {
+  flex: none;
+  height: 32px;
+  padding: 0 var(--space-3);
+  font-size: 0.8125rem;
+}
+
+/* --- Message log (scroll region) --- */
+.chat-log {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-height: 440px;
+  min-height: 132px;
+  overflow-y: auto;
+  padding: var(--space-1) var(--space-1) var(--space-2);
+  scroll-behavior: smooth;
+  overscroll-behavior: contain;
+}
+
+/* --- Empty state --- */
+.chat-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  margin: auto;
+  padding: var(--space-5) var(--space-4);
+  text-align: center;
+}
+.chat-empty-mark {
+  width: 40px;
+  height: 40px;
+  margin-bottom: var(--space-1);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-highlight);
+}
+.chat-empty-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.chat-empty-copy {
+  margin: 0;
+  max-width: 42ch;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+.chat-starters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+.chat-chip {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  line-height: 1.2;
+  cursor: pointer;
+  box-shadow: var(--glass-highlight);
+  animation: rise 360ms var(--transition) both;
+  animation-delay: calc(var(--i, 0) * 60ms + 80ms);
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    color var(--transition),
+    transform var(--transition-fast);
+}
+.chat-chip:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+.chat-chip:active {
+  transform: translateY(1px);
+}
+.chat-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+/* --- Message rows + bubbles --- */
+.chat-row {
+  display: flex;
+  max-width: 100%;
+  animation: bubble-in 320ms var(--ease-spring) both;
+}
+.chat-row.is-user {
+  justify-content: flex-end;
+}
+.chat-row.is-assistant {
+  justify-content: flex-start;
+}
+.chat-bubble {
+  max-width: 82%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  /* Preserve the model's line breaks + spacing as plain text. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.is-user .chat-bubble {
+  background: var(--accent-gradient);
+  border-color: transparent;
+  color: var(--text-on-accent);
+  border-bottom-right-radius: var(--radius-sm);
+  box-shadow: var(--shadow-accent), var(--glass-highlight);
+}
+.is-assistant .chat-bubble {
+  background: var(--surface-raised);
+  -webkit-backdrop-filter: blur(var(--glass-blur))
+    saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  color: var(--text-primary);
+  border-bottom-left-radius: var(--radius-sm);
+  box-shadow: var(--glass-highlight);
+  /* Markdown renders its own block layout — don't let pre-wrap inject blank lines. */
+  white-space: normal;
+}
+
+/* --- Typing indicator --- */
+.chat-typing {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: var(--space-3) var(--space-4);
+}
+.chat-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  animation: typing 1.2s ease-in-out infinite;
+}
+.chat-dot:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.chat-dot:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+/* --- Inline error + retry --- */
+.chat-error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: var(--radius-md);
+  background: var(--danger-soft);
+  animation: rise 240ms var(--transition) both;
+}
+.chat-error-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+.chat-retry {
+  flex: none;
+  height: 30px;
+  padding: 0 var(--space-3);
+  font-size: 0.8125rem;
+}
+
+/* --- Composer --- */
+/* Source-scoped Brain picker — sits just above the composer. */
+.chat-sources {
+  display: block;
+  margin-bottom: calc(-1 * var(--space-1));
+}
+
+.chat-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+.chat-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 44px;
+  max-height: 168px;
+  padding: var(--space-3) var(--space-4);
+  line-height: 1.5;
+  resize: none;
+}
+.chat-send {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: var(--radius-md);
+}
+/* Pure-CSS send glyph (no icon dependency). */
+.chat-send-arrow {
+  width: 16px;
+  height: 16px;
+  background: currentColor;
+  -webkit-mask: var(--send-mask) center / contain no-repeat;
+  mask: var(--send-mask) center / contain no-repeat;
+  --send-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M4 12L20 4l-4 16-4-7-8-1z' fill='black'/%3E%3C/svg%3E");
+}
+.chat-send-spin {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: var(--text-on-accent);
+  animation: chat-spin 0.7s linear infinite;
+}
+
+@keyframes bubble-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes typing {
+  0%,
+  60%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+@keyframes chat-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat,
+  .chat-row,
+  .chat-chip,
+  .chat-error {
+    animation: none;
+  }
+  .chat-dot,
+  .chat-send-spin {
+    animation-duration: 0.01ms;
+  }
+  .chat-log {
+    scroll-behavior: auto;
+  }
+}
+    

--- a/src/app/features/notes/note-chat/note-chat.component.ts
+++ b/src/app/features/notes/note-chat/note-chat.component.ts
@@ -1,0 +1,232 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { ChatTurn, SourceRef } from "../../../core/models";
+import { SourceScopeService } from "../../../services/source-scope.service";
+import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
+import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+
+/** The starter prompts shown in the empty state — tap to ask immediately. */
+const STARTERS: readonly string[] = [
+  "Summarize this note",
+  "What's missing?",
+  "Find related meetings",
+];
+
+/**
+ * "Ask about this note" — a grounded Q&A panel anchored to a single authored
+ * note (Brain v3, source-scoped Brain PR-4). A presentational TWIN of
+ * {@link MeetingChatComponent}: the same conversation/draft/pending/error/
+ * canSend/send/retry/clear/auto-scroll idioms and MarkdownComponent replies.
+ *
+ * The one shape difference from the meeting twin is grounding: it answers via
+ * {@link IpcService.askVault} PINNED to this note's source scope (the note +
+ * its active links, pre-filled into the `<mur-source-picker>`), rather than a
+ * per-meeting transcript chat. Like meeting-chat it is STATELESS — no thread
+ * persistence — so `askVault`'s `askThreadId` is left `undefined` and the FULL
+ * prior conversation is re-sent as history each turn.
+ *
+ * Lives in its own file so its scoped styles get their own per-component
+ * `anyComponentStyle` budget.
+ */
+@Component({
+  selector: "app-note-chat",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MarkdownComponent, SourcePickerComponent],
+  templateUrl: "./note-chat.component.html",
+  styleUrl: "./note-chat.component.scss",
+})
+export class NoteChatComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly injector = inject(Injector);
+  private readonly sourceScope = inject(SourceScopeService);
+
+  /** The note whose content grounds every answer (the pre-fill anchor). */
+  readonly noteId = input.required<string>();
+  /**
+   * The note's display title — the label of the anchor chip pre-filled into the
+   * picker (falls back to the id when absent). Display-only; identity is
+   * `kind + id`.
+   */
+  readonly anchorTitle = input<string | null>(null);
+
+  /** The running conversation (optimistic user turns + grounded replies). */
+  readonly conversation = signal<ChatTurn[]>([]);
+  /** True while an {@link IpcService.askVault} call is in flight. */
+  readonly pending = signal(false);
+  /** Inline error message (with a Retry affordance); null when clear. */
+  readonly error = signal<string | null>(null);
+  /** Working copy of the composer text (textarea (input) → signal). */
+  readonly draft = signal("");
+
+  /**
+   * Source-scoped Brain — the `<mur-source-picker>` selection (this note + its
+   * active links, pre-filled on load). A NON-empty selection PINS the answer to
+   * exactly those sources + their links; `send()` always passes it (the note
+   * itself is one of the sources, so the scope is never whole-vault by default).
+   */
+  readonly sources = signal<SourceRef[]>([]);
+
+  /** Starter prompts for the empty state. */
+  protected readonly starters = STARTERS;
+
+  /**
+   * Pre-fill the picker with the default scope for THIS note (the note itself +
+   * its active linked neighbours) whenever the note id changes. A legitimate
+   * signal-writing IPC effect (T1): keyed on `noteId()`, with a monotonic
+   * stale-result guard so a late reply for a superseded note is dropped.
+   */
+  private prefillSeq = 0;
+  private readonly _prefill = effect(() => {
+    const id = this.noteId();
+    const title = this.anchorTitle() ?? undefined;
+    const seq = ++this.prefillSeq;
+    void this.sourceScope.defaultSources("note", id, title).then((defaults) => {
+      if (seq === this.prefillSeq) {
+        this.sources.set(defaults);
+      }
+    });
+  });
+
+  /** A submit is allowed only with non-empty text and no in-flight request. */
+  readonly canSend = computed(
+    () => !this.pending() && this.draft().trim().length > 0,
+  );
+
+  /** Mirror the textarea value into the `draft` signal. */
+  onDraftInput(event: Event): void {
+    this.draft.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  /** Enter sends; Shift+Enter inserts a newline (textarea default). */
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void this.send();
+    }
+  }
+
+  /** Composer form submit (Send button / Enter). */
+  onSubmit(event: Event): void {
+    event.preventDefault();
+    void this.send();
+  }
+
+  /** Fill + send a starter chip's question. */
+  ask(question: string): void {
+    if (this.pending()) {
+      return;
+    }
+    this.draft.set(question);
+    void this.send();
+  }
+
+  /** Re-send the last user question after an error (it's still in the log). */
+  retry(): void {
+    if (this.pending()) {
+      return;
+    }
+    const turns = this.conversation();
+    const last = turns[turns.length - 1];
+    if (last?.role !== "user") {
+      this.error.set(null);
+      return;
+    }
+    // Pop the dangling user turn back into the composer, then re-run send()
+    // so it captures the correct prior history.
+    this.conversation.set(turns.slice(0, -1));
+    this.draft.set(last.content);
+    void this.send();
+  }
+
+  /** Clear the whole conversation back to the empty state. */
+  clear(): void {
+    if (this.pending()) {
+      return;
+    }
+    this.conversation.set([]);
+    this.error.set(null);
+  }
+
+  /**
+   * Ask the current question, grounded in this note's source scope. Captures the
+   * question + the PRIOR history (the conversation before this turn),
+   * optimistically appends the user turn, awaits the grounded reply, then
+   * appends the assistant turn. On failure the user's question is kept (an inline
+   * Retry re-runs it). Stateless like the meeting twin: no `askThreadId`.
+   */
+  async send(): Promise<void> {
+    const question = this.draft().trim();
+    if (!question || this.pending()) {
+      return;
+    }
+
+    // History as seen by the model = everything BEFORE this turn.
+    const priorHistory = this.conversation();
+    // Source-scoped Brain: pin the answer to this note + its links.
+    const scope = this.sources();
+
+    this.error.set(null);
+    this.draft.set("");
+    this.conversation.set([
+      ...priorHistory,
+      { role: "user", content: question },
+    ]);
+    this.pending.set(true);
+    this.scrollToLatest();
+
+    try {
+      const result = await this.ipc.askVault(
+        question,
+        priorHistory,
+        undefined,
+        scope.length ? scope : undefined,
+      );
+      this.conversation.update((turns) => [
+        ...turns,
+        { role: "assistant", content: result.answer },
+      ]);
+    } catch (e) {
+      // Keep the user's question in the log so Retry can re-send it.
+      this.error.set("Couldn’t get an answer: " + String(e));
+    } finally {
+      this.pending.set(false);
+      this.scrollToLatest();
+    }
+  }
+
+  // --- Auto-scroll ---------------------------------------------------------
+
+  /** The scrollable message log. */
+  private readonly scroller = viewChild<ElementRef<HTMLDivElement>>("scroller");
+
+  /**
+   * Pin the log to the newest message. Runs after the next render so the new
+   * row/typing indicator is laid out before we measure scrollHeight — zoneless
+   * safe, no setTimeout. afterNextRender registered with this component's
+   * injector is a one-shot torn down with the component, so there is nothing to
+   * clean up manually.
+   */
+  private scrollToLatest(): void {
+    afterNextRender(
+      () => {
+        const el = this.scroller()?.nativeElement;
+        if (el) {
+          el.scrollTop = el.scrollHeight;
+        }
+      },
+      { injector: this.injector },
+    );
+  }
+}

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -564,6 +564,20 @@
               }
             </div>
           }
+
+          <!-- ASK-ABOUT-THIS-NOTE (Brain v3, source-scoped Brain PR-4) — a
+               grounded Q&A panel below the body, scoped to this note + its
+               active links. ROUTED mode ONLY: hidden when embedded (the
+               recording companion's Note tab is pure writing — its Ask Brain
+               tab owns Q&A) and impossible behind a lock (this `@else` branch
+               is the not-locked, note-loaded state). -->
+          @if (!embedded()) {
+            <app-note-chat
+              class="note-chat"
+              [noteId]="doc.id"
+              [anchorTitle]="doc.title"
+            />
+          }
         </article>
       }
     }

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -305,6 +305,11 @@
 .note-doc.is-full-width {
   max-width: max(var(--editor-max), min(1600px, 92%));
 }
+/* Ask-about-this-note panel — separated from the body it sits below. */
+.note-chat {
+  display: block;
+  margin-top: var(--space-6);
+}
 .note-title-input {
   width: 100%;
   border: 0;

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -48,6 +48,7 @@ import {
 } from "../note-brain-popover/note-brain-popover.component";
 import { NoteSharePanelComponent } from "../note-share-panel/note-share-panel.component";
 import { NoteSelectionToolbarComponent } from "../note-selection-toolbar/note-selection-toolbar.component";
+import { NoteChatComponent } from "../note-chat/note-chat.component";
 import { MurToggleComponent } from "../../../design-system/toggle/toggle.component";
 import { parseDoc, serializeDoc } from "./front-matter";
 import {
@@ -162,6 +163,7 @@ const FULL_WIDTH_KEY = "murmur-note-full-width";
     NoteBrainPopoverComponent,
     NoteSelectionToolbarComponent,
     NoteSharePanelComponent,
+    NoteChatComponent,
     MurToggleComponent,
     FormsModule,
   ],

--- a/src/app/services/source-scope.service.ts
+++ b/src/app/services/source-scope.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, inject } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type { LinkKind, SourceRef } from "../core/models";
+
+/**
+ * Source-scoped Brain — the ONE place the "sensible default scope for an anchor"
+ * is computed, so every Ask surface (meeting @brain chat, the Ask-about-this-note
+ * panel) pre-fills its `<mur-source-picker>` identically.
+ *
+ * The default scope for an anchor `(kind, id)` is:
+ *   1. the anchor itself (`{kind, id, title}`), then
+ *   2. every ACTIVE (`status: "active"`) neighbour from {@link IpcService.listLinks}
+ *      — deterministic wikilink/companion/manual edges — mapped to the neighbour's
+ *      `{kind: otherKind, id: otherId, title: otherTitle}`.
+ * The list is deduped by `kind + id` (the same identity `SourceRef` uses) with the
+ * anchor kept first. `suggested` (un-accepted semantic) edges are deliberately
+ * EXCLUDED — a default scope should only include links the user has confirmed.
+ *
+ * `listLinks` is visibility-gated server-side (a sealed queried item yields `[]`,
+ * a sealed neighbour is dropped), so the default never leaks a locked source.
+ */
+@Injectable({ providedIn: "root" })
+export class SourceScopeService {
+  private readonly ipc = inject(IpcService);
+
+  /**
+   * The default source scope for an anchor: the anchor itself + its ACTIVE linked
+   * neighbours, deduped. `title` is the display label for the picker's chips.
+   *
+   * Best-effort: if `listLinks` rejects (e.g. no Tauri, a transient error) this
+   * still resolves with JUST the anchor, so a picker always pre-fills with at
+   * least the current item. The CALLER owns the stale-result guard (drop a late
+   * reply when its `kind`/`id` has changed since the fetch began).
+   */
+  async defaultSources(
+    kind: LinkKind,
+    id: string,
+    title?: string,
+  ): Promise<SourceRef[]> {
+    const anchor: SourceRef = { kind, id, title };
+    const out: SourceRef[] = [anchor];
+    const seen = new Set<string>([kind + id]);
+    try {
+      const edges = await this.ipc.listLinks(kind, id);
+      for (const e of edges) {
+        if (e.status !== "active") {
+          continue; // only confirmed links seed the default scope.
+        }
+        const key = e.otherKind + e.otherId;
+        if (seen.has(key)) {
+          continue; // dedupe by kind + id (anchor + a repeated edge).
+        }
+        seen.add(key);
+        out.push({ kind: e.otherKind, id: e.otherId, title: e.otherTitle });
+      }
+    } catch {
+      // Best-effort: fall back to just the anchor.
+    }
+    return out;
+  }
+}

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -1,11 +1,50 @@
-@if (deterministic().length || suggestions().length) {
-  <div class="cx">
-    <!-- DETERMINISTIC edges (wikilink / companion) — plain link chips, mirroring
-         the "Linked mentions" chip row. -->
-    @if (deterministic().length) {
-      <div class="cx-group">
-        <span class="cx-label">Connections</span>
-        @for (e of deterministic(); track e.id) {
+<!-- Never surface (or offer to add) connections behind a lock: the whole panel —
+     header + `+ Link` chooser included — is suppressed while `locked`. Otherwise it
+     always renders so a user can add the FIRST connection to an item with none. -->
+@if (!locked()) {
+<div class="cx">
+  <!-- Header: the "Connections" label + the `+ Link` chooser. The query <input>
+       is BOTH the filter field and the popover's keyboard target; the panel owns
+       query/activeIndex (the picker is presentational) and anchors it here. -->
+  <div class="cx-head">
+    <span class="cx-label cx-label--head">Connections</span>
+    @if (pickerOpen()) {
+      <input
+        #pickerAnchor
+        type="text"
+        class="cx-link-input"
+        placeholder="Link a meeting, note, or document…"
+        [value]="pickerQuery()"
+        (input)="onQueryInput($event)"
+        (keydown)="onQueryKey($event)"
+        (blur)="closePicker()"
+        aria-label="Search items to link"
+      />
+    } @else {
+      <button
+        #pickerAnchor
+        type="button"
+        class="cx-add"
+        [disabled]="linking()"
+        (click)="openPicker()"
+      >
+        @if (linking()) {
+          <span class="cx-add-label">Linking…</span>
+        } @else {
+          <span class="cx-add-plus" aria-hidden="true">+</span>
+          <span class="cx-add-label">Link</span>
+        }
+      </button>
+    }
+  </div>
+
+  <!-- DETERMINISTIC edges (wikilink / companion / manual) — plain link chips,
+       mirroring the "Linked mentions" chip row. A manual (user-created) chip
+       gets a hover × to remove the link. -->
+  @if (deterministic().length) {
+    <div class="cx-group">
+      @for (e of deterministic(); track e.id) {
+        <span class="cx-chipwrap" [class.is-pending]="isPending(e.id)">
           <a class="cx-chip" [routerLink]="routeFor(e)">
             @switch (e.otherKind) {
               @case ("meeting") {
@@ -25,56 +64,83 @@
               <span class="cx-edge" aria-hidden="true">link</span>
             }
           </a>
-        }
-      </div>
-    }
+          @if (isRemovable(e)) {
+            <button
+              type="button"
+              class="cx-remove"
+              [disabled]="isPending(e.id)"
+              [attr.aria-label]="'Remove link to ' + e.otherTitle"
+              title="Remove link"
+              (click)="unlink(e)"
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+          }
+        </span>
+      }
+    </div>
+  }
 
-    <!-- SEMANTIC suggestions — a confidence chip + Accept / Dismiss per row. -->
-    @if (suggestions().length) {
-      <div class="cx-group">
-        <span class="cx-label">Suggested connections</span>
-        @for (e of suggestions(); track e.id) {
-          <div class="cx-row" [class.is-pending]="isPending(e.id)">
-            <a class="cx-chip cx-chip--suggested" [routerLink]="routeFor(e)">
-              @switch (e.otherKind) {
-                @case ("meeting") {
-                  <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
-                }
-                @case ("document") {
-                  <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
-                }
-                @default {
-                  <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
-                }
+  <!-- SEMANTIC suggestions — a confidence chip + Accept / Dismiss per row. -->
+  @if (suggestions().length) {
+    <div class="cx-group">
+      <span class="cx-label">Suggested connections</span>
+      @for (e of suggestions(); track e.id) {
+        <div class="cx-row" [class.is-pending]="isPending(e.id)">
+          <a class="cx-chip cx-chip--suggested" [routerLink]="routeFor(e)">
+            @switch (e.otherKind) {
+              @case ("meeting") {
+                <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
               }
-              <span class="cx-title">{{ e.otherTitle }}</span>
-              <span
-                class="cx-score"
-                [class]="'cx-score--' + tier(e.score)"
-                [attr.title]="'Confidence ' + scoreLabel(e.score)"
-              >{{ scoreLabel(e.score) }}</span>
-            </a>
-            <div class="cx-actions">
-              <button
-                type="button"
-                class="cx-btn cx-btn--accept"
-                [disabled]="isPending(e.id)"
-                (click)="accept(e)"
-              >
-                Accept
-              </button>
-              <button
-                type="button"
-                class="cx-btn cx-btn--dismiss"
-                [disabled]="isPending(e.id)"
-                (click)="dismiss(e)"
-              >
-                Dismiss
-              </button>
-            </div>
+              @case ("document") {
+                <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+              }
+              @default {
+                <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+              }
+            }
+            <span class="cx-title">{{ e.otherTitle }}</span>
+            <span
+              class="cx-score"
+              [class]="'cx-score--' + tier(e.score)"
+              [attr.title]="'Confidence ' + scoreLabel(e.score)"
+            >{{ scoreLabel(e.score) }}</span>
+          </a>
+          <div class="cx-actions">
+            <button
+              type="button"
+              class="cx-btn cx-btn--accept"
+              [disabled]="isPending(e.id)"
+              (click)="accept(e)"
+            >
+              Accept
+            </button>
+            <button
+              type="button"
+              class="cx-btn cx-btn--dismiss"
+              [disabled]="isPending(e.id)"
+              (click)="dismiss(e)"
+            >
+              Dismiss
+            </button>
           </div>
-        }
-      </div>
-    }
-  </div>
+        </div>
+      }
+    </div>
+  }
+</div>
+
+  <!-- The single-pick chooser popover (reused note-editor LinkPickerComponent):
+       OPAQUE, paginated autocomplete over list_link_candidates. THIS panel owns the
+       query / activeIndex (fed as inputs) + keyboard nav; the picker renders + emits
+       the picked candidate. Anchored under the header <input>. -->
+  @if (pickerOpen()) {
+    <app-link-picker
+      [anchorRect]="pickerRect()"
+      [query]="pickerQuery()"
+      [activeIndex]="pickerActiveIndex()"
+      (candidatesChange)="onPickerCandidates($event)"
+      (picked)="pickCandidate($event)"
+    />
+  }
 }

--- a/src/app/shared/connections/connections.component.scss
+++ b/src/app/shared/connections/connections.component.scss
@@ -8,6 +8,13 @@
   gap: var(--space-3);
 }
 
+/* Header row: the "Connections" label + the `+ Link` chooser. */
+.cx-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 /* One labelled cluster (deterministic chips, or suggestion rows). */
 .cx-group {
   display: flex;
@@ -23,6 +30,79 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+/* The header label sits INLINE beside the `+ Link` control, not full-width. */
+.cx-label--head {
+  flex: 0 1 auto;
+}
+
+/* `+ Link` chooser trigger — a quiet ghost pill (leans on the token language, not
+   a new global primitive since it needs the compact chip metrics). */
+.cx-add {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+  padding: 4px var(--space-3);
+  background: transparent;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+.cx-add:hover:not(:disabled) {
+  border-color: var(--accent-ring);
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+.cx-add:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.cx-add-plus {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* The chooser's filter input (replaces the trigger while open). */
+.cx-link-input {
+  flex: 1 1 auto;
+  margin-left: auto;
+  min-width: 12rem;
+  max-width: 22rem;
+  padding: 5px var(--space-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--accent-ring);
+  border-radius: var(--radius-pill);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+}
+.cx-link-input::placeholder {
+  color: var(--text-muted);
+}
+.cx-link-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* A deterministic chip + its optional hover × remove control. The × sits just
+   INSIDE the pill's trailing edge (revealed on hover of the wrap) so a manual
+   link reads as one removable unit. */
+.cx-chipwrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  transition: opacity var(--transition-fast);
+}
+.cx-chipwrap.is-pending {
+  opacity: 0.55;
 }
 
 /* Chip — mirrors `app-backlinks`'s `.bl-chip` language. */
@@ -47,6 +127,41 @@
   border-color: var(--accent-ring);
   color: var(--text-primary);
   background: var(--surface-hover);
+}
+
+/* Remove (×) on a manual chip — hidden until the wrap is hovered/focused. */
+.cx-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-left: calc(-1 * var(--space-1));
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+.cx-chipwrap:hover .cx-remove,
+.cx-remove:focus-visible {
+  opacity: 1;
+}
+.cx-remove:hover:not(:disabled) {
+  color: var(--danger);
+  background: var(--surface-hover);
+}
+.cx-remove:disabled {
+  cursor: default;
+  opacity: 0.4;
 }
 
 /* Neighbour-kind badge. */

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -1,17 +1,23 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
   computed,
   effect,
   inject,
   input,
   signal,
+  viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 
 import { IpcService } from "../../core/ipc.service";
-import type { LinkEdge, LinkKind } from "../../core/models";
+import type { LinkEdge, LinkKind, NoteCitation } from "../../core/models";
 import { FoldersService } from "../../services/folders.service";
+import { ToastService } from "../../services/toast.service";
+import { LinkPickerComponent } from "../../features/notes/link-picker/link-picker.component";
 
 /** One rendered semantic-suggestion confidence tier (chip color + label). */
 type ConfidenceTier = "high" | "med" | "low";
@@ -36,17 +42,31 @@ type ConfidenceTier = "high" | "med" | "low";
  * (never surface connections behind a lock) and re-runs on a session lock-tree
  * change (a folder unlock/relock, or screen-share relock-all) so sealed neighbours
  * drop out — or reappear — live, exactly like `graph.component`'s `_refetchOnLock`.
+ *
+ * PR-1 (user-initiated linking) adds two write affordances over the same edges:
+ *  - a `+ Link` header control that opens the single-pick {@link LinkPickerComponent}
+ *    (the SAME opaque, paginated autocomplete the note editor uses) filtered to
+ *    `meeting | note | document`; on pick it calls `link_items(anchor → candidate)`
+ *    and re-fetches. This panel OWNS the picker's `query` / `activeIndex` / keyboard
+ *    nav (the picker is presentational) via a small header `<input>`.
+ *  - a hover `×` on each DETERMINISTIC chip whose edge is `manual === true`
+ *    (a user-created link), which calls `unlink_items(anchor → neighbour)` and
+ *    re-fetches. Non-manual chips (auto wikilink/companion, semantic) get NO `×`.
+ * Both writes are gated by the same pending set as Accept/Dismiss and surface a
+ * failure through the {@link ToastService} rather than leaving a stuck spinner.
  */
 @Component({
   selector: "app-connections",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, LinkPickerComponent],
   templateUrl: "./connections.component.html",
   styleUrl: "./connections.component.scss",
 })
 export class ConnectionsComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
+  private readonly toast = inject(ToastService);
+  private readonly injector = inject(Injector);
 
   /** The link-endpoint kind this panel is anchored to. */
   readonly kind = input.required<LinkKind>();
@@ -61,8 +81,54 @@ export class ConnectionsComponent {
 
   /** The visible edges for the current `(kind, id)`; `[]` while locked/loading. */
   readonly edges = signal<LinkEdge[]>([]);
-  /** In-flight Accept/Dismiss link ids — disables that row's buttons meanwhile. */
+  /**
+   * In-flight Accept/Dismiss/Unlink edge ids — disables that row's buttons (and its
+   * `×`) meanwhile. Keyed by `LinkEdge.id` (unlink guards on the manual chip's id).
+   */
   private readonly pending = signal<ReadonlySet<number>>(new Set());
+
+  /** The single-pick `+ Link` chooser element (the header `<input>`) for anchoring. */
+  private readonly pickerAnchor =
+    viewChild<ElementRef<HTMLElement>>("pickerAnchor");
+
+  /** Whether the `+ Link` picker is open. */
+  readonly pickerOpen = signal(false);
+  /** True while a `link_items` call from a pick is in flight (disables the chooser). */
+  readonly linking = signal(false);
+  /** The picker's live filter text (this panel owns it — the picker is presentational). */
+  readonly pickerQuery = signal("");
+  /** Keyboard-highlighted row in the open picker (↑/↓). */
+  readonly pickerActiveIndex = signal(0);
+  /** The picker's resolved candidates for the current query (drives keyboard nav). */
+  readonly pickerCandidates = signal<NoteCitation[]>([]);
+  /**
+   * The chooser's viewport anchor rect for the popover. A NEW object re-positions
+   * it; recomputed from the header `<input>` on open and on every reposition tick.
+   */
+  readonly pickerRect = signal<{
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+  }>({ top: 0, left: 0, right: 0, bottom: 0 });
+
+  /**
+   * A candidate kind that is NOT a valid `link_items` endpoint (a {@link LinkKind}
+   * is `meeting | note | document`). `list_link_candidates` may surface Shared-Brain
+   * `org` rows (and, in principle, `person`/`entity` from the shared shape); those
+   * are NOT linkable, so a pick is refused with a toast rather than silently
+   * dropped — the picker renders its own rows, so this guards them at pick time.
+   */
+  private static readonly NON_LINKABLE_KINDS: ReadonlySet<NoteCitation["kind"]> =
+    new Set<NoteCitation["kind"]>(["person", "entity", "org"]);
+
+  /** True when a candidate is a linkable meeting/note/document endpoint (not org/person/entity, not self). */
+  private isLinkable(c: NoteCitation): boolean {
+    return (
+      !ConnectionsComponent.NON_LINKABLE_KINDS.has(c.kind) &&
+      !(c.kind === this.kind() && c.id === this.id())
+    );
+  }
 
   /**
    * Monotonic request token — a late `list_links` reply for a superseded
@@ -158,11 +224,39 @@ export class ConnectionsComponent {
   }
 
   /**
-   * Run an Accept/Dismiss mutation guarded by the pending set, then re-fetch the
-   * edges for the CURRENT `(kind, id)` (never a stale closure) so the panel reflects
-   * the server truth. The seq token drops a reply for a since-changed item.
+   * PR-1 — whether a deterministic chip is USER-REMOVABLE (shows the hover `×`).
+   * Only manual links (`manual === true`, set by the backend on the deduped
+   * manual+wikilink chip) are removable here; auto wikilink/companion edges are not.
    */
-  private async mutate(id: number, run: () => Promise<void>): Promise<void> {
+  isRemovable(e: LinkEdge): boolean {
+    return e.manual === true;
+  }
+
+  /**
+   * PR-1 — remove a user-created link: `unlink_items(anchor → neighbour)`, then
+   * re-fetch so the chip drops out. Guarded by the same pending set (keyed on the
+   * chip's edge id) so its `×` disables mid-flight. Surfaces a failure via a toast.
+   */
+  unlink(e: LinkEdge): void {
+    void this.mutate(
+      e.id,
+      () => this.ipc.unlinkItems(this.kind(), this.id(), e.otherKind, e.otherId),
+      "Couldn't remove the link.",
+    );
+  }
+
+  /**
+   * Run an Accept/Dismiss/Unlink mutation guarded by the pending set, then re-fetch
+   * the edges for the CURRENT `(kind, id)` (never a stale closure) so the panel
+   * reflects the server truth. The seq token drops a reply for a since-changed item.
+   * A non-null `errorMsg` surfaces a toast on failure (used by Unlink; Accept/Dismiss
+   * stay silent, matching their prior behavior).
+   */
+  private async mutate(
+    id: number,
+    run: () => Promise<void>,
+    errorMsg?: string,
+  ): Promise<void> {
     if (this.isPending(id)) {
       return;
     }
@@ -173,6 +267,9 @@ export class ConnectionsComponent {
       await this.fetch(this.kind(), this.id(), seq);
     } catch {
       // Leave the current edges untouched; drop the pending flag below.
+      if (errorMsg) {
+        this.toast.danger(errorMsg);
+      }
     } finally {
       this.pending.update((s) => {
         const next = new Set(s);
@@ -180,5 +277,143 @@ export class ConnectionsComponent {
         return next;
       });
     }
+  }
+
+  // --- `+ Link` chooser (reuses the note editor's LinkPickerComponent) --------
+
+  /**
+   * Open the single-pick `+ Link` chooser: anchor the popover under the header
+   * `<input>`, reset its query/keyboard state. The picker is presentational, so
+   * THIS panel owns `pickerQuery` / `pickerActiveIndex` and feeds the picker an
+   * `anchorRect`; the header input is the query field + keyboard target.
+   */
+  openPicker(): void {
+    if (this.linking()) {
+      return;
+    }
+    this.pickerQuery.set("");
+    this.pickerActiveIndex.set(0);
+    this.pickerCandidates.set([]);
+    this.pickerOpen.set(true);
+    this.repositionPicker();
+    // Focus the query field once it's in the DOM (zoneless-safe, no setTimeout).
+    afterNextRender(() => this.pickerAnchor()?.nativeElement.focus?.(), {
+      injector: this.injector,
+    });
+  }
+
+  /** Close the chooser without linking anything (Esc / outside / after a pick). */
+  closePicker(): void {
+    this.pickerOpen.set(false);
+    this.pickerQuery.set("");
+    this.pickerCandidates.set([]);
+    this.pickerActiveIndex.set(0);
+  }
+
+  /** The chooser query changed (input event) → refresh the anchored query + reset selection. */
+  onQueryInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.pickerQuery.set(value);
+    this.pickerActiveIndex.set(0);
+  }
+
+  /**
+   * The picker's resolved candidates for the current query (drives keyboard nav).
+   * The picker renders + click-emits its OWN rows, so `pickerActiveIndex` indexes
+   * THIS same list (kept in lockstep with what the popover shows).
+   */
+  onPickerCandidates(rows: NoteCitation[]): void {
+    this.pickerCandidates.set(rows);
+    // A shrunk list can leave the highlight past the end — clamp it.
+    const max = rows.length - 1;
+    if (this.pickerActiveIndex() > max) {
+      this.pickerActiveIndex.set(Math.max(0, max));
+    }
+  }
+
+  /** ↑/↓/Enter/Esc while the chooser input has focus (nav over the picker's rows). */
+  onQueryKey(event: KeyboardEvent): void {
+    if (!this.pickerOpen()) {
+      return;
+    }
+    const rows = this.pickerCandidates();
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.pickerActiveIndex.update((i) => (i + 1) % rows.length);
+        }
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.pickerActiveIndex.update(
+            (i) => (i - 1 + rows.length) % rows.length,
+          );
+        }
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (rows.length > 0) {
+          this.pickCandidate(rows[this.pickerActiveIndex()]);
+        }
+        break;
+      case "Escape":
+        event.preventDefault();
+        this.closePicker();
+        break;
+    }
+  }
+
+  /**
+   * A candidate was picked (click or Enter): create the link from this panel's
+   * anchor `(kind, id)` → the picked candidate, then re-fetch so the new chip
+   * appears. The picker renders its own rows, so a non-linkable kind (a Shared-Brain
+   * `org` hit / `person` / `entity`, or the anchor itself) is REFUSED here with a
+   * toast rather than sent to `link_items`. Guarded by `linking` (a stuck spinner is
+   * impossible — cleared in `finally`); a failure surfaces a toast.
+   */
+  pickCandidate(candidate: NoteCitation): void {
+    if (this.linking()) {
+      return;
+    }
+    if (!this.isLinkable(candidate)) {
+      this.toast.info("You can only link meetings, notes, and documents.");
+      return;
+    }
+    const dstKind = candidate.kind as LinkKind;
+    this.linking.set(true);
+    this.closePicker();
+    void (async () => {
+      try {
+        await this.ipc.linkItems(this.kind(), this.id(), dstKind, candidate.id);
+        const seq = ++this.seq;
+        await this.fetch(this.kind(), this.id(), seq);
+      } catch {
+        this.toast.danger("Couldn't create the link.");
+      } finally {
+        this.linking.set(false);
+      }
+    })();
+  }
+
+  /** Recompute the popover anchor rect from the header chooser input. */
+  repositionPicker(): void {
+    afterNextRender(
+      () => {
+        const el = this.pickerAnchor()?.nativeElement;
+        if (!el) {
+          return;
+        }
+        const r = el.getBoundingClientRect();
+        this.pickerRect.set({
+          top: r.top,
+          left: r.left,
+          right: r.right,
+          bottom: r.bottom,
+        });
+      },
+      { injector: this.injector },
+    );
   }
 }

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -138,12 +138,18 @@ export class ConnectionsComponent {
   private seq = 0;
 
   /**
-   * Deterministic (removable/active) chips — `wikilink` / `companion` / `manual`, PLUS any chip the
-   * backend flagged `manual` (a user's active link is always a removable chip, never a suggestion,
-   * even in the pathological case where its surviving collapsed `edgeType` is still `semantic`).
+   * The active/link chips — the EXACT complement of {@link suggestions}, so every edge renders in
+   * exactly one partition (no fall-through, no double-render). This is everything that is NOT a
+   * pending semantic suggestion: `wikilink`/`companion`/`manual`, any `manual`-flagged chip (a user's
+   * active link is always removable, never a suggestion — even if its collapsed `edgeType` is still
+   * `semantic`), AND an ACCEPTED semantic edge (`status !== "suggested"`) — the last case closes a
+   * pre-existing gap where an accepted semantic link between two non-owned endpoints
+   * (no `[[Title]]` to materialize, e.g. meeting↔meeting) rendered no chip at all.
    */
   readonly deterministic = computed(() =>
-    this.edges().filter((e) => e.edgeType !== "semantic" || e.manual),
+    this.edges().filter(
+      (e) => !(e.edgeType === "semantic" && e.status === "suggested" && !e.manual),
+    ),
   );
 
   /**

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -137,15 +137,24 @@ export class ConnectionsComponent {
    */
   private seq = 0;
 
-  /** Deterministic edges (`wikilink` / `companion`) → plain link chips. */
+  /**
+   * Deterministic (removable/active) chips — `wikilink` / `companion` / `manual`, PLUS any chip the
+   * backend flagged `manual` (a user's active link is always a removable chip, never a suggestion,
+   * even in the pathological case where its surviving collapsed `edgeType` is still `semantic`).
+   */
   readonly deterministic = computed(() =>
-    this.edges().filter((e) => e.edgeType !== "semantic"),
+    this.edges().filter((e) => e.edgeType !== "semantic" || e.manual),
   );
 
-  /** Semantic suggestions (`status === "suggested"`) → Accept/Dismiss rows. */
+  /**
+   * Semantic suggestions (`status === "suggested"`) → Accept/Dismiss rows. A chip flagged `manual`
+   * is EXCLUDED — a user has already actively linked that pair, so it renders as a removable
+   * deterministic chip above, never as an unconfirmed suggestion (defensive twin of the backend's
+   * `edge_rank` fix that makes a `manual` edge outrank a semantic suggestion in the collapse).
+   */
   readonly suggestions = computed(() =>
     this.edges().filter(
-      (e) => e.edgeType === "semantic" && e.status === "suggested",
+      (e) => e.edgeType === "semantic" && e.status === "suggested" && !e.manual,
     ),
   );
 


### PR DESCRIPTION
## Note↔Meeting linking + source-scoped Brain

Adds a **user-control layer on top of brain v3's link engine**: link notes↔meetings by hand, control exactly which sources feed any Brain answer, have the Brain automatically pull a scoped item's linked items into context, and ask the Brain about a single note. Built ON the merged brain v3 (`links` table, `app-connections`, full-graph) — **no duplication**; rebased cleanly onto trunk (feature files are disjoint from #366 Receipts / #367 Knowledge Diff).

Design spec: `docs/superpowers/specs/2026-07-17-note-meeting-links-source-scoped-brain-design.md`.

### What ships

- **Manual linking** — `EdgeType::Manual` + `link_items`/`unlink_items` (gated both endpoints, fail-closed `Locked`). A row is always created; linking **from a note** also materializes `[[Title]]` into its body (reusing `apply_link_markers`); **from a meeting** (no body) it's a pure relation. A `+ Link` chooser + a gated `×` unlink land in the existing `app-connections` panel — so they light up in **both** the meeting Note tab and the note editor, symmetrically. Manual+wikilink display-dedupe to one removable chip (`LinkEdge.manual`).
- **Source-scoped + link-aware retrieval** — `explicit_sources` on `ask_vault` / `chat_meeting` / `ask_assistant_chat`. When sources are pinned, the corpus is **exactly** those sources + their active links (capped `LINK_CONTEXT_CAP=8`), gated, with the vault-wide search skipped — the user controls the context. `None` = whole-vault, byte-identical to today (bound by a regression test).
- **`mur-source-picker`** — a reusable opaque chip-multiselect above every Ask input (meeting @brain chat + global Ask + note chat), pre-filled with the current item + its active links (removable), empty ⇒ whole-vault.
- **Ask-about-this-note** — `app-note-chat`, a twin of `app-meeting-chat`, mounted below the body in the routed note editor (hidden when locked/embedded), defaulting its sources to `[this note + its links]`.

### Verification

- **`scripts/ci.sh` green** (PR-gate mode) on the rebased HEAD: `clippy --all-targets -D warnings` clean, **cargo test 1867 passed / 0 failed**, `ng lint` + `ng build` clean. (Audio-pipeline E2E skipped, orthogonal to this feature — same as the per-PR gate.)
- **lock-security-reviewer: PASS** — every new content read/write gated; the cloud-egressing pinned corpus + link-expansion assemble only from `*_visible` readers (E9 holds — proven RED→GREEN); manual edges ride the edge-type-agnostic `purge_links_tx` on seal; materialized `[[Title]]` rides the normal note seal; no PII in logs; no new asset/`convertFileSrc` path.
- **adversarial-verifier: PASS** — found + fixed one HIGH UX bug (a manually-linked pair that was also auto-suggested rendered as an un-removable suggestion; root-caused via `edge_rank` so `manual` outranks a semantic *suggestion*, + a total FE partition, + a RED test) and one LOW pre-existing fall-through (accepted semantic links now render). Every failure mode this app ships was hunted and cleared.

### Needs a real-Mac live test before release (honest bar — unverifiable headless)

Touch ID seal round-trip on a note linked into a lockable folder; live cloud-egress actually grounding on the pinned corpus; the picker/note-chat/linking UX in the packaged WKWebView; screen-share auto-relock dropping manual edges.
