### PR TITLE
fix(links): resolve backlinks by id, not title string (stop the Untitled fan-out)

### DIFF
--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -6095,6 +6095,133 @@
         );
     }
 
+    /// backlink-id fix (RED before the fan-out guard): the title-string body-scan legs must NOT
+    /// attribute a source's `[[Untitled]]` to EVERY item titled "Untitled" — only to the ONE that
+    /// `resolve_wikilink("Untitled")` actually navigates to. Two VISIBLE notes A and B are BOTH titled
+    /// "Untitled"; B is `updated_at`-newer so the resolver (`ORDER BY updated_at DESC`) picks B. Source
+    /// S carries `[[Untitled]]` in its body but is NOT in the `links` index (never indexed), forcing
+    /// the body-scan leg. Pre-fix (title-string match): BOTH A and B get S — a bogus fan-out. Post-fix:
+    /// only B (the resolved target) gets S; A gets none.
+    #[test]
+    fn backlinks_body_scan_no_fanout_across_duplicate_titles() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+
+        // A and B BOTH titled "Untitled". B is updated more recently (higher created_at ⇒ higher
+        // updated_at, since insert_note stores created_at as updated_at too) so resolve_wikilink picks
+        // B. Do NOT index either — their bodies are irrelevant here; they are the duplicate TARGETS.
+        db.insert_note("n-a", "f1", "a", "Untitled", "the A body, empty note", 1_000)
+            .unwrap();
+        db.insert_note("n-b", "f1", "b", "Untitled", "the B body, empty note", 2_000)
+            .unwrap();
+
+        // Sanity: the resolver picks B (the newest same-titled note) — this is where a click navigates.
+        let nothing = std::collections::HashSet::new();
+        let resolved = db.resolve_wikilink("Untitled", &nothing).unwrap().unwrap();
+        assert_eq!(
+            (resolved.kind.as_str(), resolved.id.as_str()),
+            ("note", "n-b"),
+            "resolve_wikilink must pick the newest same-titled note (B)"
+        );
+
+        // SOURCE S carries [[Untitled]] but is deliberately NOT indexed → served only by the body scan.
+        db.insert_note("n-s", "f1", "s", "Source", "please see [[Untitled]] for context", 3_000)
+            .unwrap();
+
+        let a_back = db
+            .backlinks_for_visible(SourceKind::Note, "n-a", &nothing)
+            .unwrap();
+        let b_back = db
+            .backlinks_for_visible(SourceKind::Note, "n-b", &nothing)
+            .unwrap();
+        let a_ids: Vec<&str> = a_back.iter().map(|s| s.id.as_str()).collect();
+        let b_ids: Vec<&str> = b_back.iter().map(|s| s.id.as_str()).collect();
+
+        assert!(
+            b_ids.contains(&"n-s"),
+            "the resolved target (B) must get the [[Untitled]] body-scan backlink; got {b_ids:?}"
+        );
+        assert!(
+            !a_ids.contains(&"n-s"),
+            "the NON-resolved same-titled note (A) must NOT fan-out and steal the backlink; got {a_ids:?}"
+        );
+    }
+
+    /// backlink-id fix: a UNIQUELY-titled target still gets its body-scan backlink (no regression) —
+    /// its title resolves to itself, so `title_targets_us` is true and the leg runs. Un-indexed source.
+    #[test]
+    fn backlinks_body_scan_unique_title_still_works() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+
+        // A uniquely-titled target T.
+        db.insert_note("n-t", "f1", "t", "UniqueTitle", "the target body", 1_000)
+            .unwrap();
+        // A source S with [[UniqueTitle]] in its body — NOT indexed, so served only by the body scan.
+        db.insert_note("n-s", "f1", "s", "Source", "refer to [[UniqueTitle]] here", 2_000)
+            .unwrap();
+
+        let nothing = std::collections::HashSet::new();
+        let back = db
+            .backlinks_for_visible(SourceKind::Note, "n-t", &nothing)
+            .unwrap();
+        let ids: Vec<&str> = back.iter().map(|s| s.id.as_str()).collect();
+        assert!(
+            ids.contains(&"n-s"),
+            "a uniquely-titled target must still surface its body-scan backlink; got {ids:?}"
+        );
+    }
+
+    /// backlink-id fix: the id-based INDEX fast path is UNCONDITIONAL — a real indexed wikilink edge to
+    /// A is returned even when `title_targets_us` is false for A (a duplicate-title scenario where the
+    /// title resolves to a DIFFERENT same-titled item, B). The guard only ever removes BOGUS title-
+    /// string fan-out; it never suppresses a legitimate id-keyed edge.
+    #[test]
+    fn backlinks_index_path_unaffected_by_title_guard() {
+        let db = mem_db();
+        seed_folder(&db, "f1", "Notes");
+
+        // A and B BOTH titled "Untitled"; B newer ⇒ resolve_wikilink("Untitled") picks B, so for TARGET
+        // A the guard is FALSE.
+        db.insert_note("n-a", "f1", "a", "Untitled", "A body", 1_000)
+            .unwrap();
+        db.insert_note("n-b", "f1", "b", "Untitled", "B body", 2_000)
+            .unwrap();
+
+        // SOURCE S is INDEXED against A's id directly (a resolved, id-keyed `links` edge), NOT via the
+        // current title. Build the edge by indexing S while A is the resolvable target, then flip so the
+        // title now resolves to B — the id-keyed edge to A must remain.
+        db.insert_note("n-s", "f1", "s", "Source", "see [[A Unique Handle]]", 3_000)
+            .unwrap();
+        // Give A a unique title momentarily so the wikilink resolves to A's id and gets indexed.
+        db.lock()
+            .execute("UPDATE documents SET title='A Unique Handle' WHERE id='n-a'", [])
+            .unwrap();
+        let nothing = std::collections::HashSet::new();
+        db.index_wikilinks_for_source(
+            crate::links::LinkKind::Note,
+            "n-s",
+            "see [[A Unique Handle]]",
+            &nothing,
+        )
+        .unwrap();
+        // Now rename A back to "Untitled" (duplicate with B, B newer) so title resolution points at B.
+        db.lock()
+            .execute("UPDATE documents SET title='Untitled' WHERE id='n-a'", [])
+            .unwrap();
+
+        // For target A: title_targets_us is FALSE (resolve_wikilink("Untitled") → B), yet the id-keyed
+        // index edge S → A must still surface.
+        let a_back = db
+            .backlinks_for_visible(SourceKind::Note, "n-a", &nothing)
+            .unwrap();
+        assert!(
+            a_back.iter().any(|s| s.id == "n-s"),
+            "the id-keyed INDEX edge to A must survive the title guard; got {:?}",
+            a_back.iter().map(|s| s.id.as_str()).collect::<Vec<_>>()
+        );
+    }
+
     /// Fix 6 (RED before case-insensitive wikilink resolution): Obsidian resolves `[[links]]`
     /// case-insensitively — `[[project x]]` must resolve to a note titled "Project X". The old
     /// byte-exact match returned `None`.

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -497,6 +497,27 @@ impl Db {
             _ => return Ok(Vec::new()),
         };
 
