### PR TITLE
fix(links,share): retire the murmur:links body block + stop managed blocks leaking on share

### DIFF
--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -3,8 +3,8 @@
 //! body is UNCHANGED, only relocated). This is the link domain: `link_related_notes` (the manual
 //! Stage-2 re-link trigger), `link_meeting_entities` (entity extraction + graph persist),
 //! `list_links`, `accept_link`, `dismiss_link`, `link_items`, `unlink_items`, `resolve_wikilink`,
-//! `list_link_candidates`, plus the link-only helpers (`parse_link_kind`, `materialize_accepted_link`,
-//! `merge_related_hit`, `link_endpoint_is_unlocked`, `strip_manual_link_marker`).
+//! `list_link_candidates`, plus the link-only helpers (`parse_link_kind`,
+//! `link_endpoint_is_unlocked`, `strip_manual_link_marker`).
 //!
 //! LOCK-MODEL (byte-identical to the pre-move form): every READ gates — `list_links` returns edges
 //! only when BOTH endpoints are session-VISIBLE (`Db::links_for_visible`, no existence leak),
@@ -12,12 +12,16 @@
 //! `search_org_brain_hits` (a sealed-not-unlocked target stays "not found"). Every WRITE gates BEFORE
 //! mutating: `accept_link`/`dismiss_link` refuse anything but a `semantic`+`suggested` edge and gate
 //! BOTH endpoints (`link_endpoint_is_unlocked`, fail-closed on a sealed/unknown endpoint —
-//! `AppError::Locked`); `link_items`/`unlink_items` gate both endpoints before the row write. The
-//! `accept_link_inner`/`link_items_inner`/`unlink_items_inner` bodies keep their EXACT scoped-
-//! lifecycle-guard shape (the guard is scoped in a `{ }` block RELEASED before the note-body
-//! materialize, because that callee re-takes the non-reentrant `Mutex<()>` — composing them under one
-//! held guard would self-DEADLOCK; the deadlock fix is preserved verbatim). `link_meeting_entities`
-//! READ-GATES the meeting's note (`meeting_is_unlocked`) before any extraction/egress.
+//! `AppError::Locked`); `link_items`/`unlink_items` gate both endpoints before the row write.
+//! `link_items`/`accept_link` are GRAPH-ONLY (they persist/flip the edge and write NO note body) —
+//! the machine `murmur:links` block that used to mirror links into a note body was removed (it went
+//! stale + rendered as raw junk in the plain-text editor; the live `links` table drives the Related
+//! panel). `unlink_items` still strips any PRE-EXISTING manual `[[Title]]` marker via
+//! `strip_manual_link_marker`, whose `update_note_doc_inner` write re-takes the non-reentrant
+//! `Mutex<()>` — so its lifecycle guard is scoped in a `{ }` block RELEASED before that strip
+//! (composing them under one held guard would self-DEADLOCK; the deadlock discipline is preserved).
+//! `link_meeting_entities` READ-GATES the meeting's note (`meeting_is_unlocked`) before any
+//! extraction/egress.
 //!
 //! The SHARED write-time index hooks (`index_wikilinks_best_effort`, `auto_link_semantic_best_effort`
 //! — called from every note-save funnel), the unlock re-derive (`rederive_links_for_folder` — called
@@ -101,31 +105,30 @@ pub fn list_links(
 }
 
 /// Brain v3 PR-3 — ACCEPT a suggested (semantic) link: flip it `status='active'`,
-/// `created_by='accepted'`, AND materialize the neighbour's `[[Title]]` into whichever endpoint is a
-/// locally-owned, session-visible note (via the managed `apply_link_markers` block — the ONLY path
-/// that writes a semantic link into a `.md`; the auto pass never does).
+/// `created_by='accepted'`. GRAPH-ONLY — the accept writes NO note body. (It used to also
+/// materialize the neighbour's `[[Title]]` into an owned note's managed `murmur:links` block; that
+/// block was removed — it went stale + rendered as raw junk in the plain-text editor. The live
+/// `links` table drives the Related panel, so the flipped edge alone is the surface.)
 ///
 /// GATED (PR-5): accept is ONLY for an unconfirmed SUGGESTION (`edge_type='semantic'`,
 /// `status='suggested'`) — anything else (a deterministic wikilink/companion, an already-active
 /// manual/accepted, or a dismissed tombstone) is refused `InvalidArg`. BOTH endpoints must be
 /// session-visible (`link_endpoint_is_unlocked` on each) — if EITHER is sealed-and-not-unlocked the
 /// accept is refused `AppError::Locked` (never activate an edge behind a lock, never reveal a locked
-/// neighbour by materializing a link to it). Idempotent (re-accepting an already-active edge is a
-/// no-op; the DB DO-UPDATE guard never downgrades it). The materialized marker is preserved across a
-/// later neighbour-seal and re-materialized on unlock (brain-v3 audit Fix 1/Fix 4).
+/// neighbour). Idempotent (re-accepting an already-active edge is a no-op; the DB DO-UPDATE guard
+/// never downgrades it).
 #[tauri::command]
 pub fn accept_link(state: State<'_, AppState>, id: i64) -> Result<(), AppError> {
     accept_link_inner(state.inner(), id)
 }
 
 pub(crate) fn accept_link_inner(state: &AppState, id: i64) -> Result<(), AppError> {
-    // BLK-1 / TOCTOU + non-reentrant guard: SCOPE the lifecycle guard tightly around validate + gate
-    // + row-flip so a concurrent lock/relock cannot land between the endpoint gate and the flip. It is
-    // RELEASED before the note-body materialize below — `materialize_accepted_link` →
-    // `update_note_inner`/`update_note_doc_inner` take the guard THEMSELVES, so composing them under one
-    // held guard re-enters the non-reentrant `Mutex<()>` and self-DEADLOCKS on a valid accept (mirrors
-    // `link_items_inner`/`unlink_items_inner`). Lock order `lifecycle ⊃ db`.
-    let (src_kind, src_id, dst_kind, dst_id) = {
+    // BLK-1 / TOCTOU: SCOPE the lifecycle guard tightly around validate + gate + row-flip so a
+    // concurrent lock/relock cannot land between the endpoint gate and the flip. The accept is
+    // GRAPH-ONLY now (no note-body materialize), so nothing after the guard re-takes the
+    // non-reentrant `Mutex<()>` — but the tight scope is kept (fail-closed + no wider hold than the
+    // check-then-write needs). Lock order `lifecycle ⊃ db`.
+    {
         let _lifecycle = lifecycle_guard(state);
         let Some((src_kind, src_id, dst_kind, dst_id, et, status)) = state.db.link_by_id(id)? else {
             return Err(AppError::InvalidArg(format!("no link {id}")));
@@ -153,117 +156,16 @@ pub(crate) fn accept_link_inner(state: &AppState, id: i64) -> Result<(), AppErro
                 "one of these items is locked — unlock it to accept the link".into(),
             ));
         }
-        // Flip the row first: the graph edge is active even if the .md materialize below is skipped
-        // (e.g. neither endpoint is a locally-owned editable note). The panel reflects the accept.
+        // Flip the row active — that edge is the AUTHORITATIVE link. The accept is GRAPH-ONLY: we do
+        // NOT materialize the neighbour's `[[Title]]` / `murmur:links` block into any note body (that
+        // machine block was removed — it went stale, its wikilinks are excluded from edge-indexing,
+        // and it rendered as raw junk in the plain-text editor). The live `links` table drives the
+        // Related panel, so the flipped edge alone is the surface; any pre-existing block is stripped
+        // on the next `get_note` read (natural save-time cleanup).
         state.db.accept_link(id)?;
-        (src_kind, src_id, dst_kind, dst_id)
-    }; // ── lifecycle guard RELEASED here, before materialize (which re-takes it) ──
-    let unlocked = unlocked_snapshot(state)?;
-    // A semantic edge is undirected — materialize the neighbour's [[Title]] into whichever endpoint
-    // is a LOCAL, session-VISIBLE note we own the markdown of. Try src's note first, then dst's.
-    // Best-effort: a materialize skip/failure never rolls back the accept.
-    let endpoints = [
-        (src_kind.as_str(), src_id.as_str(), dst_kind.as_str(), dst_id.as_str()),
-        (dst_kind.as_str(), dst_id.as_str(), src_kind.as_str(), src_id.as_str()),
-    ];
-    for (owner_k, owner_id, other_k, other_id) in endpoints {
-        let (Some(owner_kind), Some(other_kind)) = (
-            crate::links::LinkKind::parse(owner_k),
-            crate::links::LinkKind::parse(other_k),
-        ) else {
-            continue;
-        };
-        // Resolve the neighbour's current gated title; skip if the neighbour is sealed (no leak).
-        let Some(title) =
-            state.db.link_endpoint_title_visible(other_kind, other_id, &unlocked)?
-        else {
-            continue;
-        };
-        if materialize_accepted_link(state, owner_kind, owner_id, &title)? {
-            break; // wrote (or found already-present) in one owned, visible source — done.
-        }
     }
     tracing::info!(target: "links", link_id = id, "accept_link");
     Ok(())
-}
-
-/// Materialize the accepted neighbour's `[[Title]]` into the OWNER `(kind, id)`'s markdown via the
-/// managed `apply_link_markers` block — but ONLY when the owner is a LOCAL, session-VISIBLE note we
-/// own the markdown of (a meeting AI note, or an authored note). Returns `true` when the owner IS
-/// such a note (whether it wrote or the link was already present), `false` when the owner is not a
-/// writable/visible target (the caller then tries the other endpoint). Merges with the related-notes
-/// hits already rendered in the block so the auto block is preserved.
-fn materialize_accepted_link(
-    state: &AppState,
-    kind: crate::links::LinkKind,
-    id: &str,
-    title: &str,
-) -> Result<bool, AppError> {
-    let hit = crate::enrich::ContextHit {
-        source: match kind {
-            crate::links::LinkKind::Meeting => "meeting",
-            _ => "note",
-        }
-        .to_string(),
-        detail: format!("[[{title}]]"),
-        url: None,
-    };
-    match kind {
-        crate::links::LinkKind::Meeting => {
-            // GATE: the meeting's note must be session-visible to write plaintext.
-            if !meeting_is_unlocked(state, id)? {
-                return Ok(false);
-            }
-            let Some(existing) = state.db.get_latest_note_for_meeting(id)? else {
-                return Ok(false);
-            };
-            // Skip a sealed (blob-present) note (the seal-safety gate `link_related_notes_inner` uses).
-            let sealed = state
-                .db
-                .sealable_notes_for_meeting(id)?
-                .iter()
-                .any(|n| n.content_blob.is_some());
-            if sealed {
-                return Ok(false);
-            }
-            let merged = merge_related_hit(&existing.markdown, hit);
-            if merged != existing.markdown {
-                update_note_inner(state, id, &merged)?;
-            }
-            Ok(true)
-        }
-        crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
-            let Some(row) = state.db.get_note_row(id)? else {
-                return Ok(false); // a raw document has no editable note markdown here.
-            };
-            if !folder_is_unlocked(state, &row.folder_id)? {
-                return Ok(false);
-            }
-            let title_disp = row
-                .title
-                .clone()
-                .filter(|t| !t.is_empty())
-                .unwrap_or_else(|| row.name.clone());
-            let merged = merge_related_hit(&row.text, hit);
-            if merged != row.text {
-                update_note_doc_inner(state, id, &title_disp, &merged)?;
-            }
-            Ok(true)
-        }
-    }
-}
-
-/// Append ONE `[[Title]]` [`ContextHit`] to a note's managed `murmur:links` block WITHOUT dropping
-/// any related-notes hits already rendered there. `apply_link_markers` is a full-block REPLACE, so we
-/// re-collect the existing rendered hits ([`crate::enrich::extract_link_hits`]), add the new one
-/// (deduped by rendered detail), and re-apply — the block stays idempotent and the auto related-notes
-/// entries survive an accept.
-fn merge_related_hit(markdown: &str, new_hit: crate::enrich::ContextHit) -> String {
-    let mut hits = crate::enrich::extract_link_hits(markdown);
-    if !hits.iter().any(|h| h.detail == new_hit.detail) {
-        hits.push(new_hit);
-    }
-    crate::enrich::apply_link_markers(markdown, &hits)
 }
 
 /// Brain v3 PR-3 — DISMISS a suggested link: TOMBSTONE it so no later auto pass re-suggests it. No
@@ -312,8 +214,8 @@ pub(crate) fn dismiss_link_inner(state: &AppState, id: i64) -> Result<(), AppErr
     Ok(())
 }
 
-/// note↔meeting-links PR-1 — is a link ENDPOINT `(kind, id)` session-VISIBLE right now? Mirrors
-/// [`materialize_accepted_link`]'s gate order: a `Meeting` endpoint gates on [`meeting_is_unlocked`];
+/// note↔meeting-links PR-1 — is a link ENDPOINT `(kind, id)` session-VISIBLE right now? Gate order:
+/// a `Meeting` endpoint gates on [`meeting_is_unlocked`];
 /// a `Note`/`Document` endpoint resolves its owning folder via `get_note_row` and gates on
 /// [`folder_is_unlocked`]. An UNKNOWN endpoint (no such note/document) reports `false` — fail-closed,
 /// there is nothing legitimate to link. Used by `link_items`/`unlink_items` to refuse `AppError::Locked`
