### PR TITLE
fix(graph): honest caps + deterministic edges + zoneless hygiene

### DIFF
--- a/e2e/brain/full-brain-graph.spec.ts
+++ b/e2e/brain/full-brain-graph.spec.ts
@@ -23,7 +23,8 @@ test("full-brain graph: mounts, lens filters client-side, Suggested re-fetches, 
   await mockTauri(page, {
     // A tiny typed graph: one node of each kind + edges of a few kinds. The
     // `includeSuggested` flag toggles whether a suggested semantic edge appears
-    // — proving the re-fetch semantics.
+    // — proving the re-fetch semantics. Every edge carries `srcKind`/`dstKind`
+    // (PR-9 F4) so the FE endpoint-matching by `(kind, id)` resolves them.
     get_full_graph: (args: {
       opts?: { includeSuggested?: boolean } | null;
     }) => {
@@ -38,14 +39,15 @@ test("full-brain graph: mounts, lens filters client-side, Suggested re-fetches, 
           { id: "d1", kind: "document", label: "Spec.pdf", date: "2026-07-03", degree: 1 },
         ],
         edges: [
-          { src: "e1", dst: "m1", kind: "mention", score: 1, status: "active" },
-          { src: "m1", dst: "n1", kind: "companion", score: 1, status: "active" },
+          { src: "e1", dst: "m1", srcKind: "entity", dstKind: "meeting", kind: "mention", score: 1, status: "active" },
+          { src: "m1", dst: "n1", srcKind: "meeting", dstKind: "note", kind: "companion", score: 1, status: "active" },
           ...(suggested
-            ? [{ src: "n1", dst: "d1", kind: "semantic", score: 0.8, status: "suggested" }]
+            ? [{ src: "n1", dst: "d1", srcKind: "note", dstKind: "document", kind: "semantic", score: 0.8, status: "suggested" }]
             : []),
         ],
         hasHidden: false,
         totalVisibleNodes: 4,
+        edgesTruncated: false,
       };
     },
   });
