### PR TITLE
feat(brain): on-device OCR — ingest scanned PDFs + images (Apple Vision)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4668,6 +4668,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-pdf-kit",
+ "objc2-vision",
  "opaque-ke",
  "quick-xml",
  "rand 0.8.6",
@@ -5221,6 +5222,7 @@ checksum = "c14ed801ae810c6ba487cedd7616bb48f9a8e37940042f57e862538e2c7db117"
 dependencies = [
  "bitflags 2.13.0",
  "objc2",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -5264,6 +5266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
  "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-vision"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc194758a2d5d7540b1ad283bfb9ca318ec608991892326e95b428230b2689b"
+dependencies = [
+ "objc2",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -172,13 +172,35 @@ block2 = "0.6"
 # PDF text + outline extraction via Apple's PDFKit (same objc2 0.6/0.3 family we already ship; zero
 # new binaries, no dylib to sign). Only the PDFDocument/PDFPage/PDFOutline/PDFDestination surface is
 # needed — `src/extract/pdf.rs`. All calls wrapped in `objc2::exception::catch`. macOS-only.
-objc2-pdf-kit = { version = "0.3", default-features = false, features = ["PDFDocument", "PDFPage", "PDFOutline", "PDFDestination"] }
+# `objc2-core-graphics` feature: `PDFPage::drawWithBox:toContext:` — render a scanned page into the
+# OCR bitmap context (Brain v3 OCR fallback in `src/extract/ocr.rs`).
+objc2-pdf-kit = { version = "0.3", default-features = false, features = ["PDFDocument", "PDFPage", "PDFOutline", "PDFDestination", "objc2-core-graphics"] }
+# On-device OCR via Apple's Vision framework (Brain v3 — scanned-PDF + direct image import).
+# Same objc2 0.3 family we already ship (Zlib/Apache/MIT); NO new binary, no dylib to sign.
+# Only the text-recognition surface is compiled: VNRecognizeTextRequest (recognitionLevel/languages/
+# usesLanguageCorrection), VNImageRequestHandler (initWithCGImage:options: / initWithData:options:),
+# VNRecognizedTextObservation (topCandidates → VNRecognizedText.string). The `objc2-core-graphics`
+# feature enables the CGImage handler init (we render a PDFPage into a CGBitmapContext for OCR).
+# EVERY Vision/CoreGraphics/PDFKit call is wrapped in `objc2::exception::catch` (rules §7 crash-safe
+# FFI — the screenshare.rs war story): a stray ObjC NSException is CAUGHT and mapped to a fail-closed
+# `AppError::InvalidArg`, never an FFI abort. macOS-only — `src/extract/ocr.rs` + `src/extract/image.rs`.
+objc2-vision = { version = "0.3", default-features = false, features = ["VNRequest", "VNRequestHandler", "VNRecognizeTextRequest", "VNObservation", "objc2-core-graphics"] }
 # `NSProcessInfo` feature: the typed `thermalState` binding for the live-loop thermal governor
-# (`src/thermal.rs`) — a feature flip on an existing dep, no new crate.
-objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSProcessInfo", "NSURL"] }
-objc2-app-kit = { version = "0.3", features = ["NSScreen"] }
-objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGWindow"] }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFDictionary", "CFString"] }
+# (`src/thermal.rs`) — a feature flip on an existing dep, no new crate. `NSData`/`NSDictionary`/`NSArray`
+# feed the Vision OCR path (image bytes → NSData handler; empty options dict; the requests array).
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSProcessInfo", "NSURL", "NSData", "NSDictionary", "NSArray"] }
+# `NSScreen`: the screen-share probe. `NSImage` + `NSImageRep` + `NSGraphicsContext` + the
+# `objc2-core-graphics` feature: decode a standalone image FILE → CGImage
+# (`NSImage::initWithContentsOfFile` → `CGImageForProposedRect:context:hints:`) so direct-image OCR
+# runs the SAME proven `ocr_cgimage` path the scanned-PDF page uses — Vision's `initWithData` handler
+# returns zero results on a valid PNG on this Mac, the CGImage handler does not. See `src/extract/ocr.rs`.
+objc2-app-kit = { version = "0.3", features = ["NSScreen", "NSImage", "NSImageRep", "NSGraphicsContext", "objc2-core-graphics"] }
+# `CGContext`/`CGImage`/`CGColorSpace`/`CGBitmapContext`: render a PDFPage into an RGBX bitmap → CGImage
+# for OCR (the scanned-PDF fallback). `CGWindow` is the screen-share window-list probe (screenshare.rs).
+objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGWindow", "CGContext", "CGImage", "CGColorSpace", "CGBitmapContext"] }
+# `CFCGTypes` provides CGRect/CGPoint/CGSize (the PDFPage media box + the OCR bitmap rect) for the
+# scanned-PDF renderer in `src/extract/ocr.rs`. CFArray/CFDictionary/CFString are the screen-share probe.
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFDictionary", "CFString", "CFCGTypes"] }
 # v0.3.2 — BIOMETRIC-GATED master KEK. The KEK is stored as a generic-password Keychain item with a
 # kSecAttrAccessControl requiring user presence (Touch ID, device-passcode fallback). Reading it pops
 # the system Touch ID sheet directly (with our reason string) — that single sheet IS the unlock auth,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2742,9 +2742,14 @@ pub(crate) fn get_note_receipts_inner(
 }
 
 /// The extensions document ingestion accepts (Brain v3 PR-2). Text (md/txt) plus the extracted
