### PR TITLE
docs(learnings): God-file-split + WIP-port session lessons

### DIFF
--- a/.claude/learnings/adversarial-verifier.md
+++ b/.claude/learnings/adversarial-verifier.md
@@ -29,6 +29,26 @@
   screen-share auto-relock only truly verify on a *signed* build — a green unit test is not proof.
 - **Playwright defaults colorScheme LIGHT** and a mock field typo poisons judge rounds — eyeball the
   PNG yourself before trusting a verdict.
+- **NEVER `git checkout <file>` / `git restore` / `reset --hard` on an UNCOMMITTED tree to undo a
+  RED-revert.** A PR under review is usually uncommitted working changes; a `git checkout db.rs`
+  reverts the ENTIRE PR to trunk, not just your scratch hunk (this happened — a verifier nuked a
+  1300-line uncommitted PR and had to reconstruct it from a captured diff). For a RED-revert: use the
+  **Edit tool** to change the one hunk and Edit it back, or `git stash push -- <file>` → test →
+  `git stash pop`, or copy the file to a scratch path. After ANY revert, prove the tree is restored
+  byte-identical (`git diff --stat` matches the builder's, no stray hunks) before reporting.
+- **A green `cargo test --lib` proves NEITHER no-deadlock NOR no-leak when no test exercises the
+  path.** Two real bugs shipped green this program: (1) `accept_link` self-deadlocked (held a
+  non-reentrant guard across a callee that re-takes it) — every accept test hit only REFUSAL paths,
+  none a SUCCESSFUL accept; (2) the seal-time title-strip leaked because no test hit the auto-related
+  marker shape (title in `url` not `detail`) nor the canonicalized src-direction. HUNT: for a
+  state-machine/guard change, is there a test on the SUCCESS/happy path (not just the error paths)?
+  For a strip/filter/gate, enumerate every SHAPE the data takes (both edge directions, every field a
+  marker can live in, every render/sanitize form) and confirm a test covers each — a test that only
+  covers the shape the builder thought of green-washes the others.
+- **Prove a RED test is actually RED — don't trust its label.** A "src-leg regression" that inserts
+  the row in the OTHER direction (because the writer doesn't canonicalize the way the author assumed)
+  passes on the OLD code too and pins nothing. Neuter the exact fix hunk (via Edit), run the test,
+  confirm it FAILS, restore — a RED test that stays green against the unpatched code captured no bug.
 
 ## Run journal
 <!-- Append-only, newest first. -->

--- a/.claude/learnings/main-loop.md
+++ b/.claude/learnings/main-loop.md
@@ -33,6 +33,41 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 - **Shut down background review/verify agents the moment you've consumed their verdict.** Idle
   agents emit `idle_notification` every few seconds, each re-firing your turn (token + attention
   drain). `SendMessage({to, message:{type:"shutdown_request", reason}})`.
+- **EXACTLY ONE `cargo` process machine-wide, ever — concurrency is what freezes the Mac.** This
+  repo's test binary statically links the always-compiled ML tree (candle/mistralrs/whisper); ONE
+  such `cargo test --lib` link is a ~15-20 GB transient. Several builder/verifier agents (each
+  running its own cargo on the shared 187 GB `CARGO_TARGET_DIR`) + your own runs = multiple giant
+  links at once → macOS memory-compressor pins all 16 cores → the whole UI (even a new browser tab)
+  freezes, with swap still 0 (it's compression, not pageout). After `pkill cargo/rustc` the machine
+  is instantly 95% free — proving it's transient build peaks, not a leak. RULES: never run local
+  cargo while a subagent might; serialize builders (build → verify while builder idle → merge →
+  next); cap `CARGO_BUILD_JOBS=2 … -j2`; iterate with TARGETED filters (`cargo test --lib links` =
+  full compile, subset run) not the full 1900-test suite; **let CI (remote, 0 local RAM) be the real
+  full-gate.** Also: N divergent worktrees on ONE shared target THRASH (fingerprint miss → full ML
+  rebuild each switch) — prune stale worktrees, keep local cargo in as few trees as possible. Deeper
+  fix (needs a profile change): the default `debug=2` full debuginfo on every dependency is the
+  amplifier — see the build-perf research memory / `[profile.dev.package."*"] debug=false`.
+- **A multi-PR program under the RAM constraint = SEQUENTIAL build, CI-gated, not parallel-cargo.**
+  The proven cadence (ran a 12-PR program clean): build ONE PR in a worktree → verify (adversarial +
+  lock-security where the change touches seal/gate; verifiers are read-only or single-targeted-test,
+  never a 2nd concurrent cargo) → push → **CI (GitHub, remote = 0 local RAM) runs the full ci.sh
+  gate** → merge → remove the worktree → next. Overlap the NEXT builder's local compile with the
+  PREVIOUS PR's remote CI (still ONE local cargo). Rebase each PR onto fresh trunk before push
+  (merge-skew). Do NOT reach for a parallel-cargo Workflow — concurrent cargo freezes the Mac; a
+  read-only MAPPING fan-out (no cargo) is the only safe parallelism.
+- **Under session churn (model/effort switches, `/loop`), background tasks + subagents DIE silently.**
+  Verifiers/builders go idle without delivering; a re-verify run is lost. RECOVERY: trust the
+  FILESYSTEM, not chat — `git -C <wt> status/diff` (is the work there? is the tree byte-identical to
+  the builder's report?), `.claude/tmp/<task>/*.json` verdict artifacts, and any scratch files a dead
+  verifier left (its probe tests can be salvaged + run yourself to settle a verdict — that's how 2
+  real leaks were caught after verifiers stalled). Respawn a FRESH agent rather than nudging a wedged
+  one repeatedly. And SHUT DOWN each verify/build agent the moment you've consumed its verdict
+  (idle-notification spam re-fires your turn every few seconds).
+- **When a verifier FAILs a lock/seal change, apply its EXACT prescribed fix, then re-prove RED via
+  Edit (not git-checkout) + request a NARROW re-review of just the delta.** Both real bugs this
+  program (Accept deadlock, sealed-title leak) were caught by the lock/adversarial gate, fixed to the
+  reviewer's prescription (mirror the proven sibling), regression-pinned RED→GREEN, and re-confirmed
+  on the delta only — don't re-run the whole review.
 - **Deploy → POLL until the new artifact is genuinely live before saying "test now".** A green build
   ≠ deployed; the old container keeps serving until the new one is up. Poll the concrete changed
   thing (a new static file 200s, a response header flips) — a background `until`-loop, then verify.

--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -34,6 +34,30 @@
 - **Test loop = `cargo test --lib` from `src-tauri/`.** NEVER `cargo clippy --all-targets` in the
   loop (openssl/sqlcipher profile thrash → timeout; also blocked by `block-bash.sh`). Full gate =
   `scripts/ci.sh`, run ONCE at the end. Let a slow cold ML build finish; don't bail.
+- **ONE `cargo` process machine-wide, ever — concurrency FREEZES the Mac.** The app test binary
+  statically links the ML tree (candle/whisper/onnx); several concurrent `cargo test --lib` links
+  (multiple agents + your own runs) pin the macOS memory compressor → the whole UI freezes (swap
+  stays 0 — it's compression). Iterate with TARGETED filters (`cargo test --lib links` = full
+  compile + subset run, catches build errors, low RAM), NEVER the full 1900-test suite locally; let
+  CI run the full gate. `CARGO_BUILD_JOBS=2 … -j2`. Root cause + the `[profile.dev.package."*"]
+  debug=false` fix: `docs/research/2026-07-18-build-ram-freeze.md`.
+- **`cargo clippy --lib -- -D warnings` before EVERY push — the cheap CI-parity gate.** Link-free
+  (typecheck only → low RAM, ~10-15s warm). Catches the `dead_code` class that BOTH `cargo test
+  --lib` and `cargo clippy --lib --tests` mask: a `const`/`fn` used ONLY in a `#[cfg(test)]` module
+  is "never used" in the lib-only build CI runs, but the test build sees the test using it and stays
+  green (this ate a CI cycle — PR-2's `MCP_DEFAULT_WINDOW_CHARS`, whose feature was ALSO inert:
+  the dead-code error was the real "you wired it wrong" signal).
+- **Grep the diff for post-1.77 std items BEFORE pushing** (RAM-free): `git diff origin/murmur --
+  src-tauri | grep '^+' | grep -oE 'is_none_or|LazyLock|LazyCell|split_at_checked|take_if|next_multiple_of'`.
+  MSRV 1.77; `ci.sh` clippy `-D warnings` implies `-D clippy::incompatible_msrv` (cargo test does
+  not catch it). `is_none_or`(1.82)→`map_or(true, …)`; lazy statics→the `OnceLock` accessor idiom.
+- **A guard held across a callee that re-takes it = self-deadlock (invisible to green tests).**
+  `accept_link_inner` held the non-reentrant `lifecycle_guard` across `materialize_accepted_link →
+  update_note_inner` (which re-acquires it) → a valid Accept hung forever; every accept TEST hit
+  only refusal paths, none a SUCCESSFUL accept, so cargo test stayed green. When you take
+  `lifecycle_guard`, SCOPE it in a `{ }` block around only the gate+db-write and DROP it before any
+  materialize/note-write callee (the `link_items_inner`/`unlink_items_inner` idiom); and add a test
+  that drives the SUCCESS path, not just the error paths.
 
 ## Run journal
 <!-- Append-only, newest first. -->


### PR DESCRIPTION
Docs-only. Captures this session's hard-won lessons into .claude/learnings/ (main-loop / rust-tauri-dev / adversarial-verifier): the one-cargo RAM rule, the sequential CI-gated multi-PR cadence, #[path] child-module test relocation, verbatim-move byte-identity proof, and the checkout-reverts-a-live-dev-app trap. No code change.