### PR TITLE
feat(links): documents are first-class link targets — pick, link & open from any surface

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5589,7 +5589,65 @@ impl Db {
                 });
             }
         }
-        Ok((out, note_count + meeting_count))
+
+        // Documents leg — LAST in the combined ordering (so existing notes/meetings page
+        // positions are untouched; a doc-free vault reports document_count == 0). Mirrors the
+        // notes leg exactly but for `d.kind = 'document'`, and titles on the SAME
+        // COALESCE(title, name) so a filename (e.g. `Oskar_Orlowski_CV.pdf`, no `title`) is
+        // searchable/displayable. The COUNT twin shares the page query's WHERE body, so a
+        // sealed-and-not-unlocked document neither appears NOR inflates the total.
+        let visible_docs = visibility_clause("f", unlocked);
+        let docs_where = format!(
+            "d.kind = 'document' AND {visible_docs}
+             AND (:pat IS NULL OR COALESCE(NULLIF(TRIM(d.title), ''), d.name) LIKE :pat ESCAPE '\\')"
+        );
+        let document_count: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE {docs_where}"
+                ),
+                rusqlite::named_params! { ":pat": pat },
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        let remaining = limit - out.len() as i64;
+        let doc_offset = (offset - note_count - meeting_count).max(0);
+        if remaining > 0 && doc_offset < document_count {
+            let sql = format!(
+                "SELECT d.id, COALESCE(NULLIF(TRIM(d.title), ''), d.name)
+                   FROM documents d
+                   JOIN folders f ON f.id = d.folder_id
+                  WHERE {docs_where}
+                  ORDER BY COALESCE(d.updated_at, d.created_at) DESC, d.id ASC
+                  LIMIT :limit OFFSET :offset"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::named_params! {
+                        ":pat": pat,
+                        ":limit": remaining,
+                        ":offset": doc_offset,
+                    },
+                    |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
+                        Ok((r.get(0)?, r.get(1)?))
+                    },
+                )
+                .map_err(map_err)?;
+            for r in rows {
+                let (id, title) = r.map_err(map_err)?;
+                out.push(NoteCitation {
+                    kind: "document".into(),
+                    id,
+                    title,
+                    snippet: String::new(),
+                });
+            }
+        }
+        Ok((out, note_count + meeting_count + document_count))
     }
 
     // `get_note_if_visible` moved to `storage::notes_store` (God-file split) — still callable as inherent `db.method()` cross-file.

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -2344,6 +2344,235 @@
         assert_eq!(visible_total, 2);
     }
 