+        // ── TITLE-STRING FAN-OUT GUARD (backlink-id fix): a source's `[[target_title]]` is a backlink
+        // to THIS target ONLY IF `[[target_title]]` actually RESOLVES to it — exactly where clicking
+        // the wikilink navigates. `resolve_wikilink` (the SAME gated resolver the write-time index and
+        // click-navigation use: note-leg-first, most-recent `ORDER BY updated_at DESC`, case-folded
+        // fallback, companion self-link avoidance) collapses a `[[Title]]` to EXACTLY ONE target.
+        // When two items share a title (e.g. the default "Untitled"), the resolver picks ONE — so only
+        // THAT one may claim the body-scan backlinks; the others must not fan-out and steal them.
+        // Compute the mapping once: our (target_kind, target_id) as a `WikiTarget` kind string, and
+        // check the resolved target equals us. An `org` resolution never equals a note/meeting target,
+        // so `title_targets_us` is false there too. The two title-string body-scan legs below run ONLY
+        // when this is true; the id-based INDEX fast path and the structural companion leg are
+        // unconditional (they carry the correct, resolved backlinks regardless).
+        let target_kind_wiki = match target_kind {
+            SourceKind::Meeting => "meeting",
+            SourceKind::Note => "note",
+        };
+        let title_targets_us = matches!(
+            self.resolve_wikilink(&target_title, unlocked)?,
+            Some(ref wt) if wt.kind == target_kind_wiki && wt.id == target_id
+        );
+
         // ── INDEXED FAST PATH: wikilink + companion backlinks straight from `links` (Fix 3). ──
         // Each returned source id is remembered so the body-scan legs below skip it (no double-count,
         // no rescan). A source that fails its own visibility gate is dropped here (source gate).
