### PR TITLE
fix(record): Ask-Brain discoverable in / menu + one coherent top bar that fits the viewport

### DIFF
--- a/e2e/record/ask-ai-fail-no-orphan.spec.ts
+++ b/e2e/record/ask-ai-fail-no-orphan.spec.ts
@@ -39,7 +39,7 @@ test.describe("Record — a failed Ask AI leaves no orphaned mic bubble", () => 
     await page.goto("/record");
 
     await page.locator("button.start-btn").click();
-    await expect(page.locator(".rec-topline")).toBeVisible({
+    await expect(page.locator(".rec-topbar")).toBeVisible({
       timeout: 10_000,
     });
 

--- a/e2e/record/ask-brain-slash.spec.ts
+++ b/e2e/record/ask-brain-slash.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Calm-Notepad discoverability (2026-07-19): typing `/` in the recording note surfaces
+ * "✦ Ask Brain" as the FIRST slash-menu item (Notion-style AI-at-the-top), and picking
+ * it summons the Ask-Brain panel with the bare `/` stripped from the note. Guards the
+ * fix for it being buried at the bottom of the scrollable block menu (undiscoverable).
+ */
+test("typing / in the recording note shows Ask Brain first and summons the panel", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+  await mockTauri(page, {
+    model_present: () => true,
+    start_recording: () => ({
+      meetingId: "m-rec",
+      startedAt: "2026-07-01T09:00:00Z",
+    }),
+    get_or_create_companion_note: () => ({
+      noteId: "n1",
+      meetingWikilink: "[[Test Meeting]]",
+    }),
+    get_note: () => ({
+      id: "n1",
+      title: "Test Meeting",
+      folderId: "",
+      markdown: '---\nmeeting: "[[Test Meeting]]"\n---\n',
+      tags: [],
+      properties: {},
+      updatedAt: 0,
+      createdAt: 0,
+      exportedPath: null,
+      locked: false,
+      shared: false,
+    }),
+    get_backlinks: () => [],
+  });
+
+  await page.goto("/record");
+  await page.locator("button.start-btn").click();
+  const body = page.locator(
+    "app-meeting-conversation app-note-editor .editor-body textarea.body-area",
+  );
+  await expect(body).toBeVisible({ timeout: 10_000 });
+
+  // Type "/" at line start → the slash menu opens with Ask Brain pinned FIRST.
+  await body.click();
+  await body.press("/");
+  const menu = page.locator("app-meeting-conversation .slash-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu.locator(".menu-item").first()).toHaveText(/Ask Brain/);
+  await expect(menu.locator(".menu-item.is-ask")).toHaveText(/Ask Brain/);
+
+  // Pick it → the Ask panel is summoned and the bare "/" is stripped from the note.
+  await menu.locator(".menu-item.is-ask").click();
+  await expect(
+    page.locator("app-meeting-conversation .ask-panel"),
+  ).toBeVisible();
+  await expect(body).toHaveValue("");
+  expect(consoleErrors).toEqual([]);
+});

--- a/e2e/record/reload-reconcile-stage.spec.ts
+++ b/e2e/record/reload-reconcile-stage.spec.ts
@@ -39,7 +39,7 @@ test.describe("Record — webview (re)load reconciles the stage with the backend
 
     // WITHOUT clicking Start: the store's init() resync must adopt the
     // backend's in-flight recording.
-    await expect(page.locator(".rec-topline")).toBeVisible({
+    await expect(page.locator(".rec-topbar")).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.locator("button.stop-btn")).toBeVisible();
@@ -81,6 +81,6 @@ test.describe("Record — webview (re)load reconciles the stage with the backend
     });
     await expect(page.getByText(/Transcribing on-device/i)).toHaveCount(0);
     await expect(page.locator("button.stop-btn")).toHaveCount(0);
-    await expect(page.locator(".rec-topline")).toHaveCount(0);
+    await expect(page.locator(".rec-topbar")).toHaveCount(0);
   });
 });

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -92,6 +92,14 @@ export class LinkPickerComponent {
   readonly query = input<string>("");
   /** Which row is keyboard-highlighted, owned by the host. */
   readonly activeIndex = input<number>(0);
+  /**
+   * The ANCHOR item this picker links FROM — excluded from its own candidate list so a user can
+   * never pick the item they're already on (`list_link_candidates` is anchor-agnostic and would
+   * otherwise surface the current meeting/note in its own list, where picking it hit the self-link
+   * guard with a misleading toast). `null` (the default) excludes nothing.
+   */
+  readonly excludeKind = input<string | null>(null);
+  readonly excludeId = input<string | null>(null);
 
   /** A candidate was picked (click) — the host inserts `[[title]]` at the trigger position. */
   readonly picked = output<NoteCitation>();
@@ -156,15 +164,28 @@ export class LinkPickerComponent {
     this.destroyRef.onDestroy(() => this.debounce.cancel(DEBOUNCE_KEY));
   }
 
+  /** Drop the anchor item (the thing this picker links FROM) so it can't be picked as its own target. */
+  private withoutAnchor(rows: NoteCitation[]): NoteCitation[] {
+    const k = this.excludeKind();
+    const i = this.excludeId();
+    if (!k || !i) {
+      return rows;
+    }
+    return rows.filter((r) => !(r.kind === k && r.id === i));
+  }
+
   private async fetch(q: string): Promise<void> {
     const seq = ++this.requestSeq;
     this._loading.set(true);
     try {
-      const rows = await this.ipc.listLinkCandidates(q, 0, PAGE_SIZE);
+      const raw = await this.ipc.listLinkCandidates(q, 0, PAGE_SIZE);
       if (seq !== this.requestSeq) {
         return; // superseded by a newer query.
       }
-      this.hasMore = rows.length === PAGE_SIZE;
+      // `hasMore` keys on the RAW page length (the backend paginates the unfiltered list); the
+      // anchor is dropped only from what we display, so a full raw page still means "more to load".
+      this.hasMore = raw.length === PAGE_SIZE;
+      const rows = this.withoutAnchor(raw);
       this.candidates.set(rows);
       this.candidatesChange.emit(rows);
       // The list height changed (fresh page) — re-fit around the caret so a
@@ -195,7 +216,7 @@ export class LinkPickerComponent {
     const seq = this.requestSeq;
     this.loadingMore = true;
     try {
-      const page = await this.ipc.listLinkCandidates(
+      const rawPage = await this.ipc.listLinkCandidates(
         this.query(),
         this.candidates().length,
         PAGE_SIZE,
@@ -203,7 +224,8 @@ export class LinkPickerComponent {
       if (seq !== this.requestSeq) {
         return; // a newer query reset the list while this page was in flight.
       }
-      this.hasMore = page.length === PAGE_SIZE;
+      this.hasMore = rawPage.length === PAGE_SIZE;
+      const page = this.withoutAnchor(rawPage);
       // Dedupe on append: a row that shifted pages mid-scroll (e.g. a title
       // edit reordered recency) must not repeat — the template's
       // `track c.kind + c.id` requires unique keys.

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -594,6 +594,7 @@
                       class="menu-item"
                       role="option"
                       [class.is-active]="i === slashIndex()"
+                      [class.is-ask]="item.id === 'askBrain'"
                       [attr.aria-selected]="i === slashIndex()"
                       (click)="pickSlash(item)"
                     >

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -688,6 +688,15 @@
 .slash-menu .menu-item.is-active {
   background: var(--surface-hover);
 }
+/* "✦ Ask Brain" — the accented AI entry pinned to the top of the recording slash
+   menu, set apart from the block items by a hairline separator (Notion-style). */
+.slash-menu .menu-item.is-ask {
+  color: var(--accent-hover);
+  font-weight: 550;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 4px;
+  padding-bottom: calc(var(--space-2) + 4px);
+}
 
 /* "Full width" toggle item (⋯ menu) — a checkbox-style row: the checkmark
    floats to the trailing edge when the preference is ON. */

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -201,13 +201,16 @@ export class NoteEditorComponent {
 
   /**
    * The slash-menu catalog. On the routed editor this is exactly {@link SLASH_ITEMS}
-   * (byte-for-byte unchanged). When {@link embedded} (the recording surface) it
-   * appends an "Ask Brain" entry so `/` at the start of a line can summon the Brain
-   * without a standing side panel — the Calm-Notepad "summon, don't station" model.
+   * (byte-for-byte unchanged). When {@link embedded} (the recording surface) it puts
+   * an "Ask Brain" entry FIRST (Notion-style AI-at-the-top) so `/` immediately surfaces
+   * the Brain instead of burying it below 12 block items in the scrollable menu — the
+   * Calm-Notepad "summon, don't station" model. The default keyboard highlight still
+   * lands on the first BLOCK (see {@link maybeOpenSlash}) so `/`+Enter keeps inserting a
+   * heading; Ask is the prominent top item you click or arrow up to.
    */
   protected readonly slashItems = computed<readonly SlashItem[]>(() =>
     this.embedded()
-      ? [...SLASH_ITEMS, { id: "askBrain", label: "✦ Ask Brain" }]
+      ? [{ id: "askBrain", label: "✦ Ask Brain" }, ...SLASH_ITEMS]
       : SLASH_ITEMS,
   );
 
@@ -1866,7 +1869,10 @@ export class NoteEditorComponent {
     const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
     const line = value.slice(lineStart, pos);
     if (line === "/") {
-      this.slashIndex.set(0);
+      // When embedded, "Ask Brain" is item 0 — default the keyboard highlight to the
+      // first BLOCK (index 1) so `/`+Enter still inserts a heading; Ask stays the
+      // visible top item (click or ArrowUp). Routed editor is unchanged (index 0).
+      this.slashIndex.set(this.embedded() ? 1 : 0);
       this.slashOpen.set(true);
     } else if (!line.startsWith("/") || line.includes(" ")) {
       this.slashOpen.set(false);

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -1,4 +1,4 @@
-<section class="record">
+<section class="record" [class.is-recording]="store.isRecording()">
   @if (modelPresent() === false) {
     <div class="banner is-accent model-banner" role="alert">
       <span class="banner-icon" aria-hidden="true">↓</span>
@@ -43,7 +43,9 @@
     </div>
   }
 
-  @if (headphonesHint()) {
+  <!-- Headphones hint — a separate banner only when NOT recording; while recording it
+       folds into the single coherent top bar below (no stacked bands). -->
+  @if (headphonesHint() && !store.isRecording()) {
     <div class="banner is-accent" role="note">
       <span class="banner-icon" aria-hidden="true">🎧</span>
       <span>
@@ -53,15 +55,26 @@
     </div>
   }
 
-  <!-- ── While recording: a THIN top line — the single alive heartbeat (the orb) +
-       the timer. Recording is ambient chrome; the centered notepad below is the hero.
-       Controls (mic-mute · captions · Ask · Stop) live in the footer HUD. ────────── -->
+  <!-- ── While recording: ONE coherent top bar — the recording heartbeat (orb + timer)
+       + the headphones hint folded in (not a separate stacked banner) + Pop out. The
+       whole strip above the notepad reads as a single bar. ─────────────────────────── -->
   @if (store.isRecording()) {
-    <div class="rec-topline" role="status">
-      <span class="orb live" aria-hidden="true"></span>
-      <span class="timer">{{ elapsedLabel() }}</span>
-      <span class="rec-topline-label">Recording</span>
-      <span class="rec-topline-spacer"></span>
+    <div class="rec-topbar" role="status">
+      <span class="rt-status">
+        <span class="orb live" aria-hidden="true"></span>
+        <span class="timer">{{ elapsedLabel() }}</span>
+        <span class="rt-label">Recording</span>
+      </span>
+      @if (headphonesHint()) {
+        <span
+          class="rt-hint"
+          title="Capturing system audio — use headphones so the other participants' voices don't echo back into your microphone."
+        >
+          <span class="rt-hint-ico" aria-hidden="true">🎧</span>
+          Use <strong>headphones</strong> so others' voices don't echo into your mic
+        </span>
+      }
+      <span class="rt-spacer"></span>
       <button type="button" class="popout" (click)="popOut()">
         Pop out
         <span class="kbd-inline">⌘⇧R</span>
@@ -224,7 +237,7 @@
             opacity="0.85"
           />
         </svg>
-        <span class="ask-pill-label">Ask</span>
+        <span class="ask-pill-label">Ask Brain</span>
         @if (assistant.hasNotes() && !assistant.askPanelOpen()) {
           <span class="ask-dot" aria-hidden="true"></span>
         }

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -1,4 +1,4 @@
-<section class="record" [class.is-recording]="store.isRecording()">
+<section class="record" [class.is-bounded]="boundToViewport()">
   @if (modelPresent() === false) {
     <div class="banner is-accent model-banner" role="alert">
       <span class="banner-icon" aria-hidden="true">↓</span>

--- a/src/app/features/record/record/record.component.scss
+++ b/src/app/features/record/record/record.component.scss
@@ -8,6 +8,17 @@
   animation: rise 420ms var(--transition) both;
 }
 
+/* While recording, BOUND the surface to the viewport so the whole thing (top bar →
+   notepad → footer HUD) fits with NO page scroll — the note scrolls INTERNALLY. Mirrors
+   the note-editor's proven fill-the-pane calc (cancel app-main's top padding + tab strip)
+   + a negative bottom margin to cancel app-main's bottom padding so the footer reaches
+   the window bottom. Idle/done keep the min-height above (their stacked cards may scroll). */
+.record.is-recording {
+  height: calc(100vh - 10px - var(--tabs-strip-height, 0px) - var(--space-7));
+  min-height: 0;
+  margin-bottom: calc(-1 * var(--space-8));
+}
+
 /* ── The conversation thread = the full-height main surface ─────────── */
 .conversation {
   display: block;
@@ -115,26 +126,55 @@
   box-shadow: var(--glass-highlight);
   animation: bar-in 320ms var(--ease-spring) both;
 }
-/* ── While recording: a THIN, quiet top line — the single alive heartbeat (the orb)
-   + the timer. Ambient chrome: low contrast, NO card/glow, so the notepad below reads
-   as the hero (Calm-Notepad, 2026-07-19). ── */
-.rec-topline {
+/* ── While recording: ONE coherent top bar — the recording heartbeat (orb + timer) +
+   the headphones hint folded in + Pop out. A quiet glass strip matching the footer HUD,
+   so the top and bottom chrome bracket the notepad symmetrically (2026-07-19). ── */
+.rec-topbar {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   flex: none;
-  padding: var(--space-1) var(--space-2);
-  color: var(--text-secondary);
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  -webkit-backdrop-filter: blur(var(--glass-blur))
+    saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  box-shadow: var(--glass-highlight);
   animation: bar-in 320ms var(--ease-spring) both;
 }
-.rec-topline-label {
+.rt-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+.rt-label {
   font-size: 0.85rem;
   font-weight: 550;
   color: var(--text-secondary);
   letter-spacing: -0.005em;
 }
-.rec-topline-spacer {
-  flex: 1;
+/* Headphones hint, folded inline — muted, shrinks + truncates before it crowds. */
+.rt-hint {
+  flex: 0 1 auto;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rt-hint strong {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.rt-hint-ico {
+  margin-right: var(--space-1);
+}
+.rt-spacer {
+  flex: 1 1 auto;
 }
 .rec-strip.is-idle {
   flex-wrap: wrap;

--- a/src/app/features/record/record/record.component.scss
+++ b/src/app/features/record/record/record.component.scss
@@ -2,21 +2,25 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  /* Fill the routed viewport so the conversation thread can grow to the
-     bottom (conversation-first). The host is the flex parent. */
-  min-height: calc(100vh - var(--space-8));
+  /* Fill the routed viewport (conversation-first). CORRECT the fill so it never
+     overflows: cancel the chrome ABOVE the surface (main-col margin 10px + tab strip +
+     app-main's top padding --space-7); the old `calc(100vh - --space-8)` ignored all of
+     that and forced the surface ~--space-7 too tall (a permanent bottom overflow, worst
+     on small screens). A negative bottom margin cancels app-main's bottom padding so the
+     footer / last card can reach the window bottom. Mirrors the note-editor :host math. */
+  min-height: calc(100vh - 10px - var(--tabs-strip-height, 0px) - var(--space-7));
+  margin-bottom: calc(-1 * var(--space-8));
   animation: rise 420ms var(--transition) both;
 }
 
-/* While recording, BOUND the surface to the viewport so the whole thing (top bar →
-   notepad → footer HUD) fits with NO page scroll — the note scrolls INTERNALLY. Mirrors
-   the note-editor's proven fill-the-pane calc (cancel app-main's top padding + tab strip)
-   + a negative bottom margin to cancel app-main's bottom padding so the footer reaches
-   the window bottom. Idle/done keep the min-height above (their stacked cards may scroll). */
-.record.is-recording {
+/* When the note is the ACTIVE writing surface (recording / an in-flight pipeline with
+   the companion note visible — see boundToViewport), BOUND the height so the whole thing
+   (top bar → notepad → footer HUD) fits with NO page scroll and the note scrolls
+   INTERNALLY. The "done" review state stays unbounded (min-height above) so its stacked
+   Brain-reveal / Re-Truth cards can scroll. */
+.record.is-bounded {
   height: calc(100vh - 10px - var(--tabs-strip-height, 0px) - var(--space-7));
   min-height: 0;
-  margin-bottom: calc(-1 * var(--space-8));
 }
 
 /* ── The conversation thread = the full-height main surface ─────────── */

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -248,6 +248,20 @@ export class RecordComponent implements OnInit {
   );
 
   /**
+   * BOUND the record surface to the viewport (fixed height → the note scrolls
+   * INTERNALLY, nothing spills past the window) whenever the note is the active
+   * writing surface: while recording AND while a pipeline runs with the companion
+   * note visible. EXCLUDES the "done" review state — that stacks the Brain-reveal /
+   * Re-Truth cards below the note and legitimately needs the page to scroll. Idle
+   * (no note surface) also stays unbounded (its short content just fills the calm
+   * min-height). Fixes the note overflowing off the bottom on smaller screens
+   * (2026-07-19).
+   */
+  readonly boundToViewport = computed(
+    () => this.showAssistant() && this.store.stage() !== "done",
+  );
+
+  /**
    * The processing status line. Prefer the backend's status message — it is
    * already a clean, properly-cased sentence ("Summarizing with Claude Code…",
    * "Writing note to vault…") — and fall back to a Title-cased stage word only


### PR DESCRIPTION
Follow-up polish on the Calm-Notepad recording surface (#405), from live feedback.

## 1. Ask Brain is discoverable via `/`
Before, "✦ Ask Brain" was appended to the **bottom** of the 12-item scrollable slash menu — below the fold, invisible (users typed `/` and only saw block options). Now it's pinned **first**, accented, with a hairline separator (Notion-style AI-at-the-top). The default keyboard highlight stays on the first **block** so `/`+Enter still inserts a heading. Embedded-only — the routed `/notes` editor is byte-identical. The footer pill is relabeled **"Ask" → "Ask Brain"**.

## 2. One coherent top bar
The recording indicator and the headphones hint were two stacked bands. They now fold into a **single coherent glass top bar** (`● timer · Recording · 🎧 headphones hint · Pop out`) that matches the footer HUD — top and bottom chrome bracket the notepad symmetrically.

## 3. Everything fits the viewport
While recording, the surface is **bounded to the viewport** (the note-editor's proven fill-the-pane calc + a negative bottom margin to cancel `app-main`'s padding), so **top bar → notepad → footer HUD fit with no page scroll** — the note scrolls internally. Idle/done states keep their scrollable stacked cards.

## Verification
- `ng lint` + `ng build` green.
- **record e2e 11/11** (incl. a new `ask-brain-slash` guard: `/` shows Ask Brain first → picking it summons the panel + strips the `/`).
- Viewport fit measured at **1440×900** and **1280×720**: `scrollHeight === innerHeight`, footer HUD bottom exactly at the viewport edge.
- Notes e2e unaffected (only the pre-existing, base-failing `source-picker-teleport-dismiss` flake).

FE-only — no backend/lock/visibility change.
