### PR TITLE
fix(receipts): front-matter skip, negation-polarity veto, honest copy + confidence tiers, one-shot seek

### DIFF
--- a/e2e/detail/receipts.spec.ts
+++ b/e2e/detail/receipts.spec.ts
@@ -8,30 +8,40 @@ import { mockTauri } from "../settings-ai/mock-invoke";
  * REAL Angular bundle (only the Tauri IPC boundary is mocked) to prove the
  * user-facing claim the adversarial verifier flagged as absent dead code:
  *
- *   - a receipt chip renders in the Note tab for each aligned claim,
+ *   - a receipt chip renders in the Note tab for each aligned BODY claim (a
+ *     YAML front-matter line never chips, even if a stale backend aligns one),
+ *   - the copy is honest: likely-source phrasing, ASR confidence as a TIER in
+ *     the tooltip (never the raw float), h:mm:ss timestamps above 60 min,
  *   - clicking it switches to the Audio tab, seeks the player to the claim's
- *     second, and FLASHES the proving transcript segment (`.frag.is-flash`).
+ *     second, and FLASHES the likely-source transcript segment
+ *     (`.frag.is-flash`),
+ *   - the seek is consumed ONE-SHOT (no replay on an Audio-tab revisit) while a
+ *     repeat click on the SAME chip still re-fires (the `seq` re-arm).
  *
  * RED contract (fails on commit 43b7926, the unwired state): `getNoteReceipts`
  * had zero callers, `note-panel` had no `[receipts]` input and rendered no chip,
  * and `audio-panel` had no `[seekTarget]` input driving the flash — so the
  * `.receipt-chip` below never existed and the click had nothing to drive.