-/// formats: PDF (macOS PDFKit), DOCX/PPTX (pure-Rust OOXML), XLSX (calamine), HTML. Dispatch +
-/// extraction live in `crate::extract`; anything else is rejected with `InvalidArg`.
-const DOC_ALLOWED_EXTS: &[&str] = &["md", "txt", "pdf", "docx", "pptx", "xlsx", "html", "htm"];
+/// formats: PDF (macOS PDFKit, scanned-PDF pages fall back to on-device Vision OCR), DOCX/PPTX
+/// (pure-Rust OOXML), XLSX (calamine), HTML, and — Brain v3 OCR — direct image import
+/// (png/jpg/jpeg/heic/tiff/tif/bmp/gif) via on-device Apple Vision. Dispatch + extraction live in
+/// `crate::extract`; anything else is rejected with `InvalidArg`.
+const DOC_ALLOWED_EXTS: &[&str] = &[
+    "md", "txt", "pdf", "docx", "pptx", "xlsx", "html", "htm", "png", "jpg", "jpeg", "heic", "tiff",
+    "tif", "bmp", "gif",
+];
 
 /// Document ingestion — upload a local file INTO a folder so its EXTRACTED text is chunked + embedded
 /// into the on-device vector layer and the brain/Ask can retrieve it. Returns the new document id.
@@ -2863,7 +2868,7 @@ fn extract_document_text(path: &str) -> Result<(String, String), AppError> {
         Some(e) if DOC_ALLOWED_EXTS.contains(&e.as_str()) => e,
         _ => {
             return Err(AppError::InvalidArg(
-                "unsupported document type — import md, txt, pdf, docx, pptx, xlsx, or html".into(),
+                "unsupported document type — import md, txt, pdf, docx, pptx, xlsx, html, or an image (png/jpg/heic/tiff/bmp/gif)".into(),
             ))
         }
     };

