### PR TITLE
chore(e2e): remove debug screenshots writing to a dead session's scratchpad

### DIFF
--- a/e2e/notes/ask-citation-overflow.spec.ts
+++ b/e2e/notes/ask-citation-overflow.spec.ts
@@ -68,9 +68,5 @@ test("a long Ask citation wraps INSIDE the drawer pane (no horizontal overflow)"
   // font-size-tall row; a wrapped one is clearly taller).
   expect(rects.chipHeight).toBeGreaterThan(rects.lineHeight * 1.5);
 
-  await drawer.screenshot({
-    path: "/private/tmp/claude-501/-Users-jakubgawronski-Projects-meetnotes/d3db29b4-fbd3-49ac-868a-fd86a0c14a1f/scratchpad/ask-citation.png",
-  });
-
   expect(consoleErrors).toEqual([]);
 });

--- a/e2e/notes/related-consolidation.spec.ts
+++ b/e2e/notes/related-consolidation.spec.ts
@@ -216,11 +216,7 @@ test("Related panel: collapse-by-default, dedup, cross-dedup, ambient suggestion
   await expect(head.locator(".head-more .crumb-btn")).toHaveCount(1);
   await expect(head.getByRole("button", { name: "Share" })).toHaveCount(0);
 
-  // Screenshot the expanded Related section (dark scheme is the config default).
   await panel.scrollIntoViewIfNeeded();
-  await panel.screenshot({
-    path: "/private/tmp/claude-501/-Users-jakubgawronski-Projects-meetnotes/d3db29b4-fbd3-49ac-868a-fd86a0c14a1f/scratchpad/related-panel.png",
-  });
 
   // (5b) promote the suggestion by TAPPING its chip body → acceptLink runs, the
   // dashed chip becomes a real "Design doc" link and the suggestion group empties.


### PR DESCRIPTION
Two specs (`ask-citation-overflow`, `related-consolidation`) saved a Playwright `.screenshot({path})` into a hardcoded absolute path under a previous session's scratchpad dir that no longer exists, so every run failed with EPERM — blocking the e2e gate for unrelated changes. These were debug saves (not `toHaveScreenshot` visual assertions), so removing them loses no coverage; the related-section `scrollIntoViewIfNeeded` is kept.