### PR TITLE
fix(brain): manual 'Related' links now show as edges in the full-brain graph

### DIFF
--- a/src-tauri/src/storage/db_tests/graph_tests.rs
+++ b/src-tauri/src/storage/db_tests/graph_tests.rs
@@ -448,6 +448,44 @@
         assert!((sem.score - 0.9).abs() < 1e-9, "semantic score = cosine");
     }
 
+    /// A USER-created `manual` link (the note↔document "Related" chip, written by `upsert_manual_link`)
+    /// MUST appear as an ACTIVE edge in the full-brain graph and bump both endpoints' degree.
+    /// REGRESSION (2026-07-20): `full_graph_edge_kind_from_type` mapped only wikilink/companion/semantic,
+    /// so every `manual` edge fell to `_ => None` and was `continue`-skipped — a linked document showed
+    /// "0 connections". RED-before-GREEN: drop the `"manual"` arm and this test fails (no edge, degree 0).
+    #[test]
+    fn build_full_graph_includes_manual_link_edge() {
+        let db = file_db("fullgraph-manual");
+        seed_folder(&db, "f", "Notes");
+        db.insert_note("n1", "f", "n1", "Note One", "body", 1_000)
+            .unwrap();
+        db.insert_document("d1", "f", "cv.pdf", "doc body", "document", 1_000)
+            .unwrap();
+        // A user-created manual link note → document (exactly what `upsert_manual_link` writes).
+        seed_link(&db, ("note", "n1"), ("document", "d1"), "manual", "active", 1.0);
+
+        let empty: HashSet<String> = HashSet::new();
+        let g = db.build_full_graph(&empty, FullGraphOpts::default()).unwrap();
+
+        // The manual edge is present, active, and correctly typed at both endpoints.
+        let edge = g
+            .edges
+            .iter()
+            .find(|e| e.src == "n1" && e.dst == "d1")
+            .expect("the manual note→document link must be a graph edge (regression: it was dropped)");
+        assert_eq!(edge.kind, FullGraphEdgeKind::Manual, "typed as a manual edge");
+        assert_eq!(edge.src_kind, FullGraphNodeKind::Note);
+        assert_eq!(edge.dst_kind, FullGraphNodeKind::Document);
+        assert_eq!(edge.status, "active", "a manual link is an active edge");
+        // The document is no longer a 0-connection orphan.
+        let doc = g
+            .nodes
+            .iter()
+            .find(|n| n.id == "d1" && n.kind == FullGraphNodeKind::Document)
+            .expect("document node present");
+        assert_eq!(doc.degree, 1, "the linked document has one connection, not zero");
+    }
+
     /// HONEST CAPS: the per-kind node cap trims `nodes` while `total_visible_nodes` reports the TRUE
     /// pre-cap count, and `has_hidden` reflects LOCKED folders independently. RED-before-GREEN: set
     /// `total_visible_nodes = nodes.len()` and the silent cap-drop is invisible to the FE.

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -676,7 +676,7 @@ impl Db {
                 });
             }
         }
