### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "0.9.18"
+version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ across your whole history, and browse what it knows — all over the same store.
 
 - **One page for your whole brain.** A status header counts your (visible) **meetings**, **documents**,
   and **notes**, shows whether semantic search is on, and links straight to Ask.
-- **Expand it with your own sources.** Drop in Markdown/text **documents**, or paste a quick **note** —
-  each is chunked and (when the on-device embedding model is present) vector-indexed into the same brain,
-  gated by the same per-folder lock.
+- **Expand it with your own sources.** Drop in a **PDF** (scanned pages fall back to on-device Apple
+  Vision OCR), a **Word / PowerPoint / Excel** file, an **HTML** page, Markdown/text, or even a
+  screenshot — or paste a quick **note**. Each is extracted, chunked, and (when the on-device embedding
+  model is present) vector-indexed into the same brain, gated by the same per-folder lock.
 - **See the connections.** A collapsible graph shows how people and projects link across everything.
 
 ### 🔎 Ask across every meeting — and every note
@@ -272,7 +273,7 @@ recording. Same store, same lock model, same brain.
   properties, just like a locked meeting.
 - **AI auto-organize** — the brain proposes a folder/tag reorganization plan, you review it, nothing
   moves until you approve.
-- **A 19-action AI command menu on selected text** — ClickUp-style, grouped into Edit / Structure / From
+- **A 19-action AI command menu on selected text** — grouped into Edit / Structure / From
   your brain / Extract / Create, with a compact 5-action default, tone and translation submenus, and a
   free-text custom instruction. The same command backs all 19 actions, gated on the folder being
   unlocked and routed through the identical provider seam, redaction firewall, and egress ledger as
@@ -541,7 +542,7 @@ axum + Postgres relay, AGPL-3.0).
 
 ## 🗺️ Status
 
-Murmur ships at **v0.9.6** — a signed, notarized macOS app, roughly 20 releases past the record →
+Murmur ships at **v1.0.0** — a signed, notarized macOS app, ~30 releases past the record →
 transcribe → summarize MVP.
 
 **Shipped and in daily use:**
@@ -549,6 +550,15 @@ transcribe → summarize MVP.
   screen with in-meeting `@brain` threads, and the floating recorder bar.
 - The on-device brain (agentic tool-use loop + hybrid FTS/semantic/entity-graph retrieval), the `/brain`
   knowledge hub, Ask-Your-Vault, and the knowledge graph.
+- **Universal document ingest** — drop in a PDF (scanned pages fall back to on-device Apple Vision OCR),
+  a Word / PowerPoint / Excel file, an HTML page, Markdown/text, or an image, and it's extracted,
+  chunked, and vector-indexed into the same brain, gated by the same per-folder lock.
+- **Receipts** — every claim in a generated note that aligns to what was actually said carries a
+  receipt chip that jumps you to the exact transcript segment (audio second, speaker, ASR-confidence)
+  it came from; unsupported lines earn none, and a sealed meeting leaks no timing or speaker.
+- **A self-building link graph** — notes, meetings, *and* imported documents are first-class
+  `[[link]]` targets you pick/link/open from any surface; backlinks resolve by id, and the full-brain
+  graph renders as a living neural map.
 - **Notes** as a full standalone product — editor, note folders with their own lock lifecycle, AI
   auto-organize, and the 19-action AI command menu.
 - **Shared Brain** — free, opt-in, end-to-end-encrypted org sharing of notes and meetings, multi-org

--- a/landing/index.html
+++ b/landing/index.html
@@ -654,9 +654,26 @@
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Ask across every meeting with hybrid semantic search</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Entity dossiers, related meetings, weekly digests</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Action items can push to Apple Reminders</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Feed it PDFs, Office docs, web pages &amp; images — chunked into the same brain, on-device</li>
           </ul>
         </div>
         <div class="shot"><img src="./assets/graph.jpg" alt="People & Projects knowledge graph, extracted automatically" loading="lazy" /></div>
+      </div>
+
+      <!-- Feature: Receipts -->
+      <div class="feature flip reveal">
+        <div class="ftext">
+          <span class="eyebrow">Receipts</span>
+          <h3>Every claim traces back to the tape.</h3>
+          <p>Murmur's notes don't ask you to trust them. Each line that's grounded in what was actually said carries a receipt — click it to jump straight to that second of audio, with the speaker and confidence. Paraphrased or unsupported lines get none, so you can see at a glance what's verified.</p>
+          <ul class="flist">
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Click a claim, hear exactly where it came from</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Speaker + ASR-confidence on every receipt</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Sealed folders leak no timing or speaker, ever</li>
+          </ul>
+        </div>
+        <!-- TODO(screenshot): replace detail-note.jpg with a real receipts.jpg showing the receipt chips on a note's claims -->
+        <div class="shot"><img src="./assets/detail-note.jpg" alt="A generated note where each grounded line carries a receipt chip linking to the exact transcript segment" loading="lazy" /></div>
       </div>
 
       <!-- Feature 4 -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "0.9.18",
+  "version": "1.0.0",
   "scripts": {
     "start": "ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "0.9.18"
+version = "1.0.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -8640,10 +8640,15 @@
     fn analytics_excludes_sealed_not_unlocked_folder() {
         let db = mem_db();
         // Two OPEN meetings (folder_id NULL) + one meeting in a LOCKED, not-session-unlocked folder.
+        // Dates are RELATIVE to now (well inside the analytics 30-day per_day window) so this test is
+        // never calendar-flaky: a hardcoded absolute date ages OUT of the window as real time passes
+        // (the old `open-1` at 2026-06-20 dropped off the chart exactly 30 days later — this is that fix).
+        let day = |n: i64| (chrono::Utc::now() - chrono::Duration::days(n)).to_rfc3339();
+        let (open1_at, open2_at, secret_at) = (day(5), day(4), day(3));
         for (id, at, dur) in [
-            ("open-1", "2026-06-20T10:00:00Z", 600i64),
-            ("open-2", "2026-06-21T10:00:00Z", 900i64),
-            ("secret", "2026-06-22T10:00:00Z", 6000i64),
+            ("open-1", open1_at.as_str(), 600i64),
+            ("open-2", open2_at.as_str(), 900i64),
+            ("secret", secret_at.as_str(), 6000i64),
         ] {
             db.insert_meeting(&crate::storage::Meeting {
                 id: id.into(),
@@ -8704,7 +8709,7 @@
             "per-day activity chart must not include the sealed meeting's day"
         );
         assert!(
-            !a.per_day.iter().any(|d| d.date == "2026-06-22"),
+            !a.per_day.iter().any(|d| d.date == secret_at[..10]),
             "the sealed meeting's day must not appear in the 30-day activity chart at all"
         );
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "0.9.18",
+  "version": "1.0.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 0.9.18 → **1.0.0** — the 1.0 milestone.

package.json + src-tauri/tauri.conf.json + src-tauri/Cargo.toml + Cargo.lock (murmur pinned 1.0.0). identifier com.meetnotes.app unchanged.

Docs refresh (README + landing + repo description) lands as a separate PR after copy approval. Full ci.sh runs in CI.