+    /// DOCUMENTS LEG (2026-07-20 link-documents): `list_link_candidates_visible` now surfaces
+    /// uploaded `kind='document'` rows too — matched by TITLE when present AND by the `name`
+    /// (filename) fallback when a document has no `title` — prefix-filtered case-insensitively.
+    /// RED against the pre-fix two-leg reader (which only ever returned notes + meetings).
+    #[test]
+    fn list_link_candidates_returns_visible_documents_by_title_and_name() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // A document WITH a title (matched on the title). Documents carry a title only after a
+        // rename/ingest, so set it directly here (the test-only raw-UPDATE pattern this file uses).
+        db.insert_document("d-titled", "f-open", "report-final.pdf", "body", "document", 1_000)
+            .unwrap();
+        db.lock()
+            .execute("UPDATE documents SET title = 'Quarterly Report' WHERE id='d-titled'", [])
+            .unwrap();
+        // A document with NO title — only a filename (matched on the `name` fallback).
+        db.insert_document("d-cv", "f-open", "Oskar_Orlowski_CV.pdf", "body", "document", 2_000)
+            .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+
+        // Prefix "Quart" hits the titled doc; not the CV.
+        let (by_title, _) = db
+            .list_link_candidates_visible("Quart", 10, 0, &nothing)
+            .unwrap();
+        assert_eq!(by_title.len(), 1);
+        assert_eq!(by_title[0].kind, "document");
+        assert_eq!(by_title[0].id, "d-titled");
+        assert_eq!(by_title[0].title, "Quarterly Report");
+
+        // Prefix "Oskar" hits the CV by its filename (COALESCE(title, name) fallback).
+        let (by_name, _) = db
+            .list_link_candidates_visible("Oskar", 10, 0, &nothing)
+            .unwrap();
+        assert_eq!(by_name.len(), 1);
+        assert_eq!(by_name[0].kind, "document");
+        assert_eq!(by_name[0].id, "d-cv");
+        assert_eq!(by_name[0].title, "Oskar_Orlowski_CV.pdf");
+
+        // Case-insensitive (SQLite LIKE is ASCII-case-insensitive), same as the notes/meetings legs.
+        let (ci, _) = db
+            .list_link_candidates_visible("oskar", 10, 0, &nothing)
+            .unwrap();
+        assert_eq!(ci.len(), 1);
+        assert_eq!(ci[0].id, "d-cv");
+    }
+
+    /// GATED (documents): a sealed-and-not-session-unlocked document is ABSENT from candidates AND
+    /// must not inflate `local_total` — session-unlock reverses it. Same discipline as
+    /// `list_link_candidates_hides_sealed_sources` for notes/meetings, now for the documents leg.
+    /// RED against an ungated documents scan.
+    #[test]
+    fn list_link_candidates_hides_sealed_documents() {
+        let db = mem_db();
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // A sealed document titled "Secret Dossier" — plaintext still present, so the gate is the
+        // sole suppressor.
+        db.insert_document("d-secret", "f-locked", "dossier.pdf", "classified", "document", 1_000)
+            .unwrap();
+        db.lock()
+            .execute("UPDATE documents SET title = 'Secret Dossier' WHERE id='d-secret'", [])
+            .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let (hidden, hidden_total) = db
+            .list_link_candidates_visible("Secret", 10, 0, &nothing)
+            .unwrap();
+        assert!(
+            hidden.is_empty(),
+            "a sealed-and-not-unlocked document must not be a link candidate"
+        );
+        assert_eq!(
+            hidden_total, 0,
+            "the pagination total must not leak that a sealed document exists"
+        );
+
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let (visible, visible_total) = db
+            .list_link_candidates_visible("Secret", 10, 0, &unlocked)
+            .unwrap();
+        assert_eq!(visible.len(), 1, "unlocking reveals the document");
+        assert_eq!(visible[0].id, "d-secret");
+        assert_eq!(visible_total, 1);
+    }
+
+    /// PAGINATION across the notes → meetings → documents seam: `offset` walks the ONE combined
+    /// ordering without duplicating or skipping rows, and the documents leg sits AFTER both notes
+    /// and meetings (so pre-existing notes/meetings page positions are unchanged). RED against the
+    /// pre-fix reader (documents never appeared, and `local_total` omitted the document count).
+    #[test]
+    fn list_link_candidates_paginates_across_the_documents_seam() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+
+        // 2 notes (newest-updated first: n2, n1) + 1 meeting + 1 document.
+        db.insert_note("n1", "f-open", "one", "Note One", "body", 1_000)
+            .unwrap();
+        db.insert_note("n2", "f-open", "two", "Note Two", "body", 2_000)
+            .unwrap();
+        let mut m = sample_meeting("m1", "2026-06-20T10:00:00Z");
+        m.title = Some("Meeting One".to_string());
+        db.insert_meeting(&m).unwrap();
+        note_for(&db, "m1", "claude_code", "note");
+        db.set_note_folder("m1", Some("f-open")).unwrap();
+        db.insert_document("d1", "f-open", "Handbook.pdf", "body", "document", 3_000)
+            .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let page = |offset: i64| {
+            db.list_link_candidates_visible("", 2, offset, &nothing)
+                .unwrap()
+        };
+
+        // The combined stable ordering is [Note Two, Note One] ++ [Meeting One] ++ [Handbook.pdf].
+        // Total spans all three legs on every page (it feeds the org-leg offset math downstream).
+        let (p0, total) = page(0);
+        assert_eq!(
+            p0.iter().map(|c| c.title.as_str()).collect::<Vec<_>>(),
+            vec!["Note Two", "Note One"]
+        );
+        assert_eq!(total, 4, "local total = notes + meetings + documents");
+
+        // Page 1 straddles the meetings→documents seam: the meeting, then the document last.
+        let (p1, _) = page(2);
+        assert_eq!(
+            p1.iter()
+                .map(|c| (c.kind.as_str(), c.title.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("meeting", "Meeting One"), ("document", "Handbook.pdf")]
+        );
+
+        // Past the end: an empty page, never an error, and no duplicate of the document.
+        let (p2, _) = page(4);
+        assert!(p2.is_empty());
+
+        // Cross-page dedup + no-gap sanity: the union of all pages is exactly the 4 distinct ids.
+        let mut seen: Vec<String> = Vec::new();
+        for off in [0, 2, 4] {
+            for c in page(off).0 {
+                assert!(!seen.contains(&c.id), "no row appears on two pages");
+                seen.push(c.id);
+            }
+        }
+        let mut ids = seen.clone();
+        ids.sort();
+        assert_eq!(ids, vec!["d1", "m1", "n1", "n2"]);
+    }
+
+    /// DOCUMENT LEG (`resolve_wikilink`): a visible `kind='document'` resolves to
+    /// `WikiTarget{kind:"document"}`; a SEALED document does NOT resolve (falls through to None);
+    /// and a title shared by a note AND a document prefers the NOTE (note-first ordering). RED
+    /// against the pre-fix resolver, which had no document leg (a doc-only title returned None).
+    #[test]
+    fn resolve_wikilink_resolves_visible_document_and_prefers_note_and_hides_sealed() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        seed_folder(&db, "f-locked", "Secret");
+        db.set_folder_locked("f-locked", true, Some(b"wrapped"))
+            .unwrap();
+
+        // A visible document titled "Roadmap" (a doc-only title, no note/meeting names it).
+        db.insert_document("d-road", "f-open", "roadmap.pdf", "body", "document", 1_000)
+            .unwrap();
+        // A sealed document titled "Dossier" — plaintext present, so the gate is the sole suppressor.
+        db.insert_document("d-seal", "f-locked", "dossier.pdf", "body", "document", 1_000)
+            .unwrap();
+        // A note AND a document sharing the title "Shared" — note-first must win.
+        db.insert_note("n-shared", "f-open", "shared-note", "Shared", "body", 2_000)
+            .unwrap();
+        db.insert_document("d-shared", "f-open", "shared.pdf", "body", "document", 2_000)
+            .unwrap();
+        // Set the document titles directly (the test-only raw-UPDATE pattern this file uses).
+        {
+            let conn = db.lock();
+            conn.execute("UPDATE documents SET title='Roadmap' WHERE id='d-road'", [])
+                .unwrap();
+            conn.execute("UPDATE documents SET title='Dossier' WHERE id='d-seal'", [])
+                .unwrap();
+            conn.execute("UPDATE documents SET title='Shared' WHERE id='d-shared'", [])
+                .unwrap();
+        }
+
+        let nothing = std::collections::HashSet::new();
+
+        // Doc-only title resolves to the document.
+        let road = db
+            .resolve_wikilink("Roadmap", &nothing)
+            .unwrap()
+            .expect("[[Roadmap]] resolves to the document");
+        assert_eq!(road.kind, "document");
+        assert_eq!(road.id, "d-road");
+
+        // Case-insensitive fallback also reaches the document.
+        let road_ci = db
+            .resolve_wikilink("roadmap", &nothing)
+            .unwrap()
+            .expect("[[roadmap]] resolves case-insensitively");
+        assert_eq!(road_ci.kind, "document");
+        assert_eq!(road_ci.id, "d-road");
+
+        // Sealed document does NOT resolve (nothing unlocked).
+        assert!(
+            db.resolve_wikilink("Dossier", &nothing).unwrap().is_none(),
+            "a sealed document must not be resolvable from a wikilink"
+        );
+        // Session-unlock reverses it.
+        let mut unlocked = std::collections::HashSet::new();
+        unlocked.insert("f-locked".to_string());
+        let sealed = db
+            .resolve_wikilink("Dossier", &unlocked)
+            .unwrap()
+            .expect("unlocked document resolves");
+        assert_eq!(sealed.kind, "document");
+        assert_eq!(sealed.id, "d-seal");
+
+        // A title shared by a note AND a document prefers the NOTE (note leg runs first).
+        let shared = db
+            .resolve_wikilink("Shared", &nothing)
+            .unwrap()
+            .expect("[[Shared]] resolves");
+        assert_eq!(shared.kind, "note", "a note+doc title collision prefers the note");
+        assert_eq!(shared.id, "n-shared");
+    }
+
     /// FAIL-CLOSED: a correction row with a NULL `meeting_id` (legacy/unattributed) is never returned
     /// by the gated reader, even with nothing locked.
     #[test]

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -243,6 +243,50 @@ impl Db {
                 id: m.id,
             }));
         }
