### PR TITLE
Opt-in harness (/harness) + relaxed normal mode

### DIFF
--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -44,6 +44,10 @@ class GuardFailure(RuntimeError):
     """A deterministic reason the attempted operation must be refused."""
 
 
+class NoTaskForWorktree(GuardFailure):
+    """Raised when no harness task claims the current worktree (normal mode)."""
+
+
 @dataclass(frozen=True)
 class SimpleCommand:
     tokens: Tuple[str, ...]
@@ -629,7 +633,9 @@ def _resolve_task(repo: Path, common: Path) -> Tuple[Dict[str, Any], Path]:
             if _manifest_worktree(document) == repo.resolve():
                 return document, task_dir
             raise GuardFailure("legacy current-task pointer belongs to a different worktree")
-    raise GuardFailure("no task manifest matches this worktree; use scripts/agent-harness init/run")
+    raise NoTaskForWorktree(
+        "no task manifest matches this worktree; use scripts/agent-harness init/run"
+    )
 
 
 def _parse_time(raw: Any, label: str) -> dt.datetime:
@@ -953,6 +959,8 @@ def _finish_guard(
                 allow_test_adapter=allow_test_adapter,
             )
             return None
+        except NoTaskForWorktree:
+            return None  # normal mode: no active harness task → allow the commit
         except GuardFailure as exc:
             reason = str(exc)
     if mode == "advisory":
@@ -1833,7 +1841,7 @@ def _run_selftest() -> int:
             repo,
             use_default_finish=True,
         )
-        test.result(f"{vendor}: default-enforce missing manifest", got, "BLOCK")
+        test.result(f"{vendor}: default-enforce missing manifest", got, "ALLOW")
 
         # Malformed manifest is found by explicit task id and must fail closed.
         _, common, _, _ = _repo_context(repo)

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -1709,6 +1709,17 @@ def _run_selftest() -> int:
             ("direct full CI", "bash scripts/ci.sh", "BLOCK"),
             ("read-only cargo search", "rg 'cargo test --lib' .", "ALLOW"),
             (
+                "gh PR body mentions cargo",
+                "gh pr create --base murmur --title x --body 'Fixes the cargo build path'",
+                "ALLOW",
+            ),
+            (
+                "gh PR body with backticks",
+                "gh pr create --title x --body 'run `cargo test --lib` first'",
+                "ALLOW",
+            ),
+            ("gh then cargo still heavy", "gh pr view 1 && cargo build", "BLOCK"),
+            (
                 "lane-wrapped Rust test",
                 "scripts/agent-resource-run --chdir src-tauri -- cargo test --lib",
                 "ALLOW",

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -1798,6 +1798,14 @@ def _run_selftest() -> int:
         for label, command, want in resource_cases:
             test.expect(label, vendor, "block-bash", command, SOURCE_ROOT, want)
 
+        for label, cmd, want in [
+            ("gh live $() substitution is heavy", 'gh pr create --title x --body "$(cargo build --release)"', "HEAVY"),
+            ("gh single-quoted backticks are light", "gh pr create --title x --body 'run `cargo test` first'", "LIGHT"),
+            ("gh plain cargo word is light", 'gh pr create --title x --body "fixes the cargo build"', "LIGHT"),
+        ]:
+            got = "HEAVY" if resource_policy.command_is_heavy(cmd) else "LIGHT"
+            test.result(label, got, want)
+
     print("-- staged secret scan (no path exclusions) --")
     for vendor in ("codex", "claude"):
         _secret_case(test, vendor, "plain.txt", "token=" + "sk" + "-ant-" + "A" * 28, "BLOCK")

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -1837,6 +1837,76 @@ def _run_selftest() -> int:
             got = "HEAVY" if resource_policy.command_is_heavy(cmd) else "LIGHT"
             test.result(label, got, want)
 
+        # Finding 2 fix: mode-independent anti-bypass classifier coverage.
+        # These are the misuse/lookalike patterns whose block-bash result
+        # correctly flipped BLOCK -> ALLOW in the no-task fixture above (the
+        # resource-lane gate now only fires when a harness task claims the
+        # worktree). Their classification in resource_policy.py did NOT
+        # change and is still correct, but block-bash no longer exercises it
+        # in no-task mode, so it lost its only regression guard. Pin the
+        # classifier directly, independent of task/mode, using the exact
+        # execution directory (SOURCE_ROOT) the hook payload would carry --
+        # command_is_heavy_in/command_is_dev_in resolve lookalike-runner
+        # paths relative to that cwd, so the real repo root is required for
+        # the "outside the repo" impostor checks to behave as intended.
+        # Verified non-vacuous: a clearly-safe command ("git status --short")
+        # classifies heavy=False, dev=False against the same cwd.
+        anti_bypass_heavy = [
+            ("plain unwrapped cargo test", "cargo test --lib"),
+            (
+                "dev-runner allowlist violation: injected config flag",
+                "scripts/agent-dev-run -- npm run dev -- --config injected.json",
+            ),
+            (
+                "dev-runner allowlist violation: arbitrary cargo",
+                "scripts/agent-dev-run -- cargo test --lib",
+            ),
+            (
+                "dev-runner allowlist violation: npm build",
+                "scripts/agent-dev-run -- npm run build",
+            ),
+            (
+                "impostor dev runner outside the repo",
+                "/tmp/scripts/agent-dev-run -- npm run dev",
+            ),
+            (
+                "impostor lane runner outside the repo",
+                "/tmp/scripts/agent-resource-run -- cargo test --lib",
+            ),
+            (
+                "forged selftest-guardian-release env",
+                "MURMUR_AGENT_SELFTEST_GUARDIAN_RELEASE=/tmp/x scripts/agent-resource-run -- true",
+            ),
+            (
+                "forged resource-lane-active env",
+                "MURMUR_AGENT_RESOURCE_LANE_ACTIVE=1 scripts/agent-dev-run -- npm run dev",
+            ),
+        ]
+        for label, cmd in anti_bypass_heavy:
+            got = "HEAVY" if resource_policy.command_is_heavy_in(cmd, SOURCE_ROOT) else "LIGHT"
+            test.result(f"anti-bypass classifier: {label}", got, "HEAVY")
+
+        # The lane runner (agent-resource-run) is only meant to wrap bounded
+        # one-off commands; wrapping a long-lived dev server in it (instead
+        # of agent-dev-run) is itself a lane-starvation misuse pattern -- and
+        # it is the one case here where command_is_dev_in is the function
+        # that actually reproduces the original BLOCK (command_is_heavy_in
+        # is also true for these, but the dev-axis classification is the one
+        # this pattern specifically hinges on).
+        anti_bypass_dev = [
+            (
+                "lane runner misused for a long-lived dev server",
+                "scripts/agent-resource-run -- npm run dev",
+            ),
+            (
+                "lane runner misused for a chdir'd long-lived dev server",
+                "scripts/agent-resource-run --chdir /tmp/deck npm run dev -- --port 4173",
+            ),
+        ]
+        for label, cmd in anti_bypass_dev:
+            got = "DEV" if resource_policy.command_is_dev_in(cmd, SOURCE_ROOT) else "NOT-DEV"
+            test.result(f"anti-bypass classifier: {label}", got, "DEV")
+
     print("-- staged secret scan (no path exclusions) --")
     for vendor in ("codex", "claude"):
         _secret_case(test, vendor, "plain.txt", "token=" + "sk" + "-ant-" + "A" * 28, "BLOCK")
@@ -1899,12 +1969,30 @@ def _run_selftest() -> int:
         test.result(f"{vendor}: minimal receipt", got, "BLOCK")
 
         # With a task claiming the worktree, the resource lane is enforced again.
-        # Use a distinct task id + local variable names so this scratch task does
-        # not clobber the "fresh" task_dir/attestation this loop keeps mutating.
-        lane_task_dir, _lane_task, _lane_attestation = _write_receipt(repo, "lane")
-        got, _ = test.invoke(vendor, "block-bash", "cargo test --lib", repo)
-        test.result(f"{vendor}: task-present unwrapped heavy blocked", got, "BLOCK")
-        # Absolute path: the fixture repo is a separate git init unrelated to
+        # This MUST be pinned through CLEAN single-task resolution, not the
+        # ambiguous fail-safe: reusing `repo` here would leave TWO manifests
+        # ("fresh" above + a new one) claiming the same worktree_path, so
+        # _resolve_task raises GuardFailure("multiple task manifests claim
+        # this worktree") and _worktree_has_active_task returns True via its
+        # `except GuardFailure` fail-safe branch -- never exercising the real
+        # "exactly one task resolves" happy path the gate depends on. Use a
+        # DEDICATED _finish_repo() fixture instead: it starts with no task
+        # manifest of its own, so writing exactly one receipt on it resolves
+        # unambiguously (see _resolve_task: `len(matches) == 1` returns
+        # directly, only `len(matches) > 1` raises the ambiguous GuardFailure).
+        lane_repo = _finish_repo()
+        got, _ = test.invoke(vendor, "block-bash", "cargo test --lib", lane_repo)
+        test.result(f"{vendor}: no-task heavy allowed (clean fixture mirror)", got, "ALLOW")
+
+        _write_receipt(lane_repo, "lane")
+        # Exactly one manifest (this "lane" task) now claims lane_repo's
+        # worktree, so _resolve_task's `matches` list has length 1 and
+        # returns that single match directly -- _worktree_has_active_task
+        # returns True via the real "task found" path, not the
+        # ambiguous-manifests fail-safe. This is the happy path pinned.
+        got, _ = test.invoke(vendor, "block-bash", "cargo test --lib", lane_repo)
+        test.result(f"{vendor}: task-present unwrapped heavy blocked (clean single-task)", got, "BLOCK")
+        # Absolute path: lane_repo is a separate git init unrelated to
         # SOURCE_ROOT, so a *relative* "scripts/agent-resource-run" would not
         # resolve to the canonical runner from this cwd and would misclassify
         # as an untrusted lookalike (see resource_policy.is_lane_runner).
@@ -1913,10 +2001,10 @@ def _run_selftest() -> int:
             vendor,
             "block-bash",
             f"{lane_runner} --chdir src-tauri -- cargo test --lib",
-            repo,
+            lane_repo,
         )
         test.result(f"{vendor}: task-present lane-wrapped allowed", got, "ALLOW")
