### PR TITLE
fix(import): per-page OCR fallback, bounded OCR, real progress, universal text budget

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2871,25 +2871,47 @@ pub async fn import_document(
     let folder2 = folder_id.clone();
     crate::perf::run_heavy(&sem, move || {
         crate::events::emit_doc_import(&app2, "", "extracting", 0, 0);
-        // EXTRACT (pure `path → text`, no DB/state).
-        let (name, stored) = extract_document_text(&path2)?;
+        // EXTRACT (pure `path → text`, no DB/state). The progress closure translates the extractor's
+        // per-page signal into `EVENT_DOC_IMPORT` "extracting done/total" events (Fix 3: real counts)
+        // and records an OCR-cap truncation so the "done" event can flag a partial import (Fix 2).
+        let ocr_truncated = std::cell::Cell::new(false);
+        let (name, stored) = {
+            let app_p = &app2;
+            let extract_progress = |p: crate::extract::ExtractProgress| match p {
+                crate::extract::ExtractProgress::Page { done, total } => {
+                    crate::events::emit_doc_import(app_p, "", "extracting", done, total);
+                }
+                crate::extract::ExtractProgress::OcrTruncated { .. } => {
+                    ocr_truncated.set(true);
+                }
+            };
+            extract_document_text(&path2, &extract_progress)?
+        };
 
         crate::events::emit_doc_import(&app2, "", "chunking", 0, 0);
         // GATE (re-checked from the cloned handle) + INSERT + CHUNK-ONLY index (FTS durable now).
         let id = insert_extracted_document(&db, &unlocked, &folder2, &name, &stored)?;
 
         // EMBED only if the RAM floor permitted (else defer to the repair tick). Best-effort: a
-        // failure logs (no PII) and leaves the durable chunks/FTS + row in place.
+        // failure logs (no PII) and leaves the durable chunks/FTS + row in place. Per-sub-batch
+        // progress (Fix 3) streams "embedding done/total" as each embed sub-batch completes.
         if ram_permits {
             let embedder = crate::embed::embed_model_present().then(crate::embed::active_embedder);
             crate::events::emit_doc_import(&app2, &id, "embedding", 0, 0);
-            if let Err(e) = index_document_row_kind_routed(&db, &id, embedder.as_deref()) {
+            let id_for_progress = id.clone();
+            let embed_progress = |done: usize, total: usize| {
+                crate::events::emit_doc_import(&app2, &id_for_progress, "embedding", done, total);
+            };
+            if let Err(e) =
+                index_document_row_kind_routed_progress(&db, &id, embedder.as_deref(), &embed_progress)
+            {
                 tracing::warn!(target: "rag", error = %e, document_id = %id, "import: embed failed (content stored)");
             }
         } else {
             tracing::info!(target: "documents", document_id = %id, "import: RAM floor — deferring embed to repair tick");
         }
-        crate::events::emit_doc_import(&app2, &id, "done", 0, 0);
+        // DONE — carry the OCR-cap truncation flag so the FE can surface a partial-import notice.
+        crate::events::emit_doc_import_done(&app2, &id, ocr_truncated.get());
         Ok(id)
     })
     .await
@@ -2912,7 +2934,7 @@ pub(crate) fn import_document_inner(
     folder_id: &str,
 ) -> Result<String, AppError> {
     // EXTRACT (allowlist + `path → text`, pure, no DB/state).
-    let (name, stored) = extract_document_text(path)?;
+    let (name, stored) = extract_document_text(path, &crate::extract::no_progress)?;
     // GATE + INSERT + chunk-only index (the shared seam the async wrapper also uses).
     insert_extracted_document(&state.db, &state.unlocked_folders, folder_id, &name, &stored)
 }
@@ -2923,7 +2945,10 @@ pub(crate) fn import_document_inner(
 /// Tokio runtime inside `run_heavy`. Fails CLOSED with `AppError::InvalidArg` for an unsupported /
 /// extension-less / unreadable / no-extractable-text file. Returns the file-name component as the
 /// display name (never an on-disk path — no PII in the stored name/logs).
-fn extract_document_text(path: &str) -> Result<(String, String), AppError> {
+fn extract_document_text(
+    path: &str,
+    progress: &crate::extract::ProgressFn<'_>,
+) -> Result<(String, String), AppError> {
     // Extension allowlist. Lowercased; an extension-less path is rejected.
     let p = std::path::Path::new(path);
     let ext = p
@@ -2940,9 +2965,10 @@ fn extract_document_text(path: &str) -> Result<(String, String), AppError> {
     };
 
     // EXTRACT to blocks (page/heading preserved), then serialize to the storable text form. A
-    // non-UTF-8 / unreadable / malformed / scanned-PDF / zip-bomb file fails closed inside
-    // `extract_blocks` (the OOXML/XLSX decompression-ratio guard lives there — see extract/ooxml.rs).
-    let blocks = crate::extract::extract_blocks(p, &ext)?;
+    // non-UTF-8 / unreadable / malformed / scanned-PDF / zip-bomb / over-size file fails closed inside
+    // `extract_blocks` (the OOXML/XLSX decompression-ratio guard + the universal extracted-text
+    // ceiling live there — see extract/mod.rs + extract/ooxml.rs). `progress` streams per-page counts.
+    let blocks = crate::extract::extract_blocks(p, &ext, progress)?;
     if blocks.is_empty() || blocks.iter().all(|b| b.text.trim().is_empty()) {
         return Err(AppError::InvalidArg(
             "this document has no extractable text".into(),
@@ -13125,6 +13151,24 @@ pub(crate) fn index_document_row_kind_routed(
     document_id: &str,
     embedder: Option<&dyn crate::embed::Embedder>,
 ) -> Result<(), AppError> {
+    index_document_row_kind_routed_progress(
+        db,
+        document_id,
+        embedder,
+        &crate::storage::db::no_embed_progress,
+    )
+}
+
+/// [`index_document_row_kind_routed`] with a per-sub-batch embed-progress callback (Brain v3 PR-4,
+/// Fix 3): the document-import path streams "Embedding k/M" to the FE as each embed sub-batch lands.
+/// KIND-ROUTED exactly like the no-op variant — a note routes through `index_note_chunks_progress`,
+/// an uploaded document through `index_document_chunks_progress`.
+pub(crate) fn index_document_row_kind_routed_progress(
+    db: &crate::storage::Db,
+    document_id: &str,
+    embedder: Option<&dyn crate::embed::Embedder>,
+    embed_progress: &crate::storage::db::EmbedProgressFn<'_>,
+) -> Result<(), AppError> {
     match db.get_note_row(document_id)? {
         Some(row) => {
             // `kind='note'` — mirror `update_note_doc_inner`'s title fallback + body strip exactly.
@@ -13132,10 +13176,10 @@ pub(crate) fn index_document_row_kind_routed(
             let title = title.trim();
             let title = if title.is_empty() { "Untitled" } else { title };
             let (_yaml, body) = crate::storage::db::split_front_matter(&row.text);
-            db.index_note_chunks(document_id, title, &body, embedder)
+            db.index_note_chunks_progress(document_id, title, &body, embedder, embed_progress)
         }
         // Uploaded document (`kind='document'`) — the raw-text path is correct (no front-matter).
-        None => db.index_document_chunks(document_id, embedder),
+        None => db.index_document_chunks_progress(document_id, embedder, embed_progress),
     }
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -233,8 +233,12 @@ pub struct NerDownloadPayload {
 pub const EVENT_DOC_IMPORT: &str = "murmur://doc-import";
 
 /// Payload for [`EVENT_DOC_IMPORT`]. `stage` is `"extracting"` | `"chunking"` | `"embedding"` |
-/// `"done"`. `done`/`total` are chunk counts within the embedding stage (0/0 for the earlier
-/// stages). The `document_id` is a random UUID (no content). NO PII.
+/// `"done"`. `done`/`total` are real counts WITHIN a stage: PAGES for `"extracting"` (page k of N of
+/// a PDF/scanned OCR), and embed SUB-BATCHES for `"embedding"` (batch k of M). `0`/`0` for stages
+/// with no natural count (chunking). `truncated` is `true` ONLY on the final `"done"` event when the
+/// scanned-PDF OCR page cap was reached (some scanned pages were skipped — partial content); the FE
+/// surfaces a "some scanned pages exceeded the limit" notice. The `document_id` is a random UUID (no
+/// content). NO PII.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocImportPayload {
@@ -243,9 +247,14 @@ pub struct DocImportPayload {
     pub stage: String,
     pub done: usize,
     pub total: usize,
+    /// `true` on the final `"done"` event when the OCR page cap truncated a huge scanned document
+    /// (partial content). `false` on every non-final stage and on a complete import.
+    pub truncated: bool,
 }
 
-/// Emit [`EVENT_DOC_IMPORT`] to the FE (best-effort). Swallows the emit failure with a non-PII warn.
+/// Emit [`EVENT_DOC_IMPORT`] for a NON-FINAL stage (`extracting`/`chunking`/`embedding`) with real
+/// `done`/`total` counts (best-effort; swallows the emit failure with a non-PII warn). `truncated` is
+/// always `false` here — only the terminal `done` event (via [`emit_doc_import_done`]) can flag it.
 pub fn emit_doc_import(app: &AppHandle, document_id: &str, stage: &str, done: usize, total: usize) {
     if let Err(e) = app.emit(
         EVENT_DOC_IMPORT,
@@ -254,9 +263,27 @@ pub fn emit_doc_import(app: &AppHandle, document_id: &str, stage: &str, done: us
             stage: stage.to_string(),
             done,
             total,
+            truncated: false,
         },
     ) {
         tracing::warn!(target: "documents", error = %e, stage, "emit doc-import failed");
+    }
+}
+
+/// Emit the TERMINAL [`EVENT_DOC_IMPORT`] `"done"` event, carrying `truncated` — `true` when the
+/// scanned-PDF OCR page cap skipped pages (partial content). Best-effort; swallows the emit failure.
+pub fn emit_doc_import_done(app: &AppHandle, document_id: &str, truncated: bool) {
+    if let Err(e) = app.emit(
+        EVENT_DOC_IMPORT,
+        DocImportPayload {
+            document_id: document_id.to_string(),
+            stage: "done".to_string(),
+            done: 0,
+            total: 0,
+            truncated,
+        },
+    ) {
+        tracing::warn!(target: "documents", error = %e, stage = "done", "emit doc-import done failed");
     }
 }
 
@@ -488,5 +515,43 @@ mod tests {
     #[test]
     fn org_sync_tick_cadence_is_one_minute() {
         assert_eq!(crate::commands::ORG_SYNC_TICK_SECS, 60);
+    }
+
+    /// The FE listens on this exact event name; a rename silently drops the import progress bar.
+    #[test]
+    fn doc_import_event_name_is_stable() {
+        assert_eq!(EVENT_DOC_IMPORT, "murmur://doc-import");
+    }
+
+    /// The doc-import payload serializes as camelCase with the real per-stage counts AND the terminal
+    /// `truncated` flag (the FE contract — [`crate::events::DocImportPayload`] ⇒ `DocImportProgress`).
+    /// A non-final stage carries `truncated: false`; the terminal `done` event can carry `true`.
+    #[test]
+    fn doc_import_payload_is_camel_case_counts_and_truncated() {
+        let extracting = DocImportPayload {
+            document_id: "d1".into(),
+            stage: "extracting".into(),
+            done: 12,
+            total: 300,
+            truncated: false,
+        };
+        let json = serde_json::to_string(&extracting).unwrap();
+        assert_eq!(
+            json,
+            r#"{"documentId":"d1","stage":"extracting","done":12,"total":300,"truncated":false}"#
+        );
+        // The terminal done event can flag a truncated (partial) OCR import.
+        let done = DocImportPayload {
+            document_id: "d1".into(),
+            stage: "done".into(),
+            done: 0,
+            total: 0,
+            truncated: true,
+        };
+        let json = serde_json::to_string(&done).unwrap();
+        assert_eq!(
+            json,
+            r#"{"documentId":"d1","stage":"done","done":0,"total":0,"truncated":true}"#
+        );
     }
 }

--- a/src-tauri/src/extract/html.rs
+++ b/src-tauri/src/extract/html.rs
@@ -13,8 +13,18 @@ use crate::error::{AppError, Result};
 /// (we want readable flow text for embedding/snippets, not a terminal column layout).
 const RENDER_WIDTH: usize = 100;
 
-/// Extract an HTML file into one plain-text block.
+/// Extract an HTML file into one plain-text block. A file-size sanity cap
+/// ([`super::MAX_FLOW_FILE_BYTES`]) is applied BEFORE the read (HTML has no decompression step, so a
+/// multi-gigabyte `.html` would otherwise be slurped whole into RAM before any block-level check).
 pub fn extract_html(path: &Path) -> Result<Vec<ExtractedBlock>> {
+    // FILE-SIZE SANITY CAP (flow format): reject an oversized file before reading it into memory.
+    let meta = std::fs::metadata(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read HTML: {e}")))?;
+    if meta.len() > super::MAX_FLOW_FILE_BYTES {
+        return Err(AppError::InvalidArg(
+            "this HTML is too large to import — it exceeds the size limit".into(),
+        ));
+    }
     let bytes = std::fs::read(path)
         .map_err(|e| AppError::InvalidArg(format!("could not read HTML: {e}")))?;
     let text = html2text::from_read(bytes.as_slice(), RENDER_WIDTH)

--- a/src-tauri/src/extract/mod.rs
+++ b/src-tauri/src/extract/mod.rs
@@ -71,19 +71,107 @@ pub const HEADING_SEP: &str = " › ";
 /// yet small enough to never let a bomb exhaust memory. Enforced in [`ooxml`] and [`xlsx`].
 pub const MAX_EXTRACT_DECOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
 
+/// UNIVERSAL EXTRACTED-TEXT CEILING (Brain v3 PR-4, audit finding: asymmetric memory bounds) — the
+/// maximum TOTAL number of UTF-8 bytes of EXTRACTED TEXT one document may accumulate across all its
+/// blocks before extraction fails closed with [`AppError::InvalidArg`]. Where
+/// [`MAX_EXTRACT_DECOMPRESSED_BYTES`] guards ONLY the zip-container formats (the decompressed XML),
+/// this guards the ACCUMULATED OUTPUT of EVERY format — PDF content-stream text, calamine's in-memory
+/// range, the flow formats (md/txt/html) — so no path can materialize an unbounded String at rest in
+/// the ingest surface. 256 MiB of extracted plain text is far beyond any real document a user imports
+/// into a note vault (a 256 MiB PLAIN-TEXT corpus is ~40M words / a small library) yet bounds the
+/// worst case. Enforced once in [`extract_blocks`] over the assembled block list, and mirrored as a
+/// per-file read cap for the flow formats ([`MAX_FLOW_FILE_BYTES`]) so a huge md/txt/html never even
+/// reaches `read_to_string`.
+pub const MAX_EXTRACTED_TEXT_BYTES: u64 = 256 * 1024 * 1024;
+
+/// FILE-SIZE SANITY CAP for the FLOW formats (md/txt/html) read whole via `read_to_string`/`read`.
+/// These formats have no decompression step, so [`MAX_EXTRACT_DECOMPRESSED_BYTES`] never applied to
+/// them and a multi-gigabyte `.txt` would be slurped entirely into RAM before any block-level check.
+/// This caps the ON-DISK file size BEFORE the read, so an oversized flow file fails closed
+/// immediately (no giant allocation). Same 256 MiB ceiling as [`MAX_EXTRACTED_TEXT_BYTES`] (a flow
+/// file's text ≈ its bytes), applied at the read seam in [`extract_text`] and [`html::extract_html`].
+pub const MAX_FLOW_FILE_BYTES: u64 = MAX_EXTRACTED_TEXT_BYTES;
+
+/// Sum the UTF-8 byte length of every block's text and fail closed if the running total exceeds
+/// [`MAX_EXTRACTED_TEXT_BYTES`] — the universal post-extraction memory guard for ALL formats. Runs
+/// once over the assembled block list in [`extract_blocks`]. NO PII (a byte count only).
+fn guard_extracted_text_size(blocks: &[ExtractedBlock]) -> Result<()> {
+    guard_extracted_text_size_with_ceiling(blocks, MAX_EXTRACTED_TEXT_BYTES)
+}
+
+/// [`guard_extracted_text_size`] with an explicit ceiling — production passes the shared const; a
+/// test injects a tiny ceiling so a small synthetic block list trips the guard without materializing
+/// 256 MiB. Uses a saturating sum so a pathological count can't overflow.
+fn guard_extracted_text_size_with_ceiling(blocks: &[ExtractedBlock], ceiling: u64) -> Result<()> {
+    let total: u64 = blocks
+        .iter()
+        .fold(0u64, |acc, b| acc.saturating_add(b.text.len() as u64));
+    if total > ceiling {
+        return Err(AppError::InvalidArg(
+            "this document is too large to import — its extracted text exceeds the size limit".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Read a FLOW-format file (md/txt) to a String with a file-size sanity cap applied BEFORE the read
+/// (so an oversized file never allocates a giant String). Fails closed with [`AppError::InvalidArg`]
+/// on a missing/unreadable/non-UTF-8 file OR one whose on-disk size exceeds [`MAX_FLOW_FILE_BYTES`].
+/// The `label` is a non-PII format name ("document" / "HTML") for the error text.
+pub(crate) fn read_flow_file_to_string(path: &Path, label: &str) -> Result<String> {
+    let meta = std::fs::metadata(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read {label}: {e}")))?;
+    if meta.len() > MAX_FLOW_FILE_BYTES {
+        return Err(AppError::InvalidArg(format!(
+            "this {label} is too large to import — it exceeds the size limit"
+        )));
+    }
+    std::fs::read_to_string(path)
+        .map_err(|e| AppError::InvalidArg(format!("could not read {label}: {e}")))
+}
+
+/// An extraction-progress signal emitted by the paged formats (PDF) as they process. Threaded from
+/// the import command through [`extract_blocks`] so the FE can render live progress during a
+/// multi-minute scanned-PDF OCR AND learn when the OCR page cap truncated a huge scanned document.
+/// The extract module stays a pure `path → blocks` transform (no `AppHandle`/DB/state): this signal
+/// is the ONLY outward channel, and the caller owns the emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtractProgress {
+    /// `done` pages of `total` have been processed (text-layer read or OCR'd). "page k of N".
+    Page { done: usize, total: usize },
+    /// The OCR page cap ([`pdf::MAX_OCR_PAGES`]) was reached: `ocred` scanned pages were OCR'd and
+    /// `skipped` further scanned pages were left un-OCR'd (their text is absent). The import still
+    /// SUCCEEDS with partial content — this lets the caller tell the FE the result was truncated.
+    OcrTruncated { ocred: usize, skipped: usize },
+}
+
+/// A progress callback for [`extract_blocks`]. The caller (the import command) owns the emit; the
+/// non-paged formats never call it. A no-op default ([`no_progress`]) is used by the tests and any
+/// caller that doesn't care.
+pub type ProgressFn<'a> = dyn Fn(ExtractProgress) + 'a;
+
+/// A no-op [`ProgressFn`] — the default for formats that report no page-level progress and for tests.
+pub fn no_progress(_p: ExtractProgress) {}
+
 /// Extract a supported document into its blocks, dispatching on the LOWERCASED `ext` (the extension
 /// WITHOUT the dot). An unsupported extension is [`AppError::InvalidArg`]. `path` must point at a
 /// readable local file; a read/parse failure is mapped to `InvalidArg` (fail-closed), never a
 /// panic. Deterministic: the same file always yields the same block sequence.
-pub fn extract_blocks(path: &Path, ext: &str) -> Result<Vec<ExtractedBlock>> {
-    match ext.to_ascii_lowercase().as_str() {
+///
+/// `progress` is called with `(pages_done, page_count)` for the PAGED formats (PDF) as pages are
+/// processed — the FE renders it as "page k of N" so a large scanned-PDF OCR isn't a frozen dialog.
+/// The non-paged formats never call it. The UNIVERSAL extracted-text ceiling
+/// ([`MAX_EXTRACTED_TEXT_BYTES`]) is enforced once here over the assembled blocks, so EVERY format's
+/// accumulated output is memory-bounded (not just the zip containers).
+pub fn extract_blocks(path: &Path, ext: &str, progress: &ProgressFn<'_>) -> Result<Vec<ExtractedBlock>> {
+    let blocks = match ext.to_ascii_lowercase().as_str() {
         "md" | "txt" => extract_text(path),
         "docx" => ooxml::extract_docx(path),
         "pptx" => ooxml::extract_pptx(path),
         "xlsx" => xlsx::extract_xlsx(path),
         "html" | "htm" => html::extract_html(path),
         #[cfg(target_os = "macos")]
-        "pdf" => pdf::extract_pdf(path),
+        "pdf" => pdf::extract_pdf(path, progress),
         #[cfg(not(target_os = "macos"))]
         "pdf" => Err(AppError::InvalidArg(
             "PDF extraction is only available on macOS".into(),
@@ -101,14 +189,19 @@ pub fn extract_blocks(path: &Path, ext: &str) -> Result<Vec<ExtractedBlock>> {
         other => Err(AppError::InvalidArg(format!(
             "unsupported document type: .{other}"
         ))),
-    }
+    }?;
+    // UNIVERSAL memory guard: cap the accumulated extracted text for ALL formats (finding: the
+    // 512 MiB guard covered only zip containers). A PDF/xlsx/flow document whose text output exceeds
+    // the ceiling fails closed here BEFORE it's serialized + inserted.
+    guard_extracted_text_size(&blocks)?;
+    Ok(blocks)
 }
 
 /// md/txt: the whole file as ONE block, byte-for-byte the pre-PR-2 `read_to_string` behavior. A
-/// non-UTF-8 / unreadable file fails closed with `InvalidArg`.
+/// non-UTF-8 / unreadable / OVER-SIZE file fails closed with `InvalidArg` (the file-size sanity cap
+/// in [`read_flow_file_to_string`] rejects a huge flow file before it allocates a giant String).
 fn extract_text(path: &Path) -> Result<Vec<ExtractedBlock>> {
-    let text = std::fs::read_to_string(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read document: {e}")))?;
+    let text = read_flow_file_to_string(path, "document")?;
     Ok(vec![ExtractedBlock::plain(text)])
 }
 
@@ -246,7 +339,7 @@ mod tests {
         let body = "# Spec\n\nThe budget is 100k.\n\nAnna owns delivery.";
         for ext in ["md", "txt"] {
             let p = write_tmp(ext, body.as_bytes());
-            let blocks = extract_blocks(&p, ext).unwrap();
+            let blocks = extract_blocks(&p, ext, &no_progress).unwrap();
             assert_eq!(blocks.len(), 1, ".{ext} must be one block");
             assert_eq!(blocks[0].text, body, ".{ext} text must be byte-identical");
             assert_eq!(blocks[0].page, None);
@@ -258,7 +351,7 @@ mod tests {
     #[test]
     fn unknown_extension_is_invalid_arg() {
         let p = write_tmp("xyz", b"whatever");
-        let err = extract_blocks(&p, "xyz").unwrap_err();
+        let err = extract_blocks(&p, "xyz", &no_progress).unwrap_err();
         assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
     }
 
@@ -267,7 +360,7 @@ mod tests {
     #[test]
     fn extension_dispatch_is_case_insensitive() {
         let p = write_tmp("MD", b"hello");
-        let blocks = extract_blocks(&p, "MD").unwrap();
+        let blocks = extract_blocks(&p, "MD", &no_progress).unwrap();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].text, "hello");
     }
@@ -277,6 +370,47 @@ mod tests {
         assert_eq!(join_heading(None, "Design"), "Design");
         assert_eq!(join_heading(Some(""), "Design"), "Design");
         assert_eq!(join_heading(Some("Design"), "Storage"), "Design › Storage");
+    }
+
+    /// Fix 4 (RED→GREEN): the UNIVERSAL extracted-text budget passes blocks under the ceiling and
+    /// fails closed once the ACCUMULATED text across all blocks EXCEEDS it — the memory guard that now
+    /// covers EVERY format (not just the zip containers). Uses a TINY injected ceiling (like the
+    /// decompress-budget tests) so a small synthetic block list trips the REAL fold-and-compare path
+    /// without materializing 256 MiB.
+    #[test]
+    fn extracted_text_budget_passes_normal_and_fails_oversize() {
+        // Two blocks summing to 30 bytes.
+        let blocks = vec![
+            ExtractedBlock::plain("a".repeat(10)),
+            ExtractedBlock::plain("b".repeat(20)),
+        ];
+        // Ceiling above the total → OK.
+        assert!(
+            guard_extracted_text_size_with_ceiling(&blocks, 30).is_ok(),
+            "a total exactly AT the ceiling is allowed (fail only when EXCEEDED)"
+        );
+        assert!(
+            guard_extracted_text_size_with_ceiling(&blocks, 1_000).is_ok(),
+            "well under the ceiling passes"
+        );
+        // Ceiling one below the total → the fold sums past it and fails closed with InvalidArg.
+        let err = guard_extracted_text_size_with_ceiling(&blocks, 29).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArg(_)), "over-ceiling fails closed: {err:?}");
+        // Production const is generously large — normal blocks never trip it.
+        assert!(guard_extracted_text_size(&blocks).is_ok(), "the real ceiling passes normal text");
+    }
+
+    /// Fix 4: the flow-format file-size sanity cap. A real small file passes the cap and reads back
+    /// verbatim (the happy path is unchanged); the cap arithmetic (`meta.len() > MAX_FLOW_FILE_BYTES`)
+    /// only rejects an oversized file, which we don't materialize here.
+    #[test]
+    fn flow_file_size_cap_reads_small_file_verbatim() {
+        let p = write_tmp("txt", b"under the cap");
+        let text = read_flow_file_to_string(&p, "document").unwrap();
+        assert_eq!(text, "under the cap");
+        // A missing file fails closed (no panic).
+        let missing = std::path::Path::new("/nonexistent/murmur/flow-missing.txt");
+        assert!(read_flow_file_to_string(missing, "document").is_err());
     }
 
     /// A single flow block is stored VERBATIM (no sentinel) so a `.md` upload's plaintext is

--- a/src-tauri/src/extract/ocr.rs
+++ b/src-tauri/src/extract/ocr.rs
@@ -59,21 +59,74 @@ fn catch_objc<R>(f: impl FnOnce() -> R) -> Option<R> {
     catch(AssertUnwindSafe(f)).ok()
 }
 
-/// Build a configured Accurate/pl+en/language-correcting `VNRecognizeTextRequest`. Inside `catch`
+/// Murmur's PREFERRED OCR languages, in priority order: Polish first, English second (Murmur's two
+/// primary languages — the multilingual whisper ships Polish too). Intersected at runtime with the
+/// system's actually-supported set (see [`choose_ocr_languages`]) so an older Vision that lacks "pl"
+/// on the app's 13.4 floor never fails the whole import — it degrades to the supported subset.
+const PREFERRED_OCR_LANGUAGES: &[&str] = &["pl", "en"];
+
+/// Choose the recognition languages to request, intersecting our [`PREFERRED_OCR_LANGUAGES`] (in
+/// PRIORITY order) with the `supported` set Vision reports at runtime. Pure logic (no FFI) so it is
+/// headless-testable — the FFI wrapper [`supported_recognition_languages`] feeds it the live set.
+///
+/// - Keep every preferred language the system supports, in our priority order (pl before en).
+/// - If NONE of our preferred languages are supported (a very old Vision, or an empty/failed probe),
+///   return EMPTY — the caller then leaves Vision's OWN default language selection in place rather
+///   than forcing an unsupported language (forcing "pl" on a Vision that doesn't support it is the
+///   "no text found" failure this fix closes). Fail-open to the system default, never fail-closed.
+fn choose_ocr_languages(supported: &[String], preferred: &[&str]) -> Vec<String> {
+    preferred
+        .iter()
+        .filter(|p| supported.iter().any(|s| s.eq_ignore_ascii_case(p)))
+        .map(|p| p.to_string())
+        .collect()
+}
+
+/// The languages Vision reports as supported for the request's current configuration
+/// (`supportedRecognitionLanguagesAndReturnError:`). Crash-safe: the ObjC call is inside `catch`; a
+/// caught exception / error / nil yields an EMPTY vec (the caller then keeps Vision's default — see
+/// [`choose_ocr_languages`]). Call AFTER `setRecognitionLevel:` (the supported set is level-dependent).
+fn supported_recognition_languages(req: &VNRecognizeTextRequest) -> Vec<String> {
+    catch_objc(|| {
+        // SAFETY: reads the supported-language collection for the request's current state; wrapped in
+        // `catch`. On an ObjC error (`Err`) or nil, fall through to an empty vec.
+        match unsafe { req.supportedRecognitionLanguagesAndReturnError() } {
+            Ok(arr) => arr.iter().map(|s| s.to_string()).collect(),
+            Err(_) => Vec::new(),
+        }
+    })
+    .unwrap_or_default()
+}
+
+/// Build a configured Accurate/language-correcting `VNRecognizeTextRequest`. Inside `catch`
 /// because the alloc/init + property setters are ObjC that could (in principle) throw. `None` on any
 /// caught exception.
+///
+/// LANGUAGE SELECTION (Brain v3 PR-4, finding: hardcoded "pl"/"en" can fail on an older Vision):
+/// after setting the recognition level, we INTERSECT [`PREFERRED_OCR_LANGUAGES`] with the languages
+/// Vision reports as supported at runtime and request only that subset (in priority order). If the
+/// intersection is empty (a very old Vision without "pl"/"en", or a failed probe) we DON'T force a
+/// language at all — Vision's own default selection stays, so the import still attempts recognition
+/// rather than failing "no text found". This is FFI — it only TRULY verifies on a real Mac; the pure
+/// intersection ([`choose_ocr_languages`]) is unit-tested headless.
 fn make_text_request() -> Option<Retained<VNRecognizeTextRequest>> {
     catch_objc(|| {
         // SAFETY: standard `[[VNRecognizeTextRequest alloc] init]`; the whole closure is inside
         // `catch` so any ObjC exception is contained.
         let req = unsafe { VNRecognizeTextRequest::init(VNRecognizeTextRequest::alloc()) };
         req.setRecognitionLevel(VNRequestTextRecognitionLevel::Accurate);
-        // Polish first, English second — Murmur's two primary languages (multilingual whisper ships
-        // Polish too). Vision falls back gracefully for other scripts.
-        let pl = NSString::from_str("pl");
-        let en = NSString::from_str("en");
-        let langs = NSArray::from_slice(&[&*pl, &*en]);
-        req.setRecognitionLanguages(&langs);
+        // Intersect our preferred languages with what THIS system's Vision actually supports (queried
+        // after the level is set — the supported set is level-dependent). Only set them when the
+        // intersection is non-empty; otherwise leave Vision's default selection (fail-open).
+        let supported = supported_recognition_languages(&req);
+        let chosen = choose_ocr_languages(&supported, PREFERRED_OCR_LANGUAGES);
+        if !chosen.is_empty() {
+            let ns_langs: Vec<Retained<NSString>> =
+                chosen.iter().map(|l| NSString::from_str(l)).collect();
+            let refs: Vec<&NSString> = ns_langs.iter().map(|r| &**r).collect();
+            let langs = NSArray::from_slice(&refs);
+            req.setRecognitionLanguages(&langs);
+        }
         req.setUsesLanguageCorrection(true);
         req
     })
@@ -304,9 +357,10 @@ fn with_rgbx_bitmap(
     .flatten()
 }
 
-/// Pixel dimensions for OCR-rendering a page whose media box is `pw × ph` points: scale up so the
-/// long edge is [`MAX_OCR_LONG_EDGE`] (never scale DOWN below native — a small page stays at least its
-/// point size), clamped so neither edge exceeds the cap. Pure arithmetic (unit-testable without FFI).
+/// Pixel dimensions for OCR-rendering a page whose media box is `pw × ph` points: scale the LONG edge
+/// to exactly [`MAX_OCR_LONG_EDGE`] — a small page is scaled UP (better OCR fidelity for low-DPI type)
+/// and an oversized page is scaled DOWN to the cap (the RAM guard: a bitmap is at most
+/// `MAX_OCR_LONG_EDGE² * 4` bytes). Pure arithmetic (unit-testable without FFI).
 fn ocr_render_pixels(pw: f64, ph: f64) -> (usize, usize) {
     // A degenerate box (either edge non-finite or <= 0) yields zero pixels — the renderer bails with
     // no allocation. Both edges must be positive-finite for a valid page.
@@ -317,11 +371,9 @@ fn ocr_render_pixels(pw: f64, ph: f64) -> (usize, usize) {
     if long_edge <= 0.0 {
         return (0, 0);
     }
-    // Scale so the long edge hits the target, but never below 1x (don't downscale small pages).
-    let scale = (MAX_OCR_LONG_EDGE / long_edge).max(1.0);
-    // Clamp the long edge to the cap regardless (a page already larger than the cap is scaled DOWN to
-    // it — the RAM guard wins over "never downscale").
-    let scale = scale.min(MAX_OCR_LONG_EDGE / long_edge);
+    // Scale the long edge to exactly the target (up for a small page, down for an oversized one — the
+    // cap is a hard RAM ceiling, so downscaling a huge page wins).
+    let scale = MAX_OCR_LONG_EDGE / long_edge;
     let w = (pw * scale).round();
     let h = (ph * scale).round();
     // Final hard ceiling on each edge (defense-in-depth against a non-finite/overflow scale).
@@ -365,6 +417,40 @@ mod tests {
     fn render_pixels_rejects_degenerate_box() {
         assert_eq!(ocr_render_pixels(0.0, 0.0), (0, 0));
         assert_eq!(ocr_render_pixels(-1.0, 100.0), (0, 0));
+    }
+
+    /// Fix 6 regression: a page SMALLER than the cap is scaled UP (not left at native size) — proves
+    /// the removed `.max(1.0)`/`.min(...)` no-op pair never gated upscaling. A 100×100pt page → the
+    /// long edge hits the target (2000px).
+    #[test]
+    fn render_pixels_scales_a_small_page_up_to_the_target() {
+        let (w, h) = ocr_render_pixels(100.0, 100.0);
+        assert_eq!((w, h), (2000, 2000), "a small page is scaled UP to the cap, not left native");
+    }
+
+    /// Fix 5 (pure logic, headless): the chosen OCR languages are our preferred set intersected with
+    /// what the system supports, in PRIORITY order (pl before en).
+    #[test]
+    fn choose_ocr_languages_intersects_in_priority_order() {
+        // Both supported → both requested, pl first.
+        let both = vec!["en".to_string(), "fr".to_string(), "pl".to_string()];
+        assert_eq!(choose_ocr_languages(&both, PREFERRED_OCR_LANGUAGES), vec!["pl", "en"]);
+        // Only English supported (an older Vision without Polish) → request only "en", never force pl.
+        let en_only = vec!["en-US".to_string(), "en".to_string(), "de".to_string()];
+        assert_eq!(choose_ocr_languages(&en_only, PREFERRED_OCR_LANGUAGES), vec!["en"]);
+        // Matching is case-insensitive (Vision may report "EN"/"PL").
+        let upper = vec!["PL".to_string(), "EN".to_string()];
+        assert_eq!(choose_ocr_languages(&upper, PREFERRED_OCR_LANGUAGES), vec!["pl", "en"]);
+    }
+
+    /// Fix 5: when NONE of our preferred languages are supported (or the probe returned nothing), the
+    /// chosen set is EMPTY — the caller then leaves Vision's own default selection (fail-open, so the
+    /// import still attempts OCR instead of forcing an unsupported language and failing "no text").
+    #[test]
+    fn choose_ocr_languages_empty_when_none_supported_falls_open() {
+        let none = vec!["ja".to_string(), "zh-Hans".to_string()];
+        assert!(choose_ocr_languages(&none, PREFERRED_OCR_LANGUAGES).is_empty());
+        assert!(choose_ocr_languages(&[], PREFERRED_OCR_LANGUAGES).is_empty(), "empty probe → empty (system default)");
     }
 
     /// A missing image FILE fails CLOSED (None) — `NSImage::initWithContentsOfFile` returns nil for a

--- a/src-tauri/src/extract/pdf.rs
+++ b/src-tauri/src/extract/pdf.rs
@@ -13,12 +13,25 @@
 //! document has an outline (`outlineRoot`), each page's `heading_path` is the outline entry whose
 //! destination page is nearest-at-or-before that page (best-effort; `None` when no outline).
 //!
-//! SCANNED-PDF OCR FALLBACK (Brain v3): a PDF with NO extractable text layer on ANY page (a
-//! scanned/image-only PDF) is NOT rejected — it falls back to on-device Apple Vision OCR
-//! ([`crate::extract::ocr`]): each page is rendered to a CGImage and OCR'd, and any recognized text is
-//! emitted as page blocks (heading `None`). The OCR path runs ONLY on the no-text-layer fallback, so a
-//! normal text PDF is never slowed. Only if OCR ALSO yields nothing on EVERY page do we fail closed
-//! with `InvalidArg("no text found in this document, even with OCR")`.
+//! SCANNED-PDF OCR FALLBACK (Brain v3; PER-PAGE since PR-4): OCR is decided PER PAGE, not for the
+//! whole document. For each page we read its text-layer string; a page whose trimmed text is empty or
+//! shorter than [`OCR_MIN_TEXT_CHARS`] (a scanned page, or a scanned page behind a text-layer cover)
+//! is rendered to a CGImage and OCR'd via on-device Apple Vision ([`crate::extract::ocr`]); a page
+//! that already has a real text layer keeps it and is NEVER rendered (so a normal text PDF pays no OCR
+//! cost). This closes the "one text-layer cover page suppresses OCR for 299 scanned pages" bug — a
+//! mixed document now gets text-layer text where it exists AND OCR text where it doesn't.
+//!
+//! OCR PAGE CAP (PR-4, availability): OCR is expensive (render + Vision per page, multi-second), so at
+//! most [`MAX_OCR_PAGES`] pages are OCR'd per document. Scanned pages BEYOND the cap are skipped (their
+//! text is absent) and the import still SUCCEEDS with partial content — never a hang, never total
+//! failure. The truncation is surfaced to the caller via [`crate::extract::ExtractProgress::OcrTruncated`]
+//! (the FE shows a "some scanned pages exceeded the limit" notice) and logged (counts only, NO PII).
+//! Text-layer pages are NEVER capped — only the OCR work is bounded.
+//!
+//! PROGRESS (PR-4): a per-page [`crate::extract::ExtractProgress::Page`] is emitted as pages are
+//! processed, so a multi-minute scanned-PDF OCR shows live "page k of N" progress instead of a frozen
+//! dialog. Only if the document has NO text on ANY page AND OCR yields nothing on EVERY page do we fail
+//! closed with `InvalidArg("no text found in this document, even with OCR")`.
 //!
 //! REAL-MAC CAVEAT: this compiles everywhere but only TRULY verifies on a signed build on a real Mac
 //! (PDFKit text/outline fidelity, RAM on a 500-page PDF, and — new — Vision OCR fidelity on a real
@@ -33,8 +46,39 @@ use objc2::AllocAnyThread;
 use objc2_foundation::{NSString, NSURL};
 use objc2_pdf_kit::{PDFDocument, PDFPage};
 
-use super::ExtractedBlock;
+use super::{ExtractProgress, ExtractedBlock, ProgressFn};
 use crate::error::{AppError, Result};
+
+/// The minimum length (in CHARACTERS, after trimming) of a page's text-layer string for us to treat
+/// the page as having a real text layer. A page whose text-layer string is empty or shorter than this
+/// is treated as a scanned/image page and OCR'd (Fix 1: per-page OCR). 16 chars is short enough that a
+/// genuinely sparse text page (a single word/heading) still counts as text, but long enough that a
+/// scanned page carrying only an empty string or a stray artifact ligature falls through to OCR.
+const OCR_MIN_TEXT_CHARS: usize = 16;
+
+/// The maximum number of pages we will OCR in ONE document (Fix 2: availability). OCR is expensive
+/// (render + Vision per page, multi-second each) and holds the ONE heavy-inference permit, so an
+/// unbounded scanned book could starve ASR/summarize for many minutes. 300 pages is generous (a full
+/// scanned book) yet finite: the worst case is bounded at ~300 × per-page-OCR. Scanned pages BEYOND
+/// the cap are skipped (partial content, never a hang) and the truncation is surfaced to the caller
+/// via [`ExtractProgress::OcrTruncated`]. Text-layer pages are never subject to this cap.
+///
+/// COOPERATIVE CANCEL DECISION (documented): the import runs inside `perf::run_heavy`'s
+/// `spawn_blocking` closure, which is NOT cancellable (a dropped caller future orphans the closure —
+/// see `perf.rs`), and `AppState` carries no per-import abort handle. Adding a cooperative cancel
+/// signal (a shared `AtomicBool` registry keyed by document id, checked between pages + wired to a
+/// `cancel_import` command + FE button) is >~40 lines across `state.rs`/`commands.rs`/`lib.rs`/the FE
+/// and out of scope here. Instead THIS CAP + the per-page progress bound the worst case: an import can
+/// take at most `MAX_OCR_PAGES` OCR steps, with live progress, rather than running unbounded. Mid-OCR
+/// cancel is therefore NOT supported in this PR — it is bounded, not interruptible.
+pub const MAX_OCR_PAGES: usize = 300;
+
+/// Whether a page's text-layer string is too short to be a real text layer → OCR it. Pure logic
+/// (no FFI), so the per-page OCR DECISION is unit-testable headless. Counts CHARACTERS (not bytes) so
+/// a short multi-byte (e.g. Polish) heading is judged by its glyph count, not its UTF-8 length.
+fn page_needs_ocr(text_layer: &str) -> bool {
+    text_layer.trim().chars().count() < OCR_MIN_TEXT_CHARS
+}
 
 /// Map a caught-exception / nil / empty result into a single fail-closed error.
 fn read_failed() -> AppError {
@@ -50,9 +94,13 @@ fn catch_objc<R>(f: impl FnOnce() -> R) -> Option<R> {
     catch(AssertUnwindSafe(f)).ok()
 }
 
-/// Extract a PDF into per-page blocks. Fail-closed on any FFI exception / unreadable document; a
-/// text-layer-less (scanned) PDF returns a distinct OCR-hint error.
-pub fn extract_pdf(path: &Path) -> Result<Vec<ExtractedBlock>> {
+/// Extract a PDF into per-page blocks with a PER-PAGE OCR fallback. For each page: keep its text-layer
+/// string if it's a real text layer; otherwise (empty/short — a scanned page) OCR it, up to
+/// [`MAX_OCR_PAGES`] OCR'd pages. Fail-closed on any FFI exception / unreadable / password-locked
+/// document; fail closed only if EVERY page yields nothing (text layer AND OCR). `progress` receives a
+/// per-page [`ExtractProgress::Page`] as pages are processed, and an [`ExtractProgress::OcrTruncated`]
+/// if the OCR cap skipped scanned pages.
+pub fn extract_pdf(path: &Path, progress: &ProgressFn<'_>) -> Result<Vec<ExtractedBlock>> {
     let path_str = path.to_string_lossy().to_string();
 
     // Open the document. `initWithURL` + everything downstream is UNSAFE ObjC that MAY throw — wrap
@@ -86,18 +134,50 @@ pub fn extract_pdf(path: &Path) -> Result<Vec<ExtractedBlock>> {
     let headings = outline_headings(&doc, page_count).unwrap_or_default();
 
     let mut blocks: Vec<ExtractedBlock> = Vec::new();
-    let mut any_text = false;
+    let mut any_text = false; // any real text-layer OR OCR text on any page
+    let mut pages_ocred = 0usize; // pages we actually OCR'd (under the cap)
+    let mut pages_ocr_skipped = 0usize; // scanned pages skipped because the cap was reached
+
     for i in 0..page_count {
-        // Each page fetch + `string` read is a separate catch — one bad page never aborts the rest.
-        let page_text: Option<String> = catch_objc(|| {
+        // 1) Read the page's text layer (each fetch + `string` read is a separate catch — one bad
+        //    page never aborts the rest).
+        let text_layer: String = catch_objc(|| {
             let page = unsafe { doc.pageAtIndex(i) }?;
             let s = unsafe { page.string() }?;
             Some(s.to_string())
         })
-        .flatten();
+        .flatten()
+        .unwrap_or_default();
 
-        let text = page_text.unwrap_or_default();
-        let trimmed = text.trim();
+        // 2) PER-PAGE decision: a page with a real text layer keeps it (no render/OCR); a page with
+        //    no/short text layer (scanned) is OCR'd — but only up to the cap.
+        let page_text: String = if page_needs_ocr(&text_layer) {
+            if pages_ocred < MAX_OCR_PAGES {
+                // Fetch + OCR this page (inside catch). A page that fails to render/recognize simply
+                // contributes no text — it never aborts the loop.
+                let ocr_text = match catch_objc(|| unsafe { doc.pageAtIndex(i) }).flatten() {
+                    Some(page) => crate::extract::ocr::ocr_pdf_page(&page).unwrap_or_default(),
+                    None => String::new(),
+                };
+                pages_ocred += 1;
+                // Prefer OCR text; fall back to whatever short text-layer string existed (rare).
+                if ocr_text.trim().is_empty() {
+                    text_layer
+                } else {
+                    ocr_text
+                }
+            } else {
+                // Past the OCR cap: skip OCR (partial content). Keep any short text-layer text that
+                // existed so we never DROP text a page did have.
+                pages_ocr_skipped += 1;
+                text_layer
+            }
+        } else {
+            // Real text layer — keep it verbatim, never render.
+            text_layer
+        };
+
+        let trimmed = page_text.trim();
         if !trimmed.is_empty() {
             any_text = true;
         }
@@ -108,56 +188,38 @@ pub fn extract_pdf(path: &Path) -> Result<Vec<ExtractedBlock>> {
             page: Some((i + 1) as u32),
             heading_path: heading_for_page(&headings, i),
         });
+
+        // Per-page progress (1-based done). Cheap; the caller throttles/emits as it sees fit.
+        progress(ExtractProgress::Page {
+            done: i + 1,
+            total: page_count,
+        });
     }
 
     if !any_text {
-        // A PDF with text on NO page is a scanned/image PDF → fall back to on-device Vision OCR.
-        // This branch ONLY runs when the fast text-layer path found nothing, so a normal text PDF is
-        // never slowed by rendering + OCR.
-        return ocr_scanned_pdf(&doc, page_count, &headings);
-    }
-
-    Ok(blocks)
-}
-
-/// OCR fallback for a text-layer-less (scanned) PDF: render each page to a CGImage and run Vision OCR
-/// ([`crate::extract::ocr::ocr_pdf_page`]). Emits one block per page that yielded recognized text
-/// (page number preserved, heading from the outline if any); a page OCR can fail/blank without failing
-/// the whole document. If OCR yields NOTHING on EVERY page, fail closed with a clear `InvalidArg`.
-/// Every PDFKit/Vision/CoreGraphics call is crash-safe (wrapped in `catch` inside `ocr`).
-fn ocr_scanned_pdf(
-    doc: &PDFDocument,
-    page_count: usize,
-    headings: &[(usize, String)],
-) -> Result<Vec<ExtractedBlock>> {
-    let mut blocks: Vec<ExtractedBlock> = Vec::new();
-    let mut any_ocr_text = false;
-    for i in 0..page_count {
-        // Fetch the page (inside catch) then OCR it. A page that fails to fetch / render / recognize
-        // simply contributes no text — it never aborts the loop.
-        let page = match catch_objc(|| unsafe { doc.pageAtIndex(i) }).flatten() {
-            Some(p) => p,
-            None => continue,
-        };
-        let ocr_text = crate::extract::ocr::ocr_pdf_page(&page).unwrap_or_default();
-        let trimmed = ocr_text.trim();
-        if !trimmed.is_empty() {
-            any_ocr_text = true;
-            blocks.push(ExtractedBlock {
-                text: trimmed.to_string(),
-                page: Some((i + 1) as u32),
-                heading_path: heading_for_page(headings, i),
-            });
-        }
-    }
-
-    if !any_ocr_text {
-        // No text layer AND OCR found nothing on any page — the document has no readable text.
+        // Every page yielded nothing — no text layer anywhere AND OCR (where attempted) found nothing.
         return Err(AppError::InvalidArg(
             "no text found in this document, even with OCR".into(),
         ));
     }
-    tracing::info!(target: "documents", pages = page_count, ocr_blocks = blocks.len(), "pdf: scanned-PDF OCR fallback produced text");
+
+    // Surface OCR-cap truncation to the caller (the FE shows a partial-import notice). Counts only.
+    if pages_ocr_skipped > 0 {
+        tracing::warn!(
+            target: "documents",
+            pages = page_count,
+            ocred = pages_ocred,
+            skipped = pages_ocr_skipped,
+            cap = MAX_OCR_PAGES,
+            "pdf: OCR page cap reached — some scanned pages were skipped (partial content)"
+        );
+        progress(ExtractProgress::OcrTruncated {
+            ocred: pages_ocred,
+            skipped: pages_ocr_skipped,
+        });
+    } else if pages_ocred > 0 {
+        tracing::info!(target: "documents", pages = page_count, ocred = pages_ocred, "pdf: per-page OCR fallback produced text");
+    }
     Ok(blocks)
 }
 
@@ -258,7 +320,7 @@ mod tests {
         let mut p = std::env::temp_dir();
         p.push(format!("murmur-notpdf-{}.pdf", std::process::id()));
         std::fs::write(&p, b"this is definitely not a pdf").unwrap();
-        let err = extract_pdf(&p).unwrap_err();
+        let err = extract_pdf(&p, &crate::extract::no_progress).unwrap_err();
         assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
     }
 
@@ -266,7 +328,41 @@ mod tests {
     #[test]
     fn missing_pdf_fails_closed() {
         let p = std::path::Path::new("/nonexistent/murmur/does-not-exist.pdf");
-        let err = extract_pdf(p).unwrap_err();
+        let err = extract_pdf(p, &crate::extract::no_progress).unwrap_err();
         assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    /// Fix 1 (per-page OCR DECISION, headless): a page whose trimmed text-layer string is empty or
+    /// shorter than [`OCR_MIN_TEXT_CHARS`] needs OCR; a page with a real text layer does not. This is
+    /// the pure core of the mixed-document fix — one text-layer COVER page (page 1) no longer
+    /// suppresses OCR for the scanned pages behind it, because the decision is per-page. (End-to-end —
+    /// does Vision actually read page 2/3 — needs a real Mac + a signed build + a real scanned PDF; the
+    /// FFI render/OCR can't run headless. This test pins the DECISION that routes each page.)
+    #[test]
+    fn page_needs_ocr_decides_per_page() {
+        // A real text-layer page (≥ 16 chars) does NOT need OCR.
+        assert!(!page_needs_ocr("This page has a real, extractable text layer."));
+        // An empty page (a scanned/image page with no text layer) needs OCR.
+        assert!(page_needs_ocr(""));
+        assert!(page_needs_ocr("   \n  "));
+        // A near-empty page (a stray artifact under the threshold) needs OCR.
+        assert!(page_needs_ocr("Ch. 1"));
+        // Exactly at the threshold (16 chars) counts as a text layer (no OCR).
+        assert!(!page_needs_ocr("abcdefghijklmnop")); // 16 chars
+        assert!(page_needs_ocr("abcdefghijklmno")); // 15 chars → OCR
+        // Character count, not byte count: a short Polish heading is judged by glyphs. "zażółć gęślą"
+        // is 12 chars (< 16) → OCR, even though its UTF-8 byte length is larger.
+        assert!(page_needs_ocr("zażółć gęślą"));
+    }
+
+    /// Fix 2: the OCR page cap is a named, generous-but-finite const — the availability bound that
+    /// stops an unbounded scanned book from starving the heavy-inference permit. (The end-to-end cap
+    /// behavior — a >300-page scanned PDF truncating with an OcrTruncated signal — needs a real Mac +
+    /// signed build + a huge scanned fixture; here we pin the const is set to the documented value.)
+    #[test]
+    fn max_ocr_pages_is_bounded() {
+        // Pinned to the documented value: generous (a full scanned book) yet finite (bounds the
+        // worst-case OCR work + heavy-permit hold). A change here is a deliberate policy change.
+        assert_eq!(MAX_OCR_PAGES, 300, "the OCR page cap is the documented bound");
     }
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -169,19 +169,43 @@ fn doc_sealed_at_rest_tx(tx: &rusqlite::Transaction<'_>, document_id: &str) -> R
 /// chunk indexing — the far more common path, since it runs on every recording Stop, not just
 /// the startup catch-up — is closed here too, both callers now sharing this one helper).
 fn embed_in_sub_batches(embedder: &dyn Embedder, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    embed_in_sub_batches_progress(embedder, texts, &no_embed_progress)
+}
+
+/// A per-sub-batch embed-progress callback: `(sub_batches_done, sub_batches_total)`. Used by the
+/// document-import path so the FE can render "Embedding k/M" during a large document's embed loop
+/// (Brain v3 PR-4, Fix 3). A no-op ([`no_embed_progress`]) is used everywhere else (meeting/topic
+/// indexing, tests) so no other caller changes behavior.
+pub(crate) type EmbedProgressFn<'a> = dyn Fn(usize, usize) + 'a;
+
+/// The no-op [`EmbedProgressFn`] — the default for every embed caller that doesn't report progress.
+pub(crate) fn no_embed_progress(_done: usize, _total: usize) {}
+
+/// [`embed_in_sub_batches`] with a per-sub-batch progress callback. Same sub-batching + pacing; after
+/// each sub-batch completes it reports `(done, total)` sub-batch counts. `total` is `1` for the
+/// single-call small path so a small document still reports 1/1 at completion.
+fn embed_in_sub_batches_progress(
+    embedder: &dyn Embedder,
+    texts: &[String],
+    progress: &EmbedProgressFn<'_>,
+) -> Result<Vec<Vec<f32>>> {
     const SUB_BATCH: usize = 8;
     if texts.is_empty() {
         return Ok(Vec::new());
     }
     if texts.len() <= SUB_BATCH {
-        return embedder.embed_passage(texts);
+        let v = embedder.embed_passage(texts)?;
+        progress(1, 1);
+        return Ok(v);
     }
+    let total = texts.len().div_ceil(SUB_BATCH);
     let mut vectors = Vec::with_capacity(texts.len());
     for (i, sub_batch) in texts.chunks(SUB_BATCH).enumerate() {
         if i > 0 {
             std::thread::sleep(std::time::Duration::from_millis(30));
         }
         vectors.extend(embedder.embed_passage(sub_batch)?);
+        progress(i + 1, total);
     }
     Ok(vectors)
 }
@@ -5218,6 +5242,18 @@ impl Db {
         document_id: &str,
         embedder: Option<&dyn Embedder>,
     ) -> Result<()> {
+        self.index_document_chunks_progress(document_id, embedder, &no_embed_progress)
+    }
+
+    /// [`Db::index_document_chunks`] with a per-sub-batch embed-progress callback (Brain v3 PR-4,
+    /// Fix 3): reports `(done, total)` embed sub-batches so the import path can stream "Embedding k/M"
+    /// to the FE. Identical behavior otherwise — the no-op default preserves every existing caller.
+    pub fn index_document_chunks_progress(
+        &self,
+        document_id: &str,
+        embedder: Option<&dyn Embedder>,
+        embed_progress: &EmbedProgressFn<'_>,
+    ) -> Result<()> {
         let Some((_folder_id, name, text)) = self.get_document(document_id)? else {
             return Ok(()); // unknown document — nothing to index.
         };
@@ -5254,7 +5290,9 @@ impl Db {
             .map(|&i| hier[i].embed_text.clone())
             .collect();
         let embed_vecs: Vec<Vec<f32>> = match embedder {
-            Some(e) if !embed_texts.is_empty() => embed_in_sub_batches(e, &embed_texts)?,
+            Some(e) if !embed_texts.is_empty() => {
+                embed_in_sub_batches_progress(e, &embed_texts, embed_progress)?
+            }
             _ => Vec::new(), // model absent → chunk-only (FTS still covers it); vectors come later.
         };
         // Map HierChunk-index → its vector (only for embed-worthy chunks that actually got embedded).
@@ -5329,12 +5367,28 @@ impl Db {
         body: &str,
         embedder: Option<&dyn Embedder>,
     ) -> Result<()> {
+        self.index_note_chunks_progress(note_id, title, body, embedder, &no_embed_progress)
+    }
+
+    /// [`Db::index_note_chunks`] with a per-sub-batch embed-progress callback (Brain v3 PR-4, Fix 3):
+    /// an imported NOTE document streams "Embedding k/M" like an uploaded document. Identical behavior
+    /// otherwise — the no-op default preserves every existing caller (recording Stop, reindex).
+    pub fn index_note_chunks_progress(
+        &self,
+        note_id: &str,
+        title: &str,
+        body: &str,
+        embedder: Option<&dyn Embedder>,
+        embed_progress: &EmbedProgressFn<'_>,
+    ) -> Result<()> {
         let chunks = crate::embed::chunk_note(title, "", body);
         // Sub-batch to bound the per-call Metal tensor for a long note (mirror
         // index_meeting_chunks/index_document_chunks — this indexer was the one remaining
         // whole-item single-call embed, brain-v3 audit H3).
         let vectors = match embedder {
-            Some(e) if !chunks.is_empty() => embed_in_sub_batches(e, &chunks)?,
+            Some(e) if !chunks.is_empty() => {
+                embed_in_sub_batches_progress(e, &chunks, embed_progress)?
+            }
             _ => Vec::new(), // model absent → chunk-only (FTS still covers it); vectors come later.
         };
         let this_doc = [note_id.to_string()];
@@ -21170,6 +21224,46 @@ mod tests {
             calls.len() > 1,
             "10 chunks over an 8-per-batch cap must take more than one embed call, got: {calls:?}"
         );
+    }
+
+    /// Brain v3 PR-4 Fix 3 (RED→GREEN): `embed_in_sub_batches_progress` reports `(done, total)`
+    /// sub-batch counts as each embed sub-batch completes — the real counts the import path streams to
+    /// the FE ("Embedding k/M") instead of the old always-`0/0`. 20 texts over an 8-per-batch cap →
+    /// 3 sub-batches, so progress must land 1/3, 2/3, 3/3 in order and end at total==done.
+    #[test]
+    fn embed_sub_batch_progress_reports_real_running_counts() {
+        let embedder = RecordingEmbedder {
+            call_sizes: std::sync::Mutex::new(Vec::new()),
+        };
+        let texts: Vec<String> = (0..20).map(|i| format!("chunk {i}")).collect();
+        let seen: std::sync::Mutex<Vec<(usize, usize)>> = std::sync::Mutex::new(Vec::new());
+        let progress = |done: usize, total: usize| seen.lock().unwrap().push((done, total));
+
+        let vecs = embed_in_sub_batches_progress(&embedder, &texts, &progress).unwrap();
+        assert_eq!(vecs.len(), 20, "every text is embedded exactly once");
+
+        let seen = seen.into_inner().unwrap();
+        assert_eq!(
+            seen,
+            vec![(1, 3), (2, 3), (3, 3)],
+            "progress reports each sub-batch as done/total, in order, ending at total==done"
+        );
+    }
+
+    /// Fix 3: the small-input path (<= one sub-batch) still reports a single 1/1 completion, so a tiny
+    /// document's progress bar reaches 100% rather than never firing.
+    #[test]
+    fn embed_sub_batch_progress_small_input_reports_one_of_one() {
+        let embedder = RecordingEmbedder {
+            call_sizes: std::sync::Mutex::new(Vec::new()),
+        };
+        let texts: Vec<String> = (0..3).map(|i| format!("chunk {i}")).collect();
+        let seen: std::sync::Mutex<Vec<(usize, usize)>> = std::sync::Mutex::new(Vec::new());
+        let progress = |done: usize, total: usize| seen.lock().unwrap().push((done, total));
+
+        let vecs = embed_in_sub_batches_progress(&embedder, &texts, &progress).unwrap();
+        assert_eq!(vecs.len(), 3);
+        assert_eq!(seen.into_inner().unwrap(), vec![(1, 1)], "small input → single 1/1 completion");
     }
 
     /// 2026-07-13 launch-freeze fix (round 3): `index_meeting_chunks` (the REGULAR transcript/note

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -542,11 +542,14 @@ export interface ReindexProgress {
 }
 
 /**
- * Brain v3 PR-2 — progress for an in-flight document import (`importDocument`):
+ * Brain v3 PR-2/PR-4 — progress for an in-flight document import (`importDocument`):
  * the extract → chunk → embed pipeline for ONE document. Mirrors the backend
  * `DocImportPayload` (camelCase). Counts + a stage ONLY — NO PII (`documentId`
- * is a random UUID; no filename / text). `done`/`total` are chunk counts within
- * the embedding stage (`0`/`0` for the earlier stages). `stage`:
+ * is a random UUID; no filename / text). `done`/`total` are REAL counts within a
+ * stage: PAGES for `"extracting"` (page k of N — including a scanned-PDF OCR) and
+ * embed SUB-BATCHES for `"embedding"` (batch k of M); `0`/`0` for `"chunking"`.
+ * `truncated` is `true` ONLY on the final `"done"` event when the scanned-PDF OCR
+ * page cap was reached (some scanned pages were skipped — partial content). `stage`:
  * `"extracting"` | `"chunking"` | `"embedding"` | `"done"`.
  */
 export interface DocImportProgress {
@@ -554,6 +557,7 @@ export interface DocImportProgress {
   stage: "extracting" | "chunking" | "embedding" | "done";
   done: number;
   total: number;
+  truncated: boolean;
 }
 
 /**

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -267,6 +267,15 @@ export class BrainComponent {
   private readonly importProgress = signal<DocImportProgress | null>(null);
 
   /**
+   * Set when the in-flight import's terminal `"done"` event reported `truncated`
+   * (the scanned-PDF OCR page cap skipped pages — partial content). Read in
+   * {@link pickAndImportDocument}'s success branch to show a distinct "partial
+   * import" toast instead of the plain success one. Reset at the start of each
+   * import. Content-free (a boolean) — NO PII.
+   */
+  private readonly importTruncated = signal(false);
+
+  /**
    * A short, human progress line for the importing Documents card, e.g.
    * "Extracting…" or "Embedding 12/40". Null unless an import is running.
    */
@@ -280,7 +289,10 @@ export class BrainComponent {
     }
     switch (p.stage) {
       case "extracting":
-        return "Extracting text…";
+        // Real page counts when known ("page 12/300" during a scanned-PDF OCR).
+        return p.total > 0
+          ? `Extracting ${p.done}/${p.total}`
+          : "Extracting text…";
       case "chunking":
         return "Chunking…";
       case "embedding":
@@ -425,7 +437,15 @@ export class BrainComponent {
     // — the `importing` flag already gates a second import.
     let unlisten: UnlistenFn | null = null;
     void this.ipc
-      .onDocImportProgress((p) => this.importProgress.set(p))
+      .onDocImportProgress((p) => {
+        this.importProgress.set(p);
+        // Latch a truncation reported on the terminal "done" event (partial import
+        // — the scanned-PDF OCR page cap skipped pages), read after the import call
+        // resolves to pick the toast copy.
+        if (p.stage === "done" && p.truncated) {
+          this.importTruncated.set(true);
+        }
+      })
       .then((fn) => {
         unlisten = fn;
       });
@@ -570,10 +590,19 @@ export class BrainComponent {
     }
 
     this.importProgress.set(null);
+    this.importTruncated.set(false);
     this.importing.set(true);
     try {
       await this.ipc.importDocument(chosen, folderId);
-      this.toast.success("Document added to the brain.");
+      // A scanned PDF past the OCR page cap imports PARTIALLY — say so, don't
+      // claim a clean success (the pages beyond the cap have no text).
+      if (this.importTruncated()) {
+        this.toast.danger(
+          "Document added, but it had more scanned pages than we can read — some pages were skipped.",
+        );
+      } else {
+        this.toast.success("Document added to the brain.");
+      }
       this.docsExpanded.set(true);
       await this.afterMutation();
     } catch (e) {


### PR DESCRIPTION
PR-4 of the brain-v3 audit-fix program (audit: docs/research/2026-07-18-brain-v3-audit.md).

## Fixes
- **[MED] scanned-PDF OCR was all-or-nothing** — one text-layer page (a publisher cover) suppressed OCR for every scanned page (~100% of a scanned book silently absent). Now a per-page loop OCRs each page whose text layer < OCR_MIN_TEXT_CHARS=16; text-layer pages skip rendering (a normal PDF never pays for OCR).
- **[MED] unbounded OCR held the heavy permit** — MAX_OCR_PAGES=300 caps it; pages past the cap are skipped and DISCLOSED via an OcrTruncated event → a partial-import toast (never a silent hang, never data loss). Mid-OCR cancel out of scope (spawn_blocking non-cancellable) — cap + progress bound the worst case.
- **[MED] dead progress (done=0,total=0)** — now REAL per-page (extract) + per-sub-batch (embed) counts, so a multi-minute import shows movement instead of looking hung.
- **[MED] memory bounds asymmetric** — a universal 256 MiB extracted-text ceiling for ALL formats (was zip-only 512 MiB) + a flow-file size cap; closes the PDF-inflation / calamine / giant-file OOM class. Friendly AppError, never mid-codepoint truncation.
- **[LOW] OCR langs hardcoded ['pl','en']** — intersected with runtime supportedRecognitionLanguages (crash-safe FFI, fails OPEN to Vision default); no more forcing 'pl' on an OS build that lacks it (which returned no text).

## Verified
- cargo test --lib **1939/0** (+ RED regressions: per-page OCR decision, language intersection, text budget fail-closed, progress counts), clippy -D warnings clean, ng lint/build clean.
- **adversarial-verifier PASS** — 4 targeted RED-reverts (each reproduced the exact audit bug), crash posture intact (extract stays pure path→blocks, one-tx insert, repair-tick backfill), new supportedRecognitionLanguages FFI fails OPEN (war-story-safe), progress payload serde matches the FE consumer exactly.
- No new gated read / no new seal / no PII in logs → lock-security not required.

Signed-build residuals: real Vision OCR fidelity, the >300-page truncation end-to-end, the language-intersection FFI (only the pure choose_ocr_languages is headless-tested).