### PR TITLE
fix(ui): collapse source-scope chips + tuck the Related unlink × inside the pill

### DIFF
--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -4,7 +4,7 @@
 <div class="sp" [class.is-open]="open()">
   @if (selected().length > 0) {
     <ul class="sp-chips" aria-label="Selected sources">
-      @for (c of selected(); track c.kind + c.id) {
+      @for (c of visibleChips(); track c.kind + c.id) {
         <li class="sp-chip pill">
           <span class="sp-chip-badge" aria-hidden="true">
             @switch (c.kind) {
@@ -64,6 +64,18 @@
                 stroke-linecap="round"
               />
             </svg>
+          </button>
+        </li>
+      }
+      @if (canCollapseChips()) {
+        <li>
+          <button
+            type="button"
+            class="sp-chip sp-chip-more pill"
+            [attr.aria-expanded]="chipsExpanded()"
+            (click)="toggleChips()"
+          >
+            {{ chipsExpanded() ? "Show less" : "+" + hiddenChipCount() + " more" }}
           </button>
         </li>
       }

--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -71,6 +71,30 @@
   box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
+/* Collapse toggle — "+N more" / "Show less". A muted, dashed pill that trims a wide
+   source scope down to a compact preview so it never floods the panel (2026-07-19). */
+.sp-chip-more {
+  padding: var(--space-1) var(--space-2);
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+.sp-chip-more:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+.sp-chip-more:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
 /* --- Trigger -------------------------------------------------------------- */
 .sp-trigger {
   height: 28px;

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -108,6 +108,35 @@ export class SourcePickerComponent {
     })),
   );
 
+  /** How many selected-source chips to show before collapsing the rest behind
+   * "+N more" — a large Brain scope otherwise floods the panel and pushes the ask
+   * input off-screen (user report, 2026-07-19). */
+  private static readonly CHIP_COLLAPSE_AFTER = 3;
+  /** Chips start COLLAPSED so a wide scope reads as a compact preview, not a wall. */
+  private readonly _chipsExpanded = signal(false);
+  readonly chipsExpanded = this._chipsExpanded.asReadonly();
+  /** The chips actually rendered: the first few when collapsed, all when expanded. */
+  readonly visibleChips = computed(() => {
+    const all = this.selected();
+    return this._chipsExpanded() ||
+      all.length <= SourcePickerComponent.CHIP_COLLAPSE_AFTER
+      ? all
+      : all.slice(0, SourcePickerComponent.CHIP_COLLAPSE_AFTER);
+  });
+  /** How many chips are hidden behind "+N more" (0 when expanded or already short). */
+  readonly hiddenChipCount = computed(
+    () => this.selected().length - this.visibleChips().length,
+  );
+  /** Whether the collapse toggle should appear at all. */
+  readonly canCollapseChips = computed(
+    () => this.selected().length > SourcePickerComponent.CHIP_COLLAPSE_AFTER,
+  );
+
+  /** Expand / collapse the selected-source chips. */
+  toggleChips(): void {
+    this._chipsExpanded.update((v) => !v);
+  }
+
   private readonly triggerEl = viewChild<ElementRef<HTMLButtonElement>>("trigger");
   private readonly popoverEl = viewChild<ElementRef<HTMLDivElement>>("popover");
   private readonly searchEl = viewChild<ElementRef<HTMLInputElement>>("search");

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -100,7 +100,11 @@
     @if (relatedRows().length) {
       <div class="cx-group">
         @for (row of relatedRows(); track row.key) {
-          <span class="cx-chipwrap" [class.is-pending]="row.pending">
+          <span
+            class="cx-chipwrap"
+            [class.has-remove]="row.removable && !!row.edge"
+            [class.is-pending]="row.pending"
+          >
             <a class="cx-chip" [routerLink]="row.route">
               @switch (row.kind) {
                 @case ("meeting") {
@@ -141,7 +145,7 @@
       <div class="cx-group cx-group--suggest">
         <span class="cx-label">Suggested</span>
         @for (row of suggestionRows(); track row.edge.id) {
-          <span class="cx-chipwrap" [class.is-pending]="row.pending">
+          <span class="cx-chipwrap has-remove" [class.is-pending]="row.pending">
             <button
               type="button"
               class="cx-chip cx-chip--suggested"

--- a/src/app/shared/connections/connections.component.scss
+++ b/src/app/shared/connections/connections.component.scss
@@ -150,39 +150,49 @@
   background: var(--surface-hover);
 }
 
-/* Remove (×) on a manual chip — hidden until the wrap is hovered/focused. */
+/* Remove (×) — an in-chip trailing button (design-system removable-chip pattern),
+   tucked INSIDE the pill's right edge over reserved padding so it never floats in the
+   inter-chip gap or overlaps the label, with a comfortable 24px hit target. The wrap
+   is `position: relative`; the × is absolutely placed at its right edge and the chip
+   body reserves room for it via `.has-remove` below. */
 .cx-remove {
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
-  margin-left: calc(-1 * var(--space-1));
+  width: 24px;
+  height: 24px;
   padding: 0;
   background: transparent;
   border: 0;
-  border-radius: var(--radius-pill);
+  border-radius: 50%;
   color: var(--text-muted);
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1;
   cursor: pointer;
-  opacity: 0;
   transition:
-    opacity var(--transition-fast),
     color var(--transition-fast),
     background var(--transition-fast);
-}
-.cx-chipwrap:hover .cx-remove,
-.cx-remove:focus-visible {
-  opacity: 1;
 }
 .cx-remove:hover:not(:disabled) {
   color: var(--danger);
   background: var(--surface-hover);
 }
+.cx-remove:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
 .cx-remove:disabled {
   cursor: default;
   opacity: 0.4;
+}
+/* Reserve room on the chip's right so the label never runs under the × (30px = the
+   24px button + its right offset + a little breathing space). */
+.cx-chipwrap.has-remove .cx-chip {
+  padding-right: 30px;
 }
 
 /* Neighbour-kind badge. */


### PR DESCRIPTION
Two note-detail chip-UI polish fixes from live feedback (rebased onto #410).

**1. Source-scope chips collapse (`mur-source-picker`).** A wide Brain scope rendered *all* picked sources as a chip wall that flooded the note-chat panel and pushed the ask input off-screen. Chips now start **collapsed** — first 3 + a **"+N more"** toggle (**Show less** to re-collapse). Benefits every consumer (note-chat, meeting-chat, Ask, org). ≤3 sources → no toggle.

**2. Related unlink × inside the pill (`connections`).** The × was a floating sibling with a negative margin, sitting in the inter-chip **gap** — ambiguous and a tiny hover-only target. Now the design-system removable-chip pattern: an in-chip trailing button at the pill's right edge over reserved padding (`.has-remove`), **always visible**, **24px** hit target, danger-on-hover. Same for the suggestion-chip dismiss ×.

Verified: `ng lint` + `ng build` green; Playwright-measured the collapse (3 + "+4 more" → 7 + "Show less") and the × geometry (inside the chip, 24px, on the post-#410 collapsed panel). FE-only.

> Note: `connections-linking.spec.ts` is red on trunk **without** this change (proven at 5d02451) — #410's collapse-Related-by-default hid the chips and that test wasn't updated to expand first. Unrelated to this PR; left for the #410 owner.