### PR TITLE
Note/recording surface redesign: overlay portal, idle launch hero, recording recompose

### DIFF
--- a/docs/superpowers/specs/2026-07-18-note-recording-surface-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-18-note-recording-surface-redesign-design.md
@@ -1,0 +1,162 @@
+# Note / Recording Surface Redesign — Design Spec
+
+**Date:** 2026-07-18
+**Branch:** `murmur` (implemented in an isolated worktree → PR into trunk)
+**Status:** Design approved on direction (4 forks decided); awaiting spec review before planning.
+**Related in-flight work:** an uncommitted concurrent-agent change adds an "Ask Brain" right-side drawer (`bare` mode on `note-chat`) + collapses semantic suggestions in `connections`. **This redesign ABSORBS and canonicalizes that drawer** — it does not replace or discard it.
+
+---
+
+## 1. Why (the problem)
+
+The single surface that serves as both the **idle note editor** and the **live recording companion** is incoherent. Three visible user complaints, plus one composition problem, trace to a small number of roots:
+
+### 1a. One CSS root cause = four broken overlays (CONFIRMED empirically on WebKit)
+
+`<mur-source-picker>`'s popover, the note **selection formatting toolbar**, the in-note **Brain popover**, and the `[[` **link-picker** are all `position: fixed` elements rendered *inside their host component's subtree* and positioned with **viewport coordinates** from `getBoundingClientRect()`.
+
+Per CSS, a `position: fixed` element anchors to the nearest ancestor that establishes a **containing block** — any ancestor with `transform`, `filter`, `backdrop-filter`, `perspective`, `will-change`, or `contain` — **not** the viewport. On every real surface such an ancestor exists:
+
+- the frosted global `.card` (`primitives.css` → `backdrop-filter: blur(30px) saturate(1.35)`) wraps `note-chat`, `meeting-chat`, and `ask`;
+- `.ask-panel` additionally has `overflow: hidden`, which *clips* the popover;
+- worst: the concurrent `.note-chat-drawer` is itself `position: fixed` **and** runs an entry animation whose keyframes set `transform: translateX()` — an active transform makes it the containing block for any fixed descendant.
+
+So the viewport-computed `left/top` resolve relative to that ancestor's box → the overlay lands offset / off-screen / clipped → **"the source picker looks dead", "the toolbar is positioned wrong"**. These are the *same bug* on different overlays.
+
+**Evidence (live):** a `position:fixed` child at viewport `left:200` inside an ancestor offset by `margin-left:400` renders at `left:600` (`anchoredToAncestor:true`) when the ancestor has *any* of `backdrop-filter`/`transform`/`filter`/`will-change`; with none it stays at `left:200`. Measured in the app's shipping engine (Playwright + WebKit + the real stylesheet).
+
+**Anti-fix:** subtracting the ancestor's rect in `reposition()` is a symptom patch — it re-breaks the instant an ancestor's transform changes, which the drawer's entry animation guarantees.
+
+### 1b. Idle "Loading note…" forever (CONFIRMED)
+
+The record screen mounts the embedded companion-note editor whenever `realtimeReactions` is on, **independent of whether a meeting exists** (`record.component.ts` → `showAssistant()` is true at stage `idle`). Idle, `meetingId` is `null` → `ensureCompanionNote()` early-returns → the editor receives `noteIdInput = null` → its `_load` effect deliberately holds `loading = true` forever for the "embedded + no id yet" case — a state assumed transient ("host will supply an id shortly") but **permanent** while idle because there is no host meeting. Embedded mode also strips title/props/chrome, so the pane reads as a purposeless, permanently-spinning box. The routed `/notes/new` create path shows the same bare `Loading note…` line (`note-editor.component.html`) during the create round-trip.
+
+### 1c. Recording view reads as "a mess" (composition, not a single bug)
+
+Two competing heroes: the embedded document editor (Note tab) **and** a structurally different live `@brain` thread (`MeetingConversationStore`), behind a `Note | Ask Brain` segmented control, plus a reactions rail — layered over the toolbar containing-block bug (1a), glass-on-glass stacking (`.rec-strip` and `.card` both blur), and nested scroll regions.
+
+---
+
+## 2. Decisions (locked)
+
+| # | Decision | Choice | Consequence |
+|---|---|---|---|
+| D1 | **Mode model** | **One morphing surface** | idle → recording → note are *states* of one note surface, not separate screens/components. |
+| D2 | **Idle record screen** | **"Ready to record" launch hero** | No companion editor while idle. The companion note is lazily created on Record-start; `delete_companion_note_if_empty` cleans up empties. "Loading note…" is gone. |
+| D3 | **Ask Brain placement** | **Right-side drawer everywhere** | The drawer (recording + routed notes) is the single note+Brain pattern. The `Note | Ask Brain` segmented tabs are retired. Absorbs the concurrent drawer work. |
+| D4 | **Live strip density** | **Keep the rich "live" strip** | Preserve the energetic feel (waveform + caption + controls). Fix *composition/hierarchy*, not richness. |
+| D5 | **Source-scope UI** (resolved by research) | **Persistent inline "Sources" chip row** | Chips always visible above every Ask composer; `+ Source` opens the (portaled) popover only to *add*; `×` removes. Surface `askVault` citations on replies. |
+
+---
+
+## 3. The design
+
+### 3.1 Load-bearing root fix — `mur-overlay-host` (a body-level overlay portal)
+
+A new design-system component mounted **once at the app root**, providing a `document.body`-level outlet into which floating overlays teleport their popover + scrim so **no ancestor can ever be their containing block**.
+
+- **Consumers (all four):** `SourcePickerComponent`, `NoteSelectionToolbarComponent`, `NoteBrainPopoverComponent`, `LinkPickerComponent`.
+- **Mechanism:** on open, move the popover/scrim DOM node into the overlay host via `afterNextRender({ injector })` (zoneless, **no `setTimeout`/`rAF`**); on close and in `DestroyRef.onDestroy`, detach/return it. `reposition()` (viewport `getBoundingClientRect` → `style.left/top`) then works **unchanged** because `body` has no containing-block ancestor.
+- **Styling:** the popover stays the **opaque** `.menu` (`--surface-overlay`, `backdrop-filter: none`) per **T3** — glass never stacks on glass. Tokens-only. **No new npm deps.**
+- **Stacking:** the host owns a single, documented z-index band above app chrome; supports multiple concurrent overlays without leaks (teardown on destroy).
+
+> This one change fixes the source-picker AND the recording formatting toolbar AND the Brain popover AND the link-picker on **every** surface, and can never re-break when an ancestor gains a transform/filter. It is verified **first**.
+
+### 3.2 The morphing surface — states, not screens
+
+A single note surface expresses three states. State morphs the **chrome around** the document; the editable document itself is the persistent hero and is never swapped out.
+
+```
+IDLE (record screen, no meeting)      RECORDING / NOTE
+┌───────────────────────────┐         ┌──────────────────────────────────────┐
+│  ▶  Ready to record        │         │ ● 00:14  ~~live caption~~     [⏹ Stop] │ ← rich status strip
+│      ⌘R                    │   ──▶   ├───────────────────────────┬──────────┤
+│  device ok · vault ok      │         │  Your note                │  Ask     │
+│  (launch hero — no editor) │         │  (one growing document,   │  Brain   │ ← one hero:
+└───────────────────────────┘         │   the real embedded       │  drawer  │   doc + Brain drawer
+                                       │   editor)                 │          │
+                                       └───────────────────────────┴──────────┘
+```
+
+- **IDLE (D2):** the record screen shows a **launch hero** — recording/device/vault status + a primary Record affordance (⌘R). No embedded companion editor is mounted (root fix for 1b: don't show a companion editor when there's nothing to be a companion to). Gate on `store.meetingId()` — do not mount the note-hosting path / do not default to the note tab when there is no meeting.
+- **RECORDING / NOTE:** the embedded editor is the single hero — **one growing document** (AI "Add to note" appends into the body, styled to show provenance, per Granola/Notion). The **Ask Brain drawer** docks on the right and *shrinks* the document column (never covers it — the existing flex-row behavior). The `Note | Ask Brain` segmented tabs are retired (D3). The live `.rec-strip` sits above as **rich status chrome** (D4).
+- **ROUTED note (`/notes/:id`, `/notes/new`):** identical editor with full chrome (title, properties, backlinks) + the same Ask Brain drawer. The `/notes/new` create renders the editor **optimistically with a placeholder** (`Type to start writing · / for blocks · Record to capture a meeting`) while `create` resolves underneath — **never a bare spinner** (root fix for the routed half of 1b; stale-while-revalidate per rule §8).
+
+### 3.3 Ask Brain drawer = the one note+Brain pattern (D3)
+
+- The right drawer hosts `NoteChatComponent` in `bare` mode (the concurrent work), on **both** the recording surface and routed notes.
+- The recording surface's `MeetingConversationStore` live `@brain` thread is **consolidated toward the drawer + the companion note**: Q&A lives in the drawer (source-scoped `askVault`); useful answers are promotable into the document ("Add to note"). Proactive/live Brain reactions (hint cards, whisper cards) remain **ambient and subordinate** — not a competing hero.
+- The strip's **"Ask" button toggles the Ask Brain drawer** (D4 consistency), replacing the separate voice-thread entry point.
+
+> **Open trace before final wiring (from research):** confirm whether the live `@brain` thread (`MeetingConversationStore`) holds any persistence/behavior the companion note + drawer lack, before retiring it. Called out in §7.
+
+### 3.4 Source scope = persistent inline chips + citations (D5)
+
+- Above **every** Ask composer (note-chat, meeting-chat, ask), render `sources()` as an **always-visible chip row** ("Grounded in: [This note ×] [Design sync ×] [+ Source]"). Lift the chips **out** of the source-picker's `open()` gate — today they only show while the popover is engaged, which is the legibility bug.
+- `+ Source` opens the (now-portaled, correctly-positioned) popover **only to add**; each chip's `×` removes. Pre-fill remains the note + its active links (`SourceScopeService.defaultSources`).
+- On each grounded reply, **surface the sources it cited** (`askVault` already returns citations), closing the "did it actually scope?" loop.
+
+### 3.5 Glass discipline + formatting-bubble placement
+
+- **Opaque hero card:** give the meeting-conversation / note-hosting card an **opaque, filter-free** variant (a token) so glass is strictly *chrome*, never a content wrapper hosting fixed overlays (T3/T4). Removes glass-on-glass; part of the durable toolbar fix.
+- **Rich-but-coherent strip (D4):** keep waveform + live-caption + controls; fix hierarchy and spacing (resolve the 16-vs-28-bar overflow), tidy the "your side · full transcript after Stop" honesty chip. No stripping of the live energy.
+- **Formatting bubble rules:** with overlays portaled to body, the selection bubble must **clamp horizontally to the shrunk document column** (not `window.innerWidth`) so it never straddles/hides under the open drawer; **hide** while the drawer/popover holds focus (a `shouldShow`-style guard, no two floating surfaces stacked); z-index below the drawer, above the doc.
+
+---
+
+## 4. What changes where (implementation surface)
+
+| Area | Change |
+|---|---|
+| `src/app/design-system/overlay-host/` (NEW) | The body-level overlay outlet + a small directive/service consumers teleport into. Mounted at app root. |
+| `source-picker.component.ts/.scss` | Teleport popover+scrim to the overlay host on open; detach on close/destroy. **Lift chips into a persistent inline row** (or expose them so consumers render them always-visible). |
+| `note-selection-toolbar`, `note-brain-popover`, `link-picker` | Same teleport-to-overlay-host treatment. Selection bubble: clamp to doc column + hide-when-drawer-focused. |
+| `record.component.ts/.html/.scss` | Idle **launch hero**; gate the companion-editor mount on `meetingId()`; strip **"Ask" toggles the drawer**; tidy the rich strip (hierarchy/spacing). |
+| `meeting-conversation.component.*` + `meeting-conversation.store.ts` | Retire `Note | Ask Brain` segmented tabs → embedded editor hero + Ask Brain drawer; **opaque** hero card; consolidate the live thread toward drawer+companion note (pending §7 trace). |
+| `note-editor.component.ts/.html` | Split `loading` (in-flight fetch only) from the idle/empty state; add an `idleNoMeeting`-style computed; **optimistic create + placeholder** for `/notes/new`; adopt the drawer as the routed note+Brain pattern (absorb concurrent work). |
+| `note-chat.component.*`, `meeting-chat.component.*`, `ask.component.*` | Persistent inline **Sources** chip row above the composer; render reply **citations**. `.ask-panel` overflow no longer clips (popover is portaled). |
+| `src/design-tokens/*.css` | Add the opaque filter-free surface variant + any drawer/overlay-band tokens (with light-theme overrides). |
+
+---
+
+## 5. Phasing (each phase independently verifiable; RED→GREEN)
+
+Sequenced **portal-first** so the load-bearing fix lands and is verified before the larger recompose. If scope must shrink, stopping after Phase 2 already resolves the two "feels broken" bugs (this is the "minimal-coherent" fallback, which is literally the first phases of this plan).
+
+1. **Portal** — `mur-overlay-host` + move all four overlays into it. **RED:** picker/toolbar offset inside a transformed drawer on real WebKit. **GREEN:** lands on-anchor everywhere.
+2. **Idle** — launch hero on the record screen (no companion editor when `meetingId` null) + optimistic `/notes/new` placeholder + split `loading`. **RED:** idle shows `Loading note…` forever / null-id spinner. **GREEN:** hero / placeholder, never a permanent spinner.
+3. **Drawer + recompose** — retire segmented tabs → drawer everywhere; opaque hero card; "Ask" toggles drawer; tidy rich strip. (Touches the record surface's Stop→flush→delete-if-empty path — re-verify the content-loss race is intact.)
+4. **Source pills + citations** — persistent inline chips + reply citations across the three Ask surfaces.
+5. **Consistency pass** — token/spacing/hierarchy sweep so idle/recording/routed read as one language; formatting-bubble clamp + hide-when-drawer rules.
+
+**Verification (every phase):** `cargo test --lib` (if backend touched) + `npx ng lint` + `npx ng build`; live-reproduce against `:1420` (mocked `invoke`); **adversarial-verifier owns PASS/FAIL**; **lock-security-reviewer** on anything touching content reads / the masked-DTO audio gate (this work should not, but the reviewer confirms no regression). Real-WebKit render test for the CSP/style + overlay behavior (green `ng serve` ≠ shipped). The live strip's true behavior (mic→waveform, caption cadence, Stop→flush→delete race) needs a **signed build on a real Mac** — stated honestly, not claimed from a unit test.
+
+---
+
+## 6. Coordination (multiple agents in the shared tree)
+
+- Another agent has **uncommitted work** in `note-chat` / `note-editor` / `connections` / `commands.rs` / `db.rs` (the drawer + collapsed suggestions). This redesign **absorbs** that drawer.
+- **All implementation runs in an isolated git worktree** (branched from `murmur` HEAD; shared `CARGO_TARGET_DIR`, murmur-server symlink, private Playwright port per the repo recipe) so the shared working tree is never stomped ([[shared-workdir-commit-on-wrong-branch]], [[worktree-collision-mid-verification]]).
+- Land via **PR → `murmur`** (direct trunk push is blocked). Author `QueaT <kgm004a@gmail.com>`, no Claude trailers.
+- Before merge: rebase onto latest trunk and **re-run the gate on the merged result** (merge-skew guard) — especially if the concurrent drawer work merges first.
+
+---
+
+## 7. Open questions / risks
+
+1. **Live-thread consolidation:** does `MeetingConversationStore`'s live `@brain` thread carry persistence/behavior the companion note + drawer don't? Trace before retiring it (Phase 3). If yes, keep it as an ambient reactions feed, not a hero.
+2. **Proactive reactions home:** where do hint/whisper cards live in the drawer-everywhere model — inside the drawer, or as ambient cards over the doc? Kept subordinate either way; final placement decided during Phase 3 with a live look.
+3. **Overlay-host stacking:** multiple concurrent overlays (e.g. link-picker open while a bubble exists) must not fight for z-index or leak on destroy — covered by the host's single band + `DestroyRef` teardown; verify.
+4. **Real-Mac-only truths:** waveform/caption perceptual density and the Stop→flush→delete-if-empty race are not headless-verifiable — signed build required.
+
+---
+
+## 8. Constraints honored
+
+Local-first (pure client UI over the existing `askVault` seam — no new egress; scoping *strengthens* privacy legibility) · Obsidian-owned `.md` (the "one growing document" **is** the vault note; "Add to note" appends into the real body) · SQLite canonical (transcript/note/AI output are three views of one store — resist a separate persisted live artifact) · Liquid Glass / tokens-only, T3 opaque overlays, T4 CSP untouched · provider seam + redaction firewall untouched · **no new npm deps** · zoneless signals, `@if`/`@for`, `afterNextRender`, no `setTimeout` in components.
+
+---
+
+## 9. References (research, 2026-07-18)
+
+Granola (transcript = toggle, notepad = hero; gray-AI/black-user in one doc; ephemeral-chat is the anti-pattern) · Notion AI Meeting Notes (Notes/Transcript tabs in-doc, idle = prep + Start, in-place summary + clickable transcript citations) · Obsidian meeting/voice plugins (record → one `.md`, live-transcript sidebar) · Cursor / Perplexity / ChatGPT & Claude Projects (persistent context pills / Sources tab = scope legibility) · Tiptap BubbleMenu / Lexical (floating bubble, `shouldShow`, no persistent toolbar) · Notion "blank page" (placeholder-as-affordance, never a spinner). Full source list in the research brief (workflow `w6aqqcezj` + follow-up research agent).

--- a/e2e/ask/ask-source-scope.spec.ts
+++ b/e2e/ask/ask-source-scope.spec.ts
@@ -66,13 +66,16 @@ test("Ask page threads the picked source into ask_vault's explicitSources (empty
 
   // Open the picker, pick the one candidate → a chip appears.
   await page.locator("mur-source-picker .sp-trigger").click();
-  await page.locator("mur-source-picker .sp-row").first().click();
+  // The popover (`.sp-pop`/`.sp-scrim`/`.sp-row`) is TELEPORTED to <body>
+  // (appTeleportToBody), so it is NOT under `mur-source-picker` — locate it at
+  // page level. The trigger + selected chips stay in-tree.
+  await page.locator(".sp-row").first().click();
   await expect(page.locator("mur-source-picker .sp-chip-title")).toHaveText([
     "Planning sync",
   ]);
   // Close the popover so the composer regains focus.
-  await page.locator("mur-source-picker .sp-scrim").click();
-  await expect(page.locator("mur-source-picker .sp-pop")).toHaveCount(0);
+  await page.locator(".sp-scrim").click();
+  await expect(page.locator(".sp-pop")).toHaveCount(0);
 
   // Scoped turn: the picked meeting rides ask_vault as explicitSources. Click
   // Send explicitly (deterministic) and wait for the SECOND user row to land.

--- a/e2e/notes/brain-popover.spec.ts
+++ b/e2e/notes/brain-popover.spec.ts
@@ -2,8 +2,14 @@ import { test, expect } from "@playwright/test";
 import { mockNotes } from "./mock-invoke";
 
 /**
+ * NOTE (2026-07-18 teleport): the floating bubble + Brain popover boxes are
+ * TELEPORTED to `<body>` (appTeleportToBody) so `position: fixed` escapes any
+ * filtered/transformed ancestor. They therefore no longer live INSIDE their
+ * `app-note-selection-toolbar` / `app-note-brain-popover` hosts in the DOM — this
+ * spec locates the boxes by their class (`.sel-bar` / `.brain-pop`) at page level.
+ *
  * The selection Brain-assistant popover (FP3). Selecting body text now floats a
- * FORMATTING BUBBLE (`app-note-selection-toolbar`); the Brain popover opens only
+ * FORMATTING BUBBLE (`.sel-bar`); the Brain popover (`.brain-pop`) opens only
  * when its "Ask Brain" button is pressed — the modal no longer auto-appears.
  * `onBodySelect()` is wired to the textarea's (mouseup)/(keyup)/(select) events
  * and reads `selectionStart/End`. We simulate that by focusing `.body-area`,
@@ -47,12 +53,12 @@ test("selecting body text floats the bubble; Ask Brain → Refine → Accept upd
   // The FORMATTING BUBBLE floats first (not the Brain modal). Its "Ask Brain"
   // button opens the popover. Use dispatchEvent("click") — a plain DOM click that
   // doesn't disturb the live textarea selection (see the Refine note below).
-  const bubble = page.locator("app-note-selection-toolbar");
+  const bubble = page.locator(".sel-bar");
   await expect(bubble).toBeVisible();
-  await expect(page.locator("app-note-brain-popover")).toHaveCount(0);
+  await expect(page.locator(".brain-pop")).toHaveCount(0);
   await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
 
-  const popover = page.locator("app-note-brain-popover");
+  const popover = page.locator(".brain-pop");
   await expect(popover).toBeVisible();
 
   // The ClickUp-style command menu: the "Ask Brain to edit…" input + the 5 quick
@@ -149,11 +155,11 @@ test("Find related: an org-kind citation routes to the read-only /org-item viewe
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
   });
 
-  const bubble = page.locator("app-note-selection-toolbar");
+  const bubble = page.locator(".sel-bar");
   await expect(bubble).toBeVisible();
   await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
 
-  const popover = page.locator("app-note-brain-popover");
+  const popover = page.locator(".brain-pop");
   await expect(popover).toBeVisible();
   await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
 
@@ -223,11 +229,11 @@ test("Find related: Insert link drops a [[Title]] wikilink into the body instead
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
   });
 
-  const bubble = page.locator("app-note-selection-toolbar");
+  const bubble = page.locator(".sel-bar");
   await expect(bubble).toBeVisible();
   await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
 
-  const popover = page.locator("app-note-brain-popover");
+  const popover = page.locator(".brain-pop");
   await expect(popover).toBeVisible();
   await popover.getByRole("button", { name: "Find related" }).dispatchEvent("click");
 

--- a/e2e/notes/connections-linking.spec.ts
+++ b/e2e/notes/connections-linking.spec.ts
@@ -171,7 +171,9 @@ test("connections panel: × only on manual chips (unlink), + Link chooser links 
   // Open the + Link chooser → the query input + the opaque picker popover appear.
   await panel.getByRole("button", { name: "Link" }).click();
   await expect(panel.getByPlaceholder(/Link a meeting, note/)).toBeVisible();
-  const picker = page.locator("app-link-picker");
+  // The link-picker popover box is TELEPORTED to <body> (appTeleportToBody) —
+  // locate it by class, not by the `app-link-picker` host.
+  const picker = page.locator(".link-pop");
   await expect(picker).toBeVisible();
 
   // The picker offers the candidates (org row is not a valid endpoint; picking a

--- a/e2e/notes/link-picker.spec.ts
+++ b/e2e/notes/link-picker.spec.ts
@@ -98,7 +98,7 @@ test("slash menu 'Link to note' opens the autocomplete popover and inserts [[Tit
   await slashMenu.getByRole("option", { name: "Link to note" }).click();
 
   // The link picker is now open (OPAQUE overlay, T3) with the mocked candidates.
-  const picker = page.locator("app-link-picker");
+  const picker = page.locator(".link-pop");
   await expect(picker).toBeVisible();
   await expect(picker.getByText("Weekly plan")).toBeVisible();
   await expect(picker.getByText("Kickoff")).toBeVisible();
@@ -160,14 +160,15 @@ test("scrolling the picker to the bottom loads further candidate pages", async (
   await body.press("[");
   await body.press("[");
 
-  const picker = page.locator("app-link-picker");
+  const picker = page.locator(".link-pop");
   await expect(picker).toBeVisible();
   const rows = picker.locator(".link-pop-row");
   // Page 0: exactly one backend page, not the old top-8.
   await expect(rows).toHaveCount(40);
 
-  // Scroll the popover itself to the bottom → the next page appends.
-  const pop = picker.locator(".link-pop");
+  // Scroll the popover itself to the bottom → the next page appends. The picker
+  // locator IS the teleported `.link-pop` box now (moved to <body>).
+  const pop = picker;
   await pop.evaluate((el) => {
     el.scrollTop = el.scrollHeight;
   });
@@ -212,7 +213,7 @@ test("typing [[ also opens the link-picker autocomplete", async ({ page }) => {
   await body.press("[");
   await body.press("[");
 
-  const picker = page.locator("app-link-picker");
+  const picker = page.locator(".link-pop");
   await expect(picker).toBeVisible();
   await expect(picker.getByText("Weekly plan")).toBeVisible();
 

--- a/e2e/notes/note-editor-embedded.spec.ts
+++ b/e2e/notes/note-editor-embedded.spec.ts
@@ -161,10 +161,12 @@ test("(b) embedded mount shows ONLY the body + working Ask Brain — no header/t
     el.setSelectionRange(start, start + "body text".length);
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
   });
-  const bubble = embed.locator("app-note-selection-toolbar");
+  // The bubble + Brain popover boxes are TELEPORTED to <body> (appTeleportToBody),
+  // so they're located by class at page level, not under the embed host.
+  const bubble = page.locator(".sel-bar");
   await expect(bubble).toBeVisible();
   await bubble.getByRole("button", { name: "Ask Brain" }).dispatchEvent("click");
-  await expect(embed.locator("app-note-brain-popover")).toBeVisible();
+  await expect(page.locator(".brain-pop")).toBeVisible();
 
   // Tear the embedded instance down cleanly (no leaked effect across tests).
   await page.evaluate(() => {

--- a/e2e/notes/note-editor.spec.ts
+++ b/e2e/notes/note-editor.spec.ts
@@ -36,7 +36,7 @@ test("note editor loads a note, floats the formatting bubble on selection, and P
     el.setSelectionRange(start, start + "body text".length);
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
   });
-  const bubble = page.locator("app-note-selection-toolbar");
+  const bubble = page.locator(".sel-bar");
   await expect(bubble).toBeVisible();
   // The button label is its text ("H1"); the descriptive "Heading 1" is its title.
   await expect(bubble.getByRole("button", { name: "H1", exact: true })).toBeVisible();

--- a/e2e/notes/source-picker-teleport-dismiss.spec.ts
+++ b/e2e/notes/source-picker-teleport-dismiss.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * Regression (2026-07-18, note-surface redesign Phase 1): the `<mur-source-picker>`
+ * popover + scrim are TELEPORTED to `<body>` (`appTeleportToBody`) so their
+ * `position: fixed` anchors to the VIEWPORT instead of the `.chat.card`
+ * backdrop-filter containing block (which offset it off-anchor — "looked dead").
+ *
+ * The teleport must ALSO stay dismissable: a prior revision left the popover
+ * UNDISMISSABLE because the directive moved the node back to its in-tree slot on
+ * destroy — but Angular's `detachView` removes DOM nodes (via their CURRENT parent,
+ * `body`) BEFORE destroy hooks run, so the move-back RESURRECTED the just-removed
+ * popover. This asserts: open → teleported to <body> + on-anchor → dismiss via
+ * outside-click (scrim) AND via Escape → the popover is gone with ZERO orphan
+ * overlay nodes left in the document. RED on the move-back revision, GREEN now.
+ */
+test("source-picker teleports on-anchor and stays dismissable (scrim + Escape), no orphan", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  await mockNotes(page, {
+    list_links: () => [],
+  });
+  await page.goto("/notes/n1");
+
+  const picker = page.locator("app-note-chat mur-source-picker");
+  await expect(picker).toBeVisible();
+  const trigger = picker.locator(".sp-trigger");
+
+  // --- Open: the popover mounts, TELEPORTED to <body>, ON-ANCHOR under the trigger.
+  await trigger.click();
+  const pop = page.locator(".sp-pop");
+  await expect(pop).toBeVisible();
+
+  const teleportParent = await page.evaluate(
+    () => document.querySelector(".sp-overlay")?.parentElement?.tagName ?? null,
+  );
+  expect(teleportParent).toBe("BODY");
+
+  const geo = await page.evaluate(() => {
+    const t = document
+      .querySelector("app-note-chat .sp-trigger")!
+      .getBoundingClientRect();
+    const p = document.querySelector(".sp-pop")!.getBoundingClientRect();
+    return { dLeft: Math.abs(p.left - t.left), below: p.top >= t.top };
+  });
+  // On-anchor: aligned to the trigger's left and below it — NOT shoved hundreds of
+  // px away by the card's box (the containing-block bug the teleport fixes).
+  expect(geo.dLeft).toBeLessThan(60);
+  expect(geo.below).toBe(true);
+
+  // --- Dismiss #1: outside click (the full-viewport scrim) → gone, no orphan.
+  await page.mouse.click(4, 4);
+  await expect(pop).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () => document.querySelectorAll(".sp-overlay, .sp-pop, .sp-scrim").length,
+    ),
+  ).toBe(0);
+
+  // --- Dismiss #2: Escape from the search field → gone, no orphan.
+  await trigger.click();
+  await expect(pop).toBeVisible();
+  await page.locator(".sp-search").focus();
+  await page.keyboard.press("Escape");
+  await expect(pop).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () => document.querySelectorAll(".sp-overlay, .sp-pop, .sp-scrim").length,
+    ),
+  ).toBe(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/record/companion-note-tabs.spec.ts
+++ b/e2e/record/companion-note-tabs.spec.ts
@@ -2,19 +2,18 @@ import { test, expect } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
 /**
- * v2 DOCUMENT-FIRST recording panel — a two-tab surface (Note | Ask Brain).
+ * v3 DOCUMENT-FIRST recording panel — the note is the always-visible HERO, Ask
+ * Brain is a right-side DRAWER (2026-07-18 redesign; replaces the v2 Note|Ask
+ * segmented tabs).
  *
- *  - The "Note" tab (default) mounts the EMBEDDED note editor on the meeting's ONE
- *    companion note (eagerly created via `get_or_create_companion_note`). It is ONE
- *    editable DOCUMENT — no per-jot "Saved to Notes" badges.
- *  - The "Ask Brain" tab hosts the `@brain` conversation. A plain single-line input
- *    opens a thread; the answer renders with the brain identity.
- *  - The tabs switch cleanly (the segmented control drives `activeTab`).
- *
- * These replace the retired v1 specs (`companion-note-card` / `note-save-failure-toast`),
- * which asserted on the removed `mur-markdown-composer` + per-jot "Saved to Notes" card.
+ *  - The embedded note editor mounts on the meeting's ONE companion note (eagerly
+ *    created via `get_or_create_companion_note`) and is ALWAYS VISIBLE — one editable
+ *    DOCUMENT, no per-jot "Saved to Notes" badges.
+ *  - The "Ask Brain" head toggle opens/closes a drawer hosting the `@brain` thread
+ *    BESIDE the editor (shrinks it, never hides it). One live editor instance stays
+ *    mounted for the whole recording (the flush-at-Stop target).
  */
-test.describe("Record — document-first companion-note tabs (v2)", () => {
+test.describe("Record — document-first companion note + Ask Brain drawer (v3)", () => {
   test.beforeEach(async ({ page }) => {
     await mockTauri(page, {
       model_present: () => true,
@@ -22,7 +21,7 @@ test.describe("Record — document-first companion-note tabs (v2)", () => {
         meetingId: "m-rec",
         startedAt: "2026-07-01T09:00:00Z",
       }),
-      // Eager get-or-create for the "Note" tab's embedded editor mount.
+      // Eager get-or-create for the hero editor's mount.
       get_or_create_companion_note: () => ({
         noteId: "n1",
         meetingWikilink: "[[Test Meeting]]",
@@ -67,12 +66,12 @@ test.describe("Record — document-first companion-note tabs (v2)", () => {
     await expect(page.locator("app-meeting-conversation")).toBeVisible();
   }
 
-  test("(a) the Note tab shows an editable document body — no per-jot badges", async ({
+  test("(a) the note document is the always-visible editable hero — no per-jot badges", async ({
     page,
   }) => {
     await startRecording(page);
 
-    // The default tab is "Note": the embedded editor mounts on the companion note.
+    // The embedded editor mounts on the companion note as the visible hero.
     const body = page.locator(
       "app-meeting-conversation app-note-editor .editor-body textarea.body-area",
     );
@@ -89,26 +88,23 @@ test.describe("Record — document-first companion-note tabs (v2)", () => {
     await expect(body).toHaveValue(/ship the three flows/);
   });
 
-  test("(b) switching to Ask Brain shows the conversation and can ask", async ({
+  test("(b) opening the Ask Brain drawer shows the conversation and can ask (editor stays visible)", async ({
     page,
   }) => {
     await startRecording(page);
 
-    // Switch to the Ask Brain tab via the segmented control.
-    await page
-      .locator("app-meeting-conversation mur-segmented")
-      .getByText("Ask Brain", { exact: true })
-      .click();
+    // Open the Ask Brain drawer via the head toggle.
+    await page.locator("app-meeting-conversation .ask-toggle").click();
 
     const ask = page.locator("app-meeting-conversation .ask-input");
     await expect(ask).toBeVisible();
 
-    // The embedded document editor stays MOUNTED for the whole recording (the fix
-    // keeps ONE live editor to flush at Stop) but is HIDDEN while on the Ask tab —
-    // so it must be present-but-not-visible, not removed from the DOM.
+    // The embedded document editor is the always-visible HERO — the drawer docks
+    // BESIDE it (shrinks it), it is NOT hidden. One live editor stays mounted as the
+    // flush-at-Stop target.
     await expect(
       page.locator("app-meeting-conversation app-note-editor"),
-    ).toBeHidden();
+    ).toBeVisible();
 
     // Ask a question → a thread opens and the brain answers.
     await ask.fill("why was the mobile redesign deferred?");
@@ -120,25 +116,34 @@ test.describe("Record — document-first companion-note tabs (v2)", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test("(c) tabs switch cleanly back and forth", async ({ page }) => {
+  test("(c) the Ask Brain drawer toggles open and closed cleanly", async ({
+    page,
+  }) => {
     await startRecording(page);
 
-    const seg = page.locator("app-meeting-conversation mur-segmented");
+    const toggle = page.locator("app-meeting-conversation .ask-toggle");
     const body = page.locator(
       "app-meeting-conversation app-note-editor .editor-body textarea.body-area",
     );
 
-    // Note tab (default) → editor mounted.
+    // Default: the editor is the visible hero, drawer closed (no ask input).
     await expect(body).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator("app-meeting-conversation .ask-input"),
+    ).toHaveCount(0);
 
-    // → Ask Brain: editor HIDDEN (stays mounted — one live flush target), ask input shown.
-    await seg.getByText("Ask Brain", { exact: true }).click();
-    await expect(page.locator("app-meeting-conversation .ask-input")).toBeVisible();
-    await expect(page.locator("app-meeting-conversation app-note-editor")).toBeHidden();
+    // Open the drawer → the ask input shows, the editor STAYS visible beside it.
+    await toggle.click();
+    await expect(
+      page.locator("app-meeting-conversation .ask-input"),
+    ).toBeVisible();
+    await expect(body).toBeVisible();
 
-    // → back to Note: the editor re-shows + reloads in place (no re-mount), ask input gone.
-    await seg.getByText("Note", { exact: true }).click();
-    await expect(body).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator("app-meeting-conversation .ask-input")).toHaveCount(0);
+    // Close the drawer → the editor reloads in place (no re-mount), ask input gone.
+    await toggle.click();
+    await expect(
+      page.locator("app-meeting-conversation .ask-input"),
+    ).toHaveCount(0);
+    await expect(body).toBeVisible();
   });
 });

--- a/e2e/record/idle-no-companion-loading.spec.ts
+++ b/e2e/record/idle-no-companion-loading.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * D2 (idle redesign, 2026-07-18). The base mock's config has `realtimeReactions:
+ * true`, so the record screen at IDLE (nothing recording, no live meeting) is
+ * exactly the bug path: `showAssistant()` used to be true on that setting ALONE,
+ * mounting `app-meeting-conversation` → the embedded companion editor with a null
+ * note id → a PERMANENT "Loading note…" spinner (the user's "I don't know why we
+ * need this note" complaint).
+ *
+ * The fix gates the `realtimeReactions` term on an actual live meeting
+ * (`store.meetingId()`), so idle shows the LAUNCH HERO (Start button) and NEVER
+ * the companion surface / a loading note. RED before the guard (companion mounts +
+ * "Loading note…" shows); GREEN after.
+ */
+test("idle record screen (realtimeReactions ON) shows the launch hero, not a Loading-note companion", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  await mockTauri(page, { model_present: () => true });
+  await page.goto("/record");
+
+  // The launch hero (Start) is present — the idle surface is a launch surface.
+  await expect(page.locator("button.start-btn")).toBeVisible();
+  // With no live meeting, the companion surface is NOT mounted …
+  await expect(page.locator("app-meeting-conversation")).toHaveCount(0);
+  // … so a permanent "Loading note…" spinner can never appear at idle.
+  await expect(page.getByText("Loading note…")).toHaveCount(0);
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -83,6 +83,11 @@
 </div>
 
 @if (open()) {
+  <!-- Scrim + popover are TELEPORTED to <body> (appTeleportToBody) as one overlay
+       so `position: fixed` anchors to the VIEWPORT, never a filtered/transformed
+       ancestor (the `.card` backdrop-filter / drawer transform containing-block
+       trap that made the picker "look dead"). display:contents → no extra box. -->
+  <div class="sp-overlay" appTeleportToBody>
   <!-- Scrim: a click OUTSIDE the popover closes it. Transparent (only the panel
        carries the opaque overlay — T3). role=button + Enter/Space/Esc satisfy the
        a11y lints (mirrors the quick-search scrim). -->
@@ -168,5 +173,6 @@
         }
       }
     </div>
+  </div>
   </div>
 }

--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -82,17 +82,25 @@
 /* --- Popover (opaque overlay) --------------------------------------------- */
 /* A fixed full-viewport scrim so an outside click closes the popover; only the
    panel is opaque — the scrim itself is transparent (T3: glass never on glass). */
+/* Teleport wrapper (appTeleportToBody): no box of its own — the scrim + popover
+   inside keep their own `position: fixed` and are anchored to the viewport once
+   this wrapper is a direct child of <body>. */
+.sp-overlay {
+  display: contents;
+}
 .sp-scrim {
   position: fixed;
   inset: 0;
-  z-index: 40;
+  /* Teleported to <body>: must cover ALL app chrome so an outside click closes. */
+  z-index: var(--z-overlay);
   background: transparent;
 }
 .sp-pop {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 41;
+  /* One above the scrim (same top layer, teleported to <body>). */
+  z-index: calc(var(--z-overlay) + 1);
   width: 300px;
   max-width: calc(100vw - 2 * var(--space-3));
   gap: var(--space-2);

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -17,6 +17,7 @@ import { IpcService } from "../../core/ipc.service";
 import type { LinkKind, NoteCitation, SourceRef } from "../../core/models";
 import { DebounceService } from "../../services/debounce.service";
 import { RepositionOnScrollDirective } from "../../features/notes/note-brain-popover/reposition-on-scroll.directive";
+import { TeleportToBodyDirective } from "../teleport-to-body.directive";
 
 /** How long to wait after the last keystroke before re-querying the backend. */
 const QUERY_DEBOUNCE_MS = 150;
@@ -65,7 +66,7 @@ const ALLOWED_KINDS: ReadonlySet<string> = new Set<LinkKind>([
 @Component({
   selector: "mur-source-picker",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RepositionOnScrollDirective],
+  imports: [RepositionOnScrollDirective, TeleportToBodyDirective],
   templateUrl: "./source-picker.component.html",
   styleUrl: "./source-picker.component.scss",
 })

--- a/src/app/design-system/teleport-to-body.directive.ts
+++ b/src/app/design-system/teleport-to-body.directive.ts
@@ -1,0 +1,73 @@
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  inject,
+} from "@angular/core";
+
+/**
+ * `[appTeleportToBody]` — moves the host element to `document.body` so a floating
+ * overlay escapes any ancestor that would otherwise be its `position: fixed`
+ * CONTAINING BLOCK.
+ *
+ * WHY (the bug this closes): an overlay that is `position: fixed` and positioned
+ * in JS from a viewport `getBoundingClientRect()` only anchors to the VIEWPORT
+ * when NO ancestor establishes a fixed-positioning containing block. Any ancestor
+ * with `transform` / `filter` / `backdrop-filter` / `perspective` / `will-change`
+ * / `contain` becomes that containing block instead, so the viewport-computed
+ * `left/top` resolve relative to the ancestor's box and the overlay lands
+ * offset / off-screen / clipped. Murmur's frosted `.card` (backdrop-filter) and
+ * the note drawer (a `translateX` entry animation) routinely trip this, which is
+ * why the source picker "looked dead" and the selection toolbar floated off the
+ * text. Teleporting the overlay box to `body` (always the viewport containing
+ * block) makes the EXISTING coordinate math correct on every surface, and can
+ * never re-break when an ancestor later gains a transform/filter.
+ *
+ * TEARDOWN (the subtle part — a prior version got this WRONG and made the picker
+ * undismissable): when the host `@if` flips false, Angular's `detachView` removes
+ * the view's DOM nodes via their CURRENT parent (`document.body`) BEFORE it runs
+ * destroy hooks. So the teleported node is ALREADY removed by the time this
+ * directive's `onDestroy` fires. We must therefore NOT try to move the node back
+ * to its original slot — doing so re-inserts (RESURRECTS) an already-removed
+ * overlay into the DOM. We simply detach from `body` as an idempotent safety net
+ * (a no-op when Angular already removed it, `parentNode === null`), so a
+ * teleported node can never orphan/leak either. Zoneless — `afterNextRender`
+ * (never `setTimeout`/`rAF`), cleanup via `DestroyRef`.
+ */
+@Directive({
+  selector: "[appTeleportToBody]",
+})
+export class TeleportToBodyDirective {
+  private readonly el = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Whether the node was actually moved to <body> (afterNextRender ran). */
+  private teleported = false;
+
+  constructor() {
+    afterNextRender(
+      () => {
+        const node = this.el.nativeElement;
+        if (node.parentNode) {
+          document.body.appendChild(node);
+          this.teleported = true;
+        }
+      },
+      { injector: this.injector },
+    );
+
+    this.destroyRef.onDestroy(() => {
+      // Idempotent detach ONLY — never re-insert. Angular's view teardown already
+      // removed the node (via its current parent) before this hook, so remove() is
+      // usually a no-op; it only bites if some path left the node parented to body,
+      // guaranteeing no orphan. Re-inserting here would resurrect a dismissed
+      // overlay — the exact defect this replaces.
+      if (this.teleported) {
+        this.el.nativeElement.remove();
+      }
+    });
+  }
+}

--- a/src/app/features/notes/link-picker/link-picker.component.html
+++ b/src/app/features/notes/link-picker/link-picker.component.html
@@ -8,6 +8,7 @@
 <div
   #popover
   class="link-pop"
+  appTeleportToBody
   appRepositionOnScroll
   (reposition)="reposition()"
   (scroll)="onScroll()"

--- a/src/app/features/notes/link-picker/link-picker.component.scss
+++ b/src/app/features/notes/link-picker/link-picker.component.scss
@@ -12,6 +12,9 @@
   position: fixed;
   top: 0;
   left: 0;
+  /* Teleported to <body> (appTeleportToBody) so `position: fixed` anchors to the
+     viewport, never a filtered/transformed ancestor; must beat all app chrome. */
+  z-index: var(--z-overlay);
   width: 280px;
   max-width: calc(100vw - 2 * var(--space-3));
   /* Tall enough for ~9 rows — the list is an infinite scroll over the whole

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -17,6 +17,7 @@ import { IpcService } from "../../../core/ipc.service";
 import type { NoteCitation } from "../../../core/models";
 import { DebounceService } from "../../../services/debounce.service";
 import { RepositionOnScrollDirective } from "../note-brain-popover/reposition-on-scroll.directive";
+import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
 
 /** How long to wait after the last keystroke before re-querying the backend. */
 const QUERY_DEBOUNCE_MS = 150;
@@ -70,7 +71,7 @@ const KEYBOARD_LOAD_AHEAD_ROWS = 3;
 @Component({
   selector: "app-link-picker",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RepositionOnScrollDirective],
+  imports: [RepositionOnScrollDirective, TeleportToBodyDirective],
   templateUrl: "./link-picker.component.html",
   styleUrl: "./link-picker.component.scss",
 })

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
@@ -4,6 +4,7 @@
 <div
   #popover
   class="brain-pop"
+  appTeleportToBody
   appRepositionOnScroll
   (reposition)="reposition()"
   (mousedown)="$event.preventDefault()"

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.scss
@@ -12,6 +12,9 @@
   position: fixed;
   top: 0;
   left: 0;
+  /* Teleported to <body> (appTeleportToBody) so `position: fixed` anchors to the
+     viewport, never a filtered/transformed ancestor; must beat all app chrome. */
+  z-index: var(--z-overlay);
   width: 340px;
   max-width: calc(100vw - 2 * var(--space-3));
   pointer-events: auto;

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -30,6 +30,7 @@ import {
   noteAssistEntry,
 } from "./note-assist-catalog";
 import { RepositionOnScrollDirective } from "./reposition-on-scroll.directive";
+import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
 
 /** The live text selection the popover acts on, plus its viewport anchor rect. */
 export interface PopoverSelection {
@@ -112,7 +113,7 @@ const RETRIEVAL_ACTIONS = new Set<NoteAssistAction>([
 @Component({
   selector: "app-note-brain-popover",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RepositionOnScrollDirective],
+  imports: [RepositionOnScrollDirective, TeleportToBodyDirective],
   templateUrl: "./note-brain-popover.component.html",
   styleUrl: "./note-brain-popover.component.scss",
 })

--- a/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.html
+++ b/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.html
@@ -5,6 +5,7 @@
 <div
   #bar
   class="sel-bar"
+  appTeleportToBody
   appRepositionOnScroll
   (reposition)="reposition()"
   (mousedown)="$event.preventDefault()"

--- a/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.scss
+++ b/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.scss
@@ -12,6 +12,9 @@
   position: fixed;
   top: 0;
   left: 0;
+  /* Teleported to <body> (appTeleportToBody) so `position: fixed` anchors to the
+     viewport, never a filtered/transformed ancestor; must beat all app chrome. */
+  z-index: var(--z-overlay);
   pointer-events: auto;
   display: inline-flex;
   align-items: center;

--- a/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.ts
+++ b/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.ts
@@ -12,6 +12,7 @@ import {
 } from "@angular/core";
 import type { PopoverSelection } from "../note-brain-popover/note-brain-popover.component";
 import { RepositionOnScrollDirective } from "../note-brain-popover/reposition-on-scroll.directive";
+import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
 import type { FormatOp } from "../note-editor/note-editor.component";
 
 /** Viewport gap kept between the bubble and the selection rect. */
@@ -41,7 +42,7 @@ const BAR_WIDTH = 480;
 @Component({
   selector: "app-note-selection-toolbar",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RepositionOnScrollDirective],
+  imports: [RepositionOnScrollDirective, TeleportToBodyDirective],
   templateUrl: "./note-selection-toolbar.component.html",
   styleUrl: "./note-selection-toolbar.component.scss",
 })

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.html
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.html
@@ -1,13 +1,6 @@
 <div class="card surface" role="group" aria-label="In-meeting note and Ask Brain">
   <div class="surface-head">
     <app-ai-orb class="head-orb" [state]="orbStateView()" />
-    <mur-segmented
-      class="tabs"
-      ariaLabel="Note or Ask Brain"
-      [options]="tabOptions"
-      [value]="tabValue()"
-      (valueChange)="selectTab($event)"
-    />
     <span
       class="surface-hint"
       role="status"
@@ -23,134 +16,149 @@
         ✨ This note will shape your summary
       }
     </span>
-  </div>
 
-  <!-- ── NOTE TAB — the meeting's ONE companion note as an editable DOCUMENT.
-       The embedded note editor is ALWAYS MOUNTED for the whole recording (HIDDEN,
-       not destroyed, while the Ask Brain tab is active — see [hidden]) so there is
-       exactly ONE live editor instance. That single instance is the flush-at-Stop
-       target: RecorderStore.stop() awaits its durable save via RecordingFlushService
-       before finalizing, so a Stop fired inside the autosave debounce window never
-       loses the user's prose. Returning to the tab calls the editor's reload() (see
-       selectTab) — no destroy/re-mount — to reflect Ask-Brain "Add to note" appends
-       + external edits. -->
-  <div class="note-host" [hidden]="activeTab() !== 'note'">
-    <app-note-editor
-      [embedded]="true"
-      [noteIdInput]="store.companionNoteId()"
-    />
-  </div>
-
-  @if (activeTab() !== "note") {
-    <!-- ── ASK BRAIN TAB — the conversational @brain thread. ── -->
-
-    <!-- Reactions rail — PINNED above the conversation flow (not inside the
-         scroller). Two lanes: the proactive RECALL hint (hintsEnabled is the FE
-         half of its global mute) and the realtime CONTRADICTION whisper cards.
-         Both are PURGED on any lock transition by the store. -->
-    @if (
-      (hintsEnabled() && store.hint()) ||
-      store.whisperCards().length > 0 ||
-      store.showShadowCalibration()
-    ) {
-      <div class="reactions-rail">
-        @if (hintsEnabled() && store.hint(); as h) {
-          <app-proactive-hint-card
-            [hint]="h"
-            (dismissed)="store.dismissHint()"
-          />
-        }
-        @for (w of store.whisperCards(); track w.id) {
-          <app-whisper-card
-            [card]="w"
-            (dismissed)="store.dismissWhisper(w.id)"
-          />
-        }
-
-        <!-- Shadow-mode calibration — offer to switch on contradiction cards
-             once the user's OWN recording would have flagged enough of them. -->
-        @if (store.showShadowCalibration()) {
-          <div class="shadow-calibration" role="status">
-            <span class="shadow-copy">
-              The brain would have flagged {{ store.shadowCount() }}
-              {{ store.shadowCount() === 1 ? "contradiction" : "contradictions" }}
-              in this session — show them live?
-            </span>
-            <div class="shadow-actions">
-              <button
-                type="button"
-                class="btn btn-primary btn-sm"
-                (click)="store.enableContradictionCards()"
-              >
-                Show live
-              </button>
-              <button
-                type="button"
-                class="btn btn-ghost btn-sm"
-                (click)="store.dismissShadowCalibration()"
-              >
-                Not now
-              </button>
-            </div>
-          </div>
-        }
-      </div>
-    }
-
-    <div class="flow" #flow>
-      @if (!store.hasNotes()) {
-        <p class="flow-empty text-muted">
-          Ask the brain about this meeting and everything related — it answers
-          here with sources you can follow. An answer can be added straight into
-          your note.
-        </p>
+    <!-- Ask Brain drawer toggle — replaces the retired Note|Ask segmented tabs. The
+         note is the always-visible hero; this opens the @brain thread beside it. -->
+    <button
+      type="button"
+      class="btn btn-ghost ask-toggle"
+      [class.is-active]="drawerOpen()"
+      [attr.aria-expanded]="drawerOpen()"
+      (click)="toggleDrawer()"
+    >
+      <svg
+        class="ask-toggle-glyph"
+        viewBox="0 0 16 16"
+        width="13"
+        height="13"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M8 1.5l1.3 3.2L12.5 6 9.3 7.3 8 10.5 6.7 7.3 3.5 6l3.2-1.3L8 1.5Z"
+          stroke="currentColor"
+          stroke-width="1.2"
+          stroke-linejoin="round"
+        />
+      </svg>
+      Ask Brain
+      @if (askUnseen()) {
+        <span class="ask-toggle-dot" aria-hidden="true"></span>
       }
-      @for (n of store.notes(); track n.id) {
-        <app-note-item [note]="n" (followed)="scrollToBottom()" />
+    </button>
+  </div>
+
+  <!-- Ambient live reactions — the recall hint + contradiction whisper cards + the
+       shadow-mode calibration prompt. ABOVE the body so they surface even with the
+       drawer closed (never buried behind the toggle). All PURGED on any lock
+       transition by the store. -->
+  @if (hasReactions()) {
+    <div class="reactions-rail">
+      @if (hintsEnabled() && store.hint(); as h) {
+        <app-proactive-hint-card [hint]="h" (dismissed)="store.dismissHint()" />
+      }
+      @for (w of store.whisperCards(); track w.id) {
+        <app-whisper-card [card]="w" (dismissed)="store.dismissWhisper(w.id)" />
+      }
+
+      <!-- Shadow-mode calibration — offer to switch on contradiction cards once the
+           user's OWN recording would have flagged enough of them. -->
+      @if (store.showShadowCalibration()) {
+        <div class="shadow-calibration" role="status">
+          <span class="shadow-copy">
+            The brain would have flagged {{ store.shadowCount() }}
+            {{ store.shadowCount() === 1 ? "contradiction" : "contradictions" }}
+            in this session — show them live?
+          </span>
+          <div class="shadow-actions">
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              (click)="store.enableContradictionCards()"
+            >
+              Show live
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm"
+              (click)="store.dismissShadowCalibration()"
+            >
+              Not now
+            </button>
+          </div>
+        </div>
       }
     </div>
-
-    <form class="composer" (submit)="submitAsk($event)">
-      <button
-        type="button"
-        class="mic-btn"
-        [class.is-listening]="store.listening()"
-        [disabled]="store.processing()"
-        (click)="toggleAsk()"
-        [attr.aria-pressed]="store.listening()"
-        [attr.aria-label]="
-          store.listening() ? 'Stop listening and ask' : 'Ask by voice'
-        "
-        [title]="store.listening() ? 'Stop & ask' : 'Ask by voice'"
-      >
-        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-          <path
-            d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
-            fill="currentColor"
-          />
-          <path
-            d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
-            fill="currentColor"
-            opacity="0.85"
-          />
-        </svg>
-      </button>
-      <input
-        #askInput
-        type="text"
-        class="ask-input"
-        placeholder="Ask about this meeting…"
-        aria-label="Ask about this meeting"
-        [value]="askDraft()"
-        (input)="onAskInput($event)"
-      />
-      <button
-        type="submit"
-        class="btn btn-primary send-btn"
-        [disabled]="!canAsk()"
-      >
-        Ask
-      </button>
-    </form>
   }
+
+  <!-- ===== Body row: the note document (HERO) + the optional Ask-Brain drawer.
+       A flex ROW so opening the drawer SHRINKS the document column (the editor
+       stays fully visible, never covered). The embedded editor is ALWAYS MOUNTED
+       (one live flush target). ===== -->
+  <div class="surface-body">
+    <div class="note-host">
+      <app-note-editor [embedded]="true" [noteIdInput]="store.companionNoteId()" />
+    </div>
+
+    @if (drawerOpen()) {
+      <aside class="ask-drawer" aria-label="Ask Brain about this meeting">
+        <div class="flow" #flow>
+          @if (!store.hasNotes()) {
+            <p class="flow-empty text-muted">
+              Ask the brain about this meeting and everything related — it answers
+              here with sources you can follow. An answer can be added straight into
+              your note.
+            </p>
+          }
+          @for (n of store.notes(); track n.id) {
+            <app-note-item [note]="n" (followed)="scrollToBottom()" />
+          }
+        </div>
+
+        <!-- Ask-Brain input row: voice mic + a plain single-line question input + Ask. -->
+        <form class="composer" (submit)="submitAsk($event)">
+          <button
+            type="button"
+            class="mic-btn"
+            [class.is-listening]="store.listening()"
+            [disabled]="store.processing()"
+            (click)="toggleAsk()"
+            [attr.aria-pressed]="store.listening()"
+            [attr.aria-label]="
+              store.listening() ? 'Stop listening and ask' : 'Ask by voice'
+            "
+            [title]="store.listening() ? 'Stop & ask' : 'Ask by voice'"
+          >
+            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+              <path
+                d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
+                fill="currentColor"
+              />
+              <path
+                d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
+                fill="currentColor"
+                opacity="0.85"
+              />
+            </svg>
+          </button>
+          <input
+            #askInput
+            type="text"
+            class="ask-input"
+            placeholder="Ask about this meeting…"
+            aria-label="Ask about this meeting"
+            [value]="askDraft()"
+            (input)="onAskInput($event)"
+          />
+          <button
+            type="submit"
+            class="btn btn-primary send-btn"
+            [disabled]="!canAsk()"
+          >
+            Ask
+          </button>
+        </form>
+      </aside>
+    }
+  </div>
 </div>

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
@@ -1,16 +1,25 @@
-/* The surface fills its host (the record screen makes it the full-height
-   main view) so the notes flow grows to the bottom. */
+/* The surface fills its host (the record screen makes it the full-height main
+   view) so the note + drawer grow to the bottom. */
 :host {
   display: block;
   height: 100%;
 }
+
+/* OPAQUE hero card (v3, 2026-07-18): overrides the frosted global `.card` so glass
+   stays CHROME, never a content panel wrapping the editor + its overlays (T3/T4).
+   The floating overlays the editor spawns teleport to <body>, so this card no
+   longer needs to be their (broken) containing block. */
 .surface {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
   height: 100%;
   min-height: 0;
+  background: var(--surface-solid);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
+
 .surface-head {
   display: flex;
   align-items: center;
@@ -19,29 +28,55 @@
 .head-orb {
   --orb-size: 22px;
 }
-.tabs {
-  flex: none;
-}
 .surface-hint {
-  margin-left: auto;
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text-muted);
   font-size: 0.78rem;
-  text-align: right;
 }
 
-/* ── NOTE TAB — the embedded companion-note editor fills the panel body. ── */
+/* Ask-Brain drawer toggle (replaces the retired segmented tabs). Neutral ghost
+   pill; the active/open state reads as a selected chrome control. */
+.ask-toggle {
+  position: relative;
+  flex: none;
+  gap: var(--space-1);
+  height: 30px;
+  padding: 0 var(--space-3);
+  font-size: 0.82rem;
+}
+.ask-toggle.is-active {
+  background: var(--shell-active-bg, var(--surface-hover));
+  color: var(--text-primary);
+}
+.ask-toggle-glyph {
+  color: var(--accent-hover);
+}
+.ask-toggle-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-soft);
+}
+
+/* ── Body row: the note document (hero) + optional Ask-Brain drawer ────────── */
+.surface-body {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: var(--space-3);
+  flex: 1 1 auto;
+  min-height: 0;
+}
+/* The note editor is the always-visible HERO; it SHRINKS when the drawer opens. */
 .note-host {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
-}
-/* The editor is ALWAYS MOUNTED (one live flush target); it is HIDDEN — not
-   destroyed — while the Ask Brain tab is active. `display: flex` above overrides
-   the UA `[hidden] { display: none }`, so force it explicitly. */
-.note-host[hidden] {
-  display: none;
 }
 .note-host app-note-editor {
   display: block;
@@ -50,8 +85,35 @@
   overflow: auto;
 }
 
-/* ── The scrollable notes flow (oldest → newest) ─────────────────────── */
-/* Reactions rail — the recall + contradiction lanes stacked above the flow. */
+/* The Ask-Brain drawer — a docked side panel (in-flow, not a floating overlay), so
+   it uses a left border + its own scroll. Slides in without a transform-based
+   entry animation (which would trap any position:fixed descendant). */
+.ask-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 0 0 clamp(280px, 34%, 380px);
+  min-width: 0;
+  min-height: 0;
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--border-subtle);
+  animation: ask-drawer-in var(--transition-dur) var(--transition-ease, ease) both;
+}
+@keyframes ask-drawer-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ask-drawer {
+    animation: none;
+  }
+}
+
+/* ── Ambient live reactions — recall + contradiction lanes above the body ──── */
 .reactions-rail {
   display: flex;
   flex-direction: column;
@@ -89,12 +151,14 @@
   padding: 0 var(--space-3);
   font-size: 0.8rem;
 }
+
+/* ── The scrollable Ask-Brain flow (oldest → newest), inside the drawer ────── */
 .flow {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
   flex: 1 1 auto;
-  min-height: 180px;
+  min-height: 120px;
   overflow-y: auto;
   padding-right: var(--space-1);
 }
@@ -103,20 +167,11 @@
   font-size: 0.875rem;
   line-height: 1.55;
 }
-
-/* inline keycap (head + empty-state hint) */
-.kbd {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.74rem;
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
-  background: var(--surface-input);
-  border: 1px solid var(--border-subtle);
-  color: var(--text-secondary);
+.flow app-note-item {
+  display: block;
 }
 
-/* ── Ask-Brain input row: voice mic + a plain single-line question input +
-   Ask button, pinned at the foot of the Ask-Brain tab. ──────────────────── */
+/* ── Ask-Brain input row: voice mic + single-line question input + Ask ─────── */
 .composer {
   display: flex;
   align-items: center;
@@ -205,12 +260,7 @@
   }
 }
 
-/* ── ENHANCE-MY-NOTES: the head hint tints accent as the note shapes the
-   summary (the sweep-over-note-lines animation is retired — the note is now
-   ONE document, not per-jot lines). ─────────────────────────────────────── */
-.flow app-note-item {
-  display: block;
-}
+/* ── ENHANCE-MY-NOTES: the head hint tints accent as the note shapes the summary. ── */
 .surface-hint.is-enhancing,
 .surface-hint.is-settled {
   color: var(--accent);
@@ -222,4 +272,3 @@
     animation: none;
   }
 }
-

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
@@ -14,52 +14,44 @@ import {
 } from "@angular/core";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
 import { NoteEditorComponent } from "../../notes/note-editor/note-editor.component";
-import {
-  MurSegmentedComponent,
-  type SegmentOption,
-} from "../../../design-system/segmented/segmented.component";
 import { AiOrbComponent } from "../ai-orb/ai-orb.component";
 import { NoteItemComponent } from "../note-item/note-item.component";
 import { ProactiveHintCardComponent } from "../proactive-hint-card/proactive-hint-card.component";
 import { WhisperCardComponent } from "../whisper-card/whisper-card.component";
 
-/** The two tabs of the recording panel. */
-type PanelTab = "note" | "ask";
-
 /**
- * The in-meeting panel — a DOCUMENT-FIRST two-tab surface (v2 redesign):
+ * The in-meeting panel — a DOCUMENT-FIRST surface (v3 redesign, 2026-07-18):
  *
- *  - **"Note" (default):** the meeting's ONE companion note rendered as ONE editable
- *    DOCUMENT via the embedded {@link NoteEditorComponent} (`[embedded]="true"`) — the
- *    real create-note experience (`/` blocks, `[[` links, selection toolbar, in-note
- *    Ask-Brain popover, autosave). The HOST eagerly gets-or-creates the companion note
- *    (via {@link MeetingConversationStore.ensureCompanionNote}) so the editor mounts on
- *    a stable id — there are NO per-jot "Saved" badges; the note IS the document.
- *  - **"Ask Brain":** the conversational `@brain` thread (reuses the store's
- *    open/run/resolve/follow-up/tool-trace/citation machinery). A plain single-line
- *    input at the foot opens a thread (everything here is a question — no `@brain`
- *    marker parsing). An answer's "Add to note" appends into the companion note.
+ *  - The meeting's ONE companion note is the always-visible HERO, rendered as ONE
+ *    editable DOCUMENT via the embedded {@link NoteEditorComponent} (`[embedded]`) —
+ *    the real create-note experience (`/` blocks, `[[` links, selection toolbar,
+ *    in-note Ask-Brain popover, autosave). The HOST eagerly gets-or-creates the
+ *    companion note so the editor mounts on a stable id.
+ *  - **Ask Brain** — the conversational `@brain` thread — lives in a RIGHT-SIDE
+ *    DRAWER toggled from the head (the same note+Brain pattern as routed notes,
+ *    replacing the retired Note|Ask segmented tabs). Opening it SHRINKS the
+ *    document column (never covers it).
+ *  - Live brain REACTIONS (recall hints + contradiction whisper cards + the
+ *    shadow-mode calibration prompt) stay AMBIENT above the body so they surface
+ *    even with the drawer closed — never buried behind a toggle.
  *
- * The embedded editor is ALWAYS MOUNTED for the whole recording — the Note tab is
- * HIDDEN (not destroyed) when the user is on Ask Brain, and returning to it calls the
- * editor's `reload()` (not a re-mount) so an Ask-Brain "Add to note" append / a
- * mid-session external edit is reflected. Keeping ONE live editor instance is what
- * makes the flush-before-Stop deterministic: {@link RecorderStore.stop} awaits that
- * single editor's durable save via {@link RecordingFlushService} before finalizing, so
- * a Stop fired inside the autosave debounce window can never lose the user's prose (an
- * earlier destroy/re-mount left an in-flight destroy-flush racing Stop when the user
- * clicked Stop from the Ask Brain tab). The reactions rail (recall hints / whisper
- * cards) lives in the Ask-Brain tab.
+ * The embedded editor is ALWAYS MOUNTED (and now always visible) for the whole
+ * recording — one live editor instance is the flush-at-Stop target:
+ * {@link RecorderStore.stop} awaits its durable save via {@link RecordingFlushService}
+ * before finalizing, so a Stop fired inside the autosave debounce window can never
+ * lose the user's prose. Closing the Ask drawer RELOADS the editor (not a re-mount)
+ * so an Ask-Brain "Add to note" append / a mid-session external edit is reflected.
  *
- * IN-FLOW (not a floating overlay) — the frosted `.card` chrome is correct (trap T3 is
- * handled inside the editor's own `/`/`[[` menus + the Ask-Brain popover).
+ * The card is OPAQUE (`--surface-solid`), not the frosted glass `.card` — glass is
+ * chrome, never a content panel wrapping overlays (T3/T4); the floating overlays the
+ * editor spawns (`/`/`[[` menus, the Ask-Brain popover, the selection toolbar) all
+ * teleport to <body> so their position:fixed anchors to the viewport.
  */
 @Component({
   selector: "app-meeting-conversation",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AiOrbComponent,
-    MurSegmentedComponent,
     NoteEditorComponent,
     NoteItemComponent,
     ProactiveHintCardComponent,
@@ -75,42 +67,32 @@ export class MeetingConversationComponent implements OnInit {
   private readonly askInput = viewChild<ElementRef<HTMLInputElement>>("askInput");
   /**
    * The ONE always-mounted embedded companion note editor. Used to `reload()` it on
-   * return to the Note tab (in place of the retired re-mount nonce). It stays in the
-   * DOM (hidden while on Ask Brain) so exactly one editor instance is live for the
-   * whole recording — the flush-at-Stop target.
+   * drawer close. Exactly one editor instance is live for the whole recording — the
+   * flush-at-Stop target.
    */
   private readonly noteEditor = viewChild(NoteEditorComponent);
 
-  /**
-   * The active recording's meeting id (null when there's no meeting yet). Pushed
-   * into the store so the companion note + Ask-Brain scope bind to THIS meeting.
-   */
   readonly meetingId = input<string | null>(null);
-
-  /**
-   * The `proactiveHintsEnabled` config flag (the record screen passes its config
-   * snapshot down). False ⇒ the recall card NEVER renders, even if an event
-   * slips through before the backend mute takes effect. Defaults true, matching
-   * the backend default.
-   */
   readonly hintsEnabled = input<boolean>(true);
-
-  /** ENHANCE-MY-NOTES presentation inputs (pure; all state lives in root stores). */
   readonly enhancing = input(false);
   readonly settled = input(false);
   readonly enhanceAware = input(false);
 
-  /** The active tab — the DOCUMENT-FIRST "Note" tab is the default. */
-  protected readonly activeTab = signal<PanelTab>("note");
+  /** Whether the Ask-Brain drawer is open (the note editor is the always-visible hero). */
+  protected readonly drawerOpen = signal(false);
 
-  /** The two-tab segmented control options. */
-  protected readonly tabOptions: readonly SegmentOption[] = [
-    { value: "note", label: "Note" },
-    { value: "ask", label: "Ask Brain" },
-  ];
+  /** A quiet dot on the Ask-Brain toggle when a closed drawer hides an ongoing thread. */
+  protected readonly askUnseen = computed(
+    () => !this.drawerOpen() && this.store.hasNotes(),
+  );
 
-  /** The active tab as the segmented control's two-way value (mirrors {@link activeTab}). */
-  protected readonly tabValue = computed<string>(() => this.activeTab());
+  /** Whether any live reaction is showing (drives the ambient rail's presence). */
+  protected readonly hasReactions = computed(
+    () =>
+      (this.hintsEnabled() && !!this.store.hint()) ||
+      this.store.whisperCards().length > 0 ||
+      this.store.showShadowCalibration(),
+  );
 
   /** During the enhance pass the orb shows its shipped 'processing' choreography. */
   readonly orbStateView = computed(() =>
@@ -129,20 +111,18 @@ export class MeetingConversationComponent implements OnInit {
       this.store.setMeetingId(this.meetingId());
     });
 
-    // EAGERLY get-or-create the companion note whenever a meeting is set, so the
-    // "Note" tab always has a document to mount on (the HOST owns eager creation;
-    // the embedded editor never auto-creates). The effect only reads the input +
-    // calls an async store method (the signal write happens inside the store).
+    // EAGERLY get-or-create the companion note whenever a meeting is set, so the note
+    // hero always has a document to mount on (the HOST owns eager creation; the
+    // embedded editor never auto-creates).
     effect(() => {
       if (this.meetingId()) void this.store.ensureCompanionNote();
     });
 
-    // Auto-scroll the Ask-Brain flow to the newest turn whenever the conversation
-    // changes AND the Ask tab is showing. Tracks the notes signal; schedules the
-    // DOM work via afterNextRender (zoneless-safe; no signal writes → no NG0600).
+    // Auto-scroll the Ask flow to the newest turn whenever the conversation changes
+    // AND the drawer is open. afterNextRender is zoneless-safe (no signal writes).
     effect(() => {
       this.store.notes();
-      if (this.activeTab() === "ask") {
+      if (this.drawerOpen()) {
         afterNextRender(() => this.scrollToBottom(), { injector: this.injector });
       }
     });
@@ -154,23 +134,23 @@ export class MeetingConversationComponent implements OnInit {
     void this.store.init();
   }
 
-  /** Switch tabs. Re-entering "Note" RELOADS the always-mounted editor (no re-mount)
-   *  + refreshes the enhance-honesty content signal; entering "Ask" focuses the
-   *  question input. */
-  protected selectTab(tab: string): void {
-    const next = tab as PanelTab;
-    if (next === this.activeTab()) return;
-    this.activeTab.set(next);
-    if (next === "note") {
-      // The editor stays mounted (hidden) while on Ask Brain, so returning re-reads
-      // its body in place — reflecting an Ask-Brain "Add to note" append / external
-      // edit — rather than destroying + recreating the one live flush target.
-      this.noteEditor()?.reload();
-      this.store.refreshCompanionContentNow();
-    } else {
+  /**
+   * Toggle the Ask-Brain drawer. CLOSING reloads the always-mounted editor in place
+   * (so an Ask-Brain "Add to note" append / external edit is reflected in the hero
+   * document) + refreshes the enhance-honesty content signal — mirroring the retired
+   * return-to-Note-tab semantics without destroying the one live flush target.
+   * OPENING focuses the question input for a fast ask.
+   */
+  protected toggleDrawer(): void {
+    const next = !this.drawerOpen();
+    this.drawerOpen.set(next);
+    if (next) {
       afterNextRender(() => this.askInput()?.nativeElement.focus(), {
         injector: this.injector,
       });
+    } else {
+      this.noteEditor()?.reload();
+      this.store.refreshCompanionContentNow();
     }
   }
 
@@ -185,7 +165,7 @@ export class MeetingConversationComponent implements OnInit {
   }
 
   /**
-   * Submit the Ask-Brain question → open a thread (everything in this tab is a
+   * Submit the Ask-Brain question → open a thread (everything in the drawer is a
    * question — no `@brain` marker parsing). Self-clears; a no-op for blank text.
    */
   protected submitAsk(event: Event): void {
@@ -196,7 +176,6 @@ export class MeetingConversationComponent implements OnInit {
     void this.store.openThread(q).catch(() => {
       /* the store resolves the agent turn with an error in the thread */
     });
-    // Keep the focus in the ask input for a fast back-and-forth.
     afterNextRender(() => this.askInput()?.nativeElement.focus(), {
       injector: this.injector,
     });

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -136,7 +136,15 @@ export class RecordComponent implements OnInit {
     const liveConn = c ? c.roleLiveConnection || c.brainBackend : "";
     const enabled = !!c && c.realtimeReactions === true && liveConn !== "off";
     return (
-      enabled ||
+      // D2 (idle redesign, 2026-07-18): `realtimeReactions` surfaces the companion
+      // editor + Ask Brain ONLY when a live meeting exists. At pure idle (no
+      // meeting) this term used to be true on the setting alone, mounting the
+      // embedded companion editor with a null note id — which then spun
+      // "Loading note…" forever. Every OTHER trigger below is already an active
+      // state (recording / listening / processing / enhance), so gating just this
+      // one leaves the idle screen as the launch hero (+ analytics) with no
+      // purposeless, permanently-loading note pane.
+      (enabled && !!this.store.meetingId()) ||
       this.store.isRecording() ||
       this.assistant.listening() ||
       this.assistant.processing() ||

--- a/src/design-tokens/layout.css
+++ b/src/design-tokens/layout.css
@@ -68,4 +68,12 @@
      consumer (the drill-down hosts' `top` offset) reads `var(--tabs-strip-
      height, 0px)` regardless, so a missing property degrades safely too. */
   --tabs-strip-height: 0px;
+
+  /* Stacking band for overlays teleported to <body> via `[appTeleportToBody]`
+     (source-picker popover/scrim, the note selection toolbar, the in-note Brain
+     popover, the [[ link-picker). Once an overlay is a direct child of <body> it
+     leaves its component's local stacking context, so it must beat ALL in-app
+     chrome (the highest in the app is 120) — one shared token keeps the four
+     portaled overlays on the same top layer instead of drifting apart. */
+  --z-overlay: 2000;
 }


### PR DESCRIPTION
## Note / recording surface redesign

Redesigns the note + recording surface into one coherent, well-designed experience and fixes the three concrete bugs behind it. Design spec: `docs/superpowers/specs/2026-07-18-note-recording-surface-redesign-design.md`. Direction was chosen with the user (one morphing surface · idle launch hero · Ask-Brain drawer everywhere · rich-but-coherent live bar).

### The one root cause behind two of the bugs

The source-picker "looked dead / couldn't be clicked", and the recording formatting toolbar "was positioned wrong" — **the same bug**. Four floating overlays (`<mur-source-picker>` popover, the selection toolbar, the in-note Brain popover, the `[[` link-picker) are `position: fixed` positioned from viewport `getBoundingClientRect()` coords, but were rendered inside their host subtree. On every real surface an ancestor establishes a fixed-positioning **containing block** — the frosted `.card`'s `backdrop-filter`, and worst the note drawer's `transform` animation — so the overlay anchored to that ancestor's box, not the viewport, and landed offset / off-screen / clipped. Verified empirically in **both Chromium and WebKit**.

### What's in this PR

**1 — Overlay portal (`fix(overlays)`)** — a reusable `[appTeleportToBody]` directive moves each floating box to `document.body` (always the viewport containing block) on render and **detaches** it on destroy. The teardown only detaches, never re-inserts: Angular's `detachView` removes the node via its current parent *before* destroy hooks run, so a move-back would **resurrect a dismissed overlay** (an undismissable-picker regression the adversarial verifier caught — now fixed + regression-tested). A `--z-overlay` token keeps them above app chrome. Fixes the picker on all surfaces (note-chat, meeting-chat, ask) and the recording toolbar/popover/link-picker at once, and can never re-break when an ancestor gains a transform/filter.

**2 — Idle launch hero (`fix(record)`)** — `showAssistant()` was true on the `realtimeReactions` setting alone, so at pure idle (no live meeting) the record screen mounted the embedded companion editor with a null note id → a permanent **"Loading note…"** spinner. Gate the `realtimeReactions` term on an actual `meetingId()`; idle now shows the launch hero (+ analytics), companion notes are created only when recording starts.

**3 — Recording recompose (`refactor(record)`)** — the companion note editor is the **always-visible hero**, and Ask Brain (the `@brain` thread + composer) moves into a **right-side drawer** toggled from the head (retiring the `Note|Ask` segmented tabs). Opening it shrinks the document column (never covers it). Live brain **reactions stay ambient** above the body so contradictions/hints surface even with the drawer closed. The hero card is now **opaque** (`--surface-solid`) — glass is chrome, not a content panel (T3/T4). The one live editor stays mounted (the flush-at-Stop target); closing the drawer reloads it in place.

### How it was verified

- **Adversarial-verifier owns the verdict** (author does not self-certify). Phase 1+2: **PASS** — RED→GREEN proven in **Chromium AND WebKit**; the undismissable-picker regression it first caught is fixed. Phase 3: verified (drawer behavior, flush-before-Stop contract intact, opaque card, ambient reactions, visual sanity).
- `npx ng lint` + `npx ng build` green. Full Playwright e2e green (incl. new regression specs `source-picker-teleport-dismiss`, `idle-no-companion-loading`, and the rewritten `companion-note-tabs` drawer specs). FE-only — no Rust/lock/crypto/visibility path touched.
- **Real-Mac honesty bar:** live mic→waveform, caption cadence, and Touch-ID lock paths are not headless-verifiable and need a signed build — untouched here.

### Coordination

Built in an isolated worktree off trunk. This **absorbs** the concurrent Ask-Brain-drawer direction rather than fighting it — the portal fix already repairs that drawer's source-picker (its `translateX` entry animation was the worst containing-block trap). Re-run the gate on the merged result if the concurrent work lands first (merge-skew guard).

### Deliberate follow-ups (not blockers)

- Source-scoped **citations on replies** (surface `ask_vault`'s citations under note-chat/meeting-chat/ask answers) — the "did it scope → what did it cite" loop.
- Selection-toolbar **clamp to the document column** when the drawer is open (currently clamps to the viewport — an edge case only when a selection sits at the editor/drawer seam).
