### PR TITLE
feat(record): Calm-Notepad while-recording surface (centered note, ambient chrome, summoned Ask)

### DIFF
--- a/e2e/record/ask-ai-fail-no-orphan.spec.ts
+++ b/e2e/record/ask-ai-fail-no-orphan.spec.ts
@@ -39,15 +39,22 @@ test.describe("Record — a failed Ask AI leaves no orphaned mic bubble", () => 
     await page.goto("/record");
 
     await page.locator("button.start-btn").click();
-    await expect(page.locator(".rec-strip.is-recording")).toBeVisible({
+    await expect(page.locator(".rec-topline")).toBeVisible({
       timeout: 10_000,
     });
 
-    // Click "Ask AI" — begin_voice_command rejects immediately.
-    await page.locator("button.ask-btn").click();
+    // Summon the Ask-Brain panel from the footer, then trigger a voice ask via its
+    // mic — begin_voice_command rejects immediately (Calm-Notepad: voice now lives
+    // inside the summoned panel, not a top-strip Ask button).
+    await page.locator("app-record .ask-pill").click();
+    const mic = page.locator("app-meeting-conversation .ask-panel .mic-btn");
+    await expect(mic).toBeVisible();
+    await mic.click();
 
-    // The orb must NOT get stuck listening/processing.
-    await expect(page.locator("button.ask-btn.is-listening")).toHaveCount(0);
+    // The mic must NOT get stuck listening/processing.
+    await expect(
+      page.locator("app-meeting-conversation .mic-btn.is-listening"),
+    ).toHaveCount(0);
 
     // No orphaned "🎙 …" bubble/thread should remain anywhere in the flow.
     await expect(page.getByText("🎙 …", { exact: true })).toHaveCount(0);

--- a/e2e/record/companion-note-tabs.spec.ts
+++ b/e2e/record/companion-note-tabs.spec.ts
@@ -2,18 +2,18 @@ import { test, expect } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
 /**
- * v3 DOCUMENT-FIRST recording panel — the note is the always-visible HERO, Ask
- * Brain is a right-side DRAWER (2026-07-18 redesign; replaces the v2 Note|Ask
- * segmented tabs).
+ * Calm-Notepad recording surface (2026-07-19) — the companion note is the
+ * always-visible, centered HERO; Ask Brain is a SUMMONED opaque panel (footer ✦),
+ * not a beside-the-editor split.
  *
  *  - The embedded note editor mounts on the meeting's ONE companion note (eagerly
  *    created via `get_or_create_companion_note`) and is ALWAYS VISIBLE — one editable
  *    DOCUMENT, no per-jot "Saved to Notes" badges.
- *  - The "Ask Brain" head toggle opens/closes a drawer hosting the `@brain` thread
- *    BESIDE the editor (shrinks it, never hides it). One live editor instance stays
- *    mounted for the whole recording (the flush-at-Stop target).
+ *  - The footer "Ask" pill summons the Ask-Brain panel hosting the `@brain` thread
+ *    (preset chips + text/voice). The editor stays mounted (the flush-at-Stop target)
+ *    and visible beneath the sheet.
  */
-test.describe("Record — document-first companion note + Ask Brain drawer (v3)", () => {
+test.describe("Record — companion note hero + summoned Ask Brain panel", () => {
   test.beforeEach(async ({ page }) => {
     await mockTauri(page, {
       model_present: () => true,
@@ -88,27 +88,26 @@ test.describe("Record — document-first companion note + Ask Brain drawer (v3)"
     await expect(body).toHaveValue(/ship the three flows/);
   });
 
-  test("(b) opening the Ask Brain drawer shows the conversation and can ask (editor stays visible)", async ({
+  test("(b) summoning the Ask Brain panel shows the conversation and can ask (editor stays visible)", async ({
     page,
   }) => {
     await startRecording(page);
 
-    // Open the Ask Brain drawer via the head toggle.
-    await page.locator("app-meeting-conversation .ask-toggle").click();
+    // Summon the Ask Brain panel via the footer ✦ pill.
+    await page.locator("app-record .ask-pill").click();
 
-    const ask = page.locator("app-meeting-conversation .ask-input");
+    const ask = page.locator("app-meeting-conversation .ask-panel .ask-input");
     await expect(ask).toBeVisible();
 
-    // The embedded document editor is the always-visible HERO — the drawer docks
-    // BESIDE it (shrinks it), it is NOT hidden. One live editor stays mounted as the
-    // flush-at-Stop target.
+    // The embedded document editor is the always-visible HERO — the panel floats
+    // OVER the notepad without unmounting it (the flush-at-Stop target).
     await expect(
       page.locator("app-meeting-conversation app-note-editor"),
     ).toBeVisible();
 
     // Ask a question → a thread opens and the brain answers.
     await ask.fill("why was the mobile redesign deferred?");
-    await page.locator("app-meeting-conversation .send-btn").click();
+    await page.locator("app-meeting-conversation .ask-panel .send-btn").click();
 
     await expect(page.locator("app-note-item")).toHaveCount(1);
     await expect(
@@ -116,33 +115,33 @@ test.describe("Record — document-first companion note + Ask Brain drawer (v3)"
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test("(c) the Ask Brain drawer toggles open and closed cleanly", async ({
+  test("(c) the Ask Brain panel summons and dismisses cleanly", async ({
     page,
   }) => {
     await startRecording(page);
 
-    const toggle = page.locator("app-meeting-conversation .ask-toggle");
+    const pill = page.locator("app-record .ask-pill");
     const body = page.locator(
       "app-meeting-conversation app-note-editor .editor-body textarea.body-area",
     );
 
-    // Default: the editor is the visible hero, drawer closed (no ask input).
+    // Default: the editor is the visible hero, panel closed (no ask panel).
     await expect(body).toBeVisible({ timeout: 10_000 });
     await expect(
-      page.locator("app-meeting-conversation .ask-input"),
+      page.locator("app-meeting-conversation .ask-panel"),
     ).toHaveCount(0);
 
-    // Open the drawer → the ask input shows, the editor STAYS visible beside it.
-    await toggle.click();
+    // Summon the panel → the ask input shows, the editor STAYS visible beneath it.
+    await pill.click();
     await expect(
-      page.locator("app-meeting-conversation .ask-input"),
+      page.locator("app-meeting-conversation .ask-panel .ask-input"),
     ).toBeVisible();
     await expect(body).toBeVisible();
 
-    // Close the drawer → the editor reloads in place (no re-mount), ask input gone.
-    await toggle.click();
+    // Dismiss via the panel close × → the editor reloads in place, panel gone.
+    await page.locator("app-meeting-conversation .ask-panel-close").click();
     await expect(
-      page.locator("app-meeting-conversation .ask-input"),
+      page.locator("app-meeting-conversation .ask-panel"),
     ).toHaveCount(0);
     await expect(body).toBeVisible();
   });

--- a/e2e/record/reload-reconcile-stage.spec.ts
+++ b/e2e/record/reload-reconcile-stage.spec.ts
@@ -39,7 +39,7 @@ test.describe("Record — webview (re)load reconciles the stage with the backend
 
     // WITHOUT clicking Start: the store's init() resync must adopt the
     // backend's in-flight recording.
-    await expect(page.locator(".rec-strip.is-recording")).toBeVisible({
+    await expect(page.locator(".rec-topline")).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.locator("button.stop-btn")).toBeVisible();
@@ -81,6 +81,6 @@ test.describe("Record — webview (re)load reconciles the stage with the backend
     });
     await expect(page.getByText(/Transcribing on-device/i)).toHaveCount(0);
     await expect(page.locator("button.stop-btn")).toHaveCount(0);
-    await expect(page.locator(".rec-strip.is-recording")).toHaveCount(0);
+    await expect(page.locator(".rec-topline")).toHaveCount(0);
   });
 });

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -304,6 +304,33 @@ export class MeetingConversationStore {
   readonly processing = this._processing.asReadonly();
 
   /**
+   * Whether the SUMMONED Ask-Brain panel is open (Calm-Notepad redesign,
+   * 2026-07-19). Ask is no longer a beside-editor split that halves the note
+   * column — it is an on-demand opaque sheet the user summons from the footer ✦,
+   * the `/` slash "Ask Brain" entry, or a preset chip. Lives in the ROOT store
+   * (not the surface component) so the record screen's footer and the note-editor
+   * slash item can open the SAME panel the surface renders. Defaults closed so the
+   * note is always the full centered hero.
+   */
+  private readonly _askPanelOpen = signal(false);
+  readonly askPanelOpen = this._askPanelOpen.asReadonly();
+
+  /** Summon the Ask-Brain panel (footer ✦ / `/` slash entry / preset chip). */
+  openAskPanel(): void {
+    this._askPanelOpen.set(true);
+  }
+
+  /** Dismiss the Ask-Brain panel (the note stays the always-visible hero). */
+  closeAskPanel(): void {
+    this._askPanelOpen.set(false);
+  }
+
+  /** Toggle the Ask-Brain panel from a single footer affordance. */
+  toggleAskPanel(): void {
+    this._askPanelOpen.update((open) => !open);
+  }
+
+  /**
    * The 4-state orb model collapsed from the existing signals — a PURE
    * `computed` (no signal writes → no NG0600 / trap T1):
    *   processing → "processing" (a voice dispatch is in flight)
@@ -483,6 +510,7 @@ export class MeetingConversationStore {
   clear(): void {
     this._notes.set([]);
     this.voiceTargetNoteId = null;
+    this._askPanelOpen.set(false);
     this.clearRail();
   }
 

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -570,7 +570,7 @@
                 <textarea
                   #bodyArea
                   class="body-area"
-                  placeholder="Start writing… Type / for blocks."
+                  [placeholder]="bodyPlaceholder()"
                   aria-label="Note body"
                   autocapitalize="sentences"
                   autocomplete="off"
@@ -588,7 +588,7 @@
               <!-- Slash menu (opaque overlay, T3). -->
               @if (slashOpen()) {
                 <div class="menu slash-menu" role="listbox" aria-label="Insert block">
-                  @for (item of slashItems; track item.id; let i = $index) {
+                  @for (item of slashItems(); track item.id; let i = $index) {
                     <button
                       type="button"
                       class="menu-item"

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -45,12 +45,18 @@
   height: 100%;
 }
 .editor.is-embedded .editor-body {
-  padding: var(--space-4) var(--space-5) var(--space-6);
+  /* Extra top breathing room so the title/first line sits on a calm field, not
+     jammed under the recording chrome (Calm-Notepad, 2026-07-19). */
+  padding: var(--space-6) var(--space-5) var(--space-8);
 }
 .editor.is-embedded .note-doc {
-  /* No centered document column when embedded — fill the panel width (the panel
-     is already a narrow tab, so the routed 920px cap would just leave dead space). */
-  max-width: none;
+  /* Calm-Notepad measure (2026-07-19): a CENTERED writing column, not the
+     full-bleed void. The old `max-width: none` assumed a narrow beside-the-drawer
+     tab; the drawer is gone (Ask is now a summoned panel), so an unmeasured note
+     spanned the whole card and one line read as a gargantuan empty canvas. A
+     bounded, centered ~40rem column turns the surplus into deliberate margin. */
+  max-width: var(--editor-measure);
+  margin: 0 auto;
 }
 
 /* Transparent full-viewport backdrop that closes an open header menu on an

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -10,6 +10,7 @@ import {
   effect,
   inject,
   input,
+  output,
   signal,
   untracked,
   viewChild,
@@ -198,8 +199,29 @@ export class NoteEditorComponent {
   /** Drill-down back navigation ("← Notes"). */
   readonly nav = inject(NavHistoryService);
 
-  /** The slash-menu block catalog. */
-  protected readonly slashItems = SLASH_ITEMS;
+  /**
+   * The slash-menu catalog. On the routed editor this is exactly {@link SLASH_ITEMS}
+   * (byte-for-byte unchanged). When {@link embedded} (the recording surface) it
+   * appends an "Ask Brain" entry so `/` at the start of a line can summon the Brain
+   * without a standing side panel — the Calm-Notepad "summon, don't station" model.
+   */
+  protected readonly slashItems = computed<readonly SlashItem[]>(() =>
+    this.embedded()
+      ? [...SLASH_ITEMS, { id: "askBrain", label: "✦ Ask Brain" }]
+      : SLASH_ITEMS,
+  );
+
+  /**
+   * The body textarea's placeholder — a warm ghost prompt. In the recording
+   * surface ({@link embedded}) it names both note-taking AND the two ways to reach
+   * the Brain, so an empty note reads as an invitation, not a void. The routed
+   * editor keeps its original block-oriented prompt.
+   */
+  protected readonly bodyPlaceholder = computed(() =>
+    this.embedded()
+      ? "Type to take notes — / for blocks, or Ask Brain"
+      : "Start writing… Type / for blocks.",
+  );
 
   /**
    * EMBEDDED mode (additive, 2026-07-17) — when true this editor is HOSTED
@@ -215,6 +237,15 @@ export class NoteEditorComponent {
   readonly embedded = input(false);
   /** The note id to load when {@link embedded}. Ignored on the route. */
   readonly noteIdInput = input<string | null>(null);
+
+  /**
+   * Emitted when the user picks the "Ask Brain" entry from the `/` slash menu
+   * (Calm-Notepad redesign, 2026-07-19). ONLY offered when {@link embedded} (the
+   * recording surface), so the routed `/notes/:id` slash menu is byte-for-byte
+   * unchanged. The recording surface host summons the Ask-Brain panel on this —
+   * the editor itself owns no Ask panel, keeping the note the hero.
+   */
+  readonly askBrain = output<void>();
 
   /**
    * The route `:id`, tracked so a same-route navigation re-fetches even though
@@ -1844,18 +1875,19 @@ export class NoteEditorComponent {
 
   /** Handle ↑/↓/Enter/Esc in the open slash menu. Returns true when consumed. */
   private handleSlashKey(event: KeyboardEvent): boolean {
+    const items = this.slashItems();
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
-        this.slashIndex.update((i) => (i + 1) % SLASH_ITEMS.length);
+        this.slashIndex.update((i) => (i + 1) % items.length);
         return true;
       case "ArrowUp":
         event.preventDefault();
-        this.slashIndex.update((i) => (i - 1 + SLASH_ITEMS.length) % SLASH_ITEMS.length);
+        this.slashIndex.update((i) => (i - 1 + items.length) % items.length);
         return true;
       case "Enter":
         event.preventDefault();
-        this.pickSlash(SLASH_ITEMS[this.slashIndex()]);
+        this.pickSlash(items[this.slashIndex()]);
         return true;
       case "Escape":
         event.preventDefault();
@@ -1879,6 +1911,14 @@ export class NoteEditorComponent {
     const pos = el.selectionStart;
     const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
     this.slashOpen.set(false);
+    if (item.id === "askBrain") {
+      // Summon the Ask-Brain panel — remove the bare `/` trigger first so no
+      // stray slash is left in the note, then let the recording host open the
+      // panel. Caret returns to the (now-empty) line start.
+      this.replaceRange(el, lineStart, pos, "", lineStart, lineStart);
+      this.askBrain.emit();
+      return;
+    }
     if (item.id === "linkToNote" || item.snippet === undefined) {
       // Replace the `/` trigger with `[[` (the natural Obsidian trigger text),
       // then open the picker anchored right after it.

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.html
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.html
@@ -1,8 +1,14 @@
+<!-- Calm-Notepad recording surface (2026-07-19). The meeting's companion note is the
+     always-visible, always-full, CENTERED hero (the embedded editor). Recording state
+     lives in the record screen's thin top line + ambient footer HUD; Ask Brain is a
+     SUMMONED opaque sheet (footer ✦ / `/` slash entry / preset chip), never a standing
+     beside-the-editor split. The card is OPAQUE (`--surface-solid`), not the frosted
+     `.card` — glass is chrome, never a content panel wrapping the editor's overlays. -->
 <div class="card surface" role="group" aria-label="In-meeting note and Ask Brain">
-  <div class="surface-head">
-    <app-ai-orb class="head-orb" [state]="orbStateView()" />
-    <span
-      class="surface-hint"
+  <!-- Quiet enhance-honesty hint — centered above the note, only while it applies. -->
+  @if (enhanceHintVisible()) {
+    <p
+      class="enhance-hint"
       role="status"
       aria-live="polite"
       [class.is-enhancing]="enhancing()"
@@ -12,46 +18,15 @@
         Enhancing your notes…
       } @else if (settled()) {
         ✨ Notes enhanced — your note became the outline.
-      } @else if (enhanceAware() && store.hasPersistedNotes()) {
+      } @else {
         ✨ This note will shape your summary
       }
-    </span>
-
-    <!-- Ask Brain drawer toggle — replaces the retired Note|Ask segmented tabs. The
-         note is the always-visible hero; this opens the @brain thread beside it. -->
-    <button
-      type="button"
-      class="btn btn-ghost ask-toggle"
-      [class.is-active]="drawerOpen()"
-      [attr.aria-expanded]="drawerOpen()"
-      (click)="toggleDrawer()"
-    >
-      <svg
-        class="ask-toggle-glyph"
-        viewBox="0 0 16 16"
-        width="13"
-        height="13"
-        fill="none"
-        aria-hidden="true"
-      >
-        <path
-          d="M8 1.5l1.3 3.2L12.5 6 9.3 7.3 8 10.5 6.7 7.3 3.5 6l3.2-1.3L8 1.5Z"
-          stroke="currentColor"
-          stroke-width="1.2"
-          stroke-linejoin="round"
-        />
-      </svg>
-      Ask Brain
-      @if (askUnseen()) {
-        <span class="ask-toggle-dot" aria-hidden="true"></span>
-      }
-    </button>
-  </div>
+    </p>
+  }
 
   <!-- Ambient live reactions — the recall hint + contradiction whisper cards + the
-       shadow-mode calibration prompt. ABOVE the body so they surface even with the
-       drawer closed (never buried behind the toggle). All PURGED on any lock
-       transition by the store. -->
+       shadow-mode calibration prompt. Stay ABOVE the note so they surface with the Ask
+       panel closed (never buried). All PURGED on any lock transition by the store. -->
   @if (hasReactions()) {
     <div class="reactions-rail">
       @if (hintsEnabled() && store.hint(); as h) {
@@ -91,74 +66,124 @@
     </div>
   }
 
-  <!-- ===== Body row: the note document (HERO) + the optional Ask-Brain drawer.
-       A flex ROW so opening the drawer SHRINKS the document column (the editor
-       stays fully visible, never covered). The embedded editor is ALWAYS MOUNTED
-       (one live flush target). ===== -->
+  <!-- The note document (HERO) — the embedded editor, ALWAYS MOUNTED (one live flush
+       target) and ALWAYS FULL WIDTH of the card; its own `.note-doc` centers the
+       writing column to the calm measure. The `/` slash "Ask Brain" entry emits
+       `askBrain` → summon the panel below. -->
   <div class="surface-body">
     <div class="note-host">
-      <app-note-editor [embedded]="true" [noteIdInput]="store.companionNoteId()" />
+      <app-note-editor
+        [embedded]="true"
+        [noteIdInput]="store.companionNoteId()"
+        (askBrain)="store.openAskPanel()"
+      />
     </div>
-
-    @if (drawerOpen()) {
-      <aside class="ask-drawer" aria-label="Ask Brain about this meeting">
-        <div class="flow" #flow>
-          @if (!store.hasNotes()) {
-            <p class="flow-empty text-muted">
-              Ask the brain about this meeting and everything related — it answers
-              here with sources you can follow. An answer can be added straight into
-              your note.
-            </p>
-          }
-          @for (n of store.notes(); track n.id) {
-            <app-note-item [note]="n" (followed)="scrollToBottom()" />
-          }
-        </div>
-
-        <!-- Ask-Brain input row: voice mic + a plain single-line question input + Ask. -->
-        <form class="composer" (submit)="submitAsk($event)">
-          <button
-            type="button"
-            class="mic-btn"
-            [class.is-listening]="store.listening()"
-            [disabled]="store.processing()"
-            (click)="toggleAsk()"
-            [attr.aria-pressed]="store.listening()"
-            [attr.aria-label]="
-              store.listening() ? 'Stop listening and ask' : 'Ask by voice'
-            "
-            [title]="store.listening() ? 'Stop & ask' : 'Ask by voice'"
-          >
-            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-              <path
-                d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
-                fill="currentColor"
-              />
-              <path
-                d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
-                fill="currentColor"
-                opacity="0.85"
-              />
-            </svg>
-          </button>
-          <input
-            #askInput
-            type="text"
-            class="ask-input"
-            placeholder="Ask about this meeting…"
-            aria-label="Ask about this meeting"
-            [value]="askDraft()"
-            (input)="onAskInput($event)"
-          />
-          <button
-            type="submit"
-            class="btn btn-primary send-btn"
-            [disabled]="!canAsk()"
-          >
-            Ask
-          </button>
-        </form>
-      </aside>
-    }
   </div>
+
+  <!-- ===== Summoned Ask-Brain panel — an OPAQUE sheet (T3) that floats over the
+       notepad ON DEMAND without unmounting the always-mounted editor. Preset chips
+       in the empty state replace the lonely "Ask Brain" link. ===== -->
+  @if (store.askPanelOpen()) {
+    <aside class="ask-panel" role="dialog" aria-label="Ask Brain about this meeting">
+      <header class="ask-panel-head">
+        <span class="ask-panel-title">
+          <svg
+            class="ask-panel-glyph"
+            viewBox="0 0 16 16"
+            width="14"
+            height="14"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M8 1.5l1.3 3.2L12.5 6 9.3 7.3 8 10.5 6.7 7.3 3.5 6l3.2-1.3L8 1.5Z"
+              stroke="currentColor"
+              stroke-width="1.2"
+              stroke-linejoin="round"
+            />
+          </svg>
+          Ask Brain
+        </span>
+        <button
+          type="button"
+          class="ask-panel-close"
+          (click)="closeAsk()"
+          aria-label="Close Ask Brain"
+        >
+          <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+
+      <div class="flow" #flow>
+        @if (!store.hasNotes()) {
+          <p class="flow-empty text-muted">
+            Ask about this meeting and everything related — the Brain answers here
+            with sources you can follow, and an answer can be added straight into
+            your note.
+          </p>
+          <div class="preset-chips" role="group" aria-label="Suggested questions">
+            @for (p of askPresets; track p) {
+              <button type="button" class="preset-chip" (click)="askPreset(p)">
+                {{ p }}
+              </button>
+            }
+          </div>
+        }
+        @for (n of store.notes(); track n.id) {
+          <app-note-item [note]="n" (followed)="scrollToBottom()" />
+        }
+      </div>
+
+      <!-- Ask-Brain input row: voice mic + a plain single-line question input + Ask. -->
+      <form class="composer" (submit)="submitAsk($event)">
+        <button
+          type="button"
+          class="mic-btn"
+          [class.is-listening]="store.listening()"
+          [disabled]="store.processing()"
+          (click)="toggleAsk()"
+          [attr.aria-pressed]="store.listening()"
+          [attr.aria-label]="
+            store.listening() ? 'Stop listening and ask' : 'Ask by voice'
+          "
+          [title]="store.listening() ? 'Stop & ask' : 'Ask by voice'"
+        >
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <path
+              d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
+              fill="currentColor"
+            />
+            <path
+              d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
+              fill="currentColor"
+              opacity="0.85"
+            />
+          </svg>
+        </button>
+        <input
+          #askInput
+          type="text"
+          class="ask-input"
+          placeholder="Ask about this meeting…"
+          aria-label="Ask about this meeting"
+          [value]="askDraft()"
+          (input)="onAskInput($event)"
+        />
+        <button
+          type="submit"
+          class="btn btn-primary send-btn"
+          [disabled]="!canAsk()"
+        >
+          Ask
+        </button>
+      </form>
+    </aside>
+  }
 </div>

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.scss
@@ -1,15 +1,18 @@
-/* The surface fills its host (the record screen makes it the full-height main
-   view) so the note + drawer grow to the bottom. */
+/* Calm-Notepad recording surface (2026-07-19). The surface fills its host (the record
+   screen makes it the full-height main view); the companion note is the centered HERO
+   and Ask Brain is a SUMMONED opaque sheet, never a beside-the-editor split. */
 :host {
   display: block;
   height: 100%;
 }
 
-/* OPAQUE hero card (v3, 2026-07-18): overrides the frosted global `.card` so glass
-   stays CHROME, never a content panel wrapping the editor + its overlays (T3/T4).
-   The floating overlays the editor spawns teleport to <body>, so this card no
-   longer needs to be their (broken) containing block. */
+/* OPAQUE hero card: overrides the frosted global `.card` so glass stays CHROME, never a
+   content panel wrapping the editor + its overlays (T3/T4). `position: relative` anchors
+   the summoned Ask-Brain sheet within the card. The floating overlays the editor spawns
+   (`/`/`[[` menus, selection toolbar) teleport to <body>, so this card doesn't need to be
+   their containing block. */
 .surface {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -20,56 +23,37 @@
   backdrop-filter: none;
 }
 
-.surface-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.head-orb {
-  --orb-size: 22px;
-}
-.surface-hint {
-  flex: 1 1 auto;
-  min-width: 0;
-  color: var(--text-muted);
-  font-size: 0.78rem;
-}
-
-/* Ask-Brain drawer toggle (replaces the retired segmented tabs). Neutral ghost
-   pill; the active/open state reads as a selected chrome control. */
-.ask-toggle {
-  position: relative;
+/* Quiet enhance-honesty hint — centered on the note's measure, above the document. It
+   tints accent as the note shapes the summary (enhancing / settled). */
+.enhance-hint {
   flex: none;
-  gap: var(--space-1);
-  height: 30px;
-  padding: 0 var(--space-3);
-  font-size: 0.82rem;
+  width: 100%;
+  max-width: var(--editor-measure);
+  margin: 0 auto;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.8rem;
 }
-.ask-toggle.is-active {
-  background: var(--shell-active-bg, var(--surface-hover));
-  color: var(--text-primary);
+.enhance-hint.is-enhancing,
+.enhance-hint.is-settled {
+  color: var(--accent);
+  animation: rise 200ms var(--transition) both;
 }
-.ask-toggle-glyph {
-  color: var(--accent-hover);
-}
-.ask-toggle-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 8px var(--accent-soft);
+@media (prefers-reduced-motion: reduce) {
+  .enhance-hint.is-enhancing,
+  .enhance-hint.is-settled {
+    animation: none;
+  }
 }
 
-/* ── Body row: the note document (hero) + optional Ask-Brain drawer ────────── */
+/* ── The note document is the full-width HERO; its own `.note-doc` centers the writing
+   column to the calm measure (--editor-measure). The embedded editor is ALWAYS MOUNTED
+   (one live flush target). ── */
 .surface-body {
   display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  gap: var(--space-3);
   flex: 1 1 auto;
   min-height: 0;
 }
-/* The note editor is the always-visible HERO; it SHRINKS when the drawer opens. */
 .note-host {
   display: flex;
   flex-direction: column;
@@ -85,35 +69,7 @@
   overflow: auto;
 }
 
-/* The Ask-Brain drawer — a docked side panel (in-flow, not a floating overlay), so
-   it uses a left border + its own scroll. Slides in without a transform-based
-   entry animation (which would trap any position:fixed descendant). */
-.ask-drawer {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  flex: 0 0 clamp(280px, 34%, 380px);
-  min-width: 0;
-  min-height: 0;
-  padding-left: var(--space-3);
-  border-left: 1px solid var(--border-subtle);
-  animation: ask-drawer-in var(--transition-dur) var(--transition-ease, ease) both;
-}
-@keyframes ask-drawer-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .ask-drawer {
-    animation: none;
-  }
-}
-
-/* ── Ambient live reactions — recall + contradiction lanes above the body ──── */
+/* ── Ambient live reactions — recall + contradiction lanes above the body ── */
 .reactions-rail {
   display: flex;
   flex-direction: column;
@@ -152,13 +108,118 @@
   font-size: 0.8rem;
 }
 
-/* ── The scrollable Ask-Brain flow (oldest → newest), inside the drawer ────── */
+/* ===== Summoned Ask-Brain panel — an OPAQUE sheet (T3: --surface-overlay + border-strong
+   + shadow-lg, NEVER the frosted `.card`) floating over the notepad ON DEMAND, without
+   unmounting the always-mounted editor. Opacity-only entry: a transform would trap any
+   position:fixed descendant. ===== */
+.ask-panel {
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  bottom: var(--space-3);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 62%;
+  padding: var(--space-3);
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  animation: ask-panel-in var(--transition-dur) ease both;
+}
+@keyframes ask-panel-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ask-panel {
+    animation: none;
+  }
+}
+.ask-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: none;
+}
+.ask-panel-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.ask-panel-glyph {
+  color: var(--accent-hover);
+}
+.ask-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    color var(--transition);
+}
+.ask-panel-close:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.ask-panel-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+/* Preset one-tap Ask starters — the empty-state antidote to the lonely link. */
+.preset-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+.preset-chip {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition:
+    border-color var(--transition),
+    background var(--transition);
+}
+.preset-chip:hover {
+  border-color: var(--accent-ring);
+  background: var(--accent-soft);
+}
+.preset-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+/* ── The scrollable Ask-Brain flow (oldest → newest), inside the panel ── */
 .flow {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
   flex: 1 1 auto;
-  min-height: 120px;
+  min-height: 80px;
   overflow-y: auto;
   padding-right: var(--space-1);
 }
@@ -171,7 +232,7 @@
   display: block;
 }
 
-/* ── Ask-Brain input row: voice mic + single-line question input + Ask ─────── */
+/* ── Ask-Brain input row: voice mic + single-line question input + Ask ── */
 .composer {
   display: flex;
   align-items: center;
@@ -256,19 +317,6 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .mic-btn.is-listening {
-    animation: none;
-  }
-}
-
-/* ── ENHANCE-MY-NOTES: the head hint tints accent as the note shapes the summary. ── */
-.surface-hint.is-enhancing,
-.surface-hint.is-settled {
-  color: var(--accent);
-  animation: rise 200ms var(--transition) both;
-}
-@media (prefers-reduced-motion: reduce) {
-  .surface-hint.is-enhancing,
-  .surface-hint.is-settled {
     animation: none;
   }
 }

--- a/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
+++ b/src/app/features/record/meeting-conversation/meeting-conversation.component.ts
@@ -14,7 +14,6 @@ import {
 } from "@angular/core";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
 import { NoteEditorComponent } from "../../notes/note-editor/note-editor.component";
-import { AiOrbComponent } from "../ai-orb/ai-orb.component";
 import { NoteItemComponent } from "../note-item/note-item.component";
 import { ProactiveHintCardComponent } from "../proactive-hint-card/proactive-hint-card.component";
 import { WhisperCardComponent } from "../whisper-card/whisper-card.component";
@@ -51,7 +50,6 @@ import { WhisperCardComponent } from "../whisper-card/whisper-card.component";
   selector: "app-meeting-conversation",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    AiOrbComponent,
     NoteEditorComponent,
     NoteItemComponent,
     ProactiveHintCardComponent,
@@ -78,13 +76,18 @@ export class MeetingConversationComponent implements OnInit {
   readonly settled = input(false);
   readonly enhanceAware = input(false);
 
-  /** Whether the Ask-Brain drawer is open (the note editor is the always-visible hero). */
-  protected readonly drawerOpen = signal(false);
-
-  /** A quiet dot on the Ask-Brain toggle when a closed drawer hides an ongoing thread. */
-  protected readonly askUnseen = computed(
-    () => !this.drawerOpen() && this.store.hasNotes(),
-  );
+  /**
+   * Preset one-tap Ask-Brain starters shown in the summoned panel's empty state —
+   * the antidote to the "lonely Ask Brain link" (Fireflies/Zoom live-assist).
+   * Biased to what the on-device Brain answers well DURING a meeting (your notes +
+   * prior-meeting retrieval), not a pretend two-speaker live transcript.
+   */
+  protected readonly askPresets: readonly string[] = [
+    "Summarize what I've noted so far",
+    "What did we decide?",
+    "Draft a follow-up message",
+    "Pull related notes on this meeting",
+  ];
 
   /** Whether any live reaction is showing (drives the ambient rail's presence). */
   protected readonly hasReactions = computed(
@@ -94,9 +97,12 @@ export class MeetingConversationComponent implements OnInit {
       this.store.showShadowCalibration(),
   );
 
-  /** During the enhance pass the orb shows its shipped 'processing' choreography. */
-  readonly orbStateView = computed(() =>
-    this.enhancing() ? ("processing" as const) : this.store.orbState(),
+  /** True while the enhance hint should surface (quiet, centered, above the note). */
+  protected readonly enhanceHintVisible = computed(
+    () =>
+      this.enhancing() ||
+      this.settled() ||
+      (this.enhanceAware() && this.store.hasPersistedNotes()),
   );
 
   /** This session's Ask-Brain question draft (signal-backed — zoneless). */
@@ -119,12 +125,34 @@ export class MeetingConversationComponent implements OnInit {
     });
 
     // Auto-scroll the Ask flow to the newest turn whenever the conversation changes
-    // AND the drawer is open. afterNextRender is zoneless-safe (no signal writes).
+    // AND the panel is open. afterNextRender is zoneless-safe (no signal writes).
     effect(() => {
       this.store.notes();
-      if (this.drawerOpen()) {
+      if (this.store.askPanelOpen()) {
         afterNextRender(() => this.scrollToBottom(), { injector: this.injector });
       }
+    });
+
+    // Ask-Brain panel lifecycle (Calm-Notepad, 2026-07-19). The open/closed state
+    // lives in the ROOT store (summoned by the footer ✦ / the `/` slash "Ask Brain"
+    // entry / a preset chip). On OPEN, focus the question input for a fast ask. On
+    // CLOSE, reload the always-mounted editor + refresh the enhance-honesty content
+    // so an Ask-Brain "Add to note" append is reflected in the hero document — the
+    // retired toggleDrawer's close semantics, now driven by the shared signal. The
+    // prev flag is closure-local: on a remount both values start false (the panel is
+    // closed on mount), so no spurious reload/focus fires.
+    let prevPanelOpen = false;
+    effect(() => {
+      const open = this.store.askPanelOpen();
+      if (open && !prevPanelOpen) {
+        afterNextRender(() => this.askInput()?.nativeElement.focus(), {
+          injector: this.injector,
+        });
+      } else if (!open && prevPanelOpen) {
+        this.noteEditor()?.reload();
+        this.store.refreshCompanionContentNow();
+      }
+      prevPanelOpen = open;
     });
   }
 
@@ -134,24 +162,18 @@ export class MeetingConversationComponent implements OnInit {
     void this.store.init();
   }
 
-  /**
-   * Toggle the Ask-Brain drawer. CLOSING reloads the always-mounted editor in place
-   * (so an Ask-Brain "Add to note" append / external edit is reflected in the hero
-   * document) + refreshes the enhance-honesty content signal — mirroring the retired
-   * return-to-Note-tab semantics without destroying the one live flush target.
-   * OPENING focuses the question input for a fast ask.
-   */
-  protected toggleDrawer(): void {
-    const next = !this.drawerOpen();
-    this.drawerOpen.set(next);
-    if (next) {
-      afterNextRender(() => this.askInput()?.nativeElement.focus(), {
-        injector: this.injector,
-      });
-    } else {
-      this.noteEditor()?.reload();
-      this.store.refreshCompanionContentNow();
-    }
+  /** Dismiss the summoned Ask-Brain panel (close × / Esc). The editor reload +
+   * content refresh runs on the closed edge in the panel-lifecycle effect. */
+  protected closeAsk(): void {
+    this.store.closeAskPanel();
+  }
+
+  /** Fire a preset starter → ensure the panel is open, then open a thread. */
+  protected askPreset(question: string): void {
+    this.store.openAskPanel();
+    void this.store.openThread(question).catch(() => {
+      /* the store resolves the agent turn with an error in the thread */
+    });
   }
 
   /** Scroll the Ask-Brain flow to its newest content. */

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -53,110 +53,18 @@
     </div>
   }
 
-  <!-- ── Slim recording bar — ambient status, NOT the hero ─────────────── -->
+  <!-- ── While recording: a THIN top line — the single alive heartbeat (the orb) +
+       the timer. Recording is ambient chrome; the centered notepad below is the hero.
+       Controls (mic-mute · captions · Ask · Stop) live in the footer HUD. ────────── -->
   @if (store.isRecording()) {
-    <!-- Recording is now ambient: a compact horizontal bar carrying the orb,
-         timer, level meter, the LIVE caption ticker, mic-mute, Ask, and Stop.
-         The conversation thread below is the hero. -->
-    <div class="rec-strip is-recording" role="status">
+    <div class="rec-topline" role="status">
       <span class="orb live" aria-hidden="true"></span>
       <span class="timer">{{ elapsedLabel() }}</span>
-      <div class="wave" [style.--level]="store.level()" aria-hidden="true">
-        @for (b of bars; track b) {
-          <span class="wbar" [style.--i]="b"></span>
-        }
-      </div>
-
-      <!-- Live caption ticker — rides inline in the strip. -->
-      <p class="cc-line" aria-live="polite">
-        @if (liveCaption(); as cc) {
-          @for (rev of [cc]; track rev) {
-            <span class="cc-text">{{ cc }}</span>
-          }
-        } @else {
-          <span class="cc-idle">Listening…</span>
-        }
-      </p>
-
-      <!-- Honesty hint: live captions are mic-only until Stop (matches the
-           README "Live captions are mic-only until you stop"). The other
-           side's system audio is captured in parallel and folded into the
-           full Me / Others transcript only after you stop. Compact + muted +
-           flex:none so it never crowds the ticker (which absorbs the flex). -->
-      <span
-        class="cc-scope"
-        role="note"
-        title="Live captions show your side (your microphone) during the meeting. The other participants are captured now and added to the full Me / Others transcript after you stop."
-      >
-        <svg
-          class="cc-scope-ico"
-          viewBox="0 0 16 16"
-          width="12"
-          height="12"
-          aria-hidden="true"
-        >
-          <circle
-            cx="8"
-            cy="8"
-            r="6.5"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.3"
-          />
-          <path
-            d="M8 7.2v4"
-            stroke="currentColor"
-            stroke-width="1.3"
-            stroke-linecap="round"
-          />
-          <circle cx="8" cy="4.6" r="0.9" fill="currentColor" />
-        </svg>
-        <span class="cc-scope-text">Your side · full transcript after Stop</span>
-      </span>
-
-      <!-- Mic-mute: silences only the local mic; system audio keeps recording.
-           Compact (icon-only) so the strip stays uncrowded. -->
-      <app-mic-mute-toggle [compact]="true" #micToggle />
-      <!-- Ask AI — CLICK-TO-STOP voice toggle. The spoken answer lands in the
-           conversation thread below (the one home for asking mid-meeting). -->
-      <button
-        type="button"
-        class="ask-btn"
-        [class.is-listening]="assistant.listening()"
-        [disabled]="assistant.processing()"
-        (click)="toggleAsk()"
-        [attr.aria-pressed]="assistant.listening()"
-        [attr.aria-label]="
-          assistant.listening()
-            ? 'Stop listening and ask'
-            : 'Ask the AI assistant'
-        "
-      >
-        <svg
-          class="ask-ico"
-          viewBox="0 0 24 24"
-          width="18"
-          height="18"
-          aria-hidden="true"
-        >
-          <path
-            d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
-            fill="currentColor"
-          />
-          <path
-            d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
-            fill="currentColor"
-            opacity="0.85"
-          />
-        </svg>
-      </button>
-      <button
-        type="button"
-        class="stop-btn"
-        (click)="store.stop()"
-        aria-label="Stop recording"
-      >
-        <span class="stop-ico" aria-hidden="true"></span>
+      <span class="rec-topline-label">Recording</span>
+      <span class="rec-topline-spacer"></span>
+      <button type="button" class="popout" (click)="popOut()">
+        Pop out
+        <span class="kbd-inline">⌘⇧R</span>
       </button>
     </div>
   } @else {
@@ -234,6 +142,103 @@
       [settled]="enhanceSettled()"
       [enhanceAware]="enhanceMode()"
     />
+  }
+
+  <!-- ── Ambient footer HUD — the recording controls, receded (Calm-Notepad, 2026-07-19):
+       mic-mute · the LIVE caption ticker (mic-only, honesty-noted) · Ask (summons the
+       panel) · Stop. Only while recording, so the note owns the surface otherwise. ── -->
+  @if (store.isRecording()) {
+    <div class="rec-foot" role="group" aria-label="Recording controls">
+      <!-- Mic-mute: silences only the local mic; system audio keeps recording. -->
+      <app-mic-mute-toggle [compact]="true" #micToggle />
+
+      <!-- Live caption ticker — the mic-only partial. -->
+      <p class="cc-line" aria-live="polite">
+        @if (liveCaption(); as cc) {
+          @for (rev of [cc]; track rev) {
+            <span class="cc-text">{{ cc }}</span>
+          }
+        } @else {
+          <span class="cc-idle">Listening…</span>
+        }
+      </p>
+
+      <!-- Honesty hint: live captions are your side (your mic) only; the other
+           participants are captured now and folded into the full Me / Others
+           transcript after you Stop. -->
+      <span
+        class="cc-scope"
+        role="note"
+        title="Live captions show your side (your microphone) during the meeting. The other participants are captured now and added to the full Me / Others transcript after you stop."
+      >
+        <svg
+          class="cc-scope-ico"
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.3"
+          />
+          <path
+            d="M8 7.2v4"
+            stroke="currentColor"
+            stroke-width="1.3"
+            stroke-linecap="round"
+          />
+          <circle cx="8" cy="4.6" r="0.9" fill="currentColor" />
+        </svg>
+        <span class="cc-scope-text">Your side · full transcript after Stop</span>
+      </span>
+
+      <!-- Ask — SUMMONS the Brain panel over the notepad (voice + text + presets live
+           in the panel). A quiet dot marks an ongoing thread while the panel is closed. -->
+      <button
+        type="button"
+        class="ask-pill"
+        [class.is-active]="assistant.askPanelOpen()"
+        (click)="assistant.toggleAskPanel()"
+        [attr.aria-pressed]="assistant.askPanelOpen()"
+        aria-label="Ask the Brain about this meeting"
+      >
+        <svg
+          class="ask-ico"
+          viewBox="0 0 24 24"
+          width="16"
+          height="16"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z"
+            fill="currentColor"
+          />
+          <path
+            d="M18.5 14l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2z"
+            fill="currentColor"
+            opacity="0.85"
+          />
+        </svg>
+        <span class="ask-pill-label">Ask</span>
+        @if (assistant.hasNotes() && !assistant.askPanelOpen()) {
+          <span class="ask-dot" aria-hidden="true"></span>
+        }
+      </button>
+
+      <button
+        type="button"
+        class="stop-btn"
+        (click)="store.stop()"
+        aria-label="Stop recording"
+      >
+        <span class="stop-ico" aria-hidden="true"></span>
+      </button>
+    </div>
   }
 
   @if (store.error(); as err) {
@@ -334,4 +339,3 @@
     }
   }
 </section>
-  

--- a/src/app/features/record/record/record.component.scss
+++ b/src/app/features/record/record/record.component.scss
@@ -115,9 +115,26 @@
   box-shadow: var(--glass-highlight);
   animation: bar-in 320ms var(--ease-spring) both;
 }
-.rec-strip.is-recording {
-  border-color: rgba(255, 122, 92, 0.4);
-  box-shadow: var(--live-glow), var(--glass-highlight);
+/* ── While recording: a THIN, quiet top line — the single alive heartbeat (the orb)
+   + the timer. Ambient chrome: low contrast, NO card/glow, so the notepad below reads
+   as the hero (Calm-Notepad, 2026-07-19). ── */
+.rec-topline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-secondary);
+  animation: bar-in 320ms var(--ease-spring) both;
+}
+.rec-topline-label {
+  font-size: 0.85rem;
+  font-weight: 550;
+  color: var(--text-secondary);
+  letter-spacing: -0.005em;
+}
+.rec-topline-spacer {
+  flex: 1;
 }
 .rec-strip.is-idle {
   flex-wrap: wrap;
@@ -253,38 +270,6 @@
   min-width: 48px;
   flex: none;
 }
-.wave {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  width: 84px;
-  height: 28px;
-  /* Guard: bars can never spill past the fixed box into the caption line. */
-  overflow: hidden;
-}
-.wbar {
-  flex: 1;
-  min-width: 2px;
-  max-width: 5px;
-  height: 100%;
-  border-radius: var(--radius-pill);
-  background: var(--live-gradient);
-  transform: scaleY(0.16);
-  transform-origin: center;
-  animation: wave 1100ms ease-in-out infinite;
-  animation-delay: calc(var(--i) * -78ms);
-}
-@keyframes wave {
-  0%,
-  100% {
-    transform: scaleY(calc(0.14 + var(--level, 0) * 0.55));
-  }
-  50% {
-    transform: scaleY(calc(0.32 + var(--level, 0) * 1.15));
-  }
-}
-
 /* Stop — warm circular button with a rounded square glyph (slim). */
 .stop-btn {
   display: inline-flex;
@@ -321,67 +306,81 @@
   background: var(--text-on-accent);
 }
 
-/* Ask AI — sparkle button beside Stop. Calm accent at idle, pulsing glow
-   while the assistant is listening so it's unmistakable. */
-.ask-btn {
+/* ── Ambient footer HUD — receded recording controls (Calm-Notepad, 2026-07-19).
+   A quiet glass bar pinned below the notepad: mic-mute · caption ticker · Ask · Stop.
+   Chrome that supports the content, never competes with it. ── */
+.rec-foot {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: none;
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  -webkit-backdrop-filter: blur(var(--glass-blur))
+    saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  box-shadow: var(--glass-highlight);
+  animation: bar-in 320ms var(--ease-spring) both;
+}
+
+/* Ask — a labeled pill that SUMMONS the Brain panel (voice + text + presets live
+   in the panel). The single ✦ affordance, per Calm-Notepad. */
+.ask-pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  min-width: 40px;
+  gap: var(--space-1);
   flex: none;
+  height: 34px;
+  padding: 0 var(--space-3);
   border: 1px solid var(--accent-ring);
-  border-radius: 50%;
+  border-radius: var(--radius-pill);
   color: var(--accent-hover);
   background: var(--accent-soft);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 550;
   cursor: pointer;
   transition:
     transform var(--transition-fast),
     background var(--transition),
-    box-shadow var(--transition),
     color var(--transition);
 }
-.ask-btn:hover {
+.ask-pill:hover {
   background: var(--accent);
   color: var(--text-on-accent);
-  transform: scale(1.05);
+  transform: translateY(-1px);
 }
-.ask-btn:active {
-  transform: scale(0.96);
+.ask-pill:active {
+  transform: translateY(0);
 }
-.ask-btn:focus-visible {
+.ask-pill:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-ring);
 }
-.ask-btn.is-listening {
-  background: var(--accent-gradient);
+.ask-pill.is-active {
+  background: var(--accent);
   color: var(--text-on-accent);
   border-color: transparent;
-  animation: ask-pulse 1.5s ease-in-out infinite;
+}
+.ask-pill-label {
+  line-height: 1;
 }
 .ask-ico {
   display: block;
 }
-@keyframes ask-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 var(--accent-ring);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(110, 118, 255, 0);
-  }
-}
-
-.ask-btn:disabled {
-  opacity: 0.55;
-  cursor: default;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .ask-btn.is-listening {
-    animation: none;
-  }
+/* Quiet dot: an ongoing Ask thread while the panel is closed. */
+.ask-dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-soft);
 }
 
 /* Processing — cool, calm, working (inline in the idle strip). */

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -69,11 +69,6 @@ export class RecordComponent implements OnInit {
   /** Handle for the meeting-app poll — cleared on destroy (no leaked interval). */
   private meetingAppPoll: ReturnType<typeof setInterval> | null = null;
 
-  /** Bars in the live waveform (driven by the real mic level signal). 16 bars fit the fixed
-   * 84px `.wave` box (16×2px min + 15×2px gap ≈ 62px) with room to flex; 28 overflowed the box
-   * and spilled into the caption ("…IIIIDzięki za oglądanie!"). */
-  readonly bars = Array.from({ length: 16 }, (_, i) => i);
-
   /** The in-pill mic-mute toggle — its `muted()` signal drives the stage hint. */
   private readonly micToggle = viewChild(MicMuteToggleComponent);
 
@@ -460,27 +455,6 @@ export class RecordComponent implements OnInit {
   /** Summon the floating always-on-top bar (also bound to ⌘⇧R globally). */
   popOut(): void {
     void this.ipc.toggleBar();
-  }
-
-  /**
-   * CLICK-TO-STOP toggle for the "Ask AI" (✨) button. First click opens the
-   * voice-command listener (no wake phrase); a second click — while listening —
-   * stops it so the FULL utterance is dispatched (→ processing). The backend
-   * streams listening/processing over EVENT_VOICE_COMMAND_LISTENING /
-   * EVENT_VOICE_COMMAND_PROCESSING and the spoken answer lands in a thread on the
-   * notes surface below. Swallow rejections (e.g. brain backend off) — the store
-   * resets its listening/processing/in-flight state on error.
-   */
-  toggleAsk(): void {
-    if (this.assistant.listening()) {
-      void this.assistant.endAsk().catch(() => {
-        /* stop failed — store cleared processing/in-flight */
-      });
-    } else {
-      void this.assistant.askNow().catch(() => {
-        /* listener unavailable — store resets the in-flight/listening state */
-      });
-    }
   }
 
   /**

--- a/src/design-tokens/layout.css
+++ b/src/design-tokens/layout.css
@@ -49,6 +49,15 @@
      (92% of the available pane), not a fixed design value. */
   --editor-max: 920px;
 
+  /* The EMBEDDED note editor's calm-notepad measure (Calm-Notepad recording
+     redesign, 2026-07-19). While recording, the companion note is a centered
+     WRITING column — not a full-bleed document — so a single line reads as a
+     calm notepad, not a gargantuan empty canvas. ~40rem (≈640px) is a
+     comfortable reading measure (~66ch at the body size) with generous
+     symmetric margin. Distinct from --editor-max (920px), which is the routed
+     full-page document width, not the in-meeting notepad. */
+  --editor-measure: 40rem;
+
   /* Per-NESTING-LEVEL indent step for the sidebar's folder trees (2026-07-12
      fix) — ONE shared token so Meetings' recursive `--depth` calc
      (folder-row.component.scss) and Notes' flat single-level list


### PR DESCRIPTION
## The problem

While recording, the note view read as **"gargantuan"** — a viewport-filling, unmeasured, mostly-empty note card with the text jammed top-left, a lonely "Ask Brain" link, and a beside-editor drawer that halved the column. The chrome carried all the visual mass; the content was dwarfed by its own frame.

## The redesign — "Calm Notepad" (Direction A, research-backed)

Synthesized from four research streams (Granola & notes-first recorders · transcript-heavy tools · empty-state / Liquid-Glass principles · inline-AI patterns) and chosen via an interactive prototype.

| Before | After |
|---|---|
| Note full-width, text top-left of a void | **Centered ~40rem writing column** (new `--editor-measure` token) — surplus becomes deliberate margin |
| Heavy strip with orb/timer/wave/caption/ask/stop | **Thin top line** (live orb + timer) — one breathing heartbeat, waveform dropped |
| — | **Ambient footer HUD**: mic-mute · caption ticker · "Your side · full transcript after Stop" · **✦ Ask** · Stop |
| Ask = beside-editor split / lonely link | **Summoned opaque sheet** (T3 `--surface-overlay`) via footer ✦, a `/` slash "Ask Brain" entry (embedded-only), or **preset chips** — never a standing split |
| Empty canvas | **Warm ghost prompt** — "Type to take notes — / for blocks, or Ask Brain" |

The embedded editor stays **always-mounted** (the flush-at-Stop target); the panel floats over it without unmounting. Panel state lives in the root `MeetingConversationStore` (shared bus for the footer / slash / chips). The routed `/notes/:id` editor is **byte-identical** (slash catalog + placeholder gated on `embedded()`).

**FE-only** — no backend/IPC/lock/crypto/visibility change.

## Verification

- `ng lint` + `ng build` green (record-component within the 16 kB per-component budget).
- **Record e2e 10/10** — incl. `companion-note-flush-before-stop` (flush path intact) and the three updated summon-model specs.
- **Independent adversarial-verifier: PASS** — the flush-target editor never remounts across panel toggle; the summoned panel is opaque + on-screen (T3); `/`-ask strips its slash; the routed editor is unchanged with no "Ask Brain" leak; the idle screen is crash-free — all with zero console / NG0600 / ɵcmp errors.
- Signed-build boundary (unchanged, FE-only): Touch ID / lock-at-rest / screen-share still only truly verify on a notarized build.

## Follow-up — pre-existing, deliberately NOT bundled here

The verifier flagged a LOW, pre-existing prose-loss race: `reload()` on panel-close can clobber unsaved local edits within the 600 ms autosave debounce (present on trunk today via the old drawer, byte-identical). I built the "obvious" fix (`flushPendingSave()` before the re-fetch) **and rejected it** — an e2e proved it overwrites an Ask-Brain "Add to note" **append** in the common edit→append→close flow, trading a rare loss for a worse one. A correct fix needs a merge-aware strategy (or reflecting the append into the editor signal directly), tracked as a separate task.