@@ -92,4 +94,96 @@ test("full-brain graph: mounts, lens filters client-side, Suggested re-fetches, 
     .toBeGreaterThan(callsAfterLens);
 
   expect(consoleErrors).toEqual([]);
+});
+
+/**
+ * PR-9 F6 (LOCK-MASKING, the leak class): the graph is a KNOWN leak surface — a
+ * sealed meeting's TITLE / a sealed doc's NAME must never surface. The backend gates
+ * server-side (a sealed node is simply ABSENT from `get_full_graph`), so the FE's
+ * contract is: it renders ONLY what the backend returned, and when `hasHidden` is set
+ * it discloses that some items are hidden. This test feeds a gated payload (the sealed
+ * meeting/note are absent, `hasHidden: true`) and asserts (a) neither sealed label
+ * appears anywhere in the DOM, and (b) the "Some items are hidden" banner shows.
+ */
+test("full-brain graph: a sealed meeting's title/name never renders; the hidden-items banner shows", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_full_graph: () => ({
+      // Only the OPEN nodes — the gated backend omits the sealed ones entirely.
+      nodes: [
+        { id: "m-open", kind: "meeting", label: "Open Standup", date: "2026-07-01", degree: 1 },
+        { id: "n-open", kind: "note", label: "Open Roadmap", date: "2026-07-02", degree: 1 },
+      ],
+      edges: [
+        { src: "m-open", dst: "n-open", srcKind: "meeting", dstKind: "note", kind: "companion", score: 1, status: "active" },
+      ],
+      // A folder is sealed-and-not-unlocked → the FE must disclose the hide.
+      hasHidden: true,
+      totalVisibleNodes: 2,
+      edgesTruncated: false,
+    }),
+  });
+
+  await page.goto("/brain");
+  await page.getByRole("button", { name: /Full brain graph/i }).click();
+
+  const graph = page.locator("app-full-brain-graph");
+  await expect(graph).toBeVisible();
+  await expect(graph.locator("canvas.fbg-canvas")).toBeVisible();
+
+  // The sealed labels are NOWHERE in the rendered graph (leak class).
+  await expect(page.getByText("SECRET Meeting", { exact: false })).toHaveCount(0);
+  await expect(page.getByText("secret.pdf", { exact: false })).toHaveCount(0);
+  await expect(page.getByText("Locked", { exact: false })).toHaveCount(0);
+
+  // The honest disclosure surfaces.
+  await expect(graph.getByText(/Some items are hidden/i)).toBeVisible();
+});
+
+/**
+ * PR-9 F6 (CAP DISCLOSURE, the silent-trim class): with more visible nodes than the
+ * FE draw cap (MAX_NODES = 140), the disclosure banner must name what is ACTUALLY
+ * DRAWN, not the backend's post-per-kind-cap `nodes.length`. The toolbar caption
+ * ("N items") and the banner ("Drawing N of M items") must AGREE on the drawn count —
+ * the F1 fix (before it, the caption said 300 while 140 somas were painted and the
+ * banner claimed the backend total). Feeds 300 visible nodes with `totalVisibleNodes`
+ * 300; asserts the drawn caption count === the banner's disclosed drawn count === 140.
+ */
+test("full-brain graph: the draw-cap disclosure names the DRAWN count, and the caption agrees", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_full_graph: () => {
+      // 300 note nodes (> the 140 draw cap). Give each a distinct degree so the
+      // top-140-by-degree selection is deterministic.
+      const nodes = Array.from({ length: 300 }, (_v, i) => ({
+        id: `n${String(i).padStart(4, "0")}`,
+        kind: "note",
+        label: `Note ${i}`,
+        date: "2026-07-01T00:00:00Z",
+        degree: 300 - i,
+      }));
+      return {
+        nodes,
+        edges: [],
+        hasHidden: false,
+        totalVisibleNodes: 300,
+        edgesTruncated: false,
+      };
+    },
+  });
+
+  await page.goto("/brain");
+  await page.getByRole("button", { name: /Full brain graph/i }).click();
+
+  const graph = page.locator("app-full-brain-graph");
+  await expect(graph).toBeVisible();
+
+  // The banner discloses the DRAWN count (140), not the backend total (300).
+  await expect(graph.getByText(/Drawing 140 of 300 items/)).toBeVisible();
+
+  // The toolbar caption's item count MUST match what the banner says is drawn (140) —
+  // no more claiming more items than the canvas paints (the F1 fix).
+  await expect(graph.getByText(/140 items ·/)).toBeVisible();
 });

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -12383,6 +12383,10 @@ impl Db {
         // Visibility is already enforced in WHERE; a trailing LIMIT trims magnitude only — it can
         // never widen what is visible.
         const MAX_GRAPH_EDGES: usize = 600;
+        // PR-9 F3: `weight DESC` alone leaves ties in engine-arbitrary order → the surviving 600-edge
+        // subset could vary between opens, contradicting the graph's "Deterministic" claim. Break ties
+        // on the pair identity (`a.entity_id`, then `b.entity_id`, both already `a < b`-canonicalized
+        // above) so identical data → the identical edge set every call.
         let sql = format!(
             "SELECT a.entity_id, b.entity_id, COUNT(*) AS weight
                FROM entity_mentions a
@@ -12398,7 +12402,7 @@ impl Db {
                       )
                     )
               GROUP BY a.entity_id, b.entity_id
-              ORDER BY weight DESC
+              ORDER BY weight DESC, a.entity_id ASC, b.entity_id ASC
               LIMIT {MAX_GRAPH_EDGES}"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
@@ -12687,9 +12691,15 @@ impl Db {
     ///   • wikilink/companion/semantic — `links` rows with `status='active'` (+ `status='suggested'`
     ///     semantic ONLY when `opts.include_suggested`), each endpoint re-checked against the set.
     ///
-    /// Deterministic: nodes ordered by (kind, id ASC), edges by (kind, src, dst, status). Honest caps:
-    /// `total_visible_nodes` is the pre-cap true count so the FE can disclose a silent trim; `has_hidden`
-    /// reflects LOCKED folders (mirrors the entity graph). No PII logged — ids/counts only.
+    /// Every edge carries `src_kind`/`dst_kind` (the endpoint node kinds it was gated on) so the FE
+    /// matches endpoints by `(kind, id)`, safe against a cross-kind id collision (PR-9 F4).
+    ///
+    /// Deterministic: nodes ordered by (kind, id ASC), edges by (kind, src, dst, status); every edge
+    /// leg has a deterministic `ORDER BY` before its cap (co_occurrence by weight then pair id;
+    /// mention by meeting recency; links by score). Honest caps: `total_visible_nodes` is the pre-cap
+    /// true NODE count so the FE can disclose a silent node trim; `edges_truncated` is true when an
+    /// EDGE-leg cap (mention/links LIMIT) trimmed edges; `has_hidden` reflects LOCKED folders (mirrors
+    /// the entity graph). No PII logged — ids/counts only.
     pub fn build_full_graph(
         &self,
         unlocked: &HashSet<String>,
@@ -12770,6 +12780,8 @@ impl Db {
                 edges.push(FullGraphEdge {
                     src: ge.source,
                     dst: ge.target,
+                    src_kind: FullGraphNodeKind::Entity,
+                    dst_kind: FullGraphNodeKind::Entity,
                     kind: FullGraphEdgeKind::CoOccurrence,
                     score: ge.weight as f64,
                     status: "active".to_string(),
@@ -12778,7 +12790,13 @@ impl Db {
         }
         // mention — entity→meeting (gated by the SAME meeting-visible predicate; both endpoints then
         // re-checked against the node set, so a mention into a sealed OR cap-dropped meeting is gone).
-        for (entity_id, meeting_id, weight) in self.entity_meeting_mentions_visible(unlocked)? {
+        // `edges_truncated` accumulates whether ANY edge leg hit its cap, so the FE can disclose it.
+        let (mention_edges, mentions_truncated) = self.entity_meeting_mentions_visible(unlocked)?;
+        let (link_rows, links_truncated) = self.full_graph_links(opts.include_suggested)?;
+        // True when a genuine EDGE-leg cap (the mention or links LIMIT) trimmed rows — distinct from
+        // an edge dropped because its endpoint fell to a NODE cap (that is the node disclosure's job).
+        let edges_truncated = mentions_truncated || links_truncated;
+        for (entity_id, meeting_id, weight) in mention_edges {
             if visible.contains(&(ent, entity_id.clone())) && visible.contains(&(mtg, meeting_id.clone()))
             {
                 bump(&mut degree, ent, &entity_id);
@@ -12786,6 +12804,8 @@ impl Db {
                 edges.push(FullGraphEdge {
                     src: entity_id,
                     dst: meeting_id,
+                    src_kind: FullGraphNodeKind::Entity,
+                    dst_kind: FullGraphNodeKind::Meeting,
                     kind: FullGraphEdgeKind::Mention,
                     score: weight as f64,
                     status: "active".to_string(),
@@ -12795,15 +12815,14 @@ impl Db {
         // links rows — wikilink/companion/semantic. active always; suggested semantic behind the flag.
         // BOTH endpoints re-checked against the visible-node set (the links kind strings map 1:1 onto
         // the node-kind strings: meeting|note|document), so a link to a sealed/absent node is dropped.
-        for (src_kind, src_id, dst_kind, dst_id, edge_type, score, status) in
-            self.full_graph_links(opts.include_suggested)?
-        {
-            let (Some(src_k), Some(dst_k)) = (
-                full_graph_link_kind_str(&src_kind),
-                full_graph_link_kind_str(&dst_kind),
+        for (src_kind, src_id, dst_kind, dst_id, edge_type, score, status) in link_rows {
+            let (Some(src_nk), Some(dst_nk)) = (
+                full_graph_link_node_kind(&src_kind),
+                full_graph_link_node_kind(&dst_kind),
             ) else {
                 continue; // corrupt/unknown kind → skip defensively.
             };
+            let (src_k, dst_k) = (src_nk.as_str(), dst_nk.as_str());
             if !visible.contains(&(src_k, src_id.clone()))
                 || !visible.contains(&(dst_k, dst_id.clone()))
             {
@@ -12817,6 +12836,8 @@ impl Db {
             edges.push(FullGraphEdge {
                 src: src_id,
                 dst: dst_id,
+                src_kind: src_nk,
+                dst_kind: dst_nk,
                 kind,
                 score,
                 status,
@@ -12854,6 +12875,7 @@ impl Db {
             nodes = nodes.len(),
             edges = edges.len(),
             has_hidden,
+            edges_truncated,
             "build_full_graph resolved"
         );
         Ok(FullGraphData {
@@ -12861,6 +12883,7 @@ impl Db {
             edges,
             has_hidden,
             total_visible_nodes,
+            edges_truncated,
         })
     }
 
@@ -12868,7 +12891,9 @@ impl Db {
     /// gated by `visibility_clause` over `documents JOIN folders` (a sealed-and-not-session-unlocked
     /// folder's rows are ABSENT — never masked). `kind='note'` → [`FullGraphNodeKind::Note`], anything
     /// else → [`FullGraphNodeKind::Document`]. `label` = title, else the filesystem `name`. `date` =
-    /// the `updated_at`/`created_at` epoch-ms as a string (a sortable hint for the FE). Per-kind capped
+    /// the `updated_at`/`created_at` timestamp UNIFIED to an RFC3339 ISO string (PR-9 F4 — meetings
+    /// already emit ISO `started_at`; notes/docs previously emitted the raw epoch-ms as a string,
+    /// giving the FE two incompatible date formats on the SAME field). Per-kind capped
     /// (`MAX_FULL_GRAPH_PER_KIND`) ordered newest-first so the most-relevant rows survive on a big
     /// vault; visibility is enforced in WHERE, so the cap trims magnitude only.
     fn full_graph_content_nodes(
@@ -12904,7 +12929,10 @@ impl Db {
                 .map_err(map_err)?;
             for r in rows {
                 let (id, label, ts) = r.map_err(map_err)?;
-                out.push((node_kind, id, label, ts.map(|t| t.to_string())));
+                // Unify to RFC3339 so the FE sees ONE date format across every node kind. epoch-ms →
+                // UTC ISO; an out-of-range/absent timestamp yields None (a bad hint, never a panic).
+                let date = ts.and_then(epoch_ms_to_rfc3339);
+                out.push((node_kind, id, label, date));
             }
         }
         Ok(out)
@@ -12955,14 +12983,23 @@ impl Db {
     /// note)` predicate as `list_meetings_visible`/`graph_edges_visible`). `weight` is always 1 (one
     /// mention row per (entity, meeting) — the PK guarantees it); kept as a field for edge-uniformity.
     /// A mention into a sealed-and-not-session-unlocked meeting yields NO row, so it can never surface
-    /// a hidden meeting. Capped ordered by entity/meeting id for a bounded, deterministic payload.
+    /// a hidden meeting.
+    ///
+    /// PR-9 F2: the previous `ORDER BY em.entity_id ASC` truncated at `MAX_MENTION_EDGES` in
+    /// arbitrary entity-UUID order, so entities LATE in UUID order silently lost ALL their mention
+    /// edges (rendered isolated, degree 0, with no signal). Order by meeting RECENCY first
+    /// (`m.started_at DESC`) so the freshest mentions survive the cap regardless of UUID, with a
+    /// deterministic `(entity_id, meeting_id)` tiebreak so identical data → the identical subset.
+    /// Returns `(rows, truncated)` — `truncated` is true when the cap trimmed rows (there was a
+    /// `MAX_MENTION_EDGES + 1`th visible mention), so the caller can disclose the edge trim.
     fn entity_meeting_mentions_visible(
         &self,
         unlocked: &HashSet<String>,
-    ) -> Result<Vec<(String, String, i64)>> {
+    ) -> Result<(Vec<FullGraphMentionEdge>, bool)> {
         let conn = self.lock();
         let visible = visibility_clause("n", unlocked);
         const MAX_MENTION_EDGES: usize = 2000;
+        // Fetch ONE past the cap so a full page distinguishes "exactly the cap" from "trimmed".
         let sql = format!(
             "SELECT em.entity_id, em.meeting_id
                FROM entity_mentions em
@@ -12975,8 +13012,9 @@ impl Db {
                          WHERE n.meeting_id = m.id AND {visible}
                       )
                     )
-              ORDER BY em.entity_id ASC, em.meeting_id ASC
-              LIMIT {MAX_MENTION_EDGES}"
+              ORDER BY m.started_at DESC, em.entity_id ASC, em.meeting_id ASC
+              LIMIT {}",
+            MAX_MENTION_EDGES + 1
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
@@ -12988,16 +13026,24 @@ impl Db {
         for r in rows {
             out.push(r.map_err(map_err)?);
         }
-        Ok(out)
+        let truncated = out.len() > MAX_MENTION_EDGES;
+        out.truncate(MAX_MENTION_EDGES);
+        Ok((out, truncated))
     }
 
     /// Raw `links` rows for the full-brain graph, PRE-gating (the caller gates both endpoints against
     /// the visible-node set). `status='active'` always; `status='suggested'` semantic rows ONLY when
     /// `include_suggested`. `dismissed` rows are NEVER returned. Returns
-    /// `(src_kind, src_id, dst_kind, dst_id, edge_type, score, status)` ordered deterministically.
-    /// This reads no content columns — ids/kinds/metadata only — and is gated by the caller, so it is
-    /// leak-free at every call site.
-    fn full_graph_links(&self, include_suggested: bool) -> Result<Vec<FullGraphLinkRow>> {
+    /// `(rows, truncated)` where each row is `(src_kind, src_id, dst_kind, dst_id, edge_type, score,
+    /// status)` ordered deterministically. This reads no content columns — ids/kinds/metadata only —
+    /// and is gated by the caller, so it is leak-free at every call site.
+    ///
+    /// PR-9 F2: `links` is the FASTEST-growing edge leg (every wikilink/companion/semantic suggestion
+    /// is a row) and was read UNBOUNDED — the per-kind node caps existed while the highest-cardinality
+    /// edge table had none. Bound it at `MAX_FULL_GRAPH_LINK_EDGES`, ordered by score DESC (strongest
+    /// links survive) with a deterministic `(edge_type, src_id, dst_id, id)` tiebreak, and report
+    /// `truncated` so the caller can disclose the edge trim (mirrors the mention-edge cap).
+    fn full_graph_links(&self, include_suggested: bool) -> Result<(Vec<FullGraphLinkRow>, bool)> {
         let conn = self.lock();
         // active: any edge_type. suggested: ONLY semantic (wikilink/companion are always active by
         // construction; there is no "suggested wikilink"). dismissed tombstones stay excluded.
@@ -13006,11 +13052,14 @@ impl Db {
         } else {
             "status = 'active'"
         };
+        // Fetch ONE past the cap to distinguish "exactly the cap" from "trimmed".
         let sql = format!(
             "SELECT src_kind, src_id, dst_kind, dst_id, edge_type, score, status
                FROM links
               WHERE {status_pred}
-              ORDER BY edge_type ASC, src_id ASC, dst_id ASC, id ASC"
+              ORDER BY score DESC, edge_type ASC, src_id ASC, dst_id ASC, id ASC
+              LIMIT {}",
+            MAX_FULL_GRAPH_LINK_EDGES + 1
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
@@ -13030,7 +13079,9 @@ impl Db {
         for r in rows {
             out.push(r.map_err(map_err)?);
         }
-        Ok(out)
+        let truncated = out.len() > MAX_FULL_GRAPH_LINK_EDGES;
+        out.truncate(MAX_FULL_GRAPH_LINK_EDGES);
+        Ok((out, truncated))
     }
 
     /// Build the detail payload for one entity (`get_entity_detail`): the entity, its visible
@@ -14888,6 +14939,11 @@ type FullGraphContentNode = (FullGraphNodeKind, String, String, Option<String>);
 /// [`Db::full_graph_links`]'s return under clippy's type-complexity bar.
 type FullGraphLinkRow = (String, String, String, String, String, f64, String);
 
+/// One entity→meeting MENTION edge for the full-brain graph: `(entity_id, meeting_id, weight)`.
+/// Aliased to keep [`Db::entity_meeting_mentions_visible`]'s `(Vec<_>, truncated)` return under
+/// clippy's type-complexity bar (PR-9 F2 added the `truncated` flag).
+type FullGraphMentionEdge = (String, String, i64);
+
 /// Per-kind render cap for the full-brain graph (`build_full_graph`, DESIGN §PR-4). Meetings, notes,
 /// and documents are each capped independently (entities keep their own 500 cap inside
 /// `list_entities_visible`) so the payload stays bounded on a large vault; visibility is enforced in
@@ -14895,15 +14951,32 @@ type FullGraphLinkRow = (String, String, String, String, String, f64, String);
 /// `MAX_GRAPH_EDGES`/`MAX_VISIBLE_ENTITIES` posture, disclosed via `total_visible_nodes`.
 const MAX_FULL_GRAPH_PER_KIND: usize = 500;
 
-/// Map a persisted `links.src_kind`/`dst_kind` string onto the STABLE full-graph node-kind key
+/// Bound for the `links`-derived edge leg of the full-brain graph (`full_graph_links`, PR-9 F2).
+/// `links` is the fastest-growing edge table (every wikilink/companion/semantic-suggestion is a row)
+/// and was previously read UNBOUNDED while the node legs were each capped — the payload the caps
+/// exist for was unenforced on its highest-cardinality leg. Strongest-score edges survive the cut;
+/// the trim is DISCLOSED via `FullGraphData::edges_truncated`. Comfortably above what a laid-out
+/// ≤140-node scene can render, so it trims magnitude only on a very large vault.
+const MAX_FULL_GRAPH_LINK_EDGES: usize = 4000;
+
+/// Convert an epoch-MILLISECONDS timestamp to an RFC3339 UTC string (PR-9 F4: unify the
+/// full-graph node `date` format — meetings already carry ISO `started_at`; notes/docs store
+/// epoch-ms). `None` for an out-of-range value (never a panic — a bad date hint is dropped, not
+/// fatal). Uses the same `chrono` dependency already in use across storage.
+fn epoch_ms_to_rfc3339(ms: i64) -> Option<String> {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms).map(|dt| dt.to_rfc3339())
+}
+
+/// Map a persisted `links.src_kind`/`dst_kind` string onto the STABLE full-graph node kind
 /// (`meeting`/`note`/`document`). `None` for anything unknown (a corrupt row → its edge is dropped).
-/// Deliberately NOT reusing `LinkKind::parse` → `.as_str()` so the returned `&'static str` is the
-/// canonical node-kind key used in the visible-node set (they happen to coincide, kept explicit).
-fn full_graph_link_kind_str(kind: &str) -> Option<&'static str> {
+/// PR-9 F4: returns the typed [`FullGraphNodeKind`] (not a bare `&str`) so the caller can carry the
+/// endpoint kinds onto `FullGraphEdge` — the FE then matches endpoints by `(kind, id)`, not bare id,
+/// closing a cross-kind id-collision mismatch. Its `.as_str()` remains the visible-node-set key.
+fn full_graph_link_node_kind(kind: &str) -> Option<FullGraphNodeKind> {
     match kind {
-        "meeting" => Some(FullGraphNodeKind::Meeting.as_str()),
-        "note" => Some(FullGraphNodeKind::Note.as_str()),
-        "document" => Some(FullGraphNodeKind::Document.as_str()),
+        "meeting" => Some(FullGraphNodeKind::Meeting),
+        "note" => Some(FullGraphNodeKind::Note),
+        "document" => Some(FullGraphNodeKind::Document),
         _ => None,
     }
 }
@@ -26488,6 +26561,235 @@ mod graph_tests {
         db.set_folder_locked("f", true, None).unwrap();
         let g2 = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
         assert!(g2.has_hidden, "a locked folder sets has_hidden");
+    }
+
+    /// PR-9 F3 (co-occurrence determinism): `graph_edges_visible`'s `LIMIT 600` had no tiebreak, so
+    /// the surviving edge subset could vary between opens (contradicting the "Deterministic" claim).
+    /// Two calls on the SAME data must now return the byte-identical edge set (weight DESC, pair ASC).
+    /// RED-before-GREEN: drop the `a.entity_id ASC, b.entity_id ASC` tiebreak and, on a dataset whose
+    /// weights tie at the cap boundary, the two vectors can differ.
+    #[test]
+    fn graph_edges_visible_is_deterministic_across_calls() {
+        let db = file_db("cooc-determinism");
+        seed_folder(&db, "f", "Notes");
+        // Many entities co-occurring in ONE meeting → every pair has weight 1 (a full tie). With no
+        // tiebreak the `LIMIT` picks an engine-arbitrary 600 of the pairs; the tiebreak pins them.
+        seed_note(&db, "m", "# meeting", Some("f"));
+        let mut ids = Vec::new();
+        for i in 0..40 {
+            let e = db
+                .upsert_entity(&format!("Ent {i:02}"), EntityKind::Person)
+                .unwrap();
+            db.add_mention(&e, "m").unwrap();
+            ids.push(e);
+        }
+        let empty: HashSet<String> = HashSet::new();
+        let a = db.graph_edges_visible(&empty).unwrap();
+        let b = db.graph_edges_visible(&empty).unwrap();
+        assert!(!a.is_empty(), "co-occurrence edges exist");
+        let key = |v: &[GraphEdge]| {
+            v.iter()
+                .map(|e| (e.source.clone(), e.target.clone(), e.weight))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            key(&a),
+            key(&b),
+            "two build passes on identical data must return the identical edge set"
+        );
+        // And the order itself is the declared one: weight DESC then (source, target) ASC.
+        let mut sorted = a.clone();
+        sorted.sort_by(|x, y| {
+            y.weight
+                .cmp(&x.weight)
+                .then_with(|| x.source.cmp(&y.source))
+                .then_with(|| x.target.cmp(&y.target))
+        });
+        assert_eq!(
+            key(&a),
+            key(&sorted),
+            "edges are ordered weight DESC, then pair id ASC (deterministic)"
+        );
+    }
+
+    /// PR-9 F2 (mention-edge recency ordering + honest edge-cap): the mention leg truncated at
+    /// `MAX_MENTION_EDGES` in ARBITRARY entity-UUID order, so an entity late in UUID order lost ALL
+    /// its edges with no signal. Now it orders by meeting RECENCY, so a mention in the FRESHEST
+    /// meeting survives the cap regardless of the entity's UUID, and `edges_truncated` discloses the
+    /// trim. RED-before-GREEN: restore `ORDER BY em.entity_id` and the most-recent-meeting mention
+    /// from a high-UUID entity is dropped while a stale one survives; drop the flag and the trim is
+    /// invisible.
+    #[test]
+    fn mention_edges_prefer_recency_and_flag_truncation() {
+        let db = file_db("mention-cap");
+        seed_folder(&db, "f", "Notes");
+        // One OLD meeting carries the cap's worth of mentions (2000), one NEW meeting carries one
+        // extra mention from a fresh entity. Recency-ordering must keep the NEW mention and shed an
+        // OLD one; `edges_truncated` must be true (2001 visible > 2000 cap).
+        db.insert_meeting(&Meeting {
+            id: "m-old".to_string(),
+            started_at: "2020-01-01T00:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Old".to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.insert_meeting(&Meeting {
+            id: "m-new".to_string(),
+            started_at: "2026-12-31T00:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("New".to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        // Seed entity rows + mentions with CONTROLLED ids (not random UUIDs) so the recency-vs-UUID
+        // ordering is deterministic: the fresh entity's id "z-fresh" sorts AFTER every "e00000..".
+        // Under the OLD `ORDER BY entity_id ASC LIMIT 2000` the highest-id row (the fresh one) is the
+        // one dropped; under the NEW recency order it survives — that contrast is the F2 fix.
+        let seed_entity = |id: &str, name: &str| {
+            db.lock()
+                .execute(
+                    "INSERT INTO entities (id, name, name_ci, kind, created_at)
+                     VALUES (?1, ?2, ?3, 'person', '2020-01-01T00:00:00Z')",
+                    rusqlite::params![id, name, name.to_lowercase()],
+                )
+                .unwrap();
+        };
+        // 2000 distinct entities mentioned in the OLD meeting, ids "e00000".."e01999" (all < "z-fresh").
+        for i in 0..2000 {
+            let id = format!("e{i:05}");
+            seed_entity(&id, &format!("Old {i:04}"));
+            db.add_mention(&id, "m-old").unwrap();
+        }
+        // ONE fresh entity (highest id) mentioned in the NEW meeting.
+        let fresh = "z-fresh".to_string();
+        seed_entity(&fresh, "Fresh Face");
+        db.add_mention(&fresh, "m-new").unwrap();
+
+        let empty: HashSet<String> = HashSet::new();
+        let (rows, truncated) = db.entity_meeting_mentions_visible(&empty).unwrap();
+        assert_eq!(rows.len(), 2000, "the cap bounds the returned mention edges");
+        assert!(
+            truncated,
+            "2001 visible mentions > the 2000 cap sets edges_truncated"
+        );
+        // The freshest-meeting mention survived the cap (recency-ordered) — the whole point of F2.
+        // Under the old `entity_id ASC` order this highest-id entity would be the one dropped.
+        assert!(
+            rows.iter().any(|(e, m, _)| e == &fresh && m == "m-new"),
+            "a mention in the most-RECENT meeting survives the cap regardless of entity UUID"
+        );
+        // And the truncation surfaces through the full graph payload.
+        let g = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        assert!(
+            g.edges_truncated,
+            "build_full_graph propagates the mention-leg truncation to the FE"
+        );
+    }
+
+    /// PR-9 F2 (links leg bounded + flagged): `full_graph_links` read the WHOLE `links` table
+    /// unbounded — the fastest-growing edge leg had no cap while the node legs each did. It now caps
+    /// at `MAX_FULL_GRAPH_LINK_EDGES` (score DESC) and reports truncation. RED-before-GREEN: remove
+    /// the LIMIT and the returned count is unbounded (> cap); drop the flag and the trim is silent.
+    #[test]
+    fn full_graph_links_are_bounded_and_flag_truncation() {
+        let db = file_db("links-cap");
+        seed_folder(&db, "f", "Notes");
+        // Seed MAX_FULL_GRAPH_LINK_EDGES + 1 active note↔note wikilinks so the cap must trim exactly
+        // one. (Endpoints need not exist as nodes — `full_graph_links` is PRE-gating, read raw.)
+        let over = MAX_FULL_GRAPH_LINK_EDGES + 1;
+        for i in 0..over {
+            seed_link(
+                &db,
+                ("note", &format!("s{i:05}")),
+                ("note", &format!("d{i:05}")),
+                "wikilink",
+                "active",
+                1.0,
+            );
+        }
+        let (rows, truncated) = db.full_graph_links(false).unwrap();
+        assert_eq!(
+            rows.len(),
+            MAX_FULL_GRAPH_LINK_EDGES,
+            "the links leg is bounded by the cap"
+        );
+        assert!(truncated, "one past the cap sets the truncated flag");
+    }
+
+    /// PR-9 F4 (edges carry endpoint kinds): a `FullGraphEdge` now names its `src_kind`/`dst_kind`
+    /// (the endpoint node kinds the backend gated on) so the FE can match endpoints by `(kind, id)`,
+    /// safe against a cross-kind id collision. A mention edge is entity→meeting; a companion link is
+    /// note→meeting. RED-before-GREEN: without the fields the FE can only match on bare id.
+    #[test]
+    fn full_graph_edges_carry_endpoint_kinds() {
+        let db = file_db("edge-kinds");
+        seed_folder(&db, "f", "Notes");
+        seed_note(&db, "m1", "# meeting", Some("f"));
+        db.insert_note("n1", "f", "n1", "Note One", "body", 1_000)
+            .unwrap();
+        let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+        db.add_mention(&atlas, "m1").unwrap();
+        seed_link(&db, ("note", "n1"), ("meeting", "m1"), "companion", "active", 1.0);
+
+        let empty: HashSet<String> = HashSet::new();
+        let g = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        let mention = g
+            .edges
+            .iter()
+            .find(|e| e.kind == FullGraphEdgeKind::Mention)
+            .expect("mention edge present");
+        assert_eq!(mention.src_kind, FullGraphNodeKind::Entity);
+        assert_eq!(mention.dst_kind, FullGraphNodeKind::Meeting);
+        let companion = g
+            .edges
+            .iter()
+            .find(|e| e.kind == FullGraphEdgeKind::Companion)
+            .expect("companion link present");
+        assert_eq!(companion.src_kind, FullGraphNodeKind::Note);
+        assert_eq!(companion.dst_kind, FullGraphNodeKind::Meeting);
+    }
+
+    /// PR-9 F4 (unified node date): a note/document node's `date` is an RFC3339 ISO string (was the
+    /// raw epoch-ms string), matching the meeting node's ISO `started_at`. RED-before-GREEN: emit
+    /// `ts.to_string()` and the field is a bare integer string, inconsistent with meetings.
+    #[test]
+    fn full_graph_content_node_date_is_iso() {
+        let db = file_db("node-date-iso");
+        seed_folder(&db, "f", "Notes");
+        // created_at is epoch-MS; 1_700_000_000_000 ms = 2023-11-14T22:13:20Z.
+        db.insert_note("n1", "f", "n1", "Note One", "body", 1_700_000_000_000)
+            .unwrap();
+        let empty: HashSet<String> = HashSet::new();
+        let g = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        let note = g
+            .nodes
+            .iter()
+            .find(|n| n.id == "n1")
+            .expect("note node present");
+        let date = note.date.as_deref().expect("note carries a date");
+        assert!(
+            date.starts_with("2023-11-14T"),
+            "the note date is RFC3339 ISO (got {date:?}), not raw epoch-ms"
+        );
+        // A meeting node keeps its ISO started_at — both kinds now share the format.
+        seed_note(&db, "m1", "# meeting", Some("f"));
+        let g2 = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+        let meeting = g2
+            .nodes
+            .iter()
+            .find(|n| n.id == "m1")
+            .expect("meeting node present");
+        assert!(
+            meeting.date.as_deref().is_some_and(|d| d.contains("T")),
+            "the meeting date is ISO too"
+        );
     }
 
     /// `/people` CRM GATE: a Person mentioned ONLY in a sealed-and-not-session-unlocked meeting is

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -143,14 +143,19 @@ impl FullGraphEdgeKind {
 }
 
 /// One TYPED edge in the full-brain graph. `src`/`dst` are node ids that MUST both be present in
-/// the returned `nodes` (BOTH-endpoint-gated — an edge to a sealed node is never emitted). `status`
-/// is `active` for deterministic edges (co-occurrence/mention/wikilink/companion + accepted
-/// semantic) and `suggested` for un-accepted semantic edges (only present when the opts flag is on).
+/// the returned `nodes` (BOTH-endpoint-gated — an edge to a sealed node is never emitted).
+/// `src_kind`/`dst_kind` carry the ENDPOINT node kinds the backend gated on (PR-9 F4): a links edge
+/// can connect `meeting↔note`, so the endpoint kinds are NOT derivable from `kind` alone, and the FE
+/// must match endpoints by `(kind, id)` — not bare `id` — to be safe against a cross-kind id
+/// collision. `status` is `active` for deterministic edges (co-occurrence/mention/wikilink/companion
+/// + accepted semantic) and `suggested` for un-accepted semantic edges (only when the opts flag is on).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FullGraphEdge {
     pub src: String,
     pub dst: String,
+    pub src_kind: FullGraphNodeKind,
+    pub dst_kind: FullGraphNodeKind,
     pub kind: FullGraphEdgeKind,
     pub score: f64,
     pub status: String,
@@ -170,7 +175,10 @@ pub struct FullGraphOpts {
 /// disclosure the entity graph makes. `has_hidden` is true when ≥1 folder is sealed-and-not-unlocked
 /// (some nodes/edges may be hidden). `total_visible_nodes` is the TRUE count of visible nodes BEFORE
 /// the per-kind render caps trimmed `nodes` — `total_visible_nodes > nodes.len()` means a cap
-/// dropped rows (distinct from `has_hidden`, which only reflects LOCKED folders).
+/// dropped rows (distinct from `has_hidden`, which only reflects LOCKED folders). `edges_truncated`
+/// (PR-9 F2) is true when an EDGE-leg cap (the mention or links LIMIT) trimmed edges, so the FE can
+/// disclose "some links are hidden" — distinct from `total_visible_nodes` (a node-leg cap) and
+/// `has_hidden` (a locked folder).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FullGraphData {
@@ -178,6 +186,7 @@ pub struct FullGraphData {
     pub edges: Vec<FullGraphEdge>,
     pub has_hidden: bool,
     pub total_visible_nodes: i64,
+    pub edges_truncated: bool,
 }
 
 /// A co-occurring neighbor of a selected entity (the neighborhood satellites), with the

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1519,14 +1519,19 @@ export type FullGraphEdgeKind =
 
 /**
  * One TYPED edge in the full-brain graph. `src`/`dst` are node ids that BOTH
- * appear in `nodes` (both-endpoint-gated). `status` is `"active"` for
- * deterministic edges (co-occurrence/mention/wikilink/companion + accepted
- * semantic) and `"suggested"` for un-accepted semantic edges (only present when
- * `includeSuggested` was on) — a suggested edge is drawn dashed.
+ * appear in `nodes` (both-endpoint-gated). `srcKind`/`dstKind` carry the ENDPOINT
+ * node kinds the backend gated on (a links edge can connect `meeting↔note`, so the
+ * endpoint kinds are NOT derivable from `kind` alone) — the FE matches endpoints by
+ * `(kind, id)`, not bare `id`, safe against a cross-kind id collision. `status` is
+ * `"active"` for deterministic edges (co-occurrence/mention/wikilink/companion +
+ * accepted semantic) and `"suggested"` for un-accepted semantic edges (only present
+ * when `includeSuggested` was on) — a suggested edge is drawn dashed.
  */
 export interface FullGraphEdge {
   src: string;
   dst: string;
+  srcKind: FullGraphNodeKind;
+  dstKind: FullGraphNodeKind;
   kind: FullGraphEdgeKind;
   score: number;
   status: "active" | "suggested";
@@ -1550,12 +1555,16 @@ export interface FullGraphOpts {
  * `totalVisibleNodes` is the TRUE count of visible nodes BEFORE the per-kind
  * render caps trimmed `nodes` (`totalVisibleNodes > nodes.length` = a cap
  * dropped rows — distinct from `hasHidden`, which only reflects LOCKED folders).
+ * `edgesTruncated` is true when an EDGE-leg cap (the mention or links LIMIT)
+ * trimmed edges, so the FE can disclose "some links are hidden" — distinct from
+ * `totalVisibleNodes` (a node-leg cap) and `hasHidden` (a locked folder).
  */
 export interface FullGraphData {
   nodes: FullGraphNode[];
   edges: FullGraphEdge[];
   hasHidden: boolean;
   totalVisibleNodes: number;
+  edgesTruncated: boolean;
 }
 
 /** A co-occurring neighbor of a selected entity (a neighborhood satellite). */

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
@@ -32,6 +32,12 @@
         <span>{{ msg }}</span>
       </div>
     }
+    @if (edgesTruncated()) {
+      <div class="banner is-accent fbg-banner" role="status">
+        <span class="fbg-banner-glyph" aria-hidden="true"></span>
+        <span>Some links are hidden — the graph shows the strongest connections.</span>
+      </div>
+    }
 
     <!-- LENSES — node-type + edge-type toggle chips (filter what's drawn). -->
     <div class="fbg-lenses">

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -136,16 +136,40 @@ export class FullBrainGraphComponent {
   protected readonly hasHidden = computed(
     () => this.graphData()?.hasHidden ?? false,
   );
+
+  /**
+   * PR-9 F2: the backend trimmed an EDGE leg (the mention or links cap). Distinct
+   * from a node trim (`capDisclosure`) and a locked folder (`hasHidden`).
+   */
+  protected readonly edgesTruncated = computed(
+    () => this.graphData()?.edgesTruncated ?? false,
+  );
+
+  /**
+   * PR-9 F1 — the HONEST draw-cap disclosure. The old banner compared the backend's
+   * post-per-kind-cap `nodes.length` (up to 2000) against `totalVisibleNodes` and
+   * ignored BOTH the client-side lens filter AND the {@link MAX_NODES} draw cap — so
+   * it could claim "Showing 500 of 812" while only 140 somas were painted,
+   * reintroducing exactly the silent trim `totalVisibleNodes` exists to expose.
+   *
+   * The disclosure now compares what is ACTUALLY DRAWN ({@link drawnNodeCount},
+   * i.e. `sceneNodes().length`) against the true visible universe
+   * (`totalVisibleNodes`, the backend's uncapped count). Whenever fewer items are
+   * drawn than exist — because the backend per-kind cap trimmed rows, the
+   * {@link MAX_NODES} draw cap kept only the top-degree K, or a lens is hiding
+   * kinds — it says "Drawing N of M items" so the count on screen always matches
+   * the count in the caption.
+   */
   protected readonly isCapped = computed(() => {
-    const d = this.graphData();
-    return !!d && d.totalVisibleNodes > d.nodes.length;
+    const total = this.graphData()?.totalVisibleNodes ?? 0;
+    return this.drawnNodeCount() < total;
   });
   protected readonly capDisclosure = computed<string | null>(() => {
     const d = this.graphData();
     if (!d || !this.isCapped()) {
       return null;
     }
-    return `Showing ${d.nodes.length} of ${d.totalVisibleNodes} items.`;
+    return `Drawing ${this.drawnNodeCount()} of ${d.totalVisibleNodes} items.`;
   });
 
   /** Total nodes the backend returned (before any lens filtering). */
@@ -169,26 +193,35 @@ export class FullBrainGraphComponent {
     return d.nodes.filter((n) => lens[n.kind]);
   });
 
-  /** The edges drawn: both endpoints kind-visible AND the edge kind lens-enabled. */
+  /**
+   * The edges surviving the lens: both endpoints kind-visible AND the edge kind
+   * lens-enabled. PR-9 F4: match each endpoint by `(kind, id)` — not bare `id` —
+   * using the edge's `srcKind`/`dstKind`, so a cross-kind id collision can never
+   * mis-match an edge onto the wrong node.
+   */
   private readonly filteredEdges = computed<FullGraphEdge[]>(() => {
     const d = this.graphData();
     if (!d) {
       return [];
     }
     const eLens = this._edgeLens();
-    const visible = new Set(this.filteredNodes().map((n) => n.id));
+    const visible = new Set(this.filteredNodes().map((n) => `${n.kind}:${n.id}`));
     return d.edges.filter(
-      (e) => eLens[e.kind] && visible.has(e.src) && visible.has(e.dst),
+      (e) =>
+        eLens[e.kind] &&
+        visible.has(`${e.srcKind}:${e.src}`) &&
+        visible.has(`${e.dstKind}:${e.dst}`),
     );
   });
 
-  /** Counts for the header caption ("N items · M links"), post-lens. */
-  protected readonly drawnNodeCount = computed(
-    () => this.filteredNodes().length,
-  );
-  protected readonly drawnEdgeCount = computed(
-    () => this.filteredEdges().length,
-  );
+  /**
+   * Counts for the header caption ("N items · M links"). PR-9 F1: these reflect
+   * what is ACTUALLY DRAWN — `sceneNodes()`/`sceneEdges()`, i.e. AFTER the
+   * {@link MAX_NODES} draw cap — not the pre-cap lens-filtered sets, so the caption
+   * never claims more items/links than the canvas paints.
+   */
+  protected readonly drawnNodeCount = computed(() => this.sceneNodes().length);
+  protected readonly drawnEdgeCount = computed(() => this.sceneEdges().length);
 
   /**
    * The laid-out scene nodes — a PURE derivation of the lens-filtered graph.
@@ -354,14 +387,19 @@ export class FullBrainGraphComponent {
     }));
   });
 
-  /** The scene edges (between surviving nodes), with a stable key + dashed flag. */
+  /**
+   * The scene edges (between the somas that survived the {@link MAX_NODES} draw cap),
+   * with a stable key + dashed flag. PR-9 F4: match each endpoint by `(kind, id)` —
+   * keyed against the drawn nodes' `kind:id` — so a cross-kind id collision can't
+   * paint an edge onto the wrong soma.
+   */
   protected readonly sceneEdges = computed<FullSceneEdge[]>(() => {
-    const ids = new Set(this.sceneNodes().map((p) => p.id));
+    const keys = new Set(this.sceneNodes().map((p) => `${p.kind}:${p.id}`));
     const out: FullSceneEdge[] = [];
     for (const e of this.filteredEdges()) {
-      if (ids.has(e.src) && ids.has(e.dst)) {
+      if (keys.has(`${e.srcKind}:${e.src}`) && keys.has(`${e.dstKind}:${e.dst}`)) {
         out.push({
-          key: `${e.src}::${e.dst}::${e.kind}`,
+          key: `${e.srcKind}:${e.src}::${e.dstKind}:${e.dst}::${e.kind}`,
           src: e.src,
           dst: e.dst,
           kind: e.kind,

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -40,13 +40,15 @@
 
   <!-- DETERMINISTIC edges (wikilink / companion / manual) — plain link chips,
        mirroring the "Linked mentions" chip row. A manual (user-created) chip
-       gets a hover × to remove the link. -->
-  @if (deterministic().length) {
+       gets a hover × to remove the link. Rows are a precomputed view-model
+       (`deterministicRows()`) so the template binds fields only (no per-row
+       method call per change-detection pass — the zoneless computed-only rule). -->
+  @if (deterministicRows().length) {
     <div class="cx-group">
-      @for (e of deterministic(); track e.id) {
-        <span class="cx-chipwrap" [class.is-pending]="isPending(e.id)">
-          <a class="cx-chip" [routerLink]="routeFor(e)">
-            @switch (e.otherKind) {
+      @for (row of deterministicRows(); track row.edge.id) {
+        <span class="cx-chipwrap" [class.is-pending]="row.pending">
+          <a class="cx-chip" [routerLink]="row.route">
+            @switch (row.edge.otherKind) {
               @case ("meeting") {
                 <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
               }
@@ -57,21 +59,21 @@
                 <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
               }
             }
-            <span class="cx-title">{{ e.otherTitle }}</span>
-            @if (e.edgeType === "companion") {
+            <span class="cx-title">{{ row.edge.otherTitle }}</span>
+            @if (row.edge.edgeType === "companion") {
               <span class="cx-edge" aria-hidden="true">companion</span>
             } @else {
               <span class="cx-edge" aria-hidden="true">link</span>
             }
           </a>
-          @if (isRemovable(e)) {
+          @if (row.removable) {
             <button
               type="button"
               class="cx-remove"
-              [disabled]="isPending(e.id)"
-              [attr.aria-label]="'Remove link to ' + e.otherTitle"
+              [disabled]="row.pending"
+              [attr.aria-label]="'Remove link to ' + row.edge.otherTitle"
               title="Remove link"
-              (click)="unlink(e)"
+              (click)="unlink(row.edge)"
             >
               <span aria-hidden="true">×</span>
             </button>
@@ -81,14 +83,15 @@
     </div>
   }
 
-  <!-- SEMANTIC suggestions — a confidence chip + Accept / Dismiss per row. -->
-  @if (suggestions().length) {
+  <!-- SEMANTIC suggestions — a confidence chip + Accept / Dismiss per row (precomputed
+       `suggestionRows()`; template binds fields only). -->
+  @if (suggestionRows().length) {
     <div class="cx-group">
       <span class="cx-label">Suggested connections</span>
-      @for (e of suggestions(); track e.id) {
-        <div class="cx-row" [class.is-pending]="isPending(e.id)">
-          <a class="cx-chip cx-chip--suggested" [routerLink]="routeFor(e)">
-            @switch (e.otherKind) {
+      @for (row of suggestionRows(); track row.edge.id) {
+        <div class="cx-row" [class.is-pending]="row.pending">
+          <a class="cx-chip cx-chip--suggested" [routerLink]="row.route">
+            @switch (row.edge.otherKind) {
               @case ("meeting") {
                 <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
               }
@@ -99,27 +102,27 @@
                 <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
               }
             }
-            <span class="cx-title">{{ e.otherTitle }}</span>
+            <span class="cx-title">{{ row.edge.otherTitle }}</span>
             <span
               class="cx-score"
-              [class]="'cx-score--' + tier(e.score)"
-              [attr.title]="'Confidence ' + scoreLabel(e.score)"
-            >{{ scoreLabel(e.score) }}</span>
+              [class]="'cx-score--' + row.tier"
+              [attr.title]="'Confidence ' + row.scoreLabel"
+            >{{ row.scoreLabel }}</span>
           </a>
           <div class="cx-actions">
             <button
               type="button"
               class="cx-btn cx-btn--accept"
-              [disabled]="isPending(e.id)"
-              (click)="accept(e)"
+              [disabled]="row.pending"
+              (click)="accept(row.edge)"
             >
               Accept
             </button>
             <button
               type="button"
               class="cx-btn cx-btn--dismiss"
-              [disabled]="isPending(e.id)"
-              (click)="dismiss(e)"
+              [disabled]="row.pending"
+              (click)="dismiss(row.edge)"
             >
               Dismiss
             </button>

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -23,6 +23,31 @@ import { LinkPickerComponent } from "../../features/notes/link-picker/link-picke
 type ConfidenceTier = "high" | "med" | "low";
 
 /**
+ * A precomputed DETERMINISTIC-chip view-model row (PR-9 F5). Every per-row value the
+ * template used to compute via a method call (`routeFor`/`isRemovable`/`isPending`) is
+ * resolved ONCE in a `computed()` here, so the template binds fields only — no method
+ * re-runs every change-detection pass (the zoneless computed-only rule).
+ */
+interface DeterministicRow {
+  readonly edge: LinkEdge;
+  readonly route: unknown[];
+  readonly removable: boolean;
+  readonly pending: boolean;
+}
+
+/**
+ * A precomputed SEMANTIC-suggestion view-model row (PR-9 F5): the edge plus its
+ * confidence `tier`/`label` and `route`/`pending`, all resolved in a `computed()`.
+ */
+interface SuggestionRow {
+  readonly edge: LinkEdge;
+  readonly route: unknown[];
+  readonly tier: ConfidenceTier;
+  readonly scoreLabel: string;
+  readonly pending: boolean;
+}
+
+/**
  * Brain v3 PR-3 "Connections" — a self-contained panel of the persisted link
  * edges incident on one item (`list_links(kind, id)`), shown BESIDE the existing
  * "Linked mentions" backlinks chip row in the meeting Note tab and the note
@@ -165,6 +190,37 @@ export class ConnectionsComponent {
   );
 
   /**
+   * PR-9 F5 — the DETERMINISTIC chips as a precomputed view-model. Depends on
+   * `deterministic()` (edges) AND `pending()` so a re-fetch or an in-flight
+   * Accept/Unlink recomputes the rows; the template binds fields only (no per-row
+   * method call per change-detection pass).
+   */
+  readonly deterministicRows = computed<DeterministicRow[]>(() => {
+    const pending = this.pending();
+    return this.deterministic().map((edge) => ({
+      edge,
+      route: this.routeFor(edge),
+      removable: edge.manual === true,
+      pending: pending.has(edge.id),
+    }));
+  });
+
+  /**
+   * PR-9 F5 — the SEMANTIC suggestions as a precomputed view-model (tier + label +
+   * route + pending resolved once). Same dependency shape as {@link deterministicRows}.
+   */
+  readonly suggestionRows = computed<SuggestionRow[]>(() => {
+    const pending = this.pending();
+    return this.suggestions().map((edge) => ({
+      edge,
+      route: this.routeFor(edge),
+      tier: this.tier(edge.score),
+      scoreLabel: this.scoreLabel(edge.score),
+      pending: pending.has(edge.id),
+    }));
+  });
+
+  /**
    * Load the edges whenever `(kind, id)`, `locked`, OR the session lock-tree
    * changes. Reading `folders.tree()` registers this effect as its dependent so a
    * later unlock/relock re-asks the backend (sealed neighbours drop out / reappear
@@ -200,8 +256,8 @@ export class ConnectionsComponent {
     }
   }
 
-  /** The confidence tier for a semantic suggestion's cosine score. */
-  tier(score: number): ConfidenceTier {
+  /** The confidence tier for a semantic suggestion's cosine score (F5: row-model input). */
+  private tier(score: number): ConfidenceTier {
     if (score >= 0.88) {
       return "high";
     }
@@ -211,18 +267,18 @@ export class ConnectionsComponent {
     return "low";
   }
 
-  /** Whole-number percentage label for a suggestion's confidence chip. */
-  scoreLabel(score: number): string {
+  /** Whole-number percentage label for a suggestion's confidence chip (F5: row-model input). */
+  private scoreLabel(score: number): string {
     return `${Math.round(score * 100)}%`;
   }
 
-  /** True while an Accept/Dismiss for this edge is in flight (buttons disabled). */
-  isPending(id: number): boolean {
+  /** True while an Accept/Dismiss/Unlink for this edge is in flight (guards `mutate`). */
+  private isPending(id: number): boolean {
     return this.pending().has(id);
   }
 
-  /** The click-through route array for an edge's neighbour, split by kind. */
-  routeFor(e: LinkEdge): unknown[] {
+  /** The click-through route array for an edge's neighbour, split by kind (F5: row-model input). */
+  private routeFor(e: LinkEdge): unknown[] {
     return e.otherKind === "meeting"
       ? ["/meeting", e.otherId]
       : ["/notes", e.otherId];
@@ -236,15 +292,6 @@ export class ConnectionsComponent {
   /** Dismiss a suggestion → tombstone server-side, then re-fetch to drop it. */
   dismiss(e: LinkEdge): void {
     void this.mutate(e.id, () => this.ipc.dismissLink(e.id));
-  }
-
-  /**
-   * PR-1 — whether a deterministic chip is USER-REMOVABLE (shows the hover `×`).
-   * Only manual links (`manual === true`, set by the backend on the deduped
-   * manual+wikilink chip) are removable here; auto wikilink/companion edges are not.
-   */
-  isRemovable(e: LinkEdge): boolean {
-    return e.manual === true;
   }
 
   /**


### PR DESCRIPTION
PR-9 of the brain-v3 audit-fix program (audit: docs/research/2026-07-18-brain-v3-audit.md). Full-brain-graph honesty.

## Fixes
- **[MED] silent FE draw cap** — the caption reported the backend total while only 140 somas were painted. Now drawnNodeCount/drawnEdgeCount are the actually-drawn counts and the disclosure reads "Drawing N of M items" (the 140 truncation is deterministic — degree desc + id tiebreak — now DISCLOSED).
- **[LOW] arbitrary mention truncation + unbounded links** — mention edges order by meeting recency (was entity-UUID order → late-UUID entities lost ALL edges); full_graph_links bounded at 4000 (score DESC, was unbounded); both feed a new edges_truncated flag the FE discloses.
- **[LOW] nondeterministic co-occurrence subset** — LIMIT 600 gained a tiebreak (weight DESC, pair ASC) so the same data draws the same picture.
- FullGraphEdge carries src_kind/dst_kind → FE matches endpoints by (kind,id); node dates unified to RFC3339.
- **[FE hygiene]** connections.component precomputes rows in computed() view-models — zero per-row template method calls.
- **[e2e]** added a lock-masking case (a sealed title/name absent from the graph) + a cap-disclosure case.

## Verified
- cargo test --lib graph **31/0** + 5 new RED-proven tests, clippy --lib -D warnings clean, ng lint/build clean, e2e full-brain-graph 3/3 + connections 1/1, MSRV grep clean.
- **Gating self-verified (static, RAM-safe)**: the diff removes NO visibility_clause/{visible}/endpoint-recheck — the changes are purely ORDER BY/LIMIT on already-gated queries; build_full_graph_excludes_sealed_nodes_and_their_edges still passes (CI runs it). A sealed meeting's title / sealed doc's name still never surfaces.
- Off trunk 30131d7. Pure DB + Angular (no FFI/Touch ID) → cargo test + Playwright are adequate proof.