### PR TITLE
fix(record): reveal cards above the note in the done state + no note overflow

### DIFF
--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -143,6 +143,18 @@
     </div>
   }
 
+  <!-- ── Brain reveal + Re-Truth — surfaced ABOVE the note (2026-07-19, user request):
+       once a meeting resolves, show the already-alive brain (people + open commitments)
+       and the facts this note supersedes at the TOP, beside the "Saved ✓ in Murmur"
+       strip — not buried below a full-height note. Gated on stage = done. ─────────── -->
+  @if (store.stage() === "done") {
+    <app-brain-reveal-card [active]="!!store.lastNote()" />
+    <app-re-truth-card
+      [active]="!!store.lastNote()"
+      [meetingId]="store.meetingId()"
+    />
+  }
+
   <!-- ── The notes + @brain threads surface — the full-height main view ── -->
   <!-- The main flow is the user's NOTES (persisted to manual_notes); the one
        composer splits a line by @brain (a plain note vs opening a thread). -->
@@ -285,20 +297,6 @@
         <span>{{ err }}</span>
       </div>
     }
-  }
-
-  <!-- ── Brain reveal — after the first note lands, surface the already-alive
-       shallow brain (people + open commitments) mapped on defaults. In-flow,
-       gated on a resolved note; one-time dismissible. ──────────────────── -->
-  @if (store.stage() === "done") {
-    <app-brain-reveal-card [active]="!!store.lastNote()" />
-    <!-- ── Re-Truth — the vault heals itself: surface the facts this meeting
-         supersedes from earlier notes; one tap appends a reversible
-         [!superseded] callout. In-flow, gated on the resolved note + its id. ── -->
-    <app-re-truth-card
-      [active]="!!store.lastNote()"
-      [meetingId]="store.meetingId()"
-    />
   }
 
   <!-- ── Minimal stats strip — hidden once the conversation thread is the

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -249,16 +249,16 @@ export class RecordComponent implements OnInit {
 
   /**
    * BOUND the record surface to the viewport (fixed height → the note scrolls
-   * INTERNALLY, nothing spills past the window) whenever the note is the active
-   * writing surface: while recording AND while a pipeline runs with the companion
-   * note visible. EXCLUDES the "done" review state — that stacks the Brain-reveal /
-   * Re-Truth cards below the note and legitimately needs the page to scroll. Idle
-   * (no note surface) also stays unbounded (its short content just fills the calm
-   * min-height). Fixes the note overflowing off the bottom on smaller screens
-   * (2026-07-19).
+   * INTERNALLY, nothing spills past the window) whenever the note surface is shown —
+   * recording, an in-flight pipeline, AND the resolved "done" review (the Brain-reveal
+   * / Re-Truth cards now sit ABOVE the note, so the note is always the flex:1 filler
+   * and everything fits). EXCLUDED only when an error banner is up: it renders below
+   * the note and legitimately needs the page to scroll so it stays visible. Idle (no
+   * note surface) stays unbounded (its short content fills the calm min-height). Fixes
+   * the note overflowing off the bottom on smaller screens (2026-07-19).
    */
   readonly boundToViewport = computed(
-    () => this.showAssistant() && this.store.stage() !== "done",
+    () => this.showAssistant() && !this.store.error(),
   );
 
   /**


### PR DESCRIPTION
Two done-state fixes on the Calm-Notepad recording surface, from live feedback.

**1. Brain-reveal / Re-Truth at the TOP.** They rendered *below* the note, so with a full-height note the "YOUR BRAIN IS ALREADY WORKING" reveal landed off the bottom (below the fold). Moved them **above** the note, beside the "Saved ✓ in Murmur" strip. Both cards are in-flow (no fixed positioning), so the DOM reorder moves them visually to the top.

**2. No note overflow in the done state.** The done state was excluded from the viewport bound, so its note spilled off the bottom on smaller screens. `boundToViewport` now covers it (`showAssistant() && !error`): the reveal cards sit above, the note is the flex:1 filler that scrolls **internally**, everything fits. Error states stay unbounded so an error banner below the note scrolls into view.

Verified: `ng lint` + `ng build` green; record e2e **11/11**; Playwright done-state @1200×700 measured `scrollHeight === innerHeight`, note within the viewport. FE-only.