@@ -542,7 +563,9 @@ impl Db {
             if seen_meetings.contains(&id) {
                 continue; // already emitted this meeting (fast path or an earlier note).
             }
-            if extract_wikilink_titles(&body).contains(&target_title) {
+            // FAN-OUT GUARD: only attribute a title-string `[[target_title]]` when the title actually
+            // resolves to US — otherwise it links a DIFFERENT same-titled item (or nothing), not us.
+            if title_targets_us && extract_wikilink_titles(&body).contains(&target_title) {
                 seen_meetings.insert(id.clone());
                 out.push(BacklinkSource {
                     id,
@@ -585,7 +608,9 @@ impl Db {
             if indexed_note_ids.contains(&id) {
                 continue; // already served from the `links` index (Fix 3) — never rescan/duplicate.
             }
-            if extract_wikilink_titles(&text).contains(&target_title) {
+            // FAN-OUT GUARD (see the meeting leg): a title-string `[[target_title]]` counts as a
+            // backlink to US only when the title resolves to us; else it links a same-titled sibling.
+            if title_targets_us && extract_wikilink_titles(&text).contains(&target_title) {
                 note_hits.push(BacklinkSource {
                     id,
                     kind: SourceKind::Note,


### PR DESCRIPTION
## What

`backlinks_for_visible`'s two title-string body-scan legs matched a source's `[[target_title]]` by **string**, so a default `"Untitled"` title (or any duplicate) **fanned out** — every same-titled note claimed the same backlinks. Real symptom: an empty note titled "Untitled" showed 4 "mentions" it never earned, leaked from other notes' `[[Untitled]]` via a title-string collision (the follow-up bug #2 from `docs/research/2026-07-20-linking-egress-leak-class-audit.md`).

## Fix

Resolve `[[target_title]]` **once** via the gated `resolve_wikilink` — the same resolver the write-time index and click-navigation use (note-leg-first, most-recent, case-folded, companion-aware) — and only run the body-scan legs when it points at **this** target. When the title resolves to a different same-titled item (or none / a document / an org), skip the scan; the id-based index fast-path and the structural companion leg still return the real backlinks.

The guard can only ever **remove** bogus matches (strictly more-correct, never a new leak); `resolve_wikilink` is already visibility-gated, and the guard is monotone over the *visible* set (a sealed sibling can't influence it → no existence leak). Index + companion legs are unconditional, so no genuinely-linked backlink is lost.

## How verified

- `cargo test --lib links` — **58/0**, incl. 3 new **RED-before-GREEN** tests (no-fanout across duplicate titles; unique-title no-regression; index-path unaffected) and all 12 existing `backlinks_*`; `clippy --lib -D warnings` clean, MSRV-safe.
- **lock-security-reviewer PASS + adversarial-verifier PASS** — the adversary specifically hunted *dropped legit backlinks* (case-fold, meeting-vs-note resolution, #415's documents leg) and found none; the one "risk" case (meeting+note share a title → meeting body-scan skipped) is correct de-duplication matching where `[[Title]]` actually navigates.
- Rebased onto current trunk (#415) — compatible with its `resolve_wikilink` documents leg.

Backend-only; `BacklinkSource` DTO unchanged. Needs a real Mac only for lock-at-rest behavior, which is untouched.