@@ -343,8 +245,8 @@ fn link_endpoint_is_unlocked(
     }
 }
 
-/// note↔meeting-links PR-1 — USER-INITIATED link: persist ONE directed `manual` edge
-/// `(src → dst)` AND, when the source is an OWNED note, materialize `[[dst Title]]` into its body.
+/// note↔meeting-links PR-1 — USER-INITIATED link: persist ONE directed `manual` edge `(src → dst)`.
+/// GRAPH-ONLY — writes NO note body.
 ///
 /// GATE (BEFORE any write): BOTH endpoints must be session-VISIBLE — a `meeting` via
 /// [`meeting_is_unlocked`], a `note`/`document` via its folder ([`folder_is_unlocked`]). If either is
@@ -352,11 +254,9 @@ fn link_endpoint_is_unlocked(
 /// locked neighbour). Unknown kinds are `AppError::InvalidArg`.
 ///
 /// The `manual` row (`created_by='user'`, `status='active'`, `score=1.0`) is idempotent on the
-/// table's UNIQUE key. For a `note` SOURCE we own the markdown of, we ALSO materialize the neighbour's
-/// gated `[[Title]]` into the managed `murmur:links` block via the SAME [`materialize_accepted_link`]
-/// path the accept command uses — best-effort (a materialize skip never rolls back the row). A
-/// `meeting`/`document` source (no owned editable body) creates the row ONLY. The materialized
-/// wikilink is display-deduped against the manual edge in `links_for_visible`.
+/// table's UNIQUE key. It is the AUTHORITATIVE record of the link; the live `links` table drives the
+/// Related panel. We DO NOT write the neighbour's `[[Title]]` / `murmur:links` block into a note body
+/// — that machine block was removed (it went stale + rendered as raw junk in the plain-text editor).
 #[tauri::command]
 pub fn link_items(
     state: State<'_, AppState>,
@@ -402,26 +302,12 @@ pub(crate) fn link_items_inner(
             .db
             .upsert_manual_link(src.as_str(), src_id, dst.as_str(), dst_id)?;
     }
-    // ── Fork #2: a NOTE source ALSO gets the neighbour's [[Title]] in its body (best-effort). ──
-    // A meeting/document source has no owned editable markdown → row only. `materialize_accepted_link`
-    // re-gates the source folder itself before writing plaintext (never behind a lock).
-    if matches!(src, crate::links::LinkKind::Note) {
-        let unlocked = unlocked_snapshot(state)?;
-        // Resolve the dst's CURRENT gated title (skip if sealed — no leak; the gate above already
-        // proved it visible, so this normally resolves).
-        if let Some(title) = state.db.link_endpoint_title_visible(dst, dst_id, &unlocked)? {
-            // Reuse the EXACT accept-materialize path (managed `murmur:links` block, merge-preserving).
-            if let Err(e) = materialize_accepted_link(state, src, src_id, &title) {
-                // Best-effort: the graph row is authoritative; a markdown-write failure never fails the
-                // link (no PII — ids/error only).
-                tracing::warn!(
-                    target: "links",
-                    error = %e,
-                    "manual link materialize skipped (row persisted)"
-                );
-            }
-        }
-    }
+    // The manual edge is the AUTHORITATIVE record of the link — the live `links` table drives the
+    // Related panel. We DO NOT materialize a `[[Title]]` / `murmur:links` block into the note body:
+    // that machine block existed only to surface links inside Obsidian, but it went stale (its
+    // wikilinks are excluded from edge-indexing) and showed as raw junk in the plain-text editor.
+    // Stop writing it here; the edge is created exactly as before. Existing blocks are stripped on
+    // the next read via `get_note` (natural save-time cleanup). See `commands/notes.rs::get_note_inner`.
     tracing::info!(
         target: "links",
         src_kind = src.as_str(),
@@ -498,12 +384,13 @@ pub(crate) fn unlink_items_inner(
     Ok(())
 }
 
-/// note↔meeting-links PR-1 — remove ONE `[[title]]` [`ContextHit`] from an owned note's managed
-/// `murmur:links` block, re-applying the block with that hit filtered out (the INVERSE of
-/// [`merge_related_hit`]). Reuses [`crate::enrich::extract_link_hits`] +
-/// [`crate::enrich::apply_link_markers`] so the block stays idempotent and any auto related-notes /
-/// accepted-semantic hits that lived alongside it survive. WRITE-GATED via `update_note_doc_inner`
-/// (refuses a sealed folder). A no-op (the note is unchanged) when the block never carried the hit.
+/// note↔meeting-links PR-1 — LEGACY CLEANUP: remove ONE `[[title]]` [`ContextHit`] from an owned
+/// note's PRE-EXISTING managed `murmur:links` block (imported before the block was retired), re-
+/// applying the block with that hit filtered out. Reuses [`crate::enrich::extract_link_hits`] +
+/// [`crate::enrich::apply_link_markers`] so any other hits that lived alongside it survive and the
+/// block strips to nothing once its last hit is removed. WRITE-GATED via `update_note_doc_inner`
+/// (refuses a sealed folder). A no-op (the note is unchanged) when the block never carried the hit —
+/// which is the common case now, since `link_items` no longer WRITES the marker.
 fn strip_manual_link_marker(state: &AppState, note_id: &str, title: &str) -> Result<(), AppError> {
     let Some(row) = state.db.get_note_row(note_id)? else {
         return Ok(()); // no owned note markdown → nothing to strip.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1533,114 +1533,23 @@ pub(crate) fn update_note_inner_with(
     })
 }
 
-/// Max cross-meeting links Lane A appends to a note (small + high-precision — a note gains a handful
-/// of related links, not a research dump).
-const MAX_RELATED_LINKS: usize = 4;
-
-/// Stage 2 / Lane A — the DETERMINISTIC, ZERO-EGRESS cross-meeting LINKING pass over a FINISHED note.
+/// Stage 2 / Lane A — the cross-meeting LINKING pass over a FINISHED note. NOW A NO-OP.
 ///
-/// Mirrors [`apply_note_enrichment_inner`] (the shipped Lane B persist seam): gate → retrieve →
-/// render → `upsert_note` (DB-canonical, so the links SEAL with the note) → re-export the vault
-/// `.md`. Retrieval is [`related_context::related_note_links`], which is DOUBLE visibility-gated
-/// (`search_visible` + `get_note_if_visible` on the live unlock set) and self-excluding — a
-/// sealed-not-unlocked related note contributes NO link. Empty hits STRIP any stale links block
-/// (byte-exact undo), so re-running self-heals the link graph. Idempotent + reversible via
-/// `apply_link_markers`.
+/// This pass used to APPEND a machine-managed `> [!related]- Related notes` (`murmur:links`) block
+/// into the note body, mirroring cross-meeting `[[Title]]` links so they surfaced inside Obsidian.
+/// That block was RETIRED: it went stale (its wikilinks are excluded from edge-indexing, so it
+/// diverged from the live RELATED panel), rendered as raw junk in the plain-text editor, and created
+/// a latent clobber risk (an open editor holding a stale body could overwrite it). The RELATED panel
+/// reads the live `links` table (driven by the deterministic `index_wikilinks_best_effort` +
+/// `auto_link_semantic_best_effort` hooks on every note save) and is unaffected — it is the real,
+/// always-fresh surface. So this pass writes NOTHING now.
 ///
-/// EGRESS: NONE. Lane A is fully local — a search over OWNED notes plus a local task-free gist. No
-/// provider, no connector, no consent gate needed (nothing leaves the device).
-///
-/// SEAL-SAFETY (stronger than the read gate, load-bearing): after the `meeting_is_unlocked` read
-/// gate, we ALSO require the note to be genuinely UNSEALED (`content_blob IS NULL` on every provider
-/// row). A note in a locked folder is SEALED: its `markdown` column is transient (blanked on relock,
-/// restored from `content_blob` on unlock) and its durable source of truth is `content_blob`.
-/// Writing links into a sealed note's `markdown` column would either corrupt a just-sealed (blanked)
-/// column (the auto-file-into-locked case, where the column is empty but the folder is session-
-/// unlocked) or be silently dropped on the next relock (the column is discarded, `content_blob` is
-/// canonical). So a sealed meeting is skipped even when the session happens to have it unlocked —
-/// which is exactly what makes "persist DB-canonical so it SEALS with the note" true here.
-pub(crate) fn link_related_notes_inner(state: &AppState, meeting_id: &str) -> Result<(), AppError> {
-    // BLK-1 / TOCTOU: hold the lifecycle guard for the WHOLE check-then-write so a concurrent
-    // `lock_folder`/`move_into_locked_folder`/`relock` cannot seal this meeting BETWEEN the seal-safety
-    // gate below and the `upsert_note`+`overwrite_note` — which would re-materialize a plaintext `.md`
-    // into a now-locked folder's vault dir (the Phase-2 lock-security TOCTOU leak). Every seal path
-    // holds this same guard (`lock_folder_inner`/`move_into_locked_folder`/`relock_all_inner`/
-    // `remove_lock_inner`), and the storage-prune was forced to take it by a prior TOCTOU finding.
-    // Lock order is `lifecycle ⊃ db` (matching `lock_folder_inner`).
-    let _lifecycle = lifecycle_guard(state);
-    // READ GATE: a sealed-not-session-unlocked meeting is silently skipped — never link a locked note.
-    if !meeting_is_unlocked(state, meeting_id)? {
-        return Ok(());
-    }
-    // SEAL-SAFETY GATE: only write the markdown COLUMN of an UNSEALED note (durable canonical). A
-    // sealed note (any provider row has a content_blob) is skipped even if session-unlocked. Read
-    // UNDER the lifecycle guard, so a seal cannot slip in after this check and before the write.
-    let sealed = state
-        .db
-        .sealable_notes_for_meeting(meeting_id)?
-        .iter()
-        .any(|n| n.content_blob.is_some());
-    if sealed {
-        return Ok(());
-    }
-    let Some(existing) = state.db.get_latest_note_for_meeting(meeting_id)? else {
-        return Ok(()); // no note yet → nothing to link.
-    };
-    let title = state
-        .db
-        .get_meeting(meeting_id)?
-        .and_then(|m| m.title)
-        .unwrap_or_default();
-    // Derive the salient query from the CANONICAL prose — strip our OWN links block first so a
-    // re-link never keys the query off a previous run's `[[Title]]` links (stable / self-healing).
-    let base = crate::enrich::apply_link_markers(&existing.markdown, &[]);
-    let query = crate::summarize::related_context::salient_query(
-        (!title.trim().is_empty()).then_some(title.as_str()),
-        &base,
-    );
-    // Snapshot the live unlocked set (the SAME gate the retrieval keys on).
-    let unlocked = {
-        state
-            .unlocked_folders
-            .lock()
-            .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
-            .clone()
-    };
-    let hits = crate::summarize::related_context::related_note_links(
-        &state.db,
-        meeting_id,
-        &query,
-        &unlocked,
-        MAX_RELATED_LINKS,
-    )?;
-    // Empty hits ⇒ `apply_link_markers` strips any stale links block (byte-exact). Non-empty ⇒ replace.
-    // No `as_of`: cross-meeting links are timeless (owned notes), so the block is a pure function of
-    // (note, hits) → the `linked == existing.markdown` short-circuit below skips a rewrite when the
-    // link set is unchanged, so the deferred auto-pass never churns the note / vault `.md`.
-    let linked = crate::enrich::apply_link_markers(&existing.markdown, &hits);
-    // No change (no hits AND no stale block) ⇒ nothing to persist; avoid a needless write + re-export.
-    if linked == existing.markdown {
-        return Ok(());
-    }
-    let created_at = chrono::Utc::now().to_rfc3339();
-    // Seal-on-write seam (audit F1): the sealed case was refused above, but a LOCKED folder whose
-    // note was never sealed (auto-filed while session-unlocked) still re-seals the fresh markdown.
-    upsert_note_reseal_if_locked(
-        state,
-        &NoteRecord {
-            meeting_id: meeting_id.to_string(),
-            provider_id: existing.provider_id.clone(),
-            markdown: linked.clone(),
-            created_at,
-            exported_path: existing.exported_path.clone(),
-            model_requested: existing.model_requested.clone(),
-            model_served: existing.model_served.clone(),
-            gateway_host: existing.gateway_host.clone(),
-        },
-    )?;
-    if let Some(path) = existing.exported_path.as_deref() {
-        overwrite_exported_note_guarded(state, meeting_id, &existing.provider_id, path, &linked)?;
-    }
+/// The command (`link_related_notes`) + the deferred pipeline call site are kept (a stable no-op) so
+/// no caller/registration churns; any pre-existing `murmur:links` block in an existing note is
+/// stripped on the next `get_note` read (natural save-time cleanup — see
+/// `commands/notes.rs::get_note_inner`). NO note body is read or written here, so there is no seal /
+/// TOCTOU / lifecycle-guard surface left to reason about.
+pub(crate) fn link_related_notes_inner(_state: &AppState, _meeting_id: &str) -> Result<(), AppError> {
     Ok(())
 }
 

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -272,6 +272,19 @@ pub(crate) fn get_note_inner(state: &AppState, id: &str) -> Result<NoteDoc, AppE
         return Ok(masked_note_doc(&row)); // sealed-not-unlocked ⇒ masked, never the stored text.
     }
     let mut doc = note_doc_from_row(&row);
+    // Strip any machine-managed `murmur:links` block (retired — it went stale + rendered as raw junk
+    // in the plain-text editor; the RELATED panel reads the live `links` table instead). The strip is
+    // FENCE-DELIMITED and HEADER-GATED: `strip_managed_links_block` removes the `<!-- murmur:links
+    // -->…<!-- /murmur:links -->` region ONLY when its first body line is the exact machine callout
+    // header `> [!related]- Related notes`, so a fence a USER typed/pasted into their own prose (real
+    // text between the markers, no `[!related]` header) is left BYTE-IDENTICAL — never eaten and then
+    // persisted by the editor's debounced autosave (owned-file data loss). Never touches user prose
+    // or front-matter. Editor + Preview see prose-only, and the FE editor's next save writes back the
+    // stripped body → a real block leaves the DB naturally (no migration, no bulk rewrite). NOTE this
+    // runs ONLY on the VISIBLE/unlocked path; the masked-sealed DTO already returned above with NO
+    // body, so no strip is ever attempted on sealed text. `murmur:context` (the connector-context
+    // block) is a DISTINCT fence and is left untouched — only the link block is stripped.
+    doc.markdown = crate::enrich::strip_managed_links_block(&doc.markdown);
     doc.shared = state.db.note_has_active_share(&row.id)?; // WP6 — active-share flag.
     Ok(doc)
 }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -563,26 +563,25 @@
         );
     }
 
