### PR TITLE
fix(links): keep the never-named 'Untitled' sentinel out of the link picker + Vault Audit

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -740,8 +740,11 @@ fn orphan_pass(
                 if j == i || suggestions.len() >= MAX_ORPHAN_SUGGESTIONS {
                     continue;
                 }
-                if other.title.is_empty() || suggestions.contains(&other.title) {
-                    continue;
+                if other.title.is_empty()
+                    || crate::storage::db::is_untitled_title(&other.title)
+                    || suggestions.contains(&other.title)
+                {
+                    continue; // never suggest the shared "Untitled" sentinel as a reconnection.
                 }
                 if find_unlinked_mention_line(&other.body, &doc.title).is_some() {
                     suggestions.push(other.title.clone());
@@ -875,6 +878,13 @@ fn dedupe_disc(text: &str) -> String {
 /// word-bounded, un-linked occurrence outside any ``` code fence. PURE.
 pub(crate) fn find_unlinked_mention_line<'a>(body: &'a str, title: &str) -> Option<&'a str> {
     if title.chars().count() < MIN_MENTION_TITLE_CHARS {
+        return None;
+    }
+    // The never-named "Untitled" sentinel is not a unique title (a vault has many), so it must never
+    // be suggested as a mention/link target. Both the `unlinked_mention_pass` target scan and the
+    // `orphan_pass` reconnection scan route through here, so one guard covers both.
+    // See `crate::storage::db::UNTITLED_TITLE`.
+    if crate::storage::db::is_untitled_title(title) {
         return None;
     }
     let mut in_fence = false;
@@ -1407,6 +1417,33 @@ mod tests {
             .collect();
         assert!(!targets.contains(&"Target Five"), "already-linked title skipped");
         assert!(!targets.contains(&"Target Sixxx"), "code-fenced mention skipped");
+    }
+
+    /// 2026-07-20 — the "Untitled" sentinel must not be a mention TARGET (same title-collision class
+    /// as the phantom-mentions panel that #417 fixed for backlinks): a body naming the bare word
+    /// "Untitled" must NOT suggest a `[[Untitled]]` link to every never-named note. RED before the
+    /// `is_untitled_title` skip in the shared `find_unlinked_mention_line`.
+    #[test]
+    fn unlinked_mention_pass_ignores_untitled_sentinel_target() {
+        let corpus = vec![
+            // A real note whose body names the bare word "Untitled" (word-bounded).
+            doc("note", "src", "Notes Hub", "I saved it into my Untitled draft earlier.\n"),
+            // Two never-named notes sharing the sentinel (empty-body notes are dropped from the
+            // corpus, so give them content).
+            doc("note", "u1", "Untitled", "scratch one\n"),
+            doc("note", "u2", "Untitled", "scratch two\n"),
+        ];
+        let found = unlinked_mention_pass(&corpus);
+        assert!(
+            !found
+                .iter()
+                .any(|f| f.target_title.as_deref() == Some("Untitled")),
+            "must not suggest linking to the shared 'Untitled' sentinel; got {:?}",
+            found
+                .iter()
+                .map(|f| f.target_title.clone())
+                .collect::<Vec<_>>()
+        );
     }
 
     // ── stale (file DB) ──

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -81,7 +81,13 @@ pub(crate) fn create_note_inner(
     }
 
     let title = title.trim();
-    let title = if title.is_empty() { "Untitled" } else { title };
+    // The stored default for a never-named note — coupled to `UNTITLED_TITLE` so the written value and
+    // the picker/audit `is_untitled_title` guards can never drift (see `crate::storage::db`).
+    let title = if title.is_empty() {
+        crate::storage::db::UNTITLED_TITLE
+    } else {
+        title
+    };
     // The `name` is the filesystem-safe slug; `title` is the display title.
     let name = crate::export::sanitize_title(title);
 

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5488,8 +5488,12 @@ impl Db {
         // Notes leg — the COUNT twin shares the page query's exact WHERE body, so the
         // offset arithmetic below can never drift from what the page query returns.
         let visible_notes = visibility_clause("f", unlocked);
+        // Exclude the never-named "Untitled" sentinel (`UNTITLED_TITLE`): a screen of identical
+        // "Untitled" rows is useless and an unnamed note is not a meaningful link target (2026-07-20).
+        // On `notes_where` so the COUNT twin and the page query stay in lockstep (offset arithmetic).
         let notes_where = format!(
             "d.kind = 'note' AND {visible_notes}
+             AND LOWER(COALESCE(NULLIF(TRIM(d.title), ''), d.name)) != LOWER(:untitled)
              AND (:pat IS NULL OR COALESCE(NULLIF(TRIM(d.title), ''), d.name) LIKE :pat ESCAPE '\\')"
         );
         let note_count: i64 = conn
@@ -5500,7 +5504,7 @@ impl Db {
                        JOIN folders f ON f.id = d.folder_id
                       WHERE {notes_where}"
                 ),
-                rusqlite::named_params! { ":pat": pat },
+                rusqlite::named_params! { ":pat": pat, ":untitled": UNTITLED_TITLE },
                 |r| r.get(0),
             )
             .map_err(map_err)?;
@@ -5516,7 +5520,12 @@ impl Db {
             let mut stmt = conn.prepare(&sql).map_err(map_err)?;
             let rows = stmt
                 .query_map(
-                    rusqlite::named_params! { ":pat": pat, ":limit": limit, ":offset": offset },
+                    rusqlite::named_params! {
+                        ":pat": pat,
+                        ":limit": limit,
+                        ":offset": offset,
+                        ":untitled": UNTITLED_TITLE,
+                    },
                     |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
                         Ok((r.get(0)?, r.get(1)?))
                     },
@@ -6449,6 +6458,24 @@ pub(crate) fn extract_wikilink_titles(text: &str) -> Vec<String> {
         }
     }
     out
+}
+
+/// The sentinel display title auto-assigned to a note the user never named. `create_note_inner`
+/// writes the literal `"Untitled"` when the user supplies no title, and the auto-title guard in
+/// `commands::notes` treats `== "Untitled"` as "not yet named". It is NOT a unique identity — a real
+/// vault has MANY notes sharing it — so it must not be surfaced as a linkable identity: the link
+/// candidate picker (`list_link_candidates_visible`) does not OFFER it, and the Vault Audit mention
+/// scan (`find_unlinked_mention_line` / `orphan_pass`) never SUGGESTS `[[Untitled]]`. (The backlink
+/// fan-out itself — an untitled note claiming mentions it never earned — is fixed separately by the
+/// resolve-by-id guard in `backlinks_for_visible` (#417), which keeps `[[Untitled]]` resolving to one
+/// note; this const governs ONLY the picker + audit surfaces #417 does not touch.) Kept as one const
+/// so the write site and these read guards can never drift.
+pub(crate) const UNTITLED_TITLE: &str = "Untitled";
+
+/// True when `title` is the never-named sentinel (see [`UNTITLED_TITLE`]) — trimmed + ASCII-case
+/// -folded. Keeps an unnamed note out of the link-candidate picker and the audit link suggestions.
+pub(crate) fn is_untitled_title(title: &str) -> bool {
+    title.trim().eq_ignore_ascii_case(UNTITLED_TITLE)
 }
 
 /// A comparable newest-first sort key (epoch-millis) for a backlink chip. Both legs emit an RFC3339

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -1904,6 +1904,31 @@
         assert!(db.resolve_wikilink("   ", &nothing).unwrap().is_none());
     }
 
+    /// The `+ Link` / `[[` picker must not offer never-named notes: a screen of identical "Untitled"
+    /// rows is useless and a pick can't be a meaningful link target (2026-07-20). RED before the
+    /// `list_link_candidates_visible` sentinel filter (which listed every untitled note). Complements
+    /// #417 (which fixed the backlink fan-out) by covering the candidate-picker surface.
+    #[test]
+    fn link_candidates_exclude_untitled_notes() {
+        let db = mem_db();
+        seed_folder(&db, "f-open", "Open");
+        db.insert_note("n-real", "f-open", "real", "Design Doc", "body", 2_000)
+            .unwrap();
+        db.insert_note("n-unnamed", "f-open", "Untitled", "Untitled", "", 3_000)
+            .unwrap();
+        let nothing = std::collections::HashSet::new();
+        let (rows, _total) = db.list_link_candidates_visible("", 40, 0, &nothing).unwrap();
+        let ids: Vec<&str> = rows.iter().map(|c| c.id.as_str()).collect();
+        assert!(
+            ids.contains(&"n-real"),
+            "a real-titled note is still a candidate; got {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"n-unnamed"),
+            "a never-named 'Untitled' note must NOT be offered as a link candidate; got {ids:?}"
+        );
+    }
+
     /// SELF-LINK AVOIDANCE (2026-07-16 companion note): a companion note (`documents` row with a
     /// non-null `meeting_id`) whose managed title EQUALS its meeting's title must be EXCLUDED from the
     /// note-leg, so `[[Meeting Title]]` resolves to the MEETING (kind='meeting'), never to its own


### PR DESCRIPTION
A note the user never titled is stored as 'Untitled' — NOT a unique identity (a vault has many). #417 fixed the backlink fan-out (resolve-by-id); this closes the two surfaces it doesn't touch:
- **link-candidate picker** (`list_link_candidates_visible`) offered every unnamed note — a screen of identical 'Untitled' rows.
- **Vault Audit** mention scan (`find_unlinked_mention_line` / `orphan_pass`) suggested `[[Untitled]]`, reconnecting a body's bare word 'Untitled' to every never-named note.

## Fix (one source of truth, no drift)
`UNTITLED_TITLE` const + `is_untitled_title` helper in `storage::db`, coupled to the `create_note_inner` write site. The picker query excludes it — with the **COUNT twin updated in lockstep** so the offset arithmetic can't drift (the double-count trap). The audit routes both its target scan and orphan-reconnection scan through the shared `find_unlinked_mention_line` guard.

## Gating
The `list_link_candidates_visible` change is a NARROWING only (adds `AND title != 'Untitled'`) — no gate bypassed or widened. Routed to lock-security per the rule.

## Verification
RED-before-GREEN tests (list_link_candidates excludes untitled; unlinked_mention_pass_ignores_untitled_sentinel_target). cargo test --lib green (untitled/link_candidate/orphan/unlinked_mention 21/0); clippy --lib -D warnings clean; MSRV clean. Full ci.sh in CI.