### PR TITLE
docs(harness): add interactive agent guide

### DIFF
--- a/docs/agent-harness-guide/README.md
+++ b/docs/agent-harness-guide/README.md
@@ -1,0 +1,13 @@
+# Murmur agent-harness guide
+
+Interaktywna, statyczna prezentacja po polsku o rzeczywistym harnessie Murmura: worktree, kontrakt, checki, review, attestation oraz evale.
+
+Otwórz ją bez serwera i bez instalowania czegokolwiek:
+
+```bash
+open docs/agent-harness-guide/index.html
+```
+
+Sterowanie: strzałki lub spacja — slajdy; `O` — przegląd; `N` — notatki; `F` — pełny ekran. Każdy slajd ma własny hash URL.
+
+Źródła opisywane w prezentacji: `.agents/harness/`, `scripts/agent-harness`, `.codex/rules/agentic-workflow.md`.

--- a/docs/agent-harness-guide/index.html
+++ b/docs/agent-harness-guide/index.html
@@ -1,0 +1,372 @@
+<!doctype html>
+<html lang="pl">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Murmur — przewodnik po harnessie agentów</title>
+<!--
+  Self-contained, dependency-free static guide to the Murmur development harness.
+  No build step, no framework, no network: open this file directly in a browser.
+  Migrated from the local Next.js/React deck (murmur-agent-loop-deck); the 14-slide
+  Polish "from zero" narrative, the animated diagrams, the folder map, the notes and
+  the overview are preserved verbatim in plain HTML + CSS + vanilla JS.
+  Documents real repository sources under .agents/harness/ and scripts/agent-harness*.
+-->
+<style>
+:root { --bg:#090b12; --surface:#111520; --surface-2:#171c2a; --ink:#f2f4fb; --muted:#a8b0c5; --line:rgba(196,205,238,.14); --blue:#7b8cff; --violet:#c58bff; --orange:#ffb263; --red:#ff7f89; --green:#70d8ad;
+  --mono:"DM Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  --sans:"Manrope",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
+* { box-sizing:border-box; }
+html,body { margin:0; min-height:100%; background:var(--bg); color:var(--ink); font-family:var(--sans); }
+button { font:inherit; }
+.deck-shell { position:relative; min-height:100vh; overflow:hidden; background:radial-gradient(circle at 50% -20%,#1c2140 0,transparent 44%),var(--bg); }
+.mesh { position:fixed; border-radius:999px; filter:blur(100px); opacity:.2; pointer-events:none; }
+.mesh-a { width:42vw; height:42vw; top:-20vw; left:-12vw; background:var(--blue); }.mesh-b{ width:34vw;height:34vw;right:-15vw;bottom:-18vw;background:var(--violet); }
+.deck-header,.deck-footer { position:fixed; z-index:10; right:clamp(20px,5vw,80px); left:clamp(20px,5vw,80px); display:flex; align-items:center; justify-content:space-between; }
+.deck-header { top:25px; }.deck-footer { bottom:22px; color:var(--muted); font-size:12px; }
+.deck-header button,.deck-footer button { border:0; background:transparent; color:var(--muted); cursor:pointer; }.deck-header>div{display:flex;gap:14px}.deck-header>div button:hover,.deck-footer button:hover{color:var(--ink)}
+.brand { display:flex; gap:9px; align-items:baseline; padding:0; }.brand span{font-size:24px;color:var(--blue)}.brand b{color:var(--ink);font-size:15px}.brand small{font:10px var(--mono);letter-spacing:.08em;text-transform:uppercase}
+.deck-footer>div{display:flex;gap:14px}.deck-footer>div button{font-size:20px}.deck-footer>div button:disabled{opacity:.25;cursor:default}.deck-footer b{font:10px var(--mono);letter-spacing:.08em;text-transform:uppercase}
+.stage { position:relative; min-height:100vh; }
+.slide { position:absolute; inset:0; display:none; padding:105px clamp(28px,7vw,130px) 92px; }.slide.active{display:flex;flex-direction:column;justify-content:center;animation:appear .42s ease both}@keyframes appear{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}
+.eyebrow { margin:0 0 14px; color:var(--blue); font:500 11px var(--mono); letter-spacing:.13em; text-transform:uppercase; }.slide-head{display:flex;align-items:flex-end;justify-content:space-between;gap:32px;margin-bottom:clamp(24px,4vh,56px)}h1,h2,h3,p{margin-top:0}h1{max-width:850px;margin-bottom:24px;font-size:clamp(48px,6vw,90px);line-height:.99;letter-spacing:-.075em}h2{max-width:1000px;margin-bottom:0;font-size:clamp(35px,4.4vw,64px);line-height:1.04;letter-spacing:-.06em}h3{font-size:clamp(18px,1.7vw,25px);letter-spacing:-.04em}.lede{max-width:620px;color:var(--muted);font-size:clamp(17px,1.4vw,21px);line-height:1.6}em{font-style:normal;color:var(--blue)}p{line-height:1.55}.primary{display:inline-flex;gap:15px;align-items:center;padding:13px 18px;border:1px solid rgba(123,140,255,.55);border-radius:10px;background:rgba(123,140,255,.12);color:var(--ink);font-weight:700;cursor:pointer}.primary:hover{background:rgba(123,140,255,.24)}.compact{white-space:nowrap}.tag{display:inline-block;margin-bottom:16px;padding:5px 8px;border-radius:999px;font:10px var(--mono);letter-spacing:.08em}.blue{background:rgba(123,140,255,.16);color:var(--blue)}.orange{background:rgba(255,178,99,.14);color:var(--orange)}.violet{background:rgba(197,139,255,.14);color:var(--violet)}.red{background:rgba(255,127,137,.14);color:var(--red)}code,pre{font-family:var(--mono)}
+.hero{display:grid;grid-template-columns:1.05fr .95fr;gap:60px;align-items:center;max-width:1330px;margin:auto}.hero-diagram{position:relative;width:min(38vw,490px);aspect-ratio:1;margin:auto;border:1px solid var(--line);border-radius:50%;display:grid;place-content:center;text-align:center;background:radial-gradient(circle,rgba(123,140,255,.16),transparent 65%)}.hero-diagram strong{font-size:28px;letter-spacing:-.06em}.hero-diagram small{color:var(--muted)}.hero-ring{position:absolute;inset:12%;border:1px solid rgba(123,140,255,.3);border-radius:50%}.ring-two{inset:27%;border-color:rgba(197,139,255,.45)}.hero-diagram span{position:absolute;padding:7px 10px;border:1px solid var(--line);border-radius:8px;background:#121728;font:10px var(--mono)}.person{top:8%;left:11%;color:var(--orange)}.agent{right:3%;top:42%;color:var(--violet)}.proof{bottom:8%;left:15%;color:var(--green)}
+.two-paths{display:grid;grid-template-columns:1fr auto 1fr;gap:28px;align-items:center;max-width:1180px;margin:auto}.two-paths section,.value-grid section,.role-grid section,.guard-grid section,.fail-grid section{padding:28px;border:1px solid var(--line);border-radius:18px;background:linear-gradient(145deg,rgba(26,31,46,.92),rgba(13,17,27,.92))}.two-paths section p{min-height:96px;color:var(--muted)}.two-paths i{font-size:38px;font-style:normal;color:var(--muted)}.two-paths code{color:var(--blue);font-size:12px}.bottom-explain{margin:28px auto 0;max-width:900px;padding-top:18px;border-top:1px solid var(--line);color:var(--muted);text-align:center}
+.value-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;max-width:1250px;margin:auto}.value-grid section{min-height:250px}.value-grid span{color:var(--blue);font:11px var(--mono)}.value-grid p,.guard-grid p{color:var(--muted)}
+.architecture{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;position:relative;max-width:1260px;margin:auto}.architecture:before{content:"";position:absolute;top:50%;right:9%;left:9%;height:1px;background:var(--line)}.arch-node{position:relative;z-index:1;min-height:255px;padding:20px;border:1px solid var(--line);border-radius:16px;background:#101521;opacity:.36;transition:.3s}.arch-node.lit{opacity:1;border-color:rgba(123,140,255,.7);box-shadow:0 0 45px rgba(123,140,255,.12);transform:translateY(-6px)}.arch-node>b{display:block;margin-bottom:34px;color:var(--blue);font:11px var(--mono)}.arch-node strong{display:block;font-size:19px}.arch-node small,.arch-node p{color:var(--muted)}.arch-node p{font-size:13px}.arch-legend,.outcomes{display:flex;justify-content:center;gap:28px;margin:30px auto 0;color:var(--muted);font-size:13px}.arch-legend b{color:var(--ink)}
+.lifecycle{display:grid;grid-template-columns:repeat(7,1fr);gap:9px;max-width:1280px;margin:auto}.life-node{min-height:190px;padding:17px;border:1px solid var(--line);border-radius:13px;background:var(--surface);opacity:.34;transition:.25s}.life-node.lit{opacity:1;border-color:rgba(112,216,173,.55);transform:translateY(-5px)}.life-node span{display:block;margin-bottom:34px;color:var(--green);font:11px var(--mono)}.life-node strong{display:block;font-size:17px}.life-node small{display:block;margin-top:7px;color:var(--muted);font-size:12px;line-height:1.4}.outcomes{flex-wrap:wrap}.outcomes span:first-child{color:var(--green)}.outcomes span:nth-child(2){color:var(--orange)}.outcomes span:last-child{color:var(--red)}
+.folder-layout{display:grid;grid-template-columns:1.2fr .8fr;gap:30px;max-width:1200px;margin:auto}.folder-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}.folder-grid button{min-height:150px;padding:16px;border:1px solid var(--line);border-radius:13px;background:var(--surface);color:var(--ink);text-align:left;cursor:pointer}.folder-grid button:hover,.folder-grid button.selected{border-color:var(--blue);background:rgba(123,140,255,.12)}.folder-grid span{display:block;margin-bottom:19px;color:var(--blue);font:11px var(--mono)}.folder-grid strong,.folder-grid small{display:block}.folder-grid small{margin-top:7px;color:var(--muted);font:11px var(--mono)}.folder-detail{padding:28px;border:1px solid rgba(123,140,255,.4);border-radius:18px;background:linear-gradient(150deg,rgba(123,140,255,.14),rgba(16,20,32,.9))}.folder-detail>span{color:var(--blue);font:10px var(--mono)}.folder-detail code{display:block;margin:16px 0;color:var(--muted);font-size:12px}.folder-detail p{color:var(--muted)}
+.runner-contract{display:grid;grid-template-columns:1.05fr .95fr;gap:26px;max-width:1170px;margin:auto}.terminal{overflow:hidden;border:1px solid var(--line);border-radius:16px;background:#0c1019}.terminal header{padding:13px 16px;border-bottom:1px solid var(--line);color:var(--muted);font:11px var(--mono)}.terminal pre{padding:20px;color:#cfd7fb;font-size:13px;line-height:1.75;margin:0}.explain-list{display:grid;gap:10px}.explain-list>div{padding:15px;border-left:2px solid var(--blue);background:rgba(123,140,255,.08)}.explain-list code{color:var(--blue)}.explain-list p{margin:7px 0 0;color:var(--muted);font-size:13px}
+.role-grid,.fail-grid,.daily{display:grid;grid-template-columns:1fr 1fr;gap:20px;max-width:1120px;margin:auto}.role-grid li{margin:13px 0;color:var(--muted)}.role-grid code{color:var(--blue);font-size:12px}.role-grid ul{padding-left:18px}.guard-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;max-width:1200px;margin:auto}.guard-grid section{min-height:230px}.guard-grid span{font-size:31px;color:var(--green)}.hard-rule{max-width:1000px;margin:30px auto 0;padding:16px;border:1px solid rgba(255,178,99,.3);border-radius:11px;color:var(--orange);text-align:center}.hard-rule b{color:var(--ink)}
+.eval-intro{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:16px;align-items:center;max-width:1230px;margin:auto}.eval-intro section{min-height:245px;padding:24px;border:1px solid var(--line);border-radius:16px;background:var(--surface)}.eval-intro span{color:var(--orange);font:10px var(--mono)}.eval-intro p{color:var(--muted)}.eval-intro i{color:var(--blue);font-size:27px;font-style:normal}.eval-callout{max-width:1000px;margin:27px auto 0;padding:17px;border-radius:12px;background:rgba(197,139,255,.1);color:var(--muted);text-align:center}.eval-callout b{color:var(--ink)}
+.eval-anatomy{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;max-width:1240px;margin:auto}.eval-part{min-height:225px;padding:17px;border:1px solid var(--line);border-radius:15px;background:var(--surface);opacity:.36;transition:.25s}.eval-part.lit{opacity:1;border-color:rgba(255,178,99,.7);transform:translateY(-5px)}.eval-part span{display:block;margin-bottom:28px;color:var(--orange);font:10px var(--mono)}.eval-part strong{font-size:18px}.eval-part p{color:var(--muted);font-size:13px}.file-tree{display:flex;justify-content:center;gap:20px;margin-top:30px;color:var(--muted);font:12px var(--mono)}.file-tree code{color:var(--blue)}.file-tree>div{display:flex;flex-direction:column;gap:2px}
+.fail-grid section{min-height:300px}.fail-grid li{margin:15px 0;color:var(--muted)}.fail-grid ol{padding-left:18px}.daily section{min-height:300px;padding:27px;border:1px solid var(--line);border-radius:16px;background:var(--surface)}blockquote{margin:18px 0;padding:15px;border-left:2px solid var(--blue);background:rgba(123,140,255,.08);font-size:17px} .daily p{color:var(--muted)}.daily pre{color:#cfd7fb;line-height:1.75;font-size:12px;margin:0;white-space:pre-wrap}
+.final{max-width:1100px;margin:auto;text-align:center}.final h2{margin-right:auto;margin-left:auto}.final>p:last-child{max-width:700px;margin:28px auto;color:var(--muted)}.final-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:44px}.final-grid span{padding:18px;border:1px solid var(--line);border-radius:10px;background:var(--surface);color:var(--muted);font-size:13px}.final-grid b{display:block;margin-bottom:5px;color:var(--ink)}
+.modal{position:fixed;z-index:30;inset:0;display:grid;place-items:center;padding:30px;background:rgba(3,4,8,.78);backdrop-filter:blur(10px)}.modal[hidden]{display:none}.modal-card{position:relative;width:min(100%,960px);max-height:85vh;overflow:auto;padding:35px;border:1px solid var(--line);border-radius:20px;background:#111622;box-shadow:0 25px 80px #000}.close{position:absolute;top:16px;right:18px;border:0;background:transparent;color:var(--muted);font-size:25px;cursor:pointer}.overview{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}.overview button{padding:15px;border:1px solid var(--line);border-radius:8px;background:var(--surface);color:var(--ink);text-align:left;cursor:pointer}.overview button:hover{border-color:var(--blue)}.overview span{display:inline-block;width:34px;color:var(--blue);font:11px var(--mono)}.notes h3{font-size:28px}.notes p:last-child{color:var(--muted);font-size:18px}
+@media (max-width:900px){.slide{padding:100px 26px 80px;overflow:auto;justify-content:flex-start!important}.deck-header,.deck-footer{right:20px;left:20px}.deck-header>div button:last-child{display:none}.hero,.folder-layout,.runner-contract,.role-grid,.fail-grid,.daily{grid-template-columns:1fr}.hero-diagram{width:min(74vw,370px)}.two-paths{grid-template-columns:1fr}.two-paths i{display:none}.value-grid,.guard-grid{grid-template-columns:1fr 1fr}.architecture,.lifecycle,.eval-anatomy{grid-template-columns:1fr 1fr}.architecture:before{display:none}.arch-node,.life-node,.eval-part{min-height:145px}.arch-node>b,.life-node span,.eval-part span{margin-bottom:15px}.eval-intro{grid-template-columns:1fr}.eval-intro i{display:none}.file-tree{flex-wrap:wrap}.final-grid{grid-template-columns:1fr 1fr}.slide-head{align-items:flex-start;flex-direction:column}.arch-legend,.outcomes{gap:10px;flex-direction:column;text-align:center}.folder-grid{grid-template-columns:1fr 1fr}}
+@media (max-width:560px){h1{font-size:48px}h2{font-size:36px}.value-grid,.guard-grid,.architecture,.lifecycle,.eval-anatomy,.final-grid,.overview{grid-template-columns:1fr}.deck-header>div{display:none}.slide{padding-top:80px}.folder-grid{grid-template-columns:1fr}.two-paths section p{min-height:0}}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+</style>
+</head>
+<body>
+<main class="deck-shell">
+  <div class="mesh mesh-a"></div><div class="mesh mesh-b"></div>
+  <header class="deck-header">
+    <button class="brand" data-goto="0"><span>μ</span><b>Murmur</b><small>harness guide</small></button>
+    <div><button id="btn-overview">O wszystkie slajdy</button><button id="btn-notes">N notatki</button></div>
+  </header>
+
+  <section class="stage" aria-live="polite">
+    <!-- 01 -->
+    <article class="slide active" data-id="01-start">
+      <div class="hero">
+        <div><p class="eyebrow">Murmur development harness · przewodnik od zera</p><h1>Nie „AI robi kod”.<br /><em>System pilnuje pracy AI.</em></h1><p class="lede">Gdy zlecasz agentowi zmianę w Murmurze, harness daje mu osobny katalog pracy, wyznacza granice, uruchamia testy i niezależne review — a potem pozwala zacommitować wyłącznie dokładnie sprawdzony kod.</p><button class="primary" data-goto="1">Zacznij od mapy <span>→</span></button></div>
+        <div class="hero-diagram"><div class="hero-ring ring-one"></div><div class="hero-ring ring-two"></div><span class="person">TY</span><span class="agent">AGENT</span><span class="proof">DOWÓD</span><strong>HARNESS</strong><small>organizuje, sprawdza, blokuje</small></div>
+      </div>
+    </article>
+
+    <!-- 02 -->
+    <article class="slide" data-id="02-what">
+      <header class="slide-head"><div><p class="eyebrow">01 · czym jest</p><h2>Harness jest kierownikiem pracy agentów.</h2></div></header>
+      <div class="two-paths"><section><span class="tag blue">PRAWDZIWY TASK</span><h3>Zmienia Murmura</h3><p>„Dodaj element X” albo „napraw błąd Y”. Agent pracuje w izolowanym worktree, a harness sprawdza konkretną zmianę.</p><code>prompt → kod → checki → review → PASS/BLOCKED</code></section><i>≠</i><section><span class="tag orange">EVAL</span><h3>Egzaminuje agenta</h3><p>Daje Claude’owi/Codexowi małe sztuczne zadanie i sprawdza, czy zachowuje się rozsądnie.</p><code>mini-zadanie → agent → grader → raport</code></section></div><p class="bottom-explain">Eval nie uruchamia się po każdym prompcie. Prawdziwy task nie jest egzaminem modelu.</p>
+    </article>
+
+    <!-- 03 -->
+    <article class="slide" data-id="03-value">
+      <header class="slide-head"><div><p class="eyebrow">02 · co nam daje</p><h2>Nie ufamy deklaracji „gotowe”. Zbieramy dowód.</h2></div></header>
+      <div class="value-grid"><section><span>01</span><h3>Nie psuje Twojego checkoutu</h3><p>Writer dostaje osobny worktree startujący z committed base.</p></section><section><span>02</span><h3>Nie ufa samemu writerowi</h3><p>Writer nie posiada PASS i nie może sam commitować.</p></section><section><span>03</span><h3>Wymaga konkretnego dowodu</h3><p>Checki, logi i review są przypięte do dokładnego diffu.</p></section><section><span>04</span><h3>Uczciwie umie się zatrzymać</h3><p>Gdy naprawa nie idzie, dostajesz BLOCKED zamiast udawanego sukcesu.</p></section></div>
+    </article>
+
+    <!-- 04 -->
+    <article class="slide" data-id="04-architecture">
+      <header class="slide-head"><div><p class="eyebrow">03 · architektura</p><h2>Cztery części, jedna kontrolowana droga.</h2></div><button class="primary compact" id="btn-arch">Pokaż przepływ</button></header>
+      <div class="architecture" id="architecture">
+        <div class="arch-node"><b>01</b><strong>TY + CHAT</strong><small>intencja</small><p>Napraw attachment loss</p></div>
+        <div class="arch-node"><b>02</b><strong>RUNNER</strong><small>task_runner.py</small><p>kontrakt, stan, limity</p></div>
+        <div class="arch-node"><b>03</b><strong>WORKTREE</strong><small>writer + checki + review</small><p>osobny katalog pracy</p></div>
+        <div class="arch-node"><b>04</b><strong>GIT + GITHUB</strong><small>operator</small><p>commit, push, PR</p></div>
+      </div>
+      <div class="arch-legend"><span><b>Model</b> robi pracę</span><span><b>Runner</b> prowadzi proces</span><span><b>Programy</b> mierzą wynik</span><span><b>Człowiek</b> publikuje</span></div>
+    </article>
+
+    <!-- 05 -->
+    <article class="slide" data-id="05-lifecycle">
+      <header class="slide-head"><div><p class="eyebrow">04 · lifecycle</p><h2>Od promptu do PASS albo BLOCKED.</h2></div><button class="primary compact" id="btn-life">Uruchom task</button></header>
+      <div class="lifecycle" id="lifecycle">
+        <div class="life-node"><span>1</span><strong>init</strong><small>tworzy task.json + worktree</small></div>
+        <div class="life-node"><span>2</span><strong>writer</strong><small>edytuje owned paths</small></div>
+        <div class="life-node"><span>3</span><strong>checks</strong><small>testy w sandboxie</small></div>
+        <div class="life-node"><span>4</span><strong>review</strong><small>spec + adversarial</small></div>
+        <div class="life-node"><span>5</span><strong>repair</strong><small>maks. 2 rundy</small></div>
+        <div class="life-node"><span>6</span><strong>attest</strong><small>wiąże PASS z diffem</small></div>
+        <div class="life-node"><span>7</span><strong>commit</strong><small>dopiero po PASS</small></div>
+      </div>
+      <div class="outcomes"><span>✓ PASS → verify-attestation → commit → push → PR</span><span>× FAIL → feedback → repair</span><span>■ BLOCKED → człowiek przejmuje decyzję</span></div>
+    </article>
+
+    <!-- 06 -->
+    <article class="slide" data-id="06-folder-map">
+      <header class="slide-head"><div><p class="eyebrow">05 · foldery</p><h2>Mapa <code>.agents/harness/</code> — który plik do czego?</h2></div></header>
+      <div class="folder-layout"><div class="folder-grid" id="folder-grid"></div>
+        <aside class="folder-detail"><span>WYBRANY ELEMENT</span><code id="fd-path"></code><h3 id="fd-title"></h3><p id="fd-text"></p><b>Po ludzku:</b><p id="fd-human"></p></aside>
+      </div>
+    </article>
+
+    <!-- 07 -->
+    <article class="slide" data-id="07-runner-contract">
+      <header class="slide-head"><div><p class="eyebrow">06 · rdzeń taska</p><h2><code>task_runner.py</code> prowadzi task, a <code>task.json</code> opisuje jego granice.</h2></div></header>
+      <div class="runner-contract"><section class="terminal"><header>scripts/agent-harness init attachment-loss</header><pre>task_id: attachment-loss
+base_sha: 8f2c...
+owned_paths:
+  - src-tauri/src/storage/attachment_store.rs
+risk_flags: [lock]
+checks: [rust-lib, playwright]
+writer: claude
+reviewer: codex
+max_repair_rounds: 2</pre></section><section class="explain-list"><div><code>task_runner.py</code><p>Wykonuje kolejność kroków i zapisuje state.json.</p></div><div><code>task.json</code><p>Jasna umowa: scope, ryzyko, testy, role i limity.</p></div><div><code>Worktree</code><p>../.murmur-agent-tasks/&lt;id&gt;/meetnotes/ — osobny katalog dla writera.</p></div><div><code>Evidence</code><p>.git/agent-harness/tasks/&lt;id&gt;/ — kontrakt, logi, review i receipts.</p></div></section></div>
+    </article>
+
+    <!-- 08 -->
+    <article class="slide" data-id="08-prompts-schemas">
+      <header class="slide-head"><div><p class="eyebrow">07 · role i formularze</p><h2>Prompty mówią jak działać. Schemas mówią jak zwrócić wynik.</h2></div></header>
+      <div class="role-grid"><section><span class="tag blue">PROMPTS/</span><h3>Instrukcje ról</h3><ul><li><code>implementer.md</code> — writer: scope, bez commita, bez PASS</li><li><code>spec-reviewer.md</code> — czy zrobiono to, o co proszono?</li><li><code>adversarial-reviewer.md</code> — spróbuj złamać zmianę</li><li><code>lock / egress / protocol</code> — dodatkowe ryzyka</li></ul></section><section><span class="tag violet">SCHEMAS/</span><h3>Formularze dla programu</h3><ul><li><code>task.schema.json</code> — kontrakt ma komplet pól</li><li><code>review.schema.json</code> — verdict i findings</li><li><code>attestation.schema.json</code> — exact diff + dowody</li><li><code>commit.schema.json</code> — prawdziwy commit receipt</li></ul></section></div><p class="bottom-explain">Prompt mówi agentowi, <b>jak ma działać</b>. Schema wymusza, <b>jak ma zwrócić wynik</b>.</p>
+    </article>
+
+    <!-- 09 -->
+    <article class="slide" data-id="09-guards">
+      <header class="slide-head"><div><p class="eyebrow">08 · twarde ochrony</p><h2>Checki, hooki i sandbox zatrzymują rzeczy, których prompt nie powinien pilnować.</h2></div></header>
+      <div class="guard-grid"><section><span>✓</span><h3>checks/</h3><p>Np. <code>perf-contracts.sh</code>: deterministyczne testy dla ryzykownej zmiany.</p></section><section><span>⊘</span><h3>hook_guard.py</h3><p>Blokuje sekrety, zły commit, direct push i niebezpieczne komendy.</p></section><section><span>□</span><h3>sandbox</h3><p>Checki bez Internetu, Keychaina i produkcyjnych danych.</p></section><section><span>↔</span><h3>resource_policy.py</h3><p>Nie pozwala kilku ciężkim Cargo/CI procesom walczyć o tę samą maszynę.</p></section></div><div class="hard-rule">Jeżeli błąd da się wykryć programem, <b>nie rozwiązujemy go tylko promptem.</b></div>
+    </article>
+
+    <!-- 10 -->
+    <article class="slide" data-id="10-evals">
+      <header class="slide-head"><div><p class="eyebrow">09 · evale</p><h2>Eval egzaminuje agenta. Nie testuje Murmura.</h2></div></header>
+      <div class="eval-intro"><section><span>PRZYKŁAD PYTANIA</span><h3><code>angular22-noop</code></h3><p>„Ktoś radzi dodać starą opcję <code>allowSignalWrites</code>. Czy agent rozpozna, że w Angularze 22 nie należy tego robić?”</p></section><i>→</i><section><span>CO DOSTAJE AGENT</span><h3>mały fixture</h3><p>Mini-komponent, ograniczony scope, bez dostępu do rozwiązania ani gradera.</p></section><i>→</i><section><span>KTO OCENIA</span><h3>grader</h3><p>Zwykły kod sprawdza odpowiedź. Nie agent i nie drugi model.</p></section></div><div class="eval-callout">Eval odpala operator po zmianie modelu, promptów, reguł albo po realnej wpadce agenta. <b>Nie po każdym feature prompcie.</b></div>
+    </article>
+
+    <!-- 11 -->
+    <article class="slide" data-id="11-eval-files">
+      <header class="slide-head"><div><p class="eyebrow">10 · anatomy evala</p><h2>Jedno pytanie egzaminacyjne ma pięć części.</h2></div><button class="primary compact" id="btn-eval">Pokaż anatomy</button></header>
+      <div class="eval-anatomy" id="eval-anatomy">
+        <div class="eval-part"><span>01</span><strong>tasks/</strong><p>Pytanie: prompt, allowed paths, expected change i grader.</p></div>
+        <div class="eval-part"><span>02</span><strong>fixtures/</strong><p>Startowy mini-projekt, który dostaje agent.</p></div>
+        <div class="eval-part"><span>03</span><strong>graders/</strong><p>Niezależny kod oceniający poza workspace agenta.</p></div>
+        <div class="eval-part"><span>04</span><strong>suites/</strong><p>Lista pytań w paczce, np. smoke.</p></div>
+        <div class="eval-part"><span>05</span><strong>good / bad</strong><p>Tylko selftest: czy harness odróżnia dobrą i złą odpowiedź.</p></div>
+      </div>
+      <div class="file-tree"><code>.agents/harness/evals/</code><div><span>├── tasks/</span><span>├── fixtures/</span><span>├── graders/</span><span>└── suites/</span></div></div>
+    </article>
+
+    <!-- 12 -->
+    <article class="slide" data-id="12-improve">
+      <header class="slide-head"><div><p class="eyebrow">11 · gdy coś failuje</p><h2>FAIL mówi, którą warstwę workflow wzmocnić.</h2></div></header>
+      <div class="fail-grid"><section><span class="tag red">REAL TASK FAIL</span><h3>Zmiana nie przechodzi.</h3><ol><li>Runner daje writerowi log testu albo finding reviewera.</li><li>Writer ma maksymalnie dwie rundy napraw.</li><li>Jeśli nadal failuje: <code>FAILED</code> albo <code>BLOCKED</code>.</li><li>Nie ma attestation, commit ani PR z tego taska.</li></ol></section><section><span class="tag orange">EVAL FAIL</span><h3>Agent zawiódł na egzaminie.</h3><ol><li>Operator czyta trace i ustala, czego agent nie umie.</li><li>Poprawia regułę, prompt, hard guard albo wybór roli.</li><li>Powtarza eval kilka razy.</li><li>Nie zmienia się nic automatycznie w Murmurze.</li></ol></section></div>
+    </article>
+
+    <!-- 13 -->
+    <article class="slide" data-id="13-daily">
+      <header class="slide-head"><div><p class="eyebrow">12 · codzienne użycie</p><h2>Ty dajesz cel. System pilnuje pracy. Ty decydujesz o publikacji.</h2></div></header>
+      <div class="daily"><section><span class="tag blue">NAJCZĘŚCIEJ</span><h3>Ty piszesz naturalnie</h3><blockquote>„Napraw attachment loss i dowieź to end-to-end.”</blockquote><p>Agent przygotowuje kontrakt oraz prowadzi lokalny workflow zgodnie z zasadami repo.</p></section><section><span class="tag violet">GDY CHCESZ KONTROLI</span><h3>Ty używasz CLI</h3><pre>agent-harness init &lt;id&gt;
+agent-harness run &lt;id&gt;
+agent-harness status &lt;id&gt;
+agent-harness verify-attestation &lt;id&gt;
+agent-harness commit &lt;id&gt;
+git push agent/&lt;id&gt;
+PR → murmur → close</pre></section></div><p class="bottom-explain"><code>status</code> i <code>verify-attestation</code> tylko czytają. <b>Push i PR są świadomą, zewnętrzną decyzją operatora.</b></p>
+    </article>
+
+    <!-- 14 -->
+    <article class="slide" data-id="14-map">
+      <div class="final"><p class="eyebrow">Murmur harness · mapa na jedną kartkę</p><h2>Wiesz już, <em>gdzie szukać</em>, gdy coś nie działa.</h2><div class="final-grid"><span><b>task_runner.py</b> prowadzi realny task</span><span><b>config.json</b> ustala politykę</span><span><b>prompts/</b> prowadzą role</span><span><b>schemas/</b> walidują dokumenty</span><span><b>checks + hooks</b> twardo chronią</span><span><b>evals/</b> okresowo mierzą agenta</span></div><p>Nie pytaj: „który model jest mądrzejszy?”. Najpierw pytaj: „która warstwa ma za to odpowiadać?”.</p></div>
+    </article>
+  </section>
+
+  <footer class="deck-footer"><span id="counter">01 / 14</span><b id="foot-eyebrow"></b><div><button id="prev">←</button><button id="next">→</button></div></footer>
+
+  <div class="modal" id="overview-modal" hidden><div class="modal-card"><button class="close" data-close="overview-modal">×</button><p class="eyebrow">Wszystkie slajdy</p><div class="overview" id="overview-list"></div></div></div>
+  <div class="modal" id="notes-modal" hidden><div class="modal-card notes"><button class="close" data-close="notes-modal">×</button><p class="eyebrow">Notatka do aktualnego slajdu</p><h3 id="notes-title"></h3><p id="notes-body"></p></div></div>
+</main>
+
+<script>
+(function () {
+  "use strict";
+
+  var slides = [
+    { id: "01-start", eyebrow: "Murmur development harness", title: "Jak bezpiecznie zlecamy agentom zmianę kodu.", note: "Harness to nie agent i nie chatbot. To program, który organizuje pracę agentów, sprawdza ją i nie pozwala im samym przyznać sobie PASS." },
+    { id: "02-what", eyebrow: "01 · czym jest", title: "Harness jest kierownikiem pracy agentów.", note: "Model robi kawałek pracy. Harness pilnuje, gdzie pracuje, co wolno mu zmienić, jakie testy mają przejść i kto niezależnie sprawdzi wynik." },
+    { id: "03-value", eyebrow: "02 · co nam daje", title: "Nie ufamy deklaracji „gotowe”. Zbieramy dowód.", note: "Efekt to mniej false-greenów: agent nie może ukryć czerwonego testu ani zacommitować innego diffu niż ten, który przeszedł review." },
+    { id: "04-architecture", eyebrow: "03 · architektura", title: "Cztery części, jedna kontrolowana droga.", note: "Ty dajesz intencję. Runner tworzy zadanie. Agenci pracują w osobnym worktree. Dopiero na końcu człowiek publikuje zmianę przez push i PR." },
+    { id: "05-lifecycle", eyebrow: "04 · lifecycle", title: "Od promptu do PASS albo BLOCKED.", note: "Prawdziwy task ma stan: init, writer, checki, review, maksymalnie dwie naprawy i końcowy PASS lub BLOCKED." },
+    { id: "06-folder-map", eyebrow: "05 · foldery", title: "Mapa .agents/harness/ — który plik do czego?", note: "Nie trzeba pamiętać wszystkiego. Najpierw wybierz kategorię: rdzeń procesu, zasady, role, dowody, ochrony albo egzaminy agentów." },
+    { id: "07-runner-contract", eyebrow: "06 · rdzeń taska", title: "task_runner.py prowadzi task, a task.json opisuje jego granice.", note: "Runner jest programem Pythonowym. Kontrakt mówi mu: z którego commita startować, które pliki wolno zmieniać, jakie ryzyka i checki obowiązują." },
+    { id: "08-prompts-schemas", eyebrow: "07 · role i formularze", title: "Prompty mówią jak działać. Schemas mówią jak zwrócić wynik.", note: "implementer.md prowadzi writera. Prompty reviewerów prowadzą review. JSON schemas nie pozwalają na mgliste „chyba działa” zamiast kompletnego dowodu." },
+    { id: "09-guards", eyebrow: "08 · twarde ochrony", title: "Checki, hooki i sandbox zatrzymują rzeczy, których prompt nie powinien pilnować.", note: "Jeśli błąd da się wykryć programem, nie ufamy pamięci modelu: dodajemy test, hook albo odcięcie zasobów." },
+    { id: "10-evals", eyebrow: "09 · evale", title: "Eval egzaminuje agenta. Nie testuje Murmura.", note: "Prawdziwy task pyta: czy ta zmiana działa? Eval pyta: czy Claude albo Codex potrafi właściwie zachować się w małej, kontrolowanej sytuacji?" },
+    { id: "11-eval-files", eyebrow: "10 · anatomy evala", title: "Jedno pytanie egzaminacyjne ma pięć części.", note: "Task opisuje pytanie. Fixture daje mini-projekt. Grader sprawdza odpowiedź. Suite grupuje pytania. Good/bad sprawdza, czy sam harness umie rozróżnić wynik." },
+    { id: "12-improve", eyebrow: "11 · gdy coś failuje", title: "FAIL mówi, którą warstwę workflow wzmocnić.", note: "Prawdziwy task FAIL blokuje commit. Eval FAIL jest informacją dla operatora: popraw regułę, prompt, hard guard albo podział ról, a potem powtórz egzamin." },
+    { id: "13-daily", eyebrow: "12 · codzienne użycie", title: "Ty dajesz cel. System pilnuje pracy. Ty decydujesz o publikacji.", note: "Normalnie zlecasz feature. Jawne komendy służą do obserwacji i reprodukcji. Runner nie pushuje sam kodu na GitHub." },
+    { id: "14-map", eyebrow: "13 · zapamiętaj", title: "Najkrótsza mapa całego systemu.", note: "Task runner prowadzi realną zmianę. Prompts i schemas organizują role oraz dowody. Checks chronią kod. Evals okresowo mierzą zachowanie agentów." }
+  ];
+
+  var folderCards = [
+    { key: "core", icon: "01", title: "Rdzeń", path: "task_runner.py", text: "Maszyna stanów taska: init, run, verify, commit, close.", human: "To główny program, który wie, co robić dalej." },
+    { key: "policy", icon: "02", title: "Polityka", path: "config.json", text: "Limity, vendorzy, ryzyka i kanoniczne checki.", human: "To część procesu, której używasz, gdy potrzebujesz właśnie tej funkcji." },
+    { key: "roles", icon: "03", title: "Role", path: "prompts/", text: "Instrukcje dla writera i niezależnych reviewerów.", human: "To część procesu, której używasz, gdy potrzebujesz właśnie tej funkcji." },
+    { key: "proof", icon: "04", title: "Dowody", path: "schemas/", text: "Format tasków, review, attestation i commita.", human: "To część procesu, której używasz, gdy potrzebujesz właśnie tej funkcji." },
+    { key: "guards", icon: "05", title: "Ochrony", path: "checks/ · hook_guard.py", text: "Testy, blokady komend, sekrety i commit gate.", human: "To część procesu, której używasz, gdy potrzebujesz właśnie tej funkcji." },
+    { key: "evals", icon: "06", title: "Egzaminy", path: "evals/", text: "Mini-zadania do okresowego sprawdzania Claude’a/Codexa.", human: "To jest osobne laboratorium do sprawdzania zachowania agentów." }
+  ];
+
+  var articles = Array.prototype.slice.call(document.querySelectorAll(".slide"));
+  var counter = document.getElementById("counter");
+  var footEyebrow = document.getElementById("foot-eyebrow");
+  var prevBtn = document.getElementById("prev");
+  var nextBtn = document.getElementById("next");
+  var overviewModal = document.getElementById("overview-modal");
+  var notesModal = document.getElementById("notes-modal");
+
+  var current = 0;
+
+  function pad(n) { return String(n).padStart(2, "0"); }
+
+  function render() {
+    articles.forEach(function (a, i) { a.classList.toggle("active", i === current); });
+    counter.textContent = pad(current + 1) + " / " + pad(slides.length);
+    footEyebrow.textContent = slides[current].eyebrow;
+    prevBtn.disabled = current === 0;
+    nextBtn.disabled = current === slides.length - 1;
+    var notesTitle = document.getElementById("notes-title");
+    var notesBody = document.getElementById("notes-body");
+    notesTitle.textContent = slides[current].title;
+    notesBody.textContent = slides[current].note;
+  }
+
+  function goTo(index) {
+    var next = Math.max(0, Math.min(slides.length - 1, index));
+    current = next;
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState(null, "", "#" + slides[next].id);
+    } else {
+      window.location.hash = slides[next].id;
+    }
+    render();
+  }
+
+  // Deep-link via URL hash.
+  function syncFromHash() {
+    var target = window.location.hash.slice(1);
+    for (var i = 0; i < slides.length; i++) {
+      if (slides[i].id === target) { current = i; render(); return; }
+    }
+  }
+  window.addEventListener("hashchange", syncFromHash);
+
+  // Sequential "lit" reveal shared by the three animated diagrams.
+  function animate(container, delay) {
+    var nodes = Array.prototype.slice.call(container.children);
+    nodes.forEach(function (n) { n.classList.remove("lit"); });
+    nodes.forEach(function (n, i) {
+      window.setTimeout(function () { n.classList.add("lit"); }, delay * (i + 1));
+    });
+  }
+
+  document.getElementById("btn-arch").addEventListener("click", function () {
+    this.textContent = "Animacja trwa…";
+    animate(document.getElementById("architecture"), 580);
+  });
+  document.getElementById("btn-life").addEventListener("click", function () {
+    this.textContent = "Pętla trwa…";
+    animate(document.getElementById("lifecycle"), 500);
+  });
+  document.getElementById("btn-eval").addEventListener("click", function () {
+    this.textContent = "Składamy egzamin…";
+    animate(document.getElementById("eval-anatomy"), 520);
+  });
+
+  // Folder map: build the cards + wire selection into the detail aside.
+  var folderGrid = document.getElementById("folder-grid");
+  var fdPath = document.getElementById("fd-path");
+  var fdTitle = document.getElementById("fd-title");
+  var fdText = document.getElementById("fd-text");
+  var fdHuman = document.getElementById("fd-human");
+
+  function selectFolder(key) {
+    var item = null;
+    for (var i = 0; i < folderCards.length; i++) { if (folderCards[i].key === key) { item = folderCards[i]; break; } }
+    if (!item) item = folderCards[0];
+    Array.prototype.forEach.call(folderGrid.children, function (btn) {
+      btn.classList.toggle("selected", btn.getAttribute("data-key") === item.key);
+    });
+    fdPath.textContent = ".agents/harness/" + item.path;
+    fdTitle.textContent = item.title;
+    fdText.textContent = item.text;
+    fdHuman.textContent = item.human;
+  }
+
+  folderCards.forEach(function (item) {
+    var btn = document.createElement("button");
+    btn.setAttribute("data-key", item.key);
+    btn.innerHTML = "<span></span><strong></strong><small></small>";
+    btn.querySelector("span").textContent = item.icon;
+    btn.querySelector("strong").textContent = item.title;
+    btn.querySelector("small").textContent = item.path;
+    btn.addEventListener("click", function () { selectFolder(item.key); });
+    folderGrid.appendChild(btn);
+  });
+  selectFolder(folderCards[0].key);
+
+  // Overview grid.
+  var overviewList = document.getElementById("overview-list");
+  slides.forEach(function (slide, index) {
+    var btn = document.createElement("button");
+    btn.innerHTML = "<span></span><b></b>";
+    btn.querySelector("span").textContent = pad(index + 1);
+    btn.querySelector("b").textContent = slide.title;
+    btn.addEventListener("click", function () { closeModals(); goTo(index); });
+    overviewList.appendChild(btn);
+  });
+
+  function openModal(el) { el.hidden = false; }
+  function closeModals() { overviewModal.hidden = true; notesModal.hidden = true; }
+
+  document.getElementById("btn-overview").addEventListener("click", function () { openModal(overviewModal); });
+  document.getElementById("btn-notes").addEventListener("click", function () { openModal(notesModal); });
+  Array.prototype.forEach.call(document.querySelectorAll("[data-close]"), function (btn) {
+    btn.addEventListener("click", closeModals);
+  });
+  Array.prototype.forEach.call(document.querySelectorAll(".modal"), function (m) {
+    m.addEventListener("click", function (e) { if (e.target === m) closeModals(); });
+  });
+
+  // Navigation buttons + brand/CTA jumps.
+  prevBtn.addEventListener("click", function () { goTo(current - 1); });
+  nextBtn.addEventListener("click", function () { goTo(current + 1); });
+  Array.prototype.forEach.call(document.querySelectorAll("[data-goto]"), function (btn) {
+    btn.addEventListener("click", function () { goTo(parseInt(btn.getAttribute("data-goto"), 10)); });
+  });
+
+  // Keyboard: arrows/space/Home/End navigate; O overview; N notes; F fullscreen; Esc closes.
+  window.addEventListener("keydown", function (event) {
+    var modalOpen = !overviewModal.hidden || !notesModal.hidden;
+    if (event.key === "Escape") { closeModals(); return; }
+    if (modalOpen) return;
+    var k = event.key;
+    if (k === "ArrowRight" || k === "ArrowDown" || k === " ") { event.preventDefault(); goTo(current + 1); }
+    else if (k === "ArrowLeft" || k === "ArrowUp") { event.preventDefault(); goTo(current - 1); }
+    else if (k === "Home") { goTo(0); }
+    else if (k === "End") { goTo(slides.length - 1); }
+    else if (k.toLowerCase() === "o") { openModal(overviewModal); }
+    else if (k.toLowerCase() === "n") { openModal(notesModal); }
+    else if (k.toLowerCase() === "f") {
+      if (!document.fullscreenElement && document.documentElement.requestFullscreen) document.documentElement.requestFullscreen();
+      else if (document.exitFullscreen) document.exitFullscreen();
+    }
+  });
+
+  // Initial paint (honour a bookmarked slide hash).
+  if (window.location.hash) { syncFromHash(); }
+  render();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a dependency-free Polish interactive guide at docs/agent-harness-guide/. It documents the real harness lifecycle, worktrees, prompts, schemas, guards, evals, and failure handling.\n\nVerification performed: static diff check; 14 slide elements confirmed. Browser smoke remains tracked separately because the current harness sandbox blocks Chrome bundle reads.