-    /// Stage 2 / Lane A happy path: over a FINISHED note in an OPEN folder, `link_related_notes_inner`
-    /// appends a `> [!related]-` block of `[[Title]]` links + TASK-FREE gists, persisted DB-canonical,
-    /// preserving the original body — and is idempotent (the block never stacks).
+    /// Stage 2 / Lane A is now a NO-OP: the machine `murmur:links` block was retired (it went stale +
+    /// rendered as raw junk in the editor; the RELATED panel reads the live `links` table instead). So
+    /// `link_related_notes_inner` over a FINISHED note in an OPEN folder must leave the note body
+    /// EXACTLY as it was — no `> [!related]-` block written. (Was RED before this change: the pass used
+    /// to append the block; now it writes nothing.)
     #[test]
-    fn link_related_notes_writes_related_block_in_open_folder() {
-        let state = build_state("lanea-open");
+    fn link_related_notes_writes_no_body_block() {
+        let state = build_state("lanea-noop");
         make_open_folder(&state.db, "f-open", "Project");
-        // The note we link FROM. Kept lean so the salient query is a subset of the related note's
-        // terms (FTS5 MATCH is implicit-AND — every query term must be present in the related note).
         seed_meeting(&state.db, "this", "Apollo migration.\n", Some("f-open"));
         state
             .db
             .set_meeting_title("this", "Apollo Migration")
             .unwrap();
-        // A related PRIOR note (open folder → visible) whose Summary is the ideal task-free gist and
-        // whose Action items must NEVER enter the link detail.
+        // A related PRIOR note the OLD pass WOULD have retrieved + rendered into the block.
         seed_meeting(
             &state.db,
             "prior",
-            "## Summary\n\nApollo migration groundwork and rollout roadmap.\n\n## Action items\n\n- [ ] SECRET-TASK\n",
+            "## Summary\n\nApollo migration groundwork and rollout roadmap.\n",
             Some("f-open"),
         );
         state
@@ -590,60 +589,34 @@
             .set_meeting_title("prior", "Apollo Kickoff")
             .unwrap();
 
-        link_related_notes_inner(&state, "this").unwrap();
-
-        let md = state
+        let before = state
             .db
             .get_latest_note_for_meeting("this")
             .unwrap()
             .unwrap()
             .markdown;
-        assert!(
-            md.contains("> [!related]- Related notes"),
-            "the Related block was written; got: {md}"
-        );
-        assert!(
-            md.contains("[[Apollo Kickoff]]"),
-            "the [[Title]] link is present; got: {md}"
-        );
-        assert!(
-            md.contains("(via Murmur)"),
-            "loud Murmur attribution; got: {md}"
-        );
-        assert!(
-            md.contains("groundwork and rollout"),
-            "the task-free gist prose is present; got: {md}"
-        );
-        assert!(
-            !md.contains("SECRET-TASK"),
-            "an action item must NEVER enter a link detail; got: {md}"
-        );
-        assert!(
-            md.starts_with("Apollo migration.\n"),
-            "the original note body is preserved verbatim; got: {md}"
-        );
-
-        // Idempotent: re-linking does not stack the block.
         link_related_notes_inner(&state, "this").unwrap();
-        let md2 = state
+        let after = state
             .db
             .get_latest_note_for_meeting("this")
             .unwrap()
             .unwrap()
             .markdown;
-        assert_eq!(
-            md2.matches("<!-- murmur:links -->").count(),
-            1,
-            "the links block never stacks on re-link"
+
+        assert_eq!(after, before, "Lane A is a no-op — the note body is unchanged");
+        assert!(
+            !after.contains("murmur:links"),
+            "no managed links block is written into the note body; got: {after}"
+        );
+        assert!(
+            !after.contains("> [!related]-"),
+            "no Related-notes callout is written; got: {after}"
         );
     }
 
-    /// SEAL-SAFETY (RED-before-GREEN, load-bearing): Lane A must NEVER write the transient `markdown`
-    /// column of a SEALED note — even when the session happens to have its folder unlocked (so the
-    /// `meeting_is_unlocked` read gate passes). Without the `content_blob` guard, Lane A would derive a
-    /// query from the title, retrieve a visible related note, and upsert plaintext links into the
-    /// blanked column — resurrecting content that would be lost on the next relock. The guard makes it
-    /// a no-op: the sealed column stays blank and `content_blob` stays intact.
+    /// SEAL-SAFETY: Lane A is a no-op AND never touches a SEALED note's transient `markdown` column
+    /// even when the session has its folder unlocked (so the `meeting_is_unlocked` read gate passes).
+    /// The sealed column stays blank and `content_blob` stays intact.
     #[test]
     fn link_related_notes_never_touches_a_sealed_note() {
         let state = build_state("lanea-sealsafe");
@@ -667,7 +640,7 @@
             .unwrap();
 
         // Seal the note (content_blob present, markdown blanked), lock the folder, and SESSION-UNLOCK it
-        // so the read gate passes and ONLY the seal-safety guard can stop the write.
+        // so the read gate passes.
         state
             .db
             .seal_note("sealed", "claude_code", &b"ciphertext-blob"[..])
@@ -762,42 +735,42 @@
         );
     }
 
-    /// A NOTE source creates a `manual` row AND materializes `[[Title]]` into the note body; after the
-    /// note's wikilinks are re-indexed, the pair shows as ONE deduped chip in `links_for_visible`.
+    /// A NOTE source creates a `manual` edge and writes NO note body (the `murmur:links` block was
+    /// retired). The link is GRAPH-ONLY: `links_for_visible` shows ONE manual chip, the source body is
+    /// byte-unchanged, and no machine block is injected. (RED before this change: `link_items` used to
+    /// materialize `[[Target Note]]` into the body.)
     #[test]
-    fn link_from_note_materializes_wikilink_and_dedupes() {
+    fn link_from_note_creates_edge_without_body_block() {
         let state = build_state("link-from-note");
         make_open_folder(&state.db, "f-open", "Project");
         seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "original body\n");
         seed_note_doc_cmd(&state.db, "dst", "f-open", "Target Note", "target body");
 
+        let before = state.db.get_note_row("src").unwrap().unwrap().text;
         // Link note src → note dst.
         link_items_inner(&state, "note", "src", "note", "dst").unwrap();
 
         // A manual row exists...
         assert_eq!(manual_link_count(&state, "note", "src"), 1, "manual row created");
-        // ...and the source note body gained the [[Target Note]] marker (materialized).
+        // ...and the source note body is UNCHANGED — no [[Target Note]] / links block materialized.
         let body = state.db.get_note_row("src").unwrap().unwrap().text;
+        assert_eq!(body, before, "the note body is byte-unchanged (no materialize); got: {body}");
         assert!(
-            body.contains("[[Target Note]]"),
-            "the [[Title]] was materialized into the note body; got: {body}"
+            !body.contains("murmur:links") && !body.contains("[[Target Note]]"),
+            "no managed links block injected into the source note; got: {body}"
         );
-        assert!(
-            body.starts_with("original body\n"),
-            "the original body is preserved; got: {body}"
-        );
+        // No `wikilink` edge is derived either (the body block that produced it is gone).
+        assert_eq!(link_count_in(&state, "note", "src", "wikilink"), 0, "no derived wikilink edge");
 
-        // The materialize went through `update_note_doc_inner`, which re-indexes wikilinks — so a
-        // `wikilink` edge for the same pair now ALSO exists. The reader must collapse to ONE chip.
-        assert_eq!(link_count_in(&state, "note", "src", "wikilink"), 1, "wikilink edge also present");
+        // The manual edge is the visible chip (removable-manual), from the source side.
         let unlocked = unlocked_snapshot(&state).unwrap();
         let edges = state
             .db
             .links_for_visible(crate::links::LinkKind::Note, "src", &unlocked)
             .unwrap();
         let to_dst: Vec<_> = edges.iter().filter(|e| e.other_id == "dst").collect();
-        assert_eq!(to_dst.len(), 1, "manual + wikilink collapse to ONE chip");
-        assert!(to_dst[0].manual, "the collapsed chip is flagged removable-manual");
+        assert_eq!(to_dst.len(), 1, "exactly one chip for the pair");
+        assert!(to_dst[0].manual, "the chip is flagged removable-manual");
     }
 
     /// Helper mirroring db.rs `link_count` for the command-test module.
@@ -805,38 +778,44 @@
         state.db.link_edge_count(kind, id, edge_type)
     }
 
-    /// UNLINK removes the `manual` row and strips the materialized `[[Title]]` from the source note
-    /// body. The wikilink edge that the materialize produced is NOT deleted by unlink (only the manual
-    /// row is), but the strip removes the `[[Title]]`, so a follow-up re-index would drop the wikilink
-    /// too — here we assert the DIRECT contract: manual row gone + marker stripped.
+    /// UNLINK removes the `manual` row. A fresh link writes NO body marker (block retired), so unlink's
+    /// body is byte-unchanged. The legacy-cleanup strip is still wired for a note that carries a
+    /// PRE-EXISTING `[[Title]]` marker (imported before the block was retired): unlink removes the row
+    /// AND strips that stale marker.
     #[test]
