### PR TITLE
docs: drop Obsidian framing (README + landing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ zero-knowledge, no plaintext ever touching a server.
 - 🎧 **It hears the whole call.** Your mic *and* the other side's system audio are captured and transcribed
   separately, then merged into a **Me / Others** transcript.
 - 🧩 **One store, three surfaces.** An encrypted SQLite DB is the single source of truth; the app, a
-  read-only **MCP server**, and your Obsidian vault are thin readers — never diverging copies.
-- 📁 **You own the output.** Notes are plain Markdown (and Obsidian-friendly) — no proprietary format, no lock-in.
+  read-only **MCP server**, and your exported Markdown files are thin readers — never diverging copies.
+- 📁 **You own the output.** Notes are plain Markdown — no proprietary format, no lock-in.
 - 🪟 **A Liquid Glass shell (macOS 26).** Floating glass rails that collapse into an Apple TV-style pill bar,
   a **⌘K** spotlight over your whole vault, **⌘N** for a new note, light/dark, and a transparency slider that
   honors macOS "Reduce transparency".
@@ -87,7 +87,7 @@ zero-knowledge, no plaintext ever touching a server.
 
 **Just want to use it?** → [**Download the latest signed & notarized build**](https://github.com/murmur-io/murmur/releases/latest),
 drag `Murmur.app` to Applications, and open it. A first-run wizard walks you through the Whisper model,
-an AI provider, and (optionally) an Obsidian vault.
+an AI provider, and (optionally) a Markdown vault folder to export into.
 
 <p align="center">
   <img src="docs/screenshots/onboarding.png" alt="First-run onboarding wizard" width="720">
@@ -249,10 +249,10 @@ across your whole history, and browse what it knows — all over the same store.
 
 ### 📁 Yours to keep
 
-A nice-to-have, not a lock-in: every note is also exported as plain **Obsidian Markdown** — atomic `.md`
-with YAML front-matter, `[[wikilinks]]`, `obsidian://` deep-links, and a `.canvas` board option. People and
-projects mirror into vault stub notes, so your Obsidian graph builds itself. Don't use Obsidian? The files
-are still just Markdown you own. (The encrypted SQLite DB — not the vault — is the source of truth.)
+A nice-to-have, not a lock-in: every note is also exported as plain **Markdown** — atomic `.md`
+with YAML front-matter, `[[wikilinks]]`, block-level deep-links, and a `.canvas` board option. People and
+projects mirror into vault stub notes, so your graph builds itself in your files too. They're just plain
+Markdown you own, openable in any editor. (The encrypted SQLite DB — not the vault — is the source of truth.)
 
 ---
 
@@ -332,7 +332,7 @@ persists everything to **one SQLCipher-encrypted SQLite database** — the canon
 **brain** (a grounded RAG + agentic reasoning layer powering the in-meeting assistant, Ask, and the Notes
 AI command menu — full model-driven agentic tool-choice with a provider connection incl. local Ollama, a
 grounded retrieval floor on a downloaded on-device model), plus three read surfaces: the app UI, a
-read-only **MCP server**, and your Obsidian vault. Opt in to a free account and a fourth path opens: a
+read-only **MCP server**, and your exported Markdown vault. Opt in to a free account and a fourth path opens: a
 zero-knowledge **sync relay** (`murmur-server`, a separate sibling repo) that lets Shared Brain content —
 and nothing else — flow, always as ciphertext, between your org's devices.
 
@@ -351,7 +351,7 @@ flowchart LR
   brain --> live["💬 In-meeting @brain threads"]
   brain --> ask["🔎 Ask across meetings + notes"]
   db --> mcp["🧩 MCP server · 127.0.0.1:8765"]
-  db --> vault["📁 Obsidian vault (.md · .canvas)"]
+  db --> vault["📁 Your Markdown vault (.md · .canvas)"]
   db -.opt-in, E2EE.-> relay["☁️ murmur-server<br/>ciphertext-only relay"]
   relay -.opt-in, E2EE.-> orgdb[("🗄️ Org members' local replicas")]
 ```

--- a/landing/index.html
+++ b/landing/index.html
@@ -611,7 +611,7 @@
       <div class="section-head reveal">
         <span class="eyebrow">What you get</span>
         <h2>A meeting tool that actually remembers.</h2>
-        <p>One encrypted store, three ways to use it — the app, a local MCP server, and your Obsidian vault.</p>
+        <p>One encrypted store, three ways to use it — the app, a local MCP server, and your exported Markdown files.</p>
       </div>
 
       <!-- Feature 1 -->
@@ -681,7 +681,7 @@
         <div class="ftext">
           <span class="eyebrow">Yours to keep</span>
           <h3>Plain Markdown. No lock-in.</h3>
-          <p>Every note is also exported as atomic Obsidian Markdown — YAML front-matter, <code>[[wikilinks]]</code>, deep-links, and a canvas board option. Don't use Obsidian? They're still just files you own.</p>
+          <p>Every note is also exported as atomic Markdown — YAML front-matter, <code>[[wikilinks]]</code>, block deep-links, and a canvas board option. They're just plain files you own, openable in any editor.</p>
           <ul class="flist">
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> An encrypted SQLite DB is the single source of truth</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> A read-only local MCP server for Claude Desktop / Code</li>
@@ -700,7 +700,7 @@
           <ul class="flist">
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Nineteen Brain actions, one keystroke away</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Grounded in your own meetings &amp; notes, not the model's guesses</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Same encrypted store, same Touch ID lock, same Obsidian export</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Same encrypted store, same Touch ID lock, same Markdown export</li>
           </ul>
         </div>
         <div class="shot"><img src="assets/notes-editor-brain-menu.png" alt="The standalone note editor with a text selection and the Brain command menu open, showing Refine, Shorten, Change tone and more actions" loading="lazy" /></div>
@@ -747,7 +747,7 @@
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Expiring, encrypted share links for a note or meeting</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Per-folder Touch ID lock &amp; AES-256 encryption</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Screen-share auto-relock</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Local MCP server + Obsidian export</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Local MCP server + Markdown export</li>
           </ul>
           <a class="btn btn-primary" href="https://github.com/murmur-io/murmur/releases/latest">Download for macOS</a>
         </div>


### PR DESCRIPTION
Murmur is a native local-first app, not an Obsidian layer. Reframe both public docs to stop naming Obsidian / positioning the export as an 'Obsidian vault', while keeping the real value intact: plain-Markdown export (YAML front-matter, [[wikilinks]], block deep-links, canvas board), no lock-in, files you own openable in any editor. Repo description already updated via gh. Landing auto-deploys on merge.