### PR TITLE
fix(brain): hit-aligned parent expansion, packed L2 outline, char-safe leaf splitting

### DIFF
--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -624,8 +624,8 @@ pub fn chunk_note(title: &str, date: &str, markdown: &str) -> Vec<String> {
 //     chunks) — embedded + FTS (the RAPTOR collapsed-tree effect at ZERO LLM cost).
 // The contextual header extends the shipped `chunk_note` header mechanism (Anthropic contextual
 // retrieval): every embed-text is prefixed `"<name> | <section_path> | p.<N>"\n<raw>` so a chunk
-// carries its provenance into both the vector and the FTS legs, while the RAW text is kept separate
-// for snippet display.
+// carries its provenance into the VECTOR leg. The FTS leg indexes the RAW text only (see
+// `hier_embed_text` for why), and the RAW text is what snippet display serves.
 
 /// L1 section-parent cap (chars). Heading-bounded parents beyond this are truncated for the FTS/fetch
 /// row (the leaves under them still carry the full text).
@@ -680,8 +680,11 @@ fn hier_header(name: &str, section_path: Option<&str>, page_no: Option<u32>) -> 
     parts.join(" | ")
 }
 
-/// Prefix `raw` with the contextual header for embedding (the header rides the embedding AND the FTS
-/// text). A leaf with no header context embeds the raw text unchanged.
+/// Prefix `raw` with the contextual header for embedding. The header rides the VECTOR leg ONLY:
+/// `doc_chunks.text` (and therefore the external-content FTS index) stores the RAW text — repeating
+/// the doc name/section in every FTS row would inflate those terms' document frequency and distort
+/// bm25 ranking doc-wide, and changing it now would require a full FTS reindex. A leaf with no
+/// header context embeds the raw text unchanged.
 fn hier_embed_text(name: &str, section_path: Option<&str>, page_no: Option<u32>, raw: &str) -> String {
     let header = hier_header(name, section_path, page_no);
     if header.is_empty() {
@@ -691,30 +694,142 @@ fn hier_embed_text(name: &str, section_path: Option<&str>, page_no: Option<u32>,
     }
 }
 
-/// Greedily pack blank-line-separated paragraphs of `text` into ≤[`CHUNK_CHAR_TARGET`] leaf strings
-/// (the SAME sizing as `chunk_note`, minus the header — the header is added per-leaf later). A single
-/// oversized paragraph becomes its own leaf.
-fn pack_leaves(text: &str) -> Vec<String> {
-    let paragraphs: Vec<&str> = text
-        .split("\n\n")
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-        .collect();
+/// Greedily pack whole `lines` into chunks of ≤`target` CHARS (never split mid-line), order
+/// preserved, joined by `'\n'`. A single over-target line becomes its own chunk. Char-counted —
+/// never bytes — so multi-byte text packs to the same effective size as ASCII. Used for the L2
+/// outline (audit Fix 2: the old join-then-split-on-blank-lines path always yielded ONE unbounded
+/// chunk the embedder truncated at 512 tokens).
+fn pack_lines(lines: &[String], target: usize) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut cur = String::new();
-    for p in paragraphs {
-        if !cur.is_empty() && cur.len() + 1 + p.len() > CHUNK_CHAR_TARGET {
+    let mut cur_chars = 0usize;
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let n = line.chars().count();
+        if cur_chars > 0 && cur_chars + 1 + n > target {
             out.push(std::mem::take(&mut cur));
+            cur_chars = 0;
         }
-        if !cur.is_empty() {
+        if cur_chars > 0 {
             cur.push('\n');
+            cur_chars += 1;
         }
-        cur.push_str(p);
+        cur.push_str(line);
+        cur_chars += n;
     }
-    if !cur.is_empty() {
+    if cur_chars > 0 {
         out.push(cur);
     }
     out
+}
+
+/// Hard-split ONE over-`target` paragraph into ≤`target`-CHAR pieces (audit Fix 3: PDF extraction
+/// emits whole pages as a single blank-line-free paragraph, so without this the "800-char" leaves
+/// were routinely whole pages whose tails never reached the vector index). Each cut lands at the
+/// most natural boundary available inside the char window: the last single line break, else the
+/// last sentence end (ASCII terminator + whitespace, the [`first_sentence`] convention), else the
+/// last whitespace, else — truly unbroken text — a plain char-window cut. Every candidate cut is a
+/// char boundary (newline/whitespace byte positions and `char_indices` offsets), so multi-byte text
+/// never slices mid-codepoint.
+fn hard_split_paragraph(para: &str, target: usize) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut rest = para.trim();
+    while !rest.is_empty() {
+        if rest.chars().count() <= target {
+            out.push(rest.to_string());
+            break;
+        }
+        // Byte offset of the (target+1)-th char — the exclusive char-window cap, always a boundary.
+        let cap_byte = rest
+            .char_indices()
+            .nth(target)
+            .map(|(i, _)| i)
+            .unwrap_or(rest.len());
+        let window = &rest[..cap_byte];
+        let cut = window
+            .rfind('\n')
+            .or_else(|| last_sentence_end(window))
+            .or_else(|| window.rfind(char::is_whitespace))
+            .filter(|&i| i > 0)
+            .unwrap_or(cap_byte);
+        let piece = window[..cut].trim();
+        if !piece.is_empty() {
+            out.push(piece.to_string());
+        }
+        rest = rest[cut..].trim_start();
+    }
+    out
+}
+
+/// Byte offset just AFTER the last sentence terminator (`. ! ?` followed by ASCII whitespace) in
+/// `window`, or `None`. The returned offset points AT the whitespace byte — a char boundary.
+fn last_sentence_end(window: &str) -> Option<usize> {
+    let b = window.as_bytes();
+    (1..b.len())
+        .rev()
+        .find(|&i| matches!(b[i - 1], b'.' | b'!' | b'?') && b[i].is_ascii_whitespace())
+}
+
+/// Greedily pack paragraph `units` — each `(text, source-block page)` — into ≤[`CHUNK_CHAR_TARGET`]
+/// leaves (the same sizing idea as `chunk_note`, minus the header). Over-target units are
+/// hard-split FIRST ([`hard_split_paragraph`]) so no leaf ever exceeds the target; all counting is
+/// CHARS, never bytes (audit Fix 3). Each leaf carries the page of its FIRST contributing unit
+/// (audit Fix 4a: per-leaf page provenance for the embed header, instead of the section head's
+/// page stamped on every leaf).
+fn pack_leaves_paged(units: &[(String, Option<u32>)]) -> Vec<(String, Option<u32>)> {
+    let mut pieces: Vec<(String, Option<u32>)> = Vec::new();
+    for (text, page) in units {
+        let t = text.trim();
+        if t.is_empty() {
+            continue;
+        }
+        if t.chars().count() <= CHUNK_CHAR_TARGET {
+            pieces.push((t.to_string(), *page));
+        } else {
+            for p in hard_split_paragraph(t, CHUNK_CHAR_TARGET) {
+                pieces.push((p, *page));
+            }
+        }
+    }
+    let mut out: Vec<(String, Option<u32>)> = Vec::new();
+    let mut cur = String::new();
+    let mut cur_chars = 0usize;
+    let mut cur_page: Option<u32> = None;
+    for (p, page) in pieces {
+        let n = p.chars().count();
+        if cur_chars > 0 && cur_chars + 1 + n > CHUNK_CHAR_TARGET {
+            out.push((std::mem::take(&mut cur), cur_page));
+            cur_chars = 0;
+        }
+        if cur_chars == 0 {
+            cur_page = page;
+        } else {
+            cur.push('\n');
+            cur_chars += 1;
+        }
+        cur.push_str(&p);
+        cur_chars += n;
+    }
+    if cur_chars > 0 {
+        out.push((cur, cur_page));
+    }
+    out
+}
+
+/// Render one L2 outline line: `# {heading}: {sentence}` with the sentence CAPPED at `cap` chars
+/// (`0` → heading-only `# {heading}`); a heading-less section renders the capped sentence alone
+/// (possibly empty — the caller skips empties). Deterministic; the degradation ladder in
+/// [`chunk_document_hierarchical`] calls this with shrinking caps so EVERY section keeps a line.
+fn outline_line(path: Option<&str>, sentence: &str, cap: usize) -> String {
+    let s: String = sentence.chars().take(cap).collect();
+    match path {
+        Some(p) if s.trim().is_empty() => format!("# {p}"),
+        Some(p) => format!("# {p}: {s}"),
+        None => s,
+    }
 }
 
 /// The first sentence of `text` (up to the first `. ! ?` followed by whitespace/end, capped so a
@@ -740,9 +855,22 @@ fn first_sentence(text: &str) -> String {
 /// A running heading section being assembled by [`chunk_document_hierarchical`].
 struct Section {
     path: Option<String>,
+    /// The FIRST block's page — anchors the L1 parent row (leaves carry their OWN block's page).
     page_no: Option<u32>,
-    /// Accumulated raw block texts (joined by blank lines for leaf packing).
-    body: String,
+    /// Per source block: (trimmed text, its own page). Kept per-block so a leaf can carry the page
+    /// of the block it was packed from (audit Fix 4a) instead of the section head's.
+    blocks: Vec<(String, Option<u32>)>,
+}
+
+impl Section {
+    /// The section's full body — blocks joined by blank lines (the L1 parent / outline source).
+    fn body(&self) -> String {
+        self.blocks
+            .iter()
+            .map(|(t, _)| t.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
 }
 
 /// Turn a document's extracted `blocks` into the full 3-level [`HierChunk`] tree. Deterministic; no
@@ -766,13 +894,12 @@ pub fn chunk_document_hierarchical(name: &str, blocks: &[crate::extract::Extract
         // `unwrap`/`expect` — a `None` last simply starts the first section).
         match sections.last_mut() {
             Some(sec) if sec.path.as_deref() == b.heading_path.as_deref() => {
-                sec.body.push_str("\n\n");
-                sec.body.push_str(text);
+                sec.blocks.push((text.to_string(), b.page));
             }
             _ => sections.push(Section {
                 path: b.heading_path.clone(),
                 page_no: b.page,
-                body: text.to_string(),
+                blocks: vec![(text.to_string(), b.page)],
             }),
         }
     }
@@ -784,18 +911,29 @@ pub fn chunk_document_hierarchical(name: &str, blocks: &[crate::extract::Extract
 
     // 2) Per section: emit the L1 parent, then its L0 leaves.
     for sec in &sections {
-        let leaves = pack_leaves(&sec.body);
+        // Paragraph units: each block split on blank lines, every unit tagged with ITS block's
+        // page so a leaf's page follows its source content (audit Fix 4a).
+        let units: Vec<(String, Option<u32>)> = sec
+            .blocks
+            .iter()
+            .flat_map(|(t, page)| {
+                t.split("\n\n")
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .map(|p| (p.to_string(), *page))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        let leaves = pack_leaves_paged(&units);
         if leaves.is_empty() {
             continue;
         }
-        // L1 section-parent (heading-bounded, capped, FTS-only — NOT embedded).
-        let parent_raw: String = {
-            let mut s = sec.body.clone();
-            if s.len() > SECTION_PARENT_CHAR_CAP {
-                // char-safe truncation
-                s = s.chars().take(SECTION_PARENT_CHAR_CAP).collect();
-            }
-            s
+        let body = sec.body();
+        // L1 section-parent (heading-bounded, capped, FTS-only — NOT embedded). Char-counted cap.
+        let parent_raw: String = if body.chars().count() > SECTION_PARENT_CHAR_CAP {
+            body.chars().take(SECTION_PARENT_CHAR_CAP).collect()
+        } else {
+            body
         };
         let parent_idx = out.len();
         out.push(HierChunk {
@@ -807,59 +945,74 @@ pub fn chunk_document_hierarchical(name: &str, blocks: &[crate::extract::Extract
             page_no: sec.page_no,
             embed: false,
         });
-        // L0 leaves under this parent.
-        for leaf in leaves {
-            let embed_text = hier_embed_text(name, sec.path.as_deref(), sec.page_no, &leaf);
+        // L0 leaves under this parent, each with its OWN page in the contextual header.
+        for (leaf, leaf_page) in leaves {
+            let embed_text = hier_embed_text(name, sec.path.as_deref(), leaf_page, &leaf);
             out.push(HierChunk {
                 level: HIER_LEVEL_LEAF,
                 parent: Some(parent_idx),
                 embed_text,
                 raw: leaf,
                 section_path: sec.path.clone(),
-                page_no: sec.page_no,
+                page_no: leaf_page,
                 embed: true,
             });
         }
     }
 
-    // 3) L2 doc-summary: deterministic outline = heading tree + first sentence per section. Packed
-    //    into 1..=3 chunks of ≤CHUNK_CHAR_TARGET (embedded + FTS). If there is no heading structure
-    //    at all (a flat md/txt), still emit ONE summary from the first sentences (bounded).
-    let mut outline_lines: Vec<String> = Vec::new();
-    for sec in &sections {
-        let sentence = first_sentence(&sec.body);
-        match &sec.path {
-            Some(p) if !p.trim().is_empty() => {
-                if sentence.is_empty() {
-                    outline_lines.push(format!("# {p}"));
-                } else {
-                    outline_lines.push(format!("# {p}: {sentence}"));
-                }
-            }
-            _ => {
-                if !sentence.is_empty() {
-                    outline_lines.push(sentence);
-                }
-            }
+    // 3) L2 doc-summary: deterministic outline = heading tree + first sentence per section,
+    //    packed LINE-BASED into 1..=3 chunks of ≤CHUNK_CHAR_TARGET chars (embedded + FTS) — audit
+    //    Fix 2: the old join-then-split-on-blank-lines always produced ONE unbounded chunk the
+    //    embedder truncated at 512 tokens. EVERY section (the last included) must survive into some
+    //    chunk, so an over-deep outline DEGRADES deterministically instead of dropping its tail:
+    //    full lines → proportionally condensed sentences → heading-only lines; the final
+    //    truncate(3) is only the pathological floor (hundreds of long headings). If there is no
+    //    heading structure at all (a flat md/txt), the first sentences still form the summary.
+    let entries: Vec<(Option<&str>, String)> = sections
+        .iter()
+        .map(|sec| {
+            let path = sec.path.as_deref().map(str::trim).filter(|p| !p.is_empty());
+            (path, first_sentence(&sec.body()))
+        })
+        .collect();
+    let lines_at = |cap_for: &dyn Fn(Option<&str>) -> usize| -> Vec<String> {
+        entries
+            .iter()
+            .map(|(p, s)| outline_line(*p, s, cap_for(*p)))
+            .filter(|l| !l.trim().is_empty())
+            .collect()
+    };
+    let mut summary_chunks = pack_lines(&lines_at(&|_| usize::MAX), CHUNK_CHAR_TARGET);
+    if summary_chunks.len() > 3 && !entries.is_empty() {
+        // Condensed pass: split ~90% of the 3-chunk char budget evenly across the lines (the 10%
+        // discount absorbs greedy packing waste at chunk boundaries), spend each line's share on
+        // its heading first and the remainder on its sentence — a sub-8-char sentence stub earns
+        // no recall, so it degrades to the heading-only form instead.
+        let per_line = (CHUNK_CHAR_TARGET * 3 * 9 / 10) / entries.len();
+        summary_chunks = pack_lines(
+            &lines_at(&|p| {
+                let prefix = p.map(|p| p.chars().count() + 4).unwrap_or(0);
+                let cap = per_line.saturating_sub(prefix);
+                if cap < 8 { 0 } else { cap }
+            }),
+            CHUNK_CHAR_TARGET,
+        );
+        if summary_chunks.len() > 3 {
+            summary_chunks = pack_lines(&lines_at(&|_| 0), CHUNK_CHAR_TARGET);
         }
     }
-    let outline = outline_lines.join("\n");
-    if !outline.trim().is_empty() {
-        // Pack the outline into ≤3 leaf-sized summary chunks (an unusually deep doc yields a few).
-        let mut summary_chunks = pack_leaves(&outline);
-        summary_chunks.truncate(3);
-        for sc in summary_chunks {
-            let embed_text = hier_embed_text(name, None, None, &sc);
-            out.push(HierChunk {
-                level: HIER_LEVEL_SUMMARY,
-                parent: None,
-                embed_text,
-                raw: sc,
-                section_path: None,
-                page_no: None,
-                embed: true,
-            });
-        }
+    summary_chunks.truncate(3);
+    for sc in summary_chunks {
+        let embed_text = hier_embed_text(name, None, None, &sc);
+        out.push(HierChunk {
+            level: HIER_LEVEL_SUMMARY,
+            parent: None,
+            embed_text,
+            raw: sc,
+            section_path: None,
+            page_no: None,
+            embed: true,
+        });
     }
 
     out
@@ -1625,6 +1778,167 @@ mod tests {
     fn hierarchical_chunker_empty_input_yields_nothing() {
         assert!(chunk_document_hierarchical("x", &[]).is_empty());
         assert!(chunk_document_hierarchical("x", &[blk("   ", None, None)]).is_empty());
+    }
+
+    /// Audit Fix 3 — a PDF page extracts as ONE paragraph with only single line breaks; it must
+    /// hard-split into ≤[`CHUNK_CHAR_TARGET`]-char leaves instead of one whole-page leaf whose
+    /// tail the embedder never sees.
+    #[test]
+    fn oversized_single_paragraph_hard_splits_into_bounded_leaves() {
+        let line = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima.";
+        let para = std::iter::repeat_n(line, 54).collect::<Vec<_>>().join("\n"); // ~4000 chars, no blank lines
+        let out = chunk_document_hierarchical("big.pdf", &[blk(&para, Some(1), None)]);
+        let leaves: Vec<&HierChunk> =
+            out.iter().filter(|c| c.level == HIER_LEVEL_LEAF).collect();
+        assert!(
+            leaves.len() > 1,
+            "a 4000-char paragraph must hard-split, got {} leaf/leaves of sizes {:?}",
+            leaves.len(),
+            leaves.iter().map(|l| l.raw.chars().count()).collect::<Vec<_>>()
+        );
+        assert!(
+            leaves.iter().all(|l| l.raw.chars().count() <= CHUNK_CHAR_TARGET),
+            "every leaf must be within CHUNK_CHAR_TARGET chars, got sizes {:?}",
+            leaves.iter().map(|l| l.raw.chars().count()).collect::<Vec<_>>()
+        );
+        // The page TAIL must survive into some leaf (the whole point of the split): the last
+        // line's text appears in the LAST leaf, not only inside one oversized blob.
+        assert!(
+            leaves.last().map(|l| l.raw.contains("kilo lima.")).unwrap_or(false),
+            "the paragraph tail must land in the last leaf"
+        );
+    }
+
+    /// Audit Fix 3 — when a paragraph has no line breaks, the hard-split falls back to sentence
+    /// boundaries; with neither, to plain char windows (char-SAFE on multi-byte text — no panic,
+    /// no mid-codepoint slice).
+    #[test]
+    fn hard_split_falls_back_to_sentences_then_char_windows() {
+        // ~2000 chars of ". "-separated sentences, zero '\n'.
+        let sent = "The plan covers hiring and the budget for the second quarter of the year. ";
+        let para = sent.repeat(27);
+        let out = chunk_document_hierarchical("run-on.txt", &[blk(para.trim(), None, None)]);
+        let leaves: Vec<&HierChunk> =
+            out.iter().filter(|c| c.level == HIER_LEVEL_LEAF).collect();
+        assert!(leaves.len() > 1, "sentence fallback must split a run-on paragraph");
+        assert!(leaves.iter().all(|l| l.raw.chars().count() <= CHUNK_CHAR_TARGET));
+
+        // 1200 unbroken multi-byte chars: last-resort char windows, split points char-safe.
+        let solid: String = "ąćęłńóśźż".chars().cycle().take(1200).collect();
+        let out = chunk_document_hierarchical("solid.txt", &[blk(&solid, None, None)]);
+        let leaves: Vec<&HierChunk> =
+            out.iter().filter(|c| c.level == HIER_LEVEL_LEAF).collect();
+        assert!(leaves.len() > 1, "char-window fallback must split an unbroken run");
+        assert!(leaves.iter().all(|l| l.raw.chars().count() <= CHUNK_CHAR_TARGET));
+    }
+
+    /// Audit Fix 3 — leaf packing counts CHARS, not bytes: two 350-char Polish paragraphs
+    /// (~700 BYTES each) fit ONE ≤800-char leaf; byte counting wrongly split them.
+    #[test]
+    fn leaf_packing_counts_chars_not_bytes() {
+        let p1: String = "ąę".chars().cycle().take(350).collect();
+        let p2: String = "ół".chars().cycle().take(350).collect();
+        let body = format!("{p1}\n\n{p2}");
+        let out = chunk_document_hierarchical("pl.txt", &[blk(&body, None, None)]);
+        let leaves: Vec<&HierChunk> =
+            out.iter().filter(|c| c.level == HIER_LEVEL_LEAF).collect();
+        assert_eq!(
+            leaves.len(),
+            1,
+            "350+1+350 CHARS fits one ≤{CHUNK_CHAR_TARGET}-char leaf — packing must count chars, not bytes"
+        );
+    }
+
+    /// Audit Fix 2 — the L2 outline must pack line-based into >1 (≤3) chunks of
+    /// ≤[`CHUNK_CHAR_TARGET`] chars, so the embedder sees ALL of it instead of truncating one
+    /// unbounded chunk at 512 tokens; EVERY section (the LAST included) survives into some chunk,
+    /// degrading sentences before ever dropping a section.
+    #[test]
+    fn l2_outline_packs_into_bounded_line_based_chunks() {
+        let outline_l2 = |n: usize, name: &str| -> Vec<HierChunk> {
+            let blocks: Vec<ExtractedBlock> = (0..n)
+                .map(|i| {
+                    blk(
+                        &format!("Content of section number {i} goes right here."),
+                        None,
+                        Some(&format!("Heading {i}")),
+                    )
+                })
+                .collect();
+            chunk_document_hierarchical(name, &blocks)
+                .into_iter()
+                .filter(|c| c.level == HIER_LEVEL_SUMMARY)
+                .collect()
+        };
+
+        // 30 sections (~1.8k chars of full lines): packs into 2..=3 bounded chunks with the LAST
+        // section's SENTENCE intact (no degradation needed).
+        let l2 = outline_l2(30, "deep.pdf");
+        assert!(
+            l2.len() >= 2 && l2.len() <= 3,
+            "a ~1.8k-char outline must pack into 2..=3 bounded chunks, got {} of sizes {:?}",
+            l2.len(),
+            l2.iter().map(|c| c.raw.chars().count()).collect::<Vec<_>>()
+        );
+        assert!(
+            l2.iter().all(|c| c.raw.chars().count() <= CHUNK_CHAR_TARGET),
+            "every L2 chunk must be ≤CHUNK_CHAR_TARGET chars, got {:?}",
+            l2.iter().map(|c| c.raw.chars().count()).collect::<Vec<_>>()
+        );
+        assert!(
+            l2.iter()
+                .any(|c| c.raw.contains("Heading 29: Content of section number 29")),
+            "the LAST section keeps its sentence when the outline fits the 3-chunk budget"
+        );
+
+        // 100 sections (~6k chars of full lines): the degradation ladder condenses lines instead of
+        // dropping the tail — still ≤3 bounded chunks, and the LAST section's heading survives.
+        let l2 = outline_l2(100, "deeper.pdf");
+        assert!(
+            l2.len() >= 2 && l2.len() <= 3,
+            "a 100-section outline must degrade into 2..=3 bounded chunks, got {} of sizes {:?}",
+            l2.len(),
+            l2.iter().map(|c| c.raw.chars().count()).collect::<Vec<_>>()
+        );
+        assert!(
+            l2.iter().all(|c| c.raw.chars().count() <= CHUNK_CHAR_TARGET),
+            "every L2 chunk must be ≤CHUNK_CHAR_TARGET chars, got {:?}",
+            l2.iter().map(|c| c.raw.chars().count()).collect::<Vec<_>>()
+        );
+        assert!(
+            l2.iter().any(|c| c.raw.contains("Heading 99")),
+            "the LAST of 100 sections must survive into some L2 chunk (never tail-dropped)"
+        );
+    }
+
+    /// Audit Fix 4a — a leaf carries the page of ITS OWN source block, not the page of the
+    /// section's first block (the embed header must cite `p.2` for page-2 content).
+    #[test]
+    fn leaf_page_no_follows_its_source_block() {
+        let p1 = "alpha ".repeat(120);
+        let p2 = "omega ".repeat(120);
+        let blocks = vec![
+            blk(p1.trim_end(), Some(1), Some("Long Section")),
+            blk(p2.trim_end(), Some(2), Some("Long Section")),
+        ];
+        let out = chunk_document_hierarchical("paged.pdf", &blocks);
+        let leaves: Vec<&HierChunk> =
+            out.iter().filter(|c| c.level == HIER_LEVEL_LEAF).collect();
+        assert_eq!(leaves.len(), 2, "two ~720-char paragraphs cannot merge into one leaf");
+        let leaf2 = leaves
+            .iter()
+            .find(|l| l.raw.starts_with("omega"))
+            .expect("the page-2 leaf must exist");
+        assert_eq!(
+            leaf2.page_no,
+            Some(2),
+            "a leaf must carry its OWN source block's page, not the section head's"
+        );
+        assert!(
+            leaf2.embed_text.contains("p.2"),
+            "the embed header must cite the leaf's page: {:?}",
+            leaf2.embed_text
+        );
     }
 
     #[test]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5473,12 +5473,77 @@ impl Db {
         Ok(())
     }
 
+    /// Map one doc-chunk candidate row (the shared 10-column SELECT of the two doc readers) into a
+    /// [`DocChunkHit`] carrying the chunk's hierarchy metadata. `sibling_hits` starts at 0 — it is
+    /// populated by [`Db::fold_doc_candidates`] for the winner of each document's dedup.
+    fn doc_candidate_from_row(row: &Row<'_>) -> rusqlite::Result<DocChunkHit> {
+        Ok(DocChunkHit {
+            document_id: row.get(0)?,
+            name: row.get(1)?,
+            folder_id: row.get(2)?,
+            snippet: row.get(3)?,
+            kind: row.get(4)?,
+            chunk_id: row.get(5)?,
+            parent_id: row.get(6)?,
+            section_path: row.get(7)?,
+            page_no: row.get(8)?,
+            level: row.get(9)?,
+            sibling_hits: 0,
+        })
+    }
+
+    /// Fold a BEST-FIRST pre-dedup doc-chunk candidate stream into the per-document deduped hit
+    /// list. The first candidate seen for a document WINS (exactly the nearest-KNN / best-bm25
+    /// dedup the callers have always had — ranking and snippets stay byte-identical), and later
+    /// candidates only feed the winner's `sibling_hits`: the count of distinct L0 leaves under the
+    /// winning chunk's L1 parent present in the candidate set (winner included). `limit` caps how
+    /// many DOCUMENTS are collected (`None` = all); candidates past the limit still corroborate
+    /// siblings for already-collected winners. Audit Fix 1: this is what makes parent expansion
+    /// hit-aligned and sibling-gated instead of query-independent.
+    fn fold_doc_candidates(
+        candidates: impl Iterator<Item = rusqlite::Result<DocChunkHit>>,
+        limit: Option<usize>,
+    ) -> Result<Vec<DocChunkHit>> {
+        let mut idx_by_doc: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        let mut hits: Vec<DocChunkHit> = Vec::new();
+        for cand in candidates {
+            let cand = cand.map_err(map_err)?;
+            match idx_by_doc.get(&cand.document_id) {
+                None => {
+                    if limit.map_or(true, |l| hits.len() < l) {
+                        // MSRV 1.77: no Option::is_none_or (stable 1.82)
+                        let mut winner = cand;
+                        // The winner counts itself when it is a leaf under a real parent.
+                        winner.sibling_hits =
+                            u32::from(winner.level == 0 && winner.parent_id.is_some());
+                        idx_by_doc.insert(winner.document_id.clone(), hits.len());
+                        hits.push(winner);
+                    }
+                }
+                Some(&i) => {
+                    let w = &mut hits[i];
+                    if cand.level == 0
+                        && w.parent_id.is_some()
+                        && cand.parent_id == w.parent_id
+                        && cand.chunk_id != w.chunk_id
+                    {
+                        w.sibling_hits += 1;
+                    }
+                }
+            }
+        }
+        Ok(hits)
+    }
+
     /// GATED semantic (vector KNN) search over DOCUMENT chunks. Runs a `doc_vec_chunks` KNN for the
     /// top-`k` nearest chunks, then applies EXACTLY the `visibility_clause` predicate (joined
     /// doc_chunks → documents → folders) so a chunk in a sealed-and-not-session-unlocked folder is
     /// EXCLUDED even if a stray chunk survived purge — the same defense-in-depth as
-    /// `search_semantic_visible`. Dedups to one hit per document (best/nearest). Returns the chunk
-    /// snippet + the document name + its folder id (NO meeting — documents are not meetings).
+    /// `search_semantic_visible`. Dedups to one hit per document (best/nearest) while counting the
+    /// winner's `sibling_hits` across the pre-dedup KNN candidates ([`Db::fold_doc_candidates`]).
+    /// Returns the chunk snippet + the document name + its folder id + the winning chunk's
+    /// hierarchy metadata (NO meeting — documents are not meetings).
     pub fn search_doc_chunks_visible(
         &self,
         query_vec: &[f32],
@@ -5497,7 +5562,8 @@ impl Db {
                   WHERE embedding MATCH ?1 AND k = ?2
                   ORDER BY distance
              )
-             SELECT d.id, d.name, d.folder_id, dc.text, d.kind, knn.distance
+             SELECT d.id, d.name, d.folder_id, dc.text, d.kind,
+                    dc.id, dc.parent_id, dc.section_path, dc.page_no, dc.level
                FROM knn
                JOIN doc_chunks dc ON dc.id = knn.chunk_id
                JOIN documents d ON d.id = dc.document_id
@@ -5508,26 +5574,10 @@ impl Db {
         let blob = crate::embed::vec_to_blob(query_vec);
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
-            .query_map(rusqlite::params![blob, k], |row| {
-                Ok(DocChunkHit {
-                    document_id: row.get(0)?,
-                    name: row.get(1)?,
-                    folder_id: row.get(2)?,
-                    snippet: row.get(3)?,
-                    kind: row.get(4)?,
-                })
-            })
+            .query_map(rusqlite::params![blob, k], Self::doc_candidate_from_row)
             .map_err(map_err)?;
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut hits = Vec::new();
-        for r in rows {
-            let hit = r.map_err(map_err)?;
-            if !seen.insert(hit.document_id.clone()) {
-                continue; // already have a nearer chunk for this document.
-            }
-            hits.push(hit);
-        }
-        Ok(hits)
+        // The k-row KNN CTE already bounds the candidate set; every deduped hit is kept (as before).
+        Self::fold_doc_candidates(rows, None)
     }
 
     /// GATED keyword (FTS5/BM25) search over DOCUMENT chunks — the model-free twin of
@@ -5535,7 +5585,9 @@ impl Db {
     /// install (no e5 model, semantic flag off). Applies EXACTLY the `visibility_clause` predicate
     /// (joined doc_chunks → documents → folders) so a chunk in a sealed-and-not-session-unlocked
     /// folder is EXCLUDED even if a stray chunk survived purge — defense-in-depth on top of the
-    /// trigger-purged FTS index. Dedups to one hit per document (best bm25), capped at `limit`.
+    /// trigger-purged FTS index. Dedups to one hit per document (best bm25), capped at `limit`;
+    /// the scan continues past the cap (bounded at 10×`limit` rows) ONLY to count the winners'
+    /// `sibling_hits` — the returned documents, order, and snippets are unchanged.
     pub fn search_doc_chunks_fts_visible(
         &self,
         query: &str,
@@ -5551,120 +5603,93 @@ impl Db {
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
         let sql = format!(
-            "SELECT d.id, d.name, d.folder_id, dc.text, d.kind, bm25(fts_doc_chunks) AS rank
+            "SELECT d.id, d.name, d.folder_id, dc.text, d.kind,
+                    dc.id, dc.parent_id, dc.section_path, dc.page_no, dc.level
                FROM fts_doc_chunks
                JOIN doc_chunks dc ON dc.id = fts_doc_chunks.rowid
                JOIN documents d ON d.id = dc.document_id
                JOIN folders f ON f.id = d.folder_id
               WHERE fts_doc_chunks MATCH ?1 AND {visible}
-              ORDER BY rank ASC, d.id ASC"
+              ORDER BY bm25(fts_doc_chunks) ASC, d.id ASC"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
-            .query_map(rusqlite::params![match_expr], |row| {
-                Ok(DocChunkHit {
-                    document_id: row.get(0)?,
-                    name: row.get(1)?,
-                    folder_id: row.get(2)?,
-                    snippet: row.get(3)?,
-                    kind: row.get(4)?,
-                })
-            })
+            .query_map(rusqlite::params![match_expr], Self::doc_candidate_from_row)
             .map_err(map_err)?;
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut hits = Vec::new();
-        for r in rows {
-            let hit = r.map_err(map_err)?;
-            if !seen.insert(hit.document_id.clone()) {
-                continue; // already have a better-ranked chunk for this document.
-            }
-            hits.push(hit);
-            if hits.len() as i64 >= limit {
-                break;
-            }
-        }
-        Ok(hits)
+        // Bound the sibling-count scan so a stop-word-ish query over a large corpus stays cheap;
+        // sibling counts are then a LOWER bound, which can only under-trigger expansion (safe).
+        let scan_cap = (limit as usize).saturating_mul(10).max(64);
+        Self::fold_doc_candidates(rows.take(scan_cap), Some(limit as usize))
     }
 
-    /// Brain v3 PR-2 — GATED parent-document expansion (LlamaIndex parent-document / RAPTOR effect).
-    /// For each of the given `document_ids` (the TOP fused doc hits), return the document's DOMINANT
-    /// L1 section-parent text — the section covering the MOST leaf chunks — so the reasoner reads a
-    /// coherent SECTION instead of an isolated 800-char leaf. Documents with no L1 parents (a flat /
-    /// legacy doc, or one section only) are simply omitted (the caller keeps the original leaf hit).
+    /// Brain v3 audit Fix 1 — HIT-ALIGNED, SIBLING-GATED parent expansion (LlamaIndex auto-merging
+    /// semantics). For each of the given top fused doc `hits`, return the text of the WINNING
+    /// chunk's OWN L1 section-parent (`doc_chunks WHERE id = hit.parent_id`) — but ONLY when the
+    /// retrieval corroborated that section (`sibling_hits >= 2`: at least two distinct L0 leaves of
+    /// the same parent in the pre-dedup candidate set). A single-leaf hit yields no expansion row
+    /// (the caller keeps the leaf snippet), and a FLAT hit (`section_path` `None`) NEVER expands —
+    /// the flat L1 is the doc head, not a real section. The pre-fix dominant-by-leaf-count
+    /// expansion replaced relevant retrieved snippets with an unrelated section's text.
     ///
-    /// GATING (lock-model, load-bearing): the query applies EXACTLY the same `visibility_clause`
-    /// predicate over `doc_chunks → documents → folders` as the doc-search readers — a document in a
-    /// sealed-and-not-session-unlocked folder yields NOTHING here (its `level=1` rows are purged while
-    /// sealed anyway, and the gate is defense-in-depth on top). No raw-SQL bypass; parents are DERIVED
-    /// content, so this is a pure gated READ that never widens what the session can see.
+    /// GATING (lock-model, load-bearing): each parent lookup applies EXACTLY the same
+    /// `visibility_clause` predicate over `doc_chunks → documents → folders` as the doc-search
+    /// readers — a document in a sealed-and-not-session-unlocked folder yields NOTHING here even
+    /// for a STALE pre-seal hit (its `level=1` rows are purged while sealed anyway, and the gate is
+    /// defense-in-depth on top). The parent row is additionally pinned to the hit's own document
+    /// (`p.document_id = hit.document_id`) and to `p.level = 1`, so a stale/foreign `parent_id`
+    /// can never fetch across documents or levels. Parents are DERIVED content — a pure gated READ.
     ///
-    /// Returns `document_id → (name, folder_id, parent_text)`. `parent_text` is the L1 `text` (already
-    /// capped at ingest to ~6000 chars — the reasoner budget stays tight).
+    /// Returns one [`DocChunkHit`] per EXPANDED hit (`snippet` = the L1 parent text, already capped
+    /// at ingest to ~6000 chars); non-expanded hits are simply absent.
     pub fn expand_doc_parents_visible(
         &self,
-        document_ids: &[String],
+        hits: &[DocChunkHit],
         unlocked: &HashSet<String>,
     ) -> Result<Vec<DocChunkHit>> {
-        if document_ids.is_empty() {
+        if hits.is_empty() {
             return Ok(Vec::new());
         }
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
-        // For each doc's L1 parents, count how many L0 leaves point at each parent, then pick the
-        // parent with the most leaves (ties broken by lowest parent id, deterministic). One row per
-        // document. `child.parent_id = parent.id` is the hierarchy edge. Gate on the parent's folder.
-        let placeholders = document_ids
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(",");
         let sql = format!(
-            "WITH parent_counts AS (
-                 SELECT p.id AS parent_id,
-                        p.document_id AS document_id,
-                        p.text AS parent_text,
-                        COUNT(c.id) AS leaf_count
-                   FROM doc_chunks p
-                   JOIN documents d ON d.id = p.document_id
-                   JOIN folders f ON f.id = d.folder_id
-                   LEFT JOIN doc_chunks c
-                          ON c.parent_id = p.id AND c.level = 0
-                  WHERE p.level = 1
-                    AND p.document_id IN ({placeholders})
-                    AND {visible}
-                  GROUP BY p.id
-             ),
-             ranked AS (
-                 SELECT parent_counts.*,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY document_id
-                            ORDER BY leaf_count DESC, parent_id ASC
-                        ) AS rn
-                   FROM parent_counts
-             )
-             SELECT d.id, d.name, d.folder_id, r.parent_text, d.kind
-               FROM ranked r
-               JOIN documents d ON d.id = r.document_id
-              WHERE r.rn = 1"
+            "SELECT p.text
+               FROM doc_chunks p
+               JOIN documents d ON d.id = p.document_id
+               JOIN folders f ON f.id = d.folder_id
+              WHERE p.id = ?1 AND p.document_id = ?2 AND p.level = 1 AND {visible}"
         );
-        let params: Vec<&dyn rusqlite::ToSql> =
-            document_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-        let rows = stmt
-            .query_map(params.as_slice(), |row| {
-                Ok(DocChunkHit {
-                    document_id: row.get(0)?,
-                    name: row.get(1)?,
-                    folder_id: row.get(2)?,
-                    snippet: row.get(3)?,
-                    kind: row.get(4)?,
-                })
-            })
-            .map_err(map_err)?;
-        let mut out = Vec::new();
-        for r in rows {
-            out.push(r.map_err(map_err)?);
+        let mut out: Vec<DocChunkHit> = Vec::new();
+        for h in hits {
+            if h.sibling_hits < 2 || h.section_path.is_none() {
+                continue; // uncorroborated or flat — the leaf snippet stays.
+            }
+            let Some(parent_id) = h.parent_id else {
+                continue; // an L1/L2/legacy winner has no parent to expand to.
+            };
+            let text: Option<String> = stmt
+                .query_row(rusqlite::params![parent_id, h.document_id], |row| row.get(0))
+                .optional()
+                .map_err(map_err)?;
+            let Some(text) = text else {
+                continue; // gated out (sealed-not-unlocked) or a vanished parent row.
+            };
+            if text.trim().is_empty() {
+                continue;
+            }
+            out.push(DocChunkHit {
+                document_id: h.document_id.clone(),
+                name: h.name.clone(),
+                folder_id: h.folder_id.clone(),
+                snippet: text,
+                kind: h.kind.clone(),
+                chunk_id: parent_id,
+                parent_id: None,
+                section_path: h.section_path.clone(),
+                page_no: h.page_no,
+                level: 1,
+                sibling_hits: h.sibling_hits,
+            });
         }
         Ok(out)
     }
@@ -18937,53 +18962,175 @@ mod tests {
         assert_eq!(vec_count("SELECT COUNT(*) FROM doc_vec_chunks"), 0);
     }
 
-    /// Brain v3 PR-2 — `expand_doc_parents_visible` returns the dominant L1 SECTION-parent text for a
-    /// top doc hit, and is GATED: a sealed-not-unlocked folder's document yields NOTHING (RED if the
-    /// `visibility_clause` were removed), and unlocking restores it.
+    /// Audit Fix 1 test fixture — one document with a DOMINANT "Alpha" section (3 leaves of plain
+    /// filler) and a SMALLER "Beta" section (2 leaves; "pistachio" appears mid-paragraph in both —
+    /// past the first sentence, so the L2 outline never matches it; "zloty" appears in the second
+    /// Beta leaf ONLY). The pre-fix dominant-by-leaf-count expansion always served Alpha.
+    fn seed_two_section_doc(db: &Db, doc_id: &str, folder_id: &str) {
+        let alpha_para = "Alpha filler sentence with plain ordinary words in it. ".repeat(13);
+        let beta_one = format!(
+            "This beta paragraph opens with a plain first sentence. \
+             The pistachio pistachio pistachio budget appears in the middle here. {}",
+            "Beta filler words about the plan. ".repeat(16)
+        );
+        let beta_two = format!(
+            "Another beta paragraph opens plainly as well. \
+             A second pistachio mention and one zloty token live right here. {}",
+            "More beta filler words in this spot. ".repeat(16)
+        );
+        let mk = |text: &str, page: u32, heading: &str| crate::extract::ExtractedBlock {
+            text: text.trim().to_string(),
+            page: Some(page),
+            heading_path: Some(heading.to_string()),
+        };
+        let blocks = vec![
+            mk(&alpha_para, 1, "Alpha"),
+            mk(&alpha_para, 1, "Alpha"),
+            mk(&alpha_para, 2, "Alpha"),
+            mk(&beta_one, 3, "Beta"),
+            mk(&beta_two, 3, "Beta"),
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document(doc_id, folder_id, "plan.pdf", &stored, "document", 100)
+            .unwrap();
+        db.index_document_chunks(doc_id, Some(&crate::embed::StubEmbedder))
+            .unwrap();
+    }
+
+    /// Audit Fix 1 (RED observed pre-fix: expansion served the dominant Alpha section) — a hit in
+    /// the SMALLER Beta section, corroborated by its sibling leaf, expands to the HIT's OWN L1
+    /// parent: the full Beta section, never Alpha.
+    #[test]
+    fn expand_serves_the_hit_sections_own_parent_when_siblings_corroborate() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Docs");
+        seed_two_section_doc(&db, "d1", "f1");
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .search_doc_chunks_fts_visible("pistachio", 20, &nothing)
+            .unwrap();
+        assert_eq!(hits.len(), 1, "one document → one deduped hit");
+        let h = &hits[0];
+        assert_eq!(h.level, 0, "a Beta LEAF must win the per-document dedup");
+        assert_eq!(h.section_path.as_deref(), Some("Beta"));
+        assert!(h.parent_id.is_some(), "a section leaf carries its L1 parent id");
+        assert!(h.chunk_id > 0);
+        assert_eq!(
+            h.sibling_hits, 2,
+            "both Beta leaves are in the pre-dedup candidate set (winner + 1 sibling)"
+        );
+        let parents = db.expand_doc_parents_visible(&hits, &nothing).unwrap();
+        assert_eq!(parents.len(), 1, "a corroborated section hit expands");
+        let p = &parents[0];
+        assert_eq!(p.level, 1);
+        assert!(
+            p.snippet.contains("This beta paragraph opens")
+                && p.snippet.contains("Another beta paragraph opens"),
+            "expansion serves the FULL Beta section (both leaves), got: {:?}…",
+            p.snippet.chars().take(80).collect::<String>()
+        );
+        assert!(
+            !p.snippet.contains("Alpha filler"),
+            "expansion must NEVER serve the dominant Alpha section for a Beta hit"
+        );
+    }
+
+    /// Audit Fix 1 — a SINGLE uncorroborated leaf hit (`sibling_hits == 1`) keeps its leaf snippet:
+    /// no expansion row. (RED pre-fix: expansion was unconditional and query-independent.)
+    #[test]
+    fn expand_requires_two_corroborating_sibling_leaves() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Docs");
+        seed_two_section_doc(&db, "d1", "f1");
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .search_doc_chunks_fts_visible("zloty", 20, &nothing)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, 0, "the single matching Beta leaf wins");
+        assert_eq!(
+            hits[0].sibling_hits, 1,
+            "only the winner itself matched — no corroborating sibling"
+        );
+        assert!(
+            db.expand_doc_parents_visible(&hits, &nothing).unwrap().is_empty(),
+            "an uncorroborated single-leaf hit must keep its leaf snippet"
+        );
+    }
+
+    /// Audit Fix 1 — a FLAT document (no headings; `section_path` NULL) NEVER expands, even when
+    /// two of its leaves corroborate: its L1 is the doc head, not a real section. (RED pre-fix:
+    /// the old code expanded flat docs to the head, contrary to its own comments.)
+    #[test]
+    fn flat_doc_hit_keeps_its_leaf_no_expansion() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Docs");
+        let mut text = String::new();
+        for i in 0..6 {
+            let marker = if i == 2 || i == 5 {
+                "The zanzibar clause appears in this very paragraph. "
+            } else {
+                ""
+            };
+            text.push_str(&format!(
+                "Flat paragraph number {i} with plain filler words. {marker}{}\n\n",
+                "More flat filler text in this paragraph. ".repeat(16)
+            ));
+        }
+        db.insert_document("d2", "f1", "notes.md", &text, "document", 100)
+            .unwrap();
+        db.index_document_chunks("d2", Some(&crate::embed::StubEmbedder))
+            .unwrap();
+        let nothing = std::collections::HashSet::new();
+        let hits = db
+            .search_doc_chunks_fts_visible("zanzibar", 20, &nothing)
+            .unwrap();
+        assert_eq!(hits.len(), 1, "a mid-file leaf must be keyword-reachable");
+        assert!(hits[0].section_path.is_none(), "a flat doc's leaf has no section path");
+        assert_eq!(
+            hits[0].sibling_hits, 2,
+            "both matching flat leaves share the flat L1 — corroboration alone must NOT expand"
+        );
+        assert!(
+            db.expand_doc_parents_visible(&hits, &nothing).unwrap().is_empty(),
+            "a flat doc must keep its leaf snippet — never expand to the doc head"
+        );
+    }
+
+    /// Brain v3 — `expand_doc_parents_visible` is GATED: a sealed-not-unlocked folder's document
+    /// yields NOTHING even for a STALE pre-seal hit still carrying a valid `parent_id` (RED if the
+    /// `visibility_clause` were removed), and unlocking restores the expansion.
     #[test]
     fn expand_doc_parents_is_gated_and_returns_section_text() {
         let db = mem_db();
         seed_folder(&db, "f-lock", "Secret");
-        let blocks = vec![
-            crate::extract::ExtractedBlock {
-                text: "First paragraph about the classified launch plan for the product.".into(),
-                page: Some(1),
-                heading_path: Some("Launch".into()),
-            },
-            crate::extract::ExtractedBlock {
-                text: "Second paragraph under the same launch heading with more detail here.".into(),
-                page: Some(1),
-                heading_path: Some("Launch".into()),
-            },
-        ];
-        let stored = crate::extract::blocks_to_stored_text(&blocks);
-        db.insert_document("d1", "f-lock", "plan.pdf", &stored, "document", 100)
-            .unwrap();
-        db.index_document_chunks("d1", Some(&crate::embed::StubEmbedder))
-            .unwrap();
-
-        let ids = vec!["d1".to_string()];
-        // Open folder → the dominant L1 "Launch" section text comes back.
+        seed_two_section_doc(&db, "d1", "f-lock");
         let nothing = std::collections::HashSet::new();
-        let open = db.expand_doc_parents_visible(&ids, &nothing).unwrap();
-        assert_eq!(open.len(), 1, "one document → one dominant parent");
+        // Open folder → the corroborated Beta hit expands to its section text.
+        let hits = db
+            .search_doc_chunks_fts_visible("pistachio", 20, &nothing)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        let open = db.expand_doc_parents_visible(&hits, &nothing).unwrap();
+        assert_eq!(open.len(), 1, "one corroborated hit → one parent");
         assert!(
-            open[0].snippet.contains("classified launch plan"),
+            open[0].snippet.contains("beta paragraph"),
             "parent text is the SECTION body, got: {:?}",
-            open[0].snippet
+            open[0].snippet.chars().take(80).collect::<String>()
         );
 
-        // Seal → gated OUT with empty unlock set.
+        // Seal → the SAME (now stale) hits are gated OUT with an empty unlock set: the parent
+        // lookup re-applies the visibility gate per hit, so a pre-seal hit cannot fetch anything.
         db.set_folder_locked("f-lock", true, None).unwrap();
         assert!(
-            db.expand_doc_parents_visible(&ids, &nothing).unwrap().is_empty(),
+            db.expand_doc_parents_visible(&hits, &nothing).unwrap().is_empty(),
             "sealed-not-unlocked parent leaked through expand gate"
         );
         // Unlock → restored.
         let mut unlocked = std::collections::HashSet::new();
         unlocked.insert("f-lock".to_string());
         assert_eq!(
-            db.expand_doc_parents_visible(&ids, &unlocked).unwrap().len(),
+            db.expand_doc_parents_visible(&hits, &unlocked).unwrap().len(),
             1,
             "unlock restores the parent"
         );

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -623,6 +623,7 @@ pub struct BrainOverview {
 /// One gated document-chunk retrieval hit (the document analogue of [`SearchHit`], minus the
 /// meeting): the nearest chunk's snippet + the source document name + its (visible) folder id.
 /// Returned by `search_doc_chunks_visible` and folded into the brain/Ask grounding corpus.
+/// Backend-internal: this struct never crosses IPC to the FE (no `models.ts` counterpart).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocChunkHit {
@@ -635,6 +636,23 @@ pub struct DocChunkHit {
     /// concrete kind (`[document:note:<id>]` vs `[document:document:<id>]`) so a model knows which
     /// `get_*` tool to call. Populated straight off the existing `documents.kind` column.
     pub kind: String,
+    /// Brain v3 audit Fix 1 — the WINNING (post-dedup) chunk's `doc_chunks.id`, so parent expansion
+    /// can align to the chunk that was actually retrieved instead of the document's dominant section.
+    pub chunk_id: i64,
+    /// The winning chunk's L1 section-parent row id (`doc_chunks.parent_id`); `None` for an L1/L2
+    /// winner and for legacy flat rows.
+    pub parent_id: Option<i64>,
+    /// The heading trail the winning chunk sits under; `None` = flat/heading-less content, for
+    /// which parent expansion NEVER fires (the flat L1 is the doc head, not a real section).
+    pub section_path: Option<String>,
+    /// The winning chunk's own 1-based page/slide; `None` for flow formats.
+    pub page_no: Option<u32>,
+    /// The winning chunk's `doc_chunks.level` (0 leaf / 1 section-parent / 2 doc-summary).
+    pub level: i64,
+    /// Distinct L0 leaves under the winning chunk's parent that appeared in the PRE-dedup candidate
+    /// set of the SAME query (the winner itself included). `>= 2` is the auto-merging trigger:
+    /// only a section corroborated by a second sibling hit is expanded to its L1 parent.
+    pub sibling_hits: u32,
 }
 
 /// The full body of ONE standalone note OR imported/uploaded document, by id — the transport DTO

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -238,24 +238,20 @@ fn pack_doc_chunks(
     if hits.is_empty() {
         return Ok(());
     }
-    // Brain v3 PR-2 — GATED PARENT EXPANSION: for the top-3 fused doc hits, replace the isolated
-    // leaf snippet with the document's dominant L1 SECTION-parent text (coherent section beats a
+    // Brain v3 audit Fix 1 — GATED, HIT-ALIGNED PARENT EXPANSION: for a top-3 fused doc hit whose
+    // section was CORROBORATED by a second sibling leaf in the same retrieval (auto-merging), swap
+    // the leaf snippet for the WINNING chunk's own L1 section-parent text (coherent section beats a
     // fragment; context-rot lesson keeps it to the top few). `expand_doc_parents_visible` re-applies
-    // the visibility gate, so a sealed-not-unlocked doc contributes nothing. A doc with no L1 parent
-    // (flat/legacy) keeps its original leaf snippet unchanged.
+    // the visibility gate, so a sealed-not-unlocked doc contributes nothing. A single-leaf hit and
+    // a flat/legacy doc keep their original leaf snippet unchanged — expansion may only ever add
+    // the section AROUND what was retrieved, never substitute a different section.
     const EXPAND_TOP_N: usize = 3;
-    let top_ids: Vec<String> = hits
-        .iter()
-        .take(EXPAND_TOP_N)
-        .map(|h| h.document_id.clone())
-        .collect();
-    if !top_ids.is_empty() {
-        let parents = db.expand_doc_parents_visible(&top_ids, unlocked)?;
-        for p in parents {
-            if let Some(h) = hits.iter_mut().find(|h| h.document_id == p.document_id) {
-                if !p.snippet.trim().is_empty() {
-                    h.snippet = p.snippet;
-                }
+    let parents =
+        db.expand_doc_parents_visible(&hits[..hits.len().min(EXPAND_TOP_N)], unlocked)?;
+    for p in parents {
+        if let Some(h) = hits.iter_mut().find(|h| h.document_id == p.document_id) {
+            if !p.snippet.trim().is_empty() {
+                h.snippet = p.snippet;
             }
         }
     }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -531,14 +531,15 @@ pub fn execute_tool(
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
                 .unwrap_or_default();
             let mut docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
-            // Brain v3 PR-2 — GATED PARENT EXPANSION: for the top-3 fused doc hits, swap the isolated
-            // leaf snippet for the document's dominant L1 SECTION-parent text so the agent reads a
-            // coherent section. `expand_doc_parents_visible` re-applies the visibility gate (a
-            // sealed-not-unlocked doc yields nothing); a flat/legacy doc keeps its leaf snippet.
-            let top_ids: Vec<String> =
-                docs.iter().take(3).map(|h| h.document_id.clone()).collect();
-            if !top_ids.is_empty() {
-                if let Ok(parents) = db.expand_doc_parents_visible(&top_ids, unlocked) {
+            // Brain v3 audit Fix 1 — GATED, HIT-ALIGNED PARENT EXPANSION: a top-3 fused doc hit
+            // whose section was corroborated by a second sibling leaf (auto-merging) swaps its leaf
+            // snippet for the WINNING chunk's own L1 section-parent text, so the agent reads the
+            // coherent section AROUND what was retrieved — never a different (dominant) section.
+            // `expand_doc_parents_visible` re-applies the visibility gate (a sealed-not-unlocked
+            // doc yields nothing); single-leaf hits and flat/legacy docs keep their leaf snippet.
+            if !docs.is_empty() {
+                let top_n = docs.len().min(3);
+                if let Ok(parents) = db.expand_doc_parents_visible(&docs[..top_n], unlocked) {
                     for p in parents {
                         if let Some(h) = docs.iter_mut().find(|h| h.document_id == p.document_id) {
                             if !p.snippet.trim().is_empty() {


### PR DESCRIPTION
PR-1 of the brain-v3 audit-fix program (audit: docs/research/2026-07-18-brain-v3-audit.md). The retrieval last-mile — three confirmed retrieval-quality bugs in the L0/L1/L2 hierarchical doc index, all invisible to cargo test.

## Fixes
- **[headline] parent expansion was query-INDEPENDENT** — it served the document's statically dominant-by-leaf-count section, unconditionally, for the top-3 docs (and expanded flat docs too), replacing the relevant retrieved snippet with up to 6k chars of the WRONG section (a context-rot distractor injector). Now HIT-ALIGNED (LlamaIndex auto-merging): DocChunkHit carries chunk_id/parent_id/section_path so both gated readers survive per-doc dedup while remembering the winning chunk + its sibling-hit count; expansion serves the parent of the leaf the query HIT, ONLY when ≥2 retrieved siblings corroborate, NEVER for a flat doc (section_path NULL).
- **L2 outline was ONE unbounded chunk** the embedder truncated at 512 tokens — now packed into ≤3 ≤CHUNK_CHAR_TARGET line-based chunks, so the collapsed-tree summary covers the whole document.
- **pack_leaves had no hard-split and counted bytes** — a PDF page-block became one oversized leaf whose tail never reached the vector index; now hard-splits (newline→sentence→char-safe) and counts chars (Polish/CJK pack correctly).
- per-leaf page_no; contextual-header doc-comment corrected (rides the vector leg only).

## Verified (dual)
- cargo test --lib **1912/0** on the rebased tree (no #373 tools.rs merge-skew); +25 tests incl. RED regressions.
- **adversarial-verifier PASS** — RED-before-GREEN proven empirically by reverting expand to the dominant-section behavior (all 4 hit-aligned tests + the L2 test went RED with the exact audit symptom, GREEN on restore); 109,213-split fuzz over CJK/emoji/Polish (no panic, no mid-codepoint slice); ranking byte-identical for non-expanded hits (verified by construction).
- **lock-security-reviewer PASS** — all 3 doc readers gated in the compiled SQL (visibility_clause); the stale-pre-seal-hit vector is closed (expand re-gates per hit, pins document_id to the hit's own doc); no seal/write path, documents.text untouched, zero new log lines.

Residual (honest): real-Mac recall at scale needs a signed build + real e5/corpus (unit tests use StubEmbedder — they validate chunking/hierarchy/gating, not embedding recall). Existing docs keep old chunking until reindex/re-import.