### PR TITLE
fix(source-picker): keep the label readable on an active+picked row

### DIFF
--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -159,6 +159,13 @@
 .sp-row.is-picked {
   color: var(--accent);
 }
+/* Active-AND-picked row: the accent bg from `.is-active` + the accent TEXT from
+   `.is-picked` (equal specificity, declared later) collided → an accent title on the
+   accent highlight = an invisible label (only the ✓ showed). The active highlight must
+   win: force contrasting text so the picked row stays readable when keyboard-focused. */
+.sp-row.is-active.is-picked {
+  color: var(--text-on-accent);
+}
 .sp-title {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
**Bug:** in the source-picker popover ("Scope to a note or meeting…"), a candidate row that was both keyboard-**active** (accent background, `.is-active`) and already-**picked** (accent text, `.is-picked`) rendered an accent title on the accent highlight — an **invisible label**; only the ✓ showed (the solid-blue "ghost" row in the screenshot).

**Cause:** `.is-active` and `.is-picked` set `color` at equal specificity, and `.is-picked` (blue text) was declared *after* `.is-active` (white text) → blue won → blue-on-blue.

**Fix:** `.sp-row.is-active.is-picked { color: var(--text-on-accent) }` — the active highlight wins, so a picked row stays readable when focused.

Verified: `ng lint` + `ng build` green; Playwright measured the active+picked title colour = `rgb(255,255,255)` on the `rgb(110,118,255)` accent row (was accent-on-accent). FE-only, one line.