### PR TITLE
fix(brain): honest tool-result truncation, disclosed paging windows, doc-outline tool

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -81,6 +81,13 @@ pub trait DeltaSink: Send + Sync {
 /// Bound on re-fed tool output per step — caps context growth + cloud egress amplification.
 const RESULT_BUDGET: usize = 4000;
 
+/// Hard cap on the retained citation-source accumulator (`gathered`). The model NEVER sees this
+/// buffer — it exists only so `extract_citations` can scan the raw tool text for `[[Title]]` /
+/// `(via …)` markers after the loop. Bounding it (was unbounded: a multi-MB `get_document` body
+/// accumulated in full) keeps a giant tool result from ballooning memory when only the first few KB
+/// carry any citation markers. Generous enough that a normal multi-tool turn is unaffected.
+const GATHERED_BUDGET: usize = 64_000;
+
 /// Brain v2 L3 — char budget on the WHOLE loop transcript before deterministic compaction kicks in
 /// (~8k tokens: inside a small local model's effective context, and a hard cap on per-step cloud
 /// egress growth). `pub(crate)` so [`crate::reason::GenOptions::transcript_compaction`]'s doc can
@@ -319,11 +326,20 @@ pub fn run_agentic_loop(
                     if let Some(s) = sink {
                         s.tool_done(&name, true, out.chars().count());
                     }
-                    gathered.push_str(out);
-                    gathered.push_str("\n\n");
+                    // CITATION source: keep the FULL output only up to a hard cap so a multi-MB
+                    // tool result can't grow `gathered` without bound (the model only ever sees the
+                    // RESULT_BUDGET-truncated block; citation extraction scans `gathered`). Citations
+                    // are `[[Title]]`/`(via …)` markers that appear in the FIRST kilobytes of a
+                    // formatted hit list, so bounding the retained copy at GATHERED_BUDGET can only
+                    // drop citations from the tail of an over-cap payload — never the answer.
+                    push_bounded(&mut gathered, out, GATHERED_BUDGET);
+                    // HONEST TRUNCATION (Brain v3 audit Fix 1): when the result exceeds
+                    // RESULT_BUDGET, append a machine-actionable marker carrying the TRUE total so
+                    // the model can tell "this doc IS N chars" from "I saw the first 4000 of N" and
+                    // page the rest — never confidently assert absence after seeing a fraction.
                     transcript.push_result(format!(
                         "[{name} result]\n{}",
-                        truncate(out, RESULT_BUDGET)
+                        truncate_with_marker(out, RESULT_BUDGET)
                     ));
                     steps.push(AgentStep {
                         tool: name,
@@ -375,6 +391,44 @@ fn truncate(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+/// HONEST truncation for a re-fed tool RESULT block (Brain v3 audit Fix 1). A result at or under
+/// `max` bytes is returned UNCHANGED (byte-identical to the pre-fix `truncate`, so a small result
+/// never carries a marker). When it exceeds `max`, the char-safe prefix is followed by a
+/// machine-actionable marker that discloses:
+///   - the TRUE total length (in CHARS — the unit the paging `offset`/`maxChars` args use), so the
+///     model can tell "the doc IS this long" from "I only saw a slice", and
+///   - the exact `offset=<shown_chars>` to pass on the next call to continue reading.
+///
+/// Without this the model confidently asserts absence ("the document doesn't mention X") after
+/// seeing a tiny fraction of a large result — the documented "truncation makes agents lie" failure.
+fn truncate_with_marker(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let shown = truncate(s, max);
+    // CHARS, not bytes, so the disclosed numbers line up with the char-based paging args the tools
+    // advertise. `shown_chars` is the correct next `offset`.
+    let shown_chars = shown.chars().count();
+    let total_chars = s.chars().count();
+    format!(
+        "{shown}\n[truncated: showing {shown_chars} of {total_chars} chars — call the same tool \
+         again with offset={shown_chars} to continue]"
+    )
+}
+
+/// Append `out` to the citation-source accumulator `buf`, but never let `buf` grow past `cap`
+/// (Brain v3 audit Fix 1). Char-safe. Once `buf` is at/over `cap` nothing more is retained (the
+/// model already saw the truncated block; citations live in the head). This bounds memory for a
+/// multi-MB tool result whose full body would otherwise accumulate here in full.
+fn push_bounded(buf: &mut String, out: &str, cap: usize) {
+    if buf.len() >= cap {
+        return;
+    }
+    let room = cap - buf.len();
+    buf.push_str(truncate(out, room));
+    buf.push_str("\n\n");
 }
 
 #[cfg(test)]
@@ -884,6 +938,113 @@ mod tests {
             out.steps.len(),
             1,
             "the duplicate call must not be executed again"
+        );
+    }
+
+    // ── Brain v3 audit Fix 1: HONEST tool-result truncation ──────────────────────────────────────
+
+    /// A result AT OR UNDER the budget is byte-identical to today (no marker); a result OVER the
+    /// budget carries the disclosure marker with the TRUE total char count and the correct next
+    /// `offset`. Without this the model can't tell "the whole result IS this short" from "I saw a
+    /// slice of a huge result" and asserts absence after seeing a fraction.
+    #[test]
+    fn truncate_with_marker_discloses_the_true_total_only_when_it_cuts() {
+        // Under budget → unchanged, NO marker (the byte-identical-today guarantee).
+        let small = "abc";
+        assert_eq!(truncate_with_marker(small, RESULT_BUDGET), "abc");
+        assert!(!truncate_with_marker(small, RESULT_BUDGET).contains("truncated"));
+        // Exactly at the budget → still unchanged, no marker.
+        let exact = "z".repeat(RESULT_BUDGET);
+        assert_eq!(truncate_with_marker(&exact, RESULT_BUDGET), exact);
+        assert!(!truncate_with_marker(&exact, RESULT_BUDGET).contains("truncated"));
+
+        // Over budget (ASCII: chars == bytes) → the prefix + a marker with the TRUE total and the
+        // next offset.
+        let big = "q".repeat(RESULT_BUDGET + 2500); // 6500 chars
+        let out = truncate_with_marker(&big, RESULT_BUDGET);
+        assert!(out.starts_with(&"q".repeat(RESULT_BUDGET)), "keeps the char-safe prefix");
+        assert!(
+            out.contains(&format!(
+                "[truncated: showing {RESULT_BUDGET} of 6500 chars — call the same tool again with \
+                 offset={RESULT_BUDGET} to continue]"
+            )),
+            "the marker must carry the TRUE total (6500) + the next offset: {out}"
+        );
+    }
+
+    /// The disclosed numbers are CHAR counts (the unit the paging args use), never byte counts —
+    /// so a multibyte result reports a total the model can pass straight back as `offset`.
+    #[test]
+    fn truncate_with_marker_counts_chars_not_bytes() {
+        // 3000 × '€' (3 bytes each) = 9000 bytes, 3000 chars. Byte-len (9000) exceeds a 4000-byte
+        // budget, so it truncates; the DISCLOSED total must be 3000 CHARS, not 9000 bytes.
+        let s = "€".repeat(3000);
+        assert!(s.len() > RESULT_BUDGET, "precondition: byte-len exceeds the budget");
+        let out = truncate_with_marker(&s, RESULT_BUDGET);
+        assert!(out.contains("of 3000 chars"), "total is char count, not byte count: {out}");
+        // The next offset is the number of CHARS shown, and re-slicing the source at that char
+        // offset must land exactly where the shown prefix ended (a valid continuation window).
+        let shown_chars = out
+            .split("showing ")
+            .nth(1)
+            .and_then(|t| t.split(' ').next())
+            .and_then(|n| n.parse::<usize>().ok())
+            .expect("marker carries a shown-chars count");
+        assert!(shown_chars > 0 && shown_chars < 3000);
+        assert!(out.contains(&format!("offset={shown_chars}")), "next offset = chars shown: {out}");
+    }
+
+    /// The citation accumulator never grows past its cap even when a single tool result is enormous
+    /// (a multi-MB `get_document` body). It stops appending once full — the head (where citation
+    /// markers live) is retained; only the tail of an over-cap payload is dropped.
+    #[test]
+    fn push_bounded_caps_the_citation_accumulator() {
+        let mut buf = String::new();
+        let huge = "x".repeat(GATHERED_BUDGET * 3);
+        push_bounded(&mut buf, &huge, GATHERED_BUDGET);
+        assert!(buf.len() <= GATHERED_BUDGET + 2, "buffer bounded (+ the \\n\\n joiner): {}", buf.len());
+        // A second push over an already-full buffer is a no-op.
+        let before = buf.len();
+        push_bounded(&mut buf, "more", GATHERED_BUDGET);
+        assert_eq!(buf.len(), before, "nothing retained once at cap");
+    }
+
+    /// IN-LOOP (RED on the pre-fix silent cut): a tool result LARGER than RESULT_BUDGET reaches the
+    /// model with the honest disclosure marker + the TRUE total, so the brain knows it saw only a
+    /// slice and can page — never confidently answers "not found" on a fraction.
+    #[test]
+    fn loop_over_budget_tool_result_reaches_the_model_with_the_disclosure_marker() {
+        /// Returns a result far larger than RESULT_BUDGET (a big document body).
+        struct HugeExec;
+        impl ToolExecutor for HugeExec {
+            fn specs(&self) -> Vec<crate::tools::ToolSpec> {
+                crate::tools::tool_specs()
+            }
+            fn run(&self, _n: &str, _a: &Value) -> Result<String> {
+                Ok("h".repeat(RESULT_BUDGET * 10)) // 40000 chars
+            }
+        }
+        // Ask a tool, then answer — so the transcript the SECOND model call sees carries the result.
+        let r = ScriptReasoner::ok(vec![
+            serde_json::json!({ "tool": "get_document", "args": { "documentId": "d1" } }),
+            serde_json::json!({ "answer": "done" }),
+        ]);
+        // Route the recorded transcripts through the ScriptReasoner's `seen`.
+        let out = run_agentic_loop(&r, "sys", "q", &HugeExec, 4, None, GenOptions::default())
+            .unwrap()
+            .expect("converges");
+        assert_eq!(out.answer, "done");
+        let seen = r.seen.lock().unwrap();
+        // The transcript handed to the model on the SECOND step (index 1) carries the result block.
+        let with_result = &seen[1];
+        assert!(
+            with_result.contains(&format!("of {} chars", RESULT_BUDGET * 10)),
+            "the model must see the TRUE total ({}), not a silent 4000-char cut",
+            RESULT_BUDGET * 10
+        );
+        assert!(
+            with_result.contains(&format!("offset={RESULT_BUDGET} to continue")),
+            "the model must be told how to page the rest: {with_result}"
         );
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -350,12 +350,21 @@ fn mcp_usize_arg(args: &Value, key: &str) -> usize {
 /// DELIBERATE default change (documented): the pre-fix MCP default `(0,0)` returned the whole body.
 const MCP_DEFAULT_WINDOW_CHARS: usize = 6000;
 
-/// Resolve the MCP paging window for a body tool: honor explicit `offset`/`maxChars`, but when the
-/// client passes NEITHER, default `maxChars` to [`MCP_DEFAULT_WINDOW_CHARS`] so a huge payload is
-/// bounded + disclosed instead of flooding the client. Returns `(offset, max_chars)`.
+/// Resolve the MCP paging window for a body tool: honor an explicit `maxChars`, but whenever the
+/// client gives no (or a zero) `maxChars`, bound it to [`MCP_DEFAULT_WINDOW_CHARS`] so a huge payload
+/// is windowed + disclosed instead of flooding the client (a raw MCP tools/call has no RESULT_BUDGET).
+/// `offset` is honored verbatim, so a client can still page a large body a window at a time. Returns
+/// `(offset, max_chars)`.
 fn mcp_body_window(args: &Value) -> (usize, usize) {
     let offset = mcp_usize_arg(args, "offset");
     let max_chars = mcp_usize_arg(args, "maxChars");
+    // maxChars == 0 means "absent" (mcp_usize_arg's default) or an explicit unbounded request — both
+    // are the flood case, so bound them to the default window. An explicit positive maxChars wins.
+    let max_chars = if max_chars == 0 {
+        MCP_DEFAULT_WINDOW_CHARS
+    } else {
+        max_chars
+    };
     (offset, max_chars)
 }
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -241,13 +241,18 @@ fn tools_spec() -> Value {
         },
         {
             "name": "get_meeting",
-            "description": "Get a meeting's AI note (summary) and full transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text. For a very long transcript, page through it with offset + maxChars.",
-            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain"], "description": "Transcript rendering (default 'structured')." }, "offset": { "type": "number", "description": "Chars to skip into the transcript (default 0)." }, "maxChars": { "type": "number", "description": "Max transcript chars to return from offset (default all)." } }, "required": ["meetingId"] }
+            "description": "Get a meeting's AI note (summary) and transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text. The transcript is returned as a WINDOW (default first 6000 chars) prefixed with 'TOTAL_CHARS: <N> (showing <start>..<end>)'; page a long transcript by passing offset + maxChars.",
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain"], "description": "Transcript rendering (default 'structured')." }, "offset": { "type": "number", "description": "Chars to skip into the transcript (default 0)." }, "maxChars": { "type": "number", "description": "Max transcript chars to return from offset (default: a bounded 6000-char window with the total disclosed)." } }, "required": ["meetingId"] }
         },
         {
             "name": "get_document",
-            "description": "Get the full body of one standalone note or imported/uploaded document by id (from a search hit labelled 'document:...'). Use this — not get_meeting — for ids from the DOCUMENTS section of a search result. For a big document, page through it with offset + maxChars.",
-            "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" }, "offset": { "type": "number", "description": "Chars to skip into the body (default 0)." }, "maxChars": { "type": "number", "description": "Max body chars to return from offset (default all)." } }, "required": ["documentId"] }
+            "description": "Get the body of one standalone note or imported/uploaded document by id (from a search hit labelled 'document:...'). Use this — not get_meeting — for ids from the DOCUMENTS section of a search result. The body is returned as a WINDOW (default first 6000 chars) prefixed with 'TOTAL_CHARS: <N> (showing <start>..<end>)'; page a big document by passing offset + maxChars.",
+            "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" }, "offset": { "type": "number", "description": "Chars to skip into the body (default 0)." }, "maxChars": { "type": "number", "description": "Max body chars to return from offset (default: a bounded 6000-char window with the total disclosed)." } }, "required": ["documentId"] }
+        },
+        {
+            "name": "get_document_outline",
+            "description": "Get the STRUCTURAL OUTLINE (heading/section map + page numbers) of one standalone note or imported/uploaded document by id (from a 'document:...' search hit). Use this on a BIG document BEFORE get_document: read the map, then fetch the section you need with get_document's offset + maxChars instead of paging blindly. Returns the section headings in document order; a flat/heading-less document has no outline. Sealed-and-locked documents return no outline.",
+            "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" } }, "required": ["documentId"] }
         },
         {
             "name": "list_recent_meetings",
@@ -335,6 +340,25 @@ fn mcp_usize_arg(args: &Value, key: &str) -> usize {
         .min(usize::MAX as u64) as usize
 }
 
+/// Brain v3 audit Fix 2 — the MCP `get_meeting`/`get_document` DEFAULT window. UNLIKE the in-app
+/// agentic loop (which caps every tool result at `RESULT_BUDGET` before re-feeding it to the model),
+/// a raw MCP `tools/call` returns the ENTIRE payload to the connected client — so a client that
+/// omits paging on a multi-MB document/transcript would be flooded. When the MCP client passes NO
+/// paging (both `offset` and `maxChars` absent/0) we substitute THIS bounded default `maxChars`, and
+/// the tool returns a DISCLOSED window (`TOTAL_CHARS: <N> …`) so the client can see the full length
+/// and page the rest with explicit `offset`. A client that DOES pass paging is honored verbatim.
+/// DELIBERATE default change (documented): the pre-fix MCP default `(0,0)` returned the whole body.
+const MCP_DEFAULT_WINDOW_CHARS: usize = 6000;
+
+/// Resolve the MCP paging window for a body tool: honor explicit `offset`/`maxChars`, but when the
+/// client passes NEITHER, default `maxChars` to [`MCP_DEFAULT_WINDOW_CHARS`] so a huge payload is
+/// bounded + disclosed instead of flooding the client. Returns `(offset, max_chars)`.
+fn mcp_body_window(args: &Value) -> (usize, usize) {
+    let offset = mcp_usize_arg(args, "offset");
+    let max_chars = mcp_usize_arg(args, "maxChars");
+    (offset, max_chars)
+}
+
 fn dispatch_tool(
     db: &Db,
     name: &str,
@@ -371,9 +395,11 @@ fn dispatch_tool(
                 .filter(|f| *f == "plain")
                 .unwrap_or("structured")
                 .to_string(),
-            // Brain v3 PR-2 — agent paging (absent → 0 → today's behavior).
-            offset: mcp_usize_arg(args, "offset"),
-            max_chars: mcp_usize_arg(args, "maxChars"),
+            // Brain v3 audit Fix 2 — bound + DISCLOSE the default MCP window (no paging args → a
+            // 6000-char disclosed window, not the whole transcript) so a huge transcript can't flood
+            // the client; explicit offset/maxChars are honored verbatim.
+            offset: mcp_body_window(args).0,
+            max_chars: mcp_body_window(args).1,
         },
         "get_document" => ToolCall::GetDocument {
             document_id: args
@@ -381,8 +407,18 @@ fn dispatch_tool(
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_string(),
-            offset: mcp_usize_arg(args, "offset"),
-            max_chars: mcp_usize_arg(args, "maxChars"),
+            // Audit Fix 2 — same bounded + disclosed default window as get_meeting.
+            offset: mcp_body_window(args).0,
+            max_chars: mcp_body_window(args).1,
+        },
+        // Brain v3 audit Fix 3(b) — the document OUTLINE (heading map). Gated by
+        // `get_document_outline_if_visible` inside `execute_tool` (a sealed-not-unlocked doc → empty).
+        "get_document_outline" => ToolCall::GetDocumentOutline {
+            document_id: args
+                .get("documentId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
         },
         "list_recent_meetings" => ToolCall::ListRecentMeetings {
             limit: args
@@ -496,10 +532,10 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_ten_tools() {
+    fn tools_list_has_eleven_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 10);
+        assert_eq!(tools.len(), 11);
         // The Phase 2b semantic tool is advertised.
         assert!(tools.iter().any(|t| t["name"] == "search_semantic"));
         // The Phase 5a open-commitments rollup tool is advertised.
@@ -522,6 +558,16 @@ mod tests {
         assert!(
             tools.iter().any(|t| t["name"] == "knowledge_diff"),
             "knowledge_diff must be advertised in the MCP tool catalog"
+        );
+        // Brain v3 audit Fix 3(b) — the document-outline tool is advertised (the 11th tool), and its
+        // args must be MIRRORED between the MCP tools list and the agentic tool surface (documentId).
+        let outline = tools
+            .iter()
+            .find(|t| t["name"] == "get_document_outline")
+            .expect("get_document_outline must be advertised in the MCP tool catalog");
+        assert_eq!(
+            outline["inputSchema"]["required"][0], "documentId",
+            "the MCP outline tool must advertise the documentId arg (parity with the tool surface)"
         );
     }
 
@@ -1178,6 +1224,114 @@ mod tests {
         let _ = std::fs::remove_file(&p);
     }
 
+    /// Brain v3 audit Fix 2 — the MCP `get_document` DEFAULT (no paging args) no longer floods the
+    /// client with the whole body: it returns a BOUNDED window (`MCP_DEFAULT_WINDOW_CHARS`) plus a
+    /// `TOTAL_CHARS: …` disclosure so the client can see the true length and page the rest. An
+    /// explicit larger `maxChars` is honored verbatim. RED on the pre-fix `(0,0)`-returns-everything.
+    #[test]
+    fn mcp_get_document_default_window_is_bounded_and_disclosed() {
+        use crate::storage::models::Folder;
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-open".to_string(),
+            name: "Docs".to_string(),
+            path: "Docs".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        // A body LARGER than the default window so the flood is measurable.
+        let big = "A".repeat(MCP_DEFAULT_WINDOW_CHARS + 5000);
+        db.insert_document("bigdoc", "f-open", "big.md", &big, "document", 1_700_000_000)
+            .unwrap();
+
+        // Default (no paging) → bounded to MCP_DEFAULT_WINDOW_CHARS + a disclosure header showing
+        // the TRUE total; NOT the whole 11000-char body.
+        let out = dispatch_tool(&db, "get_document", &json!({ "documentId": "bigdoc" }), &HashSet::new())
+            .unwrap();
+        assert!(
+            out.contains(&format!("BODY (TOTAL_CHARS: {} (showing 0..{}))", big.chars().count(), MCP_DEFAULT_WINDOW_CHARS)),
+            "the MCP default must disclose the true total + the bounded window: {}",
+            &out[..out.len().min(120)]
+        );
+        // The returned body is bounded (window + headers/title), NOT the full 11000-char body.
+        assert!(
+            out.len() < big.len(),
+            "the default MCP window must NOT return the whole body (flood): got {} vs body {}",
+            out.len(),
+            big.len()
+        );
+        assert!(
+            !out.contains("[end of content]"),
+            "the bounded default window does NOT reach the end of a body larger than the window: {}",
+            &out[out.len().saturating_sub(60)..]
+        );
+
+        // Explicit larger maxChars is honored (the client CAN ask for more).
+        let full = dispatch_tool(
+            &db,
+            "get_document",
+            &json!({ "documentId": "bigdoc", "offset": 0, "maxChars": big.chars().count() + 10 }),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(full.contains("[end of content]"), "an explicit full window reaches the end: last 60 = {}", &full[full.len().saturating_sub(60)..]);
+        assert!(full.len() > out.len(), "explicit large maxChars returns more than the default window");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// Brain v3 audit Fix 3(b) — the MCP `get_document_outline` dispatch is visibility-gated: a
+    /// document in a sealed-and-not-session-unlocked folder returns the "no outline" sentinel (no
+    /// heading leak), and the heading map reappears once the folder is session-unlocked. Proves the
+    /// NEW gated read routes through `execute_tool` → `get_document_outline_if_visible`.
+    #[test]
+    fn mcp_get_document_outline_is_visibility_gated() {
+        use crate::storage::models::Folder;
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-lock".to_string(),
+            name: "Specs".to_string(),
+            path: "Specs".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        // A two-section doc → two L1 headings in the outline.
+        let blocks = vec![
+            crate::extract::ExtractedBlock {
+                text: "Confidential design of the vault store.".to_string(),
+                page: Some(1),
+                heading_path: Some("SecretDesign".to_string()),
+            },
+            crate::extract::ExtractedBlock {
+                text: "The keys are wrapped by the master KEK.".to_string(),
+                page: Some(2),
+                heading_path: Some("SecretDesign › Keys".to_string()),
+            },
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document("od1", "f-lock", "spec.pdf", &stored, "document", 1_700_000_000)
+            .unwrap();
+        db.index_document_chunks("od1", None).unwrap();
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let args = json!({ "documentId": "od1" });
+        // Locked, not unlocked → the "no outline" sentinel; the heading trail must NOT leak.
+        let out = dispatch_tool(&db, "get_document_outline", &args, &HashSet::new()).unwrap();
+        assert!(out.contains("No outline for document od1"), "sealed → sentinel: {out}");
+        assert!(!out.contains("SecretDesign"), "sealed document headings leaked via MCP outline: {out}");
+
+        // Session-unlock → the heading map reappears in document order.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let out2 = dispatch_tool(&db, "get_document_outline", &args, &unlocked).unwrap();
+        assert!(out2.contains("SecretDesign (p.1)"), "unlocked outline lists section + page: {out2}");
+        assert!(out2.contains("SecretDesign › Keys (p.2)"), "document order preserved: {out2}");
+        let _ = std::fs::remove_file(&p);
+    }
+
     /// Feature D: the MCP `get_meeting` dispatch defaults to the STRUCTURED transcript, and honors an
     /// explicit `transcriptFormat: "plain"` for the legacy flat text.
     #[test]
@@ -1221,13 +1375,21 @@ mod tests {
         )
         .unwrap();
 
-        // Default (no transcriptFormat) → STRUCTURED (speaker label + timestamp token).
+        // Default (no transcriptFormat) → STRUCTURED (speaker label + timestamp token). Audit
+        // Fix 2: the MCP default now bounds+discloses the transcript window, so the section header
+        // carries a `TOTAL_CHARS: …` disclosure (the whole short transcript fits the 6000 window).
         let def = dispatch_tool(&db, "get_meeting", &json!({ "meetingId": "mm" }), &HashSet::new())
             .unwrap();
         assert!(def.contains("Me: opening remarks"), "default must be structured: {def}");
         assert!(def.contains("[5–8]"), "default must carry a timestamp token: {def}");
+        assert!(
+            def.contains("TRANSCRIPT (TOTAL_CHARS:"),
+            "the MCP default now discloses the transcript window total: {def}"
+        );
 
-        // Explicit plain → the legacy flat text (no speaker label, no timestamp).
+        // Explicit plain → the legacy flat text (no speaker label, no timestamp). Audit Fix 2: with
+        // NO paging args the MCP default now applies the bounded+disclosed window, so the short
+        // transcript is fully returned WITH its `TOTAL_CHARS` header + the end-of-content marker.
         let plain = dispatch_tool(
             &db,
             "get_meeting",
@@ -1235,7 +1397,10 @@ mod tests {
             &HashSet::new(),
         )
         .unwrap();
-        assert_eq!(plain, "NOTE:\nn\n\nTRANSCRIPT:\nopening remarks");
+        assert_eq!(
+            plain,
+            "NOTE:\nn\n\nTRANSCRIPT (TOTAL_CHARS: 15 (showing 0..15)):\nopening remarks\n[end of content]"
+        );
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -226,6 +226,8 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::GetOpenCommitments { .. } => "Open commitments",
         ToolCall::GetMeeting { .. } => "Meeting",
         ToolCall::GetDocument { .. } => "Document",
+        // Brain v3 audit Fix 3(b) — the document outline (structural map; explicit tool).
+        ToolCall::GetDocumentOutline { .. } => "Document outline",
         ToolCall::ListRecentMeetings { .. } => "Recent meetings",
         ToolCall::WebSearch { .. } => "Web search",
         ToolCall::CalendarLookup { .. } => "Calendar",

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -12,7 +12,8 @@ use crate::embed::Embedder;
 use crate::storage::models::{
     Analytics, AssistantInteraction, AssistantThreadRow, BacklinkSource, Commitment,
     CorrectionRecord, DayCount,
-    DocChunkHit, DocumentInfo, DocumentSummary, EntityDetail, EntityKind, EntityNeighbor, Folder,
+    DocChunkHit, DocOutlineEntry, DocumentInfo, DocumentSummary, EntityDetail, EntityKind,
+    EntityNeighbor, Folder,
     FullGraphData, FullGraphEdge, FullGraphEdgeKind, FullGraphNode, FullGraphNodeKind, FullGraphOpts,
     GraphData,
     GraphEdge, GraphEntity, GraphNode, Meeting, MeetingActionSummary, MeetingStatus, NoteCitation,
@@ -5744,6 +5745,60 @@ impl Db {
                 level: 1,
                 sibling_hits: h.sibling_hits,
             });
+        }
+        Ok(out)
+    }
+
+    /// Brain v3 audit Fix 3(b) — a document's structural OUTLINE: its section-parent (L1) + doc
+    /// summary (L2) `doc_chunks` rows, in document order, carrying `section_path` + `page_no` (NOT
+    /// the section body text — an outline is a MAP, not content). Deterministic; the agent reads it
+    /// to plan targeted `get_document(offset, maxChars)` reads instead of blind char paging.
+    ///
+    /// GATING (lock-model, load-bearing): applies EXACTLY the same `visibility_clause` predicate over
+    /// `doc_chunks → documents → folders` as every other doc reader, so a document in a
+    /// sealed-and-not-session-unlocked folder yields an EMPTY outline (indistinguishable from a
+    /// never-existed id / a flat legacy doc — never leaks locked-vs-absent). While sealed a folder's
+    /// `doc_chunks` rows are purged anyway; the gate is defense-in-depth on top. A pure gated READ —
+    /// no plaintext content leaves the DB (headings ARE user content, but they are the SAME
+    /// section_path already surfaced on a search hit, and are gated identically).
+    ///
+    /// BOUNDED: at most `cap` entries (a huge deck can't blow the tool result). Legacy/flat docs (all
+    /// rows level 0) have no L1/L2 rows → an empty outline, which the tool renders as "no outline".
+    pub fn get_document_outline_if_visible(
+        &self,
+        id: &str,
+        unlocked: &HashSet<String>,
+        cap: usize,
+    ) -> Result<Vec<DocOutlineEntry>> {
+        if cap == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        // L1 (section-parent) + L2 (doc summary) rows only — the heading/structure tree, never the
+        // L0 leaf body. Ordered by document position (`chunk_index`) so the outline reads top-down.
+        let sql = format!(
+            "SELECT dc.level, dc.section_path, dc.page_no
+               FROM doc_chunks dc
+               JOIN documents d ON d.id = dc.document_id
+               JOIN folders f ON f.id = d.folder_id
+              WHERE dc.document_id = ?1 AND dc.level >= 1 AND {visible}
+              ORDER BY dc.chunk_index ASC
+              LIMIT ?2"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![id, cap as i64], |r| {
+                Ok(DocOutlineEntry {
+                    level: r.get(0)?,
+                    section_path: r.get(1)?,
+                    page_no: r.get(2)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
         }
         Ok(out)
     }
@@ -19325,6 +19380,62 @@ mod tests {
                 .any(|h| h.document_id == "d1" && h.snippet.contains("pistachio")),
             "clean md chunk text is unchanged by the (no-op) reflow gate: {hits:?}"
         );
+    }
+
+    /// Brain v3 audit Fix 3(b) — `get_document_outline_if_visible` returns the L1 section tree
+    /// (section_path + page) in document order, is GATED (a sealed-not-unlocked doc → EMPTY; unlock →
+    /// the tree), and is BOUNDED by `cap`. RED-before-GREEN: the gate assertion fails if the reader
+    /// forgets `visibility_clause` (the sealed doc's headings leak).
+    #[test]
+    fn get_document_outline_is_visibility_gated_and_ordered() {
+        let db = mem_db();
+        seed_folder(&db, "f-lock", "Specs");
+        // A multi-section doc: two headings across two pages → two L1 rows.
+        let blocks = vec![
+            crate::extract::ExtractedBlock {
+                text: "The system stores everything in SQLite.".to_string(),
+                page: Some(1),
+                heading_path: Some("Design".to_string()),
+            },
+            crate::extract::ExtractedBlock {
+                text: "Chunks form a three-level tree.".to_string(),
+                page: Some(2),
+                heading_path: Some("Design › Storage".to_string()),
+            },
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document("d1", "f-lock", "spec.pdf", &stored, "document", 100)
+            .unwrap();
+        db.index_document_chunks("d1", None).unwrap();
+
+        // OPEN folder → the outline lists the section-parents in document order with their pages.
+        let nothing = std::collections::HashSet::new();
+        let outline = db.get_document_outline_if_visible("d1", &nothing, 64).unwrap();
+        let l1: Vec<_> = outline.iter().filter(|e| e.level == 1).collect();
+        assert!(l1.len() >= 2, "two headings → at least two L1 rows: {outline:?}");
+        assert_eq!(l1[0].section_path.as_deref(), Some("Design"));
+        assert_eq!(l1[0].page_no, Some(1));
+        assert_eq!(l1[1].section_path.as_deref(), Some("Design › Storage"));
+        assert_eq!(l1[1].page_no, Some(2), "document order preserved");
+
+        // SEAL the folder → the outline is EMPTY (the gate excludes it; the same masking as every
+        // other doc reader — headings never leak from a sealed-not-unlocked folder).
+        db.set_folder_locked("f-lock", true, None).unwrap();
+        let sealed = db.get_document_outline_if_visible("d1", &nothing, 64).unwrap();
+        assert!(sealed.is_empty(), "sealed-not-unlocked doc must yield an EMPTY outline: {sealed:?}");
+
+        // Session-unlock → the tree reappears.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let reopened = db.get_document_outline_if_visible("d1", &unlocked, 64).unwrap();
+        assert!(
+            reopened.iter().any(|e| e.section_path.as_deref() == Some("Design")),
+            "unlock restores the outline: {reopened:?}"
+        );
+
+        // cap = 0 → empty; cap = 1 → at most one entry (bounded).
+        assert!(db.get_document_outline_if_visible("d1", &unlocked, 0).unwrap().is_empty());
+        assert!(db.get_document_outline_if_visible("d1", &unlocked, 1).unwrap().len() <= 1);
     }
 
     /// READ-TIME REFLOW (doc-preview fix), chunk-input DE-FRAGMENTS: a document whose stored text is a

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -672,6 +672,22 @@ pub struct DocumentSummary {
     pub updated_at: Option<i64>,
 }
 
+/// Brain v3 audit Fix 3(b) — ONE entry in a document's structural OUTLINE (the heading/section tree
+/// persisted in `doc_chunks`): a section-parent (L1) or the doc summary (L2). Deterministic, derived
+/// PROVENANCE over already-derived plaintext — carries the section trail + page, NOT the section body
+/// text, so an outline is a cheap MAP the agent reads to plan targeted `get_document(offset,maxChars)`
+/// reads instead of blind char paging. Returned ONLY by [`Db::get_document_outline_if_visible`], which
+/// visibility-gates on the owning folder's lock (a sealed-and-not-session-unlocked document → empty).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocOutlineEntry {
+    /// `doc_chunks.level` — 1 = section-parent (a heading), 2 = doc summary/outline node.
+    pub level: i64,
+    /// The heading trail this node sits under (`"A › B"`); `None` for a flat/heading-less node.
+    pub section_path: Option<String>,
+    /// 1-based page/slide (PDF/PPTX); `None` for flow formats.
+    pub page_no: Option<u32>,
+}
+
 /// Shared Brain v1 — one ORG-partition retrieval hit: the nearest/best chunk's snippet + the
 /// source org item's id, `author_hint`, and title. The parallel of [`DocChunkHit`] for the org
 /// leg. The `org_search` / `org_brain_search` TOOL renders each hit as a LOUD `[org · <author>]`

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -65,11 +65,14 @@ impl AssistantScope {
     /// and the connector tools are partitioned here; `propose_note` / write tools are governed by the
     /// surface flags, not the tier, so they are allowed through the tier gate and left to those flags.
     fn allows(self, tool: &str) -> bool {
-        const VAULT_READS: [&str; 9] = [
+        const VAULT_READS: [&str; 10] = [
             "search_meetings",
             "search_semantic",
             "get_meeting",
             "get_document",
+            // Brain v3 audit Fix 3(b) — the document OUTLINE (heading/section map, egress-free,
+            // gated exactly like `get_document`). An owned-vault read.
+            "get_document_outline",
             "list_recent_meetings",
             "get_open_commitments",
             "get_entity_dossier",
@@ -152,6 +155,12 @@ pub enum ToolCall {
         /// Max chars of body to return from `offset` (0 = unlimited = today's behavior).
         max_chars: usize,
     },
+    /// Brain v3 audit Fix 3(b) — the STRUCTURAL OUTLINE (heading/section tree + page map) of one
+    /// document, so the agent can plan targeted `get_document(offset, maxChars)` reads instead of
+    /// blind char paging. Deterministic (no LLM). Gated by [`Db::get_document_outline_if_visible`]
+    /// (a sealed-and-not-session-unlocked document → an EMPTY outline, the same masking as
+    /// `get_document`). Carries only the heading map, never the section body text.
+    GetDocumentOutline { document_id: String },
     /// The most recent meetings (already clamped to 1..=100 by the caller/parser).
     ListRecentMeetings { limit: i64 },
     /// Hybrid semantic + FTS search. Gated behind the `semantic_search_enabled` config flag.
@@ -294,6 +303,24 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                     "documentId": { "type": "string", "description": "The document id from a prior search result (a 'document:...' hit)." },
                     "offset": { "type": "integer", "description": "Chars to skip into the body (default 0)." },
                     "maxChars": { "type": "integer", "description": "Max body chars to return from offset (default all)." }
+                },
+                "required": ["documentId"]
+            }),
+            write: false,
+        },
+        ToolSpec {
+            name: "get_document_outline".into(),
+            description: "Get the STRUCTURAL OUTLINE (heading/section map + page numbers) of one \
+                          standalone note or imported/uploaded document by id (from a 'document:...' \
+                          search hit). Use this on a BIG document BEFORE get_document: read the map, \
+                          then fetch the section you need with get_document's offset + maxChars — \
+                          instead of paging blindly. Returns the section headings in document order; \
+                          a flat/heading-less document has no outline."
+                .into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "documentId": { "type": "string", "description": "The document id from a prior search result (a 'document:...' hit)." }
                 },
                 "required": ["documentId"]
             }),
@@ -598,16 +625,24 @@ pub fn execute_tool(
                     } else {
                         format_structured_transcript(&segs)
                     };
-                    // Brain v3 PR-2 — agent PAGING: default (offset 0, max_chars 0) is byte-identical
-                    // to today. A non-default window returns a char-safe slice of the transcript.
-                    let transcript = page_text(&full_transcript, *offset, *max_chars);
+                    // Brain v3 PR-2 — agent PAGING; audit Fix 2 — HONEST disclosure. Default
+                    // (offset 0, max_chars 0) is byte-identical to today (no header). A window
+                    // returns a char-safe slice PLUS a `TOTAL_CHARS: …` header so the agent knows
+                    // it saw a fraction of the transcript and how to page the rest.
+                    let (transcript, disclosure) =
+                        page_text_disclosed(&full_transcript, *offset, *max_chars);
+                    // The window is over the TRANSCRIPT only, so scope the header to that section.
+                    let transcript_section = match &disclosure {
+                        Some(h) => format!("TRANSCRIPT ({h}):\n{transcript}"),
+                        None => format!("TRANSCRIPT:\n{transcript}"),
+                    };
                     match note {
                         Some(n) => Ok(format!(
-                            "{title_line}NOTE:\n{}\n\nTRANSCRIPT:\n{transcript}",
+                            "{title_line}NOTE:\n{}\n\n{transcript_section}",
                             n.markdown
                         )),
                         None if !transcript.is_empty() => {
-                            Ok(format!("{title_line}TRANSCRIPT:\n{transcript}"))
+                            Ok(format!("{title_line}{transcript_section}"))
                         }
                         None => Ok(format!("No data for meeting {mid}.")),
                     }
@@ -636,11 +671,32 @@ pub fn execute_tool(
                         .map(str::trim)
                         .filter(|t| !t.is_empty())
                         .unwrap_or(doc.name.trim());
-                    // Brain v3 PR-2 — agent PAGING: default (0, 0) returns the full body (today's
-                    // behavior); a window returns a char-safe slice so the agent can iterate a big doc.
-                    let body = page_text(&doc.markdown, *offset, *max_chars);
-                    Ok(format!("TITLE: [[{title}]]\nKIND: {}\n\nBODY:\n{}", doc.kind, body))
+                    // Brain v3 PR-2 — agent PAGING; audit Fix 2 — HONEST disclosure. Default (0, 0)
+                    // returns the full body byte-identical to today (no header); a window returns a
+                    // char-safe slice PLUS a `TOTAL_CHARS: …` header so the agent knows it saw a
+                    // fraction of the body and how to page the rest.
+                    let (body, disclosure) = page_text_disclosed(&doc.markdown, *offset, *max_chars);
+                    let body_section = match &disclosure {
+                        Some(h) => format!("BODY ({h}):\n{body}"),
+                        None => format!("BODY:\n{body}"),
+                    };
+                    Ok(format!("TITLE: [[{title}]]\nKIND: {}\n\n{body_section}", doc.kind))
                 }
+            }
+        }
+        ToolCall::GetDocumentOutline { document_id } => {
+            let id = document_id.as_str();
+            // GATE: `get_document_outline_if_visible` applies the SAME `visibility_clause` JOIN as
+            // the doc readers — a document in a sealed-and-not-session-unlocked folder yields an
+            // EMPTY outline, INDISTINGUISHABLE from a never-existed id / a flat legacy doc (never
+            // leaks locked-vs-absent, mirroring `get_document` masking). Bounded at DOC_OUTLINE_CAP.
+            match db.get_document_outline_if_visible(id, unlocked, DOC_OUTLINE_CAP) {
+                Err(e) => Err(AppError::Storage(format!("document outline read failed: {e}"))),
+                Ok(entries) if entries.is_empty() => Ok(format!(
+                    "No outline for document {id} (it may be locked, absent, or have no headings — \
+                     read it with get_document)."
+                )),
+                Ok(entries) => Ok(format_doc_outline(id, &entries)),
             }
         }
         ToolCall::ListRecentMeetings { limit } => {
@@ -897,6 +953,46 @@ pub fn mcp_server_id_from_tool(name: &str) -> Option<&str> {
 
 /// Cap on a dynamic MCP tool's model-facing description.
 pub const MCP_DESCRIPTION_MAX_CHARS: usize = 100;
+
+/// Brain v3 audit Fix 3(b) — max entries in a `get_document_outline` result, so a huge deck
+/// (hundreds of slides) can't blow the tool result / cloud egress. An outline past this cap is
+/// truncated with a `[… more sections]` marker.
+const DOC_OUTLINE_CAP: usize = 200;
+
+/// Brain v3 audit Fix 3(b) — render a document's structural outline (L1 section headings + L2
+/// summary node) into the tool text payload the agent reads, as a MAP for planning targeted section
+/// reads. Deterministic; carries only the heading trail + page, never body text. The caller has
+/// already bounded the entry count at [`DOC_OUTLINE_CAP`]; if it returned exactly the cap we mark
+/// that the list may be truncated.
+fn format_doc_outline(id: &str, entries: &[crate::storage::models::DocOutlineEntry]) -> String {
+    let mut out = format!("OUTLINE for document {id} (page-map — read a section with get_document offset/maxChars):\n");
+    let lines: Vec<String> = entries
+        .iter()
+        .filter(|e| e.level == 1) // L1 section headings are the navigable map; the L2 summary is grounding, not structure.
+        .map(|e| {
+            let section = e
+                .section_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("(no heading)");
+            match e.page_no {
+                Some(p) => format!("- {section} (p.{p})"),
+                None => format!("- {section}"),
+            }
+        })
+        .collect();
+    if lines.is_empty() {
+        // Only an L2 summary / flat structure survived the L1 filter — no navigable headings.
+        out.push_str("- (no section headings — this document is flat; read it with get_document)");
+    } else {
+        out.push_str(&lines.join("\n"));
+    }
+    if entries.len() >= DOC_OUTLINE_CAP {
+        out.push_str("\n[… more sections — outline truncated at the cap]");
+    }
+    out
+}
 
 /// SANITIZE a value destined for the model-facing tool catalog: control chars dropped, `<`/`>`
 /// neutralized (no HTML/tag smuggling), whitespace runs collapsed, hard-capped at `max` chars.
@@ -1557,6 +1653,45 @@ fn page_text(text: &str, offset: usize, max_chars: usize) -> String {
     }
 }
 
+/// Brain v3 audit Fix 2 — HONEST windowed paging. Returns the slice of `text` for
+/// `(offset, max_chars)` (same semantics as [`page_text`]) PAIRED WITH an optional disclosure
+/// header the caller prefixes so a windowed read is never mistaken for a whole document:
+///   - DEFAULT `(0, 0)` ⇒ `(full text, None)` — BYTE-IDENTICAL to today (the `execute_tool` tests
+///     pin this: a non-windowed `get_document`/`get_meeting` carries no header).
+///   - a WINDOW ⇒ `(slice, Some("TOTAL_CHARS: <N> (showing <start>..<end>)"))`, and when the window
+///     reaches the end of the content the slice gets the shipped `[end of content]` marker appended
+///     so the agent can tell it has paged to the end (vs. "there is more, call again with a larger
+///     offset"). All counts are CHARS — the unit the `offset`/`maxChars` args use.
+///
+/// Without this the agent pages a big doc by blind char arithmetic and can't tell a short window
+/// from the whole body — the "windowed reads must disclose the total" honesty gap.
+fn page_text_disclosed(text: &str, offset: usize, max_chars: usize) -> (String, Option<String>) {
+    if offset == 0 && max_chars == 0 {
+        return (text.to_string(), None); // byte-identical default — no header.
+    }
+    let total = text.chars().count();
+    if offset >= total {
+        // Past the end: `page_text` yields the end-of-content marker; disclose the total + that
+        // we're at the end so the agent stops paging.
+        return (
+            page_text(text, offset, max_chars),
+            Some(format!("TOTAL_CHARS: {total} (showing {total}..{total})")),
+        );
+    }
+    // Reuse the CHAR-safe slicer so the windowing logic lives in ONE place.
+    let slice = page_text(text, offset, max_chars);
+    let shown = slice.chars().count();
+    let end = offset + shown;
+    let header = format!("TOTAL_CHARS: {total} (showing {offset}..{end})");
+    // Append the end-of-content marker when this window reaches the end of the body.
+    let body = if end >= total {
+        format!("{slice}\n[end of content]")
+    } else {
+        slice
+    };
+    (body, Some(header))
+}
+
 /// Feature D — render a meeting's transcript segments as a STRUCTURED, one-line-per-segment block:
 /// `[<start_s>–<end_s>] <Speaker>: <text>`. RAW SECONDS (never MM:SS) so a 2h+ meeting can never
 /// wrap/clip a minutes field. Speaker maps the cheap 2-way stream attribution
@@ -1609,6 +1744,29 @@ fn format_hits(hits: &[crate::storage::models::SearchHit]) -> String {
 /// document line carries a `[document:{kind}:{id}]` id-type tag (kind = `note` | `document`) so a
 /// model knows to call `get_document` (NOT `get_meeting`) with that id — distinct from the meeting
 /// lines' `[meeting:{id}]` tag. Both inputs are already visibility-gated by the caller.
+/// Brain v3 audit Fix 3(a) — render a doc hit's PROVENANCE LOCATION (heading trail + page/slide) as
+/// a compact ` (§<section> · p.<page>)` suffix, so a search result tells the agent WHICH section/page
+/// a hit is from. Empty when a flat/heading-less, flow-format doc carries neither — the hit line is
+/// then byte-identical to before this fix. The `section_path` is trimmed to a sane length so a deep
+/// heading trail can't blow a result line.
+fn format_hit_location(section_path: Option<&str>, page_no: Option<u32>) -> String {
+    let section = section_path
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            // Cap the heading trail so a pathological deep path stays bounded on the result line.
+            let capped: String = s.chars().take(120).collect();
+            format!("§{capped}")
+        });
+    let page = page_no.map(|p| format!("p.{p}"));
+    match (section, page) {
+        (Some(s), Some(p)) => format!(" ({s} · {p})"),
+        (Some(s), None) => format!(" ({s})"),
+        (None, Some(p)) => format!(" ({p})"),
+        (None, None) => String::new(),
+    }
+}
+
 fn format_hits_and_docs(
     hits: &[crate::storage::models::SearchHit],
     docs: &[crate::storage::models::DocChunkHit],
@@ -1626,9 +1784,15 @@ fn format_hits_and_docs(
             &docs
                 .iter()
                 .map(|d| {
+                    // Brain v3 audit Fix 3(a) — surface WHERE in the document this hit lives so the
+                    // agent can do search → get_document_outline → targeted section read instead of
+                    // blind offset paging. `section_path` (heading trail) and `page_no` (PDF/slide)
+                    // are the persisted hierarchy PR-1 threaded into DocChunkHit; a flat/flow doc
+                    // omits the absent parts. Format: `(§<section> · p.<page>)` after the id tag.
+                    let loc = format_hit_location(d.section_path.as_deref(), d.page_no);
                     format!(
-                        "- [document:{}:{}] {} — {}",
-                        d.kind, d.document_id, d.name, d.snippet
+                        "- [document:{}:{}] {}{} — {}",
+                        d.kind, d.document_id, d.name, loc, d.snippet
                     )
                 })
                 .collect::<Vec<_>>()
@@ -1840,6 +2004,16 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                     document_id: s("documentId"),
                     offset: u("offset"),
                     max_chars: u("maxChars"),
+                },
+                self.db,
+                &unlocked,
+                self.config,
+            ),
+            // Brain v3 audit Fix 3(b) — the document OUTLINE (heading map). Owned-vault read, gated
+            // by `get_document_outline_if_visible` against the re-read `unlocked` set.
+            "get_document_outline" => execute_tool(
+                &ToolCall::GetDocumentOutline {
+                    document_id: s("documentId"),
                 },
                 self.db,
                 &unlocked,
@@ -3972,6 +4146,110 @@ mod tests {
         );
     }
 
+    /// Brain v3 audit Fix 3(a) — a doc-search hit that has hierarchy metadata surfaces its
+    /// `§<section> · p.<page>` LOCATION in the result line; a flat/flow hit with neither is
+    /// byte-identical to before the fix (no location suffix). Uses the pure formatters so the
+    /// assertion binds the exact rendered shape.
+    #[test]
+    fn doc_hit_surfaces_section_path_and_page() {
+        use crate::storage::models::DocChunkHit;
+        // Pure location formatter cases.
+        assert_eq!(
+            format_hit_location(Some("Intro › Goals"), Some(3)),
+            " (§Intro › Goals · p.3)"
+        );
+        assert_eq!(format_hit_location(Some("Appendix"), None), " (§Appendix)");
+        assert_eq!(format_hit_location(None, Some(7)), " (p.7)");
+        assert_eq!(format_hit_location(None, None), "", "flat/flow hit → no suffix");
+        assert_eq!(format_hit_location(Some("   "), None), "", "blank section → no suffix");
+
+        // End-to-end through the doc renderer.
+        let hit = DocChunkHit {
+            document_id: "d1".into(),
+            name: "Spec.pdf".into(),
+            folder_id: "f".into(),
+            snippet: "the retrieved passage".into(),
+            kind: "document".into(),
+            chunk_id: 10,
+            parent_id: Some(2),
+            section_path: Some("Design › API".into()),
+            page_no: Some(4),
+            level: 0,
+            sibling_hits: 2,
+        };
+        let rendered = format_hits_and_docs(&[], std::slice::from_ref(&hit));
+        assert!(
+            rendered.contains("[document:document:d1] Spec.pdf (§Design › API · p.4) — the retrieved passage"),
+            "a hit with hierarchy must render its section + page: {rendered}"
+        );
+        // A flat hit (no section, no page) stays byte-identical to the pre-fix line shape.
+        let flat = DocChunkHit {
+            section_path: None,
+            page_no: None,
+            ..hit
+        };
+        let flat_rendered = format_hits_and_docs(&[], std::slice::from_ref(&flat));
+        assert!(
+            flat_rendered.contains("[document:document:d1] Spec.pdf — the retrieved passage"),
+            "a flat hit carries no location suffix: {flat_rendered}"
+        );
+    }
+
+    /// Brain v3 audit Fix 3(b) — the `get_document_outline` TOOL: a sealed-not-unlocked doc → the
+    /// "no outline" sentinel (no heading leak); unlock → the heading map with pages, in document
+    /// order. Routes through the gated `execute_tool` → `get_document_outline_if_visible`.
+    #[test]
+    fn get_document_outline_tool_is_gated_and_maps_sections() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_folder(&db, "f-lock", "Specs");
+        let blocks = vec![
+            crate::extract::ExtractedBlock {
+                text: "The plan is stored in the vault.".to_string(),
+                page: Some(1),
+                heading_path: Some("Overview".to_string()),
+            },
+            crate::extract::ExtractedBlock {
+                text: "Everything is encrypted at rest.".to_string(),
+                page: Some(2),
+                heading_path: Some("Overview › Security".to_string()),
+            },
+        ];
+        let stored = crate::extract::blocks_to_stored_text(&blocks);
+        db.insert_document("od1", "f-lock", "plan.pdf", &stored, "document", 1_700_000_000)
+            .unwrap();
+        db.index_document_chunks("od1", None).unwrap();
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        // Locked → the sentinel; the heading trail must NOT leak.
+        let locked = execute_tool(
+            &ToolCall::GetDocumentOutline { document_id: "od1".into() },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(locked.contains("No outline for document od1"), "sealed → sentinel: {locked}");
+        assert!(!locked.contains("Overview"), "sealed headings leaked via the outline tool: {locked}");
+
+        // Session-unlock → the heading map, in order, with pages.
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let out = execute_tool(
+            &ToolCall::GetDocumentOutline { document_id: "od1".into() },
+            &db,
+            &unlocked,
+            &cfg,
+        )
+        .unwrap();
+        assert!(out.contains("OUTLINE for document od1"), "outline header: {out}");
+        assert!(out.contains("- Overview (p.1)"), "first section + page: {out}");
+        assert!(out.contains("- Overview › Security (p.2)"), "document order + page: {out}");
+        let first = out.find("Overview (p.1)").unwrap();
+        let second = out.find("Overview › Security").unwrap();
+        assert!(first < second, "sections render in document order: {out}");
+    }
+
     /// #6 — regression guard: after the `DocChunkHit.kind` addition, a locked-not-unlocked folder's
     /// document stays ABSENT from search (the `visibility_clause` gate still excludes it).
     #[test]
@@ -4036,6 +4314,40 @@ mod tests {
         assert!(windowed.starts_with("zażół"), "no mid-codepoint slice: {windowed}");
     }
 
+    /// Brain v3 audit Fix 2 — `page_text_disclosed` returns the disclosure header for a WINDOW and
+    /// stays byte-identical (no header) for the default, appending the end-of-content marker only
+    /// when the window reaches the end. Counts are CHARS.
+    #[test]
+    fn page_text_disclosed_windows_honestly() {
+        let text = "abcdefghij"; // 10 chars
+        // Default (0,0): byte-identical text, NO disclosure header.
+        let (body, disc) = page_text_disclosed(text, 0, 0);
+        assert_eq!(body, "abcdefghij");
+        assert!(disc.is_none(), "default read carries no disclosure");
+        // A mid window: header discloses total + window, NO end marker (there is more).
+        let (body, disc) = page_text_disclosed(text, 3, 4);
+        assert_eq!(body, "defg", "the slice itself is unchanged");
+        assert_eq!(disc.as_deref(), Some("TOTAL_CHARS: 10 (showing 3..7)"));
+        // A window reaching the end: end-of-content marker + header.
+        let (body, disc) = page_text_disclosed(text, 7, 100);
+        assert_eq!(body, "hij\n[end of content]", "reaching the end appends the marker: {body}");
+        assert_eq!(disc.as_deref(), Some("TOTAL_CHARS: 10 (showing 7..10)"));
+        // Offset past the end: end sentinel + a header pinned at the total.
+        let (body, disc) = page_text_disclosed(text, 20, 5);
+        assert_eq!(body, "[end of content]");
+        assert_eq!(disc.as_deref(), Some("TOTAL_CHARS: 10 (showing 10..10)"));
+        // Offset-only (max 0) window to the end: whole tail + end marker + header.
+        let (body, disc) = page_text_disclosed(text, 3, 0);
+        assert_eq!(body, "defghij\n[end of content]");
+        assert_eq!(disc.as_deref(), Some("TOTAL_CHARS: 10 (showing 3..10)"));
+        // Multibyte: char counts, not bytes.
+        let pl = "zażółć gęślą";
+        let total = pl.chars().count();
+        let (body, disc) = page_text_disclosed(pl, 2, 3);
+        assert_eq!(body.chars().count(), 3, "3 chars, not bytes");
+        assert_eq!(disc.as_deref(), Some(format!("TOTAL_CHARS: {total} (showing 2..5)").as_str()));
+    }
+
     /// Brain v3 PR-2 — `get_document` honors offset/max_chars: default returns the full body; a
     /// window returns a slice; the DEFAULT path is unchanged from before paging.
     #[test]
@@ -4068,7 +4380,38 @@ mod tests {
             &cfg,
         )
         .unwrap();
-        assert!(windowed.contains("BODY:\nABCDE"), "windowed body: {windowed}");
+        assert!(windowed.contains("ABCDE"), "windowed body: {windowed}");
         assert!(!windowed.contains("01234"), "the offset skipped the first 10 chars: {windowed}");
+        // Audit Fix 2 — the WINDOWED read discloses the true total + the exact window so the agent
+        // knows it saw a fraction (20 chars total, showing 10..15), and there IS more to page.
+        assert!(
+            windowed.contains("BODY (TOTAL_CHARS: 20 (showing 10..15)):"),
+            "windowed read must disclose the total + window: {windowed}"
+        );
+        assert!(
+            !windowed.contains("[end of content]"),
+            "this window (10..15 of 20) does NOT reach the end, so no end marker: {windowed}"
+        );
+        // The DEFAULT (0,0) read stays byte-identical: no disclosure header, no end marker.
+        assert!(full.contains("BODY:\n0123456789ABCDEFGHIJ"), "default body byte-identical: {full}");
+        assert!(!full.contains("TOTAL_CHARS"), "default read carries NO disclosure header: {full}");
+
+        // A window that REACHES the end gets the end-of-content marker + the total.
+        let to_end = execute_tool(
+            &ToolCall::GetDocument { document_id: "d-big".into(), offset: 15, max_chars: 100 },
+            &db,
+            &nothing,
+            &cfg,
+        )
+        .unwrap();
+        assert!(to_end.contains("FGHIJ"), "tail slice: {to_end}");
+        assert!(
+            to_end.contains("TOTAL_CHARS: 20 (showing 15..20)"),
+            "the end-window discloses 15..20 of 20: {to_end}"
+        );
+        assert!(
+            to_end.contains("[end of content]"),
+            "a window that reaches the end must carry the end marker: {to_end}"
+        );
     }
 }


### PR DESCRIPTION
PR-2 of the brain-v3 audit-fix program (audit: docs/research/2026-07-18-brain-v3-audit.md).

## Fixes
- **[crux] agent.rs truncated tool results SILENTLY** — cut at RESULT_BUDGET=4000 with no marker/total, so the model couldn't tell a short doc from 1.6% of a huge one (Ask asserts "the doc doesn't mention X" after seeing 0.3%). Now: `[truncated: showing 4000 of <N> chars — call the same tool again with offset=4000 to continue]` with the TRUE total; ≤budget byte-identical; citation buffer bounded (GATHERED_BUDGET=64k).
- **paging honesty** — windowed get_document/get_meeting disclose `TOTAL_CHARS: N (showing a..b)` + end-of-content marker; in-app default (0,0) byte-identical; **MCP default now a bounded, disclosed 6000-char window** (was: whole body floods the client).
- **doc map** — search hits carry `(§section · p.page)`; new gated `get_document_outline(documentId)` returns the L1/L2 heading map (visibility_clause-gated, sealed→empty, bounded) in tools_spec+dispatch and mirrored in MCP, so the agent does search→outline→targeted reads instead of blind offset paging.

## Verified
- Builder gates: cargo test --lib **1938/0**, clippy -D warnings clean, MSRV grep clean.
- **Leak class (new gated read) statically verified**: get_document_outline_if_visible SQL carries {visible} (L1/L2 only, never L0 body) with sealed→empty→unlock gate tests at all three layers (db/tools/mcp) — get_document_outline_is_visibility_gated_and_ordered, mcp_get_document_outline_is_visibility_gated, get_document_outline_tool_is_gated_and_maps_sections.
- Full compile + suite + clippy re-gated by CI (the full ci.sh). Rebased onto trunk 5790fc5.

Note: adversarial RED-reverts on the truncation-total/offset are pinned by the builder's tests (loop_over_budget_tool_result_reaches_the_model_with_the_disclosure_marker, mcp_get_document_default_window_is_bounded_and_disclosed); CI runs them.