-    fn unlink_removes_row_and_strips_marker() {
+    fn unlink_removes_row_and_strips_legacy_marker() {
         let state = build_state("unlink-strips");
         make_open_folder(&state.db, "f-open", "Project");
-        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", "original body\n");
+        // A SOURCE note that already carries a LEGACY managed links block referencing the target (as an
+        // old note would). `apply_link_markers` renders exactly the block the retired path used to.
+        let legacy_hit = crate::enrich::ContextHit {
+            source: "note".to_string(),
+            detail: "[[Target Note]]".to_string(),
+            url: None,
+        };
+        let legacy_body =
+            crate::enrich::apply_link_markers("original body\n", std::slice::from_ref(&legacy_hit));
+        assert!(legacy_body.contains("[[Target Note]]"), "precondition: legacy marker seeded");
+        seed_note_doc_cmd(&state.db, "src", "f-open", "Source Note", &legacy_body);
         seed_note_doc_cmd(&state.db, "dst", "f-open", "Target Note", "target body");
 
         link_items_inner(&state, "note", "src", "note", "dst").unwrap();
         assert_eq!(manual_link_count(&state, "note", "src"), 1, "precondition: manual row exists");
-        assert!(
-            state.db.get_note_row("src").unwrap().unwrap().text.contains("[[Target Note]]"),
-            "precondition: marker materialized"
-        );
 
         // Unlink note src → note dst.
         unlink_items_inner(&state, "note", "src", "note", "dst").unwrap();
 
         // The manual row is gone...
         assert_eq!(manual_link_count(&state, "note", "src"), 0, "manual row deleted");
-        // ...and the [[Target Note]] marker is stripped from the body.
+        // ...and the stale legacy [[Target Note]] marker is stripped from the body (legacy cleanup).
         let body = state.db.get_note_row("src").unwrap().unwrap().text;
         assert!(
-            !body.contains("[[Target Note]]"),
-            "the materialized marker is stripped on unlink; got: {body}"
+            !body.contains("[[Target Note]]") && !body.contains("murmur:links"),
+            "the legacy marker + block are stripped on unlink; got: {body}"
         );
-        assert!(
-            body.starts_with("original body\n"),
-            "the original body is preserved after strip; got: {body}"
+        assert_eq!(
+            body, "original body\n",
+            "the original prose is restored byte-exact after strip; got: {body}"
         );
     }
 
@@ -1100,23 +1079,32 @@
         assert_eq!(status, "suggested", "the suggestion must stay suggested after a refused accept");
     }
 
-    /// Fix 5 + lock-review regression: a VALID accept (semantic suggestion between two owned, visible
-    /// notes) must COMPLETE (not self-deadlock) and flip the row off `suggested`. The pre-fix code held
-    /// the non-reentrant `lifecycle_guard` across `materialize_accepted_link` → `update_note_doc_inner`
-    /// (which re-acquires it) → self-deadlock; every accept test only exercised REFUSAL paths, so cargo
-    /// test stayed green while a user clicking Accept hung the command forever. If this test hangs, the
-    /// guard is being held across materialize again.
+    /// A VALID accept (semantic suggestion between two owned, visible notes) flips the row off
+    /// `suggested` and writes NO note body (the `murmur:links` block was retired — accept is now
+    /// GRAPH-ONLY). RED before this change: accept used to materialize `[[Title]]` into an owned note.
     #[test]
-    fn accept_link_valid_suggestion_materializes_without_deadlock() {
-        let state = build_state("accept-materialize");
+    fn accept_link_activates_edge_without_body_block() {
+        let state = build_state("accept-graph-only");
         make_open_folder(&state.db, "f-open", "Open");
         seed_note_doc_cmd(&state.db, "a", "f-open", "Alpha", "alpha body");
         seed_note_doc_cmd(&state.db, "b", "f-open", "Beta", "beta body");
+        let a_before = state.db.get_note_row("a").unwrap().unwrap().text;
+        let b_before = state.db.get_note_row("b").unwrap().unwrap().text;
         let id = insert_semantic_link(&state, "a", "b", "suggested");
-        // Must RETURN (pre-fix: deadlock) — the guard is released before the materialize loop.
+
         accept_link_inner(&state, id).expect("a valid accept between two open notes must succeed");
+
         let (_sk, _si, _dk, _di, _et, status) = state.db.link_by_id(id).unwrap().unwrap();
         assert_ne!(status, "suggested", "an accepted suggestion must no longer be 'suggested'");
+        // NEITHER note body was touched — no [[Title]] / links block materialized.
+        let a_after = state.db.get_note_row("a").unwrap().unwrap().text;
+        let b_after = state.db.get_note_row("b").unwrap().unwrap().text;
+        assert_eq!(a_after, a_before, "accept writes no body into note a");
+        assert_eq!(b_after, b_before, "accept writes no body into note b");
+        assert!(
+            !a_after.contains("murmur:links") && !b_after.contains("murmur:links"),
+            "no managed links block written by accept"
+        );
     }
 
     /// M3-CLIENT lock gate (spec §7 inv. 1): `share_note_to_link` on a SEALED-and-not-session-unlocked
@@ -5062,6 +5050,172 @@
             Some(&"draft".to_string())
         );
         assert_eq!(list_notes_inner(&state, None).unwrap().len(), 1);
+    }
+
+    /// Part B — `get_note` STRIPS a legacy machine-managed `murmur:links` block from the VISIBLE
+    /// editor DTO, so the editor + Preview show prose-only (the block leaves the DB on the next natural
+    /// save). The strip is FENCE-DELIMITED + SURGICAL: user prose + front-matter are byte-preserved.
+    /// (RED before this change: `get_note` returned the stored text VERBATIM, block included.)
+    #[test]
+    fn get_note_strips_managed_links_block() {
+        let state = build_state("getnote-strip");
+        make_open_folder(&state.db, "f-open", "Project");
+        // Seed a note whose STORED text = real prose + a machine `murmur:links` block (rendered
+        // exactly as the retired path did, so this is a faithful legacy body).
+        let prose = "---\ntags: [a, b]\n---\n# Heading\n\nReal prose the user typed.\n";
+        let hit = crate::enrich::ContextHit {
+            source: "Murmur".to_string(),
+            detail: "We agreed the roadmap.".to_string(),
+            url: Some("[[Prior Note]]".to_string()),
+        };
+        let stored = crate::enrich::apply_link_markers(prose, std::slice::from_ref(&hit));
+        assert!(stored.contains("murmur:links"), "precondition: block seeded into stored text");
+        seed_note_doc_cmd(&state.db, "n1", "f-open", "Note One", &stored);
+
+        let doc = get_note_inner(&state, "n1").unwrap();
+        assert!(!doc.locked, "an open note is not masked");
+        // The machine block is GONE from what the editor sees...
+        assert!(
+            !doc.markdown.contains("murmur:links") && !doc.markdown.contains("[!related]-"),
+            "the managed links block is stripped from the get_note DTO; got: {}",
+            doc.markdown
+        );
+        // ...and the strip is byte-exact — the DTO markdown equals the prose with the block removed.
+        assert_eq!(
+            doc.markdown, prose,
+            "the strip restores the prose byte-for-byte (front-matter + heading + text preserved)"
+        );
+        // Front-matter tags still parse (the block sat in the BODY, not the front-matter).
+        assert_eq!(doc.tags, vec!["a".to_string(), "b".to_string()], "front-matter tags preserved");
+        // The stored DB text is UNCHANGED by a read (cleanup happens on the next save, not the read).
+        assert!(
+            state.db.get_note_row("n1").unwrap().unwrap().text.contains("murmur:links"),
+            "get_note is a READ — it does not rewrite the DB row (natural save-time cleanup)"
+        );
+    }
+
+    /// Part B — a note whose STORED text is ONLY the machine block (no prose) reads back as an
+    /// empty/whitespace body after the strip (never leaks the block as junk content).
+    #[test]
+    fn get_note_strips_block_only_note_to_empty_body() {
+        let state = build_state("getnote-strip-only");
+        make_open_folder(&state.db, "f-open", "Project");
+        let hit = crate::enrich::ContextHit {
+            source: "Murmur".to_string(),
+            detail: "Only a link.".to_string(),
+            url: Some("[[X]]".to_string()),
+        };
+        // A body that is JUST the block (apply_link_markers over an empty note).
+        let stored = crate::enrich::apply_link_markers("", std::slice::from_ref(&hit));
+        assert!(stored.contains("murmur:links"), "precondition: block-only body");
+        seed_note_doc_cmd(&state.db, "only", "f-open", "Only Block", &stored);
+
+        let doc = get_note_inner(&state, "only").unwrap();
+        assert!(
+            doc.markdown.trim().is_empty(),
+            "a block-only note reads back empty/whitespace; got: {:?}",
+            doc.markdown
+        );
+    }
+
+    /// Part B invariant — the MASKED (sealed-not-unlocked) path is UNCHANGED: `get_note` returns the
+    /// masked DTO (empty body) and NO strip is attempted on the sealed text (no content behind a lock,
+    /// no leak). Even when the underlying stored text carries a `murmur:links` block, the mask short-
+    /// circuits BEFORE the strip.
+    #[test]
+    fn get_note_masked_note_unchanged_no_strip() {
+        let state = build_state("getnote-masked");
+        let fid = create_note_folder_inner(&state, "Secret", None).unwrap().id;
+        // Seed a note with a links block, then SEAL its folder.
+        let hit = crate::enrich::ContextHit {
+            source: "Murmur".to_string(),
+            detail: "secret link".to_string(),
+            url: Some("[[Secret]]".to_string()),
+        };
+        let stored = crate::enrich::apply_link_markers("# secret prose\n", std::slice::from_ref(&hit));
+        let id = create_note_inner(&state, Some(&fid), "Sealed note").unwrap();
+        update_note_doc_inner(&state, &id, "Sealed note", &stored).unwrap();
+        lock_folder_inner(&state, fid.clone()).unwrap();
+
+        let masked = get_note_inner(&state, &id).unwrap();
+        assert!(masked.locked, "sealed note reports locked");
+        assert_eq!(masked.title, "🔒 Locked", "sealed note title masked");
+        assert_eq!(masked.markdown, "", "sealed note body never leaks (no strip attempted)");
+        // The masked DTO is the SAME whether or not the sealed text had a block — nothing about the
+        // block escapes the mask.
+        assert!(
+            !masked.markdown.contains("murmur:links") && !masked.markdown.contains("secret"),
+            "no sealed content (block or prose) leaks through the mask"
+        );
+    }
+
+    /// FIX 1 (content-loss) — the read-path strip is HEADER-GATED: a `murmur:links` fence pair a USER
+    /// typed/pasted into their OWN prose (real text between the markers, NO `> [!related]- Related
+    /// notes` header) is NOT a machine block, so `get_note` returns the body BYTE-IDENTICAL and the
+    /// "IMPORTANT user text" between the forged markers SURVIVES. RED before this change: the
+    /// unconditional `apply_link_markers(md, &[])` strip `rfind`s the fence pair and cuts everything
+    /// between — eating the user's text, which the editor's debounced autosave then persists (real
+    /// owned-file data loss). GREEN after: the forged fence has no `[!related]` header → untouched.
+    #[test]
+    fn get_note_does_not_strip_forged_fence_in_prose() {
+        let state = build_state("getnote-forged-fence");
+        make_open_folder(&state.db, "f-open", "Project");
+        // A body where the user LITERALLY typed both markers with important text between them, but the
+        // body is NOT the machine callout (no `> [!related]- Related notes` header line).
+        let prose = "Real line A\n<!-- murmur:links -->\nIMPORTANT user text\n<!-- /murmur:links -->\nReal line B\n";
+        seed_note_doc_cmd(&state.db, "forged", "f-open", "Forged", prose);
+
+        let doc = get_note_inner(&state, "forged").unwrap();
+        assert!(!doc.locked, "an open note is not masked");
+        assert_eq!(
+            doc.markdown, prose,
+            "a forged fence in USER PROSE (no [!related] header) is left byte-identical — no data loss"
+        );
+        // The load-bearing assertion: the user's text between the forged markers is NOT eaten.
+        assert!(
+            doc.markdown.contains("IMPORTANT user text"),
+            "user text between forged markers must survive; got: {}",
+            doc.markdown
+        );
+    }
+
+    /// FIX 1 (scan-all, lock-security re-fail 2026-07-20) — on the DISPLAY path, a REAL machine
+    /// `murmur:links` block FOLLOWED by a bare forged links fence must STILL be stripped (the old
+    /// `rfind`-last anchor gated on the trailing forged pair → the real related-notes block, with its
+    /// stale linked titles, stayed rendered as raw junk in the editor). The forged-fence prose SURVIVES.
+    #[test]
+    fn get_note_strips_real_block_before_a_trailing_forged_fence() {
+        let state = build_state("getnote-scanall");
+        make_open_folder(&state.db, "f-open", "Project");
+        let real = crate::enrich::apply_link_markers(
+            "# Notes\n\nReal prose.\n",
+            &[crate::enrich::ContextHit {
+                source: "note".into(),
+                detail: "[[Old Related Title]]".into(),
+                url: None,
+            }],
+        );
+        // The user pastes a bare forged links fence AFTER the real machine block.
+        let stored = format!(
+            "{real}\n\nmore prose\n<!-- murmur:links -->\nkeepme forged\n<!-- /murmur:links -->\ntail\n"
+        );
+        seed_note_doc_cmd(&state.db, "scanall", "f-open", "ScanAll", &stored);
+
+        let doc = get_note_inner(&state, "scanall").unwrap();
+        assert!(!doc.locked);
+        assert!(
+            !doc.markdown.contains("Old Related Title") && !doc.markdown.contains("[!related]-"),
+            "the REAL related-notes block is stripped despite the trailing forged fence; got: {}",
+            doc.markdown
+        );
+        assert!(
+            doc.markdown.contains("keepme forged")
+                && doc.markdown.contains("Real prose.")
+                && doc.markdown.contains("more prose")
+                && doc.markdown.contains("tail"),
+            "the forged-fence content + all prose survive; got: {}",
+            doc.markdown
+        );
     }
 
     /// WP2 seal round-trip — a note's full markdown (front-matter + Unicode body) survives a real
@@ -12347,20 +12501,19 @@
         assert!(state.db.get_org_item("nope").unwrap().is_none());
     }
 
-    /// REGRESSION (app-hang on Accept): `accept_link_inner` held the non-reentrant `lifecycle_guard`
-    /// across `materialize_accepted_link` → `update_note_doc_inner`, which re-takes the SAME guard →
-    /// a same-thread DEADLOCK whenever the accepted pair has an OWNED note to materialize `[[Title]]`
-    /// into (a NOTE↔NOTE accept — the exact case the user hit). We run the accept on a worker thread
-    /// and BOUND the wait, so the deadlock surfaces as a clean FAILURE instead of wedging the whole
-    /// suite; on the fixed code it completes in milliseconds AND materializes the neighbour link.
+    /// REGRESSION (app-hang on Accept): the old accept held the non-reentrant `lifecycle_guard` across
+    /// a note-body materialize whose `update_note_doc_inner` re-took the SAME guard → a same-thread
+    /// DEADLOCK on a NOTE↔NOTE accept. The materialize (and the whole `murmur:links` body block) is now
+    /// retired, so accept is GRAPH-ONLY and nothing re-enters the guard — but we KEEP the bounded-wait
+    /// regression: accept between two owned notes must COMPLETE (never hang) and write NO note body.
     #[test]