--- a/src-tauri/src/extract/image.rs
+++ b/src-tauri/src/extract/image.rs
@@ -1,0 +1,90 @@
+//! Direct image import — OCR a standalone image file (png / jpg / jpeg / heic / tiff / bmp / gif) into
+//! ONE [`ExtractedBlock`] via Apple Vision (`super::ocr`). macOS-only. No new binary; the file is
+//! decoded to a `CGImage` (via `NSImage`, ImageIO under the hood) and OCR'd through the SAME proven
+//! `ocr_cgimage` core the scanned-PDF page uses (`ocr_image_file`) — the `initWithData` Vision handler
+//! returns zero results on a valid PNG on this Mac, the CGImage handler reads the same pixels.
+//!
+//! CRASH-SAFE FFI (rules §7): the whole decode + OCR path is wrapped in `objc2::exception::catch`
+//! inside `super::ocr`; a corrupt / non-image / undecodable / missing file fails CLOSED to
+//! `AppError::InvalidArg`, never an abort. An image with NO recognizable text is a clear `InvalidArg`
+//! ("no text found in this image").
+//!
+//! LOCK MODEL: extraction is a pure `path → Vec<ExtractedBlock>` transform, no DB / keychain touch. The
+//! recognized text rides the SAME `documents.text` seal/gate the md/txt/pdf path already uses — no new
+//! seal path, no new read gate. NO PII is logged (the caller logs counts/stages only; never the text).
+//!
+//! REAL-MAC CAVEAT: OCR fidelity only TRULY verifies on a signed build on a real Mac; the headless test
+//! here only asserts the fail-closed contract for a non-image file (no abort, `InvalidArg`).
+
+use std::path::Path;
+
+use super::ExtractedBlock;
+use crate::error::{AppError, Result};
+
+/// The image extensions direct import accepts. Kept in sync with the `commands::DOC_ALLOWED_EXTS`
+/// additions; dispatch routes each of these to [`extract_image`].
+pub const IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "heic", "tiff", "tif", "bmp", "gif"];
+
+/// Extract an image file into ONE block (page `Some(1)`, no heading) via on-device OCR. Decodes the
+/// file to a `CGImage` and runs the PROVEN `ocr_cgimage` core (the same path the scanned-PDF page
+/// uses — Vision's `initWithData` handler returns zero results on a valid PNG on this Mac). Fails
+/// CLOSED with `AppError::InvalidArg` for an unreadable/missing file, an undecodable/corrupt image, or
+/// an image with no recognizable text — never a panic / abort.
+pub fn extract_image(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    // Decode → up-scale → OCR ENTIRELY inside `objc2::exception::catch` (NSImage/CoreGraphics/Vision),
+    // returning `None` on any exception / missing file / undecodable data / empty result — so this is
+    // the fail-closed boundary. No PII logged.
+    match super::ocr::ocr_image_file(path) {
+        Some(text) if !text.trim().is_empty() => Ok(vec![ExtractedBlock {
+            text: text.trim().to_string(),
+            page: Some(1),
+            heading_path: None,
+        }]),
+        _ => Err(AppError::InvalidArg(
+            "no text found in this image".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_tmp(ext: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-ocr-image-{}-{}.{ext}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    /// IMAGE_EXTS is the exact set the dispatch + allowlist accept (regression guard).
+    #[test]
+    fn image_exts_are_the_expected_set() {
+        assert_eq!(
+            IMAGE_EXTS,
+            &["png", "jpg", "jpeg", "heic", "tiff", "tif", "bmp", "gif"]
+        );
+    }
+
+    /// A non-image file (plain text bytes with an image extension) fails CLOSED with `InvalidArg` and
+    /// does NOT abort — proves the Vision FFI (`initWithData` on undecodable bytes) is caught, not
+    /// crashed. (Real OCR of a REAL image needs a signed build on a real Mac.)
+    #[test]
+    fn non_image_file_fails_closed_without_abort() {
+        let p = write_tmp("png", b"this is definitely not a PNG, just ascii text");
+        let err = extract_image(&p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    /// A missing file fails closed (no panic).
+    #[test]
+    fn missing_image_fails_closed() {
+        let p = std::path::Path::new("/nonexistent/murmur/does-not-exist.png");
+        let err = extract_image(p).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+}

--- a/src-tauri/src/extract/mod.rs
+++ b/src-tauri/src/extract/mod.rs
@@ -12,6 +12,10 @@
 //!   so a malformed/encrypted PDF fails CLOSED with `AppError::InvalidArg`, never an FFI abort.
 //! - `xlsx` — [`calamine`](self::xlsx) (sheet name = heading, rows → pipe text).
 //! - `html` / `htm` — [`html`] via `html2text` (one plain-text block).
+//! - `png`/`jpg`/`jpeg`/`heic`/`tiff`/`tif`/`bmp`/`gif` — direct image import ([`image`], macOS-only):
+//!   on-device Apple Vision OCR ([`ocr`]) into ONE block. A scanned/image-only PDF (no text layer)
+//!   also falls back to the SAME Vision OCR inside [`pdf`]. NO cloud egress; every FFI call wrapped in
+//!   `objc2::exception::catch` — fail-closed to `AppError::InvalidArg`, never an abort.
 //! - anything else — [`AppError::InvalidArg`].
 //!
 //! Lock model: extraction is a pure `path → Vec<ExtractedBlock>` transform with no DB / keychain
@@ -23,6 +27,10 @@ use std::path::Path;
 use crate::error::{AppError, Result};
 
 pub mod html;
+#[cfg(target_os = "macos")]
+pub mod image;
+#[cfg(target_os = "macos")]
+pub mod ocr;
 pub mod ooxml;
 #[cfg(target_os = "macos")]
 pub mod pdf;
@@ -79,6 +87,16 @@ pub fn extract_blocks(path: &Path, ext: &str) -> Result<Vec<ExtractedBlock>> {
         "pdf" => Err(AppError::InvalidArg(
             "PDF extraction is only available on macOS".into(),
         )),
+        // Direct image import → on-device Vision OCR (macOS-only). `png`/`jpg`/`jpeg`/`heic`/`tiff`/
+        // `tif`/`bmp`/`gif` all route to the OCR path in `image::extract_image`.
+        #[cfg(target_os = "macos")]
+        "png" | "jpg" | "jpeg" | "heic" | "tiff" | "tif" | "bmp" | "gif" => {
+            image::extract_image(path)
+        }
+        #[cfg(not(target_os = "macos"))]
+        "png" | "jpg" | "jpeg" | "heic" | "tiff" | "tif" | "bmp" | "gif" => Err(
+            AppError::InvalidArg("image OCR is only available on macOS".into()),
+        ),
         other => Err(AppError::InvalidArg(format!(
             "unsupported document type: .{other}"
         ))),

--- a/src-tauri/src/extract/ocr.rs
+++ b/src-tauri/src/extract/ocr.rs
@@ -1,0 +1,397 @@
+//! On-device OCR via Apple **Vision** (`objc2-vision`) — macOS-only. Turns a rendered PDF page (or a
+//! decoded image file) into recognized text WITHOUT any cloud egress and WITHOUT a new binary/dylib
+//! (same objc2 0.3 family we already ship). Used by the scanned-PDF fallback in [`super::pdf`] and by
+//! direct image import in [`super::image`].
+//!
+//! ONE OCR CORE — always via a `CGImage`. Both the scanned-PDF page ([`ocr_pdf_page`]) and a standalone
+//! image file ([`ocr_image_file`]) decode/render to a `CGImage` and run [`ocr_cgimage`], which uses
+//! `VNImageRequestHandler::initWithCGImage:options:`. We deliberately do NOT use the `initWithData`
+//! handler: on this Mac it returns ZERO observations for a valid PNG while the CGImage handler reads
+//! the identical pixels correctly. Both paths share the up-scale-to-~2000px logic ([`ocr_render_pixels`]
+//! + [`with_rgbx_bitmap`]) so small / low-DPI inputs are scaled up for recognition fidelity.
+//!
+//! CRASH-SAFE FFI (rules §7, the `screenshare.rs` war story): a malformed image, an unusual PDF page,
+//! or an unexpected Vision/CoreGraphics state can raise an Objective-C `NSException`, which — if it
+//! unwinds across the FFI boundary — ABORTS the process ("Rust cannot catch foreign exceptions"). So
+//! EVERY Vision/CoreGraphics/PDFKit call here runs inside `objc2::exception::catch`; ANY caught
+//! exception (or a nil handle / empty result) fails CLOSED to `None` — never a panic, never an abort.
+//! The caller maps `None` to a fail-closed `AppError::InvalidArg`.
+//!
+//! NO PII IN LOGS: this module logs nothing but (in the caller) counts/stages — never a recognized
+//! string. The recognized text flows straight into the EXISTING `documents.text` seal/gate; there is
+//! NO new seal path and NO new read gate.
+//!
+//! REAL-MAC CAVEAT: this compiles everywhere it's gated to, but OCR FIDELITY (does Vision actually
+//! read this scanned page? Polish diacritics? layout order?) only TRULY verifies on a real Mac with a
+//! signed build. `cargo test` cannot exercise the Vision FFI path — the headless tests only assert the
+//! fail-closed contract (a corrupt/non-image input returns `None`, never aborts).
+
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+
+use objc2::exception::catch;
+use objc2::rc::Retained;
+use objc2::{AllocAnyThread, ClassType};
+use objc2_app_kit::NSImage;
+use objc2_core_foundation::{CFRetained, CGPoint, CGRect, CGSize};
+use objc2_core_graphics::{
+    CGBitmapContextCreate, CGBitmapContextCreateImage, CGColorSpace, CGContext, CGImage,
+    CGImageAlphaInfo, CGInterpolationQuality,
+};
+use objc2_foundation::{NSArray, NSDictionary, NSString};
+use objc2_pdf_kit::{PDFDisplayBox, PDFPage};
+use objc2_vision::{
+    VNImageRequestHandler, VNRecognizeTextRequest, VNRecognizedTextObservation, VNRequest,
+    VNRequestTextRecognitionLevel,
+};
+
+/// The longest edge (in pixels) we render a PDF page to before OCR. ~2000px is a good accuracy/RAM
+/// tradeoff (Vision reads small type well at this DPI) and CAPS memory: a bitmap is at most
+/// `MAX_OCR_LONG_EDGE² * 4` bytes ≈ 16 MiB, so a pathologically large page box can never allocate
+/// unbounded RAM in the render step.
+const MAX_OCR_LONG_EDGE: f64 = 2000.0;
+
+/// Run an ObjC closure that borrows non-`UnwindSafe` Vision/CG/PDFKit handles inside
+/// `objc2::exception::catch`. These are pure reads/renders with no interior-mutability hazard left
+/// half-mutated across a caught exception, so `AssertUnwindSafe` is sound — and REQUIRED because
+/// `Retained<_>`/`&CGImage` are not `UnwindSafe`. Returns `None` on a caught ObjC exception.
+fn catch_objc<R>(f: impl FnOnce() -> R) -> Option<R> {
+    catch(AssertUnwindSafe(f)).ok()
+}
+
+/// Build a configured Accurate/pl+en/language-correcting `VNRecognizeTextRequest`. Inside `catch`
+/// because the alloc/init + property setters are ObjC that could (in principle) throw. `None` on any
+/// caught exception.
+fn make_text_request() -> Option<Retained<VNRecognizeTextRequest>> {
+    catch_objc(|| {
+        // SAFETY: standard `[[VNRecognizeTextRequest alloc] init]`; the whole closure is inside
+        // `catch` so any ObjC exception is contained.
+        let req = unsafe { VNRecognizeTextRequest::init(VNRecognizeTextRequest::alloc()) };
+        req.setRecognitionLevel(VNRequestTextRecognitionLevel::Accurate);
+        // Polish first, English second — Murmur's two primary languages (multilingual whisper ships
+        // Polish too). Vision falls back gracefully for other scripts.
+        let pl = NSString::from_str("pl");
+        let en = NSString::from_str("en");
+        let langs = NSArray::from_slice(&[&*pl, &*en]);
+        req.setRecognitionLanguages(&langs);
+        req.setUsesLanguageCorrection(true);
+        req
+    })
+}
+
+/// Run a configured text-recognition `request` against `handler` and collect the recognized text:
+/// for each `VNRecognizedTextObservation` take `topCandidates(1)`'s first string, joined by newlines
+/// in Vision's (roughly top-to-bottom) result order. Returns `None` on a caught exception or when no
+/// observation yielded a non-empty candidate. All ObjC inside `catch`.
+fn run_and_collect(
+    handler: &VNImageRequestHandler,
+    request: &VNRecognizeTextRequest,
+) -> Option<String> {
+    catch_objc(|| {
+        // `VNRecognizeTextRequest` is a `VNRequest` subclass; up-cast for the requests array.
+        let as_req: &VNRequest = request.as_super().as_super();
+        let requests = NSArray::from_slice(&[as_req]);
+        // `performRequests` blocks until done; on a scheduling error we get Err → fail closed.
+        if handler.performRequests_error(&requests).is_err() {
+            return None;
+        }
+        let results = request.results()?;
+        let mut lines: Vec<String> = Vec::new();
+        for obs in results.iter() {
+            let line = top_candidate_string(&obs);
+            if let Some(s) = line {
+                let t = s.trim();
+                if !t.is_empty() {
+                    lines.push(t.to_string());
+                }
+            }
+        }
+        if lines.is_empty() {
+            None
+        } else {
+            Some(lines.join("\n"))
+        }
+    })
+    .flatten()
+}
+
+/// The top-candidate string for one observation (`topCandidates(1)` → first `VNRecognizedText`'s
+/// `string`). `None` when the observation has no candidate.
+fn top_candidate_string(obs: &VNRecognizedTextObservation) -> Option<String> {
+    let candidates = obs.topCandidates(1);
+    let first = candidates.iter().next()?;
+    Some(first.string().to_string())
+}
+
+/// OCR a `CGImage` → recognized text (newline-joined observations). Crash-safe: any FFI exception /
+/// nil handle / empty result yields `None`. This is the core the PDF-page path calls after rendering
+/// a page to a bitmap image.
+pub fn ocr_cgimage(image: &CGImage) -> Option<String> {
+    let request = make_text_request()?;
+    // Build the image handler for this CGImage with an empty options dict. `initWithCGImage:options:`
+    // is `unsafe` (the options generic must be correct — an empty `NSDictionary<NSString, AnyObject>`
+    // is trivially correct) and could throw for a degenerate image → wrapped in `catch`.
+    let handler: Retained<VNImageRequestHandler> = catch_objc(|| {
+        let options: Retained<NSDictionary<NSString, _>> = NSDictionary::new();
+        // SAFETY: `image` is a valid CGImage; the options dict is empty and correctly typed; the whole
+        // closure is inside `catch`.
+        unsafe {
+            VNImageRequestHandler::initWithCGImage_options(
+                VNImageRequestHandler::alloc(),
+                image,
+                &options,
+            )
+        }
+    })?;
+    run_and_collect(&handler, &request)
+}
+
+/// OCR a standalone image FILE → recognized text. Decodes the file to a `CGImage` (via `NSImage`),
+/// up-scales it to ~[`MAX_OCR_LONG_EDGE`] on the long edge for OCR fidelity (the SAME scaling the
+/// scanned-PDF page path uses — see [`ocr_render_pixels`]), then runs the PROVEN [`ocr_cgimage`] core.
+///
+/// WHY NOT `initWithData`: `VNImageRequestHandler::initWithData:options:` returns ZERO observations on
+/// a valid PNG on this machine, while `initWithCGImage:options:` reads the identical pixels correctly.
+/// So the image path is routed through the same CGImage handler the (working) PDF-page path uses.
+///
+/// Crash-safe: the decode + up-scale + recognize all run inside `objc2::exception::catch` (fail-closed
+/// to `None`) — a corrupt / undecodable / non-image file yields `None`, never a panic / abort. `None`
+/// on a missing/unreadable path, an undecodable image, or an image with no recognizable text.
+pub fn ocr_image_file(path: &Path) -> Option<String> {
+    let decoded = cgimage_from_file(path)?;
+    // Up-scale for OCR fidelity (small / low-DPI photos). Fall back to the decoded image if the
+    // up-scale render can't allocate (still OCR the native-resolution pixels rather than fail). The
+    // two owned handles differ (`CFRetained` from the CG bitmap snapshot vs `Retained` from NSImage),
+    // so branch and pass a `&CGImage` from each arm rather than unify the owned type.
+    match upscale_cgimage_for_ocr(&decoded) {
+        Some(scaled) => ocr_cgimage(&scaled),
+        None => ocr_cgimage(&decoded),
+    }
+}
+
+/// Decode an image FILE to a `CGImage` via `NSImage` (ImageIO under the hood — png / jpg / jpeg / heic
+/// / tiff / bmp / gif). `NSImage::initWithContentsOfFile` returns `nil` (→ `None`) for a missing /
+/// undecodable / non-image file; `CGImageForProposedRect:context:hints:` with a NULL proposed rect
+/// and no reference context/hints yields the image's natural-size CGImage. Every ObjC/CG call inside
+/// `catch` → fail-closed `None`, never an FFI abort. Returns an ObjC-`Retained<CGImage>`.
+fn cgimage_from_file(path: &Path) -> Option<Retained<CGImage>> {
+    let path_str = path.to_str()?;
+    catch_objc(|| {
+        let ns_path = NSString::from_str(path_str);
+        let ns_image = NSImage::initWithContentsOfFile(NSImage::alloc(), &ns_path)?;
+        // SAFETY: a NULL `proposed_dest_rect` (allowed — means "natural size"), no reference context,
+        // no hints; the whole closure is inside `catch`, so any ObjC exception is contained. Returns
+        // `nil` (→ None) if the image has no CGImage representation.
+        unsafe {
+            ns_image.CGImageForProposedRect_context_hints(std::ptr::null_mut(), None, None)
+        }
+    })
+    .flatten()
+}
+
+/// Up-scale a decoded `CGImage` to ~[`MAX_OCR_LONG_EDGE`] on the long edge for OCR fidelity, reusing
+/// the SAME pixel-target logic ([`ocr_render_pixels`]) as the scanned-PDF page renderer. Draws the
+/// source image into a white RGBX bitmap at the target size (high interpolation) and snapshots a new
+/// CGImage. Returns `None` if the source has no usable dimensions or the bitmap can't allocate — the
+/// caller then falls back to OCR-ing the native-resolution image. All CG calls inside `catch`.
+fn upscale_cgimage_for_ocr(src: &CGImage) -> Option<CFRetained<CGImage>> {
+    let sw = CGImage::width(Some(src));
+    let sh = CGImage::height(Some(src));
+    if sw == 0 || sh == 0 {
+        return None;
+    }
+    let (px_w, px_h) = ocr_render_pixels(sw as f64, sh as f64);
+    if px_w == 0 || px_h == 0 {
+        return None;
+    }
+    render_cgimage_into_rgbx(src, px_w, px_h)
+}
+
+/// Draw `src` into a fresh white RGBX bitmap of `px_w × px_h` (CG owns the backing store) and snapshot
+/// an immutable `CGImage`. Shared bitmap-render primitive: the scanned-PDF page path and the image
+/// up-scale path both funnel their draw through this (white bg → high-quality interpolation → snapshot)
+/// via [`with_rgbx_bitmap`]. `None` on any allocation failure / caught exception.
+fn render_cgimage_into_rgbx(src: &CGImage, px_w: usize, px_h: usize) -> Option<CFRetained<CGImage>> {
+    with_rgbx_bitmap(px_w, px_h, |ctx| {
+        let full = CGRect::new(
+            CGPoint::new(0.0, 0.0),
+            CGSize::new(px_w as f64, px_h as f64),
+        );
+        // High interpolation so an up-scaled small image stays legible to Vision.
+        CGContext::set_interpolation_quality(Some(ctx), CGInterpolationQuality::High);
+        CGContext::draw_image(Some(ctx), full, Some(src));
+    })
+}
+
+/// Render a `PDFPage` into a `CGImage` at ~[`MAX_OCR_LONG_EDGE`] on the long edge (scaled up from the
+/// page's media box for OCR fidelity, but capped so a huge page can't allocate unbounded RAM), then
+/// OCR it. Draws into a self-allocated RGBX `CGBitmapContext` (CG owns the backing store — `data:
+/// null`), fills white first (a transparent bitmap OCRs poorly), then `drawWithBox:toContext:`.
+/// Crash-safe: every PDFKit/CoreGraphics call is inside `catch`; any failure yields `None`.
+pub fn ocr_pdf_page(page: &PDFPage) -> Option<String> {
+    let image = render_page_to_cgimage(page)?;
+    ocr_cgimage(&image)
+}
+
+/// Render a `PDFPage` to a `CGImage`. `None` on any FFI exception / zero-area page / allocation
+/// failure. Kept separate so the size/clamp logic is unit-visible; the render itself needs a real Mac.
+/// CG functions return `CFRetained<_>` (Core Foundation types, not ObjC objects).
+fn render_page_to_cgimage(page: &PDFPage) -> Option<CFRetained<CGImage>> {
+    // Page box (media box) in PDF points. Inside `catch` — `boundsForBox` is `unsafe` ObjC.
+    let bounds = catch_objc(|| unsafe { page.boundsForBox(PDFDisplayBox::MediaBox) })?;
+    let pw = bounds.size.width;
+    let ph = bounds.size.height;
+    // Guard degenerate / non-finite boxes.
+    if !(pw.is_finite() && ph.is_finite()) || pw <= 1.0 || ph <= 1.0 {
+        return None;
+    }
+    let (px_w, px_h) = ocr_render_pixels(pw, ph);
+    if px_w == 0 || px_h == 0 {
+        return None;
+    }
+    let scale = px_w as f64 / pw; // uniform scale (px_w/pw == px_h/ph by construction)
+
+    with_rgbx_bitmap(px_w, px_h, |ctx| {
+        // Scale the CTM so the page's point-space fills the pixel bitmap, then draw the media box.
+        CGContext::scale_ctm(Some(ctx), scale, scale);
+        // SAFETY: valid page + context, both live for the call; inside `catch`.
+        unsafe { page.drawWithBox_toContext(PDFDisplayBox::MediaBox, ctx) };
+    })
+}
+
+/// Create a white-filled RGBX `CGBitmapContext` of `px_w × px_h` (CG owns the backing store, `data:
+/// null`), run `draw` to render into it, then snapshot an immutable `CGImage`. The ONE bitmap-render
+/// primitive shared by the scanned-PDF page renderer and the image up-scaler: a white background
+/// (scanned pages / photos OCR best on white — a transparent bitmap reads poorly) is filled BEFORE
+/// `draw`. Every CG call is inside `catch`; `None` on any allocation failure / caught exception.
+fn with_rgbx_bitmap(
+    px_w: usize,
+    px_h: usize,
+    draw: impl FnOnce(&CGContext),
+) -> Option<CFRetained<CGImage>> {
+    catch_objc(|| {
+        // Device RGB colorspace; 8 bits/component; RGBX (alpha skipped) so 4 bytes/pixel.
+        let space = CGColorSpace::new_device_rgb()?;
+        let bytes_per_row = px_w.checked_mul(4)?;
+        let bitmap_info = CGImageAlphaInfo::NoneSkipLast.0;
+        // SAFETY: `data = null` → CG allocates + owns the backing store; params are internally
+        // consistent (RGBX 8bpc). Returns nil on bad params → mapped to None.
+        let ctx: CFRetained<CGContext> = unsafe {
+            CGBitmapContextCreate(
+                std::ptr::null_mut(),
+                px_w,
+                px_h,
+                8,
+                bytes_per_row,
+                Some(&space),
+                bitmap_info,
+            )
+        }?;
+
+        // White background first (scanned pages / photos read best on white).
+        CGContext::set_rgb_fill_color(Some(&ctx), 1.0, 1.0, 1.0, 1.0);
+        let full = CGRect::new(
+            CGPoint::new(0.0, 0.0),
+            CGSize::new(px_w as f64, px_h as f64),
+        );
+        CGContext::fill_rect(Some(&ctx), full);
+
+        draw(&ctx);
+
+        // Snapshot the drawn bitmap into an immutable CGImage.
+        CGBitmapContextCreateImage(Some(&ctx))
+    })
+    .flatten()
+}
+
+/// Pixel dimensions for OCR-rendering a page whose media box is `pw × ph` points: scale up so the
+/// long edge is [`MAX_OCR_LONG_EDGE`] (never scale DOWN below native — a small page stays at least its
+/// point size), clamped so neither edge exceeds the cap. Pure arithmetic (unit-testable without FFI).
+fn ocr_render_pixels(pw: f64, ph: f64) -> (usize, usize) {
+    // A degenerate box (either edge non-finite or <= 0) yields zero pixels — the renderer bails with
+    // no allocation. Both edges must be positive-finite for a valid page.
+    if !(pw.is_finite() && ph.is_finite()) || pw <= 0.0 || ph <= 0.0 {
+        return (0, 0);
+    }
+    let long_edge = pw.max(ph);
+    if long_edge <= 0.0 {
+        return (0, 0);
+    }
+    // Scale so the long edge hits the target, but never below 1x (don't downscale small pages).
+    let scale = (MAX_OCR_LONG_EDGE / long_edge).max(1.0);
+    // Clamp the long edge to the cap regardless (a page already larger than the cap is scaled DOWN to
+    // it — the RAM guard wins over "never downscale").
+    let scale = scale.min(MAX_OCR_LONG_EDGE / long_edge);
+    let w = (pw * scale).round();
+    let h = (ph * scale).round();
+    // Final hard ceiling on each edge (defense-in-depth against a non-finite/overflow scale).
+    let clamp = |v: f64| -> usize {
+        if !v.is_finite() || v <= 0.0 {
+            0
+        } else {
+            (v as usize).min(MAX_OCR_LONG_EDGE as usize)
+        }
+    };
+    (clamp(w), clamp(h))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ocr_render_pixels` scales a page's long edge to the target and caps each edge — pure logic,
+    /// no FFI, so it runs headless. (Real render + OCR needs a signed build on a real Mac.)
+    #[test]
+    fn render_pixels_scales_long_edge_to_target_and_caps() {
+        // A US-Letter page (612 × 792 pt) scales so the LONG edge (792) → 2000px.
+        let (w, h) = ocr_render_pixels(612.0, 792.0);
+        assert_eq!(h, 2000, "long edge scales to the target");
+        // width scaled by the same factor (612 * 2000/792 ≈ 1545), within the cap.
+        assert!((1540..=1550).contains(&w), "short edge scaled proportionally, got {w}");
+        assert!(w <= MAX_OCR_LONG_EDGE as usize && h <= MAX_OCR_LONG_EDGE as usize);
+    }
+
+    /// A page already LARGER than the cap is scaled DOWN to the cap (the RAM guard wins).
+    #[test]
+    fn render_pixels_caps_an_oversized_page() {
+        let (w, h) = ocr_render_pixels(10000.0, 5000.0);
+        assert_eq!(w, 2000, "oversized long edge is clamped to the cap");
+        assert!(h <= 2000);
+        assert!(w * h * 4 <= (MAX_OCR_LONG_EDGE as usize).pow(2) * 4, "bitmap RAM is bounded");
+    }
+
+    /// A degenerate (zero / negative) box yields zero pixels (the renderer bails, no allocation).
+    #[test]
+    fn render_pixels_rejects_degenerate_box() {
+        assert_eq!(ocr_render_pixels(0.0, 0.0), (0, 0));
+        assert_eq!(ocr_render_pixels(-1.0, 100.0), (0, 0));
+    }
+
+    /// A missing image FILE fails CLOSED (None) — `NSImage::initWithContentsOfFile` returns nil for a
+    /// nonexistent path, so the CGImage decode yields None BEFORE any Vision call.
+    #[test]
+    fn ocr_image_file_missing_path_is_none() {
+        let p = std::path::Path::new("/nonexistent/murmur/does-not-exist-ocr.png");
+        assert_eq!(ocr_image_file(p), None);
+    }
+
+    /// A non-image FILE (random garbage bytes on disk) fails CLOSED (None) without aborting — this
+    /// DOES touch the NSImage/CGImage/Vision FFI (decode of undecodable bytes) and must be caught, not
+    /// crash. On a real Mac `initWithContentsOfFile` returns nil for garbage; the `catch` wrapper turns
+    /// any exception into None. The point is: no FFI abort.
+    #[test]
+    fn ocr_image_file_garbage_fails_closed_without_abort() {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "murmur-ocr-garbage-{}-{}.png",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&p, b"this is definitely not an image file, just plain ascii bytes")
+            .expect("write tmp garbage file");
+        // The ONLY assertion we can make headless is "it returns (no panic/abort)". The value is
+        // None on a real Mac (undecodable) but we accept any return — the point is no FFI abort.
+        let _ = ocr_image_file(&p);
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/src-tauri/src/extract/pdf.rs
+++ b/src-tauri/src/extract/pdf.rs
@@ -11,13 +11,19 @@
 //!
 //! Output: one [`ExtractedBlock`] per page (`page = Some(i+1)`), text = the page's `string`. When the
 //! document has an outline (`outlineRoot`), each page's `heading_path` is the outline entry whose
-//! destination page is nearest-at-or-before that page (best-effort; `None` when no outline). A PDF
-//! with NO extractable text on ANY page (a scanned/image-only PDF) returns a specific `InvalidArg`
-//! the FE maps to "scanned PDF — OCR not yet supported". Vision OCR is explicitly NOT in scope.
+//! destination page is nearest-at-or-before that page (best-effort; `None` when no outline).
+//!
+//! SCANNED-PDF OCR FALLBACK (Brain v3): a PDF with NO extractable text layer on ANY page (a
+//! scanned/image-only PDF) is NOT rejected — it falls back to on-device Apple Vision OCR
+//! ([`crate::extract::ocr`]): each page is rendered to a CGImage and OCR'd, and any recognized text is
+//! emitted as page blocks (heading `None`). The OCR path runs ONLY on the no-text-layer fallback, so a
+//! normal text PDF is never slowed. Only if OCR ALSO yields nothing on EVERY page do we fail closed
+//! with `InvalidArg("no text found in this document, even with OCR")`.
 //!
 //! REAL-MAC CAVEAT: this compiles everywhere but only TRULY verifies on a signed build on a real Mac
-//! (PDFKit text/outline fidelity, RAM on a 500-page PDF). `cargo test` cannot exercise the FFI path —
-//! the headless test here only asserts the fail-closed behavior for a non-PDF input.
+//! (PDFKit text/outline fidelity, RAM on a 500-page PDF, and — new — Vision OCR fidelity on a real
+//! scanned page). `cargo test` cannot exercise the FFI path — the headless test here only asserts the
+//! fail-closed behavior for a non-PDF input.
 
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
@@ -105,12 +111,53 @@ pub fn extract_pdf(path: &Path) -> Result<Vec<ExtractedBlock>> {
     }
 
     if !any_text {
-        // A PDF with text on NO page is a scanned/image PDF — OCR (Vision) is out of scope for v1.
-        return Err(AppError::InvalidArg(
-            "scanned PDF — OCR not yet supported".into(),
-        ));
+        // A PDF with text on NO page is a scanned/image PDF → fall back to on-device Vision OCR.
+        // This branch ONLY runs when the fast text-layer path found nothing, so a normal text PDF is
+        // never slowed by rendering + OCR.
+        return ocr_scanned_pdf(&doc, page_count, &headings);
     }
 
+    Ok(blocks)
+}
+
+/// OCR fallback for a text-layer-less (scanned) PDF: render each page to a CGImage and run Vision OCR
+/// ([`crate::extract::ocr::ocr_pdf_page`]). Emits one block per page that yielded recognized text
+/// (page number preserved, heading from the outline if any); a page OCR can fail/blank without failing
+/// the whole document. If OCR yields NOTHING on EVERY page, fail closed with a clear `InvalidArg`.
+/// Every PDFKit/Vision/CoreGraphics call is crash-safe (wrapped in `catch` inside `ocr`).
+fn ocr_scanned_pdf(
+    doc: &PDFDocument,
+    page_count: usize,
+    headings: &[(usize, String)],
+) -> Result<Vec<ExtractedBlock>> {
+    let mut blocks: Vec<ExtractedBlock> = Vec::new();
+    let mut any_ocr_text = false;
+    for i in 0..page_count {
+        // Fetch the page (inside catch) then OCR it. A page that fails to fetch / render / recognize
+        // simply contributes no text — it never aborts the loop.
+        let page = match catch_objc(|| unsafe { doc.pageAtIndex(i) }).flatten() {
+            Some(p) => p,
+            None => continue,
+        };
+        let ocr_text = crate::extract::ocr::ocr_pdf_page(&page).unwrap_or_default();
+        let trimmed = ocr_text.trim();
+        if !trimmed.is_empty() {
+            any_ocr_text = true;
+            blocks.push(ExtractedBlock {
+                text: trimmed.to_string(),
+                page: Some((i + 1) as u32),
+                heading_path: heading_for_page(headings, i),
+            });
+        }
+    }
+
+    if !any_ocr_text {
+        // No text layer AND OCR found nothing on any page — the document has no readable text.
+        return Err(AppError::InvalidArg(
+            "no text found in this document, even with OCR".into(),
+        ));
+    }
+    tracing::info!(target: "documents", pages = page_count, ocr_blocks = blocks.len(), "pdf: scanned-PDF OCR fallback produced text");
     Ok(blocks)
 }
 

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -519,8 +519,9 @@ export class BrainComponent {
 
   /**
    * Open the native file dialog (Markdown / text / PDF / Word / PowerPoint /
-   * Excel / HTML) → import the chosen path as a document. The backend extracts
-   * the text, then chunks + embeds it behind the RAM floor, streaming progress
+   * Excel / HTML / image) → import the chosen path as a document. The backend
+   * extracts the text — scanned PDFs and images run through on-device Vision
+   * OCR — then chunks + embeds it behind the RAM floor, streaming progress
    * over `EVENT_DOC_IMPORT` (surfaced on the card via {@link importProgressLabel}).
    */
   async pickAndImportDocument(): Promise<void> {
@@ -542,6 +543,14 @@ export class BrainComponent {
             "xlsx",
             "html",
             "htm",
+            "png",
+            "jpg",
+            "jpeg",
+            "heic",
+            "tiff",
+            "tif",
+            "bmp",
+            "gif",
           ],
         },
       ],
@@ -652,9 +661,12 @@ export class BrainComponent {
     if (/^locked:|\block/i.test(msg)) {
       return "That folder is locked — unlock it first to add to the brain.";
     }
-    // Scanned / image-only PDF — no text layer, OCR not supported yet.
-    if (/scanned pdf|no extractable text|has no extractable/i.test(msg)) {
-      return "That file has no extractable text (a scanned or image-only document). OCR isn’t supported yet.";
+    // OCR ran but found nothing — a scanned PDF or an image with no readable
+    // text ("no text found in this document, even with OCR" / "no text found
+    // in this image"). Scanned PDFs now OCR automatically, so this is the only
+    // remaining no-text failure.
+    if (/no text found/i.test(msg)) {
+      return "No readable text found in that file, even after OCR.";
     }
     // Encrypted / password-protected PDF.
     if (/password-protected|password|encrypted/i.test(msg)) {


### PR DESCRIPTION
Follow-up to the Brain v3 doc-ingestion work (#363). A scanned/image-only PDF has no text layer, so PDFKit returns nothing and the import failed with "no extractable text." This adds **on-device OCR** (Apple Vision) so scanned PDFs — and imported **images** — become ingestable, all local, zero egress.

## What's new
- **Scanned-PDF fallback**: when a PDF has no extractable text on any page, each page is rendered to a bitmap and OCR'd (`VNRecognizeTextRequest`, accurate, languages `pl`+`en`). A normal text-layer PDF is untouched (OCR runs *only* on the empty-text fallback).
- **Direct image import**: `png/jpg/jpeg/heic/tiff/bmp/gif` → decode via `NSImage` → `CGImageForProposedRect` → OCR → one block. (The `initWithData` handler returned nothing on a valid image on this Mac, so we route through the proven CGImage path.)
- Shared `with_rgbx_bitmap` render primitive + ~2000px long-edge up-scaling (RAM-capped) for OCR fidelity.
- Runs off the runtime thread (`import_document → perf::run_heavy`).

## Safety
- **Crash-safe FFI**: every Vision / CoreGraphics / AppKit / PDFKit call inside `objc2::exception::catch`, fail-closed to `InvalidArg` — **RED-proven**: forcing an unrecognized selector without the catch aborts the test binary (the `screenshare.rs` war-story signature); with it, a corrupt/garbage/missing file fails closed with no abort. Allocation is size-capped.
- **Lock model unchanged**: OCR text rides the existing gated `documents.text` ingest — no new seal path, no new read gate; a sealed folder still refuses import. No PII in logs.
- New dep `objc2-vision` (user-approved); no new binary/dylib, no new npm dep.

## Verification
- **Empirically verified on a real Mac**: a genuine image-only PDF and a real PNG both OCR to text (live Vision run — headless `cargo test` only proves fail-closed).
- `cargo test --lib` **1858/0**; `clippy --lib --tests -D warnings` clean; `ng lint` + `ng build` clean.
- **adversarial-verifier: PASS** (crash-safe FFI RED-before-GREEN; no leak/regression). lock-security: not gate-touching (extraction is a pure transform into the existing gated ingest) — confirmed by the earlier OCR lock-security PASS.

Real-Mac follow-up: OCR fidelity on arbitrary photos, HEIC/TIFF/BMP/GIF decode, Polish-diacritic accuracy need a signed build to fully confirm.