+        // Document leg — AFTER meetings, BEFORE org. A note that links a document materializes
+        // `[[Doc Title]]` into its body (`link_items`), and the inline `[[` autocomplete now
+        // surfaces documents, so a clicked doc-titled wikilink must resolve. Note-first ordering
+        // above means a title shared by a note AND a doc still prefers the note. VISIBLE documents
+        // only (`visibility_clause` on the folder) — a sealed-not-unlocked document resolves to
+        // None, exactly like the note/meeting legs. Exact first, then the ASCII-case-folded
+        // fallback on an exact miss — the same two-tier pattern the note leg uses.
+        {
+            let conn = self.lock();
+            let visible = visibility_clause("f", unlocked);
+            let doc_sql = |exact: bool| {
+                let title_pred = if exact {
+                    "COALESCE(NULLIF(TRIM(d.title), ''), d.name) = ?1"
+                } else {
+                    "LOWER(COALESCE(NULLIF(TRIM(d.title), ''), d.name)) = LOWER(?1)"
+                };
+                format!(
+                    "SELECT d.id
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE d.kind = 'document'
+                        AND {title_pred}
+                        AND {visible}
+                      ORDER BY d.updated_at DESC, d.id ASC
+                      LIMIT 1"
+                )
+            };
+            let doc_id: Option<String> = conn
+                .query_row(&doc_sql(true), rusqlite::params![title], |r| r.get(0))
+                .optional()
+                .map_err(map_err)?
+                .or_else(|| {
+                    conn.query_row(&doc_sql(false), rusqlite::params![title], |r| r.get(0))
+                        .optional()
+                        .ok()
+                        .flatten()
+                });
+            if let Some(id) = doc_id {
+                return Ok(Some(WikiTarget {
+                    kind: "document".to_string(),
+                    id,
+                }));
+            }
+        }
         // Org (Shared Brain) leg — deliberately-disclosed content living OUTSIDE the folder-lock
         // domain, so no `unlocked`/`visibility_clause` gate applies here; instead it is scoped to
         // orgs the caller has actually JOINED and left ENABLED on this install, and excludes

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1270,12 +1270,13 @@ pub struct LinkEdge {
     pub manual: bool,
 }
 
-/// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, or (2026-07-15)
-/// org (Shared Brain) item whose exact title the link names, so the FE can route `/notes/:id`,
-/// `/meeting/:id`, or `/org-item/:id`. Resolution is visibility-gated: a sealed-and-not-
-/// session-unlocked note/meeting with that title resolves to `None`, so clicking a wikilink can
-/// never reveal or navigate to locked content. `kind` is a raw string (`"meeting"` | `"note"` |
-/// `"org"`), NOT [`SourceKind`] — mirrors the convention [`NoteCitation`] already established for
+/// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, document, or
+/// (2026-07-15) org (Shared Brain) item whose exact title the link names, so the FE can route
+/// `/notes/:id`, `/meeting/:id`, the document viewer, or `/org-item/:id`. Resolution is
+/// visibility-gated: a sealed-and-not-session-unlocked note/meeting/document with that title
+/// resolves to `None`, so clicking a wikilink can never reveal or navigate to locked content.
+/// `kind` is a raw string (`"meeting"` | `"note"` | `"document"` | `"org"`), NOT [`SourceKind`] —
+/// mirrors the convention [`NoteCitation`] already established for
 /// the identical tri-state (`SourceKind` stays a strict local meeting/note enum, used only for
 /// backlinks, which have no org leg). For `kind == "org"`, `id` is the org item id
 /// (`org_items.item_id`), never a local id — the FE routes it through
