### PR TITLE
fix(notes): collapse Related by default + cross-dedup suggestions vs Related

### DIFF
--- a/e2e/notes/related-consolidation.spec.ts
+++ b/e2e/notes/related-consolidation.spec.ts
@@ -2,18 +2,20 @@ import { test, expect } from "@playwright/test";
 import { mockNotes } from "./mock-invoke";
 
 /**
- * VERIFICATION (2026-07-19 IA consolidation) — the merged "Related" panel in the
- * note editor at /notes/n1, driven over mocked Tauri IPC. Asserts the six behaviors
- * the redesign promises:
- *  1. ONE "Related · N" section (no separate "Linked mentions" / "Connections").
+ * VERIFICATION (2026-07-19 IA consolidation + collapse/cross-dedup follow-up) — the
+ * merged "Related" panel in the note editor at /notes/n1, over mocked Tauri IPC:
+ *  1. COLLAPSED BY DEFAULT — a single "Related · N" affordance (Notion-style); the
+ *     chips appear only after expanding. N = related rows + (deduped) suggestions.
  *  2. A neighbour that is BOTH an inbound backlink AND an outbound edge shows ONCE.
- *  3. A body-inline [[wikilink]] neighbour is NOT re-chipped (item 4).
- *  4. A suggestion is an ambient dashed chip: tap promotes (acceptLink), hover ×
+ *  3. A body-inline [[wikilink]] neighbour is NOT re-chipped.
+ *  4. CROSS-DEDUP — a semantic suggestion whose neighbour is ALSO a Related row is
+ *     NOT shown as a suggestion (no item in both "Related" and "Suggested").
+ *  5. A suggestion is an ambient dashed chip: tap promotes (acceptLink), hover ×
  *     dismisses (dismissLink) — no % label, no Accept/Dismiss buttons.
- *  5. The header shows ≤5 top-level controls (Move / Edit-Preview seg / Ask / ⋯).
- *  6. Zero console/page errors.
+ *  6. The header shows ≤5 top-level controls (Move / Edit-Preview seg / Ask / ⋯).
+ *  7. Zero console/page errors.
  */