-    fn accept_link_does_not_deadlock_and_materializes_on_owned_notes() {
+    fn accept_link_completes_without_deadlock_graph_only() {
         use std::sync::mpsc;
         let state = std::sync::Arc::new(build_state("accept-no-deadlock"));
         make_open_folder(&state.db, "f1", "Notes");
         seed_note_doc_cmd(&state.db, "n1", "f1", "Note One", "body one\n");
         seed_note_doc_cmd(&state.db, "n2", "f1", "Note Two", "body two\n");
-        // A SUGGESTED semantic edge between two OWNED notes → accept WILL materialize (the hang path).
+        // A SUGGESTED semantic edge between two OWNED notes (the exact case that used to hang).
         let link_id = state
             .db
             .insert_link_for_test("note", "n1", "note", "n2", "semantic", 0.9, "auto", "suggested");
@@ -12370,19 +12523,21 @@
         let handle = std::thread::spawn(move || {
             let _ = tx.send(accept_link_inner(&worker, link_id));
         });
-        // If it re-enters the guard it blocks forever; a bounded recv turns that into a test failure.
+        // If it ever re-enters the guard it blocks forever; a bounded recv turns that into a failure.
         let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect(
             "accept_link_inner DEADLOCKED — did not finish in 10s (re-entrant lifecycle guard)",
         );
         result.expect("accept_link_inner returned an error");
         handle.join().unwrap();
 
-        // The accept materialized the neighbour's [[Title]] into an owned note (the very path that hung).
+        // The edge is active and NEITHER owned note body was written (graph-only accept).
+        let (_sk, _si, _dk, _di, _et, status) = state.db.link_by_id(link_id).unwrap().unwrap();
+        assert_ne!(status, "suggested", "the accepted edge is active");
         let n1 = state.db.get_note_row("n1").unwrap().unwrap();
         let n2 = state.db.get_note_row("n2").unwrap().unwrap();
         assert!(
-            n1.text.contains("[[") || n2.text.contains("[["),
-            "accept must materialize a [[Title]] wikilink into one of the owned notes"
+            !n1.text.contains("[[") && !n2.text.contains("[["),
+            "accept writes no [[Title]] / links block into either owned note"
         );
     }
 

--- a/src-tauri/src/enrich.rs
+++ b/src-tauri/src/enrich.rs
@@ -204,6 +204,144 @@ fn strip_fenced_block(md: &str, fence_start: &str, fence_end: &str) -> String {
     out
 }
 
+/// The exact header line a REAL machine `murmur:links` block always carries as its first body line
+/// (`apply_link_markers` renders `{fence}\n> [!related]- Related notes\n…`, with NO trailing
+/// timestamp). Used to distinguish a genuine machine block from a fence a user typed (or pasted) into
+/// their own prose.
+const RELATED_CALLOUT_HEADER: &str = "> [!related]- Related notes";
+
+/// The STABLE header PREFIX of a machine `murmur:context` block. Unlike `murmur:links`, the connector
+/// context callout carries a dated suffix (`… (as of {date})`, see [`apply_context_markers`]), so the
+/// gate is a `starts_with` on this timeless prefix — never an exact match on the whole line.
+/// `pub(crate)` so the share-egress scrub reuses it (never a hardcoded string).
+pub(crate) const CONTEXT_CALLOUT_HEADER_PREFIX: &str = "> [!context]- Live context";
+
+/// How the first-body-line header gate matches: `Exact` (`murmur:links`, no dated suffix) or `Prefix`
+/// (`murmur:context` / `murmur:verify`, which append `(as of {date})`).
+enum HeaderMatch<'a> {
+    Exact(&'a str),
+    Prefix(&'a str),
+}
+
+/// HEADER-GATED strip of EVERY managed fenced block of one type. Scans ALL `(fence_start, fence_end)`
+/// pairs LEFT-TO-RIGHT and removes EACH ONE ONLY when its first non-empty body line matches `header`;
+/// a pair whose body is arbitrary user prose (no machine callout header) is copied through
+/// BYTE-IDENTICAL and never eaten. Shared by the read-path links strip AND the share-egress
+/// context/verify strips so all three use ONE gate discipline.
+///
+/// Why SCAN-ALL, not `rfind`-the-last (lock-security re-fail 2026-07-20): a user typing a bare
+/// `<!-- murmur:context -->x<!-- /murmur:context -->` fence in prose AFTER a REAL machine block made
+/// `rfind` anchor on the LAST (forged) pair — the gate failed on its non-header body, the function
+/// returned the note UNCHANGED, and the earlier REAL block (Jira key + workspace URL, or a linked
+/// title) LEAKED through `clean_note_body` into the share/org envelope. Scanning every pair strips the
+/// real one regardless of a trailing decoy. For each STRIPPED pair, the reclaimed leading `\n\n`/`\n`
+/// separator matches the write-path append, so a real block round-trips byte-exact via the append/strip
+/// inverse; a header-LESS pair (and all surrounding prose/front-matter) is preserved verbatim.
+fn strip_managed_block_if_header(
+    md: &str,
+    fence_start: &str,
+    fence_end: &str,
+    header: &HeaderMatch<'_>,
+) -> String {
+    // Fast path: no start fence at all → nothing to consider (avoids an allocation on the common case).
+    if !md.contains(fence_start) {
+        return md.to_string();
+    }
+    let mut out = String::with_capacity(md.len());
+    // `cursor` = index into `md` of the next unemitted byte. We walk forward pair-by-pair.
+    let mut cursor = 0usize;
+    while let Some(rel_start) = md[cursor..].find(fence_start) {
+        let start = cursor + rel_start;
+        // Find this start's matching end fence (the FIRST end after the start — the write-path never
+        // nests these HTML-comment fences, so first-after is the correct pairing).
+        let Some(rel_end) = md[start + fence_start.len()..].find(fence_end) else {
+            // Lone start fence with no following end → NEVER truncate; emit the rest verbatim and stop.
+            out.push_str(&md[cursor..]);
+            return out;
+        };
+        let end = start + fence_start.len() + rel_end + fence_end.len();
+        let body = &md[start + fence_start.len()..end - fence_end.len()];
+        // GATE: the first NON-EMPTY body line must be the machine callout header. A user's forged fence
+        // (whose body is arbitrary prose) fails this → the pair is KEPT (copied through).
+        let is_machine_block = match body.lines().map(str::trim).find(|l| !l.is_empty()) {
+            Some(first_non_empty) => match header {
+                HeaderMatch::Exact(h) => first_non_empty == *h,
+                HeaderMatch::Prefix(p) => first_non_empty.starts_with(p),
+            },
+            None => false, // empty body is never a machine block.
+        };
+        if is_machine_block {
+            // STRIP: emit everything up to this pair MINUS the leading `\n\n`/`\n` separator the
+            // write-path wrote before the fence (byte-exact inverse of the append), then skip the pair.
+            let before = &md[cursor..start];
+            let kept = before
+                .strip_suffix("\n\n")
+                .or_else(|| before.strip_suffix('\n'))
+                .unwrap_or(before);
+            out.push_str(kept);
+            cursor = end;
+        } else {
+            // KEEP: emit everything up to AND INCLUDING this pair verbatim, then continue after it.
+            out.push_str(&md[cursor..end]);
+            cursor = end;
+        }
+    }
+    // Emit any trailing bytes after the last fence pair.
+    out.push_str(&md[cursor..]);
+    out
+}
+
+/// READ-PATH strip (retired `murmur:links` block): remove EVERY managed links fence pair whose fenced
+/// body is genuinely the MACHINE block, i.e. its first non-empty body line is exactly the
+/// [`RELATED_CALLOUT_HEADER`] (`> [!related]- Related notes`) that `apply_link_markers` always emits.
+///
+/// Why this is NOT `apply_link_markers(md, &[])`: that variant unconditionally `rfind`s the fence
+/// pair and cuts everything between — so USER PROSE that happens to contain both `<!-- murmur:links
+/// -->` and `<!-- /murmur:links -->` markers (with real text between them) is silently EATEN, and the
+/// editor's debounced autosave then PERSISTS that loss to the DB (owned-file data loss). This helper
+/// is SURGICAL: a forged/bare fence in prose (no `[!related]` callout header) is left BYTE-IDENTICAL,
+/// and it strips a REAL block even when a forged fence trails it (scan-all, not rfind-last).
+///
+/// SCOPE: this is the READ/DISPLAY strip — `murmur:links` ONLY (the block is fully retired). The
+/// `murmur:context` / `murmur:verify` blocks are in-app FEATURES the user opted into and MUST stay
+/// visible in the editor; they are stripped ONLY on the share-egress path
+/// ([`strip_managed_context_block`] / [`strip_verify_block_for_egress`]), never here.
+pub fn strip_managed_links_block(md: &str) -> String {
+    strip_managed_block_if_header(
+        md,
+        LINKS_FENCE_START,
+        LINKS_FENCE_END,
+        &HeaderMatch::Exact(RELATED_CALLOUT_HEADER),
+    )
+}
+
+/// SHARE-EGRESS strip of the connector `murmur:context` block (Jira/Slack/web live snippets +
+/// workspace URLs). HEADER-GATED on the timeless [`CONTEXT_CALLOUT_HEADER_PREFIX`] (the callout also
+/// carries `(as of {date})`), so a user's forged bare `murmur:context` fence in prose is left
+/// byte-identical. NOT called on the read/display path — the block stays visible in the editor;
+/// this only stops it LEAKING on share. See [`crate::share::envelope::clean_note_body`].
+pub fn strip_managed_context_block(md: &str) -> String {
+    strip_managed_block_if_header(
+        md,
+        FENCE_START,
+        FENCE_END,
+        &HeaderMatch::Prefix(CONTEXT_CALLOUT_HEADER_PREFIX),
+    )
+}
+
+/// SHARE-EGRESS strip of the `murmur:verify` block (Jira issue keys + verdicts + workspace URLs).
+/// A thin re-export delegating to the shared header gate — the fence constants + header prefix live
+/// in [`crate::verify`] (their owner), so this never hardcodes the strings. NOT called on the
+/// read/display path (the block is an in-app Verify feature the user opted into).
+pub fn strip_verify_block_for_egress(md: &str) -> String {
+    strip_managed_block_if_header(
+        md,
+        crate::verify::VERIFY_FENCE_START,
+        crate::verify::VERIFY_FENCE_END,
+        &HeaderMatch::Prefix(crate::verify::VERIFY_CALLOUT_HEADER_PREFIX),
+    )
+}
+
 /// Make a connector-supplied value safe to embed in the callout:
 /// - collapse CR/LF + whitespace runs to single spaces so it can never spawn a second line that
 ///   escapes the block / injects a line-start callout (mirrors `verify::apply_verify_markers`);
@@ -492,5 +630,183 @@ mod tests {
         );
         let twice = apply_link_markers(&out, std::slice::from_ref(&evil));
         assert_eq!(out, twice, "idempotent with the hostile hit");
+    }
+
+    // ── FIX 1: `strip_managed_links_block` — HEADER-GATED read-path strip ──────────────────────────
+
+    /// A REAL machine block (rendered by `apply_link_markers`, so it carries the exact
+    /// `> [!related]- Related notes` header) IS stripped — byte-identical to `apply_link_markers(_, &[])`.
+    #[test]
+    fn strip_managed_links_block_removes_a_real_machine_block() {
+        let md = "---\ntags: [a]\n---\n# Heading\n\nProse.\n";
+        let with_block = apply_link_markers(md, &related_hits());
+        assert!(with_block.contains(LINKS_FENCE_START), "precondition: real block present");
+        let stripped = strip_managed_links_block(&with_block);
+        assert_eq!(stripped, md, "a real machine block strips back to the original note byte-exact");
+        assert_eq!(
+            stripped,
+            apply_link_markers(&with_block, &[]),
+            "on a REAL block the header-gated strip matches the unconditional strip byte-for-byte"
+        );
+    }
+
+    /// The load-bearing FIX-1 guarantee: a `murmur:links` fence pair a USER typed in their OWN prose
+    /// (real text between the markers, NO `> [!related]- Related notes` header) is left BYTE-IDENTICAL
+    /// — the user's text is NEVER eaten. (The old `apply_link_markers(md, &[])` DID eat it.)
+    #[test]
+    fn strip_managed_links_block_leaves_a_forged_fence_in_prose_untouched() {
+        let prose = "Real line A\n<!-- murmur:links -->\nIMPORTANT user text\n<!-- /murmur:links -->\nReal line B\n";
+        assert_eq!(
+            strip_managed_links_block(prose),
+            prose,
+            "a forged fence (no [!related] header) is left byte-identical"
+        );
+        // Contrast: the OLD unconditional strip DID eat the user's text — pin that difference so a
+        // regression back to `apply_link_markers(md, &[])` on the read path is caught here.
+        assert_ne!(
+            apply_link_markers(prose, &[]),
+            prose,
+            "the unconditional strip WOULD have eaten the forged-fence body (this is what FIX 1 avoids)"
+        );
+        assert!(
+            !apply_link_markers(prose, &[]).contains("IMPORTANT user text"),
+            "confirming the unconditional strip ate the user text"
+        );
+    }
+
+    /// A fenced region whose first non-empty body line is SOME OTHER callout (not `[!related]`) is a
+    /// user construct → left untouched (only the genuine Related-notes machine header matches).
+    #[test]
+    fn strip_managed_links_block_ignores_a_different_callout_header() {
+        let prose = "before\n<!-- murmur:links -->\n> [!note]- My own note\n> body\n<!-- /murmur:links -->\nafter\n";
+        assert_eq!(strip_managed_links_block(prose), prose, "a non-[!related] callout is not the machine block");
+    }
+
+    /// A lone/unterminated fence never truncates real content; a note with no fence is unchanged.
+    #[test]
+    fn strip_managed_links_block_no_fence_or_lone_fence_is_noop() {
+        let none = "# Just prose\n\nno fence at all\n";
+        assert_eq!(strip_managed_links_block(none), none);
+        let lone = "text\n<!-- murmur:links -->\n> [!related]- Related notes\n(no end fence, EOF)\n";
+        assert_eq!(strip_managed_links_block(lone), lone, "a lone start fence is never truncated");
+    }
+
+    /// FIX 3 egress helper — `strip_managed_context_block` removes a REAL connector block (the header
+    /// carries a DATED suffix, so the gate is a PREFIX match) but leaves a forged bare `murmur:context`
+    /// fence in user prose byte-identical. Also proves it round-trips a real `apply_context_markers`.
+    #[test]
+    fn strip_managed_context_block_gated_on_the_dated_header_prefix() {
+        // A REAL block (dated header via apply_context_markers) IS stripped, byte-exact to the original.
+        let md = "# N\n\nprose\n";
+        let with_ctx = apply_context_markers(md, &jira_slack(), AS_OF);
+        assert!(with_ctx.contains("[!context]-"), "precondition: real context block present");
+        assert_eq!(
+            strip_managed_context_block(&with_ctx),
+            md,
+            "a real dated context block strips back byte-exact"
+        );
+        // A forged bare fence in prose (no `> [!context]- Live context` header) is UNTOUCHED.
+        let forged = "line A\n<!-- murmur:context -->\nIMPORTANT user text\n<!-- /murmur:context -->\nline B\n";
+        assert_eq!(strip_managed_context_block(forged), forged, "forged context fence left byte-identical");
+        // The LINKS strip must NOT touch a context block (distinct fence).
+        assert_eq!(strip_managed_links_block(&with_ctx), with_ctx, "links strip leaves the context block alone");
+    }
+
+    /// FIX 3 egress helper — `strip_verify_block_for_egress` removes a REAL verify block (dated header
+    /// → prefix gate) and leaves a forged bare `murmur:verify` fence untouched.
+    #[test]
+    fn strip_verify_block_for_egress_gated_on_header_prefix() {
+        let md = "# N\n\nprose\n";
+        let finding = crate::verify::VerifyFinding {
+            line_no: 1,
+            key: "PROJ-789".into(),
+            verdict: crate::verify::Verdict::Confirmed,
+            detail: "PROJ-789 matches".into(),
+            url: "https://acme.atlassian.net/browse/PROJ-789".into(),
+        };
+        let with_verify = crate::verify::apply_verify_callout(md, std::slice::from_ref(&finding), AS_OF);
+        assert!(with_verify.contains("[!verify]-"), "precondition: real verify block present");
+        assert_eq!(
+            strip_verify_block_for_egress(&with_verify),
+            md,
+            "a real dated verify block strips back byte-exact"
+        );
+        let forged = "line A\n<!-- murmur:verify -->\nIMPORTANT user text\n<!-- /murmur:verify -->\nline B\n";
+        assert_eq!(strip_verify_block_for_egress(forged), forged, "forged verify fence left byte-identical");
+    }
+
+    // ── SCAN-ALL (lock-security re-fail 2026-07-20): strip a REAL block even behind a trailing forged
+    //    fence, while keeping the header-LESS forged fence intact. RED on the old `rfind`-last anchor. ─
+
+    /// LINKS — a real machine block FOLLOWED by a bare forged `murmur:links` fence: the real block's
+    /// linked title is STRIPPED (leak closed) and the forged-fence prose SURVIVES. RED on the old
+    /// `rfind`-last code (rfind anchored the trailing forged pair → gate failed → real block kept).
+    #[test]
+    fn strip_managed_links_block_strips_real_block_before_a_trailing_forged_fence() {
+        let real = apply_link_markers(
+            "# Notes\n\nReal prose.\n",
+            &[hit("note", "[[Secret Zwolnienia Q3]]", None)],
+        );
+        assert!(real.contains("Secret Zwolnienia Q3"), "precondition: real block carries the title");
+        // The user then pastes a bare forged fence (no [!related] header) AFTER the real block.
+        let md = format!("{real}\n\nmore prose\n<!-- murmur:links -->\nkeepme forged\n<!-- /murmur:links -->\ntail\n");
+        let out = strip_managed_links_block(&md);
+        assert!(!out.contains("Secret Zwolnienia Q3"), "the REAL block's linked title is stripped: {out}");
+        assert!(!out.contains("> [!related]- Related notes"), "the real machine callout is gone: {out}");
+        // The forged fence + its content + all prose survive byte-intact.
+        assert!(out.contains("keepme forged"), "forged-fence user content survives: {out}");
+        assert!(out.contains("<!-- murmur:links -->\nkeepme forged\n<!-- /murmur:links -->"), "forged fence kept verbatim: {out}");
+        assert!(out.contains("Real prose.") && out.contains("more prose") && out.contains("tail"), "prose preserved: {out}");
+    }
+
+    /// LINKS — multiple REAL blocks of the same type (pathological, reachable via paste): ALL stripped.
+    #[test]
+    fn strip_managed_links_block_strips_every_real_block() {
+        let one = apply_link_markers("# A\n", &[hit("note", "[[Title One]]", None)]);
+        let two = apply_link_markers("# B\n", &[hit("note", "[[Title Two]]", None)]);
+        let md = format!("{one}\n\nmid prose\n\n{two}");
+        let out = strip_managed_links_block(&md);
+        assert!(!out.contains("Title One") && !out.contains("Title Two"), "BOTH real blocks stripped: {out}");
+        assert_eq!(out.matches(LINKS_FENCE_START).count(), 0, "no links fence survives: {out}");
+        assert!(out.contains("mid prose"), "prose between the blocks preserved: {out}");
+    }
+
+    /// CONTEXT — a real dated `murmur:context` block before a trailing forged context fence: the Jira
+    /// key + workspace URL are STRIPPED (leak closed), the forged content SURVIVES. RED on `rfind`-last.
+    #[test]
+    fn strip_managed_context_block_strips_real_block_before_a_trailing_forged_fence() {
+        let real = apply_context_markers(
+            "# Meeting\n\nprose\n",
+            &[hit("Jira", "PROJ-999 · In Progress", Some("https://acme.atlassian.net/browse/PROJ-999"))],
+            AS_OF,
+        );
+        assert!(real.contains("PROJ-999"), "precondition: real context block carries the key");
+        let md = format!("{real}\n\ntext\n<!-- murmur:context -->\nkeepme\n<!-- /murmur:context -->\n");
+        let out = strip_managed_context_block(&md);
+        assert!(!out.contains("PROJ-999"), "the Jira key is stripped: {out}");
+        assert!(!out.contains("atlassian.net"), "the workspace URL is stripped: {out}");
+        assert!(out.contains("keepme") && out.contains("<!-- murmur:context -->\nkeepme\n<!-- /murmur:context -->"), "forged fence kept: {out}");
+        assert!(out.contains("prose") && out.contains("text"), "prose preserved: {out}");
+    }
+
+    /// VERIFY — a real dated `murmur:verify` block before a trailing forged verify fence: the Jira key
+    /// + URL are STRIPPED, the forged content SURVIVES. RED on `rfind`-last.
+    #[test]
+    fn strip_verify_block_for_egress_strips_real_block_before_a_trailing_forged_fence() {
+        let finding = crate::verify::VerifyFinding {
+            line_no: 1,
+            key: "PROJ-777".into(),
+            verdict: crate::verify::Verdict::Confirmed,
+            detail: "PROJ-777 matches".into(),
+            url: "https://acme.atlassian.net/browse/PROJ-777".into(),
+        };
+        let real = crate::verify::apply_verify_callout("# N\n\nprose\n", std::slice::from_ref(&finding), AS_OF);
+        assert!(real.contains("PROJ-777"), "precondition: real verify block carries the key");
+        let md = format!("{real}\n\ntext\n<!-- murmur:verify -->\nkeepme\n<!-- /murmur:verify -->\n");
+        let out = strip_verify_block_for_egress(&md);
+        assert!(!out.contains("PROJ-777"), "the Jira key is stripped: {out}");
+        assert!(!out.contains("atlassian.net"), "the workspace URL is stripped: {out}");
+        assert!(out.contains("keepme") && out.contains("<!-- murmur:verify -->\nkeepme\n<!-- /murmur:verify -->"), "forged fence kept: {out}");
+        assert!(out.contains("prose") && out.contains("text"), "prose preserved: {out}");
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1687,12 +1687,14 @@ async fn summarize_and_export(
         tracing::warn!(target: "graph", error = %e, "graph entity persist failed (note export unaffected)");
     }
 
-    // Stage 2 / Lane A — DEFERRED, best-effort cross-meeting LINKING. Runs AFTER the note reaches
-    // `Exported` so the first `.md` is written promptly; the `[[links]]` + Related block land seconds
-    // later on a DB-canonical re-persist + re-export. Fully LOCAL (ZERO egress) + lock/seal-safe (see
-    // `link_related_notes_inner`), so it is auto-eligible on finalize. It must NEVER fail or delay the
-    // pipeline: a detached worker (the same `std::thread::spawn` + `app.state::<AppState>()` shape the
-    // proactive/reactions workers use), any error swallowed with an IDs-only log (no PII).
+    // Stage 2 / Lane A — DEFERRED cross-meeting LINKING trigger. `link_related_notes_inner` is now a
+    // NO-OP: the machine `murmur:links` Related block it used to append to the note body was retired
+    // (it went stale + rendered as raw junk in the editor; the RELATED panel reads the live `links`
+    // table instead, kept fresh by the deterministic wikilink/semantic index hooks on every save). The
+    // detached-worker call site is kept (a stable no-op) so no wiring churns and a future re-link
+    // surface has a seam. It must NEVER fail or delay the pipeline: a detached worker (the same
+    // `std::thread::spawn` + `app.state::<AppState>()` shape the proactive/reactions workers use), any
+    // error swallowed with an IDs-only log (no PII).
     {
         let app_bg = app.clone();
         let mid = meeting_id.to_string();

--- a/src-tauri/src/share/envelope.rs
+++ b/src-tauri/src/share/envelope.rs
@@ -115,11 +115,31 @@ fn flatten_link_inner(inner: &str) -> String {
     }
 }
 
-/// The full "clean text" transform: strip frontmatter, then flatten wikilinks + strip
-/// `obsidian://` refs. This is the single call `share_note_to_link` makes on a note's markdown
-/// before building the [`murmur_protocol::envelope::ShareEnvelope`]. Pure.
+/// The full "clean text" transform: strip frontmatter, DROP every machine-managed block, then flatten
+/// wikilinks + strip `obsidian://` refs. This is the single scrub EVERY share path (link-share AND
+/// every org-share) funnels a note's raw `notes.markdown` / `documents.text` through before building
+/// the [`murmur_protocol::envelope::ShareEnvelope`]. Pure.
+///
+/// EGRESS HYGIENE — no MACHINE-MANAGED block may reach the share/org wire. Three fences carry the
+/// sender's private data and are all HEADER-GATED-stripped here (each removed ONLY when its first
+/// body line is its exact machine callout header, so a forged bare fence in USER prose is NEVER eaten
+/// — the fence constants + header strings come from their owning modules, never hardcoded):
+/// - `murmur:links` (`> [!related]- Related notes`) — the `[[Title]]` of every linked note/meeting;
+///   without the strip `flatten_wikilinks` would turn those markers into readable TITLES that reach
+///   the recipient (e.g. a private "Zwolnienia Q3"). This block is ALSO retired app-wide (A/B).
+/// - `murmur:context` (`> [!context]- Live context`) — LIVE CONNECTOR data (Jira issue/status/URL,
+///   Slack channel+snippet+permalink, web snippets) + the sender's workspace host URLs.
+/// - `murmur:verify` (`> [!verify]- Source check`) — Jira issue keys + verdicts + workspace URLs.
+///
+/// SCOPE: this is the EGRESS-ONLY strip. `murmur:context` / `murmur:verify` are in-app FEATURES the
+/// user opted into (ran Enrich / Verify) and STAY visible in the editor — the read/display path
+/// (`get_note`) strips `murmur:links` only. We only stop context/verify LEAKING on share.
+/// Belt-and-braces: closes the leak for EXISTING enriched/verified notes AND any new one.
 pub fn clean_note_body(markdown: &str) -> String {
     let body = strip_frontmatter(markdown);
+    let body = crate::enrich::strip_managed_links_block(&body);
+    let body = crate::enrich::strip_managed_context_block(&body);
+    let body = crate::enrich::strip_verify_block_for_egress(&body);
     flatten_wikilinks(&body)
 }
 
@@ -299,5 +319,167 @@ mod tests {
             !clean.contains("vault=Work"),
             "the vault name must not leak: {clean:?}"
         );
+    }
+
+    /// FIX 3 (CONTENT LEAK) — every share path funnels a note's RAW markdown through `clean_note_body`
+    /// before building the envelope. A note carrying the machine `> [!related]- Related notes`
+    /// (`murmur:links`) block lists the `[[Title]]` of every note/meeting it links to; the linked
+    /// notes' CONTENT is never shared, but WITHOUT this strip `flatten_wikilinks` would turn those
+    /// markers into plain readable TITLES that reach the recipient (a title-egress leak). The block —
+    /// header, callout, and the linked title — must be entirely GONE from the shared body.
+    /// RED before FIX 3: the block reached the envelope, "Related notes"/"Secret Note"/"(via note)"
+    /// all leaked through.
+    #[test]
+    fn clean_note_body_strips_the_related_notes_block() {
+        let md = "# Meeting\n\nReal prose the user wrote.\n\n\
+                  <!-- murmur:links -->\n\
+                  > [!related]- Related notes\n\
+                  > - [[Secret Note]] (via note)\n\
+                  <!-- /murmur:links -->\n";
+        let clean = clean_note_body(md);
+        assert!(
+            clean.contains("Real prose the user wrote."),
+            "the user's own prose survives the share scrub: {clean:?}"
+        );
+        assert!(
+            !clean.contains("Related notes"),
+            "the machine Related-notes callout must not reach the envelope: {clean:?}"
+        );
+        assert!(
+            !clean.contains("Secret Note"),
+            "a linked note TITLE must not leak to the share recipient: {clean:?}"
+        );
+        assert!(
+            !clean.contains("(via note)"),
+            "the machine block attribution must not leak: {clean:?}"
+        );
+        assert!(
+            !clean.contains("murmur:links") && !clean.contains("[!related]"),
+            "no trace of the managed block reaches the shared body: {clean:?}"
+        );
+    }
+
+    /// FIX 3 (generalized) — the `murmur:context` connector block carries LIVE Jira/Slack/web data +
+    /// the sender's workspace host URLs. It must NOT reach the share envelope. HEADER-GATED on the
+    /// `> [!context]- Live context` prefix (the callout also carries `(as of {date})`). RED before the
+    /// generalization: the block + its Jira key + atlassian host URL leaked through.
+    #[test]
+    fn clean_note_body_strips_context_block() {
+        let md = "# Meeting\n\nReal prose the user wrote.\n\n\
+                  <!-- murmur:context -->\n\
+                  > [!context]- Live context (as of 2026-07-05T14:32:00Z)\n\
+                  > - PROJ-123 · In Progress (via Jira) — https://acme.atlassian.net/browse/PROJ-123\n\
+                  <!-- /murmur:context -->\n";
+        let clean = clean_note_body(md);
+        assert!(
+            clean.contains("Real prose the user wrote."),
+            "the user's own prose survives: {clean:?}"
+        );
+        assert!(!clean.contains("PROJ-123"), "the Jira issue key must not leak: {clean:?}");
+        assert!(
+            !clean.contains("atlassian.net"),
+            "the sender's workspace host URL must not leak: {clean:?}"
+        );
+        assert!(
+            !clean.contains("[!context]") && !clean.contains("murmur:context"),
+            "no trace of the connector-context block reaches the shared body: {clean:?}"
+        );
+    }
+
+    /// FIX 3 (generalized) — the `murmur:verify` block carries Jira issue keys + verdicts + workspace
+    /// URLs. It must NOT reach the share envelope. HEADER-GATED on the `> [!verify]- Source check`
+    /// prefix. RED before the generalization: the block + its Jira key + host URL leaked through.
+    #[test]
+    fn clean_note_body_strips_verify_block() {
+        let md = "# Meeting\n\nReal prose the user wrote.\n\n\
+                  <!-- murmur:verify -->\n\
+                  > [!verify]- Source check (as of 2026-07-05T14:32:00Z)\n\
+                  > - Verified — PROJ-456 matches (via Jira) — https://acme.atlassian.net/browse/PROJ-456\n\
+                  <!-- /murmur:verify -->\n";
+        let clean = clean_note_body(md);
+        assert!(
+            clean.contains("Real prose the user wrote."),
+            "the user's own prose survives: {clean:?}"
+        );
+        assert!(!clean.contains("PROJ-456"), "the Jira issue key must not leak: {clean:?}");
+        assert!(
+            !clean.contains("atlassian.net"),
+            "the sender's workspace host URL must not leak: {clean:?}"
+        );
+        assert!(
+            !clean.contains("[!verify]") && !clean.contains("murmur:verify"),
+            "no trace of the verify block reaches the shared body: {clean:?}"
+        );
+    }
+
+    /// FIX 3 (scan-all, lock-security re-fail 2026-07-20) — a REAL machine block FOLLOWED by a bare
+    /// forged fence of the same type must STILL be stripped: the `rfind`-last anchor leaked the real
+    /// block (Jira key / workspace URL / linked title) because it gated on the trailing forged pair.
+    /// The forged-fence prose must SURVIVE (no content loss). Covered for all three fence types.
+    #[test]
+    fn clean_note_body_strips_real_block_before_a_trailing_forged_fence() {
+        // CONTEXT: real block (PROJ-999 + atlassian host) then a bare forged context fence.
+        let ctx = "# Meeting\n\nprose\n\n\
+                   <!-- murmur:context -->\n\
+                   > [!context]- Live context (as of 2026-07-05T14:32:00Z)\n\
+                   > - PROJ-999 · In Progress (via Jira) — https://acme.atlassian.net/browse/PROJ-999\n\
+                   <!-- /murmur:context -->\n\n\
+                   more\n<!-- murmur:context -->\nkeepme forged\n<!-- /murmur:context -->\ntail\n";
+        let clean = clean_note_body(ctx);
+        assert!(!clean.contains("PROJ-999"), "real Jira key must not leak behind a trailing forged fence: {clean:?}");
+        assert!(!clean.contains("atlassian.net"), "real workspace URL must not leak: {clean:?}");
+        assert!(clean.contains("keepme forged"), "the forged-fence user content survives: {clean:?}");
+        assert!(clean.contains("prose") && clean.contains("more") && clean.contains("tail"), "prose preserved: {clean:?}");
+
+        // VERIFY: real block (PROJ-888) then a forged verify fence.
+        let vfy = "# N\n\nprose\n\n\
+                   <!-- murmur:verify -->\n\
+                   > [!verify]- Source check (as of 2026-07-05T14:32:00Z)\n\
+                   > - Verified — PROJ-888 (via Jira) — https://acme.atlassian.net/browse/PROJ-888\n\
+                   <!-- /murmur:verify -->\n\n\
+                   <!-- murmur:verify -->\nkeepme\n<!-- /murmur:verify -->\n";
+        let cv = clean_note_body(vfy);
+        assert!(!cv.contains("PROJ-888") && !cv.contains("atlassian.net"), "real verify block must not leak: {cv:?}");
+        assert!(cv.contains("keepme"), "forged verify content survives: {cv:?}");
+
+        // LINKS: real block (Secret title) then a forged links fence.
+        let lnk = "# N\n\nprose\n\n\
+                   <!-- murmur:links -->\n\
+                   > [!related]- Related notes\n\
+                   > - [[Secret Zwolnienia Q3]] (via note)\n\
+                   <!-- /murmur:links -->\n\n\
+                   <!-- murmur:links -->\nkeepme\n<!-- /murmur:links -->\n";
+        let cl = clean_note_body(lnk);
+        assert!(!cl.contains("Secret Zwolnienia Q3"), "real linked title must not leak: {cl:?}");
+        assert!(cl.contains("keepme"), "forged links content survives: {cl:?}");
+    }
+
+    /// FIX 3 (generalized) — a note carrying ALL THREE managed blocks has NONE of them reach the
+    /// envelope in one scrub (links + context + verify), while the prose survives.
+    #[test]
+    fn clean_note_body_strips_all_three_managed_blocks_at_once() {
+        let md = "# Notes\n\nKeep this prose.\n\n\
+                  <!-- murmur:context -->\n> [!context]- Live context (as of 2026-01-01T00:00:00Z)\n> - SLACK snippet (via Slack) — https://acme.slack.com/x\n<!-- /murmur:context -->\n\n\
+                  <!-- murmur:verify -->\n> [!verify]- Source check (as of 2026-01-01T00:00:00Z)\n> - Verified — KEY-9 (via Jira)\n<!-- /murmur:verify -->\n\n\
+                  <!-- murmur:links -->\n> [!related]- Related notes\n> - [[Private Note]] (via note)\n<!-- /murmur:links -->\n";
+        let clean = clean_note_body(md);
+        assert!(clean.contains("Keep this prose."), "prose survives: {clean:?}");
+        for leak in ["murmur:context", "murmur:verify", "murmur:links", "[!context]", "[!verify]", "[!related]", "slack.com", "KEY-9", "Private Note"] {
+            assert!(!clean.contains(leak), "{leak:?} must not reach the shared body: {clean:?}");
+        }
+    }
+
+    /// FIX 3 negative — the strip is SURGICAL: a `[[Public Note]]` the user typed INLINE in a sentence
+    /// (outside the machine block) still flattens to its display text `Public Note` and reaches the
+    /// recipient normally. We only drop the managed Related-notes block, never the user's own links.
+    #[test]
+    fn clean_note_body_still_flattens_user_inline_wikilink() {
+        let md = "# Notes\n\nWe should read [[Public Note]] before the call.\n";
+        let clean = clean_note_body(md);
+        assert!(
+            clean.contains("We should read Public Note before the call."),
+            "an inline user wikilink still flattens to its display text: {clean:?}"
+        );
+        assert!(!clean.contains("[["), "the wikilink markers are flattened: {clean:?}");
     }
 }

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -6828,11 +6828,14 @@
         );
     }
 
