### PR TITLE
feat(brain): full-brain graph as a living neural map — layered layout + glowing synapses

### DIFF
--- a/docs/research/2026-07-19-full-brain-graph-viz-redesign.md
+++ b/docs/research/2026-07-19-full-brain-graph-viz-redesign.md
@@ -1,0 +1,99 @@
+<!-- Generated 2026-07-19 via /research (murmur-researcher fan-out ×3: layout science / UX patterns / vanilla-canvas techniques). -->
+# Research: Full-brain graph visualization redesign — see ALL nodes, no scatter, professional look
+
+> **Addendum (2026-07-19, during implementation).** After the organic per-component
+> fix landed and was verified, the user judged the result "constellations, not an
+> advanced structure" and pointed at layered neural-network visualisations as the
+> aspiration. Honest constraint: a neural net looks dense because it is fully
+> connected in layers; Murmur's brain is a genuinely SPARSE knowledge graph (many
+> orphan docs/notes) — we cannot fabricate connections that don't exist. So the
+> ship added, on top of the organic layout: (1) a LAYERED "neural" layout mode
+> (horizontal bands by kind — people→meetings→notes→documents — barycentrically
+> ordered to minimise edge crossings), now the DEFAULT, with the organic layout
+> kept behind a `Layers | Clusters` toggle; (2) rich GLOWING curved synapses that
+> gradient between endpoint node hues; (3) a bounded, reduced-motion-safe animation
+> loop with FIRING PULSES travelling src→dst (data flowing down the layers) +
+> soma breathing. Both adversarial-verifier and lock-security-reviewer re-passed
+> the addition (loop §5-bounded on destroy/hidden/reduced-motion, `layoutLayered`
+> deterministic, no leak). The "advanced" feel now comes from STRUCTURE + FLOW,
+> not fabricated density.
+
+## TL;DR / Verdict
+
+The graph looks broken because of **three compounding bugs**, not one — and the fix is well-founded, vanilla-TS, no new deps, and largely a **port from our own sibling `neural-scene.directive.ts`** (which already solved ~80% of the "pro but cheap" rendering).
+
+1. **Degree-0 singletons (backend, confirmed).** `build_full_graph` (`storage/graph_store.rs:580-614`) pushes *every* visible entity/meeting/note/document as a node with `degree: 0` **before** any edge is counted. So every orphan document (no wikilink), fresh note, or meeting whose entities co-occur nowhere else is a genuine **1-node connected component**.
+2. **Global force-sim flings them + weak gravity (layout).** One global Fruchterman-Reingold over all nodes repels those singletons outward with long-reach inverse-linear `k²/d`, held back only by a per-iteration `xs[i]*0.006` centre pull that is **~40× too weak** (industry per-node positional gravity ≈ 0.1/tick). There is **no connected-component packing**. → the three corner-clusters in the screenshot.
+3. **Fit zooms to the blown-out bbox (renderer).** `fit()` (`full-brain-scene.directive.ts:349-372`) scales to `max(|x|+r)`, which the scattered singletons dominate → `scale` collapses toward `MIN_SCALE=0.25` → `p.sr < 7` → **labels never render** → "unlabeled dots."
+
+**Fix:** (A) replace the single global sim with **per-connected-component layout + bounding-box spiral packing** (the technique `fcose`/Graphviz/Gephi use), tiling degree-0 singletons into one compact grid block; (B) **port the neural-scene rendering** — cached halo sprites, collision-decluttered adaptive labels, opaque hover tooltip, batched edges, robust mass-centroid fit; (C) fix the interaction (**click = focus/stay, double-click = open** — today click yanks you to a route), add **Fit + zoom-%**, and **raise the 140 draw cap** so a normal vault shows everything. Skip Barnes-Hut (crossover ~6000 nodes; we're ≤500 and the layout is one-shot off the render thread), skip polyomino-exact packing, skip minimap/hulls for now.
+
+On the user's explicit *"see ALL nodes"* vs. the research caution *"a full global graph past ~200 nodes is a useless hairball"*: **both are satisfied by good layout, not by hiding nodes.** The user's vault is ~155 items — trivially renderable in full. Component-packing + tiling keeps even ~500 nodes compact and legible; the hairball concern only bites pathological 2000-node vaults, where LOD labels + search are the answer. So we raise the cap AND make it legible.
+
+## What we already have (from repo, file:line)
+
+- **The component:** `src/app/features/brain/full-brain-graph/full-brain-graph.component.ts` — `sceneNodes` computed (`:234-388`) is a one-shot deterministic 2D FR: golden-angle spiral seed (`:254`), all-pairs O(n²) repulsion `k²/dist` (`:287-305`), hub-attenuated springs (`:314-317`), weak centre pull `xs[i]*0.006` (`:330-331`), centroid recenter (`:336-348`), 30-pass overlap relax (`:351-378`). `MAX_NODES=140` draw cap (`:41`). Radius `7+(√deg/√maxDeg)·13` → [7,20] sqrt-scaled (`:249-251`) — already best-practice. **Deterministic (no `Math.random`); must stay so** (the `computed` re-runs on every lens toggle).
+- **The renderer:** `full-brain-scene.directive.ts` — per-node `createRadialGradient` ×2 per frame (`:501`,`:518`), `fit()` zoom-to-bbox (`:349`), `MIN_SCALE=0.25` (`:63`), primitive label gate `p.sr >= 7` with **no collision test** (`:545-546`), per-edge state changes (`:472-476`), focus-fade only on select (`:141-155`,`:446-463`).
+- **The sibling to port from:** `src/app/features/brain/neural-scene.directive.ts` — already ships **cached halo sprites** (`haloSprite` `:1537`), **cached backdrop** (`makeBg` `:1453`), **collision-decluttered fan-out labels + zoom-scaled budget** (`drawLabels` `:1160`, `collides` `:1227`, fan-out `:1248`, budget `LABEL_TOP*zoomK` `:1190`), **opaque hover tooltip** (`drawTooltip` `:1283`), **robust mass-centroid fit** (`fitCamera` `:1350`, 30% centroid blend `:1404-1408`), **bounded reduced-motion-safe loop** (`startLoop`/`stopLoop`/`invalidate` `:595`/`:610`/`:620`, all released in `onDestroy` `:464`), djb2/r01 deterministic hashes (`:150`,`:159`). This is the reference implementation; the full-brain scene is the un-migrated laggard.
+- **The backend caps:** `MAX_FULL_GRAPH_PER_KIND=500` (`storage/db.rs:6420`) → up to ~2000 nodes; `MAX_FULL_GRAPH_LINK_EDGES=4000` (`:6428`), `MAX_MENTION_EDGES=2000` (`graph_store.rs:865`). `FullGraphNode` carries `{id,kind,label,date,degree}` (`models.ts:1499`); edges carry `srcKind/dstKind` (`:1533`) — enough to build correct component adjacency and a richer hover card, no backend change.
+- **The search pattern to copy:** `graph.component.ts:112-136` — the `query()` signal + filter, proven shape for an in-canvas search box.
+- **Colors:** `--graph-entity/-meeting/-note/-document` (`design-tokens/colors.css:66-69` + light overrides `theme-light.css:43-46`); the scene mirrors them as fixed constants (dark field — glow only reads on dark).
+
+## Findings
+
+### A — Layout science (per-component packing is the root-cause fix)
+
+- **Every serious tool lays out each connected component independently, then packs the bounding shapes** — no inter-component repulsion, no wasted space. Graphviz `pack`/`packmode=graph` packs component **bounding boxes** (polyomino degenerates to a rectangle), 8pt margins; `fcose`/`cose-bilkent` pack via polyomino with `desiredAspectRatio=1`, `componentSpacing=80`, and **tile degree-0 nodes into a grid** (`tile:true`, padding 10) instead of force-laying them. [high] (Graphviz packMode docs; cytoscape layout-utilities/fcose/cose-bilkent READMEs)
+- **The packing algorithm (Freivalds–Doğrusöz–Kikusts, GD 2001):** sort components largest-first by bbox perimeter; place each at the grid cell minimizing **`max(|x|,|y|)`** → a **square spiral outward from centre**; grid cells shaped `DAR:1` where `DAR = canvasW/canvasH` for aspect-fit; enlarge each box by half-spacing for gaps. O(n²) in components — trivial at our scale. **Bounding-box packing (not full polyomino) captures ~all the benefit** for our data shape (one dominant cluster + many singletons). [high / med on the box≈polyomino gap]
+- **Gravity that actually contains components is per-node positional (d3 `forceX/forceY`, default strength 0.1 applied every tick), NOT `forceCenter`** (which only recenters the centre of mass — exactly our weak spot). ForceAtlas2 "strong gravity" `∝ d²` forces very compact layouts. Our `*0.006`-once is the known-broken pattern. **But with component packing, per-node gravity becomes near-irrelevant** — it only tidies each component's own layout; the packer handles inter-component compactness. [high]
+- Inverse-**square** repulsion (`1/d²`, Gephi) has shorter reach than our inverse-**linear** (`k²/d`) → less singleton fling; capping repulsion at a `distanceMax` also helps. [med]
+- Node sizing: our sqrt radius is correct (area ∝ degree). For a mega-hub that dominates, quasi-log `log(1+deg)/log(1+maxDeg)` is the escape hatch. [high]
+
+### B — UX / interaction (what makes it feel pro, ranked)
+
+- **#1 gap: adaptive collision-avoided labels.** Obsidian's own users beg for "map-style" labels (big nodes labelled when zoomed out, more on zoom-in) instead of its all-or-nothing zoom fade. The algorithm — greedy, largest-first, screen-space rect-occlusion, zoom-gated budget — **is already implemented in our `neural-scene.drawLabels`.** Porting it erases the "unlabeled dots" look. [high]
+- **The click-yanks-away bug:** today a node click routes to the item (`onPick` → `router.navigate`), so a user can never *dwell* on a node. Best-in-class: **single click = select + focus its neighbourhood (stay), double-click / a hover-card "Open" = navigate.** Also move the neighbour-fade onto **hover** (today it's only on select). [high]
+- **Orientation:** a proper **Fit** affordance + a **zoom-% readout**; an in-canvas **search-to-node** (type → matches glow, rest dim, camera eases to best hit) — the "find a node" the user is really asking for. [high]
+- **Strategic:** the global graph is a "poster," the local/focus graph + search is the "tool," past ~200 nodes. Bias future work toward land-on-one-node-and-explore, not bigger hairballs. [high]
+- **Defer:** community-detection colouring, convex-hull cluster blobs, minimap — diminishing returns until graphs are routinely huge. [med]
+
+### C — Vanilla-canvas implementation (port the sibling; skip the quadtree)
+
+- **Replace per-node `createRadialGradient` (×2/node/frame, and it leaks) with cached per-kind sprites** (`haloSprite`) + `globalCompositeOperation="lighter"` additive glow; pre-render the backdrop once (`makeBg`). Real win from ~150 nodes, mandatory by 400. [high]
+- **Skip Barnes-Hut.** Heer's benchmark: θ=0.5 doesn't beat naive O(n²) until **~6000 points** (tree-build overhead); we're ≤500 and the layout is a one-shot `computed()` off the render thread (~33M ops once at n=500 ≈ a few ms, invisible). Only revisit for a per-frame animated sim or n≫600. [high]
+- **Batch edges by (kind, dashed) into one path per style**; hoist `strokeStyle`/`lineWidth`/`setLineDash` out of the per-edge loop (MDN: batch calls, avoid state changes). At 4000 edges this matters. [high]
+- **Bounded animated "settle"** is honest under zoneless §5 if it *terminates*: ease node positions seed→final over ~600ms via one rAF chain that stops at t=1, snapped under `prefers-reduced-motion`, released on destroy — the neural-scene loop lifecycle proves the pattern. This is presentation-only (the deterministic final layout is precomputed). [high]
+- **Robust fit:** port `fitCamera`'s **30%-mass-centroid blend** so a couple of stray singletons can't park the mass in a corner / collapse the scale. [high]
+
+## Fit with Murmur's constraints
+
+- **No new deps** — everything is algorithmic vanilla TS on canvas (union-find, spiral box-packer, sprite cache, collision labels). ✔ [high]
+- **Local-first / SQLite-canonical / lock model** — pure presentation over already-`getFullGraph()`-gated data. Zero egress, zero backend, zero schema change. Raising the draw cap surfaces **more of what the backend already deemed visible** → **no new leak surface**, and it makes the honest "Drawing N of M" disclosure fire *less* (a correctness win). One caveat to respect: if focus-depth ever expands beyond 1 hop on the *drawn* set, an n-hop walk must honestly account for the draw cap. [high]
+- **Zoneless §5** — layout stays a pure `computed()` in the component; all DOM-loop concerns (RO, bounded settle rAF, listeners) live in the directive, released in `onDestroy` — the exact shape neural-scene already ships. Determinism preserved (union-find in sorted order, golden-angle seed, `max(|x|,|y|)` spiral — no `Math.random`). ✔ [high]
+- **CI / honesty bar** — FE-only, testable headless (Playwright `:4210` + `mock-tauri.js` with a seeded multi-component `FullGraphData`). But "professional look" is a **real-render judgment**: a green `ng build` proves nothing; the deliverable must be verified with screenshots against a realistic multi-component fixture at min/mid/max zoom. [high]
+
+## Options & tradeoffs
+
+- **Option A — Quick win (S):** per-node positional gravity (~0.04–0.06/iter) replacing `*0.006`, softer/`1/d²`-capped repulsion, robust `fit()` (mass-centroid blend / raise `MIN_SCALE`). ~70% of the scatter fix, ships fast, but a global sim still can't fully centralise k singletons. Stopgap.
+- **Option B — The real fix (M):** connected-components (union-find) → per-component FR (reuse existing) → tile degree-0 singletons into one grid block → **`max(|x|,|y|)` spiral bounding-box packing**, aspect-aware → per-component shift. Compact, centred, no corner-scatter, aspect-filled. **This is the layout decision.**
+- **Option C — Renderer parity (M, do with B):** port `haloSprite`/`makeBg`/`drawLabels`/`drawTooltip`/`fitCamera` + batched edges + hover-mute + zoom-% + Fit + a bounded settle; raise `MAX_NODES→~500`; click=focus/dblclick=open. **This is the "stop looking bare" decision.**
+- **Option D — Showcase (L, defer):** in-canvas search-to-node, community colouring, hulls, minimap, polyomino-exact packing. Search is the most valuable of these and a strong fast-follow; the rest are diminishing returns.
+
+## Recommendation & first step
+
+**Ship B + C together** (they touch the same two files and are jointly the redesign the user asked for), with **search (from D) as the immediate fast-follow**. Skip Barnes-Hut, polyomino-exact, minimap/hulls.
+
+**Smallest verifiable first slice / de-risk spike:** implement `packComponents(boxes:{w,h}[], aspect) → {dx,dy}[]` as a standalone pure deterministic function (unit-test: 3 boxes → known offsets), plus the union-find split, then render a **seeded fixture** (one ~30-node cluster + ~40 degree-0 singletons) via the Playwright mock and screenshot at min/mid/max zoom. Success = the drawn node-centre bbox is a small, centred fraction of the canvas (not three corners) and ≥N labels render (scale didn't collapse to `MIN_SCALE`). That same fixture verifies the whole redesign.
+
+## Open questions / what I couldn't verify
+
+- **Real vault component distribution** — the *mechanism* creating singletons is proven (`build_full_graph` adds all nodes at degree 0), but not the live count of isolated components in this vault. If almost everything is connected, Option A alone might suffice — but B is robust either way. (Cheap check: log `components.length` + singleton count on load.)
+- **Obsidian's factory force defaults** — parameter names/roles solid; exact default numbers not published (one user's custom config only).
+- **box-packing vs polyomino compactness gap on *our* data** — inference (mostly singletons + one dominant cluster → box ≈ polyomino); only a real-render comparison settles it.
+- **"Professional" quality + per-frame cost at 400–500 nodes** — inherently a real-render/Playwright-timing judgment on a real Mac, not a unit test. The honest bar: screenshots + a repaint-time measurement, not a green build.
+
+## Sources
+
+**External (fetched):** Graphviz packMode docs; cytoscape.js layout-utilities / fcose / cose-bilkent READMEs; Freivalds–Doğrusöz–Kikusts "Disconnected Graph Layout and the Polyomino Packing Approach" (GD 2001, Bilkent PDF); ForceAtlas2 (Jacomy et al., PLOS ONE 2014) + Gephi `ForceFactory.java`; d3-force `forceX/forceY` position docs + D3-in-Depth force layout; Jeff Heer "The Barnes-Hut Approximation" (~6000-node crossover); MDN "Optimizing canvas" + `createRadialGradient`/`globalCompositeOperation`; d3 `alphaDecay≈0.0228`/`alphaMin=0.001` (300-tick stop); Cytoscape Rendering-Engine LOD (labels <200 nodes, coarse LOD ≥4000); Kumu Focus/SNA (hover-mute, adjustable degree); Obsidian graph-view help + forum (text-fade-threshold, local-graph depth); Sigma.js (search + neighbourhood); d3-hierarchy #86 (radius ∝ √value).
+
+**Code (this repo):** `src/app/features/brain/full-brain-graph/full-brain-graph.component.ts:41,234-388`; `full-brain-scene.directive.ts:63,349-372,472-476,501,518,545-546`; `src/app/features/brain/neural-scene.directive.ts:150,159,595,610,620,1160,1190,1227,1248,1283,1350,1404-1408,1453,1537`; `src-tauri/src/storage/graph_store.rs:567-700,865`; `src-tauri/src/storage/db.rs:6420,6428`; `src/app/core/models.ts:1499-1567`; `src/app/features/graph/graph/graph.component.ts:112-136`; `src/design-tokens/colors.css:66-69`.

--- a/e2e/brain/full-brain-graph.spec.ts
+++ b/e2e/brain/full-brain-graph.spec.ts
@@ -143,32 +143,31 @@ test("full-brain graph: a sealed meeting's title/name never renders; the hidden-
 
 /**
  * PR-9 F6 (CAP DISCLOSURE, the silent-trim class): with more visible nodes than the
- * FE draw cap (MAX_NODES = 140), the disclosure banner must name what is ACTUALLY
- * DRAWN, not the backend's post-per-kind-cap `nodes.length`. The toolbar caption
- * ("N items") and the banner ("Drawing N of M items") must AGREE on the drawn count —
- * the F1 fix (before it, the caption said 300 while 140 somas were painted and the
- * banner claimed the backend total). Feeds 300 visible nodes with `totalVisibleNodes`
- * 300; asserts the drawn caption count === the banner's disclosed drawn count === 140.
+ * FE draw cap (MAX_NODES = 500 since the 2026-07-19 redesign), the disclosure banner
+ * must name what is ACTUALLY DRAWN, not the backend's post-per-kind-cap `nodes.length`.
+ * The toolbar caption ("N items") and the banner ("Drawing N of M items") must AGREE on
+ * the drawn count. Feeds 600 visible nodes with `totalVisibleNodes` 600; asserts the
+ * drawn caption count === the banner's disclosed drawn count === 500.
  */
 test("full-brain graph: the draw-cap disclosure names the DRAWN count, and the caption agrees", async ({
   page,
 }) => {
   await mockTauri(page, {
     get_full_graph: () => {
-      // 300 note nodes (> the 140 draw cap). Give each a distinct degree so the
-      // top-140-by-degree selection is deterministic.
-      const nodes = Array.from({ length: 300 }, (_v, i) => ({
+      // 600 note nodes (> the 500 draw cap). Give each a distinct degree so the
+      // top-500-by-degree selection is deterministic.
+      const nodes = Array.from({ length: 600 }, (_v, i) => ({
         id: `n${String(i).padStart(4, "0")}`,
         kind: "note",
         label: `Note ${i}`,
         date: "2026-07-01T00:00:00Z",
-        degree: 300 - i,
+        degree: 600 - i,
       }));
       return {
         nodes,
         edges: [],
         hasHidden: false,
-        totalVisibleNodes: 300,
+        totalVisibleNodes: 600,
         edgesTruncated: false,
       };
     },
@@ -180,10 +179,74 @@ test("full-brain graph: the draw-cap disclosure names the DRAWN count, and the c
   const graph = page.locator("app-full-brain-graph");
   await expect(graph).toBeVisible();
 
-  // The banner discloses the DRAWN count (140), not the backend total (300).
-  await expect(graph.getByText(/Drawing 140 of 300 items/)).toBeVisible();
+  // The banner discloses the DRAWN count (500), not the backend total (600).
+  await expect(graph.getByText(/Drawing 500 of 600 items/)).toBeVisible();
 
-  // The toolbar caption's item count MUST match what the banner says is drawn (140) —
+  // The toolbar caption's item count MUST match what the banner says is drawn (500) —
   // no more claiming more items than the canvas paints (the F1 fix).
-  await expect(graph.getByText(/140 items ·/)).toBeVisible();
+  await expect(graph.getByText(/500 items ·/)).toBeVisible();
+});
+
+/**
+ * The Layers|Clusters view-mode toggle (2026-07-19 "neural" redesign): the graph
+ * defaults to the LAYERED (neural-band) layout, and switching to Clusters (the
+ * organic per-component layout) is a CLIENT-SIDE re-layout — same nodes, NO
+ * re-fetch — with a clean console (guards the animation-loop + layout swap against
+ * NG0600 / paint regressions).
+ */
+test("full-brain graph: the Layers|Clusters mode toggle re-lays out client-side, clean console", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+  await mockTauri(page, {
+    get_full_graph: () => {
+      const w = window as unknown as { __fullGraphCalls?: number };
+      w.__fullGraphCalls = (w.__fullGraphCalls ?? 0) + 1;
+      return {
+        nodes: [
+          { id: "e1", kind: "entity", label: "Alice", date: null, degree: 1 },
+          { id: "m1", kind: "meeting", label: "Standup", date: "2026-07-01", degree: 2 },
+          { id: "n1", kind: "note", label: "Roadmap", date: "2026-07-02", degree: 1 },
+        ],
+        edges: [
+          { src: "e1", dst: "m1", srcKind: "entity", dstKind: "meeting", kind: "mention", score: 1, status: "active" },
+          { src: "m1", dst: "n1", srcKind: "meeting", dstKind: "note", kind: "companion", score: 1, status: "active" },
+        ],
+        hasHidden: false,
+        totalVisibleNodes: 3,
+        edgesTruncated: false,
+      };
+    },
+  });
+
+  await page.goto("/brain");
+  await page.getByRole("button", { name: /Full brain graph/i }).click();
+  const graph = page.locator("app-full-brain-graph");
+  await expect(graph.locator("canvas.fbg-canvas")).toBeVisible();
+
+  // Defaults to Layers (pressed); Clusters is not.
+  await expect(graph.getByRole("button", { name: "Layers" })).toHaveAttribute("aria-pressed", "true");
+  await expect(graph.getByRole("button", { name: "Clusters" })).toHaveAttribute("aria-pressed", "false");
+
+  const callsBefore = await page.evaluate(
+    () => (window as unknown as { __fullGraphCalls?: number }).__fullGraphCalls ?? 0,
+  );
+
+  // Switch to Clusters → client-side re-layout, no re-fetch.
+  await graph.getByRole("button", { name: "Clusters" }).click();
+  await expect(graph.getByRole("button", { name: "Clusters" })).toHaveAttribute("aria-pressed", "true");
+  await expect(graph.getByRole("button", { name: "Layers" })).toHaveAttribute("aria-pressed", "false");
+  const callsAfter = await page.evaluate(
+    () => (window as unknown as { __fullGraphCalls?: number }).__fullGraphCalls ?? 0,
+  );
+  expect(callsAfter).toBe(callsBefore); // NO re-fetch on a mode toggle
+
+  // The caption still reflects the same drawn graph.
+  await expect(graph.getByText(/3 items · 2 links/)).toBeVisible();
+  expect(consoleErrors).toEqual([]);
 });

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.html
@@ -39,6 +39,21 @@
       </div>
     }
 
+    <!-- VIEW MODE — layered "neural" bands vs organic clustered islands. -->
+    <div class="fbg-seg" role="group" aria-label="Graph layout">
+      @for (m of layoutModes; track m.key) {
+        <button
+          type="button"
+          class="fbg-seg-btn"
+          [class.is-on]="layoutMode() === m.key"
+          [attr.aria-pressed]="layoutMode() === m.key"
+          (click)="setLayoutMode(m.key)"
+        >
+          {{ m.label }}
+        </button>
+      }
+    </div>
+
     <!-- LENSES — node-type + edge-type toggle chips (filter what's drawn). -->
     <div class="fbg-lenses">
       <div class="fbg-lens-group" role="group" aria-label="Show node types">
@@ -102,7 +117,9 @@
         [sceneEdges]="sceneEdges()"
         [selectedId]="selectedId()"
         (nodePick)="onPick($event)"
+        (nodeOpen)="onOpen($event)"
         (nodeHover)="hoverId.set($event)"
+        (zoom)="zoomPct.set($event)"
       ></canvas>
 
       <div class="fbg-toolbar" role="toolbar" aria-label="Graph controls">
@@ -112,12 +129,13 @@
         <div class="fbg-pill fbg-zoom">
           <button
             type="button"
-            class="fbg-zbtn"
-            aria-label="Zoom in"
-            (click)="zoomIn()"
+            class="fbg-zbtn fbg-zreset"
+            aria-label="Fit graph to view"
+            (click)="fitView()"
           >
-            +
+            Fit
           </button>
+          <span class="fbg-zdiv" aria-hidden="true"></span>
           <button
             type="button"
             class="fbg-zbtn"
@@ -126,13 +144,14 @@
           >
             −
           </button>
+          <span class="fbg-zpct" aria-hidden="true">{{ zoomPct() }}%</span>
           <button
             type="button"
-            class="fbg-zbtn fbg-zreset"
-            aria-label="Reset view"
-            (click)="resetView()"
+            class="fbg-zbtn"
+            aria-label="Zoom in"
+            (click)="zoomIn()"
           >
-            Reset
+            +
           </button>
         </div>
       </div>
@@ -142,7 +161,8 @@
       @if (hoverLabel(); as label) {
         {{ label }}
       } @else {
-        Drag to pan · scroll to zoom · click a node to open it.
+        Drag to pan · scroll to zoom · click to focus a node · double-click to
+        open it.
       }
     </p>
   }

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.scss
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.scss
@@ -21,6 +21,43 @@
   flex: none;
 }
 
+/* ── VIEW-MODE segmented control (Layers | Clusters) ── */
+.fbg-seg {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--surface-hover);
+}
+.fbg-seg-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: 600 0.8125rem var(--font-sans);
+  height: 26px;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+.fbg-seg-btn:hover {
+  color: var(--text-primary);
+}
+.fbg-seg-btn.is-on {
+  background: var(--surface-overlay);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+.fbg-seg-btn:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+}
+
 /* ── LENSES — node/edge toggle chips (in-flow, above the frame) ── */
 .fbg-lenses {
   display: flex;
@@ -144,6 +181,20 @@
   padding: 2px;
   gap: 2px;
 }
+.fbg-zpct {
+  min-width: 42px;
+  padding: 0 var(--space-1);
+  text-align: center;
+  font: 600 0.75rem var(--font-sans);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.fbg-zdiv {
+  width: 1px;
+  align-self: stretch;
+  margin: 4px 2px;
+  background: var(--border-strong);
+}
 .fbg-zbtn {
   appearance: none;
   border: 0;
@@ -182,7 +233,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .fbg-chip,
-  .fbg-zbtn {
+  .fbg-zbtn,
+  .fbg-seg-btn {
     transition: none;
   }
 }

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -23,6 +23,10 @@ import {
   type FullSceneEdge,
   type FullSceneNode,
 } from "./full-brain-scene.directive";
+import { layoutFullBrain, layoutLayered } from "./full-brain-layout";
+
+/** The two graph shapes: layered "neural" bands, or organic clustered islands. */
+type LayoutMode = "layers" | "clusters";
 
 /** Per-kind node lens chip metadata (label + the token that colors its dot). */
 interface NodeLens {
@@ -37,12 +41,15 @@ interface EdgeLens {
   token: string;
 }
 
-/** Rendered-node hard cap — the strongest-degree top-K keep the draw bounded. */
-const MAX_NODES = 140;
-/** Fixed force-directed iteration count — run ONCE, synchronously, no loop. */
-const ITERATIONS = 260;
-/** Logical world scale (world units); the scene camera fits to the cloud. */
-const WORLD = 1000;
+/**
+ * Rendered-node hard cap — the strongest-degree top-K keep the draw bounded.
+ * Raised 140 → 500 (2026-07-19): the previous cap dropped ~15 of a 155-node vault
+ * ("Drawing 140 of 155"); 500 shows a normal vault IN FULL, and the per-component
+ * layout + tiling in `full-brain-layout.ts` keeps even 500 nodes compact + legible.
+ * Only a pathological vault (the backend returns up to ~2000) now hits the cap,
+ * where the honest "Drawing N of M" disclosure + LOD labels carry it.
+ */
+const MAX_NODES = 500;
 
 /**
  * The FULL-BRAIN GRAPH — `getFullGraph()` rendered as one unified, typed graph:
@@ -131,6 +138,14 @@ export class FullBrainGraphComponent {
   // ── hover hint (a11y / affordance) ───────────────────────────────────────
   readonly hoverId = signal<string | null>(null);
   readonly selectedId = signal<string | null>(null);
+  /** Current zoom as a % of fit (100 = fit-to-view) — the scene reports it. */
+  readonly zoomPct = signal(100);
+  /** Graph shape: layered "neural" bands (default) or organic clustered islands. */
+  readonly layoutMode = signal<LayoutMode>("layers");
+  protected readonly layoutModes: readonly { key: LayoutMode; label: string }[] = [
+    { key: "layers", label: "Layers" },
+    { key: "clusters", label: "Clusters" },
+  ];
 
   // ── honest disclosures (mirror the entity graph) ─────────────────────────
   protected readonly hasHidden = computed(
@@ -224,167 +239,42 @@ export class FullBrainGraphComponent {
   protected readonly drawnEdgeCount = computed(() => this.sceneEdges().length);
 
   /**
-   * The laid-out scene nodes — a PURE derivation of the lens-filtered graph.
-   * Top-{@link MAX_NODES} by in-graph degree (id tiebreak), circular seed keyed
-   * by sort index, a fixed {@link ITERATIONS}-iteration 2-D Fruchterman-Reingold
-   * pass (pairwise repulsion + edge springs + gentle centre pull), then an
-   * overlap-relaxation pass. Deterministic: no `Math.random`, coincident points
-   * get index-hash nudges — same data → identical layout every render.
+   * The laid-out scene nodes — a PURE derivation of the lens-filtered graph via
+   * {@link layoutFullBrain}: top-{@link MAX_NODES} by in-graph degree (id
+   * tiebreak), then per-connected-component Fruchterman-Reingold + degree-0
+   * singleton tiling + shelf-packing so disconnected orphans never scatter to the
+   * corners. Deterministic (no `Math.random`) — same data → identical layout, as
+   * the `computed()` re-run on every lens toggle requires.
    */
   protected readonly sceneNodes = computed<FullSceneNode[]>(() => {
     const all = this.filteredNodes();
     if (all.length === 0) {
       return [];
     }
-    // Deterministic order: highest-degree first, id as a stable tiebreak.
+    // Deterministic order: highest-degree first, id as a stable tiebreak; cap.
     const ordered = [...all].sort(
       (a, b) => b.degree - a.degree || a.id.localeCompare(b.id),
     );
-    const nodes = ordered.slice(0, MAX_NODES);
-    const n = nodes.length;
-    const idIndex = new Map(nodes.map((x, i) => [x.id, i]));
-
-    // Degree → soma radius (7…20 world units), sqrt-scaled.
-    const maxDeg = Math.max(1, ...nodes.map((x) => x.degree));
-    const radii = nodes.map(
-      (x) => 7 + (Math.sqrt(x.degree) / Math.sqrt(maxDeg)) * 13,
+    const capped = ordered.slice(0, MAX_NODES);
+    const layout =
+      this.layoutMode() === "layers" ? layoutLayered : layoutFullBrain;
+    return layout(
+      capped.map((nd) => ({
+        id: nd.id,
+        kind: nd.kind,
+        label: nd.label,
+        degree: nd.degree,
+        date: nd.date,
+      })),
+      // Only edges whose endpoints both survive the cap contribute; the layout
+      // filters internally, so passing all lens-filtered edges is fine.
+      this.filteredEdges().map((e) => ({
+        src: e.src,
+        dst: e.dst,
+        srcKind: e.srcKind,
+        dstKind: e.dstKind,
+      })),
     );
-
-    // SEED: a golden-angle spiral keyed by sort index → identical every render.
-    const golden = Math.PI * (3 - Math.sqrt(5));
-    const seedR = WORLD * 0.42;
-    const xs = new Float64Array(n);
-    const ys = new Float64Array(n);
-    for (let i = 0; i < n; i++) {
-      const rr = seedR * Math.sqrt((i + 0.5) / n);
-      const ang = i * golden;
-      xs[i] = rr * Math.cos(ang);
-      ys[i] = rr * Math.sin(ang);
-    }
-
-    // Only edges whose endpoints both survived the cap participate in springs.
-    const edges = this.filteredEdges().filter(
-      (e) => idIndex.has(e.src) && idIndex.has(e.dst),
-    );
-    const degree = new Map<string, number>();
-    for (const e of edges) {
-      degree.set(e.src, (degree.get(e.src) ?? 0) + 1);
-      degree.set(e.dst, (degree.get(e.dst) ?? 0) + 1);
-    }
-
-    // 2-D Fruchterman-Reingold.
-    const k = Math.sqrt((WORLD * WORLD) / Math.max(1, n)) * 1.1;
-    const k2 = k * k;
-    let temp = WORLD * 0.14;
-    const cool = temp / (ITERATIONS + 1);
-    const dxs = new Float64Array(n);
-    const dys = new Float64Array(n);
-
-    for (let iter = 0; iter < ITERATIONS; iter++) {
-      dxs.fill(0);
-      dys.fill(0);
-      for (let i = 0; i < n; i++) {
-        for (let j = i + 1; j < n; j++) {
-          let dx = xs[i] - xs[j];
-          let dy = ys[i] - ys[j];
-          let d2 = dx * dx + dy * dy;
-          if (d2 < 0.01) {
-            dx = ((i * 31 + j) % 7) - 3 + 0.5;
-            dy = ((i * 17 + j) % 5) - 2 + 0.5;
-            d2 = dx * dx + dy * dy;
-          }
-          const dist = Math.sqrt(d2);
-          const force = k2 / dist;
-          const fx = (dx / dist) * force;
-          const fy = (dy / dist) * force;
-          dxs[i] += fx;
-          dys[i] += fy;
-          dxs[j] -= fx;
-          dys[j] -= fy;
-        }
-      }
-      for (const e of edges) {
-        const i = idIndex.get(e.src) as number;
-        const j = idIndex.get(e.dst) as number;
-        const dx = xs[i] - xs[j];
-        const dy = ys[i] - ys[j];
-        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
-        // Attenuate hub springs (÷√min-degree) so high-degree nodes don't crush
-        // their whole neighbourhood into one clump.
-        const hub = Math.sqrt(
-          Math.min(degree.get(e.src) ?? 1, degree.get(e.dst) ?? 1),
-        );
-        const force = ((dist * dist) / k / hub) * 0.9;
-        const fx = (dx / dist) * force;
-        const fy = (dy / dist) * force;
-        dxs[i] -= fx;
-        dys[i] -= fy;
-        dxs[j] += fx;
-        dys[j] += fy;
-      }
-      for (let i = 0; i < n; i++) {
-        const dl = Math.sqrt(dxs[i] * dxs[i] + dys[i] * dys[i]) || 1;
-        const step = Math.min(dl, temp);
-        xs[i] += (dxs[i] / dl) * step;
-        ys[i] += (dys[i] / dl) * step;
-        xs[i] -= xs[i] * 0.006;
-        ys[i] -= ys[i] * 0.006;
-      }
-      temp = Math.max(0, temp - cool);
-    }
-
-    // Recentre on the centroid.
-    let mx = 0;
-    let my = 0;
-    for (let i = 0; i < n; i++) {
-      mx += xs[i];
-      my += ys[i];
-    }
-    mx /= n;
-    my /= n;
-    for (let i = 0; i < n; i++) {
-      xs[i] -= mx;
-      ys[i] -= my;
-    }
-
-    // OVERLAP RELAXATION: push any two somas apart until clear.
-    for (let pass = 0; pass < 30; pass++) {
-      let moved = false;
-      for (let i = 0; i < n; i++) {
-        for (let j = i + 1; j < n; j++) {
-          let dx = xs[i] - xs[j];
-          let dy = ys[i] - ys[j];
-          let dist = Math.sqrt(dx * dx + dy * dy);
-          const need = radii[i] + radii[j] + 16;
-          if (dist >= need) {
-            continue;
-          }
-          if (dist < 0.01) {
-            dx = ((i * 31 + j) % 7) - 3 + 0.5;
-            dy = ((i * 17 + j) % 5) - 2 + 0.5;
-            dist = Math.sqrt(dx * dx + dy * dy);
-          }
-          const push = (need - dist) / 2 / dist;
-          xs[i] += dx * push;
-          ys[i] += dy * push;
-          xs[j] -= dx * push;
-          ys[j] -= dy * push;
-          moved = true;
-        }
-      }
-      if (!moved) {
-        break;
-      }
-    }
-
-    return nodes.map((node, i) => ({
-      id: node.id,
-      kind: node.kind,
-      label: node.label,
-      r: radii[i],
-      x: xs[i],
-      y: ys[i],
-    }));
   });
 
   /**
@@ -402,6 +292,8 @@ export class FullBrainGraphComponent {
           key: `${e.srcKind}:${e.src}::${e.dstKind}:${e.dst}::${e.kind}`,
           src: e.src,
           dst: e.dst,
+          srcKind: e.srcKind,
+          dstKind: e.dstKind,
           kind: e.kind,
           suggested: e.status === "suggested",
         });
@@ -486,6 +378,9 @@ export class FullBrainGraphComponent {
   protected toggleSuggested(): void {
     this.showSuggested.update((v) => !v);
   }
+  protected setLayoutMode(mode: LayoutMode): void {
+    this.layoutMode.set(mode);
+  }
 
   // ── camera toolbar (delegates to the scene directive) ────────────────────
   protected zoomIn(): void {
@@ -494,21 +389,27 @@ export class FullBrainGraphComponent {
   protected zoomOut(): void {
     this.scene()?.zoomBy(0.8);
   }
-  protected resetView(): void {
+  /** "Fit" — re-frame the whole cloud in the viewport. */
+  protected fitView(): void {
     this.scene()?.resetView();
   }
 
-  // ── click-through (route by node kind — reuse existing nav) ──────────────
+  /**
+   * Single click = FOCUS a node (pin selection so its neighbourhood spotlights
+   * and the user can dwell on it), toggling off on a second click or on empty
+   * space. It NEVER navigates — that's {@link onOpen} (double-click). This fixes
+   * the old "a click yanks you to a route so you can never explore" behaviour.
+   */
   protected onPick(id: string | null): void {
-    if (id === null) {
-      this.selectedId.set(null);
-      return;
-    }
+    this.selectedId.update((cur) => (id !== null && cur === id ? null : id));
+  }
+
+  /** Double click = OPEN the node (route by kind — reuse existing nav). */
+  protected onOpen(id: string): void {
     const node = this.graphData()?.nodes.find((n) => n.id === id);
     if (!node) {
       return;
     }
-    this.selectedId.set(id);
     switch (node.kind) {
       case "meeting":
         void this.router.navigate(["/meeting", id]);

--- a/src/app/features/brain/full-brain-graph/full-brain-layout.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-layout.ts
@@ -1,0 +1,616 @@
+import type { FullGraphNodeKind } from "../../../core/models";
+import type { FullSceneNode } from "./full-brain-scene.directive";
+
+/**
+ * THE FULL-BRAIN LAYOUT ENGINE — a pure, deterministic function that turns the
+ * lens-filtered (already draw-capped) typed nodes + edges into origin-centred
+ * world positions for the scene to project.
+ *
+ * WHY THIS EXISTS (the 2026-07-19 redesign): the previous layout ran ONE global
+ * Fruchterman-Reingold over every node. `build_full_graph` emits every visible
+ * entity/meeting/note/document as a node — many with `degree: 0` (an orphan doc
+ * with no wikilink, a fresh note, a meeting whose entities co-occur nowhere) —
+ * i.e. genuine 1-node connected components. A single global sim REPELS those
+ * singletons to the corners (long-reach `k²/d` repulsion, near-zero centre pull)
+ * and the camera then fits the blown-out bounding box → everything shrinks below
+ * the label threshold → the "scattered unlabeled dots" bug.
+ *
+ * THE FIX (per-component layout + packing — the technique fcose/Graphviz/Gephi
+ * use): detect connected components (union-find), lay out EACH ONE independently
+ * with a local FR at a FIXED ideal edge length (so a 2-node component stays small
+ * instead of spanning the world), TILE all degree-0 singletons into ONE compact
+ * grid block, then SHELF-PACK every component's bounding box into a target aspect
+ * ratio and centre the whole cloud on the origin. No inter-component repulsion,
+ * no wasted space, no corner-scatter — and it stays fully DETERMINISTIC (no
+ * `Math.random`; a golden-angle seed keyed by index, union-find in index order),
+ * which the caller's `computed()` requires (it re-runs on every lens toggle).
+ *
+ * Everything here is O(n²) at worst over ≤ a few hundred nodes and runs ONCE per
+ * graph/lens change off the render thread — no Barnes-Hut quadtree needed (its
+ * build overhead doesn't pay off until ~thousands of nodes).
+ */
+
+/** Ideal edge length (world units) — the natural spacing between two linked
+ *  nodes. FIXED per component (not `√(WORLD²/n)`) so small components stay
+ *  physically small and pack tightly instead of ballooning. */
+const IDEAL_EDGE = 92;
+/** Min / max soma radius (world units), sqrt(degree)-scaled between them. */
+const MIN_R = 6;
+const MAX_R = 18;
+/** Clear gap (world units) enforced between any two somas after layout. */
+const NODE_GAP = 14;
+/** Gap (world units) padded around every component before packing. */
+const COMPONENT_SPACING = 46;
+/** Extra gap between tiled singleton cells. */
+const TILE_GAP = 14;
+/** Pack toward this width:height ratio; the camera then fits the real viewport. */
+const TARGET_ASPECT = 1.6;
+/** Half-width (in grid cells) of the packing spiral lattice. */
+const PACK_R = 84;
+/**
+ * A deterministic square-spiral of integer grid offsets, sorted center-out with
+ * cost `max(|gx|, |gy|·aspect)` so packing grows WIDER than tall (fills the
+ * usually-wide canvas). Precomputed ONCE at module load (data-independent) so
+ * `packBoxes` never re-sorts. This is the Freivalds–Doğrusöz–Kikusts placement
+ * order — each component lands at the free cell nearest the centre.
+ */
+const SORTED_LATTICE: readonly (readonly [number, number])[] = (() => {
+  const pts: [number, number][] = [];
+  for (let gx = -PACK_R; gx <= PACK_R; gx++) {
+    for (let gy = -PACK_R; gy <= PACK_R; gy++) {
+      pts.push([gx, gy]);
+    }
+  }
+  const cost = (p: [number, number]): number =>
+    Math.max(Math.abs(p[0]), Math.abs(p[1]) * TARGET_ASPECT);
+  pts.sort((a, b) => {
+    const ca = cost(a);
+    const cb = cost(b);
+    if (ca !== cb) return ca - cb;
+    const ma = Math.abs(a[0]) + Math.abs(a[1]);
+    const mb = Math.abs(b[0]) + Math.abs(b[1]);
+    if (ma !== mb) return ma - mb;
+    // Deterministic angular tiebreak so the same data always packs identically.
+    return (
+      Math.atan2(a[1], a[0]) - Math.atan2(b[1], b[0]) ||
+      a[0] - b[0] ||
+      a[1] - b[1]
+    );
+  });
+  return pts;
+})();
+/** FR iterations for a small component; scaled DOWN for large ones (they cost
+ *  O(n²) per iter and converge sooner). */
+const MAX_ITERS = 260;
+
+/** One node the layout consumes — the display fields carried through untouched
+ *  plus the `degree` that drives radius, seeding order and (downstream) labels. */
+export type FbLayoutNode = Omit<FullSceneNode, "r" | "x" | "y">;
+
+/** The one edge shape the layout needs: endpoints matched by `(kind, id)` so a
+ *  cross-kind id collision can never wire the wrong nodes together. */
+export interface FbLayoutEdge {
+  src: string;
+  dst: string;
+  srcKind: FullGraphNodeKind;
+  dstKind: FullGraphNodeKind;
+}
+
+interface Box {
+  /** Half-extent (world units), INCLUDING the member soma radii. */
+  halfW: number;
+  halfH: number;
+  /** Global node indices this box owns (its positions already origin-local). */
+  members: number[];
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Coerce degree to a finite, non-negative number (a single non-finite degree
+ *  would otherwise poison `maxDeg` → every radius/position to NaN). Not reachable
+ *  via the typed backend, but keeps the pure layout total on any input. */
+function degOf(x: FbLayoutNode): number {
+  return Number.isFinite(x.degree) ? Math.max(0, x.degree) : 0;
+}
+
+/** Per-node soma radius, sqrt(degree)-scaled between MIN_R and MAX_R. */
+function computeRadii(nodes: FbLayoutNode[]): number[] {
+  const sqMaxDeg = Math.sqrt(Math.max(1, ...nodes.map(degOf)));
+  return nodes.map((x) => MIN_R + (Math.sqrt(degOf(x)) / sqMaxDeg) * (MAX_R - MIN_R));
+}
+
+/** Edges as index pairs into `nodes`, matched by (kind:id), self-loops dropped. */
+function edgeIndexPairs(
+  nodes: FbLayoutNode[],
+  edges: FbLayoutEdge[],
+): [number, number][] {
+  const index = new Map<string, number>();
+  for (let i = 0; i < nodes.length; i++) {
+    index.set(`${nodes[i].kind}:${nodes[i].id}`, i);
+  }
+  const pairs: [number, number][] = [];
+  for (const e of edges) {
+    const a = index.get(`${e.srcKind}:${e.src}`);
+    const b = index.get(`${e.dstKind}:${e.dst}`);
+    if (a === undefined || b === undefined || a === b) {
+      continue;
+    }
+    pairs.push([a, b]);
+  }
+  return pairs;
+}
+
+/**
+ * Lay the whole brain out. Returns one placed node per input node (same fields,
+ * plus `r`/`x`/`y`), origin-centred. Empty in → empty out.
+ */
+export function layoutFullBrain(
+  inputNodes: FbLayoutNode[],
+  inputEdges: FbLayoutEdge[],
+): FullSceneNode[] {
+  const n = inputNodes.length;
+  if (n === 0) {
+    return [];
+  }
+
+  // ── radii (area ∝ degree ⇒ radius ∝ √degree) ──
+  const radii = computeRadii(inputNodes);
+
+  // ── adjacency by (kind:id) — collision-safe endpoint matching ──
+  const edgePairs = edgeIndexPairs(inputNodes, inputEdges);
+
+  // ── connected components (union-find; lower root wins ⇒ deterministic) ──
+  const parent = new Int32Array(n);
+  for (let i = 0; i < n; i++) {
+    parent[i] = i;
+  }
+  const find = (i: number): number => {
+    let r = i;
+    while (parent[r] !== r) {
+      parent[r] = parent[parent[r]];
+      r = parent[r];
+    }
+    return r;
+  };
+  for (const [a, b] of edgePairs) {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) {
+      parent[Math.max(ra, rb)] = Math.min(ra, rb);
+    }
+  }
+  // Group nodes by root, preserving ascending-index order within each group.
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const r = find(i);
+    const g = groups.get(r);
+    if (g) {
+      g.push(i);
+    } else {
+      groups.set(r, [i]);
+    }
+  }
+
+  const xs = new Float64Array(n);
+  const ys = new Float64Array(n);
+
+  // Split into real clusters (≥2) and degree-isolated singletons.
+  const clusters: number[][] = [];
+  const singletons: number[] = [];
+  for (const members of groups.values()) {
+    if (members.length === 1) {
+      singletons.push(members[0]);
+    } else {
+      clusters.push(members);
+    }
+  }
+
+  const boxes: Box[] = [];
+
+  // ── lay out each cluster locally (origin-centred), record its bbox ──
+  for (const members of clusters) {
+    layoutCluster(members, edgePairs, radii, xs, ys);
+    boxes.push(bboxOf(members, radii, xs, ys));
+  }
+
+  // ── tile every singleton into ONE compact grid block ──
+  if (singletons.length > 0) {
+    boxes.push(tileSingletons(singletons, radii, xs, ys));
+  }
+
+  // ── spiral-pack the boxes center-out, centred on the origin ──
+  const offsets = packBoxes(boxes);
+  for (let bi = 0; bi < boxes.length; bi++) {
+    const { dx, dy } = offsets[bi];
+    for (const i of boxes[bi].members) {
+      xs[i] += dx;
+      ys[i] += dy;
+    }
+  }
+
+  return inputNodes.map((nd, i) => ({
+    ...nd,
+    r: radii[i],
+    x: xs[i],
+    y: ys[i],
+  }));
+}
+
+/**
+ * LAYERED "neural-net" layout — nodes in horizontal BANDS by kind (people/
+ * projects → meetings → notes → documents, top to bottom), ordered left-to-right
+ * within each band by a barycentric sweep that minimises edge crossings (a
+ * connected node drifts over the nodes it links to, so cross-band edges read as
+ * clean vertical flows — the "neural net" look). Bands are WIDE not tall, so it
+ * fills the usually-wide canvas. Fully deterministic. Empty in → empty out.
+ */
+export function layoutLayered(
+  inputNodes: FbLayoutNode[],
+  inputEdges: FbLayoutEdge[],
+): FullSceneNode[] {
+  const n = inputNodes.length;
+  if (n === 0) {
+    return [];
+  }
+  const radii = computeRadii(inputNodes);
+
+  // Fixed semantic top→bottom order; only kinds actually present get a band.
+  const KIND_ORDER: FullGraphNodeKind[] = [
+    "entity",
+    "meeting",
+    "note",
+    "document",
+  ];
+  const bandOf = new Map<FullGraphNodeKind, number>();
+  const bands: number[][] = [];
+  for (const k of KIND_ORDER) {
+    if (inputNodes.some((nd) => nd.kind === k)) {
+      bandOf.set(k, bands.length);
+      bands.push([]);
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    bands[bandOf.get(inputNodes[i].kind) as number].push(i);
+  }
+
+  const adj: number[][] = inputNodes.map(() => []);
+  for (const [a, b] of edgeIndexPairs(inputNodes, inputEdges)) {
+    adj[a].push(b);
+    adj[b].push(a);
+  }
+
+  // Seed each band by degree desc (id tiebreak).
+  for (const band of bands) {
+    band.sort(
+      (a, b) =>
+        degOf(inputNodes[b]) - degOf(inputNodes[a]) ||
+        (inputNodes[a].id < inputNodes[b].id ? -1 : 1),
+    );
+  }
+  // lane[idx] = position within its band (the crossing-reduction coordinate).
+  const lane = new Float64Array(n);
+  for (const band of bands) {
+    band.forEach((idx, r) => (lane[idx] = r));
+  }
+
+  // Barycentric sweeps: each node drifts toward the mean lane of its neighbours,
+  // so connected nodes stack over one another and edges stop crossing.
+  for (let iter = 0; iter < 14; iter++) {
+    for (const band of bands) {
+      const bary = band.map((idx) => {
+        let sum = 0;
+        let cnt = 0;
+        for (const nb of adj[idx]) {
+          sum += lane[nb];
+          cnt++;
+        }
+        return cnt > 0 ? sum / cnt : lane[idx];
+      });
+      const order = band
+        .map((_, k) => k)
+        .sort((x, y) => bary[x] - bary[y] || band[x] - band[y]);
+      const reordered = order.map((k) => band[k]);
+      for (let r = 0; r < reordered.length; r++) {
+        band[r] = reordered[r];
+        lane[reordered[r]] = r;
+      }
+    }
+  }
+
+  // Final coords: bands stacked vertically, laid out left→right within each band,
+  // both axes centred on the origin.
+  const LANE_GAP = 46;
+  const BAND_GAP = 200;
+  const xs = new Float64Array(n);
+  const ys = new Float64Array(n);
+  const totalH = (bands.length - 1) * BAND_GAP;
+  for (let bi = 0; bi < bands.length; bi++) {
+    const band = bands[bi];
+    const bandW = (band.length - 1) * LANE_GAP;
+    for (let r = 0; r < band.length; r++) {
+      xs[band[r]] = r * LANE_GAP - bandW / 2;
+      ys[band[r]] = bi * BAND_GAP - totalH / 2;
+    }
+  }
+
+  return inputNodes.map((nd, i) => ({ ...nd, r: radii[i], x: xs[i], y: ys[i] }));
+}
+
+/**
+ * Fruchterman-Reingold for ONE connected component, at a FIXED ideal edge length
+ * so components stay size-proportionate. Golden-angle seed (deterministic),
+ * pairwise repulsion + hub-attenuated springs + a gentle per-node centre pull,
+ * then an overlap-relaxation pass. Writes final origin-local coords into the
+ * global `xs`/`ys` at the members' indices.
+ */
+function layoutCluster(
+  members: number[],
+  allEdges: [number, number][],
+  radii: number[],
+  xs: Float64Array,
+  ys: Float64Array,
+): void {
+  const m = members.length;
+  const local = new Map<number, number>();
+  for (let l = 0; l < m; l++) {
+    local.set(members[l], l);
+  }
+  const lr = members.map((g) => radii[g]);
+
+  // Internal edges as local index pairs + local degree.
+  const edges: [number, number][] = [];
+  const degree = new Int32Array(m);
+  for (const [a, b] of allEdges) {
+    const la = local.get(a);
+    const lb = local.get(b);
+    if (la === undefined || lb === undefined) {
+      continue;
+    }
+    edges.push([la, lb]);
+    degree[la]++;
+    degree[lb]++;
+  }
+
+  const lx = new Float64Array(m);
+  const ly = new Float64Array(m);
+  // SEED: golden-angle (phyllotaxis) spiral keyed by index → identical every run.
+  const golden = Math.PI * (3 - Math.sqrt(5));
+  const seedR = IDEAL_EDGE * Math.sqrt(m) * 0.5;
+  for (let i = 0; i < m; i++) {
+    const rr = seedR * Math.sqrt((i + 0.5) / m);
+    const ang = i * golden;
+    lx[i] = rr * Math.cos(ang);
+    ly[i] = rr * Math.sin(ang);
+  }
+
+  const k = IDEAL_EDGE;
+  const k2 = k * k;
+  const iters = clamp(Math.round(2600 / Math.sqrt(m)), 90, MAX_ITERS);
+  let temp = k * 1.6;
+  const cool = temp / (iters + 1);
+  const dxs = new Float64Array(m);
+  const dys = new Float64Array(m);
+
+  for (let iter = 0; iter < iters; iter++) {
+    dxs.fill(0);
+    dys.fill(0);
+    // repulsion (all pairs)
+    for (let i = 0; i < m; i++) {
+      for (let j = i + 1; j < m; j++) {
+        let dx = lx[i] - lx[j];
+        let dy = ly[i] - ly[j];
+        let d2 = dx * dx + dy * dy;
+        if (d2 < 0.01) {
+          dx = ((i * 31 + j) % 7) - 3 + 0.5;
+          dy = ((i * 17 + j) % 5) - 2 + 0.5;
+          d2 = dx * dx + dy * dy;
+        }
+        const dist = Math.sqrt(d2);
+        const force = k2 / dist;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        dxs[i] += fx;
+        dys[i] += fy;
+        dxs[j] -= fx;
+        dys[j] -= fy;
+      }
+    }
+    // springs (hub-attenuated so a hub doesn't crush its neighbourhood)
+    for (const [a, b] of edges) {
+      const dx = lx[a] - lx[b];
+      const dy = ly[a] - ly[b];
+      const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+      const hub = Math.sqrt(Math.min(degree[a] || 1, degree[b] || 1));
+      const force = ((dist * dist) / k / hub) * 0.9;
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      dxs[a] -= fx;
+      dys[a] -= fy;
+      dxs[b] += fx;
+      dys[b] += fy;
+    }
+    // integrate + a gentle per-node centre pull (keeps the component compact)
+    for (let i = 0; i < m; i++) {
+      const dl = Math.sqrt(dxs[i] * dxs[i] + dys[i] * dys[i]) || 1;
+      const step = Math.min(dl, temp);
+      lx[i] += (dxs[i] / dl) * step;
+      ly[i] += (dys[i] / dl) * step;
+      lx[i] -= lx[i] * 0.03;
+      ly[i] -= ly[i] * 0.03;
+    }
+    temp = Math.max(0, temp - cool);
+  }
+
+  // recentre on the centroid
+  let mx = 0;
+  let my = 0;
+  for (let i = 0; i < m; i++) {
+    mx += lx[i];
+    my += ly[i];
+  }
+  mx /= m;
+  my /= m;
+  for (let i = 0; i < m; i++) {
+    lx[i] -= mx;
+    ly[i] -= my;
+  }
+
+  // overlap relaxation — push any two somas apart until clear
+  for (let pass = 0; pass < 30; pass++) {
+    let moved = false;
+    for (let i = 0; i < m; i++) {
+      for (let j = i + 1; j < m; j++) {
+        let dx = lx[i] - lx[j];
+        let dy = ly[i] - ly[j];
+        let dist = Math.sqrt(dx * dx + dy * dy);
+        const need = lr[i] + lr[j] + NODE_GAP;
+        if (dist >= need) {
+          continue;
+        }
+        if (dist < 0.01) {
+          dx = ((i * 31 + j) % 7) - 3 + 0.5;
+          dy = ((i * 17 + j) % 5) - 2 + 0.5;
+          dist = Math.sqrt(dx * dx + dy * dy);
+        }
+        const push = (need - dist) / 2 / dist;
+        lx[i] += dx * push;
+        ly[i] += dy * push;
+        lx[j] -= dx * push;
+        ly[j] -= dy * push;
+        moved = true;
+      }
+    }
+    if (!moved) {
+      break;
+    }
+  }
+
+  for (let i = 0; i < m; i++) {
+    xs[members[i]] = lx[i];
+    ys[members[i]] = ly[i];
+  }
+}
+
+/** Tile the degree-isolated singletons into one compact, origin-centred grid. */
+function tileSingletons(
+  singletons: number[],
+  radii: number[],
+  xs: Float64Array,
+  ys: Float64Array,
+): Box {
+  const count = singletons.length;
+  let r = MIN_R;
+  for (const i of singletons) {
+    r = Math.max(r, radii[i]);
+  }
+  const cell = 2 * r + TILE_GAP;
+  const cols = Math.max(1, Math.round(Math.sqrt(count * TARGET_ASPECT)));
+  const rows = Math.ceil(count / cols);
+  const blockW = cols * cell;
+  const blockH = rows * cell;
+  for (let kk = 0; kk < count; kk++) {
+    const col = kk % cols;
+    const row = Math.floor(kk / cols);
+    xs[singletons[kk]] = (col + 0.5) * cell - blockW / 2;
+    ys[singletons[kk]] = (row + 0.5) * cell - blockH / 2;
+  }
+  return { halfW: blockW / 2, halfH: blockH / 2, members: singletons };
+}
+
+/** Bounding half-extents of a component's placed somas (radii included). */
+function bboxOf(
+  members: number[],
+  radii: number[],
+  xs: Float64Array,
+  ys: Float64Array,
+): Box {
+  let hw = 1;
+  let hh = 1;
+  for (const i of members) {
+    hw = Math.max(hw, Math.abs(xs[i]) + radii[i]);
+    hh = Math.max(hh, Math.abs(ys[i]) + radii[i]);
+  }
+  return { halfW: hw, halfH: hh, members };
+}
+
+/**
+ * SPIRAL-PACK the component boxes center-out (Freivalds–Doğrusöz–Kikusts): place
+ * each box, largest-first, at the free lattice cell nearest the centre (the cost
+ * is `max(|x|, |y|·aspect)` — see {@link SORTED_LATTICE}), so the dominant cluster
+ * anchors the middle and every smaller component fills a GAP around it rather than
+ * trailing off in a shelf row. Then centre the packed cloud on the origin. Returns
+ * one `{dx,dy}` shift per box (index-aligned with `boxes`). Fully deterministic;
+ * no two boxes overlap (half-extents include {@link COMPONENT_SPACING}).
+ */
+function packBoxes(boxes: Box[]): { dx: number; dy: number }[] {
+  const nb = boxes.length;
+  if (nb === 0) {
+    return [];
+  }
+  // Padded half-extents (the spacing gap is baked into the overlap test).
+  const hw = boxes.map((b) => b.halfW + COMPONENT_SPACING / 2);
+  const hh = boxes.map((b) => b.halfH + COMPONENT_SPACING / 2);
+  if (nb === 1) {
+    return [{ dx: 0, dy: 0 }];
+  }
+
+  // Largest-first (area desc, index tiebreak) — anchors the composition centre.
+  const order = boxes
+    .map((_, i) => i)
+    .sort((a, b) => hw[b] * hh[b] - hw[a] * hh[a] || a - b);
+
+  // Grid step = the smallest box's min half-extent (clamped): fine enough to nest
+  // tightly, coarse enough that the ±PACK_R lattice spans the whole layout.
+  let smallest = Infinity;
+  for (let i = 0; i < nb; i++) {
+    smallest = Math.min(smallest, Math.min(hw[i], hh[i]));
+  }
+  const step = clamp(smallest, 20, 70);
+
+  const placed: { cx: number; cy: number; hw: number; hh: number }[] = [];
+  const centre = new Array<{ x: number; y: number }>(nb);
+  for (const idx of order) {
+    let cx = 0;
+    let cy = 0;
+    if (placed.length > 0) {
+      for (const [gx, gy] of SORTED_LATTICE) {
+        const tx = gx * step;
+        const ty = gy * step;
+        let ok = true;
+        for (const p of placed) {
+          if (
+            Math.abs(tx - p.cx) < hw[idx] + p.hw &&
+            Math.abs(ty - p.cy) < hh[idx] + p.hh
+          ) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) {
+          cx = tx;
+          cy = ty;
+          break;
+        }
+      }
+    }
+    centre[idx] = { x: cx, y: cy };
+    placed.push({ cx, cy, hw: hw[idx], hh: hh[idx] });
+  }
+
+  // Centre the whole packed cloud on the origin.
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < nb; i++) {
+    minX = Math.min(minX, centre[i].x - hw[i]);
+    maxX = Math.max(maxX, centre[i].x + hw[i]);
+    minY = Math.min(minY, centre[i].y - hh[i]);
+    maxY = Math.max(maxY, centre[i].y + hh[i]);
+  }
+  const mx = (minX + maxX) / 2;
+  const my = (minY + maxY) / 2;
+  return centre.map((c) => ({ dx: c.x - mx, dy: c.y - my }));
+}

--- a/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
@@ -17,24 +17,33 @@ import type {
 
 /**
  * A node the {@link FullBrainGraphComponent} has already laid out (world units,
- * origin-centred) — the directive only projects + paints it, never lays out.
+ * origin-centred, by `full-brain-layout.ts`) — the directive only projects +
+ * paints it, never lays out. `degree`/`date` are carried for the label ranking
+ * and the hover tooltip.
  */
 export interface FullSceneNode {
   id: string;
   kind: FullGraphNodeKind;
   label: string;
-  /** Radius in world units (degree-scaled by the component). */
+  /** In-graph edge count — drives label priority + the tooltip meta line. */
+  degree: number;
+  /** ISO/epoch-derived date string when the source carries one (entities: null). */
+  date: string | null;
+  /** Radius in world units (degree-scaled by the layout). */
   r: number;
   x: number;
   y: number;
 }
 
-/** A laid-out edge whose endpoints both survived the lens filter. */
+/** A laid-out edge whose endpoints both survived the lens filter + draw cap. */
 export interface FullSceneEdge {
-  /** `${src}::${dst}::${kind}` — stable identity. */
+  /** Stable identity. */
   key: string;
   src: string;
   dst: string;
+  /** Endpoint kinds — endpoint matching is by `(kind, id)`, never bare `id`. */
+  srcKind: FullGraphNodeKind;
+  dstKind: FullGraphNodeKind;
   kind: FullGraphEdgeKind;
   /** `true` = un-accepted semantic suggestion → drawn DASHED. */
   suggested: boolean;
@@ -42,13 +51,21 @@ export interface FullSceneEdge {
 
 type Rgb = [number, number, number];
 
+/** Tooltip chrome (the one piece of canvas paint that follows the app theme). */
+interface Theme {
+  textPri: Rgb;
+  textSec: Rgb;
+  overlay: Rgb;
+  border: Rgb;
+  font: string;
+}
+
 /* ── THE SCENE PALETTE — a FIXED dark field, independent of the page theme ──
  * Same rationale as neural-scene.directive.ts: glow/tint only reads on a dark
- * surface, so the canvas is its own artwork field even under the light theme
- * (design review R3). The four node hues MIRROR the DOM tokens
- * `--graph-entity/-meeting/-note/-document` (whose values the chips + legend
- * dots consume) — kept in sync by intent, exactly like the neural-scene
- * PERSON/PROJECT constants mirror the legend dots. */
+ * surface, so the canvas is its own artwork field even under the light theme.
+ * The four node hues MIRROR the DOM tokens `--graph-entity/-meeting/-note/
+ * -document` (whose values the chips + legend dots consume) — kept in sync by
+ * intent, exactly like the neural-scene PERSON/PROJECT constants. */
 const BG: Rgb = [8, 9, 20];
 const BG_LIFT: Rgb = [17, 19, 40];
 const NODE_COLORS: Record<FullGraphNodeKind, Rgb> = {
@@ -57,16 +74,41 @@ const NODE_COLORS: Record<FullGraphNodeKind, Rgb> = {
   note: [76, 224, 160], // #4ce0a0 mint
   document: [200, 111, 242], // #c86ff2 orchid
 };
+const KIND_LABEL: Record<FullGraphNodeKind, string> = {
+  entity: "Person / project",
+  meeting: "Meeting",
+  note: "Note",
+  document: "Document",
+};
 const LABEL: Rgb = [216, 222, 242];
+const LABEL_DIM: Rgb = [150, 158, 190];
 const WHITE: Rgb = [255, 255, 255];
 
-const MIN_SCALE = 0.25;
-const MAX_SCALE = 4;
+const MIN_SCALE = 0.3;
+const MAX_SCALE = 4.5;
+/** The strongest N edges carry a travelling firing pulse (keeps dense graphs cheap). */
+const PULSE_EDGE_CAP = 160;
+/** Node breathing angular frequency — a ~2.6 s period. */
+const BREATH_W = (Math.PI * 2) / 2.6;
+
+/** djb2 hash → a deterministic per-edge/node phase so pulses never fire in lockstep. */
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
+  }
+  return h >>> 0;
+}
+/** Halo radius as a multiple of the soma radius (cached sprite space). */
+const HALO_F = 2.4;
+/** Always-on label count at fit zoom; grows as the camera zooms IN. */
+const LABEL_TOP = 14;
+/** Ghost labels kept alive OUTSIDE a focused neighbourhood (context). */
+const LABEL_GHOSTS = 5;
 
 function rgba(c: Rgb, a: number): string {
   return `rgba(${c[0]},${c[1]},${c[2]},${a})`;
 }
-
 function mix(a: Rgb, b: Rgb, t: number): Rgb {
   return [
     Math.round(a[0] + (b[0] - a[0]) * t),
@@ -74,30 +116,65 @@ function mix(a: Rgb, b: Rgb, t: number): Rgb {
     Math.round(a[2] + (b[2] - a[2]) * t),
   ];
 }
-
 function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
+}
+/** Parse a token value (`#rgb`, `#rrggbb`, `rgb()/rgba()`) with a fallback. */
+function parseColor(raw: string, fallback: Rgb): Rgb {
+  const s = raw.trim();
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(s);
+  if (hex) {
+    const v = hex[1];
+    if (v.length === 3) {
+      return [
+        parseInt(v[0] + v[0], 16),
+        parseInt(v[1] + v[1], 16),
+        parseInt(v[2] + v[2], 16),
+      ];
+    }
+    return [
+      parseInt(v.slice(0, 2), 16),
+      parseInt(v.slice(2, 4), 16),
+      parseInt(v.slice(4, 6), 16),
+    ];
+  }
+  const fn = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i.exec(s);
+  if (fn) {
+    return [Number(fn[1]), Number(fn[2]), Number(fn[3])];
+  }
+  return fallback;
+}
+
+interface Proj {
+  sx: number;
+  sy: number;
+  sr: number;
 }
 
 /**
  * The FULL-BRAIN scene renderer — a canvas-drawn, pan/zoom multi-kind graph over
- * the typed nodes/edges the {@link FullBrainGraphComponent} lays out: per-kind
- * colored somas with labels, per-kind styled edges (co-occurrence/mention thin,
- * wikilink/companion solid accent, semantic — suggested drawn DASHED), hover +
- * click-through, on a fixed deep-indigo field.
+ * the typed nodes/edges the component lays out: per-kind colored somas with
+ * CACHED halo sprites (no per-frame gradient allocation), curved GLOWING synapses
+ * (bloom underpass + a core gradienting between the endpoint node hues) carrying
+ * travelling FIRING PULSES, breathing somas, COLLISION-DECLUTTERED adaptive labels
+ * (largest-first, zoom-scaled budget, fan-out placement — the map-style labels),
+ * a hover neighbourhood spotlight, an opaque hover tooltip, and click-to-focus /
+ * double-click-to-open, on a fixed deep-indigo field.
  *
- * ZONELESS RULE (.claude/rules/angular-zoneless.md §5): a bare rAF/timer or a
- * DOM observer in a COMPONENT is banned — every DOM-loop concern (the
- * ResizeObserver, the reduced-motion + visibilitychange + color-scheme
- * listeners, the invalidate-on-demand paint) lives HERE in a directive and is
- * released in `DestroyRef.onDestroy()`. There is NO continuous animation loop:
- * the scene is a still that repaints on input / camera / hover change via
- * `invalidate()` (a single one-shot `requestAnimationFrame`), so it costs
- * nothing at rest and needs no reduced-motion branch beyond skipping repaints
- * while hidden.
+ * ZONELESS RULE (.claude/rules/angular-zoneless.md §5): a bare rAF/timer or a DOM
+ * observer in a COMPONENT is banned — every DOM-loop concern (the ResizeObserver,
+ * the visibilitychange + reduced-motion + color-scheme listeners, the FX loop, the
+ * invalidate-on-demand paint) lives HERE in a directive and is released in
+ * `DestroyRef.onDestroy()`. The animation loop is BOUNDED and drives ONLY the
+ * decorative FX (synapse pulses + soma breathing) over the still, pre-computed
+ * layout — there is NO per-frame physics. It is stopped entirely under
+ * `prefers-reduced-motion: reduce` and while `document.hidden`, where the scene
+ * falls back to a one-shot `invalidate()` repaint (a still), so it costs nothing
+ * at rest.
  *
- * The component owns the deterministic Fruchterman-Reingold LAYOUT (a pure
- * `computed()`); this directive owns only projection, paint, and pointer input.
+ * The component owns the deterministic layout — layered "neural" bands OR organic
+ * per-component packing (pure functions in `full-brain-layout.ts`, called from a
+ * `computed()`); this directive owns only projection, paint, camera, pointer.
  */
 @Directive({
   selector: "canvas[appFullBrainScene]",
@@ -108,6 +185,7 @@ function clamp(v: number, lo: number, hi: number): number {
     "(pointerup)": "onPointerUp($event)",
     "(pointercancel)": "onPointerUp($event)",
     "(pointerleave)": "onPointerLeave()",
+    "(dblclick)": "onDblClick($event)",
     "(wheel)": "onWheel($event)",
   },
 })
@@ -122,10 +200,14 @@ export class FullBrainSceneDirective {
   /** The focused node id (null = no focus) — drives neighbourhood dimming. */
   readonly selectedId = input<string | null>(null);
 
-  /** Click: a node id, or null for empty space (the component owns navigation). */
+  /** Single click on a node → focus it (the component pins selection, no nav). */
   readonly nodePick = output<string | null>();
+  /** Double click on a node → open it (the component owns navigation). */
+  readonly nodeOpen = output<string>();
   /** Hover enter/leave over a node (the component drives an aria-live hint). */
   readonly nodeHover = output<string | null>();
+  /** Current zoom as a percentage of the fit scale (100 = fit-to-view). */
+  readonly zoom = output<number>();
 
   private readonly _hoverId = signal<string | null>(null);
   private readonly _dragging = signal(false);
@@ -137,27 +219,38 @@ export class FullBrainSceneDirective {
         : "grab",
   );
 
-  /** Selected node + its one-hop neighbours (null = no focus). */
-  private readonly neighborSet = computed<Set<string> | null>(() => {
+  /**
+   * The focus ANCHOR + its one-hop neighbours. Anchored on the SELECTED node
+   * (a pinned click) if any, else on the HOVERED node (a transient spotlight) —
+   * this is what "hover to preview a neighbourhood, click to pin it" needs. The
+   * dim floor is stronger for a pinned selection than for a hover preview.
+   */
+  private readonly focus = computed<{
+    set: Set<string>;
+    anchor: string;
+    pinned: boolean;
+  } | null>(() => {
     const sel = this.selectedId();
-    if (!sel) {
+    const anchor = sel ?? this._hoverId();
+    if (!anchor) {
       return null;
     }
-    const set = new Set<string>([sel]);
+    const set = new Set<string>([anchor]);
     for (const e of this.sceneEdges()) {
-      if (e.src === sel) {
+      if (e.src === anchor) {
         set.add(e.dst);
-      } else if (e.dst === sel) {
+      } else if (e.dst === anchor) {
         set.add(e.src);
       }
     }
-    return set;
+    return { set, anchor, pinned: sel !== null };
   });
 
   // camera (world → screen: screen = center + pan + world * scale)
   private scale = 1;
   private panX = 0;
   private panY = 0;
+  private fitScale = 1;
   private fitted = false;
 
   // pointer
@@ -169,12 +262,35 @@ export class FullBrainSceneDirective {
   private lastPY = 0;
 
   // projected screen positions (index-aligned with sceneNodes())
-  private proj: { sx: number; sy: number; sr: number }[] = [];
+  private proj: Proj[] = [];
 
   private cssW = 0;
   private cssH = 0;
   private oneShotId: number | null = null;
   private ctx: CanvasRenderingContext2D | null;
+
+  // paint caches (rebuilt only on resize / theme flip)
+  private theme: Theme | null = null;
+  private bg: HTMLCanvasElement | null = null;
+  private pulseC: HTMLCanvasElement | null = null;
+  private readonly sprites = new Map<string, HTMLCanvasElement>();
+
+  // animation loop — bounded, reduced-motion + visibility gated. Drives ONLY the
+  // decorative FX (travelling synapse pulses + node breathing) over the still,
+  // pre-computed layout; there is no per-frame physics. Off under reduced motion.
+  private rafId: number | null = null;
+  private loopRunning = false;
+  private reduced: boolean;
+  private readonly media = window.matchMedia("(prefers-reduced-motion: reduce)");
+  private readonly onMedia = (): void => {
+    this.reduced = this.media.matches;
+    if (this.reduced) {
+      this.stopLoop();
+      this.invalidate();
+    } else {
+      this.startLoop();
+    }
+  };
 
   private readonly ro = new ResizeObserver((entries) => {
     const rect = entries[entries.length - 1]?.contentRect;
@@ -184,28 +300,38 @@ export class FullBrainSceneDirective {
     const wasZero = this.cssW < 2 || this.cssH < 2;
     this.cssW = rect.width;
     this.cssH = rect.height;
+    this.bg = null;
     if (wasZero) {
       this.fitted = false; // (re)fit once we have a real size
     }
     this.invalidate();
   });
   private readonly onVisibility = (): void => {
-    if (!document.hidden) {
+    if (document.hidden) {
+      this.stopLoop();
+    } else if (this.reduced) {
       this.invalidate();
+    } else {
+      this.startLoop();
     }
   };
   private readonly scheme = window.matchMedia("(prefers-color-scheme: light)");
-  private readonly onScheme = (): void => this.invalidate();
+  private readonly onScheme = (): void => {
+    this.theme = null;
+    this.invalidate();
+  };
 
   constructor() {
     this.ctx = this.hostRef.nativeElement.getContext("2d");
+    this.reduced = this.media.matches;
     this.ro.observe(this.hostRef.nativeElement);
     document.addEventListener("visibilitychange", this.onVisibility);
     this.scheme.addEventListener("change", this.onScheme);
+    this.media.addEventListener("change", this.onMedia);
 
     // Refit + repaint when the laid-out graph changes; a signal write inside a
     // tracked effect is allowed since Angular 19. The hover read is untracked so
-    // hovering doesn't refit.
+    // hovering doesn't refit. Restart the FX loop so pulses run on the new graph.
     effect(() => {
       const nodes = this.sceneNodes();
       this.sceneEdges();
@@ -215,17 +341,25 @@ export class FullBrainSceneDirective {
         this._hoverId.set(null);
         this.nodeHover.emit(null);
       }
-      this.invalidate();
+      if (this.reduced) {
+        this.invalidate();
+      } else {
+        this.startLoop();
+      }
     });
 
-    // Repaint on selection/hover change (neighbourhood dimming).
+    // Repaint on selection/hover change (neighbourhood spotlight). Under reduced
+    // motion there's no loop, so a one-shot repaint keeps the spotlight live.
     effect(() => {
       this.selectedId();
       this._hoverId();
-      this.invalidate();
+      if (this.reduced) {
+        this.invalidate();
+      }
     });
 
     this.destroyRef.onDestroy(() => {
+      this.stopLoop();
       if (this.oneShotId !== null) {
         cancelAnimationFrame(this.oneShotId);
         this.oneShotId = null;
@@ -233,7 +367,32 @@ export class FullBrainSceneDirective {
       this.ro.disconnect();
       document.removeEventListener("visibilitychange", this.onVisibility);
       this.scheme.removeEventListener("change", this.onScheme);
+      this.media.removeEventListener("change", this.onMedia);
     });
+  }
+
+  // ── animation loop (only decorative FX; no per-frame physics) ──────────
+  private startLoop(): void {
+    if (this.loopRunning || this.reduced || document.hidden) {
+      return;
+    }
+    this.loopRunning = true;
+    const step = (t: number): void => {
+      if (!this.loopRunning) {
+        return;
+      }
+      this.render(t);
+      this.rafId = requestAnimationFrame(step);
+    };
+    this.rafId = requestAnimationFrame(step);
+  }
+
+  private stopLoop(): void {
+    this.loopRunning = false;
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
   }
 
   // ── public camera API (the component's toolbar drives these) ──────────
@@ -244,9 +403,11 @@ export class FullBrainSceneDirective {
     const k = this.scale / old;
     this.panX *= k;
     this.panY *= k;
+    this.emitZoom();
     this.invalidate();
   }
 
+  /** Re-fit the whole cloud into the viewport. */
   resetView(): void {
     this.fitted = false;
     this.panX = 0;
@@ -304,6 +465,8 @@ export class FullBrainSceneDirective {
     this._dragging.set(false);
     (event.target as Element).releasePointerCapture?.(event.pointerId);
     if (wasClick) {
+      // Single click = FOCUS (pin selection); it never navigates — that's the
+      // double-click. Lets the user dwell on a node + read its neighbourhood.
       this.nodePick.emit(this.hitTest(event));
     }
     this.invalidate();
@@ -314,6 +477,14 @@ export class FullBrainSceneDirective {
       this._hoverId.set(null);
       this.nodeHover.emit(null);
       this.invalidate();
+    }
+  }
+
+  /** Double click = OPEN the node (navigate). Empty space is ignored. */
+  protected onDblClick(event: MouseEvent): void {
+    const hit = this.hitTestXY(event.clientX, event.clientY);
+    if (hit !== null) {
+      this.nodeOpen.emit(hit);
     }
   }
 
@@ -329,49 +500,81 @@ export class FullBrainSceneDirective {
     const k = this.scale / old;
     this.panX = ox - (ox - this.panX) * k;
     this.panY = oy - (oy - this.panY) * k;
+    this.emitZoom();
     this.invalidate();
+  }
+
+  private emitZoom(): void {
+    const pct = this.fitScale > 0 ? Math.round((this.scale / this.fitScale) * 100) : 100;
+    this.zoom.emit(pct);
   }
 
   // ── paint (invalidate-on-demand, no continuous loop) ──────────────────
 
-  /** One-shot repaint; coalesces multiple invalidations into one frame. */
+  /** One-shot repaint for the idle/reduced-motion path; coalesces into one frame.
+   *  A no-op while the FX loop is running (it already renders every frame). */
   private invalidate(): void {
-    if (this.oneShotId !== null || document.hidden) {
+    if (this.loopRunning || this.oneShotId !== null || document.hidden) {
       return;
     }
-    this.oneShotId = requestAnimationFrame(() => {
+    this.oneShotId = requestAnimationFrame((t) => {
       this.oneShotId = null;
-      this.render();
+      this.render(t);
     });
   }
 
-  /** Fit the laid-out cloud into the padded viewport (once per graph/resize). */
+  /**
+   * Fit the laid-out cloud into the padded viewport (once per graph/resize).
+   * Robust framing: fit to the node bounding box, then centre the box but blend
+   * 30% toward the projected MASS centroid so a couple of stray singletons can't
+   * park the whole connected mass off in a corner.
+   */
   private fit(): void {
     const nodes = this.sceneNodes();
     if (nodes.length === 0 || this.cssW < 4 || this.cssH < 4) {
       this.scale = 1;
+      this.fitScale = 1;
       this.panX = 0;
       this.panY = 0;
       return;
     }
-    let maxX = 1;
-    let maxY = 1;
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    let cxm = 0;
+    let cym = 0;
     for (const n of nodes) {
-      maxX = Math.max(maxX, Math.abs(n.x) + n.r);
-      maxY = Math.max(maxY, Math.abs(n.y) + n.r);
+      minX = Math.min(minX, n.x - n.r);
+      maxX = Math.max(maxX, n.x + n.r);
+      minY = Math.min(minY, n.y - n.r);
+      maxY = Math.max(maxY, n.y + n.r);
+      cxm += n.x;
+      cym += n.y;
     }
-    const padW = this.cssW / 2 - 40;
-    const padH = this.cssH / 2 - 40;
+    cxm /= nodes.length;
+    cym /= nodes.length;
+    const spanX = Math.max(1, maxX - minX);
+    const spanY = Math.max(1, maxY - minY);
+    const padW = this.cssW - 96;
+    const padH = this.cssH - 112; // extra bottom room for labels
     this.scale = clamp(
-      Math.min(padW / maxX, padH / maxY),
+      Math.min(padW / spanX, padH / spanY),
       MIN_SCALE,
       MAX_SCALE,
     );
-    this.panX = 0;
-    this.panY = 0;
+    this.fitScale = this.scale;
+    // Centre the bbox, blended 15% toward the mass centroid (the spiral packer
+    // already balances the cloud, so bbox-centre dominates — a heavier mass blend
+    // biased the frame toward the densest cluster).
+    const bx = (minX + maxX) / 2;
+    const by = (minY + maxY) / 2;
+    this.panX = -(0.85 * bx + 0.15 * cxm) * this.scale;
+    this.panY = -(0.85 * by + 0.15 * cym) * this.scale;
+    this.emitZoom();
   }
 
-  private render(): void {
+  private render(now: number): void {
     const ctx = this.ctx;
     const canvas = this.hostRef.nativeElement;
     const w = this.cssW;
@@ -379,39 +582,33 @@ export class FullBrainSceneDirective {
     if (!ctx || w < 4 || h < 4 || document.hidden) {
       return;
     }
+    // In reduced motion the scene is a still: freeze the animation clock.
+    const tSec = this.reduced ? 0 : now / 1000;
     const dpr = Math.min(2, window.devicePixelRatio || 1);
     const bw = Math.max(1, Math.round(w * dpr));
     const bh = Math.max(1, Math.round(h * dpr));
     if (canvas.width !== bw || canvas.height !== bh) {
       canvas.width = bw;
       canvas.height = bh;
+      this.bg = null;
     }
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
+    if (!this.theme) {
+      this.theme = this.buildTheme();
+    }
+    if (!this.bg) {
+      this.bg = this.makeBg(w, h, dpr);
+    }
     if (!this.fitted) {
       this.fit();
       this.fitted = true;
     }
 
-    // ── backdrop (deep-indigo field + gentle vignette) ──
-    const bg = ctx.createLinearGradient(0, 0, 0, h);
-    bg.addColorStop(0, rgba(BG_LIFT, 1));
-    bg.addColorStop(0.6, rgba(BG, 1));
-    bg.addColorStop(1, rgba(mix(BG, BG_LIFT, 0.35), 1));
-    ctx.fillStyle = bg;
-    ctx.fillRect(0, 0, w, h);
-    const vg = ctx.createRadialGradient(
-      w / 2,
-      h / 2,
-      Math.min(w, h) * 0.4,
-      w / 2,
-      h / 2,
-      Math.max(w, h) * 0.78,
-    );
-    vg.addColorStop(0, "rgba(0,0,0,0)");
-    vg.addColorStop(1, "rgba(0,0,0,0.45)");
-    ctx.fillStyle = vg;
-    ctx.fillRect(0, 0, w, h);
+    // ── backdrop (cached deep-indigo field + vignette) ──
+    ctx.globalCompositeOperation = "source-over";
+    ctx.globalAlpha = 1;
+    ctx.drawImage(this.bg, 0, 0, w, h);
 
     const nodes = this.sceneNodes();
     const n = nodes.length;
@@ -422,99 +619,213 @@ export class FullBrainSceneDirective {
     const cx = w / 2 + this.panX;
     const cy = h / 2 + this.panY;
     const s = this.scale;
-    const idIndex = new Map(nodes.map((nd, i) => [nd.id, i]));
+    const idIndex = new Map(nodes.map((nd, i) => [`${nd.kind}:${nd.id}`, i]));
     this.proj = nodes.map((nd) => ({
       sx: cx + nd.x * s,
       sy: cy + nd.y * s,
       sr: Math.max(2.5, nd.r * s),
     }));
 
-    const hover = this._hoverId();
-    const selId = this.selectedId();
-    const focus = this.neighborSet();
+    const focus = this.focus();
+    const dimFloor = focus ? (focus.pinned ? 0.24 : 0.5) : 1;
 
-    // ── edges (per-kind style; suggested = dashed) ──
+    this.drawEdges(ctx, idIndex, focus, dimFloor, tSec);
+    this.drawNodes(ctx, nodes, focus, dimFloor, tSec);
+    this.drawLabels(ctx, w, h, nodes, focus);
+    const hover = this._hoverId();
+    if (hover !== null && !this.pointerDown) {
+      this.drawTooltip(ctx, w, h, nodes, hover);
+    }
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+  }
+
+  /**
+   * SYNAPSES — every edge as a curved, glowing connection: an additive BLOOM
+   * underpass (a wide soft ribbon of light) beneath a tapered CORE stroke whose
+   * colour GRADIENTS between the two endpoint node hues (azure/amber/mint/orchid),
+   * so connections read as vivid neural links rather than flat lines. Suggested
+   * semantic links are dashed. The focus spotlight brightens the anchor's edges
+   * and ghosts the rest. Firing pulses (when the animation loop runs) travel the
+   * same curves — see {@link drawPulses}.
+   */
+  private drawEdges(
+    ctx: CanvasRenderingContext2D,
+    idIndex: Map<string, number>,
+    focus: { set: Set<string>; anchor: string; pinned: boolean } | null,
+    dimFloor: number,
+    tSec: number,
+  ): void {
     ctx.lineCap = "round";
+    let pulsed = 0;
     for (const e of this.sceneEdges()) {
-      const a = idIndex.get(e.src);
-      const b = idIndex.get(e.dst);
+      const a = idIndex.get(`${e.srcKind}:${e.src}`);
+      const b = idIndex.get(`${e.dstKind}:${e.dst}`);
       if (a === undefined || b === undefined) {
         continue;
       }
       const A = this.proj[a];
       const B = this.proj[b];
-      const inFocus =
-        !focus || (focus.has(e.src) && focus.has(e.dst));
-      const touchesSel =
-        selId !== null && (e.src === selId || e.dst === selId);
-      const hoverHit =
-        hover !== null && (e.src === hover || e.dst === hover);
+      const colA = NODE_COLORS[e.srcKind];
+      const colB = NODE_COLORS[e.dstKind];
+      const structural = e.kind === "wikilink" || e.kind === "companion";
 
-      const style = this.edgeStyle(e.kind);
-      let alpha = style.alpha;
-      let width = style.width;
-      if (!focus) {
-        // no selection — everything at rest strength
-      } else if (inFocus) {
-        alpha = Math.min(0.95, alpha * 1.8);
-        width += 0.4;
-      } else {
-        alpha *= 0.22; // out-of-neighbourhood ghost
-      }
-      if (touchesSel) {
-        alpha = Math.min(1, alpha * 1.4);
-        width += 0.6;
-      }
-      if (hoverHit) {
-        alpha = Math.min(1, alpha * 1.5);
+      // Focus tier → alpha/width.
+      let aBase = 0.5;
+      let wBase = structural ? 1.7 : 1.25;
+      let ghost = false;
+      if (focus) {
+        const touches = e.src === focus.anchor || e.dst === focus.anchor;
+        const bothIn = focus.set.has(e.src) && focus.set.has(e.dst);
+        if (touches) {
+          aBase = 0.95;
+          wBase += 0.9;
+        } else if (bothIn) {
+          aBase = 0.62;
+        } else {
+          aBase = 0.13 * (dimFloor / 0.24);
+          ghost = true;
+        }
       }
 
-      ctx.globalAlpha = alpha;
-      ctx.strokeStyle = rgba(style.color, 1);
-      ctx.lineWidth = width;
-      ctx.setLineDash(e.suggested ? [5, 5] : []);
+      // Curve geometry: quadratic bulge ~12% of length, hash-stable side.
+      const mx = (A.sx + B.sx) / 2;
+      const my = (A.sy + B.sy) / 2;
+      const ddx = B.sx - A.sx;
+      const ddy = B.sy - A.sy;
+      const len = Math.hypot(ddx, ddy) || 1;
+      const side = a < b ? 1 : -1;
+      const cpx = mx + (-ddy / len) * len * 0.12 * side;
+      const cpy = my + (ddx / len) * len * 0.12 * side;
+      const q = (u: number): [number, number] => {
+        const v = 1 - u;
+        return [
+          v * v * A.sx + 2 * v * u * cpx + u * u * B.sx,
+          v * v * A.sy + 2 * v * u * cpy + u * u * B.sy,
+        ];
+      };
+      // Trim endpoints to the soma surfaces so the synapse attaches cleanly.
+      const tA = clamp((A.sr * 1.05) / len, 0, 0.24);
+      const tB = clamp((B.sr * 1.05) / len, 0, 0.24);
+      const span = Math.max(0.0001, 1 - tA - tB);
+      const [bx0, by0] = q(tA);
+      const [bx1, by1] = q(1 - tB);
+
+      ctx.setLineDash(e.suggested ? [6, 6] : []);
+
+      if (ghost) {
+        // Out-of-neighbourhood: one dim curved stroke, still traceable.
+        ctx.globalCompositeOperation = "source-over";
+        ctx.globalAlpha = aBase;
+        ctx.strokeStyle = rgba(mix(colA, colB, 0.5), 1);
+        ctx.lineWidth = 0.8;
+        ctx.beginPath();
+        ctx.moveTo(bx0, by0);
+        ctx.quadraticCurveTo(cpx, cpy, bx1, by1);
+        ctx.stroke();
+        continue;
+      }
+
+      // 1) additive BLOOM underpass — the soft light ribbon that makes it glow.
+      ctx.globalCompositeOperation = "lighter";
+      ctx.globalAlpha = aBase * 0.3;
+      ctx.lineWidth = wBase * 3.2;
+      ctx.strokeStyle = rgba(mix(colA, colB, 0.5), 1);
       ctx.beginPath();
-      ctx.moveTo(A.sx, A.sy);
-      ctx.lineTo(B.sx, B.sy);
+      ctx.moveTo(bx0, by0);
+      ctx.quadraticCurveTo(cpx, cpy, bx1, by1);
       ctx.stroke();
+
+      // 2) tapered gradient CORE — brighter/wider at the somas, slim mid-span.
+      ctx.globalCompositeOperation = "source-over";
+      const segs = 5;
+      let [px, py] = q(tA);
+      for (let sg = 0; sg < segs; sg++) {
+        const u1 = tA + (span * (sg + 1)) / segs;
+        const um = (u1 - span / segs / 2 - tA) / span;
+        const endness = Math.abs(2 * um - 1);
+        const [nx, ny] = q(u1);
+        ctx.globalAlpha = aBase * (0.6 + 0.4 * endness);
+        ctx.lineWidth = wBase * (0.7 + 0.4 * endness);
+        ctx.strokeStyle = rgba(mix(colA, colB, um), 1);
+        ctx.beginPath();
+        ctx.moveTo(px, py);
+        ctx.lineTo(nx, ny);
+        ctx.stroke();
+        px = nx;
+        py = ny;
+      }
+
+      // 3) FIRING PULSE — a hot orb + short ghost tail travelling src→dst (i.e.
+      //    DOWN the layers: person → meeting → note → doc), the "data flowing
+      //    through the network" signature. Only the strongest N edges fire.
+      if (tSec > 0 && !e.suggested && pulsed < PULSE_EDGE_CAP) {
+        pulsed++;
+        const sprite = this.pulseSprite();
+        const hh = djb2(e.key);
+        const phase = (hh % 1000) / 1000;
+        const period = 2.4 + (hh % 7) * 0.25; // 2.4…4.0 s, desynced per edge
+        const tt = (tSec / period + phase) % 1;
+        ctx.globalCompositeOperation = "lighter";
+        for (let k = 3; k >= 1; k--) {
+          const tg = tt - k * 0.03;
+          if (tg < 0) {
+            continue;
+          }
+          const [tx, ty] = q(tA + span * tg);
+          const gs = 2.4 + (3 - k) * 0.5;
+          ctx.globalAlpha = aBase * (0.05 + (3 - k) * 0.05);
+          ctx.drawImage(sprite, tx - gs, ty - gs, gs * 2, gs * 2);
+        }
+        const [gx, gy] = q(tA + span * tt);
+        ctx.globalAlpha = Math.min(1, aBase * 1.5);
+        ctx.drawImage(sprite, gx - 3.6, gy - 3.6, 7.2, 7.2);
+      }
     }
     ctx.setLineDash([]);
+    ctx.globalCompositeOperation = "source-over";
+  }
 
-    // ── nodes (per-kind color; label when big/hovered/focused) ──
-    const t = getComputedStyle(canvas);
-    const font =
-      t.getPropertyValue("--font-sans").trim() || "system-ui, sans-serif";
-    ctx.font = `600 12px ${font}`;
-    ctx.textAlign = "center";
-    ctx.lineJoin = "round";
-    for (let i = 0; i < n; i++) {
+  /** Nodes — cached per-kind halo sprite (additive) + a crisp vector core.
+   *  When the FX loop runs (`tSec > 0`) in-focus somas gently BREATHE (a slow
+   *  glow pulse) — the "alive" signature. Only the glow breathes; the core radius
+   *  and hit-test stay fixed. */
+  private drawNodes(
+    ctx: CanvasRenderingContext2D,
+    nodes: FullSceneNode[],
+    focus: { set: Set<string> } | null,
+    dimFloor: number,
+    tSec: number,
+  ): void {
+    const hover = this._hoverId();
+    const selId = this.selectedId();
+    for (let i = 0; i < nodes.length; i++) {
       const nd = nodes[i];
       const p = this.proj[i];
-      const inSet = !focus || focus.has(nd.id);
-      const a = inSet ? 1 : 0.28;
+      const inSet = !focus || focus.set.has(nd.id);
+      const a = inSet ? 1 : dimFloor;
       const isSel = selId === nd.id;
       const isHover = hover === nd.id;
       const col = NODE_COLORS[nd.kind];
+      const glowB =
+        tSec > 0 && inSet
+          ? 1 + 0.18 * Math.sin(tSec * BREATH_W + (djb2(nd.id) % 628) / 100)
+          : 1;
 
-      // soft halo
-      ctx.globalAlpha = a * 0.5;
-      const halo = ctx.createRadialGradient(
-        p.sx,
-        p.sy,
-        0,
-        p.sx,
-        p.sy,
-        p.sr * 2.4,
-      );
-      halo.addColorStop(0, rgba(col, 0.4));
-      halo.addColorStop(1, rgba(col, 0));
-      ctx.fillStyle = halo;
-      ctx.beginPath();
-      ctx.arc(p.sx, p.sy, p.sr * 2.4, 0, Math.PI * 2);
-      ctx.fill();
+      // 1) cached halo sprite (additive `lighter` — no per-frame gradient)
+      const halo = this.haloSprite(nd.kind);
+      const hs = p.sr * HALO_F * 2;
+      ctx.globalCompositeOperation = "lighter";
+      ctx.globalAlpha = Math.min(1, a * 0.55 * glowB);
+      ctx.drawImage(halo, p.sx - hs / 2, p.sy - hs / 2, hs, hs);
+      if (isHover || isSel) {
+        ctx.globalAlpha = a * 0.4;
+        const hs2 = hs * 1.2;
+        ctx.drawImage(halo, p.sx - hs2 / 2, p.sy - hs2 / 2, hs2, hs2);
+      }
 
-      // core
-      ctx.globalAlpha = a;
+      // 2) crisp vector core: white-hot nucleus → hue body → darker membrane
+      ctx.globalCompositeOperation = "source-over";
       const core = ctx.createRadialGradient(
         p.sx - p.sr * 0.25,
         p.sy - p.sr * 0.25,
@@ -526,6 +837,7 @@ export class FullBrainSceneDirective {
       core.addColorStop(0, rgba(mix(col, WHITE, 0.6), 1));
       core.addColorStop(0.7, rgba(col, 1));
       core.addColorStop(1, rgba(mix(col, BG, 0.4), 1));
+      ctx.globalAlpha = a;
       ctx.fillStyle = core;
       ctx.beginPath();
       ctx.arc(p.sx, p.sy, p.sr, 0, Math.PI * 2);
@@ -539,51 +851,203 @@ export class FullBrainSceneDirective {
         ctx.arc(p.sx, p.sy, p.sr + (isSel ? 4 : 2.5), 0, Math.PI * 2);
         ctx.stroke();
       }
-
-      // label — always for the focused set / hovered / selected, else only
-      // reasonably large somas (keeps dense graphs legible).
-      const showLabel =
-        isSel || isHover || (focus ? inSet : p.sr >= 7);
-      if (showLabel && p.sr >= 3) {
-        const label =
-          nd.label.length > 26 ? nd.label.slice(0, 25) + "…" : nd.label;
-        const ly = p.sy + p.sr + 13;
-        ctx.globalAlpha = isSel || isHover ? 1 : a * 0.85;
-        ctx.lineWidth = 3;
-        ctx.strokeStyle = rgba(BG, 0.9);
-        ctx.strokeText(label, p.sx, ly);
-        ctx.fillStyle = rgba(isSel || isHover ? WHITE : LABEL, 1);
-        ctx.fillText(label, p.sx, ly);
-      }
     }
-    ctx.globalAlpha = 1;
   }
 
-  /** Per-edge-kind stroke color + base alpha/width (design encoding). */
-  private edgeStyle(kind: FullGraphEdgeKind): {
-    color: Rgb;
-    alpha: number;
-    width: number;
-  } {
-    switch (kind) {
-      case "co_occurrence":
-        return { color: [120, 130, 170], alpha: 0.28, width: 1 };
-      case "mention":
-        return { color: [150, 160, 210], alpha: 0.34, width: 1.1 };
-      case "wikilink":
-        return { color: [110, 118, 255], alpha: 0.55, width: 1.6 };
-      case "companion":
-        return { color: [76, 224, 160], alpha: 0.55, width: 1.6 };
-      case "semantic":
-        return { color: [200, 111, 242], alpha: 0.5, width: 1.4 };
+  /**
+   * COLLISION-DECLUTTERED adaptive labels (the "map-style" fix): candidates are
+   * ranked (hovered → selected → focused neighbours → biggest projected somas),
+   * each placed greedily and SKIPPED if its rect would overprint an already-placed
+   * one — two labels never overlap. Zoom LOD: zooming IN raises the always-on
+   * label budget. In focus mode the whole neighbourhood is labelled + a few ghost
+   * labels survive outside for context. A dark halo keeps text readable over glow.
+   */
+  private drawLabels(
+    ctx: CanvasRenderingContext2D,
+    w: number,
+    h: number,
+    nodes: FullSceneNode[],
+    focus: { set: Set<string> } | null,
+  ): void {
+    const n = nodes.length;
+    if (n === 0) {
+      return;
     }
+    const hover = this._hoverId();
+    const selId = this.selectedId();
+    const t = this.theme as Theme;
+
+    const cands: number[] = [];
+    const ghost = new Set<number>();
+    const push = (i: number): void => {
+      if (i >= 0 && !cands.includes(i)) {
+        cands.push(i);
+      }
+    };
+    if (hover !== null) {
+      push(nodes.findIndex((x) => x.id === hover));
+    }
+    if (selId !== null) {
+      push(nodes.findIndex((x) => x.id === selId));
+    }
+    const bySize = nodes
+      .map((_, i) => i)
+      .sort((a, b) => this.proj[b].sr - this.proj[a].sr || a - b);
+    const zoomK = clamp(this.scale / Math.max(0.0001, this.fitScale), 1, 3);
+    const budget = Math.round(LABEL_TOP * zoomK);
+    if (focus) {
+      for (const i of bySize) {
+        if (focus.set.has(nodes[i].id)) {
+          push(i);
+        }
+      }
+      let ghosts = 0;
+      for (const i of bySize) {
+        if (ghosts >= LABEL_GHOSTS) {
+          break;
+        }
+        if (!focus.set.has(nodes[i].id)) {
+          push(i);
+          ghost.add(i);
+          ghosts++;
+        }
+      }
+    } else {
+      let taken = 0;
+      for (const i of bySize) {
+        if (taken >= budget) {
+          break;
+        }
+        push(i);
+        taken++;
+      }
+    }
+
+    ctx.globalCompositeOperation = "source-over";
+    ctx.font = `600 12px ${t.font}`;
+    ctx.textAlign = "center";
+    ctx.lineJoin = "round";
+    const placed: { x: number; y: number; w: number; h: number }[] = [];
+    const collides = (r: { x: number; y: number; w: number; h: number }): boolean =>
+      placed.some(
+        (o) =>
+          r.x < o.x + o.w && r.x + r.w > o.x && r.y < o.y + o.h && r.y + r.h > o.y,
+      );
+
+    for (const i of cands) {
+      const nd = nodes[i];
+      const p = this.proj[i];
+      if (p.sr < 2 || p.sx < -60 || p.sx > w + 60 || p.sy < -24 || p.sy > h + 24) {
+        continue;
+      }
+      const isHot = hover === nd.id || selId === nd.id;
+      const isGhost = ghost.has(i);
+      const label =
+        nd.label.length > 26 ? nd.label.slice(0, 25) + "…" : nd.label;
+      const tw = ctx.measureText(label).width;
+      const spots: [number, number][] = [
+        [p.sx, p.sy + p.sr * 1.2 + 14],
+        [p.sx, p.sy - p.sr * 1.2 - 8],
+        [p.sx + p.sr * 1.35 + tw / 2 + 7, p.sy + 4],
+        [p.sx - p.sr * 1.35 - tw / 2 - 7, p.sy + 4],
+      ];
+      let lx = 0;
+      let ly = 0;
+      let rect: { x: number; y: number; w: number; h: number } | null = null;
+      for (const [sx, sy] of spots) {
+        const cand = { x: sx - tw / 2 - 5, y: sy - 12, w: tw + 10, h: 17 };
+        if (!collides(cand)) {
+          lx = sx;
+          ly = sy;
+          rect = cand;
+          break;
+        }
+      }
+      if (!rect) {
+        continue; // hot labels are pushed first, so they always win a slot
+      }
+      placed.push(rect);
+      ctx.globalAlpha = isHot ? 1 : isGhost ? 0.5 : 0.9;
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = rgba(BG, 0.92);
+      ctx.strokeText(label, lx, ly);
+      ctx.fillStyle = rgba(isHot ? WHITE : isGhost ? LABEL_DIM : LABEL, 1);
+      ctx.fillText(label, lx, ly);
+    }
+  }
+
+  /** Opaque hover tooltip: label + a kind-dot meta line (kind · date · degree). */
+  private drawTooltip(
+    ctx: CanvasRenderingContext2D,
+    w: number,
+    h: number,
+    nodes: FullSceneNode[],
+    hoverId: string,
+  ): void {
+    const i = nodes.findIndex((x) => x.id === hoverId);
+    if (i < 0) {
+      return;
+    }
+    const t = this.theme as Theme;
+    const nd = nodes[i];
+    const p = this.proj[i];
+    const parts = [KIND_LABEL[nd.kind]];
+    if (nd.date) {
+      parts.push(nd.date.slice(0, 10));
+    }
+    parts.push(`${nd.degree} connection${nd.degree === 1 ? "" : "s"}`);
+    const meta = parts.join(" · ");
+    const name = nd.label.length > 40 ? nd.label.slice(0, 39) + "…" : nd.label;
+
+    ctx.textAlign = "left";
+    ctx.font = `600 12.5px ${t.font}`;
+    const w1 = ctx.measureText(name).width;
+    ctx.font = `500 11px ${t.font}`;
+    const w2 = ctx.measureText(meta).width + 12; // + the kind-dot
+    const bw = Math.max(w1, w2) + 24;
+    const bh = 44;
+    const bx = clamp(p.sx - bw / 2, 8, w - bw - 8);
+    let by = p.sy - p.sr * HALO_F - bh - 6;
+    if (by < 8) {
+      by = Math.min(h - bh - 8, p.sy + p.sr * HALO_F + 8);
+    }
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+    const r = 8;
+    ctx.beginPath();
+    ctx.moveTo(bx + r, by);
+    ctx.arcTo(bx + bw, by, bx + bw, by + bh, r);
+    ctx.arcTo(bx + bw, by + bh, bx, by + bh, r);
+    ctx.arcTo(bx, by + bh, bx, by, r);
+    ctx.arcTo(bx, by, bx + bw, by, r);
+    ctx.closePath();
+    ctx.fillStyle = rgba(t.overlay, 0.97);
+    ctx.fill();
+    ctx.strokeStyle = rgba(t.border, 0.9);
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.fillStyle = rgba(t.textPri, 1);
+    ctx.font = `600 12.5px ${t.font}`;
+    ctx.fillText(name, bx + 12, by + 18);
+    ctx.beginPath();
+    ctx.arc(bx + 15.5, by + 30.5, 3.5, 0, Math.PI * 2);
+    ctx.fillStyle = rgba(NODE_COLORS[nd.kind], 1);
+    ctx.fill();
+    ctx.font = `500 11px ${t.font}`;
+    ctx.fillStyle = rgba(t.textSec, 1);
+    ctx.fillText(meta, bx + 24, by + 34);
+    ctx.textAlign = "center";
   }
 
   /** Nearest node under the pointer (uses the last frame's projection). */
   private hitTest(event: PointerEvent): string | null {
+    return this.hitTestXY(event.clientX, event.clientY);
+  }
+
+  private hitTestXY(clientX: number, clientY: number): string | null {
     const rect = this.hostRef.nativeElement.getBoundingClientRect();
-    const px = event.clientX - rect.left;
-    const py = event.clientY - rect.top;
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
     const nodes = this.sceneNodes();
     let best: string | null = null;
     let bestR = Infinity;
@@ -602,5 +1066,131 @@ export class FullBrainSceneDirective {
       }
     }
     return best;
+  }
+
+  // ── theme + paint caches ──────────────────────────────────────────────
+
+  private buildTheme(): Theme {
+    const cs = getComputedStyle(this.hostRef.nativeElement);
+    const read = (name: string, fb: Rgb): Rgb =>
+      parseColor(cs.getPropertyValue(name), fb);
+    return {
+      textPri: read("--text-primary", [246, 246, 250]),
+      textSec: read("--text-secondary", [166, 166, 182]),
+      overlay: read("--surface-overlay", [27, 27, 36]),
+      border: read("--border-strong", [255, 255, 255]),
+      font: cs.getPropertyValue("--font-sans").trim() || "system-ui, sans-serif",
+    };
+  }
+
+  /** Cached deep-indigo backdrop: vertical field gradient + corner vignette. */
+  private makeBg(w: number, h: number, dpr: number): HTMLCanvasElement {
+    const c = document.createElement("canvas");
+    c.width = Math.max(1, Math.round(w * dpr));
+    c.height = Math.max(1, Math.round(h * dpr));
+    const g = c.getContext("2d");
+    if (!g) {
+      return c;
+    }
+    g.scale(dpr, dpr);
+    const v = g.createLinearGradient(0, 0, 0, h);
+    v.addColorStop(0, rgba(BG_LIFT, 1));
+    v.addColorStop(0.6, rgba(BG, 1));
+    v.addColorStop(1, rgba(mix(BG, BG_LIFT, 0.35), 1));
+    g.fillStyle = v;
+    g.fillRect(0, 0, w, h);
+    // Two faint nebula washes in the entity/meeting hues for depth.
+    const n1 = g.createRadialGradient(
+      w * 0.28,
+      h * 0.3,
+      0,
+      w * 0.28,
+      h * 0.3,
+      Math.max(w, h) * 0.55,
+    );
+    n1.addColorStop(0, rgba(NODE_COLORS.entity, 0.05));
+    n1.addColorStop(1, rgba(NODE_COLORS.entity, 0));
+    g.fillStyle = n1;
+    g.fillRect(0, 0, w, h);
+    const n2 = g.createRadialGradient(
+      w * 0.74,
+      h * 0.72,
+      0,
+      w * 0.74,
+      h * 0.72,
+      Math.max(w, h) * 0.5,
+    );
+    n2.addColorStop(0, rgba(NODE_COLORS.document, 0.045));
+    n2.addColorStop(1, rgba(NODE_COLORS.document, 0));
+    g.fillStyle = n2;
+    g.fillRect(0, 0, w, h);
+    const vg = g.createRadialGradient(
+      w / 2,
+      h / 2,
+      Math.min(w, h) * 0.4,
+      w / 2,
+      h / 2,
+      Math.max(w, h) * 0.78,
+    );
+    vg.addColorStop(0, "rgba(0,0,0,0)");
+    vg.addColorStop(1, "rgba(0,0,0,0.45)");
+    g.fillStyle = vg;
+    g.fillRect(0, 0, w, h);
+    return c;
+  }
+
+  /** Cached CAPPED halo sprite per kind — white-hot centre bleeding through a
+   *  saturated hue glow, transparent by {@link HALO_F}× the soma radius. Drawn
+   *  with `lighter`; the crisp core is vector-drawn on top (never in the sprite). */
+  private haloSprite(kind: FullGraphNodeKind): HTMLCanvasElement {
+    const key = `halo:${kind}`;
+    const cached = this.sprites.get(key);
+    if (cached) {
+      return cached;
+    }
+    const col = NODE_COLORS[kind];
+    const size = 128;
+    const c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    const g = c.getContext("2d");
+    if (g) {
+      const half = size / 2;
+      const somaStop = 1 / HALO_F;
+      const grad = g.createRadialGradient(half, half, 0, half, half, half);
+      grad.addColorStop(0, rgba(mix(col, WHITE, 0.6), 0.55));
+      grad.addColorStop(somaStop * 0.55, rgba(mix(col, WHITE, 0.28), 0.45));
+      grad.addColorStop(somaStop, rgba(col, 0.4));
+      grad.addColorStop(somaStop + (1 - somaStop) * 0.4, rgba(col, 0.12));
+      grad.addColorStop(1, rgba(col, 0));
+      g.fillStyle = grad;
+      g.fillRect(0, 0, size, size);
+    }
+    this.sprites.set(key, c);
+    return c;
+  }
+
+  /** Cached hot-white pulse orb sprite (white core → azure-orchid falloff). */
+  private pulseSprite(): HTMLCanvasElement {
+    if (this.pulseC) {
+      return this.pulseC;
+    }
+    const size = 24;
+    const c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    const g = c.getContext("2d");
+    if (g) {
+      const half = size / 2;
+      const glow = mix(NODE_COLORS.entity, NODE_COLORS.document, 0.5);
+      const grad = g.createRadialGradient(half, half, 0, half, half, half);
+      grad.addColorStop(0, "rgba(255,255,255,0.95)");
+      grad.addColorStop(0.35, rgba(glow, 0.6));
+      grad.addColorStop(1, rgba(glow, 0));
+      g.fillStyle = grad;
+      g.fillRect(0, 0, size, size);
+    }
+    this.pulseC = c;
+    return c;
   }
 }


### PR DESCRIPTION
## Why

The full-brain graph rendered as "constellations": every degree-0 orphan (imported docs, fresh notes, uncorrelated meetings — each a 1-node connected component) was flung to the canvas corners by a single global force sim, then the camera fit the blown-out bbox → tiny unlabeled dots. It also looked bare (no labels, no interaction beyond click-navigates-away).

## What

A ground-up redesign of `src/app/features/brain/full-brain-graph/`, grounded in a 3-angle research fan-out (`docs/research/2026-07-19-full-brain-graph-viz-redesign.md`).

**Layout** (new pure, deterministic `full-brain-layout.ts`) — two modes via a `Layers | Clusters` toggle (client-side, no re-fetch):
- **Layers** (default): a "neural net" layout — horizontal bands by kind (people → meetings → notes → documents), barycentrically ordered to minimise edge crossings so cross-band edges read as clean vertical flows.
- **Clusters**: union-find connected components → per-component Fruchterman-Reingold at a fixed ideal edge length → degree-0 singletons tiled into one compact grid → spiral (center-out) bounding-box packing. No inter-component repulsion, no corner scatter.

**Renderer** (`full-brain-scene.directive.ts`) — cached per-kind halo sprites (was per-node `createRadialGradient` ×2/frame), cached backdrop, curved **glowing synapses** whose core gradients between the endpoint node hues, **collision-decluttered adaptive labels** (largest-first, zoom-scaled budget, fan-out — the map-style labels that were missing), an opaque hover tooltip (kind · date · connections), robust mass-centroid fit. A **bounded, reduced-motion-safe animation loop** drives **firing pulses** travelling src→dst (data flowing down the layers) + soma breathing.

**Chrome/interaction** — draw cap 140 → 500 (a normal vault now renders in full — was "Drawing 140 of 155"); single-click = **focus** (pin, stay) / double-click = **open** (was click-navigates-away); **Fit** button + **zoom-%** readout.

## Scope / safety

FE-only — **zero `src-tauri/` changes**. The lock model is untouched: the graph renders only backend-gated `getFullGraph` nodes, and raising the cap surfaces nothing sealed (the backend per-kind cap is already 500; sealed nodes never reach the FE).

## Verification

- Gates: `ng lint` ✓, `ng build` ✓, `playwright e2e/brain/` ✓ (added a `Layers | Clusters` mode-toggle regression test + updated the cap-disclosure test 140→500).
- **adversarial-verifier PASS ×2** — determinism byte-identical across lens + mode toggle; NaN-safe on every edge case (0/1/all-one-kind/all-singleton/600-node/self-loop/dup-id/NaN-degree); the FX loop is **§5-bounded** (RED-before-GREEN on all four guards: stops on destroy / hidden / reduced-motion, single loop); perf 300n/400e p95 9.3ms; RED-before-GREEN on the core bug (old span 14066×14070 / 4.2px somas → 357×492 / 8.9px).
- **lock-security-reviewer PASS ×2** — renders nothing the backend didn't gate-approve; no new read/asset path; no PII in logs.

Visual quality was verified with real-render Playwright screenshots at fit / zoom / focus across both modes; final polish (layered "neural" default) was a direct user call during review.