-        shutil.rmtree(lane_task_dir)
+        shutil.rmtree(lane_repo.parent)
 
         (task_dir / "attestation.json").write_text(json.dumps(attestation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         attestation["reviews"][0]["verdict"] = "FAIL"

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -330,7 +330,14 @@ def _unsupported_execution_indirection(command: str) -> Optional[str]:
         if not effective:
             continue
         executable = effective[0] if effective[0] == "." else Path(effective[0]).name
-        if executable in {"eval", "source", ".", "exec", "xargs"}:
+        if executable in {"source", "."}:
+            # `source`/`.` of a known-safe env file (e.g. ~/.cargo/env) is a
+            # standard setup step, not executable indirection. All other targets
+            # stay blocked.
+            target = effective[1] if len(effective) > 1 else ""
+            if target not in resource_policy.SAFE_SOURCE_TARGETS:
+                return f"execution indirection via {executable!r} is unsupported by the command guard"
+        elif executable in {"eval", "exec", "xargs"}:
             return f"execution indirection via {executable!r} is unsupported by the command guard"
         if executable == "find" and any(
             token in {"-exec", "-execdir", "-ok", "-okdir"} or token.startswith("-exec")
@@ -1664,6 +1671,9 @@ def _run_selftest() -> int:
                 ("PR creation", "gh pr create --base murmur --title x", "ALLOW"),
                 ("quoted push search", "rg 'git push origin murmur' .", "ALLOW"),
                 ("quoted security search", "rg 'security find-identity' .", "ALLOW"),
+                ("source cargo env", "source ~/.cargo/env", "ALLOW"),
+                ("dot source cargo env", ". $HOME/.cargo/env", "ALLOW"),
+                ("source arbitrary script", "source ./guard-bypass.sh", "BLOCK"),
             ]
             for label, command, want in cases:
                 test.expect(label, vendor, "block-bash", command, repo, want)

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -502,13 +502,15 @@ def _block_bash(command: str, process_cwd: Path) -> Optional[str]:
             dangerous = {"/", "//", "/*", "~", "~/", "~/*", "$HOME", "${HOME}", "$HOME/", "${HOME}/"}
             if recursive and any(token in dangerous for token in targets):
                 return "recursive deletion of filesystem root or the home directory is forbidden"
-    if resource_policy.command_is_dev_in(command, process_cwd):
-        return (
-            "long-lived dev commands must run through scripts/agent-dev-run; "
-            "the dev supervisor stays outside the global lane while its cargo/rustc "
-            "descendants acquire it per process"
-        )
-    if resource_policy.command_is_heavy_in(command, process_cwd):
+    dev = resource_policy.command_is_dev_in(command, process_cwd)
+    heavy = resource_policy.command_is_heavy_in(command, process_cwd)
+    if (dev or heavy) and _worktree_has_active_task(process_cwd):
+        if dev:
+            return (
+                "long-lived dev commands must run through scripts/agent-dev-run; "
+                "the dev supervisor stays outside the global lane while its cargo/rustc "
+                "descendants acquire it per process"
+            )
         return (
             "unwrapped resource-heavy build/test/dev command; run it through "
             "scripts/agent-resource-run so Murmur worktrees share one supervised lane"
@@ -636,6 +638,27 @@ def _resolve_task(repo: Path, common: Path) -> Tuple[Dict[str, Any], Path]:
     raise NoTaskForWorktree(
         "no task manifest matches this worktree; use scripts/agent-harness init/run"
     )
+
+
+def _worktree_has_active_task(process_cwd: Path) -> bool:
+    """True when a harness task claims this worktree (harness mode)."""
+    try:
+        top = _git_text(process_cwd, "rev-parse", "--show-toplevel", check=False)
+        if not top:
+            return False
+        repo = Path(top).resolve()
+        _, common, _, _ = _repo_context(repo)
+        _resolve_task(repo, common)
+        return True
+    except NoTaskForWorktree:
+        return False
+    except GuardFailure:
+        # Tasks exist but are ambiguous/malformed → fail safe: treat as harness
+        # mode so the lane stays enforced.
+        return True
+    except Exception:
+        # Not a resolvable git worktree → normal mode.
+        return False
 
 
 def _parse_time(raw: Any, label: str) -> dt.datetime:
@@ -1671,7 +1694,7 @@ def _run_selftest() -> int:
                 ("notary credential store", "xcrun notarytool store-credentials murmur", "BLOCK"),
                 ("notary submit", "xcrun notarytool submit app.dmg --wait", "ALLOW"),
                 ("cargo toolchain clippy", "cargo +stable clippy --all-targets", "BLOCK"),
-                ("cargo test", "cargo test --lib", "BLOCK"),
+                ("cargo test", "cargo test --lib", "ALLOW"),
                 ("codesign deep", "/usr/bin/codesign --deep --sign X app", "BLOCK"),
                 ("codesign helper", "/usr/bin/codesign --options runtime --sign X helper", "ALLOW"),
                 ("root delete", "/bin/rm -rf -- /", "BLOCK"),
@@ -1710,11 +1733,11 @@ def _run_selftest() -> int:
                 )
 
         resource_cases = [
-            ("direct cargo metadata", "cargo metadata --no-deps", "BLOCK"),
-            ("direct Rust test", "cd src-tauri && cargo test --lib", "BLOCK"),
-            ("direct Angular build", "npx ng build", "BLOCK"),
-            ("direct npm dev", "npm run dev", "BLOCK"),
-            ("direct full CI", "bash scripts/ci.sh", "BLOCK"),
+            ("direct cargo metadata", "cargo metadata --no-deps", "ALLOW"),
+            ("direct Rust test", "cd src-tauri && cargo test --lib", "ALLOW"),
+            ("direct Angular build", "npx ng build", "ALLOW"),
+            ("direct npm dev", "npm run dev", "ALLOW"),
+            ("direct full CI", "bash scripts/ci.sh", "ALLOW"),
             ("read-only cargo search", "rg 'cargo test --lib' .", "ALLOW"),
             (
                 "gh PR body mentions cargo",
@@ -1726,7 +1749,7 @@ def _run_selftest() -> int:
                 "gh pr create --title x --body 'run `cargo test --lib` first'",
                 "ALLOW",
             ),
-            ("gh then cargo still heavy", "gh pr view 1 && cargo build", "BLOCK"),
+            ("gh then cargo still heavy", "gh pr view 1 && cargo build", "ALLOW"),
             (
                 "lane-wrapped Rust test",
                 "scripts/agent-resource-run --chdir src-tauri -- cargo test --lib",
@@ -1740,12 +1763,12 @@ def _run_selftest() -> int:
             (
                 "lane-wrapped long-lived dev",
                 "scripts/agent-resource-run -- npm run dev",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "lane-wrapped chdir long-lived dev",
                 "scripts/agent-resource-run --chdir /tmp/deck npm run dev -- --port 4173",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "dedicated npm dev",
@@ -1770,37 +1793,37 @@ def _run_selftest() -> int:
             (
                 "dedicated dev config override",
                 "scripts/agent-dev-run -- npm run dev -- --config injected.json",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "dedicated runner arbitrary cargo",
                 "scripts/agent-dev-run -- cargo test --lib",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "dedicated runner npm build",
                 "scripts/agent-dev-run -- npm run build",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "lookalike dev runner",
                 "/tmp/scripts/agent-dev-run -- npm run dev",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "lookalike lane runner",
                 "/tmp/scripts/agent-resource-run -- cargo test --lib",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "test-only guardian env",
                 "MURMUR_AGENT_SELFTEST_GUARDIAN_RELEASE=/tmp/x scripts/agent-resource-run -- true",
-                "BLOCK",
+                "ALLOW",
             ),
             (
                 "forged lane-active env",
                 "MURMUR_AGENT_RESOURCE_LANE_ACTIVE=1 scripts/agent-dev-run -- npm run dev",
-                "BLOCK",
+                "ALLOW",
             ),
         ]
         for label, command, want in resource_cases:
@@ -1874,6 +1897,26 @@ def _run_selftest() -> int:
             vendor, "finish-guard", "git commit -m x", repo, allow_test_adapter=True
         )
         test.result(f"{vendor}: minimal receipt", got, "BLOCK")
+
+        # With a task claiming the worktree, the resource lane is enforced again.
+        # Use a distinct task id + local variable names so this scratch task does
+        # not clobber the "fresh" task_dir/attestation this loop keeps mutating.
+        lane_task_dir, _lane_task, _lane_attestation = _write_receipt(repo, "lane")
+        got, _ = test.invoke(vendor, "block-bash", "cargo test --lib", repo)
+        test.result(f"{vendor}: task-present unwrapped heavy blocked", got, "BLOCK")
+        # Absolute path: the fixture repo is a separate git init unrelated to
+        # SOURCE_ROOT, so a *relative* "scripts/agent-resource-run" would not
+        # resolve to the canonical runner from this cwd and would misclassify
+        # as an untrusted lookalike (see resource_policy.is_lane_runner).
+        lane_runner = SOURCE_ROOT / "scripts" / "agent-resource-run"
+        got, _ = test.invoke(
+            vendor,
+            "block-bash",
+            f"{lane_runner} --chdir src-tauri -- cargo test --lib",
+            repo,
+        )
+        test.result(f"{vendor}: task-present lane-wrapped allowed", got, "ALLOW")
+        shutil.rmtree(lane_task_dir)
 
         (task_dir / "attestation.json").write_text(json.dumps(attestation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         attestation["reviews"][0]["verdict"] = "FAIL"

--- a/.agents/harness/resource_policy.py
+++ b/.agents/harness/resource_policy.py
@@ -593,6 +593,46 @@ def _segment_leading_tool(tokens):
     return basename(tokens[index])
 
 
+def _has_live_substitution(command):
+    """True if $()/backtick/<()/>() appears outside single-quoted spans.
+
+    Single-quoted text is inert (the shell never expands it); a substitution in
+    double-quoted or unquoted context IS executed, so such a command can launch
+    heavy work regardless of its leading executable.
+    """
+    single = False
+    double = False
+    escaped = False
+    index = 0
+    while index < len(command):
+        character = command[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if character == "\\" and not single:
+            escaped = True
+            index += 1
+            continue
+        if character == "'" and not double:
+            single = not single
+            index += 1
+            continue
+        if character == '"' and not single:
+            double = not double
+            index += 1
+            continue
+        if not single and (
+            character == "`"
+            or command.startswith("$(", index)
+            or command.startswith("<(", index)
+            or command.startswith(">(", index)
+        ):
+            return True
+        index += 1
+    return False
+
+
 def command_is_heavy(command, depth=0):
     if depth > MAX_DEPTH:
         return True
@@ -601,10 +641,16 @@ def command_is_heavy(command, depth=0):
     # A command whose every segment leads with a safe non-build tool (gh, grep,
     # rg) cannot launch heavy work. Skip the substitution scan whose only job is
     # to catch build commands hidden in backticks/$() — those are exactly what a
-    # gh PR/issue body legitimately contains as free-form text.
+    # gh PR/issue body legitimately contains as free-form text. This exemption
+    # only applies when there is no LIVE substitution: single-quoted `$(...)`/
+    # backtick text is inert, but the same syntax in double-quoted or unquoted
+    # context is executed by the shell BEFORE gh ever runs, so it must fall
+    # through to the normal heavy scan below.
     segments = list(command_segments(tokenize(command)))
-    if segments and all(
-        _segment_leading_tool(segment) in SAFE_NONBUILD_TOOLS for segment in segments
+    if (
+        segments
+        and all(_segment_leading_tool(segment) in SAFE_NONBUILD_TOOLS for segment in segments)
+        and not _has_live_substitution(command)
     ):
         return False
     for backtick_body in re.findall(r"`([^`]*)`", command, flags=re.DOTALL):

--- a/.agents/harness/resource_policy.py
+++ b/.agents/harness/resource_policy.py
@@ -14,6 +14,8 @@ ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$", re.DOTALL)
 SHELLS = {"bash", "dash", "ksh", "sh", "zsh"}
 LAUNCHERS = {"command", "env", "exec", "nice", "nohup", "sudo", "time"}
 READ_ONLY_SEARCHES = {"grep", "rg"}
+ALWAYS_ALLOWED_TOOLS = {"gh"}
+SAFE_NONBUILD_TOOLS = READ_ONLY_SEARCHES | ALWAYS_ALLOWED_TOOLS
 MAX_DEPTH = 12
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RESOURCE_RUN = (REPO_ROOT / "scripts/agent-resource-run").resolve()
@@ -577,11 +579,34 @@ def substitution_bodies(command):
         cursor = index
 
 
+def _segment_leading_tool(tokens):
+    """Best-effort basename of the executable a segment launches, or None."""
+    if not tokens:
+        return None
+    if tokens[0] == "__MURMUR_UNPARSEABLE__":
+        raw = tokens[1].lstrip()
+        match = re.match(r"(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;|&]+)", raw)
+        return basename(match.group(1)) if match else None
+    index = skip_assignments(tokens, 0)
+    if index >= len(tokens):
+        return None
+    return basename(tokens[index])
+
+
 def command_is_heavy(command, depth=0):
     if depth > MAX_DEPTH:
         return True
     if TEST_GUARDIAN_ENV in command:
         return True
+    # A command whose every segment leads with a safe non-build tool (gh, grep,
+    # rg) cannot launch heavy work. Skip the substitution scan whose only job is
+    # to catch build commands hidden in backticks/$() — those are exactly what a
+    # gh PR/issue body legitimately contains as free-form text.
+    segments = list(command_segments(tokenize(command)))
+    if segments and all(
+        _segment_leading_tool(segment) in SAFE_NONBUILD_TOOLS for segment in segments
+    ):
+        return False
     for backtick_body in re.findall(r"`([^`]*)`", command, flags=re.DOTALL):
         if command_is_heavy(backtick_body, depth + 1):
             return True

--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -31,19 +31,22 @@ full attestation and the resource lane is required for heavy commands. Your main
 ## Run it
 
 ```bash
-# 1. Create the contract + isolated worktree
-scripts/agent-harness init --kind <feature|refactor|docs|harness> --title "<what>"
+# 1. Create the contract + isolated worktree (task_id is positional;
+#    --prompt and --owned are required, --owned may repeat for multiple paths)
+scripts/agent-harness init <task-id> --kind <bug|feature|refactor|docs|harness> \
+  --prompt "<what>" --owned <path> [--owned <path> ...] \
+  [--risk <lock|egress|protocol|runtime|ui|performance|release>]
 
 # 2. Drive writer → checks → independent reviews → PASS attestation
-scripts/agent-harness run
+scripts/agent-harness run <task-id>
 
 # 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
-scripts/agent-harness commit
+scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
 gh pr create -R murmur-io/murmur --base murmur
 gh pr merge --merge
 
 # 4. Close the task
-scripts/agent-harness close
+scripts/agent-harness close <task-id>
 ```
 
 The default vendor pair is Claude writer → Codex reviewer (the only supported

--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: harness
+description: Run a change through the full Murmur harness — isolated worktree, writer, deterministic checks, independent adversarial + risk reviews, hash-bound PASS attestation, guarded commit. Use PROACTIVELY when a change is risky, multi-step, or you want the earned safety net (lock/crypto/egress/protocol, or anything you want independently verified). Skip it for docs, chores, and low-risk edits — those commit normally.
+---
+
+# `/harness` — opt-in rigor
+
+Murmur's harness is **opt-in**. Normal commits run freely (only secret-scan and
+trunk-push protection are always on). Invoke the harness deliberately, via this
+skill, when a change deserves independent verification.
+
+## When to reach for it
+
+- Anything touching the lock model / crypto / secrets / storage / MCP / egress /
+  the sharing protocol (the `risk_classification` paths in
+  `.agents/harness/config.json`).
+- A multi-step feature or refactor where you want a fresh adversarial reviewer to
+  try to break the change before it lands.
+- Any time you want the hash-bound Definition-of-Done receipt on the commit.
+
+For a docs fix, a chore, a version bump, or a small low-risk edit: **do not use
+this** — just commit normally.
+
+## How it works
+
+The switch is physical: the harness runs in an **isolated sibling worktree** that
+carries a task manifest. While that task is active, `finish-guard` enforces the
+full attestation and the resource lane is required for heavy commands. Your main
+`murmur` checkout never has a task, so work there is unconstrained.
+
+## Run it
+
+```bash
+# 1. Create the contract + isolated worktree
+scripts/agent-harness init --kind <feature|refactor|docs|harness> --title "<what>"
+
+# 2. Drive writer → checks → independent reviews → PASS attestation
+scripts/agent-harness run
+
+# 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
+scripts/agent-harness commit
+gh pr create -R murmur-io/murmur --base murmur
+gh pr merge --merge
+
+# 4. Close the task
+scripts/agent-harness close
+```
+
+The default vendor pair is Claude writer → Codex reviewer (the only supported
+reversal is Codex writer → Claude reviewer). The implementer never owns the
+verdict.
+
+## Verify the harness itself
+
+```bash
+bash .claude/hooks/selftest.sh
+scripts/agent-harness selftest --ci
+scripts/agent-config-audit --ci
+```

--- a/.agents/skills/release-murmur/SKILL.md
+++ b/.agents/skills/release-murmur/SKILL.md
@@ -125,6 +125,41 @@ git checkout murmur && git pull origin murmur             # local trunk now has 
 > "Developer ID Application" cert in the login keychain and (for stage 10) Apple notary
 > credentials. If running headless, STOP here and hand the user stages 5–11 verbatim.
 
+## Sandbox & human-pause recipe (do not rely on memory recall)
+
+Release steps that touch the keychain, codesign, notarytool, or `gh`/`git push`
+**must run unsandboxed** and **must not** be wrapped in `agent-resource-run`
+(the harness is opt-in; on the release machine you are in normal mode).
+
+- **Sandbox:** the release machine keeps a per-machine, git-ignored
+  `.claude/settings.local.json` override. Never commit sandbox-disabling to the
+  repo — it would weaken the sandbox for the whole team.
+- **Heavy commands run directly** in normal mode (no `agent-resource-run`
+  wrapping required). `finish-guard` is asleep, so the version-bump commit goes
+  through directly; merge to `murmur` still requires a **PR** (never a direct
+  push), and `gh` PR bodies are no longer misclassified as heavy.
+
+Irreducible human pause points (macOS auth dialogs the agent shell cannot answer):
+
+1. **P1 — unlock the login keychain** (once, up front): needed for `git`/`gh`
+   push and for Developer-ID key + notary-profile access. Run
+   `security unlock-keychain` **yourself** — the agent must never run `security`.
+2. **P2 — supply the Developer-ID hash** as `DEVELOPER_ID` (40 hex chars) to
+   `scripts/macos-sign-notarize.sh`. Pre-supply it so it does not stall the run.
+3. **P3 — approve the Developer-ID codesign key dialog** once ("Always Allow");
+   this collapses the per-helper + app + DMG prompts into one interaction.
+
+One-time-only (not per release): `xcrun notarytool store-credentials murmur`,
+run interactively by you.
+
+Everything else — CI gate, version bump, universal build, DMG, `notarytool
+submit --wait`, staple, `spctl`, `gh release create/upload` — is headless.
+
+## Enable repo auto-merge
+
+`gh pr merge --merge --auto` requires auto-merge enabled on the repo (Settings →
+General → "Allow auto-merge"). Enable it once to stop hand-waiting on CI.
+
 ## Stage 5 — Add the universal Rust targets (once per machine)
 
 ```bash

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -31,19 +31,22 @@ full attestation and the resource lane is required for heavy commands. Your main
 ## Run it
 
 ```bash
-# 1. Create the contract + isolated worktree
-scripts/agent-harness init --kind <feature|refactor|docs|harness> --title "<what>"
+# 1. Create the contract + isolated worktree (task_id is positional;
+#    --prompt and --owned are required, --owned may repeat for multiple paths)
+scripts/agent-harness init <task-id> --kind <bug|feature|refactor|docs|harness> \
+  --prompt "<what>" --owned <path> [--owned <path> ...] \
+  [--risk <lock|egress|protocol|runtime|ui|performance|release>]
 
 # 2. Drive writer → checks → independent reviews → PASS attestation
-scripts/agent-harness run
+scripts/agent-harness run <task-id>
 
 # 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
-scripts/agent-harness commit
+scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
 gh pr create -R murmur-io/murmur --base murmur
 gh pr merge --merge
 
 # 4. Close the task
-scripts/agent-harness close
+scripts/agent-harness close <task-id>
 ```
 
 The default vendor pair is Claude writer → Codex reviewer (the only supported

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: harness
+description: Run a change through the full Murmur harness — isolated worktree, writer, deterministic checks, independent adversarial + risk reviews, hash-bound PASS attestation, guarded commit. Use PROACTIVELY when a change is risky, multi-step, or you want the earned safety net (lock/crypto/egress/protocol, or anything you want independently verified). Skip it for docs, chores, and low-risk edits — those commit normally.
+---
+
+# `/harness` — opt-in rigor
+
+Murmur's harness is **opt-in**. Normal commits run freely (only secret-scan and
+trunk-push protection are always on). Invoke the harness deliberately, via this
+skill, when a change deserves independent verification.
+
+## When to reach for it
+
+- Anything touching the lock model / crypto / secrets / storage / MCP / egress /
+  the sharing protocol (the `risk_classification` paths in
+  `.agents/harness/config.json`).
+- A multi-step feature or refactor where you want a fresh adversarial reviewer to
+  try to break the change before it lands.
+- Any time you want the hash-bound Definition-of-Done receipt on the commit.
+
+For a docs fix, a chore, a version bump, or a small low-risk edit: **do not use
+this** — just commit normally.
+
+## How it works
+
+The switch is physical: the harness runs in an **isolated sibling worktree** that
+carries a task manifest. While that task is active, `finish-guard` enforces the
+full attestation and the resource lane is required for heavy commands. Your main
+`murmur` checkout never has a task, so work there is unconstrained.
+
+## Run it
+
+```bash
+# 1. Create the contract + isolated worktree
+scripts/agent-harness init --kind <feature|refactor|docs|harness> --title "<what>"
+
+# 2. Drive writer → checks → independent reviews → PASS attestation
+scripts/agent-harness run
+
+# 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
+scripts/agent-harness commit
+gh pr create -R murmur-io/murmur --base murmur
+gh pr merge --merge
+
+# 4. Close the task
+scripts/agent-harness close
+```
+
+The default vendor pair is Claude writer → Codex reviewer (the only supported
+reversal is Codex writer → Claude reviewer). The implementer never owns the
+verdict.
+
+## Verify the harness itself
+
+```bash
+bash .claude/hooks/selftest.sh
+scripts/agent-harness selftest --ci
+scripts/agent-config-audit --ci
+```

--- a/.claude/skills/release-murmur/SKILL.md
+++ b/.claude/skills/release-murmur/SKILL.md
@@ -125,6 +125,41 @@ git checkout murmur && git pull origin murmur             # local trunk now has 
 > "Developer ID Application" cert in the login keychain and (for stage 10) Apple notary
 > credentials. If running headless, STOP here and hand the user stages 5–11 verbatim.
 
+## Sandbox & human-pause recipe (do not rely on memory recall)
+
+Release steps that touch the keychain, codesign, notarytool, or `gh`/`git push`
+**must run unsandboxed** and **must not** be wrapped in `agent-resource-run`
+(the harness is opt-in; on the release machine you are in normal mode).
+
+- **Sandbox:** the release machine keeps a per-machine, git-ignored
+  `.claude/settings.local.json` override. Never commit sandbox-disabling to the
+  repo — it would weaken the sandbox for the whole team.
+- **Heavy commands run directly** in normal mode (no `agent-resource-run`
+  wrapping required). `finish-guard` is asleep, so the version-bump commit goes
+  through directly; merge to `murmur` still requires a **PR** (never a direct
+  push), and `gh` PR bodies are no longer misclassified as heavy.
+
+Irreducible human pause points (macOS auth dialogs the agent shell cannot answer):
+
+1. **P1 — unlock the login keychain** (once, up front): needed for `git`/`gh`
+   push and for Developer-ID key + notary-profile access. Run
+   `security unlock-keychain` **yourself** — the agent must never run `security`.
+2. **P2 — supply the Developer-ID hash** as `DEVELOPER_ID` (40 hex chars) to
+   `scripts/macos-sign-notarize.sh`. Pre-supply it so it does not stall the run.
+3. **P3 — approve the Developer-ID codesign key dialog** once ("Always Allow");
+   this collapses the per-helper + app + DMG prompts into one interaction.
+
+One-time-only (not per release): `xcrun notarytool store-credentials murmur`,
+run interactively by you.
+
+Everything else — CI gate, version bump, universal build, DMG, `notarytool
+submit --wait`, staple, `spctl`, `gh release create/upload` — is headless.
+
+## Enable repo auto-merge
+
+`gh pr merge --merge --auto` requires auto-merge enabled on the repo (Settings →
+General → "Allow auto-merge"). Enable it once to stop hand-waiting on CI.
+
 ## Stage 5 — Add the universal Rust targets (once per machine)
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,16 @@ Full runbook: **[`.agents/skills/release-murmur`](.agents/skills/release-murmur/
 - **Agents** (`.codex/agents/*.toml`): `rust-tauri-dev`, `angular-zoneless-dev`, `adversarial-verifier`, `lock-security-reviewer`, `release-engineer`, `ci-cd-engineer` (designs & maintains CI — the local `scripts/ci.sh` gate + the GitHub Actions macOS PR-gate that wraps it; CD/notarized release stays with `release-engineer`), `murmur-researcher` — spawn as custom subagents; the implementer never owns the verdict.
 
 When a task mutates the repository, use `scripts/agent-harness`: one isolated writer, deterministic checks, fresh independent reviewers, bounded repair and a hash-bound attestation. The implementer never owns the verdict.
+
+## Opt-in harness (`/harness`)
+
+The harness is **opt-in**. Normal commits run freely; only `secret-scan` and
+direct-push-to-`murmur` protection are always on. Reach for rigor deliberately:
+
+- **Codex has no skills mechanism** — invoke the harness directly:
+  `scripts/agent-harness init … && scripts/agent-harness run && scripts/agent-harness commit`.
+- Use it for lock/crypto/egress/protocol changes or anything you want a fresh
+  adversarial reviewer to verify. Skip it for docs/chores/low-risk edits.
+- Guard behavior is identical across vendors (same `hook_guard.py`): a commit in
+  a worktree with **no** active task is allowed; a worktree **with** a task
+  enforces the full hash-bound attestation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ The harness is **opt-in**. Normal commits run freely; only `secret-scan` and
 direct-push-to-`murmur` protection are always on. Reach for rigor deliberately:
 
 - **Codex has no skills mechanism** — invoke the harness directly:
-  `scripts/agent-harness init … && scripts/agent-harness run && scripts/agent-harness commit`.
+  `scripts/agent-harness init <task-id> --prompt "…" --owned <path> && scripts/agent-harness run <task-id> && scripts/agent-harness commit <task-id> -m "…"`.
 - Use it for lock/crypto/egress/protocol changes or anything you want a fresh
   adversarial reviewer to verify. Skip it for docs/chores/low-risk edits.
 - Guard behavior is identical across vendors (same `hook_guard.py`): a commit in

--- a/docs/superpowers/plans/2026-07-24-opt-in-harness-skill.md
+++ b/docs/superpowers/plans/2026-07-24-opt-in-harness-skill.md
@@ -1,0 +1,680 @@
+# Opt-in Harness (`/harness`) + Relaxed Normal Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Murmur agent harness *opt-in* — full ceremony only when a harness task is active in the worktree (entered via `/harness`); otherwise commits/heavy commands run freely — while keeping `secret-scan` and trunk-push protection always on, and fixing two block-bash false-positives (`source ~/.cargo/env`, `gh` bodies mentioning "cargo").
+
+**Architecture:** One switch — *"does this worktree have an active harness task?"* (`_resolve_task`, already computed) — governs both the `finish-guard` review gate and the resource-lane wrapping requirement. No new persistent state. `/harness` is a thin guided wrapper over the existing `scripts/agent-harness`. The guard logic lives in two canonical files (`hook_guard.py`, `resource_policy.py`) shared by both the Claude and Codex adapters, so there is no vendor-parity work.
+
+**Tech Stack:** Python 3 (harness guards + selftest), Markdown (skills/docs). No new dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-07-24-opt-in-harness-skill-design.md`
+
+## Global Constraints
+
+- **Commit identity:** author **only** `QueaT <kgm004a@gmail.com>`; **no** AI co-author trailers. `gh` active account = `JakubGawr`.
+- **Never push directly to `murmur`/`main`/`master`** — work on a feature branch (`feat/opt-in-harness`) and merge via `gh pr create` → `gh pr merge`.
+- **This change edits `protected_paths` files and changes `instructions_sha256`** (it touches `hook_guard.py`, `resource_policy.py`, `.claude/`, `.agents/`, `AGENTS.md`, `scripts/`). Land it by committing from a normal terminal (agent PreToolUse hooks do not fire there) **or** via `scripts/agent-harness` with `--kind harness`. Expect the pre-Task-3 commits to require the terminal path; after Task 3 lands, no-task commits pass `finish-guard` anyway.
+- **`MURMUR_FINISH_GUARD` stays `"enforce"`** in `.claude/settings.json` — its *semantics* change (enforce = "enforce if a task is present"), its wiring does not, so `config_audit --ci` stays green.
+- **The gate for guard-logic changes is `bash .claude/hooks/selftest.sh`** (runs the canonical `hook_guard.py` selftest against both vendor payloads); `config_audit` does not inspect this logic. Keep hooks fast.
+- **No new npm packages or crates.**
+- **`com.meetnotes.app` is immutable** (not touched here).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `.agents/harness/hook_guard.py` | canonical guard | `NoTaskForWorktree` exception; `_finish_guard` allow-on-no-task; `_block_bash` resource-lane gated on task-present; `source` allowlist in the indirection guard; new selftest cases |
+| `.agents/harness/resource_policy.py` | heavy/dev classifier | `gh` exemption (`command_is_heavy` skips substitution scan for gh-only commands) |
+| `.claude/skills/harness/SKILL.md` | Claude opt-in entry | create |
+| `.agents/skills/harness/SKILL.md` | canonical mirror | create |
+| `AGENTS.md` | Codex opt-in entry | add "want rigor → `scripts/agent-harness`" note |
+| `.claude/skills/release-murmur/SKILL.md` | release runbook | bake sandbox + P1/P3 human-pause recipe |
+| `.agents/skills/release-murmur/SKILL.md` | canonical mirror | same recipe |
+| `scripts/release.sh` | ad-hoc packaging smoke test | deprecation header (stale `MeetNotes.app` path) |
+
+---
+
+## Task 1: Allowlist `source ~/.cargo/env` in the indirection guard
+
+`_unsupported_execution_indirection` (`hook_guard.py:282`) hard-blocks `source`/`.` with no exceptions, even though `resource_policy.SAFE_SOURCE_TARGETS` already lists the safe cargo env file. CLAUDE.md lists `source ~/.cargo/env` as a standard command; unblock exactly that allowlist, keep everything else blocked.
+
+**Files:**
+- Modify: `.agents/harness/hook_guard.py` (function `_unsupported_execution_indirection`, ~line 333; selftest `cases` list, ~line 1648)
+
+**Interfaces:**
+- Consumes: `resource_policy.SAFE_SOURCE_TARGETS` (= `{"$HOME/.cargo/env", "${HOME}/.cargo/env", "~/.cargo/env"}`), already importable (`resource_policy` is imported in `hook_guard.py`).
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Add the failing selftest cases**
+
+In `hook_guard.py`, in the `cases` list inside `_run_selftest` (currently ending at the `("quoted security search", ...)` entry ~line 1666), add three entries:
+
+```python
+                ("PR creation", "gh pr create --base murmur --title x", "ALLOW"),
+                ("quoted push search", "rg 'git push origin murmur' .", "ALLOW"),
+                ("quoted security search", "rg 'security find-identity' .", "ALLOW"),
+                ("source cargo env", "source ~/.cargo/env", "ALLOW"),
+                ("dot source cargo env", ". $HOME/.cargo/env", "ALLOW"),
+                ("source arbitrary script", "source ./guard-bypass.sh", "BLOCK"),
+```
+
+(The first three lines already exist — shown for placement. The `source ./guard-bypass.sh` BLOCK also lives in the `indirections` list; duplicating it in `cases` guards against the allowlist being too broad.)
+
+- [ ] **Step 2: Run the selftest to verify the new ALLOW cases fail**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: FAIL lines for `source cargo env` and `dot source cargo env` — `got BLOCK, want ALLOW` (current code blocks all `source`).
+
+- [ ] **Step 3: Implement the allowlist**
+
+In `_unsupported_execution_indirection`, replace the combined `source`/`.` block (currently):
+
+```python
+        if executable in {"eval", "source", ".", "exec", "xargs"}:
+            return f"execution indirection via {executable!r} is unsupported by the command guard"
+```
+
+with:
+
+```python
+        if executable in {"source", "."}:
+            # `source`/`.` of a known-safe env file (e.g. ~/.cargo/env) is a
+            # standard setup step, not executable indirection. All other targets
+            # stay blocked.
+            target = effective[1] if len(effective) > 1 else ""
+            if target not in resource_policy.SAFE_SOURCE_TARGETS:
+                return f"execution indirection via {executable!r} is unsupported by the command guard"
+        elif executable in {"eval", "exec", "xargs"}:
+            return f"execution indirection via {executable!r} is unsupported by the command guard"
+```
+
+- [ ] **Step 4: Run the selftest to verify all cases pass**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: PASS — including `source cargo env` (ALLOW), `dot source cargo env` (ALLOW), `source arbitrary script` (BLOCK), and the existing `indirections` `source`/`dot source` guard-bypass cases (still BLOCK).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .agents/harness/hook_guard.py
+git commit -m "fix(harness): allow source ~/.cargo/env through the command guard"
+```
+
+---
+
+## Task 2: Stop classifying `gh` invocations as resource-heavy
+
+A `gh pr create --body "…cargo…"` (free-form PR text that mentions cargo, or contains markdown backticks / `$()`, or an unbalanced quote that breaks `shlex`) is flagged heavy by `command_is_heavy` — via its backtick/`$()` substitution scan (`resource_policy.py:585-594`) and/or the `__MURMUR_UNPARSEABLE__` regex (`:474-486`). `gh` is a network/VCS CLI, never a build tool. Exempt commands whose every segment leads with a safe non-build tool.
+
+**Files:**
+- Modify: `.agents/harness/resource_policy.py` (constants ~line 16; new helper; `command_is_heavy` ~line 580)
+- Modify: `.agents/harness/hook_guard.py` (resource selftest `resource_cases` list, ~line 1694)
+
+**Interfaces:**
+- Consumes: existing `READ_ONLY_SEARCHES`, `skip_assignments`, `basename`, `tokenize`, `command_segments` in `resource_policy.py`.
+- Produces: `resource_policy.SAFE_NONBUILD_TOOLS` (set) and `resource_policy._segment_leading_tool(tokens) -> Optional[str]` — used only within `resource_policy.py`.
+
+- [ ] **Step 1: Add the failing selftest cases**
+
+In `hook_guard.py`, in the `resource_cases` list (~line 1694), add three entries after the existing `("read-only cargo search", …)` line:
+
+```python
+            ("read-only cargo search", "rg 'cargo test --lib' .", "ALLOW"),
+            ("gh PR body mentions cargo", "gh pr create --base murmur --title x --body 'Fixes the cargo build path'", "ALLOW"),
+            ("gh PR body with backticks", "gh pr create --title x --body 'run `cargo test --lib` first'", "ALLOW"),
+            ("gh then cargo still heavy", "gh pr view 1 && cargo build", "BLOCK"),
+```
+
+(First line exists — shown for placement.)
+
+- [ ] **Step 2: Run the selftest to verify the two gh ALLOW cases fail**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: FAIL for `gh PR body with backticks` — `got BLOCK, want ALLOW` (the backtick scan finds `cargo test --lib`). `gh then cargo still heavy` must already be BLOCK (cargo segment).
+
+- [ ] **Step 3: Add the constant and helper**
+
+In `resource_policy.py`, after `READ_ONLY_SEARCHES = {"grep", "rg"}` (line 16) add:
+
+```python
+ALWAYS_ALLOWED_TOOLS = {"gh"}
+SAFE_NONBUILD_TOOLS = READ_ONLY_SEARCHES | ALWAYS_ALLOWED_TOOLS
+```
+
+Then add this helper above `command_is_heavy` (near the other segment helpers):
+
+```python
+def _segment_leading_tool(tokens):
+    """Best-effort basename of the executable a segment launches, or None."""
+    if not tokens:
+        return None
+    if tokens[0] == "__MURMUR_UNPARSEABLE__":
+        raw = tokens[1].lstrip()
+        match = re.match(r"(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*([^\s;|&]+)", raw)
+        return basename(match.group(1)) if match else None
+    index = skip_assignments(tokens, 0)
+    if index >= len(tokens):
+        return None
+    return basename(tokens[index])
+```
+
+- [ ] **Step 4: Exempt safe-tool-only commands in `command_is_heavy`**
+
+In `command_is_heavy` (line 580), immediately after the `TEST_GUARDIAN_ENV` check and BEFORE the backtick loop, insert:
+
+```python
+def command_is_heavy(command, depth=0):
+    if depth > MAX_DEPTH:
+        return True
+    if TEST_GUARDIAN_ENV in command:
+        return True
+    # A command whose every segment leads with a safe non-build tool (gh, grep,
+    # rg) cannot launch heavy work. Skip the substitution scan whose only job is
+    # to catch build commands hidden in backticks/$() — those are exactly what a
+    # gh PR/issue body legitimately contains as free-form text.
+    segments = list(command_segments(tokenize(command)))
+    if segments and all(
+        _segment_leading_tool(segment) in SAFE_NONBUILD_TOOLS for segment in segments
+    ):
+        return False
+    for backtick_body in re.findall(r"`([^`]*)`", command, flags=re.DOTALL):
+        ...
+```
+
+(Leave the rest of the function unchanged; the final line still returns `any(segment_is_heavy(...))`.)
+
+- [ ] **Step 5: Run the selftest to verify all cases pass**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: PASS — `gh PR body mentions cargo` (ALLOW), `gh PR body with backticks` (ALLOW), `gh then cargo still heavy` (BLOCK, mixed segments), `read-only cargo search` (ALLOW, still), and all existing cargo/ng/npm cases still BLOCK (no task-gating yet — that is Task 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .agents/harness/resource_policy.py .agents/harness/hook_guard.py
+git commit -m "fix(harness): exempt gh invocations from resource-heavy classification"
+```
+
+---
+
+## Task 3: `finish-guard` allows commits when no harness task is active
+
+Invert the fail-closed-on-no-task behavior. When `_resolve_task` finds no task for the worktree, `finish-guard` allows the commit (normal mode). A task that is *present but invalid* (malformed, wrong worktree, failed attestation) still blocks. `secret-scan` and trunk protection are separate hooks and are unaffected.
+
+**Files:**
+- Modify: `.agents/harness/hook_guard.py` (new exception; `_resolve_task` ~line 625; `_finish_guard` ~line 937; selftest assertion ~line 1807)
+
+**Interfaces:**
+- Consumes: existing `GuardFailure`, `_resolve_task`, `_validate_attestation`.
+- Produces: `NoTaskForWorktree(GuardFailure)` exception — reused by Task 4.
+
+- [ ] **Step 1: Flip the failing selftest assertion**
+
+In `hook_guard.py` (~line 1807), change the "missing manifest" expectation from `BLOCK` to `ALLOW`:
+
+```python
+        test.result(f"{vendor}: default-enforce missing manifest", got, "ALLOW")
+```
+
+Leave the malformed-manifest (`BLOCK`, ~1821), fake-receipt (`BLOCK`, ~1825), and minimal-receipt (`BLOCK`, ~1839) assertions unchanged.
+
+- [ ] **Step 2: Run the selftest to verify it now fails**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: FAIL for `default-enforce missing manifest` — `got BLOCK, want ALLOW` (current code fails closed on no task).
+
+- [ ] **Step 3: Define the distinct exception and raise it only for the true no-task case**
+
+In `hook_guard.py`, near the `GuardFailure` definition, add:
+
+```python
+class NoTaskForWorktree(GuardFailure):
+    """Raised when no harness task claims the current worktree (normal mode)."""
+```
+
+In `_resolve_task`, change ONLY the final raise (line 625) from `GuardFailure` to `NoTaskForWorktree`:
+
+```python
+    raise NoTaskForWorktree(
+        "no task manifest matches this worktree; use scripts/agent-harness init/run"
+    )
+```
+
+Leave the "multiple task manifests" (line 604) and every other raise as plain `GuardFailure` — those mean tasks exist and must still fail closed.
+
+- [ ] **Step 4: Allow-on-no-task in `_finish_guard`**
+
+In `_finish_guard` (the `try` block ~line 937-950), add a dedicated `except` before the generic one:
+
+```python
+        try:
+            repo = _repo_for_invocation(commits[0])
+            _, common, _, _ = _repo_context(repo)
+            task, task_dir = _resolve_task(repo, common)
+            _validate_attestation(
+                repo,
+                common,
+                task,
+                task_dir,
+                allow_test_adapter=allow_test_adapter,
+            )
+            return None
+        except NoTaskForWorktree:
+            return None  # normal mode: no active harness task → allow the commit
+        except GuardFailure as exc:
+            reason = str(exc)
+```
+
+- [ ] **Step 5: Run the selftest to verify all cases pass**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: PASS — `default-enforce missing manifest` (ALLOW), `malformed task manifest` (BLOCK), `production rejects fake receipt` (BLOCK), `minimal receipt` (BLOCK). The `secret-scan` cases (including the clean `git commit` ALLOW at ~1795) still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .agents/harness/hook_guard.py
+git commit -m "feat(harness): finish-guard allows commits when no task is active (opt-in)"
+```
+
+---
+
+## Task 4: Resource-lane wrapping required only when a harness task is active
+
+`_block_bash` currently forces every heavy/dev command through `agent-resource-run`/`agent-dev-run` unconditionally. Gate that on the same switch: only enforce it when a task claims the worktree (parallel harness writers must serialize on the shared cargo lane). In normal mode, heavy commands run directly.
+
+**Files:**
+- Modify: `.agents/harness/hook_guard.py` (new helper; `_block_bash` ~line 494-504; resource selftest `resource_cases` ~line 1694, and add a task-present block case)
+
+**Interfaces:**
+- Consumes: `NoTaskForWorktree` (Task 3), `_resolve_task`, `_repo_context`, `_git_text`.
+- Produces: `_worktree_has_active_task(process_cwd) -> bool` — internal to `hook_guard.py`.
+
+- [ ] **Step 1: Update the resource selftest expectations (no-task → ALLOW)**
+
+The `resource_cases` list runs against a repo with **no** task, so under the new rule they must ALLOW. Change each unwrapped-heavy expectation from `BLOCK` to `ALLOW`:
+
+```python
+        resource_cases = [
+            ("direct cargo metadata", "cargo metadata --no-deps", "ALLOW"),
+            ("direct Rust test", "cd src-tauri && cargo test --lib", "ALLOW"),
+            ("direct Angular build", "npx ng build", "ALLOW"),
+            ("direct npm dev", "npm run dev", "ALLOW"),
+            ("direct full CI", "bash scripts/ci.sh", "ALLOW"),
+            ("read-only cargo search", "rg 'cargo test --lib' .", "ALLOW"),
+            ("gh PR body mentions cargo", "gh pr create --base murmur --title x --body 'Fixes the cargo build path'", "ALLOW"),
+            ("gh PR body with backticks", "gh pr create --title x --body 'run `cargo test --lib` first'", "ALLOW"),
+            ("gh then cargo still heavy", "gh pr view 1 && cargo build", "ALLOW"),
+```
+
+Note `gh then cargo still heavy` also becomes ALLOW here (no task). Keep the `lane-wrapped Rust test` entry (~line 1701) as `ALLOW` (unchanged). Leave any assertions that check the wrapper-forging / dev-runner allowlist as-is — those test classification, not the block gate; verify them individually if any turn red and adjust only genuine no-task cases.
+
+- [ ] **Step 2: Add a task-present BLOCK case for the resource lane**
+
+The finish-guard selftest already builds a task-bearing repo via `_finish_repo()` + `_write_receipt(repo, "fresh")` (~line 1823). Add, right after the `minimal receipt` block (~line 1839), a resource-lane assertion proving wrapping is still required in harness mode:
+
+```python
+        # With a task claiming the worktree, the resource lane is enforced again.
+        task_dir, task, attestation = _write_receipt(repo, "lane")
+        got, _ = test.invoke(vendor, "block-bash", "cargo test --lib", repo)
+        test.result(f"{vendor}: task-present unwrapped heavy blocked", got, "BLOCK")
+        got, _ = test.invoke(
+            vendor,
+            "block-bash",
+            "scripts/agent-resource-run --chdir src-tauri -- cargo test --lib",
+            repo,
+        )
+        test.result(f"{vendor}: task-present lane-wrapped allowed", got, "ALLOW")
+```
+
+- [ ] **Step 3: Run the selftest to verify the new expectations fail**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: FAIL for the `direct …` no-task cases (`got BLOCK, want ALLOW`) — current code blocks regardless of task. The `task-present unwrapped heavy blocked` case may pass or fail depending on ordering; the decisive failures are the no-task ones.
+
+- [ ] **Step 4: Add the task-detection helper**
+
+In `hook_guard.py`, add near `_resolve_task`:
+
+```python
+def _worktree_has_active_task(process_cwd: Path) -> bool:
+    """True when a harness task claims this worktree (harness mode)."""
+    try:
+        top = _git_text(process_cwd, "rev-parse", "--show-toplevel", check=False)
+        if not top:
+            return False
+        repo = Path(top).resolve()
+        _, common, _, _ = _repo_context(repo)
+        _resolve_task(repo, common)
+        return True
+    except NoTaskForWorktree:
+        return False
+    except GuardFailure:
+        # Tasks exist but are ambiguous/malformed → fail safe: treat as harness
+        # mode so the lane stays enforced.
+        return True
+    except Exception:
+        # Not a resolvable git worktree → normal mode.
+        return False
+```
+
+- [ ] **Step 5: Gate the resource-lane block on task presence**
+
+In `_block_bash`, wrap the two resource-lane checks (lines 494-504) so they only fire in harness mode. Replace:
+
+```python
+    if resource_policy.command_is_dev_in(command, process_cwd):
+        return (
+            "long-lived dev commands must run through scripts/agent-dev-run; "
+            "the dev supervisor stays outside the global lane while its cargo/rustc "
+            "descendants acquire it per process"
+        )
+    if resource_policy.command_is_heavy_in(command, process_cwd):
+        return (
+            "unwrapped resource-heavy build/test/dev command; run it through "
+            "scripts/agent-resource-run so Murmur worktrees share one supervised lane"
+        )
+    return None
+```
+
+with:
+
+```python
+    dev = resource_policy.command_is_dev_in(command, process_cwd)
+    heavy = resource_policy.command_is_heavy_in(command, process_cwd)
+    if (dev or heavy) and _worktree_has_active_task(process_cwd):
+        if dev:
+            return (
+                "long-lived dev commands must run through scripts/agent-dev-run; "
+                "the dev supervisor stays outside the global lane while its cargo/rustc "
+                "descendants acquire it per process"
+            )
+        return (
+            "unwrapped resource-heavy build/test/dev command; run it through "
+            "scripts/agent-resource-run so Murmur worktrees share one supervised lane"
+        )
+    return None
+```
+
+(Note: `_worktree_has_active_task` is only called when the command is already classified heavy/dev, so the common fast path pays no git cost.)
+
+- [ ] **Step 6: Run the selftest to verify all cases pass**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: PASS — all no-task `direct …` cases ALLOW; `task-present unwrapped heavy blocked` BLOCK; `task-present lane-wrapped allowed` ALLOW; trunk-push/security/codesign block-bash cases still BLOCK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .agents/harness/hook_guard.py
+git commit -m "feat(harness): require the resource lane only when a task is active"
+```
+
+---
+
+## Task 5: The `/harness` skill (both vendors) + Codex entry
+
+Create the opt-in entry point. Claude gets a skill; the canonical runbook is mirrored under `.agents/skills/`; Codex (no skills mechanism) is pointed at the CLI from `AGENTS.md`. Skills are not part of the `config_audit` parity contract, so no Codex `.toml` mirror is required.
+
+**Files:**
+- Create: `.agents/skills/harness/SKILL.md`
+- Create: `.claude/skills/harness/SKILL.md`
+- Modify: `AGENTS.md` (add a Codex-facing opt-in note)
+
+**Interfaces:** none (documentation/runbook).
+
+- [ ] **Step 1: Write the canonical runbook**
+
+Create `.agents/skills/harness/SKILL.md`:
+
+```markdown
+---
+name: harness
+description: Run a change through the full Murmur harness — isolated worktree, writer, deterministic checks, independent adversarial + risk reviews, hash-bound PASS attestation, guarded commit. Use PROACTIVELY when a change is risky, multi-step, or you want the earned safety net (lock/crypto/egress/protocol, or anything you want independently verified). Skip it for docs, chores, and low-risk edits — those commit normally.
+---
+
+# `/harness` — opt-in rigor
+
+Murmur's harness is **opt-in**. Normal commits run freely (only secret-scan and
+trunk-push protection are always on). Invoke the harness deliberately, via this
+skill, when a change deserves independent verification.
+
+## When to reach for it
+
+- Anything touching the lock model / crypto / secrets / storage / MCP / egress /
+  the sharing protocol (the `risk_classification` paths in
+  `.agents/harness/config.json`).
+- A multi-step feature or refactor where you want a fresh adversarial reviewer to
+  try to break the change before it lands.
+- Any time you want the hash-bound Definition-of-Done receipt on the commit.
+
+For a docs fix, a chore, a version bump, or a small low-risk edit: **do not use
+this** — just commit normally.
+
+## How it works
+
+The switch is physical: the harness runs in an **isolated sibling worktree** that
+carries a task manifest. While that task is active, `finish-guard` enforces the
+full attestation and the resource lane is required for heavy commands. Your main
+`murmur` checkout never has a task, so work there is unconstrained.
+
+## Run it
+
+```bash
+# 1. Create the contract + isolated worktree
+scripts/agent-harness init --kind <feature|refactor|docs|harness> --title "<what>"
+
+# 2. Drive writer → checks → independent reviews → PASS attestation
+scripts/agent-harness run
+
+# 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
+scripts/agent-harness commit
+gh pr create -R murmur-io/murmur --base murmur
+gh pr merge --merge
+
+# 4. Close the task
+scripts/agent-harness close
+```
+
+The default vendor pair is Claude writer → Codex reviewer (the only supported
+reversal is Codex writer → Claude reviewer). The implementer never owns the
+verdict.
+
+## Verify the harness itself
+
+```bash
+bash .claude/hooks/selftest.sh
+scripts/agent-harness selftest --ci
+scripts/agent-config-audit --ci
+```
+```
+
+- [ ] **Step 2: Mirror it for Claude**
+
+Create `.claude/skills/harness/SKILL.md` with **identical** content to Step 1 (the repo mirrors `.agents/skills/` runbooks into `.claude/skills/`).
+
+```bash
+cp .agents/skills/harness/SKILL.md .claude/skills/harness/SKILL.md
+```
+
+- [ ] **Step 3: Add the Codex-facing note to `AGENTS.md`**
+
+In `AGENTS.md`, under the agents/skills/harness section (mirroring where `CLAUDE.md` documents the harness), add:
+
+```markdown
+## Opt-in harness (`/harness`)
+
+The harness is **opt-in**. Normal commits run freely; only `secret-scan` and
+direct-push-to-`murmur` protection are always on. Reach for rigor deliberately:
+
+- **Codex has no skills mechanism** — invoke the harness directly:
+  `scripts/agent-harness init … && scripts/agent-harness run && scripts/agent-harness commit`.
+- Use it for lock/crypto/egress/protocol changes or anything you want a fresh
+  adversarial reviewer to verify. Skip it for docs/chores/low-risk edits.
+- Guard behavior is identical across vendors (same `hook_guard.py`): a commit in
+  a worktree with **no** active task is allowed; a worktree **with** a task
+  enforces the full hash-bound attestation.
+```
+
+- [ ] **Step 4: Verify config-audit stays green**
+
+Run: `scripts/agent-config-audit --ci`
+Expected: exits 0 (skills are not parity-checked; the `AGENTS.md` edit passes the semantic lint — no "angular 18" / `allowSignalWrites` / `provideExperimentalZonelessChangeDetection` strings introduced).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .agents/skills/harness/SKILL.md .claude/skills/harness/SKILL.md AGENTS.md
+git commit -m "docs(harness): add opt-in /harness skill (Claude) + Codex AGENTS entry"
+```
+
+---
+
+## Task 6: Bake the release recipe into `release-murmur`; deprecate `scripts/release.sh`
+
+Make a smooth release independent of memory recall: document the unsandboxed steps, the human pause points, and the correct order in the `release-murmur` skill. Mark the stale `scripts/release.sh` (targets `MeetNotes.app`) as a smoke test only.
+
+**Files:**
+- Modify: `.claude/skills/release-murmur/SKILL.md`
+- Modify: `.agents/skills/release-murmur/SKILL.md`
+- Modify: `scripts/release.sh` (deprecation header)
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Add the sandbox + human-pause recipe to the release skill**
+
+Append a section to `.claude/skills/release-murmur/SKILL.md` (near the "Mac-only boundary"):
+
+```markdown
+## Sandbox & human-pause recipe (do not rely on memory recall)
+
+Release steps that touch the keychain, codesign, notarytool, or `gh`/`git push`
+**must run unsandboxed** and **must not** be wrapped in `agent-resource-run`
+(the harness is opt-in; on the release machine you are in normal mode).
+
+- **Sandbox:** the release machine keeps a per-machine, git-ignored
+  `.claude/settings.local.json` override. Never commit sandbox-disabling to the
+  repo — it would weaken the sandbox for the whole team.
+- **Heavy commands run directly** in normal mode (no `agent-resource-run`
+  wrapping required). `finish-guard` is asleep, so the version-bump commit goes
+  through directly; merge to `murmur` still requires a **PR** (never a direct
+  push), and `gh` PR bodies are no longer misclassified as heavy.
+
+Irreducible human pause points (macOS auth dialogs the agent shell cannot answer):
+
+1. **P1 — unlock the login keychain** (once, up front): needed for `git`/`gh`
+   push and for Developer-ID key + notary-profile access. Run
+   `security unlock-keychain` **yourself** — the agent must never run `security`.
+2. **P2 — supply the Developer-ID hash** as `DEVELOPER_ID` (40 hex chars) to
+   `scripts/macos-sign-notarize.sh`. Pre-supply it so it does not stall the run.
+3. **P3 — approve the Developer-ID codesign key dialog** once ("Always Allow");
+   this collapses the per-helper + app + DMG prompts into one interaction.
+
+One-time-only (not per release): `xcrun notarytool store-credentials murmur`,
+run interactively by you.
+
+Everything else — CI gate, version bump, universal build, DMG, `notarytool
+submit --wait`, staple, `spctl`, `gh release create/upload` — is headless.
+
+## Enable repo auto-merge
+
+`gh pr merge --merge --auto` requires auto-merge enabled on the repo (Settings →
+General → "Allow auto-merge"). Enable it once to stop hand-waiting on CI.
+```
+
+- [ ] **Step 2: Mirror to the canonical skill**
+
+Apply the **same** appended section to `.agents/skills/release-murmur/SKILL.md`.
+
+- [ ] **Step 3: Deprecate `scripts/release.sh`**
+
+Replace the top comment block of `scripts/release.sh` (lines 2-6) with:
+
+```bash
+# DEPRECATED — smoke test only, NOT the release path.
+# This targets the stale bundle name (MeetNotes.app); the real universal release
+# is Murmur.app at the workspace-root target/, driven by the `release-murmur`
+# skill + scripts/macos-sign-notarize.sh. Use this file only to prove the bundle
+# builds, ad-hoc-signs, and packages into a functional .dmg on a headless box.
+```
+
+- [ ] **Step 4: Verify config-audit stays green**
+
+Run: `scripts/agent-config-audit --ci`
+Expected: exits 0 (the release skill is not parity-fingerprinted beyond `risk_classification`; `bash -n scripts/*.sh` passes for `release.sh`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/release-murmur/SKILL.md .agents/skills/release-murmur/SKILL.md scripts/release.sh
+git commit -m "docs(release): bake sandbox + human-pause recipe; deprecate stale release.sh"
+```
+
+---
+
+## Task 7: Full-gate verification + rollout
+
+Prove the whole change is coherent, then merge and clean up.
+
+**Files:** none (verification + ops).
+
+- [ ] **Step 1: Run the canonical selftest against both vendors**
+
+Run: `bash .claude/hooks/selftest.sh`
+Expected: `0 failures` across all sections (command guard, indirection, resource lane, secret scan, finish gate).
+
+- [ ] **Step 2: Run the harness selftest and config audit**
+
+Run:
+```bash
+scripts/agent-harness selftest --ci
+scripts/agent-config-audit --ci
+```
+Expected: both exit 0. `config_audit` confirms `MURMUR_FINISH_GUARD=enforce` still wired, hook parity intact, no rule/agent drift.
+
+- [ ] **Step 3: Smoke-test the switch end to end (manual)**
+
+From the main `murmur` worktree (no task), from a normal terminal:
+```bash
+git commit --allow-empty -m "chore: switch smoke test"   # expected: succeeds (no task → finish-guard allows)
+git push origin murmur                                     # expected: BLOCKED by the agent hook if run via the agent; from your terminal it is your call — do NOT push the smoke commit; drop it:
+git reset --hard HEAD~1
+```
+Then confirm harness mode still enforces: `scripts/agent-harness init …` in a sibling worktree and verify a bare `git commit` there is rejected without a receipt.
+
+- [ ] **Step 4: Open the PR and merge**
+
+```bash
+git push -u origin feat/opt-in-harness
+gh pr create -R murmur-io/murmur --base murmur --title "Opt-in harness (/harness) + relaxed normal mode"
+# after CI green:
+gh pr merge --merge
+```
+
+- [ ] **Step 5: Prune abandoned task worktrees**
+
+The `instructions_sha256` change invalidates in-flight receipts; remove the stale experiments:
+```bash
+git worktree list
+# for each ../.murmur-agent-tasks/* worktree (incl. opt-in-harness-quick-lane-v2..v4,
+# harness-light-lane-v2..v7, release-1-0-2-*):
+git worktree remove --force <path>
+git branch -D <agent/branch>
+```
+
+- [ ] **Step 6: Final commit / confirmation**
+
+No code to commit here; confirm `git worktree list` shows only the main checkout (+ any intentional worktree) and that the feature is merged to `murmur`.
+
+---
+
+## Self-review notes
+
+- **Spec §3.1.1** (finish-guard allow-on-no-task) → Task 3. **§3.1.2** (resource-lane task-gated) → Task 4. **§3.1.3** (secret-scan/branch unconditional) → preserved (not modified; verified in Task 3 Step 5 / Task 7 Step 1).
+- **Spec §3.2.4** (`source ~/.cargo/env`) → Task 1. **§3.2.5** (`gh` exempt) → Task 2 (residual: shell-substitution in a *double-quoted* gh body is still expanded by the shell → use `--body-file`; documented in Task 6 recipe).
+- **Spec §3.3** (`/harness` both vendors) → Task 5. **§3.4** (sandbox + release recipe, release.sh) → Task 6.
+- **Spec §6** (testing) → each task's selftest steps + Task 7. **§8** (rollout/cleanup) → Task 7 Steps 4-5. **§7** (accepted risk) → inherent to Tasks 3-4 (no risk-gating added, by design).
+- **Type consistency:** `NoTaskForWorktree` defined in Task 3, consumed in Task 4's `_worktree_has_active_task`. `SAFE_NONBUILD_TOOLS` / `_segment_leading_tool` defined and used within Task 2.

--- a/docs/superpowers/specs/2026-07-24-opt-in-harness-skill-design.md
+++ b/docs/superpowers/specs/2026-07-24-opt-in-harness-skill-design.md
@@ -1,0 +1,106 @@
+# Opt-in harness (`/harness`) + relaxed normal mode — design
+
+- **Date:** 2026-07-24
+- **Status:** Approved (design); implementation plan pending
+- **Author:** QueaT
+- **Topic:** Make the agent development harness *opt-in* instead of *mandatory on every commit*, and relax the day-to-day shell guardrails that bit the last release — without weakening the two catastrophe-prevention rails (secret-scan, trunk protection).
+
+---
+
+## 1. Problem
+
+The harness (`.agents/harness/` + the `.claude`/`.codex` adapters) is well-built and every rule has a real production incident behind it. Its one structural flaw is **lack of proportionality**: a docs typo pays the exact same ceremony as a change to `crypto.rs`. Two distinct layers of friction fall out of this, and they had been conflated:
+
+**Layer 1 — commit/review ceremony (`finish-guard` + task machinery).** Every `git commit` the agent makes fails closed unless the current worktree has a harness task with a hash-bound PASS attestation (`hook_guard.py:923` `_finish_guard`; `MURMUR_FINISH_GUARD=enforce` pinned in `.claude/settings.json:4`). There is no light path — `kind:"docs"` runs the identical writer → checks → spec+adversarial review → attestation flow.
+
+**Layer 2 — shell guardrails (`block-bash` + resource-lane + Claude Code sandbox).** Always-on, independent of harness mode. This is what actually hurt the last release.
+
+Concrete pains observed on the last release (the failure surface this design must close):
+
+| Pain | Root layer |
+| --- | --- |
+| `finish-guard` blocked a chore/version-bump commit → had to hack `MURMUR_FINISH_GUARD=advisory` | Layer 1 (finish-guard) |
+| Claude Code sandbox blocked build / keychain / `gh` entirely | Layer 2 (sandbox) |
+| Had to wrap every heavy command in `agent-resource-run` | Layer 2 (resource-lane) |
+| `--body-file` needed because a PR body containing "cargo"/"tauri" was classified heavy | Layer 2 (`resource_policy` false positive) |
+| Waiting on CI because repo auto-merge is off | GitHub setting (out of code) |
+
+## 2. Decision
+
+**Pure opt-in.** The harness becomes a tool the operator invokes deliberately (`/harness`), not a gate on every commit. This is an explicit, accepted trade-off (see §7): in normal mode, a commit touching risk-classified paths (`crypto`/lock/egress/…) is **not** auto-blocked. The safety net is *available* via `/harness`, not *forced*.
+
+**One switch governs both layers.** The switch is the signal the harness already computes: *"does this worktree have an active harness task?"* (`_resolve_task`, `hook_guard.py:582`). No new persistent state, env flag, or lock file.
+
+- **No task present (normal mode):** `finish-guard` sleeps; heavy commands run directly; only `secret-scan` + trunk protection fire.
+- **Task present (harness mode, entered via `/harness`):** full ceremony + resource-lane serialization + attestation, exactly as today.
+
+Because `/harness` creates an isolated sibling worktree (as `scripts/agent-harness init` does today), rigor physically lives in that worktree; the main `murmur` checkout never has a task, so day-to-day work there is unconstrained.
+
+## 3. Design
+
+### 3.1 The switch — guard changes (`.agents/harness/hook_guard.py`)
+
+1. **`_finish_guard` (`hook_guard.py:923`): invert the no-task branch.** Today `_resolve_task` raising "no task manifest matches this worktree" → BLOCK. Change to: **no-task → ALLOW (return `None`)**. Keep BLOCK when a task *is present but invalid* (malformed manifest, branch mismatch, worktree mismatch, failed attestation) — the operator clearly intended rigor and something is wrong. `off` mode unchanged. `enforce` now means "enforce *if* a task is present."
+   - Implementation note: distinguish the specific "no task at all" `GuardFailure` from the other `_resolve_task`/`_validate_attestation` failures so only the former is downgraded to ALLOW. Do **not** blanket-catch.
+2. **Resource-lane heavy/dev block (`hook_guard.py:494-504`): gate on task-present.** No task → `command_is_heavy_in` / `command_is_dev_in` do not block (bare `cargo`, `tauri build`, `ng build`, `npm run dev` run directly). Task present → keep the current requirement to route through `scripts/agent-resource-run` / `scripts/agent-dev-run` (parallel worktrees must serialize on the shared cargo lane).
+3. **`secret-scan` and trunk protection: unchanged, unconditional.** They fire in both modes (`_secret_scan` `hook_guard.py:539`; `_push_targets_protected` `hook_guard.py:411`, `PROTECTED_BRANCHES = {"murmur","main","master"}`).
+
+### 3.2 block-bash fixes (always-on, both modes)
+
+4. **Unblock `source ~/.cargo/env`.** The indirection guard (`_unsupported_execution_indirection`, `hook_guard.py:282`) hard-blocks `source`/`.` with no allowlist, even though `SAFE_SOURCE_TARGETS` already exists in `resource_policy.py:43` (it is only consulted by the heavy classifier, never by the indirection guard, which fires first). Make the indirection guard consult that allowlist for `source`/`.` targets. CLAUDE.md lists `source ~/.cargo/env` as a standard command; it must not be blocked.
+5. **Stop classifying `gh` as heavy.** A `gh pr create --body "...cargo..."` was flagged because `resource_policy` fail-closes on commands that mention `cargo|rustc|tauri` when it cannot confidently parse them, and/or substring-matches quoted argument text. Add `gh` to the always-allowed set (like `grep`/`rg`, `READ_ONLY_SEARCHES` `resource_policy.py:15`) and ensure quoted-argument content is not substring-matched against command names. Removes the `--body-file` workaround.
+
+### 3.3 The `/harness` entry (both vendors)
+
+6. **Claude:** `.claude/skills/harness/SKILL.md` — a guided wrapper over `scripts/agent-harness init/run/commit/close`. Canonical runbook mirrored at `.agents/skills/harness/SKILL.md` per repo convention. The skill explains: when to reach for rigor, how the switch works, and that it operates in an isolated worktree.
+7. **Codex:** Codex has **no skills mechanism** (verified: `.codex/` has `agents/`, `rules/`, `hooks/`, but no `skills/` or `prompts/`). Document the opt-in path in `AGENTS.md` ("want rigor → `scripts/agent-harness`"). Guard behavior is identical across vendors because both adapters call the same `hook_guard.py`, so behavioral parity is free.
+8. **`config_audit` impact:** skills are *not* part of the parity contract (`config_audit.py` checks `rules/` and `agents/` for cross-vendor parity, not `skills/`). A Claude-only skill does not break `config_audit --ci`. Keep the `.agents/` ↔ `.claude/` mirror convention regardless.
+
+### 3.4 Sandbox + release durability (docs, not sandbox weakening)
+
+9. **Keep the project sandbox strict.** The `sandbox` block in `.claude/settings.json` (`enabled:true`, `failIfUnavailable:true`) stays. The per-machine `.claude/settings.local.json` (git-ignored) remains the release-machine override — do not commit sandbox-disabling to the repo (it would weaken the sandbox for the whole team).
+10. **Bake the release routine into the `release-murmur` skill** so a smooth release does not depend on memory recall: the unsandboxed steps, the human pause points (P1 = unlock login keychain; P3 = approve the Developer-ID codesign key ACL dialog once; P2 = supply the 40-hex `DEVELOPER_ID` up front), and the correct order. Fix or deprecate the stale `scripts/release.sh` (it still targets `MeetNotes.app`; the real bundle is `Murmur.app` at the workspace-root `target/`).
+11. **Emergent benefit:** with `finish-guard` asleep and the resource-lane not forcing wrappers in normal mode, the release becomes largely smooth without writing a new driver script — the version-bump commit goes through directly and heavy build commands run directly. A dedicated "one resumable command" release driver is therefore **out of scope** here (see §9); the pain it addressed is mostly removed by §3.1.
+
+## 4. Fixes → pains (traceability)
+
+| Pain | Resolved by |
+| --- | --- |
+| `finish-guard` blocked chore → `advisory` hack | §3.1.1 (normal mode: guard sleeps) |
+| sandbox blocked build/keychain/gh | §3.4 (`settings.local.json` + recipe baked into `release-murmur`) |
+| wrapping heavy commands in `agent-resource-run` | §3.1.2 (normal mode: heavy commands run directly) |
+| `--body-file` due to "cargo" in PR body | §3.2.5 (`gh` exempt from heavy classification) |
+| waiting on CI (auto-merge off) | Out of code — enable repo auto-merge; documented in `release-murmur` |
+
+## 5. Components & boundaries
+
+- **`hook_guard.py`** — the single canonical guard (both vendor adapters call it). All switch logic and block-bash fixes live here + `resource_policy.py`. No Claude↔Codex drift risk; `config_audit` only fingerprints `hook_guard.py` (informational) and does not inspect `resource_policy.py`.
+- **`resource_policy.py`** — heavy/dev classifier. Receives the `gh` exemption and the quoted-arg fix. Its `command_is_heavy_in`/`command_is_dev_in` callers in `hook_guard.py` become task-gated.
+- **`scripts/agent-harness`** — unchanged CLI; `/harness` is a thin guided entry to it.
+- **`.claude/skills/harness/`, `.agents/skills/harness/`, `AGENTS.md`** — the opt-in entry, per vendor.
+- **`.claude/skills/release-murmur/`** — gains the durable release recipe.
+
+## 6. Testing
+
+- **`hook_guard --selftest`** (the real gate for guard changes; `config_audit` does not cover this logic):
+  - Invert the existing "default-enforce missing manifest → BLOCK" assertion (`hook_guard.py:~1807`) to **ALLOW**.
+  - Add RED assertions (must still BLOCK): task present but invalid → BLOCK; staged secret in normal mode → BLOCK; `git push origin murmur` / bare push on `murmur` in normal mode → BLOCK; heavy command with a task present but unwrapped → BLOCK.
+  - Add ALLOW assertions: heavy command with no task → ALLOW; `source ~/.cargo/env` → ALLOW; `gh pr create --body "...cargo..."` → ALLOW.
+- **`config_audit --ci`** must stay green: `MURMUR_FINISH_GUARD` stays `enforce` in `settings.json` (semantics changed, wiring unchanged); no new wired hooks; no rule/agent parity changes.
+- **`scripts/agent-config-audit`** and **`scripts/agent-harness selftest`** run clean.
+
+## 7. Accepted risk / trade-offs
+
+- **Explicit operator choice — pure opt-in.** In normal mode, a commit touching a risk-classified path (`config.json risk_classification`: `crypto.rs`, `secrets/**`, `storage/**`, lock/egress/protocol/etc.) is **not** auto-blocked and gets **no** review. The lock-security / egress-security review nets are available only when the operator runs `/harness`. This is knowingly weaker than the previous fail-closed-everywhere posture; it is acceptable because this is a solo repo and the operator opts into rigor deliberately. A future middle option ("risk-gated normal mode") is recorded in §9 but explicitly not built now.
+- **Preserved regardless of mode:** secret-in-git-history prevention (`secret-scan`) and direct-push-to-trunk prevention (branch protection). In harness mode, the full contract is unchanged: hash-bound attestation, vendor separation (writer ≠ reviewer), staged-diff binding, required reviews + risk evidence.
+
+## 8. Rollout / migration
+
+- The change edits `hook_guard.py`, `resource_policy.py`, `.claude/`, `.agents/`, `AGENTS.md` — all under `config.json protected_paths`. It also changes `instructions_sha256` (these files are in `instruction_paths`), invalidating any in-flight task receipts. Land it either through the harness as a `--kind harness` change (with the one-time `seal-prepared` bootstrap) or by committing from a normal terminal (no hooks).
+- **Cleanup:** prune the ~20 abandoned worktrees under `../.murmur-agent-tasks/` (`git worktree remove`) — their receipts are invalidated by the fingerprint change anyway. Includes the stale `opt-in-harness-quick-lane-v2..v4` / `harness-light-lane-v2..v7` experiments this design supersedes.
+
+## 9. Out of scope / follow-ups
+
+- **Risk-gated normal mode** (block only risk-classified commits in normal mode, allow the rest): a stronger-safety alternative to pure opt-in. Deliberately deferred per operator choice.
+- **"One resumable command" release driver** with explicit P1/P3 pauses: mostly obviated by §3.1/§3.4; revisit only if release still feels manual after this lands.
+- **Repo auto-merge**: a GitHub setting, not code; note it in `release-murmur`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Build + package MeetNotes. What this does HEADLESS (all verified to work):
-#   1. release .app build, 2. ad-hoc codesign + verify (proves the bundle is well-formed
-#   and signable), 3. a functional .dmg via hdiutil.
-# What still needs a real Mac / paid Apple Developer ID (see printout): Developer-ID
-# signing + notarization, and Tauri's *styled* .dmg layout (bundle_dmg.sh uses Finder).
+# DEPRECATED — smoke test only, NOT the release path.
+# This targets the stale bundle name (MeetNotes.app); the real universal release
+# is Murmur.app at the workspace-root target/, driven by the `release-murmur`
+# skill + scripts/macos-sign-notarize.sh. Use this file only to prove the bundle
+# builds, ad-hoc-signs, and packages into a functional .dmg on a headless box.
 set -euo pipefail
 # shellcheck disable=SC1091
 source "$HOME/.cargo/env" 2>/dev/null || true


### PR DESCRIPTION
## Opt-in harness (`/harness`) + relaxed normal mode

Makes the agent development harness **opt-in** instead of mandatory on every commit, and fixes two block-bash false-positives — while keeping the always-on catastrophe rails (secret-scan, direct-push-to-trunk protection).

### The switch
One signal — *does this worktree have an active harness task?* (`_resolve_task` / new `NoTaskForWorktree`) — governs both layers:
- **No task (normal mode):** `finish-guard` allows the commit **and** the resource-lane wrapping requirement is not enforced.
- **Task present (harness mode, entered via `/harness`):** full hash-bound attestation enforced **and** the resource lane required.
- **Always on regardless of mode:** `secret-scan` on commit + direct-push-to-`murmur`/`main` protection. Ambiguous/malformed tasks still fail closed.

### Changes
- `finish-guard`: no active task → allow (opt-in). Malformed/ambiguous task → still BLOCK.
- resource-lane: `agent-resource-run` wrapping required only when a task is active (fast path: the git check runs only for already-heavy/dev commands).
- block-bash: `source ~/.cargo/env` allowed; `gh` invocations no longer misclassified as resource-heavy (quote-aware — live `$()`/backtick substitution still blocked).
- docs: `/harness` skill (Claude + canonical mirror) + Codex `AGENTS.md` entry; release recipe (sandbox handling + P1/P3 human pauses) baked into `release-murmur`; stale `scripts/release.sh` marked deprecated.

### Verification
- `bash .claude/hooks/selftest.sh` → PASS (232 assertions, 0 failures)
- `scripts/agent-config-audit --ci` → PASS (136 checks, 0 warnings)
- `scripts/agent-harness selftest --ci` → PASS

### Accepted trade-off
Pure opt-in: in normal mode, commits touching risk-classified paths (crypto/lock/egress) are **not** auto-blocked — the safety net is available via `/harness`, not forced (deliberate, per the design spec §7).

### Deferred follow-ups (non-blocking)
- `_resolve_task`: a corrupt-JSON manifest as the sole one for a worktree falls through to no-task (both layers stay consistent; dangerous invalid cases still fail closed).
- `gh --body` with double-quoted `$()`/backticks stays blocked (shell would execute it) — use `--body-file`.

Design: `docs/superpowers/specs/2026-07-24-opt-in-harness-skill-design.md`
Plan: `docs/superpowers/plans/2026-07-24-opt-in-harness-skill.md`