-        // links rows — wikilink/companion/semantic. active always; suggested semantic behind the flag.
+        // links rows — wikilink/companion/manual/semantic. active always; suggested semantic behind the flag.
         // BOTH endpoints re-checked against the visible-node set (the links kind strings map 1:1 onto
         // the node-kind strings: meeting|note|document), so a link to a sealed/absent node is dropped.
         for (src_kind, src_id, dst_kind, dst_id, edge_type, score, status) in link_rows {
@@ -1027,6 +1027,10 @@ fn full_graph_edge_kind_from_type(edge_type: &str) -> Option<FullGraphEdgeKind> 
         "wikilink" => Some(FullGraphEdgeKind::Wikilink),
         "companion" => Some(FullGraphEdgeKind::Companion),
         "semantic" => Some(FullGraphEdgeKind::Semantic),
+        // A USER-created "Related" link (`upsert_manual_link`). Deterministic + always active — WITHOUT
+        // this arm every manual edge fell to `None` and was dropped, so a manually-linked note/meeting/
+        // document showed "0 connections" in the full-brain graph (2026-07-20 regression).
+        "manual" => Some(FullGraphEdgeKind::Manual),
         _ => None,
     }
 }

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -128,6 +128,11 @@ pub enum FullGraphEdgeKind {
     Wikilink,
     Companion,
     Semantic,
+    /// A USER-created link (`links.edge_type = 'manual'`, written by `upsert_manual_link` for the
+    /// note↔meeting↔document "Related" chip). Deterministic + always `active` — the most intentional
+    /// link there is, so it MUST render in the full-brain graph like wikilink/companion. Omitting it
+    /// from the edge taxonomy is what made a manually-linked document show "0 connections" (2026-07-20).
+    Manual,
 }
 
 impl FullGraphEdgeKind {
@@ -138,6 +143,7 @@ impl FullGraphEdgeKind {
             FullGraphEdgeKind::Wikilink => "wikilink",
             FullGraphEdgeKind::Companion => "companion",
             FullGraphEdgeKind::Semantic => "semantic",
+            FullGraphEdgeKind::Manual => "manual",
         }
     }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1527,14 +1527,16 @@ export interface FullGraphNode {
 /**
  * The relation a full-brain edge encodes (Rust `FullGraphEdgeKind`, snake_case).
  * `co_occurrence` = entity↔entity; `mention` = entity→meeting; `wikilink` /
- * `companion` / `semantic` = a `links` row. Drives the per-kind edge style + the
- * edge lens.
+ * `companion` / `manual` / `semantic` = a `links` row. `manual` is a USER-created
+ * "Related" link (the most intentional edge — always active). Drives the per-kind
+ * edge style + the edge lens.
  */
 export type FullGraphEdgeKind =
   | "co_occurrence"
   | "mention"
   | "wikilink"
   | "companion"
+  | "manual"
   | "semantic";
 
 /**

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -111,6 +111,7 @@ export class FullBrainGraphComponent {
     mention: true,
     wikilink: true,
     companion: true,
+    manual: true,
     semantic: true,
   });
   readonly nodeLens = this._nodeLens.asReadonly();
@@ -135,6 +136,7 @@ export class FullBrainGraphComponent {
     { kind: "mention", label: "Mentions", token: "--text-secondary" },
     { kind: "wikilink", label: "Wikilinks", token: "--accent" },
     { kind: "companion", label: "Companion", token: "--graph-note" },
+    { kind: "manual", label: "Manual", token: "--accent-hover" },
     { kind: "semantic", label: "Semantic", token: "--graph-document" },
   ];
 

--- a/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-scene.directive.ts
@@ -668,7 +668,10 @@ export class FullBrainSceneDirective {
       const B = this.proj[b];
       const colA = NODE_COLORS[e.srcKind];
       const colB = NODE_COLORS[e.dstKind];
-      const structural = e.kind === "wikilink" || e.kind === "companion";
+      const structural =
+        e.kind === "wikilink" ||
+        e.kind === "companion" ||
+        e.kind === "manual";
 
       // Focus tier → alpha/width.
       let aBase = 0.5;


### PR DESCRIPTION
## Problem
A user-created **Related** link to a document showed **"0 connections"** in the full-brain graph, even though the note's Related panel clearly listed it as `linked`.

## Root cause
`link_items` → `upsert_manual_link` writes a `links` row with `edge_type = 'manual'`. But `build_full_graph`'s edge mapper `full_graph_edge_kind_from_type` only handled `wikilink`/`companion`/`semantic` → `manual` fell to `_ => None` and the builder `continue`-skipped it. So **every** manual link (note↔note, note↔meeting, note↔document) was invisible in the graph — most obvious on a freshly-imported document whose only edge is that manual link.

## Fix
Add `Manual` as a first-class edge kind end-to-end:
- `FullGraphEdgeKind::Manual` (Rust `models.rs` + TS `models.ts`)
- the `"manual"` arm in `full_graph_edge_kind_from_type` (`graph_store.rs`)
- FE edge-lens key + "Manual" legend entry (`full-brain-graph.component.ts`)
- treat manual as a **structural** (solid, thicker) edge like wikilink/companion (`full-brain-scene.directive.ts`)

## Safety
Both-endpoint visibility gating is **unchanged** and still runs *before* the edge_type map, so a manual edge to a sealed-and-not-unlocked node stays dropped — no leak. Reader (`full_graph_links`) is unchanged (no content columns; still excludes dismissed rows). Write path unchanged.

## Verification
- RED→GREEN: new test `build_full_graph_includes_manual_link_edge` fails without the mapper arm (edge absent, document degree 0), passes with it.
- `cargo test --lib`: 2033 passed, 0 failed · `ng lint` clean · `ng build` clean.
- Leak-ordering confirmed by direct code read (endpoint gate precedes edge_type map).