### PR TITLE
fix(brain): heavy-gate note-doc saves, free the lifecycle guard for the embed leg, cap the repair tick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 /.playwright/
 # E2E-generated screenshot artifacts (verification output, never committed)
 e2e/**/__screens__/
+
+# Stray dev database must never be committed (PII-bearing SQLite)
+meetnotes.db
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm

--- a/docs/research/2026-07-18-brain-v3-audit.md
+++ b/docs/research/2026-07-18-brain-v3-audit.md
@@ -1,0 +1,334 @@
+<!-- Generated 2026-07-18. Research-grounded audit of the merged brain v3 program (PRs #362–#367 + OCR #369,
+     with #368 interactions), pinned at trunk 71bac31. Method: 60-agent workflow — 6 SOTA research briefs
+     (web + code grounding) + 9 parallel code auditors + adversarial verification of every critical/high/medium
+     finding (33 verified, 1 refuted, 32 survived) + independent grading pass. All claims below cite file:symbol
+     and survived at least one dedicated refutation attempt unless marked low/info (unverified pass-through). -->
+
+# Audit: Brain v3 — implementation vs AI-engineering best practice (2026-07-18)
+
+**Scope:** the merged brain-v3 program — PR-1 #362 integrity, PR-2 #363 universal ingest + hierarchy,
+PR-3 #364 link engine, PR-4 #365 full-brain graph, PR-5 #366 Receipts, PR-6 #367 Knowledge Diff,
+follow-up #369 Vision OCR — audited as it lives on trunk `71bac31` (which also carries #368's manual-link
+layer on top). Basis of comparison: the original user prompt, `docs/research/2026-07-17-brain-v3-maximization.md`,
+`docs/superpowers/specs/2026-07-17-brain-v3-design.md`, and six fresh SOTA research briefs (contextual
+retrieval / RAPTOR / LazyGraphRAG / context-rot / Karpathy context engineering; Docling-class extraction;
+e5 hubness & threshold literature; Zep/Graphiti bitemporal KG; AIS/NLI attribution; Anthropic/SWE-agent/A-RAG
+ACI design + July-2026 competitor reality).
+
+## TL;DR verdict
+
+**A disciplined, adversarially-verified implementation with a genuinely SOTA-adjacent security layer and an
+architecturally-ahead-of-market substrate — whose product-visible quality still rests on uncalibrated
+constants and a handful of confirmed retrieval-quality bugs.** The program delivered ~90% of its spec.
+Where it is best (lock model, verification process, bitemporal core, suggest-then-accept linking policy) it
+exceeds every named competitor and some published research systems. Where it falls short, the pattern is
+consistent: *the architecture matches SOTA, the last mile of the mechanism doesn't* — parent expansion is
+query-independent, the L2 outline degenerates to one truncated chunk, the kNN fan-out is chunk- not
+item-granular, receipts are negation-blind, the agent loop truncates silently. None of these is visible to
+`cargo test`; all were confirmed by adversarial verification against the code. The three headline claims
+(500-page PDF fidelity, 0.80/0.88 link precision, receipt coverage on paraphrased notes) remain unvalidated
+on real corpora — the program's own research gated release quality on spikes that have not run.
+
+### Scorecard
+
+Grades are this audit's synthesis of the six research briefs' criteria applied to the verified code findings
+(an independent grader pass ran as well and landed within ±1 on every dimension). 10 = would impress the
+authors of the cited SOTA work; 5 = competent but clearly behind SOTA.
+
+| Dimension | Score | One-line justification |
+|---|---|---|
+| Lock-model security | **9** | purge-on-seal at every choke point, both-endpoint gating, in-tx TOCTOU guards — all RED-proven; two residual composition gaps, both bounded |
+| Engineering quality & tests | **8.5** | suite 1762→1850, overwhelmingly RED-capable; dual-verify caught real bugs in 4 of 6 PRs; minus: God-file growth, several spec promises silently dropped |
+| Ingest & extraction | **7.5** | crash-safe FFI + actual-bytes zip-bomb guard exceed industry practice; minus: nested-table/PPTX-table/localized-heading silent losses, plain-text in a structured-elements world |
+| Knowledge Diff / bitemporal | **7.5** | genuine invalidate-not-delete + pure boundary-tested interval algebra (no consumer competitor has any); minus: time axes collapsed (as-of = knowledge-time), inert FE control |
+| Semantic linking math | **7** | mutual-kNN is the literature's recommended hubness defence and the policy layer beats all shipped competitors; minus: chunk-granular fan-out bug + uncalibrated e5 thresholds |
+| Full-brain graph | **7** | typed nodes/edges with exemplary gating and honest backend caps; minus: silent FE 140-node draw cap, no search/expand/cluster affordances (below Bloom/Kumu) |
+| Performance & scalability | **7** | ingest properly off-thread/RAM-gated/sub-batched with excellent crash posture; minus: `update_note_doc` heavy-permit bypass, O(k·n) linker with false O(k·log n) claims, backlinks full-vault scan |
+| Hierarchical index & retrieval | **6.5** | right architecture (L0/L1/L2, zero-LLM ingest, contextual headers); three of four load-bearing mechanisms partially broken (expansion, L2, PDF leaves) |
+| Receipts / grounding | **6.5** | honest abstain-over-wrong posture and a real structural moat; minus: lexical-only alignment is negation-unsafe, coverage unmeasured, front-matter bug |
+| Agentic ACI | **6.5** | paging + MCP mirrors + no-repeat guard match good practice; minus: silent 4k truncation (the "agents lie" class), doc map persisted but never surfaced |
+
+**Overall ≈ 7.3/10** — excellent substrate and process; the gap to "credibly the best AI brain" is now
+mostly *empirical calibration + last-mile mechanism fixes*, not architecture.
+
+## 1. Conformance to the original prompt
+
+| Prompt requirement | Status |
+|---|---|
+| Ingest documents of ANY size (PDF/DOCX/…) into brain contexts | **Delivered** (all formats + OCR), with silent-loss caveats (nested/PPTX tables, localized headings) and unvalidated 500-page fidelity |
+| Analyze how the brain holds data; fix gaps/refactor | **Delivered** — the PR-1 audit found real staleness bugs and fixed all six, plus a TOCTOU nobody had asked about |
+| Manual `[[links]]` + automatic content-similarity linking | **Delivered** — rename-proof wikilink edges by ID + mutual-kNN suggester; precision uncalibrated, fan-out bug confirmed |
+| Visualize ALL connections, not just people | **Delivered** — typed 4-kind/5-edge graph; but the FE silently draws at most 140 nodes while captions report more |
+| 2 killer features, maximally polished | **Delivered** (Receipts, Knowledge Diff) — both real moats, both with the polish gap in the last mile (negation-unsafe receipts; as-of diff computed but never rendered) |
+| "Mathematically grounded, not empty words" | **Largely honest** — cos identity unit-tested, pure deterministic cores, named consts; but two documented complexity claims are false (O(k·log n)) and thresholds are uncalibrated start values |
+| "Powerful tool for SHARING huge contexts (e.g. via org)" | **NOT delivered at "huge"** — org sharing of documents exists but is hard-capped at 1 MiB/item (`murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES`, terminal `too_large`); a 500-page PDF's extracted text typically exceeds it, so the exact artifact the program exists to ingest cannot be org-shared. The v3 append-only envelope was consciously deferred — but relative to the prompt this is the largest open scope item. |
+
+## 2. Where the implementation MATCHES or EXCEEDS SOTA (verified)
+
+- **Lock discipline (9/10, the program's crown).** `purge_links_tx` + `purge_doc_chunks_tx` fire inside all
+  eight seal/relock/delete/reconcile transactions; `links_for_visible` gates BOTH endpoints fail-closed
+  before touching a row; `build_full_graph` drops any edge whose endpoint is sealed (no existence leak);
+  the PR-1 seal-vs-index TOCTOU fix keys on a session-independent at-rest invariant (`doc_sealed_at_rest_tx`)
+  *inside the write tx, before the purge*, composing correctly with WAL snapshot semantics; the repair tick
+  and consolidation run under the EMPTY unlock set; receipts are recompute-on-demand with a content-free DTO.
+  No cloud SOTA system (Zep included) has an equivalent of purge-on-seal for derived knowledge.
+- **Verification process.** Every PR dual-verified; verifiers caught real bugs the implementers missed
+  (PR-1 TOCTOU, PR-5 dead FE code, PR-6 lexical-timestamp compare, #368's HIGH mislabel). The eval harness
+  forced a measured revert of a tempting fusion change. This is the discipline most teams claim and few run.
+- **Extraction safety.** Every PDFKit/Vision/AppKit ObjC call inside `objc2::exception::catch` (per-page
+  granularity — one bad page never kills an import); the zip-bomb guard bounds *actual inflated bytes* via
+  `Read::take` with one budget across entries (stronger than the industry's ratio-only screening); OCR bitmaps
+  RAM-capped at ~16 MiB/page; import write-gate re-checked inside the blocking closure against a racing relock.
+  Polish Vision OCR verified empirically on this Mac.
+- **Linking policy layer.** Suggest-then-accept with a dismissed-tombstone + no-downgrade upsert
+  (`ON CONFLICT … WHERE status != 'dismissed'` + CASE guard) is more disciplined than Smart Connections,
+  Reflect, or Mem — none of which writes silently into user files either, so the differentiation is the
+  *integration* (purge-on-seal, canonical undirected edges, both-endpoint gates), which nobody else has.
+- **Bitemporal core.** `reconcile_facts` invalidate-not-delete + `snapshot_as_of` half-open intervals with
+  instant compare (`cmp_instant`) and boundary tests incl. Z-vs-+00:00 cross-rendering — matches the
+  SQL:2011/Zep convention and is *better-engineered for auditability* than Graphiti's LLM-in-the-loop
+  invalidation (pure, deterministic, clock-injected).
+- **ACI positives.** Search-first tool catalog, char-safe `page_text` with `[end of content]` marker, MCP
+  mirrors, no-repeat guard (≈ A-RAG's context tracker), deterministic 32k transcript compaction with
+  surviving markers (≈ Anthropic's compaction guidance).
+
+## 3. Confirmed findings (survived adversarial refutation)
+
+33 critical/high/medium claims went to verification (1–2 independent skeptics each, instructed to refute);
+1 was refuted, 32 survived. The three HIGHs:
+
+### H1 — Semantic-link kNN fan-out is CHUNK-granular; an item's own chunks starve its candidate list
+`db.rs: Db::knn_items_visible / Db::auto_link_semantic`. The spec promised "k=10 **items** over
+vec_chunks ∪ doc_vec_chunks"; the shipped query fetches k+1=11 **chunks per table**, and since an item's
+own chunks dominate proximity to its own centroid, any item with ≥11 chunks (every long meeting note, every
+real document — i.e. exactly the content-rich items the feature exists for) gets few or zero same-table
+candidates, and the mutuality back-probe fails the same way. The links.rs unit tests pin only the pure
+selection math on synthetic cosines, so this never shows in `cargo test`.
+**Fix (S):** over-fetch chunks (k≈64; brute-force vec0 makes larger k nearly free) or exclude the source's
+own chunk ids in the CTE, then truncate to K distinct items; same for the back-probe.
+
+### H2 — DOCX nested tables silently destroy already-extracted text
+`extract/ooxml.rs: parse_docx_xml`. An inner `w:tc`/`w:tr` fires `para_text.clear()`/`row_cells.clear()`
+while still inside the outer cell — outer-cell text and earlier sibling cells are wiped. Nested tables are
+routine in real Word documents (layout tables, forms, agendas). The import "succeeds", the FE toasts
+success, and the brain silently cannot retrieve the lost text — silent index-content loss.
+**Fix (S):** table-depth counter or a stack of (row_cells, para_text) frames + a RED fixture test.
+
+### H3 — Authored-note save embeds + auto-links on the async runtime, bypassing the heavy-inference permit
+`commands.rs: update_note_doc`. Runs Candle/Metal embedding + the semantic-link pass synchronously without
+`perf::run_heavy` and without `embed_in_sub_batches` — the exact co-residency + unbounded-Metal-tensor
+classes PR-1 fixed on its meeting twin `update_note`. A textbook instance of the repo's own
+"sibling functions carry the same bug" heuristic; can co-run with an in-flight whisper pass (the documented
+launch-freeze class).
+**Fix (S):** wrap in `run_heavy` like the sibling; route `index_note_chunks` through `embed_in_sub_batches`.
+
+### Mediums, grouped (all CONFIRMED unless marked PARTIAL)
+
+**Retrieval quality (the "last mile" cluster — these blunt the hierarchy's whole point):**
+- `db.rs: expand_doc_parents_visible` — parent expansion is **query-independent**: it serves the document's
+  *dominant-by-leaf-count* L1 section, not the hit leaf's parent (the spec's "≥2 sibling L0 hits" trigger is
+  unimplementable because both doc readers dedup to one snippet per doc before chunk ids survive), and flat
+  docs DO get an L1 (their first ~6000 chars) contrary to the in-code comment — so for multi-section and
+  flat docs alike, expansion replaces the relevant retrieved snippet with up to 6k chars of the WRONG
+  section. Per Chroma's context-rot data this is a distractor *injector*. Fix: carry `chunk_id`/`parent_id`
+  through `DocChunkHit`, dedup after fusion, expand to the hit's parent only when ≥2 retrieved siblings
+  share it (LlamaIndex auto-merging semantics).
+- `embed.rs: chunk_document_hierarchical` — the L2 outline is always exactly ONE unbounded chunk (outline
+  joined with `\n` defeats `pack_leaves`' `\n\n` split; `truncate(3)` is dead code), so e5's 512-token
+  window embeds only the first few dozen sections — the collapsed-tree effect is gutted for precisely the
+  large docs it was built for. FTS still indexes the full outline, so the degradation is vector-side and
+  invisible to tests.
+- `embed.rs: pack_leaves` — PDF (the flagship format) emits one block per page with no blank lines, so L0
+  "800-char" leaves are routinely whole pages whose tails never reach the vector index; sizes are counted
+  in BYTES not chars (Polish ≈ 720 effective chars, CJK ≈ 266). Fix: hard-split fallback on `\n`/sentence
+  boundaries; count with `chars()`.
+- `agent.rs: truncate / RESULT_BUDGET` — tool results are cut at 4000 chars **silently**: no marker, no
+  total. The model cannot distinguish "the doc is 4k chars" from "I saw 0.3% of it" — the documented
+  "tool-result truncation makes agents lie" class: Ask can confidently assert *"the document doesn't mention
+  X"* after seeing 1.6% of a 500-page PDF. (On MCP the opposite: default `(0,0)` returns the ENTIRE body.)
+  Fix: `[truncated at 4000 of N chars — call again with offset]` + `TOTAL_CHARS` in windowed reads. The
+  research brief also notes: `section_path`/`page_no`/`level` are *persisted but never surfaced* to the
+  agent (`DocChunkHit` drops them; no `get_document_outline` tool) — the doc map exists in SQLite and the
+  agent pages blind by char arithmetic.
+
+**Extraction fidelity/availability:**
+- `extract/pdf.rs: extract_pdf` — scanned-PDF OCR is all-or-nothing: ONE page with a text layer (a
+  publisher cover page) suppresses OCR for the other 299 → ~100% of content silently absent. Fix: per-page
+  fallback (OCR pages whose text layer is empty/short).
+- `extract/ooxml.rs: parse_pptx_slide` — PPTX table text (`a:tbl` in `graphicFrame`) is dropped entirely;
+  table-only slides (status grids, budgets) ingest empty, silently.
+- `extract/pdf.rs: ocr_scanned_pdf` — a 500-page scanned PDF OCRs unboundedly (~4–15+ min) while holding
+  the ONE heavy-inference permit — ASR/summarize for a meeting started meanwhile queue behind it; no page
+  cap, no cancellation, no per-page progress.
+- `extract/mod.rs: MAX_EXTRACT_DECOMPRESSED_BYTES` — the 512 MiB guard covers only zip containers; PDF
+  content-stream inflation, calamine's in-memory expansion, and flow-format reads are unbounded, and the
+  RAM floor gates only the embed stage, not extraction.
+- Low but pointed (research-confirmed, hits the primary user): **localized Word heading styles are never
+  detected** (`heading_level()` matches only the English `heading` prefix) — a Polish-authored DOCX
+  (`Nagłówek1`) gets `heading_path=None` everywhere, degrading the entire hierarchy for the app's
+  primary-language documents. Fix: resolve `w:outlineLvl` via `styles.xml` (language-agnostic).
+
+**Link-engine state machine across seal cycles (needs a lock-security review as a set):**
+- `db.rs: purge_links_tx` destroys dismissed tombstones and accepted status on seal → a lock→unlock cycle
+  **resurrects dismissed suggestions**, contradicting the spec's "a rejected suggestion never reappears".
+- `commands.rs: rederive_links_for_folder` re-derives wikilink+semantic only → **companion edges are
+  permanently deleted** by one lock cycle (backfill sentinel is one-shot); **inbound wikilinks** from
+  outside sources into the unlocked folder are purged and never restored.
+- `db.rs: auto_link_semantic` — the cap 5 is source-side only: hub nodes accumulate unbounded inbound
+  suggestions (the exact hubness noise mutual-kNN was meant to prevent).
+- PARTIAL: the spec's **indexed backlinks fast path over `links` was silently not built** —
+  `backlinks_for_visible` remains an O(entire-vault-text) regex scan per note/detail open, under the DB
+  mutex (tens-to-hundreds of ms on a big vault, growing linearly).
+
+**Lock-model composition gaps (the between-PR class):**
+- `commands.rs: materialize_accepted_link / merge_related_hit` — a SYSTEM-written `[[Title]]` of a
+  later-sealed neighbour survives in a visible note's plaintext body AND its exported vault `.md` — the
+  same title+existence information the links-row purge exists to remove. Fix: strip matching hits from the
+  machine-owned `murmur:links` block at seal (the purged rows name exactly the affected sources), or
+  document the residual in lock-model.md as accepted.
+- Low/PARTIAL: link writers (`index_wikilinks_for_source`/`auto_link_semantic`/`upsert_manual_link`) lack
+  the in-tx sealed-at-rest re-check PR-1 added to every chunk indexer — a seal-vs-link-derive TOCTOU can
+  persist id+score rows referencing sealed endpoints until the next relock/reconcile (reads stay gated;
+  exposure bounded). Mirror `doc_sealed_at_rest_tx` in the link-write tx.
+
+**Receipts:**
+- `grounding.rs: align_claims_to_segments` — never splits YAML front-matter (contrary to its caller's
+  comment): `attendees: Anna, Bob` earns a receipt chip if the names were spoken. Fix: `split_frontmatter`
+  + index offset.
+- Negation-blind: `not`/`nie` are stopwords, so a claim can earn a high-overlap receipt from a segment
+  asserting the OPPOSITE — the one spec-flagged failure mode that fails UNSAFE (paraphrase/aggregation/short
+  claims all fail safe via threshold refusal). Fix: keep negators as content tokens for this pass, or veto
+  on one-sided negator presence. Related: the FE copy "Click to hear the moment this was said" overclaims
+  for a 0.5 lexical match — the attribution literature is unanimous that lexical overlap is the bottom tier;
+  say "likely source", show tiers not floats.
+- Low: the spec's "ASR confidence in the tooltip" never shipped (fetched, then dropped by the FE).
+
+**Knowledge Diff:**
+- `facts.rs: supersession_ledger` — still sorts/pairs by byte-lexical `valid_from.cmp()`; the
+  instant-compare fix stopped at `snapshot_as_of`. Mixed RFC3339 renderings (imported/shared facts) can
+  flip old→new in the ledger — the exact class `cmp_instant` was added to kill.
+- `entity-detail`: the 90d/All-time control is functionally inert (bounds a diff the template never
+  renders) and the headline as-of diff (added/removed/changed) has **no human-facing UI at all** —
+  MCP/agent text only. Shipped-but-dead machinery; render it or delete the control.
+- Research-confirmed structural note: the two time axes are COLLAPSED — `valid_from` is always the
+  reconcile instant, so "as of t" answers *knowledge-time*, not world-time; retroactive facts ("shipped
+  last Tuesday") are mis-dated. Zep's `t_ref` pattern (extractor emits an optional 'since', resolved
+  against the meeting date) would make the bitemporal schema actually bitemporal with no change to the
+  deterministic core.
+
+**Graph & perf hygiene:**
+- FE draws at most `MAX_NODES=140` nodes while caption/banner report up to 2000 — the silent-trim the
+  backend's honest `total_visible_nodes` was built to expose, reintroduced one layer up.
+- `auto_link_semantic` is O(k·n) brute force (~22 mutex-held vec-table scans per save at the 20-book
+  target ≈ 0.5–1 s; `rederive_links_for_folder` multiplies per item) — and the in-code "O(k·log n), no
+  corpus scans" claims are false. sqlite-vec has no ANN; fix the comments, cache back-probes, consider a
+  corpus-size-aware schedule.
+- Import progress events always fire `done=0,total=0` — the FE's "Embedding 12/40" branch is dead code; a
+  multi-minute import is indistinguishable from a hang, and there is no cancellation.
+- God-file growth: brain-v3 added ~2.2k lines to `commands.rs` (now 37,238) and ~2.7k to `db.rs` (24,489);
+  `extract/` proves the escape pattern works — the links storage half (+1,086 lines in db.rs) should follow.
+
+## 4. Research-brief verdicts in one paragraph each
+
+- **Hierarchical RAG:** the design matches all five SOTA pillars (contextual headers on both legs, small
+  embedded leaves + fetch-only parents, zero-LLM ingest per LazyGraphRAG, tight budgets, hybrid+RRF) except
+  hit-aligned expansion — which is precisely the confirmed bug. The "RAPTOR collapsed-tree effect at ZERO
+  LLM cost" comment overstates (RAPTOR's +20% hinges on abstractive LLM summaries; a first-sentence outline
+  is a floor). The unexploited seam: the existing `rerank.rs` never touches the doc leg — Anthropic's data
+  makes reranking the largest post-hybrid stage (−49→−67% failure).
+- **Extraction:** we ship a *plain-text-per-page* extractor in a world where the bar (Docling 97.9%
+  table-cells, Marker 96.1% multi-column) is structured elements; no page-furniture removal (headers/footers
+  poison every chunk embedding), headings only from the usually-absent PDF outline. The OOXML fixes are cheap
+  and headless-testable. Strategic: the source binary is discarded (`mod.rs`), freezing v1 fidelity into
+  every already-imported document — retain it (SQLCipher-encrypted) or add `extractor_version` for re-import
+  prompts. OCR language list is hardcoded `["pl","en"]` — fine on Tahoe (verified), risky on the 13.4 floor;
+  intersect with `supportedRecognitionLanguages()` at runtime.
+- **Linking math:** mutual-kNN at K=10 is the literature's recommended hubness defence (CSLS family, K
+  validated 5–50) — structurally right. But e5 cosines are compressed (~0.7–1.0, InfoNCE τ=0.01) and the
+  maintainer says only *relative* order is meaningful: FLOOR=0.80 barely binds (unrelated pairs routinely
+  score 0.75–0.85), the 0.88 non-mutual bypass is the concentrated false-positive channel, and the
+  passage-passage similarity deviates from e5's query-query symmetric contract — so external threshold
+  folklore does not transfer and in-situ calibration is mandatory. Best lever: a zero-egress per-vault
+  calibration harness (null distribution from ~2k random visible pairs → percentile floor; accept/dismiss
+  buckets as a live precision curve — the telemetry already exists in the links table).
+- **Bitemporal KG:** matches Zep's load-bearing core (invalidate-not-delete, half-open as-of) with rarer
+  virtues (pure/deterministic/clock-injected, gated+purged) — and three material gaps: collapsed time axes,
+  EAV strings instead of relational edges (facts never link to the Anna node), exact-key contradiction
+  matching (paraphrased predicates fragment ledgers silently; `confidence` is hardcoded 1.0 dead weight).
+  Graph UX sits above Obsidian-native (honest caps, typed lenses, determinism), below Bloom/Kumu (no
+  search-to-locate, no expand-from-selection, no clustering, no time filter).
+- **Grounding:** lexical overlap is the bottom of the attribution hierarchy (entailment correlates best with
+  human faithfulness judgments; MiniCheck shows sub-1B models reach GPT-4-level checking). The shipped
+  *posture* is SOTA-pragmatic (abstain-over-wrong, cause-separated confidence fields, no storage) but
+  negation fails unsafe and PL inflection (no stemming) depresses coverage. The moat is real and verified:
+  Granola deletes audio post-transcription; Fathom/Fireflies do cloud transcript-timestamp jumps; nobody
+  does LLM-claim→second-of-audio locally. v2 path: gold set first → e5 embedding rescue (model already
+  resident) → on-device NLI (mDeBERTa-XNLI via the existing DeBERTa load path in `ner_deberta.rs`).
+- **ACI & competitors:** paging/MCP mirrors/no-repeat/compaction match good practice; silent truncation and
+  the unsurfaced doc map are the two violations of Anthropic's own tool-writing guidance ("steer agents when
+  truncating"). 6 steps × 4k chars ≈ 24k visible ≈ 1.6% of a 500-page PDF: needle questions work (retrieval
+  does the lifting), section summaries and aggregations do not. Competitive: **"only local-first meeting
+  notetaker" is false today** (Hyprnote YC S25 + ≥4 other local Mac apps; capture is commoditizing via
+  Recall.ai's Tauri-compatible SDK) — but the CONJUNCTION (local meetings + any-size hierarchical doc ingest
+  + typed graph + bitemporal facts + E2EE org sharing + Obsidian-native owned files + no per-seat AI fee)
+  remains unique as of 2026-07. NotebookLM's hard 500k-words/source cap is a genuine wedge — *once* the ACI
+  gaps are fixed; today our 500-page story is no better in practice.
+
+## 5. Priority fix plan
+
+**P0 — trust & correctness (all S-effort, headless-testable, do before the next release):**
+1. Truncation honesty: marker + `TOTAL_CHARS` in `agent.rs`/`tools.rs` windowed reads (kills the
+   false-"not mentioned" class).
+2. Hit-aligned, sibling-gated parent expansion (chunk_id/parent_id through `DocChunkHit`; RED test that
+   today's SQL returns the wrong section).
+3. `update_note_doc` → `run_heavy` + `embed_in_sub_batches` (the sibling bug).
+4. OOXML batch: nested-table depth, PPTX `graphicFrame` tables, `w:outlineLvl` heading resolution
+   (Polish DOCX!), `w:br`/`w:tab` whitespace, `instrText`/`delText` exclusion.
+5. kNN over-fetch → K distinct items (+ same for the back-probe).
+6. L2 outline: line-based packing into ≤3 ≤800-char chunks; `pack_leaves` hard-split for page-sized
+   paragraphs; count chars not bytes.
+
+**P1 — product promises (S/M):**
+7. Per-page OCR fallback + OCR page cap/cancellation + real `done/total` progress counts.
+8. Backlinks indexed fast path over `links` (the dropped spec promise; the scan stays as legacy fallback).
+9. Receipts: front-matter skip + negation veto + "likely source" copy + confidence tooltip (or amend spec).
+10. Knowledge Diff: `cmp_instant` in `supersession_ledger`; render the as-of diff or delete the inert toggle.
+11. Link state machine across seal cycles (tombstones/accepted/companion/inbound survival) — one PR,
+    lock-security-reviewed as a set; plus both-endpoint cap enforcement and the in-tx sealed-at-rest check
+    in link writers; plus the seal-time `murmur:links` block scrub (or a documented accepted-residual).
+12. FE graph: disclose the 140-node draw cap; bound `full_graph_links`; relevance-ordered mention LIMIT.
+
+**P2 — the program's own release gates (real Mac, cannot be skipped by more code):**
+13. Semantic-link calibration spike (hand-label precision@5; null-distribution percentile floor) — the
+    release-gating condition from the design spec, still open.
+14. 500-page PDF fidelity/RAM measurement + Polish scanned-PDF OCR quality.
+15. Receipts coverage gold set (100–200 lines, EN+PL) — do not market "every claim has a receipt" before.
+
+**P3 — strategic (needs decisions):**
+16. **Org sharing of large docs (v3 append-only envelope)** — the original prompt's "share huge contexts"
+    is still capped at 1 MiB; this is the biggest remaining prompt-level gap.
+17. Retain encrypted source binaries (or `extractor_version`) so parser upgrades apply retroactively.
+18. Doc-leg reranking through the existing `rerank.rs` seam + `get_document_outline` tool + doc-scoped step
+    raise (makes the NotebookLM wedge real).
+19. Zep-style `t_ref` extraction → true bitemporal valid time; entity alias/merge (the single upstream fix
+    that improves fusion, dossiers, graph, and ledgers at once).
+20. Factor links storage out of db.rs (extract/ is the proven pattern); narrow marketing to the conjunction.
+21. Hygiene: remove the stray `meetnotes.db` from the repo root working tree + gitignore it (PII-bearing
+    dev DB one broad `git add` away from a commit; the secret-scan hook targets keys, not DB files).
+
+## 6. Honest limits of this audit
+
+Static analysis + adversarial verification against trunk `71bac31`; no builds were run (the merged suite was
+CI-green at each merge). Everything Metal/Vision/PDFKit-fidelity-related is explicitly *not provable
+headless* — the P2 items are measurements, not code review. Competitor facts are point-in-time (2026-07);
+pricing partly from aggregators (medium confidence). One workflow artifact: the automated grading agent
+received malformed inputs (script bug) and re-derived its grades from in-tree sources; the scorecard above
+is this audit's own synthesis from the verified findings and research briefs, with the grader pass used as
+a cross-check (agreement within ±1 everywhere).
+
+**Bottom line:** brain v3 is *real engineering, not empty words* — the user's bar. The substrate would
+survive scrutiny from the authors of the systems it borrows from (Zep's invalidation, LazyGraphRAG's
+deferred-LLM thesis, mutual-kNN hubness defence), and the security layer exceeds them. What stands between
+"excellent substrate" and "credibly the best AI brain" is: 6 S-effort last-mile mechanism fixes (P0), the
+program's own three uncompleted calibration spikes (P2), and the 1 MiB org ceiling that still contradicts
+the prompt's sharing ambition (P3.16).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1774,7 +1774,7 @@ pub(crate) fn update_note_inner_with(
 ) -> Result<NoteDto, AppError> {
     // BLK-1 / TOCTOU (2026-07-10 audit F4): hold the lifecycle guard across gate+write so a
     // concurrent relock/seal cannot land between the unlock check and the upsert.
-    let _lifecycle = lifecycle_guard(state);
+    let lifecycle = lifecycle_guard(state);
     // D4 READ/WRITE-GATE: refuse to mutate a sealed-and-not-session-unlocked meeting's note. Its
     // plaintext markdown is blanked while sealed, so an edit here would overwrite the (sealed)
     // content with the blanked value and corrupt it. Fail closed.
@@ -1809,6 +1809,15 @@ pub(crate) fn update_note_inner_with(
     if let Some(path) = existing.exported_path.as_deref() {
         overwrite_exported_note_guarded(state, meeting_id, &existing.provider_id, path, markdown)?;
     }
+
+    // PERF (brain-v3 audit fix 2): release the GLOBAL lifecycle guard BEFORE the heavy leg — the
+    // re-embed is multi-second Candle/Metal work on a long meeting, and holding the guard across
+    // it delays screen-share auto-relock (`relock_all_inner`) and every lock/unlock op. Race-safe
+    // without it: the indexers re-check the sealed-at-rest invariant INSIDE their write tx (a
+    // mid-flight seal makes the write a refused no-op), and `rename_meeting_inner` already runs
+    // the identical re-index with no guard. The fast leg above (gate + seal-on-write upsert +
+    // guarded vault overwrite) stays under the guard.
+    drop(lifecycle);
 
     // Brain v3 (audit gap #1): re-derive the meeting's chunks/vectors from the FRESH markdown so
     // deleted text stops surfacing in semantic search/snippets. Best-effort + empty-unlock-set
@@ -3515,7 +3524,20 @@ pub async fn update_note_doc(
     title: String,
     markdown: String,
 ) -> Result<NoteDoc, AppError> {
-    let doc = update_note_doc_inner(state.inner(), &id, &title, &markdown)?;
+    // PERF (brain-v3 audit H3): the inner runs Candle/Metal embedding + the semantic-link pass —
+    // route the whole synchronous body through the shared heavy-inference gate on the blocking
+    // pool, exactly like the meeting twin `update_note` (PR-1 #362). Re-fetch `AppState` inside
+    // the closure via `app.state()` — a bare `&AppState` cannot be captured by a `'static` closure.
+    let heavy_inference = state.heavy_inference.clone();
+    let app_for_edit = app.clone();
+    let id_for_edit = id.clone();
+    let title_for_edit = title.clone();
+    let markdown_for_edit = markdown.clone();
+    let doc = crate::perf::run_heavy(&heavy_inference, move || -> Result<NoteDoc, AppError> {
+        let state = app_for_edit.state::<AppState>();
+        update_note_doc_inner(&state, &id_for_edit, &title_for_edit, &markdown_for_edit)
+    })
+    .await?;
     // See `update_note`: ping open org views when the edit re-published ≥1 org copy. Best-effort.
     if republish_org_shares_for_source(state.inner(), None, Some(&id))
         .await
@@ -3527,16 +3549,31 @@ pub async fn update_note_doc(
     Ok(doc)
 }
 
-/// Inner of [`update_note_doc`] taking `&AppState` (unit-testable gate).
+/// Inner of [`update_note_doc`] taking `&AppState` (unit-testable gate). Resolves the model-gated
+/// embedder and delegates to [`update_note_doc_inner_with`] (embedder injected for deterministic
+/// tests — the [`update_note_inner`] precedent).
 pub(crate) fn update_note_doc_inner(
     state: &AppState,
     id: &str,
     title: &str,
     markdown: &str,
 ) -> Result<NoteDoc, AppError> {
+    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
+    update_note_doc_inner_with(state, id, title, markdown, embedder.as_deref())
+}
+
+/// Core of [`update_note_doc_inner`] with the re-index embedder INJECTED (`None` = model absent →
+/// chunk-only re-index, FTS still covers keyword retrieval; `Some` = fresh vectors too).
+pub(crate) fn update_note_doc_inner_with(
+    state: &AppState,
+    id: &str,
+    title: &str,
+    markdown: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
+) -> Result<NoteDoc, AppError> {
     // BLK-1 / TOCTOU (2026-07-10 audit F4): hold the lifecycle guard across gate+write so a
     // concurrent relock/seal cannot land between the unlock check and the row write.
-    let _lifecycle = lifecycle_guard(state);
+    let lifecycle = lifecycle_guard(state);
     let Some(row) = state.db.get_note_row(id)? else {
         return Err(AppError::InvalidArg(format!("no note {id}")));
     };
@@ -3555,13 +3592,30 @@ pub(crate) fn update_note_doc_inner(
     // missing session KEK.
     reseal_document_if_locked(state, &row.folder_id, id, title, markdown, now)?;
 
+    // Re-export the vault `.md` (best-effort). A sealed folder has no export (gated above), so this
+    // only runs for a visible note.
+    if let Err(e) = export_note_to_vault(state, id) {
+        tracing::warn!(target: "notes", error = %e, "note vault re-export failed (text saved)");
+    }
+    // Read the fresh DTO while still guarded (the row cannot be resealed under us); the heavy leg
+    // below never mutates the note row, so the DTO stays accurate.
+    let doc = get_note_inner(state, id)?;
+
+    // PERF (brain-v3 audit H3, the `update_note_inner_with` twin): release the GLOBAL lifecycle
+    // guard BEFORE the heavy leg — the note-body re-embed + semantic-link pass is multi-second
+    // Candle/Metal work on a long note, and holding the guard across it delays screen-share
+    // auto-relock and every lock/unlock op. Race-safe without it: `index_note_chunks` re-checks
+    // the sealed-at-rest invariant (`doc_sealed_at_rest_tx`) INSIDE its write tx, so a mid-flight
+    // seal makes the write a refused no-op. The fast leg above (gate + seal-on-write + vault
+    // export + DTO read) stays under the guard.
+    drop(lifecycle);
+
     // WP3 — the note is a first-class brain source: purge the old chunks and re-index the new BODY
     // (front-matter stripped inside `index_note_body_chunks`). Chunks + FTS come back
     // unconditionally (keyword works model-less); vectors ONLY when the REAL e5 model is present
     // (never stub vectors; mirrors `ingest_into_folder`/`should_auto_index`). Best-effort: a failure
     // logs (no PII) and does NOT fail the update — the plaintext is durable.
-    let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
-    if let Err(e) = index_note_body_chunks(state, id, title, markdown, embedder.as_deref()) {
+    if let Err(e) = index_note_body_chunks(state, id, title, markdown, embedder) {
         tracing::warn!(target: "rag", error = %e, "note re-index on update failed (text saved)");
     }
 
@@ -3571,14 +3625,8 @@ pub(crate) fn update_note_doc_inner(
     index_wikilinks_best_effort(state, crate::links::LinkKind::Note, id, markdown);
     auto_link_semantic_best_effort(state, crate::links::LinkKind::Note, id);
 
-    // Re-export the vault `.md` (best-effort). A sealed folder has no export (gated above), so this
-    // only runs for a visible note.
-    if let Err(e) = export_note_to_vault(state, id) {
-        tracing::warn!(target: "notes", error = %e, "note vault re-export failed (text saved)");
-    }
-
     tracing::info!(target: "notes", note_id = %id, "note updated + re-indexed");
-    get_note_inner(state, id)
+    Ok(doc)
 }
 
 /// FAST autosave path — persist the note's title + markdown + `updated_at` ONLY. NO re-chunk, NO
@@ -12950,7 +12998,7 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
     // never a purge-then-reinsert of an already-chunked document, which would DESTROY its existing
     // real vectors without replacing them. The shared leg is kind-ROUTED (Brain v3 audit gap #3):
     // authored notes re-chunk through the front-matter-stripping path, never raw `documents.text`.
-    let docs_indexed = backfill_document_chunks(db, unlocked, model_present, embedder, true)?;
+    let docs_indexed = backfill_document_chunks(db, unlocked, model_present, embedder, true, None)?;
     if docs_indexed > 0 {
         tracing::info!(target: "rag", docs_indexed, "reindex: document chunks backfilled");
     }
@@ -13054,16 +13102,33 @@ pub(crate) fn index_document_row_kind_routed(
 /// GATING (lock-model): the corpus is exactly `visible_document_ids(unlocked)` — a
 /// sealed-and-not-in-`unlocked` folder's documents are never returned, so their (blank) plaintext
 /// is never chunked and their index rows STAY purged.
+///
+/// `repair_budget` scopes the repair tick's per-run resource envelope to THAT caller (the
+/// per-call-bounds discipline): `Some` ⇒ the tick's posture — spend one budget slot (and pace by
+/// [`REPAIR_TICK_PACING_MS`]) per REAL index op, stop at zero, and never count/spend a ZERO-YIELD
+/// row (its needs-probe is unchanged, so it would re-burn the cap every launch); `None` ⇒ the
+/// user-triggered reindex, unbounded and counted exactly as before.
 fn backfill_document_chunks(
     db: &crate::storage::Db,
     unlocked: &std::collections::HashSet<String>,
     model_present: bool,
     embedder: &dyn crate::embed::Embedder,
     force_reembed: bool,
+    mut repair_budget: Option<&mut usize>,
 ) -> Result<usize, AppError> {
     let doc_embedder = model_present.then_some(embedder);
     let mut docs_indexed = 0usize;
     for did in db.visible_document_ids(unlocked)? {
+        if let Some(budget) = repair_budget.as_deref_mut() {
+            if *budget == 0 {
+                tracing::info!(
+                    target: "rag",
+                    docs_indexed,
+                    "doc backfill: per-run repair cap reached; remainder deferred to the next launch"
+                );
+                break;
+            }
+        }
         let should_index = if force_reembed {
             model_present || !db.document_has_chunks(&did)?
         } else {
@@ -13077,7 +13142,21 @@ fn backfill_document_chunks(
             continue;
         }
         match index_document_row_kind_routed(db, &did, doc_embedder) {
-            Ok(()) => docs_indexed += 1,
+            Ok(()) => match repair_budget.as_deref_mut() {
+                Some(budget) => {
+                    // Fix 3c — spend the budget ONLY on a row whose index pass actually produced
+                    // rows: re-run the needs-probe and treat "still missing" as zero-yield.
+                    let (chunks, vectors) = db.doc_chunk_vector_counts(&did)?;
+                    let still_missing = chunks == 0 || (model_present && vectors == 0);
+                    if !still_missing {
+                        docs_indexed += 1;
+                        *budget -= 1;
+                        // Pacing between REAL index ops (the topic backfill's posture).
+                        std::thread::sleep(std::time::Duration::from_millis(REPAIR_TICK_PACING_MS));
+                    }
+                }
+                None => docs_indexed += 1,
+            },
             Err(e) => {
                 // Never abort the whole backfill on one bad document — log (no PII) and continue.
                 tracing::warn!(target: "rag", error = %e, "doc backfill: indexing one document failed (skipped)");
@@ -13106,21 +13185,75 @@ fn backfill_document_chunks(
 ///
 /// Idempotent: a re-run finds full coverage and touches nothing (returns `(0, 0)`). Logs counts
 /// only — no PII.
+///
+/// CAPPED at [`REPAIR_TICK_MAX_INDEX_PER_RUN`] REAL index operations per run with a
+/// [`REPAIR_TICK_PACING_MS`] pacing sleep between them — the exact
+/// [`Db::backfill_topic_chunks_idempotent`] launch-freeze posture (2026-07-13): a vault with
+/// hundreds of missing rows must never re-embed everything in ONE unthrottled launch pass. The
+/// needs-probe is the cursor — a capped run just defers the remainder to the next launch. A
+/// ZERO-YIELD row (one whose index pass produces no chunks/vectors — e.g. an empty-bodied note)
+/// is never counted as work and never spends the cap, otherwise permanently-empty rows would
+/// re-burn the cap on every launch and starve the real tail.
 pub(crate) fn backfill_missing_brain_indexes(
     db: &crate::storage::Db,
     semantic_enabled: bool,
     model_present: bool,
     embedder: &dyn crate::embed::Embedder,
 ) -> Result<(usize, usize), AppError> {
+    backfill_missing_brain_indexes_capped(
+        db,
+        semantic_enabled,
+        model_present,
+        embedder,
+        REPAIR_TICK_MAX_INDEX_PER_RUN,
+    )
+}
+
+/// Max REAL index operations (rows that actually produced chunks/vectors) per repair-tick run —
+/// mirrors `TOPIC_BACKFILL_MAX_REEMBED_PER_RUN` in [`Db::backfill_topic_chunks_idempotent`].
+const REPAIR_TICK_MAX_INDEX_PER_RUN: usize = 50;
+
+/// Pacing sleep between REAL repair-tick index operations — breathing room for the shared DB
+/// connection + the Metal queue, mirroring the topic backfill's per-embed pause.
+const REPAIR_TICK_PACING_MS: u64 = 50;
+
+/// [`backfill_missing_brain_indexes`] with the per-run cap INJECTED (the test seam — production
+/// always passes [`REPAIR_TICK_MAX_INDEX_PER_RUN`]).
+pub(crate) fn backfill_missing_brain_indexes_capped(
+    db: &crate::storage::Db,
+    semantic_enabled: bool,
+    model_present: bool,
+    embedder: &dyn crate::embed::Embedder,
+    max_real_index_ops: usize,
+) -> Result<(usize, usize), AppError> {
     let empty = std::collections::HashSet::new();
+    // ONE budget across both halves — a launch tick is one resource envelope, however the missing
+    // rows are split between documents and meetings.
+    let mut remaining = max_real_index_ops;
 
     // DOC half — needs-only (never the reindex command's wholesale re-embed).
-    let docs = backfill_document_chunks(db, &empty, model_present, embedder, false)?;
+    let docs = backfill_document_chunks(
+        db,
+        &empty,
+        model_present,
+        embedder,
+        false,
+        Some(&mut remaining),
+    )?;
 
     // MEETING half — flag + model gated (see the gating matrix above).
     let mut meetings = 0usize;
     if semantic_enabled && model_present {
         for m in db.list_meetings_visible(100_000, &empty)? {
+            if remaining == 0 {
+                tracing::info!(
+                    target: "rag",
+                    meetings,
+                    docs,
+                    "repair tick: per-run cap reached; remainder deferred to the next launch"
+                );
+                break;
+            }
             // Defense-in-depth (the reindex idiom): only a meeting whose latest note is visible
             // under the SAME empty set is considered — and "has a note" is the tick's precondition.
             match db.get_note_if_visible(&m.id, &empty) {
@@ -13147,13 +13280,33 @@ pub(crate) fn backfill_missing_brain_indexes(
                     if let Err(e) = db.index_meeting_chunks(&m.id, &segments, embedder) {
                         tracing::warn!(target: "rag", error = %e, "repair tick: indexing one meeting failed (skipped)");
                     } else {
-                        meetings += 1;
-                        // Topic chunks follow the note/transcript index (the reindex idiom) —
-                        // under the SAME empty unlock set (sealed context never persists).
-                        if let Err(e) =
-                            db.index_meeting_topic_chunks(&m.id, &segments, embedder, &empty)
-                        {
-                            tracing::warn!(target: "rag", error = %e, "repair tick: topic indexing failed (skipped)");
+                        // Fix 3c — count + spend the cap ONLY when the pass actually produced
+                        // rows. A zero-yield meeting (empty note body AND no segments → no
+                        // chunks) stays "missing" forever; counting it would re-burn the cap on
+                        // every launch. Zero-yield ⇒ the segments were empty, so the topic
+                        // indexer (segment-derived) is skipped as the no-op it would be.
+                        match db.meeting_chunk_vector_counts(&m.id) {
+                            Ok((chunks, vectors)) if chunks > 0 && vectors > 0 => {
+                                meetings += 1;
+                                remaining -= 1;
+                                // Topic chunks follow the note/transcript index (the reindex
+                                // idiom) — under the SAME empty unlock set (sealed context
+                                // never persists).
+                                if let Err(e) = db.index_meeting_topic_chunks(
+                                    &m.id, &segments, embedder, &empty,
+                                ) {
+                                    tracing::warn!(target: "rag", error = %e, "repair tick: topic indexing failed (skipped)");
+                                }
+                                // Pacing between REAL index ops (the topic backfill's posture) —
+                                // idempotent no-ops stay unpaced.
+                                std::thread::sleep(std::time::Duration::from_millis(
+                                    REPAIR_TICK_PACING_MS,
+                                ));
+                            }
+                            Ok(_) => {} // zero-yield: not work, no cap spend, no pacing.
+                            Err(e) => {
+                                tracing::warn!(target: "rag", error = %e, "repair tick: yield probe failed (skipped)");
+                            }
                         }
                     }
                 }
@@ -25893,6 +26046,158 @@ mod lifecycle_tests {
         );
     }
 
+    /// Test-only `Embedder` recording the SIZE of every `embed()` call (the db.rs sub-batch test
+    /// precedent) — proves a save path sub-batches its embeds instead of one item-sized call.
+    struct RecordingEmbedder {
+        call_sizes: std::sync::Mutex<Vec<usize>>,
+    }
+
+    impl crate::embed::Embedder for RecordingEmbedder {
+        fn dim(&self) -> usize {
+            crate::embed::EMBED_DIM
+        }
+        fn embed(&self, texts: &[String]) -> crate::error::Result<Vec<Vec<f32>>> {
+            self.call_sizes.lock().unwrap().push(texts.len());
+            Ok(texts
+                .iter()
+                .map(|_| vec![0.0f32; crate::embed::EMBED_DIM])
+                .collect())
+        }
+    }
+
+    /// Test-only `Embedder` that probes, from INSIDE each embed call, whether the GLOBAL
+    /// [`AppState::lifecycle`] mutex is currently held (a same-thread `try_lock` on a held
+    /// `std::sync::Mutex` returns `WouldBlock`). Proves the multi-second embed leg runs with the
+    /// lifecycle guard RELEASED — holding it there delays screen-share auto-relock and every
+    /// lock/unlock op.
+    struct GuardProbeEmbedder<'a> {
+        state: &'a AppState,
+        calls: std::sync::atomic::AtomicUsize,
+        saw_guard_held: std::sync::atomic::AtomicBool,
+    }
+
+    impl crate::embed::Embedder for GuardProbeEmbedder<'_> {
+        fn dim(&self) -> usize {
+            crate::embed::EMBED_DIM
+        }
+        fn embed(&self, texts: &[String]) -> crate::error::Result<Vec<Vec<f32>>> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match self.state.lifecycle.try_lock() {
+                Ok(free) => drop(free),
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    self.saw_guard_held
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+                Err(std::sync::TryLockError::Poisoned(p)) => drop(p.into_inner()),
+            }
+            Ok(texts
+                .iter()
+                .map(|_| vec![0.0f32; crate::embed::EMBED_DIM])
+                .collect())
+        }
+    }
+
+    /// Brain v3 perf audit H3 (RED-before-GREEN): the authored-note save (`update_note_doc`)
+    /// embedded a long note's chunks in ONE Candle/Metal call sized to the whole note — the exact
+    /// unbounded-tensor class the 2026-07-13 launch-freeze fix closed for topic/transcript/document
+    /// chunks (`embed_in_sub_batches`); the note indexer was the one remaining miss. Pre-fix the
+    /// recorder saw a single 10-sized call: RED.
+    #[test]
+    fn update_note_doc_embeds_long_note_in_small_sub_batches() {
+        let state = build_state("note-doc-sub-batch");
+        make_open_folder(&state.db, "f-notes", "Notes");
+        // 10 paragraphs of ~690 chars: each fills its own ~800-char chunk → 10 chunks, more than
+        // one 8-sized sub-batch.
+        let body: String = (0..10)
+            .map(|i| format!("paragraph {i} {}", "x".repeat(680)))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        state
+            .db
+            .insert_note("n-long", "f-notes", "long", "Long", &body, 1)
+            .unwrap();
+        let expected = crate::embed::chunk_note("Long", "", &body).len();
+        assert!(
+            expected > 8,
+            "fixture sanity: the body must exceed one sub-batch, got {expected} chunks"
+        );
+
+        let rec = RecordingEmbedder {
+            call_sizes: std::sync::Mutex::new(Vec::new()),
+        };
+        update_note_doc_inner_with(&state, "n-long", "Long", &body, Some(&rec)).unwrap();
+
+        let calls = rec.call_sizes.into_inner().unwrap();
+        assert!(!calls.is_empty(), "the injected embedder must actually be exercised");
+        assert!(
+            calls.iter().all(|&n| n <= 8),
+            "no single embed call on the note-save path may exceed the sub-batch size (8): {calls:?}"
+        );
+        assert_eq!(
+            calls.iter().sum::<usize>(),
+            expected,
+            "every chunk is embedded exactly once across the sub-batches"
+        );
+    }
+
+    /// Brain v3 perf audit fix 2 (RED-before-GREEN): the meeting-note edit held the GLOBAL
+    /// lifecycle mutex across the multi-second Candle/Metal re-embed, delaying screen-share
+    /// auto-relock (`relock_all_inner`) and every lock/unlock op behind a long meeting's re-index.
+    /// The in-tx sealed-at-rest re-check inside the indexers is what makes the embed race-safe
+    /// (`rename_meeting_inner` runs the identical re-index with NO guard), so the guard must be
+    /// RELEASED before the heavy leg. Pre-fix the probe observed the guard held: RED.
+    #[test]
+    fn update_note_edit_releases_lifecycle_guard_before_the_embed_leg() {
+        let state = build_state("edit-guard-release");
+        make_open_folder(&state.db, "f-edit", "Team");
+        seed_meeting(&state.db, "m1", "# Plan\n\noriginal body", Some("f-edit"));
+        let probe = GuardProbeEmbedder {
+            state: &state,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            saw_guard_held: std::sync::atomic::AtomicBool::new(false),
+        };
+        update_note_inner_with(&state, "m1", "# Plan\n\nedited body", Some(&probe)).unwrap();
+        assert!(
+            probe.calls.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "the re-index must actually run (the probe is exercised)"
+        );
+        assert!(
+            !probe.saw_guard_held.load(std::sync::atomic::Ordering::SeqCst),
+            "the lifecycle guard must be RELEASED before the embed leg — holding it delays \
+             auto-relock and every lock/unlock op"
+        );
+    }
+
+    /// The authored-note twin of the guard-release test above: `update_note_doc` held the same
+    /// global lifecycle mutex across its note-body re-embed + link pass. Same race-safety argument
+    /// (the `doc_sealed_at_rest_tx` in-tx re-check refuses a mid-flight seal), same fix: the fast
+    /// leg (gate + seal-on-write + vault export) stays guarded, the heavy leg runs released.
+    #[test]
+    fn update_note_doc_releases_lifecycle_guard_before_the_embed_leg() {
+        let state = build_state("note-doc-guard-release");
+        make_open_folder(&state.db, "f-notes", "Notes");
+        state
+            .db
+            .insert_note("n1", "f-notes", "plan", "Plan", "quarterly plan body", 1)
+            .unwrap();
+        let probe = GuardProbeEmbedder {
+            state: &state,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            saw_guard_held: std::sync::atomic::AtomicBool::new(false),
+        };
+        update_note_doc_inner_with(&state, "n1", "Plan", "quarterly plan body", Some(&probe))
+            .unwrap();
+        assert!(
+            probe.calls.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "the note re-index must actually run (the probe is exercised)"
+        );
+        assert!(
+            !probe.saw_guard_held.load(std::sync::atomic::Ordering::SeqCst),
+            "the lifecycle guard must be RELEASED before the note-body embed leg"
+        );
+    }
+
     /// Brain v3 audit gap #4 (RED-before-GREEN): a RENAME left the OLD title baked into every
     /// chunk's header/augmented text/vector until a manual full reindex (`chunk_note` embeds
     /// `<title> · <date>` into each chunk). Pre-fix `rename_meeting` only set the title + synced the
@@ -26101,13 +26406,23 @@ mod lifecycle_tests {
                 1,
             )
             .unwrap();
+        // Fix 3c: a permanently-EMPTY note (zero chunks forever) rides along — it must never be
+        // counted as backfilled work in ANY pass (pre-fix it re-counted on every run, so the
+        // pass-1/2 doc counts read 3 and the tick never became a reported no-op: RED).
+        state
+            .db
+            .insert_note("n-empty", "f-open", "empty", "Empty", "", 1)
+            .unwrap();
 
         // PASS 1 — MODEL ABSENT.
         let (meetings, docs) =
             backfill_missing_brain_indexes(&state.db, true, false, &crate::embed::StubEmbedder)
                 .unwrap();
         assert_eq!(meetings, 0, "model absent: no meeting indexing (no stub vectors)");
-        assert_eq!(docs, 2, "model absent: both documents chunk-only backfilled");
+        assert_eq!(
+            docs, 2,
+            "model absent: both non-empty documents chunk-only backfilled (the empty row is zero-yield, never counted)"
+        );
         let (d_chunks, d_vecs) = state.db.doc_chunk_vector_counts("d1").unwrap();
         assert!(d_chunks > 0, "doc chunks present after the chunk-only pass");
         assert_eq!(d_vecs, 0, "no vectors without the model");
@@ -26194,6 +26509,141 @@ mod lifecycle_tests {
             0,
             "no chunks materialize for the sealed meeting"
         );
+    }
+
+    /// Brain v3 perf audit fix 3 (RED-before-GREEN): the repair tick had NO per-run cap — a vault
+    /// with hundreds of missing rows re-embedded EVERYTHING on one launch (the class the 2026-07-13
+    /// launch freeze pinned on the topic backfill, whose `TOPIC_BACKFILL_MAX_REEMBED_PER_RUN` this
+    /// mirrors). With the cap forced small, one run performs exactly `cap` REAL index ops and the
+    /// next run RESUMES where it left off (the needs-probe is the cursor — no state carried).
+    /// Pre-fix everything indexed in one pass: RED.
+    #[test]
+    fn repair_tick_caps_real_index_ops_per_run_and_resumes_next_launch() {
+        let state = build_state("repair-tick-cap");
+        make_open_folder(&state.db, "f-open", "Team");
+        for i in 0..4 {
+            state
+                .db
+                .insert_document(
+                    &format!("d{i}"),
+                    "f-open",
+                    &format!("doc{i}.md"),
+                    &format!("doc {i} body paragraph"),
+                    "document",
+                    (i + 1) as i64,
+                )
+                .unwrap();
+        }
+        seed_meeting(&state.db, "m1", "# Plan\n\nbudget line", Some("f-open"));
+
+        // RUN 1 (cap 2): exactly two docs (oldest-first) — no budget left for the meeting half.
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            2,
+        )
+        .unwrap();
+        assert_eq!((m, d), (0, 2), "run 1 spends the whole cap on the first two docs");
+        let covered = (0..4)
+            .filter(|i| {
+                state
+                    .db
+                    .doc_chunk_vector_counts(&format!("d{i}"))
+                    .unwrap()
+                    .0
+                    > 0
+            })
+            .count();
+        assert_eq!(covered, 2, "exactly cap-many docs are indexed in one run");
+        assert_eq!(
+            state.db.note_chunk_count("m1").unwrap(),
+            0,
+            "the meeting half gets no leftover budget in run 1"
+        );
+
+        // RUN 2: resumes with the remaining two docs (the needs-probe skips the covered ones).
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            2,
+        )
+        .unwrap();
+        assert_eq!((m, d), (0, 2), "run 2 continues from where run 1 stopped");
+
+        // RUN 3: docs covered → the leftover budget finally reaches the meeting half.
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            2,
+        )
+        .unwrap();
+        assert_eq!((m, d), (1, 0), "run 3 indexes the meeting with the freed budget");
+        assert!(state.db.note_chunk_count("m1").unwrap() > 0);
+
+        // RUN 4: full coverage ⇒ a no-op (idempotence preserved under the cap).
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            2,
+        )
+        .unwrap();
+        assert_eq!((m, d), (0, 0), "a capped tick still converges to the no-op");
+    }
+
+    /// Fix 3c (RED-before-GREEN): a row that yields NOTHING (an empty-bodied note produces zero
+    /// chunks, forever) must neither consume the per-run cap nor count as backfilled work —
+    /// otherwise a vault with permanently-empty rows re-burns the cap on every launch and the
+    /// tail of REAL missing rows behind them never gets indexed. Pre-fix every attempted row was
+    /// counted: RED.
+    #[test]
+    fn repair_tick_zero_yield_rows_never_consume_the_cap() {
+        let state = build_state("repair-tick-zero-yield");
+        make_open_folder(&state.db, "f-open", "Team");
+        // Oldest row first: an EMPTY note (zero chunks forever), then a real doc behind it.
+        state
+            .db
+            .insert_note("n-empty", "f-open", "empty", "Empty", "", 1)
+            .unwrap();
+        state
+            .db
+            .insert_document("d-real", "f-open", "doc.md", "real doc body paragraph", "document", 2)
+            .unwrap();
+
+        // Cap 1: the empty note is probed first but yields nothing — the ONE budget slot must
+        // still reach the real doc behind it.
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            1,
+        )
+        .unwrap();
+        assert_eq!((m, d), (0, 1), "only the REAL doc counts as backfilled work");
+        assert!(
+            state.db.doc_chunk_vector_counts("d-real").unwrap().0 > 0,
+            "the real doc got the cap slot despite the zero-yield row ahead of it"
+        );
+
+        // Re-run: the empty row is re-probed (still zero-yield) — never counted, so the tick
+        // reports the honest no-op.
+        let (m, d) = backfill_missing_brain_indexes_capped(
+            &state.db,
+            true,
+            true,
+            &crate::embed::StubEmbedder,
+            1,
+        )
+        .unwrap();
+        assert_eq!((m, d), (0, 0), "zero-yield rows are not 'work' — the re-run is a no-op");
     }
 
     /// RELOCK re-purges the freshly-rebuilt meeting chunks: a lock → unlock (re-index) → relock cycle

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5317,8 +5317,11 @@ impl Db {
         embedder: Option<&dyn Embedder>,
     ) -> Result<()> {
         let chunks = crate::embed::chunk_note(title, "", body);
+        // Sub-batch to bound the per-call Metal tensor for a long note (mirror
+        // index_meeting_chunks/index_document_chunks — this indexer was the one remaining
+        // whole-item single-call embed, brain-v3 audit H3).
         let vectors = match embedder {
-            Some(e) if !chunks.is_empty() => e.embed_passage(&chunks)?,
+            Some(e) if !chunks.is_empty() => embed_in_sub_batches(e, &chunks)?,
             _ => Vec::new(), // model absent → chunk-only (FTS still covers it); vectors come later.
         };
         let this_doc = [note_id.to_string()];


### PR DESCRIPTION
PR-0 of the brain-v3 audit-fix program (audit report included: docs/research/2026-07-18-brain-v3-audit.md, ≈7.3/10, 32 adversarially-verified findings).

## Fixes (3 verified findings)
- **[HIGH] update_note_doc bypassed the heavy-inference permit + sub-batching** — the authored-note save path ran Candle/Metal embedding + the semantic-link pass synchronously on the async runtime (the co-residency + unbounded-Metal-tensor classes PR-1 #362 fixed on its meeting twin). Now the whole inner routes through perf::run_heavy and index_note_chunks embeds via embed_in_sub_batches (≤8/call).
- **[MED] update_note_inner_with held the GLOBAL lifecycle mutex across the multi-second re-embed** — delaying screen-share auto-relock and every lock op. The guard now drops after the fast leg (gate + seal-on-write + vault export + DTO read); race-safety = the in-tx sealed-at-rest re-checks in every chunk indexer (precedent: rename_meeting_inner). Same treatment applied to the note twin.
- **[MED] the startup repair tick had no per-run cap/pacing** (its sibling gained cap-50 + 50ms pacing after the 2026-07-13 launch freeze) — now one 50-op budget across the doc+meeting halves, pacing after each real op, zero-yield rows never spend the cap.
- Hygiene: .gitignore meetnotes.db / *.sqlite* (stray PII-bearing dev DB).

## How verified
- cargo test --lib **1883/0** (+6 new RED-proven regressions — each first failed against the unfixed logic), clippy --lib --tests -D warnings clean.
- **adversarial-verifier PASS** — re-proved RED via targeted reverts (sub-batch, guard-drop, cap accounting), attacked the export/DTO reorder (heavy leg writes nothing the .md/DTO reads), findings LOW/INFO only.
- **lock-security-reviewer PASS** — in-tx sealed-at-rest re-checks confirmed for every writer reachable from the released leg; the known link-writer TOCTOU window is bounded (id+score rows, both-endpoint-gated readers, startup reconcile) and its closure is a binding condition on the upcoming seal-cycle PR.

Real-Mac note: actual auto-relock latency + launch smoothing under real Metal load need the dev app / a signed build.