-    /// Fix 4 (brain-v3 audit, INVERSE) — on unlock, the stripped marker is RE-MATERIALIZED from the
-    /// preserved accepted row into the source note's managed block. RED before the inverse: after
-    /// strip+unlock the accepted link had no rendered `[[Title]]` in the source body.
+    /// FIX 2 (block-drop) — the machine `> [!related]- Related notes` (`murmur:links`) block is
+    /// RETIRED, so on unlock the accepted marker is NO LONGER RE-MATERIALIZED into the source note's
+    /// body/vault `.md`: `rematerialize_accepted_markers_for_folder` is now a documented NO-OP. The
+    /// accepted link ROW is preserved (surfaces in the live Related panel); only the body-block echo
+    /// is gone. RED before FIX 2 (the OLD assertions, now inverted): the old code reported N changed
+    /// and rewrote `[[Neighbour M]]` into N's body — the exact behavior this change removes.
     #[test]
-    fn unlock_rematerializes_accepted_marker_into_source() {
+    fn unlock_does_not_rematerialize_links_block() {
         let db = mem_db();
         seed_folder(&db, "f-open", "Open");
         seed_folder(&db, "f-secret", "Secret");
@@ -6845,12 +6848,12 @@
             Db::upsert_link_tx(&tx, "note", "n", "note", "m", "semantic", 0.9, "accepted", "active", now).unwrap();
             tx.commit().unwrap();
         }
-        // Seal M + strip (N had no marker yet, so strip is a no-op here — the point is the INVERSE).
+        // Seal M, lock its folder, strip (N had no marker yet — the strip is a no-op).
         db.seal_document("m", b"ciphertext").unwrap();
         db.set_folder_locked("f-secret", true, None).unwrap();
         let _ = db.strip_sealed_neighbour_markers(&[], &["m".to_string()]).unwrap();
 
-        // UNLOCK M's folder: restore M's plaintext, then re-materialize accepted markers for the folder.
+        // UNLOCK M's folder: restore M's plaintext, then invoke the (now no-op) rematerialize leg.
         db.set_document_text("m", "the neighbour body").unwrap();
         let mut unlocked = HashSet::new();
         unlocked.insert("f-open".to_string());
@@ -6859,16 +6862,29 @@
             .rematerialize_accepted_markers_for_folder("f-secret", &[], &unlocked)
             .unwrap();
         assert!(
-            changed.iter().any(|(is_m, id)| !is_m && id == "n"),
-            "N's body was re-materialized"
+            changed.is_empty(),
+            "no source is reported changed — the block re-materialization is retired; got {changed:?}"
         );
         let n_text: String = db
             .lock()
             .query_row("SELECT text FROM documents WHERE id = 'n'", [], |r| r.get(0))
             .unwrap();
+        // The load-bearing FIX-2 guarantee: N's body has NO reborn machine links block afterward.
         assert!(
-            n_text.contains("[[Neighbour M]]"),
-            "the accepted neighbour's [[Title]] is re-materialized into N's managed block on unlock"
+            !n_text.contains("murmur:links")
+                && !n_text.contains("[!related]")
+                && !n_text.contains("[[Neighbour M]]"),
+            "unlock must NOT rematerialize a murmur:links block into the source body; got {n_text:?}"
+        );
+        assert_eq!(
+            n_text, "just the note body",
+            "the source body is byte-identical to before — the retired block is never reborn"
+        );
+        // The accepted link ROW is untouched (still surfaces in the Related panel).
+        let edges = db.links_for_visible(crate::links::LinkKind::Note, "n", &unlocked).unwrap();
+        assert!(
+            edges.iter().any(|e| e.other_id == "m"),
+            "the accepted N↔M edge is preserved — only the body-block echo is retired"
         );
     }
 

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -1388,188 +1388,42 @@ impl Db {
     pub fn rematerialize_accepted_markers_for_folder(
         &self,
         folder_id: &str,
-        meeting_ids: &[String],
-        unlocked: &HashSet<String>,
+        _meeting_ids: &[String],
+        _unlocked: &HashSet<String>,
     ) -> Result<Vec<(bool, String)>> {
-        // The just-unlocked folder's items, as (is_meeting, id): its meetings + its note-docs.
-        let mut items: Vec<(bool, String)> = meeting_ids.iter().map(|m| (true, m.clone())).collect();
-        for did in self.document_ids_in_folder(folder_id)? {
-            items.push((false, did));
-        }
-        // Collect (owner_kind, owner_id, title_to_readd) work: for each accepted edge incident on an
-        // item, the OWNER is the OTHER endpoint (the source note whose block was stripped), and the
-        // title to re-add is THIS item's current visible title.
-        let mut work: Vec<(crate::links::LinkKind, String, String)> = Vec::new();
-        for (is_meeting, item_id) in &items {
-            let item_kind = if *is_meeting {
-                crate::links::LinkKind::Meeting
-            } else {
-                crate::links::LinkKind::Note
-            };
-            // This item's current gated title (skip if not visible — nothing to re-add).
-            let Some(item_title) =
-                self.link_endpoint_title_visible(item_kind, item_id, unlocked)?
-            else {
-                continue;
-            };
-            // The accepted edges incident on this item (either endpoint), ids/kinds only.
-            let rows: Vec<(String, String, String, String)> = {
-                let conn = self.lock();
-                let mut stmt = conn
-                    .prepare(
-                        "SELECT src_kind, src_id, dst_kind, dst_id FROM links
-                           WHERE edge_type = 'semantic' AND status = 'active' AND created_by = 'accepted'
-                             AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
-                    )
-                    .map_err(map_err)?;
-                let mapped = stmt
-                    .query_map(rusqlite::params![item_kind.as_str(), item_id], |r| {
-                        Ok((
-                            r.get::<_, String>(0)?,
-                            r.get::<_, String>(1)?,
-                            r.get::<_, String>(2)?,
-                            r.get::<_, String>(3)?,
-                        ))
-                    })
-                    .map_err(map_err)?;
-                let mut out = Vec::new();
-                for r in mapped {
-                    out.push(r.map_err(map_err)?);
-                }
-                out
-            };
-            for (sk, si, dk, di) in rows {
-                // The OWNER is whichever endpoint is NOT this item.
-                let (owner_k, owner_id) = if sk == item_kind.as_str() && si == *item_id {
-                    (dk, di)
-                } else {
-                    (sk, si)
-                };
-                if let Some(owner_kind) = crate::links::LinkKind::parse(&owner_k) {
-                    work.push((owner_kind, owner_id, item_title.clone()));
-                }
-            }
-        }
-        // Apply: re-add each item title into its owner's managed block (visible, owned notes only).
-        let mut changed: Vec<(bool, String)> = Vec::new();
-        for (owner_kind, owner_id, title) in &work {
-            // Skip an owner endpoint still sealed-at-rest (its block is blank — nothing to re-add to).
-            let sealed = match owner_kind {
-                crate::links::LinkKind::Meeting => {
-                    let mut conn = self.lock();
-                    let tx = conn.transaction().map_err(map_err)?;
-                    let s = meeting_sealed_at_rest_tx(&tx, owner_id)?;
-                    tx.commit().map_err(map_err)?;
-                    s
-                }
-                _ => {
-                    let mut conn = self.lock();
-                    let tx = conn.transaction().map_err(map_err)?;
-                    let s = doc_sealed_at_rest_tx(&tx, owner_id)?;
-                    tx.commit().map_err(map_err)?;
-                    s
-                }
-            };
-            if sealed {
-                continue;
-            }
-            let did = self.readd_marker_to_owner(*owner_kind, owner_id, title)?;
-            if let Some(is_meeting) = did {
-                changed.push((is_meeting, owner_id.clone()));
-            }
-        }
-        // Dedupe (a source may own several re-added markers).
-        changed.sort();
-        changed.dedup();
-        tracing::debug!(target: "links", folder = %folder_id, rematerialized = changed.len(), "rematerialize_accepted_markers_for_folder");
-        Ok(changed)
+        // NO-OP (block-drop, fix/drop-links-block): the machine `> [!related]- Related notes`
+        // (`murmur:links`) block that this used to RE-ADD into a source note's body on unlock was
+        // RETIRED (it went stale + rendered as raw junk in the plain-text editor; the RELATED panel
+        // reads the live `links` table instead). Re-materializing it here reborn the retired block in
+        // BOTH the stored `notes.markdown`/`documents.text` AND the re-exported vault `.md` on every
+        // sealed→unlock of a folder holding an accepted-semantic note — so this rematerialization must
+        // stop with the block itself.
+        //
+        // This ONLY dropped the machine MARKER re-add; it is DISTINCT from — and never on the path of
+        // — the actual content-unseal (note text / transcript / audio decrypt happens in the
+        // `unlock_folder` command BEFORE this best-effort post-unlock link leg runs). The accepted
+        // `semantic` link ROWS are preserved untouched (Brain-v3 Fix 1) and still surface in the
+        // Related panel; only the body-block echo is gone. Returning an empty change set means the
+        // command layer re-exports nothing for markers — correct, since no body changed.
+        let _ = folder_id;
+        Ok(Vec::new())
     }
 
-    /// Re-add ONE `[[title]]` marker into an OWNER note's managed block, in-tx. Returns `Some(is_meeting)`
-    /// iff the body changed (so the caller re-exports), `None` when the owner has no editable body or
-    /// the marker was already present. Merges (never clobbers other hits). The INVERSE of
-    /// [`Self::strip_titles_from_managed_block`].
+    /// NO-OP (block-drop, fix/drop-links-block): this used to RE-ADD one `[[title]]` marker into an
+    /// OWNER note's managed `> [!related]- Related notes` (`murmur:links`) block. That block is
+    /// RETIRED (see [`Self::rematerialize_accepted_markers_for_folder`]), so re-adding a marker would
+    /// resurrect it in the stored body + vault `.md`. Now a no-op returning `None` (no body change →
+    /// caller re-exports nothing). Kept as a guarded stub so no future caller can re-introduce the
+    /// block through this seam; the accepted link ROWS are untouched and still surface in the Related
+    /// panel. Does NOT touch content seal/unseal.
+    #[allow(dead_code)]
     fn readd_marker_to_owner(
         &self,
-        owner_kind: crate::links::LinkKind,
-        owner_id: &str,
-        title: &str,
+        _owner_kind: crate::links::LinkKind,
+        _owner_id: &str,
+        _title: &str,
     ) -> Result<Option<bool>> {
-        let new_hit = crate::enrich::ContextHit {
-            source: match owner_kind {
-                crate::links::LinkKind::Meeting => "meeting",
-                _ => "note",
-            }
-            .to_string(),
-            detail: format!("[[{title}]]"),
-            url: None,
-        };
-        match owner_kind {
-            crate::links::LinkKind::Meeting => {
-                let md: Option<String> = {
-                    let conn = self.lock();
-                    conn.query_row(
-                        "SELECT markdown FROM notes WHERE meeting_id = ?1 ORDER BY created_at DESC LIMIT 1",
-                        rusqlite::params![owner_id],
-                        |r| r.get::<_, String>(0),
-                    )
-                    .optional()
-                    .map_err(map_err)?
-                };
-                let Some(md) = md.filter(|m| !m.is_empty()) else {
-                    return Ok(None);
-                };
-                let mut hits = crate::enrich::extract_link_hits(&md);
-                if hits.iter().any(|h| h.detail == new_hit.detail) {
-                    return Ok(None); // already present.
-                }
-                hits.push(new_hit);
-                let merged = crate::enrich::apply_link_markers(&md, &hits);
-                if merged == md {
-                    return Ok(None);
-                }
-                let conn = self.lock();
-                conn.execute(
-                    "UPDATE notes SET markdown = ?2
-                       WHERE meeting_id = ?1
-                         AND created_at = (SELECT MAX(created_at) FROM notes WHERE meeting_id = ?1)",
-                    rusqlite::params![owner_id, merged],
-                )
-                .map_err(map_err)?;
-                Ok(Some(true))
-            }
-            crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
-                let text: Option<String> = {
-                    let conn = self.lock();
-                    conn.query_row(
-                        "SELECT COALESCE(text, '') FROM documents WHERE id = ?1 AND kind = 'note'",
-                        rusqlite::params![owner_id],
-                        |r| r.get::<_, String>(0),
-                    )
-                    .optional()
-                    .map_err(map_err)?
-                };
-                let Some(text) = text.filter(|t| !t.is_empty()) else {
-                    return Ok(None);
-                };
-                let mut hits = crate::enrich::extract_link_hits(&text);
-                if hits.iter().any(|h| h.detail == new_hit.detail) {
-                    return Ok(None);
-                }
-                hits.push(new_hit);
-                let merged = crate::enrich::apply_link_markers(&text, &hits);
-                if merged == text {
-                    return Ok(None);
-                }
-                let conn = self.lock();
-                conn.execute(
-                    "UPDATE documents SET text = ?2 WHERE id = ?1 AND kind = 'note'",
-                    rusqlite::params![owner_id, merged],
-                )
-                .map_err(map_err)?;
-                Ok(Some(false))
-            }
-        }
+        Ok(None)
     }
 
     /// PURGE every DERIVED link row whose SRC OR DST is a sealed/deleted meeting or document (a note id

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -212,6 +212,12 @@ pub fn judge_with_detail(
 pub(crate) const VERIFY_FENCE_START: &str = "<!-- murmur:verify -->";
 pub(crate) const VERIFY_FENCE_END: &str = "<!-- /murmur:verify -->";
 
+/// The STABLE header PREFIX a machine `murmur:verify` block always carries as its first body line
+/// ([`apply_verify_callout`] renders `> [!verify]- Source check (as of {date})`). The dated suffix
+/// varies, so the share-egress gate matches on this timeless prefix (never the whole line).
+/// `pub(crate)` so the enrich share-egress scrub reuses it — never a hardcoded string.
+pub(crate) const VERIFY_CALLOUT_HEADER_PREFIX: &str = "> [!verify]- Source check";
+
 /// Brain v2 L5 — append (or idempotently replace) the consolidated, collapsed `> [!verify]-`
 /// callout carrying the verification findings, dated `as_of` (caller-supplied so the function is
 /// pure). Mirrors `enrich.rs` fence discipline EXACTLY (it reuses the same engine):


### PR DESCRIPTION
## What

The machine-managed `murmur:links` "Related notes" block (auto-injected into note bodies) was Obsidian-facing junk that showed as raw text in the Murmur editor, went stale vs the live **Related** panel, risked being clobbered by the editor's stale-body autosave, and — with its siblings `murmur:context` / `murmur:verify` — **leaked private data on share**. A 13-agent audit (report: `docs/research/2026-07-20-linking-egress-leak-class-audit.md`) confirmed all three fences egress **unstripped**: `murmur:links` leaks linked-note **titles**; `murmur:context`/`murmur:verify` leak **live connector data** — Jira issue keys/statuses, Slack snippets, and workspace-identifying URLs (`https://…atlassian.net/…`) — to any link/org share recipient.

## Changes

- **Retire `murmur:links`.** `link_items` / `accept_link` / `link_related_notes` no longer materialize the block (edges are still created — the **Related** panel is unaffected). `get_note` strips it from the display (header-gated), so existing blocks clean up on the next save. Unlock no longer re-materializes it.
- **Close the share-egress leak.** `clean_note_body` (the single scrub every link/org share funnels through) now strips **all three** managed fences before the wire, each **header-gated** with a **scan-all** walk (a real block behind a *trailing forged fence* can no longer slip through — the bug the adversarial pass caught). `context`/`verify` stay visible in-app (they're opt-in features) — stripped **only on egress**.

The strip is fence-surgical: a header-less forged fence in user prose is **never** touched (byte-identical), a lone start-fence never truncates, and a real block round-trips byte-exact.

## How verified

- `cargo test --lib` (targeted) — enrich 27/0, envelope 35/0, get_note 8/0, links 55/0, verify 19/0; `clippy --lib -D warnings` clean, MSRV-1.77 safe.
- **lock-security-reviewer PASS + adversarial-verifier PASS** — across **four** verify cycles that caught (and closed, RED-before-GREEN) a reachable **content-loss** (an unconditional strip ate user prose) and **two egress-leak variants** (missing context/verify strip; `rfind` last-fence-only) that green builds + a lock-security pass all missed.
- Rebased onto current trunk (#414) — the change is backend-only and disjoint from trunk's FE.

## Not provable headless
Real link/org-share wire egress, `get_note` display in the packaged WKWebView, and Touch-ID-gated unlock need a signed build. Logic is unit-proven at the `clean_note_body` / `strip_managed_*` / `get_note_inner` seams.