### PR TITLE
feat(brain): preview document contents + de-fragment letter-spaced PDF text

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13070,6 +13070,18 @@ fn backfill_document_chunks(
             // Repair-tick probe (counts only, no content): missing chunks entirely (chunk-only
             // backfill works model-less), or chunked-but-vectorless while the REAL model is present
             // (the model arrived after import) — never a wholesale re-embed.
+            //
+            // TODO(reflow): re-index EXISTING fragmented docs so their RETRIEVAL (not just preview)
+            // uses de-fragmented text. The preview is already fixed on read (`render_display_text` +
+            // `get_document_if_visible` reflow), and any FUTURE (re)index reflows the chunk input
+            // (`index_document_chunks`). But an ALREADY-chunked fragmented doc has chunks>0/vectors>0,
+            // so this needs-only probe skips it — its stored chunks stay built from mangled glyphs.
+            // A naive "re-index if `reflow::looks_fragmented(stored_text)` fires" is UNSAFE here: reflow
+            // is read-only, so `documents.text` STAYS fragmented after a re-index → the probe fires
+            // again every tick → an unbounded re-chunk loop. A safe version needs a one-shot guard
+            // (a new additive `documents.reflow_reindexed_at` column + write-back), which is NEW at-rest
+            // state on the seal-adjacent `documents` table — out of scope for this read-only change and
+            // deferred to a follow-up. Users can force it today via Settings → Reindex.
             let (chunks, vectors) = db.doc_chunk_vector_counts(&did)?;
             chunks == 0 || (model_present && vectors == 0)
         };

--- a/src-tauri/src/extract/mod.rs
+++ b/src-tauri/src/extract/mod.rs
@@ -34,6 +34,7 @@ pub mod ocr;
 pub mod ooxml;
 #[cfg(target_os = "macos")]
 pub mod pdf;
+pub mod reflow;
 pub mod xlsx;
 
 /// One extracted unit of a document: a run of plain text, optionally located by 1-based `page`
