### PR TITLE
perf(brain): clamp meetnotes-brain sidecar to a single scheduler sequence (KV footprint)

### DIFF
--- a/crates/murmur-brain/src/main.rs
+++ b/crates/murmur-brain/src/main.rs
@@ -253,7 +253,16 @@ fn load_model(
     // after the first few generations, so the 2nd+ call samples from NaN/Inf logits ("za drugim
     // razem"). A RESIDENT child answering MANY requests is PRECISELY that multi-generation scenario,
     // so this line is even more load-bearing here than in-process: every request gets a FRESH KV cache.
-    .with_prefix_cache_n(None);
+    .with_prefix_cache_n(None)
+    // KV FOOTPRINT — clamp the scheduler to a SINGLE concurrent sequence. `GgufModelBuilder` defaults
+    // `max_num_seqs` to 32 (mistralrs 0.8.1 `gguf.rs`), which sizes the scheduler — and the reserved
+    // KV headroom — for 32 sequences this sidecar NEVER runs: generation is strictly one-request-at-a-
+    // time (`generate_blocking` below; the app dispatches single-flight over NDJSON). Pinning it to 1
+    // matches actual usage and removes the 32-slot concurrency reservation. Correct + harmless for BOTH
+    // the light and heavy children (neither serves concurrent requests); it never constrains a lone
+    // request's own prefill/decode. The exact resident-GB win is a Metal/KV-allocator property — MEASURE
+    // it with `footprint` on a signed Mac (`scripts/measure-recording-ram.sh` shows the sidecar plateau).
+    .with_max_num_seqs(1);
 
     // `build()` is async → drive it to completion on a scoped thread so it never trips the
     // nested-runtime panic. It returns `anyhow::Result<Model>`.


### PR DESCRIPTION
## What

One line in `crates/murmur-brain/src/main.rs::load_model`: add `.with_max_num_seqs(1)` to the `GgufModelBuilder` chain.

## Why

The sidecar sat at **3.59 GB** resident during a recording. `GgufModelBuilder` defaults `max_num_seqs` to **32** (mistralrs 0.8.1 `gguf.rs:60`), which sizes the scheduler and its reserved KV headroom for 32 concurrent sequences — but this sidecar generates **strictly one request at a time** over the NDJSON wire (`generate_blocking`; the app dispatches single-flight). Pinning it to 1 matches actual usage and drops the 32-slot concurrency reservation.

- Safe for **both** the light and heavy children — neither serves concurrent requests.
- Never constrains a lone request's own prefill/decode.
- `with_prefix_cache_n(None)` (the NaN trap) is left untouched.

## Verification

- `cargo check -p murmur-brain` clean (API confirmed on mistralrs 0.8.1); MSRV grep clean.
- **Runtime GB win is a Metal KV-allocator property that can only be measured on a signed Mac** — do not merge on faith. Confirm with `footprint -p $(pgrep -x meetnotes-brain)` before/after, or the sidecar plateau in `scripts/measure-recording-ram.sh` (PR #425). Worst case the change is a harmless no-op that still correctly matches single-flight usage.

Part of the recording-RAM series (root-caused 2026-07-21). Sibling: PR #425 (measurement harness).