+ * The PR-7 honesty assertions each failed RED on the pre-fix code too (bogus
+ * front-matter chip, "Click to hear the moment this was said", raw-float-less
+ * tier absent, "125:27", and the stale flash replay on revisit).
  */
 test.describe("Detail — Receipts (claim → second of audio)", () => {
   test("a note claim's receipt chip seeks the Audio tab and flashes its segment", async ({
     page,
   }) => {
     await mockTauri(page, {
-      // A meeting whose note has ONE claim line that the transcript proves.
+      // A meeting whose note has TWO claim lines the transcript proves — one
+      // early (2:00) and one past the hour mark (2:05:27, the h:mm:ss form).
       // The mocked `get_note_receipts` mirrors the backend's shape: an alignment
-      // for that claim (claimIndex into `markdown.split('\n')`) → segment idx 1.
+      // per claim (claimIndex into `markdown.split('\n')`).
       get_meeting_detail: () => ({
         meeting: {
           id: "m-receipts",
           startedAt: "2026-07-01T09:00:00Z",
-          endedAt: "2026-07-01T09:10:00Z",
+          endedAt: "2026-07-01T11:10:00Z",
           title: "Receipts meeting",
-          durationS: 600,
+          durationS: 7800,
           audioPath: null,
           status: "EXPORTED",
           folderId: null,
@@ -39,9 +49,9 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
         note: {
           meetingId: "m-receipts",
           providerId: "claude_code",
-          // Line 0 heading, line 1 blank, line 2 the claim (matches segment 1).
+          // Lines 0..=3 YAML front-matter, 4 heading, 5 blank, 6 + 7 the claims.
           markdown:
-            "## Decisions\n\nWe will ship the redaction firewall next sprint.",
+            "---\ntitle: Receipts meeting\nattendees: Anna, Bob\n---\n## Decisions\n\nWe will ship the redaction firewall next sprint.\nThe infra migration wrapped up late in the session.",
           exportedPath: null,
         },
         segments: [
@@ -59,6 +69,13 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
             text: "We will ship the redaction firewall next sprint.",
             speaker: "me",
           },
+          {
+            idx: 2,
+            startS: 7527,
+            endS: 7560,
+            text: "The infra migration wrapped up late in the session.",
+            speaker: "others",
+          },
         ],
         assistantInteractions: [],
         locked: false,
@@ -66,7 +83,16 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
         aiModel: null,
         modelServed: null,
       }),
-      // The gated receipt read. Line index 2 = the claim; segment idx 1 at 120s.
+      // The Audio tab's side reads, with their REAL backend shapes (serde gives
+      // `[]`/`false`, never undefined — the base mock's undefined fallback made
+      // the timeline's `suggestionByLabel` computed throw "not iterable" during
+      // CD on the revisit, killing rendering for the rest of the test).
+      timeline_generation_on_device: () => false,
+      suggest_speaker_labels: () => [],
+      // The gated receipt read. A confident (0.92 → "audio: clear") receipt at
+      // 2:00 and a shaky (0.4 → "audio: unclear") one past the hour mark — PLUS
+      // a bogus alignment pointing at the `attendees:` FRONT-MATTER line (a
+      // stale/older backend could emit one): the FE must never chip it.
       get_note_receipts: () => [
         {
           claimIndex: 2,
@@ -74,24 +100,56 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
           startS: 120,
           endS: 150,
           speaker: "me",
+          confidence: 0.9,
+          overlap: 0.8,
+        },
+        {
+          claimIndex: 6,
+          segmentId: 1,
+          startS: 120,
+          endS: 150,
+          speaker: "me",
           confidence: 0.92,
           overlap: 0.85,
+        },
+        {
+          claimIndex: 7,
+          segmentId: 2,
+          startS: 7527,
+          endS: 7560,
+          speaker: "others",
+          confidence: 0.4,
+          overlap: 0.8,
         },
       ],
     });
 
     await page.goto("/meeting/m-receipts");
 
-    // The Note tab is the default: the receipt chip renders, labelled with the
-    // claim snippet + speaker + m:ss timestamp.
+    // The Note tab is the default: ONLY the two body claims chip (the bogus
+    // front-matter alignment is dropped), labelled with the claim snippet +
+    // speaker + timestamp. The hint uses likely-source phrasing (never the
+    // over-claiming "the moment this was said").
     const chip = page.locator("button.receipt-chip");
-    await expect(chip).toHaveCount(1, { timeout: 10_000 });
-    await expect(chip).toContainText("redaction firewall");
-    await expect(chip).toContainText("Me");
-    await expect(chip).toContainText("2:00");
+    await expect(chip).toHaveCount(2, { timeout: 10_000 });
+    await expect(page.locator("button.receipt-chip", { hasText: "attendees" })).toHaveCount(0);
+    await expect(page.locator(".receipts-hint")).toHaveText(
+      "Jump to the likely source in the audio",
+    );
+    await expect(chip.first()).toContainText("redaction firewall");
+    await expect(chip.first()).toContainText("Me");
+    await expect(chip.first()).toContainText("2:00");
 
-    // Clicking it switches to the Audio tab (its panel is now mounted).
-    await chip.click();
+    // ASR confidence surfaces as a TIER in the tooltip — never the raw float.
+    await expect(chip.first()).toHaveAttribute("title", /audio: clear/);
+    await expect(chip.first()).not.toHaveAttribute("title", /0\.92/);
+    await expect(chip.nth(1)).toHaveAttribute("title", /audio: unclear/);
+
+    // Above 60 min the timestamp is h:mm:ss (7527s = 2:05:27), never "125:27".
+    await expect(chip.nth(1)).toContainText("2:05:27");
+
+    // Clicking a chip switches to the Audio tab (its panel is now mounted).
+    await chip.first().click();
     await expect(page.getByRole("tab", { name: "Audio" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -101,6 +159,26 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
     const flashed = page.locator(".frag.is-flash");
     await expect(flashed).toHaveCount(1, { timeout: 10_000 });
     await expect(flashed).toContainText("redaction firewall");
+
+    // ONE-SHOT consumption: leaving the Audio tab and returning must NOT replay
+    // the consumed seek — no stale flash on the recreated panel.
+    await page.getByRole("tab", { name: "Note" }).click();
+    await page.getByRole("tab", { name: "Audio" }).click();
+    await expect(page.locator(".frag").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator(".frag.is-flash")).toHaveCount(0);
+
+    // …but a REPEAT CLICK on the SAME chip still re-fires (the seq re-arm).
+    await page.getByRole("tab", { name: "Note" }).click();
+    await chip.first().click();
+    await expect(page.getByRole("tab", { name: "Audio" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.locator(".frag.is-flash")).toHaveCount(1, {
+      timeout: 10_000,
+    });
   });
 
   test("a locked meeting surfaces NO receipt chips (backend returns none)", async ({

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2744,8 +2744,9 @@ pub(crate) fn get_note_receipts_inner(
     };
     let segments = state.db.get_segments(meeting_id)?;
     // `claim_index` refers to the RAW markdown lines (`markdown.split('\n')`) the FE renders, so a
-    // chip maps straight back to its note line. `align_claims_to_segments` itself skips
-    // front-matter/headings/blockquotes/etc., so passing every line is safe.
+    // chip maps straight back to its note line. `align_claims_to_segments` skips a leading YAML
+    // front-matter block BY INDEX (metadata like `attendees:` never earns a receipt) plus headings/
+    // blockquotes/fences/etc., so passing every raw line is safe and indices keep this numbering.
     let lines: Vec<&str> = note.markdown.split('\n').collect();
     let receipts = crate::summarize::grounding::align_claims_to_segments(&lines, &segments);
     tracing::debug!(

--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -219,38 +219,51 @@ pub struct ClaimAlignment {
 /// Deterministically align each candidate note line to the transcript segment it most likely derives
 /// from, by normalized content-token overlap (the SAME `content_tokens` math the grounding pass uses).
 ///
-/// - `note_lines`: the note body lines (front-matter already split off by the caller is fine — this
-///   fn also skips headings / code fences / blockquotes / wikilink-only / protected sections / too-
-///   short lines itself, so a claim index always refers to a REAL claim line and never a heading).
+/// - `note_lines`: the note's RAW lines are fine — a LEADING `---` YAML front-matter block is
+///   skipped here (metadata like `title:`/`attendees:` is never a claim, even when the attendees'
+///   names are spoken), and this fn also skips headings / code fences / blockquotes / wikilink-only
+///   / protected sections / too-short lines itself. Skipping (not re-slicing) keeps every emitted
+///   `claim_index` in the ORIGINAL numbering of the passed lines.
 /// - For each candidate line: score overlap against every non-empty, non-assistant-directed segment;
 ///   pick the segment with the MOST overlapping distinct content tokens (ties → the EARLIEST segment,
 ///   for determinism); emit a [`ClaimAlignment`] iff `overlapping / claim_tokens >= RECEIPT_MIN_OVERLAP`.
 /// - Below threshold ⇒ NO entry for that line (a paraphrased LLM line the transcript doesn't clearly
 ///   support gets no — possibly wrong — receipt).
+/// - POLARITY VETO: a segment whose negator presence mismatches the claim's (see
+///   [`NEGATOR_TOKENS`]) can never be its receipt — "we will NOT ship X" must not "prove"
+///   "we will ship X" just because "not" is a stopword.
 ///
 /// Pure: no DB, no clock, no LLM, no I/O. Deterministic: same inputs ⇒ byte-identical output.
 pub fn align_claims_to_segments(note_lines: &[&str], segments: &[Segment]) -> Vec<ClaimAlignment> {
-    // Per-segment content-token set, keeping the segment's audio coordinates + metadata. Filtered
-    // with the IDENTICAL predicate as the grounding pass (drop empty + assistant-directed spans — an
-    // assistant command is not transcript evidence to point a receipt at).
-    let seg_index: Vec<(HashSet<String>, &Segment)> = segments
+    // Per-segment content-token set + negator flag, keeping the segment's audio coordinates +
+    // metadata. Filtered with the IDENTICAL predicate as the grounding pass (drop empty +
+    // assistant-directed spans — an assistant command is not transcript evidence to point a
+    // receipt at).
+    let seg_index: Vec<(HashSet<String>, bool, &Segment)> = segments
         .iter()
         .filter(|s| {
             let t = s.text.trim();
             !t.is_empty() && !crate::audio::wake::is_assistant_directed(t)
         })
-        .map(|s| (content_tokens(&s.text), s))
+        .map(|s| (content_tokens(&s.text), has_negator(&s.text), s))
         .collect();
 
     if seg_index.is_empty() {
         return Vec::new();
     }
 
+    // A leading YAML front-matter block is metadata, never a claim. Skipped by index (not
+    // re-sliced) so claim indices keep the original numbering the FE renders.
+    let fm_end = frontmatter_end(note_lines);
+
     let mut out: Vec<ClaimAlignment> = Vec::new();
     let mut in_code_fence = false;
     let mut in_skipped_section = false;
 
     for (i, &line) in note_lines.iter().enumerate() {
+        if i < fm_end {
+            continue;
+        }
         let trimmed = line.trim();
 
         // Code fences: toggle state; never a claim.
@@ -284,11 +297,20 @@ pub fn align_claims_to_segments(note_lines: &[&str], segments: &[Segment]) -> Ve
             continue;
         }
 
+        let claim_negated = has_negator(unit);
+
         // Best-matching segment = most overlapping distinct content tokens; ties → EARLIEST (first
-        // wins because we only replace on a STRICTLY greater overlap). Deterministic.
+        // wins because we only replace on a STRICTLY greater overlap). Deterministic. A candidate
+        // whose negator presence mismatches the claim's is VETOED outright (it can never be the
+        // receipt) — negators are stopwords, so without this a claim and its negation are
+        // token-identical and a receipt could "prove" the opposite of what was said. A
+        // polarity-CONSISTENT weaker segment may still win.
         let mut best_overlap = 0usize;
         let mut best: Option<&Segment> = None;
-        for (seg_toks, seg) in &seg_index {
+        for (seg_toks, seg_negated, seg) in &seg_index {
+            if *seg_negated != claim_negated {
+                continue;
+            }
             let overlap = toks.iter().filter(|t| seg_toks.contains(*t)).count();
             if overlap > best_overlap {
                 best_overlap = overlap;
@@ -323,6 +345,45 @@ fn content_tokens(s: &str) -> HashSet<String> {
         .into_iter()
         .filter(|t| !is_stopword(t))
         .collect()
+}
+
+/// Negator tokens for the receipts polarity veto — a deterministic, documented HEURISTIC used by
+/// the receipts pass ONLY (retrieval's tokenizer/stopwords are untouched). Standalone EN + PL
+/// forms; the EN contractions (can't / won't / don't / doesn't / didn't / isn't / aren't / wasn't
+/// / wouldn't / shouldn't) are covered by the `n't` substring scan in [`has_negator`], because
+/// `tokenize` splits on the apostrophe (`won't` → `won`,`t`) so no listed token could ever match
+/// them — and their stems (`won`, `can`) are common affirmative words we must not flag.
+const NEGATOR_TOKENS: &[&str] = &[
+    // English
+    "not", "no", "never", "none", "cannot",
+    // Polish
+    "nie", "nigdy", "żaden", "żadna", "żadne", "bez",
+];
+
+/// Whether `text` carries at least one negator: an `n't` contraction (ASCII or typographic
+/// apostrophe) in the raw lowercased text, or a [`NEGATOR_TOKENS`] token. Pure + deterministic.
+fn has_negator(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    if lower.contains("n't") || lower.contains("n’t") {
+        return true;
+    }
+    tokenize(text)
+        .iter()
+        .any(|t| NEGATOR_TOKENS.contains(&t.as_str()))
+}
+
+/// The number of leading lines occupied by a YAML front-matter block (a `---` fence on line 0
+/// through the closing `---`), or 0 when there is none. Mirrors [`split_frontmatter`]'s semantics
+/// over a pre-split line slice, including the conservative unterminated case (an opened-but-never-
+/// closed block makes EVERY line front-matter — never chip a line we cannot prove is body).
+fn frontmatter_end(lines: &[&str]) -> usize {
+    if lines.first().copied() != Some("---") {
+        return 0;
+    }
+    match lines[1..].iter().position(|l| *l == "---") {
+        Some(close) => close + 2, // fence line 0 + offset into the tail + the closing fence
+        None => lines.len(),
+    }
 }
 
 /// Strip a leading list / checklist / numbered marker from a trimmed line so the marker glyphs
@@ -777,6 +838,155 @@ mod tests {
         assert!(
             align_claims_to_segments(&lines, &cmd).is_empty(),
             "assistant-directed spans are not transcript evidence for a receipt"
+        );
+    }
+
+    /// RED-before-GREEN (audit MED, front-matter receipts): YAML front-matter lines (`title:`,
+    /// `attendees:`) are METADATA, not claims — even when the attendees' names are spoken in the
+    /// meeting they must never earn a receipt chip. Before the fix the walk treated every raw line
+    /// as a claim, so `attendees: Anna, Bob, …` aligned to the segment that spoke those names.
+    /// The body claim's `claim_index` must keep the ORIGINAL note's line numbering (the FE maps it
+    /// straight into `markdown.split('\n')`).
+    #[test]
+    fn frontmatter_lines_never_earn_receipts() {
+        let segments = vec![seg_full(
+            1,
+            10.0,
+            16.0,
+            "me",
+            Some(0.9),
+            "anna and bob agreed the quarterly budget review is approved",
+        )];
+        // Raw note exactly as the FE renders it: lines 0..=3 are the front-matter block,
+        // line 5 the heading, line 7 the real claim.
+        let note = "---\ntitle: Budget sync\nattendees: Anna, Bob, quarterly budget\n---\n\n## Summary\n\nAnna and Bob approved the quarterly budget review.";
+        let lines: Vec<&str> = note.split('\n').collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert!(
+            out.iter().all(|a| a.claim_index > 3),
+            "front-matter lines (0..=3) must never earn a receipt; got:\n{out:?}"
+        );
+        assert_eq!(
+            out.len(),
+            1,
+            "the real body claim still earns its receipt; got:\n{out:?}"
+        );
+        assert_eq!(
+            out[0].claim_index, 7,
+            "claim_index keeps the ORIGINAL note's line numbering"
+        );
+    }
+
+    /// Conservative unterminated front-matter (mirrors `split_frontmatter`): a note that OPENS a
+    /// `---` block and never closes it is all metadata — no receipts, rather than chipping lines
+    /// we cannot prove are body.
+    #[test]
+    fn unterminated_frontmatter_yields_no_receipts() {
+        let segments = vec![seg_full(
+            1,
+            0.0,
+            5.0,
+            "me",
+            None,
+            "anna and bob agreed the quarterly budget review is approved",
+        )];
+        let note = "---\ntitle: Budget sync\nAnna and Bob approved the quarterly budget review.";
+        let lines: Vec<&str> = note.split('\n').collect();
+        assert!(
+            align_claims_to_segments(&lines, &segments).is_empty(),
+            "an unterminated front-matter block must yield no receipts"
+        );
+    }
+
+    /// RED-before-GREEN (audit MED, negation-blind alignment fails UNSAFE): "not" is a stopword,
+    /// so a claim and its negation are token-identical — before the veto, the affirmative claim
+    /// "we will ship X in May" earned a receipt from the segment "we will NOT ship X in May",
+    /// i.e. the receipt "proved" the opposite of what was said. Polarity mismatch ⇒ no receipt.
+    #[test]
+    fn negation_mismatch_vetoes_the_receipt() {
+        let segments = vec![seg_full(
+            2,
+            33.0,
+            37.0,
+            "others",
+            Some(0.9),
+            "we will not ship the billing exporter in May",
+        )];
+        let lines: Vec<&str> = "We will ship the billing exporter in May."
+            .split('\n')
+            .collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert!(
+            out.is_empty(),
+            "a negated segment must never receipt an affirmative claim; got:\n{out:?}"
+        );
+    }
+
+    /// Symmetric polarity is ALLOWED: when the claim and the segment are BOTH negated, the claim
+    /// faithfully reports the negation and the receipt stands — proves the veto is a MISMATCH
+    /// check, not a blanket negation blocklist.
+    #[test]
+    fn matching_negation_on_both_sides_keeps_the_receipt() {
+        let segments = vec![seg_full(
+            2,
+            33.0,
+            37.0,
+            "others",
+            Some(0.9),
+            "we will not ship the billing exporter in May",
+        )];
+        let lines: Vec<&str> = "We will not ship the billing exporter in May."
+            .split('\n')
+            .collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert_eq!(
+            out.len(),
+            1,
+            "both-negated claim+segment must still align; got:\n{out:?}"
+        );
+        assert_eq!(out[0].segment_id, 2);
+    }
+
+    /// RED-before-GREEN (contraction negators): `tokenize` splits on the apostrophe (`won't` →
+    /// `won`,`t`), so contraction negators can never match a token list — the veto must scan the
+    /// RAW text for the `n't` form. An affirmative claim vs a "won't" segment gets no receipt.
+    #[test]
+    fn contraction_negator_mismatch_vetoes_the_receipt() {
+        let segments = vec![seg_full(
+            3,
+            50.0,
+            55.0,
+            "me",
+            None,
+            "we won't renew the vendor contract this quarter",
+        )];
+        let lines: Vec<&str> = "We will renew the vendor contract this quarter."
+            .split('\n')
+            .collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert!(
+            out.is_empty(),
+            "a contraction-negated segment must never receipt an affirmative claim; got:\n{out:?}"
+        );
+    }
+
+    /// The Polish negator list binds too: "nigdy nie wdrożymy …" must not receipt the affirmative
+    /// "wdrożymy …" claim ("nie" is a PL stopword, so without the veto they are token-compatible).
+    #[test]
+    fn polish_negator_mismatch_vetoes_the_receipt() {
+        let segments = vec![seg_full(
+            5,
+            60.0,
+            66.0,
+            "me",
+            None,
+            "nigdy nie wdrożymy tego eksportu faktur w maju",
+        )];
+        let lines: Vec<&str> = "Wdrożymy eksport faktur w maju.".split('\n').collect();
+        let out = align_claims_to_segments(&lines, &segments);
+        assert!(
+            out.is_empty(),
+            "a PL-negated segment must never receipt an affirmative claim; got:\n{out:?}"
         );
     }
 }

--- a/src/app/features/detail/audio-panel/audio-panel.component.ts
+++ b/src/app/features/detail/audio-panel/audio-panel.component.ts
@@ -115,6 +115,15 @@ export class AudioPanelComponent {
   readonly pin = output<number>();
   /** Rename a timeline speaker lane. */
   readonly renameSpeaker = output<{ oldLabel: string; newLabel: string }>();
+  /**
+   * The pending receipt seek was APPLIED (carries its `seq`): the shell clears
+   * `seekTarget` on this ack, making consumption ONE-SHOT — without it the
+   * still-set input replays the seek + flash every time the Audio tab is
+   * revisited (this panel is recreated per `@switch` case, so the mount effect
+   * re-fires on a stale target). Repeat clicks on the SAME chip still work: the
+   * note panel bumps `seq` per click, so a fresh target always arrives.
+   */
+  readonly seekConsumed = output<number>();
 
   // --- Audio playback state (driven by the <audio> event bindings) --------
   private readonly audio = viewChild<ElementRef<HTMLAudioElement>>("player");
@@ -305,8 +314,11 @@ export class AudioPanelComponent {
    * on the exact line that proves the claim. Tracks `seq` (bumped by the shell)
    * so re-clicking the SAME receipt re-arms; `flashSeq` re-arms the pure-CSS
    * animation when the SAME segment is receipted twice (a net-zero `flashSegId`
-   * write wouldn't restart it). Legitimate signal-writing effect (T1): it
-   * reacts to an input and drives the player — no async fetch, no stale race.
+   * write wouldn't restart it). Consumption is ONE-SHOT: after applying, the
+   * effect acks via `seekConsumed` so the shell nulls the input — a later
+   * Audio-tab revisit (a fresh panel instance) must not replay the seek/flash.
+   * Legitimate signal-writing effect (T1): it reacts to an input and drives the
+   * player — no async fetch, no stale race.
    */
   private readonly _applyReceiptSeek = effect(() => {
     const target = this.seekTarget();
@@ -318,6 +330,9 @@ export class AudioPanelComponent {
     this.seekTo(target.startS); // (also clears any prior flash)
     this.flashSegId.set(target.segId);
     this.flashSeq.update((n) => n + 1);
+    // Ack consumption (the shell nulls `seekTarget`; the flash/karaoke state
+    // above is panel-local and survives — only the REPLAY trigger is retired).
+    this.seekConsumed.emit(target.seq);
     // Restart the pure-CSS pulse deterministically (a repeat of the SAME segment
     // keeps the `.is-flash` class, so the animation wouldn't retrigger on its own)
     // and bring the flashed fragment into view. One-shot, zoneless-safe: no timer.

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -333,6 +333,7 @@
             (generateTimeline)="generateTimeline()"
             (pin)="onPin($event)"
             (renameSpeaker)="onRenameSpeaker($event)"
+            (seekConsumed)="onSeekConsumed($event)"
           />
         }
         @case ("share") {

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -363,7 +363,9 @@ export class DetailComponent implements OnInit {
    * panel is (re)created for the Audio `@switch` case, so a viewChild method call
    * from the Note tab would hit a not-yet-existing instance — instead we pass the
    * target as an INPUT the panel applies on mount. `seq` (bumped per click) makes
-   * a repeat click on the same receipt re-fire the panel effect. Null when idle.
+   * a repeat click on the same receipt re-fire the panel effect. Null when idle
+   * AND after the panel acks consumption (`onSeekConsumed`) — a consumed target
+   * must not replay on the next Audio-tab visit.
    */
   readonly seekTarget = signal<{
     startS: number;
@@ -477,6 +479,20 @@ export class DetailComponent implements OnInit {
       replaceUrl: true,
     });
   });
+
+  /**
+   * The audio panel APPLIED the pending receipt seek: clear it so a later
+   * Audio-tab revisit (which recreates the panel) never replays the consumed
+   * seek/flash. The seq match guards the (theoretical) race where a newer chip
+   * click landed between the panel applying and this ack — the newer target
+   * survives to be applied. Repeat clicks on the SAME chip keep working: the
+   * note panel bumps `seq` per click, so a fresh non-null target always arrives.
+   */
+  onSeekConsumed(seq: number): void {
+    if (this.seekTarget()?.seq === seq) {
+      this.seekTarget.set(null);
+    }
+  }
 
   // --- Phase 5 model-provenance badge -------------------------------------
   /**

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -292,16 +292,18 @@
           </article>
         }
 
-        <!-- RECEIPTS (Brain v3 PR-5): every claim the transcript proves →
-             a chip that seeks the Audio tab to that second + flashes the
-             segment. Empty (nothing rendered) for a locked meeting (the
-             backend returns no receipts) or a note with no aligned claim. -->
+        <!-- RECEIPTS (Brain v3 PR-5): every claim the transcript likely
+             supports → a chip that seeks the Audio tab to that second +
+             flashes the segment. The alignment is a token-overlap HEURISTIC,
+             so the copy says "likely source", never "proof". Empty (nothing
+             rendered) for a locked meeting (the backend returns no receipts)
+             or a note with no aligned claim. -->
         @if (receiptChips().length) {
           <article class="card receipts" aria-label="Audio receipts">
             <div class="receipts-head">
               <span class="section-label">Receipts</span>
               <span class="count">{{ receiptChips().length }}</span>
-              <span class="receipts-hint">Click to hear the moment this was said</span>
+              <span class="receipts-hint">Jump to the likely source in the audio</span>
             </div>
             <ul class="receipt-list">
               @for (r of receiptChips(); track r.claimIndex) {
@@ -309,7 +311,7 @@
                   <button
                     type="button"
                     class="receipt-chip"
-                    [attr.title]="'Play ' + r.time + (r.speaker ? ' · ' + r.speaker : '')"
+                    [attr.title]="r.title"
                     (click)="onReceipt(r)"
                   >
                     <span class="receipt-play" aria-hidden="true">▸</span>

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -56,12 +56,17 @@ export interface ParsedNote {
  * `segId`/`startS`/`seq` drive the audio panel's flash + seek.
  */
 export interface ReceiptChip {
-  /** Short label of the claim line this receipt proves. */
+  /** Short label of the claim line this receipt likely derives from. */
   claim: string;
   /** "Me" / "Others" / "" — from the segment speaker. */
   speaker: string;
-  /** m:ss timestamp of the segment start. */
+  /** m:ss (h:mm:ss above 60 min) timestamp of the segment start. */
   time: string;
+  /**
+   * The full tooltip: likely-source phrasing + timestamp + speaker + the ASR
+   * confidence TIER ("audio: clear" / "audio: unclear" — never the raw float).
+   */
+  title: string;
   /** The segment start in raw seconds (the player seek target). */
   startS: number;
   /** `Segment.idx` to flash in the transcript. */
@@ -71,6 +76,16 @@ export interface ReceiptChip {
   /** Monotonic id so the parent can re-fire a repeat click on the same chip. */
   seq: number;
 }
+
+/**
+ * ASR-confidence tier bounds for the receipt tooltip: at/above `CLEAR` the audio
+ * was decoded confidently ("audio: clear"), below `UNCLEAR` it was acoustically
+ * shaky ("audio: unclear" — the backend's `LOW_CONFIDENCE_P` operating point),
+ * and the band between renders NOTHING (no over-claiming either way). The raw
+ * float never reaches the UI.
+ */
+const RECEIPT_AUDIO_CLEAR_MIN = 0.8;
+const RECEIPT_AUDIO_UNCLEAR_MAX = 0.55;
 
 /** One grounding citation, split into vault vs web shapes for rendering. */
 export interface ParsedCitation {
@@ -239,9 +254,12 @@ export class NotePanelComponent {
   /**
    * The receipts decorated for display: each aligned claim → a chip labelled with
    * a snippet of the claim line (from the raw markdown at `claimIndex`) + the
-   * speaker + m:ss timestamp of the proving segment. A receipt whose `claimIndex`
-   * is out of range (a stale note vs a just-recomputed alignment) is dropped so a
-   * chip never shows a wrong/blank claim. Pure `computed` (no template method).
+   * speaker + timestamp of the likely-source segment. A receipt whose `claimIndex`
+   * is out of range (a stale note vs a just-recomputed alignment) OR points into
+   * the YAML front-matter (metadata like `attendees:` is never a claim — the
+   * backend skips it too; this is defense-in-depth against a stale/older backend)
+   * is dropped so a chip never shows a wrong/blank/metadata claim. Pure
+   * `computed` (no template method).
    */
   readonly receiptChips = computed<ReceiptChip[]>(() => {
     const raw = this.noteRaw();
@@ -249,17 +267,24 @@ export class NotePanelComponent {
       return [];
     }
     const lines = raw.split("\n");
+    const fmEnd = this.frontmatterEnd(lines);
     const out: ReceiptChip[] = [];
     for (const r of this.receipts()) {
+      if (r.claimIndex < fmEnd) {
+        continue; // front-matter line ⇒ never a chip
+      }
       const line = lines[r.claimIndex];
       const claim = line ? this.claimSnippet(line) : "";
       if (!claim) {
         continue; // out-of-range / non-content line ⇒ no chip
       }
+      const speaker = this.speakerLabel(r.speaker);
+      const time = this.fmtTime(r.startS);
       out.push({
         claim,
-        speaker: this.speakerLabel(r.speaker),
-        time: this.fmtTime(r.startS),
+        speaker,
+        time,
+        title: this.receiptTitle(time, speaker, r.confidence ?? null),
         startS: r.startS,
         segId: r.segmentId,
         claimIndex: r.claimIndex,
@@ -276,6 +301,45 @@ export class NotePanelComponent {
       segId: chip.segId,
       seq: ++this.receiptSeq,
     });
+  }
+
+  /**
+   * The number of leading lines occupied by a YAML front-matter block (`---`
+   * fence on line 0 through the closing `---`), or 0 when there is none. Mirrors
+   * the backend's `frontmatter_end` semantics, including the conservative
+   * unterminated case (an opened-but-never-closed block makes EVERY line
+   * front-matter — never chip a line we cannot prove is body).
+   */
+  private frontmatterEnd(lines: string[]): number {
+    if (lines[0] !== "---") {
+      return 0;
+    }
+    const close = lines.indexOf("---", 1);
+    return close === -1 ? lines.length : close + 1;
+  }
+
+  /**
+   * The chip tooltip: likely-source phrasing (an overlap heuristic, never a
+   * proof) + the ASR confidence rendered as a TIER — "audio: clear" at/above
+   * {@link RECEIPT_AUDIO_CLEAR_MIN}, "audio: unclear" below
+   * {@link RECEIPT_AUDIO_UNCLEAR_MAX}, nothing in the band between or when
+   * whisper computed no confidence. The raw float is never rendered.
+   */
+  private receiptTitle(
+    time: string,
+    speaker: string,
+    confidence: number | null,
+  ): string {
+    let title = `Likely source · ${time}`;
+    if (speaker) {
+      title += ` · ${speaker}`;
+    }
+    if (confidence !== null && confidence >= RECEIPT_AUDIO_CLEAR_MIN) {
+      title += " · audio: clear";
+    } else if (confidence !== null && confidence < RECEIPT_AUDIO_UNCLEAR_MAX) {
+      title += " · audio: unclear";
+    }
+    return title;
   }
 
   /** A short, marker-stripped snippet of a claim line for the chip label. */
@@ -304,11 +368,17 @@ export class NotePanelComponent {
     return "";
   }
 
-  /** Seconds → m:ss for the receipt timestamp. */
+  /** Seconds → m:ss, or h:mm:ss above 60 min (a 2h receipt is never "125:07"). */
   private fmtTime(s: number): string {
     const total = Math.max(0, Math.floor(s || 0));
-    const m = Math.floor(total / 60);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
     const sec = total % 60;
+    if (h > 0) {
+      return `${h}:${m.toString().padStart(2, "0")}:${sec
+        .toString()
+        .padStart(2, "0")}`;
+    }
     return `${m}:${sec.toString().padStart(2, "0")}`;
   }
 


### PR DESCRIPTION
PR-7 of the brain-v3 audit-fix program (audit: docs/research/2026-07-18-brain-v3-audit.md).

## Fixes (6 verified findings)
- **[MED] front-matter receipts** — align_claims_to_segments skips a leading YAML block by index (claim_index keeps the note's original line numbering); title:/attendees: lines can no longer earn bogus chips. FE receiptChips drops front-matter indices too (edge semantics verified to agree with the Rust side).
- **[MED] negation-blind alignment (fails UNSAFE)** — a candidate segment whose negator presence mismatches the claim (EN not/no/never/none/cannot + n't scan incl. curly apostrophe; PL nie/nigdy/żaden/…/bez) can never be the receipt, so a chip can no longer point at the second where the OPPOSITE was said. Per-candidate filter (a weaker polarity-consistent segment still wins); both-sides-negated allowed; receipts pass only. Fails safe; documented as a heuristic (recall edge flagged for the PR-10 calibration job).
- **[LOW] ASR confidence** — rendered as TIERS (audio: clear/unclear at 0.8/0.55) in the tooltip, never a raw float.
- **copy honesty** — the hint no longer overclaims: "Jump to the likely source in the audio".
- **[LOW] one-shot seek** — the audio panel acks the applied seek (seekConsumed) and detail clears the consumed target seq-guarded; an Audio-tab revisit no longer replays the stale seek, same-chip re-click still re-seeks.
- **[LOW]** receipt timestamps gain the hour form (h:mm:ss past 60 min).

## Verified
- cargo test --lib 1901/0 (+6 RED-proven regressions), clippy -D warnings clean, ng lint/build clean, receipts e2e 2/2 (private port).
- **adversarial-verifier PASS** — 3 independent RED reverts + 7 adversarial scratch probes (per-candidate veto semantics, Rust/FE front-matter edge agreement, mid-doc hr, one-shot replay).
- Rebased onto trunk 53a159e (post #372/#373); the detail.component.ts overlap with #373's route-seek resolved as a union — both funnel through onSeekReceipt→seekTarget→audio-panel→seekConsumed (one coherent pipeline). Post-rebase grounding suite + FE gates re-run green.

Signed-build residual: real-audio seek playback; tier thresholds 0.8/0.55 are placeholders pending PR-10 calibration.