@@ -199,6 +200,13 @@ pub fn blocks_from_stored_text(text: &str) -> Vec<ExtractedBlock> {
 /// per-block metadata markers (page/heading sentinel lines) are stripped and blocks are joined by
 /// blank lines. Text with NO sentinel (md/txt/note/legacy) is returned UNCHANGED — so a `.md`
 /// upload, a typed note, and every pre-PR-2 row read byte-identically to before. Deterministic.
+///
+/// READ-TIME REFLOW (doc-preview fix): each LOCATED block's text is run through
+/// [`reflow::reflow_fragmented_text`] before joining — a self-targeting, conservative de-fragmentation
+/// of pathologically letter-spaced PDF text (`"Fron\nt\nend"` → `"Frontend"`). The gate no-ops on
+/// clean text, so a normal PDF page / invoice is byte-identical; a fragmented CV page reads clean. This
+/// is READ-ONLY (a copy of the block text) — `documents.text` at rest is never touched. The sentinel
+/// guard above leaves md/txt/note/legacy rows unreflowed (they never carry located blocks).
 pub fn render_display_text(stored: &str) -> String {
     if !stored.contains(BLOCK_SENTINEL) {
         return stored.to_string();
@@ -206,7 +214,8 @@ pub fn render_display_text(stored: &str) -> String {
     let blocks = blocks_from_stored_text(stored);
     let mut parts: Vec<String> = Vec::with_capacity(blocks.len());
     for b in blocks {
-        let t = b.text.trim();
+        let reflowed = reflow::reflow_fragmented_text(&b.text);
+        let t = reflowed.trim();
         if t.is_empty() {
             continue;
         }

--- a/src-tauri/src/extract/reflow.rs
+++ b/src-tauri/src/extract/reflow.rs
@@ -1,0 +1,434 @@
+//! READ-TIME de-fragmentation of pathologically letter-spaced PDF text (Brain v3 doc-preview fix).
+//!
+//! THE BUG this repairs: Apple PDFKit's `page.string()` (see [`crate::extract::pdf`]) can return
+//! per-glyph / per-syllable text with spurious newlines for PDFs built with letter-spacing / custom
+//! glyph layout (a common CV / résumé style). A real uploaded CV stores in `documents.text` as e.g.
+//! `"Fron\nt\nend engineer"` — one word shattered across three lines. That mangled text feeds BOTH the
+//! preview (unreadable) AND the retrieval chunker (a query for "frontend" never matches "Fron").
+//!
+//! THE FIX: [`reflow_fragmented_text`] is a pure, READ-ONLY string→string transform applied at the two
+//! CONSUMPTION points only — display rendering ([`crate::extract::render_display_text`]) and chunk
+//! input ([`crate::storage::Db::index_document_chunks`]). It NEVER mutates `documents.text` at rest, so
+//! there is NO new seal path, the stored ciphertext / seal round-trip is byte-identical, and md/txt/
+//! note/legacy rows are provably untouched (they never reach the sentinel branch, and even if they did
+//! the conservative gate below is a no-op on normal prose).
+//!
+//! IT IS SELF-TARGETING via a conservative FRAGMENTATION GATE (see [`looks_fragmented`]): reflow only
+//! fires when a high fraction of lines are pathologically short, so normal prose / an invoice / a spec
+//! / markdown returns UNCHANGED. A false positive here would corrupt a clean document's preview, so the
+//! gate is deliberately strict.
+//!
+//! IDEMPOTENT: `reflow(reflow(x)) == reflow(x)` — a reflowed document is no longer fragmented, so a
+//! second pass hits the no-op branch (the [`reflow_is_idempotent`] test proves it).
+
+/// A line is "short" (a fragmentation signal) when it has at most this many NON-whitespace chars.
+/// Letter-spaced glyph fragments are 1–3 chars (`"O"`, `"ng"`, `"t"`); real prose lines are far
+/// longer, so `3` separates the pathological case from normal text without catching short headings in
+/// isolation (the gate also requires a high FRACTION of such lines, not just their presence).
+const SHORT_LINE_MAX_NONWS: usize = 3;
+
+/// The MINIMUM number of short lines before the gate can fire. A handful of short lines is normal
+/// (a title, a date, a bullet); a fragmented document has dozens. This floor stops the gate ever
+/// firing on a small clean block.
+const MIN_SHORT_LINES: usize = 5;
+
+/// The MINIMUM fraction of non-empty lines that must be short for the text to count as fragmented.
+/// A real letter-spaced PDF is >50% short lines; normal prose is a few percent. `0.30` is well above
+/// any normal document yet comfortably below the pathological case, so it fires on the mangled CV and
+/// no-ops on the clean invoice.
+const MIN_SHORT_FRACTION: f64 = 0.30;
+
+/// The MINIMUM fraction of non-empty lines that must be a SINGLE alphabetic character for the text to
+/// count as letter-spacing-fragmented. This is the DISTINGUISHING FINGERPRINT of the glyph-spacing
+/// pathology: a real letter-spaced CV shatters words into single-letter lines (`"O"`, `"S"`, `"t"`,
+/// `"u"`, `"i"`, `"l"`, `"A"`…) so single-char-ALPHA lines run ~0.29 of the page. A TOC / form / vertical
+/// short-word list has NONE (its short lines are whole words like `"AWS"` or PAGE-NUMBER digits like
+/// `"1"` — digits are excluded on purpose so a TOC's page numbers can't spoof the signature). Without
+/// this second condition the short-line-fraction gate false-positives on those pages and the join then
+/// welds separate tokens (`"Intro\n1"`→`"Intro1"`). `0.15` sits well below the real CV's 0.29 yet far
+/// above the counterexamples' 0.00, so the CV still fires and the TOC/form/list stay a NO-OP.
+const MIN_SINGLE_ALPHA_FRACTION: f64 = 0.15;
+
+/// De-fragment pathologically letter-spaced text ON READ. Conservative: returns `s.to_string()`
+/// UNCHANGED unless the [fragmentation gate](looks_fragmented) fires (normal prose / invoice / md /
+/// txt / notes hit the no-op branch). Idempotent. Never mutates anything at rest — the caller applies
+/// this to a COPY of the stored text at the display / chunk-input seam.
+pub fn reflow_fragmented_text(s: &str) -> String {
+    if s.is_empty() || !looks_fragmented(s) {
+        return s.to_string();
+    }
+    reflow(s)
+}
+
+/// The conservative fragmentation gate. True only when a document is PATHOLOGICALLY letter-spaced:
+/// enough short lines ([`MIN_SHORT_LINES`]) AND a high enough short-line fraction
+/// ([`MIN_SHORT_FRACTION`]) AND a high enough SINGLE-ALPHA-line fraction
+/// ([`MIN_SINGLE_ALPHA_FRACTION`], the glyph-spacing fingerprint) that it cannot be a normal
+/// short-line page (TOC / form / vertical short-word list). All three are required; a page that has
+/// many short lines but NO shattered single-letter lines (a TOC's page numbers, a form's label/value
+/// pairs, an acronym list) is a NO-OP. Counts NON-empty lines only (blank paragraph breaks don't
+/// dilute the ratio).
+fn looks_fragmented(s: &str) -> bool {
+    let mut non_empty = 0usize;
+    let mut short = 0usize;
+    let mut single_alpha = 0usize;
+    for line in s.lines() {
+        // Collect the non-whitespace chars of the line once so we can inspect both the count and the
+        // sole char (for the single-alphabetic-line fingerprint).
+        let mut nonws_chars = line.chars().filter(|c| !c.is_whitespace());
+        let first = nonws_chars.next();
+        let Some(first) = first else {
+            continue; // blank line — a paragraph break, not a fragmentation signal.
+        };
+        let nonws = 1 + nonws_chars.count();
+        non_empty += 1;
+        if nonws <= SHORT_LINE_MAX_NONWS {
+            short += 1;
+        }
+        // A SINGLE alphabetic char (letters only — digits are page numbers, not shattered glyphs) is
+        // the letter-spacing signature. `is_alphabetic()` covers the CV's Unicode `Ł` too.
+        if nonws == 1 && first.is_alphabetic() {
+            single_alpha += 1;
+        }
+    }
+    if short < MIN_SHORT_LINES || non_empty == 0 {
+        return false;
+    }
+    (short as f64) / (non_empty as f64) >= MIN_SHORT_FRACTION
+        && (single_alpha as f64) / (non_empty as f64) >= MIN_SINGLE_ALPHA_FRACTION
+}
+
+/// Rejoin fragmented lines into readable text (called ONLY when the gate has fired). Walk lines;
+/// preserve blank-line paragraph breaks; within a paragraph, join a line to the running text with NO
+/// separator only when the break is genuinely MID-WORD, otherwise with a single space. Runs of spaces
+/// are collapsed to one per line already (each source line is a fragment).
+///
+/// The join rule (see [`join_kind`]) recovers body words (`"Fron\nt\nend"` → `"Frontend"`,
+/// `"A\nng\nular"` → `"Angular"`, `"realt\nime"` → `"realtime"`) and split numbers (the CV phone
+/// `"90\n7"` → `"907"`) while REFUSING to weld across a label→value / entry→page-number DIGIT boundary
+/// (`"Age\n42"` → `"Age 42"`, `"Intro\n1"` → `"Intro 1"`) and keeping ALLCAPS heading words
+/// space-separated (an uppercase-leading fragment starts a new word).
+fn reflow(s: &str) -> String {
+    let mut out = String::new();
+    // The running paragraph text; flushed (with a paragraph break) on a blank line.
+    let mut para = String::new();
+
+    let flush_para = |out: &mut String, para: &mut String| {
+        let trimmed = para.trim();
+        if !trimmed.is_empty() {
+            if !out.is_empty() {
+                out.push_str("\n\n");
+            }
+            out.push_str(trimmed);
+        }
+        para.clear();
+    };
+
+    for line in s.lines() {
+        let piece = collapse_spaces(line.trim());
+        if piece.is_empty() {
+            // Blank line → paragraph break.
+            flush_para(&mut out, &mut para);
+            continue;
+        }
+        if para.is_empty() {
+            para.push_str(&piece);
+            continue;
+        }
+        // Decide the separator between the running text and this fragment.
+        let prev = last_nonspace_char(&para);
+        let next = piece.chars().next();
+        if join_kind(prev, next) == Join::Space {
+            para.push(' ');
+        }
+        para.push_str(&piece);
+    }
+    flush_para(&mut out, &mut para);
+    out
+}
+
+/// How to join a fragment to the running paragraph text.
+#[derive(PartialEq, Eq, Debug)]
+enum Join {
+    /// Weld with NO separator (a genuine mid-word / mid-number break).
+    Weld,
+    /// Insert a single space (a new word / a label→value / entry→page-number boundary).
+    Space,
+}
+
+/// Decide the join between the previous emitted non-space char (`prev`) and the first char of the next
+/// fragment (`next`). This is the fix for the weld false-positives: a bare digit is welded ONLY when it
+/// continues a digit run — otherwise it is a form value / page number and gets a space.
+///
+/// - `next` is a LOWERCASE letter → [`Join::Weld`] iff `prev` is alphanumeric (mid-word: `"Fron\nt"` →
+///   `"Front"`, `"realt\nime"` → `"realtime"`).
+/// - `next` is a DIGIT → [`Join::Weld`] ONLY if `prev` is ALSO a digit (a split number: the CV phone
+///   `"90\n7"` → `"907"`); otherwise [`Join::Space`] (`"Age\n42"` → `"Age 42"`, `"Intro\n1"` →
+///   `"Intro 1"`) — a label→value / entry→page-number boundary is NOT a mid-word break.
+/// - otherwise (uppercase letter / punctuation / anything else) → [`Join::Space`] (unchanged: ALLCAPS
+///   heading words and new words stay space-separated).
+fn join_kind(prev: Option<char>, next: Option<char>) -> Join {
+    match next {
+        Some(n) if n.is_alphabetic() && n.is_lowercase() => {
+            if matches!(prev, Some(p) if p.is_alphanumeric()) {
+                Join::Weld
+            } else {
+                Join::Space
+            }
+        }
+        Some(n) if n.is_ascii_digit() => {
+            if matches!(prev, Some(p) if p.is_ascii_digit()) {
+                Join::Weld
+            } else {
+                Join::Space
+            }
+        }
+        _ => Join::Space,
+    }
+}
+
+/// The last non-space char of a string (the char a following fragment would attach to), or `None`.
+fn last_nonspace_char(s: &str) -> Option<char> {
+    s.chars().rev().find(|c| !c.is_whitespace())
+}
+
+/// Collapse every run of ASCII/Unicode whitespace WITHIN a line to a single space (the line is already
+/// trimmed by the caller). Keeps intra-line words separated by exactly one space.
+fn collapse_spaces(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_ws = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The VERBATIM fragmented-CV excerpt pulled from the live DB (the real bug). Used as the
+    /// regression fixture: reflow must recover the mangled body words.
+    const CV_FRAGMENT: &str = "O\nSKAR\nO\nRŁ\nO\nWSKI\nS\ntaff Fron\nt\nend Engineer · Realt\nime Trading Plat\nforms & Web Archi\nt\nec\nture at\nScale\nWarsaw , Po\nland · +48 786 327 90\n7 ·oskar .orl\now@wp.pl\nS UMMAR Y\nFron\nt\nend engineering leader wi\nt\nh 10+ years b\nu\ni\nlding large-scale realt\nime web plat\nforms in\nA\nng\nular, Reac\nt, and TypeScript. A\nt XTB, drives fron\nt\nend\narchi\nt\nec\nture for a mult\ni-asse\nt trading plat\nform serving 1.4M+ traders worldwide";
+
+    /// A real invoice excerpt that extracts CLEANLY — the gate must NOT fire on it (no false positive).
+    const INVOICE_CLEAN: &str = "INVOICE\nInvoice # INV-9752r79-2026-5\nIssue date May 21, 2026\nDue date May 29, 2026\nBILL FROM:\nJakub Gawronski\nAl.Lawendowa 9\nCzłuchów, 77-300\nPoland\nTOTAL DUE\nPLN zł49,883.33";
+
+    /// A table-of-contents page: many short lines (entry title + PAGE NUMBER), but ZERO shattered
+    /// single-LETTER lines (the page numbers are single DIGITS, not glyph fragments). The short-line
+    /// gate alone would fire and the old join would weld `"Introduction\n1"` → `"Introduction1"`. The
+    /// single-alpha fingerprint must keep the gate a NO-OP, and even if it fired the digit-boundary weld
+    /// rule must never produce `"Introduction1"`.
+    const TOC_PAGE: &str = "Introduction\n1\nOverview\n2\nArchitecture\n3\nStorage\n4\nAppendix\n5";
+
+    /// A form page: label / value pairs down the page. The verifier's `"Age\n42"` case: welding across
+    /// the label→value DIGIT boundary would produce `"Age42"`.
+    const FORM_PAGE: &str = "Name\nJohn\nAge\n42\nCity\nNewYork\nRole\nEngineer";
+
+    /// A vertical list of short ACRONYMS. High short-line fraction (0.83) but ZERO single-letter lines —
+    /// the gate must not fire and the tokens must stay separate (`"AWS\nGCP"` → not `"AWSGCP"`).
+    const ACRONYM_LIST: &str = "AWS\nGCP\nAzure\nk8s\nEC2\nRDS";
+
+    /// RED baseline: the RAW fragmented fixture does NOT contain the recovered words and DOES still
+    /// carry the `"Fron\nt"` fragment. This proves the fixture is genuinely broken (the fix has work to
+    /// do) — without it a passing GREEN test could be vacuous.
+    #[test]
+    fn cv_fixture_is_fragmented_before_reflow_red_baseline() {
+        assert!(
+            !CV_FRAGMENT.contains("Frontend"),
+            "the raw fixture must NOT already contain the recovered word (else the test is vacuous)"
+        );
+        assert!(
+            CV_FRAGMENT.contains("Fron\nt"),
+            "the raw fixture must still carry the shattered fragment (RED state)"
+        );
+        assert!(
+            !CV_FRAGMENT.contains("building large-scale realtime web platforms"),
+            "the raw fixture must NOT already contain the recovered phrase (RED state)"
+        );
+    }
+
+    /// GREEN: reflow recovers the fragmented body words / phrases and drops the shattered fragment.
+    #[test]
+    fn cv_fixture_reflows_to_recovered_words() {
+        let out = reflow_fragmented_text(CV_FRAGMENT);
+        for needle in [
+            "Frontend",
+            "TypeScript",
+            "Angular",
+            "React",
+            "Staff Frontend Engineer",
+            "building large-scale realtime web platforms",
+        ] {
+            assert!(out.contains(needle), "reflow must recover {needle:?}\n---\n{out}\n---");
+        }
+        assert!(
+            !out.contains("Fron\nt"),
+            "reflow must not leave the shattered fragment\n---\n{out}\n---"
+        );
+    }
+
+    /// The invoice extracts cleanly → the gate must NOT fire; its key strings survive intact. Ideally
+    /// the whole thing is byte-identical (a clean document is never touched).
+    #[test]
+    fn invoice_gate_does_not_fire_and_is_unchanged() {
+        assert!(
+            !looks_fragmented(INVOICE_CLEAN),
+            "the gate must NOT fire on the clean invoice"
+        );
+        let out = reflow_fragmented_text(INVOICE_CLEAN);
+        assert_eq!(out, INVOICE_CLEAN, "a clean invoice must pass through byte-identical");
+        assert!(out.contains("Invoice # INV-9752r79-2026-5"));
+        assert!(out.contains("PLN zł49,883.33"));
+    }
+
+    /// RED baseline for the WELD false-positive: prove the OLD unconditional digit-weld (a digit was
+    /// welded to any alphanumeric `prev`) would corrupt these — this documents the exact bug the fix
+    /// closes. The `join_kind` rule below asserts the FIXED behavior; this asserts the fixture is a
+    /// genuine trigger (previous non-space char is a LETTER, next is a DIGIT — the label→value shape).
+    #[test]
+    fn weld_counterexamples_have_the_label_then_digit_shape_red_context() {
+        // "Age" then "42": prev='e' (letter), next='4' (digit) — the shape the old code welded.
+        assert_eq!(join_kind(Some('e'), Some('4')), Join::Space, "label→digit value must space, not weld");
+        // "Intro" then "1": prev='o', next='1'.
+        assert_eq!(join_kind(Some('o'), Some('1')), Join::Space, "entry→page-number must space, not weld");
+        // "Soup" then "5".
+        assert_eq!(join_kind(Some('p'), Some('5')), Join::Space);
+        // But a SPLIT NUMBER still welds: "90" then "7" (the CV phone) — prev='0' is a digit.
+        assert_eq!(join_kind(Some('0'), Some('7')), Join::Weld, "a split number must still weld");
+        // And a genuine mid-word still welds: "Fron" then "t".
+        assert_eq!(join_kind(Some('n'), Some('t')), Join::Weld, "mid-word must still weld");
+    }
+
+    /// A TOC page must NOT weld its entry titles onto their page numbers. Either the gate no-ops (the
+    /// single-alpha fingerprint is 0) or, if it fired, the digit-boundary rule spaces — either way
+    /// `"Introduction1"` must NEVER appear. (RED against the old code: it welded to `Introduction1`.)
+    #[test]
+    fn toc_page_is_not_welded() {
+        assert!(
+            !looks_fragmented(TOC_PAGE),
+            "the single-alpha fingerprint (0 single-letter lines) must keep the gate a no-op on a TOC"
+        );
+        let out = reflow_fragmented_text(TOC_PAGE);
+        assert!(
+            !out.contains("Introduction1"),
+            "a TOC entry must never weld onto its page number\n---\n{out}\n---"
+        );
+        // Concrete verifier counterexamples: `Intro\n1`→ not `Intro1`, `Soup\n5`→ not `Soup5`.
+        assert!(!reflow_fragmented_text("Intro\n1").contains("Intro1"));
+        assert!(!reflow_fragmented_text("Soup\n5").contains("Soup5"));
+    }
+
+    /// A form page must NOT weld a label onto its value (`"Age\n42"` → not `"Age42"`).
+    #[test]
+    fn form_page_is_not_welded() {
+        let out = reflow_fragmented_text(FORM_PAGE);
+        assert!(
+            !out.contains("Age42"),
+            "a form label must never weld onto its value\n---\n{out}\n---"
+        );
+        // The gate also should not fire (2 short lines < floor; and 0 single-alpha lines).
+        assert!(!looks_fragmented(FORM_PAGE), "a form page must not trip the gate");
+    }
+
+    /// NON-VACUOUS join proof: embed the label→value pair inside a document whose gate GENUINELY FIRES
+    /// (letter-spaced fragments give it the single-alpha fingerprint) so the join rule is actually
+    /// exercised. The OLD unconditional digit-weld produced `"Age42"` here; the digit-boundary rule must
+    /// space it to `"Age 42"` while still recovering the mid-word fragments in the same block.
+    #[test]
+    fn label_value_not_welded_even_when_gate_fires() {
+        let frag = "Fron\nt\nend\nA\nng\nular\nb\nu\ni\nld\nRealt\nime\nAge\n42";
+        assert!(looks_fragmented(frag), "this mixed block must trip the gate (letter-spaced fragments)");
+        let out = reflow_fragmented_text(frag);
+        assert!(out.contains("Frontend"), "mid-word fragments still recover\n---\n{out}\n---");
+        assert!(
+            !out.contains("Age42"),
+            "a label→value digit boundary must NOT weld even inside a firing block\n---\n{out}\n---"
+        );
+        assert!(out.contains("Age 42"), "the label→value pair must be space-joined\n---\n{out}\n---");
+    }
+
+    /// A vertical acronym list must not fire the gate (no single-letter lines) nor weld into one token.
+    #[test]
+    fn acronym_list_is_not_welded() {
+        assert!(
+            !looks_fragmented(ACRONYM_LIST),
+            "a short-word list with no single-letter lines must not trip the gate"
+        );
+        let out = reflow_fragmented_text(ACRONYM_LIST);
+        assert!(!out.contains("AWSGCP"), "acronyms must stay separate tokens\n---\n{out}\n---");
+        assert_eq!(out, ACRONYM_LIST, "gate no-op → byte-identical passthrough");
+    }
+
+    /// The real letter-spaced CV must STILL trip the tightened gate (its single-alpha fraction ≈ 0.29 is
+    /// well above the 0.15 threshold). Without this the fix could over-tighten and stop repairing the
+    /// actual bug.
+    #[test]
+    fn cv_fixture_still_trips_the_tightened_gate() {
+        assert!(
+            looks_fragmented(CV_FRAGMENT),
+            "the tightened gate must still fire on the genuinely letter-spaced CV"
+        );
+    }
+
+    /// The CV's split phone number is welded back (a digit continues a digit run): `"...327 90\n7"` →
+    /// `"...907"`.
+    #[test]
+    fn cv_phone_number_split_digits_reweld() {
+        let out = reflow_fragmented_text(CV_FRAGMENT);
+        assert!(out.contains("907"), "the split phone number must re-weld to 907\n---\n{out}\n---");
+    }
+
+    /// Normal prose / markdown is returned UNCHANGED (the gate no-ops). This is the same body the
+    /// extract-module regression guard uses.
+    #[test]
+    fn normal_prose_is_unchanged() {
+        let prose = "# Spec\n\nThe budget is 100k.\n\nAnna owns delivery.";
+        assert!(!looks_fragmented(prose), "normal prose must not trip the gate");
+        assert_eq!(reflow_fragmented_text(prose), prose);
+    }
+
+    /// A longer normal paragraph (many words per line, few short lines) is untouched.
+    #[test]
+    fn long_prose_is_unchanged() {
+        let prose = "The frontend engineering team ships a realtime trading platform.\n\
+                     It serves over one million traders worldwide across many asset classes.\n\
+                     Anna owns delivery and the quarterly roadmap is on track for May.";
+        assert!(!looks_fragmented(prose));
+        assert_eq!(reflow_fragmented_text(prose), prose);
+    }
+
+    /// Empty and tiny inputs are returned unchanged (below the short-line floor / empty).
+    #[test]
+    fn empty_and_tiny_inputs_unchanged() {
+        assert_eq!(reflow_fragmented_text(""), "");
+        assert_eq!(reflow_fragmented_text("hi"), "hi");
+        assert_eq!(reflow_fragmented_text("a\nb\nc"), "a\nb\nc"); // 3 short lines < MIN_SHORT_LINES.
+    }
+
+    /// Idempotency: reflowing a reflowed document changes nothing (the reflowed text no longer trips
+    /// the gate).
+    #[test]
+    fn reflow_is_idempotent() {
+        let once = reflow_fragmented_text(CV_FRAGMENT);
+        let twice = reflow_fragmented_text(&once);
+        assert_eq!(once, twice, "reflow must be idempotent");
+    }
+
+    /// Blank-line paragraph breaks are preserved across a reflow (structure isn't flattened to one
+    /// blob). A fragmented doc with two paragraphs stays two paragraphs.
+    #[test]
+    fn paragraph_breaks_are_preserved() {
+        let frag = "Fron\nt\nend one\nA\nng\nular two\n\nRealt\nime three\nplat\nform four\nb\nu\ni\nld";
+        let out = reflow_fragmented_text(frag);
+        assert!(out.contains("\n\n"), "a blank-line paragraph break must survive\n{out}");
+    }
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5226,6 +5226,19 @@ impl Db {
         // identical leaves + a summary), then build the L0/L1/L2 tree. `name` provenance carries into
         // the deterministic contextual header on the embed text.
         let blocks = crate::extract::blocks_from_stored_text(&text);
+        // READ-TIME REFLOW (doc-preview fix): de-fragment pathologically letter-spaced PDF text on a
+        // COPY before chunking, so (re)indexed chunks/embeddings retrieve on clean words
+        // (`"Fron\nt\nend"` → `"Frontend"`) instead of shattered glyph fragments. The gate is
+        // conservative — md/txt/note/legacy + clean PDF pages are byte-identical no-ops, so a normal
+        // document's chunk input is unchanged. `documents.text` at rest is NEVER mutated: only the
+        // in-memory block text fed to the chunker is reflowed.
+        let blocks: Vec<crate::extract::ExtractedBlock> = blocks
+            .into_iter()
+            .map(|b| crate::extract::ExtractedBlock {
+                text: crate::extract::reflow::reflow_fragmented_text(&b.text),
+                ..b
+            })
+            .collect();
         let hier = crate::embed::chunk_document_hierarchical(&name, &blocks);
         // Embed ONLY the embed-worthy chunks (L0 leaves + L2 summary; L1 parents are FTS-only). We
         // sub-batch to bound the per-call Metal tensor for a large PDF (mirror index_meeting_chunks).
@@ -19079,6 +19092,73 @@ mod tests {
             .search_doc_chunks_fts_visible("?!*(", 10, &nothing)
             .unwrap()
             .is_empty());
+    }
+
+    /// READ-TIME REFLOW (doc-preview fix), chunk-input NO-OP: an md upload's stored text carries NO
+    /// block sentinel → it reconstructs as one plain block, the reflow gate no-ops on clean prose, and
+    /// the chunk text is byte-identical to the stored text (retrieval unchanged for normal docs).
+    #[test]
+    fn index_document_chunks_reflow_is_noop_on_clean_md() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Project");
+        // A clean md doc (no sentinel, normal prose) — the gate must NOT fire.
+        db.insert_document(
+            "d1",
+            "f-open",
+            "spec.md",
+            "the pistachio launch is in March",
+            "document",
+            100,
+        )
+        .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .search_doc_chunks_fts_visible("pistachio", 10, &nothing)
+            .unwrap();
+        assert!(
+            hits.iter()
+                .any(|h| h.document_id == "d1" && h.snippet.contains("pistachio")),
+            "clean md chunk text is unchanged by the (no-op) reflow gate: {hits:?}"
+        );
+    }
+
+    /// READ-TIME REFLOW (doc-preview fix), chunk-input DE-FRAGMENTS: a document whose stored text is a
+    /// LOCATED (page) block of pathologically letter-spaced PDF glyphs (`"Fron\nt\nend"`) must chunk on
+    /// the RECOVERED word ("Frontend") so a query for the real word retrieves it — proving reflow runs
+    /// on the chunk input, not just the display. RED-before-GREEN: the raw fragment does NOT contain
+    /// "Frontend", so without reflow the FTS query for "Frontend" finds nothing.
+    #[test]
+    fn index_document_chunks_reflow_defragments_letter_spaced_pdf_text() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "CVs");
+        // Build a stored text that carries the block sentinel (a located PDF page block), so
+        // `blocks_from_stored_text` reconstructs a located block whose fragmented text reflow repairs.
+        // The fragment is heavily letter-spaced (many ≤3-char lines) so it trips the conservative
+        // fragmentation gate — a lightly-broken block would (correctly) NOT reflow.
+        let block = crate::extract::ExtractedBlock {
+            text: "S\ntaff Fron\nt\nend Engineer bu\ni\nl\nd\ning realt\nime web plat\nforms in\nA\nng\nular and TypeScript".to_string(),
+            page: Some(1),
+            heading_path: None,
+        };
+        let stored = crate::extract::blocks_to_stored_text(std::slice::from_ref(&block));
+        assert!(
+            !stored.contains("Frontend"),
+            "precondition: the raw stored fragment does NOT contain the recovered word (RED state)"
+        );
+        db.insert_document("d1", "f-open", "cv.pdf", &stored, "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .search_doc_chunks_fts_visible("Frontend", 10, &nothing)
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.document_id == "d1"),
+            "reflow must de-fragment the chunk input so a query for the recovered word retrieves the \
+             document — without reflow the shattered fragment never matches: {hits:?}"
+        );
     }
 
     /// TOCTOU (lock-security finding, PR-1): `index_document_chunks` must REFUSE the entire write —

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.html
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.html
@@ -108,38 +108,91 @@
         <ul class="sc-list" role="list">
           @for (doc of items(); track doc.id) {
             <li class="sc-item">
-              <span class="sc-item-glyph" aria-hidden="true">
-                <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
-                  <path
-                    d="M9 1.75H4.5A1.25 1.25 0 0 0 3.25 3v10A1.25 1.25 0 0 0 4.5 14.25h7A1.25 1.25 0 0 0 12.75 13V5.5z"
-                    stroke="currentColor"
-                    stroke-width="1.3"
-                    stroke-linejoin="round"
-                  />
-                  <path d="M9 1.75V5.5h3.75" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" />
-                </svg>
-              </span>
-              <span class="sc-item-text">
-                <span class="sc-item-name">{{ doc.name }}</span>
-                <span class="sc-item-date">{{ formatDate(doc.createdAt) }}</span>
-              </span>
-              <button
-                type="button"
-                class="btn btn-ghost sc-del"
-                [attr.aria-label]="'Delete ' + doc.name"
-                [disabled]="deletingId() === doc.id"
-                (click)="deleteItem.emit(doc)"
-              >
-                <svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
-                  <path
-                    d="M3 4.5h10M6.5 4.5V3.2c0-.4.3-.7.7-.7h1.6c.4 0 .7.3.7.7v1.3M5 4.5l.5 8.3h5L11 4.5"
-                    stroke="currentColor"
-                    stroke-width="1.3"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </button>
+              @if (previewable()) {
+                <!-- Previewable source (Documents): the row itself opens the
+                     content preview (click / Enter / Space). A document read
+                     that returns "" is provably sealed (imports fail closed on
+                     empty), so the preview's "🔒 Locked" case is unambiguous.
+                     The delete button is a SEPARATE sibling control, so a delete
+                     click never also opens the preview. -->
+                <button
+                  type="button"
+                  class="sc-item-open"
+                  [attr.aria-label]="'Preview ' + doc.name"
+                  (click)="openItem.emit(doc)"
+                >
+                  <span class="sc-item-glyph" aria-hidden="true">
+                    <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                      <path
+                        d="M9 1.75H4.5A1.25 1.25 0 0 0 3.25 3v10A1.25 1.25 0 0 0 4.5 14.25h7A1.25 1.25 0 0 0 12.75 13V5.5z"
+                        stroke="currentColor"
+                        stroke-width="1.3"
+                        stroke-linejoin="round"
+                      />
+                      <path d="M9 1.75V5.5h3.75" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" />
+                    </svg>
+                  </span>
+                  <span class="sc-item-text">
+                    <span class="sc-item-name">{{ doc.name }}</span>
+                    <span class="sc-item-date">{{ formatDate(doc.createdAt) }}</span>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-ghost sc-del"
+                  [attr.aria-label]="'Delete ' + doc.name"
+                  [disabled]="deletingId() === doc.id"
+                  (click)="$event.stopPropagation(); deleteItem.emit(doc)"
+                >
+                  <svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
+                    <path
+                      d="M3 4.5h10M6.5 4.5V3.2c0-.4.3-.7.7-.7h1.6c.4 0 .7.3.7.7v1.3M5 4.5l.5 8.3h5L11 4.5"
+                      stroke="currentColor"
+                      stroke-width="1.3"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </button>
+              } @else {
+                <!-- Non-previewable source (Notes): the pre-feature, NON-clickable
+                     row (glyph + name + date + delete). A note read can return ""
+                     for a genuinely-empty note, so `""` is NOT provably "locked"
+                     there → we do not offer a preview (which would falsely claim
+                     "🔒 Locked" for a normal empty note). -->
+                <span class="sc-item-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 16 16" width="15" height="15" fill="none">
+                    <path
+                      d="M9 1.75H4.5A1.25 1.25 0 0 0 3.25 3v10A1.25 1.25 0 0 0 4.5 14.25h7A1.25 1.25 0 0 0 12.75 13V5.5z"
+                      stroke="currentColor"
+                      stroke-width="1.3"
+                      stroke-linejoin="round"
+                    />
+                    <path d="M9 1.75V5.5h3.75" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" />
+                  </svg>
+                </span>
+                <span class="sc-item-text">
+                  <span class="sc-item-name">{{ doc.name }}</span>
+                  <span class="sc-item-date">{{ formatDate(doc.createdAt) }}</span>
+                </span>
+                <button
+                  type="button"
+                  class="btn btn-ghost sc-del"
+                  [attr.aria-label]="'Delete ' + doc.name"
+                  [disabled]="deletingId() === doc.id"
+                  (click)="deleteItem.emit(doc)"
+                >
+                  <svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
+                    <path
+                      d="M3 4.5h10M6.5 4.5V3.2c0-.4.3-.7.7-.7h1.6c.4 0 .7.3.7.7v1.3M5 4.5l.5 8.3h5L11 4.5"
+                      stroke="currentColor"
+                      stroke-width="1.3"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </button>
+              }
             </li>
           }
         </ul>

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.scss
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.scss
@@ -172,6 +172,32 @@
 .sc-item:hover {
   border-color: var(--border-strong);
 }
+/* The clickable region of a row (glyph + name + date) — a real <button> reset
+   to sit flush in the row and stretch to fill it, so the whole row area opens
+   the preview. The delete <button> is a separate sibling. */
+.sc-item-open {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.sc-item-open:hover .sc-item-name {
+  color: var(--accent-hover);
+}
+.sc-item-open:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
 .sc-item-glyph {
   display: inline-flex;
   flex: none;

--- a/src/app/features/brain/brain-source-card/brain-source-card.component.ts
+++ b/src/app/features/brain/brain-source-card/brain-source-card.component.ts
@@ -51,6 +51,16 @@ export class BrainSourceCardComponent {
   readonly busyLabel = input("Adding…");
   readonly emptyLabel = input("Nothing here yet.");
   /**
+   * When true, each list row is a clickable `<button>` that emits {@link openItem}
+   * to open a content preview. When false (the default), rows are NON-interactive
+   * (the pre-preview-feature shape) — used for sources where an empty read is
+   * AMBIGUOUS (a Note can be genuinely empty, so `""` from `getDocument` can't be
+   * proven to mean "locked"; Documents can never be empty, so preview is safe
+   * there only). Kept OFF for Notes so a normal empty note is never mislabeled
+   * "🔒 Locked".
+   */
+  readonly previewable = input(false);
+  /**
    * Optional fine-grained progress line shown under the Add button while
    * {@link busy} (e.g. a document's extract → chunk → embed stage). Null hides it.
    */
@@ -59,6 +69,8 @@ export class BrainSourceCardComponent {
   readonly add = output<void>();
   readonly deleteItem = output<DocumentInfo>();
   readonly toggleList = output<void>();
+  /** A list row was activated (click / Enter / Space) → open its preview. */
+  readonly openItem = output<DocumentInfo>();
 
   /** Epoch-millis → a short local date string. */
   protected formatDate(epochMs: number): string {

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -143,9 +143,11 @@
         [emptyLabel]="
           isAll() ? 'No documents yet.' : 'No documents in this folder yet.'
         "
+        [previewable]="true"
         (add)="pickAndImportDocument()"
         (deleteItem)="removeItem($event)"
         (toggleList)="docsExpanded.set(!docsExpanded())"
+        (openItem)="openPreview($event)"
       />
 
       <app-brain-source-card
@@ -297,6 +299,10 @@
       (save)="onSaveNote($event)"
       (dismiss)="closeNoteEditor()"
     />
+  }
+
+  @if (previewDoc(); as doc) {
+    <app-document-preview [doc]="doc" (dismiss)="closePreview()" />
   }
 </section>
   

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -26,6 +26,7 @@ import { FullBrainGraphComponent } from "../full-brain-graph/full-brain-graph.co
 import { BrainMemoryComponent } from "../brain-memory/brain-memory.component";
 import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor.component";
 import { BrainSourceCardComponent } from "../brain-source-card/brain-source-card.component";
+import { DocumentPreviewComponent } from "../document-preview/document-preview.component";
 import { BriefsComponent } from "../../briefs/briefs/briefs.component";
 import { AuditComponent } from "../../audit/audit/audit.component";
 
@@ -82,6 +83,7 @@ interface FolderOption {
     RouterLink,
     BrainEnableCardComponent,
     BrainSourceCardComponent,
+    DocumentPreviewComponent,
     BrainNoteEditorComponent,
     BrainMapComponent,
     FullBrainGraphComponent,
@@ -302,6 +304,14 @@ export class BrainComponent {
 
   // ── note editor modal ──────────────────────────────────────────────────
   readonly noteEditorOpen = signal(false);
+
+  // ── document/note content-preview modal ────────────────────────────────
+  /**
+   * The document/note currently open in the read-only preview modal, or null
+   * when closed. Set from a source card's `openItem`; the modal fetches the
+   * gated text itself (sealed folders mask to "" → it renders LOCKED).
+   */
+  readonly previewDoc = signal<DocumentInfo | null>(null);
 
   // ── connections (graph) ────────────────────────────────────────────────
   readonly graphData = signal<GraphData | null>(null);
@@ -572,6 +582,16 @@ export class BrainComponent {
       this.importing.set(false);
       this.importProgress.set(null);
     }
+  }
+
+  /** Open the read-only content preview for a document/note row. */
+  openPreview(doc: DocumentInfo): void {
+    this.previewDoc.set(doc);
+  }
+
+  /** Close the content preview modal. */
+  closePreview(): void {
+    this.previewDoc.set(null);
   }
 
   openNoteEditor(): void {

--- a/src/app/features/brain/document-preview/document-preview.component.html
+++ b/src/app/features/brain/document-preview/document-preview.component.html
@@ -1,0 +1,67 @@
+@if (doc(); as d) {
+  <div class="dp-backdrop">
+    <!-- Full-viewport dismiss target: a real <button> so it's natively
+         focusable + keyboard-operable (a11y) — a click closes. Escape is
+         handled at document level (host listener), NOT here, so it still fires
+         after focus falls to <body> from clicking the preview text. -->
+    <button
+      type="button"
+      class="dp-scrim"
+      aria-label="Close preview"
+      (click)="dismiss.emit()"
+    ></button>
+
+    <div
+      class="dp-panel"
+      role="dialog"
+      aria-modal="true"
+      [attr.aria-label]="'Preview of ' + d.name"
+    >
+      <header class="dp-head">
+        <span class="dp-badge" aria-hidden="true">{{ badge() }}</span>
+        <h3 class="dp-title" [attr.title]="d.name">{{ d.name }}</h3>
+        <button
+          #closeBtn
+          type="button"
+          class="dp-close btn btn-ghost"
+          aria-label="Close"
+          (click)="dismiss.emit()"
+        >
+          <svg viewBox="0 0 16 16" width="15" height="15" fill="none" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+
+      @if (loading()) {
+        <div class="dp-state" role="status" aria-live="polite">
+          <mur-spinner [size]="22" />
+          <span class="dp-state-text">Loading document…</span>
+        </div>
+      } @else if (error()) {
+        <div class="dp-state dp-state-error" role="alert">
+          <span class="dp-state-glyph" aria-hidden="true">⚠️</span>
+          <span class="dp-state-text">Couldn’t open this document. Please try again.</span>
+        </div>
+      } @else if (masked()) {
+        <!-- Sealed-and-not-unlocked folder → the backend masks the text to "".
+             Show LOCKED, never a blank body (leak-relevant path). -->
+        <div class="dp-state dp-state-locked" role="status">
+          <span class="dp-state-glyph" aria-hidden="true">🔒</span>
+          <span class="dp-state-title">Locked</span>
+          <span class="dp-state-text">
+            This document is in a locked folder. Unlock it (in Meetings →
+            folders) to read its contents.
+          </span>
+        </div>
+      } @else {
+        <pre class="dp-body" tabindex="0">{{ content() }}</pre>
+      }
+    </div>
+  </div>
+}

--- a/src/app/features/brain/document-preview/document-preview.component.scss
+++ b/src/app/features/brain/document-preview/document-preview.component.scss
@@ -1,0 +1,156 @@
+:host {
+  display: block;
+}
+
+.dp-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-5);
+}
+
+.dp-scrim {
+  position: fixed;
+  inset: 0;
+  border: none;
+  margin: 0;
+  padding: 0;
+  cursor: default;
+  background: rgba(0, 0, 0, 0.55);
+  animation: dp-fade 160ms var(--transition) both;
+}
+
+.dp-panel {
+  /* Floating modal OVER the page → OPAQUE (T3), never the frosted .card. */
+  position: relative;
+  z-index: 1;
+  width: min(720px, 100%);
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  animation: dp-rise 200ms var(--transition) both;
+}
+
+.dp-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.dp-badge {
+  flex: none;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dp-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  font-size: 1.0625rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dp-close {
+  flex: none;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  color: var(--text-muted);
+}
+.dp-close:hover {
+  color: var(--text-primary);
+}
+
+/* The scrollable content well — long PDFs scroll INSIDE the modal (the page
+   body never scrolls). It's translucent (--surface-input) but composites over
+   the ALREADY-OPAQUE panel, so nothing behind the modal bleeds through. */
+.dp-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 60vh;
+  overflow-y: auto;
+  margin: 0;
+  padding: var(--space-4);
+  background: var(--surface-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Loading / error / locked / empty share one centered stack. */
+.dp-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  min-height: 220px;
+  padding: var(--space-6) var(--space-4);
+  text-align: center;
+}
+
+.dp-state-glyph {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.dp-state-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.dp-state-text {
+  max-width: 40ch;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.dp-state-error .dp-state-text {
+  color: var(--text-secondary);
+}
+
+@keyframes dp-fade {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes dp-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dp-scrim,
+  .dp-panel {
+    animation: none;
+  }
+}

--- a/src/app/features/brain/document-preview/document-preview.component.ts
+++ b/src/app/features/brain/document-preview/document-preview.component.ts
@@ -1,0 +1,197 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { IpcService } from "../../../core/ipc.service";
+import type { DocumentInfo } from "../../../core/models";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+
+/**
+ * A read-only CONTENT PREVIEW for one brain document/note — presented as an
+ * OPAQUE modal (T3): a full-viewport dim scrim + an opaque
+ * `var(--surface-overlay)` panel, NEVER the frosted `.card` (which would bleed
+ * the Brain page through). The body is the CLEAN display text from
+ * `IpcService.getDocument(id)`.
+ *
+ * The read is GATED server-side: a sealed-and-NOT-session-unlocked folder
+ * returns "" (masked — never the stored text). We render that empty-string case
+ * as an explicit "🔒 Locked" state — NOT a blank/broken panel — so a sealed
+ * document is visibly locked and its content never appears (leak-relevant path).
+ * `get_document` also returns "" for an unknown id or a document whose display
+ * text is genuinely empty; those are INDISTINGUISHABLE from the sealed mask at
+ * the FE, so we FAIL SAFE and treat every "" as LOCKED — a sealed doc is never
+ * mislabeled "empty", and no content is ever shown behind the lock. (A
+ * genuinely-empty document is a near-impossible edge: import rejects no-text
+ * files with "No readable text found".)
+ *
+ * Pure/presentational: it owns the fetch + view state (`content` / `loading` /
+ * `error` signals, fed by a stale-guarded effect keyed on the doc id); the
+ * parent owns which doc is open (the `doc` input) and closes on {@link dismiss}
+ * (scrim click / × button / Escape).
+ */
+@Component({
+  selector: "app-document-preview",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Esc lives at DOCUMENT level on purpose: after clicking non-focusable text
+  // (the preview body) focus falls to <body>, so a panel-scoped
+  // (keydown.escape) would go dead. Mirrors LibraryComponent / MoveToMenu.
+  host: {
+    "(document:keydown.escape)": "onEscape()",
+  },
+  imports: [MurSpinnerComponent],
+  templateUrl: "./document-preview.component.html",
+  styleUrl: "./document-preview.component.scss",
+})
+export class DocumentPreviewComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly injector = inject(Injector);
+
+  /** The document to preview; null = the modal is closed (renders nothing). */
+  readonly doc = input<DocumentInfo | null>(null);
+
+  // Named `dismiss` (not `close`): `close` is a native DOM event name, which
+  // `@angular-eslint/no-output-native` forbids as an output. Matches the
+  // BrainNoteEditorComponent modal's `dismiss` convention.
+  readonly dismiss = output<void>();
+
+  /** The fetched clean text ("" when sealed-masked or genuinely empty). */
+  protected readonly content = signal<string>("");
+  /** True while `getDocument` is in flight. */
+  protected readonly loading = signal(false);
+  /** A read failure (e.g. transient IPC error) — distinct from locked/empty. */
+  protected readonly error = signal<string | null>(null);
+
+  private readonly closeBtn =
+    viewChild<ElementRef<HTMLButtonElement>>("closeBtn");
+
+  /**
+   * The type BADGE for the header, derived from the file extension in the doc
+   * name — a `kind: "note"` doc is always "Note" regardless of its name.
+   */
+  protected readonly badge = computed<string>(() => {
+    const d = this.doc();
+    if (!d) {
+      return "";
+    }
+    if (d.kind === "note") {
+      return "Note";
+    }
+    const ext = this.extensionOf(d.name);
+    switch (ext) {
+      case "pdf":
+        return "PDF";
+      case "docx":
+        return "DOCX";
+      case "pptx":
+        return "PPTX";
+      case "xlsx":
+        return "XLSX";
+      case "html":
+      case "htm":
+        return "HTML";
+      case "md":
+        return "MD";
+      case "txt":
+        return "TXT";
+      case "png":
+      case "jpg":
+      case "jpeg":
+      case "heic":
+      case "tiff":
+      case "tif":
+      case "bmp":
+      case "gif":
+        return "Image";
+      default:
+        return "Doc";
+    }
+  });
+
+  /**
+   * Sealed-masked state: the fetch resolved successfully but returned "" — the
+   * folder is sealed-and-not-unlocked (the backend masks the text). We show a
+   * "🔒 Locked" panel, never the (absent) content. Distinct from a genuinely
+   * empty visible document only in that we can't tell them apart from "" alone,
+   * so we treat "" as LOCKED (fail-safe: never imply a sealed doc is "empty").
+   * A load error is a THIRD, separate state.
+   */
+  protected readonly masked = computed(
+    () => !this.loading() && !this.error() && this.content().length === 0,
+  );
+
+  constructor() {
+    // Focus the close button once the modal has rendered (afterNextRender,
+    // never setTimeout/rAF). The parent renders this component behind an
+    // `@if (previewDoc())`, so it's created fresh on open → this one-shot fires
+    // exactly when the modal appears. Runs in the field-init injection context;
+    // the explicit injector is belt-and-braces consistent with the tree.
+    afterNextRender(() => this.closeBtn()?.nativeElement.focus(), {
+      injector: this.injector,
+    });
+
+    // Fetch the document text whenever a non-null doc is set. Stale-result
+    // guard keyed on the doc id: an id can change mid-flight (the user opens a
+    // different doc), so a late response for a doc we've since left is dropped.
+    // Writes-in-effect are allowed since v19 (no allowSignalWrites flag); this
+    // effect genuinely orchestrates an async IPC fetch, the sanctioned case.
+    effect(() => {
+      const d = this.doc();
+      if (!d) {
+        this.content.set("");
+        this.loading.set(false);
+        this.error.set(null);
+        return;
+      }
+      const id = d.id;
+      this.loading.set(true);
+      this.error.set(null);
+      this.content.set("");
+      void this.fetch(id);
+    });
+  }
+
+  /** Await the gated read; drop the response if the open doc changed since. */
+  private async fetch(id: string): Promise<void> {
+    try {
+      const text = await this.ipc.getDocument(id);
+      if (this.doc()?.id !== id) {
+        return;
+      }
+      this.content.set(text);
+    } catch (e) {
+      if (this.doc()?.id !== id) {
+        return;
+      }
+      this.error.set(String(e));
+    } finally {
+      if (this.doc()?.id === id) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  protected onEscape(): void {
+    if (this.doc()) {
+      this.dismiss.emit();
+    }
+  }
+
+  /** Lowercased final extension of a filename, or "" when there is none. */
+  private extensionOf(name: string): string {
+    const dot = name.lastIndexOf(".");
+    if (dot < 0 || dot === name.length - 1) {
+      return "";
+    }
+    return name.slice(dot + 1).toLowerCase();
+  }
+}


### PR DESCRIPTION
## What

Two things on the Brain **Documents** surface:

1. **Document content preview** — clicking a document card opens an opaque modal (T3) showing the extracted text the brain actually reasons over, with a file-type badge (PDF / DOCX / XLSX / …), Esc/scrim close, and a stale-result-guarded fetch. Scoped to the **Documents card only** (a `previewable` input): uploaded documents can never be empty, so an empty string from the gated `get_document` unambiguously means a sealed folder → a "🔒 Locked" panel. The Notes card stays non-previewable to avoid the empty-note-vs-sealed ambiguity.

2. **De-fragment letter-spaced PDF text** — PDFKit's `page.string()` shatters letter-spaced/kerned PDFs (e.g. a designed CV) into per-glyph lines (`O\nSKAR`, `Fron\nt\nend`), hurting readability and embedding quality. A new **read-only** `extract::reflow::reflow_fragmented_text` rejoins them **at read time** — in `render_display_text` (preview + MCP `get_document`) and `index_document_chunks` (retrieval), always on a copy. It never mutates `documents.text` or any seal blob, so it is fully re-derivable and applies to existing *and* future documents. A conservative gate (short-line fraction + a ≥0.15 single-alphabetic-char-line fingerprint) fires only on the pathology; TOC / form / menu / acronym-list pages and normal prose/md are a no-op. `extract/pdf.rs` FFI is untouched.

## Why

Verified live against the running app (its read-only MCP server) that the brain already ingests, indexes and retrieves PDF content — but extraction fragments letter-spaced PDFs. This makes that content viewable in-app and cleans it up for both display and retrieval.

## How verified

- `cargo test --lib` **1892 passed / 0 failed / 12 ignored** — new reflow + chunk-input regression tests, RED→GREEN on the real CV fragmentation fixture.
- `cargo clippy --lib --tests -D warnings` clean; `ng lint` + `ng build` clean.
- **adversarial-verifier** caught 2 findings — an empty-note "Locked" mislabel and reflow gate false-positives welding legitimate short-line pages (`Intro\n1`→`Intro1`, `Age\n42`→`Age42`) — **both fixed and re-verified** (added `toc_page_is_not_welded` / `form_page_is_not_welded` / `acronym_list_is_not_welded` / `label_value_not_welded_even_when_gate_fires`).
- **lock-security review: PASS** — no ungated read/export, no at-rest mutation (documents.text keeps the raw extraction), no leak/loss; the preview reads only the existing gated `get_document` (no `convertFileSrc`/asset path).

## Residual / follow-up

- Existing already-chunked fragmented docs are **not** auto-re-indexed (a `TODO(reflow)` in `backfill_document_chunks`): their *preview* is fixed now, but their *retrieval* embeddings stay on the old text until a manual Settings → Reindex. A one-shot re-index needs a new at-rest marker column to avoid an unbounded re-chunk loop — deferred.
- Note-preview (with proper folder lock-state) is a possible future add.
- Signed-build/real-Mac only: real PDFKit letter-spacing fidelity, lock-at-rest on disk, Touch ID.
