### PR TITLE
perf(detail): lazy-load transcript off the Note tab; move Ask into a slideout

### DIFF
--- a/e2e/detail/meeting-chat-source-scope.spec.ts
+++ b/e2e/detail/meeting-chat-source-scope.spec.ts
@@ -50,7 +50,9 @@ test("meeting chat pre-fills this meeting + its links and sends chat_meeting wit
 
   await page.goto("/meeting/m-atlas-roadmap");
 
-  // The meeting chat is on the default Note tab.
+  // "Ask about this meeting" now lives in a summoned right-side drawer (default-
+  // closed); open it via the header ✦ Ask button, then the chat is visible.
+  await page.getByRole("button", { name: /Ask/ }).click();
   const chat = page.locator("app-meeting-chat");
   await expect(chat).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/detail/receipts.spec.ts
+++ b/e2e/detail/receipts.spec.ts
@@ -54,35 +54,41 @@ test.describe("Detail — Receipts (claim → second of audio)", () => {
             "---\ntitle: Receipts meeting\nattendees: Anna, Bob\n---\n## Decisions\n\nWe will ship the redaction firewall next sprint.\nThe infra migration wrapped up late in the session.",
           exportedPath: null,
         },
-        segments: [
-          {
-            idx: 0,
-            startS: 0,
-            endS: 30,
-            text: "Intro chatter before the decision.",
-            speaker: "others",
-          },
-          {
-            idx: 1,
-            startS: 120,
-            endS: 150,
-            text: "We will ship the redaction firewall next sprint.",
-            speaker: "me",
-          },
-          {
-            idx: 2,
-            startS: 7527,
-            endS: 7560,
-            text: "The infra migration wrapped up late in the session.",
-            speaker: "others",
-          },
-        ],
+        // The detail DTO now ships EMPTY segments (perf: transcript off the Note tab); the
+        // transcript is fetched LAZILY via `get_meeting_segments` when the Audio tab opens.
+        segments: [],
         assistantInteractions: [],
         locked: false,
         aiProvider: null,
         aiModel: null,
         modelServed: null,
       }),
+      // Lazy transcript segments, arriving AFTER the receipt click switches to the Audio tab —
+      // this exercises the flash-resolves-on-segments-arrival path (the `_scrollFlashIntoView`
+      // effect keyed on renderedTurns), not just the seekTarget-arrival path.
+      get_meeting_segments: () => [
+        {
+          idx: 0,
+          startS: 0,
+          endS: 30,
+          text: "Intro chatter before the decision.",
+          speaker: "others",
+        },
+        {
+          idx: 1,
+          startS: 120,
+          endS: 150,
+          text: "We will ship the redaction firewall next sprint.",
+          speaker: "me",
+        },
+        {
+          idx: 2,
+          startS: 7527,
+          endS: 7560,
+          text: "The infra migration wrapped up late in the session.",
+          speaker: "others",
+        },
+      ],
       // The Audio tab's side reads, with their REAL backend shapes (serde gives
       // `[]`/`false`, never undefined — the base mock's undefined fallback made
       // the timeline's `suggestionByLabel` computed throw "not iterable" during

--- a/e2e/detail/transcript-cap.spec.ts
+++ b/e2e/detail/transcript-cap.spec.ts
@@ -17,10 +17,32 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
     page,
   }) => {
     await mockTauri(page, {
+      // The detail DTO now ships EMPTY segments (perf: transcript off the Note tab); the transcript
+      // is fetched LAZILY via `get_meeting_segments` when the Audio tab opens. No audio (audioPath
+      // null) keeps the test off the asset protocol; the transcript renders from the lazy segments.
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-atlas-roadmap",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T09:50:00Z",
+          title: "Long meeting",
+          durationS: 3000,
+          audioPath: null,
+          status: "EXPORTED",
+          folderId: null,
+        },
+        note: null,
+        segments: [],
+        assistantInteractions: [],
+        locked: false,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
       // A 100-turn meeting: alternating me/others so every segment is its own turn (turns fold
-      // only CONSECUTIVE same-speaker segments). No audio (audioPath null) keeps the test off the
-      // asset protocol; the transcript renders from segments regardless.
-      get_meeting_detail: () => {
+      // only CONSECUTIVE same-speaker segments). Built self-contained (overrides serialize page-
+      // side and can't close over test-scope variables).
+      get_meeting_segments: () => {
         const segments = [];
         for (let i = 0; i < 100; i++) {
           segments.push({
@@ -31,25 +53,7 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
             speaker: i % 2 === 0 ? "me" : "others",
           });
         }
-        return {
-          meeting: {
-            id: "m-atlas-roadmap",
-            startedAt: "2026-07-01T09:00:00Z",
-            endedAt: "2026-07-01T09:50:00Z",
-            title: "Long meeting",
-            durationS: 3000,
-            audioPath: null,
-            status: "EXPORTED",
-            folderId: null,
-          },
-          note: null,
-          segments,
-          assistantInteractions: [],
-          locked: false,
-          aiProvider: null,
-          aiModel: null,
-          modelServed: null,
-        };
+        return segments;
       },
     });
 
@@ -74,10 +78,30 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
     page,
   }) => {
     await mockTauri(page, {
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-atlas-roadmap",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T10:30:00Z",
+          title: "Long deep-seek meeting",
+          durationS: 5_000,
+          audioPath: null,
+          status: "EXPORTED",
+          folderId: null,
+        },
+        note: null,
+        segments: [],
+        assistantInteractions: [],
+        locked: false,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
       // 1,000 alternating turns approximate a long dual-stream meeting. A receipt deep-link seeks
-      // straight to the final turn before the Audio panel renders. The old prefix window then did
+      // straight to the final turn; the transcript is fetched lazily on Audio-tab open (the seek is
+      // deep-linked, which switches to the Audio tab). The old prefix window then did
       // `slice(0, activeIdx + 1)`, silently expanding the nominal cap to all 1,000 turns.
-      get_meeting_detail: () => {
+      get_meeting_segments: () => {
         const segments = [];
         for (let i = 0; i < 1_000; i++) {
           segments.push({
@@ -88,25 +112,7 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
             speaker: i % 2 === 0 ? "me" : "others",
           });
         }
-        return {
-          meeting: {
-            id: "m-atlas-roadmap",
-            startedAt: "2026-07-01T09:00:00Z",
-            endedAt: "2026-07-01T10:30:00Z",
-            title: "Long deep-seek meeting",
-            durationS: 5_000,
-            audioPath: null,
-            status: "EXPORTED",
-            folderId: null,
-          },
-          note: null,
-          segments,
-          assistantInteractions: [],
-          locked: false,
-          aiProvider: null,
-          aiModel: null,
-          modelServed: null,
-        };
+        return segments;
       },
     });
 
@@ -153,7 +159,26 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
       HTMLMediaElement.prototype.pause = () => undefined;
     });
     await mockTauri(page, {
-      get_meeting_detail: () => {
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-atlas-roadmap",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T10:30:00Z",
+          title: "Long overlapping meeting",
+          durationS: 6_000,
+          audioPath: "/tmp/overlap.wav",
+          status: "EXPORTED",
+          folderId: null,
+        },
+        note: null,
+        segments: [],
+        assistantInteractions: [],
+        locked: false,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
+      get_meeting_segments: () => {
         const segments = [];
         for (let i = 0; i < 1_200; i++) {
           segments.push({
@@ -164,25 +189,7 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
             speaker: i % 2 === 0 ? "me" : "others",
           });
         }
-        return {
-          meeting: {
-            id: "m-atlas-roadmap",
-            startedAt: "2026-07-01T09:00:00Z",
-            endedAt: "2026-07-01T10:30:00Z",
-            title: "Long overlapping meeting",
-            durationS: 6_000,
-            audioPath: "/tmp/overlap.wav",
-            status: "EXPORTED",
-            folderId: null,
-          },
-          note: null,
-          segments,
-          assistantInteractions: [],
-          locked: false,
-          aiProvider: null,
-          aiModel: null,
-          modelServed: null,
-        };
+        return segments;
       },
     });
 