-test("merged Related panel: dedup, inline-suppress, ambient suggestions, slim header", async ({
+test("Related panel: collapse-by-default, dedup, cross-dedup, ambient suggestions, slim header", async ({
   page,
 }) => {
   const consoleErrors: string[] = [];
@@ -40,8 +42,10 @@ test("merged Related panel: dedup, inline-suppress, ambient suggestions, slim he
     }),
 
     // list_links: a companion edge, a manual link, a wikilink edge whose title is
-    // ALREADY inline (must be suppressed), and a wikilink edge that ALSO appears as
-    // a backlink below (must dedup to ONE chip), plus a semantic SUGGESTION.
+    // ALREADY inline (must be suppressed), a wikilink edge that ALSO appears as a
+    // backlink below (must dedup to ONE chip), a semantic SUGGESTION ("Design doc"),
+    // and a semantic suggestion for "Roadmap" — which is ALSO a manual Related row,
+    // so it must be CROSS-DEDUPED out of the suggestions.
     list_links: () => {
       const w = window as unknown as { __dismissed?: boolean; __accepted?: boolean };
       const rows = [
@@ -110,6 +114,21 @@ test("merged Related panel: dedup, inline-suppress, ambient suggestions, slim he
           createdAt: 5,
           manual: false,
         },
+        {
+          // CROSS-DEDUP FIXTURE: a semantic suggestion for "Roadmap" — but Roadmap is
+          // already a manual Related row (id 2), so this must NOT render as a suggestion.
+          id: 6,
+          direction: "in",
+          otherKind: "note",
+          otherId: "n-roadmap",
+          otherTitle: "Roadmap",
+          edgeType: "semantic",
+          createdBy: "auto",
+          status: "suggested",
+          score: 0.9,
+          createdAt: 6,
+          manual: false,
+        },
       ];
       let out = rows;
       if (w.__dismissed) out = out.filter((r) => r.id !== 5);
@@ -143,10 +162,20 @@ test("merged Related panel: dedup, inline-suppress, ambient suggestions, slim he
   const panel = page.locator("app-connections");
   await expect(panel).toBeVisible();
 
-  // (1) ONE "Related" section header (with a count), no old labels.
-  await expect(panel.locator(".cx-label--head")).toContainText("Related");
+  // (1) COLLAPSED BY DEFAULT — a single "Related · N" toggle; no chips yet.
+  // N = 4 related (Kickoff, Roadmap, Standup[dedup'd], Retro) + 1 suggestion
+  // (Design doc; Roadmap-suggestion cross-deduped away) = 5.
+  const collapsed = panel.locator(".cx-collapsed");
+  await expect(collapsed).toBeVisible();
+  await expect(collapsed).toContainText("Related");
+  await expect(collapsed.locator(".cx-count")).toHaveText("5");
+  await expect(panel.locator(".cx-group")).toHaveCount(0); // chips hidden while collapsed
   await expect(page.getByText("Linked mentions")).toHaveCount(0);
   await expect(page.getByText("Suggested connections")).toHaveCount(0);
+
+  // Expand the section.
+  await collapsed.click();
+  await expect(panel.locator(".cx-group").first()).toBeVisible();
 
   // (2) dedup — "Standup notes" is both an inbound backlink AND an outbound edge;
   // it renders exactly ONCE.
@@ -158,38 +187,42 @@ test("merged Related panel: dedup, inline-suppress, ambient suggestions, slim he
     panel.locator(".cx-chip").filter({ hasText: "Meeting 2026-07-17" }),
   ).toHaveCount(0);
 
+  // (4) CROSS-DEDUP — "Roadmap" is a manual Related row AND a semantic suggestion;
+  // it shows exactly ONCE, and NOT as a suggested chip.
+  await expect(panel.getByText("Roadmap", { exact: true })).toHaveCount(1);
+  await expect(
+    panel.locator(".cx-chip--suggested").filter({ hasText: "Roadmap" }),
+  ).toHaveCount(0);
+
   // The real relationships DO show: companion, manual, dedup'd backlink, mentions-only.
   await expect(panel.getByText("Kickoff", { exact: true })).toBeVisible();
   await expect(panel.getByText("Roadmap", { exact: true })).toBeVisible();
   await expect(panel.getByText("Retro", { exact: true })).toBeVisible();
 
-  // (4a) NO raw confidence % anywhere in the panel (the score chip is gone).
+  // (5a) NO raw confidence % anywhere; NO Accept/Dismiss buttons; the ONE surviving
+  // suggestion is a dashed chip for "Design doc".
   await expect(panel.getByText("86%")).toHaveCount(0);
   await expect(panel.locator(".cx-score")).toHaveCount(0);
-  // NO persistent Accept/Dismiss buttons.
   await expect(panel.getByRole("button", { name: "Accept" })).toHaveCount(0);
   await expect(panel.getByRole("button", { name: "Dismiss", exact: true })).toHaveCount(0);
-  // The suggestion IS a dashed chip.
+  await expect(panel.locator(".cx-chip--suggested")).toHaveCount(1);
   await expect(panel.locator(".cx-chip--suggested")).toContainText("Design doc");
 
-  // (5) slim header — count the top-level controls in `.editor-head` (before any
-  // menu opens): breadcrumb (Move), the Edit/Preview segmented control, Ask Brain,
-  // and the ⋯ trigger. Save-state is silent at rest. That is 4 (≤5).
+  // (6) slim header — breadcrumb (Move), Edit/Preview seg, Ask Brain, ⋯. 4 (≤5).
   const head = page.locator(".editor-head");
-  await expect(head.locator(".crumb-btn").first()).toBeVisible(); // breadcrumb/Move
-  await expect(head.locator(".head-seg")).toHaveCount(1); // Edit/Preview seg
-  await expect(head.locator(".head-chat-btn")).toHaveCount(1); // Ask Brain
-  await expect(head.locator(".head-more .crumb-btn")).toHaveCount(1); // ⋯
-  // Share is NOT a top-level header button anymore.
+  await expect(head.locator(".crumb-btn").first()).toBeVisible();
+  await expect(head.locator(".head-seg")).toHaveCount(1);
+  await expect(head.locator(".head-chat-btn")).toHaveCount(1);
+  await expect(head.locator(".head-more .crumb-btn")).toHaveCount(1);
   await expect(head.getByRole("button", { name: "Share" })).toHaveCount(0);
 
-  // Screenshot the collapsed Related section (dark scheme is the config default).
+  // Screenshot the expanded Related section (dark scheme is the config default).
   await panel.scrollIntoViewIfNeeded();
   await panel.screenshot({
     path: "/private/tmp/claude-501/-Users-jakubgawronski-Projects-meetnotes/d3db29b4-fbd3-49ac-868a-fd86a0c14a1f/scratchpad/related-panel.png",
   });
 
-  // (4b) promote a suggestion by TAPPING its chip body → acceptLink runs, the
+  // (5b) promote the suggestion by TAPPING its chip body → acceptLink runs, the
   // dashed chip becomes a real "Design doc" link and the suggestion group empties.
   await panel.locator(".cx-chip--suggested").click();
   await expect(panel.locator(".cx-chip--suggested")).toHaveCount(0);

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -1,147 +1,191 @@
 <!-- Never surface (or offer to add) relationships behind a lock: the whole panel —
-     header + `+ Link` chooser included — is suppressed while `locked`. It is also
-     auto-hidden when there is NOTHING to show (no related rows AND no suggestions)
-     so a fresh note carries near-zero footprint (the collapsed "Related" IA). -->
+     collapsed header + `+ Link` chooser included — is suppressed while `locked`. It is
+     also auto-hidden when there is NOTHING to show (no related rows AND no suggestions)
+     so a fresh note carries zero footprint. COLLAPSED BY DEFAULT (Notion-style): a
+     single "Related · N" affordance under Properties; clicking it reveals the merged
+     Related chips + the ambient Suggested chips. -->
 @if (!locked() && hasAnything()) {
 <div class="cx">
-  <!-- Header: the "Related · N" count label + the `+ Link` chooser. The query
-       <input> is BOTH the filter field and the popover's keyboard target; the panel
-       owns query/activeIndex (the picker is presentational) and anchors it here. -->
-  <div class="cx-head">
-    <span class="cx-label cx-label--head">
-      Related
-      @if (relatedCount() > 0) {
-        <span class="cx-count" aria-hidden="true">{{ relatedCount() }}</span>
-      }
-    </span>
-    @if (pickerOpen()) {
-      <input
-        #pickerAnchor
-        type="text"
-        class="cx-link-input"
-        placeholder="Link a meeting, note, or document…"
-        [value]="pickerQuery()"
-        (input)="onQueryInput($event)"
-        (keydown)="onQueryKey($event)"
-        (blur)="closePicker()"
-        aria-label="Search items to link"
-      />
-    } @else {
-      <button
-        #pickerAnchor
-        type="button"
-        class="cx-add"
-        [disabled]="linking()"
-        (click)="openPicker()"
+  @if (!expanded()) {
+    <!-- COLLAPSED (default) — one quiet "Related · N" line; near-zero footprint. -->
+    <button
+      type="button"
+      class="cx-collapsed"
+      (click)="toggleExpanded()"
+      [attr.aria-expanded]="false"
+      aria-label="Show related items and suggestions"
+    >
+      <svg
+        class="cx-chev"
+        viewBox="0 0 16 16"
+        width="11"
+        height="11"
+        fill="none"
+        aria-hidden="true"
       >
-        @if (linking()) {
-          <span class="cx-add-label">Linking…</span>
-        } @else {
-          <span class="cx-add-plus" aria-hidden="true">+</span>
-          <span class="cx-add-label">Link</span>
-        }
+        <path
+          d="M6 4l4 4-4 4"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="cx-collapsed-label">Related</span>
+      <span class="cx-count" aria-hidden="true">{{ totalCount() }}</span>
+    </button>
+  } @else {
+    <!-- EXPANDED — the collapse toggle + `+ Link` chooser, then the two chip groups. -->
+    <div class="cx-head">
+      <button
+        type="button"
+        class="cx-collapsed cx-collapsed--open"
+        (click)="toggleExpanded()"
+        [attr.aria-expanded]="true"
+        aria-label="Hide related items"
+      >
+        <svg
+          class="cx-chev cx-chev--open"
+          viewBox="0 0 16 16"
+          width="11"
+          height="11"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 6l4 4 4-4"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span class="cx-collapsed-label">Related</span>
+        <span class="cx-count" aria-hidden="true">{{ totalCount() }}</span>
       </button>
-    }
-  </div>
+      @if (pickerOpen()) {
+        <input
+          #pickerAnchor
+          type="text"
+          class="cx-link-input"
+          placeholder="Link a meeting, note, or document…"
+          [value]="pickerQuery()"
+          (input)="onQueryInput($event)"
+          (keydown)="onQueryKey($event)"
+          (blur)="closePicker()"
+          aria-label="Search items to link"
+        />
+      } @else {
+        <button
+          #pickerAnchor
+          type="button"
+          class="cx-add"
+          [disabled]="linking()"
+          (click)="openPicker()"
+        >
+          @if (linking()) {
+            <span class="cx-add-label">Linking…</span>
+          } @else {
+            <span class="cx-add-plus" aria-hidden="true">+</span>
+            <span class="cx-add-label">Link</span>
+          }
+        </button>
+      }
+    </div>
 
-  <!-- MERGED "Related" chips — inbound backlinks + incident deterministic edges,
-       deduped by (kind, id) so a neighbour that is both shows ONCE. A small tag
-       reads the direction/type ("linked" / "mentions" / "companion" / "related");
-       a user-created MANUAL link keeps its hover × to remove. Collapsed to the
-       first `limit` with a "+N more" / "Show less" toggle (the app-backlinks
-       idiom). Rows are a precomputed view-model (fields only in the template). -->
-  @if (visibleRelated().length) {
-    <div class="cx-group">
-      @for (row of visibleRelated(); track row.key) {
-        <span class="cx-chipwrap" [class.is-pending]="row.pending">
-          <a class="cx-chip" [routerLink]="row.route">
-            @switch (row.kind) {
-              @case ("meeting") {
-                <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+    <!-- MERGED "Related" chips — inbound backlinks + incident deterministic edges,
+         deduped by (kind, id) so a neighbour that is both shows ONCE. A small tag
+         reads the direction/type ("linked" / "mentions" / "companion" / "related");
+         a user-created MANUAL link keeps its hover × to remove. -->
+    @if (relatedRows().length) {
+      <div class="cx-group">
+        @for (row of relatedRows(); track row.key) {
+          <span class="cx-chipwrap" [class.is-pending]="row.pending">
+            <a class="cx-chip" [routerLink]="row.route">
+              @switch (row.kind) {
+                @case ("meeting") {
+                  <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+                }
+                @case ("document") {
+                  <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+                }
+                @default {
+                  <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+                }
               }
-              @case ("document") {
-                <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
-              }
-              @default {
-                <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
-              }
+              <span class="cx-title">{{ row.title }}</span>
+              <span class="cx-edge" aria-hidden="true">{{ row.tag }}</span>
+            </a>
+            @if (row.removable && row.edge) {
+              <button
+                type="button"
+                class="cx-remove"
+                [disabled]="row.pending"
+                [attr.aria-label]="'Remove link to ' + row.title"
+                title="Remove link"
+                (click)="unlink(row.edge)"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
             }
-            <span class="cx-title">{{ row.title }}</span>
-            <span class="cx-edge" aria-hidden="true">{{ row.tag }}</span>
-          </a>
-          @if (row.removable && row.edge) {
+          </span>
+        }
+      </div>
+    }
+
+    <!-- AMBIENT semantic SUGGESTIONS — "related, not yet linked". A dashed chip whose
+         BODY promotes (tap → acceptLink materializes the [[wikilink]]) and whose hover ×
+         dismisses (dismissLink). No confidence %, no persistent Accept/Dismiss buttons —
+         the chip IS the affordance. Cross-deduped against Related (never a repeat). -->
+    @if (suggestionRows().length) {
+      <div class="cx-group cx-group--suggest">
+        <span class="cx-label">Suggested</span>
+        @for (row of suggestionRows(); track row.edge.id) {
+          <span class="cx-chipwrap" [class.is-pending]="row.pending">
+            <button
+              type="button"
+              class="cx-chip cx-chip--suggested"
+              [disabled]="row.pending"
+              [attr.aria-label]="'Add link to ' + row.title"
+              title="Add this link"
+              (click)="accept(row.edge)"
+            >
+              @switch (row.kind) {
+                @case ("meeting") {
+                  <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+                }
+                @case ("document") {
+                  <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+                }
+                @default {
+                  <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+                }
+              }
+              <span class="cx-title">{{ row.title }}</span>
+              <span class="cx-edge cx-edge--add" aria-hidden="true">+ add</span>
+            </button>
             <button
               type="button"
               class="cx-remove"
               [disabled]="row.pending"
-              [attr.aria-label]="'Remove link to ' + row.title"
-              title="Remove link"
-              (click)="unlink(row.edge)"
+              [attr.aria-label]="'Dismiss suggestion ' + row.title"
+              title="Dismiss suggestion"
+              (click)="dismiss(row.edge)"
             >
               <span aria-hidden="true">×</span>
             </button>
-          }
-        </span>
-      }
-      @if (hiddenRelatedCount() > 0 || expanded()) {
-        <button type="button" class="cx-more" (click)="toggleExpanded()">
-          {{ expanded() ? "Show less" : "+" + hiddenRelatedCount() + " more" }}
-        </button>
-      }
-    </div>
-  }
-
-  <!-- AMBIENT semantic SUGGESTIONS — "related, not yet linked". A dashed chip whose
-       BODY promotes (tap → acceptLink materializes the [[wikilink]]) and whose hover ×
-       dismisses (dismissLink). No confidence %, no persistent Accept/Dismiss buttons —
-       the chip IS the affordance (precomputed `suggestionRows()`, fields only). -->
-  @if (suggestionRows().length) {
-    <div class="cx-group cx-group--suggest">
-      <span class="cx-label">Suggested</span>
-      @for (row of suggestionRows(); track row.edge.id) {
-        <span class="cx-chipwrap" [class.is-pending]="row.pending">
-          <button
-            type="button"
-            class="cx-chip cx-chip--suggested"
-            [disabled]="row.pending"
-            [attr.aria-label]="'Add link to ' + row.title"
-            title="Add this link"
-            (click)="accept(row.edge)"
-          >
-            @switch (row.kind) {
-              @case ("meeting") {
-                <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
-              }
-              @case ("document") {
-                <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
-              }
-              @default {
-                <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
-              }
-            }
-            <span class="cx-title">{{ row.title }}</span>
-            <span class="cx-edge cx-edge--add" aria-hidden="true">+ add</span>
-          </button>
-          <button
-            type="button"
-            class="cx-remove"
-            [disabled]="row.pending"
-            [attr.aria-label]="'Dismiss suggestion ' + row.title"
-            title="Dismiss suggestion"
-            (click)="dismiss(row.edge)"
-          >
-            <span aria-hidden="true">×</span>
-          </button>
-        </span>
-      }
-    </div>
+          </span>
+        }
+      </div>
+    }
   }
 </div>
 
   <!-- The single-pick chooser popover (reused note-editor LinkPickerComponent):
        OPAQUE, paginated autocomplete over list_link_candidates. THIS panel owns the
        query / activeIndex (fed as inputs) + keyboard nav; the picker renders + emits
-       the picked candidate. Anchored under the header <input>. -->
+       the picked candidate. Anchored under the header <input> (only reachable while
+       expanded). -->
   @if (pickerOpen()) {
     <app-link-picker
       [anchorRect]="pickerRect()"

--- a/src/app/shared/connections/connections.component.scss
+++ b/src/app/shared/connections/connections.component.scss
@@ -224,20 +224,44 @@
   letter-spacing: 0.04em;
 }
 
-/* "+N more" / "Show less" — collapses the Related list (the app-backlinks idiom). */
-.cx-more {
-  padding: 6px var(--space-3);
+/* Collapsed "Related · N" toggle — a quiet inline row (Notion-style collapse-by-
+   default). Doubles as the expanded-state collapse control (in `.cx-head`). */
+.cx-collapsed {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  align-self: flex-start;
+  padding: 4px var(--space-2) 4px var(--space-1);
   background: transparent;
-  border: 1px dashed var(--border-strong);
-  border-radius: var(--radius-pill);
-  color: var(--accent-hover);
-  font-size: 12px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
-.cx-more:hover {
-  background: var(--accent-soft);
+.cx-collapsed:hover {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+.cx-collapsed:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.cx-collapsed-label {
+  letter-spacing: 0.08em;
+}
+.cx-chev {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: color var(--transition-fast);
+}
+.cx-collapsed:hover .cx-chev {
+  color: var(--text-secondary);
 }
 
 /* --- Ambient semantic suggestions ("related, not yet linked") ----------- */

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -143,10 +143,8 @@ export class ConnectionsComponent {
    */
   private readonly pending = signal<ReadonlySet<number>>(new Set());
 
-  /** Whether the whole Related section is expanded past the collapsed count. */
+  /** Whether the whole Related section is expanded (Notion-style collapse-by-default). */
   readonly expanded = signal(false);
-  /** Collapsed count affordance shows the first this-many related chips. */
-  readonly limit = input(6);
 
   /** The single-pick `+ Link` chooser element (the header `<input>`) for anchoring. */
   private readonly pickerAnchor =
@@ -308,10 +306,26 @@ export class ConnectionsComponent {
     return [...this.deterministic()].sort((a, b) => weight(a) - weight(b));
   });
 
-  /** The ambient suggestion chips as a precomputed view-model (strongest-first). */
+  /**
+   * The `(kind:id)` keys already present as a Related row — used to drop a semantic
+   * suggestion whose neighbour is ALSO an inbound/outbound relationship. Without
+   * this the SAME note renders in BOTH "Related" and "Suggested" (the exact
+   * duplication the consolidation set out to kill — a suggestion is only ever
+   * "related, not yet linked", never a repeat of something already linked/mentioned).
+   */
+  private readonly relatedKeys = computed(
+    () => new Set(this.relatedRows().map((r) => r.key)),
+  );
+
+  /**
+   * The ambient suggestion chips (strongest-first), EXCLUDING any neighbour already
+   * shown as a Related row (cross-surface dedup).
+   */
   readonly suggestionRows = computed<SuggestionRow[]>(() => {
     const pending = this.pending();
+    const related = this.relatedKeys();
     return [...this.semanticSuggestions()]
+      .filter((e) => !related.has(`${e.otherKind}:${e.otherId}`))
       .sort((a, b) => b.score - a.score)
       .map((edge) => ({
         edge,
@@ -322,19 +336,16 @@ export class ConnectionsComponent {
       }));
   });
 
-  /** The total related count (drives the collapsed "N related" affordance). */
+  /** The Related-row count (the "linked"/"mentions" chips). */
   readonly relatedCount = computed(() => this.relatedRows().length);
 
-  /** The Related rows to actually render — the first `limit` unless expanded. */
-  readonly visibleRelated = computed<RelatedRow[]>(() =>
-    this.expanded()
-      ? this.relatedRows()
-      : this.relatedRows().slice(0, this.limit()),
-  );
-
-  /** How many related rows are hidden behind the collapsed count. */
-  readonly hiddenRelatedCount = computed(() =>
-    Math.max(0, this.relatedCount() - this.limit()),
+  /**
+   * The whole-section count behind the collapsed "Related · N" affordance: Related
+   * rows + (deduped) suggestions. The section is COLLAPSED BY DEFAULT (Notion-style,
+   * near-zero footprint above the note body); `expanded` reveals both groups.
+   */
+  readonly totalCount = computed(
+    () => this.relatedCount() + this.suggestionRows().length,
   );
 
   /**
@@ -428,7 +439,7 @@ export class ConnectionsComponent {
     return kind === "meeting" ? ["/meeting", id] : ["/notes", id];
   }
 
-  /** Toggle the collapsed/expanded Related list ("N more" / "Show less"). */
+  /** Toggle the whole Related section collapsed ↔ expanded. */
   toggleExpanded(): void {
     this.expanded.update((v) => !v);
   }


### PR DESCRIPTION
Follow-up to #408 from live testing.

**Collapse-by-default (Notion-style).** The Related section is now one quiet `Related · N` line under Properties; clicking reveals the merged chips + ambient suggestions. Fixes the full Related+Suggested stack looming over an empty note body.

**Cross-dedup.** A semantic suggestion whose neighbour is ALSO a Related row is dropped from Suggested — the same note never appears in BOTH sections (the duplication that survived #408: e.g. `Meeting Notes July 17 2026` / `Related Notes Link List` showed as a Related chip AND a `+ add` suggestion).

FE-only; removed dead `limit`/`visibleRelated`/`hiddenRelatedCount`. Verified: `ng lint` + `ng build` clean; `e2e/notes/related-consolidation.spec.ts` updated (collapsed count, cross-dedup, promote-on-tap) and PASSES.