@@ -1283,7 +1284,7 @@ pub struct LinkEdge {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WikiTarget {
-    /// `"meeting"` | `"note"` | `"org"`.
+    /// `"meeting"` | `"note"` | `"document"` | `"org"`.
     pub kind: String,
     pub id: String,
 }

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -362,4 +362,14 @@
     (cancelled)="lockFlow.cancel()"
   />
 }
-  
+
+<!-- Read-only document/note content-preview modal — the SINGLE app-wide host
+     (see the `docPreview` field doc). Reachable from every route: a Related /
+     Suggested chip, a `[[wikilink]]`, or a full-brain-graph node opens it via
+     `DocumentPreviewService.open`; the component renders nothing while its
+     `target` is null. Opaque overlay (T3), owned by the component. -->
+<app-document-preview
+  [doc]="docPreview.target()"
+  (dismiss)="docPreview.close()"
+/>
+

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -29,10 +29,12 @@ import { MurQuickSearchComponent } from "../design-system/quick-search/quick-sea
 import { MurSidebarComponent } from "../design-system/sidebar/sidebar.component";
 import { MurSidebarSectionComponent } from "../design-system/sidebar-section/sidebar-section.component";
 import { MurTabStripComponent } from "../design-system/tab-strip/tab-strip.component";
+import { DocumentPreviewComponent } from "../features/brain/document-preview/document-preview.component";
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
 import { MeetingsSidebarTreeComponent } from "../features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component";
 import { NotesSidebarTreeComponent } from "../features/notes/notes-sidebar-tree/notes-sidebar-tree.component";
 import { ChromeService } from "../services/chrome.service";
+import { DocumentPreviewService } from "../services/document-preview.service";
 import { FolderLockFlowService } from "../services/folder-lock-flow.service";
 import { FoldersService } from "../services/folders.service";
 import { NotesService } from "../services/notes.service";
@@ -162,6 +164,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     NotesSidebarTreeComponent,
     MurSidebarSectionComponent,
     LockSharesDialogComponent,