@@ -222,10 +229,29 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
     page,
   }) => {
     await mockTauri(page, {
+      get_meeting_detail: () => ({
+        meeting: {
+          id: "m-atlas-roadmap",
+          startedAt: "2026-07-01T09:00:00Z",
+          endedAt: "2026-07-01T10:30:00Z",
+          title: "Long monologue",
+          durationS: 5_000,
+          audioPath: null,
+          status: "EXPORTED",
+          folderId: null,
+        },
+        note: null,
+        segments: [],
+        assistantInteractions: [],
+        locked: false,
+        aiProvider: null,
+        aiModel: null,
+        modelServed: null,
+      }),
       // A real single-speaker recording is the adversarial shape for turn-only windowing: all
       // consecutive segments fold into one turn, so a cap expressed only in turns still renders
       // every fragment and attaches every click handler.
-      get_meeting_detail: () => {
+      get_meeting_segments: () => {
         const segments = [];
         for (let i = 0; i < 1_000; i++) {
           segments.push({
@@ -236,25 +262,7 @@ test.describe("Detail — transcript render cap (P1 virtualization)", () => {
             speaker: "me",
           });
         }
-        return {
-          meeting: {
-            id: "m-atlas-roadmap",
-            startedAt: "2026-07-01T09:00:00Z",
-            endedAt: "2026-07-01T10:30:00Z",
-            title: "Long monologue",
-            durationS: 5_000,
-            audioPath: null,
-            status: "EXPORTED",
-            folderId: null,
-          },
-          note: null,
-          segments,
-          assistantInteractions: [],
-          locked: false,
-          aiProvider: null,
-          aiModel: null,
-          modelServed: null,
-        };
+        return segments;
       },
     });
 

--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -463,8 +463,15 @@ pub fn get_timeline(
     Ok(MeetingTimeline::default())
 }
 
-/// A meeting + its latest note + transcript segments for the Detail view.
+/// A meeting + its latest note for the Detail view.
 /// Returns `None` if the meeting id is unknown.
+///
+/// PERF (Note-tab payload): the DTO's `segments` field is now emitted EMPTY. The FE Note tab never
+/// renders the transcript — only the Audio tab does — yet packing the full `Vec<Segment>` here made
+/// `detail()` carry ~0.5 MB for a 1h meeting (>1 MB for 2h), re-parsed/re-spread on every mutation.
+/// The transcript is now fetched LAZILY by the Audio tab via [`get_meeting_segments`] (same read
+/// gate). The `segments: Vec::new()` shape is byte-identical to the masked/locked DTO
+/// (`super::masked_detail`) that every consumer already tolerates — no new DTO fork.
 #[tauri::command]
 pub fn get_meeting_detail(
     state: State<'_, AppState>,
@@ -504,7 +511,10 @@ pub fn get_meeting_detail(
         markdown: n.markdown,
         exported_path: n.exported_path,
     });
-    let segments = state.db.get_segments(&meeting_id)?;
+    // PERF: the transcript is NO LONGER packed into the detail DTO — the Note tab never renders it,
+    // and it dominated the payload. The Audio tab fetches it lazily via `get_meeting_segments` (same
+    // gate). Emit an empty Vec, keeping the field so the DTO shape is unchanged for every consumer.
+    let segments = Vec::new();
     // GATED read: only past the `meeting_is_unlocked` gate above do we surface the persisted
     // assistant Q&A. The DB read is ALSO `visibility_clause`-gated (it returns empty for a sealed-
     // not-unlocked meeting) — defense-in-depth, double-gated exactly like the rest of the DTO.
@@ -526,4 +536,32 @@ pub fn get_meeting_detail(
         ai_model,
         model_served,
     }))
+}
+
+/// LAZY transcript read for the Audio tab — the segments `get_meeting_detail` no longer ships in its
+/// DTO (see the perf note there). Split into a thin `#[tauri::command]` wrapper over an `_inner` that
+/// takes `&AppState` (the pervasive command-vs-`_inner` shape in this file — `set_focus_meeting`,
+/// `brain_overview`, `rename_speaker`, …) so the read gate is unit-testable without a Tauri `State`.
+#[tauri::command]
+pub fn get_meeting_segments(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<Segment>, AppError> {
+    get_meeting_segments_inner(state.inner(), &meeting_id)
+}
+
+/// Phase 0.5 READ-GATE (mirrors `get_meeting_detail` / `get_timeline`): a sealed-and-NOT-session-
+/// unlocked meeting returns an EMPTY Vec — never the raw rows. `db.get_segments` is a RAW,
+/// non-visibility-gated read (it returns the still-present segment rows with their text BLANKED at
+/// rest while sealed), so this gate is what keeps a locked meeting's transcript from leaking through
+/// the lazy path. Returning `[]` (not `Locked`) matches the `get_timeline` / `masked_detail`
+/// precedent — the Audio tab is unreachable while locked anyway.
+pub(crate) fn get_meeting_segments_inner(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<Vec<Segment>, AppError> {
+    if !meeting_is_unlocked(state, meeting_id)? {
+        return Ok(Vec::new());
+    }
+    state.db.get_segments(meeting_id)
 }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -4005,6 +4005,79 @@
         );
     }
 
+    /// PERF lazy-transcript READ-GATE (RED-before-GREEN): `get_meeting_segments` (the lazy Audio-tab
+    /// read that replaces the transcript `get_meeting_detail` used to ship) MUST return an EMPTY Vec
+    /// for a sealed-and-NOT-session-unlocked meeting, and the FULL transcript once the session
+    /// unlocks — byte-identical to `db.get_segments`.
+    ///
+    /// RED-if-gate-removed: `db.get_segments` is a RAW read. On seal the segment TEXT is blanked but
+    /// the ROWS remain (`raw_segments` still has 2), so the ungated call returns a NON-empty Vec of
+    /// 2 blanked-text rows. Removing the `meeting_is_unlocked` gate therefore makes the
+    /// `sealed.is_empty()` assertion FAIL — the gate is doing real work, not shadowing an already-
+    /// empty at-rest read. (Proven inline: we assert `raw_segments` == 2 while `get_meeting_segments`
+    /// == 0.)
+    #[test]
+    fn get_meeting_segments_gated() {
+        let state = build_state("get-meeting-segments-gated");
+        make_open_folder(&state.db, "f-lock", "Secret");
+        // `seed_meeting` seeds 2 plaintext segments ("alpha bravo" / "charlie delta").
+        seed_meeting(&state.db, "m1", "# note", Some("f-lock"));
+
+        // Baseline: the plaintext transcript BEFORE any seal, to compare byte-identically after unlock.
+        let plaintext = state.db.get_segments("m1").unwrap();
+        assert_eq!(plaintext.len(), 2, "precondition: 2 seeded segments");
+        assert_eq!(plaintext[0].text, "alpha bravo");
+
+        // LOCK → production seal: segment TEXT blanked at rest, rows kept (text_blob present).
+        lock_folder_inner(&state, "f-lock".to_string()).unwrap();
+        // NOT session-unlocked: `unlocked_folders` stays empty.
+
+        // The RED anchor: the RAW read still returns 2 rows (text blanked) — an UNGATED lazy read
+        // would leak exactly these, so the gate below must collapse them to [].
+        assert_eq!(
+            state.db.raw_segments("m1").unwrap().len(),
+            2,
+            "sealed rows are kept (text blanked) — proves the gate, not an empty at-rest read, returns []"
+        );
+
+        // GATE: sealed-not-unlocked → empty Vec. RED-if-`meeting_is_unlocked`-gate-removed.
+        let masked = get_meeting_segments_inner(&state, "m1").unwrap();
+        assert!(
+            masked.is_empty(),
+            "sealed-not-unlocked meeting must return NO segments through the lazy read (leak gate)"
+        );
+
+        // SESSION-UNLOCK (mirror unlock_folder's internals — same idiom as the manual-notes test):
+        // KEK → unwrap CK → unseal extras (restores segment text) → add folder to the session set.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-lock").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-lock")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-lock", &ck, None).unwrap();
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-lock".to_string());
+
+        // GREEN: past the gate the lazy read returns the FULL transcript, field-for-field identical
+        // to the raw `db.get_segments` — the lazy command reads through the SAME db call, so the two
+        // must agree on idx/times/text once unlocked. (`Segment` has no `PartialEq`, so compare the
+        // load-bearing fields explicitly rather than widen a shipped type's derive.)
+        let unlocked = get_meeting_segments_inner(&state, "m1").unwrap();
+        let direct = state.db.get_segments("m1").unwrap();
+        assert_eq!(unlocked.len(), 2, "the full transcript is surfaced once unlocked");
+        assert_eq!(unlocked.len(), direct.len(), "lazy read row count == db.get_segments");
+        for (a, b) in unlocked.iter().zip(direct.iter()) {
+            assert_eq!(a.idx, b.idx, "idx identical to db.get_segments");
+            assert_eq!(a.start_s, b.start_s, "start_s identical");
+            assert_eq!(a.end_s, b.end_s, "end_s identical");
+            assert_eq!(a.text, b.text, "text identical (restored plaintext)");
+        }
+        assert_eq!(unlocked[0].text, "alpha bravo", "segment 0 restored byte-identical");
+        assert_eq!(unlocked[1].text, "charlie delta", "segment 1 restored byte-identical");
+    }
+
     /// REMOVE-LOCK: permanently removing a folder's lock decrypts the typed notes back to plaintext
     /// and clears the blob — the typed notes are NEVER lost.
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -348,6 +348,7 @@ pub fn run() {
             commands::list_calendar_events,
             commands::calendar_context_for,
             commands::get_meeting_detail,
+            commands::get_meeting_segments,
             commands::get_analytics,
             commands::get_timeline,
             commands::generate_timeline,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -56,6 +56,7 @@ import type {
   Meeting,
   MeetingDetail,
   MeetingTimeline,
+  Segment,
   SpeakerSuggestion,
   VoiceprintInfo,
   ModelDownloadProgress,
@@ -1748,6 +1749,18 @@ export class IpcService {
    */
   getTimeline(meetingId: string): Promise<MeetingTimeline> {
     return invoke<MeetingTimeline>("get_timeline", { meetingId });
+  }
+
+  /**
+   * The meeting's transcript segments, fetched LAZILY only when the Audio tab
+   * opens (`get_meeting_detail` now returns an EMPTY `segments` so a plain
+   * Note-tab open never ships the whole transcript). GATED server-side exactly
+   * like every content read: a sealed-and-not-session-unlocked meeting returns
+   * `[]`, never leaking transcript text behind the lock. Mirrors
+   * {@link getTimeline}'s `{ meetingId }` invoke-arg convention.
+   */
+  getMeetingSegments(meetingId: string): Promise<Segment[]> {
+    return invoke<Segment[]>("get_meeting_segments", { meetingId });
   }
 
   /**

--- a/src/app/features/detail/audio-panel/audio-panel.component.ts
+++ b/src/app/features/detail/audio-panel/audio-panel.component.ts
@@ -368,15 +368,25 @@ export class AudioPanelComponent {
   /**
    * Apply a pending note-receipt seek (Brain v3 PR-5): when the shell sets
    * `seekTarget` (and switches to this tab), seek the player to the claim's
-   * second of audio and PULSE the matching transcript segment so the eye lands
-   * on the exact line that proves the claim. Tracks `seq` (bumped by the shell)
-   * so re-clicking the SAME receipt re-arms; `flashSeq` re-arms the pure-CSS
-   * animation when the SAME segment is receipted twice (a net-zero `flashSegId`
-   * write wouldn't restart it). Consumption is ONE-SHOT: after applying, the
-   * effect acks via `seekConsumed` so the shell nulls the input — a later
-   * Audio-tab revisit (a fresh panel instance) must not replay the seek/flash.
-   * Legitimate signal-writing effect (T1): it reacts to an input and drives the
-   * player — no async fetch, no stale race.
+   * second of audio and ARM a PULSE over the matching transcript segment so the
+   * eye lands on the exact line that proves the claim. Tracks `seq` (bumped by
+   * the shell) so re-clicking the SAME receipt re-arms; `flashSeq` re-arms the
+   * pure-CSS animation when the SAME segment is receipted twice (a net-zero
+   * `flashSegId` write wouldn't restart it). Consumption is ONE-SHOT: after
+   * applying, the effect acks via `seekConsumed` so the shell nulls the input —
+   * a later Audio-tab revisit (a fresh panel instance) must not replay the
+   * seek/flash. Legitimate signal-writing effect (T1): it reacts to an input and
+   * drives the player — no async fetch, no stale race.
+   *
+   * This ONLY sets the panel-local flash STATE (`flashSegId`/`flashSeq`) + seeks
+   * — the DOM work (scroll-into-view + deterministic pulse restart) lives in the
+   * separate `_scrollFlashIntoView` effect below, because the transcript
+   * `segments` are now fetched LAZILY (off the Note tab): when a receipt is
+   * clicked from the Note tab, `seekTarget` arrives BEFORE the segments do, so
+   * the flashed `.frag` does not exist yet at this moment. Doing the DOM lookup
+   * here (a one-shot `afterNextRender`) would fire against the still-empty
+   * transcript and never scroll/restart. Splitting it lets the DOM step run when
+   * the fragment actually renders (on segments-arrival).
    */
   private readonly _applyReceiptSeek = effect(() => {
     const target = this.seekTarget();
@@ -391,10 +401,35 @@ export class AudioPanelComponent {
     // Ack consumption (the shell nulls `seekTarget`; the flash/karaoke state
     // above is panel-local and survives — only the REPLAY trigger is retired).
     this.seekConsumed.emit(target.seq);
-    // Restart the pure-CSS pulse deterministically (a repeat of the SAME segment
-    // keeps the `.is-flash` class, so the animation wouldn't retrigger on its own)
-    // and bring the flashed fragment into view. One-shot, zoneless-safe: no timer.
+  });
+
+  /**
+   * Bring the flashed receipt fragment into view + restart its pulse — keyed on
+   * both `flashKey()` (a fresh receipt) AND `renderedTurns()` (the transcript
+   * DOM). With LAZY segments the transcript can render AFTER the flash is armed
+   * (a receipt clicked from the Note tab arrives before its segments), so this
+   * re-runs when the segments finally land and the flashed `.frag` exists —
+   * fixing the "seek/flash must resolve when segments ARRIVE, not only when
+   * seekTarget arrives" case. A no-op while nothing is flashed or the fragment
+   * isn't in the rendered window yet; the `renderedTurns` window itself prefers
+   * the flashed segment (see `flashIdx`) so it enters the bounded view. One-shot
+   * `afterNextRender` per run, zoneless-safe (no timer).
+   */
+  /** The `flashKey` this panel has already scrolled+restarted for (once-per-key guard). */
+  private lastScrolledFlashKey = "";
+  private readonly _scrollFlashIntoView = effect(() => {
+    const flashSeg = this.flashSegId();
     const key = this.flashKey();
+    // Depend on the rendered transcript so a lazy segments-arrival re-runs this.
+    const turns = this.renderedTurns();
+    // Once-per-flash: a receipt is a distinct `flashKey` (flashSeq bumps per
+    // click). Only act while a fresh flash is armed AND we haven't already
+    // resolved it — so ordinary `renderedTurns()` churn during playback (a
+    // moving playhead) never re-scrolls a lingering flash, but a lazy
+    // segments-arrival for a not-yet-resolved key still does.
+    if (flashSeg === null || turns.length === 0 || key === this.lastScrolledFlashKey) {
+      return;
+    }
     afterNextRender(
       () => {
         const box = this.scroller()?.nativeElement;
@@ -402,8 +437,11 @@ export class AudioPanelComponent {
           `.frag[data-flash="${CSS.escape(key)}"]`,
         );
         if (!frag) {
-          return;
+          return; // not rendered yet — a later renderedTurns() change re-runs us
         }
+        // Mark this key resolved only once the fragment truly exists, so we keep
+        // retrying across renders until the lazy segments land.
+        this.lastScrolledFlashKey = key;
         // Force the browser to drop the running animation, then re-apply it on
         // the next frame — the canonical restart with no `@angular/animations`.
         frag.style.animation = "none";

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -143,6 +143,44 @@
           }
         }
       </div>
+
+      <!-- Ask about this meeting — summons the right-side chat drawer (below).
+           Hidden while locked (nothing to ask a masked meeting). Inline SVG spark
+           glyph (no icon lib, per convention); mirrors note-editor's Ask Brain. -->
+      @if (!locked()) {
+        <div class="head-actions">
+          <button
+            type="button"
+            class="btn btn-ghost head-chat-btn"
+            [class.is-active]="askDrawerOpen()"
+            [attr.aria-expanded]="askDrawerOpen()"
+            (click)="toggleAskDrawer()"
+          >
+            <svg
+              class="head-chat-glyph"
+              viewBox="0 0 16 16"
+              width="13"
+              height="13"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M8 1.5l1.3 3.2L12.5 6 9.3 7.3 8 10.5 6.7 7.3 3.5 6l3.2-1.3L8 1.5Z"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M12.5 10.5l.6 1.4 1.4.6-1.4.6-.6 1.4-.6-1.4-1.4-.6 1.4-.6.6-1.4Z"
+                stroke="currentColor"
+                stroke-width="1.1"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Ask
+          </button>
+        </div>
+      }
     </header>
 
     <!-- ============================================================= -->
@@ -318,7 +356,7 @@
           <app-audio-panel
             #audioPanel
             [audioSrc]="audioSrc()"
-            [segments]="d.segments"
+            [segments]="segments()"
             [seekTarget]="seekTarget()"
             [timeline]="timeline()"
             [timelineTotal]="timelineTotal()"
@@ -350,6 +388,24 @@
             (changed)="onShareChanged()"
           />
         }
+      }
+
+      <!-- Ask about this meeting — a FLOATING, OPAQUE right-docked drawer (T3:
+           var(--surface-overlay) + backdrop-filter:none, NOT the frosted .card).
+           Hosted here (not per-tab) so the conversation survives tab switches;
+           the `askDrawerOpen() && !locked()` reactive guard tears it down the
+           moment the meeting locks while open. `d.meeting` is the current
+           (unlocked) meeting — safe to pass its title/id. -->
+      @if (askDrawerOpen() && !locked()) {
+        <aside class="ask-drawer" aria-label="Ask about this meeting">
+          <app-meeting-chat
+            [bare]="true"
+            [showClose]="true"
+            [meetingId]="d.meeting.id"
+            [anchorTitle]="d.meeting.title"
+            (closed)="closeAskDrawer()"
+          />
+        </aside>
       }
     }
   } @else if (loading()) {

--- a/src/app/features/detail/detail/detail.component.scss
+++ b/src/app/features/detail/detail/detail.component.scss
@@ -47,6 +47,83 @@
 .head h2 {
   margin: 0;
 }
+/* Header actions cluster (the ✦ Ask summon button), right-aligned by the
+   .head's space-between; never shrinks below its content. */
+.head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+/* Ask summon toggle (ported from note-editor's Ask Brain): the glyph adopts the
+   accent, and the active (drawer-open) state reads as a pressed neutral pill
+   with the accent glyph/label. */
+.head-chat-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 32px;
+  padding: 0 var(--space-3);
+  font-size: 0.85rem;
+}
+.head-chat-glyph {
+  color: var(--accent);
+}
+.head-chat-btn.is-active {
+  background: var(--surface-hover);
+  color: var(--accent-hover);
+}
+.head-chat-btn.is-active .head-chat-glyph {
+  color: var(--accent-hover);
+}
+
+/* ===== Ask drawer (right-docked slideout) =====
+   A FLOATING, OPAQUE right-docked panel (trap T3): the .detail is a normal
+   document-flow scrolling column (not a height-bounded flex viewport like the
+   note editor), so an in-flow side column would force restructuring every tab —
+   this floats instead. OPAQUE (var(--surface-overlay) + backdrop-filter:none),
+   NOT the frosted .card / the Notes in-flow --surface-raised tone, or the tab
+   content bleeds through. Sits at the org-share-sheet overlay tier. `display:flex`
+   so the bare chat fills the full height (its own log scrolls, composer pinned). */
+.ask-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  width: clamp(320px, 30vw, 420px);
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-overlay);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  border-left: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-lg);
+  animation: ask-drawer-in var(--transition);
+}
+/* The bare chat fills the whole drawer as ONE flat surface (its log owns the
+   scroll, so the composer pins to the bottom with no empty strip below). */
+.ask-drawer app-meeting-chat {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+@keyframes ask-drawer-in {
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ask-drawer {
+    animation: none;
+  }
+}
 .meta {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -30,6 +30,7 @@ import type {
   MeetingDetail,
   MeetingOrgShareInfo,
   MeetingTimeline,
+  Segment,
   SpeakerSuggestion,
 } from "../../../core/models";
 import {
@@ -39,6 +40,7 @@ import {
 import { ToastService } from "../../../services/toast.service";
 import { LockBadgeComponent } from "../../folders/lock-badge/lock-badge.component";
 import { AudioPanelComponent } from "../audio-panel/audio-panel.component";
+import { MeetingChatComponent } from "../meeting-chat/meeting-chat.component";
 import {
   DetailTabsComponent,
   type DetailTab,
@@ -69,6 +71,7 @@ interface ActionItem {
     DetailTabsComponent,
     NotePanelComponent,
     AudioPanelComponent,
+    MeetingChatComponent,
     SharePanelComponent,
     VerifyPanelComponent,
   ],
@@ -140,6 +143,16 @@ export class DetailComponent implements OnInit {
     panel?.pausePlayback();
     panel?.collapseTranscript();
   }
+
+  // --- Ask-about-this-meeting slideout drawer -----------------------------
+  /**
+   * True while the right-side "Ask about this meeting" drawer is open. Hosted in
+   * this shell (not `note-panel`) so the conversation survives Note/Audio/Share
+   * tab switches AND the chat's `_prefill` runs once per meeting (not on every
+   * Note-tab open). Default-closed, NOT persisted (a fresh ask each open).
+   */
+  private readonly _askDrawerOpen = signal(false);
+  readonly askDrawerOpen = this._askDrawerOpen.asReadonly();
 
   // --- Move-to-folder popover ---------------------------------------------
   /** True while the folder-picker popover is open. */
@@ -467,6 +480,25 @@ export class DetailComponent implements OnInit {
     return { model: model ?? "", provider: provider ?? "" };
   });
 
+  // --- Lazy transcript segments (perf: off the Note tab) ------------------
+  /**
+   * The meeting's transcript segments — fetched LAZILY only when the Audio tab
+   * first opens (mirrors the lazy-timeline latch below). `get_meeting_detail`
+   * now returns an EMPTY `segments`, so a plain Note-tab open never ships the
+   * whole transcript; the Audio panel reads this signal instead of `d.segments`.
+   */
+  readonly segments = signal<Segment[]>([]);
+  /** True while the (gated) `get_meeting_segments` read is in flight. */
+  readonly segmentsLoading = signal(false);
+  /**
+   * One-shot latch (mirror of `_timelineAttempted`): the meeting id whose
+   * Audio-tab segments read has already been attempted this open, so the
+   * `_segmentsOnAudioTab` effect can never re-enter for the same meeting even
+   * when the backend returns an empty list (a legitimately transcript-less
+   * meeting). Cleared per meeting in `loadMeeting` and on `maskLocally`.
+   */
+  private readonly _segmentsAttempted = signal<string | null>(null);
+
   // --- Interactive timeline (speaker + topic viz) -------------------------
   readonly timeline = signal<MeetingTimeline | null>(null);
   readonly timelineLoading = signal(false);
@@ -516,6 +548,72 @@ export class DetailComponent implements OnInit {
       void this.loadTimeline();
     }
   });
+
+  /**
+   * PERF (transcript off the Note tab): fetch the transcript segments LAZILY —
+   * only when the Audio tab (the only surface that renders them) is first opened
+   * for an unlocked meeting and they aren't already in flight. Same guard shape
+   * as `_timelineOnAudioTab`; the `_segmentsAttempted` latch makes it fire at
+   * most once per meeting-open (an empty backend result sets no other terminal
+   * signal, so without the latch it would loop). Legitimate signal-writing
+   * effect (T1): async IPC keyed on inputs with a stale-result guard in
+   * `loadSegments`. A locked() meeting never fetches (the gate returns []).
+   */
+  private readonly _segmentsOnAudioTab = effect(() => {
+    const d = this.detail();
+    const id = d?.meeting.id ?? null;
+    if (
+      this.activeTab() === "audio" &&
+      d &&
+      id &&
+      !this.locked() &&
+      !this.segmentsLoading() &&
+      // ONE-SHOT LATCH: never re-attempt the read for a meeting id already tried
+      // this open — an empty (transcript-less) result must NOT re-loop.
+      this._segmentsAttempted() !== id
+    ) {
+      void this.loadSegments();
+    }
+  });
+
+  /**
+   * Read the (gated) transcript segments for the current meeting. Sets the
+   * one-shot latch FIRST so the Audio-tab effect can't re-enter, guards against
+   * a concurrent in-flight read, and drops a stale result if the user navigated
+   * to another meeting mid-flight (mirrors `loadTimeline`). A gated/locked read
+   * resolves to `[]`. Never throws to the caller — a failure just leaves the
+   * transcript empty.
+   */
+  async loadSegments(): Promise<void> {
+    const id = this.detail()?.meeting.id;
+    if (!id || this.segmentsLoading()) {
+      return;
+    }
+    // Latch first (mirror of loadTimeline) so the effect never re-fires for this
+    // meeting even if the read resolves to an empty list.
+    this._segmentsAttempted.set(id);
+    this.segmentsLoading.set(true);
+    try {
+      const rows = await this.ipc.getMeetingSegments(id);
+      // STALE-RESULT + LOCK guard: drop this if the user switched meetings
+      // mid-flight (never paint meeting A's transcript into meeting B), OR if the
+      // meeting locked while the read was in flight — a late real-row reply must
+      // never (even transiently) repopulate `segments()` after `maskLocally`
+      // blanked it. It couldn't render (the `@if (locked())` teardown unmounts
+      // the audio panel) and a later unlock re-fetches, but this keeps the signal
+      // from ever holding sealed rows post-lock (lock-model belt-and-braces).
+      if (this.detail()?.meeting.id !== id || this.locked()) {
+        return;
+      }
+      this.segments.set(Array.isArray(rows) ? rows : []);
+    } catch {
+      if (this.detail()?.meeting.id === id) {
+        this.segments.set([]);
+      }
+    } finally {
+      this.segmentsLoading.set(false);
+    }
+  }
 
   /**
    * LOCK-REACTIVE re-mask (required by the tabs plan §6 — a real leak surface
@@ -613,13 +711,22 @@ export class DetailComponent implements OnInit {
       locked: true,
     });
     // Plaintext-bearing side signals the lock gate doesn't unmount fast enough
-    // to excuse: timeline topics/speakers, tags, graph entities, editor draft.
+    // to excuse: transcript segments, timeline topics/speakers, tags, graph
+    // entities, editor draft. The audio binding now reads `segments()`, so a
+    // lock transition MUST drop any fetched transcript (and reset the latch so a
+    // later unlock re-fetches on the next Audio-tab open).
+    this.segments.set([]);
+    this._segmentsAttempted.set(null);
     this.timeline.set(null);
     this.speakerSuggestions.set([]);
     this.tags.set([]);
     this.graph.set(null);
     this.editing.set(false);
     this.draft.set("");
+    // Close the Ask drawer on a lock transition so it doesn't reappear on a
+    // later unlock (the `@if (askDrawerOpen() && !locked())` guard already hides
+    // it while locked; this makes a re-summon deliberate, matching default-closed).
+    this._askDrawerOpen.set(false);
     // Receipts leak WHEN/BY-WHOM: blank them (and any pending seek) synchronously
     // on the mask, matching the note/segments/audio the masked DTO already nulls.
     this.receipts.set([]);
@@ -716,7 +823,7 @@ export class DetailComponent implements OnInit {
     for (const t of tl?.topics ?? []) {
       max = Math.max(max, t.endS);
     }
-    for (const seg of this.detail()?.segments ?? []) {
+    for (const seg of this.segments()) {
       max = Math.max(max, seg.endS);
     }
     return max;
@@ -807,6 +914,10 @@ export class DetailComponent implements OnInit {
     this.timelineNeedsGeneration.set(false);
     // Reset the Audio-tab one-shot latch so the next meeting-open may attempt its timeline read once.
     this._timelineAttempted.set(null);
+    // Same for the lazy transcript segments (drop the previous meeting's rows +
+    // reset its latch so the next Audio-tab open re-fetches for this meeting).
+    this.segments.set([]);
+    this._segmentsAttempted.set(null);
     this.speakerSuggestions.set([]);
     this.tags.set([]);
     this.graph.set(null);
@@ -885,6 +996,35 @@ export class DetailComponent implements OnInit {
         this.tags.set([]);
       }
     }
+  }
+
+  // --- Ask drawer ----------------------------------------------------------
+
+  /**
+   * Toggle the "Ask about this meeting" slideout drawer. On OPEN, focus the
+   * chat composer once it has rendered (zoneless-safe `afterNextRender` with the
+   * injected `injector` — this handler runs outside the field-init context, so
+   * the injector must be passed; no setTimeout). A no-op focus if the textarea
+   * isn't found (e.g. reduced to nothing) — never throws.
+   */
+  toggleAskDrawer(): void {
+    const willOpen = !this._askDrawerOpen();
+    this._askDrawerOpen.set(willOpen);
+    if (willOpen) {
+      afterNextRender(
+        () => {
+          document
+            .querySelector<HTMLTextAreaElement>(".ask-drawer .chat-input")
+            ?.focus();
+        },
+        { injector: this.injector },
+      );
+    }
+  }
+
+  /** Close the Ask drawer (the chat's × / the reactive lock guard). */
+  closeAskDrawer(): void {
+    this._askDrawerOpen.set(false);
   }
 
   // --- Move to folder ------------------------------------------------------

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.html
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.html
@@ -1,21 +1,38 @@
-<div class="chat card">
+<div class="chat" [class.card]="!bare()" [class.is-bare]="bare()">
   <div class="chat-head">
     <div class="chat-head-text">
       <h3 class="chat-title">Ask about this meeting</h3>
-      <span class="chat-sub"
-        >Answers use this transcript and selected sources</span
-      >
+      <!-- The sub-line reads as a second header row; in BARE (drawer) mode it would break the
+           single-row header band's alignment with the meeting header, and the empty state already
+           says the same thing — so it's shown only in the standalone card. -->
+      @if (!bare()) {
+        <span class="chat-sub"
+          >Answers use this transcript and selected sources</span
+        >
+      }
     </div>
-    @if (conversation().length) {
-      <button
-        type="button"
-        class="btn btn-ghost chat-clear"
-        (click)="clear()"
-        [disabled]="pending()"
-      >
-        Clear
-      </button>
-    }
+    <div class="chat-head-actions">
+      @if (conversation().length) {
+        <button
+          type="button"
+          class="btn btn-ghost chat-clear"
+          (click)="clear()"
+          [disabled]="pending()"
+        >
+          Clear
+        </button>
+      }
+      @if (showClose()) {
+        <button
+          type="button"
+          class="chat-close"
+          aria-label="Close Ask"
+          (click)="closed.emit()"
+        >
+          ×
+        </button>
+      }
+    </div>
   </div>
 
   <!-- Message list (also the scroll region) -->

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.scss
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.scss
@@ -28,6 +28,52 @@
   z-index: 1;
 }
 
+/* BARE mode (the Ask drawer host): NO card frame (the drawer IS the surface) and FILL the host
+   height. The chat becomes a full-height PANE — a header BAND, the scrolling log, then the pinned
+   sources + composer. The container drops its OWN padding + gap so each section spans the full pane
+   width, and the log grows to eat the slack so the composer stays pinned to the bottom. */
+.chat.is-bare {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0;
+  gap: 0;
+}
+.chat.is-bare::before {
+  display: none;
+}
+/* Header band — a single control row (title + close), padded like the note-chat drawer's. */
+.chat.is-bare .chat-head {
+  flex: none;
+  box-sizing: border-box;
+  padding: var(--space-4) var(--space-5) var(--space-3);
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+.chat.is-bare .chat-title {
+  font-size: 1.05rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+.chat.is-bare .chat-log {
+  flex: 1 1 auto;
+  /* Bare (drawer) mode fills its host — drop the standalone card's 440px log cap. */
+  max-height: none;
+  padding: var(--space-4) var(--space-5) var(--space-2);
+}
+.chat.is-bare .chat-sources {
+  padding: 0 var(--space-5);
+  margin-bottom: 0;
+}
+.chat.is-bare .chat-composer {
+  padding: var(--space-3) var(--space-5) var(--space-4);
+}
+.chat.is-bare .chat-empty {
+  flex: 1 1 auto;
+  /* Fill + CENTER the empty state in the middle band (between the heading and the composer), so
+     there's no dead gap above it — the composer stays pinned to the bottom. */
+  justify-content: center;
+}
+
 /* --- Head --- */
 .chat-head {
   display: flex;
@@ -53,6 +99,36 @@
   height: 32px;
   padding: 0 var(--space-3);
   font-size: 0.8125rem;
+}
+.chat-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: none;
+}
+/* Close ✕ — lives IN the header band (the pane owns its own header + close), right-aligned. */
+.chat-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.chat-close:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.chat-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
 /* --- Message log (scroll region) --- */

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.ts
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.ts
@@ -8,6 +8,7 @@ import {
   effect,
   inject,
   input,
+  output,
   signal,
   viewChild,
 } from "@angular/core";
@@ -58,6 +59,26 @@ export class MeetingChatComponent {
    * `kind + id`.
    */
   readonly anchorTitle = input<string | null>(null);
+
+  /**
+   * BARE mode (docked in the detail view's right-side Ask drawer): drop the
+   * frosted `.card` frame + aurora glow and FILL the host height, so the drawer
+   * is ONE coherent surface (no card-in-panel double border) with the composer
+   * pinned to the bottom. Defaults false ⇒ the standalone card look (no other
+   * caller exists, so the default keeps existing behavior byte-identical).
+   */
+  readonly bare = input(false);
+
+  /**
+   * Show a close (×) affordance in the header band — set by the drawer host so
+   * the chat OWNS its own header (title + close) as a single aligned pane header
+   * rather than a floating corner button. Pressing it emits {@link closed}; the
+   * host toggles the drawer shut.
+   */
+  readonly showClose = input(false);
+  /** Emitted when the header × is pressed. The drawer host closes itself. (Not `close` — that
+   *  collides with the native DOM event name and trips `@angular-eslint/no-output-native`.) */
+  readonly closed = output<void>();
 
   /**
    * Source-scoped Brain — the `<mur-source-picker>` selection (this meeting +

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -413,13 +413,10 @@
   <!-- ACTION ITEMS (Reminders + Obsidian Tasks; hidden when none). -->
   <app-meeting-actions [meetingId]="meetingId()" />
 
-  <!-- CHAT WITH THIS MEETING (grounded Q&A over the transcript). -->
-  <section class="block">
-    <app-meeting-chat
-      [meetingId]="meetingId()"
-      [anchorTitle]="meetingTitle()"
-    />
-  </section>
+  <!-- "Ask about this meeting" moved OUT of this in-flow Note panel into the
+       detail shell's summoned right-side drawer (2026-07 slideout), so the
+       conversation survives tab switches and `_prefill` runs once per meeting
+       rather than on every Note-tab open. -->
 
   <!-- RELATED BY MEANING (semantic neighbors; silent when empty). -->
   <!-- PERF/OOM (P1): defer until it scrolls into view. Its `_load` effect fires the on-device e5

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -17,7 +17,6 @@ import { AssistantSourcesComponent } from "../../../shared/assistant-sources/ass
 import { ConnectionsComponent } from "../../../shared/connections/connections.component";
 import { MoveToMenuComponent } from "../../folders/move-to-menu/move-to-menu.component";
 import { MeetingActionsComponent } from "../meeting-actions/meeting-actions.component";
-import { MeetingChatComponent } from "../meeting-chat/meeting-chat.component";
 import { RelatedMeetingsComponent } from "../related-meetings/related-meetings.component";
 import { Stage2PanelComponent } from "../stage2-panel/stage2-panel.component";
 
@@ -123,7 +122,6 @@ export interface AssistantQa {
     ConnectionsComponent,
     MoveToMenuComponent,
     MeetingActionsComponent,
-    MeetingChatComponent,
     RelatedMeetingsComponent,
     Stage2PanelComponent,
   ],


### PR DESCRIPTION
## Why
The meeting-detail **Note tab** lagged on long (>1h) recordings — worse when opening/typing in the Ask-Brain chat. A grounded diagnosis (static audit + Playwright measurement + adversarial verify) found **two distinct causes**:

- **Payload/GC (scales with length, MEASURED):** `get_meeting_detail` shipped the **entire transcript** (`segments: Vec<Segment>`) in its DTO — measured **635 B (empty) → ~520 KB (1h)** — even though the Note tab renders segments **zero** times (only the Audio tab binds them). That rode in the `detail()` signal and was re-parsed/re-spread on every mutation (tag/save/rename/move/resummarize/lock).
- **UX:** the "Ask about this meeting" chat was pinned inline at the bottom of the note flow, unlike the Notes side which has a slideout.

## What
1. **Lazy transcript.** `get_meeting_detail` now emits an **empty** `segments`; a new gated `get_meeting_segments` command returns the transcript, fetched **lazily only when the Audio tab opens** (mirrors the existing lazy-timeline latch: one-shot `_segmentsAttempted` + stale-result + lock guard). The read gate is **byte-identical** to `get_meeting_detail`/`get_timeline` (returns `[]` for a sealed-not-session-unlocked meeting). `db.get_segments` is a raw read, so the command gate is load-bearing; `maskLocally` blanks the new signal on a lock transition.
2. **Ask slideout.** "Ask about this meeting" moved into a **summoned, floating, opaque right-side drawer** (T3: `--surface-overlay` + `backdrop-filter: none`) hosted in the detail shell — so the conversation survives tab switches and `_prefill` fires once per meeting, not on every Note-tab open. `meeting-chat` gained `bare`/`showClose`/`closed`, mirroring the Notes-side `note-chat` drawer contract. Inline slot removed from `note-panel`.

## How verified
- **Gates:** `cargo test --lib get_meeting_segments`, `cargo clippy --lib -D warnings`, `ng lint`, `ng build` — all green. (Full `ci.sh` runs here in Actions.)
- **RED-before-GREEN:** temporarily removing the `meeting_is_unlocked` gate makes the lock test fail on the exact 2 blanked-but-present sealed rows; restored byte-identical → green. The gate does real work.
- **Adversarial pass (PASS):** 7/7 detail e2e + 4 self-authored specs — a deep seek to **turn #999** in a lazy 1000-turn transcript resolves (flash scrolls into view on segments-arrival), the drawer is opaque + tears down when the meeting locks, lazy fetch fires **0× on Note tab / 1× on Audio open** with no loop, no NG0600.
- **Lock-security review (PASS):** every content read gated; no consumer of the DTO segments broke (MCP/pipeline/export/brain read `db.get_segments` directly); no verify-before-destroy concern (pure read path); `convertFileSrc`/asset trap untouched.

## Honesty bar
The blur-paint hypothesis for the mouse-move symptom (WebKit `backdrop-filter` cost) was **deliberately not addressed here** — it changes the Liquid Glass look and can only be confirmed on a signed WKWebView build. Touch-ID unlock re-fetch and real screen-share auto-relock of the open drawer need a real Mac; the reactive `!locked()` teardown was proven on a simulated lock flip.