+    DocumentPreviewComponent,
   ],
   host: {
     // Scoped to !inDrilldown so the pill-clearance padding never leaks onto
@@ -213,6 +216,15 @@ export class AppShellComponent {
    * `e2e/org/org-surfaces.spec.ts`'s strict-mode-violation failure).
    */
   readonly lockFlow = inject(FolderLockFlowService);
+
+  /**
+   * The app-wide read-only document/note preview modal, hosted ONCE here so it's
+   * reachable from every route (a Related/Suggested chip, a `[[wikilink]]`, a
+   * full-brain-graph node — none of which have a document route). The template
+   * binds its `target` into the SINGLE `<app-document-preview>` host below; every
+   * "open a document" surface calls {@link DocumentPreviewService.open}.
+   */
+  readonly docPreview = inject(DocumentPreviewService);
 
   /**
    * The current URL, updated on every completed navigation. Seeded from

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1064,6 +1064,23 @@ export interface DocumentInfo {
 }
 
 /**
+ * The MINIMAL descriptor the read-only document preview modal needs to open one
+ * `documents` row (`DocumentPreviewComponent`'s `doc` input + `DocumentPreviewService`'s
+ * `open()` argument): just the `id` (the gated `getDocument(id)` read key), the display
+ * `name`, and the `kind` (drives the header badge — `"note"` is always "Note", a
+ * `"document"` badge is derived from the filename extension). Deliberately a SUBSET of
+ * {@link DocumentInfo} (which stays structurally assignable, so the Brain page's existing
+ * `DocumentInfo`-typed call sites keep compiling), so a document reachable ONLY as a link
+ * target (a graph node, a `[[wikilink]]`, a Related chip — where we have an id + a label
+ * but no full `DocumentInfo`) can still be previewed.
+ */
+export interface DocumentPreviewTarget {
+  id: string;
+  name: string;
+  kind: "document" | "note";
+}
+
+/**
  * brain2 — headline counts + semantic flags for the Brain page ("what's in my
  * brain"). Mirrors the Rust `BrainOverview` (serde camelCase). Every count is
  * over VISIBLE/unlocked content only (a sealed-not-unlocked folder's items are
@@ -1350,7 +1367,8 @@ export interface BacklinkSource {
  *
  * - `direction` — `"out"` (the queried item is this edge's `src`) | `"in"` (it is `dst`).
  * - `otherKind` — the neighbour endpoint kind: `"meeting" | "note" | "document"`
- *   (route `meeting` → `/meeting/:id`, `note`/`document` → `/notes/:id`).
+ *   (`meeting` → `/meeting/:id`, `note` → `/notes/:id`; a `document` has no route —
+ *   its chip opens the read-only preview modal via `DocumentPreviewService`).
  * - `edgeType` — `"wikilink" | "companion" | "semantic" | "manual"`. `wikilink`/
  *   `companion`/`manual` are DETERMINISTIC edges (rendered as plain link chips);
  *   `semantic` is a SUGGESTED edge the user can Accept/Dismiss, with `score` the
@@ -1406,11 +1424,13 @@ export interface SourceRef {
  * click can never reveal or open locked content). `kind` is a raw string (NOT
  * `SourceKind` — mirrors `NoteCitation`'s convention for the same tri-state, since
  * `SourceKind` stays local-only for backlinks): `"org"` carries the org item's id,
- * routed to `TabsService.openOrgItem`, never a local id. Mirrors the Rust `WikiTarget`
- * (serde camelCase).
+ * routed to `TabsService.openOrgItem`, never a local id; `"document"` (a brain-ingested
+ * `documents` row, e.g. a PDF) carries the document id, opened in the read-only
+ * {@link DocumentPreviewTarget} modal (via `DocumentPreviewService`), never a route.
+ * Mirrors the Rust `WikiTarget` (serde camelCase).
  */
 export interface WikiTarget {
-  kind: "meeting" | "note" | "org";
+  kind: "meeting" | "note" | "org" | "document";
   id: string;
 }
 

--- a/src/app/features/brain/brain/brain.component.html
+++ b/src/app/features/brain/brain/brain.component.html
@@ -300,9 +300,8 @@
       (dismiss)="closeNoteEditor()"
     />
   }
-
-  @if (previewDoc(); as doc) {
-    <app-document-preview [doc]="doc" (dismiss)="closePreview()" />
-  }
+  <!-- The read-only document/note preview modal is now hosted ONCE at the app
+       shell (see DocumentPreviewService) so it's reachable from every surface;
+       `openPreview` delegates to that service instead of a local modal host. -->
 </section>
   

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -18,6 +18,7 @@ import type {
   FolderNode,
   GraphData,
 } from "../../../core/models";
+import { DocumentPreviewService } from "../../../services/document-preview.service";
 import { FoldersService } from "../../../services/folders.service";
 import { ToastService } from "../../../services/toast.service";
 import { BrainEnableCardComponent } from "../brain-enable-card/brain-enable-card.component";
@@ -26,7 +27,6 @@ import { FullBrainGraphComponent } from "../full-brain-graph/full-brain-graph.co
 import { BrainMemoryComponent } from "../brain-memory/brain-memory.component";
 import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor.component";
 import { BrainSourceCardComponent } from "../brain-source-card/brain-source-card.component";
-import { DocumentPreviewComponent } from "../document-preview/document-preview.component";
 import { BriefsComponent } from "../../briefs/briefs/briefs.component";
 import { AuditComponent } from "../../audit/audit/audit.component";
 
@@ -83,7 +83,6 @@ interface FolderOption {
     RouterLink,
     BrainEnableCardComponent,
     BrainSourceCardComponent,
-    DocumentPreviewComponent,
     BrainNoteEditorComponent,
     BrainMapComponent,
     FullBrainGraphComponent,
@@ -99,6 +98,7 @@ export class BrainComponent {
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly docPreview = inject(DocumentPreviewService);
 
   // ── "Enable the brain" nudge — shown only when an on-device model is missing ─
   /**
@@ -316,14 +316,6 @@ export class BrainComponent {
 
   // ── note editor modal ──────────────────────────────────────────────────
   readonly noteEditorOpen = signal(false);
-
-  // ── document/note content-preview modal ────────────────────────────────
-  /**
-   * The document/note currently open in the read-only preview modal, or null
-   * when closed. Set from a source card's `openItem`; the modal fetches the
-   * gated text itself (sealed folders mask to "" → it renders LOCKED).
-   */
-  readonly previewDoc = signal<DocumentInfo | null>(null);
 
   // ── connections (graph) ────────────────────────────────────────────────
   readonly graphData = signal<GraphData | null>(null);
@@ -613,14 +605,14 @@ export class BrainComponent {
     }
   }
 
-  /** Open the read-only content preview for a document/note row. */
+  /**
+   * Open the read-only content preview for a document/note row. Delegates to the
+   * app-wide {@link DocumentPreviewService} (hosted ONCE in the app shell) so
+   * there's a single preview host/source of truth across every surface —
+   * `DocumentInfo` is structurally a `DocumentPreviewTarget`.
+   */
   openPreview(doc: DocumentInfo): void {
-    this.previewDoc.set(doc);
-  }
-
-  /** Close the content preview modal. */
-  closePreview(): void {
-    this.previewDoc.set(null);
+    this.docPreview.open(doc);
   }
 
   openNoteEditor(): void {

--- a/src/app/features/brain/document-preview/document-preview.component.ts
+++ b/src/app/features/brain/document-preview/document-preview.component.ts
@@ -13,7 +13,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
-import type { DocumentInfo } from "../../../core/models";
+import type { DocumentPreviewTarget } from "../../../core/models";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 
 /**
@@ -56,8 +56,15 @@ export class DocumentPreviewComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
 
-  /** The document to preview; null = the modal is closed (renders nothing). */
-  readonly doc = input<DocumentInfo | null>(null);
+  /**
+   * The document/note to preview; null = the modal is closed (renders nothing).
+   * A {@link DocumentPreviewTarget} — the minimal `{ id, name, kind }` the
+   * component reads — so a document reachable only as a link target (a graph
+   * node / `[[wikilink]]` / Related chip, with no full `DocumentInfo` in hand)
+   * can be previewed too. `DocumentInfo` is structurally assignable, so the
+   * Brain page's existing `DocumentInfo`-typed call site is unaffected.
+   */
+  readonly doc = input<DocumentPreviewTarget | null>(null);
 
   // Named `dismiss` (not `close`): `close` is a native DOM event name, which
   // `@angular-eslint/no-output-native` forbids as an output. Matches the
@@ -130,13 +137,20 @@ export class DocumentPreviewComponent {
   );
 
   constructor() {
-    // Focus the close button once the modal has rendered (afterNextRender,
-    // never setTimeout/rAF). The parent renders this component behind an
-    // `@if (previewDoc())`, so it's created fresh on open → this one-shot fires
-    // exactly when the modal appears. Runs in the field-init injection context;
-    // the explicit injector is belt-and-braces consistent with the tree.
-    afterNextRender(() => this.closeBtn()?.nativeElement.focus(), {
-      injector: this.injector,
+    // Focus the close button when the modal OPENS. This host is now MOUNTED ONCE
+    // in the app shell (globally reachable) with `doc` toggled null↔target — so
+    // the component is NOT recreated per open (it used to live behind a parent
+    // `@if`). An effect keyed on `doc()` therefore fires on every open/target
+    // change; `afterNextRender` (never setTimeout/rAF) focuses the close button
+    // once the modal has painted. On close (`doc` → null) the `@if` has removed
+    // the button, so `closeBtn()` is undefined and the focus no-ops.
+    effect(() => {
+      if (!this.doc()) {
+        return;
+      }
+      afterNextRender(() => this.closeBtn()?.nativeElement.focus(), {
+        injector: this.injector,
+      });
     });
 
     // Fetch the document text whenever a non-null doc is set. Stale-result

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -17,6 +17,7 @@ import type {
   FullGraphNodeKind,
 } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
+import { DocumentPreviewService } from "../../../services/document-preview.service";
 import { TabsService } from "../../../core/tabs.service";
 import {
   FullBrainSceneDirective,
@@ -69,8 +70,9 @@ const MAX_NODES = 500;
  * - {@link FullBrainSceneDirective} owns every DOM-loop concern (ResizeObserver,
  *   invalidate-on-demand paint, pointer input) per angular-zoneless §5.
  *
- * CLICK-THROUGH: a node click routes by kind — meeting → `/meeting/:id`,
- * note/document → the note editor (`/notes/:id`, both are `documents` rows),
+ * CLICK-THROUGH: a node open routes by kind — meeting → `/meeting/:id`,
+ * note → the note editor (`/notes/:id`), document → the app-wide read-only
+ * preview modal (a `document` row has no route; `DocumentPreviewService`),
  * entity → the `/graph` page with `?entity=<id>` preselected (reuse existing
  * nav). Sizing is handled by the directive's ResizeObserver (no `setTimeout`).
  */
@@ -86,6 +88,7 @@ export class FullBrainGraphComponent {
   private readonly folders = inject(FoldersService);
   private readonly router = inject(Router);
   private readonly tabs = inject(TabsService);
+  private readonly docPreview = inject(DocumentPreviewService);
 
   private readonly scene = viewChild(FullBrainSceneDirective);
 
@@ -415,9 +418,18 @@ export class FullBrainGraphComponent {
         void this.router.navigate(["/meeting", id]);
         break;
       case "note":
-      case "document":
-        // Both are `documents` rows — the note editor renders either.
+        // A `note` documents row IS a routable editor note.
         void this.tabs.openNote(id, node.label || "Note");
+        break;
+      case "document":
+        // A brain-ingested `document` (e.g. a PDF) has NO route — `get_note`
+        // rejects a document id (`["/notes", id]` was a dead end). Open the
+        // app-wide read-only preview modal instead (gated `getDocument(id)`).
+        this.docPreview.open({
+          id,
+          name: node.label || "Document",
+          kind: "document",
+        });
         break;
       case "entity":
         // Reuse the /graph page's entity detail via a preselect deep-link.

--- a/src/app/services/document-preview.service.ts
+++ b/src/app/services/document-preview.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, signal } from "@angular/core";
+import type { DocumentPreviewTarget } from "../core/models";
+
+/**
+ * The app-wide handle to the ONE read-only document/note content-preview modal
+ * ({@link import('../features/brain/document-preview/document-preview.component').DocumentPreviewComponent}).
+ *
+ * A brain-ingested document (`documents` row, `kind:"document"`, e.g. a PDF) has
+ * no route of its own — `get_note` rejects a document id, so `["/notes", id]` is
+ * a dead end. Instead every "open a document" surface (a Related/Suggested chip,
+ * a `[[wikilink]]`, a full-brain-graph node) calls {@link open} and this service
+ * feeds the target into the SINGLE `<app-document-preview>` host mounted in the
+ * always-visible app shell — so a document is viewable from every route, from
+ * one source of truth (no per-surface modal copy).
+ *
+ * A pure signal-holder (no IPC of its own): the modal owns the gated
+ * `getDocument(id)` fetch + view state; this only tracks WHICH document is open.
+ * The read is gated server-side — a sealed-and-not-session-unlocked folder masks
+ * the text — so surfacing a target here can never reveal locked content.
+ */
+@Injectable({ providedIn: "root" })
+export class DocumentPreviewService {
+  /** The document/note currently open in the preview modal; null = closed. */
+  private readonly _target = signal<DocumentPreviewTarget | null>(null);
+
+  /** The open target (read-only); null when the modal is closed. */
+  readonly target = this._target.asReadonly();
+
+  /** Open the read-only preview for a document/note. */
+  open(t: DocumentPreviewTarget): void {
+    this._target.set(t);
+  }
+
+  /** Close the preview modal. */
+  close(): void {
+    this._target.set(null);
+  }
+}

--- a/src/app/shared/connections/connections.component.html
+++ b/src/app/shared/connections/connections.component.html
@@ -105,21 +105,34 @@
             [class.has-remove]="row.removable && !!row.edge"
             [class.is-pending]="row.pending"
           >
-            <a class="cx-chip" [routerLink]="row.route">
-              @switch (row.kind) {
-                @case ("meeting") {
-                  <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+            <!-- A `document` neighbour has NO route (`get_note` rejects a doc id) —
+                 its chip is a <button> that opens the read-only preview modal.
+                 `meeting`/`note` chips stay routed <a>s exactly as before. -->
+            @if (row.kind === "document") {
+              <button
+                type="button"
+                class="cx-chip cx-chip--open"
+                [attr.aria-label]="'Open document ' + row.title"
+                (click)="openDocument(row.id, row.title)"
+              >
+                <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
+                <span class="cx-title">{{ row.title }}</span>
+                <span class="cx-edge" aria-hidden="true">{{ row.tag }}</span>
+              </button>
+            } @else {
+              <a class="cx-chip" [routerLink]="row.route">
+                @switch (row.kind) {
+                  @case ("meeting") {
+                    <span class="cx-kind cx-kind--meeting" aria-hidden="true">meeting</span>
+                  }
+                  @default {
+                    <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
+                  }
                 }
-                @case ("document") {
-                  <span class="cx-kind cx-kind--doc" aria-hidden="true">doc</span>
-                }
-                @default {
-                  <span class="cx-kind cx-kind--note" aria-hidden="true">note</span>
-                }
-              }
-              <span class="cx-title">{{ row.title }}</span>
-              <span class="cx-edge" aria-hidden="true">{{ row.tag }}</span>
-            </a>
+                <span class="cx-title">{{ row.title }}</span>
+                <span class="cx-edge" aria-hidden="true">{{ row.tag }}</span>
+              </a>
+            }
             @if (row.removable && row.edge) {
               <button
                 type="button"

--- a/src/app/shared/connections/connections.component.scss
+++ b/src/app/shared/connections/connections.component.scss
@@ -150,6 +150,17 @@
   background: var(--surface-hover);
 }
 
+/* A Related chip rendered as a <button> (a `document` neighbour, which has no
+   route → it opens the preview modal instead of navigating). Same solid chip
+   visual as the routed <a>, plus the button resets `.cx-chip` doesn't need for
+   an anchor (inherit the app font, left-align the label, show the pointer). */
+.cx-chip--open {
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
 /* Remove (×) — an in-chip trailing button (design-system removable-chip pattern),
    tucked INSIDE the pill's right edge over reserved padding so it never floats in the
    inter-chip gap or overlaps the label, with a comfortable 24px hit target. The wrap

--- a/src/app/shared/connections/connections.component.ts
+++ b/src/app/shared/connections/connections.component.ts
@@ -20,6 +20,7 @@ import type {
   LinkKind,
   NoteCitation,
 } from "../../core/models";
+import { DocumentPreviewService } from "../../services/document-preview.service";
 import { FoldersService } from "../../services/folders.service";
 import { ToastService } from "../../services/toast.service";
 import { LinkPickerComponent } from "../../features/notes/link-picker/link-picker.component";
@@ -40,6 +41,13 @@ interface RelatedRow {
   /** Dedup identity — `${otherKind}:${otherId}`. Also the `@for` track key. */
   readonly key: string;
   readonly kind: "meeting" | "note" | "document";
+  /**
+   * The neighbour's raw id (the edge's `otherId` / the backlink's `id`) — the
+   * key `route` is built from, AND what a `document` chip passes to
+   * {@link DocumentPreviewService.open} (a document has no route, so its chip
+   * opens the read-only preview modal instead of navigating).
+   */
+  readonly id: string;
   readonly title: string;
   readonly route: unknown[];
   /** The small direction/type tag ("linked" / "mentions" / "companion" / "related"). */
@@ -61,6 +69,8 @@ interface RelatedRow {
 interface SuggestionRow {
   readonly edge: LinkEdge;
   readonly kind: "meeting" | "note" | "document";
+  /** The neighbour's raw id (`edge.otherId`) — the key `route` is built from. */
+  readonly id: string;
   readonly title: string;
   readonly route: unknown[];
   readonly pending: boolean;
@@ -109,6 +119,7 @@ export class ConnectionsComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly docPreview = inject(DocumentPreviewService);
   private readonly injector = inject(Injector);
 
   /** The link-endpoint kind this panel is anchored to. */
@@ -256,6 +267,7 @@ export class ConnectionsComponent {
       rows.push({
         key,
         kind: edge.otherKind,
+        id: edge.otherId,
         title: edge.otherTitle,
         route: this.routeForKind(edge.otherKind, edge.otherId),
         tag: this.tagForEdge(edge),
@@ -275,6 +287,7 @@ export class ConnectionsComponent {
       rows.push({
         key,
         kind: bl.kind,
+        id: bl.id,
         title: bl.title,
         route: this.routeForKind(bl.kind, bl.id),
         tag: "mentions",
@@ -330,6 +343,7 @@ export class ConnectionsComponent {
       .map((edge) => ({
         edge,
         kind: edge.otherKind,
+        id: edge.otherId,
         title: edge.otherTitle,
         route: this.routeForKind(edge.otherKind, edge.otherId),
         pending: pending.has(edge.id),
@@ -431,12 +445,29 @@ export class ConnectionsComponent {
     return this.pending().has(id);
   }
 
-  /** The click-through route array for a neighbour, split by kind. */
+  /**
+   * The click-through route array for a neighbour, split by kind. A `document`
+   * neighbour has NO valid route (`get_note` rejects a document id, so
+   * `["/notes", id]` is a dead end) — its chip opens the read-only preview via
+   * {@link openDocument} instead of a `[routerLink]`, so this route is only ever
+   * consumed for `meeting`/`note` chips. It still returns a value for a document
+   * (kept as the identity for the row) but the template never binds it there.
+   */
   private routeForKind(
     kind: "meeting" | "note" | "document",
     id: string,
   ): unknown[] {
     return kind === "meeting" ? ["/meeting", id] : ["/notes", id];
+  }
+
+  /**
+   * Open a `document` neighbour in the app-wide read-only preview modal (a
+   * document has no route). The gated `getDocument(id)` read is done by the
+   * modal; a sealed folder masks it to "🔒 Locked", so this can't reveal
+   * locked content.
+   */
+  openDocument(id: string, title: string): void {
+    this.docPreview.open({ id, name: title, kind: "document" });
   }
 
   /** Toggle the whole Related section collapsed ↔ expanded. */

--- a/src/app/shared/markdown/markdown.component.ts
+++ b/src/app/shared/markdown/markdown.component.ts
@@ -11,6 +11,7 @@ import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { IpcService } from "../../core/ipc.service";
 import { TabsService } from "../../core/tabs.service";
+import { DocumentPreviewService } from "../../services/document-preview.service";
 import { ToastService } from "../../services/toast.service";
 
 /**
@@ -61,6 +62,7 @@ import { ToastService } from "../../services/toast.service";
 export class MarkdownComponent {
   private readonly ipc = inject(IpcService);
   private readonly tabsService = inject(TabsService);
+  private readonly docPreview = inject(DocumentPreviewService);
   private readonly toast = inject(ToastService);
 
   readonly markdown = input<string>("");
@@ -116,10 +118,14 @@ export class MarkdownComponent {
         // note/meeting/org-item is a TRACKED TAB, matching every other open path in
         // the app. "org" (2026-07-15) opens the read-only Shared Brain viewer — never
         // offer to CREATE a note when an org item already matched the title.
+        // "document" (a brain-ingested `documents` row, e.g. a PDF) has NO route —
+        // open the app-wide read-only preview modal (gated `getDocument`), never a tab.
         if (target.kind === "meeting") {
           await this.tabsService.openMeeting(target.id, title);
         } else if (target.kind === "org") {
           await this.tabsService.openOrgItem(target.id, title);
+        } else if (target.kind === "document") {
+          this.docPreview.open({ id: target.id, name: title, kind: "document" });
         } else {
           await this.tabsService.openNote(target.id, title);
         }


### PR DESCRIPTION
## What

Makes Brain-ingested **documents** (PDFs/DOCX/… — `documents` rows with `kind="document"`) first-class link targets, so you can add them as context to a note or recording from the **Related** panel — exactly what the picker placeholder ("Link a meeting, note, or **document**…") already promised.

**Root cause of the gap:** the FE was already document-ready (chips render `document`, `pickCandidate` links documents, `link_items` gates a document endpoint, and `vault_context` packs linked documents into Ask context) — but two reads didn't know about documents:
1. `list_link_candidates_visible` hard-filtered `kind='note'`, so documents never appeared as candidates.
2. A document had no click-through — `/notes/:id` rejects a document id, so a doc chip/wikilink/graph-node was a dead end (the full-brain-graph's own doc double-click was already broken this way).

## How

**Backend** (pure gated read changes — no new command, no migration, no new dep):
- **`list_link_candidates_visible`** (`storage/db.rs`): new **documents leg** (`kind='document'`, title `COALESCE(NULLIF(TRIM(title),''), name)`), gated by `visibility_clause` on **both** the page query and the COUNT twin, appended after `[notes] ++ [meetings]`; `local_total` includes documents so the Shared-Brain org fold-in offset stays consistent. Ordered by `COALESCE(updated_at, created_at) DESC` (real ingested docs carry a `NULL` `updated_at`).
- **`resolve_wikilink`** (`storage/links.rs`): new gated **document leg** (exact → ASCII-folded), after the meeting leg / before org, so a materialized `[[Doc Title]]` resolves. Note-first ordering preserved; a sealed doc never appears, never counts, never resolves.

**Frontend:**
- New root **`DocumentPreviewService`** (signal-holder) + a single `<app-document-preview>` host mounted in the app shell → the existing read-only, server-gated document preview is reachable from every surface. `brain.component` migrated to delegate (one host, one source of truth).
- A document **Related/Suggested chip**, a **`[[wikilink]]`→document**, and a **full-brain-graph document node** now open that preview (content via the gated `getDocument`; a sealed folder masks to 🔒 Locked) instead of the dead `/notes/:id` route. Meetings/notes route unchanged.

Once a document is linked, it flows into the note's **Ask/Brain context automatically** via the existing link-expansion (active edges packed as pinned context) — no extra wiring.

## Verified

- `cargo test --lib` (link subset) **108/0**, incl. **4 new RED→GREEN** gated-read tests (candidate by title+name, sealed doc hidden + not counted, notes→meetings→documents pagination seam, wikilink resolve + note-preference + sealed-hidden).
- `clippy --lib -D warnings` clean · MSRV grep clean · `ng lint` + `ng build` clean.
- **adversarial-verifier PASS** — live seam on the mocked harness: a sealed doc renders 🔒 with content **absent from the DOM**, the once-mounted preview's stale-guard drops a late fetch, opaque overlay (T3), zero console errors; no dead-route / import-cycle regression.
- **lock-security-reviewer PASS** (mandatory — two new gated reads): both legs `visibility_clause`-gated (page + COUNT twin), no `convertFileSrc`/asset path handed to the FE, no seal/migration/keychain change.

> Note: adding documents to the shared candidate query also surfaces them in the inline `[[` autocomplete in the note body (not just the "+ Link" chooser) — intentional Obsidian-style parity.